### PR TITLE
fix(kb): stop the per-call vector index rebuild and the blocked fts merge

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "pillow >= 10.0.0",
   "pypinyin>=0.53.0",
   "cairosvg >= 2.7.1",
-  "lancedb>=0.13.0",
+  "lancedb>=0.18.0",
   "pyarrow>=16.1.0",
   # Basic document processing (keep pypdf for basic PDF support)
   "pypdf>=4.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
   "pillow >= 10.0.0",
   "pypinyin>=0.53.0",
   "cairosvg >= 2.7.1",
-  "lancedb>=0.18.0",
+  "lancedb>=0.24.2",
   "pyarrow>=16.1.0",
   # Basic document processing (keep pypdf for basic PDF support)
   "pypdf>=4.0.0",

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -1602,10 +1602,11 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             # panic on older-writer indices, taking the index step down (lance#8310).
             try:
                 self._rebuild_fts_index(table, table_name)
-            except Exception as exc:  # noqa: BLE001
-                # Must not take optimize down with it: compaction and version
-                # pruning run before the index step and are what reclaim the
-                # disk, so losing them costs more than a stale FTS index.
+            except (KeyboardInterrupt, SystemExit):
+                raise
+            except BaseException as exc:  # noqa: BLE001
+                # BaseException because pyo3 raises a Rust panic as
+                # PanicException; losing compaction costs more than stale FTS.
                 logger.warning("FTS rebuild failed for %s: %s", table_name, exc)
             table.optimize(cleanup_older_than=cleanup_older_than)
             # Pruning drops the versions cached handles point at, same reason

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -1442,7 +1442,10 @@ class LanceDBVectorIndexStore(VectorIndexStore):
 
                 # Check existing indexes
                 indexes = table.list_indices()
-                has_vector_index = any(idx.name == "vector" for idx in indexes)
+                # Match by column, as the FTS checks in this file do. LanceDB
+                # names the index after its column (``vector_idx``), so a check
+                # on the bare column name never matched and every call rebuilt.
+                has_vector_index = any("vector" in idx.columns for idx in indexes)
 
                 if not has_vector_index:
                     # Create index with recommended type
@@ -1595,6 +1598,13 @@ class LanceDBVectorIndexStore(VectorIndexStore):
                 cleanup_older_than = timedelta(
                     days=DEFAULT_INDEX_POLICY.version_retention_days
                 )
+            # Rebuild FTS in full before optimize merges it incrementally.
+            # That merge panics on indices written by older FTS writers
+            # (lance-format/lance#8310, still open), and optimize's index step
+            # is all-or-nothing, so the panic takes the vector index merge down
+            # with it. A rebuild leaves nothing unindexed, so the merge becomes
+            # a no-op -- and measures cheaper than the merge it replaces.
+            self._rebuild_fts_index(table, table_name)
             table.optimize(cleanup_older_than=cleanup_older_than)
             # Pruning drops the versions cached handles point at, same reason
             # the delete paths invalidate after mutating a table.
@@ -1606,6 +1616,28 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             return False
         finally:
             _safe_close_table(table)
+
+    def _rebuild_fts_index(self, table: Any, table_name: str) -> None:
+        """Rebuild the FTS index, if this table has one.
+
+        Guarded because ``compact_tables`` routes documents, parses, chunks and
+        ingestion_runs through the same path and only embeddings carries FTS.
+        """
+        try:
+            has_fts = any(
+                idx.index_type == "FTS" and "text" in idx.columns
+                for idx in table.list_indices()
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Could not list indices for %s: %s", table_name, exc)
+            return
+
+        if not has_fts:
+            return
+
+        fts_params = {"with_position": True, **(DEFAULT_INDEX_POLICY.fts_params or {})}
+        table.create_fts_index("text", replace=True, **fts_params)
+        logger.info("Rebuilt FTS index for %s before optimize", table_name)
 
     def should_compact(
         self, table_name: str, policy: Optional[IndexPolicy] = None

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -1598,12 +1598,8 @@ class LanceDBVectorIndexStore(VectorIndexStore):
                 cleanup_older_than = timedelta(
                     days=DEFAULT_INDEX_POLICY.version_retention_days
                 )
-            # Rebuild FTS in full before optimize merges it incrementally.
-            # That merge panics on indices written by older FTS writers
-            # (lance-format/lance#8310, still open), and optimize's index step
-            # is all-or-nothing, so the panic takes the vector index merge down
-            # with it. A rebuild leaves nothing unindexed, so the merge becomes
-            # a no-op -- and measures cheaper than the merge it replaces.
+            # Must precede optimize: its incremental FTS merge is reported to
+            # panic on older-writer indices, taking the index step down (lance#8310).
             try:
                 self._rebuild_fts_index(table, table_name)
             except Exception as exc:  # noqa: BLE001

--- a/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
+++ b/src/xagent/core/tools/core/RAG_tools/storage/lancedb_stores.py
@@ -1604,7 +1604,13 @@ class LanceDBVectorIndexStore(VectorIndexStore):
             # is all-or-nothing, so the panic takes the vector index merge down
             # with it. A rebuild leaves nothing unindexed, so the merge becomes
             # a no-op -- and measures cheaper than the merge it replaces.
-            self._rebuild_fts_index(table, table_name)
+            try:
+                self._rebuild_fts_index(table, table_name)
+            except Exception as exc:  # noqa: BLE001
+                # Must not take optimize down with it: compaction and version
+                # pruning run before the index step and are what reclaim the
+                # disk, so losing them costs more than a stale FTS index.
+                logger.warning("FTS rebuild failed for %s: %s", table_name, exc)
             table.optimize(cleanup_older_than=cleanup_older_than)
             # Pruning drops the versions cached handles point at, same reason
             # the delete paths invalidate after mutating a table.
@@ -1623,15 +1629,10 @@ class LanceDBVectorIndexStore(VectorIndexStore):
         Guarded because ``compact_tables`` routes documents, parses, chunks and
         ingestion_runs through the same path and only embeddings carries FTS.
         """
-        try:
-            has_fts = any(
-                idx.index_type == "FTS" and "text" in idx.columns
-                for idx in table.list_indices()
-            )
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("Could not list indices for %s: %s", table_name, exc)
-            return
-
+        has_fts = any(
+            idx.index_type == "FTS" and "text" in idx.columns
+            for idx in table.list_indices()
+        )
         if not has_fts:
             return
 

--- a/tests/core/tools/core/RAG_tools/storage/test_vector_index_contract.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_vector_index_contract.py
@@ -257,3 +257,39 @@ def test_a_failed_fts_rebuild_still_lets_optimize_run(tmp_path, monkeypatch, cap
         "FTS rebuild failed" in r.getMessage() and r.levelno == logging.WARNING
         for r in caplog.records
     ), "a silently swallowed rebuild failure is indistinguishable from success"
+
+
+def test_a_panicking_fts_rebuild_still_lets_optimize_run(tmp_path, monkeypatch):
+    """A Rust panic arrives as a BaseException, not an Exception.
+
+    pyo3 raises PanicException off BaseException, so catching Exception alone
+    would let it abort the compaction this isolation exists to protect.
+    """
+
+    class FakePanic(BaseException):
+        pass
+
+    db = lancedb.connect(str(tmp_path / "panic"))
+    table = db.create_table("embeddings_probe", data=_rows(400))
+    table.create_fts_index("text", with_position=True, replace=True)
+
+    calls: list[str] = []
+    real_optimize = table.optimize
+
+    def panicking_fts(*args, **kwargs):
+        calls.append("create_fts_index")
+        raise FakePanic("index out of bounds: the len is 10791")
+
+    def optimize(*args, **kwargs):
+        calls.append("optimize")
+        return real_optimize(*args, **kwargs)
+
+    table.create_fts_index = panicking_fts
+    table.optimize = optimize
+    store = _store_on(db)
+    monkeypatch.setattr(store, "_get_connection", lambda: db)
+    monkeypatch.setattr(db, "open_table", lambda name, **kw: table)
+
+    assert store.trigger_reindex("embeddings_probe") is True
+
+    assert calls == ["create_fts_index", "optimize"]

--- a/tests/core/tools/core/RAG_tools/storage/test_vector_index_contract.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_vector_index_contract.py
@@ -8,8 +8,10 @@ match went unnoticed for months: LanceDB names the index after its column
 
 from __future__ import annotations
 
+import logging
 import random
 
+import lancedb
 import pytest
 
 
@@ -27,7 +29,6 @@ def _rows(n: int, dim: int = 32) -> list[dict]:
 @pytest.fixture
 def indexed_table(tmp_path):
     """A real table carrying both a vector index and an FTS index."""
-    lancedb = pytest.importorskip("lancedb")
     db = lancedb.connect(str(tmp_path / "contract"))
     table = db.create_table("embeddings_probe", data=_rows(2000))
     table.create_index(metric="l2", index_type="IVF_HNSW_SQ", num_partitions=4)
@@ -50,7 +51,6 @@ def test_column_check_does_not_mistake_the_fts_index_for_a_vector_index(
     Otherwise the fix would swap a never-matches check for an always-matches
     one, and the index would never be built at all.
     """
-    lancedb = pytest.importorskip("lancedb")
     db = lancedb.connect(str(tmp_path / "fts-only"))
     table = db.create_table("embeddings_fts_only", data=_rows(200))
     table.create_fts_index("text", with_position=True, replace=True)
@@ -95,7 +95,6 @@ def test_create_index_does_not_rebuild_an_existing_index(
     Every call rebuilt it in full before this fix -- ~114 MB and ~14 s per call
     on a 77k x 1024 table, several hundred times a day.
     """
-    lancedb = pytest.importorskip("lancedb")
     db = lancedb.connect(str(tmp_path / "rebuild"))
     db.create_table("embeddings_probe", data=_rows(500))
     store = _store_on(db)
@@ -106,8 +105,8 @@ def test_create_index_does_not_rebuild_an_existing_index(
     second = store.create_index("probe")
     version_after_second = db.open_table("embeddings_probe").version
 
-    assert first.status != "failed"
-    assert second.status != "failed"
+    assert first.status == "index_building"
+    assert second.status == "index_ready"
     assert version_after_second == version_after_first, (
         "the second call rebuilt the index: table version moved from "
         f"{version_after_first} to {version_after_second}"
@@ -124,11 +123,11 @@ def _fts_index(table):
 def test_reindex_leaves_no_unindexed_fts_rows(tmp_path):
     """After maintenance the FTS index must cover every row.
 
-    ``optimize()`` merges FTS incrementally, and that merge is what panics
-    upstream (lance-format/lance#8310). A full rebuild first leaves nothing for
-    the merge to do, so it never enters that path.
+    ``optimize()`` merges FTS incrementally, and that merge is where the
+    upstream panic is reported (lance-format/lance#8310). Rebuilding first is
+    what leaves the index complete; whether the merge then still panics is not
+    something this suite can reproduce.
     """
-    lancedb = pytest.importorskip("lancedb")
     db = lancedb.connect(str(tmp_path / "fts-reindex"))
     table = db.create_table("embeddings_probe", data=_rows(500))
     table.create_fts_index("text", with_position=True, replace=True)
@@ -149,7 +148,6 @@ def test_reindex_of_a_table_without_fts_builds_no_fts_index(tmp_path):
     ``compact_tables`` sends documents, parses, chunks and ingestion_runs
     through this path; only the embeddings table has FTS.
     """
-    lancedb = pytest.importorskip("lancedb")
     db = lancedb.connect(str(tmp_path / "no-fts"))
     table = db.create_table("parses", data=_rows(200))
     assert _fts_index(table) is None
@@ -179,10 +177,9 @@ def _record_calls(table, calls):
 def test_fts_is_rebuilt_before_optimize(tmp_path, monkeypatch):
     """The rebuild has to precede optimize, or the merge still panics.
 
-    Rebuilding after optimize would leave the panicking merge in the path, and
-    rebuilding is only cheap because it makes that merge a no-op.
+    Rebuilding after optimize would leave the reported panic (lance#8310) in
+    front of the rebuild, so the order is the part worth pinning.
     """
-    lancedb = pytest.importorskip("lancedb")
     db = lancedb.connect(str(tmp_path / "order"))
     table = db.create_table("embeddings_probe", data=_rows(400))
     table.create_fts_index("text", with_position=True, replace=True)
@@ -199,7 +196,6 @@ def test_fts_is_rebuilt_before_optimize(tmp_path, monkeypatch):
 
 
 def test_optimize_of_a_table_without_fts_skips_the_rebuild(tmp_path, monkeypatch):
-    lancedb = pytest.importorskip("lancedb")
     db = lancedb.connect(str(tmp_path / "order-no-fts"))
     table = db.create_table("parses", data=_rows(200))
 
@@ -214,7 +210,7 @@ def test_optimize_of_a_table_without_fts_skips_the_rebuild(tmp_path, monkeypatch
     assert calls == ["optimize"]
 
 
-def test_a_failed_fts_rebuild_still_lets_optimize_run(tmp_path, monkeypatch):
+def test_a_failed_fts_rebuild_still_lets_optimize_run(tmp_path, monkeypatch, caplog):
     """The rebuild must not take compaction down with it.
 
     Compaction and version pruning run before optimize's index step and are
@@ -222,12 +218,20 @@ def test_a_failed_fts_rebuild_still_lets_optimize_run(tmp_path, monkeypatch):
     releasing 85-90% of it. Letting a rebuild failure skip optimize entirely
     would be the same failure mode this change exists to remove.
     """
-    lancedb = pytest.importorskip("lancedb")
+    from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
+        _fragment_count,
+    )
+
     db = lancedb.connect(str(tmp_path / "fts-boom"))
-    table = db.create_table("embeddings_probe", data=_rows(400))
+    table = db.create_table("embeddings_probe", data=_rows(100))
+    for _ in range(5):
+        table.add(_rows(20))
     table.create_fts_index("text", with_position=True, replace=True)
+    fragments_before = _fragment_count(table)
+    assert fragments_before > 1, "need a fragmented table to see compaction"
 
     calls: list[str] = []
+    real_open_table = db.open_table
     real_optimize = table.optimize
 
     def exploding_fts(*args, **kwargs):
@@ -244,6 +248,12 @@ def test_a_failed_fts_rebuild_still_lets_optimize_run(tmp_path, monkeypatch):
     monkeypatch.setattr(store, "_get_connection", lambda: db)
     monkeypatch.setattr(db, "open_table", lambda name, **kw: table)
 
-    assert store.trigger_reindex("embeddings_probe") is True
+    with caplog.at_level(logging.WARNING):
+        assert store.trigger_reindex("embeddings_probe") is True
 
     assert calls == ["create_fts_index", "optimize"]
+    assert _fragment_count(real_open_table("embeddings_probe")) < fragments_before
+    assert any(
+        "FTS rebuild failed" in r.getMessage() and r.levelno == logging.WARNING
+        for r in caplog.records
+    ), "a silently swallowed rebuild failure is indistinguishable from success"

--- a/tests/core/tools/core/RAG_tools/storage/test_vector_index_contract.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_vector_index_contract.py
@@ -35,17 +35,6 @@ def indexed_table(tmp_path):
     return table
 
 
-def test_vector_index_is_not_named_after_the_column_alone(indexed_table):
-    """The name-based check can never match, on any supported LanceDB.
-
-    Pinning this is the point: it is the assumption the bug rested on.
-    """
-    names = {idx.name for idx in indexed_table.list_indices()}
-
-    assert "vector" not in names
-    assert "vector_idx" in names
-
-
 def test_vector_index_is_discoverable_by_column(indexed_table):
     """The column-based check finds the index that was just created."""
     indexes = indexed_table.list_indices()
@@ -223,3 +212,38 @@ def test_optimize_of_a_table_without_fts_skips_the_rebuild(tmp_path, monkeypatch
     assert store.trigger_reindex("parses") is True
 
     assert calls == ["optimize"]
+
+
+def test_a_failed_fts_rebuild_still_lets_optimize_run(tmp_path, monkeypatch):
+    """The rebuild must not take compaction down with it.
+
+    Compaction and version pruning run before optimize's index step and are
+    what reclaim the disk; upstream measured a panicking index step still
+    releasing 85-90% of it. Letting a rebuild failure skip optimize entirely
+    would be the same failure mode this change exists to remove.
+    """
+    lancedb = pytest.importorskip("lancedb")
+    db = lancedb.connect(str(tmp_path / "fts-boom"))
+    table = db.create_table("embeddings_probe", data=_rows(400))
+    table.create_fts_index("text", with_position=True, replace=True)
+
+    calls: list[str] = []
+    real_optimize = table.optimize
+
+    def exploding_fts(*args, **kwargs):
+        calls.append("create_fts_index")
+        raise RuntimeError("index out of bounds: the len is 10791")
+
+    def optimize(*args, **kwargs):
+        calls.append("optimize")
+        return real_optimize(*args, **kwargs)
+
+    table.create_fts_index = exploding_fts
+    table.optimize = optimize
+    store = _store_on(db)
+    monkeypatch.setattr(store, "_get_connection", lambda: db)
+    monkeypatch.setattr(db, "open_table", lambda name, **kw: table)
+
+    assert store.trigger_reindex("embeddings_probe") is True
+
+    assert calls == ["create_fts_index", "optimize"]

--- a/tests/core/tools/core/RAG_tools/storage/test_vector_index_contract.py
+++ b/tests/core/tools/core/RAG_tools/storage/test_vector_index_contract.py
@@ -1,0 +1,225 @@
+"""Contract tests for the vector-index existence check (#1557).
+
+These run against a real LanceDB table on purpose. The rest of the store suite
+mocks ``lancedb.connect``, which is why an existence check that could never
+match went unnoticed for months: LanceDB names the index after its column
+(``vector_idx``), never ``vector``, and no mocked test could tell.
+"""
+
+from __future__ import annotations
+
+import random
+
+import pytest
+
+
+def _rows(n: int, dim: int = 32) -> list[dict]:
+    rnd = random.Random(1557)
+    return [
+        {
+            "vector": [rnd.random() for _ in range(dim)],
+            "text": f"document {i} lorem ipsum dolor",
+        }
+        for i in range(n)
+    ]
+
+
+@pytest.fixture
+def indexed_table(tmp_path):
+    """A real table carrying both a vector index and an FTS index."""
+    lancedb = pytest.importorskip("lancedb")
+    db = lancedb.connect(str(tmp_path / "contract"))
+    table = db.create_table("embeddings_probe", data=_rows(2000))
+    table.create_index(metric="l2", index_type="IVF_HNSW_SQ", num_partitions=4)
+    table.create_fts_index("text", with_position=True, replace=True)
+    return table
+
+
+def test_vector_index_is_not_named_after_the_column_alone(indexed_table):
+    """The name-based check can never match, on any supported LanceDB.
+
+    Pinning this is the point: it is the assumption the bug rested on.
+    """
+    names = {idx.name for idx in indexed_table.list_indices()}
+
+    assert "vector" not in names
+    assert "vector_idx" in names
+
+
+def test_vector_index_is_discoverable_by_column(indexed_table):
+    """The column-based check finds the index that was just created."""
+    indexes = indexed_table.list_indices()
+
+    assert any("vector" in idx.columns for idx in indexes)
+
+
+def test_column_check_does_not_mistake_the_fts_index_for_a_vector_index(
+    tmp_path,
+):
+    """An FTS index alone must not satisfy the vector-index check.
+
+    Otherwise the fix would swap a never-matches check for an always-matches
+    one, and the index would never be built at all.
+    """
+    lancedb = pytest.importorskip("lancedb")
+    db = lancedb.connect(str(tmp_path / "fts-only"))
+    table = db.create_table("embeddings_fts_only", data=_rows(200))
+    table.create_fts_index("text", with_position=True, replace=True)
+
+    indexes = table.list_indices()
+
+    assert indexes, "expected the FTS index to exist"
+    assert not any("vector" in idx.columns for idx in indexes)
+
+
+def _store_on(db):
+    """A vector-index store bound to an already-open connection."""
+    from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
+        LanceDBVectorIndexStore,
+    )
+
+    store = LanceDBVectorIndexStore()
+    store._conn = db
+    return store
+
+
+@pytest.fixture
+def low_threshold_policy(monkeypatch):
+    """Drop the 50k row gate so the index path runs on a small table."""
+    from xagent.core.tools.core.RAG_tools.core import config as config_module
+
+    original = config_module.IndexPolicy
+
+    def _policy(*args, **kwargs):
+        kwargs.setdefault("enable_threshold_rows", 100)
+        kwargs.setdefault("hnsw_params", {"num_partitions": 4})
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(config_module, "IndexPolicy", _policy)
+
+
+def test_create_index_does_not_rebuild_an_existing_index(
+    tmp_path, low_threshold_policy
+):
+    """Two calls must build the index once.
+
+    Every call rebuilt it in full before this fix -- ~114 MB and ~14 s per call
+    on a 77k x 1024 table, several hundred times a day.
+    """
+    lancedb = pytest.importorskip("lancedb")
+    db = lancedb.connect(str(tmp_path / "rebuild"))
+    db.create_table("embeddings_probe", data=_rows(500))
+    store = _store_on(db)
+
+    first = store.create_index("probe")
+    version_after_first = db.open_table("embeddings_probe").version
+
+    second = store.create_index("probe")
+    version_after_second = db.open_table("embeddings_probe").version
+
+    assert first.status != "failed"
+    assert second.status != "failed"
+    assert version_after_second == version_after_first, (
+        "the second call rebuilt the index: table version moved from "
+        f"{version_after_first} to {version_after_second}"
+    )
+
+
+def _fts_index(table):
+    return next(
+        (i for i in table.list_indices() if i.index_type == "FTS"),
+        None,
+    )
+
+
+def test_reindex_leaves_no_unindexed_fts_rows(tmp_path):
+    """After maintenance the FTS index must cover every row.
+
+    ``optimize()`` merges FTS incrementally, and that merge is what panics
+    upstream (lance-format/lance#8310). A full rebuild first leaves nothing for
+    the merge to do, so it never enters that path.
+    """
+    lancedb = pytest.importorskip("lancedb")
+    db = lancedb.connect(str(tmp_path / "fts-reindex"))
+    table = db.create_table("embeddings_probe", data=_rows(500))
+    table.create_fts_index("text", with_position=True, replace=True)
+    table.add(_rows(50))
+    assert _fts_index(table) is not None
+
+    store = _store_on(db)
+    assert store.trigger_reindex("embeddings_probe") is True
+
+    table = db.open_table("embeddings_probe")
+    stats = table.index_stats(_fts_index(table).name)
+    assert stats.num_unindexed_rows == 0
+
+
+def test_reindex_of_a_table_without_fts_builds_no_fts_index(tmp_path):
+    """The guard matters: most tables routed here carry no FTS index.
+
+    ``compact_tables`` sends documents, parses, chunks and ingestion_runs
+    through this path; only the embeddings table has FTS.
+    """
+    lancedb = pytest.importorskip("lancedb")
+    db = lancedb.connect(str(tmp_path / "no-fts"))
+    table = db.create_table("parses", data=_rows(200))
+    assert _fts_index(table) is None
+
+    store = _store_on(db)
+    assert store.trigger_reindex("parses") is True
+
+    assert _fts_index(db.open_table("parses")) is None
+
+
+def _record_calls(table, calls):
+    """Wrap the two index entry points, recording the order they fire in."""
+    real_fts, real_optimize = table.create_fts_index, table.optimize
+
+    def fts(*args, **kwargs):
+        calls.append("create_fts_index")
+        return real_fts(*args, **kwargs)
+
+    def optimize(*args, **kwargs):
+        calls.append("optimize")
+        return real_optimize(*args, **kwargs)
+
+    table.create_fts_index = fts
+    table.optimize = optimize
+
+
+def test_fts_is_rebuilt_before_optimize(tmp_path, monkeypatch):
+    """The rebuild has to precede optimize, or the merge still panics.
+
+    Rebuilding after optimize would leave the panicking merge in the path, and
+    rebuilding is only cheap because it makes that merge a no-op.
+    """
+    lancedb = pytest.importorskip("lancedb")
+    db = lancedb.connect(str(tmp_path / "order"))
+    table = db.create_table("embeddings_probe", data=_rows(400))
+    table.create_fts_index("text", with_position=True, replace=True)
+
+    calls: list[str] = []
+    _record_calls(table, calls)
+    store = _store_on(db)
+    monkeypatch.setattr(store, "_get_connection", lambda: db)
+    monkeypatch.setattr(db, "open_table", lambda name, **kw: table)
+
+    assert store.trigger_reindex("embeddings_probe") is True
+
+    assert calls == ["create_fts_index", "optimize"]
+
+
+def test_optimize_of_a_table_without_fts_skips_the_rebuild(tmp_path, monkeypatch):
+    lancedb = pytest.importorskip("lancedb")
+    db = lancedb.connect(str(tmp_path / "order-no-fts"))
+    table = db.create_table("parses", data=_rows(200))
+
+    calls: list[str] = []
+    _record_calls(table, calls)
+    store = _store_on(db)
+    monkeypatch.setattr(store, "_get_connection", lambda: db)
+    monkeypatch.setattr(db, "open_table", lambda name, **kw: table)
+
+    assert store.trigger_reindex("parses") is True
+
+    assert calls == ["optimize"]

--- a/uv.lock
+++ b/uv.lock
@@ -8027,7 +8027,7 @@ requires-dist = [
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "json-repair", specifier = "==0.35.0" },
     { name = "jsonschema", specifier = ">=4.25.1" },
-    { name = "lancedb", specifier = ">=0.13.0" },
+    { name = "lancedb", specifier = ">=0.18.0" },
     { name = "langchain", specifier = ">=0.3.26" },
     { name = "langchain-community", specifier = ">=0.3.21" },
     { name = "langchain-openai", specifier = ">=0.3.27" },

--- a/uv.lock
+++ b/uv.lock
@@ -8027,7 +8027,7 @@ requires-dist = [
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "json-repair", specifier = "==0.35.0" },
     { name = "jsonschema", specifier = ">=4.25.1" },
-    { name = "lancedb", specifier = ">=0.18.0" },
+    { name = "lancedb", specifier = ">=0.24.2" },
     { name = "langchain", specifier = ">=0.3.26" },
     { name = "langchain-community", specifier = ">=0.3.21" },
     { name = "langchain-openai", specifier = ">=0.3.27" },


### PR DESCRIPTION
Part of #1557 — defects 1 and 2. Proposed changes 3, 4 and 5 in that issue are untouched, so it stays open.

Two independent defects that compound into unbounded disk growth and a permanently stale index.

**Defect 1.** `has_vector_index = any(idx.name == "vector" ...)` can never match — LanceDB names
the index after its column (`vector_idx`), so every call fell through to
`create_index(replace=True)` and rebuilt the whole index. Production saw 303 rebuilds and
33.8 GiB of index growth in 24h. Now matched by column, consistent with the FTS checks already
in this file.

**Defect 2.** `optimize()`'s index step is all-or-nothing across indices, so the upstream panic
in the incremental FTS merge (lance-format/lance#8310, still open) aborts the vector index merge
along with it. Rebuilding FTS in full before `optimize()` leaves nothing unindexed, making that
merge a no-op. Guarded, because `compact_tables` also routes documents, parses, chunks and
ingestion_runs through this path and only embeddings carries an FTS index. The rebuild is also
isolated in its own `try`: a failure there must not skip `optimize`, since compaction and
version pruning run before the index step and are what actually reclaim the disk.

They have to ship together. The vector index currently looks current only because defect 1
rebuilds it from scratch several hundred times a day; fixing defect 1 alone would leave it
permanently stale.

### Verified locally

- On lancedb 0.29.2: `name='vector_idx'`, `columns=['vector']`, and `idx.name == "vector"` is
  False. The assertion never held on any version this project allows.
- The item the issue marked Unverified holds. `_dense_engine`, `_dense_engine_async`,
  `search_sparse` and `search_sparse_async` all call `create_index`; `readonly` defaults to
  False (`schemas.py:655` and `:886`) and `document_search.py` passes `readonly=cfg.readonly` at
  three sites. So searches were rebuilding the index too on any table past 50k rows — the blast
  radius is ingestion *and* search, not just the 303 worker-side rebuilds that were sampled.
- Behavioural regression for defect 1: two consecutive `create_index()` calls on one table must
  leave the table version unchanged. Before the fix it moved from 3 to 4.

### Not verified locally

The FTS panic itself. Twelve rounds of small add/delete cycles plus `optimize()` all succeeded,
with `unindexed_rows` at 0. Per upstream the trigger is a `TokenSet.next_id` persisted by an
*older* FTS writer exceeding the dense token count, which needs cross-version index state to
reproduce; the lance core bundled here also predates the 7.0.0 in production.

So the guard for defect 2 pins the **call order** — rebuild before optimize when FTS is present,
no rebuild when it is absent — not the absence of a panic. The claims that a full rebuild is
cheaper than the merge it replaces (6.6s / 114MB vs 7.6s / 113MB) and that this takes 12/12
panics to 0/12 are the issue's production measurements, not reproduced here.

### Dependency floor

`pyproject.toml` declared `lancedb>=0.13.0`, but two APIs this code depends on arrived later:
`table.list_indices()` in 0.18.0, and `create_fts_index`'s `ngram_min_length` / `prefix_only`
kwargs — which `DEFAULT_FTS_PARAMS` carries — only in 0.24.2. There is no `**kwargs` catch-all to
absorb them earlier.

Raised to `>=0.24.2`, `uv.lock` regenerated; the resolved version stays 0.29.2. The pre-existing
`create_index` call site (`lancedb_stores.py:1510`) splats the same params, so the real floor
predates this PR. What this PR adds is the `except Exception` isolation around the rebuild, which
would have turned that `TypeError` into a single warning and silenced the fix on a
minimum-floor install.

### Tests

New `tests/core/tools/core/RAG_tools/storage/test_vector_index_contract.py`, against a real
LanceDB table. Every other test in that directory mocks `lancedb.connect`, which is exactly how
a never-matching existence check survived six months.

Covered: the column check finds the index; an FTS-only table does not satisfy it (so the fix
cannot become an always-matches one); two `create_index()` calls leave the table version
unchanged; FTS ends with no unindexed rows; the rebuild precedes `optimize` when FTS is present
and is skipped when it is absent; and a failing rebuild still lets `optimize` run. The last one
is mutation-checked — removing the isolation fails it.

Deliberately not asserted: the generated index name. The contract is the indexed column, so a
harmless upstream rename should not block an upgrade. Storage and LanceDB suites are green.

### Still open on #1557 after this PR

- Change 3: move maintenance off the per-document hook onto `beat_schedule`. It would have to
  sweep the whole database with no ingestion context to scope it, which the existing comment on
  `_compact_storage_if_needed` argues against — a design change, not a move.
- Change 4: periodic vector index retrain.
- Change 5: alert on repeated maintenance failure.
- Pinning an upper bound on `lancedb`.

### Follow-ups (not in this PR)

- A failed FTS rebuild only logs a warning, so callers cannot tell "fully current" apart from
  "compacted, FTS silently stale". Wants a counter/metric or a distinguishable return value.
- Both FTS detection and rebuild hard-code the `"text"` column -- the same hard-coded/silent
  shape as the bug this PR fixes.
- The FTS-detection predicate is repeated four times in this file (~1400, ~1501, ~1516, ~1633)
  and is worth a helper, alongside the existing `_fragment_count` / `_stale_version_count`.
  Landmine for whoever does it: `list_indices()` reports the vector index type as `"IvfPq"`
  while creation passes `"IVF_PQ"` -- the string forms do not match.
- `_rebuild_fts_index` takes no policy, so a routine compaction silently rebuilds with today's
  default tokenizer params an index that may have been built with different ones. Pre-existing
  gap, not introduced here.
