### PR TITLE
fix(agent): replay tool exchanges when reconstructing initial messages

### DIFF
--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -141,7 +141,36 @@ class AgentRunner:
                 context_refs = message.get(
                     CONTEXT_REFS_KEY, message.get("context_refs", ())
                 )
-                if role and (content or context_refs):
+                if not role:
+                    continue
+                if not (
+                    content
+                    or context_refs
+                    or message.get("tool_calls")
+                    or role == "tool"
+                ):
+                    continue
+                if (
+                    role == "tool"
+                    and message.get("tool_name") is not None
+                    and "raw_result" in message
+                ):
+                    # Replay through add_tool_result so it gets the same
+                    # sanitization/formatting and metadata (raw_result,
+                    # tool_name) as a live tool observation would.
+                    context.add_tool_result(
+                        tool_name=str(message["tool_name"]),
+                        result=message["raw_result"],
+                        tool_call_id=message.get("tool_call_id"),
+                        context_refs=context_refs,
+                    )
+                elif role == "assistant" and message.get("tool_calls"):
+                    context.add_assistant_message(
+                        content,
+                        tool_calls=message["tool_calls"],
+                        context_refs=context_refs,
+                    )
+                else:
                     context.add_message(
                         role,
                         content,

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -1290,6 +1290,97 @@ def test_compact_with_llm_preserves_waiting_for_user_response() -> None:
     }
 
 
+def test_reconstructed_context_below_threshold_is_not_compacted() -> None:
+    """A faithfully-replayed prior turn (assistant tool_calls + add_tool_result
+    pairs) is small relative to the default threshold, so compaction must stay
+    a no-op -- only compress when the reconstructed history actually grows
+    past the budget.
+    """
+    ctx = ExecutionContext()
+    ctx.add_user_message("Reconstructed turn 1")
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "type": "function", "function": {"name": "read_file"}},
+        ],
+    )
+    ctx.add_tool_result("read_file", {"output": "line one"}, tool_call_id="call-1")
+    ctx.add_user_message("Reconstructed turn 2")
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-2", "type": "function", "function": {"name": "web_search"}},
+        ],
+    )
+    ctx.add_tool_result("web_search", {"output": "search rows"}, tool_call_id="call-2")
+    original_messages = list(ctx.messages)
+
+    result = ctx.compact_if_needed()
+
+    assert result.compacted is False
+    assert result.strategy == "none"
+    assert ctx.messages == original_messages
+
+
+def test_reconstructed_context_above_threshold_triggers_llm_summary() -> None:
+    """Regression guard: reconstructed tool observations must be ingested via
+    ``add_tool_result`` (which stamps ``metadata["tool_name"]``/["raw_result"])
+    rather than pre-formatted into a plain string. If a future "optimization"
+    skipped ``add_tool_result``, the dropped-tool-results-by-name notice below
+    would silently stop counting reconstructed observations.
+    """
+
+    class CompactLLM:
+        model_name = "compact-test"
+
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    ctx.add_user_message("Build the quarterly report")
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "type": "function", "function": {"name": "web_search"}},
+        ],
+    )
+    ctx.add_tool_result("web_search", {"output": "revenue rows"}, tool_call_id="call-1")
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-2", "type": "function", "function": {"name": "read_file"}},
+        ],
+    )
+    ctx.add_tool_result("read_file", {"output": "kpi table"}, tool_call_id="call-2")
+
+    # Pin the ingestion contract itself: add_tool_result must have stamped the
+    # metadata the dropped-tool-result accounting reads from.
+    web_search_message = ctx.messages[2]
+    assert web_search_message.role == "tool"
+    assert web_search_message.metadata["tool_name"] == "web_search"
+    assert web_search_message.metadata["raw_result"] == {"output": "revenue rows"}
+    read_file_message = ctx.messages[4]
+    assert read_file_message.role == "tool"
+    assert read_file_message.metadata["tool_name"] == "read_file"
+    assert read_file_message.metadata["raw_result"] == {"output": "kpi table"}
+
+    llm = CompactLLM()
+    request = ctx.build_llm_compact_request_if_needed()
+    assert request is not None
+
+    result = ctx.compact_with_llm_response(
+        {"content": "Collected KPI inputs."},
+        llm=llm,
+        original_tokens=request["original_tokens"],
+    )
+
+    assert result.compacted
+    assert result.strategy == "llm_summary"
+    assert result.metadata["dropped_tool_results_by_name"] == {
+        "web_search": 1,
+        "read_file": 1,
+    }
+    assert result.metadata["dropped_tool_result_count"] == 2
+
+
 def test_get_messages_for_llm_drops_orphan_tool_messages() -> None:
     ctx = ExecutionContext()
     ctx.add_tool_result("read_file", {"output": "orphaned"}, tool_call_id="call-1")

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -798,6 +798,200 @@ async def test_runner_does_not_add_empty_user_message_for_missing_task(
 
 
 @pytest.mark.asyncio
+async def test_initial_messages_replay_tool_pairs(tmp_path: Path) -> None:
+    agent = Agent(name="writer", patterns=[FakePattern({"success": True})])
+    runner = AgentRunner(
+        agent=agent,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    initial_messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_name": "read_file",
+            "tool_call_id": "call-1",
+            "raw_result": {"output": "file contents"},
+        },
+    ]
+
+    result = await runner.run(
+        task=None,
+        execution_id="exec-replay",
+        initial_messages=initial_messages,
+    )
+
+    assert result["success"] is True
+    messages = result["context"].messages
+    # initial_messages[0] is role "assistant", so AgentRunner.run prepends a
+    # synthetic leading user turn (Anthropic's Messages API rejects a request
+    # whose first message isn't role "user") before replaying the
+    # assistant/tool pair.
+    assert [message.role for message in messages] == ["user", "assistant", "tool"]
+
+    synthetic_message = messages[0]
+    assert synthetic_message.content == "(conversation start)"
+    assert synthetic_message.metadata["_xagent_synthetic"] == "leading_user_turn"
+
+    assistant_message = messages[1]
+    assert assistant_message.content == ""
+    assert assistant_message.tool_calls == initial_messages[0]["tool_calls"]
+
+    tool_message = messages[2]
+    assert tool_message.content == "Tool read_file returned: file contents"
+    assert tool_message.tool_call_id == "call-1"
+    assert tool_message.metadata["raw_result"] == {"output": "file contents"}
+    assert tool_message.metadata["tool_name"] == "read_file"
+    # The synthetic turn is prepended, not interleaved, so tool-call pairing
+    # is undisturbed: every "tool" message is still immediately preceded by
+    # the assistant message declaring its tool_call_id.
+    for index, message in enumerate(messages):
+        if message.role == "tool":
+            assert messages[index - 1].role == "assistant"
+            assert message.tool_call_id in {
+                call["id"] for call in (messages[index - 1].tool_calls or [])
+            }
+
+
+@pytest.mark.asyncio
+async def test_initial_assistant_with_empty_content_and_tool_calls_survives(
+    tmp_path: Path,
+) -> None:
+    agent = Agent(name="writer", patterns=[FakePattern({"success": True})])
+    runner = AgentRunner(
+        agent=agent,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    initial_messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-2",
+                    "type": "function",
+                    "function": {"name": "list_files", "arguments": "{}"},
+                }
+            ],
+        },
+    ]
+
+    result = await runner.run(
+        task=None,
+        execution_id="exec-empty-content-tool-calls",
+        initial_messages=initial_messages,
+    )
+
+    assert result["success"] is True
+    messages = result["context"].messages
+    # The original defect this test guards: an assistant message with
+    # content="" and non-empty tool_calls must not be dropped by the replay
+    # loop's "is there anything to keep" check. The leading synthetic user
+    # turn (added because initial_messages[0] is role "assistant") must not
+    # mask that — the assistant message must still be present right after it.
+    assert [message.role for message in messages] == ["user", "assistant"]
+
+    synthetic_message = messages[0]
+    assert synthetic_message.content == "(conversation start)"
+    assert synthetic_message.metadata["_xagent_synthetic"] == "leading_user_turn"
+
+    assistant_message = messages[1]
+    assert assistant_message.content == ""
+    assert assistant_message.tool_calls == initial_messages[0]["tool_calls"]
+
+
+@pytest.mark.asyncio
+async def test_initial_messages_starting_with_user_no_synthetic_turn(
+    tmp_path: Path,
+) -> None:
+    """A realistically-shaped reconstruction that already starts with a user
+    transcript message, followed by an assistant/tool pair, must NOT trigger
+    the synthetic leading-user-turn correction: it is only needed when the
+    replay would otherwise start with role "assistant".
+    """
+    agent = Agent(name="writer", patterns=[FakePattern({"success": True})])
+    runner = AgentRunner(
+        agent=agent,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    initial_messages = [
+        {"role": "user", "content": "Please read the file"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-3",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_name": "read_file",
+            "tool_call_id": "call-3",
+            "raw_result": {"output": "file contents"},
+        },
+    ]
+
+    result = await runner.run(
+        task=None,
+        execution_id="exec-replay-user-first",
+        initial_messages=initial_messages,
+    )
+
+    assert result["success"] is True
+    messages = result["context"].messages
+    assert [message.role for message in messages] == ["user", "assistant", "tool"]
+    assert messages[0].content == "Please read the file"
+    assert not any(
+        message.metadata.get("_xagent_synthetic") == "leading_user_turn"
+        for message in messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_initial_messages_plain_roles_unchanged(tmp_path: Path) -> None:
+    agent = Agent(name="writer", patterns=[FakePattern({"success": True})])
+    runner = AgentRunner(
+        agent=agent,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+
+    initial_messages = [
+        {"role": "system", "content": "You are helpful."},
+        {"role": "user", "content": "Hello there"},
+        {"role": "user", "content": ""},  # dropped: no content/context_refs
+    ]
+
+    result = await runner.run(
+        task=None,
+        execution_id="exec-plain-initial",
+        initial_messages=initial_messages,
+    )
+
+    assert result["success"] is True
+    messages = result["context"].messages
+    assert [(message.role, message.content) for message in messages] == [
+        ("system", "You are helpful."),
+        ("user", "Hello there"),
+    ]
+
+
+@pytest.mark.asyncio
 async def test_runner_stops_on_llm_call_interrupt(tmp_path: Path) -> None:
     fallback = FakePattern({"success": True, "output": "should not run"})
     agent = Agent(name="writer", patterns=[LLMInterruptedPattern(), fallback])

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -1138,3 +1138,113 @@ async def test_runtime_surfaces_cached_tokens_in_usage_and_trace() -> None:
     await runtime.on_llm_end(context=context, response=result)
     assert events[-1]["data"]["cached_input_tokens"] == 4
     assert events[-1]["data"]["input_tokens"] == 7
+
+
+class RaisingCompactLLM:
+    """Stub whose ``chat`` always fails, driving the llm_summary -> truncate
+    fallback in ``PatternRuntime.compact_context_if_needed``."""
+
+    model_name = "raising-compact-llm"
+
+    async def chat(self, **_: Any) -> Any:
+        raise RuntimeError("compact llm exploded")
+
+
+@pytest.mark.asyncio
+async def test_compact_context_if_needed_falls_back_to_truncate_without_orphans() -> (
+    None
+):
+    """When the LLM-summary compaction path raises, the runtime must fall back
+    to ``truncate`` -- and the fallback must never leave a native ``tool``
+    message without the assistant message that declared its ``tool_calls``
+    immediately before it, since providers reject that shape outright.
+    """
+    runtime = PatternRuntime(execution_id="task-compact-fallback")
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    # 9 messages total (u0, assistant+2 tool results, tail-0..tail-4). A
+    # max_messages of 4 would land the naive tail slice entirely inside the
+    # 5 trailing user messages (tail-1..tail-4) -- no "tool" message would
+    # ever survive, making assert_no_orphan_tool_messages below vacuous: it
+    # would pass identically even if `_tail_window_preserving_tool_pairs`
+    # were replaced by a naive `messages[-keep_count:]`. max_messages=6 puts
+    # the boundary inside the assistant+tool block instead, so the
+    # pair-preservation walk-back must expand the window back to include
+    # both tool results and their declaring assistant message, giving the
+    # assertions below something real to check.
+    ctx.compact_config.max_messages = 6
+    ctx.add_user_message("u0")
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "type": "function", "function": {"name": "read_file"}},
+            {"id": "call-2", "type": "function", "function": {"name": "write_file"}},
+        ],
+    )
+    ctx.add_tool_result("read_file", {"output": "read"}, tool_call_id="call-1")
+    ctx.add_tool_result("write_file", {"output": "written"}, tool_call_id="call-2")
+    for i in range(5):
+        ctx.add_user_message(f"tail-{i}")
+
+    result = await runtime.compact_context_if_needed(
+        context=ctx, llm=RaisingCompactLLM()
+    )
+
+    assert result is not None
+    assert result.compacted is True
+    assert result.strategy == "truncate"
+    assert result.metadata["fallback_strategy"] == "truncate"
+    assert "llm_compact_error" in result.metadata
+
+    # This is the load-bearing check for this test: with a naive
+    # `messages[-keep_count:]` slice (keep_count=6 here), the survivors would
+    # be tail-1..tail-4 plus the two dangling tool results with no preceding
+    # assistant message -- 0 messages would have role "assistant" among the
+    # last 6. The real pair-preserving walk-back must expand the window left
+    # to include the assistant message that declared both tool_calls.
+    final_roles = [message.role for message in ctx.messages]
+    assert final_roles.count("tool") == 2, (
+        "expected both tool results to survive the pair-preserving "
+        "walk-back -- if this is 0, `_tail_window_preserving_tool_pairs` "
+        "has regressed to a naive `messages[-keep_count:]` slice"
+    )
+    assert final_roles[:3] == ["assistant", "tool", "tool"]
+
+    def assert_no_orphan_tool_messages(messages: list[dict[str, Any]]) -> None:
+        for index, message in enumerate(messages):
+            if message.get("role") != "tool":
+                continue
+            assert index > 0, "tool message with no preceding message"
+            # A parallel tool-call batch is one assistant(tool_calls) message
+            # followed by a contiguous run of "tool" messages -- so a tool
+            # message's own predecessor can itself be another "tool" message
+            # from the same batch. Walk back over that run to find the
+            # declaring assistant message.
+            declaring_index = index - 1
+            while (
+                declaring_index >= 0 and messages[declaring_index].get("role") == "tool"
+            ):
+                declaring_index -= 1
+            assert declaring_index >= 0, "tool message with no preceding message"
+            declaring = messages[declaring_index]
+            assert declaring.get("role") == "assistant" and declaring.get(
+                "tool_calls"
+            ), "tool message not immediately preceded by its assistant tool_calls"
+            declared_ids = {
+                str(tool_call.get("id"))
+                for tool_call in declaring["tool_calls"]
+                if isinstance(tool_call, dict) and tool_call.get("id")
+            }
+            assert message.get("tool_call_id") in declared_ids
+
+    assert_no_orphan_tool_messages(ctx.get_messages_for_llm())
+    assert_no_orphan_tool_messages(
+        [
+            {
+                "role": message.role,
+                "tool_calls": message.tool_calls,
+                "tool_call_id": message.tool_call_id,
+            }
+            for message in ctx.messages
+        ]
+    )


### PR DESCRIPTION
Part of #1598. First of four; this one changes no behavior.

`AgentRunner.run` replays `initial_messages` into a fresh `ExecutionContext`. Two things in that loop stand in the way of ever replaying a tool exchange.

It skipped any message whose `content` was empty, which is exactly the shape of an assistant message carrying only `tool_calls`. Dropping it orphaned the tool result behind it, and the orphan was then swept for being orphaned — the whole exchange disappeared, quietly.

It also pushed everything through `add_message`, bypassing `add_tool_result`. That is the method which sanitizes the result, formats it as `Tool <name> returned: ...`, extracts context references, and stamps `metadata["raw_result"]` and `["tool_name"]` — the fields compaction reads to tell the model which observations it had to drop. A replayed result that skipped it would be invisible to that notice.

The loop now branches three ways: a `tool` message carrying `tool_name` and `raw_result` goes through `add_tool_result`, an assistant message carrying `tool_calls` through `add_assistant_message`, everything else through `add_message` exactly as before.

**This is inert on `main` today.** Every existing source of `initial_messages` produces `{"role", "content"}` messages only — `load_task_transcript` ends in `normalize_transcript_messages`, and `set_execution_context_messages` normalizes as well — so nothing currently reaches either new branch. The behavior it enables arrives with the reconstruction service.

Tests cover the replayed pair (formatting and metadata), the empty-content assistant message that used to be dropped, plain roles behaving as before, and the interaction with compaction: that dropped reconstructed observations are counted by name, and that the truncate fallback leaves no orphaned tool message.

The two runner tests also assert the synthetic `(conversation start)` turn that `main` prepends when replayed history opens with an assistant message, and a third pins that a history opening with a real user turn does not get one.
