### PR TITLE
fix(jobs): record background-job bookkeeping on sessions of its own

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -47,6 +47,9 @@ on:
       - 'src/xagent/web/models/user.py'
       - 'tests/shared/postgres_disposable.py'
       - 'tests/web/services/checkpoint_anchor_shared.py'
+      - 'src/xagent/web/services/background_jobs.py'
+      - 'src/xagent/web/jobs/tasks.py'
+      - 'tests/web/test_background_jobs_postgres.py'
   pull_request:
     branches: [main]
   # Required by the merge queue: without this the two required contexts below
@@ -130,6 +133,9 @@ jobs:
             src/xagent/web/models/user.py
             tests/shared/postgres_disposable.py
             tests/web/services/checkpoint_anchor_shared.py
+            src/xagent/web/services/background_jobs.py
+            src/xagent/web/jobs/tasks.py
+            tests/web/test_background_jobs_postgres.py
           )
 
           case "$EVENT_NAME" in
@@ -423,6 +429,16 @@ jobs:
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
           pytest tests/web/services/test_supersede_savepoint_postgresql.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
+      # Mints its own disposable database with a short
+      # idle_in_transaction_session_timeout, so it neither depends on nor
+      # disturbs the schema the steps above build.
+      - name: Test background job bookkeeping under an idle-transaction timeout (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/web/test_background_jobs_postgres.py -m postgresql -q
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -106,13 +106,14 @@ from ..models.background_job import (
     BackgroundJobStatus,
     BackgroundJobType,
 )
-from ..models.database import get_db, get_session_local
+from ..models.database import get_db, get_session_local, session_scope
 from ..models.uploaded_file import UploadedFile
 from ..models.user import User
 from ..schemas.background_job import BackgroundJobResponse
 from ..services.background_jobs import (
     QUEUE_DEFAULT,
     create_background_job,
+    get_background_job,
     get_non_terminal_background_job_by_idempotency_key,
     is_background_job_enqueue_available,
     mark_job_failed,
@@ -1808,12 +1809,6 @@ async def _enqueue_background_job_or_503_async(
             args=[job.id],
             queue=str(job.queue or QUEUE_DEFAULT),
         )
-        db.refresh(job)
-        setattr(job, "celery_task_id", async_result.id)
-        db.add(job)
-        db.commit()
-        db.refresh(job)
-        return job
     except Exception as exc:  # noqa: BLE001
         db.rollback()
         mark_job_failed(
@@ -1824,6 +1819,36 @@ async def _enqueue_background_job_or_503_async(
             status_code=503,
             detail=f"Background job queue is unavailable: {exc}",
         ) from exc
+
+    # The broker accepted the job and a worker may already be running it.
+    # Failing to persist the task id past this point must not mark that work
+    # FAILED, 503 the caller, or trigger the caller's destructive cleanup.
+    try:
+        db.refresh(job)
+        setattr(job, "celery_task_id", async_result.id)
+        db.add(job)
+        db.commit()
+        db.refresh(job)
+    except Exception:  # noqa: BLE001
+        db.rollback()
+        _reconcile_celery_task_id(job_id, str(async_result.id))
+    return job
+
+
+def _reconcile_celery_task_id(job_id: str, task_id: str) -> None:
+    """Record the task id of already-accepted work, on a session of its own."""
+    try:
+        with session_scope() as scoped_db:
+            job = get_background_job(scoped_db, job_id)
+            if job is not None:
+                setattr(job, "celery_task_id", task_id)
+                scoped_db.add(job)
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Failed to record Celery task id for accepted background job %s",
+            job_id,
+            exc_info=True,
+        )
 
 
 def _atomic_replace_file(source_path: Path, target_path: Path) -> None:

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -1778,13 +1778,16 @@ async def _enqueue_background_job_or_503_async(
     db: Session,
     job: BackgroundJob,
 ) -> BackgroundJob:
+    # mark_job_failed runs on a session of its own, so this one must not be
+    # left idle in transaction (an expired attribute read reopens one).
+    job_id = str(job.id)
     if not await asyncio.to_thread(
         is_background_job_enqueue_available,
         check_worker=False,
     ):
+        db.rollback()
         mark_job_failed(
-            db,
-            job,
+            job_id,
             error_message="Background job queue is unavailable",
         )
         raise HTTPException(
@@ -1812,9 +1815,9 @@ async def _enqueue_background_job_or_503_async(
         db.refresh(job)
         return job
     except Exception as exc:  # noqa: BLE001
+        db.rollback()
         mark_job_failed(
-            db,
-            job,
+            job_id,
             error_message=f"Background job queue is unavailable: {exc}",
         )
         raise HTTPException(

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -1775,6 +1775,21 @@ async def _ensure_background_job_queue_available_async() -> None:
         )
 
 
+def _rollback_quietly(db: Session) -> None:
+    """Give up the caller's transaction without letting a dead connection win.
+
+    Rollback runs on the connection that just failed, so it can raise too; the
+    independent failure/reconciliation write that follows must still happen.
+    """
+    try:
+        db.rollback()
+    except Exception:  # noqa: BLE001
+        logger.warning(
+            "Failed to roll back the caller session after an enqueue failure",
+            exc_info=True,
+        )
+
+
 async def _enqueue_background_job_or_503_async(
     db: Session,
     job: BackgroundJob,
@@ -1786,7 +1801,7 @@ async def _enqueue_background_job_or_503_async(
         is_background_job_enqueue_available,
         check_worker=False,
     ):
-        db.rollback()
+        _rollback_quietly(db)
         mark_job_failed(
             job_id,
             error_message="Background job queue is unavailable",
@@ -1810,7 +1825,7 @@ async def _enqueue_background_job_or_503_async(
             queue=str(job.queue or QUEUE_DEFAULT),
         )
     except Exception as exc:  # noqa: BLE001
-        db.rollback()
+        _rollback_quietly(db)
         mark_job_failed(
             job_id,
             error_message=f"Background job queue is unavailable: {exc}",
@@ -1830,7 +1845,7 @@ async def _enqueue_background_job_or_503_async(
         db.commit()
         db.refresh(job)
     except Exception:  # noqa: BLE001
-        db.rollback()
+        _rollback_quietly(db)
         _reconcile_celery_task_id(job_id, str(async_result.id))
     return job
 

--- a/src/xagent/web/jobs/tasks.py
+++ b/src/xagent/web/jobs/tasks.py
@@ -11,8 +11,14 @@ from ..models.background_job import (
     BackgroundJobStatus,
     BackgroundJobType,
 )
-from ..models.database import get_session_local, init_db
+from ..models.database import (
+    get_optional_session_local,
+    get_session_local,
+    init_db,
+    session_scope,
+)
 from ..services.background_jobs import (
+    get_background_job,
     mark_job_failed,
     mark_job_running,
     mark_job_succeeded,
@@ -21,6 +27,13 @@ from .celery_app import celery_app
 from .exceptions import BackgroundJobHandlerError
 
 logger = logging.getLogger(__name__)
+
+
+class _Unset:
+    """Sentinel type for "argument not supplied" (bare ``object`` is vacuous)."""
+
+
+_UNSET = _Unset()
 
 BackgroundJobHandler = Callable[[Session, BackgroundJob], dict[str, Any]]
 
@@ -68,13 +81,14 @@ def is_background_job_handler_registered(job_type: str) -> bool:
     return str(job_type) in _EXTRA_HANDLERS
 
 
-def _open_worker_session() -> Session:
-    try:
-        SessionLocal = get_session_local()
-    except RuntimeError:
+def _ensure_db_initialized() -> None:
+    if get_optional_session_local() is None:
         init_db()
-        SessionLocal = get_session_local()
-    return SessionLocal()
+
+
+def _open_worker_session() -> Session:
+    _ensure_db_initialized()
+    return get_session_local()()
 
 
 def _execute_job_handler(db: Session, job: BackgroundJob) -> dict[str, Any]:
@@ -114,45 +128,86 @@ def _execute_job_handler(db: Session, job: BackgroundJob) -> dict[str, Any]:
     retry_jitter=True,
 )
 def execute_background_job(self: Any, job_id: str) -> dict[str, Any]:
+    _ensure_db_initialized()
+
+    attempts = mark_job_running(job_id)
+    if attempts is None:
+        return _settled_job_result(job_id)
+
     db = _open_worker_session()
     try:
         job = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
         if job is None:
             raise ValueError(f"Background job not found: {job_id}")
-        if job.status == BackgroundJobStatus.CANCELLED.value:
-            logger.info("Skipping cancelled background job %s", job_id)
-            return {"status": "cancelled"}
-        if job.status == BackgroundJobStatus.SUCCEEDED.value:
-            logger.info("Skipping already completed background job %s", job_id)
-            return dict(job.result or {"status": "succeeded"})
+        max_attempts = int(job.max_attempts or 1)
 
-        mark_job_running(db, job)
         try:
             result = _execute_job_handler(db, job)
         except BackgroundJobHandlerError as exc:
-            db.refresh(job)
-            if exc.retryable and int(job.attempts or 0) < int(job.max_attempts or 1):
-                setattr(job, "status", BackgroundJobStatus.ENQUEUED.value)
-                setattr(job, "error_message", str(exc))
-                setattr(job, "result", exc.result)
-                db.add(job)
-                db.commit()
-                raise self.retry(exc=exc, max_retries=int(job.max_attempts or 1))
-            mark_job_failed(db, job, error_message=str(exc), result=exc.result)
+            _end_worker_transaction(db)
+            if exc.retryable and attempts < max_attempts:
+                _mark_job_for_retry(job_id, error_message=str(exc), result=exc.result)
+                raise self.retry(exc=exc, max_retries=max_attempts)
+            mark_job_failed(job_id, error_message=str(exc), result=exc.result)
             raise
         except Exception as exc:  # noqa: BLE001
-            db.refresh(job)
-            if int(job.attempts or 0) < int(job.max_attempts or 1):
-                setattr(job, "status", BackgroundJobStatus.ENQUEUED.value)
-                setattr(job, "error_message", str(exc))
-                db.add(job)
-                db.commit()
-                raise self.retry(exc=exc, max_retries=int(job.max_attempts or 1))
-            mark_job_failed(db, job, error_message=str(exc))
+            _end_worker_transaction(db)
+            if attempts < max_attempts:
+                _mark_job_for_retry(job_id, error_message=str(exc))
+                raise self.retry(exc=exc, max_retries=max_attempts)
+            mark_job_failed(job_id, error_message=str(exc))
             raise
 
-        db.refresh(job)
-        mark_job_succeeded(db, job, result=result)
+        _end_worker_transaction(db)
+        mark_job_succeeded(job_id, result=result)
         return result
     finally:
         db.close()
+
+
+def _settled_job_result(job_id: str) -> dict[str, Any]:
+    """Report the outcome of a job the claim refused as already settled."""
+    with session_scope() as db:
+        job = get_background_job(db, job_id)
+        if job is not None and job.status == BackgroundJobStatus.SUCCEEDED.value:
+            logger.info("Skipping already completed background job %s", job_id)
+            return dict(job.result or {"status": "succeeded"})
+    logger.info("Skipping cancelled background job %s", job_id)
+    return {"status": "cancelled"}
+
+
+def _end_worker_transaction(db: Session) -> None:
+    """End the handler session's transaction before bookkeeping opens its own.
+
+    Bookkeeping now runs on a second connection; leaving this one idle in
+    transaction across it is the exposure this whole path exists to remove,
+    and a rollback that fails on an already-dead connection must not replace
+    the failure being recorded.
+    """
+    try:
+        db.rollback()
+    except Exception:  # noqa: BLE001
+        logger.debug("Failed to end worker session transaction", exc_info=True)
+
+
+def _mark_job_for_retry(
+    job_id: str,
+    *,
+    error_message: str,
+    result: dict[str, Any] | None | _Unset = _UNSET,
+) -> None:
+    """Hand the job back to the broker for another attempt.
+
+    ``result`` distinguishes "not supplied" from an explicit ``None``: the
+    handler-error path overwrites the stored result even when it is None, the
+    generic path leaves it untouched.
+    """
+    with session_scope() as db:
+        job = get_background_job(db, job_id)
+        if job is None:
+            raise ValueError(f"Background job not found: {job_id}")
+        setattr(job, "status", BackgroundJobStatus.ENQUEUED.value)
+        setattr(job, "error_message", error_message)
+        if not isinstance(result, _Unset):
+            setattr(job, "result", result)
+        db.add(job)

--- a/src/xagent/web/jobs/tasks.py
+++ b/src/xagent/web/jobs/tasks.py
@@ -182,7 +182,8 @@ def _end_worker_transaction(db: Session) -> None:
     Bookkeeping now runs on a second connection; leaving this one idle in
     transaction across it is the exposure this whole path exists to remove,
     and a rollback that fails on an already-dead connection must not replace
-    the failure being recorded.
+    the failure being recorded. Handlers must commit their own writes: any
+    ORM state still pending here is discarded, not committed.
     """
     try:
         db.rollback()

--- a/src/xagent/web/jobs/tasks.py
+++ b/src/xagent/web/jobs/tasks.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable
+from datetime import datetime, timezone
 from typing import Any
 
 from sqlalchemy.orm import Session
@@ -23,7 +24,6 @@ from ..services.background_jobs import (
     get_background_job,
     mark_job_failed,
     mark_job_running,
-    mark_job_succeeded,
 )
 from .celery_app import celery_app
 from .exceptions import BackgroundJobHandlerError
@@ -146,6 +146,15 @@ def execute_background_job(self: Any, job_id: str) -> dict[str, Any]:
         if job is None:
             raise ValueError(f"Background job not found: {job_id}")
         result = _execute_job_handler(db, job)
+        # SUCCEEDED rides the handler's own commit: a separate session would
+        # leave durable side effects on a RUNNING row for the stale sweep to
+        # run a second time.
+        setattr(job, "status", BackgroundJobStatus.SUCCEEDED.value)
+        setattr(job, "result", result)
+        setattr(job, "error_message", None)
+        setattr(job, "finished_at", datetime.now(timezone.utc))
+        setattr(job, "progress", {"message": "Completed", "completed": 1, "total": 1})
+        db.add(job)
         db.commit()
     except BackgroundJobHandlerError as exc:
         _end_worker_transaction(db)
@@ -162,7 +171,6 @@ def execute_background_job(self: Any, job_id: str) -> dict[str, Any]:
         mark_job_failed(job_id, error_message=str(exc))
         raise
     else:
-        mark_job_succeeded(job_id, result=result)
         return result
     finally:
         if db is not None:

--- a/src/xagent/web/jobs/tasks.py
+++ b/src/xagent/web/jobs/tasks.py
@@ -172,6 +172,9 @@ def _settled_job_result(job_id: str) -> dict[str, Any]:
         if job is not None and job.status == BackgroundJobStatus.SUCCEEDED.value:
             logger.info("Skipping already completed background job %s", job_id)
             return dict(job.result or {"status": "succeeded"})
+        if job is not None and job.status == BackgroundJobStatus.FAILED.value:
+            logger.info("Skipping already failed background job %s", job_id)
+            return dict(job.result or {"status": "failed"})
     logger.info("Skipping cancelled background job %s", job_id)
     return {"status": "cancelled"}
 

--- a/src/xagent/web/jobs/tasks.py
+++ b/src/xagent/web/jobs/tasks.py
@@ -146,7 +146,7 @@ def execute_background_job(self: Any, job_id: str) -> dict[str, Any]:
         if job is None:
             raise ValueError(f"Background job not found: {job_id}")
         result = _execute_job_handler(db, job)
-        _end_worker_transaction(db)
+        db.commit()
     except BackgroundJobHandlerError as exc:
         _end_worker_transaction(db)
         if exc.retryable and claim.attempts < claim.max_attempts:
@@ -187,13 +187,12 @@ def _settled_job_result(job_id: str, settled: SettledJob) -> dict[str, Any]:
 
 
 def _end_worker_transaction(db: Session | None) -> None:
-    """End the handler session's transaction before bookkeeping opens its own.
+    """Discard the failed attempt's work before bookkeeping opens its own session.
 
-    Bookkeeping now runs on a second connection; leaving this one idle in
-    transaction across it is the exposure this whole path exists to remove,
-    and a rollback that fails on an already-dead connection must not replace
-    the failure being recorded. Handlers must commit their own writes: any
-    ORM state still pending here is discarded, not committed.
+    Failure only. The success path commits instead, so a handler that leaves
+    ORM work pending keeps the upstream guarantee that SUCCEEDED means its
+    writes are durable. A rollback that fails on an already-dead connection
+    must not replace the failure being recorded.
     """
     if db is None:
         return

--- a/src/xagent/web/jobs/tasks.py
+++ b/src/xagent/web/jobs/tasks.py
@@ -18,6 +18,8 @@ from ..models.database import (
     session_scope,
 )
 from ..services.background_jobs import (
+    TERMINAL_JOB_STATUSES,
+    SettledJob,
     get_background_job,
     mark_job_failed,
     mark_job_running,
@@ -130,56 +132,61 @@ def _execute_job_handler(db: Session, job: BackgroundJob) -> dict[str, Any]:
 def execute_background_job(self: Any, job_id: str) -> dict[str, Any]:
     _ensure_db_initialized()
 
-    attempts = mark_job_running(job_id)
-    if attempts is None:
-        return _settled_job_result(job_id)
+    claim = mark_job_running(job_id)
+    if isinstance(claim, SettledJob):
+        return _settled_job_result(job_id, claim)
 
-    db = _open_worker_session()
+    # Everything after a durable claim belongs to this attempt: a pool
+    # checkout or load failure here must reach the same retry/failure
+    # bookkeeping a handler failure does, or the row stays RUNNING forever.
+    db: Session | None = None
     try:
+        db = _open_worker_session()
         job = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
         if job is None:
             raise ValueError(f"Background job not found: {job_id}")
-        max_attempts = int(job.max_attempts or 1)
-
-        try:
-            result = _execute_job_handler(db, job)
-        except BackgroundJobHandlerError as exc:
-            _end_worker_transaction(db)
-            if exc.retryable and attempts < max_attempts:
-                _mark_job_for_retry(job_id, error_message=str(exc), result=exc.result)
-                raise self.retry(exc=exc, max_retries=max_attempts)
-            mark_job_failed(job_id, error_message=str(exc), result=exc.result)
-            raise
-        except Exception as exc:  # noqa: BLE001
-            _end_worker_transaction(db)
-            if attempts < max_attempts:
-                _mark_job_for_retry(job_id, error_message=str(exc))
-                raise self.retry(exc=exc, max_retries=max_attempts)
-            mark_job_failed(job_id, error_message=str(exc))
-            raise
-
+        result = _execute_job_handler(db, job)
         _end_worker_transaction(db)
+    except BackgroundJobHandlerError as exc:
+        _end_worker_transaction(db)
+        if exc.retryable and claim.attempts < claim.max_attempts:
+            _mark_job_for_retry(job_id, error_message=str(exc), result=exc.result)
+            raise self.retry(exc=exc, max_retries=claim.max_attempts)
+        mark_job_failed(job_id, error_message=str(exc), result=exc.result)
+        raise
+    except Exception as exc:  # noqa: BLE001
+        _end_worker_transaction(db)
+        if claim.attempts < claim.max_attempts:
+            _mark_job_for_retry(job_id, error_message=str(exc))
+            raise self.retry(exc=exc, max_retries=claim.max_attempts)
+        mark_job_failed(job_id, error_message=str(exc))
+        raise
+    else:
         mark_job_succeeded(job_id, result=result)
         return result
     finally:
-        db.close()
+        if db is not None:
+            db.close()
 
 
-def _settled_job_result(job_id: str) -> dict[str, Any]:
-    """Report the outcome of a job the claim refused as already settled."""
-    with session_scope() as db:
-        job = get_background_job(db, job_id)
-        if job is not None and job.status == BackgroundJobStatus.SUCCEEDED.value:
-            logger.info("Skipping already completed background job %s", job_id)
-            return dict(job.result or {"status": "succeeded"})
-        if job is not None and job.status == BackgroundJobStatus.FAILED.value:
-            logger.info("Skipping already failed background job %s", job_id)
-            return dict(job.result or {"status": "failed"})
-    logger.info("Skipping cancelled background job %s", job_id)
-    return {"status": "cancelled"}
+def _settled_job_result(job_id: str, settled: SettledJob) -> dict[str, Any]:
+    """Report the outcome the claim refused this attempt for.
+
+    The snapshot comes from the claim's own transaction, so there is no second
+    query to race with a delete.
+    """
+    if settled.status not in TERMINAL_JOB_STATUSES:
+        logger.warning(
+            "Background job %s refused the claim in non-terminal status %s",
+            job_id,
+            settled.status,
+        )
+    else:
+        logger.info("Skipping already %s background job %s", settled.status, job_id)
+    return dict(settled.result or {"status": settled.status})
 
 
-def _end_worker_transaction(db: Session) -> None:
+def _end_worker_transaction(db: Session | None) -> None:
     """End the handler session's transaction before bookkeeping opens its own.
 
     Bookkeeping now runs on a second connection; leaving this one idle in
@@ -188,6 +195,8 @@ def _end_worker_transaction(db: Session) -> None:
     the failure being recorded. Handlers must commit their own writes: any
     ORM state still pending here is discarded, not committed.
     """
+    if db is None:
+        return
     try:
         db.rollback()
     except Exception:  # noqa: BLE001

--- a/src/xagent/web/models/database.py
+++ b/src/xagent/web/models/database.py
@@ -1,6 +1,7 @@
 import logging
+from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, Generator
+from typing import Any, Generator, Iterator
 
 from sqlalchemy import Engine, create_engine, event
 from sqlalchemy.engine import Connection, make_url
@@ -135,6 +136,37 @@ def release_db_connection_if_clean(db: Session | None) -> bool:
             "Failed to release DB connection", exc_info=True
         )
         return False
+
+
+@contextmanager
+def session_scope() -> Iterator[Session]:
+    """Open a session for one unit of work, then settle and close it.
+
+    Long-running work must not hold a session open across its idle gaps: the
+    default ``expire_on_commit=True`` re-reads expired attributes after every
+    commit, which re-opens a transaction that then sits idle until the next
+    commit. Postgres terminates such a connection once
+    ``idle_in_transaction_session_timeout`` elapses, and every later statement
+    on that session fails -- including the bookkeeping meant to record the
+    failure. Callers that span minutes or hours use one scope per operation.
+    """
+    db = get_session_local()()
+    try:
+        yield db
+        # A scope that only read has nothing to commit; the helper ends its
+        # transaction instead, and returns False when a write needs one.
+        if not release_db_connection_if_clean(db):
+            db.commit()
+    except Exception:
+        try:
+            db.rollback()
+        except Exception:
+            # A rollback that fails on an already-dead connection must not
+            # replace the failure the caller is unwinding with.
+            logger.warning("Rollback failed in session_scope", exc_info=True)
+        raise
+    finally:
+        db.close()
 
 
 def get_session_local() -> sessionmaker[Session]:

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -325,27 +325,44 @@ def _rowcount(db: Session, statement: Update) -> int:
 
 
 def _fenced_job_update(
-    db: Session, job_id: str, *, expected: Collection[str], **values: Any
+    db: Session,
+    job_id: str,
+    *,
+    expected: Collection[str],
+    unchanged_since: datetime | None = None,
+    **values: Any,
 ) -> bool:
-    """Write only while the row is still in the state this pass staged.
+    """Write only while the row is still the one this pass observed.
 
     A worker or a cancellation can settle the row between the requeue's steps;
     a zero rowcount means one did, and the row is left alone instead of being
-    resurrected. Two sweepers racing at the same state still both match -- that
-    needs a claim token, not a state predicate.
+    resurrected. ``unchanged_since`` additionally pins the ``updated_at`` the
+    scan read, so a live worker that reports progress after the SELECT takes
+    the row out of this sweep. Two sweepers reading the same snapshot still
+    both match -- that needs a claim token, not a state predicate.
     """
+    predicates = [
+        BackgroundJob.id == job_id,
+        BackgroundJob.status.in_(tuple(expected)),
+    ]
+    if unchanged_since is not None:
+        predicates.append(BackgroundJob.updated_at == unchanged_since)
     return bool(
         _rowcount(
             db,
             update(BackgroundJob)
-            .where(
-                BackgroundJob.id == job_id,
-                BackgroundJob.status.in_(tuple(expected)),
-            )
+            .where(*predicates)
             .values(**values)
             .execution_options(synchronize_session=False),
         )
     )
+
+
+class RequeuedJob(NamedTuple):
+    """Immutable snapshot of one requeue claim, not of the row's later state."""
+
+    id: str
+    queue: str
 
 
 def requeue_stale_background_jobs(
@@ -353,7 +370,7 @@ def requeue_stale_background_jobs(
     *,
     stale_after_seconds: int | None = None,
     limit: int = 100,
-) -> list[BackgroundJob]:
+) -> list[RequeuedJob]:
     """Requeue non-terminal jobs whose durable DB state is stale.
 
     Redis/Celery can lose in-flight delivery state during broker loss or worker
@@ -393,28 +410,36 @@ def requeue_stale_background_jobs(
         .all()
     )
 
-    requeued: list[BackgroundJob] = []
     if not stale_jobs:
-        return requeued
+        return []
 
-    # Snapshot dispatch identities while the attributes are still loaded --
-    # after the commit each read would lazy-load on a reopened transaction.
-    targets = [(str(job.id), str(job.queue or QUEUE_DEFAULT)) for job in stale_jobs]
-    by_id = {str(job.id): job for job in stale_jobs}
+    # Snapshot dispatch identities and the observed state while the attributes
+    # are still loaded -- after the commit each read would lazy-load on a
+    # reopened transaction.
+    targets = [
+        (
+            str(job.id),
+            str(job.queue or QUEUE_DEFAULT),
+            str(job.job_type),
+            str(job.status),
+            cast("datetime | None", job.updated_at),
+        )
+        for job in stale_jobs
+    ]
 
-    claimed: list[tuple[str, str]] = []
-    for job_id, queue in targets:
-        job = by_id[job_id]
+    claimed: list[RequeuedJob] = []
+    for job_id, queue, job_type, observed_status, observed_updated_at in targets:
         logger.warning(
             "Requeueing stale background job %s type=%s status=%s",
             job_id,
-            job.job_type,
-            job.status,
+            job_type,
+            observed_status,
         )
         if _fenced_job_update(
             db,
             job_id,
-            expected=requeue_statuses,
+            expected=(observed_status,),
+            unchanged_since=observed_updated_at,
             status=BackgroundJobStatus.PENDING.value,
             celery_task_id=None,
             started_at=None,
@@ -425,16 +450,12 @@ def requeue_stale_background_jobs(
                 "total": 1,
             },
         ):
-            claimed.append((job_id, queue))
+            claimed.append(RequeuedJob(id=job_id, queue=queue))
 
-    # No post-commit refresh anywhere below: reading an expired attribute
-    # reopens a transaction. Every such read below is closed by the commit
-    # that follows it; none spans the broker call or the return.
     db.commit()
 
-    requeued = [by_id[job_id] for job_id, _queue in claimed]
     if not claimed or not get_celery_enabled():
-        return requeued
+        return claimed
 
     if get_celery_broker_url() is None:
         error_message = "Celery background jobs are enabled but no broker URL is set"
@@ -446,7 +467,7 @@ def requeue_stale_background_jobs(
                 error_message=f"Failed to requeue stale job: {error_message}",
             )
         db.commit()
-        return requeued
+        return claimed
 
     from ..jobs.tasks import execute_background_job
 
@@ -495,7 +516,7 @@ def requeue_stale_background_jobs(
 
     db.commit()
 
-    return requeued
+    return claimed
 
 
 def mark_job_failed(

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -346,7 +346,7 @@ def _fenced_job_update(
         BackgroundJob.status.in_(tuple(expected)),
     ]
     if unchanged_since is not None:
-        predicates.append(BackgroundJob.updated_at == unchanged_since)
+        predicates.append(BackgroundJob.updated_at <= unchanged_since)
     return bool(
         _rowcount(
             db,

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -359,9 +359,10 @@ def requeue_stale_background_jobs(
     if not stale_jobs:
         return requeued
 
+    # No post-commit refresh anywhere below: reading an expired attribute
+    # reopens a transaction that then stays open until the next commit -- on
+    # return, or across the broker call.
     db.commit()
-    for job in stale_jobs:
-        db.refresh(job)
 
     if not get_celery_enabled():
         return stale_jobs
@@ -374,37 +375,43 @@ def requeue_stale_background_jobs(
             )
             db.add(job)
         db.commit()
-        for job in stale_jobs:
-            db.refresh(job)
         return stale_jobs
 
     from ..jobs.tasks import execute_background_job
 
+    dispatch_targets = [
+        (str(job.id), str(job.queue or QUEUE_DEFAULT)) for job in stale_jobs
+    ]
     for job in stale_jobs:
         setattr(job, "status", BackgroundJobStatus.ENQUEUED.value)
         db.add(job)
     db.commit()
-    for job in stale_jobs:
-        db.refresh(job)
 
-    for job in stale_jobs:
+    task_ids: dict[str, str] = {}
+    dispatch_errors: dict[str, str] = {}
+    for job_id, queue in dispatch_targets:
         try:
             async_result = execute_background_job.apply_async(
-                args=[job.id],
-                queue=str(job.queue or QUEUE_DEFAULT),
+                args=[job_id],
+                queue=queue,
             )
-            setattr(job, "celery_task_id", async_result.id)
-            requeued.append(job)
+            task_ids[job_id] = async_result.id
         except Exception as exc:  # noqa: BLE001
-            logger.exception("Failed to requeue stale background job %s", job.id)
+            logger.exception("Failed to requeue stale background job %s", job_id)
+            dispatch_errors[job_id] = str(exc)
+
+    for job in stale_jobs:
+        job_id = str(job.id)
+        error = dispatch_errors.get(job_id)
+        if error is None:
+            setattr(job, "celery_task_id", task_ids.get(job_id))
+        else:
             setattr(job, "status", BackgroundJobStatus.PENDING.value)
-            setattr(job, "error_message", f"Failed to requeue stale job: {exc}")
-            requeued.append(job)
+            setattr(job, "error_message", f"Failed to requeue stale job: {error}")
+        requeued.append(job)
         db.add(job)
 
     db.commit()
-    for job in requeued:
-        db.refresh(job)
 
     return requeued
 

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -235,7 +235,7 @@ def list_background_jobs(
     )
 
 
-# mark_job_running / mark_job_succeeded / mark_job_failed each take a job id
+# mark_job_running / mark_job_failed each take a job id
 # and open a session of their own: sharing the caller's is what let a poisoned
 # connection take the failure record down with it. One contract for the
 # family -- ValueError when the row is gone, never a silent no-op.
@@ -496,19 +496,6 @@ def requeue_stale_background_jobs(
     db.commit()
 
     return requeued
-
-
-def mark_job_succeeded(job_id: str, *, result: dict[str, Any] | None = None) -> None:
-    with session_scope() as db:
-        job = get_background_job(db, job_id)
-        if job is None:
-            raise ValueError(f"Background job not found: {job_id}")
-        setattr(job, "status", BackgroundJobStatus.SUCCEEDED.value)
-        setattr(job, "result", result)
-        setattr(job, "error_message", None)
-        setattr(job, "finished_at", datetime.now(timezone.utc))
-        setattr(job, "progress", {"message": "Completed", "completed": 1, "total": 1})
-        db.add(job)
 
 
 def mark_job_failed(

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -2,11 +2,15 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from urllib.parse import urlsplit
 
-from sqlalchemy import and_, or_
+from sqlalchemy import and_, or_, select, update
 from sqlalchemy.orm import Session
+from sqlalchemy.sql import Update
+
+if TYPE_CHECKING:
+    from sqlalchemy import CursorResult
 
 from ...config import (
     get_background_job_max_retries,
@@ -236,33 +240,59 @@ def list_background_jobs(
 # family -- ValueError when the row is gone, never a silent no-op.
 
 
-def mark_job_running(job_id: str) -> int | None:
-    """Claim the job for this attempt and return the new attempt count.
+class JobClaim(NamedTuple):
+    """Immutable snapshot of a won claim, enough to decide about a retry."""
 
-    Returns ``None`` when the row already settled -- the cancellation check and
-    the claim must land in one transaction, or a cancel arriving between them
-    is silently clobbered back to RUNNING. ``with_for_update`` (a no-op on
-    SQLite) holds the row against a concurrent cancel for that window.
+    attempts: int
+    max_attempts: int
+
+
+class SettledJob(NamedTuple):
+    """Immutable snapshot of a job the claim refused as already settled."""
+
+    status: str
+    result: dict[str, Any] | None
+
+
+def mark_job_running(job_id: str) -> JobClaim | SettledJob:
+    """Claim the job for this attempt, or report the state that refused it.
+
+    The terminal check and the claim are one conditional UPDATE so no cancel
+    can land between them and be clobbered back to RUNNING. Row locking is not
+    involved, so the guarantee holds on SQLite too.
     """
     with session_scope() as db:
-        job = (
-            db.query(BackgroundJob)
-            .filter(BackgroundJob.id == job_id)
-            .with_for_update()
-            .first()
+        claimed = _rowcount(
+            db,
+            update(BackgroundJob)
+            .where(
+                BackgroundJob.id == job_id,
+                BackgroundJob.status.not_in(TERMINAL_JOB_STATUSES),
+            )
+            .values(
+                status=BackgroundJobStatus.RUNNING.value,
+                attempts=BackgroundJob.attempts + 1,
+                started_at=datetime.now(timezone.utc),
+                error_message=None,
+                progress={"message": "Running", "completed": 0, "total": 1},
+            )
+            .execution_options(synchronize_session=False),
         )
-        if job is None:
+        row = db.execute(
+            select(
+                BackgroundJob.status,
+                BackgroundJob.attempts,
+                BackgroundJob.max_attempts,
+                BackgroundJob.result,
+            ).where(BackgroundJob.id == job_id)
+        ).first()
+        if row is None:
             raise ValueError(f"Background job not found: {job_id}")
-        if job.status in TERMINAL_JOB_STATUSES:
-            return None
-        attempts = int(job.attempts or 0) + 1
-        setattr(job, "status", BackgroundJobStatus.RUNNING.value)
-        setattr(job, "attempts", attempts)
-        setattr(job, "started_at", datetime.now(timezone.utc))
-        setattr(job, "error_message", None)
-        setattr(job, "progress", {"message": "Running", "completed": 0, "total": 1})
-        db.add(job)
-        return attempts
+        if not claimed:
+            return SettledJob(status=str(row.status), result=row.result)
+        return JobClaim(
+            attempts=int(row.attempts or 0), max_attempts=int(row.max_attempts or 1)
+        )
 
 
 def update_job_progress(
@@ -287,6 +317,10 @@ def update_job_progress(
     db.commit()
     db.refresh(job)
     return job
+
+
+def _rowcount(db: Session, statement: Update) -> int:
+    return cast("CursorResult[Any]", db.execute(statement)).rowcount
 
 
 def requeue_stale_background_jobs(

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -253,10 +253,7 @@ def mark_job_running(job_id: str) -> int | None:
         )
         if job is None:
             raise ValueError(f"Background job not found: {job_id}")
-        if job.status in (
-            BackgroundJobStatus.CANCELLED.value,
-            BackgroundJobStatus.SUCCEEDED.value,
-        ):
+        if job.status in TERMINAL_JOB_STATUSES:
             return None
         attempts = int(job.attempts or 0) + 1
         setattr(job, "status", BackgroundJobStatus.RUNNING.value)
@@ -359,6 +356,12 @@ def requeue_stale_background_jobs(
     if not stale_jobs:
         return requeued
 
+    # Snapshot dispatch identities while the attributes are still loaded --
+    # after the commit each read would lazy-load on a reopened transaction.
+    dispatch_targets = [
+        (str(job.id), str(job.queue or QUEUE_DEFAULT)) for job in stale_jobs
+    ]
+
     # No post-commit refresh anywhere below: reading an expired attribute
     # reopens a transaction. Every such read below is closed by the commit
     # that follows it; none spans the broker call or the return.
@@ -379,9 +382,6 @@ def requeue_stale_background_jobs(
 
     from ..jobs.tasks import execute_background_job
 
-    dispatch_targets = [
-        (str(job.id), str(job.queue or QUEUE_DEFAULT)) for job in stale_jobs
-    ]
     for job in stale_jobs:
         setattr(job, "status", BackgroundJobStatus.ENQUEUED.value)
         db.add(job)

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -19,6 +19,7 @@ from ..models.background_job import (
     BackgroundJobStatus,
     BackgroundJobType,
 )
+from ..models.database import session_scope
 
 logger = logging.getLogger(__name__)
 
@@ -229,16 +230,42 @@ def list_background_jobs(
     )
 
 
-def mark_job_running(db: Session, job: BackgroundJob) -> BackgroundJob:
-    setattr(job, "status", BackgroundJobStatus.RUNNING.value)
-    setattr(job, "attempts", int(job.attempts or 0) + 1)
-    setattr(job, "started_at", datetime.now(timezone.utc))
-    setattr(job, "error_message", None)
-    setattr(job, "progress", {"message": "Running", "completed": 0, "total": 1})
-    db.add(job)
-    db.commit()
-    db.refresh(job)
-    return job
+# mark_job_running / mark_job_succeeded / mark_job_failed each take a job id
+# and open a session of their own: sharing the caller's is what let a poisoned
+# connection take the failure record down with it. One contract for the
+# family -- ValueError when the row is gone, never a silent no-op.
+
+
+def mark_job_running(job_id: str) -> int | None:
+    """Claim the job for this attempt and return the new attempt count.
+
+    Returns ``None`` when the row already settled -- the cancellation check and
+    the claim must land in one transaction, or a cancel arriving between them
+    is silently clobbered back to RUNNING. ``with_for_update`` (a no-op on
+    SQLite) holds the row against a concurrent cancel for that window.
+    """
+    with session_scope() as db:
+        job = (
+            db.query(BackgroundJob)
+            .filter(BackgroundJob.id == job_id)
+            .with_for_update()
+            .first()
+        )
+        if job is None:
+            raise ValueError(f"Background job not found: {job_id}")
+        if job.status in (
+            BackgroundJobStatus.CANCELLED.value,
+            BackgroundJobStatus.SUCCEEDED.value,
+        ):
+            return None
+        attempts = int(job.attempts or 0) + 1
+        setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+        setattr(job, "attempts", attempts)
+        setattr(job, "started_at", datetime.now(timezone.utc))
+        setattr(job, "error_message", None)
+        setattr(job, "progress", {"message": "Running", "completed": 0, "total": 1})
+        db.add(job)
+        return attempts
 
 
 def update_job_progress(
@@ -382,36 +409,38 @@ def requeue_stale_background_jobs(
     return requeued
 
 
-def mark_job_succeeded(
-    db: Session,
-    job: BackgroundJob,
-    *,
-    result: dict[str, Any] | None = None,
-) -> BackgroundJob:
-    setattr(job, "status", BackgroundJobStatus.SUCCEEDED.value)
-    setattr(job, "result", result)
-    setattr(job, "error_message", None)
-    setattr(job, "finished_at", datetime.now(timezone.utc))
-    setattr(job, "progress", {"message": "Completed", "completed": 1, "total": 1})
-    db.add(job)
-    db.commit()
-    db.refresh(job)
-    return job
+def mark_job_succeeded(job_id: str, *, result: dict[str, Any] | None = None) -> None:
+    with session_scope() as db:
+        job = get_background_job(db, job_id)
+        if job is None:
+            raise ValueError(f"Background job not found: {job_id}")
+        setattr(job, "status", BackgroundJobStatus.SUCCEEDED.value)
+        setattr(job, "result", result)
+        setattr(job, "error_message", None)
+        setattr(job, "finished_at", datetime.now(timezone.utc))
+        setattr(job, "progress", {"message": "Completed", "completed": 1, "total": 1})
+        db.add(job)
 
 
 def mark_job_failed(
-    db: Session,
-    job: BackgroundJob,
+    job_id: str,
     *,
     error_message: str,
     result: dict[str, Any] | None = None,
-) -> BackgroundJob:
-    setattr(job, "status", BackgroundJobStatus.FAILED.value)
-    setattr(job, "error_message", error_message)
-    setattr(job, "result", result)
-    setattr(job, "finished_at", datetime.now(timezone.utc))
-    setattr(job, "progress", {"message": error_message, "completed": 0, "total": 1})
-    db.add(job)
-    db.commit()
-    db.refresh(job)
-    return job
+) -> None:
+    """Record the terminal failure on a session of its own.
+
+    This must not share a session with the work that failed: a poisoned
+    session takes the failure record down with it, leaving the row ``running``
+    forever and bypassing ``max_attempts``.
+    """
+    with session_scope() as db:
+        job = get_background_job(db, job_id)
+        if job is None:
+            raise ValueError(f"Background job not found: {job_id}")
+        setattr(job, "status", BackgroundJobStatus.FAILED.value)
+        setattr(job, "error_message", error_message)
+        setattr(job, "result", result)
+        setattr(job, "finished_at", datetime.now(timezone.utc))
+        setattr(job, "progress", {"message": error_message, "completed": 0, "total": 1})
+        db.add(job)

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Collection
 from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 from urllib.parse import urlsplit
@@ -323,6 +324,30 @@ def _rowcount(db: Session, statement: Update) -> int:
     return cast("CursorResult[Any]", db.execute(statement)).rowcount
 
 
+def _fenced_job_update(
+    db: Session, job_id: str, *, expected: Collection[str], **values: Any
+) -> bool:
+    """Write only while the row is still in the state this pass staged.
+
+    A worker or a cancellation can settle the row between the requeue's steps;
+    a zero rowcount means one did, and the row is left alone instead of being
+    resurrected. Two sweepers racing at the same state still both match -- that
+    needs a claim token, not a state predicate.
+    """
+    return bool(
+        _rowcount(
+            db,
+            update(BackgroundJob)
+            .where(
+                BackgroundJob.id == job_id,
+                BackgroundJob.status.in_(tuple(expected)),
+            )
+            .values(**values)
+            .execution_options(synchronize_session=False),
+        )
+    )
+
+
 def requeue_stale_background_jobs(
     db: Session,
     *,
@@ -369,56 +394,72 @@ def requeue_stale_background_jobs(
     )
 
     requeued: list[BackgroundJob] = []
-    for job in stale_jobs:
-        logger.warning(
-            "Requeueing stale background job %s type=%s status=%s",
-            job.id,
-            job.job_type,
-            job.status,
-        )
-        setattr(job, "status", BackgroundJobStatus.PENDING.value)
-        setattr(job, "celery_task_id", None)
-        setattr(job, "started_at", None)
-        setattr(job, "error_message", "Requeued stale background job")
-        setattr(
-            job,
-            "progress",
-            {"message": "Requeued stale background job", "completed": 0, "total": 1},
-        )
-        db.add(job)
-
     if not stale_jobs:
         return requeued
 
     # Snapshot dispatch identities while the attributes are still loaded --
     # after the commit each read would lazy-load on a reopened transaction.
-    dispatch_targets = [
-        (str(job.id), str(job.queue or QUEUE_DEFAULT)) for job in stale_jobs
-    ]
+    targets = [(str(job.id), str(job.queue or QUEUE_DEFAULT)) for job in stale_jobs]
+    by_id = {str(job.id): job for job in stale_jobs}
+
+    claimed: list[tuple[str, str]] = []
+    for job_id, queue in targets:
+        job = by_id[job_id]
+        logger.warning(
+            "Requeueing stale background job %s type=%s status=%s",
+            job_id,
+            job.job_type,
+            job.status,
+        )
+        if _fenced_job_update(
+            db,
+            job_id,
+            expected=requeue_statuses,
+            status=BackgroundJobStatus.PENDING.value,
+            celery_task_id=None,
+            started_at=None,
+            error_message="Requeued stale background job",
+            progress={
+                "message": "Requeued stale background job",
+                "completed": 0,
+                "total": 1,
+            },
+        ):
+            claimed.append((job_id, queue))
 
     # No post-commit refresh anywhere below: reading an expired attribute
     # reopens a transaction. Every such read below is closed by the commit
     # that follows it; none spans the broker call or the return.
     db.commit()
 
-    if not get_celery_enabled():
-        return stale_jobs
+    requeued = [by_id[job_id] for job_id, _queue in claimed]
+    if not claimed or not get_celery_enabled():
+        return requeued
 
     if get_celery_broker_url() is None:
         error_message = "Celery background jobs are enabled but no broker URL is set"
-        for job in stale_jobs:
-            setattr(
-                job, "error_message", f"Failed to requeue stale job: {error_message}"
+        for job_id, _queue in claimed:
+            _fenced_job_update(
+                db,
+                job_id,
+                expected=(BackgroundJobStatus.PENDING.value,),
+                error_message=f"Failed to requeue stale job: {error_message}",
             )
-            db.add(job)
         db.commit()
-        return stale_jobs
+        return requeued
 
     from ..jobs.tasks import execute_background_job
 
-    for job in stale_jobs:
-        setattr(job, "status", BackgroundJobStatus.ENQUEUED.value)
-        db.add(job)
+    dispatch_targets = [
+        (job_id, queue)
+        for job_id, queue in claimed
+        if _fenced_job_update(
+            db,
+            job_id,
+            expected=(BackgroundJobStatus.PENDING.value,),
+            status=BackgroundJobStatus.ENQUEUED.value,
+        )
+    ]
     db.commit()
 
     task_ids: dict[str, str] = {}
@@ -434,16 +475,23 @@ def requeue_stale_background_jobs(
             logger.exception("Failed to requeue stale background job %s", job_id)
             dispatch_errors[job_id] = str(exc)
 
-    for job in stale_jobs:
-        job_id = str(job.id)
+    for job_id, _queue in dispatch_targets:
         error = dispatch_errors.get(job_id)
         if error is None:
-            setattr(job, "celery_task_id", task_ids.get(job_id))
+            _fenced_job_update(
+                db,
+                job_id,
+                expected=(BackgroundJobStatus.ENQUEUED.value,),
+                celery_task_id=task_ids.get(job_id),
+            )
         else:
-            setattr(job, "status", BackgroundJobStatus.PENDING.value)
-            setattr(job, "error_message", f"Failed to requeue stale job: {error}")
-        requeued.append(job)
-        db.add(job)
+            _fenced_job_update(
+                db,
+                job_id,
+                expected=(BackgroundJobStatus.ENQUEUED.value,),
+                status=BackgroundJobStatus.PENDING.value,
+                error_message=f"Failed to requeue stale job: {error}",
+            )
 
     db.commit()
 

--- a/src/xagent/web/services/background_jobs.py
+++ b/src/xagent/web/services/background_jobs.py
@@ -360,8 +360,8 @@ def requeue_stale_background_jobs(
         return requeued
 
     # No post-commit refresh anywhere below: reading an expired attribute
-    # reopens a transaction that then stays open until the next commit -- on
-    # return, or across the broker call.
+    # reopens a transaction. Every such read below is closed by the commit
+    # that follows it; none spans the broker call or the return.
     db.commit()
 
     if not get_celery_enabled():

--- a/tests/shared/postgres_disposable.py
+++ b/tests/shared/postgres_disposable.py
@@ -49,6 +49,20 @@ def psycopg2_kwargs(base_url: str, dbname: str | None = None) -> dict[str, objec
     }
 
 
+def _admin_connection(base_url: str):
+    conn = psycopg2.connect(**psycopg2_kwargs(base_url))
+    conn.autocommit = True
+    return conn
+
+
+def _create_disposable_database(base_url: str, dbname: str) -> None:
+    admin_conn = _admin_connection(base_url)
+    try:
+        admin_conn.cursor().execute(f'CREATE DATABASE "{dbname}"')
+    finally:
+        admin_conn.close()
+
+
 @contextmanager
 def disposable_database_factory(
     prefix: str,
@@ -67,20 +81,11 @@ def disposable_database_factory(
     if not base_url:
         pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
 
-    def _admin_connection():
-        conn = psycopg2.connect(**psycopg2_kwargs(base_url))
-        conn.autocommit = True
-        return conn
-
     minted: list[tuple[str, sa.engine.Engine]] = []
 
     def _make(tag: str) -> sa.engine.Engine:
         dbname = f"{prefix}_{tag}_{uuid.uuid4().hex[:10]}"
-        admin_conn = _admin_connection()
-        try:
-            admin_conn.cursor().execute(f'CREATE DATABASE "{dbname}"')
-        finally:
-            admin_conn.close()
+        _create_disposable_database(base_url, dbname)
 
         connect_kwargs = psycopg2_kwargs(base_url, dbname)
 
@@ -108,7 +113,7 @@ def disposable_database_factory(
         undropped: list[str] = []
         if minted:
             try:
-                admin_conn = _admin_connection()
+                admin_conn = _admin_connection(base_url)
             except Exception as exc:
                 raise RuntimeError(
                     "cannot reach the PostgreSQL server to drop the "
@@ -134,6 +139,57 @@ def disposable_database_factory(
                 "disposable databases left behind on the server; drop them "
                 "by hand: " + "; ".join(undropped)
             )
+
+
+@contextmanager
+def disposable_database_url(
+    prefix: str,
+    *,
+    settings: dict[str, str] | None = None,
+) -> Iterator[str]:
+    """Mint one disposable database and yield its connection URL.
+
+    The engine-returning factory above cannot serve callers that must hand a
+    URL to application code (``configure_db``) rather than drive an engine
+    themselves. ``settings`` are applied with ALTER DATABASE SET, so every
+    connection the application opens inherits them -- which is how a test can
+    impose a short ``idle_in_transaction_session_timeout``.
+    """
+    base_url = os.getenv("XAGENT_TEST_POSTGRES_URL")
+    if not base_url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+
+    dbname = f"{prefix}_{uuid.uuid4().hex[:10]}"
+    _create_disposable_database(base_url, dbname)
+
+    # Everything after CREATE DATABASE runs under the drop below, so a failing
+    # ALTER cannot leave the database behind.
+    try:
+        admin_conn = _admin_connection(base_url)
+        try:
+            for key, value in (settings or {}).items():
+                admin_conn.cursor().execute(
+                    f'ALTER DATABASE "{dbname}" SET {key} = %s', (value,)
+                )
+        finally:
+            admin_conn.close()
+
+        yield (
+            make_url(base_url)
+            .set(database=dbname)
+            .render_as_string(hide_password=False)
+        )
+    finally:
+        admin_conn = _admin_connection(base_url)
+        try:
+            admin_conn.cursor().execute(
+                "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+                "WHERE datname = %s AND pid <> pg_backend_pid()",
+                (dbname,),
+            )
+            admin_conn.cursor().execute(f'DROP DATABASE IF EXISTS "{dbname}"')
+        finally:
+            admin_conn.close()
 
 
 def load_migration_module(path: Path, name: str = "migration_under_test") -> ModuleType:

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -2851,6 +2851,60 @@ def test_accepted_broker_work_survives_a_failure_to_persist_its_task_id(
         verify.close()
 
 
+def test_publish_failure_still_fails_the_job_and_returns_503(tmp_path, monkeypatch):
+    """Before apply_async returns, the old contract holds: FAILED plus 503.
+
+    The acceptance split must not swallow a broker publish that never
+    happened -- only failures after acceptance are exempt from the failure
+    path.
+    """
+    import asyncio
+
+    import pytest as _pytest
+    from fastapi import HTTPException
+
+    from xagent.web.api import kb as kb_module
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.services import background_jobs as bg
+
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "redis://localhost:6379/0")
+    monkeypatch.setattr(bg, "_is_redis_broker_reachable", lambda _url: True)
+
+    def refuse_publish(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        raise RuntimeError("broker refused the publish")
+
+    monkeypatch.setattr(
+        tasks_module.execute_background_job, "apply_async", refuse_publish
+    )
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-publish-failed.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "publish-failed")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"url": "https://example.com"},
+        )
+        job_id = str(job.id)
+
+        with _pytest.raises(HTTPException) as exc_info:
+            asyncio.run(kb_module._enqueue_background_job_or_503_async(db, job))
+        assert exc_info.value.status_code == 503
+    finally:
+        db.close()
+
+    verify = SessionLocal()
+    try:
+        row = verify.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.FAILED.value
+        assert "broker refused the publish" in str(row.error_message)
+    finally:
+        verify.close()
+
+
 def test_requeue_does_not_resurrect_a_job_settled_during_dispatch(
     tmp_path, monkeypatch
 ):

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -3312,3 +3312,80 @@ def test_accepted_work_is_reconciled_even_when_rollback_also_fails(
         )
     finally:
         verify.close()
+
+
+def test_requeue_skips_a_job_that_reported_progress_after_the_scan(
+    tmp_path, monkeypatch
+):
+    """The stale SELECT is a snapshot; a live worker invalidates it.
+
+    Between the scan and the claim a RUNNING worker can commit progress. The
+    row is no longer stale, so resetting it to PENDING would clear its task id
+    and put a second copy of live work on the broker.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.services import background_jobs as bg
+
+    dispatched = MagicMock(return_value=MagicMock(id="should-not-happen"))
+    monkeypatch.setattr(tasks_module.execute_background_job, "apply_async", dispatched)
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-requeue-freshness.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "requeue-freshness")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"url": "https://example.com"},
+        )
+        db.commit()
+        job_id = str(job.id)
+        db.query(BackgroundJob).filter(BackgroundJob.id == job_id).update(
+            {
+                "status": BackgroundJobStatus.RUNNING.value,
+                "celery_task_id": "live-task-id",
+            },
+            synchronize_session=False,
+        )
+        db.commit()
+        _age_job(db, job, updated_at=datetime.now(timezone.utc) - timedelta(hours=3))
+
+        reported: list[str] = []
+        real_fenced_update = bg._fenced_job_update
+
+        def reporting_fenced_update(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+            # Called with the scan's snapshot still in hand -- the window the
+            # live worker's progress commit lands in.
+            if not reported:
+                reported.append(job_id)
+                other = SessionLocal()
+                try:
+                    other.query(BackgroundJob).filter(
+                        BackgroundJob.id == job_id
+                    ).update(
+                        {"progress": {"message": "still working"}},
+                        synchronize_session=False,
+                    )
+                    other.commit()
+                finally:
+                    other.close()
+            return real_fenced_update(*args, **kwargs)
+
+        monkeypatch.setattr(bg, "_fenced_job_update", reporting_fenced_update)
+
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert reported, "the progress window was never reached"
+        assert requeued == [], "a freshly reporting job was claimed by the sweep"
+        assert dispatched.call_count == 0, "a live job was dispatched a second time"
+
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.RUNNING.value
+        assert row.celery_task_id == "live-task-id"
+    finally:
+        db.close()

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -2608,6 +2608,64 @@ def test_requeue_records_broker_failure_per_job(tmp_path, monkeypatch):
         db.close()
 
 
+def test_successful_handler_writes_are_committed(tmp_path, monkeypatch):
+    """SUCCEEDED must still mean the handler's pending writes are durable.
+
+    The public handler contract hands out a ``Session`` and has never required
+    the handler to commit; the upstream wrapper committed it as part of marking
+    the job successful. Rolling it back instead silently drops that work while
+    the job is recorded SUCCEEDED.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.jobs.celery_app import celery_app
+
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = False
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-handler-writes.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "handler-writes")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type="kb.team.writes",
+            payload={},
+            max_attempts=1,
+        )
+        db.commit()
+        job_id = str(job.id)
+        db.rollback()
+
+        def handler(work, _job):  # noqa: ANN001, ANN202
+            work.add(User(username="handler-pending-write", password_hash="x"))
+            return {"status": "ok"}
+
+        tasks_module.register_background_job_handler("kb.team.writes", handler)
+        try:
+            tasks_module.execute_background_job.apply(args=[job_id])
+        finally:
+            tasks_module._EXTRA_HANDLERS.pop("kb.team.writes", None)
+
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.SUCCEEDED.value
+        written = (
+            db.query(User).filter(User.username == "handler-pending-write").first()
+        )
+        assert written is not None, (
+            "the handler's pending write was discarded while the job was "
+            "recorded SUCCEEDED"
+        )
+    finally:
+        db.close()
+        celery_app.conf.task_always_eager = False
+        celery_app.conf.task_eager_propagates = False
+
+
 def test_setup_failure_after_the_claim_still_reaches_terminal_bookkeeping(
     tmp_path, monkeypatch
 ):

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -3181,3 +3181,134 @@ def test_a_failed_success_commit_leaves_neither_the_writes_nor_succeeded(
         db.close()
         celery_app.conf.task_always_eager = False
         celery_app.conf.task_eager_propagates = False
+
+
+def test_enqueue_records_the_failure_even_when_rollback_also_fails(
+    tmp_path, monkeypatch
+):
+    """The caller's connection is already suspect on this path.
+
+    Rollback runs on the connection that just failed, so it can raise too. That
+    must not swallow the independent FAILED record or the 503.
+    """
+    import asyncio
+
+    import pytest as _pytest
+    from fastapi import HTTPException
+    from sqlalchemy.exc import OperationalError
+
+    from xagent.web.api import kb as kb_module
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.services import background_jobs as bg
+
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "redis://localhost:6379/0")
+    monkeypatch.setattr(bg, "_is_redis_broker_reachable", lambda _url: True)
+
+    def refuse_publish(*args, **kwargs):  # noqa: ANN002, ANN003, ANN202
+        raise RuntimeError("broker refused the publish")
+
+    monkeypatch.setattr(
+        tasks_module.execute_background_job, "apply_async", refuse_publish
+    )
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-rollback-fails.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "rollback-fails")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"url": "https://example.com"},
+        )
+        job_id = str(job.id)
+
+        def dead_rollback():  # noqa: ANN202
+            raise OperationalError("rollback", {}, Exception("server closed"))
+
+        monkeypatch.setattr(db, "rollback", dead_rollback)
+
+        with _pytest.raises(HTTPException) as exc_info:
+            asyncio.run(kb_module._enqueue_background_job_or_503_async(db, job))
+        assert exc_info.value.status_code == 503
+    finally:
+        db.close()
+
+    verify = SessionLocal()
+    try:
+        row = verify.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.FAILED.value, (
+            "a failed rollback swallowed the independent failure record"
+        )
+        assert "broker refused the publish" in str(row.error_message)
+    finally:
+        verify.close()
+
+
+def test_accepted_work_is_reconciled_even_when_rollback_also_fails(
+    tmp_path, monkeypatch
+):
+    """Past acceptance a raising rollback must not reach the caller.
+
+    ``create_ingest_job``'s exception cleanup deletes the staging input a
+    running worker still needs, so this branch must always fall through to the
+    independent task-id reconciliation.
+    """
+    import asyncio
+
+    from sqlalchemy.exc import OperationalError
+
+    from xagent.web.api import kb as kb_module
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.services import background_jobs as bg
+
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "redis://localhost:6379/0")
+    monkeypatch.setattr(bg, "_is_redis_broker_reachable", lambda _url: True)
+    monkeypatch.setattr(
+        tasks_module.execute_background_job,
+        "apply_async",
+        MagicMock(return_value=MagicMock(id="accepted-task-id")),
+    )
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-accepted-rollback-fails.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "accepted-rollback-fails")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"url": "https://example.com"},
+        )
+        job_id = str(job.id)
+
+        refreshes: list[object] = []
+        real_refresh = db.refresh
+
+        def flaky_refresh(instance, *args, **kwargs):  # noqa: ANN001, ANN202
+            refreshes.append(instance)
+            if len(refreshes) >= 2:
+                raise OperationalError("refresh", {}, Exception("server closed"))
+            return real_refresh(instance, *args, **kwargs)
+
+        def dead_rollback():  # noqa: ANN202
+            raise OperationalError("rollback", {}, Exception("server closed"))
+
+        monkeypatch.setattr(db, "refresh", flaky_refresh)
+        monkeypatch.setattr(db, "rollback", dead_rollback)
+
+        asyncio.run(kb_module._enqueue_background_job_or_503_async(db, job))
+    finally:
+        db.close()
+
+    verify = SessionLocal()
+    try:
+        row = verify.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.ENQUEUED.value
+        assert row.celery_task_id == "accepted-task-id", (
+            "a failed rollback skipped the independent task-id reconciliation"
+        )
+    finally:
+        verify.close()

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from sqlalchemy import text
 
 from xagent.config import CELERY_BROKER_URL, CELERY_ENABLED
 from xagent.core.tools.core.RAG_tools.core.schemas import (
@@ -2054,5 +2055,384 @@ def test_kb_document_job_publishes_the_config_end_to_end(tmp_path, monkeypatch):
         # have to be in it once the documents landed.
         assert saved_config is not None
         assert '"chunk_size":1234' in saved_config
+    finally:
+        db.close()
+
+
+def _track_open_transactions(engine) -> dict[str, int]:
+    """Count transactions the engine has begun but not yet ended.
+
+    This is the observable form of "idle in transaction": a session that
+    commits and then re-reads leaves a transaction open with no statement
+    running, and Postgres eventually terminates that connection.
+    """
+    from sqlalchemy import event
+
+    state = {"open": 0, "peak": 0}
+
+    @event.listens_for(engine, "begin")
+    def _begin(conn):  # noqa: ANN001, ANN202
+        state["open"] += 1
+        state["peak"] = max(state["peak"], state["open"])
+
+    @event.listens_for(engine, "commit")
+    def _commit(conn):  # noqa: ANN001, ANN202
+        state["open"] = max(0, state["open"] - 1)
+
+    @event.listens_for(engine, "rollback")
+    def _rollback(conn):  # noqa: ANN001, ANN202
+        state["open"] = max(0, state["open"] - 1)
+
+    return state
+
+
+def test_failure_is_recorded_even_when_the_worker_session_is_poisoned(
+    tmp_path, monkeypatch
+):
+    """Terminal bookkeeping must not share a session with the failed work.
+
+    The original defect was second-order: the work session died, and the
+    exception handler then tried to record the failure on that same dead
+    session, so the row stayed `running` with no error and max_attempts never
+    applied.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.jobs.celery_app import celery_app
+
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = False
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-poisoned.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "poisoned-session")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type="kb.team.poisoned",
+            payload={"collection": "kb1"},
+            max_attempts=1,
+        )
+        db.commit()
+        job_id = str(job.id)
+        db.rollback()
+
+        from sqlalchemy.exc import OperationalError
+
+        worker_sessions: list = []
+
+        def handler(work, _job):  # noqa: ANN001, ANN202
+            # SQLite cannot be made to terminate a connection server-side, so
+            # stand in for it: a session that can no longer write is what the
+            # exception path was handed. The real timeout is on Postgres, see
+            # tests/web/test_background_jobs_postgres.py.
+            work.execute(text("SELECT 1"))
+            worker_sessions.append(work)
+
+            def _dead(*_args, **_kwargs):
+                raise OperationalError("SELECT 1", {}, Exception("server closed"))
+
+            work.commit = _dead
+            work.flush = _dead
+            raise RuntimeError("ingestion died mid-run")
+
+        observed_in_transaction: list[bool] = []
+        real_mark_job_failed = tasks_module.mark_job_failed
+
+        def spying_mark_job_failed(*args, **kwargs):
+            observed_in_transaction.append(
+                any(session.in_transaction() for session in worker_sessions)
+            )
+            return real_mark_job_failed(*args, **kwargs)
+
+        monkeypatch.setattr(tasks_module, "mark_job_failed", spying_mark_job_failed)
+        tasks_module.register_background_job_handler("kb.team.poisoned", handler)
+        try:
+            tasks_module.execute_background_job.apply(args=[job_id])
+        finally:
+            tasks_module._EXTRA_HANDLERS.pop("kb.team.poisoned", None)
+
+        assert observed_in_transaction == [False], (
+            "the failed work session was still in a transaction while the "
+            "failure was recorded on a second connection"
+        )
+
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.FAILED.value
+        assert "ingestion died mid-run" in str(row.error_message)
+        assert row.finished_at is not None
+    finally:
+        db.close()
+        celery_app.conf.task_always_eager = False
+        celery_app.conf.task_eager_propagates = False
+
+
+def test_repeated_failures_stop_at_max_attempts(tmp_path, monkeypatch):
+    """A job that keeps failing must reach a terminal state, not loop forever.
+
+    Reaching FAILED is what takes the job out of requeue_stale_background_jobs'
+    reach; a row stuck at `running` is picked up again on every scan.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.jobs.celery_app import celery_app
+
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = False
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-max-attempts.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "max-attempts")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type="kb.team.always_fails",
+            payload={"collection": "kb1"},
+            max_attempts=2,
+        )
+        db.commit()
+        job_id = str(job.id)
+        db.rollback()
+
+        calls: list[str] = []
+
+        def handler(_db, job_row):  # noqa: ANN001, ANN202
+            calls.append(str(job_row.id))
+            raise RuntimeError("permanent boom")
+
+        tasks_module.register_background_job_handler("kb.team.always_fails", handler)
+        try:
+            for _ in range(5):
+                db.expire_all()
+                current = (
+                    db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+                )
+                if current.status in {
+                    BackgroundJobStatus.FAILED.value,
+                    BackgroundJobStatus.SUCCEEDED.value,
+                }:
+                    break
+                db.rollback()
+                tasks_module.execute_background_job.apply(args=[job_id])
+        finally:
+            tasks_module._EXTRA_HANDLERS.pop("kb.team.always_fails", None)
+
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.FAILED.value
+        assert int(row.attempts) == 2, f"attempts overran max_attempts: {row.attempts}"
+        assert len(calls) == 2
+
+        # A terminal row is no longer stale-requeue material.
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=0)
+        assert job_id not in {str(j.id) for j in requeued}
+    finally:
+        db.close()
+        celery_app.conf.task_always_eager = False
+        celery_app.conf.task_eager_propagates = False
+
+
+def test_claim_refuses_a_job_that_was_cancelled(tmp_path):
+    """The cancellation check and the claim must settle in one transaction.
+
+    Split across two, a cancel landing in between is clobbered back to RUNNING
+    and the cancelled job runs anyway.
+    """
+    from xagent.web.services.background_jobs import mark_job_running
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-claim-cancelled.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "claim-cancelled")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type="kb.team.cancelled",
+            payload={},
+        )
+        setattr(job, "status", BackgroundJobStatus.CANCELLED.value)
+        db.add(job)
+        db.commit()
+        job_id = str(job.id)
+        db.rollback()
+
+        assert mark_job_running(job_id) is None
+
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.CANCELLED.value
+        assert int(row.attempts or 0) == 0
+    finally:
+        db.close()
+
+
+def test_cancelled_job_is_skipped_without_running_the_handler(tmp_path, monkeypatch):
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.jobs.celery_app import celery_app
+
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = True
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-skip-cancelled.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "skip-cancelled")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type="kb.team.skip_cancelled",
+            payload={},
+        )
+        setattr(job, "status", BackgroundJobStatus.CANCELLED.value)
+        db.add(job)
+        db.commit()
+        job_id = str(job.id)
+        db.rollback()
+
+        calls: list[str] = []
+
+        def handler(_db, _job):  # noqa: ANN001, ANN202
+            calls.append(job_id)
+            return {"status": "ok"}
+
+        tasks_module.register_background_job_handler("kb.team.skip_cancelled", handler)
+        try:
+            result = tasks_module.execute_background_job.apply(args=[job_id]).get()
+        finally:
+            tasks_module._EXTRA_HANDLERS.pop("kb.team.skip_cancelled", None)
+
+        assert result == {"status": "cancelled"}
+        assert calls == []
+    finally:
+        db.close()
+        celery_app.conf.task_always_eager = False
+        celery_app.conf.task_eager_propagates = False
+
+
+def test_already_succeeded_job_returns_its_stored_result(tmp_path, monkeypatch):
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.jobs.celery_app import celery_app
+
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = True
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-skip-succeeded.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "skip-succeeded")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type="kb.team.skip_succeeded",
+            payload={},
+        )
+        setattr(job, "status", BackgroundJobStatus.SUCCEEDED.value)
+        setattr(job, "result", {"status": "succeeded", "doc_id": "doc-9"})
+        db.add(job)
+        db.commit()
+        job_id = str(job.id)
+        db.rollback()
+
+        result = tasks_module.execute_background_job.apply(args=[job_id]).get()
+
+        assert result == {"status": "succeeded", "doc_id": "doc-9"}
+    finally:
+        db.close()
+        celery_app.conf.task_always_eager = False
+        celery_app.conf.task_eager_propagates = False
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        pytest.param(lambda fn: fn.mark_job_running("missing"), id="running"),
+        pytest.param(lambda fn: fn.mark_job_succeeded("missing"), id="succeeded"),
+        pytest.param(
+            lambda fn: fn.mark_job_failed("missing", error_message="boom"), id="failed"
+        ),
+    ],
+)
+def test_mark_job_functions_raise_for_a_missing_row(tmp_path, call):
+    """One contract for the family: a vanished row is an error, never a no-op.
+
+    Silently doing nothing would let a lost job pass for a recorded one.
+    """
+    from xagent.web.services import background_jobs as service
+
+    _init_test_db(tmp_path / "jobs-missing-row.db")
+
+    with pytest.raises(ValueError, match="Background job not found"):
+        call(service)
+
+
+def test_enqueue_failure_records_the_failure_without_holding_a_transaction(
+    tmp_path, monkeypatch
+):
+    """The 503 path writes FAILED on its own session, so this one must be idle.
+
+    A caller sitting idle in transaction while a second connection records the
+    failure is the contention this split has to avoid, not create.
+    """
+    import asyncio
+
+    from xagent.web.api import kb as kb_module
+    from xagent.web.models.database import get_engine
+
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-enqueue-503.db")
+    tracker = _track_open_transactions(get_engine())
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "enqueue-503")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"collection": "kb1"},
+        )
+        db.commit()
+        # Reading an expired attribute reopens a transaction; that is the state
+        # the 503 path has to clear before the bookkeeping session opens.
+        job_id = str(job.id)
+        assert tracker["open"] == 1
+
+        observed: list[int] = []
+        real_mark_job_failed = kb_module.mark_job_failed
+
+        def spying_mark_job_failed(*args, **kwargs):
+            observed.append(tracker["open"])
+            return real_mark_job_failed(*args, **kwargs)
+
+        monkeypatch.setattr(kb_module, "mark_job_failed", spying_mark_job_failed)
+        monkeypatch.setattr(
+            kb_module, "is_background_job_enqueue_available", lambda **_kw: False
+        )
+
+        with pytest.raises(Exception) as excinfo:
+            asyncio.run(kb_module._enqueue_background_job_or_503_async(db, job))
+
+        assert getattr(excinfo.value, "status_code", None) == 503
+        assert observed == [0], (
+            f"a transaction was open while the failure was recorded: {observed}"
+        )
+
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.FAILED.value
     finally:
         db.close()

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -2785,6 +2785,72 @@ def test_claim_does_not_clobber_a_cancel_that_lands_mid_claim(tmp_path):
         db.close()
 
 
+def test_accepted_broker_work_survives_a_failure_to_persist_its_task_id(
+    tmp_path, monkeypatch
+):
+    """Once apply_async returns, a worker may already be running the job.
+
+    A refresh or commit that fails after acceptance must not mark that work
+    FAILED, must not 503 the caller (whose failure path deletes the staging
+    input the accepted worker still needs), and must still reconcile the task
+    id on a session of its own.
+    """
+    import asyncio
+
+    from sqlalchemy.exc import OperationalError
+
+    from xagent.web.api import kb as kb_module
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.services import background_jobs as bg
+
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "redis://localhost:6379/0")
+    monkeypatch.setattr(bg, "_is_redis_broker_reachable", lambda _url: True)
+    monkeypatch.setattr(
+        tasks_module.execute_background_job,
+        "apply_async",
+        MagicMock(return_value=MagicMock(id="accepted-task-id")),
+    )
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-accepted.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "accepted-publish")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"url": "https://example.com"},
+        )
+        job_id = str(job.id)
+
+        refreshes: list[object] = []
+        real_refresh = db.refresh
+
+        def flaky_refresh(instance, *args, **kwargs):  # noqa: ANN001, ANN202
+            refreshes.append(instance)
+            if len(refreshes) >= 2:
+                # The first refresh precedes apply_async; this one follows it.
+                raise OperationalError("refresh", {}, Exception("server closed"))
+            return real_refresh(instance, *args, **kwargs)
+
+        monkeypatch.setattr(db, "refresh", flaky_refresh)
+
+        asyncio.run(kb_module._enqueue_background_job_or_503_async(db, job))
+    finally:
+        db.close()
+
+    verify = SessionLocal()
+    try:
+        row = verify.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.ENQUEUED.value, (
+            "accepted broker work was recorded as failed"
+        )
+        assert row.celery_task_id == "accepted-task-id"
+    finally:
+        verify.close()
+
+
 def test_requeue_does_not_resurrect_a_job_settled_during_dispatch(
     tmp_path, monkeypatch
 ):

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -26,6 +26,7 @@ from xagent.web.models.database import get_session_local, init_db
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
 from xagent.web.services.background_jobs import (
+    SettledJob,
     create_background_job,
     enqueue_background_job,
     is_background_job_enqueue_available,
@@ -2263,7 +2264,10 @@ def test_claim_refuses_a_job_that_was_cancelled(tmp_path):
         job_id = str(job.id)
         db.rollback()
 
-        assert mark_job_running(job_id) is None
+        settled = mark_job_running(job_id)
+        assert settled == SettledJob(
+            status=BackgroundJobStatus.CANCELLED.value, result=None
+        )
 
         db.expire_all()
         row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
@@ -2298,11 +2302,16 @@ def test_claim_refuses_a_job_that_already_failed(tmp_path):
         job_id = str(job.id)
         db.rollback()
 
-        assert mark_job_running(job_id) is None
+        settled = mark_job_running(job_id)
+        assert isinstance(settled, SettledJob)
+        assert settled.status == BackgroundJobStatus.FAILED.value
 
         from xagent.web.jobs.tasks import _settled_job_result
 
-        assert _settled_job_result(job_id) == {"status": "failed", "detail": "boom"}
+        assert _settled_job_result(job_id, settled) == {
+            "status": "failed",
+            "detail": "boom",
+        }
 
         db.expire_all()
         row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
@@ -2595,5 +2604,124 @@ def test_requeue_records_broker_failure_per_job(tmp_path, monkeypatch):
         other = db.query(BackgroundJob).filter(BackgroundJob.id == job_ids[1]).first()
         assert other.status == BackgroundJobStatus.ENQUEUED.value
         assert other.celery_task_id == f"task-{job_ids[1]}"
+    finally:
+        db.close()
+
+
+def test_setup_failure_after_the_claim_still_reaches_terminal_bookkeeping(
+    tmp_path, monkeypatch
+):
+    """A durable RUNNING claim must not outlive a failure in this attempt.
+
+    ``mark_job_running`` commits RUNNING before the worker session exists, so
+    a pool checkout or initial-load failure outside the exception handlers
+    leaves the row RUNNING with no error and no attempt boundary -- exactly the
+    stuck state this PR exists to remove.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.jobs.celery_app import celery_app
+
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = False
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-setup-failure.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "setup-failure")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type="kb.team.setup",
+            payload={},
+            max_attempts=1,
+        )
+        db.commit()
+        job_id = str(job.id)
+        db.rollback()
+
+        def _no_session():  # noqa: ANN202
+            raise RuntimeError("pool checkout failed")
+
+        monkeypatch.setattr(tasks_module, "_open_worker_session", _no_session)
+        tasks_module.execute_background_job.apply(args=[job_id])
+
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.FAILED.value
+        assert "pool checkout failed" in str(row.error_message)
+        assert int(row.attempts) == 1
+    finally:
+        db.close()
+        celery_app.conf.task_always_eager = False
+        celery_app.conf.task_eager_propagates = False
+
+
+def test_claim_does_not_clobber_a_cancel_that_lands_mid_claim(tmp_path):
+    """The terminal check and the claim must be one statement.
+
+    Read-check-write loses this race: the cancel commits after the check and
+    the claim then writes RUNNING over it. ``with_for_update()`` does not close
+    it either -- it is a no-op on SQLite. The cancel here is committed from a
+    second session while the claim's own write statement is on its way out.
+    """
+    from sqlalchemy import event
+
+    from xagent.web.models.database import get_engine
+    from xagent.web.services.background_jobs import mark_job_running
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-claim-race.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "claim-race")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type="kb.team.race",
+            payload={},
+        )
+        db.commit()
+        job_id = str(job.id)
+        db.rollback()
+
+        engine = get_engine()
+        interleaved: list[str] = []
+
+        @event.listens_for(engine, "before_cursor_execute")
+        def _cancel_before_the_claim_write(  # noqa: ANN202
+            conn, cursor, statement, parameters, context, executemany
+        ):
+            if interleaved or not statement.lstrip().upper().startswith(
+                "UPDATE BACKGROUND_JOBS"
+            ):
+                return
+            interleaved.append(statement)
+            other = SessionLocal()
+            try:
+                other.query(BackgroundJob).filter(BackgroundJob.id == job_id).update(
+                    {"status": BackgroundJobStatus.CANCELLED.value},
+                    synchronize_session=False,
+                )
+                other.commit()
+            finally:
+                other.close()
+
+        try:
+            settled = mark_job_running(job_id)
+        finally:
+            event.remove(
+                engine, "before_cursor_execute", _cancel_before_the_claim_write
+            )
+
+        assert interleaved, "the claim issued no UPDATE to interleave with"
+        assert isinstance(settled, SettledJob)
+        assert settled.status == BackgroundJobStatus.CANCELLED.value
+
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.CANCELLED.value
+        assert int(row.attempts or 0) == 0
     finally:
         db.close()

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -3314,6 +3314,56 @@ def test_accepted_work_is_reconciled_even_when_rollback_also_fails(
         verify.close()
 
 
+def test_requeue_reclaims_a_row_whose_updated_at_the_server_wrote(
+    tmp_path, monkeypatch
+):
+    """The freshness fence must match a server-written timestamp.
+
+    SQLite's CURRENT_TIMESTAMP stores second precision, so an equality
+    predicate against the ORM read-back never matches and every stale row
+    is silently skipped -- the sweep does nothing on the default backend.
+    """
+    from sqlalchemy import text
+
+    monkeypatch.setenv(CELERY_ENABLED, "false")
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-server-written.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "server-written")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"url": "https://example.com"},
+        )
+        setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+        db.add(job)
+        db.commit()
+        job_id = str(job.id)
+        # Write the staleness the way the server does: second precision,
+        # no microseconds. _age_job's python datetime would round-trip.
+        db.execute(
+            text(
+                "UPDATE background_jobs"
+                " SET updated_at = datetime('now', '-3 hours'),"
+                "     started_at = datetime('now', '-3 hours')"
+                " WHERE id = :id"
+            ),
+            {"id": job_id},
+        )
+        db.commit()
+
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=3600)
+
+        assert [item.id for item in requeued] == [job_id]
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.PENDING.value
+    finally:
+        db.close()
+
+
 def test_requeue_skips_a_job_that_reported_progress_after_the_scan(
     tmp_path, monkeypatch
 ):

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -2273,6 +2273,45 @@ def test_claim_refuses_a_job_that_was_cancelled(tmp_path):
         db.close()
 
 
+def test_claim_refuses_a_job_that_already_failed(tmp_path):
+    """FAILED is terminal too: a duplicate delivery must not re-run the job.
+
+    Re-claiming would increment attempts past max_attempts and run the handler
+    once more after the failure was recorded.
+    """
+    from xagent.web.services.background_jobs import mark_job_running
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-claim-failed.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "claim-failed")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type="kb.team.failed",
+            payload={},
+        )
+        setattr(job, "status", BackgroundJobStatus.FAILED.value)
+        setattr(job, "result", {"status": "failed", "detail": "boom"})
+        db.add(job)
+        db.commit()
+        job_id = str(job.id)
+        db.rollback()
+
+        assert mark_job_running(job_id) is None
+
+        from xagent.web.jobs.tasks import _settled_job_result
+
+        assert _settled_job_result(job_id) == {"status": "failed", "detail": "boom"}
+
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.FAILED.value
+        assert int(row.attempts or 0) == 0
+    finally:
+        db.close()
+
+
 def test_cancelled_job_is_skipped_without_running_the_handler(tmp_path, monkeypatch):
     monkeypatch.setenv(CELERY_ENABLED, "true")
     monkeypatch.setenv(CELERY_BROKER_URL, "memory://")

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -2407,7 +2407,6 @@ def test_already_succeeded_job_returns_its_stored_result(tmp_path, monkeypatch):
     "call",
     [
         pytest.param(lambda fn: fn.mark_job_running("missing"), id="running"),
-        pytest.param(lambda fn: fn.mark_job_succeeded("missing"), id="succeeded"),
         pytest.param(
             lambda fn: fn.mark_job_failed("missing", error_message="boom"), id="failed"
         ),
@@ -3023,3 +3022,162 @@ def test_requeue_does_not_dispatch_a_job_settled_before_staging(tmp_path, monkey
         assert row.status == BackgroundJobStatus.CANCELLED.value
     finally:
         db.close()
+
+
+def test_success_is_one_transaction_with_the_handler_writes(tmp_path, monkeypatch):
+    """A second session must never see the handler's writes without SUCCEEDED.
+
+    Committing the handler and then marking SUCCEEDED on another session leaves
+    a window where durable side effects sit on a RUNNING row, which the stale
+    sweep is entitled to run again.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from sqlalchemy import event
+    from sqlalchemy.orm import Session as SASession
+
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.jobs.celery_app import celery_app
+
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = False
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-success-atomic.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "success-atomic")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type="kb.team.atomic",
+            payload={},
+            max_attempts=1,
+        )
+        db.commit()
+        job_id = str(job.id)
+        db.rollback()
+
+        observations: list[tuple[bool, bool]] = []
+
+        @event.listens_for(SASession, "after_commit")
+        def _observe_from_another_session(session):  # noqa: ANN001, ANN202
+            watcher = SessionLocal()
+            try:
+                written = (
+                    watcher.query(User)
+                    .filter(User.username == "atomic-pending-write")
+                    .first()
+                    is not None
+                )
+                row = (
+                    watcher.query(BackgroundJob)
+                    .filter(BackgroundJob.id == job_id)
+                    .first()
+                )
+                succeeded = (
+                    row is not None
+                    and str(row.status) == BackgroundJobStatus.SUCCEEDED.value
+                )
+            finally:
+                watcher.close()
+            observations.append((written, succeeded))
+
+        def handler(work, _job):  # noqa: ANN001, ANN202
+            work.add(User(username="atomic-pending-write", password_hash="x"))
+            return {"status": "ok"}
+
+        tasks_module.register_background_job_handler("kb.team.atomic", handler)
+        try:
+            tasks_module.execute_background_job.apply(args=[job_id])
+        finally:
+            tasks_module._EXTRA_HANDLERS.pop("kb.team.atomic", None)
+            event.remove(SASession, "after_commit", _observe_from_another_session)
+
+        assert (True, True) in observations, (
+            "the handler's write and SUCCEEDED never became visible together"
+        )
+        assert (True, False) not in observations, (
+            "a second session saw durable handler writes on a non-SUCCEEDED row"
+        )
+    finally:
+        db.close()
+        celery_app.conf.task_always_eager = False
+        celery_app.conf.task_eager_propagates = False
+
+
+def test_a_failed_success_commit_leaves_neither_the_writes_nor_succeeded(
+    tmp_path, monkeypatch
+):
+    """The terminal commit is the whole success unit, so losing it loses both.
+
+    If the handler's writes were committed first, this crash would leave them
+    durable on a row that never reached SUCCEEDED.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from sqlalchemy import event
+    from sqlalchemy.exc import OperationalError
+
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.jobs.celery_app import celery_app
+    from xagent.web.models.database import get_engine
+
+    celery_app.conf.task_always_eager = True
+    celery_app.conf.task_eager_propagates = False
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-success-commit-fails.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "success-commit-fails")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type="kb.team.commitfail",
+            payload={},
+            max_attempts=1,
+        )
+        db.commit()
+        job_id = str(job.id)
+        db.rollback()
+
+        engine = get_engine()
+
+        @event.listens_for(engine, "before_cursor_execute")
+        def _break_the_terminal_write(  # noqa: ANN202
+            conn, cursor, statement, parameters, context, executemany
+        ):
+            if not statement.lstrip().upper().startswith("UPDATE BACKGROUND_JOBS"):
+                return
+            # The first bound value is the SET status; matching anywhere in the
+            # parameters would also hit the claim's NOT IN terminal list.
+            bound = parameters if isinstance(parameters, (list, tuple)) else ()
+            if not bound or str(bound[0]) != BackgroundJobStatus.SUCCEEDED.value:
+                return
+            raise OperationalError("update", {}, Exception("server closed"))
+
+        def handler(work, _job):  # noqa: ANN001, ANN202
+            work.add(User(username="commitfail-pending-write", password_hash="x"))
+            return {"status": "ok"}
+
+        tasks_module.register_background_job_handler("kb.team.commitfail", handler)
+        try:
+            tasks_module.execute_background_job.apply(args=[job_id])
+        finally:
+            tasks_module._EXTRA_HANDLERS.pop("kb.team.commitfail", None)
+            event.remove(engine, "before_cursor_execute", _break_the_terminal_write)
+
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.FAILED.value
+        written = (
+            db.query(User).filter(User.username == "commitfail-pending-write").first()
+        )
+        assert written is None, (
+            "handler writes stayed durable although SUCCEEDED never landed"
+        )
+    finally:
+        db.close()
+        celery_app.conf.task_always_eager = False
+        celery_app.conf.task_eager_propagates = False

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -2436,3 +2436,125 @@ def test_enqueue_failure_records_the_failure_without_holding_a_transaction(
         assert row.status == BackgroundJobStatus.FAILED.value
     finally:
         db.close()
+
+
+def test_requeue_dispatches_to_broker_with_no_open_transaction(tmp_path, monkeypatch):
+    """The stale-job scan must not hold a read transaction across apply_async.
+
+    A slow or unreachable broker blocks per job while the session sits idle in
+    transaction, which is exactly what the server terminates. The task ids are
+    persisted afterwards, in a write that starts once the broker is done.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.models.database import get_engine
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-requeue-txn.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="requeue-txn")
+        old = datetime.now(timezone.utc) - timedelta(hours=3)
+        job_ids: list[str] = []
+        for index in range(2):
+            job = create_background_job(
+                db,
+                user_id=int(user.id),
+                job_type=BackgroundJobType.KB_INGEST_WEB,
+                payload={"collection": f"kb{index}"},
+            )
+            setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+            db.add(job)
+            db.commit()
+            _age_job(db, job, updated_at=old, started_at=old)
+            job_ids.append(str(job.id))
+        db.rollback()
+
+        tracker = _track_open_transactions(get_engine())
+        observed: list[int] = []
+
+        class _Result:
+            def __init__(self, task_id: str) -> None:
+                self.id = task_id
+
+        def fake_apply_async(*, args, queue):  # noqa: ANN001, ANN202
+            observed.append(tracker["open"])
+            return _Result(f"task-{args[0]}")
+
+        monkeypatch.setattr(
+            tasks_module.execute_background_job, "apply_async", fake_apply_async
+        )
+
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert observed == [0, 0], (
+            f"a transaction was open while the broker was called: {observed}"
+        )
+        assert tracker["open"] == 0, "requeue returned with a transaction still open"
+        assert sorted(str(item.id) for item in requeued) == sorted(job_ids)
+        db.expire_all()
+        for job_id in job_ids:
+            row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+            assert row.celery_task_id == f"task-{job_id}"
+            assert row.status == BackgroundJobStatus.ENQUEUED.value
+    finally:
+        db.close()
+
+
+def test_requeue_records_broker_failure_per_job(tmp_path, monkeypatch):
+    """A broker that rejects one job leaves that row PENDING with the reason."""
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-requeue-broker-fail.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, username="requeue-broker-fail")
+        old = datetime.now(timezone.utc) - timedelta(hours=3)
+        job_ids: list[str] = []
+        for index in range(2):
+            job = create_background_job(
+                db,
+                user_id=int(user.id),
+                job_type=BackgroundJobType.KB_INGEST_WEB,
+                payload={"collection": f"kb{index}"},
+            )
+            setattr(job, "status", BackgroundJobStatus.RUNNING.value)
+            db.add(job)
+            db.commit()
+            _age_job(db, job, updated_at=old, started_at=old)
+            job_ids.append(str(job.id))
+        db.rollback()
+
+        doomed = job_ids[0]
+
+        class _Result:
+            def __init__(self, task_id: str) -> None:
+                self.id = task_id
+
+        def fake_apply_async(*, args, queue):  # noqa: ANN001, ANN202
+            if args[0] == doomed:
+                raise RuntimeError("broker unreachable")
+            return _Result(f"task-{args[0]}")
+
+        monkeypatch.setattr(
+            tasks_module.execute_background_job, "apply_async", fake_apply_async
+        )
+
+        requeued = requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert sorted(str(item.id) for item in requeued) == sorted(job_ids)
+        db.expire_all()
+        failed = db.query(BackgroundJob).filter(BackgroundJob.id == doomed).first()
+        assert failed.status == BackgroundJobStatus.PENDING.value
+        assert failed.celery_task_id is None
+        assert "broker unreachable" in str(failed.error_message)
+
+        other = db.query(BackgroundJob).filter(BackgroundJob.id == job_ids[1]).first()
+        assert other.status == BackgroundJobStatus.ENQUEUED.value
+        assert other.celery_task_id == f"task-{job_ids[1]}"
+    finally:
+        db.close()

--- a/tests/web/test_background_jobs.py
+++ b/tests/web/test_background_jobs.py
@@ -2783,3 +2783,123 @@ def test_claim_does_not_clobber_a_cancel_that_lands_mid_claim(tmp_path):
         assert int(row.attempts or 0) == 0
     finally:
         db.close()
+
+
+def test_requeue_does_not_resurrect_a_job_settled_during_dispatch(
+    tmp_path, monkeypatch
+):
+    """A settlement landing between staging and reconciliation must stand.
+
+    The broker-failure reconciliation used to reset the row to PENDING
+    unconditionally, so a cancel or a worker that settled the row mid-pass was
+    resurrected and dispatched again.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-requeue-settled.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "requeue-settled")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"url": "https://example.com"},
+        )
+        db.commit()
+        job_id = str(job.id)
+        _age_job(db, job, updated_at=datetime.now(timezone.utc) - timedelta(hours=3))
+
+        def settling_apply_async(*_args, **_kwargs):  # noqa: ANN202
+            other = SessionLocal()
+            try:
+                other.query(BackgroundJob).filter(BackgroundJob.id == job_id).update(
+                    {"status": BackgroundJobStatus.CANCELLED.value},
+                    synchronize_session=False,
+                )
+                other.commit()
+            finally:
+                other.close()
+            raise RuntimeError("broker down")
+
+        monkeypatch.setattr(
+            tasks_module.execute_background_job, "apply_async", settling_apply_async
+        )
+
+        requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.CANCELLED.value, (
+            "the stale pass resurrected a job settled during its own dispatch"
+        )
+    finally:
+        db.close()
+
+
+def test_requeue_does_not_dispatch_a_job_settled_before_staging(tmp_path, monkeypatch):
+    """The staging write is fenced too, not just the reconciliation.
+
+    A settlement landing between the PENDING claim and the ENQUEUED staging
+    would otherwise be overwritten and the terminal job put back on the broker.
+    """
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    from xagent.web.jobs import tasks as tasks_module
+    from xagent.web.services import background_jobs as bg
+
+    dispatched = MagicMock(return_value=MagicMock(id="should-not-happen"))
+    monkeypatch.setattr(tasks_module.execute_background_job, "apply_async", dispatched)
+
+    SessionLocal = _init_test_db(tmp_path / "jobs-requeue-staging.db")
+    db = SessionLocal()
+    try:
+        user = _create_user(db, "requeue-staging")
+        job = create_background_job(
+            db,
+            user_id=int(user.id),
+            job_type=BackgroundJobType.KB_INGEST_WEB,
+            payload={"url": "https://example.com"},
+        )
+        db.commit()
+        job_id = str(job.id)
+        _age_job(db, job, updated_at=datetime.now(timezone.utc) - timedelta(hours=3))
+
+        settled: list[str] = []
+        real_broker_url = bg.get_celery_broker_url
+
+        def settling_broker_url():  # noqa: ANN202
+            # Called between the PENDING claim's commit and the ENQUEUED
+            # staging write -- the window another actor can settle the row in.
+            if not settled:
+                settled.append(job_id)
+                other = SessionLocal()
+                try:
+                    other.query(BackgroundJob).filter(
+                        BackgroundJob.id == job_id
+                    ).update(
+                        {"status": BackgroundJobStatus.CANCELLED.value},
+                        synchronize_session=False,
+                    )
+                    other.commit()
+                finally:
+                    other.close()
+            return real_broker_url()
+
+        monkeypatch.setattr(bg, "get_celery_broker_url", settling_broker_url)
+
+        requeue_stale_background_jobs(db, stale_after_seconds=60)
+
+        assert settled, "the settlement window was never reached"
+        assert dispatched.call_count == 0, (
+            "a settled job was staged and dispatched anyway"
+        )
+        db.expire_all()
+        row = db.query(BackgroundJob).filter(BackgroundJob.id == job_id).first()
+        assert row.status == BackgroundJobStatus.CANCELLED.value
+    finally:
+        db.close()

--- a/tests/web/test_background_jobs_postgres.py
+++ b/tests/web/test_background_jobs_postgres.py
@@ -1,0 +1,179 @@
+"""Postgres-only regression for the idle-in-transaction failure mode (#1535).
+
+The SQLite suite pins the mechanism (bookkeeping runs on a session of its own).
+Only a real server enforces ``idle_in_transaction_session_timeout``, which is
+what actually killed the connection in production, so the end-to-end
+consequence -- a job stuck at ``running`` with no error recorded -- can only be
+reproduced here. Skipped unless XAGENT_TEST_POSTGRES_URL is set.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import uuid
+
+import psycopg2
+import pytest
+
+from tests.shared.postgres_disposable import (
+    disposable_database_url,
+    psycopg2_kwargs,
+)
+
+pytestmark = pytest.mark.postgresql
+
+IDLE_TIMEOUT = "1s"
+
+
+def _create_schema() -> None:
+    import xagent.web.models.background_job  # noqa: F401
+    import xagent.web.models.uploaded_file  # noqa: F401
+    import xagent.web.models.user  # noqa: F401
+    from xagent.web.models.database import Base, get_engine
+
+    Base.metadata.create_all(get_engine())
+
+
+def test_failure_is_recorded_after_idle_transaction_timeout(monkeypatch):
+    """A job whose handler idles past the timeout must still reach FAILED.
+
+    Before bookkeeping got its own sessions, the exception path recorded the
+    failure on the same session the server had just terminated. The row stayed
+    ``running`` with ``error_message`` NULL, which also meant max_attempts
+    never applied.
+    """
+    from xagent.config import CELERY_BROKER_URL, CELERY_ENABLED
+    from xagent.web.models import database as database_module
+
+    monkeypatch.setenv(CELERY_ENABLED, "true")
+    monkeypatch.setenv(CELERY_BROKER_URL, "memory://")
+
+    with disposable_database_url(
+        "xagent_jobs_idle_txn",
+        settings={"idle_in_transaction_session_timeout": IDLE_TIMEOUT},
+    ) as db_url:
+        from xagent.web.jobs import tasks as tasks_module
+        from xagent.web.jobs.celery_app import celery_app
+        from xagent.web.models.background_job import BackgroundJob, BackgroundJobStatus
+        from xagent.web.models.database import (
+            configure_db,
+            get_engine,
+            get_session_local,
+        )
+        from xagent.web.models.user import User
+        from xagent.web.services.background_jobs import create_background_job
+
+        previous_engine = database_module._engine
+        previous_session_local = database_module._SessionLocal
+        previous_eager = celery_app.conf.task_always_eager
+        previous_propagates = celery_app.conf.task_eager_propagates
+        try:
+            configure_db(db_url)
+            _create_schema()
+
+            # The regression only reproduces if the timeout the test asked for
+            # is what the application's own connections actually get: a role or
+            # session-level override would leave the sleep below harmless and
+            # the assertions green for the wrong reason.
+            with get_engine().connect() as probe:
+                effective = probe.exec_driver_sql(
+                    "SHOW idle_in_transaction_session_timeout"
+                ).scalar()
+            assert effective == IDLE_TIMEOUT, (
+                "idle_in_transaction_session_timeout on the application "
+                f"connection is {effective!r}, not {IDLE_TIMEOUT!r}; this test "
+                "would pass without exercising the regression"
+            )
+
+            celery_app.conf.task_always_eager = True
+            celery_app.conf.task_eager_propagates = False
+
+            SessionLocal = get_session_local()
+            setup = SessionLocal()
+            try:
+                user = User(username="idle-txn", password_hash="x")
+                setup.add(user)
+                setup.commit()
+                setup.refresh(user)
+                job = create_background_job(
+                    setup,
+                    user_id=int(user.id),
+                    job_type="kb.team.idle_txn",
+                    payload={},
+                    max_attempts=1,
+                )
+                setup.commit()
+                job_id = str(job.id)
+            finally:
+                setup.close()
+
+            def handler(_db, _job):
+                # Stand in for the gap between two progress updates during a
+                # multi-hour crawl -- long enough for the server to reap an
+                # idle transaction, which is what the worker session holds.
+                time.sleep(2.5)
+                raise RuntimeError("ingestion died mid-run")
+
+            tasks_module.register_background_job_handler("kb.team.idle_txn", handler)
+            try:
+                tasks_module.execute_background_job.apply(args=[job_id])
+            finally:
+                tasks_module._EXTRA_HANDLERS.pop("kb.team.idle_txn", None)
+
+            verify = SessionLocal()
+            try:
+                row = (
+                    verify.query(BackgroundJob)
+                    .filter(BackgroundJob.id == job_id)
+                    .first()
+                )
+                assert row.status == BackgroundJobStatus.FAILED.value, (
+                    f"job did not reach a terminal state: status={row.status!r} "
+                    f"error={row.error_message!r}"
+                )
+                assert "ingestion died mid-run" in str(row.error_message)
+                assert row.finished_at is not None
+                assert int(row.attempts) == 1
+            finally:
+                verify.close()
+        finally:
+            celery_app.conf.task_always_eager = previous_eager
+            celery_app.conf.task_eager_propagates = previous_propagates
+            # configure_db rebinds process-global state; leaving it pointed at
+            # a dropped database breaks whatever test runs next.
+            if database_module._engine is not previous_engine:
+                database_module._engine.dispose()
+            database_module._engine = previous_engine
+            database_module._SessionLocal = previous_session_local
+
+
+def test_disposable_database_is_dropped_when_setup_fails():
+    """A failing ALTER after CREATE DATABASE must not leak the database.
+
+    The setup statements run between CREATE and the yield, so without a drop
+    guard registered right after CREATE, a rejected setting leaves an orphan
+    database on a shared server for every run.
+    """
+    base_url = os.getenv("XAGENT_TEST_POSTGRES_URL")
+    if not base_url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+
+    # Unique per run: a bare prefix would also match databases minted by a
+    # concurrent run against the same server.
+    prefix = f"xagent_jobs_setup_fail_{uuid.uuid4().hex[:8]}"
+    with pytest.raises(psycopg2.Error):
+        with disposable_database_url(prefix, settings={"xagent_not_a_real_guc": "1"}):
+            pytest.fail("the context manager must not yield after a failed setup")
+
+    admin = psycopg2.connect(**psycopg2_kwargs(base_url))
+    try:
+        cursor = admin.cursor()
+        cursor.execute(
+            "SELECT datname FROM pg_database WHERE datname LIKE %s", (f"{prefix}_%",)
+        )
+        leaked = [row[0] for row in cursor.fetchall()]
+    finally:
+        admin.close()
+
+    assert leaked == [], f"disposable databases left behind: {leaked}"

--- a/tests/web/test_release_db_connection.py
+++ b/tests/web/test_release_db_connection.py
@@ -1,5 +1,6 @@
-"""Tests for release_db_connection_if_clean (issue #889)."""
+"""Tests for release_db_connection_if_clean (issue #889) and session_scope."""
 
+import pytest
 from sqlalchemy import Column, Integer, String, create_engine, insert, text, update
 from sqlalchemy.orm import declarative_base, sessionmaker
 
@@ -164,3 +165,63 @@ def test_none_session_is_noop():
 def test_no_transaction_returns_true():
     db = _make_session()
     assert release_db_connection_if_clean(db) is True
+
+
+def test_session_scope_commits_a_write_and_leaves_no_transaction(tmp_path):
+    """The unit of work is committed and the connection released on exit."""
+    from xagent.web.models.background_job import BackgroundJob
+    from xagent.web.models.database import init_db, session_scope
+    from xagent.web.models.user import User
+
+    init_db(f"sqlite:///{tmp_path / 'scope-commit.db'}")
+
+    with session_scope() as db:
+        user = User(username="scope-commit", password_hash="x")
+        db.add(user)
+        db.flush()
+        user_id = int(user.id)
+
+    with session_scope() as db:
+        assert db.query(User).filter(User.id == user_id).first() is not None
+        assert db.query(BackgroundJob).count() == 0
+
+
+def test_session_scope_does_not_commit_a_read_only_scope(tmp_path):
+    """A scope that only read has nothing to commit.
+
+    Committing anyway bypasses the release helper every other call site uses
+    for this exact problem class, and issues a COMMIT per read.
+    """
+    from sqlalchemy import event
+
+    from xagent.web.models.database import get_engine, init_db, session_scope
+    from xagent.web.models.user import User
+
+    init_db(f"sqlite:///{tmp_path / 'scope-readonly.db'}")
+
+    commits: list[int] = []
+    event.listen(get_engine(), "commit", lambda _conn: commits.append(1))
+
+    with session_scope() as db:
+        db.query(User).all()
+
+    assert commits == []
+
+
+def test_session_scope_reraises_the_original_when_rollback_fails(tmp_path):
+    """A rollback that fails on a dead connection must not mask the failure.
+
+    That is precisely this path's target scenario: the connection the server
+    terminated is the one the rollback runs on.
+    """
+    from xagent.web.models.database import init_db, session_scope
+
+    init_db(f"sqlite:///{tmp_path / 'scope-rollback-fail.db'}")
+
+    class _Boom(Exception):
+        pass
+
+    with pytest.raises(_Boom):
+        with session_scope() as db:
+            db.rollback = lambda: (_ for _ in ()).throw(RuntimeError("connection gone"))
+            raise _Boom("the original failure")


### PR DESCRIPTION
## Scope: partial fix for #1535, not the full cutover

This PR is slice 2 of the series #1593 was split into ([close comment](https://github.com/xorbitsai/xagent/pull/1593#issuecomment-5381991069)). It makes the failure in #1535 **reliably recorded**; it does not close the window that causes it. **#1535 stays open** until slice 3 lands.

Still present after this PR, by design: the worker opens one `Session` for the handler body and `update_job_progress` still commits and refreshes on it, so a crawl whose progress gap exceeds `idle_in_transaction_session_timeout` can still lose that connection. What changes is the consequence — the job now reaches FAILED with its error and its attempt counted, instead of staying `running` forever. Slice 3 (`BackgroundJobRef` handler signature, progress on short independent sessions, `kb_tasks`/`trigger_tasks` conversion) removes the window itself and carries the Postgres acceptance case that proves such a job succeeds.

## What broke

`execute_background_job` held one DB session for a job's whole lifetime and did
its bookkeeping on it. A post-commit `refresh` reopens a transaction that then
sits idle until the next commit; Postgres terminates such a connection once
`idle_in_transaction_session_timeout` elapses, and every later statement on that
session fails.

The damage was second-order. The session that died was also the session
`mark_job_failed` used to record the failure, so the failure was never recorded:
the row stayed `running` with `error_message` NULL, `requeue_stale_background_jobs`
picked it up again on every scan, and `max_attempts` never applied — one job in
production reached 33 attempts against a cap of 3 (#1535).

## What this changes

- `mark_job_running` / `mark_job_failed` now take a job id
  and open a short session of their own through a new `session_scope()`
  (`models/database.py`). Recording a terminal state no longer depends on the
  health of the session the work ran on. `mark_job_succeeded` is gone entirely
  (see the success-path bullet below). This is a breaking change for the
  `mark_job_*` family — downstream callers registered through
  `register_background_job_handler` that call them directly must pass a job id
  now, and must not call `mark_job_succeeded` at all.
- The retry write moves out of `execute_background_job`'s inline block into
  `_mark_job_for_retry`, also on its own session.
- **The claim is one conditional `UPDATE`.** `mark_job_running` writes
  `status=RUNNING, attempts=attempts+1 WHERE id=:id AND status NOT IN
  (terminal)`, so the terminal check and the claim cannot be split by a cancel
  landing between them. No row lock is involved, so the guarantee is
  dialect-neutral — `with_for_update()` is a no-op on SQLite and is gone.
  It returns an immutable `JobClaim(attempts, max_attempts)` on success and an
  immutable `SettledJob(status, result)` when the row already settled; a
  missing row still raises `ValueError`. The return type is the second half of
  the breaking change above: callers that treated the result as `int | None`
  must read `claim.attempts` now.
- **Everything after the claim is inside the attempt's exception boundary.**
  Opening the worker session and loading the job used to sit outside the
  retry/failure handlers, so a pool checkout or initial-query failure left the
  row durably `RUNNING` with no error and no attempt boundary. The retry
  decision now reads the claim snapshot, so there is no second unprotected ORM
  load either.
- **Success is one transaction.** The
  handler contract still supplies `(Session, BackgroundJob)` and has never
  required the handler to commit; the upstream wrapper committed that session
  as part of marking the job successful. The success path now sets the terminal
  fields on the loaded job and commits them together with whatever the handler
  left pending, so `SUCCEEDED` and the handler's durable side effects land in a
  single commit — the handler's pending session writes and `SUCCEEDED` are one
  row for the stale sweep to run a second time. A failure of that commit falls
  into the existing exception boundary, where terminal bookkeeping still runs on
  an independent session because the worker's connection may already be dead.
  Only the failure path rolls back
  (`_end_worker_transaction`, which swallows a rollback that fails on an
  already-dead connection).
- Before failure bookkeeping runs, the caller's own transaction is ended — in
  the worker and at the `kb.py` 503 call site. Bookkeeping takes a second
  connection; the first must not be sitting idle in transaction across it.
- `requeue_stale_background_jobs` loses all four post-commit `refresh` loops. It
  snapshots `(job_id, queue)` before committing and dispatches to the broker
  from plain strings, so no transaction spans `apply_async`, and it returns with
  none open. It also returns those snapshots — an immutable `RequeuedJob(id,
  queue)` per claim — instead of ORM instances that the commits have expired.
- **Every stale-requeue write is fenced on what that pass observed.** The
  initial claim compares both the status *and* the `updated_at` the scan read
  (`WHERE id=:id AND status=:observed AND updated_at=:observed_at`); the later
  writes stay fenced on the state that pass staged. A worker that reports
  progress after the SELECT, or a cancellation landing between the requeue's
  steps, therefore takes the row out of the sweep: the rowcount comes back 0 and
  the row is left to its owner instead of being reset to PENDING and dispatched
  again. Broker failures are still recorded per job. What the fence still cannot
  express is two sweepers acting on the *same* snapshot — that needs a claim
  token and a schema change, and stays out of this slice.
- **Work the broker already accepted is never recorded as failed.**
  `_enqueue_background_job_or_503_async` splits at `apply_async`: a failure
  before publication still marks the job FAILED and 503s, while a
  refresh/commit failure *after* publication only reconciles `celery_task_id`
  on a short independent session (logged on failure) and returns the accepted
  job. This is what kept the document-ingest caller from releasing the
  generation and deleting the staging input a running worker still needs.
  What this does *not* claim is that an exception from `apply_async()` proves
  publication never happened: with Redis/Kombu the `LPUSH` can succeed and the
  response can be lost. That ambiguity is pre-existing (upstream failed the job
  for *any* enqueue exception); this slice only narrows the destructive window
  to "before `apply_async()` returned". Modelling uncertain publication —
  publisher confirms or an outbox state — is tracked separately in #1616.
- One contract for the family: the `mark_job_*` functions raise `ValueError` on a
  missing row rather than silently no-opping.
- `session_scope()` reuses the codebase's existing
  `release_db_connection_if_clean` machinery, so a read-only scope ends its
  transaction instead of issuing a no-op COMMIT, and a rollback that itself fails
  is logged rather than replacing the exception being unwound.

## What this does not change

Handlers still receive `(Session, BackgroundJob)`. The worker still opens a
session for the handler body, so a transaction can still span that body — that
is slice 3, not this one. See the scope note at the top: #1535's idle window
survives this PR.

Deliberately out of scope, to follow separately:

- threading an immutable `BackgroundJobRef` through handlers, and the registration
  guard that rejects the old `(db, job)` shape;
- `jobs/progress.py` and `update_job_progress` (still `(db, job)`, still with
  their current behaviour);
- the `kb_tasks.py` / `trigger_tasks.py` session conversions and
  `scan_due_triggers`;
- `model_resolver`'s engine pool kwargs — split out as #1609.

Known, pre-existing and unchanged: `_enqueue_background_job_or_503_async`'s
success path still returns holding a read transaction; this PR only guarantees
the caller's transaction is ended before failure bookkeeping runs.

## Tests

- `tests/web/test_background_jobs_postgres.py` (new) reproduces the incident
  end-to-end: a disposable database with
  `idle_in_transaction_session_timeout = 1s`, a handler that idles past it and
  then fails, asserting the job still reaches FAILED with the error and
  `attempts == 1`. It first asserts the timeout the application's own connection
  actually gets, so it cannot pass for the wrong reason.
- SQLite guards pin each mechanism: bookkeeping surviving a work session that can
  no longer write; a job that keeps failing stopping at `max_attempts` and
  leaving the requeue set; a cancelled job refusing the claim; the requeue
  dispatching with no transaction open; the 503 path recording FAILED with the
  caller's transaction already ended; `session_scope` not committing a read-only
  scope and not masking the original exception when rollback fails.
- New guards for this round: a successful handler's uncommitted write surviving;
  a worker-session checkout failure still reaching FAILED instead of stranding
  the row `RUNNING`; a cancel committed from a second session while the claim's
  own `UPDATE` is on its way out; an accepted `apply_async` followed by a dead
  refresh leaving the job `ENQUEUED` with its task id reconciled; and two
  requeue interleavings — a settlement during dispatch and a settlement before
  staging — neither of which is resurrected.
- New guards for review round 2: `SUCCEEDED` and the handler's writes observed
  from a second session as one commit; a killed terminal write leaving neither
  of them; a live worker's progress commit between the stale SELECT and the
  fence taking the row out of the sweep; a stale row whose `updated_at` the
  server itself stamped (second precision) still being reclaimed; and a
  rollback that itself raises on
  both the pre- and post-publication enqueue branches, neither of which may
  block the independent failure/reconciliation write.
- Each SQLite guard was checked by mutation — reverting the fix it covers turns
  exactly that test red. In particular, routing the terminal write back through
  the worker session fails the poisoned-session guard, and reverting the claim
  to read-check-write under `with_for_update()` fails the interleaving guard on
  SQLite, which pins the design invariant itself.
- The Postgres regression pins the incident's shape: reverting to upstream's
  post-commit `refresh` on the worker session turns it red with the production
  error (`server closed the connection unexpectedly`).

## CI

The Postgres file carries `pytest.mark.postgresql` (the repo convention), is
added to both path lists in `test-migrations.yml`, and gets its own step in the
Postgres job. It mints its own disposable database, so it neither depends on nor
disturbs the schema the other steps build. `ci.yml`'s fast web job runs
`-m "not slow and not postgresql"` and skips it.

Source is +421/-145; the rest of the diff is tests (~79%).

