### PR TITLE
fix(model-resolver): take pool health knobs from the shared DB policy

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/utils/model_resolver.py
+++ b/src/xagent/core/tools/core/RAG_tools/utils/model_resolver.py
@@ -28,6 +28,7 @@ from sqlalchemy.exc import DBAPIError
 from sqlalchemy.exc import OperationalError as SAOperationalError
 from sqlalchemy.orm import declarative_base, sessionmaker
 
+from xagent.config import get_db_pool_kwargs
 from xagent.core.model.chat.basic.adapter import create_base_llm
 from xagent.core.model.chat.basic.base import BaseLLM
 from xagent.core.model.chat.langchain import create_base_chat_model_with_retry
@@ -63,6 +64,10 @@ _MODEL_HUB_SESSION_LOCAL: Any = None
 _MODEL_HUB_MODEL: Any = None
 _MODEL_HUB_DB_URL: Optional[str] = None
 _MODEL_HUB_LOCK = threading.Lock()
+
+# get_db_pool_kwargs' sizing applies per engine, and a worker already holds the
+# web engine's pool, so adopting it here would double this process's ceiling.
+_POOL_SIZING_KEYS = frozenset({"pool_size", "max_overflow", "pool_timeout"})
 
 
 def _reset_model_hub_cache() -> None:
@@ -168,12 +173,22 @@ def _get_or_init_model_hub() -> Any:
             with _MODEL_HUB_LOCK:
                 if _MODEL_HUB_ENGINE is None or _MODEL_HUB_DB_URL != database_url:
                     old_engine = _MODEL_HUB_ENGINE
+                    is_sqlite = "sqlite" in database_url
+                    pool_kwargs: dict[str, Any] = (
+                        {}
+                        if is_sqlite
+                        else {
+                            key: value
+                            for key, value in get_db_pool_kwargs().items()
+                            if key not in _POOL_SIZING_KEYS
+                        }
+                    )
                     engine = create_engine(
                         database_url,
-                        connect_args={"check_same_thread": False}
-                        if "sqlite" in database_url
-                        else {},
-                        pool_pre_ping="sqlite" not in database_url,
+                        connect_args={"check_same_thread": False} if is_sqlite else {},
+                        # Every non-sizing knob comes from the shared policy, so
+                        # a new health kwarg there reaches this engine too.
+                        **pool_kwargs,
                         # Same database as the shared web engine
                         # (web/models/database.py) -- the Model table this
                         # hub reads/writes has an encrypted API key column,

--- a/src/xagent/core/tools/core/RAG_tools/utils/model_resolver.py
+++ b/src/xagent/core/tools/core/RAG_tools/utils/model_resolver.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
     from langchain_core.runnables import Runnable
 
 from sqlalchemy import create_engine
+from sqlalchemy.engine import make_url
 from sqlalchemy.exc import DBAPIError
 from sqlalchemy.exc import OperationalError as SAOperationalError
 from sqlalchemy.orm import declarative_base, sessionmaker
@@ -67,7 +68,8 @@ _MODEL_HUB_LOCK = threading.Lock()
 
 # get_db_pool_kwargs' sizing applies per engine, and a worker already holds the
 # web engine's pool, so adopting it here would double this process's ceiling.
-_POOL_SIZING_KEYS = frozenset({"pool_size", "max_overflow", "pool_timeout"})
+# pool_timeout stays: it is the acquisition wait, not capacity.
+_POOL_SIZING_KEYS = frozenset({"pool_size", "max_overflow"})
 
 
 def _reset_model_hub_cache() -> None:
@@ -173,7 +175,7 @@ def _get_or_init_model_hub() -> Any:
             with _MODEL_HUB_LOCK:
                 if _MODEL_HUB_ENGINE is None or _MODEL_HUB_DB_URL != database_url:
                     old_engine = _MODEL_HUB_ENGINE
-                    is_sqlite = "sqlite" in database_url
+                    is_sqlite = make_url(database_url).get_backend_name() == "sqlite"
                     pool_kwargs: dict[str, Any] = (
                         {}
                         if is_sqlite

--- a/tests/core/tools/core/RAG_tools/utils/test_model_resolver.py
+++ b/tests/core/tools/core/RAG_tools/utils/test_model_resolver.py
@@ -716,3 +716,88 @@ class TestModelHubEngineHideParameters:
 
         assert hub is not None
         assert model_resolver._MODEL_HUB_ENGINE.hide_parameters is True
+
+
+class TestModelHubEnginePoolKwargs:
+    """The model hub engine must take its pool health knobs from the shared
+    policy, not a local copy: a hardcoded value drifts silently the next time
+    ``get_db_pool_kwargs`` changes."""
+
+    class _StopBeforeConnect(Exception):
+        pass
+
+    def teardown_method(self) -> None:
+        model_resolver._reset_model_hub_cache()
+
+    def _capture_create_engine_kwargs(self, monkeypatch, url: str) -> Dict:
+        captured: Dict = {}
+
+        def _spy(_url, **kwargs):
+            captured.update(kwargs)
+            raise self._StopBeforeConnect("captured")
+
+        model_resolver._reset_model_hub_cache()
+        monkeypatch.setattr(model_resolver, "get_default_db_url", lambda: url)
+        monkeypatch.setattr(model_resolver, "create_engine", _spy)
+        with pytest.raises(self._StopBeforeConnect):
+            model_resolver._get_or_init_model_hub()
+        return captured
+
+    def test_non_sqlite_engine_takes_every_health_kwarg_from_shared_policy(
+        self, monkeypatch
+    ):
+        from xagent.config import get_db_pool_kwargs
+
+        policy = get_db_pool_kwargs()
+        expected = {
+            key: value
+            for key, value in policy.items()
+            if key not in model_resolver._POOL_SIZING_KEYS
+        }
+        assert set(expected) == {"pool_recycle", "pool_pre_ping"}
+
+        kwargs = self._capture_create_engine_kwargs(
+            monkeypatch, "postgresql+psycopg2://u:p@127.0.0.1:5432/xagent"
+        )
+
+        assert kwargs == {
+            "connect_args": {},
+            "hide_parameters": True,
+            **expected,
+        }
+        # Sizing stays per-engine: a worker already holds the web engine's pool.
+        assert not model_resolver._POOL_SIZING_KEYS & set(kwargs)
+
+    def test_non_sqlite_engine_follows_shared_policy_changes(self, monkeypatch):
+        """Nothing may be copied locally: a changed policy must reach this engine."""
+        drifted = {
+            "pool_size": 999,
+            "max_overflow": 999,
+            "pool_timeout": 999,
+            "pool_recycle": 61,
+            "pool_pre_ping": False,
+            "pool_use_lifo": True,
+        }
+        monkeypatch.setattr(model_resolver, "get_db_pool_kwargs", lambda: drifted)
+
+        kwargs = self._capture_create_engine_kwargs(
+            monkeypatch, "postgresql+psycopg2://u:p@127.0.0.1:5432/xagent"
+        )
+
+        assert kwargs == {
+            "connect_args": {},
+            "hide_parameters": True,
+            "pool_recycle": 61,
+            "pool_pre_ping": False,
+            "pool_use_lifo": True,
+        }
+
+    def test_sqlite_engine_takes_no_pool_kwargs(self, monkeypatch, tmp_path):
+        kwargs = self._capture_create_engine_kwargs(
+            monkeypatch, f"sqlite:///{tmp_path / 'hub.db'}"
+        )
+
+        assert kwargs == {
+            "connect_args": {"check_same_thread": False},
+            "hide_parameters": True,
+        }

--- a/tests/core/tools/core/RAG_tools/utils/test_model_resolver.py
+++ b/tests/core/tools/core/RAG_tools/utils/test_model_resolver.py
@@ -754,7 +754,7 @@ class TestModelHubEnginePoolKwargs:
             for key, value in policy.items()
             if key not in model_resolver._POOL_SIZING_KEYS
         }
-        assert set(expected) == {"pool_recycle", "pool_pre_ping"}
+        assert "pool_timeout" in expected
 
         kwargs = self._capture_create_engine_kwargs(
             monkeypatch, "postgresql+psycopg2://u:p@127.0.0.1:5432/xagent"
@@ -787,10 +787,20 @@ class TestModelHubEnginePoolKwargs:
         assert kwargs == {
             "connect_args": {},
             "hide_parameters": True,
+            "pool_timeout": 999,
             "pool_recycle": 61,
             "pool_pre_ping": False,
             "pool_use_lifo": True,
         }
+
+    def test_configured_pool_timeout_reaches_the_engine(self, monkeypatch):
+        monkeypatch.setenv("XAGENT_DB_POOL_TIMEOUT_SECONDS", "7")
+
+        kwargs = self._capture_create_engine_kwargs(
+            monkeypatch, "postgresql+psycopg2://u:p@127.0.0.1:5432/xagent"
+        )
+
+        assert kwargs["pool_timeout"] == 7
 
     def test_sqlite_engine_takes_no_pool_kwargs(self, monkeypatch, tmp_path):
         kwargs = self._capture_create_engine_kwargs(


### PR DESCRIPTION
## What

The model hub engine in `model_resolver.py` built its own `create_engine` call with a
single hardcoded health knob (`pool_pre_ping="sqlite" not in database_url`). Every other
pooled engine in the process (`web/models/database.py`, `core/storage/manager.py`) takes
its knobs from `get_db_pool_kwargs()`. So this engine silently missed `pool_recycle=3600`:
its pooled connections were never recycled and went stale behind connection-dropping
proxies, and any future health knob added to the shared policy would have missed it too.

This engine now takes its pool kwargs from `get_db_pool_kwargs()`, minus the sizing keys.

## Why the filter is deliberately a deny-list

`_POOL_SIZING_KEYS = {"pool_size", "max_overflow"}` is **subtracted** from
the shared policy — the filter is a deny-list, on purpose, not an allow-list:

- Sizing is the one thing that must not be inherited. `get_db_pool_kwargs()` values apply
  *per engine*; a worker process already holds the web engine's pool, so adopting the same
  sizing here would double this process's connection ceiling (the same caveat is called out
  in that function's own docstring).
- Everything else — every present and future *health* knob — must reach this engine
  automatically. An allow-list would silently drop the next knob added to the shared policy,
  which is exactly the drift this PR is fixing.

That behavior is pinned by `test_non_sqlite_engine_follows_shared_policy_changes`, which
injects a knob that does not exist in the current policy (`pool_use_lifo`) and asserts it
reaches `create_engine`. An allow-list makes that test fail.

`pool_timeout` is deliberately *not* in the sizing set: it is the QueuePool acquisition
wait, not capacity, so this engine takes the configured `XAGENT_DB_POOL_TIMEOUT_SECONDS`
like every other pooled engine (`test_configured_pool_timeout_reaches_the_engine`).

SQLite keeps taking no pool kwargs at all (`test_sqlite_engine_takes_no_pool_kwargs`).

## Not included

This is one slice carved out of the closed #1593. It does **not** include the rest of the
#1593 series — the job session-per-operation rework and everything else that branch touched.
Two files only.

## Tests

`tests/core/tools/core/RAG_tools/utils/test_model_resolver.py` gains
`TestModelHubEnginePoolKwargs` (4 cases) against +19/−4 lines of source —
roughly 80% of the diff is test. Full file: 32 passed.

Mutation-checked: dropping the `**pool_kwargs` spread, replacing the shared policy with a
local copy, emptying the sizing deny-list, and letting SQLite take pool kwargs each turn at
least one of the three new tests red.
