### PR TITLE
test(agent-management): stop timing out cross-thread handshakes under CI load

### DIFF
--- a/tests/web/api/v1/test_agent_management_runtime.py
+++ b/tests/web/api/v1/test_agent_management_runtime.py
@@ -33,6 +33,32 @@ from ..conftest import (
 pytestmark = pytest.mark.usefixtures("_test_db")
 
 
+# Cross-thread handshake deadline.
+#
+# Every ``Event.wait`` and ``asyncio.wait_for`` below is a rendezvous, not a
+# latency assertion: the other side releases it the moment it reaches the
+# point under test. The deadline exists only so that a genuine deadlock fails
+# one test instead of hanging the suite, so it is sized for the worst CI
+# machine rather than for the expected one.
+#
+# It has to be generous because the code these handshakes straddle is
+# deliberately expensive. Runtime-key delivery hashes with bcrypt at
+# ``BCRYPT_COST`` 12 -- ~100ms per draw on idle commodity hardware, up to
+# ``PREFIX_COLLISION_RETRIES`` draws -- and then commits. CI runs this suite
+# as ``pytest -n 4`` on a 4-vCPU runner that is simultaneously driving a
+# Docker daemon, so the 2s budget these waits used to carry (~9x headroom on
+# an idle workstation) was routinely missed there. Oversubscribing an
+# 18-core machine ~8x reproduces the exact CI failures: ``assert False`` on a
+# handshake wait, ``TimeoutError`` on a settlement wait.
+_HANDSHAKE_TIMEOUT = 30.0
+
+# Deliberately short, and deliberately not the constant above: this probe
+# waits on something that must *not* happen (a second fence acquisition while
+# the first is still held), so the wait is pure cost -- a longer one would
+# only slow the suite down without strengthening the assertion.
+_NEGATIVE_PROBE_TIMEOUT = 0.1
+
+
 def _admin_identity() -> tuple[int, bool]:
     _admin_headers()
     db = _direct_db_session()
@@ -69,11 +95,11 @@ async def _cancel_after_runtime_key_commit(
     committed: threading.Event,
     release: threading.Event,
 ) -> None:
-    assert await asyncio.to_thread(committed.wait, 2)
+    assert await asyncio.to_thread(committed.wait, _HANDSHAKE_TIMEOUT)
     operation.cancel()
     release.set()
     with pytest.raises(asyncio.CancelledError):
-        await asyncio.wait_for(operation, timeout=2)
+        await asyncio.wait_for(operation, timeout=_HANDSHAKE_TIMEOUT)
 
 
 @pytest.mark.asyncio
@@ -176,13 +202,13 @@ async def test_list_cache_io_never_holds_database_pool_slot(
     def gated_cache_get(_key: str):  # type: ignore[no-untyped-def]
         cache_observations.append(("get", engine.pool.checkedout()))
         cache_get_entered.set()
-        assert allow_cache_get.wait(timeout=2)
+        assert allow_cache_get.wait(timeout=_HANDSHAKE_TIMEOUT)
         return None
 
     def gated_cache_set(_key: str, _value):  # type: ignore[no-untyped-def]
         cache_observations.append(("set", engine.pool.checkedout()))
         cache_set_entered.set()
-        assert allow_cache_set.wait(timeout=2)
+        assert allow_cache_set.wait(timeout=_HANDSHAKE_TIMEOUT)
 
     def probe_pool() -> None:
         with engine.connect() as connection:
@@ -194,12 +220,12 @@ async def test_list_cache_io_never_holds_database_pool_slot(
     listing = asyncio.create_task(AgentManagementRuntime().list_agents(user_id=user_id))
 
     try:
-        assert await asyncio.to_thread(cache_get_entered.wait, 2)
+        assert await asyncio.to_thread(cache_get_entered.wait, _HANDSHAKE_TIMEOUT)
         assert cache_observations == [("get", 0)]
         await asyncio.to_thread(probe_pool)
         allow_cache_get.set()
 
-        assert await asyncio.to_thread(cache_set_entered.wait, 2)
+        assert await asyncio.to_thread(cache_set_entered.wait, _HANDSHAKE_TIMEOUT)
         assert cache_observations == [("get", 0), ("set", 0)]
         await asyncio.to_thread(probe_pool)
         allow_cache_set.set()
@@ -257,7 +283,7 @@ async def test_write_pool_wait_does_not_block_event_loop(
         )
 
     try:
-        assert await asyncio.to_thread(candidate_ready.wait, 2)
+        assert await asyncio.to_thread(candidate_ready.wait, _HANDSHAKE_TIMEOUT)
         for _ in range(4):
             await asyncio.sleep(0.01)
         assert write.done() is False
@@ -286,7 +312,7 @@ async def test_cancelled_pool_wait_drains_worker_before_propagating(
     monkeypatch.setattr(runtime, "_list_agents_sync", recording_list)
     listing = asyncio.create_task(runtime.list_agents(user_id=user_id))
 
-    assert await asyncio.to_thread(worker_started.wait, 1)
+    assert await asyncio.to_thread(worker_started.wait, _HANDSHAKE_TIMEOUT)
     listing.cancel()
     held_connection.close()
 
@@ -320,7 +346,7 @@ async def test_cancel_after_committed_create_revokes_the_undelivered_exact_key(
         captured["agent_id"] = int(agent.id)
         captured["prefix"] = response.key_prefix
         committed.set()
-        assert release.wait(timeout=2)
+        assert release.wait(timeout=_HANDSHAKE_TIMEOUT)
         return agent, response
 
     monkeypatch.setattr(
@@ -425,7 +451,7 @@ async def test_cancel_after_committed_rotation_revokes_the_undelivered_exact_key
         assert response is not None
         captured["prefix"] = response.key_prefix
         committed.set()
-        assert release.wait(timeout=2)
+        assert release.wait(timeout=_HANDSHAKE_TIMEOUT)
         return response
 
     monkeypatch.setattr(
@@ -496,7 +522,7 @@ async def test_later_rotation_fence_prevents_stale_compensation_from_restoring_o
         if rotate_calls == 1:
             captured["first_prefix"] = response.key_prefix
             committed.set()
-            assert release.wait(timeout=2)
+            assert release.wait(timeout=_HANDSHAKE_TIMEOUT)
         return response
 
     monkeypatch.setattr(
@@ -510,7 +536,7 @@ async def test_later_rotation_fence_prevents_stale_compensation_from_restoring_o
             agent_id=target.agent.id,
         )
     )
-    assert await asyncio.to_thread(committed.wait, 2)
+    assert await asyncio.to_thread(committed.wait, _HANDSHAKE_TIMEOUT)
 
     later = await AgentManagementRuntime().rotate_agent_runtime_key(
         user_id=user_id,
@@ -521,7 +547,7 @@ async def test_later_rotation_fence_prevents_stale_compensation_from_restoring_o
     operation.cancel()
     release.set()
     with pytest.raises(asyncio.CancelledError):
-        await asyncio.wait_for(operation, timeout=2)
+        await asyncio.wait_for(operation, timeout=_HANDSHAKE_TIMEOUT)
 
     db = _direct_db_session()
     try:
@@ -567,11 +593,11 @@ async def test_sqlite_runtime_key_transition_fence_serializes_transactions() -> 
         with SessionLocal() as db:
             assert acquire_runtime_key_transition_fence(db, target.agent.id)
             first_acquired.set()
-            assert release_first.wait(timeout=2)
+            assert release_first.wait(timeout=_HANDSHAKE_TIMEOUT)
             db.commit()
 
     def acquire_second_fence() -> None:
-        assert first_acquired.wait(timeout=2)
+        assert first_acquired.wait(timeout=_HANDSHAKE_TIMEOUT)
         with SessionLocal() as db:
             second_started.set()
             assert acquire_runtime_key_transition_fence(db, target.agent.id)
@@ -579,16 +605,18 @@ async def test_sqlite_runtime_key_transition_fence_serializes_transactions() -> 
             db.commit()
 
     first = asyncio.create_task(asyncio.to_thread(hold_first_fence))
-    assert await asyncio.to_thread(first_acquired.wait, 2)
+    assert await asyncio.to_thread(first_acquired.wait, _HANDSHAKE_TIMEOUT)
     second = asyncio.create_task(asyncio.to_thread(acquire_second_fence))
-    assert await asyncio.to_thread(second_started.wait, 2)
+    assert await asyncio.to_thread(second_started.wait, _HANDSHAKE_TIMEOUT)
     try:
-        assert not await asyncio.to_thread(second_acquired.wait, 0.1)
+        assert not await asyncio.to_thread(
+            second_acquired.wait, _NEGATIVE_PROBE_TIMEOUT
+        )
     finally:
         release_first.set()
 
-    await asyncio.wait_for(first, timeout=2)
-    await asyncio.wait_for(second, timeout=2)
+    await asyncio.wait_for(first, timeout=_HANDSHAKE_TIMEOUT)
+    await asyncio.wait_for(second, timeout=_HANDSHAKE_TIMEOUT)
     assert second_acquired.is_set()
     observer = _direct_db_session()
     try:
@@ -743,7 +771,7 @@ async def test_compensation_cancellation_is_not_swallowed_after_worker_settles(
 
     def delayed_compensation(_receipt: RuntimeKeyReceipt) -> None:
         started.set()
-        assert release.wait(timeout=2)
+        assert release.wait(timeout=_HANDSHAKE_TIMEOUT)
 
     monkeypatch.setattr(runtime, "_compensate_runtime_key_sync", delayed_compensation)
     compensation = asyncio.create_task(
@@ -751,12 +779,12 @@ async def test_compensation_cancellation_is_not_swallowed_after_worker_settles(
             RuntimeKeyReceipt(key_id=1, agent_id=2, key_prefix="ABC123")
         )
     )
-    assert await asyncio.to_thread(started.wait, 2)
+    assert await asyncio.to_thread(started.wait, _HANDSHAKE_TIMEOUT)
     compensation.cancel()
     release.set()
 
     with pytest.raises(asyncio.CancelledError):
-        await asyncio.wait_for(compensation, timeout=2)
+        await asyncio.wait_for(compensation, timeout=_HANDSHAKE_TIMEOUT)
 
 
 @pytest.mark.asyncio
@@ -800,7 +828,7 @@ async def test_runtime_key_delivery_keeps_worker_error_as_cancellation_cause() -
 
     def operation() -> _RuntimeKeyDeliveryOutcome[object]:
         started.set()
-        assert release.wait(timeout=2)
+        assert release.wait(timeout=_HANDSHAKE_TIMEOUT)
         return _RuntimeKeyDeliveryOutcome(
             result=None,
             receipt=None,
@@ -811,12 +839,12 @@ async def test_runtime_key_delivery_keeps_worker_error_as_cancellation_cause() -
     caller = asyncio.create_task(
         AgentManagementRuntime()._run_runtime_key_delivery(operation)
     )
-    assert await asyncio.to_thread(started.wait, 2)
+    assert await asyncio.to_thread(started.wait, _HANDSHAKE_TIMEOUT)
     caller.cancel()
     release.set()
 
     with pytest.raises(asyncio.CancelledError) as exc_info:
-        await asyncio.wait_for(caller, timeout=1)
+        await asyncio.wait_for(caller, timeout=_HANDSHAKE_TIMEOUT)
 
     assert exc_info.value.__cause__ is worker_error
 
@@ -832,7 +860,7 @@ async def test_runtime_key_delivery_keeps_process_control_over_cancellation() ->
 
     def operation() -> _RuntimeKeyDeliveryOutcome[object]:
         started.set()
-        assert release.wait(timeout=2)
+        assert release.wait(timeout=_HANDSHAKE_TIMEOUT)
         return _RuntimeKeyDeliveryOutcome(
             result=None,
             receipt=None,
@@ -843,12 +871,12 @@ async def test_runtime_key_delivery_keeps_process_control_over_cancellation() ->
     caller = asyncio.create_task(
         AgentManagementRuntime()._run_runtime_key_delivery(operation)
     )
-    assert await asyncio.to_thread(started.wait, 2)
+    assert await asyncio.to_thread(started.wait, _HANDSHAKE_TIMEOUT)
     caller.cancel()
     release.set()
 
     with pytest.raises(WorkerShutdown) as exc_info:
-        await asyncio.wait_for(caller, timeout=1)
+        await asyncio.wait_for(caller, timeout=_HANDSHAKE_TIMEOUT)
 
     assert exc_info.value is shutdown
 
@@ -1077,7 +1105,7 @@ async def test_cancelled_receipt_failure_is_not_replaced_by_session_close_failur
         original_close(session)
         if close_calls == 1:
             close_started.set()
-            assert release_close.wait(timeout=2)
+            assert release_close.wait(timeout=_HANDSHAKE_TIMEOUT)
             raise close_error
 
     monkeypatch.setattr(Session, "commit", fail_after_commit)
@@ -1098,12 +1126,12 @@ async def test_cancelled_receipt_failure_is_not_replaced_by_session_close_failur
             runtime.rotate_agent_runtime_key(user_id=user_id, agent_id=agent_id)
         )
 
-    assert await asyncio.to_thread(close_started.wait, 2)
+    assert await asyncio.to_thread(close_started.wait, _HANDSHAKE_TIMEOUT)
     operation.cancel()
     release_close.set()
 
     with pytest.raises(asyncio.CancelledError) as exc_info:
-        await asyncio.wait_for(operation, timeout=2)
+        await asyncio.wait_for(operation, timeout=_HANDSHAKE_TIMEOUT)
 
     assert exc_info.value.__cause__ is primary_error
     monkeypatch.undo()
@@ -1160,7 +1188,7 @@ async def test_compensation_keeps_the_event_loop_responsive_while_pool_is_held(
     def pause_after_commit(service, *args, **kwargs):  # type: ignore[no-untyped-def]
         result = original_create(service, *args, **kwargs)
         committed.set()
-        assert release.wait(timeout=2)
+        assert release.wait(timeout=_HANDSHAKE_TIMEOUT)
         return result
 
     monkeypatch.setattr(
@@ -1175,7 +1203,7 @@ async def test_compensation_keeps_the_event_loop_responsive_while_pool_is_held(
             spec=_create_spec("pool compensation"),
         )
     )
-    assert await asyncio.to_thread(committed.wait, 2)
+    assert await asyncio.to_thread(committed.wait, _HANDSHAKE_TIMEOUT)
     held_connection = engine.connect()
     operation.cancel()
     release.set()
@@ -1190,7 +1218,7 @@ async def test_compensation_keeps_the_event_loop_responsive_while_pool_is_held(
         held_connection.close()
 
     with pytest.raises(asyncio.CancelledError):
-        await asyncio.wait_for(operation, timeout=2)
+        await asyncio.wait_for(operation, timeout=_HANDSHAKE_TIMEOUT)
     assert engine.pool.checkedout() == 0
     engine.dispose()
 
@@ -1213,7 +1241,7 @@ async def test_cancellation_stays_primary_when_runtime_key_compensation_fails(
     def pause_after_commit(service, *args, **kwargs):  # type: ignore[no-untyped-def]
         result = original_create(service, *args, **kwargs)
         committed.set()
-        assert release.wait(timeout=2)
+        assert release.wait(timeout=_HANDSHAKE_TIMEOUT)
         return result
 
     monkeypatch.setattr(
@@ -1233,12 +1261,12 @@ async def test_cancellation_stays_primary_when_runtime_key_compensation_fails(
             spec=_create_spec("compensation failure"),
         )
     )
-    assert await asyncio.to_thread(committed.wait, 2)
+    assert await asyncio.to_thread(committed.wait, _HANDSHAKE_TIMEOUT)
     operation.cancel()
     release.set()
 
     with pytest.raises(asyncio.CancelledError) as exc_info:
-        await asyncio.wait_for(operation, timeout=2)
+        await asyncio.wait_for(operation, timeout=_HANDSHAKE_TIMEOUT)
 
     assert exc_info.value.__cause__ is compensation_error
 
@@ -1264,7 +1292,7 @@ async def test_compensation_process_control_wins_over_caller_cancellation(
     def pause_after_commit(service, *args, **kwargs):  # type: ignore[no-untyped-def]
         result = original_create(service, *args, **kwargs)
         committed.set()
-        assert release.wait(timeout=2)
+        assert release.wait(timeout=_HANDSHAKE_TIMEOUT)
         return result
 
     monkeypatch.setattr(
@@ -1284,12 +1312,12 @@ async def test_compensation_process_control_wins_over_caller_cancellation(
             spec=_create_spec("compensation shutdown"),
         )
     )
-    assert await asyncio.to_thread(committed.wait, 2)
+    assert await asyncio.to_thread(committed.wait, _HANDSHAKE_TIMEOUT)
     operation.cancel()
     release.set()
 
     with pytest.raises(WorkerShutdown) as exc_info:
-        await asyncio.wait_for(operation, timeout=2)
+        await asyncio.wait_for(operation, timeout=_HANDSHAKE_TIMEOUT)
 
     assert exc_info.value is shutdown
 


### PR DESCRIPTION
## Problem

Two tests in `tests/web/api/v1/test_agent_management_runtime.py` have failed CI intermittently, with different names each time:

| Where | Test | Signature |
|---|---|---|
| `main` @ `670db6a9` | `test_cancelled_receipt_failure_is_not_replaced_by_session_close_failure[commit-rotate]` | `TimeoutError` |
| #1601 | `test_cancellation_stays_primary_when_runtime_key_compensation_fails` | `assert False` at the `committed.wait` handshake |

## Root cause

Every cross-thread wait in that module was guarded by a hard-coded 1–2 second budget. Those waits are *ordering* assertions, not latency assertions — the other side releases them the moment it reaches the point under test. The budget's only job is to make a genuine deadlock fail one test instead of hanging the suite.

2 seconds is not big enough for that job, because the code the handshakes straddle is deliberately expensive:

- runtime-key delivery hashes with bcrypt at `BCRYPT_COST = 12` — **171.8 ms per draw** measured on an idle 18-core workstation — and `PREFIX_COLLISION_RETRIES = 5` allows up to five draws
- then it commits

CI runs this suite as `pytest -n 4 --dist=loadscope` on a 4-vCPU `ubuntu-latest` runner, and the `web` matrix entry is simultaneously driving a real Docker daemon (`test_sandbox_reconcile_e2e.py`). The ~9x headroom the budget has on an idle machine is gone there.

Which test loses the race is a lottery decided by where the scheduler pinches — hence the changing test name.

## Reproduction

Measured by wrapping `threading.Event.wait` and running the module under synthetic CPU oversubscription:

| Load (18-core host) | Result | Worst handshake |
|---|---|---|
| idle | pass | < 25% of budget |
| 3x oversubscribed | pass | **0.598 s / 2 s** |
| 8x oversubscribed | **fail** | budget exceeded |

The 8x run reproduced both CI signatures exactly — `assert False` at `:1101` (`test_cancelled_receipt_failure_is_not_replaced_by_session_close_failure`, here `[refresh-create]`) and at `:1287` (`test_compensation_process_control_wins_over_caller_cancellation`, the sibling of the wait that broke #1601).

Extrapolating the 3x figure by CI's ~3–4x slower single-core performance lands at ~2.1 s, right on top of the observed failures.

## Fix

Replace all 41 literals with two named, documented deadlines:

- **`_HANDSHAKE_TIMEOUT = 30.0`** — every rendezvous and settlement wait. It is a deadlock detector, not a timing assertion, so it is sized for the worst CI machine rather than the expected one. Safe: the repo configures no global `--timeout`, and the `Pytest Fast` job sets no `timeout-minutes`.
- **`_NEGATIVE_PROBE_TIMEOUT = 0.1`** — the single wait that asserts something must *not* happen (a second fence acquisition while the first is held). Deliberately kept short and deliberately not sharing the constant above: a longer wait there is pure cost and would not strengthen the assertion.

The seven `pool_timeout` values are left alone. They only fire when a connection is genuinely held, so they are not load-sensitive and are not a flakiness source.

No production code changes.

## Verification

- idle: 34 passed
- **8x oversubscription, 3 consecutive runs: all passed** (pre-fix, the first run failed)
- **11x oversubscription (200 CPU hogs): passed**
- CI-shaped `pytest tests/web/api/v1 -m "not slow and not postgresql" -n 4 --dist=loadscope`: 439 passed
- `pre-commit`: all hooks pass
