### PR TITLE
fix(jobs): use per-operation DB sessions for job bookkeeping

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/utils/model_resolver.py
+++ b/src/xagent/core/tools/core/RAG_tools/utils/model_resolver.py
@@ -28,6 +28,7 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.exc import OperationalError as SAOperationalError
 from sqlalchemy.orm import declarative_base, sessionmaker
 
+from xagent.config import get_db_pool_kwargs
 from xagent.core.model.chat.basic.adapter import create_base_llm
 from xagent.core.model.chat.basic.base import BaseLLM
 from xagent.core.model.chat.langchain import create_base_chat_model_with_retry
@@ -168,12 +169,23 @@ def _get_or_init_model_hub() -> Any:
             with _MODEL_HUB_LOCK:
                 if _MODEL_HUB_ENGINE is None or _MODEL_HUB_DB_URL != database_url:
                     old_engine = _MODEL_HUB_ENGINE
+                    is_sqlite = "sqlite" in database_url
+                    pool_kwargs: dict[str, Any] = (
+                        {}
+                        if is_sqlite
+                        else {
+                            "pool_pre_ping": True,
+                            "pool_recycle": get_db_pool_kwargs()["pool_recycle"],
+                        }
+                    )
                     engine = create_engine(
                         database_url,
-                        connect_args={"check_same_thread": False}
-                        if "sqlite" in database_url
-                        else {},
-                        pool_pre_ping="sqlite" not in database_url,
+                        connect_args={"check_same_thread": False} if is_sqlite else {},
+                        # Health knobs only. pool_recycle was the drift this
+                        # fixes; get_db_pool_kwargs' sizing applies per engine,
+                        # and a worker already holds the web engine's pool, so
+                        # adopting it here would double this process's ceiling.
+                        **pool_kwargs,
                         # Same database as the shared web engine
                         # (web/models/database.py) -- the Model table this
                         # hub reads/writes has an encrypted API key column,

--- a/src/xagent/core/tools/core/RAG_tools/utils/model_resolver.py
+++ b/src/xagent/core/tools/core/RAG_tools/utils/model_resolver.py
@@ -65,6 +65,10 @@ _MODEL_HUB_MODEL: Any = None
 _MODEL_HUB_DB_URL: Optional[str] = None
 _MODEL_HUB_LOCK = threading.Lock()
 
+# get_db_pool_kwargs' sizing applies per engine, and a worker already holds the
+# web engine's pool, so adopting it here would double this process's ceiling.
+_POOL_SIZING_KEYS = frozenset({"pool_size", "max_overflow", "pool_timeout"})
+
 
 def _reset_model_hub_cache() -> None:
     """Reset cached model hub DB resources.
@@ -174,17 +178,16 @@ def _get_or_init_model_hub() -> Any:
                         {}
                         if is_sqlite
                         else {
-                            "pool_pre_ping": True,
-                            "pool_recycle": get_db_pool_kwargs()["pool_recycle"],
+                            key: value
+                            for key, value in get_db_pool_kwargs().items()
+                            if key not in _POOL_SIZING_KEYS
                         }
                     )
                     engine = create_engine(
                         database_url,
                         connect_args={"check_same_thread": False} if is_sqlite else {},
-                        # Health knobs only. pool_recycle was the drift this
-                        # fixes; get_db_pool_kwargs' sizing applies per engine,
-                        # and a worker already holds the web engine's pool, so
-                        # adopting it here would double this process's ceiling.
+                        # Every non-sizing knob comes from the shared policy, so
+                        # a new health kwarg there reaches this engine too.
                         **pool_kwargs,
                         # Same database as the shared web engine
                         # (web/models/database.py) -- the Model table this

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -1783,8 +1783,7 @@ async def _enqueue_background_job_or_503_async(
         check_worker=False,
     ):
         mark_job_failed(
-            db,
-            job,
+            str(job.id),
             error_message="Background job queue is unavailable",
         )
         raise HTTPException(
@@ -1813,8 +1812,7 @@ async def _enqueue_background_job_or_503_async(
         return job
     except Exception as exc:  # noqa: BLE001
         mark_job_failed(
-            db,
-            job,
+            str(job.id),
             error_message=f"Background job queue is unavailable: {exc}",
         )
         raise HTTPException(

--- a/src/xagent/web/jobs/__init__.py
+++ b/src/xagent/web/jobs/__init__.py
@@ -1,11 +1,37 @@
-"""Celery-backed background job entrypoints."""
+"""Celery-backed background job entrypoints.
 
+Handler contract (breaking change; previously ``(Session, BackgroundJob)``):
+a handler now takes one positional ``BackgroundJobRef`` -- an immutable value
+snapshot of the row -- and returns the result dict. No Session is handed in,
+because the worker no longer keeps one open across the handler body; a handler
+that needs the database opens its own short session per operation
+(``xagent.web.models.database.session_scope``).
+
+Migrating a downstream handler::
+
+    def handle(db, job):                  # before
+        user = db.get(User, job.user_id)
+        ...
+
+    def handle(ref: BackgroundJobRef):    # after
+        with session_scope() as db:
+            user = db.get(User, ref.user_id)
+        ...
+
+``register_background_job_handler`` rejects the old two-argument shape at
+registration time rather than letting it fail once per attempt.
+"""
+
+from ..models.background_job import BackgroundJobRef
 from .tasks import (
+    BackgroundJobHandler,
     is_background_job_handler_registered,
     register_background_job_handler,
 )
 
 __all__ = [
+    "BackgroundJobHandler",
+    "BackgroundJobRef",
     "is_background_job_handler_registered",
     "register_background_job_handler",
 ]

--- a/src/xagent/web/jobs/kb_tasks.py
+++ b/src/xagent/web/jobs/kb_tasks.py
@@ -63,9 +63,8 @@ def _collection_existed_before(payload: dict[str, Any]) -> bool:
 def _get_job_user(payload: dict[str, Any], *, context: str) -> User | None:
     """Read the job's user on a scope of its own and hand back a detached row.
 
-    Expunged rather than expired, so the caller can read the loaded columns with
-    no transaction open while it does its external metadata/vector work; any
-    column that was not loaded raises instead of reading silently stale.
+    Expunged rather than expired, so the caller can read the columns with no
+    transaction open while it does its external metadata/vector work.
     """
     user_id = int(payload["user_id"])
     with session_scope() as db:

--- a/src/xagent/web/jobs/kb_tasks.py
+++ b/src/xagent/web/jobs/kb_tasks.py
@@ -28,8 +28,8 @@ from ...core.tools.core.RAG_tools.pipelines.web_ingestion import (
 )
 from ...core.tools.core.RAG_tools.utils.user_scope import user_scope_context
 from ..config import get_upload_path
-from ..models.background_job import BackgroundJob
-from ..models.database import get_session_local
+from ..models.background_job import BackgroundJobRef
+from ..models.database import get_session_local, session_scope
 from ..models.uploaded_file import UploadedFile
 from ..models.user import User
 from ..services.background_jobs import update_job_progress
@@ -190,21 +190,23 @@ def _cleanup_failed_job_collection_metadata_after_api_ingest(
     )
 
 
-def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]:
-    payload = dict(job.payload or {})
+def handle_kb_ingest_document(ref: BackgroundJobRef) -> dict[str, Any]:
+    payload = dict(ref.payload)
     ingestion_config = IngestionConfig.model_validate(payload["ingestion_config"])
     file_id = payload.get("file_id")
     target_path = payload.get("target_path")
     is_staged_input = bool(target_path)
-    progress_manager = BackgroundJobProgressManager(db, job)
+    progress_manager = BackgroundJobProgressManager(ref.id)
 
-    update_job_progress(db, job, message="Ingesting document")
-    if is_staged_input and not _is_staged_document_generation_latest(db, payload):
-        update_job_progress(db, job, message="Superseded by newer upload")
+    update_job_progress(ref.id, message="Ingesting document")
+    if is_staged_input and not _staged_generation_is_latest(payload):
+        update_job_progress(ref.id, message="Superseded by newer upload")
         return _superseded_staged_document_result(payload)
 
     def _assert_latest_generation() -> None:
-        if is_staged_input and not _is_staged_document_generation_latest(db, payload):
+        # Called from inside the ingestion body, which runs for as long as the
+        # document takes: it must not close over a session.
+        if is_staged_input and not _staged_generation_is_latest(payload):
             raise StagedDocumentIngestSuperseded(_SUPERSEDED_STAGED_INGEST_MESSAGE)
 
     try:
@@ -229,140 +231,155 @@ def handle_kb_ingest_document(db: Session, job: BackgroundJob) -> dict[str, Any]
             )
             result = api_result.result
     except StagedDocumentIngestSuperseded:
-        _cleanup_failed_staged_job_collection_metadata_if_current(
-            db,
-            payload,
-            context="background staged document superseded exception",
-        )
-        return _superseded_staged_document_result(payload)
-    except Exception:
-        if is_staged_input:
-            if int(job.attempts or 0) >= int(job.max_attempts or 1):
-                _cleanup_staged_document_input(payload)
+        with session_scope() as db:
             _cleanup_failed_staged_job_collection_metadata_if_current(
                 db,
                 payload,
-                context="background staged document ingest exception",
+                context="background staged document superseded exception",
             )
-        else:
-            _cleanup_failed_job_collection_metadata(
-                db,
-                payload,
-                context="background document ingest exception",
-            )
+        return _superseded_staged_document_result(payload)
+    except Exception:
+        with session_scope() as db:
+            if is_staged_input:
+                if ref.attempts >= ref.max_attempts:
+                    _cleanup_staged_document_input(payload)
+                _cleanup_failed_staged_job_collection_metadata_if_current(
+                    db,
+                    payload,
+                    context="background staged document ingest exception",
+                )
+            else:
+                _cleanup_failed_job_collection_metadata(
+                    db,
+                    payload,
+                    context="background document ingest exception",
+                )
         raise
 
     result_payload = result.model_dump(mode="json")
     if file_id:
         result_payload["file_id"] = file_id
-    if result.status in {"error", "partial"}:
-        if is_staged_input:
-            if _is_superseded_ingestion_result(result):
-                _cleanup_failed_staged_job_collection_metadata_if_current(
+
+    # Everything below is bookkeeping on a settled ingestion: no long waits, so
+    # one scope covers it.
+    with session_scope() as db:
+        if result.status in {"error", "partial"}:
+            if is_staged_input:
+                if _is_superseded_ingestion_result(result):
+                    _cleanup_failed_staged_job_collection_metadata_if_current(
+                        db,
+                        payload,
+                        context="background staged document superseded result",
+                    )
+                    return _superseded_staged_document_result(payload)
+                rollback_api_result = (
+                    _rollback_failed_staged_document_ingestion_if_current(
+                        db,
+                        payload,
+                        result,
+                        api_result=api_result,
+                    )
+                )
+                if rollback_api_result is False:
+                    _cleanup_failed_staged_job_collection_metadata_if_current(
+                        db,
+                        payload,
+                        context="background stale staged document ingest",
+                    )
+                    return _superseded_staged_document_result(payload)
+                api_result = rollback_api_result
+                _cleanup_failed_job_collection_metadata_after_api_ingest(
                     db,
                     payload,
-                    context="background staged document superseded result",
+                    api_result=api_result,
+                    context="background staged document ingest",
                 )
-                return _superseded_staged_document_result(payload)
-            rollback_api_result = _rollback_failed_staged_document_ingestion_if_current(
-                db,
-                payload,
-                result,
-                api_result=api_result,
-            )
-            if rollback_api_result is False:
-                _cleanup_failed_staged_job_collection_metadata_if_current(
+            else:
+                api_result = _rollback_failed_document_ingestion(
                     db,
                     payload,
-                    context="background stale staged document ingest",
+                    result,
+                    api_result=api_result,
                 )
-                return _superseded_staged_document_result(payload)
-            api_result = rollback_api_result
-            _cleanup_failed_job_collection_metadata_after_api_ingest(
-                db,
-                payload,
-                api_result=api_result,
-                context="background staged document ingest",
-            )
-        else:
-            api_result = _rollback_failed_document_ingestion(
-                db,
-                payload,
-                result,
-                api_result=api_result,
-            )
-            _cleanup_failed_job_collection_metadata_after_api_ingest(
-                db,
-                payload,
-                api_result=api_result,
-                context="background document ingest",
-            )
-        raise BackgroundJobHandlerError(
-            result.message,
-            result=result_payload,
-            retryable=False,
-        )
-    if is_staged_input:
-        if not _is_staged_document_generation_latest(db, payload):
-            _cleanup_failed_staged_job_collection_metadata_if_current(
-                db,
-                payload,
-                context="background stale staged document publish",
-            )
-            return _superseded_staged_document_result(payload)
-        try:
-            file_record = _publish_staged_document_ingestion(db, payload)
-            result_payload["file_id"] = str(file_record.file_id)
-        except StagedDocumentIngestSuperseded:
-            _cleanup_failed_staged_job_collection_metadata_if_current(
-                db,
-                payload,
-                context="background staged document publish superseded",
-            )
-            return _superseded_staged_document_result(payload)
-        except Exception as exc:  # noqa: BLE001
-            rollback_api_result = _rollback_failed_staged_document_ingestion_if_current(
-                db,
-                payload,
-                result,
-                api_result=api_result,
-            )
-            if rollback_api_result is False:
-                _cleanup_failed_staged_job_collection_metadata_if_current(
+                _cleanup_failed_job_collection_metadata_after_api_ingest(
                     db,
                     payload,
-                    context="background stale staged document publish rollback",
+                    api_result=api_result,
+                    context="background document ingest",
                 )
-                return _superseded_staged_document_result(payload)
-            api_result = rollback_api_result
-            _cleanup_failed_job_collection_metadata_after_api_ingest(
-                db,
-                payload,
-                api_result=api_result,
-                context="background staged document publish",
-                successful_documents=0,
-            )
             raise BackgroundJobHandlerError(
-                f"Document ingestion succeeded but publishing uploaded file failed: {exc}",
+                result.message,
                 result=result_payload,
                 retryable=False,
-            ) from exc
-    else:
-        _discard_ingest_backup(payload)
-    # Reaching here means exactly one document landed, so publish the config.
-    _save_job_collection_config_after_ingest(
-        db,
-        payload,
-        ingestion_config,
-        context="background document ingest",
-        documents_created=result.produced_documents,
-        result_payload=result_payload,
-    )
+            )
+        if is_staged_input:
+            if not _is_staged_document_generation_latest(db, payload):
+                _cleanup_failed_staged_job_collection_metadata_if_current(
+                    db,
+                    payload,
+                    context="background stale staged document publish",
+                )
+                return _superseded_staged_document_result(payload)
+            try:
+                file_record = _publish_staged_document_ingestion(db, payload)
+                result_payload["file_id"] = str(file_record.file_id)
+            except StagedDocumentIngestSuperseded:
+                _cleanup_failed_staged_job_collection_metadata_if_current(
+                    db,
+                    payload,
+                    context="background staged document publish superseded",
+                )
+                return _superseded_staged_document_result(payload)
+            except Exception as exc:  # noqa: BLE001
+                rollback_api_result = (
+                    _rollback_failed_staged_document_ingestion_if_current(
+                        db,
+                        payload,
+                        result,
+                        api_result=api_result,
+                    )
+                )
+                if rollback_api_result is False:
+                    _cleanup_failed_staged_job_collection_metadata_if_current(
+                        db,
+                        payload,
+                        context="background stale staged document publish rollback",
+                    )
+                    return _superseded_staged_document_result(payload)
+                api_result = rollback_api_result
+                _cleanup_failed_job_collection_metadata_after_api_ingest(
+                    db,
+                    payload,
+                    api_result=api_result,
+                    context="background staged document publish",
+                    successful_documents=0,
+                )
+                raise BackgroundJobHandlerError(
+                    f"Document ingestion succeeded but publishing uploaded file failed: {exc}",
+                    result=result_payload,
+                    retryable=False,
+                ) from exc
+        else:
+            _discard_ingest_backup(payload)
+        # Reaching here means exactly one document landed, so publish the config.
+        _save_job_collection_config_after_ingest(
+            db,
+            payload,
+            ingestion_config,
+            context="background document ingest",
+            documents_created=result.produced_documents,
+            result_payload=result_payload,
+        )
     return result_payload
 
 
-def handle_kb_ingest_web(db: Session, job: BackgroundJob) -> dict[str, Any]:
-    payload = dict(job.payload or {})
+def _staged_generation_is_latest(payload: dict[str, Any]) -> bool:
+    with session_scope() as db:
+        return _is_staged_document_generation_latest(db, payload)
+
+
+def handle_kb_ingest_web(ref: BackgroundJobRef) -> dict[str, Any]:
+    payload = dict(ref.payload)
     crawl_config = WebCrawlConfig.model_validate(payload["crawl_config"])
     ingestion_config = IngestionConfig.model_validate(payload["ingestion_config"])
     user_id = int(payload["user_id"])
@@ -372,8 +389,7 @@ def handle_kb_ingest_web(db: Session, job: BackgroundJob) -> dict[str, Any]:
 
     def _progress(message: str, completed: int, total: int) -> None:
         update_job_progress(
-            db,
-            job,
+            ref.id,
             message=message,
             completed=completed,
             total=total,
@@ -402,7 +418,7 @@ def handle_kb_ingest_web(db: Session, job: BackgroundJob) -> dict[str, Any]:
         finally:
             db_session.close()
 
-    update_job_progress(db, job, message="Crawling website")
+    update_job_progress(ref.id, message="Crawling website")
     try:
         with user_scope_context(user_id=user_id, is_admin=is_admin):
             api_result = asyncio.run(
@@ -422,7 +438,8 @@ def handle_kb_ingest_web(db: Session, job: BackgroundJob) -> dict[str, Any]:
             )
             result = api_result.result
     except Exception:
-        _cleanup_failed_web_collection_metadata_if_new(db, payload)
+        with session_scope() as db:
+            _cleanup_failed_web_collection_metadata_if_new(db, payload)
         raise
 
     from ..api.kb import _demote_empty_crawl_to_error
@@ -436,22 +453,23 @@ def handle_kb_ingest_web(db: Session, job: BackgroundJob) -> dict[str, Any]:
     crawled_nothing = result.status != crawl_status
     documents_created = int(result.documents_created or 0)
     result_payload = result.model_dump(mode="json")
-    # Partial crawls still leave real documents behind, so publish on any of them.
-    _save_job_collection_config_after_ingest(
-        db,
-        payload,
-        ingestion_config,
-        context="background web ingest",
-        documents_created=documents_created,
-        result_payload=result_payload,
-    )
-    if result.status in {"error", "partial"}:
-        _cleanup_failed_web_collection_metadata_if_new(
+    with session_scope() as db:
+        # Partial crawls still leave real documents behind, so publish on any of them.
+        _save_job_collection_config_after_ingest(
             db,
             payload,
-            api_result=api_result,
-            successful_documents=documents_created,
+            ingestion_config,
+            context="background web ingest",
+            documents_created=documents_created,
+            result_payload=result_payload,
         )
+        if result.status in {"error", "partial"}:
+            _cleanup_failed_web_collection_metadata_if_new(
+                db,
+                payload,
+                api_result=api_result,
+                successful_documents=documents_created,
+            )
     if result.status == "error":
         # A crawl that recorded no failures has nothing to retry: re-running it
         # re-crawls the whole site to reach the same empty result.

--- a/src/xagent/web/jobs/kb_tasks.py
+++ b/src/xagent/web/jobs/kb_tasks.py
@@ -60,21 +60,24 @@ def _collection_existed_before(payload: dict[str, Any]) -> bool:
     return bool(payload.get("collection_existed_before", True))
 
 
-def _get_job_user(
-    db: Session,
-    payload: dict[str, Any],
-    *,
-    context: str,
-) -> User | None:
+def _get_job_user(payload: dict[str, Any], *, context: str) -> User | None:
+    """Read the job's user on a scope of its own and hand back a detached row.
+
+    Expunged rather than expired, so the caller can read the loaded columns with
+    no transaction open while it does its external metadata/vector work; any
+    column that was not loaded raises instead of reading silently stale.
+    """
     user_id = int(payload["user_id"])
-    user = db.query(User).filter(User.id == user_id).first()
-    if user is None:
-        logger.warning("Cannot %s for missing user %s", context, user_id)
-    return user
+    with session_scope() as db:
+        user = db.query(User).filter(User.id == user_id).first()
+        if user is None:
+            logger.warning("Cannot %s for missing user %s", context, user_id)
+            return None
+        db.expunge(user)
+        return user
 
 
 def _save_job_collection_config_after_ingest(
-    db: Session,
     payload: dict[str, Any],
     ingestion_config: IngestionConfig,
     *,
@@ -87,9 +90,7 @@ def _save_job_collection_config_after_ingest(
         # raising here would skip the caller's failure cleanup.
         return
 
-    user = _get_job_user(
-        db, payload, context=f"save collection config during {context}"
-    )
+    user = _get_job_user(payload, context=f"save collection config during {context}")
     if user is None:
         if documents_created <= 0:
             # Nothing landed, so there is nothing this user was needed for.
@@ -129,7 +130,6 @@ def _save_job_collection_config_after_ingest(
 
 
 def _cleanup_failed_job_collection_metadata(
-    db: Session,
     payload: dict[str, Any],
     *,
     context: str,
@@ -137,7 +137,6 @@ def _cleanup_failed_job_collection_metadata(
     side_effects_may_remain: bool = False,
 ) -> None:
     user = _get_job_user(
-        db,
         payload,
         context=f"clean up failed-ingest collection metadata during {context}",
     )
@@ -159,7 +158,6 @@ def _cleanup_failed_job_collection_metadata(
 
 
 def _cleanup_failed_job_collection_metadata_after_api_ingest(
-    db: Session,
     payload: dict[str, Any],
     *,
     api_result: KBApiOperationResult[Any],
@@ -168,7 +166,6 @@ def _cleanup_failed_job_collection_metadata_after_api_ingest(
     rollback_complete: bool | None = None,
 ) -> None:
     user = _get_job_user(
-        db,
         payload,
         context=f"clean up failed-ingest collection metadata during {context}",
     )
@@ -231,145 +228,122 @@ def handle_kb_ingest_document(ref: BackgroundJobRef) -> dict[str, Any]:
             )
             result = api_result.result
     except StagedDocumentIngestSuperseded:
-        with session_scope() as db:
-            _cleanup_failed_staged_job_collection_metadata_if_current(
-                db,
-                payload,
-                context="background staged document superseded exception",
-            )
+        _cleanup_failed_staged_job_collection_metadata_if_current(
+            payload,
+            context="background staged document superseded exception",
+        )
         return _superseded_staged_document_result(payload)
     except Exception:
-        with session_scope() as db:
-            if is_staged_input:
-                if ref.attempts >= ref.max_attempts:
-                    _cleanup_staged_document_input(payload)
-                _cleanup_failed_staged_job_collection_metadata_if_current(
-                    db,
-                    payload,
-                    context="background staged document ingest exception",
-                )
-            else:
-                _cleanup_failed_job_collection_metadata(
-                    db,
-                    payload,
-                    context="background document ingest exception",
-                )
+        if is_staged_input:
+            if ref.attempts >= ref.max_attempts:
+                _cleanup_staged_document_input(payload)
+            _cleanup_failed_staged_job_collection_metadata_if_current(
+                payload,
+                context="background staged document ingest exception",
+            )
+        else:
+            _cleanup_failed_job_collection_metadata(
+                payload,
+                context="background document ingest exception",
+            )
         raise
 
     result_payload = result.model_dump(mode="json")
     if file_id:
         result_payload["file_id"] = file_id
 
-    # Everything below is bookkeeping on a settled ingestion: no long waits, so
-    # one scope covers it.
-    with session_scope() as db:
-        if result.status in {"error", "partial"}:
-            if is_staged_input:
-                if _is_superseded_ingestion_result(result):
-                    _cleanup_failed_staged_job_collection_metadata_if_current(
-                        db,
-                        payload,
-                        context="background staged document superseded result",
-                    )
-                    return _superseded_staged_document_result(payload)
-                rollback_api_result = (
-                    _rollback_failed_staged_document_ingestion_if_current(
-                        db,
-                        payload,
-                        result,
-                        api_result=api_result,
-                    )
-                )
-                if rollback_api_result is False:
-                    _cleanup_failed_staged_job_collection_metadata_if_current(
-                        db,
-                        payload,
-                        context="background stale staged document ingest",
-                    )
-                    return _superseded_staged_document_result(payload)
-                api_result = rollback_api_result
-                _cleanup_failed_job_collection_metadata_after_api_ingest(
-                    db,
+    # Bookkeeping on a settled ingestion: every step below owns its session
+    # instead of sharing one, and the metadata/config work holds none at all.
+    if result.status in {"error", "partial"}:
+        if is_staged_input:
+            if _is_superseded_ingestion_result(result):
+                _cleanup_failed_staged_job_collection_metadata_if_current(
                     payload,
-                    api_result=api_result,
-                    context="background staged document ingest",
+                    context="background staged document superseded result",
                 )
-            else:
-                api_result = _rollback_failed_document_ingestion(
-                    db,
+                return _superseded_staged_document_result(payload)
+            rollback_api_result = _rollback_failed_staged_document_ingestion_if_current(
+                payload,
+                result,
+                api_result=api_result,
+            )
+            if rollback_api_result is False:
+                _cleanup_failed_staged_job_collection_metadata_if_current(
                     payload,
-                    result,
-                    api_result=api_result,
+                    context="background stale staged document ingest",
                 )
-                _cleanup_failed_job_collection_metadata_after_api_ingest(
-                    db,
+                return _superseded_staged_document_result(payload)
+            api_result = rollback_api_result
+            _cleanup_failed_job_collection_metadata_after_api_ingest(
+                payload,
+                api_result=api_result,
+                context="background staged document ingest",
+            )
+        else:
+            api_result = _rollback_failed_document_ingestion(
+                payload,
+                result,
+                api_result=api_result,
+            )
+            _cleanup_failed_job_collection_metadata_after_api_ingest(
+                payload,
+                api_result=api_result,
+                context="background document ingest",
+            )
+        raise BackgroundJobHandlerError(
+            result.message,
+            result=result_payload,
+            retryable=False,
+        )
+    if is_staged_input:
+        if not _staged_generation_is_latest(payload):
+            _cleanup_failed_staged_job_collection_metadata_if_current(
+                payload,
+                context="background stale staged document publish",
+            )
+            return _superseded_staged_document_result(payload)
+        try:
+            result_payload["file_id"] = _publish_staged_document_ingestion(payload)
+        except StagedDocumentIngestSuperseded:
+            _cleanup_failed_staged_job_collection_metadata_if_current(
+                payload,
+                context="background staged document publish superseded",
+            )
+            return _superseded_staged_document_result(payload)
+        except Exception as exc:  # noqa: BLE001
+            rollback_api_result = _rollback_failed_staged_document_ingestion_if_current(
+                payload,
+                result,
+                api_result=api_result,
+            )
+            if rollback_api_result is False:
+                _cleanup_failed_staged_job_collection_metadata_if_current(
                     payload,
-                    api_result=api_result,
-                    context="background document ingest",
+                    context="background stale staged document publish rollback",
                 )
+                return _superseded_staged_document_result(payload)
+            api_result = rollback_api_result
+            _cleanup_failed_job_collection_metadata_after_api_ingest(
+                payload,
+                api_result=api_result,
+                context="background staged document publish",
+                successful_documents=0,
+            )
             raise BackgroundJobHandlerError(
-                result.message,
+                f"Document ingestion succeeded but publishing uploaded file failed: {exc}",
                 result=result_payload,
                 retryable=False,
-            )
-        if is_staged_input:
-            if not _is_staged_document_generation_latest(db, payload):
-                _cleanup_failed_staged_job_collection_metadata_if_current(
-                    db,
-                    payload,
-                    context="background stale staged document publish",
-                )
-                return _superseded_staged_document_result(payload)
-            try:
-                file_record = _publish_staged_document_ingestion(db, payload)
-                result_payload["file_id"] = str(file_record.file_id)
-            except StagedDocumentIngestSuperseded:
-                _cleanup_failed_staged_job_collection_metadata_if_current(
-                    db,
-                    payload,
-                    context="background staged document publish superseded",
-                )
-                return _superseded_staged_document_result(payload)
-            except Exception as exc:  # noqa: BLE001
-                rollback_api_result = (
-                    _rollback_failed_staged_document_ingestion_if_current(
-                        db,
-                        payload,
-                        result,
-                        api_result=api_result,
-                    )
-                )
-                if rollback_api_result is False:
-                    _cleanup_failed_staged_job_collection_metadata_if_current(
-                        db,
-                        payload,
-                        context="background stale staged document publish rollback",
-                    )
-                    return _superseded_staged_document_result(payload)
-                api_result = rollback_api_result
-                _cleanup_failed_job_collection_metadata_after_api_ingest(
-                    db,
-                    payload,
-                    api_result=api_result,
-                    context="background staged document publish",
-                    successful_documents=0,
-                )
-                raise BackgroundJobHandlerError(
-                    f"Document ingestion succeeded but publishing uploaded file failed: {exc}",
-                    result=result_payload,
-                    retryable=False,
-                ) from exc
-        else:
-            _discard_ingest_backup(payload)
-        # Reaching here means exactly one document landed, so publish the config.
-        _save_job_collection_config_after_ingest(
-            db,
-            payload,
-            ingestion_config,
-            context="background document ingest",
-            documents_created=result.produced_documents,
-            result_payload=result_payload,
-        )
+            ) from exc
+    else:
+        _discard_ingest_backup(payload)
+    # Reaching here means exactly one document landed, so publish the config.
+    _save_job_collection_config_after_ingest(
+        payload,
+        ingestion_config,
+        context="background document ingest",
+        documents_created=result.produced_documents,
+        result_payload=result_payload,
+    )
     return result_payload
 
 
@@ -438,8 +412,7 @@ def handle_kb_ingest_web(ref: BackgroundJobRef) -> dict[str, Any]:
             )
             result = api_result.result
     except Exception:
-        with session_scope() as db:
-            _cleanup_failed_web_collection_metadata_if_new(db, payload)
+        _cleanup_failed_web_collection_metadata_if_new(payload)
         raise
 
     from ..api.kb import _demote_empty_crawl_to_error
@@ -453,23 +426,22 @@ def handle_kb_ingest_web(ref: BackgroundJobRef) -> dict[str, Any]:
     crawled_nothing = result.status != crawl_status
     documents_created = int(result.documents_created or 0)
     result_payload = result.model_dump(mode="json")
-    with session_scope() as db:
-        # Partial crawls still leave real documents behind, so publish on any of them.
-        _save_job_collection_config_after_ingest(
-            db,
+    # Crawl finalization is async metadata and vector I/O: both calls below open
+    # their own short session for the row read and close it before that work.
+    # Partial crawls still leave real documents behind, so publish on any of them.
+    _save_job_collection_config_after_ingest(
+        payload,
+        ingestion_config,
+        context="background web ingest",
+        documents_created=documents_created,
+        result_payload=result_payload,
+    )
+    if result.status in {"error", "partial"}:
+        _cleanup_failed_web_collection_metadata_if_new(
             payload,
-            ingestion_config,
-            context="background web ingest",
-            documents_created=documents_created,
-            result_payload=result_payload,
+            api_result=api_result,
+            successful_documents=documents_created,
         )
-        if result.status in {"error", "partial"}:
-            _cleanup_failed_web_collection_metadata_if_new(
-                db,
-                payload,
-                api_result=api_result,
-                successful_documents=documents_created,
-            )
     if result.status == "error":
         # A crawl that recorded no failures has nothing to retry: re-running it
         # re-crawls the whole site to reach the same empty result.
@@ -621,12 +593,11 @@ def _is_staged_document_generation_latest(
 
 
 def _cleanup_failed_staged_job_collection_metadata_if_current(
-    db: Session,
     payload: dict[str, Any],
     *,
     context: str,
 ) -> bool:
-    if not _is_staged_document_generation_latest(db, payload):
+    if not _staged_generation_is_latest(payload):
         logger.info(
             "Skipping collection metadata cleanup for superseded KB ingest generation: "
             "%s/user_%s generation=%s",
@@ -637,7 +608,6 @@ def _cleanup_failed_staged_job_collection_metadata_if_current(
         return False
 
     _cleanup_failed_job_collection_metadata(
-        db,
         payload,
         context=context,
     )
@@ -661,30 +631,52 @@ def _superseded_staged_document_result(payload: dict[str, Any]) -> dict[str, Any
 
 
 def _rollback_failed_staged_document_ingestion(
-    db: Session,
     payload: dict[str, Any],
     result: IngestionResult,
     *,
     api_result: KBApiOperationResult[Any],
 ) -> KBApiOperationResult[Any]:
-    from ..api.kb import _rollback_failed_cloud_ingestion
-
     user_id = int(payload["user_id"])
-    user = db.query(User).filter(User.id == user_id).first()
-    if user is None:
-        _cleanup_staged_document_input(payload)
-        raise BackgroundJobHandlerError(
-            f"Cannot roll back KB ingestion for missing user {user_id}",
-            result=result.model_dump(mode="json"),
-            retryable=False,
-        )
-
     ingestion_config_payload = payload.get("ingestion_config")
     embedding_model_id = (
         ingestion_config_payload.get("embedding_model_id")
         if isinstance(ingestion_config_payload, dict)
         else None
     )
+    # Known ceiling: _rollback_failed_cloud_ingestion interleaves its DB deletes
+    # with its vector/filesystem work on the session it is handed, so this scope
+    # spans them. Bounded by one rollback, not by the ingestion; shortening it
+    # means changing that function's protocol in the request path too.
+    with session_scope() as db:
+        user = db.query(User).filter(User.id == user_id).first()
+        if user is None:
+            _cleanup_staged_document_input(payload)
+            raise BackgroundJobHandlerError(
+                f"Cannot roll back KB ingestion for missing user {user_id}",
+                result=result.model_dump(mode="json"),
+                retryable=False,
+            )
+        return _run_staged_rollback(
+            db,
+            payload,
+            result,
+            api_result=api_result,
+            user=user,
+            embedding_model_id=embedding_model_id,
+        )
+
+
+def _run_staged_rollback(
+    db: Session,
+    payload: dict[str, Any],
+    result: IngestionResult,
+    *,
+    api_result: KBApiOperationResult[Any],
+    user: User,
+    embedding_model_id: str | None,
+) -> KBApiOperationResult[Any]:
+    from ..api.kb import _rollback_failed_cloud_ingestion
+
     try:
         rollback_execution = _get_api_compatibility_facade().run_failed_ingest_rollback(
             api_result,
@@ -718,27 +710,30 @@ def _rollback_failed_staged_document_ingestion(
 
 
 def _rollback_failed_staged_document_ingestion_if_current(
-    db: Session,
     payload: dict[str, Any],
     result: IngestionResult,
     *,
     api_result: KBApiOperationResult[Any],
 ) -> KBApiOperationResult[Any] | Literal[False]:
-    if not _is_staged_document_generation_latest(db, payload):
+    if not _staged_generation_is_latest(payload):
         _cleanup_staged_document_input(payload)
         return False
     return _rollback_failed_staged_document_ingestion(
-        db,
         payload,
         result,
         api_result=api_result,
     )
 
 
-def _publish_staged_document_ingestion(
+def _publish_staged_document_ingestion(payload: dict[str, Any]) -> str:
+    with session_scope() as db:
+        return _publish_staged_document_ingestion_in_session(db, payload)
+
+
+def _publish_staged_document_ingestion_in_session(
     db: Session,
     payload: dict[str, Any],
-) -> UploadedFile:
+) -> str:
     from ..api.kb import (
         _build_ingest_backup_path,
         _cleanup_background_ingest_staging_file,
@@ -801,10 +796,25 @@ def _publish_staged_document_ingestion(
         except OSError:
             logger.warning("Failed to remove ingest backup %s", backup_path)
     _cleanup_background_ingest_staging_file(source_path)
-    return file_record
+    return str(file_record.file_id)
 
 
 def _rollback_failed_document_ingestion(
+    payload: dict[str, Any],
+    result: IngestionResult,
+    *,
+    api_result: KBApiOperationResult[Any],
+) -> KBApiOperationResult[Any]:
+    # Same known ceiling as the staged variant: _rollback_failed_ingestion does
+    # its DB deletes on this session between its vector deletes, so the scope
+    # spans them. It is bounded by one rollback, not by the ingestion.
+    with session_scope() as db:
+        return _rollback_failed_document_ingestion_in_session(
+            db, payload, result, api_result=api_result
+        )
+
+
+def _rollback_failed_document_ingestion_in_session(
     db: Session,
     payload: dict[str, Any],
     result: IngestionResult,
@@ -884,7 +894,6 @@ def _discard_ingest_backup(payload: dict[str, Any]) -> None:
 
 
 def _cleanup_failed_web_collection_metadata_if_new(
-    db: Session,
     payload: dict[str, Any],
     *,
     api_result: KBApiOperationResult[Any] | None = None,
@@ -892,7 +901,6 @@ def _cleanup_failed_web_collection_metadata_if_new(
 ) -> None:
     if api_result is None:
         _cleanup_failed_job_collection_metadata(
-            db,
             payload,
             context="background web ingest",
             successful_documents=int(successful_documents or 0),
@@ -900,7 +908,6 @@ def _cleanup_failed_web_collection_metadata_if_new(
         return
 
     _cleanup_failed_job_collection_metadata_after_api_ingest(
-        db,
         payload,
         api_result=api_result,
         context="background web ingest",

--- a/src/xagent/web/jobs/progress.py
+++ b/src/xagent/web/jobs/progress.py
@@ -7,9 +7,8 @@ from datetime import datetime, timezone
 from typing import Any
 
 from ...core.tools.core.RAG_tools.progress import get_progress_manager
-from ..models.background_job import BackgroundJob
 from ..models.database import session_scope
-from ..services.background_jobs import update_job_progress
+from ..services.background_jobs import get_background_job, update_job_progress
 
 logger = logging.getLogger(__name__)
 
@@ -193,11 +192,7 @@ class BackgroundJobProgressManager:
     def _current_progress(self) -> dict[str, Any]:
         try:
             with session_scope() as db:
-                job = (
-                    db.query(BackgroundJob)
-                    .filter(BackgroundJob.id == self.job_id)
-                    .first()
-                )
+                job = get_background_job(db, self.job_id)
                 if job is not None and isinstance(job.progress, dict):
                     return dict(job.progress)
         except Exception as exc:  # noqa: BLE001

--- a/src/xagent/web/jobs/progress.py
+++ b/src/xagent/web/jobs/progress.py
@@ -6,10 +6,9 @@ import time
 from datetime import datetime, timezone
 from typing import Any
 
-from sqlalchemy.orm import Session
-
 from ...core.tools.core.RAG_tools.progress import get_progress_manager
 from ..models.background_job import BackgroundJob
+from ..models.database import session_scope
 from ..services.background_jobs import update_job_progress
 
 logger = logging.getLogger(__name__)
@@ -49,14 +48,12 @@ class BackgroundJobProgressManager:
 
     def __init__(
         self,
-        db: Session,
-        job: BackgroundJob,
+        job_id: str,
         *,
         delegate: Any | None = None,
         throttle_seconds: float = 0.5,
     ) -> None:
-        self.db = db
-        self.job = job
+        self.job_id = job_id
         self.delegate = delegate if delegate is not None else get_progress_manager()
         self.throttle_seconds = throttle_seconds
         self._last_mirror_at = 0.0
@@ -170,9 +167,7 @@ class BackgroundJobProgressManager:
             extra["overall_progress"] = overall_progress
         if metadata is not None:
             existing_metadata = {}
-            current_progress: dict[str, Any] = {}
-            if isinstance(self.job.progress, dict):
-                current_progress = self.job.progress
+            current_progress = self._current_progress()
             raw_existing_metadata = current_progress.get("metadata")
             if isinstance(raw_existing_metadata, dict):
                 existing_metadata = dict(raw_existing_metadata)
@@ -186,19 +181,27 @@ class BackgroundJobProgressManager:
             existing_metadata.update(merged_metadata)
             extra["metadata"] = existing_metadata
 
+        update_job_progress(
+            self.job_id,
+            message=message,
+            completed=completed,
+            total=total,
+            extra=extra,
+        )
+        self._last_mirror_at = now
+
+    def _current_progress(self) -> dict[str, Any]:
         try:
-            update_job_progress(
-                self.db,
-                self.job,
-                message=message,
-                completed=completed,
-                total=total,
-                extra=extra,
-            )
-            self._last_mirror_at = now
+            with session_scope() as db:
+                job = (
+                    db.query(BackgroundJob)
+                    .filter(BackgroundJob.id == self.job_id)
+                    .first()
+                )
+                if job is not None and isinstance(job.progress, dict):
+                    return dict(job.progress)
         except Exception as exc:  # noqa: BLE001
             logger.warning(
-                "Failed to mirror RAG progress to background job %s: %s",
-                self.job.id,
-                exc,
+                "Failed to read progress for background job %s: %s", self.job_id, exc
             )
+        return {}

--- a/src/xagent/web/jobs/tasks.py
+++ b/src/xagent/web/jobs/tasks.py
@@ -4,14 +4,13 @@ import logging
 from collections.abc import Callable
 from typing import Any
 
-from sqlalchemy.orm import Session
-
 from ..models.background_job import (
     BackgroundJob,
+    BackgroundJobRef,
     BackgroundJobStatus,
     BackgroundJobType,
 )
-from ..models.database import get_session_local, init_db
+from ..models.database import get_optional_session_local, init_db, session_scope
 from ..services.background_jobs import (
     mark_job_failed,
     mark_job_running,
@@ -22,7 +21,9 @@ from .exceptions import BackgroundJobHandlerError
 
 logger = logging.getLogger(__name__)
 
-BackgroundJobHandler = Callable[[Session, BackgroundJob], dict[str, Any]]
+_UNSET: Any = object()
+
+BackgroundJobHandler = Callable[[BackgroundJobRef], dict[str, Any]]
 
 # Downstream distributions own job types this package must not import. They
 # register a handler when the worker imports their task module, so their work
@@ -68,41 +69,37 @@ def is_background_job_handler_registered(job_type: str) -> bool:
     return str(job_type) in _EXTRA_HANDLERS
 
 
-def _open_worker_session() -> Session:
-    try:
-        SessionLocal = get_session_local()
-    except RuntimeError:
+def _ensure_db_initialized() -> None:
+    if get_optional_session_local() is None:
         init_db()
-        SessionLocal = get_session_local()
-    return SessionLocal()
 
 
-def _execute_job_handler(db: Session, job: BackgroundJob) -> dict[str, Any]:
-    if job.job_type == BackgroundJobType.KB_INGEST_DOCUMENT.value:
+def _execute_job_handler(ref: BackgroundJobRef) -> dict[str, Any]:
+    if ref.job_type == BackgroundJobType.KB_INGEST_DOCUMENT.value:
         from .kb_tasks import handle_kb_ingest_document
 
-        return handle_kb_ingest_document(db, job)
-    if job.job_type == BackgroundJobType.KB_INGEST_WEB.value:
+        return handle_kb_ingest_document(ref)
+    if ref.job_type == BackgroundJobType.KB_INGEST_WEB.value:
         from .kb_tasks import handle_kb_ingest_web
 
-        return handle_kb_ingest_web(db, job)
-    if job.job_type == BackgroundJobType.TRIGGER_EVENT.value:
+        return handle_kb_ingest_web(ref)
+    if ref.job_type == BackgroundJobType.TRIGGER_EVENT.value:
         from .trigger_tasks import handle_trigger_event
 
-        return handle_trigger_event(db, job)
-    if job.job_type == BackgroundJobType.TRIGGER_SCAN.value:
+        return handle_trigger_event(ref)
+    if ref.job_type == BackgroundJobType.TRIGGER_SCAN.value:
         from .trigger_tasks import handle_trigger_scan
 
-        return handle_trigger_scan(db, job)
+        return handle_trigger_scan(ref)
 
-    handler = _EXTRA_HANDLERS.get(str(job.job_type))
+    handler = _EXTRA_HANDLERS.get(str(ref.job_type))
     if handler is not None:
-        return handler(db, job)
+        return handler(ref)
 
     # A worker that cannot route this job type will never grow a handler by
     # waiting, so this is permanent: fail fast instead of burning retries.
     raise BackgroundJobHandlerError(
-        f"Unsupported background job type: {job.job_type}",
+        f"Unsupported background job type: {ref.job_type}",
         retryable=False,
     )
 
@@ -114,8 +111,9 @@ def _execute_job_handler(db: Session, job: BackgroundJob) -> dict[str, Any]:
     retry_jitter=True,
 )
 def execute_background_job(self: Any, job_id: str) -> dict[str, Any]:
-    db = _open_worker_session()
-    try:
+    _ensure_db_initialized()
+
+    with session_scope() as db:
         job = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
         if job is None:
             raise ValueError(f"Background job not found: {job_id}")
@@ -125,34 +123,56 @@ def execute_background_job(self: Any, job_id: str) -> dict[str, Any]:
         if job.status == BackgroundJobStatus.SUCCEEDED.value:
             logger.info("Skipping already completed background job %s", job_id)
             return dict(job.result or {"status": "succeeded"})
+        job_type = str(job.job_type)
+        payload = dict(job.payload or {})
+        max_attempts = int(job.max_attempts or 1)
 
-        mark_job_running(db, job)
-        try:
-            result = _execute_job_handler(db, job)
-        except BackgroundJobHandlerError as exc:
-            db.refresh(job)
-            if exc.retryable and int(job.attempts or 0) < int(job.max_attempts or 1):
-                setattr(job, "status", BackgroundJobStatus.ENQUEUED.value)
-                setattr(job, "error_message", str(exc))
-                setattr(job, "result", exc.result)
-                db.add(job)
-                db.commit()
-                raise self.retry(exc=exc, max_retries=int(job.max_attempts or 1))
-            mark_job_failed(db, job, error_message=str(exc), result=exc.result)
-            raise
-        except Exception as exc:  # noqa: BLE001
-            db.refresh(job)
-            if int(job.attempts or 0) < int(job.max_attempts or 1):
-                setattr(job, "status", BackgroundJobStatus.ENQUEUED.value)
-                setattr(job, "error_message", str(exc))
-                db.add(job)
-                db.commit()
-                raise self.retry(exc=exc, max_retries=int(job.max_attempts or 1))
-            mark_job_failed(db, job, error_message=str(exc))
-            raise
+    attempts = mark_job_running(job_id)
+    ref = BackgroundJobRef(
+        id=job_id,
+        job_type=job_type,
+        payload=payload,
+        attempts=attempts,
+        max_attempts=max_attempts,
+    )
 
-        db.refresh(job)
-        mark_job_succeeded(db, job, result=result)
-        return result
-    finally:
-        db.close()
+    try:
+        result = _execute_job_handler(ref)
+    except BackgroundJobHandlerError as exc:
+        if exc.retryable and attempts < max_attempts:
+            _mark_job_for_retry(job_id, error_message=str(exc), result=exc.result)
+            raise self.retry(exc=exc, max_retries=max_attempts)
+        mark_job_failed(job_id, error_message=str(exc), result=exc.result)
+        raise
+    except Exception as exc:  # noqa: BLE001
+        if attempts < max_attempts:
+            _mark_job_for_retry(job_id, error_message=str(exc))
+            raise self.retry(exc=exc, max_retries=max_attempts)
+        mark_job_failed(job_id, error_message=str(exc))
+        raise
+
+    mark_job_succeeded(job_id, result=result)
+    return result
+
+
+def _mark_job_for_retry(
+    job_id: str,
+    *,
+    error_message: str,
+    result: dict[str, Any] | None | object = _UNSET,
+) -> None:
+    """Hand the job back to the broker for another attempt.
+
+    ``result`` distinguishes "not supplied" from an explicit ``None``: the
+    handler-error path overwrites the stored result even when it is None, the
+    generic path leaves it untouched.
+    """
+    with session_scope() as db:
+        job = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        if job is None:
+            return
+        setattr(job, "status", BackgroundJobStatus.ENQUEUED.value)
+        setattr(job, "error_message", error_message)
+        if result is not _UNSET:
+            setattr(job, "result", result)
+        db.add(job)

--- a/src/xagent/web/jobs/tasks.py
+++ b/src/xagent/web/jobs/tasks.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import inspect
 import logging
 from collections.abc import Callable
 from typing import Any
@@ -41,16 +42,25 @@ def register_background_job_handler(
 ) -> None:
     """Register a handler for a job type defined outside this package.
 
+    The handler takes one positional ``BackgroundJobRef`` (exported from
+    ``xagent.web.jobs``) and returns the result dict. It replaces the former
+    ``(Session, BackgroundJob)`` pair: the worker no longer holds a session
+    across the handler body, so a handler that needs the database opens its own
+    ``session_scope()`` per operation. See this package's module docstring for
+    the migration.
+
     Args:
         job_type: Durable ``BackgroundJob.job_type`` value the handler owns.
         handler: Callable invoked by ``_execute_job_handler`` for that job type.
         replace: Allow replacing an existing registration for ``job_type``.
 
     Raises:
-        ValueError: If ``job_type`` is built into this package, or is already
-            registered and ``replace`` is not set.
+        ValueError: If ``job_type`` is built into this package, is already
+            registered and ``replace`` is not set, or still takes the removed
+            ``(db, job)`` pair.
     """
     key = str(job_type)
+    _reject_legacy_handler_signature(key, handler)
     if key in _BUILTIN_JOB_TYPES:
         # _execute_job_handler would never reach such a handler, so accepting
         # the registration would silently do nothing.
@@ -58,6 +68,43 @@ def register_background_job_handler(
     if not replace and key in _EXTRA_HANDLERS:
         raise ValueError(f"Background job handler already registered: {key}")
     _EXTRA_HANDLERS[key] = handler
+
+
+def _reject_legacy_handler_signature(job_type: str, handler: Any) -> None:
+    """Refuse the removed ``(db, job)`` handler shape at registration time.
+
+    Accepting one defers the mismatch to a TypeError per attempt, so the job
+    burns through ``max_attempts`` before reaching FAILED. Registration runs at
+    worker import, which is where a downstream distribution can still react.
+    """
+    try:
+        params = list(inspect.signature(handler).parameters.values())
+    except (TypeError, ValueError):
+        # Some C callables expose no signature; let execution surface any
+        # mismatch rather than refuse a handler that may well be valid.
+        return
+
+    positional = [
+        param
+        for param in params
+        if param.kind
+        in (
+            param.POSITIONAL_ONLY,
+            param.POSITIONAL_OR_KEYWORD,
+            param.VAR_POSITIONAL,
+        )
+    ]
+    if any(param.kind == param.VAR_POSITIONAL for param in positional):
+        return
+
+    required = [param for param in positional if param.default is param.empty]
+    if len(required) > 1:
+        raise ValueError(
+            f"Background job handler for {job_type} takes {len(required)} required "
+            "arguments; handlers now receive one BackgroundJobRef. The (db, job) "
+            "signature was removed so no Session outlives a single operation -- "
+            "read what you need from the ref and open your own short session."
+        )
 
 
 def is_background_job_handler_registered(job_type: str) -> bool:
@@ -124,6 +171,7 @@ def execute_background_job(self: Any, job_id: str) -> dict[str, Any]:
             logger.info("Skipping already completed background job %s", job_id)
             return dict(job.result or {"status": "succeeded"})
         job_type = str(job.job_type)
+        user_id = int(job.user_id)
         payload = dict(job.payload or {})
         max_attempts = int(job.max_attempts or 1)
 
@@ -131,6 +179,7 @@ def execute_background_job(self: Any, job_id: str) -> dict[str, Any]:
     ref = BackgroundJobRef(
         id=job_id,
         job_type=job_type,
+        user_id=user_id,
         payload=payload,
         attempts=attempts,
         max_attempts=max_attempts,

--- a/src/xagent/web/jobs/tasks.py
+++ b/src/xagent/web/jobs/tasks.py
@@ -78,7 +78,11 @@ def _reject_legacy_handler_signature(job_type: str, handler: Any) -> None:
     worker import, which is where a downstream distribution can still react.
     """
     try:
-        params = list(inspect.signature(handler).parameters.values())
+        # follow_wrapped=False: a @functools.wraps shim around a legacy handler
+        # otherwise reports the wrapped function's two parameters and is refused.
+        params = list(
+            inspect.signature(handler, follow_wrapped=False).parameters.values()
+        )
     except (TypeError, ValueError):
         # Some C callables expose no signature; let execution surface any
         # mismatch rather than refuse a handler that may well be valid.
@@ -102,8 +106,8 @@ def _reject_legacy_handler_signature(job_type: str, handler: Any) -> None:
         raise ValueError(
             f"Background job handler for {job_type} takes {len(required)} required "
             "arguments; handlers now receive one BackgroundJobRef. The (db, job) "
-            "signature was removed so no Session outlives a single operation -- "
-            "read what you need from the ref and open your own short session."
+            "signature was removed because the worker holds no session across "
+            "the handler body -- open your own short session per operation."
         )
 
 

--- a/src/xagent/web/jobs/tasks.py
+++ b/src/xagent/web/jobs/tasks.py
@@ -5,13 +5,13 @@ from collections.abc import Callable
 from typing import Any
 
 from ..models.background_job import (
-    BackgroundJob,
     BackgroundJobRef,
     BackgroundJobStatus,
     BackgroundJobType,
 )
 from ..models.database import get_optional_session_local, init_db, session_scope
 from ..services.background_jobs import (
+    get_background_job,
     mark_job_failed,
     mark_job_running,
     mark_job_succeeded,
@@ -114,7 +114,7 @@ def execute_background_job(self: Any, job_id: str) -> dict[str, Any]:
     _ensure_db_initialized()
 
     with session_scope() as db:
-        job = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        job = get_background_job(db, job_id)
         if job is None:
             raise ValueError(f"Background job not found: {job_id}")
         if job.status == BackgroundJobStatus.CANCELLED.value:
@@ -168,7 +168,7 @@ def _mark_job_for_retry(
     generic path leaves it untouched.
     """
     with session_scope() as db:
-        job = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        job = get_background_job(db, job_id)
         if job is None:
             return
         setattr(job, "status", BackgroundJobStatus.ENQUEUED.value)

--- a/src/xagent/web/jobs/trigger_tasks.py
+++ b/src/xagent/web/jobs/trigger_tasks.py
@@ -59,11 +59,7 @@ def handle_trigger_event(ref: BackgroundJobRef) -> dict[str, Any]:
         from ..models.trigger import AgentTrigger
 
         with session_scope() as db:
-            trigger = (
-                db.query(AgentTrigger)
-                .filter(AgentTrigger.id == int(trigger_id))
-                .first()
-            )
+            trigger = db.get(AgentTrigger, int(trigger_id))
             if trigger is None:
                 raise ValueError(f"Trigger not found: {trigger_id}")
             run, created = prepare_trigger_run(

--- a/src/xagent/web/jobs/trigger_tasks.py
+++ b/src/xagent/web/jobs/trigger_tasks.py
@@ -7,8 +7,8 @@ from typing import Any
 
 from sqlalchemy.orm import Session
 
-from ..models.background_job import BackgroundJob
-from ..models.database import get_session_local, init_db
+from ..models.background_job import BackgroundJobRef
+from ..models.database import get_session_local, init_db, session_scope
 from ..services.background_jobs import (
     requeue_stale_background_jobs,
     update_job_progress,
@@ -45,42 +45,45 @@ def _reap_and_pause_stale_preview_runs(db: Session) -> int:
     return len(reaped_pause_targets)
 
 
-def handle_trigger_event(db: Session, job: BackgroundJob) -> dict[str, Any]:
+def handle_trigger_event(ref: BackgroundJobRef) -> dict[str, Any]:
     """Persisted trigger-event processing hook.
 
     This intentionally stops before agent execution. The next layer can create
     ready trigger runs or call the existing web/task scheduler from the FastAPI
     process without moving the agent runner into Celery.
     """
-    payload = dict(job.payload or {})
-    update_job_progress(db, job, message="Processing trigger event")
+    payload = dict(ref.payload)
+    update_job_progress(ref.id, message="Processing trigger event")
     trigger_id = payload.get("trigger_id")
     if trigger_id:
         from ..models.trigger import AgentTrigger
 
-        trigger = (
-            db.query(AgentTrigger).filter(AgentTrigger.id == int(trigger_id)).first()
-        )
-        if trigger is None:
-            raise ValueError(f"Trigger not found: {trigger_id}")
-        run, created = prepare_trigger_run(
-            db,
-            trigger=trigger,
-            event_payload=dict(payload.get("event_payload") or {}),
-            source_event_id=payload.get("source_event_id"),
-            background_job_id=str(job.id),
-        )
-        return {
-            "status": "prepared" if created else "duplicate",
-            "trigger_id": int(trigger.id),
-            "trigger_run_id": int(run.id),
-            "task_id": int(run.task_id) if run.task_id is not None else None,
-            "processed_at": datetime.now(timezone.utc).isoformat(),
-        }
+        with session_scope() as db:
+            trigger = (
+                db.query(AgentTrigger)
+                .filter(AgentTrigger.id == int(trigger_id))
+                .first()
+            )
+            if trigger is None:
+                raise ValueError(f"Trigger not found: {trigger_id}")
+            run, created = prepare_trigger_run(
+                db,
+                trigger=trigger,
+                event_payload=dict(payload.get("event_payload") or {}),
+                source_event_id=payload.get("source_event_id"),
+                background_job_id=str(ref.id),
+            )
+            return {
+                "status": "prepared" if created else "duplicate",
+                "trigger_id": int(trigger.id),
+                "trigger_run_id": int(run.id),
+                "task_id": int(run.task_id) if run.task_id is not None else None,
+                "processed_at": datetime.now(timezone.utc).isoformat(),
+            }
 
     logger.info(
         "Processed trigger event job=%s source=%s event=%s",
-        job.id,
+        ref.id,
         payload.get("source_type"),
         payload.get("event_type"),
     )
@@ -92,16 +95,17 @@ def handle_trigger_event(db: Session, job: BackgroundJob) -> dict[str, Any]:
     }
 
 
-def handle_trigger_scan(db: Session, job: BackgroundJob) -> dict[str, Any]:
-    payload = dict(job.payload or {})
-    update_job_progress(db, job, message="Scanning scheduled triggers")
-    requeued_jobs = requeue_stale_background_jobs(db)
-    runs = scan_due_scheduled_triggers(db)
-    # This is the BackgroundJob-driven variant of the same scan
-    # `scan_due_triggers` below runs for Celery Beat -- the reaper must run
-    # here too, or any deployment relying on this path instead of Beat gets
-    # zero preview-run reaping (see reap_stale_preview_workforce_runs).
-    reaped_preview_run_pause_dispatches = _reap_and_pause_stale_preview_runs(db)
+def handle_trigger_scan(ref: BackgroundJobRef) -> dict[str, Any]:
+    payload = dict(ref.payload)
+    update_job_progress(ref.id, message="Scanning scheduled triggers")
+    with session_scope() as db:
+        requeued_jobs = requeue_stale_background_jobs(db)
+        runs = scan_due_scheduled_triggers(db)
+        # This is the BackgroundJob-driven variant of the same scan
+        # `scan_due_triggers` below runs for Celery Beat -- the reaper must run
+        # here too, or any deployment relying on this path instead of Beat gets
+        # zero preview-run reaping (see reap_stale_preview_workforce_runs).
+        reaped_preview_run_pause_dispatches = _reap_and_pause_stale_preview_runs(db)
     return {
         "status": "scanned",
         "scan_scope": payload.get("scope", "all"),

--- a/src/xagent/web/models/background_job.py
+++ b/src/xagent/web/models/background_job.py
@@ -37,6 +37,7 @@ class BackgroundJobRef:
 
     id: str
     job_type: str
+    user_id: int
     payload: dict[str, Any]
     attempts: int
     max_attempts: int

--- a/src/xagent/web/models/background_job.py
+++ b/src/xagent/web/models/background_job.py
@@ -1,5 +1,6 @@
 import enum
 import uuid
+from dataclasses import dataclass
 from typing import Any
 
 from sqlalchemy import JSON, Column, DateTime, ForeignKey, Integer, String, Text
@@ -23,6 +24,22 @@ class BackgroundJobType(str, enum.Enum):
     KB_INGEST_WEB = "kb.ingest.web"
     TRIGGER_EVENT = "trigger.event"
     TRIGGER_SCAN = "trigger.scan"
+
+
+@dataclass(frozen=True)
+class BackgroundJobRef:
+    """Immutable snapshot of a job row, read once before the work starts.
+
+    Handlers receive values rather than an ORM instance so that no session
+    outlives a single operation: work that runs for hours must not hold a
+    transaction open across its idle gaps.
+    """
+
+    id: str
+    job_type: str
+    payload: dict[str, Any]
+    attempts: int
+    max_attempts: int
 
 
 class BackgroundJob(Base):  # type: ignore

--- a/src/xagent/web/models/background_job.py
+++ b/src/xagent/web/models/background_job.py
@@ -30,8 +30,8 @@ class BackgroundJobType(str, enum.Enum):
 class BackgroundJobRef:
     """Immutable snapshot of a job row, read once before the work starts.
 
-    Handlers receive values rather than an ORM instance so that no session
-    outlives a single operation: work that runs for hours must not hold a
+    Handlers receive values rather than an ORM instance so the worker holds no
+    session across the handler body: work that runs for hours must not hold a
     transaction open across its idle gaps.
     """
 

--- a/src/xagent/web/models/database.py
+++ b/src/xagent/web/models/database.py
@@ -1,6 +1,7 @@
 import logging
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any, Generator, Iterator
 
 from sqlalchemy import Engine, create_engine, event
 from sqlalchemy.engine import Connection, make_url
@@ -55,6 +56,33 @@ def get_db() -> Generator[Session, None, None]:
     db = _SessionLocal()
     try:
         yield db
+    finally:
+        db.close()
+
+
+@contextmanager
+def session_scope() -> Iterator[Session]:
+    """Open a session for one unit of work, then commit and close it.
+
+    Long-running work must not hold a session open across its idle gaps: the
+    default ``expire_on_commit=True`` re-reads expired attributes after every
+    commit, which re-opens a transaction that then sits idle until the next
+    commit. Postgres terminates such a connection once
+    ``idle_in_transaction_session_timeout`` elapses, and every later statement
+    on that session fails -- including the bookkeeping meant to record the
+    failure. Callers that span minutes or hours use one scope per operation.
+    """
+    if _SessionLocal is None:
+        raise RuntimeError(
+            "Session Local is not initialized. Call configure_db() or init_db() first."
+        )
+    db = _SessionLocal()
+    try:
+        yield db
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
     finally:
         db.close()
 

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -204,7 +204,7 @@ def enqueue_background_job(db: Session, job: BackgroundJob) -> BackgroundJob:
 
 
 def get_background_job(db: Session, job_id: str) -> BackgroundJob | None:
-    return db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+    return db.get(BackgroundJob, job_id)
 
 
 def list_background_jobs(
@@ -237,7 +237,7 @@ def mark_job_running(job_id: str) -> int:
     closes here, so a returned instance would be detached.
     """
     with session_scope() as db:
-        job = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        job = get_background_job(db, job_id)
         if job is None:
             raise ValueError(f"Background job not found: {job_id}")
         attempts = int(job.attempts or 0) + 1
@@ -266,7 +266,7 @@ def update_job_progress(
     """
     try:
         with session_scope() as db:
-            job = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+            job = get_background_job(db, job_id)
             if job is None:
                 return
             progress = dict(job.progress or {})
@@ -404,7 +404,7 @@ def requeue_stale_background_jobs(
 
 def mark_job_succeeded(job_id: str, *, result: dict[str, Any] | None = None) -> None:
     with session_scope() as db:
-        job = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        job = get_background_job(db, job_id)
         if job is None:
             raise ValueError(f"Background job not found: {job_id}")
         setattr(job, "status", BackgroundJobStatus.SUCCEEDED.value)
@@ -428,7 +428,7 @@ def mark_job_failed(
     ``running`` forever and bypassing ``max_attempts``.
     """
     with session_scope() as db:
-        job = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        job = get_background_job(db, job_id)
         if job is None:
             raise ValueError(f"Background job not found: {job_id}")
         setattr(job, "status", BackgroundJobStatus.FAILED.value)

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -19,6 +19,7 @@ from ..models.background_job import (
     BackgroundJobStatus,
     BackgroundJobType,
 )
+from ..models.database import session_scope
 
 logger = logging.getLogger(__name__)
 
@@ -229,40 +230,59 @@ def list_background_jobs(
     )
 
 
-def mark_job_running(db: Session, job: BackgroundJob) -> BackgroundJob:
-    setattr(job, "status", BackgroundJobStatus.RUNNING.value)
-    setattr(job, "attempts", int(job.attempts or 0) + 1)
-    setattr(job, "started_at", datetime.now(timezone.utc))
-    setattr(job, "error_message", None)
-    setattr(job, "progress", {"message": "Running", "completed": 0, "total": 1})
-    db.add(job)
-    db.commit()
-    db.refresh(job)
-    return job
+def mark_job_running(job_id: str) -> int:
+    """Claim the job for this attempt and return the new attempt count.
+
+    Returns the incremented ``attempts`` rather than the ORM row: the session
+    closes here, so a returned instance would be detached.
+    """
+    with session_scope() as db:
+        job = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        if job is None:
+            raise ValueError(f"Background job not found: {job_id}")
+        attempts = int(job.attempts or 0) + 1
+        setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+        setattr(job, "attempts", attempts)
+        setattr(job, "started_at", datetime.now(timezone.utc))
+        setattr(job, "error_message", None)
+        setattr(job, "progress", {"message": "Running", "completed": 0, "total": 1})
+        db.add(job)
+        return attempts
 
 
 def update_job_progress(
-    db: Session,
-    job: BackgroundJob,
+    job_id: str,
     *,
     message: str,
     completed: int | None = None,
     total: int | None = None,
     extra: dict[str, Any] | None = None,
-) -> BackgroundJob:
-    progress = dict(job.progress or {})
-    progress["message"] = message
-    if completed is not None:
-        progress["completed"] = completed
-    if total is not None:
-        progress["total"] = total
-    if extra:
-        progress.update(extra)
-    setattr(job, "progress", progress)
-    db.add(job)
-    db.commit()
-    db.refresh(job)
-    return job
+) -> None:
+    """Record job progress. Telemetry only -- never fails the caller.
+
+    Progress is not job state: a job that cannot report progress is still
+    making progress. The web ingestion path calls this from inside per-page
+    processing, so a raised exception here would fail the page.
+    """
+    try:
+        with session_scope() as db:
+            job = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+            if job is None:
+                return
+            progress = dict(job.progress or {})
+            progress["message"] = message
+            if completed is not None:
+                progress["completed"] = completed
+            if total is not None:
+                progress["total"] = total
+            if extra:
+                progress.update(extra)
+            setattr(job, "progress", progress)
+            db.add(job)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "Failed to update progress for background job %s: %s", job_id, exc
+        )
 
 
 def requeue_stale_background_jobs(
@@ -382,36 +402,38 @@ def requeue_stale_background_jobs(
     return requeued
 
 
-def mark_job_succeeded(
-    db: Session,
-    job: BackgroundJob,
-    *,
-    result: dict[str, Any] | None = None,
-) -> BackgroundJob:
-    setattr(job, "status", BackgroundJobStatus.SUCCEEDED.value)
-    setattr(job, "result", result)
-    setattr(job, "error_message", None)
-    setattr(job, "finished_at", datetime.now(timezone.utc))
-    setattr(job, "progress", {"message": "Completed", "completed": 1, "total": 1})
-    db.add(job)
-    db.commit()
-    db.refresh(job)
-    return job
+def mark_job_succeeded(job_id: str, *, result: dict[str, Any] | None = None) -> None:
+    with session_scope() as db:
+        job = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        if job is None:
+            raise ValueError(f"Background job not found: {job_id}")
+        setattr(job, "status", BackgroundJobStatus.SUCCEEDED.value)
+        setattr(job, "result", result)
+        setattr(job, "error_message", None)
+        setattr(job, "finished_at", datetime.now(timezone.utc))
+        setattr(job, "progress", {"message": "Completed", "completed": 1, "total": 1})
+        db.add(job)
 
 
 def mark_job_failed(
-    db: Session,
-    job: BackgroundJob,
+    job_id: str,
     *,
     error_message: str,
     result: dict[str, Any] | None = None,
-) -> BackgroundJob:
-    setattr(job, "status", BackgroundJobStatus.FAILED.value)
-    setattr(job, "error_message", error_message)
-    setattr(job, "result", result)
-    setattr(job, "finished_at", datetime.now(timezone.utc))
-    setattr(job, "progress", {"message": error_message, "completed": 0, "total": 1})
-    db.add(job)
-    db.commit()
-    db.refresh(job)
-    return job
+) -> None:
+    """Record the terminal failure on a session of its own.
+
+    This must not share a session with the work that failed: a poisoned
+    session would take the failure record down with it, leaving the row
+    ``running`` forever and bypassing ``max_attempts``.
+    """
+    with session_scope() as db:
+        job = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        if job is None:
+            raise ValueError(f"Background job not found: {job_id}")
+        setattr(job, "status", BackgroundJobStatus.FAILED.value)
+        setattr(job, "error_message", error_message)
+        setattr(job, "result", result)
+        setattr(job, "finished_at", datetime.now(timezone.utc))
+        setattr(job, "progress", {"message": error_message, "completed": 0, "total": 1})
+        db.add(job)

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -377,22 +377,37 @@ def requeue_stale_background_jobs(
         setattr(job, "status", BackgroundJobStatus.ENQUEUED.value)
         db.add(job)
     db.commit()
-    for job in stale_jobs:
-        db.refresh(job)
+    dispatch_targets = [
+        (str(job.id), str(job.queue or QUEUE_DEFAULT)) for job in stale_jobs
+    ]
 
-    for job in stale_jobs:
+    # apply_async is broker I/O and can block for as long as the broker takes.
+    # Nothing may be read from the session until it returns, or the refresh
+    # above reopens a transaction that then sits idle across that call.
+    db.rollback()
+
+    task_ids: dict[str, str] = {}
+    dispatch_errors: dict[str, str] = {}
+    for job_id, queue in dispatch_targets:
         try:
             async_result = execute_background_job.apply_async(
-                args=[job.id],
-                queue=str(job.queue or QUEUE_DEFAULT),
+                args=[job_id],
+                queue=queue,
             )
-            setattr(job, "celery_task_id", async_result.id)
-            requeued.append(job)
+            task_ids[job_id] = async_result.id
         except Exception as exc:  # noqa: BLE001
-            logger.exception("Failed to requeue stale background job %s", job.id)
+            logger.exception("Failed to requeue stale background job %s", job_id)
+            dispatch_errors[job_id] = str(exc)
+
+    for job in stale_jobs:
+        job_id = str(job.id)
+        error = dispatch_errors.get(job_id)
+        if error is None:
+            setattr(job, "celery_task_id", task_ids.get(job_id))
+        else:
             setattr(job, "status", BackgroundJobStatus.PENDING.value)
-            setattr(job, "error_message", f"Failed to requeue stale job: {exc}")
-            requeued.append(job)
+            setattr(job, "error_message", f"Failed to requeue stale job: {error}")
+        requeued.append(job)
         db.add(job)
 
     db.commit()

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -381,9 +381,8 @@ def requeue_stale_background_jobs(
         (str(job.id), str(job.queue or QUEUE_DEFAULT)) for job in stale_jobs
     ]
 
-    # apply_async is broker I/O and can block for as long as the broker takes.
-    # Nothing may be read from the session until it returns, or the refresh
-    # above reopens a transaction that then sits idle across that call.
+    # expire_on_commit means the snapshot above reopened a transaction to reread
+    # job.id; drop it before apply_async, which blocks on broker I/O.
     db.rollback()
 
     task_ids: dict[str, str] = {}

--- a/tests/core/tools/core/RAG_tools/utils/test_model_resolver.py
+++ b/tests/core/tools/core/RAG_tools/utils/test_model_resolver.py
@@ -716,3 +716,88 @@ class TestModelHubEngineHideParameters:
 
         assert hub is not None
         assert model_resolver._MODEL_HUB_ENGINE.hide_parameters is True
+
+
+class TestModelHubEnginePoolKwargs:
+    """The model hub engine must take its pool health knobs from the shared
+    policy, not a local copy: a hardcoded value drifts silently the next time
+    ``get_db_pool_kwargs`` changes."""
+
+    class _StopBeforeConnect(Exception):
+        pass
+
+    def teardown_method(self) -> None:
+        model_resolver._reset_model_hub_cache()
+
+    def _capture_create_engine_kwargs(self, monkeypatch, url: str) -> Dict:
+        captured: Dict = {}
+
+        def _spy(_url, **kwargs):
+            captured.update(kwargs)
+            raise self._StopBeforeConnect("captured")
+
+        model_resolver._reset_model_hub_cache()
+        monkeypatch.setattr(model_resolver, "get_default_db_url", lambda: url)
+        monkeypatch.setattr(model_resolver, "create_engine", _spy)
+        with pytest.raises(self._StopBeforeConnect):
+            model_resolver._get_or_init_model_hub()
+        return captured
+
+    def test_non_sqlite_engine_takes_every_health_kwarg_from_shared_policy(
+        self, monkeypatch
+    ):
+        from xagent.config import get_db_pool_kwargs
+
+        policy = get_db_pool_kwargs()
+        expected = {
+            key: value
+            for key, value in policy.items()
+            if key not in model_resolver._POOL_SIZING_KEYS
+        }
+        assert set(expected) == {"pool_recycle", "pool_pre_ping"}
+
+        kwargs = self._capture_create_engine_kwargs(
+            monkeypatch, "postgresql+psycopg2://u:p@127.0.0.1:5432/xagent"
+        )
+
+        assert kwargs == {
+            "connect_args": {},
+            "hide_parameters": True,
+            **expected,
+        }
+        # Sizing stays per-engine: a worker already holds the web engine's pool.
+        assert not model_resolver._POOL_SIZING_KEYS & set(kwargs)
+
+    def test_non_sqlite_engine_follows_shared_policy_changes(self, monkeypatch):
+        """Nothing may be copied locally: a changed policy must reach this engine."""
+        drifted = {
+            "pool_size": 999,
+            "max_overflow": 999,
+            "pool_timeout": 999,
+            "pool_recycle": 61,
+            "pool_pre_ping": False,
+            "pool_use_lifo": True,
+        }
+        monkeypatch.setattr(model_resolver, "get_db_pool_kwargs", lambda: drifted)
+
+        kwargs = self._capture_create_engine_kwargs(
+            monkeypatch, "postgresql+psycopg2://u:p@127.0.0.1:5432/xagent"
+        )
+
+        assert kwargs == {
+            "connect_args": {},
+            "hide_parameters": True,
+            "pool_recycle": 61,
+            "pool_pre_ping": False,
+            "pool_use_lifo": True,
+        }
+
+    def test_sqlite_engine_takes_no_pool_kwargs(self, monkeypatch, tmp_path):
+        kwargs = self._capture_create_engine_kwargs(
+            monkeypatch, f"sqlite:///{tmp_path / 'hub.db'}"
+        )
+
+        assert kwargs == {
+            "connect_args": {"check_same_thread": False},
+            "hide_parameters": True,
+        }

--- a/tests/shared/postgres_disposable.py
+++ b/tests/shared/postgres_disposable.py
@@ -136,6 +136,55 @@ def disposable_database_factory(
             )
 
 
+@contextmanager
+def disposable_database_url(
+    prefix: str,
+    *,
+    settings: dict[str, str] | None = None,
+) -> Iterator[str]:
+    """Mint one disposable database and yield its connection URL.
+
+    The engine-returning factory above cannot serve callers that must hand a
+    URL to application code (``configure_db``) rather than drive an engine
+    themselves. ``settings`` are applied with ALTER DATABASE SET, so every
+    connection the application opens inherits them -- which is how a test can
+    impose a short ``idle_in_transaction_session_timeout``.
+    """
+    base_url = os.getenv("XAGENT_TEST_POSTGRES_URL")
+    if not base_url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+
+    def _admin_connection():
+        conn = psycopg2.connect(**psycopg2_kwargs(base_url))
+        conn.autocommit = True
+        return conn
+
+    dbname = f"{prefix}_{uuid.uuid4().hex[:10]}"
+    admin_conn = _admin_connection()
+    try:
+        admin_conn.cursor().execute(f'CREATE DATABASE "{dbname}"')
+        for key, value in (settings or {}).items():
+            admin_conn.cursor().execute(
+                f'ALTER DATABASE "{dbname}" SET {key} = %s', (value,)
+            )
+    finally:
+        admin_conn.close()
+
+    parsed = make_url(base_url).set(database=dbname)
+    try:
+        yield parsed.render_as_string(hide_password=False)
+    finally:
+        admin_conn = _admin_connection()
+        try:
+            admin_conn.cursor().execute(
+                f"SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                f"WHERE datname = '{dbname}' AND pid <> pg_backend_pid()"
+            )
+            admin_conn.cursor().execute(f'DROP DATABASE IF EXISTS "{dbname}"')
+        finally:
+            admin_conn.close()
+
+
 def load_migration_module(path: Path, name: str = "migration_under_test") -> ModuleType:
     """Load the Alembic revision module at ``path`` under ``name`` without
     going through the revision chain or requiring it be importable as a

--- a/tests/shared/postgres_disposable.py
+++ b/tests/shared/postgres_disposable.py
@@ -163,15 +163,22 @@ def disposable_database_url(
     admin_conn = _admin_connection()
     try:
         admin_conn.cursor().execute(f'CREATE DATABASE "{dbname}"')
-        for key, value in (settings or {}).items():
-            admin_conn.cursor().execute(
-                f'ALTER DATABASE "{dbname}" SET {key} = %s', (value,)
-            )
     finally:
         admin_conn.close()
 
     parsed = make_url(base_url).set(database=dbname)
+    # Everything after CREATE DATABASE runs under the drop below, so a failing
+    # ALTER cannot leave the database behind.
     try:
+        admin_conn = _admin_connection()
+        try:
+            for key, value in (settings or {}).items():
+                admin_conn.cursor().execute(
+                    f'ALTER DATABASE "{dbname}" SET {key} = %s', (value,)
+                )
+        finally:
+            admin_conn.close()
+
         yield parsed.render_as_string(hide_password=False)
     finally:
         admin_conn = _admin_connection()

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -1551,7 +1551,9 @@ def test_requeue_spares_running_job_that_is_still_reporting_progress(
         # Go through the real reporting path, not a hand-set timestamp: that
         # progress advances updated_at is the premise the whole predicate rests
         # on, so the test has to fail if it ever stops holding.
-        update_job_progress(db, job, message="Still working", completed=536, total=699)
+        update_job_progress(
+            str(job.id), message="Still working", completed=536, total=699
+        )
         db.refresh(job)
         assert job.updated_at > stale_updated_at
 

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 import os
 import subprocess
 import sys
@@ -14,6 +15,7 @@ from xagent.config import CELERY_BROKER_URL, CELERY_ENABLED
 from xagent.core.tools.core.RAG_tools.core.schemas import (
     IngestionConfig,
     IngestionResult,
+    IngestionStepResult,
     WebCrawlConfig,
     WebIngestionResult,
 )
@@ -65,6 +67,7 @@ def _job_ref(job) -> BackgroundJobRef:
     return BackgroundJobRef(
         id=str(job.id),
         job_type=str(job.job_type),
+        user_id=int(job.user_id),
         payload=dict(job.payload or {}),
         attempts=int(job.attempts or 0),
         max_attempts=int(job.max_attempts or 1),
@@ -1345,6 +1348,208 @@ def test_kb_web_job_partial_publishes_new_config(tmp_path, monkeypatch):
         db.close()
 
 
+def test_job_user_snapshot_survives_its_own_scope(tmp_path):
+    """The user row must stay readable once its session is gone.
+
+    Every caller hands this row to async metadata work that runs with no
+    session open; an expired instance would raise there instead, replacing the
+    real ingestion outcome with a lazy-load error.
+    """
+    from xagent.web.jobs.kb_tasks import _get_job_user
+    from xagent.web.models.database import get_engine
+
+    SessionLocal = _init_test_db(tmp_path / "job-user-snapshot.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="job-user-snapshot")
+        db.commit()
+        user_id = int(user.id)
+        db.rollback()
+
+        tracker = _track_open_transactions(get_engine())
+        snapshot = _get_job_user({"user_id": user_id}, context="test")
+
+        assert snapshot is not None
+        assert int(snapshot.id) == user_id
+        assert str(snapshot.username) == "job-user-snapshot"
+        assert bool(snapshot.is_admin) is False
+        assert tracker["open"] == 0, "reading the snapshot reopened a transaction"
+    finally:
+        db.close()
+
+
+def test_job_user_snapshot_is_none_for_a_missing_row(tmp_path):
+    from xagent.web.jobs.kb_tasks import _get_job_user
+
+    _init_test_db(tmp_path / "job-user-missing.db")
+
+    assert _get_job_user({"user_id": 9999}, context="test") is None
+
+
+def test_web_ingest_finalization_holds_no_transaction(tmp_path, monkeypatch):
+    """Crawl finalization must not run inside an open read transaction.
+
+    Both steps -- publishing the collection config and cleaning up after a
+    partial crawl -- are async metadata and vector I/O. A slow finalization with
+    a transaction held open is the same idle_in_transaction exposure as the
+    crawl itself, and it happens after side effects have already landed.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    from xagent.web.api import kb as kb_module
+    from xagent.web.jobs.kb_tasks import handle_kb_ingest_web
+    from xagent.web.models.database import get_engine
+
+    SessionLocal = _init_test_db(tmp_path / "web-ingest-finalize-txn.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="web-ingest-finalize-txn")
+        ingestion_config = IngestionConfig(chunk_size=2048)
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={
+                "collection": "existing-web-kb",
+                "crawl_config": WebCrawlConfig(
+                    start_url="https://example.com"
+                ).model_dump(mode="json"),
+                "ingestion_config": ingestion_config.model_dump(mode="json"),
+                "user_id": int(user.id),
+                "is_admin": False,
+                "collection_existed_before": False,
+            },
+        )
+        db.commit()
+        ref = _job_ref(job)
+        # The worker's transactions are what this measures; the test session's
+        # own connection must be idle first.
+        db.rollback()
+
+        tracker = _track_open_transactions(get_engine())
+        observed: dict[str, int] = {}
+
+        async def fake_save(**_kwargs):
+            observed["save"] = tracker["open"]
+
+        async def fake_cleanup(**_kwargs):
+            observed["cleanup"] = tracker["open"]
+
+        monkeypatch.setattr(
+            kb_module, "_save_collection_config_after_ingest", fake_save
+        )
+        monkeypatch.setattr(
+            kb_module,
+            "_cleanup_collection_metadata_after_failed_api_ingest",
+            fake_cleanup,
+        )
+
+        async def fake_run_web_ingestion(**_kwargs):
+            return WebIngestionResult(
+                status="partial",
+                collection="existing-web-kb",
+                total_urls_found=2,
+                pages_crawled=1,
+                pages_failed=1,
+                documents_created=1,
+                chunks_created=1,
+                embeddings_created=1,
+                crawled_urls=["https://example.com/ok"],
+                failed_urls={"https://example.com/bad": "ingestion failed"},
+                message="partial failure",
+                warnings=[],
+                elapsed_time_ms=1,
+            )
+
+        monkeypatch.setattr(
+            "xagent.web.jobs.kb_tasks.run_web_ingestion",
+            fake_run_web_ingestion,
+        )
+
+        result = handle_kb_ingest_web(ref)
+
+        assert result["status"] == "partial"
+        assert observed == {"save": 0, "cleanup": 0}, (
+            f"finalization ran inside an open transaction: {observed}"
+        )
+    finally:
+        db.close()
+
+
+def test_document_ingest_config_publish_holds_no_transaction(tmp_path, monkeypatch):
+    """The settled-ingestion bookkeeping must not share one held-open session.
+
+    ``_save_collection_config_after_ingest`` is async metadata I/O reached after
+    the document already landed; a transaction spanning it can be reaped, and
+    the failure then arrives with the side effects already committed.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+    monkeypatch.delenv(CELERY_BROKER_URL, raising=False)
+
+    from xagent.web.api import kb as kb_module
+    from xagent.web.jobs.kb_tasks import handle_kb_ingest_document
+    from xagent.web.models.database import get_engine
+
+    SessionLocal = _init_test_db(tmp_path / "doc-ingest-publish-txn.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="doc-ingest-publish-txn")
+        source_file = tmp_path / "src" / "doc.txt"
+        source_file.parent.mkdir(parents=True)
+        source_file.write_text("content", encoding="utf-8")
+        ingestion_config = IngestionConfig(chunk_size=2048)
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_DOCUMENT,
+            payload={
+                "collection": "existing-kb",
+                "source_path": str(source_file),
+                "user_id": int(user.id),
+                "is_admin": False,
+                "ingestion_config": ingestion_config.model_dump(mode="json"),
+                "collection_existed_before": True,
+            },
+        )
+        db.commit()
+        ref = _job_ref(job)
+        db.rollback()
+
+        tracker = _track_open_transactions(get_engine())
+        observed: list[int] = []
+
+        async def fake_save(**_kwargs):
+            observed.append(tracker["open"])
+
+        monkeypatch.setattr(
+            kb_module, "_save_collection_config_after_ingest", fake_save
+        )
+
+        def fake_run_document_ingestion(**_kwargs):
+            return IngestionResult(
+                status="success",
+                message="ok",
+                doc_id="doc-1",
+                completed_steps=[
+                    IngestionStepResult(name="register_document", metadata={})
+                ],
+            )
+
+        monkeypatch.setattr(
+            "xagent.web.jobs.kb_tasks.run_document_ingestion",
+            fake_run_document_ingestion,
+        )
+
+        handle_kb_ingest_document(ref)
+
+        assert observed == [0], (
+            f"the config publish ran inside an open transaction: {observed}"
+        )
+    finally:
+        db.close()
+
+
 def test_kb_web_job_zero_pages_without_failures_fails(tmp_path, monkeypatch):
     """A crawl that ingested nothing publishes no KB, so the job must not succeed."""
     monkeypatch.setenv(CELERY_ENABLED, "false")
@@ -1519,6 +1724,127 @@ def test_requeue_stale_background_jobs_marks_old_running_pending(tmp_path, monke
         db.close()
 
 
+def test_requeue_dispatches_to_broker_with_no_open_transaction(tmp_path, monkeypatch):
+    """The stale-job scan must not hold a read transaction across apply_async.
+
+    A slow or unreachable broker blocks per job while the session sits idle in
+    transaction, which is exactly what the server terminates. The task ids are
+    persisted afterwards, in a write that starts once the broker is done.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.models.database import get_engine
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-requeue-txn.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="requeue-txn")
+        old = datetime.now(timezone.utc) - timedelta(hours=3)
+        job_ids: list[str] = []
+        for index in range(2):
+            job = create_background_job(
+                db,
+                user_id=int(user.id),
+                job_type=BackgroundJobType.KB_INGEST_WEB,
+                payload={"collection": f"kb{index}"},
+            )
+            setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+            db.add(job)
+            db.commit()
+            _age_job(db, job, updated_at=old, started_at=old)
+            job_ids.append(str(job.id))
+        db.rollback()
+
+        tracker = _track_open_transactions(get_engine())
+        observed: list[int] = []
+
+        class _Result:
+            def __init__(self, task_id: str) -> None:
+                self.id = task_id
+
+        def fake_apply_async(*, args, queue):  # noqa: ANN001, ANN202
+            observed.append(tracker["open"])
+            return _Result(f"task-{args[0]}")
+
+        monkeypatch.setattr(
+            tasks_module.execute_background_job, "apply_async", fake_apply_async
+        )
+
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert observed == [0, 0], (
+            f"a transaction was open while the broker was called: {observed}"
+        )
+        assert sorted(str(item.id) for item in requeued) == sorted(job_ids)
+        db.expire_all()
+        for job_id in job_ids:
+            row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+            assert row.celery_task_id == f"task-{job_id}"
+            assert row.status == BackgroundJobStatus.ENQUEUED.value
+    finally:
+        db.close()
+
+
+def test_requeue_records_broker_failure_per_job(tmp_path, monkeypatch):
+    """A broker that rejects one job leaves that row PENDING with the reason."""
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-requeue-broker-fail.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="requeue-broker-fail")
+        old = datetime.now(timezone.utc) - timedelta(hours=3)
+        job_ids: list[str] = []
+        for index in range(2):
+            job = create_background_job(
+                db,
+                user_id=int(user.id),
+                job_type=BackgroundJobType.KB_INGEST_WEB,
+                payload={"collection": f"kb{index}"},
+            )
+            setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+            db.add(job)
+            db.commit()
+            _age_job(db, job, updated_at=old, started_at=old)
+            job_ids.append(str(job.id))
+        db.rollback()
+
+        doomed = job_ids[0]
+
+        class _Result:
+            def __init__(self, task_id: str) -> None:
+                self.id = task_id
+
+        def fake_apply_async(*, args, queue):  # noqa: ANN001, ANN202
+            if args[0] == doomed:
+                raise RuntimeError("broker unreachable")
+            return _Result(f"task-{args[0]}")
+
+        monkeypatch.setattr(
+            tasks_module.execute_background_job, "apply_async", fake_apply_async
+        )
+
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert sorted(str(item.id) for item in requeued) == sorted(job_ids)
+        db.expire_all()
+        failed = db.query(BackgroundJob).filter(BackgroundJob.id == doomed).first()
+        assert failed.status == BackgroundJobStatus.PENDING.value
+        assert failed.celery_task_id is None
+        assert "broker unreachable" in str(failed.error_message)
+
+        other = db.query(BackgroundJob).filter(BackgroundJob.id == job_ids[1]).first()
+        assert other.status == BackgroundJobStatus.ENQUEUED.value
+        assert other.celery_task_id == f"task-{job_ids[1]}"
+    finally:
+        db.close()
+
+
 def test_requeue_spares_running_job_that_is_still_reporting_progress(
     tmp_path, monkeypatch
 ):
@@ -1666,10 +1992,10 @@ def test_register_background_job_handler_rejects_duplicate(tmp_path):
     """Duplicate registration is a bug, not a silent last-writer-wins overwrite."""
     from xagent.web.jobs import tasks as tasks_module
 
-    def first_handler(_session, _job):
+    def first_handler(_ref):
         return {"status": "first"}
 
-    def second_handler(_session, _job):
+    def second_handler(_ref):
         return {"status": "second"}
 
     tasks_module.register_background_job_handler("kb.team.transfer", first_handler)
@@ -1687,10 +2013,10 @@ def test_register_background_job_handler_replace_overrides_existing(tmp_path):
     """``replace=True`` is the explicit opt-in for swapping a registration."""
     from xagent.web.jobs import tasks as tasks_module
 
-    def first_handler(_session, _job):
+    def first_handler(_ref):
         return {"status": "first"}
 
-    def second_handler(_session, _job):
+    def second_handler(_ref):
         return {"status": "second"}
 
     tasks_module.register_background_job_handler("kb.team.transfer", first_handler)
@@ -1701,6 +2027,73 @@ def test_register_background_job_handler_replace_overrides_existing(tmp_path):
         assert tasks_module._EXTRA_HANDLERS["kb.team.transfer"] is second_handler
     finally:
         tasks_module._EXTRA_HANDLERS.pop("kb.team.transfer", None)
+
+
+def test_register_background_job_handler_rejects_legacy_two_arg_handler():
+    """The removed ``(db, job)`` shape must be refused where it can be fixed.
+
+    Accepting it defers the mismatch to a TypeError per attempt, so the job
+    burns through max_attempts before reaching FAILED. Registration happens at
+    worker import, which is where a downstream distribution can still react.
+    """
+    from xagent.web.jobs import tasks as tasks_module
+
+    def legacy_handler(db, job):
+        return {"status": "legacy"}
+
+    with pytest.raises(ValueError, match="one BackgroundJobRef"):
+        tasks_module.register_background_job_handler(
+            "kb.team.legacy_signature", legacy_handler
+        )
+
+    assert "kb.team.legacy_signature" not in tasks_module._EXTRA_HANDLERS
+
+
+@pytest.mark.parametrize(
+    "handler",
+    [
+        pytest.param(lambda ref: {"status": "ok"}, id="one-positional"),
+        pytest.param(lambda ref, *, retries=0: {"status": "ok"}, id="keyword-default"),
+        pytest.param(lambda ref, unused=None: {"status": "ok"}, id="optional-second"),
+        pytest.param(lambda *args: {"status": "ok"}, id="var-positional"),
+    ],
+)
+def test_register_background_job_handler_accepts_ref_only_shapes(handler):
+    """Only a second *required* positional means the old contract."""
+    from xagent.web.jobs import tasks as tasks_module
+
+    tasks_module.register_background_job_handler("kb.team.ref_shape", handler)
+    try:
+        assert tasks_module._EXTRA_HANDLERS["kb.team.ref_shape"] is handler
+    finally:
+        tasks_module._EXTRA_HANDLERS.pop("kb.team.ref_shape", None)
+
+
+def test_jobs_package_exports_the_handler_ref_contract():
+    """The value a handler receives is part of the public API, not an internal.
+
+    Without this export a downstream handler has to import the ref from
+    ``xagent.web.models.background_job`` -- a module path this package is free
+    to move -- to type or construct what it is handed.
+    """
+    import xagent.web.jobs as jobs_package
+    from xagent.web.jobs import BackgroundJobHandler, BackgroundJobRef
+
+    assert {"BackgroundJobRef", "BackgroundJobHandler"} <= set(jobs_package.__all__)
+    assert BackgroundJobHandler is not None
+
+    ref = BackgroundJobRef(
+        id="job-1",
+        job_type="kb.team.transfer",
+        user_id=7,
+        payload={"collection": "kb1"},
+        attempts=1,
+        max_attempts=3,
+    )
+    # The row identity a handler needs to scope its own queries.
+    assert (ref.id, ref.job_type, ref.user_id) == ("job-1", "kb.team.transfer", 7)
+    with pytest.raises(Exception):
+        ref.user_id = 8  # frozen: a handler cannot mutate the snapshot
 
 
 @pytest.mark.parametrize("replace", [False, True])
@@ -2350,36 +2743,101 @@ def test_repeated_failures_stop_at_max_attempts(tmp_path, monkeypatch):
         celery_app.conf.task_eager_propagates = False
 
 
-def test_progress_update_failure_does_not_propagate(tmp_path):
-    """Progress is telemetry: a failed write must not fail the caller.
+def _progress_job(db, name: str) -> str:
+    user = _create_user(db, name)
+    job = create_background_job(
+        db,
+        user_id=int(user.id),
+        job_type="kb.team.progress_best_effort",
+        payload={},
+    )
+    db.commit()
+    job_id = str(job.id)
+    db.rollback()
+    return job_id
+
+
+def test_progress_update_read_failure_does_not_propagate(tmp_path, caplog):
+    """Progress is telemetry: a failed read must not fail the caller.
 
     The web ingestion path calls this from inside per-page processing, before
     the page's own try block, so a raised exception here failed the page.
     """
-    from xagent.web.services.background_jobs import update_job_progress
+    from sqlalchemy.exc import OperationalError
 
-    SessionLocal = _init_test_db(tmp_path / "jobs-progress-best-effort.db")
+    from xagent.web.services import background_jobs as service
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-progress-read-fail.db")
     db = SessionLocal()
     try:
-        user = _create_user(db, "progress-best-effort")
-        job = create_background_job(
-            db,
-            user_id=int(user.id),
-            job_type="kb.team.progress_best_effort",
-            payload={},
-        )
-        db.commit()
-        job_id = str(job.id)
-        db.rollback()
+        job_id = _progress_job(db, "progress-read-fail")
 
-        # A job row that no longer exists is the cheap stand-in for any write
-        # failure: the call must return normally either way.
-        update_job_progress("does-not-exist", message="gone")
+        original = service.get_background_job
 
-        # And the real row still updates.
-        update_job_progress(job_id, message="page 1", completed=1, total=2)
+        def _exploding_get(*_args, **_kwargs):
+            raise OperationalError("SELECT 1", {}, Exception("server closed"))
+
+        service.get_background_job = _exploding_get
+        try:
+            with caplog.at_level(logging.WARNING, logger=service.__name__):
+                service.update_job_progress(job_id, message="page 1")
+        finally:
+            service.get_background_job = original
+
+        assert "Failed to update progress" in caplog.text
+
+        # The next call still works: nothing was left broken behind.
+        service.update_job_progress(job_id, message="page 2", completed=2, total=2)
         db.expire_all()
         row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
-        assert row.progress["message"] == "page 1"
+        assert row.progress["message"] == "page 2"
+    finally:
+        db.close()
+
+
+def test_progress_update_commit_failure_does_not_propagate(tmp_path, caplog):
+    """A write that fails at flush/commit must be swallowed the same way.
+
+    ``extra`` reaches the JSON column verbatim, so an unserializable value
+    fails inside the scope's commit rather than before any SQL is emitted --
+    the path a dead connection takes.
+    """
+    from xagent.web.services import background_jobs as service
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-progress-commit-fail.db")
+    db = SessionLocal()
+    try:
+        job_id = _progress_job(db, "progress-commit-fail")
+
+        with caplog.at_level(logging.WARNING, logger=service.__name__):
+            service.update_job_progress(
+                job_id, message="page 1", extra={"unserializable": object()}
+            )
+
+        assert "Failed to update progress" in caplog.text
+
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.progress is None or "unserializable" not in row.progress
+
+        service.update_job_progress(job_id, message="page 2", completed=2, total=2)
+        db.expire_all()
+        db.refresh(row)
+        assert row.progress["message"] == "page 2"
+    finally:
+        db.close()
+
+
+def test_progress_update_skips_missing_job_row(tmp_path, caplog):
+    """A vanished row is a normal outcome, not a failure worth warning about."""
+    from xagent.web.services import background_jobs as service
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-progress-missing-row.db")
+    db = SessionLocal()
+    try:
+        with caplog.at_level(logging.WARNING, logger=service.__name__):
+            service.update_job_progress("does-not-exist", message="gone")
+
+        assert caplog.text == ""
     finally:
         db.close()

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -2859,6 +2859,12 @@ def test_progress_update_skips_missing_job_row(tmp_path, caplog):
         with caplog.at_level(logging.WARNING, logger=service.__name__):
             service.update_job_progress("does-not-exist", message="gone")
 
-        assert caplog.text == ""
+        # Scoped to this logger: caplog also collects records other loggers
+        # propagate to root, which differ between environments.
+        assert [
+            record
+            for record in caplog.records
+            if record.name == service.__name__ and record.levelno >= logging.WARNING
+        ] == []
     finally:
         db.close()

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from sqlalchemy import text
 
 from xagent.config import CELERY_BROKER_URL, CELERY_ENABLED
 from xagent.core.tools.core.RAG_tools.core.schemas import (
@@ -18,6 +19,7 @@ from xagent.core.tools.core.RAG_tools.core.schemas import (
 )
 from xagent.web.models.background_job import (
     BackgroundJob,
+    BackgroundJobRef,
     BackgroundJobStatus,
     BackgroundJobType,
 )
@@ -56,6 +58,17 @@ def _age_job(db, job, *, updated_at=None, started_at=None) -> None:
     )
     db.commit()
     db.expire_all()
+
+
+def _job_ref(job) -> BackgroundJobRef:
+    """Snapshot a persisted job row the way execute_background_job does."""
+    return BackgroundJobRef(
+        id=str(job.id),
+        job_type=str(job.job_type),
+        payload=dict(job.payload or {}),
+        attempts=int(job.attempts or 0),
+        max_attempts=int(job.max_attempts or 1),
+    )
 
 
 def _create_user(db, username: str = "background-job-test") -> User:
@@ -388,7 +401,7 @@ def test_kb_document_job_reads_staged_file_and_publishes_canonical(
             fake_run_document_ingestion,
         )
 
-        result = handle_kb_ingest_document(db, job)
+        result = handle_kb_ingest_document(_job_ref(job))
 
         assert captured["source_path"] == str(staged_file)
         assert captured["metadata_source_path"] == str(target_file)
@@ -499,7 +512,7 @@ def test_kb_document_job_full_worker_path_new_target_end_to_end(tmp_path, monkey
             },
         )
 
-        result = handle_kb_ingest_document(db, job)
+        result = handle_kb_ingest_document(_job_ref(job))
 
         # Ingestion succeeded end-to-end on the real pipeline.
         assert result["status"] == "success"
@@ -625,8 +638,8 @@ def test_kb_document_job_supersedes_older_generation_for_same_target(
             fake_run_document_ingestion,
         )
 
-        result_b = handle_kb_ingest_document(db, job_b)
-        result_a = handle_kb_ingest_document(db, job_a)
+        result_b = handle_kb_ingest_document(_job_ref(job_b))
+        result_a = handle_kb_ingest_document(_job_ref(job_a))
 
         assert result_b["file_id"] == file_id
         assert result_a["status"] == "superseded"
@@ -752,7 +765,7 @@ def test_kb_document_job_skips_canonical_rollback_when_generation_turns_stale(
             fail_rollback,
         )
 
-        result = handle_kb_ingest_document(db, job)
+        result = handle_kb_ingest_document(_job_ref(job))
 
         assert result["status"] == "superseded"
         assert result["published"] is False
@@ -828,7 +841,7 @@ def test_kb_document_job_existing_collection_failure_keeps_previous_config(
         )
 
         with pytest.raises(BackgroundJobHandlerError):
-            handle_kb_ingest_document(db, job)
+            handle_kb_ingest_document(_job_ref(job))
 
         metadata_store.save_collection_config.assert_not_awaited()
         metadata_store.delete_collection_metadata.assert_not_awaited()
@@ -894,7 +907,7 @@ def test_kb_document_job_exception_keeps_previous_config_before_retry(
         )
 
         with pytest.raises(RuntimeError, match="transient failure"):
-            handle_kb_ingest_document(db, job)
+            handle_kb_ingest_document(_job_ref(job))
 
         assert staged_file.exists()
         metadata_store.save_collection_config.assert_not_awaited()
@@ -937,8 +950,7 @@ def test_background_job_progress_manager_mirrors_rag_progress(tmp_path, monkeypa
         )
 
         manager = BackgroundJobProgressManager(
-            db,
-            job,
+            str(job.id),
             delegate=Delegate(),
             throttle_seconds=0,
         )
@@ -1035,7 +1047,7 @@ def test_kb_web_job_cleans_new_collection_metadata_on_ingest_error(
         )
 
         with pytest.raises(BackgroundJobHandlerError):
-            handle_kb_ingest_web(db, job)
+            handle_kb_ingest_web(_job_ref(job))
 
         assert cleaned == [("web-kb", int(user.id))]
     finally:
@@ -1108,7 +1120,7 @@ def test_kb_web_job_keeps_new_collection_metadata_when_error_has_successful_docs
         )
 
         with pytest.raises(BackgroundJobHandlerError):
-            handle_kb_ingest_web(db, job)
+            handle_kb_ingest_web(_job_ref(job))
 
         assert cleaned == []
     finally:
@@ -1182,7 +1194,7 @@ def test_kb_web_job_keeps_new_collection_metadata_when_side_effects_may_remain(
         )
 
         with pytest.raises(BackgroundJobHandlerError):
-            handle_kb_ingest_web(db, job)
+            handle_kb_ingest_web(_job_ref(job))
 
         assert cleaned == []
     finally:
@@ -1253,7 +1265,7 @@ def test_kb_web_job_existing_collection_failure_keeps_previous_config(
         )
 
         with pytest.raises(BackgroundJobHandlerError):
-            handle_kb_ingest_web(db, job)
+            handle_kb_ingest_web(_job_ref(job))
 
         metadata_store.save_collection_config.assert_not_awaited()
         metadata_store.delete_collection_metadata.assert_not_awaited()
@@ -1321,7 +1333,7 @@ def test_kb_web_job_partial_publishes_new_config(tmp_path, monkeypatch):
             fake_run_web_ingestion,
         )
 
-        result = handle_kb_ingest_web(db, job)
+        result = handle_kb_ingest_web(_job_ref(job))
 
         assert result["status"] == "partial"
         saved = metadata_store.save_collection_config.await_args_list
@@ -1397,7 +1409,7 @@ def test_kb_web_job_zero_pages_without_failures_fails(tmp_path, monkeypatch):
         with pytest.raises(
             BackgroundJobHandlerError, match="No pages were ingested"
         ) as excinfo:
-            handle_kb_ingest_web(db, job)
+            handle_kb_ingest_web(_job_ref(job))
 
         # Retrying re-crawls the whole site to reach the same empty result.
         assert excinfo.value.retryable is False
@@ -1604,14 +1616,13 @@ def test_registered_external_handler_receives_job(tmp_path):
 
         calls: list[str] = []
 
-        def handler(session, received):
-            assert session is db
+        def handler(received):
             calls.append(str(received.id))
             return {"status": "ok"}
 
         tasks_module.register_background_job_handler("kb.team.transfer", handler)
         try:
-            result = tasks_module._execute_job_handler(db, job)
+            result = tasks_module._execute_job_handler(_job_ref(job))
         finally:
             tasks_module._EXTRA_HANDLERS.pop("kb.team.transfer", None)
 
@@ -1635,7 +1646,7 @@ def test_jobs_package_exports_handler_registration_api():
 
     assert is_background_job_handler_registered("kb.team.transfer") is False
 
-    def handler(_session, _job):
+    def handler(_ref):
         return {"status": "ok"}
 
     register_background_job_handler("kb.team.transfer", handler)
@@ -1700,7 +1711,7 @@ def test_register_background_job_handler_rejects_builtin_job_type(replace):
     """
     from xagent.web.jobs import tasks as tasks_module
 
-    def handler(_session, _job):
+    def handler(_ref):
         return {"status": "shadowed"}
 
     for builtin in BackgroundJobType:
@@ -1731,7 +1742,7 @@ def test_unregistered_job_type_still_raises(tmp_path):
         with pytest.raises(
             BackgroundJobHandlerError, match="Unsupported background job type"
         ) as excinfo:
-            tasks_module._execute_job_handler(db, job)
+            tasks_module._execute_job_handler(_job_ref(job))
         # Typed as a handler error so execute_background_job classifies it as
         # permanent rather than falling through to the generic retry branch.
         assert excinfo.value.retryable is False
@@ -1830,7 +1841,7 @@ def test_registered_handler_retryable_error_flows_through_execute_background_job
 
     handler_calls: list[str] = []
 
-    def flaky_handler(session, received):
+    def flaky_handler(received):
         handler_calls.append(str(received.id))
         raise BackgroundJobHandlerError("transient downstream failure", retryable=True)
 
@@ -1948,7 +1959,7 @@ def test_kb_document_job_failed_new_collection_publishes_nothing_end_to_end(
         )
 
         with pytest.raises(BackgroundJobHandlerError):
-            handle_kb_ingest_document(db, job)
+            handle_kb_ingest_document(_job_ref(job))
 
         store = get_metadata_store()
         assert (
@@ -2040,7 +2051,7 @@ def test_kb_document_job_publishes_the_config_end_to_end(tmp_path, monkeypatch):
             },
         )
 
-        result = handle_kb_ingest_document(db, job)
+        result = handle_kb_ingest_document(_job_ref(job))
 
         assert result["status"] == "success"
         saved_config = asyncio.run(
@@ -2054,5 +2065,319 @@ def test_kb_document_job_publishes_the_config_end_to_end(tmp_path, monkeypatch):
         # have to be in it once the documents landed.
         assert saved_config is not None
         assert '"chunk_size":1234' in saved_config
+    finally:
+        db.close()
+
+
+def _track_open_transactions(engine) -> dict[str, int]:
+    """Count transactions the engine has begun but not yet ended.
+
+    This is the observable form of "idle in transaction": a session that
+    commits and then re-reads leaves a transaction open with no statement
+    running, and Postgres eventually terminates that connection.
+    """
+    from sqlalchemy import event
+
+    state = {"open": 0, "peak": 0}
+
+    @event.listens_for(engine, "begin")
+    def _begin(conn):  # noqa: ANN001, ANN202
+        state["open"] += 1
+        state["peak"] = max(state["peak"], state["open"])
+
+    @event.listens_for(engine, "commit")
+    def _commit(conn):  # noqa: ANN001, ANN202
+        state["open"] = max(0, state["open"] - 1)
+
+    @event.listens_for(engine, "rollback")
+    def _rollback(conn):  # noqa: ANN001, ANN202
+        state["open"] = max(0, state["open"] - 1)
+
+    return state
+
+
+def test_job_handler_runs_with_no_open_transaction(tmp_path, monkeypatch):
+    """No DB transaction may span the handler body.
+
+    A web ingestion runs for hours between progress updates. Any transaction
+    left open across that gap is killed by the server's
+    idle_in_transaction_session_timeout, after which even the bookkeeping that
+    would record the failure cannot run.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.jobs.celery_app import celery_app
+    from xagent.web.models.database import get_engine
+
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = True
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-no-open-txn.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "no-open-txn")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type="kb.team.no_open_txn",
+            payload={"collection": "kb1"},
+        )
+        db.commit()
+
+        observed: list[int] = []
+        tracker = _track_open_transactions(get_engine())
+
+        def handler(ref):  # noqa: ANN001, ANN202
+            observed.append(tracker["open"])
+            return {"status": "ok"}
+
+        job_id = str(job.id)
+        # Release the test session's own connection first: enqueue_background_job
+        # runs in the request process, not the worker, and its commit/refresh
+        # would otherwise show up as this worker's open transaction.
+        db.rollback()
+
+        tasks_module.register_background_job_handler("kb.team.no_open_txn", handler)
+        try:
+            tasks_module.execute_background_job.apply(args=[job_id]).get()
+        finally:
+            tasks_module._EXTRA_HANDLERS.pop("kb.team.no_open_txn", None)
+
+        assert observed == [0], (
+            f"a transaction was open while the handler ran: {observed}"
+        )
+    finally:
+        db.close()
+        celery_app.conf.task_always_eager = False
+        celery_app.conf.task_eager_propagates = False
+
+
+def test_job_progress_updates_leave_no_open_transaction(tmp_path, monkeypatch):
+    """Progress updates must not re-open a transaction after committing."""
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.jobs.celery_app import celery_app
+    from xagent.web.models.database import get_engine
+    from xagent.web.services.background_jobs import update_job_progress
+
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = True
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-progress-txn.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "progress-txn")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type="kb.team.progress_txn",
+            payload={"collection": "kb1"},
+        )
+        db.commit()
+
+        after_each_update: list[int] = []
+        seen_messages: list[str] = []
+        tracker = _track_open_transactions(get_engine())
+
+        def handler(ref):  # noqa: ANN001, ANN202
+            for i in range(3):
+                update_job_progress(ref.id, message=f"page {i}", completed=i, total=3)
+                after_each_update.append(tracker["open"])
+                # Each short session must have committed: a reader that opens
+                # afterwards has to see the write.
+                probe = SessionLocal()
+                try:
+                    row = (
+                        probe.query(BackgroundJob)
+                        .filter(BackgroundJob.id == ref.id)
+                        .first()
+                    )
+                    seen_messages.append(str(row.progress.get("message")))
+                finally:
+                    probe.close()
+            return {"status": "ok"}
+
+        job_id = str(job.id)
+        db.rollback()
+
+        tasks_module.register_background_job_handler("kb.team.progress_txn", handler)
+        try:
+            tasks_module.execute_background_job.apply(args=[job_id]).get()
+        finally:
+            tasks_module._EXTRA_HANDLERS.pop("kb.team.progress_txn", None)
+
+        assert after_each_update == [0, 0, 0], (
+            f"progress updates left a transaction open: {after_each_update}"
+        )
+        assert seen_messages == ["page 0", "page 1", "page 2"]
+    finally:
+        db.close()
+        celery_app.conf.task_always_eager = False
+        celery_app.conf.task_eager_propagates = False
+
+
+def test_failure_is_recorded_even_when_handler_poisons_its_own_session(
+    tmp_path, monkeypatch
+):
+    """Terminal bookkeeping must not share a session with the failed work.
+
+    The original defect was second-order: the work session died, and the
+    exception handler then tried to record the failure on that same dead
+    session, so the row stayed `running` with no error and max_attempts never
+    applied.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.jobs.celery_app import celery_app
+    from xagent.web.models.database import session_scope
+
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = False
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-poisoned.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "poisoned-session")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type="kb.team.poisoned",
+            payload={"collection": "kb1"},
+            max_attempts=1,
+        )
+        db.commit()
+        job_id = str(job.id)
+        db.rollback()
+
+        def handler(ref):  # noqa: ANN001, ANN202
+            # Kill the connection under the session doing the work, exactly as a
+            # server-side disconnect does, then fail out of it.
+            with session_scope() as work:
+                work.execute(text("SELECT 1"))
+                work.connection().invalidate()
+                raise RuntimeError("ingestion died mid-run")
+
+        tasks_module.register_background_job_handler("kb.team.poisoned", handler)
+        try:
+            tasks_module.execute_background_job.apply(args=[job_id])
+        finally:
+            tasks_module._EXTRA_HANDLERS.pop("kb.team.poisoned", None)
+
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.FAILED.value
+        assert "ingestion died mid-run" in str(row.error_message)
+        assert row.finished_at is not None
+    finally:
+        db.close()
+        celery_app.conf.task_always_eager = False
+        celery_app.conf.task_eager_propagates = False
+
+
+def test_repeated_failures_stop_at_max_attempts(tmp_path, monkeypatch):
+    """A job that keeps failing must reach a terminal state, not loop forever.
+
+    Reaching FAILED is what takes the job out of requeue_stale_background_jobs'
+    reach; a row stuck at `running` is picked up again on every scan.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.jobs.celery_app import celery_app
+
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = False
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-max-attempts.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "max-attempts")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type="kb.team.always_fails",
+            payload={"collection": "kb1"},
+            max_attempts=2,
+        )
+        db.commit()
+        job_id = str(job.id)
+        db.rollback()
+
+        calls: list[str] = []
+
+        def handler(ref):  # noqa: ANN001, ANN202
+            calls.append(ref.id)
+            raise RuntimeError("permanent boom")
+
+        tasks_module.register_background_job_handler("kb.team.always_fails", handler)
+        try:
+            for _ in range(5):
+                db.expire_all()
+                current = (
+                    db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+                )
+                if current.status in {
+                    BackgroundJobStatus.FAILED.value,
+                    BackgroundJobStatus.SUCCEEDED.value,
+                }:
+                    break
+                db.rollback()
+                tasks_module.execute_background_job.apply(args=[job_id])
+        finally:
+            tasks_module._EXTRA_HANDLERS.pop("kb.team.always_fails", None)
+
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.FAILED.value
+        assert int(row.attempts) == 2, f"attempts overran max_attempts: {row.attempts}"
+        assert len(calls) == 2
+
+        # A terminal row is no longer stale-requeue material.
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=0)
+        assert job_id not in {str(j.id) for j in requeued}
+    finally:
+        db.close()
+        celery_app.conf.task_always_eager = False
+        celery_app.conf.task_eager_propagates = False
+
+
+def test_progress_update_failure_does_not_propagate(tmp_path):
+    """Progress is telemetry: a failed write must not fail the caller.
+
+    The web ingestion path calls this from inside per-page processing, before
+    the page's own try block, so a raised exception here failed the page.
+    """
+    from xagent.web.services.background_jobs import update_job_progress
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-progress-best-effort.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "progress-best-effort")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type="kb.team.progress_best_effort",
+            payload={},
+        )
+        db.commit()
+        job_id = str(job.id)
+        db.rollback()
+
+        # A job row that no longer exists is the cheap stand-in for any write
+        # failure: the call must return normally either way.
+        update_job_progress("does-not-exist", message="gone")
+
+        # And the real row still updates.
+        update_job_progress(job_id, message="page 1", completed=1, total=2)
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.progress["message"] == "page 1"
     finally:
         db.close()

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -2029,6 +2029,20 @@ def test_register_background_job_handler_replace_overrides_existing(tmp_path):
         tasks_module._EXTRA_HANDLERS.pop("kb.team.transfer", None)
 
 
+def _wraps_legacy_shim():
+    """A ref-only handler wrapping a legacy ``(db, job)`` implementation."""
+    import functools
+
+    def legacy(db, job):
+        return {"status": "legacy"}
+
+    @functools.wraps(legacy)
+    def shim(ref):
+        return {"status": "ok"}
+
+    return shim
+
+
 def test_register_background_job_handler_rejects_legacy_two_arg_handler():
     """The removed ``(db, job)`` shape must be refused where it can be fixed.
 
@@ -2056,10 +2070,17 @@ def test_register_background_job_handler_rejects_legacy_two_arg_handler():
         pytest.param(lambda ref, *, retries=0: {"status": "ok"}, id="keyword-default"),
         pytest.param(lambda ref, unused=None: {"status": "ok"}, id="optional-second"),
         pytest.param(lambda *args: {"status": "ok"}, id="var-positional"),
+        pytest.param(_wraps_legacy_shim(), id="functools-wraps-shim"),
     ],
 )
 def test_register_background_job_handler_accepts_ref_only_shapes(handler):
-    """Only a second *required* positional means the old contract."""
+    """Only a second *required* positional means the old contract.
+
+    The wraps shim is the standard downstream migration: keep the ``(db, job)``
+    body, wrap it. ``inspect.signature`` follows ``__wrapped__`` by default and
+    reports the wrapped two parameters, so refusing it would break the worker
+    at import for the very code that did migrate.
+    """
     from xagent.web.jobs import tasks as tasks_module
 
     tasks_module.register_background_job_handler("kb.team.ref_shape", handler)

--- a/tests/web/test_background_jobs_postgres.py
+++ b/tests/web/test_background_jobs_postgres.py
@@ -1,0 +1,108 @@
+"""Postgres-only regression for the idle-in-transaction failure mode (#1535).
+
+The SQLite suite pins the mechanism (no transaction spans the handler body).
+Only a real server enforces ``idle_in_transaction_session_timeout``, which is
+what actually killed the connection in production, so the end-to-end
+consequence -- a job stuck at ``running`` with no error recorded -- can only be
+reproduced here. Skipped unless XAGENT_TEST_POSTGRES_URL is set.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from tests.shared.postgres_disposable import disposable_database_url
+
+pytestmark = pytest.mark.integration
+
+IDLE_TIMEOUT = "1s"
+
+
+def _create_schema() -> None:
+    import xagent.web.models.background_job  # noqa: F401
+    import xagent.web.models.uploaded_file  # noqa: F401
+    import xagent.web.models.user  # noqa: F401
+    from xagent.web.models.database import Base, get_engine
+
+    Base.metadata.create_all(get_engine())
+
+
+def test_failure_is_recorded_after_idle_transaction_timeout(monkeypatch):
+    """A job whose handler idles past the timeout must still reach FAILED.
+
+    Before the per-operation sessions, the worker held one session open across
+    the handler body; the server terminated it, and the exception path then
+    tried to record the failure on that dead session. The row stayed
+    ``running`` with ``error_message`` NULL, which also meant max_attempts
+    never applied.
+    """
+    from xagent.config import CELERY_BROKER_URL, CELERY_ENABLED
+
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    with disposable_database_url(
+        "xagent_jobs_idle_txn",
+        settings={"idle_in_transaction_session_timeout": IDLE_TIMEOUT},
+    ) as db_url:
+        from xagent.web.jobs import tasks as tasks_module
+        from xagent.web.jobs.celery_app import celery_app
+        from xagent.web.models.background_job import BackgroundJob, BackgroundJobStatus
+        from xagent.web.models.database import configure_db, get_session_local
+        from xagent.web.models.user import User
+        from xagent.web.services.background_jobs import create_background_job
+
+        configure_db(db_url)
+        _create_schema()
+
+        celery_app.conf.task_always_eager = True
+        celery_app.conf.task_eager_propagates = False
+
+        SessionLocal = get_session_local()
+        setup = SessionLocal()
+        try:
+            user = User(username="idle-txn", password_hash="x")
+            setup.add(user)
+            setup.commit()
+            setup.refresh(user)
+            job = create_background_job(
+                setup,
+                user_id=int(user.id),
+                job_type="kb.team.idle_txn",
+                payload={},
+                max_attempts=1,
+            )
+            setup.commit()
+            job_id = str(job.id)
+        finally:
+            setup.close()
+
+        def handler(_ref):
+            # Stand in for the gap between two progress updates during a
+            # multi-hour crawl -- long enough for the server to reap an idle
+            # transaction, if one were open.
+            time.sleep(2.5)
+            raise RuntimeError("ingestion died mid-run")
+
+        tasks_module.register_background_job_handler("kb.team.idle_txn", handler)
+        try:
+            tasks_module.execute_background_job.apply(args=[job_id])
+        finally:
+            tasks_module._EXTRA_HANDLERS.pop("kb.team.idle_txn", None)
+            celery_app.conf.task_always_eager = False
+            celery_app.conf.task_eager_propagates = False
+
+        verify = SessionLocal()
+        try:
+            row = verify.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+            assert row.status == BackgroundJobStatus.FAILED.value, (
+                f"job did not reach a terminal state: status={row.status!r} "
+                f"error={row.error_message!r}"
+            )
+            assert "ingestion died mid-run" in str(row.error_message)
+            assert row.finished_at is not None
+            assert int(row.attempts) == 1
+        finally:
+            verify.close()

--- a/tests/web/test_background_jobs_postgres.py
+++ b/tests/web/test_background_jobs_postgres.py
@@ -9,11 +9,16 @@ reproduced here. Skipped unless XAGENT_TEST_POSTGRES_URL is set.
 
 from __future__ import annotations
 
+import os
 import time
 
+import psycopg2
 import pytest
 
-from tests.shared.postgres_disposable import disposable_database_url
+from tests.shared.postgres_disposable import (
+    disposable_database_url,
+    psycopg2_kwargs,
+)
 
 pytestmark = pytest.mark.integration
 
@@ -50,12 +55,30 @@ def test_failure_is_recorded_after_idle_transaction_timeout(monkeypatch):
         from xagent.web.jobs import tasks as tasks_module
         from xagent.web.jobs.celery_app import celery_app
         from xagent.web.models.background_job import BackgroundJob, BackgroundJobStatus
-        from xagent.web.models.database import configure_db, get_session_local
+        from xagent.web.models.database import (
+            configure_db,
+            get_engine,
+            get_session_local,
+        )
         from xagent.web.models.user import User
         from xagent.web.services.background_jobs import create_background_job
 
         configure_db(db_url)
         _create_schema()
+
+        # The regression only reproduces if the timeout the test asked for is
+        # what the application's own connections actually get: a database, role
+        # or session-level override would leave the sleep below harmless and the
+        # assertions green for the wrong reason.
+        with get_engine().connect() as probe:
+            effective = probe.exec_driver_sql(
+                "SHOW idle_in_transaction_session_timeout"
+            ).scalar()
+        assert effective == IDLE_TIMEOUT, (
+            "idle_in_transaction_session_timeout on the application connection "
+            f"is {effective!r}, not {IDLE_TIMEOUT!r}; this test would pass "
+            "without exercising the regression"
+        )
 
         celery_app.conf.task_always_eager = True
         celery_app.conf.task_eager_propagates = False
@@ -106,3 +129,32 @@ def test_failure_is_recorded_after_idle_transaction_timeout(monkeypatch):
             assert int(row.attempts) == 1
         finally:
             verify.close()
+
+
+def test_disposable_database_is_dropped_when_setup_fails():
+    """A failing ALTER after CREATE DATABASE must not leak the database.
+
+    The setup statements run between CREATE and the yield, so without a drop
+    guard registered right after CREATE, a rejected setting leaves an orphan
+    database on a shared server for every run.
+    """
+    base_url = os.getenv("XAGENT_TEST_POSTGRES_URL")
+    if not base_url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+
+    prefix = "xagent_jobs_setup_fail"
+    with pytest.raises(psycopg2.Error):
+        with disposable_database_url(prefix, settings={"xagent_not_a_real_guc": "1"}):
+            pytest.fail("the context manager must not yield after a failed setup")
+
+    admin = psycopg2.connect(**psycopg2_kwargs(base_url))
+    try:
+        cursor = admin.cursor()
+        cursor.execute(
+            "SELECT datname FROM pg_database WHERE datname LIKE %s", (f"{prefix}_%",)
+        )
+        leaked = [row[0] for row in cursor.fetchall()]
+    finally:
+        admin.close()
+
+    assert leaked == [], f"disposable databases left behind: {leaked}"

--- a/tests/web/test_kb_ingest_lifecycle.py
+++ b/tests/web/test_kb_ingest_lifecycle.py
@@ -176,7 +176,6 @@ def test_background_failed_ingest_config_cleanup_reuses_api_helper(
     )
     user = User()
     user.id = 11
-    db = object()
     calls: list[dict[str, Any]] = []
     monkeypatch.setattr(kb_tasks, "_get_job_user", lambda *args, **kwargs: user)
 
@@ -190,7 +189,6 @@ def test_background_failed_ingest_config_cleanup_reuses_api_helper(
     )
 
     kb_tasks._cleanup_failed_job_collection_metadata_after_api_ingest(
-        db,  # type: ignore[arg-type]
         {
             "collection": "job-kb",
             "collection_existed_before": False,
@@ -221,7 +219,6 @@ def test_background_web_cleanup_keeps_early_exception_fallback(
 
     fallback = MagicMock()
     api_helper = MagicMock()
-    db = object()
     payload = {"collection": "job-kb"}
     monkeypatch.setattr(
         kb_tasks,
@@ -234,13 +231,9 @@ def test_background_web_cleanup_keeps_early_exception_fallback(
         api_helper,
     )
 
-    kb_tasks._cleanup_failed_web_collection_metadata_if_new(
-        db,  # type: ignore[arg-type]
-        payload,
-    )
+    kb_tasks._cleanup_failed_web_collection_metadata_if_new(payload)
 
     fallback.assert_called_once_with(
-        db,
         payload,
         context="background web ingest",
         successful_documents=0,
@@ -557,7 +550,6 @@ def test_job_config_save_failure_is_not_retryable(
 
     with pytest.raises(BackgroundJobHandlerError) as excinfo:
         kb_tasks._save_job_collection_config_after_ingest(
-            MagicMock(),
             {"collection": "job-kb", "user_id": 13},
             IngestionConfig(),
             context="background document ingest",
@@ -924,7 +916,6 @@ def test_job_config_save_failure_keeps_the_result_payload(
 
     with pytest.raises(BackgroundJobHandlerError) as excinfo:
         kb_tasks._save_job_collection_config_after_ingest(
-            MagicMock(),
             {"collection": "job-kb", "user_id": 13},
             IngestionConfig(),
             context="background document ingest",
@@ -948,7 +939,6 @@ def test_job_with_a_missing_user_fails_instead_of_succeeding_silently(
 
     with pytest.raises(BackgroundJobHandlerError) as excinfo:
         kb_tasks._save_job_collection_config_after_ingest(
-            MagicMock(),
             {"collection": "job-kb", "user_id": 13},
             IngestionConfig(),
             context="background document ingest",
@@ -1041,7 +1031,6 @@ def test_missing_user_is_ignored_when_there_is_nothing_to_publish(
     monkeypatch.setattr(kb_tasks, "_get_job_user", get_user)
 
     kb_tasks._save_job_collection_config_after_ingest(
-        MagicMock(),
         {"collection": "job-kb", "user_id": 13, "collection_existed_before": True},
         IngestionConfig(),
         context="background web ingest",
@@ -1061,7 +1050,6 @@ def test_missing_user_on_a_failed_new_collection_does_not_raise(
     monkeypatch.setattr(kb_tasks, "_get_job_user", lambda *args, **kwargs: None)
 
     kb_tasks._save_job_collection_config_after_ingest(
-        MagicMock(),
         {"collection": "job-kb", "user_id": 13, "collection_existed_before": False},
         IngestionConfig(),
         context="background web ingest",

--- a/tests/web/test_trigger_tasks.py
+++ b/tests/web/test_trigger_tasks.py
@@ -11,8 +11,14 @@ from __future__ import annotations
 from pathlib import Path
 from unittest.mock import MagicMock
 
+from sqlalchemy.orm import Session
+
 from xagent.web.jobs import trigger_tasks
-from xagent.web.models.background_job import BackgroundJob, BackgroundJobType
+from xagent.web.models.background_job import (
+    BackgroundJob,
+    BackgroundJobRef,
+    BackgroundJobType,
+)
 from xagent.web.models.database import get_session_local, init_db
 from xagent.web.models.user import User
 from xagent.web.services.workforce_runtime import WorkforceRunPauseTarget
@@ -21,6 +27,16 @@ from xagent.web.services.workforce_runtime import WorkforceRunPauseTarget
 def _init_test_db(path: Path):
     init_db(f"sqlite:///{path}")
     return get_session_local()
+
+
+def _job_ref(job) -> BackgroundJobRef:
+    return BackgroundJobRef(
+        id=str(job.id),
+        job_type=str(job.job_type),
+        payload=dict(job.payload or {}),
+        attempts=int(job.attempts or 0),
+        max_attempts=int(job.max_attempts or 1),
+    )
 
 
 def _create_user(db, username: str = "trigger-scan-test") -> User:
@@ -63,9 +79,10 @@ def test_handle_trigger_scan_reaps_stale_preview_workforce_runs(
     db.commit()
     db.refresh(job)
 
-    result = trigger_tasks.handle_trigger_scan(db, job)
+    result = trigger_tasks.handle_trigger_scan(_job_ref(job))
 
-    reap_mock.assert_called_once_with(db)
+    reap_mock.assert_called_once()
+    assert isinstance(reap_mock.call_args[0][0], Session)
     assert dispatch_calls == [([pause_target], "preview-reap")]
     assert result["reaped_preview_run_pause_dispatches"] == 1
 
@@ -96,8 +113,9 @@ def test_handle_trigger_scan_skips_dispatch_when_nothing_reaped(
     db.commit()
     db.refresh(job)
 
-    result = trigger_tasks.handle_trigger_scan(db, job)
+    result = trigger_tasks.handle_trigger_scan(_job_ref(job))
 
-    reap_mock.assert_called_once_with(db)
+    reap_mock.assert_called_once()
+    assert isinstance(reap_mock.call_args[0][0], Session)
     dispatch_mock.assert_not_called()
     assert result["reaped_preview_run_pause_dispatches"] == 0

--- a/tests/web/test_trigger_tasks.py
+++ b/tests/web/test_trigger_tasks.py
@@ -33,6 +33,7 @@ def _job_ref(job) -> BackgroundJobRef:
     return BackgroundJobRef(
         id=str(job.id),
         job_type=str(job.job_type),
+        user_id=int(job.user_id),
         payload=dict(job.payload or {}),
         attempts=int(job.attempts or 0),
         max_attempts=int(job.max_attempts or 1),


### PR DESCRIPTION
Closes #1535. Part of #1564.

`execute_background_job` opened one `Session` and held it for the entire lifetime of a job. Web
ingestion runs for hours, and `update_job_progress` ended with a post-commit `refresh` — that
`SELECT` opens a new transaction after the commit, which then stays open until the next progress
update. Once the gap between two updates exceeds the server's
`idle_in_transaction_session_timeout`, the connection is terminated.

Three consequences followed. Every remaining page failed once the session was poisoned (70-270
consecutive page failures per occurrence). The exception path called `mark_job_failed` on that
same dead session, so the job never reached a terminal state. And because it never did,
`max_attempts` never applied — one observed job reached `attempts = 33` against a cap of 3.

The fix stops threading a long-lived `Session` through the call chain: pass `job_id` and open a
short-lived session per operation. This is already the established pattern in the same package
(`_file_handler_with_db`); the job bookkeeping path was the inconsistent half. Handlers now
receive a `BackgroundJobRef` value snapshot rather than an ORM instance, so no session outlives
a single operation.

Both hardening items from the issue are included: progress updates are best-effort (progress is
telemetry, not state — a failed telemetry write should not fail a page), and `model_resolver`'s
own engine picks up `pool_recycle`, which it silently missed by passing only `pool_pre_ping`.

**`model_resolver` takes the health knobs only, not all of `get_db_pool_kwargs()`.** That
function's own docstring notes the same values apply to *each* engine using them, so a process
running both holds up to 2 x (pool_size + max_overflow) connections. A worker already holds the
web engine's pool, so adopting the sizing here would double this process's connection ceiling.
Only `pool_recycle` and `pool_pre_ping` are taken.

**Verification.** `tests/web/test_background_jobs.py` and `tests/web/test_trigger_tasks.py` are
green. `tests/web/test_background_jobs_postgres.py` is new and needs a real server: it sets
`idle_in_transaction_session_timeout` to 1s, has the handler idle for 2.5s and then raise, and
asserts the job reaches FAILED with the error recorded. It passes against a local Postgres
instance.

That test was mutation-verified: reintroducing a transaction held open across the handler body,
with the failure recorded on that same session, makes it fail immediately with
`server closed the connection unexpectedly` — the exact error observed in production.

### Known ceiling: the rollback path still spans external work

`_rollback_failed_ingestion` / `_rollback_failed_cloud_ingestion` interleave their DB deletes with
vector and filesystem work on the session they are handed, and both are called from the request
path with `db=Depends(get_db)`. Splitting them needs a detached snapshot plus a fresh session, but
`UploadedFileStore(db).delete(file_record)` operates on the passed instance directly and I could
not establish that is safe for a detached one without rewriting ~250 lines on a path that deletes
collections and user files.

So the rollback keeps its own scope — bounded by one rollback rather than by the ingestion — and
both call sites carry a comment naming what is still spanned. On a large collection that rollback
can still outlive the idle timeout. What this PR fixes regardless is that the failure gets
recorded, because `mark_job_failed` runs on an independent session; that is what the Postgres
regression pins.

The same reasoning applies to `handle_trigger_scan`'s preview-run reaping: no transaction spans
its PAUSE dispatch today, but only because `reap_stale_preview_workforce_runs` happens to commit
just before it and returns frozen dataclasses that cannot reopen one. Nothing in
`handle_trigger_scan` expresses that constraint, and no test would fail if a future `db` read were
added between the two.

**Out of scope.** Broker redelivery and concurrent execution (#1565 / #1566), and a timer-driven
heartbeat.
