### PR TITLE
feat(agent): add faithful conversation context reconstruction service

### DIFF
--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -95,6 +95,19 @@ class _DAGStepRuntime:
     def active_react_step_id(self) -> str:
         return self.step_id
 
+    @property
+    def active_turn_id(self) -> str | None:
+        # Unlike active_react_step_id (fixed to this step at construction),
+        # this is resolved from root_context on every access rather than
+        # cached: on_pattern_start never fires for a DAG step's inner ReAct
+        # run (this adapter's own on_pattern_start below is a no-op), so
+        # there is no per-step hook to compute it once. root_context is the
+        # DAG's real conversation context (unlike the synthetic per-step
+        # child_context ReActPattern actually runs against), so this reaches
+        # the same turn_id PatternRuntime._dag_turn_id already surfaces for
+        # the on_dag_step_start/end hooks.
+        return self.parent._dag_turn_id(self.root_context)
+
     async def should_interrupt(self) -> bool:
         return await self.parent.should_interrupt()
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -3055,6 +3055,7 @@ class ReActPattern(AgentPattern):
             tool_call["id"] = f"tool_call_{len(self.tool_ledger)}"
         tool_call = self._with_tool_call_content(tool_call)
         tool_call = self._with_runtime_step(tool_call, runtime)
+        tool_call = self._with_runtime_turn_id(tool_call, runtime)
         tool_call = self._with_trace_safe_tool_args(tool_call, tools)
         self._record_tool_call(tool_call, status="running")
         recorded_terminal = False
@@ -3180,6 +3181,28 @@ class ReActPattern(AgentPattern):
             "step_id": str(step_id),
             "dag_step_id": str(step_id),
         }
+
+    def _with_runtime_turn_id(
+        self, tool_call: dict[str, Any], runtime: PatternRuntime
+    ) -> dict[str, Any]:
+        """Stamp the current turn's id onto ``tool_call`` for on_tool_* to read.
+
+        ``runtime.active_turn_id`` carries the durable turn_id: on the real
+        ``PatternRuntime`` it's set in ``on_pattern_start`` from the
+        triggering user message's metadata; on ``_DAGStepRuntime`` (dag.py)
+        it's a property resolving the same value from the DAG's root
+        context. Either way this lets ``PatternRuntime.on_tool_start`` /
+        ``on_tool_end`` / ``on_tool_error`` attribute the resulting trace
+        event to its turn by join, not by timestamp adjacency.
+        """
+        if tool_call.get("turn_id"):
+            return tool_call
+
+        turn_id = getattr(runtime, "active_turn_id", None)
+        if not turn_id:
+            return tool_call
+
+        return {**tool_call, "turn_id": str(turn_id)}
 
     def _with_tool_call_content(self, tool_call: dict[str, Any]) -> dict[str, Any]:
         tool_call_id = str(tool_call.get("id") or "")

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -918,18 +918,22 @@ class PatternRuntime:
         """Close an in-flight tool trace without reporting a pause as an error."""
 
         cancellation_reason = reason or "Tool execution interrupted"
+        data: dict[str, Any] = {
+            "tool_name": tool_call.get("name"),
+            "tool_params": tool_call.get("args", {}),
+            "tool_call_id": tool_call.get("id"),
+            "success": False,
+            "interrupted": True,
+            "interrupt_reason": cancellation_reason,
+        }
+        turn_id = self._turn_id_from_payload(tool_call)
+        if turn_id:
+            data["turn_id"] = turn_id
         await self._emit_trace_event(
             TraceEventType(TraceScope.ACTION, TraceAction.END, TraceCategory.TOOL),
             task_id=self._task_id_from_payload(tool_call),
             step_id=self._step_id_from_payload(tool_call),
-            data={
-                "tool_name": tool_call.get("name"),
-                "tool_params": tool_call.get("args", {}),
-                "tool_call_id": tool_call.get("id"),
-                "success": False,
-                "interrupted": True,
-                "interrupt_reason": cancellation_reason,
-            },
+            data=data,
         )
         await self._finish_tool_span(
             tool_call=tool_call,

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -132,6 +132,13 @@ class PatternRuntime:
     finished_spans: list[dict[str, Any]] = field(default_factory=list)
     trace_runs: list[dict[str, Any]] = field(default_factory=list)
     active_react_step_id: str | None = None
+    # The durable per-turn id (sourced from the triggering user Message's
+    # metadata["turn_id"], see _dag_turn_id) for whichever ReAct turn is
+    # currently running. Set in on_pattern_start alongside
+    # active_react_step_id, and read back by on_tool_start/on_tool_end/
+    # on_tool_error so tool trace events can be joined to their turn without
+    # relying on step_id or timestamp-adjacency heuristics.
+    active_turn_id: str | None = None
     last_final_answer_stream_message_id: str | None = None
     _active_llm_tasks: set[asyncio.Future[Any]] = field(
         default_factory=set,
@@ -665,6 +672,7 @@ class PatternRuntime:
     async def on_pattern_start(self, *, context: Any, pattern: Any) -> None:
         if pattern.__class__.__name__ == "ReActPattern":
             self.active_react_step_id = f"react_{uuid4().hex[:8]}"
+            self.active_turn_id = self._dag_turn_id(context)
         await self._emit_pattern_trace(context=context, pattern=pattern, action="start")
         if self.tracer is None:
             return
@@ -701,6 +709,7 @@ class PatternRuntime:
         )
         if pattern.__class__.__name__ == "ReActPattern":
             self.active_react_step_id = None
+            self.active_turn_id = None
         if self.tracer is None:
             return
         finish_trace = getattr(self.tracer, "finish_trace", None)
@@ -738,6 +747,7 @@ class PatternRuntime:
         )
         if pattern.__class__.__name__ == "ReActPattern":
             self.active_react_step_id = None
+            self.active_turn_id = None
         if self.tracer is None:
             return
         finish_trace = getattr(self.tracer, "finish_trace", None)
@@ -779,6 +789,9 @@ class PatternRuntime:
         assistant_content = tool_call.get("assistant_content")
         if isinstance(assistant_content, str) and assistant_content.strip():
             data["assistant_content"] = assistant_content.strip()
+        turn_id = self._turn_id_from_payload(tool_call)
+        if turn_id:
+            data["turn_id"] = turn_id
 
         await self._emit_trace_event(
             TraceEventType(TraceScope.ACTION, TraceAction.START, TraceCategory.TOOL),
@@ -799,7 +812,19 @@ class PatternRuntime:
             await self._maybe_await(start_span(**payload))
 
     async def on_tool_end(self, *, tool_call: dict[str, Any], result: Any) -> None:
+        turn_id = self._turn_id_from_payload(tool_call)
         if tool_result_waits_for_user(result):
+            data = {
+                "tool_name": tool_call.get("name"),
+                "tool_params": tool_call.get("args", {}),
+                "tool_call_id": tool_call.get("id"),
+                "result": result,
+                "success": False,
+                "status": WAITING_FOR_USER_STATUS,
+                "control_state": WAITING_FOR_USER_STATUS,
+            }
+            if turn_id:
+                data["turn_id"] = turn_id
             await self._emit_trace_event(
                 TraceEventType(
                     TraceScope.ACTION,
@@ -808,15 +833,7 @@ class PatternRuntime:
                 ),
                 task_id=self._task_id_from_payload(tool_call),
                 step_id=self._step_id_from_payload(tool_call),
-                data={
-                    "tool_name": tool_call.get("name"),
-                    "tool_params": tool_call.get("args", {}),
-                    "tool_call_id": tool_call.get("id"),
-                    "result": result,
-                    "success": False,
-                    "status": WAITING_FOR_USER_STATUS,
-                    "control_state": WAITING_FOR_USER_STATUS,
-                },
+                data=data,
             )
             await self._finish_tool_span(
                 tool_call=tool_call,
@@ -834,17 +851,20 @@ class PatternRuntime:
             )
             return
 
+        data = {
+            "tool_name": tool_call.get("name"),
+            "tool_params": tool_call.get("args", {}),
+            "tool_call_id": tool_call.get("id"),
+            "result": result,
+            "success": True,
+        }
+        if turn_id:
+            data["turn_id"] = turn_id
         await self._emit_trace_event(
             TraceEventType(TraceScope.ACTION, TraceAction.END, TraceCategory.TOOL),
             task_id=self._task_id_from_payload(tool_call),
             step_id=self._step_id_from_payload(tool_call),
-            data={
-                "tool_name": tool_call.get("name"),
-                "tool_params": tool_call.get("args", {}),
-                "tool_call_id": tool_call.get("id"),
-                "result": result,
-                "success": True,
-            },
+            data=data,
         )
         await self._finish_tool_span(
             tool_call=tool_call,
@@ -873,6 +893,9 @@ class PatternRuntime:
         )
         if failure_code is not None:
             data["failure_code"] = failure_code
+        turn_id = self._turn_id_from_payload(tool_call)
+        if turn_id:
+            data["turn_id"] = turn_id
 
         await self._emit_trace_event(
             TraceEventType(TraceScope.ACTION, TraceAction.ERROR, TraceCategory.TOOL),
@@ -1426,6 +1449,16 @@ class PatternRuntime:
             or self.execution_id
             or "root"
         )
+
+    def _turn_id_from_payload(self, payload: dict[str, Any]) -> str | None:
+        # Mirrors _step_id_from_payload's shape: a tool_call dict is stamped
+        # with "turn_id" before reaching on_tool_start/on_tool_end/
+        # on_tool_error (_with_runtime_step's sibling in react.py, and
+        # _DAGStepRuntime.active_turn_id for DAG steps), so the payload is
+        # the primary source; self.active_turn_id is the fallback for a
+        # payload that predates that stamping.
+        turn_id = payload.get("turn_id") or self.active_turn_id
+        return str(turn_id) if turn_id else None
 
     def _short_response(self, response: Any) -> Any:
         if isinstance(response, str):

--- a/src/xagent/web/services/task_conversation_context_service.py
+++ b/src/xagent/web/services/task_conversation_context_service.py
@@ -58,7 +58,6 @@ class _TranscriptRow:
     row_id: int
     role: str
     content: str
-    created_at: datetime
     # ``TaskChatMessage.turn_id``, empty string when unset (rows written
     # before this column existed, or a role that never gets one). Used to
     # place this turn's reconstructed tool exchanges immediately after this
@@ -165,21 +164,24 @@ def _load_transcript_rows(
     *,
     before_message_id: int | None,
 ) -> list[_TranscriptRow]:
-    """Load ``task_chat_messages`` rows, preserving ``created_at`` for merging.
+    """Load ``task_chat_messages`` rows for the turn_id-joined reconstruction.
 
-    ``chat_history_service``'s row-loading helpers normalize away
-    ``created_at``, which this module needs for the chronological merge
-    against trace events, so the rows are queried directly here instead.
+    ``chat_history_service``'s row-loading helpers normalize the row shape
+    for a different caller, so the rows are queried directly here instead.
     ``attachments`` is selected alongside the existing narrow column set
     (rather than loading the whole ORM row) so the historical-image budget
     below can reach uploaded-image metadata without widening this query's
-    result shape beyond what image support actually needs.
+    result shape beyond what image support actually needs. ``created_at`` is
+    deliberately NOT selected: placement of a turn's tool exchanges is a
+    ``turn_id`` join (see ``_merge_chronologically``), not a timestamp
+    comparison, and transcript ordering itself comes from ``TaskChatMessage
+    .id`` (see ``order_by`` below), so nothing in this module ever needs a
+    transcript row's clock time.
     """
     query = db.query(
         TaskChatMessage.id,
         TaskChatMessage.role,
         TaskChatMessage.content,
-        TaskChatMessage.created_at,
         TaskChatMessage.attachments,
         TaskChatMessage.turn_id,
     ).filter(TaskChatMessage.task_id == task_id)
@@ -188,7 +190,7 @@ def _load_transcript_rows(
     query = query.order_by(asc(TaskChatMessage.id))
 
     rows: list[_TranscriptRow] = []
-    for row_id, role, content, created_at, attachments, turn_id in query.all():
+    for row_id, role, content, attachments, turn_id in query.all():
         normalized_role = str(role or "").strip().lower()
         if normalized_role not in _TRANSCRIPT_ROLES:
             continue
@@ -198,7 +200,6 @@ def _load_transcript_rows(
                 row_id=int(row_id),
                 role=normalized_role,
                 content=normalized_content,
-                created_at=_as_aware_utc(created_at),
                 turn_id=str(turn_id or ""),
                 attachments=attachments,
             )
@@ -620,11 +621,17 @@ def _ids_match(tool_call_id: Any, tool_calls: Any) -> bool:
 def _as_aware_utc(value: datetime) -> datetime:
     """Normalize a possibly-naive datetime to aware UTC for safe comparison.
 
-    ``TaskChatMessage.created_at`` and ``TraceEvent.timestamp`` are both
-    declared ``DateTime(timezone=True)``, but SQLite (used by tests) returns
-    naive datetimes while Postgres returns aware ones. Comparing a naive and
-    an aware datetime raises ``TypeError``, so every value is normalized here
-    before it is ever used as a sort key.
+    Applied to every ``TraceEvent.timestamp`` value in ``_load_tool_exchanges``
+    before it feeds a ``sort_key`` (used both to order an exchange's start/end
+    pairing and to order same-turn exchanges relative to each other, and by
+    ``_dedupe_parallel_batch_prose``). ``TraceEvent.timestamp`` is declared
+    ``DateTime(timezone=True)``, but SQLite (used by tests) returns naive
+    datetimes regardless of what was stored, while Postgres returns aware
+    ones; comparing a naive and an aware datetime raises ``TypeError``.
+    Placement of a turn's exchanges relative to the transcript is a
+    ``turn_id`` join now (see ``_merge_chronologically``), not a timestamp
+    comparison, so this function is no longer applied to ``TaskChatMessage
+    .created_at`` -- that column isn't even loaded by this module any more.
     """
     if value.tzinfo is None:
         return value.replace(tzinfo=timezone.utc)

--- a/src/xagent/web/services/task_conversation_context_service.py
+++ b/src/xagent/web/services/task_conversation_context_service.py
@@ -119,6 +119,42 @@ class _MergeEntry:
     transcript: Optional[_TranscriptRow] = None
 
 
+@dataclass
+class _ReconstructionStats:
+    """Counts-only bookkeeping for the single summary log line.
+
+    No message content, tool results, or prose is ever stored here -- every
+    field is a count or, where noted, a size. Populated as a side effect
+    while the read pipeline runs, then emitted once by
+    ``load_task_conversation_context_sync``.
+    """
+
+    # Transcript rows retained after role/content filtering (R1) -- the rows
+    # that actually feed rendering, not the raw row count from the query.
+    transcript_rows: int = 0
+    # Tool exchanges that made it into the rendered output.
+    exchanges_placed: int = 0
+    # Exchanges with no usable turn_id (legacy rows, dropped in
+    # ``_group_exchanges_by_turn``).
+    exchanges_without_turn_id: int = 0
+    # Exchanges whose turn_id never matched a surviving user transcript row
+    # (``_merge_chronologically``): either that row's id fell outside
+    # ``before_message_id``, or it was an image-only row evicted by
+    # ``_attach_historical_image_context_refs``'s ref budget (see the
+    # module's F1 fix note). Both causes look identical from here -- a
+    # turn_id with no row to anchor on -- so they share one bucket.
+    exchanges_with_unmatched_turn: int = 0
+    # "tool_execution_start" events that never found a matching end/failure
+    # event and so never became a rendered exchange at all (see
+    # ``_load_tool_exchanges``). Behavior unchanged: still silently
+    # disappears, just now counted.
+    dangling_tool_starts: int = 0
+    # "tool_execution_end"/"tool_execution_failed" events with no matching
+    # start (renders with empty prose and empty tool_params). Behavior
+    # unchanged: still renders degraded, just now counted.
+    tool_ends_without_start: int = 0
+
+
 def load_task_conversation_context_sync(
     db: Session,
     task_id: int,
@@ -140,15 +176,32 @@ def load_task_conversation_context_sync(
             ``id < before_message_id`` are included (used when reconstructing
             context as of a specific point in the conversation).
     """
+    stats = _ReconstructionStats()
+
     transcript_rows = _load_transcript_rows(
         db, task_id, before_message_id=before_message_id
     )
-    exchanges = _load_tool_exchanges(db, task_id)
+    exchanges = _load_tool_exchanges(db, task_id, stats=stats)
 
-    merged = _merge_chronologically(transcript_rows, exchanges)
+    merged = _merge_chronologically(transcript_rows, exchanges, stats=stats)
 
     messages = _render_messages(merged)
     messages = _final_pairing_sweep(messages)
+
+    stats.transcript_rows = len(transcript_rows)
+    logger.info(
+        "task_conversation_context_reconstructed task_id=%s transcript_rows=%d "
+        "exchanges_placed=%d exchanges_without_turn_id=%d "
+        "exchanges_with_unmatched_turn=%d dangling_tool_starts=%d "
+        "tool_ends_without_start=%d",
+        task_id,
+        stats.transcript_rows,
+        stats.exchanges_placed,
+        stats.exchanges_without_turn_id,
+        stats.exchanges_with_unmatched_turn,
+        stats.dangling_tool_starts,
+        stats.tool_ends_without_start,
+    )
 
     return messages
 
@@ -243,7 +296,10 @@ def _attach_historical_image_context_refs(rows: list[_TranscriptRow]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _load_tool_exchanges(db: Session, task_id: int) -> list[_ToolExchange]:
+def _load_tool_exchanges(
+    db: Session, task_id: int, *, stats: _ReconstructionStats | None = None
+) -> list[_ToolExchange]:
+    stats = stats if stats is not None else _ReconstructionStats()
     trace_rows = (
         db.query(TraceEvent)
         .filter(
@@ -277,7 +333,30 @@ def _load_tool_exchanges(db: Session, task_id: int) -> list[_ToolExchange]:
     # column was populated simply carry ``step_id=None``, which normalizes
     # to the same empty-string discriminator for both events, reproducing
     # the old bare-``tool_call_id`` keying exactly.
-    pending: dict[tuple[str, str], _PendingToolStart] = {}
+    #
+    # ``turn_id`` is also folded into this key (when the event carries one;
+    # legacy rows without it fall back to the plain
+    # ``(step_discriminator, call_id)`` pair, unchanged from before). This
+    # is defensive hardening, not a fix for a reachable bug: exploiting a
+    # collision on the *current* two-part key would need two DIFFERENT
+    # turns' tool calls to interleave in the trace stream with the same
+    # ``step_id``/``tool_call_id`` pair, and today that can't happen --
+    # a task's turns are serialized by a per-task command gate, a running
+    # task refuses a new in-flight command before any DB write, the DB
+    # claim is atomic (``RUNNING`` is excluded from ``_APPENDABLE_STATUSES``,
+    # so a second writer can't append mid-turn), the pause -> new-message
+    # path explicitly drains the in-flight turn before starting the next,
+    # a hard cancel emits no end event at all (nothing to interleave), and
+    # trace writes are per-event synchronous commits with no batching that
+    # could reorder them across turns. ReAct's own ``step_id`` values
+    # (``react_{uuid8}``, minted once per pattern start) never repeat
+    # either, so only a DAG replan -- which restarts step numbering at
+    # ``step_1`` -- can even collide on the current key, and that
+    # collision is exactly what ``turn_id`` (unique per user message,
+    # shared by every step within one turn) discriminates away. Adding it
+    # here is insurance against a future change to any of those
+    # invariants, not evidence one is currently broken.
+    pending: dict[tuple[str, ...], _PendingToolStart] = {}
     exchanges: list[_ToolExchange] = []
 
     for trace_row in trace_rows:
@@ -291,28 +370,41 @@ def _load_tool_exchanges(db: Session, task_id: int) -> list[_ToolExchange]:
         if trace_row.event_type == "tool_execution_start":
             call_id = str(data.get("tool_call_id") or "") or f"recon-{row_id}"
             assistant_content = str(data.get("assistant_content") or "").strip()
-            pending[(step_discriminator, call_id)] = _PendingToolStart(
+            start_turn_id = str(data.get("turn_id") or "")
+            start_key: tuple[str, ...] = (
+                (step_discriminator, call_id, start_turn_id)
+                if start_turn_id
+                else (step_discriminator, call_id)
+            )
+            pending[start_key] = _PendingToolStart(
                 assistant_content=assistant_content,
                 tool_name=str(data.get("tool_name") or ""),
                 tool_params=data.get("tool_params"),
                 sort_key=(row_timestamp, row_id),
-                turn_id=str(data.get("turn_id") or ""),
+                turn_id=start_turn_id,
             )
             continue
 
         # tool_execution_end / tool_execution_failed: pop the matching start so
         # each start is consumed by exactly one end.
         raw_call_id = str(data.get("tool_call_id") or "")
+        end_turn_id = str(data.get("turn_id") or "")
         start = None
         call_id = raw_call_id
         if raw_call_id:
-            start = pending.pop((step_discriminator, raw_call_id), None)
+            end_key: tuple[str, ...] = (
+                (step_discriminator, raw_call_id, end_turn_id)
+                if end_turn_id
+                else (step_discriminator, raw_call_id)
+            )
+            start = pending.pop(end_key, None)
         if start is None:
             # No id, or id present but no matching start recorded (e.g. the
             # matching start fell outside this query, or lost its id, or its
             # step id doesn't match this end's). Fall back to a synthesized
             # key so pairing always has an identity.
             call_id = raw_call_id or f"recon-{row_id}"
+            stats.tool_ends_without_start += 1
 
         tool_name = str(data.get("tool_name") or "").strip()
         if not tool_name and start is not None:
@@ -371,15 +463,25 @@ def _load_tool_exchanges(db: Session, task_id: int) -> list[_ToolExchange]:
         )
 
     # Sort by the *start* time (sort_key), matching the order exchanges will
-    # ultimately appear in once merged with the transcript (R4).
+    # ultimately appear in once merged with the transcript (R4). Dedup of
+    # parallel-batch prose happens later, per turn group (see
+    # ``_group_exchanges_by_turn``) -- not here over this flat, task-wide
+    # list. Deduping here would compare exchanges across turn boundaries
+    # (blanking a later, unrelated turn's coincidentally identical prose)
+    # and would let an exchange that never survives grouping (no usable
+    # turn_id) still act as the "previous" entry and blank a legitimately
+    # rendered exchange right after it.
     exchanges.sort(key=lambda exchange: exchange.sort_key)
-    _dedupe_parallel_batch_prose(exchanges)
+    # Any start left in ``pending`` here never found its end/failure event
+    # and so never became an exchange at all; it silently disappears along
+    # with its prose (behavior unchanged), but is now counted.
+    stats.dangling_tool_starts += len(pending)
     return exchanges
 
 
 def _dedupe_parallel_batch_prose(exchanges: list[_ToolExchange]) -> None:
     """Blank assistant prose that exactly repeats the immediately preceding
-    exchange, in final chronological (sort-key) order.
+    exchange, within a single turn's group, in that group's internal order.
 
     Parallel tool-call batches share one ``assistant_content`` value (the
     runtime's ``active_react_step_id`` can't delimit iterations, so every
@@ -387,11 +489,19 @@ def _dedupe_parallel_batch_prose(exchanges: list[_ToolExchange]) -> None:
     blanks all but the first occurrence in a run of adjacent duplicates so
     the model doesn't see the same paragraph N times.
 
-    Deliberately positional rather than "seen anywhere before": comparing
-    against everything seen earlier in the stream would also blank prose
-    from a genuinely different, later turn that happens to be byte-identical
-    (e.g. a retried step re-emitting the same message) -- that is real
-    content, not a duplicate, and must not be dropped.
+    Called once per turn group (see ``_group_exchanges_by_turn``), never
+    over the flat, task-wide exchange list: adjacency in that list is not a
+    reliable signal here for two reasons. First, two *different* turns
+    whose only exchange happens to share byte-identical prose are adjacent
+    in the flat list whenever nothing else falls between them, and blanking
+    the second would drop real content from a later turn, not a duplicate.
+    Second, dedup running before ``_group_exchanges_by_turn`` drops
+    exchanges with no usable ``turn_id`` would let a dropped exchange --
+    one that never reaches the rendered output at all -- still serve as
+    "previous" and blank a legitimately rendered exchange that follows it.
+    Scoping this to one turn's already-grouped list closes both holes: a
+    turn boundary can never be crossed, and every candidate is guaranteed
+    to actually survive into the output.
     """
     previous: str | None = None
     for exchange in exchanges:
@@ -443,6 +553,8 @@ def _resolve_tool_result(event_type: str, data: dict[str, Any]) -> Any:
 
 def _group_exchanges_by_turn(
     exchanges: list[_ToolExchange],
+    *,
+    stats: _ReconstructionStats | None = None,
 ) -> dict[str, list[_ToolExchange]]:
     """Group tool exchanges by the durable turn_id that produced them.
 
@@ -460,19 +572,33 @@ def _group_exchanges_by_turn(
     Exchanges with no turn_id (``""``, from rows written before this
     column/field existed) are dropped entirely rather than grouped under a
     shared key or placed as singletons: see ``_merge_chronologically`` for
-    why omission, not inference, is the deliberate choice here.
+    why omission, not inference, is the deliberate choice here. Because that
+    drop happens here, before dedup, a dropped exchange can never stand in
+    as another exchange's "previous" for ``_dedupe_parallel_batch_prose``
+    below.
+
+    Parallel-batch prose dedup is applied per group, in the exchanges'
+    already-established relative order (see ``_load_tool_exchanges``'s
+    sort), immediately after each group is assembled -- never over the
+    flat cross-turn list. See ``_dedupe_parallel_batch_prose`` for why.
     """
+    stats = stats if stats is not None else _ReconstructionStats()
     groups: dict[str, list[_ToolExchange]] = {}
     for exchange in exchanges:
         if not exchange.turn_id:
+            stats.exchanges_without_turn_id += 1
             continue
         groups.setdefault(exchange.turn_id, []).append(exchange)
+    for group in groups.values():
+        _dedupe_parallel_batch_prose(group)
     return groups
 
 
 def _merge_chronologically(
     transcript_rows: list[_TranscriptRow],
     exchanges: list[_ToolExchange],
+    *,
+    stats: _ReconstructionStats | None = None,
 ) -> list[_MergeEntry]:
     """Interleave transcript rows with tool exchanges by turn_id, not timestamp.
 
@@ -490,21 +616,38 @@ def _merge_chronologically(
     pass regardless of timestamps. Joining on turn_id makes both cases
     correct by construction instead of narrowing the heuristic further.
 
-    Exchanges whose turn_id has no matching row in ``transcript_rows`` --
-    either it predates turn_id support (``""``), or its user row fell
-    outside ``before_message_id`` -- are silently omitted rather than
-    placed by adjacency or clock guesswork. Losing that detail is
-    acceptable (the conversation reconstructs with transcript text only,
-    exactly today's non-reconstructed behavior); fabricating a placement
-    is not, because a misplaced exchange can make the model believe a
-    later turn's tool results informed an earlier answer, or that a failed
-    turn never happened.
+    Exchanges whose turn_id has no matching row in ``transcript_rows``
+    (already-empty turn_ids are dropped earlier, by
+    ``_group_exchanges_by_turn``) are silently omitted rather than placed
+    by adjacency or clock guesswork. This happens when the turn's user row
+    fell outside ``before_message_id``, or -- F1 -- when it was an
+    image-only row (``content == ""``) whose context refs all fell outside
+    ``_attach_historical_image_context_refs``'s task-wide budget and so
+    were dropped by the retention filter in ``_load_transcript_rows``.
+    That row drop itself is correct: it deliberately matches upstream
+    (``chat_history_service.load_task_transcript`` /
+    ``normalize_transcript_messages`` apply the identical ``content or
+    context_refs`` predicate). What would NOT be correct is fabricating a
+    placement for the orphaned exchanges once their anchor row is gone --
+    there is no other row that legitimately "produced" them. So the
+    decision here is a deliberate drop, the same as the
+    ``before_message_id`` case: losing that detail is acceptable (the
+    conversation reconstructs with transcript text only, exactly today's
+    non-reconstructed behavior); fabricating a placement is not, because a
+    misplaced exchange can make the model believe a later turn's tool
+    results informed an earlier answer, or that a failed turn never
+    happened. The one change this module makes for that case is
+    observability: every exchange dropped this way is counted in
+    ``stats.exchanges_with_unmatched_turn`` (see ``load_task_conversation_
+    context_sync``'s summary log line) so the drop is no longer silent,
+    even though it is still real.
 
     Within a turn's group, members keep the relative order already
     established in ``_load_tool_exchanges`` (timestamp/id sort) -- safe
     because it is one turn's own clock, not a cross-turn comparison.
     """
-    exchanges_by_turn = _group_exchanges_by_turn(exchanges)
+    stats = stats if stats is not None else _ReconstructionStats()
+    exchanges_by_turn = _group_exchanges_by_turn(exchanges, stats=stats)
 
     entries: list[_MergeEntry] = []
     for row in transcript_rows:
@@ -516,7 +659,14 @@ def _merge_chronologically(
         # place the same group twice.
         group = exchanges_by_turn.pop(row.turn_id, None)
         if group:
+            stats.exchanges_placed += len(group)
             entries.append(_MergeEntry(kind="group", group=group))
+
+    # Whatever is left here never found a surviving user row to anchor on
+    # -- see the F1 discussion above. Deliberately dropped, now counted.
+    stats.exchanges_with_unmatched_turn += sum(
+        len(group) for group in exchanges_by_turn.values()
+    )
 
     return entries
 

--- a/src/xagent/web/services/task_conversation_context_service.py
+++ b/src/xagent/web/services/task_conversation_context_service.py
@@ -17,6 +17,21 @@ deliberately not wired into any caller yet. Bounds (a per-result size cap, a
 total exchange-count cap, and a total character budget) and the observability
 around which of them fired ship in a follow-up change, alongside the wiring
 that puts this service on the hot path.
+
+One known deviation from the live shape, deliberately left for that same
+follow-up: a single LLM response that returns several ``tool_calls`` becomes
+one assistant message declaring all of them followed by a contiguous run of
+tool results in a live run, but is reconstructed here as one
+assistant/``tool`` pair per call. B's assistant message then sits after A's
+result, which reads as a decision taken with A's result in hand when in fact
+both calls were chosen with no results available. This is not gated by
+``tool_parallel_enabled`` -- serial execution of a multi-call response has
+the same shape. The persisted rows cannot currently distinguish the two
+cases: tool trace events carry ``tool_call_id`` and ``turn_id`` but nothing
+identifying which assistant response a call belongs to (``step_id`` is per
+pattern run, ``turn_id`` per user message, ``parent_event_id`` is always
+NULL for tool events), so fixing it means plumbing a per-response
+discriminator through the runtime hooks first.
 """
 
 from __future__ import annotations

--- a/src/xagent/web/services/task_conversation_context_service.py
+++ b/src/xagent/web/services/task_conversation_context_service.py
@@ -96,6 +96,11 @@ class _ToolExchange:
     result: Any
     assistant_content: str
     sort_key: tuple[datetime, int]
+    # Raw ``TraceEvent.step_id`` discriminator (see ``_load_tool_exchanges``),
+    # empty string when the column was unset. Used only to group exchanges
+    # produced by the same turn for the R4 merge below -- never for pairing,
+    # which already has its own step-scoped keying.
+    step_id: str = ""
 
 
 @dataclass
@@ -103,8 +108,8 @@ class _MergeEntry:
     """One item queued for the chronological merge (R4)."""
 
     sort_key: tuple[datetime, int, int]
-    kind: str  # "exchange" | "transcript"
-    exchange: Optional[_ToolExchange] = None
+    kind: str  # "group" | "transcript"
+    group: Optional[list[_ToolExchange]] = None
     transcript: Optional[_TranscriptRow] = None
 
 
@@ -177,9 +182,9 @@ def _load_transcript_rows(
     rows: list[_TranscriptRow] = []
     for row_id, role, content, created_at, attachments in query.all():
         normalized_role = str(role or "").strip().lower()
-        normalized_content = str(content or "").strip()
-        if normalized_role not in _TRANSCRIPT_ROLES or not normalized_content:
+        if normalized_role not in _TRANSCRIPT_ROLES:
             continue
+        normalized_content = str(content or "").strip()
         rows.append(
             _TranscriptRow(
                 row_id=int(row_id),
@@ -189,8 +194,16 @@ def _load_transcript_rows(
                 attachments=attachments,
             )
         )
+    # Attach image context refs *before* dropping blank-content rows:
+    # ``persist_user_message_no_commit`` (chat_history_service.py) documents
+    # that "a row with empty content but non-empty attachments is still
+    # persisted" -- an image-only user turn. Filtering on content alone
+    # before this call would discard that row, and its attachment, together
+    # -- the ref would never get the chance to be built. The retention test
+    # below (content OR context refs) mirrors
+    # ``normalize_transcript_messages`` (core/agent/transcript.py).
     _attach_historical_image_context_refs(rows)
-    return rows
+    return [row for row in rows if row.content or row.context_refs]
 
 
 def _attach_historical_image_context_refs(rows: list[_TranscriptRow]) -> None:
@@ -333,6 +346,7 @@ def _load_tool_exchanges(db: Session, task_id: int) -> list[_ToolExchange]:
                 result=result,
                 assistant_content=assistant_content,
                 sort_key=sort_key,
+                step_id=step_discriminator,
             )
         )
 
@@ -407,6 +421,113 @@ def _resolve_tool_result(event_type: str, data: dict[str, Any]) -> Any:
 # ---------------------------------------------------------------------------
 
 
+def _group_exchanges_by_turn(
+    exchanges: list[_ToolExchange],
+) -> list[list[_ToolExchange]]:
+    """Group tool exchanges by the turn that produced them.
+
+    ``TraceEvent.step_id`` is the grouping key. For ReAct tasks it carries
+    ``PatternRuntime.active_react_step_id`` (runtime.py), which is minted
+    fresh (``f"react_{uuid4().hex[:8]}"``) in ``on_pattern_start`` and cleared
+    in ``on_pattern_end``/``on_pattern_error`` -- so every tool event produced
+    while handling one user turn shares one step id, and no two turns ever
+    share one. For DAG-produced events, ``_with_step`` (pattern/dag/dag.py)
+    stamps each concurrently-scheduled DAG step with its own ``step_id``, so
+    a single turn that fans out over several DAG steps yields *several*
+    groups rather than one -- that's fine here: each such group still carries
+    its own real timestamps and gets positioned (and guarded, see
+    ``_relocate_groups_before_their_user_message`` below) independently, so
+    the atomicity and ordering invariants below hold per group regardless of
+    how many groups one turn happens to produce.
+
+    Rows written before ``TraceEvent.step_id`` existed (or otherwise missing
+    it) carry ``step_id=None``, which ``_load_tool_exchanges`` normalizes to
+    ``""``. Grouping *all* such exchanges under one empty-string key would
+    silently merge unrelated turns back together -- exactly the bug this
+    function exists to avoid. So each exchange with no step id instead gets
+    its own singleton group, keyed by its position in the (already
+    time-sorted) ``exchanges`` list: this reproduces the pre-grouping,
+    per-exchange behavior exactly for that degraded case, rather than
+    inventing a new failure mode for it.
+    """
+    groups: dict[str, list[_ToolExchange]] = {}
+    order: list[str] = []
+    for index, exchange in enumerate(exchanges):
+        key = exchange.step_id or f"__no_step_id__{index}"
+        if key not in groups:
+            groups[key] = []
+            order.append(key)
+        groups[key].append(exchange)
+    return [groups[key] for key in order]
+
+
+def _relocate_groups_before_their_user_message(
+    entries: list[_MergeEntry],
+) -> list[_MergeEntry]:
+    """Generalize the clock-skew guard from the first user message to every one.
+
+    ``created_at`` (``TaskChatMessage``, DB clock via ``server_default``)
+    and the trace ``timestamp`` (``TraceEvent``, app clock) are different
+    clocks, so a turn's tool-exchange group can sort a hair before the very
+    user message that triggered it purely from sub-second skew. The old
+    guard only relocated exchanges that sorted before the conversation's
+    very first user message -- a case that's easy to make a hard rule for
+    ("nothing can precede the task's opening message"), but it left every
+    later turn unprotected.
+
+    This generalizes that rule to every user message by walking the merged,
+    timestamp-sorted entries and buffering consecutive ``"group"`` entries.
+    When a user-role transcript row is reached, any buffered groups are
+    flushed *after* it instead of before -- exactly what the old guard did
+    for the first user message, just repeated at each one. When a
+    non-user-role transcript row is reached first (typically that group's
+    own turn's assistant answer), the buffered groups are flushed in place,
+    unchanged: a group is only ever adjacent-before a user row (with no
+    other transcript row between them) when either skew misplaced it or it's
+    trailing, unanswered content at the very end of the merge, and in the
+    normal well-timestamped case a turn's own answer row already sits
+    between its group and the next user message, so this never fires there.
+
+    Grouping (see ``_group_exchanges_by_turn``) makes this correct at whole
+    turn granularity: a group is placed as one unit, so it can never
+    straddle a user message, and within a group the members keep their
+    relative (single-clock, timestamp) order from ``_load_tool_exchanges``.
+
+    Residual gap (deliberately not closed here): which group belongs to
+    which user message is still inferred from adjacency in timestamp order,
+    not from a durable link. ``TaskChatMessage.turn_id`` is an indexed,
+    populated column, but ``TraceEvent`` has no ``turn_id`` column, and the
+    only code that projects ``turn_id`` into trace ``data``
+    (``PatternRuntime._with_dag_turn_id``, runtime.py) is called from the
+    DAG hooks only -- never from ``on_tool_start``/``on_tool_end``/
+    ``on_tool_error``. Threading ``turn_id`` through those hooks and onto
+    ``TraceEvent`` would let this function match a group to its user message
+    exactly instead of by adjacency; that plumbing is deferred to a
+    follow-up change.
+    """
+    result: list[_MergeEntry] = []
+    pending_groups: list[_MergeEntry] = []
+    for entry in entries:
+        if entry.kind == "group":
+            pending_groups.append(entry)
+            continue
+        is_user_row = (
+            entry.kind == "transcript"
+            and entry.transcript is not None
+            and entry.transcript.role == "user"
+        )
+        if is_user_row:
+            result.append(entry)
+            result.extend(pending_groups)
+            pending_groups = []
+            continue
+        result.extend(pending_groups)
+        pending_groups = []
+        result.append(entry)
+    result.extend(pending_groups)
+    return result
+
+
 def _merge_chronologically(
     transcript_rows: list[_TranscriptRow],
     exchanges: list[_ToolExchange],
@@ -420,53 +541,30 @@ def _merge_chronologically(
                 transcript=row,
             )
         )
-    for index, exchange in enumerate(exchanges):
-        timestamp, event_id = exchange.sort_key
+
+    for group in _group_exchanges_by_turn(exchanges):
+        # Position the group by its earliest member's timestamp -- still a
+        # timestamp comparison, but the unit that can be misplaced by
+        # cross-clock skew is now a whole turn's worth of exchanges, not a
+        # single event, and distinct turns are separated by human thinking
+        # time (seconds to minutes), not the sub-second skew between the two
+        # clocks. Within the group, members keep the timestamp order already
+        # established in ``_load_tool_exchanges`` (one turn, one clock).
+        anchor = min(
+            (timestamp, _TIEBREAK_EXCHANGE, event_id)
+            for timestamp, event_id in (exchange.sort_key for exchange in group)
+        )
         entries.append(
             _MergeEntry(
-                sort_key=(timestamp, _TIEBREAK_EXCHANGE, event_id),
-                kind="exchange",
-                exchange=exchange,
+                sort_key=anchor,
+                kind="group",
+                group=group,
             )
         )
 
     entries.sort(key=lambda entry: entry.sort_key)
 
-    # Clock-skew guard: created_at uses the DB clock while trace timestamps use
-    # the app clock, so an exchange can sort before the conversation's first
-    # user message purely due to skew. Move any such exchange to just after it.
-    first_user_index = next(
-        (
-            index
-            for index, entry in enumerate(entries)
-            if entry.kind == "transcript"
-            and entry.transcript is not None
-            and entry.transcript.role == "user"
-        ),
-        None,
-    )
-    if first_user_index is not None:
-        misplaced = [
-            entry
-            for index, entry in enumerate(entries[:first_user_index])
-            if entry.kind == "exchange"
-        ]
-        if misplaced:
-            remaining = [
-                entry
-                for index, entry in enumerate(entries)
-                if not (index < first_user_index and entry.kind == "exchange")
-            ]
-            # first_user_index shifts left by however many exchange entries
-            # were pulled out ahead of it.
-            new_first_user_index = first_user_index - len(misplaced)
-            entries = (
-                remaining[: new_first_user_index + 1]
-                + misplaced
-                + remaining[new_first_user_index + 1 :]
-            )
-
-    return entries
+    return _relocate_groups_before_their_user_message(entries)
 
 
 # ---------------------------------------------------------------------------
@@ -491,37 +589,37 @@ def _render_messages(entries: list[_MergeEntry]) -> list[dict[str, Any]]:
             messages.append(item)
             continue
 
-        assert entry.exchange is not None
-        exchange = entry.exchange
-        messages.append(
-            {
-                "role": "assistant",
-                "content": exchange.assistant_content or "",
-                "tool_calls": [
-                    {
-                        "id": exchange.call_id,
-                        "type": "function",
-                        "function": {
-                            "name": exchange.tool_name,
-                            "arguments": json.dumps(
-                                exchange.tool_params or {},
-                                ensure_ascii=False,
-                                default=str,
-                            ),
-                        },
-                    }
-                ],
-            }
-        )
-        messages.append(
-            {
-                "role": "tool",
-                "tool_call_id": exchange.call_id,
-                "content": "",
-                "tool_name": exchange.tool_name,
-                "raw_result": exchange.result,
-            }
-        )
+        assert entry.group is not None
+        for exchange in entry.group:
+            messages.append(
+                {
+                    "role": "assistant",
+                    "content": exchange.assistant_content or "",
+                    "tool_calls": [
+                        {
+                            "id": exchange.call_id,
+                            "type": "function",
+                            "function": {
+                                "name": exchange.tool_name,
+                                "arguments": json.dumps(
+                                    exchange.tool_params or {},
+                                    ensure_ascii=False,
+                                    default=str,
+                                ),
+                            },
+                        }
+                    ],
+                }
+            )
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": exchange.call_id,
+                    "content": "",
+                    "tool_name": exchange.tool_name,
+                    "raw_result": exchange.result,
+                }
+            )
     return messages
 
 

--- a/src/xagent/web/services/task_conversation_context_service.py
+++ b/src/xagent/web/services/task_conversation_context_service.py
@@ -1,0 +1,565 @@
+"""Faithfully reconstruct a task's prior conversation from persisted trace events.
+
+Historically, ``task_execution_context_service.load_task_execution_context_messages``
+collapsed all prior turns into a single synthetic ``system`` message: it kept only
+the last few ``tool_execution_end`` events and clipped each result to a fixed
+character budget with a blind string slice. That slicing could land mid-JSON and
+destroy structured data (for example, cutting a continuation handle apart as
+``"branch": "review-pr-1392", ...`` -> ``"bran``), which then fed a syntactically
+broken fragment back to the model as "context" and caused it to hallucinate.
+
+This module instead reconstructs the true ``assistant``/``tool`` message pairs a
+live run would have produced, interleaved chronologically with the persisted
+``user``/``assistant``/``system`` transcript rows.
+
+This version reconstructs the full history with no size limiting: it is
+deliberately not wired into any caller yet. Bounds (a per-result size cap, a
+total exchange-count cap, and a total character budget) and the observability
+around which of them fired ship in a follow-up change, alongside the wiring
+that puts this service on the hot path.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional, cast
+
+from sqlalchemy import asc
+from sqlalchemy.orm import Session
+
+from ...core.agent.attachments import build_image_context_references
+from ...core.agent.result import CONTROL_TOOL_NAMES
+from ...core.context_ref import CONTEXT_REFS_KEY, ContextReference
+from ..models.chat_message import TaskChatMessage
+from ..models.task import TraceEvent
+from .chat_history_service import _MAX_HISTORICAL_IMAGE_CONTEXT_REFS
+
+logger = logging.getLogger(__name__)
+
+# Tool-side trace event types persisted by PatternRuntime (runtime.py).
+_TOOL_EVENT_TYPES = (
+    "tool_execution_start",
+    "tool_execution_end",
+    "tool_execution_failed",
+)
+
+# Transcript roles kept from ``task_chat_messages``, mirroring
+# ``normalize_transcript_messages`` (core/agent/transcript.py).
+_TRANSCRIPT_ROLES = {"user", "assistant", "system"}
+
+# Sort tiebreak when a tool exchange and a transcript row share the exact same
+# timestamp: the exchange (0) sorts before the transcript row (1), since tool
+# work logically precedes the turn's final answer.
+_TIEBREAK_EXCHANGE = 0
+_TIEBREAK_TRANSCRIPT = 1
+
+
+@dataclass
+class _TranscriptRow:
+    """A single normalized ``task_chat_messages`` row."""
+
+    row_id: int
+    role: str
+    content: str
+    created_at: datetime
+    # Raw ``TaskChatMessage.attachments`` payload, kept only long enough for
+    # ``_attach_historical_image_context_refs`` to project it into
+    # ``context_refs`` below; never read after ``_load_transcript_rows``
+    # returns.
+    attachments: Any = field(default=None, compare=False)
+    # Uploaded-image context refs surviving the historical-image budget (see
+    # ``_attach_historical_image_context_refs``). Populated after filtering,
+    # so this is empty for any row that never reaches ``_render_messages``.
+    context_refs: tuple[ContextReference, ...] = field(default=())
+
+
+@dataclass
+class _PendingToolStart:
+    """A ``tool_execution_start`` awaiting its matching end/failure event."""
+
+    assistant_content: str
+    tool_name: str
+    tool_params: Any
+    sort_key: tuple[datetime, int]
+
+
+@dataclass
+class _ToolExchange:
+    """A reconstructed assistant/tool message pair."""
+
+    call_id: str
+    tool_name: str
+    tool_params: Any
+    result: Any
+    assistant_content: str
+    sort_key: tuple[datetime, int]
+
+
+@dataclass
+class _MergeEntry:
+    """One item queued for the chronological merge (R4)."""
+
+    sort_key: tuple[datetime, int, int]
+    kind: str  # "exchange" | "transcript"
+    exchange: Optional[_ToolExchange] = None
+    transcript: Optional[_TranscriptRow] = None
+
+
+def load_task_conversation_context_sync(
+    db: Session,
+    task_id: int,
+    *,
+    before_message_id: int | None = None,
+) -> list[dict[str, Any]]:
+    """Reconstruct a task's prior conversation as planner-visible messages.
+
+    Returns a chronological list of ``{"role": ..., ...}`` dicts covering the
+    full persisted history: transcript rows plus reconstructed tool exchanges.
+    This is a pure read: it never mutates the database and performs no async
+    I/O, so it can be called from a worker thread that owns a live
+    ``Session``.
+
+    Args:
+        db: An open, caller-owned database session.
+        task_id: The task whose history to reconstruct.
+        before_message_id: If given, only ``task_chat_messages`` rows with
+            ``id < before_message_id`` are included (used when reconstructing
+            context as of a specific point in the conversation).
+    """
+    transcript_rows = _load_transcript_rows(
+        db, task_id, before_message_id=before_message_id
+    )
+    exchanges = _load_tool_exchanges(db, task_id)
+
+    merged = _merge_chronologically(transcript_rows, exchanges)
+
+    messages = _render_messages(merged)
+    messages = _final_pairing_sweep(messages)
+
+    return messages
+
+
+# ---------------------------------------------------------------------------
+# R1 -- transcript rows
+# ---------------------------------------------------------------------------
+
+
+def _load_transcript_rows(
+    db: Session,
+    task_id: int,
+    *,
+    before_message_id: int | None,
+) -> list[_TranscriptRow]:
+    """Load ``task_chat_messages`` rows, preserving ``created_at`` for merging.
+
+    ``chat_history_service``'s row-loading helpers normalize away
+    ``created_at``, which this module needs for the chronological merge
+    against trace events, so the rows are queried directly here instead.
+    ``attachments`` is selected alongside the existing narrow column set
+    (rather than loading the whole ORM row) so the historical-image budget
+    below can reach uploaded-image metadata without widening this query's
+    result shape beyond what image support actually needs.
+    """
+    query = db.query(
+        TaskChatMessage.id,
+        TaskChatMessage.role,
+        TaskChatMessage.content,
+        TaskChatMessage.created_at,
+        TaskChatMessage.attachments,
+    ).filter(TaskChatMessage.task_id == task_id)
+    if before_message_id is not None:
+        query = query.filter(TaskChatMessage.id < before_message_id)
+    query = query.order_by(asc(TaskChatMessage.id))
+
+    rows: list[_TranscriptRow] = []
+    for row_id, role, content, created_at, attachments in query.all():
+        normalized_role = str(role or "").strip().lower()
+        normalized_content = str(content or "").strip()
+        if normalized_role not in _TRANSCRIPT_ROLES or not normalized_content:
+            continue
+        rows.append(
+            _TranscriptRow(
+                row_id=int(row_id),
+                role=normalized_role,
+                content=normalized_content,
+                created_at=_as_aware_utc(created_at),
+                attachments=attachments,
+            )
+        )
+    _attach_historical_image_context_refs(rows)
+    return rows
+
+
+def _attach_historical_image_context_refs(rows: list[_TranscriptRow]) -> None:
+    """Mirror ``chat_history_service.load_task_transcript``'s image budget.
+
+    Same reverse scan, same global cap: walk the transcript newest-first
+    and keep attaching image context refs to each row until
+    ``_MAX_HISTORICAL_IMAGE_CONTEXT_REFS`` (shared with
+    ``load_task_transcript`` so the two paths can never silently diverge)
+    is exhausted, so only the most recent uploaded images survive. This is
+    the only bound this module currently applies; the tool-exchange caps
+    live in a follow-up change (see the module docstring).
+    """
+    remaining = _MAX_HISTORICAL_IMAGE_CONTEXT_REFS
+    for index in range(len(rows) - 1, -1, -1):
+        if remaining <= 0:
+            break
+        references = build_image_context_references(rows[index].attachments)
+        kept = references[:remaining]
+        rows[index].context_refs = kept
+        remaining -= len(kept)
+        rows[index].attachments = None
+
+
+# ---------------------------------------------------------------------------
+# R2/R3 -- tool events and exchange pairing
+# ---------------------------------------------------------------------------
+
+
+def _load_tool_exchanges(db: Session, task_id: int) -> list[_ToolExchange]:
+    trace_rows = (
+        db.query(TraceEvent)
+        .filter(
+            TraceEvent.task_id == task_id,
+            TraceEvent.build_id.is_(None),
+            TraceEvent.event_type.in_(_TOOL_EVENT_TYPES),
+        )
+        .order_by(asc(TraceEvent.timestamp), asc(TraceEvent.id))
+        .all()
+    )
+
+    # ``tool_call_id`` alone is not a safe pending-map key: the DAG pattern
+    # runs steps CONCURRENTLY (``dag.py``'s ``asyncio.create_task`` batch),
+    # and when a provider omits real tool-call ids, ``_normalize_tool_calls``
+    # (react.py) falls back to ``f"tool_call_{index}"`` where ``index`` is
+    # only unique WITHIN one LLM response -- two concurrent DAG steps can
+    # each emit "tool_call_0". Without a per-step discriminator, step A's
+    # pending start can be overwritten by step B's, and A's end then pops
+    # B's start: the WRONG tool_name/assistant_content gets attached to a
+    # result, corrupting history rather than merely losing it.
+    #
+    # ``TraceEvent.step_id`` is that discriminator: ``PatternRuntime`` always
+    # threads a step id through ``_step_id_from_payload`` (runtime.py) into
+    # the dedicated ``step_id`` COLUMN (not ``data``) via
+    # ``stage_trace_event_row`` (trace_event_staging.py). The DAG's
+    # ``_with_step`` (dag.py) stamps each concurrent step's tool calls with
+    # its own unique ``step_id``/``dag_step_id``, so concurrent branches get
+    # different keys here. ReAct sets the same step id on both the start and
+    # end of a given call (one LLM turn = one step), so this is a no-op for
+    # ReAct's already-unique-per-turn ids -- and rows written before this
+    # column was populated simply carry ``step_id=None``, which normalizes
+    # to the same empty-string discriminator for both events, reproducing
+    # the old bare-``tool_call_id`` keying exactly.
+    pending: dict[tuple[str, str], _PendingToolStart] = {}
+    exchanges: list[_ToolExchange] = []
+
+    for trace_row in trace_rows:
+        data: dict[str, Any] = (
+            trace_row.data if isinstance(trace_row.data, dict) else {}
+        )
+        row_timestamp = _as_aware_utc(cast(datetime, trace_row.timestamp))
+        row_id = int(trace_row.id)
+        step_discriminator = str(trace_row.step_id or "")
+
+        if trace_row.event_type == "tool_execution_start":
+            call_id = str(data.get("tool_call_id") or "") or f"recon-{row_id}"
+            assistant_content = str(data.get("assistant_content") or "").strip()
+            pending[(step_discriminator, call_id)] = _PendingToolStart(
+                assistant_content=assistant_content,
+                tool_name=str(data.get("tool_name") or ""),
+                tool_params=data.get("tool_params"),
+                sort_key=(row_timestamp, row_id),
+            )
+            continue
+
+        # tool_execution_end / tool_execution_failed: pop the matching start so
+        # each start is consumed by exactly one end.
+        raw_call_id = str(data.get("tool_call_id") or "")
+        start = None
+        call_id = raw_call_id
+        if raw_call_id:
+            start = pending.pop((step_discriminator, raw_call_id), None)
+        if start is None:
+            # No id, or id present but no matching start recorded (e.g. the
+            # matching start fell outside this query, or lost its id, or its
+            # step id doesn't match this end's). Fall back to a synthesized
+            # key so pairing always has an identity.
+            call_id = raw_call_id or f"recon-{row_id}"
+
+        tool_name = str(data.get("tool_name") or "").strip()
+        if not tool_name and start is not None:
+            tool_name = start.tool_name
+        if not tool_name:
+            # Cannot identify the tool this exchange belongs to; skip rather
+            # than emit an anonymous exchange the model can't reason about.
+            continue
+
+        if tool_name in CONTROL_TOOL_NAMES:
+            # final_answer / send_message / ask_user_question are pseudo-tools
+            # whose observable effect already exists as a TaskChatMessage row.
+            # Re-injecting them as tool exchanges would duplicate that content,
+            # and replaying a completed final_answer risks the model believing
+            # the *current* turn is already answered.
+            continue
+
+        tool_params = data.get("tool_params")
+        if tool_params is None and start is not None:
+            tool_params = start.tool_params
+        if tool_params is None:
+            tool_params = {}
+
+        result = _resolve_tool_result(cast(str, trace_row.event_type), data)
+
+        # Dedup of prose repeated across a parallel tool-call batch happens
+        # below, in final sort-key order -- not here. Trace rows are iterated
+        # in the order the *end* events arrive, which for a parallel batch
+        # can differ from the *start* order (whichever call finishes first
+        # gets processed first), so deduping inline here would attach the
+        # prose to the wrong exchange and could blank a duplicate that lands
+        # far from its match in final order. Keep the raw value for now.
+        assistant_content = start.assistant_content if start is not None else ""
+
+        sort_key = start.sort_key if start is not None else (row_timestamp, row_id)
+
+        exchanges.append(
+            _ToolExchange(
+                call_id=call_id,
+                tool_name=tool_name,
+                tool_params=tool_params,
+                result=result,
+                assistant_content=assistant_content,
+                sort_key=sort_key,
+            )
+        )
+
+    # Sort by the *start* time (sort_key), matching the order exchanges will
+    # ultimately appear in once merged with the transcript (R4).
+    exchanges.sort(key=lambda exchange: exchange.sort_key)
+    _dedupe_parallel_batch_prose(exchanges)
+    return exchanges
+
+
+def _dedupe_parallel_batch_prose(exchanges: list[_ToolExchange]) -> None:
+    """Blank assistant prose that exactly repeats the immediately preceding
+    exchange, in final chronological (sort-key) order.
+
+    Parallel tool-call batches share one ``assistant_content`` value (the
+    runtime's ``active_react_step_id`` can't delimit iterations, so every
+    concurrent call in the batch is stamped with the same prose); this
+    blanks all but the first occurrence in a run of adjacent duplicates so
+    the model doesn't see the same paragraph N times.
+
+    Deliberately positional rather than "seen anywhere before": comparing
+    against everything seen earlier in the stream would also blank prose
+    from a genuinely different, later turn that happens to be byte-identical
+    (e.g. a retried step re-emitting the same message) -- that is real
+    content, not a duplicate, and must not be dropped.
+    """
+    previous: str | None = None
+    for exchange in exchanges:
+        content = exchange.assistant_content
+        if not content:
+            continue
+        if content == previous:
+            exchange.assistant_content = ""
+            continue
+        previous = content
+
+
+def _resolve_tool_result(event_type: str, data: dict[str, Any]) -> Any:
+    if event_type == "tool_execution_end":
+        if bool(data.get("interrupted")) and "result" not in data:
+            return {
+                "success": False,
+                "interrupted": True,
+                "error": data.get("interrupt_reason"),
+            }
+        result = data.get("result")
+        if result is None:
+            # A "tool_execution_end" with neither a "result" key nor the
+            # interrupted marker above -- degraded data, but still a
+            # completed call. Mirror the shape of the other degraded cases
+            # here rather than letting a bare ``None`` flow into
+            # ``add_tool_result``.
+            return {
+                "success": False,
+                "status": "unknown",
+                "error": "tool result missing from persisted trace event",
+            }
+        return result
+
+    # tool_execution_failed
+    if "result" in data:
+        return data.get("result")
+    return {
+        "success": False,
+        "status": "error",
+        "error": data.get("error") or data.get("error_message"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# R4 -- chronological merge
+# ---------------------------------------------------------------------------
+
+
+def _merge_chronologically(
+    transcript_rows: list[_TranscriptRow],
+    exchanges: list[_ToolExchange],
+) -> list[_MergeEntry]:
+    entries: list[_MergeEntry] = []
+    for row in transcript_rows:
+        entries.append(
+            _MergeEntry(
+                sort_key=(row.created_at, _TIEBREAK_TRANSCRIPT, row.row_id),
+                kind="transcript",
+                transcript=row,
+            )
+        )
+    for index, exchange in enumerate(exchanges):
+        timestamp, event_id = exchange.sort_key
+        entries.append(
+            _MergeEntry(
+                sort_key=(timestamp, _TIEBREAK_EXCHANGE, event_id),
+                kind="exchange",
+                exchange=exchange,
+            )
+        )
+
+    entries.sort(key=lambda entry: entry.sort_key)
+
+    # Clock-skew guard: created_at uses the DB clock while trace timestamps use
+    # the app clock, so an exchange can sort before the conversation's first
+    # user message purely due to skew. Move any such exchange to just after it.
+    first_user_index = next(
+        (
+            index
+            for index, entry in enumerate(entries)
+            if entry.kind == "transcript"
+            and entry.transcript is not None
+            and entry.transcript.role == "user"
+        ),
+        None,
+    )
+    if first_user_index is not None:
+        misplaced = [
+            entry
+            for index, entry in enumerate(entries[:first_user_index])
+            if entry.kind == "exchange"
+        ]
+        if misplaced:
+            remaining = [
+                entry
+                for index, entry in enumerate(entries)
+                if not (index < first_user_index and entry.kind == "exchange")
+            ]
+            # first_user_index shifts left by however many exchange entries
+            # were pulled out ahead of it.
+            new_first_user_index = first_user_index - len(misplaced)
+            entries = (
+                remaining[: new_first_user_index + 1]
+                + misplaced
+                + remaining[new_first_user_index + 1 :]
+            )
+
+    return entries
+
+
+# ---------------------------------------------------------------------------
+# Rendering + final pairing sweep
+# ---------------------------------------------------------------------------
+
+
+def _render_messages(entries: list[_MergeEntry]) -> list[dict[str, Any]]:
+    messages: list[dict[str, Any]] = []
+    for entry in entries:
+        if entry.kind == "transcript":
+            assert entry.transcript is not None
+            item: dict[str, Any] = {
+                "role": entry.transcript.role,
+                "content": entry.transcript.content,
+            }
+            if entry.transcript.context_refs:
+                item[CONTEXT_REFS_KEY] = [
+                    reference.durable_dict()
+                    for reference in entry.transcript.context_refs
+                ]
+            messages.append(item)
+            continue
+
+        assert entry.exchange is not None
+        exchange = entry.exchange
+        messages.append(
+            {
+                "role": "assistant",
+                "content": exchange.assistant_content or "",
+                "tool_calls": [
+                    {
+                        "id": exchange.call_id,
+                        "type": "function",
+                        "function": {
+                            "name": exchange.tool_name,
+                            "arguments": json.dumps(
+                                exchange.tool_params or {},
+                                ensure_ascii=False,
+                                default=str,
+                            ),
+                        },
+                    }
+                ],
+            }
+        )
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": exchange.call_id,
+                "content": "",
+                "tool_name": exchange.tool_name,
+                "raw_result": exchange.result,
+            }
+        )
+    return messages
+
+
+def _final_pairing_sweep(messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop any ``tool`` message not immediately preceded by its declaring assistant.
+
+    Construction should never produce this, but this mirrors the invariant
+    ``ExecutionContext._sanitize_tool_message_pairs`` protects at the live
+    context layer.
+    """
+    sanitized: list[dict[str, Any]] = []
+    for index, message in enumerate(messages):
+        if message.get("role") != "tool":
+            sanitized.append(message)
+            continue
+        previous = messages[index - 1] if index > 0 else None
+        if (
+            previous is not None
+            and previous.get("role") == "assistant"
+            and any(
+                str(call.get("id")) == str(message.get("tool_call_id"))
+                for call in previous.get("tool_calls") or []
+            )
+        ):
+            sanitized.append(message)
+        # else: orphaned tool message, drop it.
+    return sanitized
+
+
+def _as_aware_utc(value: datetime) -> datetime:
+    """Normalize a possibly-naive datetime to aware UTC for safe comparison.
+
+    ``TaskChatMessage.created_at`` and ``TraceEvent.timestamp`` are both
+    declared ``DateTime(timezone=True)``, but SQLite (used by tests) returns
+    naive datetimes while Postgres returns aware ones. Comparing a naive and
+    an aware datetime raises ``TypeError``, so every value is normalized here
+    before it is ever used as a sort key.
+    """
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value

--- a/src/xagent/web/services/task_conversation_context_service.py
+++ b/src/xagent/web/services/task_conversation_context_service.py
@@ -541,14 +541,29 @@ def _final_pairing_sweep(messages: list[dict[str, Any]]) -> list[dict[str, Any]]
         if (
             previous is not None
             and previous.get("role") == "assistant"
-            and any(
-                str(call.get("id")) == str(message.get("tool_call_id"))
-                for call in previous.get("tool_calls") or []
-            )
+            and _ids_match(message.get("tool_call_id"), previous.get("tool_calls"))
         ):
             sanitized.append(message)
         # else: orphaned tool message, drop it.
     return sanitized
+
+
+def _ids_match(tool_call_id: Any, tool_calls: Any) -> bool:
+    """Whether ``tool_calls`` declares ``tool_call_id``.
+
+    Compares only present ids. ``str()`` on two ``None``s would render
+    ``"None" == "None"`` and report a match, which would let this sweep --
+    whose whole job is catching pairs construction should never have
+    produced -- pass an orphan through in exactly the case it exists for.
+    """
+    if tool_call_id is None:
+        return False
+    target = str(tool_call_id)
+    for call in tool_calls or []:
+        call_id = call.get("id") if isinstance(call, dict) else None
+        if call_id is not None and str(call_id) == target:
+            return True
+    return False
 
 
 def _as_aware_utc(value: datetime) -> datetime:

--- a/src/xagent/web/services/task_conversation_context_service.py
+++ b/src/xagent/web/services/task_conversation_context_service.py
@@ -50,12 +50,6 @@ _TOOL_EVENT_TYPES = (
 # ``normalize_transcript_messages`` (core/agent/transcript.py).
 _TRANSCRIPT_ROLES = {"user", "assistant", "system"}
 
-# Sort tiebreak when a tool exchange and a transcript row share the exact same
-# timestamp: the exchange (0) sorts before the transcript row (1), since tool
-# work logically precedes the turn's final answer.
-_TIEBREAK_EXCHANGE = 0
-_TIEBREAK_TRANSCRIPT = 1
-
 
 @dataclass
 class _TranscriptRow:
@@ -65,6 +59,11 @@ class _TranscriptRow:
     role: str
     content: str
     created_at: datetime
+    # ``TaskChatMessage.turn_id``, empty string when unset (rows written
+    # before this column existed, or a role that never gets one). Used to
+    # place this turn's reconstructed tool exchanges immediately after this
+    # row -- see ``_merge_chronologically``.
+    turn_id: str = ""
     # Raw ``TaskChatMessage.attachments`` payload, kept only long enough for
     # ``_attach_historical_image_context_refs`` to project it into
     # ``context_refs`` below; never read after ``_load_transcript_rows``
@@ -84,6 +83,11 @@ class _PendingToolStart:
     tool_name: str
     tool_params: Any
     sort_key: tuple[datetime, int]
+    # The turn_id stamped on the "tool_execution_start" event's data (see
+    # PatternRuntime.on_tool_start / _with_runtime_turn_id in react.py),
+    # empty string when absent (legacy rows, or a call whose start event
+    # fell outside this query's window).
+    turn_id: str = ""
 
 
 @dataclass
@@ -96,18 +100,21 @@ class _ToolExchange:
     result: Any
     assistant_content: str
     sort_key: tuple[datetime, int]
-    # Raw ``TraceEvent.step_id`` discriminator (see ``_load_tool_exchanges``),
-    # empty string when the column was unset. Used only to group exchanges
-    # produced by the same turn for the R4 merge below -- never for pairing,
-    # which already has its own step-scoped keying.
-    step_id: str = ""
+    # The durable turn_id this exchange belongs to (see ``_PendingToolStart
+    # .turn_id`` and ``_load_tool_exchanges``), empty string when the
+    # producing trace events predate turn_id support. Used by
+    # ``_merge_chronologically`` to place this exchange immediately after
+    # its turn's user transcript row -- a plain join, since
+    # ``TaskChatMessage.turn_id`` and this value come from the same source
+    # (see AgentRunner._ensure_user_message_turn_id). An empty turn_id means
+    # the exchange is omitted rather than placed by guesswork.
+    turn_id: str = ""
 
 
 @dataclass
 class _MergeEntry:
-    """One item queued for the chronological merge (R4)."""
+    """One item queued for the transcript/tool-exchange merge (R4)."""
 
-    sort_key: tuple[datetime, int, int]
     kind: str  # "group" | "transcript"
     group: Optional[list[_ToolExchange]] = None
     transcript: Optional[_TranscriptRow] = None
@@ -174,13 +181,14 @@ def _load_transcript_rows(
         TaskChatMessage.content,
         TaskChatMessage.created_at,
         TaskChatMessage.attachments,
+        TaskChatMessage.turn_id,
     ).filter(TaskChatMessage.task_id == task_id)
     if before_message_id is not None:
         query = query.filter(TaskChatMessage.id < before_message_id)
     query = query.order_by(asc(TaskChatMessage.id))
 
     rows: list[_TranscriptRow] = []
-    for row_id, role, content, created_at, attachments in query.all():
+    for row_id, role, content, created_at, attachments, turn_id in query.all():
         normalized_role = str(role or "").strip().lower()
         if normalized_role not in _TRANSCRIPT_ROLES:
             continue
@@ -191,6 +199,7 @@ def _load_transcript_rows(
                 role=normalized_role,
                 content=normalized_content,
                 created_at=_as_aware_utc(created_at),
+                turn_id=str(turn_id or ""),
                 attachments=attachments,
             )
         )
@@ -286,6 +295,7 @@ def _load_tool_exchanges(db: Session, task_id: int) -> list[_ToolExchange]:
                 tool_name=str(data.get("tool_name") or ""),
                 tool_params=data.get("tool_params"),
                 sort_key=(row_timestamp, row_id),
+                turn_id=str(data.get("turn_id") or ""),
             )
             continue
 
@@ -338,6 +348,15 @@ def _load_tool_exchanges(db: Session, task_id: int) -> list[_ToolExchange]:
 
         sort_key = start.sort_key if start is not None else (row_timestamp, row_id)
 
+        # The end/failure event's own "turn_id" (present since
+        # PatternRuntime.on_tool_end/on_tool_error also stamp it) wins;
+        # fall back to the matching start's value for a pair split across
+        # two events where only one carries it (e.g. a start recorded before
+        # this field shipped, matched to an end recorded after).
+        turn_id = str(data.get("turn_id") or "")
+        if not turn_id and start is not None:
+            turn_id = start.turn_id
+
         exchanges.append(
             _ToolExchange(
                 call_id=call_id,
@@ -346,7 +365,7 @@ def _load_tool_exchanges(db: Session, task_id: int) -> list[_ToolExchange]:
                 result=result,
                 assistant_content=assistant_content,
                 sort_key=sort_key,
-                step_id=step_discriminator,
+                turn_id=turn_id,
             )
         )
 
@@ -417,154 +436,88 @@ def _resolve_tool_result(event_type: str, data: dict[str, Any]) -> Any:
 
 
 # ---------------------------------------------------------------------------
-# R4 -- chronological merge
+# R4 -- turn_id join
 # ---------------------------------------------------------------------------
 
 
 def _group_exchanges_by_turn(
     exchanges: list[_ToolExchange],
-) -> list[list[_ToolExchange]]:
-    """Group tool exchanges by the turn that produced them.
+) -> dict[str, list[_ToolExchange]]:
+    """Group tool exchanges by the durable turn_id that produced them.
 
-    ``TraceEvent.step_id`` is the grouping key. For ReAct tasks it carries
-    ``PatternRuntime.active_react_step_id`` (runtime.py), which is minted
-    fresh (``f"react_{uuid4().hex[:8]}"``) in ``on_pattern_start`` and cleared
-    in ``on_pattern_end``/``on_pattern_error`` -- so every tool event produced
-    while handling one user turn shares one step id, and no two turns ever
-    share one. For DAG-produced events, ``_with_step`` (pattern/dag/dag.py)
-    stamps each concurrently-scheduled DAG step with its own ``step_id``, so
-    a single turn that fans out over several DAG steps yields *several*
-    groups rather than one -- that's fine here: each such group still carries
-    its own real timestamps and gets positioned (and guarded, see
-    ``_relocate_groups_before_their_user_message`` below) independently, so
-    the atomicity and ordering invariants below hold per group regardless of
-    how many groups one turn happens to produce.
+    Unlike the old ``TraceEvent.step_id``-keyed grouping this replaces,
+    ``turn_id`` is guaranteed fresh per turn: it is minted once per user
+    message (``AgentRunner._ensure_user_message_turn_id``) and threaded
+    verbatim into both ``TaskChatMessage.turn_id`` and the tool trace
+    events' ``data["turn_id"]`` (``PatternRuntime.on_tool_start`` /
+    ``on_tool_end`` / ``on_tool_error``, via ``_with_runtime_turn_id`` in
+    react.py and ``_DAGStepRuntime.active_turn_id`` in dag.py). A DAG turn
+    that fans out over several steps still shares that one turn_id across
+    every step, so it collapses back into a single group here -- unlike
+    ``step_id``, which is deliberately per-step and would fragment it.
 
-    Rows written before ``TraceEvent.step_id`` existed (or otherwise missing
-    it) carry ``step_id=None``, which ``_load_tool_exchanges`` normalizes to
-    ``""``. Grouping *all* such exchanges under one empty-string key would
-    silently merge unrelated turns back together -- exactly the bug this
-    function exists to avoid. So each exchange with no step id instead gets
-    its own singleton group, keyed by its position in the (already
-    time-sorted) ``exchanges`` list: this reproduces the pre-grouping,
-    per-exchange behavior exactly for that degraded case, rather than
-    inventing a new failure mode for it.
+    Exchanges with no turn_id (``""``, from rows written before this
+    column/field existed) are dropped entirely rather than grouped under a
+    shared key or placed as singletons: see ``_merge_chronologically`` for
+    why omission, not inference, is the deliberate choice here.
     """
     groups: dict[str, list[_ToolExchange]] = {}
-    order: list[str] = []
-    for index, exchange in enumerate(exchanges):
-        key = exchange.step_id or f"__no_step_id__{index}"
-        if key not in groups:
-            groups[key] = []
-            order.append(key)
-        groups[key].append(exchange)
-    return [groups[key] for key in order]
-
-
-def _relocate_groups_before_their_user_message(
-    entries: list[_MergeEntry],
-) -> list[_MergeEntry]:
-    """Generalize the clock-skew guard from the first user message to every one.
-
-    ``created_at`` (``TaskChatMessage``, DB clock via ``server_default``)
-    and the trace ``timestamp`` (``TraceEvent``, app clock) are different
-    clocks, so a turn's tool-exchange group can sort a hair before the very
-    user message that triggered it purely from sub-second skew. The old
-    guard only relocated exchanges that sorted before the conversation's
-    very first user message -- a case that's easy to make a hard rule for
-    ("nothing can precede the task's opening message"), but it left every
-    later turn unprotected.
-
-    This generalizes that rule to every user message by walking the merged,
-    timestamp-sorted entries and buffering consecutive ``"group"`` entries.
-    When a user-role transcript row is reached, any buffered groups are
-    flushed *after* it instead of before -- exactly what the old guard did
-    for the first user message, just repeated at each one. When a
-    non-user-role transcript row is reached first (typically that group's
-    own turn's assistant answer), the buffered groups are flushed in place,
-    unchanged: a group is only ever adjacent-before a user row (with no
-    other transcript row between them) when either skew misplaced it or it's
-    trailing, unanswered content at the very end of the merge, and in the
-    normal well-timestamped case a turn's own answer row already sits
-    between its group and the next user message, so this never fires there.
-
-    Grouping (see ``_group_exchanges_by_turn``) makes this correct at whole
-    turn granularity: a group is placed as one unit, so it can never
-    straddle a user message, and within a group the members keep their
-    relative (single-clock, timestamp) order from ``_load_tool_exchanges``.
-
-    Residual gap (deliberately not closed here): which group belongs to
-    which user message is still inferred from adjacency in timestamp order,
-    not from a durable link. ``TaskChatMessage.turn_id`` is an indexed,
-    populated column, but ``TraceEvent`` has no ``turn_id`` column, and the
-    only code that projects ``turn_id`` into trace ``data``
-    (``PatternRuntime._with_dag_turn_id``, runtime.py) is called from the
-    DAG hooks only -- never from ``on_tool_start``/``on_tool_end``/
-    ``on_tool_error``. Threading ``turn_id`` through those hooks and onto
-    ``TraceEvent`` would let this function match a group to its user message
-    exactly instead of by adjacency; that plumbing is deferred to a
-    follow-up change.
-    """
-    result: list[_MergeEntry] = []
-    pending_groups: list[_MergeEntry] = []
-    for entry in entries:
-        if entry.kind == "group":
-            pending_groups.append(entry)
+    for exchange in exchanges:
+        if not exchange.turn_id:
             continue
-        is_user_row = (
-            entry.kind == "transcript"
-            and entry.transcript is not None
-            and entry.transcript.role == "user"
-        )
-        if is_user_row:
-            result.append(entry)
-            result.extend(pending_groups)
-            pending_groups = []
-            continue
-        result.extend(pending_groups)
-        pending_groups = []
-        result.append(entry)
-    result.extend(pending_groups)
-    return result
+        groups.setdefault(exchange.turn_id, []).append(exchange)
+    return groups
 
 
 def _merge_chronologically(
     transcript_rows: list[_TranscriptRow],
     exchanges: list[_ToolExchange],
 ) -> list[_MergeEntry]:
+    """Interleave transcript rows with tool exchanges by turn_id, not timestamp.
+
+    Placement is now a join, not an inference: each user transcript row
+    carries the same turn_id its turn's tool exchanges were stamped with
+    (see ``_group_exchanges_by_turn``), so a turn's exchanges belong
+    unambiguously right after that row and before whatever transcript row
+    comes next. This is immune to clock skew between ``TaskChatMessage
+    .created_at`` (DB clock) and ``TraceEvent.timestamp`` (app clock) --
+    the old timestamp-adjacency approach this replaces could misplace a
+    turn either by that skew or, worse, structurally: two DAG re-plans can
+    both emit ``step_id="step_1"``, which silently merged two distinct
+    turns into one group, and a failed/interrupted turn with no assistant
+    row got flushed *after* the next user message by the old relocation
+    pass regardless of timestamps. Joining on turn_id makes both cases
+    correct by construction instead of narrowing the heuristic further.
+
+    Exchanges whose turn_id has no matching row in ``transcript_rows`` --
+    either it predates turn_id support (``""``), or its user row fell
+    outside ``before_message_id`` -- are silently omitted rather than
+    placed by adjacency or clock guesswork. Losing that detail is
+    acceptable (the conversation reconstructs with transcript text only,
+    exactly today's non-reconstructed behavior); fabricating a placement
+    is not, because a misplaced exchange can make the model believe a
+    later turn's tool results informed an earlier answer, or that a failed
+    turn never happened.
+
+    Within a turn's group, members keep the relative order already
+    established in ``_load_tool_exchanges`` (timestamp/id sort) -- safe
+    because it is one turn's own clock, not a cross-turn comparison.
+    """
+    exchanges_by_turn = _group_exchanges_by_turn(exchanges)
+
     entries: list[_MergeEntry] = []
     for row in transcript_rows:
-        entries.append(
-            _MergeEntry(
-                sort_key=(row.created_at, _TIEBREAK_TRANSCRIPT, row.row_id),
-                kind="transcript",
-                transcript=row,
-            )
-        )
+        entries.append(_MergeEntry(kind="transcript", transcript=row))
+        if row.role != "user" or not row.turn_id:
+            continue
+        # TaskChatMessage's (task_id, role, turn_id) uniqueness constraint
+        # guarantees at most one "user" row per turn_id, so this can never
+        # place the same group twice.
+        group = exchanges_by_turn.pop(row.turn_id, None)
+        if group:
+            entries.append(_MergeEntry(kind="group", group=group))
 
-    for group in _group_exchanges_by_turn(exchanges):
-        # Position the group by its earliest member's timestamp -- still a
-        # timestamp comparison, but the unit that can be misplaced by
-        # cross-clock skew is now a whole turn's worth of exchanges, not a
-        # single event, and distinct turns are separated by human thinking
-        # time (seconds to minutes), not the sub-second skew between the two
-        # clocks. Within the group, members keep the timestamp order already
-        # established in ``_load_tool_exchanges`` (one turn, one clock).
-        anchor = min(
-            (timestamp, _TIEBREAK_EXCHANGE, event_id)
-            for timestamp, event_id in (exchange.sort_key for exchange in group)
-        )
-        entries.append(
-            _MergeEntry(
-                sort_key=anchor,
-                kind="group",
-                group=group,
-            )
-        )
-
-    entries.sort(key=lambda entry: entry.sort_key)
-
-    return _relocate_groups_before_their_user_message(entries)
+    return entries
 
 
 # ---------------------------------------------------------------------------

--- a/src/xagent/web/services/task_conversation_context_service.py
+++ b/src/xagent/web/services/task_conversation_context_service.py
@@ -463,55 +463,13 @@ def _load_tool_exchanges(
         )
 
     # Sort by the *start* time (sort_key), matching the order exchanges will
-    # ultimately appear in once merged with the transcript (R4). Dedup of
-    # parallel-batch prose happens later, per turn group (see
-    # ``_group_exchanges_by_turn``) -- not here over this flat, task-wide
-    # list. Deduping here would compare exchanges across turn boundaries
-    # (blanking a later, unrelated turn's coincidentally identical prose)
-    # and would let an exchange that never survives grouping (no usable
-    # turn_id) still act as the "previous" entry and blank a legitimately
-    # rendered exchange right after it.
+    # ultimately appear in once merged with the transcript (R4).
     exchanges.sort(key=lambda exchange: exchange.sort_key)
     # Any start left in ``pending`` here never found its end/failure event
     # and so never became an exchange at all; it silently disappears along
     # with its prose (behavior unchanged), but is now counted.
     stats.dangling_tool_starts += len(pending)
     return exchanges
-
-
-def _dedupe_parallel_batch_prose(exchanges: list[_ToolExchange]) -> None:
-    """Blank assistant prose that exactly repeats the immediately preceding
-    exchange, within a single turn's group, in that group's internal order.
-
-    Parallel tool-call batches share one ``assistant_content`` value (the
-    runtime's ``active_react_step_id`` can't delimit iterations, so every
-    concurrent call in the batch is stamped with the same prose); this
-    blanks all but the first occurrence in a run of adjacent duplicates so
-    the model doesn't see the same paragraph N times.
-
-    Called once per turn group (see ``_group_exchanges_by_turn``), never
-    over the flat, task-wide exchange list: adjacency in that list is not a
-    reliable signal here for two reasons. First, two *different* turns
-    whose only exchange happens to share byte-identical prose are adjacent
-    in the flat list whenever nothing else falls between them, and blanking
-    the second would drop real content from a later turn, not a duplicate.
-    Second, dedup running before ``_group_exchanges_by_turn`` drops
-    exchanges with no usable ``turn_id`` would let a dropped exchange --
-    one that never reaches the rendered output at all -- still serve as
-    "previous" and blank a legitimately rendered exchange that follows it.
-    Scoping this to one turn's already-grouped list closes both holes: a
-    turn boundary can never be crossed, and every candidate is guaranteed
-    to actually survive into the output.
-    """
-    previous: str | None = None
-    for exchange in exchanges:
-        content = exchange.assistant_content
-        if not content:
-            continue
-        if content == previous:
-            exchange.assistant_content = ""
-            continue
-        previous = content
 
 
 def _resolve_tool_result(event_type: str, data: dict[str, Any]) -> Any:
@@ -572,15 +530,22 @@ def _group_exchanges_by_turn(
     Exchanges with no turn_id (``""``, from rows written before this
     column/field existed) are dropped entirely rather than grouped under a
     shared key or placed as singletons: see ``_merge_chronologically`` for
-    why omission, not inference, is the deliberate choice here. Because that
-    drop happens here, before dedup, a dropped exchange can never stand in
-    as another exchange's "previous" for ``_dedupe_parallel_batch_prose``
-    below.
+    why omission, not inference, is the deliberate choice here.
 
-    Parallel-batch prose dedup is applied per group, in the exchanges'
-    already-established relative order (see ``_load_tool_exchanges``'s
-    sort), immediately after each group is assembled -- never over the
-    flat cross-turn list. See ``_dedupe_parallel_batch_prose`` for why.
+    Assistant prose is carried through verbatim, one exchange at a time.
+    An earlier revision of this module also deduplicated byte-identical
+    prose on adjacent exchanges, on the theory that a parallel tool-call
+    batch stamps every concurrent call with the same ``assistant_content``.
+    That premise is false: the only writer of that field,
+    ``ReActPattern._remember_tool_call_content``, returns after the first
+    non-control call in the batch, so exactly one call in a batch ever
+    carries prose. A parallel batch therefore cannot produce the adjacent
+    duplicate that dedup looked for; the only thing that can is two
+    *serialized* iterations of one turn whose prose happens to match (the
+    ReAct step_id is minted once per pattern run, so serialized iterations
+    share it and the turn_id). Blanking the second of those dropped real
+    content the live history had, which is why dedup is gone rather than
+    made more precise.
     """
     stats = stats if stats is not None else _ReconstructionStats()
     groups: dict[str, list[_ToolExchange]] = {}
@@ -589,8 +554,6 @@ def _group_exchanges_by_turn(
             stats.exchanges_without_turn_id += 1
             continue
         groups.setdefault(exchange.turn_id, []).append(exchange)
-    for group in groups.values():
-        _dedupe_parallel_batch_prose(group)
     return groups
 
 
@@ -773,11 +736,12 @@ def _as_aware_utc(value: datetime) -> datetime:
 
     Applied to every ``TraceEvent.timestamp`` value in ``_load_tool_exchanges``
     before it feeds a ``sort_key`` (used both to order an exchange's start/end
-    pairing and to order same-turn exchanges relative to each other, and by
-    ``_dedupe_parallel_batch_prose``). ``TraceEvent.timestamp`` is declared
-    ``DateTime(timezone=True)``, but SQLite (used by tests) returns naive
-    datetimes regardless of what was stored, while Postgres returns aware
-    ones; comparing a naive and an aware datetime raises ``TypeError``.
+    pairing and to order same-turn exchanges relative to each other).
+    ``TraceEvent.timestamp`` is declared ``DateTime(timezone=True)``, but
+    SQLite (used by tests) returns naive datetimes regardless of what was
+    stored, while Postgres returns aware ones; comparing a naive and an
+    aware datetime raises ``TypeError``.
+
     Placement of a turn's exchanges relative to the transcript is a
     ``turn_id`` join now (see ``_merge_chronologically``), not a timestamp
     comparison, so this function is no longer applied to ``TaskChatMessage

--- a/tests/web/services/test_task_conversation_context_service.py
+++ b/tests/web/services/test_task_conversation_context_service.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from datetime import datetime, timedelta, timezone
 
 from sqlalchemy import create_engine
@@ -1985,5 +1986,684 @@ def test_image_only_turn_participates_correctly_in_chronological_ordering():
         assert messages[1]["tool_calls"][0]["id"] == "call-analyze"
         assert messages[2]["tool_call_id"] == "call-analyze"
         assert messages[3]["content"] == "It's a diagram."
+    finally:
+        db_session.close()
+
+
+# ---------------------------------------------------------------------------
+# Part E -- dedup scoped to one turn (item 1), turn_id in the pairing key
+# (item 2), the F1 silent-drop decision (item 4), and the summary log line
+# (item 5).
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_does_not_blank_a_different_later_turns_identical_prose():
+    """Item 1a: two DIFFERENT turns whose only exchange happens to share
+    byte-identical ``assistant_content``, with nothing else between them in
+    the task-wide flat exchange order, must both keep their prose.
+
+    Before the fix, ``_dedupe_parallel_batch_prose`` ran over the flat,
+    task-wide exchange list *before* turn grouping, so adjacency in that
+    list (not an actual parallel batch) blanked the second turn's prose.
+    Adjacency across a turn boundary is not the same thing as adjacency
+    within one turn's parallel tool-call batch.
+    """
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        shared_prose = "Looking into it now."
+
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="turn 1",
+            created_at=_ts(0),
+            turn_id="turn-1",
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(1),
+            turn_id="turn-1",
+            data={
+                "tool_name": "tool_one",
+                "tool_params": {},
+                "tool_call_id": "call-1",
+                "assistant_content": shared_prose,
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(2),
+            turn_id="turn-1",
+            data={
+                "tool_name": "tool_one",
+                "tool_call_id": "call-1",
+                "success": True,
+                "result": {"ok": True},
+            },
+        )
+
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="turn 2, a genuinely different later turn",
+            created_at=_ts(3),
+            turn_id="turn-2",
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(4),
+            turn_id="turn-2",
+            data={
+                "tool_name": "tool_two",
+                "tool_params": {},
+                "tool_call_id": "call-2",
+                # Coincidentally identical prose -- not a parallel batch,
+                # a different turn.
+                "assistant_content": shared_prose,
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(5),
+            turn_id="turn-2",
+            data={
+                "tool_name": "tool_two",
+                "tool_call_id": "call-2",
+                "success": True,
+                "result": {"ok": True},
+            },
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        assistant_by_tool = {}
+        for index, message in enumerate(messages):
+            if message["role"] != "assistant" or not message.get("tool_calls"):
+                continue
+            assistant_by_tool[message["tool_calls"][0]["function"]["name"]] = message[
+                "content"
+            ]
+
+        assert assistant_by_tool["tool_one"] == shared_prose
+        assert assistant_by_tool["tool_two"] == shared_prose
+    finally:
+        db_session.close()
+
+
+def test_dedup_ignores_a_dropped_legacy_predecessor():
+    """Item 1b: a legacy exchange with no usable ``turn_id`` is dropped by
+    ``_group_exchanges_by_turn`` and never reaches rendering -- it must not
+    still act as "previous" for a real, rendered exchange that happens to
+    share its prose and immediately follows it in the flat, pre-grouping
+    order.
+    """
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        shared_prose = "Same wording, unrelated turns."
+
+        # Legacy exchange: no turn_id on either event, so it is dropped
+        # by _group_exchanges_by_turn and never rendered.
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(0),
+            data={
+                "tool_name": "legacy_tool",
+                "tool_params": {},
+                "tool_call_id": "call-legacy",
+                "assistant_content": shared_prose,
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(1),
+            data={
+                "tool_name": "legacy_tool",
+                "tool_call_id": "call-legacy",
+                "success": True,
+                "result": {"ok": True},
+            },
+        )
+
+        # Real turn, immediately after in the flat order, sharing the same
+        # prose byte-for-byte.
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="go",
+            created_at=_ts(2),
+            turn_id="turn-1",
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(3),
+            turn_id="turn-1",
+            data={
+                "tool_name": "real_tool",
+                "tool_params": {},
+                "tool_call_id": "call-real",
+                "assistant_content": shared_prose,
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(4),
+            turn_id="turn-1",
+            data={
+                "tool_name": "real_tool",
+                "tool_call_id": "call-real",
+                "success": True,
+                "result": {"ok": True},
+            },
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        assistant_messages = [
+            m for m in messages if m["role"] == "assistant" and m.get("tool_calls")
+        ]
+        assert len(assistant_messages) == 1
+        assert assistant_messages[0]["content"] == shared_prose
+        assert assistant_messages[0]["tool_calls"][0]["function"]["name"] == (
+            "real_tool"
+        )
+    finally:
+        db_session.close()
+
+
+def test_pairing_key_with_turn_id_does_not_change_well_formed_single_turn_pairing():
+    """Item 2: folding ``turn_id`` into the pending-start pairing key must
+    not change pairing for the common, well-formed case -- a single turn
+    whose start and end events both carry the same ``turn_id``."""
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="go",
+            created_at=_ts(0),
+            turn_id="turn-1",
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(1),
+            turn_id="turn-1",
+            data={
+                "tool_name": "search",
+                "tool_params": {"query": "docs"},
+                "tool_call_id": "call-1",
+                "assistant_content": "Searching the docs.",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(2),
+            turn_id="turn-1",
+            data={
+                "tool_name": "search",
+                "tool_call_id": "call-1",
+                "success": True,
+                "result": {"hits": 3},
+            },
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        roles = [m["role"] for m in messages]
+        assert roles == ["user", "assistant", "tool"]
+        assert messages[1]["content"] == "Searching the docs."
+        assert messages[1]["tool_calls"][0]["id"] == "call-1"
+        assert messages[1]["tool_calls"][0]["function"]["name"] == "search"
+        assert json.loads(messages[1]["tool_calls"][0]["function"]["arguments"]) == {
+            "query": "docs"
+        }
+        assert messages[2]["tool_call_id"] == "call-1"
+        assert messages[2]["raw_result"] == {"hits": 3}
+    finally:
+        db_session.close()
+
+
+def test_pairing_key_turn_id_separates_colliding_step_and_call_ids():
+    """Item 2, exercising the actual mechanism the ``turn_id`` key addition
+    defends against, not just confirming it's a no-op for the common case.
+
+    The task description for item 2 is explicit that the exploit path --
+    two different turns' tool calls interleaving with the same
+    ``(step_id, tool_call_id)`` pair -- is unreachable today through the
+    real runtime (serialized turns, atomic DB claims, etc.). But the
+    pending-map keying logic itself can still be unit-tested directly by
+    constructing colliding trace rows (as a DAG replan restarting step
+    numbering at ``step_1`` would, paired with a reused synthesized
+    ``tool_call_{index}``-style id) and checking it does not mis-pair.
+
+    Without ``turn_id`` in the key: turn B's start (same step_id, same
+    call_id, different turn_id) overwrites turn A's pending entry, so
+    turn A's end pops turn B's start (wrong content) and turn B's end
+    finds nothing (already consumed). With ``turn_id`` folded in, the two
+    turns get distinct keys and both pair correctly.
+    """
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="turn a",
+            created_at=_ts(0),
+            turn_id="turn-A",
+        )
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="turn b",
+            created_at=_ts(10),
+            turn_id="turn-B",
+        )
+
+        # Turn A's start -- step_id/call_id deliberately colliding with
+        # turn B's below (simulating a DAG replan that restarts step
+        # numbering at the same id).
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(1),
+            step_id="step_1",
+            turn_id="turn-A",
+            data={
+                "tool_name": "tool_a",
+                "tool_params": {},
+                "tool_call_id": "call_0",
+                "assistant_content": "doing A",
+            },
+        )
+        # Turn B's start -- same step_id and call_id as turn A's, but a
+        # different turn_id.
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(2),
+            step_id="step_1",
+            turn_id="turn-B",
+            data={
+                "tool_name": "tool_b",
+                "tool_params": {},
+                "tool_call_id": "call_0",
+                "assistant_content": "doing B",
+            },
+        )
+        # Turn A's end arrives next -- must pop turn A's own start, not
+        # turn B's.
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(3),
+            step_id="step_1",
+            turn_id="turn-A",
+            data={
+                "tool_name": "tool_a",
+                "tool_call_id": "call_0",
+                "success": True,
+                "result": {"who": "a"},
+            },
+        )
+        # Turn B's end arrives last -- must still find turn B's own start.
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(4),
+            step_id="step_1",
+            turn_id="turn-B",
+            data={
+                "tool_name": "tool_b",
+                "tool_call_id": "call_0",
+                "success": True,
+                "result": {"who": "b"},
+            },
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        assistant_by_tool = {}
+        result_by_tool = {}
+        for index, message in enumerate(messages):
+            if message["role"] != "assistant" or not message.get("tool_calls"):
+                continue
+            tool_name = message["tool_calls"][0]["function"]["name"]
+            assistant_by_tool[tool_name] = message["content"]
+            tool_message = messages[index + 1]
+            assert tool_message["role"] == "tool"
+            result_by_tool[tool_name] = tool_message["raw_result"]
+
+        assert assistant_by_tool["tool_a"] == "doing A"
+        assert assistant_by_tool["tool_b"] == "doing B"
+        assert result_by_tool["tool_a"] == {"who": "a"}
+        assert result_by_tool["tool_b"] == {"who": "b"}
+    finally:
+        db_session.close()
+
+
+def test_image_budget_eviction_drops_tool_exchanges_deliberately_not_silently():
+    """Item 4 (F1): an image-only user turn evicted by the historical-image
+    ref budget must not silently take its tool exchanges down with it in a
+    way that's indistinguishable from a bug -- the row drop itself matches
+    upstream and is correct, but the turn's tool exchanges must be dropped
+    as a deliberate, counted choice (see ``_ReconstructionStats
+    .exchanges_with_unmatched_turn``), never fabricated a placement
+    elsewhere in the output."""
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        base = _ts(0)
+
+        # The earliest image-only turn: its ref will be evicted once enough
+        # newer images exist to exhaust the budget.
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="",
+            created_at=base,
+            turn_id="turn-evicted",
+            attachments=[
+                {
+                    "file_id": "image-evicted",
+                    "name": "old-screenshot.png",
+                    "type": "image/png",
+                }
+            ],
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=base + timedelta(seconds=1),
+            turn_id="turn-evicted",
+            data={
+                "tool_name": "analyze_image",
+                "tool_params": {},
+                "tool_call_id": "call-evicted",
+                "assistant_content": "Let me look at that image.",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=base + timedelta(seconds=2),
+            turn_id="turn-evicted",
+            data={
+                "tool_name": "analyze_image",
+                "tool_call_id": "call-evicted",
+                "success": True,
+                "result": {"label": "old diagram"},
+            },
+        )
+        # Its answer -- a plain transcript row, unaffected by the image
+        # budget -- must still survive.
+        _add_chat_message(
+            db_session,
+            task,
+            role="assistant",
+            content="It's an old diagram.",
+            created_at=base + timedelta(seconds=3),
+        )
+
+        # Enough newer image uploads to push the evicted turn's single ref
+        # entirely outside the budget (reverse scan keeps only the newest
+        # _MAX_HISTORICAL_IMAGE_CONTEXT_REFS refs).
+        for index in range(_MAX_HISTORICAL_IMAGE_CONTEXT_REFS):
+            _add_chat_message(
+                db_session,
+                task,
+                role="user",
+                content=f"newer image {index}",
+                created_at=base + timedelta(seconds=10 + index),
+                attachments=[
+                    {
+                        "file_id": f"image-newer-{index}",
+                        "name": f"newer-{index}.png",
+                        "type": "image/png",
+                    }
+                ],
+            )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+
+        # The row drop matches upstream: the image-only row with no
+        # surviving refs is gone.
+        assert all(m.get("content") != "" or CONTEXT_REFS_KEY in m for m in messages)
+        for message in messages:
+            if CONTEXT_REFS_KEY in message:
+                file_ids = {
+                    ref["file_ref"]["file_id"] for ref in message[CONTEXT_REFS_KEY]
+                }
+                assert "image-evicted" not in file_ids
+
+        # The answer to the evicted turn survives as ordinary transcript
+        # text.
+        assert any(
+            m["role"] == "assistant" and m.get("content") == "It's an old diagram."
+            for m in messages
+        )
+
+        # The deliberate part: no fabricated placement anywhere for the
+        # evicted turn's tool exchange -- it must not appear at all.
+        tool_call_ids = {
+            call.get("id")
+            for m in messages
+            if m["role"] == "assistant"
+            for call in (m.get("tool_calls") or [])
+        }
+        assert "call-evicted" not in tool_call_ids
+        assert not any(
+            m["role"] == "tool" and m.get("tool_call_id") == "call-evicted"
+            for m in messages
+        )
+    finally:
+        db_session.close()
+
+
+def test_summary_log_line_reports_every_drop_reason_with_correct_counts(caplog):
+    """Item 5: the single summary log line at the end of
+    ``load_task_conversation_context_sync`` must report accurate counts for
+    transcript rows, placed exchanges, and every drop reason, exercised
+    together in one fixture:
+
+    - a legacy exchange with no usable turn_id (dropped by grouping)
+    - a turn whose user row is excluded by ``before_message_id`` (turn_id
+      present, but no surviving row to anchor on)
+    - a dangling tool_execution_start with no matching end
+    - a tool_execution_end with no matching start (still rendered, just
+      degraded)
+    - one well-formed turn whose exchange is actually placed
+    """
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        base = _ts(0)
+
+        # turn-a: a normal, fully paired turn that survives.
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="turn a",
+            created_at=base,
+            turn_id="turn-a",
+        )
+        _add_chat_message(
+            db_session,
+            task,
+            role="assistant",
+            content="turn a answer",
+            created_at=base + timedelta(seconds=1),
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=base + timedelta(seconds=2),
+            turn_id="turn-a",
+            data={
+                "tool_name": "tool_a",
+                "tool_params": {},
+                "tool_call_id": "call-a",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=base + timedelta(seconds=3),
+            turn_id="turn-a",
+            data={
+                "tool_name": "tool_a",
+                "tool_call_id": "call-a",
+                "success": True,
+                "result": {"ok": True},
+            },
+        )
+
+        # An orphan end, attached to turn-a's own turn_id so it lands in a
+        # surviving group (isolating the "end without start" count from
+        # the "unmatched turn" count).
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=base + timedelta(seconds=4),
+            turn_id="turn-a",
+            data={
+                "tool_name": "orphan_end_tool",
+                "tool_call_id": "call-orphan-end",
+                "success": True,
+                "result": {"ok": True},
+            },
+        )
+
+        # turn-b: its user row will be excluded via before_message_id, but
+        # its tool exchange (turn_id="turn-b") is fully paired.
+        turn_b_user_row = _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="turn b",
+            created_at=base + timedelta(seconds=5),
+            turn_id="turn-b",
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=base + timedelta(seconds=6),
+            turn_id="turn-b",
+            data={
+                "tool_name": "tool_b",
+                "tool_params": {},
+                "tool_call_id": "call-b",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=base + timedelta(seconds=7),
+            turn_id="turn-b",
+            data={
+                "tool_name": "tool_b",
+                "tool_call_id": "call-b",
+                "success": True,
+                "result": {"ok": True},
+            },
+        )
+
+        # A legacy exchange with no turn_id at all.
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=base + timedelta(seconds=8),
+            data={
+                "tool_name": "legacy_tool",
+                "tool_params": {},
+                "tool_call_id": "call-legacy",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=base + timedelta(seconds=9),
+            data={
+                "tool_name": "legacy_tool",
+                "tool_call_id": "call-legacy",
+                "success": True,
+                "result": {"ok": True},
+            },
+        )
+
+        # A dangling start with no matching end at all.
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=base + timedelta(seconds=10),
+            turn_id="turn-a",
+            data={
+                "tool_name": "never_finishes",
+                "tool_params": {},
+                "tool_call_id": "call-dangling",
+            },
+        )
+
+        logger_name = "xagent.web.services.task_conversation_context_service"
+        with caplog.at_level(logging.INFO, logger=logger_name):
+            load_task_conversation_context_sync(
+                db_session, int(task.id), before_message_id=int(turn_b_user_row.id)
+            )
+
+        records = [
+            record
+            for record in caplog.records
+            if record.name == logger_name
+            and "task_conversation_context_reconstructed" in record.getMessage()
+        ]
+        assert len(records) == 1
+        message = records[0].getMessage()
+
+        assert "transcript_rows=2" in message
+        assert "exchanges_placed=2" in message
+        assert "exchanges_without_turn_id=1" in message
+        assert "exchanges_with_unmatched_turn=1" in message
+        assert "dangling_tool_starts=1" in message
+        assert "tool_ends_without_start=1" in message
     finally:
         db_session.close()

--- a/tests/web/services/test_task_conversation_context_service.py
+++ b/tests/web/services/test_task_conversation_context_service.py
@@ -991,190 +991,6 @@ def test_ids_match_ignores_malformed_tool_call_entries():
 # ---------------------------------------------------------------------------
 
 
-def test_dedup_positional_after_sort_keeps_different_turns_distinct_prose():
-    """Fix 5 regression: two DIFFERENT turns emitting byte-identical
-    assistant prose must BOTH keep their prose. The old code tracked
-    ``last_assistant_content`` across trace rows in *end-event-arrival*
-    order; when an unrelated exchange's END event lands before an earlier
-    exchange's own (slow-running) END event, positional dedup by end-order
-    could blank a later, unrelated turn's coincidentally identical prose.
-    Sorting by *start* time before deduping (the fix) keeps these turns
-    correctly separated by the truly-intervening exchange."""
-    db_session = _create_db_session()
-    try:
-        task = _create_task(db_session)
-        # All three calls are anchored to one turn: this test is about
-        # _dedupe_parallel_batch_prose's positional logic over the flat,
-        # start-time-sorted exchange list, which runs before turn grouping
-        # -- it is unconcerned with turn_id boundaries.
-        _add_chat_message(
-            db_session,
-            task,
-            role="user",
-            content="go",
-            created_at=_ts(-1),
-            turn_id="turn-1",
-        )
-        shared_prose = "Investigating the failure."
-
-        # Turn A: starts first, but is slow -- its end event arrives LAST.
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_start",
-            timestamp=_ts(0),
-            turn_id="turn-1",
-            data={
-                "tool_name": "tool_a",
-                "tool_params": {},
-                "tool_call_id": "call-a",
-                "assistant_content": shared_prose,
-            },
-        )
-        # Turn B: starts after A, but is fast -- its end event arrives
-        # before A's, and carries different prose.
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_start",
-            timestamp=_ts(1),
-            turn_id="turn-1",
-            data={
-                "tool_name": "tool_b",
-                "tool_params": {},
-                "tool_call_id": "call-b",
-                "assistant_content": "Checking a different thing.",
-            },
-        )
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_end",
-            timestamp=_ts(2),  # B's end lands before A's end below.
-            turn_id="turn-1",
-            data={
-                "tool_name": "tool_b",
-                "tool_call_id": "call-b",
-                "success": True,
-                "result": {"ok": True},
-            },
-        )
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_end",
-            timestamp=_ts(100),  # A finishes much later.
-            turn_id="turn-1",
-            data={
-                "tool_name": "tool_a",
-                "tool_call_id": "call-a",
-                "success": True,
-                "result": {"ok": True},
-            },
-        )
-        # Turn C: a much later, unrelated turn that coincidentally repeats
-        # A's exact prose.
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_start",
-            timestamp=_ts(200),
-            turn_id="turn-1",
-            data={
-                "tool_name": "tool_c",
-                "tool_params": {},
-                "tool_call_id": "call-c",
-                "assistant_content": shared_prose,
-            },
-        )
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_end",
-            timestamp=_ts(201),
-            turn_id="turn-1",
-            data={
-                "tool_name": "tool_c",
-                "tool_call_id": "call-c",
-                "success": True,
-                "result": {"ok": True},
-            },
-        )
-
-        messages = load_task_conversation_context_sync(db_session, int(task.id))
-        assistant_by_tool = {}
-        for index, message in enumerate(messages):
-            if message["role"] != "assistant" or not message.get("tool_calls"):
-                continue
-            tool_message = messages[index + 1]
-            assistant_by_tool[tool_message["tool_name"]] = message["content"]
-
-        assert assistant_by_tool["tool_a"] == shared_prose
-        assert assistant_by_tool["tool_c"] == shared_prose
-        assert assistant_by_tool["tool_b"] == "Checking a different thing."
-    finally:
-        db_session.close()
-
-
-def test_dedup_still_blanks_immediately_following_parallel_duplicate():
-    """Fix 5 regression, other half: a genuine parallel batch (same start
-    time, no other exchange between them in start order) must still have
-    its duplicate prose blanked for the immediately-following exchange."""
-    db_session = _create_db_session()
-    try:
-        task = _create_task(db_session)
-        _add_chat_message(
-            db_session,
-            task,
-            role="user",
-            content="go",
-            created_at=_ts(-1),
-            turn_id="turn-1",
-        )
-        shared_prose = "Running parallel lookups."
-
-        for index in range(3):
-            call_id = f"batch-call-{index}"
-            _add_trace_event(
-                db_session,
-                task,
-                event_type="tool_execution_start",
-                timestamp=_ts(index),
-                turn_id="turn-1",
-                data={
-                    "tool_name": "list_files",
-                    "tool_params": {"index": index},
-                    "tool_call_id": call_id,
-                    "assistant_content": shared_prose,
-                },
-            )
-            _add_trace_event(
-                db_session,
-                task,
-                event_type="tool_execution_end",
-                timestamp=_ts(index + 10),
-                turn_id="turn-1",
-                data={
-                    "tool_name": "list_files",
-                    "tool_call_id": call_id,
-                    "success": True,
-                    "result": {"index": index},
-                },
-            )
-
-        messages = load_task_conversation_context_sync(db_session, int(task.id))
-        assistant_contents = [
-            m["content"]
-            for m in messages
-            if m["role"] == "assistant" and m.get("tool_calls")
-        ]
-        assert len(assistant_contents) == 3
-        assert assistant_contents.count(shared_prose) == 1
-        assert assistant_contents.count("") == 2
-    finally:
-        db_session.close()
-
-
 def test_tool_execution_end_missing_result_yields_degraded_dict_not_none():
     """Fix 6 regression: a ``tool_execution_end`` with no ``result`` key and
     not marked ``interrupted`` must produce a degraded placeholder dict,
@@ -1991,202 +1807,9 @@ def test_image_only_turn_participates_correctly_in_chronological_ordering():
 
 
 # ---------------------------------------------------------------------------
-# Part E -- dedup scoped to one turn (item 1), turn_id in the pairing key
-# (item 2), the F1 silent-drop decision (item 4), and the summary log line
-# (item 5).
+# Part E -- turn_id in the pairing key (item 2), the F1 silent-drop decision
+# (item 4), and the summary log line (item 5).
 # ---------------------------------------------------------------------------
-
-
-def test_dedup_does_not_blank_a_different_later_turns_identical_prose():
-    """Item 1a: two DIFFERENT turns whose only exchange happens to share
-    byte-identical ``assistant_content``, with nothing else between them in
-    the task-wide flat exchange order, must both keep their prose.
-
-    Before the fix, ``_dedupe_parallel_batch_prose`` ran over the flat,
-    task-wide exchange list *before* turn grouping, so adjacency in that
-    list (not an actual parallel batch) blanked the second turn's prose.
-    Adjacency across a turn boundary is not the same thing as adjacency
-    within one turn's parallel tool-call batch.
-    """
-    db_session = _create_db_session()
-    try:
-        task = _create_task(db_session)
-        shared_prose = "Looking into it now."
-
-        _add_chat_message(
-            db_session,
-            task,
-            role="user",
-            content="turn 1",
-            created_at=_ts(0),
-            turn_id="turn-1",
-        )
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_start",
-            timestamp=_ts(1),
-            turn_id="turn-1",
-            data={
-                "tool_name": "tool_one",
-                "tool_params": {},
-                "tool_call_id": "call-1",
-                "assistant_content": shared_prose,
-            },
-        )
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_end",
-            timestamp=_ts(2),
-            turn_id="turn-1",
-            data={
-                "tool_name": "tool_one",
-                "tool_call_id": "call-1",
-                "success": True,
-                "result": {"ok": True},
-            },
-        )
-
-        _add_chat_message(
-            db_session,
-            task,
-            role="user",
-            content="turn 2, a genuinely different later turn",
-            created_at=_ts(3),
-            turn_id="turn-2",
-        )
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_start",
-            timestamp=_ts(4),
-            turn_id="turn-2",
-            data={
-                "tool_name": "tool_two",
-                "tool_params": {},
-                "tool_call_id": "call-2",
-                # Coincidentally identical prose -- not a parallel batch,
-                # a different turn.
-                "assistant_content": shared_prose,
-            },
-        )
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_end",
-            timestamp=_ts(5),
-            turn_id="turn-2",
-            data={
-                "tool_name": "tool_two",
-                "tool_call_id": "call-2",
-                "success": True,
-                "result": {"ok": True},
-            },
-        )
-
-        messages = load_task_conversation_context_sync(db_session, int(task.id))
-        assistant_by_tool = {}
-        for index, message in enumerate(messages):
-            if message["role"] != "assistant" or not message.get("tool_calls"):
-                continue
-            assistant_by_tool[message["tool_calls"][0]["function"]["name"]] = message[
-                "content"
-            ]
-
-        assert assistant_by_tool["tool_one"] == shared_prose
-        assert assistant_by_tool["tool_two"] == shared_prose
-    finally:
-        db_session.close()
-
-
-def test_dedup_ignores_a_dropped_legacy_predecessor():
-    """Item 1b: a legacy exchange with no usable ``turn_id`` is dropped by
-    ``_group_exchanges_by_turn`` and never reaches rendering -- it must not
-    still act as "previous" for a real, rendered exchange that happens to
-    share its prose and immediately follows it in the flat, pre-grouping
-    order.
-    """
-    db_session = _create_db_session()
-    try:
-        task = _create_task(db_session)
-        shared_prose = "Same wording, unrelated turns."
-
-        # Legacy exchange: no turn_id on either event, so it is dropped
-        # by _group_exchanges_by_turn and never rendered.
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_start",
-            timestamp=_ts(0),
-            data={
-                "tool_name": "legacy_tool",
-                "tool_params": {},
-                "tool_call_id": "call-legacy",
-                "assistant_content": shared_prose,
-            },
-        )
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_end",
-            timestamp=_ts(1),
-            data={
-                "tool_name": "legacy_tool",
-                "tool_call_id": "call-legacy",
-                "success": True,
-                "result": {"ok": True},
-            },
-        )
-
-        # Real turn, immediately after in the flat order, sharing the same
-        # prose byte-for-byte.
-        _add_chat_message(
-            db_session,
-            task,
-            role="user",
-            content="go",
-            created_at=_ts(2),
-            turn_id="turn-1",
-        )
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_start",
-            timestamp=_ts(3),
-            turn_id="turn-1",
-            data={
-                "tool_name": "real_tool",
-                "tool_params": {},
-                "tool_call_id": "call-real",
-                "assistant_content": shared_prose,
-            },
-        )
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_end",
-            timestamp=_ts(4),
-            turn_id="turn-1",
-            data={
-                "tool_name": "real_tool",
-                "tool_call_id": "call-real",
-                "success": True,
-                "result": {"ok": True},
-            },
-        )
-
-        messages = load_task_conversation_context_sync(db_session, int(task.id))
-        assistant_messages = [
-            m for m in messages if m["role"] == "assistant" and m.get("tool_calls")
-        ]
-        assert len(assistant_messages) == 1
-        assert assistant_messages[0]["content"] == shared_prose
-        assert assistant_messages[0]["tool_calls"][0]["function"]["name"] == (
-            "real_tool"
-        )
-    finally:
-        db_session.close()
 
 
 def test_pairing_key_with_turn_id_does_not_change_well_formed_single_turn_pairing():
@@ -2665,5 +2288,136 @@ def test_summary_log_line_reports_every_drop_reason_with_correct_counts(caplog):
         assert "exchanges_with_unmatched_turn=1" in message
         assert "dangling_tool_starts=1" in message
         assert "tool_ends_without_start=1" in message
+    finally:
+        db_session.close()
+
+
+# ---------------------------------------------------------------------------
+# Part F -- assistant prose is carried through verbatim (no dedup).
+# ---------------------------------------------------------------------------
+
+
+def test_serialized_iterations_with_identical_prose_both_keep_it():
+    """Two *serialized* ReAct iterations inside one turn -- A start, A end,
+    B start, B end -- whose LLM responses happen to carry byte-identical
+    prose must both keep it.
+
+    Serialized iterations share a step_id (minted once per pattern run) and
+    a turn_id, so they are indistinguishable from a parallel batch by key
+    alone; the removed prose dedup blanked B here, dropping content the live
+    message history had. A parallel batch cannot produce this shape in the
+    first place -- ``_remember_tool_call_content`` stamps prose on only the
+    first non-control call of a batch -- so there is nothing to trade off.
+    """
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="go",
+            created_at=_ts(-1),
+            turn_id="turn-1",
+        )
+        repeated_prose = "Let me check the file."
+
+        # Fully serialized: A's end precedes B's start.
+        for index, call_id in enumerate(("call-A", "call-B")):
+            _add_trace_event(
+                db_session,
+                task,
+                event_type="tool_execution_start",
+                timestamp=_ts(index * 10),
+                turn_id="turn-1",
+                data={
+                    "tool_name": "read_file",
+                    "tool_params": {"path": f"f{index}.py"},
+                    "tool_call_id": call_id,
+                    "assistant_content": repeated_prose,
+                },
+            )
+            _add_trace_event(
+                db_session,
+                task,
+                event_type="tool_execution_end",
+                timestamp=_ts(index * 10 + 5),
+                turn_id="turn-1",
+                data={
+                    "tool_name": "read_file",
+                    "tool_call_id": call_id,
+                    "success": True,
+                    "result": {"index": index},
+                },
+            )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        assistant_contents = [
+            m["content"]
+            for m in messages
+            if m["role"] == "assistant" and m.get("tool_calls")
+        ]
+        assert assistant_contents == [repeated_prose, repeated_prose]
+    finally:
+        db_session.close()
+
+
+def test_same_prose_separated_by_a_prose_less_exchange_is_kept():
+    """The removed dedup skipped prose-less exchanges without resetting its
+    "previous" value, so an intervening exchange with no prose did not break
+    the run of duplicates. All three exchanges here must come through with
+    exactly the prose their own start event carried."""
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="go",
+            created_at=_ts(-1),
+            turn_id="turn-1",
+        )
+        repeated_prose = "Let me check the file."
+        proses = [repeated_prose, None, repeated_prose]
+
+        for index, prose in enumerate(proses):
+            call_id = f"call-{index}"
+            data = {
+                "tool_name": "read_file",
+                "tool_params": {"path": f"f{index}.py"},
+                "tool_call_id": call_id,
+            }
+            if prose is not None:
+                data["assistant_content"] = prose
+            _add_trace_event(
+                db_session,
+                task,
+                event_type="tool_execution_start",
+                timestamp=_ts(index * 10),
+                turn_id="turn-1",
+                data=data,
+            )
+            _add_trace_event(
+                db_session,
+                task,
+                event_type="tool_execution_end",
+                timestamp=_ts(index * 10 + 5),
+                turn_id="turn-1",
+                data={
+                    "tool_name": "read_file",
+                    "tool_call_id": call_id,
+                    "success": True,
+                    "result": {"index": index},
+                },
+            )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        assistant_contents = [
+            m["content"]
+            for m in messages
+            if m["role"] == "assistant" and m.get("tool_calls")
+        ]
+        assert assistant_contents == [repeated_prose, "", repeated_prose]
     finally:
         db_session.close()

--- a/tests/web/services/test_task_conversation_context_service.py
+++ b/tests/web/services/test_task_conversation_context_service.py
@@ -424,63 +424,6 @@ def test_multi_turn_history_is_chronological():
         db_session.close()
 
 
-def test_naive_and_aware_timestamps_merge_without_error():
-    db_session = _create_db_session()
-    try:
-        task = _create_task(db_session)
-
-        # created_at written as naive (as SQLite round-trips it) while trace
-        # timestamps are aware -- must not raise TypeError when merged.
-        _add_chat_message(
-            db_session,
-            task,
-            role="user",
-            content="naive user message",
-            created_at=datetime(2026, 1, 1, 0, 0, 0),  # naive
-            turn_id="turn-1",
-        )
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_start",
-            timestamp=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
-            turn_id="turn-1",
-            data={
-                "tool_name": "list_files",
-                "tool_params": {},
-                "tool_call_id": "call-aware",
-            },
-        )
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_end",
-            timestamp=datetime(2026, 1, 1, 0, 0, 2, tzinfo=timezone.utc),
-            turn_id="turn-1",
-            data={
-                "tool_name": "list_files",
-                "tool_call_id": "call-aware",
-                "success": True,
-                "result": {"ok": True},
-            },
-        )
-        _add_chat_message(
-            db_session,
-            task,
-            role="assistant",
-            content="naive assistant reply",
-            created_at=datetime(2026, 1, 1, 0, 0, 3),  # naive
-        )
-
-        messages = load_task_conversation_context_sync(db_session, int(task.id))
-        roles = [m["role"] for m in messages]
-        assert roles == ["user", "assistant", "tool", "assistant"]
-        assert messages[0]["content"] == "naive user message"
-        assert messages[-1]["content"] == "naive assistant reply"
-    finally:
-        db_session.close()
-
-
 def test_as_aware_utc_normalizes_naive_and_preserves_aware():
     """Direct unit test of ``_as_aware_utc`` itself, independent of any DB
     round trip. A naive datetime gets stamped UTC; an already-aware datetime
@@ -506,10 +449,11 @@ def test_merge_chronologically_places_group_immediately_after_its_turn_user_row(
     Placement is a ``turn_id`` join, not a timestamp comparison (see
     ``_merge_chronologically``'s docstring), so this no longer needs to
     prove anything about naive-vs-aware datetimes -- ``_merge_chronologically``
-    doesn't compare timestamps at all any more. What it must still prove:
-    a group is spliced in immediately after the transcript row carrying its
-    turn_id, and before whatever comes next, regardless of either side's
-    ``created_at``/``sort_key`` values.
+    doesn't compare timestamps at all any more, and ``_TranscriptRow`` no
+    longer even carries a clock value. What it must still prove: a group is
+    spliced in immediately after the transcript row carrying its turn_id,
+    and before whatever comes next, regardless of the exchange's own
+    ``sort_key``.
     """
     from xagent.web.services.task_conversation_context_service import (
         _merge_chronologically,
@@ -521,14 +465,12 @@ def test_merge_chronologically_places_group_immediately_after_its_turn_user_row(
         row_id=1,
         role="user",
         content="hi",
-        created_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
         turn_id="turn-1",
     )
     reply_row = _TranscriptRow(
         row_id=2,
         role="assistant",
         content="done",
-        created_at=datetime(2026, 1, 1, 0, 0, 5, tzinfo=timezone.utc),
     )
     exchange = _ToolExchange(
         call_id="call-1",
@@ -624,61 +566,6 @@ def test_control_tools_are_excluded():
         for control_tool_name in CONTROL_TOOL_NAMES:
             assert control_tool_name not in tool_names
         assert tool_names == ["list_files"]
-    finally:
-        db_session.close()
-
-
-def test_parallel_batch_assistant_content_not_duplicated():
-    db_session = _create_db_session()
-    try:
-        task = _create_task(db_session)
-        _add_chat_message(
-            db_session,
-            task,
-            role="user",
-            content="go",
-            created_at=_ts(-1),
-            turn_id="turn-1",
-        )
-        shared_prose = "Running two lookups in parallel."
-
-        for index in range(2):
-            call_id = f"parallel-call-{index}"
-            _add_trace_event(
-                db_session,
-                task,
-                event_type="tool_execution_start",
-                timestamp=_ts(index),
-                turn_id="turn-1",
-                data={
-                    "tool_name": "list_files",
-                    "tool_params": {"index": index},
-                    "tool_call_id": call_id,
-                    "assistant_content": shared_prose,
-                },
-            )
-            _add_trace_event(
-                db_session,
-                task,
-                event_type="tool_execution_end",
-                timestamp=_ts(index + 10),
-                turn_id="turn-1",
-                data={
-                    "tool_name": "list_files",
-                    "tool_call_id": call_id,
-                    "success": True,
-                    "result": {"index": index},
-                },
-            )
-
-        messages = load_task_conversation_context_sync(db_session, int(task.id))
-        assistant_contents = [
-            m["content"]
-            for m in messages
-            if m["role"] == "assistant" and m.get("tool_calls")
-        ]
-        assert assistant_contents.count(shared_prose) == 1
-        assert assistant_contents.count("") == 1
     finally:
         db_session.close()
 
@@ -876,88 +763,6 @@ def test_react_shaped_events_without_step_discriminator_still_pair_correctly():
 # ---------------------------------------------------------------------------
 # Part C -- coverage for previously-untested paths
 # ---------------------------------------------------------------------------
-
-
-def test_clock_skew_guard_relocates_misplaced_exchange_atomically():
-    """A tool exchange timestamped BEFORE the first transcript user message
-    (DB clock vs app clock skew) must still be placed after it, and the
-    placed assistant/tool block must stay atomic (the tool message
-    immediately follows its declaring assistant message).
-
-    Placement is a ``turn_id`` join now, not a timestamp-adjacency guard, so
-    the skewed timestamps below are deliberately kept (rather than removed)
-    to prove the join makes them irrelevant: this exchange lands right after
-    its turn's user message regardless of which one has the earlier clock
-    reading.
-    """
-    db_session = _create_db_session()
-    try:
-        task = _create_task(db_session)
-        base = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
-
-        # The transcript's first user message, created_at = base.
-        _add_chat_message(
-            db_session,
-            task,
-            role="user",
-            content="first turn",
-            created_at=base,
-            turn_id="turn-1",
-        )
-
-        # This exchange's trace timestamps predate the first user message --
-        # simulating clock skew between the DB clock (created_at) and the
-        # app clock (trace timestamps). Only turn_id, not timestamp order,
-        # decides placement now.
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_start",
-            timestamp=base - timedelta(seconds=50),
-            turn_id="turn-1",
-            data={
-                "tool_name": "list_files",
-                "tool_params": {},
-                "tool_call_id": "call-skewed",
-                "assistant_content": "Looking things up.",
-            },
-        )
-        _add_trace_event(
-            db_session,
-            task,
-            event_type="tool_execution_end",
-            timestamp=base - timedelta(seconds=49),
-            turn_id="turn-1",
-            data={
-                "tool_name": "list_files",
-                "tool_call_id": "call-skewed",
-                "success": True,
-                "result": {"ok": True},
-            },
-        )
-
-        _add_chat_message(
-            db_session,
-            task,
-            role="assistant",
-            content="done",
-            created_at=base + timedelta(seconds=10),
-        )
-
-        messages = load_task_conversation_context_sync(db_session, int(task.id))
-        roles = [m["role"] for m in messages]
-
-        # Placed after the first user message, not before it.
-        assert roles[0] == "user"
-        assert messages[0]["content"] == "first turn"
-        assert roles[1] == "assistant" and messages[1].get("tool_calls")
-        assert roles[2] == "tool"
-        assert messages[2]["tool_call_id"] == "call-skewed"
-        # Atomic: the tool message is immediately preceded by its assistant.
-        assert messages[1]["tool_calls"][0]["id"] == messages[2]["tool_call_id"]
-        assert roles[3] == "assistant" and messages[3]["content"] == "done"
-    finally:
-        db_session.close()
 
 
 def test_before_message_id_excludes_current_turn_user_message():

--- a/tests/web/services/test_task_conversation_context_service.py
+++ b/tests/web/services/test_task_conversation_context_service.py
@@ -1,0 +1,1271 @@
+import json
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.core.agent.result import CONTROL_TOOL_NAMES
+from xagent.core.context_ref import CONTEXT_REFS_KEY
+from xagent.web.models.chat_message import TaskChatMessage
+from xagent.web.models.database import Base
+from xagent.web.models.task import Task, TaskStatus, TraceEvent
+from xagent.web.models.user import User
+from xagent.web.services.chat_history_service import _MAX_HISTORICAL_IMAGE_CONTEXT_REFS
+from xagent.web.services.task_conversation_context_service import (
+    load_task_conversation_context_sync,
+)
+
+# Serialized size matters here: the old buggy path blind-sliced tool results
+# at 240 chars, and this fixture must land comfortably past that boundary so
+# the test still catches a truncation regression after future edits. The
+# original 7-field version of this fixture serialized (as ``{"handle": ...}``)
+# to 241 chars -- a single character of margin over the old 240-char cutoff,
+# which the old buggy code would have slipped past undetected on nearly any
+# edit. ``commit_sha``/``container_image`` are added purely to push this to
+# ~368 chars, well clear of that boundary; don't shrink this fixture without
+# re-checking it stays well above 240.
+STRUCTURED_HANDLE = {
+    "workspace": "4b33784773d5",
+    "branch": "review-pr-1392",
+    "provider": "omp",
+    "profile": "omp",
+    "provider_session_id": "01a00aff-558e-7000-8ebf-ec547e8018b0",
+    "last_run_id": "76ff56bf27554b899e74bce25f9dc769",
+    "node_id": "node-0",
+    "commit_sha": "a1b2c3d4e5f60718293a4b5c6d7e8f9012345678",
+    "container_image": "ghcr.io/xagent/sandbox-runner:2026.08.17-py311",
+}
+
+
+def _create_db_session():
+    engine = create_engine("sqlite:///:memory:")
+    SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    Base.metadata.create_all(bind=engine)
+    return SessionLocal()
+
+
+def _create_task(db_session):
+    user = User(username="tester", password_hash="hashed_password", is_admin=False)
+    db_session.add(user)
+    db_session.commit()
+    db_session.refresh(user)
+
+    task = Task(
+        user_id=int(user.id),
+        title="Conversation context task",
+        description="Task conversation context",
+        status=TaskStatus.COMPLETED,
+    )
+    db_session.add(task)
+    db_session.commit()
+    db_session.refresh(task)
+    return task
+
+
+def _add_chat_message(
+    db_session, task, *, role, content, created_at, turn_id=None, attachments=None
+):
+    message = TaskChatMessage(
+        task_id=int(task.id),
+        user_id=int(task.user_id),
+        role=role,
+        content=content,
+        message_type=role,
+        turn_id=turn_id,
+        created_at=created_at,
+        attachments=attachments,
+    )
+    db_session.add(message)
+    db_session.commit()
+    db_session.refresh(message)
+    return message
+
+
+def _add_trace_event(
+    db_session,
+    task,
+    *,
+    event_type,
+    data,
+    timestamp,
+    event_id=None,
+    step_id=None,
+):
+    event = TraceEvent(
+        task_id=int(task.id),
+        build_id=None,
+        event_id=event_id or f"{event_type}-{timestamp.isoformat()}",
+        event_type=event_type,
+        timestamp=timestamp,
+        step_id=step_id,
+        parent_event_id=None,
+        data=data,
+    )
+    db_session.add(event)
+    db_session.commit()
+    db_session.refresh(event)
+    return event
+
+
+def _ts(seconds_offset, base=None, tz=timezone.utc):
+    base = base or datetime(2026, 1, 1, tzinfo=tz)
+    return base + timedelta(seconds=seconds_offset)
+
+
+def test_structured_handle_survives_reconstruction_byte_for_byte():
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(0),
+            data={
+                "tool_name": "resume_task",
+                "tool_params": {"workspace": "4b33784773d5"},
+                "tool_call_id": "call-handle-1",
+                "assistant_content": "Resuming previous workspace.",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(1),
+            data={
+                "tool_name": "resume_task",
+                "tool_call_id": "call-handle-1",
+                "success": True,
+                "result": {"handle": dict(STRUCTURED_HANDLE)},
+            },
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+
+        tool_messages = [m for m in messages if m["role"] == "tool"]
+        assert len(tool_messages) == 1
+        assert tool_messages[0]["raw_result"]["handle"] == STRUCTURED_HANDLE
+
+        serialized = json.dumps(messages, ensure_ascii=False, default=str)
+        # Discriminating check: the old bug did a blind fixed-length
+        # character slice, which would corrupt whichever field that offset
+        # happened to land inside. A field near the FRONT of the object
+        # (like "branch", checked by an earlier version of this test) would
+        # still survive most such slices and give a false pass -- the
+        # 237-char legacy boundary sat well past "branch"'s offset. A field
+        # placed at the very END of the object, like "container_image"
+        # here, is what a fixed-length slice would actually clip first;
+        # its exact, untruncated presence is the meaningful signal.
+        assert (
+            '"container_image": "ghcr.io/xagent/sandbox-runner:2026.08.17-py311"'
+            in serialized
+        )
+        assert json.loads(serialized) == messages  # round-trips byte-for-byte
+    finally:
+        db_session.close()
+
+
+def test_tool_call_pairing_never_orphaned():
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+
+        # Normal start + end.
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(0),
+            data={
+                "tool_name": "list_files",
+                "tool_params": {"path": "."},
+                "tool_call_id": "call-1",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(1),
+            data={
+                "tool_name": "list_files",
+                "tool_call_id": "call-1",
+                "success": True,
+                "result": {"files": ["a.txt"]},
+            },
+        )
+
+        # End with no start.
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(2),
+            data={
+                "tool_name": "read_file",
+                "tool_call_id": "call-orphan-end",
+                "success": True,
+                "result": {"content": "hello"},
+            },
+        )
+
+        # Start with no end -> should yield nothing.
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(3),
+            data={
+                "tool_name": "write_file",
+                "tool_params": {"path": "b.txt"},
+                "tool_call_id": "call-orphan-start",
+            },
+        )
+
+        # Missing tool_call_id entirely.
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(4),
+            data={
+                "tool_name": "web_search",
+                "tool_params": {"query": "xagent"},
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(5),
+            data={
+                "tool_name": "web_search",
+                "success": True,
+                "result": {"top_result": "https://example.com"},
+            },
+        )
+
+        # tool_execution_failed.
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(6),
+            data={
+                "tool_name": "run_command",
+                "tool_params": {"cmd": "false"},
+                "tool_call_id": "call-fail",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_failed",
+            timestamp=_ts(7),
+            data={
+                "tool_name": "run_command",
+                "tool_call_id": "call-fail",
+                "error_type": "agent_tool_error",
+                "error": "boom",
+                "error_message": "boom",
+            },
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+
+        tool_calls_by_id = {}
+        for index, message in enumerate(messages):
+            if message["role"] != "assistant" or not message.get("tool_calls"):
+                continue
+            for call in message["tool_calls"]:
+                tool_calls_by_id[call["id"]] = index
+
+        for index, message in enumerate(messages):
+            if message["role"] != "tool":
+                continue
+            call_id = message["tool_call_id"]
+            assert call_id in tool_calls_by_id
+            assert tool_calls_by_id[call_id] == index - 1
+
+        tool_names_emitted = [m["tool_name"] for m in messages if m["role"] == "tool"]
+        assert "write_file" not in tool_names_emitted  # start-with-no-end -> nothing
+        assert "list_files" in tool_names_emitted
+        assert "read_file" in tool_names_emitted
+        assert "run_command" in tool_names_emitted
+
+        run_command_tool = next(
+            m
+            for m in messages
+            if m["role"] == "tool" and m["tool_name"] == "run_command"
+        )
+        assert run_command_tool["raw_result"]["error"] == "boom"
+    finally:
+        db_session.close()
+
+
+def test_multi_turn_history_is_chronological():
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        for turn in range(3):
+            offset_minutes = turn * 10
+            _add_chat_message(
+                db_session,
+                task,
+                role="user",
+                content=f"user turn {turn}",
+                created_at=base + timedelta(minutes=offset_minutes),
+            )
+            for tool_index in range(2):
+                call_id = f"turn{turn}-call{tool_index}"
+                ts_start = base + timedelta(
+                    minutes=offset_minutes, seconds=1 + tool_index * 2
+                )
+                ts_end = base + timedelta(
+                    minutes=offset_minutes, seconds=2 + tool_index * 2
+                )
+                _add_trace_event(
+                    db_session,
+                    task,
+                    event_type="tool_execution_start",
+                    timestamp=ts_start,
+                    data={
+                        "tool_name": "list_files",
+                        "tool_params": {"turn": turn, "tool_index": tool_index},
+                        "tool_call_id": call_id,
+                    },
+                )
+                _add_trace_event(
+                    db_session,
+                    task,
+                    event_type="tool_execution_end",
+                    timestamp=ts_end,
+                    data={
+                        "tool_name": "list_files",
+                        "tool_call_id": call_id,
+                        "success": True,
+                        "result": {"turn": turn, "tool_index": tool_index},
+                    },
+                )
+            _add_chat_message(
+                db_session,
+                task,
+                role="assistant",
+                content=f"assistant answer {turn}",
+                created_at=base + timedelta(minutes=offset_minutes, seconds=9),
+            )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        roles = [m["role"] for m in messages]
+
+        assert roles.count("user") == 3
+        assert (
+            roles.count("assistant") == 3 + 3 * 2
+        )  # turn answers + tool-call assistants
+        assert roles.count("tool") == 6
+
+        for turn in range(3):
+            user_index = messages.index(
+                {"role": "user", "content": f"user turn {turn}"}
+            )
+            answer_index = next(
+                index
+                for index, m in enumerate(messages)
+                if m["role"] == "assistant"
+                and m.get("content") == f"assistant answer {turn}"
+            )
+            assert user_index < answer_index
+            # every tool exchange for this turn sits strictly between the two
+            for index in range(user_index + 1, answer_index):
+                message = messages[index]
+                if message["role"] == "tool":
+                    assert message["raw_result"]["turn"] == turn
+    finally:
+        db_session.close()
+
+
+def test_naive_and_aware_timestamps_merge_without_error():
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+
+        # created_at written as naive (as SQLite round-trips it) while trace
+        # timestamps are aware -- must not raise TypeError when merged.
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="naive user message",
+            created_at=datetime(2026, 1, 1, 0, 0, 0),  # naive
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+            data={
+                "tool_name": "list_files",
+                "tool_params": {},
+                "tool_call_id": "call-aware",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=datetime(2026, 1, 1, 0, 0, 2, tzinfo=timezone.utc),
+            data={
+                "tool_name": "list_files",
+                "tool_call_id": "call-aware",
+                "success": True,
+                "result": {"ok": True},
+            },
+        )
+        _add_chat_message(
+            db_session,
+            task,
+            role="assistant",
+            content="naive assistant reply",
+            created_at=datetime(2026, 1, 1, 0, 0, 3),  # naive
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        roles = [m["role"] for m in messages]
+        assert roles == ["user", "assistant", "tool", "assistant"]
+        assert messages[0]["content"] == "naive user message"
+        assert messages[-1]["content"] == "naive assistant reply"
+    finally:
+        db_session.close()
+
+
+def test_as_aware_utc_normalizes_naive_and_preserves_aware():
+    """Direct unit test of ``_as_aware_utc`` itself, independent of any DB
+    round trip. A naive datetime gets stamped UTC; an already-aware datetime
+    (in a non-UTC zone) passes through unchanged rather than being re-based.
+    """
+    from xagent.web.services.task_conversation_context_service import _as_aware_utc
+
+    naive = datetime(2026, 1, 1, 12, 0, 0)
+    normalized = _as_aware_utc(naive)
+    assert normalized.tzinfo is timezone.utc
+    assert normalized == datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    aware_non_utc = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone(timedelta(hours=5)))
+    normalized_aware = _as_aware_utc(aware_non_utc)
+    assert normalized_aware.tzinfo == timezone(timedelta(hours=5))
+    assert normalized_aware == aware_non_utc
+
+
+def test_merge_chronologically_orders_naive_and_aware_without_typeerror():
+    """Direct unit test of the merge path (R4) with hand-built naive/aware
+    datetimes, bypassing the DB round trip entirely.
+
+    ``test_naive_and_aware_timestamps_merge_without_error`` above looks like
+    it covers the naive-vs-aware hazard, but it doesn't: SQLite strips
+    tzinfo from *both* ``TaskChatMessage.created_at`` and
+    ``TraceEvent.timestamp`` on read-back, so by the time
+    ``_load_transcript_rows``/``_load_tool_exchanges`` see them, nothing
+    naive is ever compared against anything aware -- that test would pass
+    identically even if ``_as_aware_utc`` were replaced by the identity
+    function. This test builds a ``_TranscriptRow`` whose ``created_at`` is
+    genuinely naive-turned-aware and a ``_ToolExchange`` whose ``sort_key``
+    is genuinely aware, so a broken (identity) ``_as_aware_utc`` would raise
+    ``TypeError`` on the ``entries.sort`` call inside
+    ``_merge_chronologically`` -- proving the normalization is load-bearing.
+    """
+    from xagent.web.services.task_conversation_context_service import (
+        _as_aware_utc,
+        _merge_chronologically,
+        _ToolExchange,
+        _TranscriptRow,
+    )
+
+    naive_user = _TranscriptRow(
+        row_id=1,
+        role="user",
+        content="naive user",
+        created_at=_as_aware_utc(datetime(2026, 1, 1, 0, 0, 0)),  # naive input
+    )
+    aware_reply = _TranscriptRow(
+        row_id=2,
+        role="assistant",
+        content="aware assistant",
+        created_at=_as_aware_utc(datetime(2026, 1, 1, 0, 0, 5, tzinfo=timezone.utc)),
+    )
+    exchange = _ToolExchange(
+        call_id="call-1",
+        tool_name="list_files",
+        tool_params={},
+        result={"ok": True},
+        assistant_content="",
+        sort_key=(
+            _as_aware_utc(datetime(2026, 1, 1, 0, 0, 2, tzinfo=timezone.utc)),
+            10,
+        ),
+    )
+
+    entries = _merge_chronologically([naive_user, aware_reply], [exchange])
+    kinds_in_order = [entry.kind for entry in entries]
+    assert kinds_in_order == ["transcript", "exchange", "transcript"]
+    assert entries[1].exchange is exchange
+    assert entries[0].transcript is naive_user
+    assert entries[2].transcript is aware_reply
+
+
+def test_control_tools_are_excluded():
+    """Every name in ``CONTROL_TOOL_NAMES`` -- not just a couple of them --
+    must be excluded from reconstructed tool exchanges. This is checked
+    against the real ``CONTROL_TOOL_NAMES`` set rather than a hardcoded
+    tuple so a future addition to that set is automatically covered here."""
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+
+        for index, tool_name in enumerate(sorted(CONTROL_TOOL_NAMES)):
+            call_id = f"call-control-{index}"
+            _add_trace_event(
+                db_session,
+                task,
+                event_type="tool_execution_start",
+                timestamp=_ts(index * 10),
+                data={
+                    "tool_name": tool_name,
+                    "tool_params": {},
+                    "tool_call_id": call_id,
+                },
+            )
+            _add_trace_event(
+                db_session,
+                task,
+                event_type="tool_execution_end",
+                timestamp=_ts(index * 10 + 1),
+                data={
+                    "tool_name": tool_name,
+                    "tool_call_id": call_id,
+                    "success": True,
+                    "result": {"ok": True},
+                },
+            )
+
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(1000),
+            data={
+                "tool_name": "list_files",
+                "tool_params": {},
+                "tool_call_id": "call-real",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(1001),
+            data={
+                "tool_name": "list_files",
+                "tool_call_id": "call-real",
+                "success": True,
+                "result": {"files": []},
+            },
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        tool_names = [m["tool_name"] for m in messages if m["role"] == "tool"]
+        for control_tool_name in CONTROL_TOOL_NAMES:
+            assert control_tool_name not in tool_names
+        assert tool_names == ["list_files"]
+    finally:
+        db_session.close()
+
+
+def test_parallel_batch_assistant_content_not_duplicated():
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        shared_prose = "Running two lookups in parallel."
+
+        for index in range(2):
+            call_id = f"parallel-call-{index}"
+            _add_trace_event(
+                db_session,
+                task,
+                event_type="tool_execution_start",
+                timestamp=_ts(index),
+                data={
+                    "tool_name": "list_files",
+                    "tool_params": {"index": index},
+                    "tool_call_id": call_id,
+                    "assistant_content": shared_prose,
+                },
+            )
+            _add_trace_event(
+                db_session,
+                task,
+                event_type="tool_execution_end",
+                timestamp=_ts(index + 10),
+                data={
+                    "tool_name": "list_files",
+                    "tool_call_id": call_id,
+                    "success": True,
+                    "result": {"index": index},
+                },
+            )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        assistant_contents = [
+            m["content"]
+            for m in messages
+            if m["role"] == "assistant" and m.get("tool_calls")
+        ]
+        assert assistant_contents.count(shared_prose) == 1
+        assert assistant_contents.count("") == 1
+    finally:
+        db_session.close()
+
+
+def test_concurrent_dag_steps_with_colliding_tool_call_ids_are_not_mispaired():
+    """Two concurrent DAG branches whose tool-call ids collide (both fall
+    back to ``tool_call_0`` because the provider omitted a real id) must NOT
+    have their starts/ends cross-paired.
+
+    This reproduces the real corruption: DAG runs steps concurrently
+    (``asyncio.create_task`` in ``dag.py``), and ``_normalize_tool_calls``
+    (react.py) synthesizes ``tool_call_{index}`` where ``index`` is only
+    unique within a single LLM response -- so two concurrent steps can each
+    emit id "tool_call_0". Interleaving start A, start B, end A, end B with a
+    bare-``tool_call_id`` pending map would let B's start overwrite A's, and
+    A's end would then pop B's start, attaching branch B's tool_name /
+    assistant_content to branch A's result (and vice versa).
+
+    Each step carries its own ``step_id`` (DAG's ``_with_step`` stamps a
+    unique step id per concurrent branch, persisted on
+    ``TraceEvent.step_id``), which is exactly the discriminator this test
+    checks is actually used to disambiguate.
+    """
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+
+        # Branch A start (step "step-a"), then branch B start (step "step-b"),
+        # both using the colliding id "tool_call_0" -- interleaved as
+        # start A, start B, end A, end B, matching real concurrent arrival.
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(0),
+            step_id="step-a",
+            data={
+                "tool_name": "read_file",
+                "tool_params": {"path": "a.txt"},
+                "tool_call_id": "tool_call_0",
+                "assistant_content": "Branch A: reading a.txt.",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(1),
+            step_id="step-b",
+            data={
+                "tool_name": "list_files",
+                "tool_params": {"path": "b/"},
+                "tool_call_id": "tool_call_0",
+                "assistant_content": "Branch B: listing b/.",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(2),
+            step_id="step-a",
+            data={
+                "tool_name": "read_file",
+                "tool_call_id": "tool_call_0",
+                "success": True,
+                "result": {"content": "contents of a.txt"},
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(3),
+            step_id="step-b",
+            data={
+                "tool_name": "list_files",
+                "tool_call_id": "tool_call_0",
+                "success": True,
+                "result": {"files": ["b1.txt", "b2.txt"]},
+            },
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+
+        assistant_messages = [
+            m for m in messages if m["role"] == "assistant" and m.get("tool_calls")
+        ]
+        tool_messages = [m for m in messages if m["role"] == "tool"]
+        assert len(assistant_messages) == 2
+        assert len(tool_messages) == 2
+
+        by_result = {}
+        for assistant_message, tool_message in zip(assistant_messages, tool_messages):
+            call = assistant_message["tool_calls"][0]
+            by_result[tool_message["raw_result"].get("content") or "listing"] = (
+                assistant_message["content"],
+                call["function"]["name"],
+                tool_message["tool_name"],
+            )
+
+        content_a, tool_name_a, result_tool_name_a = by_result["contents of a.txt"]
+        assert content_a == "Branch A: reading a.txt."
+        assert tool_name_a == "read_file"
+        assert result_tool_name_a == "read_file"
+
+        content_b, tool_name_b, result_tool_name_b = by_result["listing"]
+        assert content_b == "Branch B: listing b/."
+        assert tool_name_b == "list_files"
+        assert result_tool_name_b == "list_files"
+    finally:
+        db_session.close()
+
+
+def test_react_shaped_events_without_step_discriminator_still_pair_correctly():
+    """ReAct never sets a colliding id within one turn, and older rows
+    persisted before ``TraceEvent.step_id`` was populated carry
+    ``step_id=None`` for every event. Both must still pair by bare
+    ``tool_call_id`` exactly as before this fix -- the step-id
+    discriminator must be a no-op here, not a behavior change.
+    """
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(0),
+            step_id=None,
+            data={
+                "tool_name": "search_web",
+                "tool_params": {"query": "xagent"},
+                "tool_call_id": "call-1",
+                "assistant_content": "Searching the web.",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(1),
+            step_id=None,
+            data={
+                "tool_name": "search_web",
+                "tool_call_id": "call-1",
+                "success": True,
+                "result": {"top_result": "https://example.com"},
+            },
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+
+        assistant_messages = [
+            m for m in messages if m["role"] == "assistant" and m.get("tool_calls")
+        ]
+        tool_messages = [m for m in messages if m["role"] == "tool"]
+        assert len(assistant_messages) == 1
+        assert len(tool_messages) == 1
+        assert assistant_messages[0]["content"] == "Searching the web."
+        assert assistant_messages[0]["tool_calls"][0]["function"]["name"] == (
+            "search_web"
+        )
+        assert tool_messages[0]["raw_result"] == {"top_result": "https://example.com"}
+    finally:
+        db_session.close()
+
+
+# ---------------------------------------------------------------------------
+# Part C -- coverage for previously-untested paths
+# ---------------------------------------------------------------------------
+
+
+def test_clock_skew_guard_relocates_misplaced_exchange_atomically():
+    """A tool exchange timestamped BEFORE the first transcript user message
+    (DB clock vs app clock skew) must be repositioned after it in the merged
+    output, and the relocated assistant/tool block must stay atomic (the
+    tool message immediately follows its declaring assistant message)."""
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        base = datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
+
+        # The transcript's first user message, created_at = base.
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="first turn",
+            created_at=base,
+        )
+
+        # This exchange's trace timestamps predate the first user message --
+        # simulating clock skew between the DB clock (created_at) and the
+        # app clock (trace timestamps).
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=base - timedelta(seconds=50),
+            data={
+                "tool_name": "list_files",
+                "tool_params": {},
+                "tool_call_id": "call-skewed",
+                "assistant_content": "Looking things up.",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=base - timedelta(seconds=49),
+            data={
+                "tool_name": "list_files",
+                "tool_call_id": "call-skewed",
+                "success": True,
+                "result": {"ok": True},
+            },
+        )
+
+        _add_chat_message(
+            db_session,
+            task,
+            role="assistant",
+            content="done",
+            created_at=base + timedelta(seconds=10),
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        roles = [m["role"] for m in messages]
+
+        # Repositioned after the first user message, not before it.
+        assert roles[0] == "user"
+        assert messages[0]["content"] == "first turn"
+        assert roles[1] == "assistant" and messages[1].get("tool_calls")
+        assert roles[2] == "tool"
+        assert messages[2]["tool_call_id"] == "call-skewed"
+        # Atomic: the tool message is immediately preceded by its assistant.
+        assert messages[1]["tool_calls"][0]["id"] == messages[2]["tool_call_id"]
+        assert roles[3] == "assistant" and messages[3]["content"] == "done"
+    finally:
+        db_session.close()
+
+
+def test_before_message_id_excludes_current_turn_user_message():
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        prior = _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="prior turn message",
+            created_at=base,
+        )
+        current = _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="current turn message",
+            created_at=base + timedelta(seconds=10),
+        )
+        assert prior.id < current.id
+
+        messages = load_task_conversation_context_sync(
+            db_session, int(task.id), before_message_id=int(current.id)
+        )
+        contents = [m.get("content") for m in messages]
+        assert "prior turn message" in contents
+        assert "current turn message" not in contents
+    finally:
+        db_session.close()
+
+
+def test_resolve_tool_result_interrupted_branch_without_result():
+    """A ``tool_execution_end`` marked ``interrupted`` with no ``result`` key
+    must produce the degraded interrupted dict, not fall through to the
+    "missing result" branch or a bare ``None``."""
+    from xagent.web.services.task_conversation_context_service import (
+        _resolve_tool_result,
+    )
+
+    resolved = _resolve_tool_result(
+        "tool_execution_end",
+        {
+            "tool_name": "run_command",
+            "interrupted": True,
+            "interrupt_reason": "user cancelled the run",
+        },
+    )
+    assert resolved == {
+        "success": False,
+        "interrupted": True,
+        "error": "user cancelled the run",
+    }
+
+
+def test_final_pairing_sweep_drops_orphaned_tool_message():
+    """Direct unit test of ``_final_pairing_sweep``: no fixture in this suite
+    naturally produces an orphaned ``tool`` message (construction is
+    designed to never emit one), so this exercises the safety-net sweep
+    itself with a hand-built orphan."""
+    from xagent.web.services.task_conversation_context_service import (
+        _final_pairing_sweep,
+    )
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "tool",
+            "tool_call_id": "orphan-1",
+            "content": "",
+            "tool_name": "orphan_tool",
+            "raw_result": {},
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "real_tool", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-1",
+            "content": "",
+            "tool_name": "real_tool",
+            "raw_result": {},
+        },
+    ]
+
+    sanitized = _final_pairing_sweep(messages)
+    assert sanitized == [messages[0], messages[2], messages[3]]
+    tool_call_ids = [m["tool_call_id"] for m in sanitized if m["role"] == "tool"]
+    assert tool_call_ids == ["call-1"]
+
+
+# ---------------------------------------------------------------------------
+# Part D -- regression tests for the fixes just made
+# ---------------------------------------------------------------------------
+
+
+def test_dedup_positional_after_sort_keeps_different_turns_distinct_prose():
+    """Fix 5 regression: two DIFFERENT turns emitting byte-identical
+    assistant prose must BOTH keep their prose. The old code tracked
+    ``last_assistant_content`` across trace rows in *end-event-arrival*
+    order; when an unrelated exchange's END event lands before an earlier
+    exchange's own (slow-running) END event, positional dedup by end-order
+    could blank a later, unrelated turn's coincidentally identical prose.
+    Sorting by *start* time before deduping (the fix) keeps these turns
+    correctly separated by the truly-intervening exchange."""
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        shared_prose = "Investigating the failure."
+
+        # Turn A: starts first, but is slow -- its end event arrives LAST.
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(0),
+            data={
+                "tool_name": "tool_a",
+                "tool_params": {},
+                "tool_call_id": "call-a",
+                "assistant_content": shared_prose,
+            },
+        )
+        # Turn B: starts after A, but is fast -- its end event arrives
+        # before A's, and carries different prose.
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(1),
+            data={
+                "tool_name": "tool_b",
+                "tool_params": {},
+                "tool_call_id": "call-b",
+                "assistant_content": "Checking a different thing.",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(2),  # B's end lands before A's end below.
+            data={
+                "tool_name": "tool_b",
+                "tool_call_id": "call-b",
+                "success": True,
+                "result": {"ok": True},
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(100),  # A finishes much later.
+            data={
+                "tool_name": "tool_a",
+                "tool_call_id": "call-a",
+                "success": True,
+                "result": {"ok": True},
+            },
+        )
+        # Turn C: a much later, unrelated turn that coincidentally repeats
+        # A's exact prose.
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(200),
+            data={
+                "tool_name": "tool_c",
+                "tool_params": {},
+                "tool_call_id": "call-c",
+                "assistant_content": shared_prose,
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(201),
+            data={
+                "tool_name": "tool_c",
+                "tool_call_id": "call-c",
+                "success": True,
+                "result": {"ok": True},
+            },
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        assistant_by_tool = {}
+        for index, message in enumerate(messages):
+            if message["role"] != "assistant" or not message.get("tool_calls"):
+                continue
+            tool_message = messages[index + 1]
+            assistant_by_tool[tool_message["tool_name"]] = message["content"]
+
+        assert assistant_by_tool["tool_a"] == shared_prose
+        assert assistant_by_tool["tool_c"] == shared_prose
+        assert assistant_by_tool["tool_b"] == "Checking a different thing."
+    finally:
+        db_session.close()
+
+
+def test_dedup_still_blanks_immediately_following_parallel_duplicate():
+    """Fix 5 regression, other half: a genuine parallel batch (same start
+    time, no other exchange between them in start order) must still have
+    its duplicate prose blanked for the immediately-following exchange."""
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        shared_prose = "Running parallel lookups."
+
+        for index in range(3):
+            call_id = f"batch-call-{index}"
+            _add_trace_event(
+                db_session,
+                task,
+                event_type="tool_execution_start",
+                timestamp=_ts(index),
+                data={
+                    "tool_name": "list_files",
+                    "tool_params": {"index": index},
+                    "tool_call_id": call_id,
+                    "assistant_content": shared_prose,
+                },
+            )
+            _add_trace_event(
+                db_session,
+                task,
+                event_type="tool_execution_end",
+                timestamp=_ts(index + 10),
+                data={
+                    "tool_name": "list_files",
+                    "tool_call_id": call_id,
+                    "success": True,
+                    "result": {"index": index},
+                },
+            )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        assistant_contents = [
+            m["content"]
+            for m in messages
+            if m["role"] == "assistant" and m.get("tool_calls")
+        ]
+        assert len(assistant_contents) == 3
+        assert assistant_contents.count(shared_prose) == 1
+        assert assistant_contents.count("") == 2
+    finally:
+        db_session.close()
+
+
+def test_tool_execution_end_missing_result_yields_degraded_dict_not_none():
+    """Fix 6 regression: a ``tool_execution_end`` with no ``result`` key and
+    not marked ``interrupted`` must produce a degraded placeholder dict,
+    never a bare ``None`` flowing into ``raw_result``."""
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=_ts(0),
+            data={
+                "tool_name": "flaky_tool",
+                "tool_params": {},
+                "tool_call_id": "call-degraded",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=_ts(1),
+            data={
+                "tool_name": "flaky_tool",
+                "tool_call_id": "call-degraded",
+                "success": True,
+                # No "result" key, and not interrupted -- the degraded case.
+            },
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        tool_message = next(m for m in messages if m["role"] == "tool")
+        assert tool_message["raw_result"] is not None
+        assert tool_message["raw_result"] == {
+            "success": False,
+            "status": "unknown",
+            "error": "tool result missing from persisted trace event",
+        }
+    finally:
+        db_session.close()
+
+
+# ---------------------------------------------------------------------------
+# Uploaded-image context refs (regression: our resume path replaced
+# ``load_task_transcript`` with ``load_task_conversation_context_sync``, but
+# this module never read ``attachments`` -- resumed conversations silently
+# dropped uploaded images even though ``load_task_transcript`` still carries
+# them. These tests pin the fix.)
+# ---------------------------------------------------------------------------
+
+
+def test_uploaded_images_on_transcript_rows_survive_reconstruction():
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        base = _ts(0)
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="What is shown?",
+            created_at=base,
+            attachments=[
+                {
+                    "file_id": "image-id",
+                    "name": "diagram.png",
+                    "size": 321,
+                    "type": "image/png",
+                },
+                {
+                    "file_id": "pdf-id",
+                    "name": "notes.pdf",
+                    "size": 654,
+                    "type": "application/pdf",
+                },
+            ],
+        )
+        _add_chat_message(
+            db_session,
+            task,
+            role="assistant",
+            content="It's a diagram.",
+            created_at=base + timedelta(seconds=1),
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"] == "What is shown?"
+        references = messages[0][CONTEXT_REFS_KEY]
+        # Only the image attachment (not the pdf) becomes a context ref,
+        # matching ``build_image_context_references``'s image-only filter.
+        assert len(references) == 1
+        assert references[0]["file_ref"]["file_id"] == "image-id"
+        assert references[0]["metadata"] == {"source": "user_upload"}
+
+        # No image attachment on the assistant row -- no key at all, not an
+        # empty list, matching ``load_task_transcript``'s shape exactly.
+        assert CONTEXT_REFS_KEY not in messages[1]
+    finally:
+        db_session.close()
+
+
+def test_historical_image_budget_keeps_only_the_newest_n_across_messages():
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        base = _ts(0)
+        total_images = _MAX_HISTORICAL_IMAGE_CONTEXT_REFS + 2
+        for index in range(total_images):
+            _add_chat_message(
+                db_session,
+                task,
+                role="user",
+                content=f"Image {index}",
+                created_at=base + timedelta(seconds=index),
+                attachments=[
+                    {
+                        "file_id": f"image-{index}",
+                        "name": f"image-{index}.png",
+                        "type": "image/png",
+                    }
+                ],
+            )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+
+        assert len(messages) == total_images
+        # The oldest two messages, over budget, carry no context refs at all.
+        assert CONTEXT_REFS_KEY not in messages[0]
+        assert CONTEXT_REFS_KEY not in messages[1]
+        retained_ids = [
+            message[CONTEXT_REFS_KEY][0]["file_ref"]["file_id"]
+            for message in messages
+            if CONTEXT_REFS_KEY in message
+        ]
+        assert retained_ids == [f"image-{index}" for index in range(2, total_images)]
+    finally:
+        db_session.close()

--- a/tests/web/services/test_task_conversation_context_service.py
+++ b/tests/web/services/test_task_conversation_context_service.py
@@ -968,6 +968,127 @@ def test_final_pairing_sweep_drops_orphaned_tool_message():
     assert tool_call_ids == ["call-1"]
 
 
+def test_final_pairing_sweep_drops_orphan_when_both_ids_are_none():
+    """Review regression (PR #1601): the old comparison was
+    ``str(call.get("id")) == str(message.get("tool_call_id"))``, so a
+    ``tool`` message with ``tool_call_id: None`` preceded by an assistant
+    whose declared call also has ``id: None`` rendered as
+    ``"None" == "None"`` and was kept -- an orphan slipping through the
+    exact defense meant to catch it. This must fail against that old
+    ``str(...) == str(...)`` form and pass with ``_ids_match``."""
+    from xagent.web.services.task_conversation_context_service import (
+        _final_pairing_sweep,
+    )
+
+    messages = [
+        {"role": "user", "content": "hi"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": None,
+                    "type": "function",
+                    "function": {"name": "real_tool", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": None,
+            "content": "",
+            "tool_name": "real_tool",
+            "raw_result": {},
+        },
+    ]
+
+    sanitized = _final_pairing_sweep(messages)
+    assert sanitized == [messages[0], messages[1]]
+    assert all(m.get("role") != "tool" for m in sanitized)
+
+
+def test_final_pairing_sweep_keeps_tool_message_with_matching_real_id():
+    """Normal path, unchanged: a tool message with a real id preceded by
+    the assistant that declared that same id is kept."""
+    from xagent.web.services.task_conversation_context_service import (
+        _final_pairing_sweep,
+    )
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-42",
+                    "type": "function",
+                    "function": {"name": "real_tool", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-42",
+            "content": "",
+            "tool_name": "real_tool",
+            "raw_result": {},
+        },
+    ]
+
+    sanitized = _final_pairing_sweep(messages)
+    assert sanitized == messages
+
+
+def test_final_pairing_sweep_drops_tool_message_with_mismatched_real_id():
+    """A tool message with a real id whose preceding assistant declares a
+    different id is still dropped as an orphan."""
+    from xagent.web.services.task_conversation_context_service import (
+        _final_pairing_sweep,
+    )
+
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-1",
+                    "type": "function",
+                    "function": {"name": "real_tool", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call-2",
+            "content": "",
+            "tool_name": "real_tool",
+            "raw_result": {},
+        },
+    ]
+
+    sanitized = _final_pairing_sweep(messages)
+    assert sanitized == [messages[0]]
+
+
+def test_ids_match_ignores_malformed_tool_call_entries():
+    """Malformed ``tool_calls`` entries -- a non-dict item, or a dict with
+    no ``id`` key -- must not raise and must not produce a false match."""
+    from xagent.web.services.task_conversation_context_service import (
+        _ids_match,
+    )
+
+    assert _ids_match("call-1", ["not-a-dict", {"type": "function"}]) is False
+    assert _ids_match(None, ["not-a-dict", {"type": "function"}]) is False
+    assert (
+        _ids_match(
+            "call-1",
+            ["not-a-dict", {"type": "function"}, {"id": "call-1"}],
+        )
+        is True
+    )
+
+
 # ---------------------------------------------------------------------------
 # Part D -- regression tests for the fixes just made
 # ---------------------------------------------------------------------------

--- a/tests/web/services/test_task_conversation_context_service.py
+++ b/tests/web/services/test_task_conversation_context_service.py
@@ -90,7 +90,14 @@ def _add_trace_event(
     timestamp,
     event_id=None,
     step_id=None,
+    turn_id=None,
 ):
+    # ``turn_id`` mirrors how PatternRuntime.on_tool_start/on_tool_end/
+    # on_tool_error stamp it into the event's JSON ``data`` (never a
+    # dedicated column, unlike ``step_id``) -- see runtime.py.
+    payload = dict(data)
+    if turn_id is not None and "turn_id" not in payload:
+        payload["turn_id"] = turn_id
     event = TraceEvent(
         task_id=int(task.id),
         build_id=None,
@@ -99,7 +106,7 @@ def _add_trace_event(
         timestamp=timestamp,
         step_id=step_id,
         parent_event_id=None,
-        data=data,
+        data=payload,
     )
     db_session.add(event)
     db_session.commit()
@@ -116,11 +123,20 @@ def test_structured_handle_survives_reconstruction_byte_for_byte():
     db_session = _create_db_session()
     try:
         task = _create_task(db_session)
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="resume",
+            created_at=_ts(-1),
+            turn_id="turn-1",
+        )
         _add_trace_event(
             db_session,
             task,
             event_type="tool_execution_start",
             timestamp=_ts(0),
+            turn_id="turn-1",
             data={
                 "tool_name": "resume_task",
                 "tool_params": {"workspace": "4b33784773d5"},
@@ -133,6 +149,7 @@ def test_structured_handle_survives_reconstruction_byte_for_byte():
             task,
             event_type="tool_execution_end",
             timestamp=_ts(1),
+            turn_id="turn-1",
             data={
                 "tool_name": "resume_task",
                 "tool_call_id": "call-handle-1",
@@ -170,6 +187,14 @@ def test_tool_call_pairing_never_orphaned():
     db_session = _create_db_session()
     try:
         task = _create_task(db_session)
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="run some tools",
+            created_at=_ts(-1),
+            turn_id="turn-1",
+        )
 
         # Normal start + end.
         _add_trace_event(
@@ -177,6 +202,7 @@ def test_tool_call_pairing_never_orphaned():
             task,
             event_type="tool_execution_start",
             timestamp=_ts(0),
+            turn_id="turn-1",
             data={
                 "tool_name": "list_files",
                 "tool_params": {"path": "."},
@@ -188,6 +214,7 @@ def test_tool_call_pairing_never_orphaned():
             task,
             event_type="tool_execution_end",
             timestamp=_ts(1),
+            turn_id="turn-1",
             data={
                 "tool_name": "list_files",
                 "tool_call_id": "call-1",
@@ -202,6 +229,7 @@ def test_tool_call_pairing_never_orphaned():
             task,
             event_type="tool_execution_end",
             timestamp=_ts(2),
+            turn_id="turn-1",
             data={
                 "tool_name": "read_file",
                 "tool_call_id": "call-orphan-end",
@@ -216,6 +244,7 @@ def test_tool_call_pairing_never_orphaned():
             task,
             event_type="tool_execution_start",
             timestamp=_ts(3),
+            turn_id="turn-1",
             data={
                 "tool_name": "write_file",
                 "tool_params": {"path": "b.txt"},
@@ -229,6 +258,7 @@ def test_tool_call_pairing_never_orphaned():
             task,
             event_type="tool_execution_start",
             timestamp=_ts(4),
+            turn_id="turn-1",
             data={
                 "tool_name": "web_search",
                 "tool_params": {"query": "xagent"},
@@ -239,6 +269,7 @@ def test_tool_call_pairing_never_orphaned():
             task,
             event_type="tool_execution_end",
             timestamp=_ts(5),
+            turn_id="turn-1",
             data={
                 "tool_name": "web_search",
                 "success": True,
@@ -252,6 +283,7 @@ def test_tool_call_pairing_never_orphaned():
             task,
             event_type="tool_execution_start",
             timestamp=_ts(6),
+            turn_id="turn-1",
             data={
                 "tool_name": "run_command",
                 "tool_params": {"cmd": "false"},
@@ -263,6 +295,7 @@ def test_tool_call_pairing_never_orphaned():
             task,
             event_type="tool_execution_failed",
             timestamp=_ts(7),
+            turn_id="turn-1",
             data={
                 "tool_name": "run_command",
                 "tool_call_id": "call-fail",
@@ -312,12 +345,14 @@ def test_multi_turn_history_is_chronological():
 
         for turn in range(3):
             offset_minutes = turn * 10
+            turn_id = f"turn-{turn}"
             _add_chat_message(
                 db_session,
                 task,
                 role="user",
                 content=f"user turn {turn}",
                 created_at=base + timedelta(minutes=offset_minutes),
+                turn_id=turn_id,
             )
             for tool_index in range(2):
                 call_id = f"turn{turn}-call{tool_index}"
@@ -332,6 +367,7 @@ def test_multi_turn_history_is_chronological():
                     task,
                     event_type="tool_execution_start",
                     timestamp=ts_start,
+                    turn_id=turn_id,
                     data={
                         "tool_name": "list_files",
                         "tool_params": {"turn": turn, "tool_index": tool_index},
@@ -343,6 +379,7 @@ def test_multi_turn_history_is_chronological():
                     task,
                     event_type="tool_execution_end",
                     timestamp=ts_end,
+                    turn_id=turn_id,
                     data={
                         "tool_name": "list_files",
                         "tool_call_id": call_id,
@@ -400,12 +437,14 @@ def test_naive_and_aware_timestamps_merge_without_error():
             role="user",
             content="naive user message",
             created_at=datetime(2026, 1, 1, 0, 0, 0),  # naive
+            turn_id="turn-1",
         )
         _add_trace_event(
             db_session,
             task,
             event_type="tool_execution_start",
             timestamp=datetime(2026, 1, 1, 0, 0, 1, tzinfo=timezone.utc),
+            turn_id="turn-1",
             data={
                 "tool_name": "list_files",
                 "tool_params": {},
@@ -417,6 +456,7 @@ def test_naive_and_aware_timestamps_merge_without_error():
             task,
             event_type="tool_execution_end",
             timestamp=datetime(2026, 1, 1, 0, 0, 2, tzinfo=timezone.utc),
+            turn_id="turn-1",
             data={
                 "tool_name": "list_files",
                 "tool_call_id": "call-aware",
@@ -459,41 +499,36 @@ def test_as_aware_utc_normalizes_naive_and_preserves_aware():
     assert normalized_aware == aware_non_utc
 
 
-def test_merge_chronologically_orders_naive_and_aware_without_typeerror():
-    """Direct unit test of the merge path (R4) with hand-built naive/aware
-    datetimes, bypassing the DB round trip entirely.
+def test_merge_chronologically_places_group_immediately_after_its_turn_user_row():
+    """Direct unit test of the merge path (R4) with hand-built rows/exchanges,
+    bypassing the DB round trip entirely.
 
-    ``test_naive_and_aware_timestamps_merge_without_error`` above looks like
-    it covers the naive-vs-aware hazard, but it doesn't: SQLite strips
-    tzinfo from *both* ``TaskChatMessage.created_at`` and
-    ``TraceEvent.timestamp`` on read-back, so by the time
-    ``_load_transcript_rows``/``_load_tool_exchanges`` see them, nothing
-    naive is ever compared against anything aware -- that test would pass
-    identically even if ``_as_aware_utc`` were replaced by the identity
-    function. This test builds a ``_TranscriptRow`` whose ``created_at`` is
-    genuinely naive-turned-aware and a ``_ToolExchange`` whose ``sort_key``
-    is genuinely aware, so a broken (identity) ``_as_aware_utc`` would raise
-    ``TypeError`` on the ``entries.sort`` call inside
-    ``_merge_chronologically`` -- proving the normalization is load-bearing.
+    Placement is a ``turn_id`` join, not a timestamp comparison (see
+    ``_merge_chronologically``'s docstring), so this no longer needs to
+    prove anything about naive-vs-aware datetimes -- ``_merge_chronologically``
+    doesn't compare timestamps at all any more. What it must still prove:
+    a group is spliced in immediately after the transcript row carrying its
+    turn_id, and before whatever comes next, regardless of either side's
+    ``created_at``/``sort_key`` values.
     """
     from xagent.web.services.task_conversation_context_service import (
-        _as_aware_utc,
         _merge_chronologically,
         _ToolExchange,
         _TranscriptRow,
     )
 
-    naive_user = _TranscriptRow(
+    user_row = _TranscriptRow(
         row_id=1,
         role="user",
-        content="naive user",
-        created_at=_as_aware_utc(datetime(2026, 1, 1, 0, 0, 0)),  # naive input
+        content="hi",
+        created_at=datetime(2026, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        turn_id="turn-1",
     )
-    aware_reply = _TranscriptRow(
+    reply_row = _TranscriptRow(
         row_id=2,
         role="assistant",
-        content="aware assistant",
-        created_at=_as_aware_utc(datetime(2026, 1, 1, 0, 0, 5, tzinfo=timezone.utc)),
+        content="done",
+        created_at=datetime(2026, 1, 1, 0, 0, 5, tzinfo=timezone.utc),
     )
     exchange = _ToolExchange(
         call_id="call-1",
@@ -501,18 +536,16 @@ def test_merge_chronologically_orders_naive_and_aware_without_typeerror():
         tool_params={},
         result={"ok": True},
         assistant_content="",
-        sort_key=(
-            _as_aware_utc(datetime(2026, 1, 1, 0, 0, 2, tzinfo=timezone.utc)),
-            10,
-        ),
+        sort_key=(datetime(2026, 1, 1, 0, 0, 2, tzinfo=timezone.utc), 10),
+        turn_id="turn-1",
     )
 
-    entries = _merge_chronologically([naive_user, aware_reply], [exchange])
+    entries = _merge_chronologically([user_row, reply_row], [exchange])
     kinds_in_order = [entry.kind for entry in entries]
     assert kinds_in_order == ["transcript", "group", "transcript"]
     assert entries[1].group == [exchange]
-    assert entries[0].transcript is naive_user
-    assert entries[2].transcript is aware_reply
+    assert entries[0].transcript is user_row
+    assert entries[2].transcript is reply_row
 
 
 def test_control_tools_are_excluded():
@@ -523,6 +556,14 @@ def test_control_tools_are_excluded():
     db_session = _create_db_session()
     try:
         task = _create_task(db_session)
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="go",
+            created_at=_ts(-1),
+            turn_id="turn-1",
+        )
 
         for index, tool_name in enumerate(sorted(CONTROL_TOOL_NAMES)):
             call_id = f"call-control-{index}"
@@ -531,6 +572,7 @@ def test_control_tools_are_excluded():
                 task,
                 event_type="tool_execution_start",
                 timestamp=_ts(index * 10),
+                turn_id="turn-1",
                 data={
                     "tool_name": tool_name,
                     "tool_params": {},
@@ -542,6 +584,7 @@ def test_control_tools_are_excluded():
                 task,
                 event_type="tool_execution_end",
                 timestamp=_ts(index * 10 + 1),
+                turn_id="turn-1",
                 data={
                     "tool_name": tool_name,
                     "tool_call_id": call_id,
@@ -555,6 +598,7 @@ def test_control_tools_are_excluded():
             task,
             event_type="tool_execution_start",
             timestamp=_ts(1000),
+            turn_id="turn-1",
             data={
                 "tool_name": "list_files",
                 "tool_params": {},
@@ -566,6 +610,7 @@ def test_control_tools_are_excluded():
             task,
             event_type="tool_execution_end",
             timestamp=_ts(1001),
+            turn_id="turn-1",
             data={
                 "tool_name": "list_files",
                 "tool_call_id": "call-real",
@@ -587,6 +632,14 @@ def test_parallel_batch_assistant_content_not_duplicated():
     db_session = _create_db_session()
     try:
         task = _create_task(db_session)
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="go",
+            created_at=_ts(-1),
+            turn_id="turn-1",
+        )
         shared_prose = "Running two lookups in parallel."
 
         for index in range(2):
@@ -596,6 +649,7 @@ def test_parallel_batch_assistant_content_not_duplicated():
                 task,
                 event_type="tool_execution_start",
                 timestamp=_ts(index),
+                turn_id="turn-1",
                 data={
                     "tool_name": "list_files",
                     "tool_params": {"index": index},
@@ -608,6 +662,7 @@ def test_parallel_batch_assistant_content_not_duplicated():
                 task,
                 event_type="tool_execution_end",
                 timestamp=_ts(index + 10),
+                turn_id="turn-1",
                 data={
                     "tool_name": "list_files",
                     "tool_call_id": call_id,
@@ -650,16 +705,28 @@ def test_concurrent_dag_steps_with_colliding_tool_call_ids_are_not_mispaired():
     db_session = _create_db_session()
     try:
         task = _create_task(db_session)
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="go",
+            created_at=_ts(-1),
+            turn_id="turn-1",
+        )
 
         # Branch A start (step "step-a"), then branch B start (step "step-b"),
         # both using the colliding id "tool_call_0" -- interleaved as
         # start A, start B, end A, end B, matching real concurrent arrival.
+        # Both branches belong to the same DAG turn, so they share one
+        # turn_id even though their step_id (the pairing discriminator)
+        # differs.
         _add_trace_event(
             db_session,
             task,
             event_type="tool_execution_start",
             timestamp=_ts(0),
             step_id="step-a",
+            turn_id="turn-1",
             data={
                 "tool_name": "read_file",
                 "tool_params": {"path": "a.txt"},
@@ -673,6 +740,7 @@ def test_concurrent_dag_steps_with_colliding_tool_call_ids_are_not_mispaired():
             event_type="tool_execution_start",
             timestamp=_ts(1),
             step_id="step-b",
+            turn_id="turn-1",
             data={
                 "tool_name": "list_files",
                 "tool_params": {"path": "b/"},
@@ -686,6 +754,7 @@ def test_concurrent_dag_steps_with_colliding_tool_call_ids_are_not_mispaired():
             event_type="tool_execution_end",
             timestamp=_ts(2),
             step_id="step-a",
+            turn_id="turn-1",
             data={
                 "tool_name": "read_file",
                 "tool_call_id": "tool_call_0",
@@ -699,6 +768,7 @@ def test_concurrent_dag_steps_with_colliding_tool_call_ids_are_not_mispaired():
             event_type="tool_execution_end",
             timestamp=_ts(3),
             step_id="step-b",
+            turn_id="turn-1",
             data={
                 "tool_name": "list_files",
                 "tool_call_id": "tool_call_0",
@@ -748,6 +818,14 @@ def test_react_shaped_events_without_step_discriminator_still_pair_correctly():
     db_session = _create_db_session()
     try:
         task = _create_task(db_session)
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="go",
+            created_at=_ts(-1),
+            turn_id="turn-1",
+        )
 
         _add_trace_event(
             db_session,
@@ -755,6 +833,7 @@ def test_react_shaped_events_without_step_discriminator_still_pair_correctly():
             event_type="tool_execution_start",
             timestamp=_ts(0),
             step_id=None,
+            turn_id="turn-1",
             data={
                 "tool_name": "search_web",
                 "tool_params": {"query": "xagent"},
@@ -768,6 +847,7 @@ def test_react_shaped_events_without_step_discriminator_still_pair_correctly():
             event_type="tool_execution_end",
             timestamp=_ts(1),
             step_id=None,
+            turn_id="turn-1",
             data={
                 "tool_name": "search_web",
                 "tool_call_id": "call-1",
@@ -800,9 +880,16 @@ def test_react_shaped_events_without_step_discriminator_still_pair_correctly():
 
 def test_clock_skew_guard_relocates_misplaced_exchange_atomically():
     """A tool exchange timestamped BEFORE the first transcript user message
-    (DB clock vs app clock skew) must be repositioned after it in the merged
-    output, and the relocated assistant/tool block must stay atomic (the
-    tool message immediately follows its declaring assistant message)."""
+    (DB clock vs app clock skew) must still be placed after it, and the
+    placed assistant/tool block must stay atomic (the tool message
+    immediately follows its declaring assistant message).
+
+    Placement is a ``turn_id`` join now, not a timestamp-adjacency guard, so
+    the skewed timestamps below are deliberately kept (rather than removed)
+    to prove the join makes them irrelevant: this exchange lands right after
+    its turn's user message regardless of which one has the earlier clock
+    reading.
+    """
     db_session = _create_db_session()
     try:
         task = _create_task(db_session)
@@ -815,16 +902,19 @@ def test_clock_skew_guard_relocates_misplaced_exchange_atomically():
             role="user",
             content="first turn",
             created_at=base,
+            turn_id="turn-1",
         )
 
         # This exchange's trace timestamps predate the first user message --
         # simulating clock skew between the DB clock (created_at) and the
-        # app clock (trace timestamps).
+        # app clock (trace timestamps). Only turn_id, not timestamp order,
+        # decides placement now.
         _add_trace_event(
             db_session,
             task,
             event_type="tool_execution_start",
             timestamp=base - timedelta(seconds=50),
+            turn_id="turn-1",
             data={
                 "tool_name": "list_files",
                 "tool_params": {},
@@ -837,6 +927,7 @@ def test_clock_skew_guard_relocates_misplaced_exchange_atomically():
             task,
             event_type="tool_execution_end",
             timestamp=base - timedelta(seconds=49),
+            turn_id="turn-1",
             data={
                 "tool_name": "list_files",
                 "tool_call_id": "call-skewed",
@@ -856,7 +947,7 @@ def test_clock_skew_guard_relocates_misplaced_exchange_atomically():
         messages = load_task_conversation_context_sync(db_session, int(task.id))
         roles = [m["role"] for m in messages]
 
-        # Repositioned after the first user message, not before it.
+        # Placed after the first user message, not before it.
         assert roles[0] == "user"
         assert messages[0]["content"] == "first turn"
         assert roles[1] == "assistant" and messages[1].get("tool_calls")
@@ -1106,6 +1197,18 @@ def test_dedup_positional_after_sort_keeps_different_turns_distinct_prose():
     db_session = _create_db_session()
     try:
         task = _create_task(db_session)
+        # All three calls are anchored to one turn: this test is about
+        # _dedupe_parallel_batch_prose's positional logic over the flat,
+        # start-time-sorted exchange list, which runs before turn grouping
+        # -- it is unconcerned with turn_id boundaries.
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="go",
+            created_at=_ts(-1),
+            turn_id="turn-1",
+        )
         shared_prose = "Investigating the failure."
 
         # Turn A: starts first, but is slow -- its end event arrives LAST.
@@ -1114,6 +1217,7 @@ def test_dedup_positional_after_sort_keeps_different_turns_distinct_prose():
             task,
             event_type="tool_execution_start",
             timestamp=_ts(0),
+            turn_id="turn-1",
             data={
                 "tool_name": "tool_a",
                 "tool_params": {},
@@ -1128,6 +1232,7 @@ def test_dedup_positional_after_sort_keeps_different_turns_distinct_prose():
             task,
             event_type="tool_execution_start",
             timestamp=_ts(1),
+            turn_id="turn-1",
             data={
                 "tool_name": "tool_b",
                 "tool_params": {},
@@ -1140,6 +1245,7 @@ def test_dedup_positional_after_sort_keeps_different_turns_distinct_prose():
             task,
             event_type="tool_execution_end",
             timestamp=_ts(2),  # B's end lands before A's end below.
+            turn_id="turn-1",
             data={
                 "tool_name": "tool_b",
                 "tool_call_id": "call-b",
@@ -1152,6 +1258,7 @@ def test_dedup_positional_after_sort_keeps_different_turns_distinct_prose():
             task,
             event_type="tool_execution_end",
             timestamp=_ts(100),  # A finishes much later.
+            turn_id="turn-1",
             data={
                 "tool_name": "tool_a",
                 "tool_call_id": "call-a",
@@ -1166,6 +1273,7 @@ def test_dedup_positional_after_sort_keeps_different_turns_distinct_prose():
             task,
             event_type="tool_execution_start",
             timestamp=_ts(200),
+            turn_id="turn-1",
             data={
                 "tool_name": "tool_c",
                 "tool_params": {},
@@ -1178,6 +1286,7 @@ def test_dedup_positional_after_sort_keeps_different_turns_distinct_prose():
             task,
             event_type="tool_execution_end",
             timestamp=_ts(201),
+            turn_id="turn-1",
             data={
                 "tool_name": "tool_c",
                 "tool_call_id": "call-c",
@@ -1208,6 +1317,14 @@ def test_dedup_still_blanks_immediately_following_parallel_duplicate():
     db_session = _create_db_session()
     try:
         task = _create_task(db_session)
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="go",
+            created_at=_ts(-1),
+            turn_id="turn-1",
+        )
         shared_prose = "Running parallel lookups."
 
         for index in range(3):
@@ -1217,6 +1334,7 @@ def test_dedup_still_blanks_immediately_following_parallel_duplicate():
                 task,
                 event_type="tool_execution_start",
                 timestamp=_ts(index),
+                turn_id="turn-1",
                 data={
                     "tool_name": "list_files",
                     "tool_params": {"index": index},
@@ -1229,6 +1347,7 @@ def test_dedup_still_blanks_immediately_following_parallel_duplicate():
                 task,
                 event_type="tool_execution_end",
                 timestamp=_ts(index + 10),
+                turn_id="turn-1",
                 data={
                     "tool_name": "list_files",
                     "tool_call_id": call_id,
@@ -1257,11 +1376,20 @@ def test_tool_execution_end_missing_result_yields_degraded_dict_not_none():
     db_session = _create_db_session()
     try:
         task = _create_task(db_session)
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="go",
+            created_at=_ts(-1),
+            turn_id="turn-1",
+        )
         _add_trace_event(
             db_session,
             task,
             event_type="tool_execution_start",
             timestamp=_ts(0),
+            turn_id="turn-1",
             data={
                 "tool_name": "flaky_tool",
                 "tool_params": {},
@@ -1273,6 +1401,7 @@ def test_tool_execution_end_missing_result_yields_degraded_dict_not_none():
             task,
             event_type="tool_execution_end",
             timestamp=_ts(1),
+            turn_id="turn-1",
             data={
                 "tool_name": "flaky_tool",
                 "tool_call_id": "call-degraded",
@@ -1393,19 +1522,29 @@ def test_historical_image_budget_keeps_only_the_newest_n_across_messages():
 
 
 # ---------------------------------------------------------------------------
-# Part D -- per-turn grouping (step_id) and image-only-turn retention (#1601)
+# Part D -- turn_id-join placement and image-only-turn retention (#1601)
+#
+# fa650272 tried to solve turn placement by grouping tool exchanges on
+# ``TraceEvent.step_id`` and relocating groups by timestamp adjacency. A
+# reviewer found two structural counterexamples (reproduced below as
+# ``test_dag_replan_reusing_step_id_keeps_turns_separate`` and
+# ``test_failed_turn_without_assistant_row_stays_before_next_user_message``),
+# so that approach was replaced with the ``turn_id`` join implemented in
+# ``_merge_chronologically``/``_group_exchanges_by_turn``: every tool trace
+# event now carries the same durable ``turn_id`` as its triggering user
+# message (``PatternRuntime.on_tool_start``/``on_tool_end``/``on_tool_error``
+# in runtime.py), so placement is a lookup, not an inference from clocks or
+# a reused step id.
 # ---------------------------------------------------------------------------
 
 
-def test_second_turn_clock_skew_relocates_exchange_after_its_own_user_message():
-    """The old guard only protected the conversation's *first* user message:
-    an exchange timestamped before ANY later user message (e.g. turn 2's)
-    sorted wherever raw timestamps put it, landing before that turn's own
-    question. Reproduces the reviewer's scenario: turn 2's
+def test_second_turn_clock_skew_placed_correctly_by_turn_id_join():
+    """Reproduces the original clock-skew scenario -- turn 2's
     ``tool_execution_start``/``tool_execution_end`` are timestamped 1s
-    before turn 2's ``TaskChatMessage`` (DB clock vs app clock skew). The
-    fix groups by ``step_id`` and relocates the whole group after the user
-    message it belongs to, for every turn -- not just the first.
+    before turn 2's own ``TaskChatMessage`` (DB clock vs app clock skew) --
+    but placement is now a ``turn_id`` join, so the skew is irrelevant: the
+    exchange still lands right after turn 2's question because that's what
+    its ``turn_id`` says, not because of any timestamp comparison.
     """
     db_session = _create_db_session()
     try:
@@ -1414,14 +1553,19 @@ def test_second_turn_clock_skew_relocates_exchange_after_its_own_user_message():
 
         # Turn 1: well-timestamped, no skew.
         _add_chat_message(
-            db_session, task, role="user", content="turn 1 question", created_at=base
+            db_session,
+            task,
+            role="user",
+            content="turn 1 question",
+            created_at=base,
+            turn_id="turn1",
         )
         _add_trace_event(
             db_session,
             task,
             event_type="tool_execution_start",
             timestamp=base + timedelta(seconds=1),
-            step_id="turn1",
+            turn_id="turn1",
             data={
                 "tool_name": "list_files",
                 "tool_params": {"turn": 1},
@@ -1434,7 +1578,7 @@ def test_second_turn_clock_skew_relocates_exchange_after_its_own_user_message():
             task,
             event_type="tool_execution_end",
             timestamp=base + timedelta(seconds=2),
-            step_id="turn1",
+            turn_id="turn1",
             data={
                 "tool_name": "list_files",
                 "tool_call_id": "turn1-call",
@@ -1458,6 +1602,7 @@ def test_second_turn_clock_skew_relocates_exchange_after_its_own_user_message():
             role="user",
             content="turn 2 question",
             created_at=turn2_user_created_at,
+            turn_id="turn2",
         )
 
         # Turn 2's tool exchange (app clock), timestamped BEFORE its own
@@ -1467,7 +1612,7 @@ def test_second_turn_clock_skew_relocates_exchange_after_its_own_user_message():
             task,
             event_type="tool_execution_start",
             timestamp=turn2_user_created_at - timedelta(seconds=1),
-            step_id="turn2",
+            turn_id="turn2",
             data={
                 "tool_name": "list_files",
                 "tool_params": {"turn": 2},
@@ -1480,7 +1625,7 @@ def test_second_turn_clock_skew_relocates_exchange_after_its_own_user_message():
             task,
             event_type="tool_execution_end",
             timestamp=turn2_user_created_at - timedelta(milliseconds=500),
-            step_id="turn2",
+            turn_id="turn2",
             data={
                 "tool_name": "list_files",
                 "tool_call_id": "turn2-call",
@@ -1522,33 +1667,31 @@ def test_second_turn_clock_skew_relocates_exchange_after_its_own_user_message():
         db_session.close()
 
 
-def test_exchanges_from_different_turns_never_merge_into_one_group():
-    """Two turns whose tool events share no ``step_id`` must never be
-    coalesced into a single group, and each turn's group must stay
-    contiguous (no interleaving between the two turns' assistant/tool
-    pairs)."""
+def test_dag_replan_reusing_step_id_keeps_turns_separate():
+    """Reviewer counterexample #1 (fa650272): ``ExecutionPlan.validate()``
+    only enforces ``step_id`` uniqueness within one plan, so a later re-plan
+    can emit ``step_1`` again -- two DAG turns can legitimately share one
+    ``step_id``. Grouping by ``step_id`` (the fa650272 approach) merged such
+    turns into one group; joining on ``turn_id`` instead keeps them separate
+    regardless of ``step_id`` collisions, because placement never looks at
+    ``step_id`` at all.
+    """
     from xagent.web.services.task_conversation_context_service import (
         _group_exchanges_by_turn,
         _ToolExchange,
     )
 
-    turn1_call_a = _ToolExchange(
+    # Direct unit check: two turns whose exchanges carry the identical
+    # step_id="step_1" (a DAG re-plan reusing the id) must still land in two
+    # distinct groups, keyed by turn_id.
+    turn1_call = _ToolExchange(
         call_id="t1-a",
         tool_name="list_files",
         tool_params={},
         result={"ok": True},
         assistant_content="",
         sort_key=(_ts(0), 1),
-        step_id="turn1",
-    )
-    turn1_call_b = _ToolExchange(
-        call_id="t1-b",
-        tool_name="list_files",
-        tool_params={},
-        result={"ok": True},
-        assistant_content="",
-        sort_key=(_ts(1), 2),
-        step_id="turn1",
+        turn_id="turn1",
     )
     turn2_call = _ToolExchange(
         call_id="t2-a",
@@ -1557,48 +1700,55 @@ def test_exchanges_from_different_turns_never_merge_into_one_group():
         result={"ok": True},
         assistant_content="",
         sort_key=(_ts(2), 3),
-        step_id="turn2",
+        turn_id="turn2",
     )
+    groups = _group_exchanges_by_turn([turn1_call, turn2_call])
+    assert groups == {"turn1": [turn1_call], "turn2": [turn2_call]}
 
-    groups = _group_exchanges_by_turn([turn1_call_a, turn1_call_b, turn2_call])
-
-    assert len(groups) == 2
-    assert groups[0] == [turn1_call_a, turn1_call_b]
-    assert groups[1] == [turn2_call]
-
-    # And end-to-end: each turn's assistant/tool block stays contiguous in
-    # the rendered output, with no cross-turn interleaving.
+    # End-to-end: both turns' trace events are stamped step_id="step_1" (the
+    # DAG re-plan collision), but distinct turn_id -- the reconstruction
+    # must still keep the turns separate and correctly ordered: user1,
+    # tools1, answer1, user2, tools2, answer2 -- never user1, tools1,
+    # tools2, answer1, user2, answer2 (the fa650272 regression).
     db_session = _create_db_session()
     try:
         task = _create_task(db_session)
         base = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        _add_chat_message(db_session, task, role="user", content="q1", created_at=base)
-        for index, call_id in enumerate(["t1-a", "t1-b"]):
-            _add_trace_event(
-                db_session,
-                task,
-                event_type="tool_execution_start",
-                timestamp=base + timedelta(seconds=1 + index),
-                step_id="turn1",
-                data={
-                    "tool_name": "list_files",
-                    "tool_params": {"call": call_id},
-                    "tool_call_id": call_id,
-                },
-            )
-            _add_trace_event(
-                db_session,
-                task,
-                event_type="tool_execution_end",
-                timestamp=base + timedelta(seconds=1 + index, milliseconds=500),
-                step_id="turn1",
-                data={
-                    "tool_name": "list_files",
-                    "tool_call_id": call_id,
-                    "success": True,
-                    "result": {"call": call_id},
-                },
-            )
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="q1",
+            created_at=base,
+            turn_id="turn1",
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=base + timedelta(seconds=1),
+            step_id="step_1",
+            turn_id="turn1",
+            data={
+                "tool_name": "list_files",
+                "tool_params": {"call": "t1-a"},
+                "tool_call_id": "t1-a",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=base + timedelta(seconds=1, milliseconds=500),
+            step_id="step_1",
+            turn_id="turn1",
+            data={
+                "tool_name": "list_files",
+                "tool_call_id": "t1-a",
+                "success": True,
+                "result": {"call": "t1-a"},
+            },
+        )
         _add_chat_message(
             db_session,
             task,
@@ -1612,13 +1762,16 @@ def test_exchanges_from_different_turns_never_merge_into_one_group():
             role="user",
             content="q2",
             created_at=base + timedelta(minutes=1),
+            turn_id="turn2",
         )
+        # The re-plan: same step_id="step_1" as turn 1, different turn_id.
         _add_trace_event(
             db_session,
             task,
             event_type="tool_execution_start",
             timestamp=base + timedelta(minutes=1, seconds=1),
-            step_id="turn2",
+            step_id="step_1",
+            turn_id="turn2",
             data={
                 "tool_name": "list_files",
                 "tool_params": {"call": "t2-a"},
@@ -1630,7 +1783,8 @@ def test_exchanges_from_different_turns_never_merge_into_one_group():
             task,
             event_type="tool_execution_end",
             timestamp=base + timedelta(minutes=1, seconds=2),
-            step_id="turn2",
+            step_id="step_1",
+            turn_id="turn2",
             data={
                 "tool_name": "list_files",
                 "tool_call_id": "t2-a",
@@ -1647,107 +1801,257 @@ def test_exchanges_from_different_turns_never_merge_into_one_group():
         )
 
         messages = load_task_conversation_context_sync(db_session, int(task.id))
-        call_ids_in_order = [m["tool_call_id"] for m in messages if m["role"] == "tool"]
-        assert call_ids_in_order == ["t1-a", "t1-b", "t2-a"]
-        # Turn 1's block (2 assistant+tool pairs) sits fully between q1/a1;
-        # turn 2's block sits fully between q2/a2 -- no interleaving.
-        q1_index = messages.index({"role": "user", "content": "q1"})
-        a1_index = next(i for i, m in enumerate(messages) if m.get("content") == "a1")
-        q2_index = messages.index({"role": "user", "content": "q2"})
-        a2_index = next(i for i, m in enumerate(messages) if m.get("content") == "a2")
-        assert q1_index < a1_index < q2_index < a2_index
-        for index in range(q1_index + 1, a1_index):
-            if messages[index]["role"] == "tool":
-                assert messages[index]["raw_result"]["call"] in ("t1-a", "t1-b")
-        for index in range(q2_index + 1, a2_index):
-            if messages[index]["role"] == "tool":
-                assert messages[index]["raw_result"]["call"] == "t2-a"
+        shapes = [
+            (m["role"], m.get("content"), m.get("tool_call_id")) for m in messages
+        ]
+        assert shapes == [
+            ("user", "q1", None),
+            ("assistant", "", None),
+            ("tool", "", "t1-a"),
+            ("assistant", "a1", None),
+            ("user", "q2", None),
+            ("assistant", "", None),
+            ("tool", "", "t2-a"),
+            ("assistant", "a2", None),
+        ]
     finally:
         db_session.close()
 
 
-def test_well_timestamped_multi_turn_history_unchanged_by_grouping():
-    """Regression guard: with proper, non-skewed timestamps and step_id set
-    per turn (exercising the new grouping path), the reconstructed order is
-    identical to the pre-grouping expectation covered by
-    ``test_multi_turn_history_is_chronological`` above."""
+def test_failed_turn_without_assistant_row_stays_before_next_user_message():
+    """Reviewer counterexample #2 (fa650272): a failed/interrupted turn
+    produces no assistant transcript row, so
+    ``_relocate_groups_before_their_user_message`` (the fa650272 relocation
+    pass) flushed its buffered exchange group *after* the next user message
+    regardless of timestamps -- turning ``user1, failed_tools1, user2`` into
+    ``user1, user2, failed_tools1``. Joining on ``turn_id`` places the
+    exchange immediately after its own turn's user row, before the next
+    transcript row, with no relocation pass to misfire.
+    """
     db_session = _create_db_session()
     try:
         task = _create_task(db_session)
         base = datetime(2026, 1, 1, tzinfo=timezone.utc)
 
-        for turn in range(3):
-            offset_minutes = turn * 10
-            _add_chat_message(
-                db_session,
-                task,
-                role="user",
-                content=f"user turn {turn}",
-                created_at=base + timedelta(minutes=offset_minutes),
-            )
-            for tool_index in range(2):
-                call_id = f"turn{turn}-call{tool_index}"
-                ts_start = base + timedelta(
-                    minutes=offset_minutes, seconds=1 + tool_index * 2
-                )
-                ts_end = base + timedelta(
-                    minutes=offset_minutes, seconds=2 + tool_index * 2
-                )
-                _add_trace_event(
-                    db_session,
-                    task,
-                    event_type="tool_execution_start",
-                    timestamp=ts_start,
-                    step_id=f"step-turn{turn}",
-                    data={
-                        "tool_name": "list_files",
-                        "tool_params": {"turn": turn, "tool_index": tool_index},
-                        "tool_call_id": call_id,
-                    },
-                )
-                _add_trace_event(
-                    db_session,
-                    task,
-                    event_type="tool_execution_end",
-                    timestamp=ts_end,
-                    step_id=f"step-turn{turn}",
-                    data={
-                        "tool_name": "list_files",
-                        "tool_call_id": call_id,
-                        "success": True,
-                        "result": {"turn": turn, "tool_index": tool_index},
-                    },
-                )
-            _add_chat_message(
-                db_session,
-                task,
-                role="assistant",
-                content=f"assistant answer {turn}",
-                created_at=base + timedelta(minutes=offset_minutes, seconds=9),
-            )
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="q1",
+            created_at=base,
+            turn_id="turn1",
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=base + timedelta(seconds=1),
+            turn_id="turn1",
+            data={
+                "tool_name": "run_command",
+                "tool_params": {"cmd": "false"},
+                "tool_call_id": "call-failed",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_failed",
+            timestamp=base + timedelta(seconds=2),
+            turn_id="turn1",
+            data={
+                "tool_name": "run_command",
+                "tool_call_id": "call-failed",
+                "error_type": "agent_tool_error",
+                "error": "boom",
+                "error_message": "boom",
+            },
+        )
+        # Turn 1 never gets an assistant answer row -- the run was
+        # interrupted/failed before producing a final_answer.
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="q2",
+            created_at=base + timedelta(minutes=1),
+            turn_id="turn2",
+        )
+        _add_chat_message(
+            db_session,
+            task,
+            role="assistant",
+            content="a2",
+            created_at=base + timedelta(minutes=1, seconds=1),
+        )
 
         messages = load_task_conversation_context_sync(db_session, int(task.id))
         roles = [m["role"] for m in messages]
 
-        assert roles.count("user") == 3
-        assert roles.count("assistant") == 3 + 3 * 2
-        assert roles.count("tool") == 6
+        # user1, failed_tools1, user2, answer2 -- never user1, user2, ...tools1.
+        assert roles == ["user", "assistant", "tool", "user", "assistant"]
+        assert messages[0]["content"] == "q1"
+        assert messages[2]["tool_call_id"] == "call-failed"
+        assert messages[2]["raw_result"]["error"] == "boom"
+        assert messages[3]["content"] == "q2"
+        assert messages[4]["content"] == "a2"
+    finally:
+        db_session.close()
 
-        for turn in range(3):
-            user_index = messages.index(
-                {"role": "user", "content": f"user turn {turn}"}
-            )
-            answer_index = next(
-                index
-                for index, m in enumerate(messages)
-                if m["role"] == "assistant"
-                and m.get("content") == f"assistant answer {turn}"
-            )
-            assert user_index < answer_index
-            for index in range(user_index + 1, answer_index):
-                message = messages[index]
-                if message["role"] == "tool":
-                    assert message["raw_result"]["turn"] == turn
+
+def test_legacy_exchange_without_turn_id_is_omitted_transcript_intact():
+    """A tool exchange whose trace events predate ``turn_id`` support (both
+    events carry no ``turn_id`` in their JSON ``data``) is omitted from the
+    reconstruction entirely -- not placed by guesswork -- while the
+    surrounding transcript rows still reconstruct intact. This is the
+    deliberate legacy behavior: conversations recorded before this shipped
+    resume with transcript text only, exactly what they got before this
+    module existed.
+    """
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        _add_chat_message(db_session, task, role="user", content="q1", created_at=base)
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=base + timedelta(seconds=1),
+            data={
+                "tool_name": "list_files",
+                "tool_params": {},
+                "tool_call_id": "legacy-call",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=base + timedelta(seconds=2),
+            data={
+                "tool_name": "list_files",
+                "tool_call_id": "legacy-call",
+                "success": True,
+                "result": {"files": []},
+            },
+        )
+        _add_chat_message(
+            db_session,
+            task,
+            role="assistant",
+            content="a1",
+            created_at=base + timedelta(seconds=3),
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        roles = [m["role"] for m in messages]
+
+        # No trace of the legacy tool exchange -- just the transcript text.
+        assert roles == ["user", "assistant"]
+        assert messages[0]["content"] == "q1"
+        assert messages[1]["content"] == "a1"
+    finally:
+        db_session.close()
+
+
+def test_mixed_turn_id_and_legacy_exchanges_in_same_task():
+    """A task spanning the turn_id deploy: turn 1's tool exchange predates
+    turn_id support (omitted, transcript-only), turn 2's postdates it
+    (placed exactly, right after turn 2's question)."""
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        # Turn 1: legacy -- no turn_id anywhere.
+        _add_chat_message(db_session, task, role="user", content="q1", created_at=base)
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=base + timedelta(seconds=1),
+            data={
+                "tool_name": "list_files",
+                "tool_params": {},
+                "tool_call_id": "legacy-call",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=base + timedelta(seconds=2),
+            data={
+                "tool_name": "list_files",
+                "tool_call_id": "legacy-call",
+                "success": True,
+                "result": {"files": []},
+            },
+        )
+        _add_chat_message(
+            db_session,
+            task,
+            role="assistant",
+            content="a1",
+            created_at=base + timedelta(seconds=3),
+        )
+
+        # Turn 2: post-deploy -- turn_id everywhere.
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="q2",
+            created_at=base + timedelta(minutes=1),
+            turn_id="turn2",
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=base + timedelta(minutes=1, seconds=1),
+            turn_id="turn2",
+            data={
+                "tool_name": "list_files",
+                "tool_params": {},
+                "tool_call_id": "post-deploy-call",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=base + timedelta(minutes=1, seconds=2),
+            turn_id="turn2",
+            data={
+                "tool_name": "list_files",
+                "tool_call_id": "post-deploy-call",
+                "success": True,
+                "result": {"files": ["a.txt"]},
+            },
+        )
+        _add_chat_message(
+            db_session,
+            task,
+            role="assistant",
+            content="a2",
+            created_at=base + timedelta(minutes=1, seconds=3),
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        roles = [m["role"] for m in messages]
+
+        # Turn 1: transcript text only, no tool exchange. Turn 2: full
+        # reconstruction, placed right after its own question.
+        assert roles == ["user", "assistant", "user", "assistant", "tool", "assistant"]
+        assert messages[0]["content"] == "q1"
+        assert messages[1]["content"] == "a1"
+        assert messages[2]["content"] == "q2"
+        assert messages[3]["tool_calls"][0]["id"] == "post-deploy-call"
+        assert messages[4]["tool_call_id"] == "post-deploy-call"
+        assert messages[5]["content"] == "a2"
     finally:
         db_session.close()
 
@@ -1823,6 +2127,7 @@ def test_image_only_turn_participates_correctly_in_chronological_ordering():
             role="user",
             content="",
             created_at=base,
+            turn_id="turn1",
             attachments=[
                 {
                     "file_id": "image-mid",
@@ -1837,6 +2142,7 @@ def test_image_only_turn_participates_correctly_in_chronological_ordering():
             event_type="tool_execution_start",
             timestamp=base + timedelta(seconds=1),
             step_id="turn1",
+            turn_id="turn1",
             data={
                 "tool_name": "analyze_image",
                 "tool_params": {},
@@ -1849,6 +2155,7 @@ def test_image_only_turn_participates_correctly_in_chronological_ordering():
             event_type="tool_execution_end",
             timestamp=base + timedelta(seconds=2),
             step_id="turn1",
+            turn_id="turn1",
             data={
                 "tool_name": "analyze_image",
                 "tool_call_id": "call-analyze",

--- a/tests/web/services/test_task_conversation_context_service.py
+++ b/tests/web/services/test_task_conversation_context_service.py
@@ -509,8 +509,8 @@ def test_merge_chronologically_orders_naive_and_aware_without_typeerror():
 
     entries = _merge_chronologically([naive_user, aware_reply], [exchange])
     kinds_in_order = [entry.kind for entry in entries]
-    assert kinds_in_order == ["transcript", "exchange", "transcript"]
-    assert entries[1].exchange is exchange
+    assert kinds_in_order == ["transcript", "group", "transcript"]
+    assert entries[1].group == [exchange]
     assert entries[0].transcript is naive_user
     assert entries[2].transcript is aware_reply
 
@@ -1388,5 +1388,490 @@ def test_historical_image_budget_keeps_only_the_newest_n_across_messages():
             if CONTEXT_REFS_KEY in message
         ]
         assert retained_ids == [f"image-{index}" for index in range(2, total_images)]
+    finally:
+        db_session.close()
+
+
+# ---------------------------------------------------------------------------
+# Part D -- per-turn grouping (step_id) and image-only-turn retention (#1601)
+# ---------------------------------------------------------------------------
+
+
+def test_second_turn_clock_skew_relocates_exchange_after_its_own_user_message():
+    """The old guard only protected the conversation's *first* user message:
+    an exchange timestamped before ANY later user message (e.g. turn 2's)
+    sorted wherever raw timestamps put it, landing before that turn's own
+    question. Reproduces the reviewer's scenario: turn 2's
+    ``tool_execution_start``/``tool_execution_end`` are timestamped 1s
+    before turn 2's ``TaskChatMessage`` (DB clock vs app clock skew). The
+    fix groups by ``step_id`` and relocates the whole group after the user
+    message it belongs to, for every turn -- not just the first.
+    """
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        # Turn 1: well-timestamped, no skew.
+        _add_chat_message(
+            db_session, task, role="user", content="turn 1 question", created_at=base
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=base + timedelta(seconds=1),
+            step_id="turn1",
+            data={
+                "tool_name": "list_files",
+                "tool_params": {"turn": 1},
+                "tool_call_id": "turn1-call",
+                "assistant_content": "Checking turn 1.",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=base + timedelta(seconds=2),
+            step_id="turn1",
+            data={
+                "tool_name": "list_files",
+                "tool_call_id": "turn1-call",
+                "success": True,
+                "result": {"turn": 1},
+            },
+        )
+        _add_chat_message(
+            db_session,
+            task,
+            role="assistant",
+            content="turn 1 answer",
+            created_at=base + timedelta(seconds=3),
+        )
+
+        # Turn 2: the TaskChatMessage row (DB clock).
+        turn2_user_created_at = base + timedelta(minutes=5)
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="turn 2 question",
+            created_at=turn2_user_created_at,
+        )
+
+        # Turn 2's tool exchange (app clock), timestamped BEFORE its own
+        # user message due to clock skew between the two clocks.
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=turn2_user_created_at - timedelta(seconds=1),
+            step_id="turn2",
+            data={
+                "tool_name": "list_files",
+                "tool_params": {"turn": 2},
+                "tool_call_id": "turn2-call",
+                "assistant_content": "Checking turn 2.",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=turn2_user_created_at - timedelta(milliseconds=500),
+            step_id="turn2",
+            data={
+                "tool_name": "list_files",
+                "tool_call_id": "turn2-call",
+                "success": True,
+                "result": {"turn": 2},
+            },
+        )
+        _add_chat_message(
+            db_session,
+            task,
+            role="assistant",
+            content="turn 2 answer",
+            created_at=turn2_user_created_at + timedelta(seconds=3),
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        roles = [m["role"] for m in messages]
+
+        assert roles == [
+            "user",
+            "assistant",
+            "tool",
+            "assistant",
+            "user",
+            "assistant",
+            "tool",
+            "assistant",
+        ]
+        assert messages[0]["content"] == "turn 1 question"
+        assert messages[1]["tool_calls"][0]["id"] == "turn1-call"
+        assert messages[2]["tool_call_id"] == "turn1-call"
+        assert messages[3]["content"] == "turn 1 answer"
+        assert messages[4]["content"] == "turn 2 question"
+        # Turn 2's exchange sits AFTER turn 2's own question, not before it.
+        assert messages[5]["tool_calls"][0]["id"] == "turn2-call"
+        assert messages[6]["tool_call_id"] == "turn2-call"
+        assert messages[7]["content"] == "turn 2 answer"
+    finally:
+        db_session.close()
+
+
+def test_exchanges_from_different_turns_never_merge_into_one_group():
+    """Two turns whose tool events share no ``step_id`` must never be
+    coalesced into a single group, and each turn's group must stay
+    contiguous (no interleaving between the two turns' assistant/tool
+    pairs)."""
+    from xagent.web.services.task_conversation_context_service import (
+        _group_exchanges_by_turn,
+        _ToolExchange,
+    )
+
+    turn1_call_a = _ToolExchange(
+        call_id="t1-a",
+        tool_name="list_files",
+        tool_params={},
+        result={"ok": True},
+        assistant_content="",
+        sort_key=(_ts(0), 1),
+        step_id="turn1",
+    )
+    turn1_call_b = _ToolExchange(
+        call_id="t1-b",
+        tool_name="list_files",
+        tool_params={},
+        result={"ok": True},
+        assistant_content="",
+        sort_key=(_ts(1), 2),
+        step_id="turn1",
+    )
+    turn2_call = _ToolExchange(
+        call_id="t2-a",
+        tool_name="list_files",
+        tool_params={},
+        result={"ok": True},
+        assistant_content="",
+        sort_key=(_ts(2), 3),
+        step_id="turn2",
+    )
+
+    groups = _group_exchanges_by_turn([turn1_call_a, turn1_call_b, turn2_call])
+
+    assert len(groups) == 2
+    assert groups[0] == [turn1_call_a, turn1_call_b]
+    assert groups[1] == [turn2_call]
+
+    # And end-to-end: each turn's assistant/tool block stays contiguous in
+    # the rendered output, with no cross-turn interleaving.
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        _add_chat_message(db_session, task, role="user", content="q1", created_at=base)
+        for index, call_id in enumerate(["t1-a", "t1-b"]):
+            _add_trace_event(
+                db_session,
+                task,
+                event_type="tool_execution_start",
+                timestamp=base + timedelta(seconds=1 + index),
+                step_id="turn1",
+                data={
+                    "tool_name": "list_files",
+                    "tool_params": {"call": call_id},
+                    "tool_call_id": call_id,
+                },
+            )
+            _add_trace_event(
+                db_session,
+                task,
+                event_type="tool_execution_end",
+                timestamp=base + timedelta(seconds=1 + index, milliseconds=500),
+                step_id="turn1",
+                data={
+                    "tool_name": "list_files",
+                    "tool_call_id": call_id,
+                    "success": True,
+                    "result": {"call": call_id},
+                },
+            )
+        _add_chat_message(
+            db_session,
+            task,
+            role="assistant",
+            content="a1",
+            created_at=base + timedelta(seconds=5),
+        )
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="q2",
+            created_at=base + timedelta(minutes=1),
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=base + timedelta(minutes=1, seconds=1),
+            step_id="turn2",
+            data={
+                "tool_name": "list_files",
+                "tool_params": {"call": "t2-a"},
+                "tool_call_id": "t2-a",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=base + timedelta(minutes=1, seconds=2),
+            step_id="turn2",
+            data={
+                "tool_name": "list_files",
+                "tool_call_id": "t2-a",
+                "success": True,
+                "result": {"call": "t2-a"},
+            },
+        )
+        _add_chat_message(
+            db_session,
+            task,
+            role="assistant",
+            content="a2",
+            created_at=base + timedelta(minutes=1, seconds=3),
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        call_ids_in_order = [m["tool_call_id"] for m in messages if m["role"] == "tool"]
+        assert call_ids_in_order == ["t1-a", "t1-b", "t2-a"]
+        # Turn 1's block (2 assistant+tool pairs) sits fully between q1/a1;
+        # turn 2's block sits fully between q2/a2 -- no interleaving.
+        q1_index = messages.index({"role": "user", "content": "q1"})
+        a1_index = next(i for i, m in enumerate(messages) if m.get("content") == "a1")
+        q2_index = messages.index({"role": "user", "content": "q2"})
+        a2_index = next(i for i, m in enumerate(messages) if m.get("content") == "a2")
+        assert q1_index < a1_index < q2_index < a2_index
+        for index in range(q1_index + 1, a1_index):
+            if messages[index]["role"] == "tool":
+                assert messages[index]["raw_result"]["call"] in ("t1-a", "t1-b")
+        for index in range(q2_index + 1, a2_index):
+            if messages[index]["role"] == "tool":
+                assert messages[index]["raw_result"]["call"] == "t2-a"
+    finally:
+        db_session.close()
+
+
+def test_well_timestamped_multi_turn_history_unchanged_by_grouping():
+    """Regression guard: with proper, non-skewed timestamps and step_id set
+    per turn (exercising the new grouping path), the reconstructed order is
+    identical to the pre-grouping expectation covered by
+    ``test_multi_turn_history_is_chronological`` above."""
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        base = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        for turn in range(3):
+            offset_minutes = turn * 10
+            _add_chat_message(
+                db_session,
+                task,
+                role="user",
+                content=f"user turn {turn}",
+                created_at=base + timedelta(minutes=offset_minutes),
+            )
+            for tool_index in range(2):
+                call_id = f"turn{turn}-call{tool_index}"
+                ts_start = base + timedelta(
+                    minutes=offset_minutes, seconds=1 + tool_index * 2
+                )
+                ts_end = base + timedelta(
+                    minutes=offset_minutes, seconds=2 + tool_index * 2
+                )
+                _add_trace_event(
+                    db_session,
+                    task,
+                    event_type="tool_execution_start",
+                    timestamp=ts_start,
+                    step_id=f"step-turn{turn}",
+                    data={
+                        "tool_name": "list_files",
+                        "tool_params": {"turn": turn, "tool_index": tool_index},
+                        "tool_call_id": call_id,
+                    },
+                )
+                _add_trace_event(
+                    db_session,
+                    task,
+                    event_type="tool_execution_end",
+                    timestamp=ts_end,
+                    step_id=f"step-turn{turn}",
+                    data={
+                        "tool_name": "list_files",
+                        "tool_call_id": call_id,
+                        "success": True,
+                        "result": {"turn": turn, "tool_index": tool_index},
+                    },
+                )
+            _add_chat_message(
+                db_session,
+                task,
+                role="assistant",
+                content=f"assistant answer {turn}",
+                created_at=base + timedelta(minutes=offset_minutes, seconds=9),
+            )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        roles = [m["role"] for m in messages]
+
+        assert roles.count("user") == 3
+        assert roles.count("assistant") == 3 + 3 * 2
+        assert roles.count("tool") == 6
+
+        for turn in range(3):
+            user_index = messages.index(
+                {"role": "user", "content": f"user turn {turn}"}
+            )
+            answer_index = next(
+                index
+                for index, m in enumerate(messages)
+                if m["role"] == "assistant"
+                and m.get("content") == f"assistant answer {turn}"
+            )
+            assert user_index < answer_index
+            for index in range(user_index + 1, answer_index):
+                message = messages[index]
+                if message["role"] == "tool":
+                    assert message["raw_result"]["turn"] == turn
+    finally:
+        db_session.close()
+
+
+def test_image_only_user_turn_survives_with_blank_content():
+    """A ``TaskChatMessage`` with ``content=""`` and an image attachment is
+    a supported product path (``persist_user_message_no_commit``,
+    chat_history_service.py, documents this explicitly) and must survive
+    reconstruction with its context refs -- not be dropped as if it were
+    truly empty."""
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        base = _ts(0)
+
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="",
+            created_at=base,
+            attachments=[
+                {
+                    "file_id": "image-only",
+                    "name": "screenshot.png",
+                    "type": "image/png",
+                }
+            ],
+        )
+        # A truly empty row -- no content, no attachments -- must still be
+        # dropped.
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="",
+            created_at=base + timedelta(seconds=1),
+            attachments=None,
+        )
+        _add_chat_message(
+            db_session,
+            task,
+            role="assistant",
+            content="I see the screenshot.",
+            created_at=base + timedelta(seconds=2),
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+
+        assert len(messages) == 2
+        assert messages[0]["role"] == "user"
+        assert messages[0]["content"] == ""
+        assert len(messages[0][CONTEXT_REFS_KEY]) == 1
+        assert messages[0][CONTEXT_REFS_KEY][0]["file_ref"]["file_id"] == ("image-only")
+        assert messages[1]["role"] == "assistant"
+        assert messages[1]["content"] == "I see the screenshot."
+    finally:
+        db_session.close()
+
+
+def test_image_only_turn_participates_correctly_in_chronological_ordering():
+    """The image-only row is not just retained -- it must land in its
+    correct chronological slot relative to a tool exchange interleaved
+    around it."""
+    db_session = _create_db_session()
+    try:
+        task = _create_task(db_session)
+        base = _ts(0)
+
+        _add_chat_message(
+            db_session,
+            task,
+            role="user",
+            content="",
+            created_at=base,
+            attachments=[
+                {
+                    "file_id": "image-mid",
+                    "name": "diagram.png",
+                    "type": "image/png",
+                }
+            ],
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_start",
+            timestamp=base + timedelta(seconds=1),
+            step_id="turn1",
+            data={
+                "tool_name": "analyze_image",
+                "tool_params": {},
+                "tool_call_id": "call-analyze",
+            },
+        )
+        _add_trace_event(
+            db_session,
+            task,
+            event_type="tool_execution_end",
+            timestamp=base + timedelta(seconds=2),
+            step_id="turn1",
+            data={
+                "tool_name": "analyze_image",
+                "tool_call_id": "call-analyze",
+                "success": True,
+                "result": {"label": "diagram"},
+            },
+        )
+        _add_chat_message(
+            db_session,
+            task,
+            role="assistant",
+            content="It's a diagram.",
+            created_at=base + timedelta(seconds=3),
+        )
+
+        messages = load_task_conversation_context_sync(db_session, int(task.id))
+        roles = [m["role"] for m in messages]
+
+        assert roles == ["user", "assistant", "tool", "assistant"]
+        assert messages[0]["content"] == ""
+        assert messages[0][CONTEXT_REFS_KEY][0]["file_ref"]["file_id"] == ("image-mid")
+        assert messages[1]["tool_calls"][0]["id"] == "call-analyze"
+        assert messages[2]["tool_call_id"] == "call-analyze"
+        assert messages[3]["content"] == "It's a diagram."
     finally:
         db_session.close()


### PR DESCRIPTION
Part of #1598. Follows #1600, which taught the runner to replay tool exchanges.

Resuming a conversation currently rebuilds prior turns as one system message: the newest 8 tool events, each clipped to 240 characters by a blind character slice, applied whether the history is 900 bytes or 900 KB. #1598 has the incident — the slice landed inside a field name of an MCP continuation token, and the model completed the severed token by guessing.

This adds the service that rebuilds those turns as the messages that actually happened, plus the one piece of plumbing it needs to place them correctly.

## Placing exchanges by turn

An earlier revision ordered everything by timestamp and guarded the head of the list. That was wrong, and review caught it with two counterexamples I could reproduce: `TaskChatMessage.created_at` comes from the database clock while `TraceEvent.timestamp` comes from the application clock, so a turn's tool work can sort ahead of the request that prompted it, and no amount of guarding fixes attribution that timestamps cannot express.

So exchanges are joined to their turn instead of inferred. `TaskChatMessage.turn_id` is an indexed column, populated per turn; the tool hooks now stamp the same value into their trace payload, so the merge walks the transcript in order and splices each turn's exchanges in after its own user row. **No timestamp comparison crosses the two clocks at all** — ordering within a turn still uses timestamps, which is safe, since that is one turn on one clock.

`_dag_turn_id` already computed this value for the DAG step hooks; it resolves the last user message's `metadata["turn_id"]` and is not DAG-specific despite the name. The gap was that `on_tool_start` / `on_tool_end` / `on_tool_error` receive only a `tool_call` dict, never the context. They now read it from a `runtime.active_turn_id` set at pattern start, exactly as `active_react_step_id` already works, so the hook signatures are unchanged. `turn_id` goes into the JSON `data` payload — no column, no migration.

## Exchanges recorded before this ships

Rows written before this change carry no `turn_id`, and nothing can recover which turn they belonged to. Those exchanges are **omitted rather than placed heuristically**: a conversation recorded earlier resumes with its transcript text, which is exactly what it gets today, while anything recorded afterwards gets the full reconstruction. A task spanning the deploy degrades per turn rather than all at once.

Losing detail is acceptable; fabricating causality is not. A misplaced exchange can make the model believe a later turn's tool results informed an earlier answer, or that a failed turn never happened — a different kind of error than the lossy truncation this replaces.

## The rest of the pipeline

Pairing uses `(step_id, tool_call_id)`, not the call id alone. When a provider omits tool-call ids the runtime synthesizes `tool_call_{index}`, positional within one LLM response; DAG runs steps concurrently, each its own response, each numbering from zero, so two branches emit `tool_call_0` under one task. Keyed on the id alone, one branch's start overwrites the other's and the first end pops the wrong one.

Exchange blocks stay atomic — nothing interleaves between an assistant message and its tool result. Transcript rows carry their image context references through, reproducing `load_task_transcript`'s reverse scan over the shared 16-reference budget, and a turn that uploaded an image without typing anything is retained on `content or context_refs` rather than dropped for having no text. Control-tool exchanges (`final_answer`, `send_message`, `ask_user_question`) are excluded: their observable effect already exists as chat messages, and replaying a completed `final_answer` risks the model reading the current turn as already answered.

## Scope

The service has no callers yet — size limits and observability come next, then the wiring that actually changes resume behavior. The `runtime.py` / `react.py` / `dag.py` change does take effect immediately, but only as an additional field on tool trace payloads.

Full suite matches `main`'s failure set exactly, including `tests/core/agent/`.
