### PR TITLE
fix(gmail): harden OAuth watch ownership lifecycle

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -115,7 +115,9 @@ If SQLite reports that an owner-aware schema name exists before migration, query
 
 ### Prerequisites and configuration
 
-This change has no new environment variable or dependency. Keep every future actor-OAuth caller disabled; this release does not expose a production path that creates actor-owned rows.
+This change has no new environment variable or dependency. Keep every future actor-OAuth caller disabled. This release does not expose a production path that creates actor-owned rows.
+
+An enabled Gmail trigger must identify its mailbox. A current trigger uses `config.oauth_account_id`. A legacy trigger can use a nonempty mailbox `resource_id`. The lifecycle marks an unbound trigger as failed and dispatches no callback event.
 
 ### Deployment and migration steps
 
@@ -129,16 +131,18 @@ Use the PostgreSQL procedure for production. Use the SQLite procedure only for l
 4. Record `PRAGMA foreign_key_check;` and `SELECT count(*) FROM gmail_watch_states;`.
 5. Run `alembic upgrade head` one time.
 6. Run both queries again. Make sure that the foreign-key result has no new row. Make sure that the watch-state count is unchanged.
-7. Verify the schema.
-8. Resume the local processes.
+7. Run the Gmail watch integrity query in the verification section. Require a zero result before you continue.
+8. Verify the schema.
+9. Resume the local processes.
 
 #### PostgreSQL production
 
 1. Pause OAuth reads and writes that access `user_oauth`, and make sure no long transaction holds a lock on the table.
-2. Run `alembic upgrade head` one time. Already-running old workers can continue non-OAuth work while the transactional DDL runs, but an old worker that starts or restarts after the schema revision advances will fail startup because it does not recognize the new revision. Prevent old-version restarts and autoscaling during this window, or ensure every replacement starts from the owner-aware image.
-3. Resume ordinary OAuth writes after the migration commits.
-4. Roll every API and task worker to the owner-aware version.
-5. Verify the schema and make sure no old worker remains before a later release enables actor-owned rows.
+2. Run `alembic upgrade head` one time. Already-running old workers can continue non-OAuth work while the transactional DDL runs. An old worker that starts after the revision advances will fail because it does not recognize the revision. Prevent old-version restarts and autoscaling during this window. Each replacement must use the owner-aware image.
+3. Run the Gmail watch integrity query in the verification section. Require a zero result before you continue.
+4. Resume ordinary OAuth writes after the migration commits.
+5. Roll every API and task worker to the owner-aware version.
+6. Verify the schema. Make sure that no old worker remains before a later release enables actor-owned rows.
 
 Do not backfill `resource_owner_key`. A null owner identifies an ordinary credential.
 
@@ -180,7 +184,9 @@ For local SQLite, run `PRAGMA index_list('user_oauth');` and `PRAGMA index_info(
 
 Run `PRAGMA foreign_key_list('user_oauth');`. Require exactly one FK on `user_id`. This FK must target `users.id` with a `CASCADE` delete action. On PostgreSQL, inspect the `user_oauth` constraints. Require the same single cascade before you enable actor-owned rows.
 
-Before restarting Gmail watch processing, run this query on either supported database:
+#### Gmail watch integrity gate
+
+The numbered deployment procedures require this query before Gmail watch processing starts. Run the query on either supported database:
 
 ```sql
 SELECT count(*)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -200,6 +200,17 @@ WHERE account.id IS NULL
 
 The result must be zero. A nonzero result identifies an orphan watch, a user mismatch, a non-Gmail account, or a non-ordinary account. Repair or remove the watch before rollout.
 
+After rollout, monitor durable cleanup retries:
+
+```sql
+SELECT count(*)
+FROM gmail_watch_states
+WHERE status = 'failed'
+  AND last_error LIKE 'Gmail watch cleanup pending:%';
+```
+
+The sweep retries these rows even when Gmail watch registration is disabled. A count that does not return to zero indicates a persistent Gmail or Pub/Sub cleanup failure.
+
 Verify existing cloud-storage, Gmail, and builtin OAuth connections. Confirm that seeded non-null-owner test rows do not appear in ordinary catalog, token, or trigger paths.
 
 ### Rollback

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -79,7 +79,7 @@ Marked tasks do not remain isolated when executed by an older worker. Keep publi
 
 ### Deployment impact
 
-The `user_oauth` table gets a nullable `resource_owner_key` column, and existing rows keep a null value. This foundation explicitly scopes non-Gmail OAuth consumers to that ordinary namespace. Gmail behavior remains unchanged here; the immediately following Gmail lifecycle release installs its complete owner boundary before any release can create actor-owned credentials.
+The `user_oauth` table gets a nullable `resource_owner_key` column, and existing rows keep a null value. The foundation explicitly scopes non-Gmail OAuth consumers to that ordinary namespace. This Gmail lifecycle release completes the Gmail owner boundary before any release can create actor-owned credentials.
 
 Two partial unique indexes replace `uq_user_provider_account`. One index protects ordinary rows. The other index separates actor-owned namespaces. Standard SQL null semantics permit duplicate identities when `provider_user_id` is null. This behavior applies to ordinary and actor-owned rows.
 
@@ -180,7 +180,21 @@ For local SQLite, run `PRAGMA index_list('user_oauth');` and `PRAGMA index_info(
 
 Run `PRAGMA foreign_key_list('user_oauth');`. Require exactly one FK on `user_id`. This FK must target `users.id` with a `CASCADE` delete action. On PostgreSQL, inspect the `user_oauth` constraints. Require the same single cascade before you enable actor-owned rows.
 
-Verify existing cloud-storage and builtin OAuth connections. Confirm that seeded non-null-owner test rows do not appear in ordinary catalog or token paths.
+Before restarting Gmail watch processing, run this query on either supported database:
+
+```sql
+SELECT count(*)
+FROM gmail_watch_states AS watch
+LEFT JOIN user_oauth AS account ON account.id = watch.oauth_account_id
+WHERE account.id IS NULL
+   OR watch.user_id <> account.user_id
+   OR account.provider <> 'gmail'
+   OR account.resource_owner_key IS NOT NULL;
+```
+
+The result must be zero. A nonzero result identifies an orphan watch, a user mismatch, a non-Gmail account, or a non-ordinary account. Repair or remove the watch before rollout.
+
+Verify existing cloud-storage, Gmail, and builtin OAuth connections. Confirm that seeded non-null-owner test rows do not appear in ordinary catalog, token, or trigger paths.
 
 ### Rollback
 

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -39,7 +39,10 @@ from ..models.user_oauth import UserOAuth
 from ..oauth_provider_quirks import requires_json_accept_header
 from ..services import gmail_provisioning
 from ..services.auth_email import send_password_reset_email
-from ..services.user_oauth import delete_scoped_user_oauth_accounts
+from ..services.user_oauth import (
+    delete_scoped_user_oauth_accounts,
+    scoped_user_oauth_query,
+)
 from ..utils.graphql_errors import graphql_errors_message, truncate_error_text
 
 logger = logging.getLogger(__name__)
@@ -2078,20 +2081,46 @@ def generic_oauth_callback(
             email = info_data.get(db_provider.email_path or "email")
 
         if user_id:
-            delete_scoped_user_oauth_accounts(
-                db,
-                user_id=user_id,
-                resource_owner_key=None,
-                providers=[app_id or provider],
-            )
+            credential_provider = app_id or provider
+            provider_user_key = str(provider_user_id) if provider_user_id else None
+            oauth_account = None
+            if credential_provider == "gmail" and provider_user_key is not None:
+                # Gmail triggers and watch cursors bind to this row's primary
+                # key. Refresh the matching mailbox in place so reconnecting
+                # one account cannot invalidate its watch or delete a sibling
+                # Gmail account connected by the same xagent user.
+                oauth_account = (
+                    scoped_user_oauth_query(
+                        db,
+                        user_id=user_id,
+                        resource_owner_key=None,
+                    )
+                    .filter(
+                        UserOAuth.provider == credential_provider,
+                        UserOAuth.provider_user_id == provider_user_key,
+                    )
+                    .one_or_none()
+                )
 
-            oauth_account = UserOAuth(
-                user_id=user_id,
-                provider=(app_id or provider),
-                resource_owner_key=None,
-                provider_user_id=str(provider_user_id) if provider_user_id else None,
-            )
-            db.add(oauth_account)
+            if oauth_account is None:
+                # Other builtin connectors retain their single-row replacement
+                # contract. A Gmail account with a new provider identity is an
+                # additional mailbox rather than a replacement for every
+                # existing Gmail connection.
+                if credential_provider != "gmail" or provider_user_key is None:
+                    delete_scoped_user_oauth_accounts(
+                        db,
+                        user_id=user_id,
+                        resource_owner_key=None,
+                        providers=[credential_provider],
+                    )
+                oauth_account = UserOAuth(
+                    user_id=user_id,
+                    provider=credential_provider,
+                    resource_owner_key=None,
+                    provider_user_id=provider_user_key,
+                )
+                db.add(oauth_account)
 
             setattr(oauth_account, "access_token", access_token)
             setattr(oauth_account, "token_type", token_data.get("token_type", "Bearer"))

--- a/src/xagent/web/api/cloud_storage.py
+++ b/src/xagent/web/api/cloud_storage.py
@@ -150,6 +150,28 @@ async def delete_connected_account(
     if not account:
         raise HTTPException(status_code=404, detail="Account not found")
 
+    if str(account.provider) == "gmail":
+        from ..services.gmail_provisioning import (
+            GmailProvisioningError,
+            request_gmail_oauth_account_deletion,
+        )
+
+        try:
+            ready_to_delete = request_gmail_oauth_account_deletion(
+                db,
+                int(account.id),
+            )
+        except GmailProvisioningError as exc:
+            raise HTTPException(status_code=409, detail=str(exc)) from exc
+        if not ready_to_delete:
+            raise HTTPException(
+                status_code=409,
+                detail=(
+                    "Gmail watch cleanup was scheduled; retry account deletion "
+                    "after cleanup completes"
+                ),
+            )
+
     db.delete(account)
     db.commit()
 

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -3469,6 +3469,69 @@ async def delete_mcp_server(
                 detail="Only a team admin can delete a team MCP server",
             )
 
+        # Legacy OAuth applications can share ordinary UserOAuth rows with
+        # Gmail trigger delivery. Team authorization runs first. When cleanup
+        # is needed, roll back hook-side mutations before committing the
+        # durable cleanup request; the user retries the disconnect afterward.
+        if server.transport == "oauth":
+            from ..mcp_apps import get_app_by_name
+
+            deletion_app = get_app_by_name(db, str(server.name))
+            if deletion_app:
+                deletion_providers = restrict_to_app_scoped_oauth_grant(
+                    deletion_app.get("id"),
+                    [deletion_app.get("provider"), deletion_app.get("id")],
+                )
+                if "gmail" in {str(value) for value in deletion_providers}:
+                    from ..models.gmail_watch import GmailWatchState
+                    from ..services.gmail_provisioning import (
+                        GmailProvisioningError,
+                        request_gmail_oauth_accounts_deletion,
+                    )
+
+                    gmail_account_ids = [
+                        int(account.id)
+                        for account in list_scoped_user_oauth_accounts(
+                            db,
+                            user_id=int(user_id),
+                            resource_owner_key=None,
+                        )
+                        if str(account.provider) == "gmail"
+                    ]
+                    has_watch_state = bool(gmail_account_ids) and (
+                        db.query(GmailWatchState.id)
+                        .filter(GmailWatchState.oauth_account_id.in_(gmail_account_ids))
+                        .first()
+                        is not None
+                    )
+                    if has_watch_state:
+                        db.rollback()
+                        try:
+                            cleanup_scheduled = not (
+                                request_gmail_oauth_accounts_deletion(
+                                    db,
+                                    gmail_account_ids,
+                                )
+                            )
+                        except GmailProvisioningError as exc:
+                            raise HTTPException(
+                                status_code=409, detail=str(exc)
+                            ) from exc
+                        if cleanup_scheduled:
+                            raise HTTPException(
+                                status_code=409,
+                                detail=(
+                                    "Gmail watch cleanup was scheduled; retry MCP "
+                                    "disconnection after cleanup completes"
+                                ),
+                            )
+                        raise HTTPException(
+                            status_code=409,
+                            detail=(
+                                "Gmail cleanup state changed; retry MCP disconnection"
+                            ),
+                        )
+
         # If it's an OAuth server, also delete the corresponding OAuth tokens
         if server.transport == "oauth":
             from ..mcp_apps import get_app_by_name

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -339,12 +339,15 @@ async def _run_trigger_dispatcher(
                                 "Trigger dispatcher renewed %s Gmail watch(es)",
                                 renewed,
                             )
-                        swept = await asyncio.to_thread(_sweep_gmail_provisioning_tick)
-                        if swept:
-                            logger.info(
-                                "Trigger dispatcher retried %s Gmail registration(s)",
-                                swept,
-                            )
+                    # Cleanup must keep running when registration is disabled;
+                    # the sweep gates only its registration phase internally.
+                    swept = await asyncio.to_thread(_sweep_gmail_provisioning_tick)
+                    if swept:
+                        logger.info(
+                            "Trigger dispatcher processed %s Gmail watch "
+                            "recovery attempt(s)",
+                            swept,
+                        )
                 finally:
                     next_gmail_watch_scan_at = (
                         now + get_gmail_watch_renewal_interval_seconds()

--- a/src/xagent/web/models/gmail_watch.py
+++ b/src/xagent/web/models/gmail_watch.py
@@ -41,7 +41,18 @@ class GmailWatchState(Base):  # type: ignore
     )
 
     user = relationship("User")
-    oauth_account = relationship("UserOAuth")
+    oauth_account = relationship(
+        "UserOAuth",
+        primaryjoin=(
+            "and_(GmailWatchState.oauth_account_id == UserOAuth.id, "
+            "foreign(GmailWatchState.user_id) == UserOAuth.user_id, "
+            "UserOAuth.resource_owner_key.is_(None))"
+        ),
+        foreign_keys="[GmailWatchState.oauth_account_id, GmailWatchState.user_id]",
+        # Gmail consumers mutate accounts through owner-scoped services. Keep
+        # this convenience relationship read-only so it cannot widen writes.
+        viewonly=True,
+    )
 
     def __repr__(self) -> str:
         return (

--- a/src/xagent/web/models/gmail_watch.py
+++ b/src/xagent/web/models/gmail_watch.py
@@ -46,6 +46,7 @@ class GmailWatchState(Base):  # type: ignore
         primaryjoin=(
             "and_(GmailWatchState.oauth_account_id == UserOAuth.id, "
             "foreign(GmailWatchState.user_id) == UserOAuth.user_id, "
+            "UserOAuth.provider == 'gmail', "
             "UserOAuth.resource_owner_key.is_(None))"
         ),
         foreign_keys="[GmailWatchState.oauth_account_id, GmailWatchState.user_id]",

--- a/src/xagent/web/services/gmail_provisioning.py
+++ b/src/xagent/web/services/gmail_provisioning.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Iterator
 
-from sqlalchemy import String
+from sqlalchemy import String, and_
 from sqlalchemy import cast as sql_cast
 from sqlalchemy import func, or_, text
 from sqlalchemy.exc import IntegrityError
@@ -820,9 +820,18 @@ def reconcile_gmail_push_endpoints(
                 GmailWatchState.subscription_name,
                 GmailWatchState.push_audience,
             )
+            .join(
+                UserOAuth,
+                and_(
+                    UserOAuth.id == GmailWatchState.oauth_account_id,
+                    UserOAuth.user_id == GmailWatchState.user_id,
+                ),
+            )
             .filter(
                 GmailWatchState.status == TriggerProvisioningStatus.ACTIVE.value,
                 GmailWatchState.id > last_state_id,
+                UserOAuth.provider == "gmail",
+                user_oauth_owner_clause(None),
             )
             .order_by(GmailWatchState.id.asc())
             .limit(page_size)
@@ -939,6 +948,10 @@ def ensure_gmail_mailbox_provisioned(
         raise GmailProvisioningError(
             "actor-owned OAuth credentials cannot provision Gmail watches"
         )
+    if str(oauth_account.provider) != "gmail":
+        raise GmailProvisioningError(
+            "Gmail watch provisioning requires an ordinary Gmail OAuth account"
+        )
     oauth_account_id = int(oauth_account.id)
     oauth_account_user_id = int(oauth_account.user_id)
     with _gmail_watch_transition_lock(db, oauth_account_id) as transition_db:
@@ -950,6 +963,7 @@ def ensure_gmail_mailbox_provisioned(
                 user_id=oauth_account_user_id,
                 account_id=oauth_account_id,
                 resource_owner_key=None,
+                provider="gmail",
             )
         )
         if transition_account is None:
@@ -1061,6 +1075,7 @@ def _provision_in_fresh_session(oauth_account_id: int) -> None:
             db,
             account_id=oauth_account_id,
             resource_owner_key=None,
+            provider="gmail",
         )
         if oauth_account is None:
             logger.warning(
@@ -1093,6 +1108,7 @@ def _watch_state_for_owned_trigger(
         user_id=int(trigger.user_id),
         account_id=oauth_account_id,
         resource_owner_key=None,
+        provider="gmail",
     )
     if account is not None and (
         state is None or int(state.user_id) == int(trigger.user_id)
@@ -1242,7 +1258,6 @@ def reconcile_gmail_trigger_provisioning(
                 for trigger in triggers
                 if str(trigger.type) == TriggerType.GMAIL.value
                 and bool(trigger.enabled)
-                and trigger.resource_id
             ],
         )
 
@@ -1255,7 +1270,6 @@ def reconcile_gmail_trigger_provisioning(
             .filter(
                 AgentTrigger.type == TriggerType.GMAIL.value,
                 AgentTrigger.enabled.is_(True),
-                AgentTrigger.resource_id.isnot(None),
                 AgentTrigger.id > last_id,
             )
             .order_by(AgentTrigger.id.asc())
@@ -1307,7 +1321,9 @@ def _reconcile_gmail_trigger_batch(
         if bound_account_id is not None:
             account_ids.add(bound_account_id)
         else:
-            emails.add(str(trigger.resource_id).strip().lower())
+            email = str(trigger.resource_id or "").strip().lower()
+            if email:
+                emails.add(email)
 
     filters = []
     if account_ids:
@@ -1328,6 +1344,7 @@ def _reconcile_gmail_trigger_batch(
             db.query(UserOAuth.id, UserOAuth.user_id)
             .filter(
                 UserOAuth.id.in_(state_account_ids),
+                UserOAuth.provider == "gmail",
                 user_oauth_owner_clause(None),
             )
             .all()
@@ -1339,13 +1356,23 @@ def _reconcile_gmail_trigger_batch(
     updated = 0
     for trigger in candidates:
         bound_account_id = _bound_gmail_oauth_account_id(trigger)
+        resource_email = str(trigger.resource_id or "").strip().lower()
+        configuration_error: str | None = None
         if bound_account_id is not None:
             state = states_by_account_id.get(bound_account_id)
-        else:
-            key = (int(trigger.user_id), str(trigger.resource_id).strip().lower())
+        elif resource_email:
+            key = (int(trigger.user_id), resource_email)
             state = states_by_key.get(key)
+        else:
+            state = None
+            configuration_error = (
+                "Gmail trigger has no OAuth account or mailbox binding"
+            )
         error: str | None
-        if state is None:
+        if configuration_error is not None:
+            status = TriggerProvisioningStatus.FAILED.value
+            error = configuration_error
+        elif state is None:
             if get_gmail_watch_enabled():
                 continue
             status = TriggerProvisioningStatus.FAILED.value
@@ -1413,6 +1440,7 @@ def release_gmail_mailbox_if_unused(
         user_id=int(state.user_id),
         account_id=int(oauth_account_id),
         resource_owner_key=None,
+        provider="gmail",
     )
     if oauth_account is not None:
         try:
@@ -1495,17 +1523,68 @@ def sweep_gmail_provisioning(
 
     scan_time = now or _now()
     stale_before = scan_time - timedelta(seconds=stale_pending_seconds)
-    candidates = (
+    batch_size = max(1, min(limit, 500))
+    retryable = or_(
+        GmailWatchState.status == TriggerProvisioningStatus.FAILED.value,
+        and_(
+            GmailWatchState.status == TriggerProvisioningStatus.PENDING.value,
+            GmailWatchState.updated_at <= stale_before,
+        ),
+    )
+    unrecorded_mismatch = or_(
+        GmailWatchState.status.is_(None),
+        GmailWatchState.status != TriggerProvisioningStatus.FAILED.value,
+        GmailWatchState.last_error.is_(None),
+        ~GmailWatchState.last_error.like("Gmail watch OAuth ownership mismatch:%"),
+    )
+    mismatches = (
         db.query(GmailWatchState)
+        .outerjoin(UserOAuth, UserOAuth.id == GmailWatchState.oauth_account_id)
         .filter(
-            (GmailWatchState.status == TriggerProvisioningStatus.FAILED.value)
-            | (
-                (GmailWatchState.status == TriggerProvisioningStatus.PENDING.value)
-                & (GmailWatchState.updated_at <= stale_before)
-            )
+            retryable,
+            unrecorded_mismatch,
+            or_(
+                UserOAuth.id.is_(None),
+                UserOAuth.user_id != GmailWatchState.user_id,
+                UserOAuth.provider != "gmail",
+                UserOAuth.resource_owner_key.is_not(None),
+            ),
         )
-        .order_by(GmailWatchState.updated_at.asc())
-        .limit(max(1, min(limit, 500)))
+        .order_by(GmailWatchState.updated_at.asc(), GmailWatchState.id.asc())
+        .limit(batch_size)
+        .all()
+    )
+    for state in mismatches:
+        logger.warning(
+            "Skipping Gmail provisioning sweep for watch state %s: OAuth "
+            "account %s is missing or not ordinary Gmail for user %s",
+            state.id,
+            state.oauth_account_id,
+            state.user_id,
+        )
+        detail = register_gmail_watch_ownership_mismatch(state)
+        setattr(state, "status", TriggerProvisioningStatus.FAILED.value)
+        setattr(state, "last_error", detail)
+        db.add(state)
+    if mismatches:
+        db.commit()
+
+    candidates = (
+        db.query(GmailWatchState, UserOAuth)
+        .join(
+            UserOAuth,
+            and_(
+                UserOAuth.id == GmailWatchState.oauth_account_id,
+                UserOAuth.user_id == GmailWatchState.user_id,
+            ),
+        )
+        .filter(
+            retryable,
+            UserOAuth.provider == "gmail",
+            user_oauth_owner_clause(None),
+        )
+        .order_by(GmailWatchState.updated_at.asc(), GmailWatchState.id.asc())
+        .limit(batch_size)
         .all()
     )
     referenced_account_ids = _referenced_gmail_oauth_account_ids(
@@ -1516,33 +1595,13 @@ def sweep_gmail_provisioning(
                 int(state.user_id),
                 str(state.email or ""),
             )
-            for state in candidates
+            for state, _account in candidates
         ],
     )
 
     attempts = 0
-    for state in candidates:
+    for state, oauth_account in candidates:
         if int(state.oauth_account_id) not in referenced_account_ids:
-            continue
-        oauth_account = get_scoped_user_oauth_account(
-            db,
-            user_id=int(state.user_id),
-            account_id=int(state.oauth_account_id),
-            resource_owner_key=None,
-        )
-        if oauth_account is None:
-            logger.warning(
-                "Skipping Gmail provisioning sweep for watch state %s: OAuth "
-                "account %s is missing or not ordinary for user %s",
-                state.id,
-                state.oauth_account_id,
-                state.user_id,
-            )
-            register_degradation(
-                GMAIL_OAUTH_OWNERSHIP_MISMATCH,
-                f"Gmail watch state {state.id} cannot resolve ordinary OAuth "
-                f"account {state.oauth_account_id} for user {state.user_id}",
-            )
             continue
         ensure_gmail_mailbox_provisioned(
             db,

--- a/src/xagent/web/services/gmail_provisioning.py
+++ b/src/xagent/web/services/gmail_provisioning.py
@@ -45,7 +45,17 @@ from ..models.trigger import (
     TriggerType,
 )
 from ..models.user_oauth import UserOAuth
+from .ops_signals import (
+    GMAIL_OAUTH_OWNERSHIP_MISMATCH,
+    register_degradation,
+)
 from .time_utils import coerce_utc as _coerce_utc
+from .user_oauth import (
+    get_scoped_user_oauth_account,
+    get_user_oauth_account_by_id,
+    scoped_user_oauth_query,
+    user_oauth_owner_clause,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +93,23 @@ def gmail_watch_disabled_error() -> str:
 
 class GmailProvisioningError(RuntimeError):
     """Raised when per-mailbox Gmail provisioning cannot proceed."""
+
+
+def gmail_watch_ownership_mismatch_error(state: GmailWatchState) -> str:
+    """Describe a watch row that cannot resolve its exact ordinary owner."""
+    return (
+        "Gmail watch OAuth ownership mismatch: state "
+        f"{state.id} cannot resolve ordinary account {state.oauth_account_id} "
+        f"for user {state.user_id}"
+    )
+
+
+def register_gmail_watch_ownership_mismatch(state: GmailWatchState) -> str:
+    """Expose an invalid watch/account relationship without changing the row."""
+    detail = gmail_watch_ownership_mismatch_error(state)
+    logger.warning(detail)
+    register_degradation(GMAIL_OAUTH_OWNERSHIP_MISMATCH, detail)
+    return detail
 
 
 @contextmanager
@@ -321,7 +348,7 @@ def _coerce_oauth_account_id(value: Any) -> int | None:
 
 def _referenced_gmail_oauth_account_ids(
     db: Session,
-    accounts: Sequence[tuple[int, str]],
+    accounts: Sequence[tuple[int, int, str]],
 ) -> set[int]:
     """Resolve enabled Gmail trigger bindings for a bounded account batch.
 
@@ -330,12 +357,18 @@ def _referenced_gmail_oauth_account_ids(
     account binding exists; this preserves the explicit choice when multiple
     OAuth accounts share one email address.
     """
-    account_ids = {int(account_id) for account_id, _email in accounts}
-    account_ids_by_email: dict[str, set[int]] = {}
-    for account_id, raw_email in accounts:
+    account_users = {
+        int(account_id): int(user_id) for account_id, user_id, _email in accounts
+    }
+    account_ids = set(account_users)
+    account_ids_by_owner_email: dict[tuple[int, str], set[int]] = {}
+    for account_id, user_id, raw_email in accounts:
         email = str(raw_email or "").strip().lower()
         if email:
-            account_ids_by_email.setdefault(email, set()).add(int(account_id))
+            account_ids_by_owner_email.setdefault(
+                (int(user_id), email),
+                set(),
+            ).add(int(account_id))
     if not account_ids:
         return set()
 
@@ -348,29 +381,41 @@ def _referenced_gmail_oauth_account_ids(
     # fails there while passing on SQLite. Duplicate rows are harmless because
     # the loop below accumulates into a set.
     candidate_rows = (
-        db.query(AgentTrigger.config, AgentTrigger.resource_id)
+        db.query(
+            AgentTrigger.user_id,
+            AgentTrigger.config,
+            AgentTrigger.resource_id,
+        )
         .filter(
             AgentTrigger.type == TriggerType.GMAIL.value,
             AgentTrigger.enabled.is_(True),
             or_(
                 binding_text.in_({str(account_id) for account_id in account_ids}),
-                func.lower(AgentTrigger.resource_id).in_(account_ids_by_email),
+                func.lower(AgentTrigger.resource_id).in_(
+                    {email for _user_id, email in account_ids_by_owner_email}
+                ),
             ),
         )
         .all()
     )
 
     referenced: set[int] = set()
-    for raw_config, raw_resource_id in candidate_rows:
+    for trigger_user_id, raw_config, raw_resource_id in candidate_rows:
         config = raw_config if isinstance(raw_config, dict) else {}
         bound_account_id = _coerce_oauth_account_id(config.get("oauth_account_id"))
         if bound_account_id in account_ids:
-            referenced.add(bound_account_id)
+            if account_users[bound_account_id] == int(trigger_user_id):
+                referenced.add(bound_account_id)
             continue
         if bound_account_id is not None:
             continue
         resource_id = str(raw_resource_id or "").strip().lower()
-        referenced.update(account_ids_by_email.get(resource_id, ()))
+        referenced.update(
+            account_ids_by_owner_email.get(
+                (int(trigger_user_id), resource_id),
+                (),
+            )
+        )
     return referenced
 
 
@@ -405,6 +450,8 @@ def _get_or_create_watch_state(
             topic_name="",
         )
         db.add(state)
+    elif int(state.user_id) != int(oauth_account.user_id):
+        raise GmailProvisioningError(register_gmail_watch_ownership_mismatch(state))
     mark_pending(state)
     try:
         db.commit()
@@ -418,6 +465,8 @@ def _get_or_create_watch_state(
         if adopted is None:  # pragma: no cover - row deleted between retries
             raise
         state = adopted
+        if int(state.user_id) != int(oauth_account.user_id):
+            raise GmailProvisioningError(register_gmail_watch_ownership_mismatch(state))
         mark_pending(state)
         db.commit()
     db.refresh(state)
@@ -765,6 +814,7 @@ def reconcile_gmail_push_endpoints(
             db.query(
                 GmailWatchState.id,
                 GmailWatchState.oauth_account_id,
+                GmailWatchState.user_id,
                 GmailWatchState.email,
                 GmailWatchState.callback_id,
                 GmailWatchState.subscription_name,
@@ -783,12 +833,20 @@ def reconcile_gmail_push_endpoints(
         last_state_id = int(state_rows[-1].id)
         referenced_account_ids = _referenced_gmail_oauth_account_ids(
             db,
-            [(int(row.oauth_account_id), str(row.email or "")) for row in state_rows],
+            [
+                (
+                    int(row.oauth_account_id),
+                    int(row.user_id),
+                    str(row.email or ""),
+                )
+                for row in state_rows
+            ],
         )
 
         for (
             state_id,
             oauth_account_id,
+            _state_user_id,
             raw_email,
             raw_callback_id,
             raw_subscription_name,
@@ -871,20 +929,31 @@ def ensure_gmail_mailbox_provisioned(
     publisher_factory: PublisherFactory | None = None,
     subscriber_factory: SubscriberFactory | None = None,
 ) -> GmailWatchState:
-    """Idempotently provision Pub/Sub resources and a Gmail watch for a mailbox.
+    """Idempotently provision Pub/Sub resources for one ordinary mailbox.
 
-    Never raises for provisioning failures: the watch state converges to
-    failed with a clear last_error, and later reconcile attempts retry.
+    Actor-owned credentials are execution-only and cannot create machine-user
+    Gmail triggers. Other provisioning failures converge to a failed watch
+    state for later reconciliation.
     """
+    if oauth_account.resource_owner_key is not None:
+        raise GmailProvisioningError(
+            "actor-owned OAuth credentials cannot provision Gmail watches"
+        )
     oauth_account_id = int(oauth_account.id)
+    oauth_account_user_id = int(oauth_account.user_id)
     with _gmail_watch_transition_lock(db, oauth_account_id) as transition_db:
         transition_account = (
             oauth_account
             if transition_db is db
-            else transition_db.query(UserOAuth)
-            .filter(UserOAuth.id == oauth_account_id)
-            .one()
+            else get_scoped_user_oauth_account(
+                transition_db,
+                user_id=oauth_account_user_id,
+                account_id=oauth_account_id,
+                resource_owner_key=None,
+            )
         )
+        if transition_account is None:
+            raise GmailProvisioningError("ordinary Gmail OAuth account not found")
         state = _ensure_gmail_mailbox_provisioned_locked(
             transition_db,
             transition_account,
@@ -988,10 +1057,16 @@ def _provision_in_fresh_session(oauth_account_id: int) -> None:
 
     db = get_session_local()()
     try:
-        oauth_account = (
-            db.query(UserOAuth).filter(UserOAuth.id == oauth_account_id).first()
+        oauth_account = get_user_oauth_account_by_id(
+            db,
+            account_id=oauth_account_id,
+            resource_owner_key=None,
         )
         if oauth_account is None:
+            logger.warning(
+                "Cannot provision Gmail watch without ordinary OAuth account %s",
+                oauth_account_id,
+            )
             return
         ensure_gmail_mailbox_provisioned(db, oauth_account)
     except Exception:
@@ -1000,6 +1075,40 @@ def _provision_in_fresh_session(oauth_account_id: int) -> None:
         )
     finally:
         db.close()
+
+
+def _watch_state_for_owned_trigger(
+    db: Session,
+    trigger: AgentTrigger,
+    oauth_account_id: int,
+) -> tuple[GmailWatchState | None, str | None]:
+    """Resolve a watch only when its account and trigger have one owner."""
+    state = (
+        db.query(GmailWatchState)
+        .filter(GmailWatchState.oauth_account_id == oauth_account_id)
+        .first()
+    )
+    account = get_scoped_user_oauth_account(
+        db,
+        user_id=int(trigger.user_id),
+        account_id=oauth_account_id,
+        resource_owner_key=None,
+    )
+    if account is not None and (
+        state is None or int(state.user_id) == int(trigger.user_id)
+    ):
+        return state, None
+    if state is not None:
+        return state, register_gmail_watch_ownership_mismatch(state)
+
+    detail = (
+        "Gmail watch OAuth ownership mismatch: trigger "
+        f"{trigger.id} cannot resolve ordinary account {oauth_account_id} "
+        f"for user {trigger.user_id}"
+    )
+    logger.warning(detail)
+    register_degradation(GMAIL_OAUTH_OWNERSHIP_MISMATCH, detail)
+    return None, detail
 
 
 def provision_gmail_trigger(
@@ -1035,12 +1144,21 @@ def provision_gmail_trigger(
         db.commit()
         return status
 
+    state, ownership_error = _watch_state_for_owned_trigger(
+        db,
+        trigger,
+        int(oauth_account_id),
+    )
+    if ownership_error is not None:
+        status = TriggerProvisioningStatus.FAILED.value
+        setattr(trigger, "provisioning_status", status)
+        setattr(trigger, "provisioning_error", ownership_error)
+        db.add(trigger)
+        db.commit()
+        db.refresh(trigger)
+        return status
+
     if not get_gmail_watch_enabled():
-        state = (
-            db.query(GmailWatchState)
-            .filter(GmailWatchState.oauth_account_id == int(oauth_account_id))
-            .first()
-        )
         if state is None:
             status = TriggerProvisioningStatus.FAILED.value
             error: str | None = gmail_watch_disabled_error()
@@ -1075,12 +1193,15 @@ def provision_gmail_trigger(
     thread.join(timeout)
 
     db.expire_all()
-    state = (
-        db.query(GmailWatchState)
-        .filter(GmailWatchState.oauth_account_id == int(oauth_account_id))
-        .first()
+    state, ownership_error = _watch_state_for_owned_trigger(
+        db,
+        trigger,
+        int(oauth_account_id),
     )
-    if thread.is_alive() or state is None:
+    if ownership_error is not None:
+        status = TriggerProvisioningStatus.FAILED.value
+        error = ownership_error
+    elif thread.is_alive() or state is None:
         status = TriggerProvisioningStatus.PENDING.value
         error = None
     else:
@@ -1200,6 +1321,20 @@ def _reconcile_gmail_trigger_batch(
         (int(state.user_id), str(state.email or "").strip().lower()): state
         for state in states
     }
+    state_account_ids = {int(state.oauth_account_id) for state in states}
+    ordinary_account_users = {
+        int(account_id): int(user_id)
+        for account_id, user_id in (
+            db.query(UserOAuth.id, UserOAuth.user_id)
+            .filter(
+                UserOAuth.id.in_(state_account_ids),
+                user_oauth_owner_clause(None),
+            )
+            .all()
+            if state_account_ids
+            else ()
+        )
+    }
 
     updated = 0
     for trigger in candidates:
@@ -1215,6 +1350,11 @@ def _reconcile_gmail_trigger_batch(
                 continue
             status = TriggerProvisioningStatus.FAILED.value
             error = gmail_watch_disabled_error()
+        elif ordinary_account_users.get(int(state.oauth_account_id)) != int(
+            state.user_id
+        ) or int(state.user_id) != int(trigger.user_id):
+            status = TriggerProvisioningStatus.FAILED.value
+            error = register_gmail_watch_ownership_mismatch(state)
         else:
             status, error = _trigger_facing_status(state)
         if (
@@ -1260,21 +1400,19 @@ def release_gmail_mailbox_if_unused(
         return False
 
     email = str(state.email or "").strip().lower()
-    remaining = (
-        db.query(AgentTrigger.id)
-        .filter(
-            AgentTrigger.type == TriggerType.GMAIL.value,
-            AgentTrigger.enabled.is_(True),
-            func.lower(AgentTrigger.resource_id) == email,
-        )
-        .count()
+    is_referenced = int(oauth_account_id) in _referenced_gmail_oauth_account_ids(
+        db,
+        [(int(oauth_account_id), int(state.user_id), email)],
     )
-    if remaining > 0:
+    if is_referenced:
         db.commit()
         return False
 
-    oauth_account = (
-        db.query(UserOAuth).filter(UserOAuth.id == int(oauth_account_id)).first()
+    oauth_account = get_scoped_user_oauth_account(
+        db,
+        user_id=int(state.user_id),
+        account_id=int(oauth_account_id),
+        resource_owner_key=None,
     )
     if oauth_account is not None:
         try:
@@ -1282,6 +1420,28 @@ def release_gmail_mailbox_if_unused(
             service.users().stop(userId="me").execute()
         except Exception as exc:
             logger.warning("Failed to stop Gmail watch for %s: %s", email, exc)
+            # Keep every cleanup handle so a later release attempt can retry
+            # the remote stop before deleting local or Pub/Sub resources.
+            db.commit()
+            return False
+    else:
+        logger.warning(
+            "Cannot stop Gmail watch for state %s: OAuth account %s is missing "
+            "or not ordinary for user %s",
+            state.id,
+            oauth_account_id,
+            state.user_id,
+        )
+        register_degradation(
+            GMAIL_OAUTH_OWNERSHIP_MISMATCH,
+            f"Gmail watch state {state.id} cannot resolve ordinary OAuth "
+            f"account {oauth_account_id} for user {state.user_id}",
+        )
+        # Preserve every cleanup handle until an operator repairs the owner
+        # mismatch. Deleting Pub/Sub resources or this row while Gmail stop()
+        # was impossible would orphan the remote watch permanently.
+        db.commit()
+        return False
 
     project_id = get_gmail_pubsub_project_id()
     if project_id:
@@ -1350,19 +1510,39 @@ def sweep_gmail_provisioning(
     )
     referenced_account_ids = _referenced_gmail_oauth_account_ids(
         db,
-        [(int(state.oauth_account_id), str(state.email or "")) for state in candidates],
+        [
+            (
+                int(state.oauth_account_id),
+                int(state.user_id),
+                str(state.email or ""),
+            )
+            for state in candidates
+        ],
     )
 
     attempts = 0
     for state in candidates:
         if int(state.oauth_account_id) not in referenced_account_ids:
             continue
-        oauth_account = (
-            db.query(UserOAuth)
-            .filter(UserOAuth.id == int(state.oauth_account_id))
-            .first()
+        oauth_account = get_scoped_user_oauth_account(
+            db,
+            user_id=int(state.user_id),
+            account_id=int(state.oauth_account_id),
+            resource_owner_key=None,
         )
         if oauth_account is None:
+            logger.warning(
+                "Skipping Gmail provisioning sweep for watch state %s: OAuth "
+                "account %s is missing or not ordinary for user %s",
+                state.id,
+                state.oauth_account_id,
+                state.user_id,
+            )
+            register_degradation(
+                GMAIL_OAUTH_OWNERSHIP_MISMATCH,
+                f"Gmail watch state {state.id} cannot resolve ordinary OAuth "
+                f"account {state.oauth_account_id} for user {state.user_id}",
+            )
             continue
         ensure_gmail_mailbox_provisioned(
             db,
@@ -1419,13 +1599,24 @@ def best_effort_provision_gmail_watches_for_user(
     # this function share the ``XAGENT_GMAIL_WATCH_ENABLED`` gate.
     try:
         accounts = (
-            db.query(UserOAuth)
-            .filter(UserOAuth.user_id == int(user_id), UserOAuth.provider == "gmail")
+            scoped_user_oauth_query(
+                db,
+                user_id=int(user_id),
+                resource_owner_key=None,
+            )
+            .filter(UserOAuth.provider == "gmail")
             .all()
         )
         referenced_account_ids = _referenced_gmail_oauth_account_ids(
             db,
-            [(int(account.id), str(account.email or "")) for account in accounts],
+            [
+                (
+                    int(account.id),
+                    int(account.user_id),
+                    str(account.email or ""),
+                )
+                for account in accounts
+            ],
         )
     except Exception as exc:
         db.rollback()

--- a/src/xagent/web/services/gmail_provisioning.py
+++ b/src/xagent/web/services/gmail_provisioning.py
@@ -76,6 +76,7 @@ GMAIL_WATCH_DISABLED_ERROR = (
     "Gmail watch registration is disabled "
     "(set XAGENT_GMAIL_WATCH_ENABLED=true to enable)"
 )
+GMAIL_WATCH_CLEANUP_PENDING_PREFIX = "Gmail watch cleanup pending:"
 
 
 def gmail_watch_disabled_error() -> str:
@@ -1447,11 +1448,21 @@ def release_gmail_mailbox_if_unused(
             service = service_factory(db, oauth_account)
             service.users().stop(userId="me").execute()
         except Exception as exc:
-            logger.warning("Failed to stop Gmail watch for %s: %s", email, exc)
-            # Keep every cleanup handle so a later release attempt can retry
-            # the remote stop before deleting local or Pub/Sub resources.
-            db.commit()
-            return False
+            if _is_not_found(exc):
+                logger.info("Gmail watch for %s was already stopped", email)
+            else:
+                logger.warning("Failed to stop Gmail watch for %s: %s", email, exc)
+                # Keep every cleanup handle and a durable retry marker so the
+                # periodic sweep can resume teardown after a process restart.
+                setattr(state, "status", TriggerProvisioningStatus.FAILED.value)
+                setattr(
+                    state,
+                    "last_error",
+                    f"{GMAIL_WATCH_CLEANUP_PENDING_PREFIX} Gmail stop failed: {exc}",
+                )
+                db.add(state)
+                db.commit()
+                return False
     else:
         logger.warning(
             "Cannot stop Gmail watch for state %s: OAuth account %s is missing "
@@ -1471,6 +1482,7 @@ def release_gmail_mailbox_if_unused(
         db.commit()
         return False
 
+    cleanup_errors: list[str] = []
     project_id = get_gmail_pubsub_project_id()
     if project_id:
         subscription_path = str(
@@ -1486,11 +1498,24 @@ def release_gmail_mailbox_if_unused(
                 logger.warning(
                     "Failed to delete subscription %s: %s", subscription_path, exc
                 )
+                cleanup_errors.append(f"subscription deletion failed: {exc}")
         try:
             publisher_factory().delete_topic(request={"topic": topic_path})
         except Exception as exc:
             if not _is_not_found(exc):
                 logger.warning("Failed to delete topic %s: %s", topic_path, exc)
+                cleanup_errors.append(f"topic deletion failed: {exc}")
+
+    if cleanup_errors:
+        setattr(state, "status", TriggerProvisioningStatus.FAILED.value)
+        setattr(
+            state,
+            "last_error",
+            f"{GMAIL_WATCH_CLEANUP_PENDING_PREFIX} {'; '.join(cleanup_errors)}",
+        )
+        db.add(state)
+        db.commit()
+        return False
 
     db.delete(state)
     db.commit()
@@ -1507,23 +1532,43 @@ def sweep_gmail_provisioning(
     publisher_factory: PublisherFactory | None = None,
     subscriber_factory: SubscriberFactory | None = None,
 ) -> int:
-    """Retry stale pending and failed Gmail registrations.
+    """Retry durable Gmail cleanup and registration work.
 
-    Only mailboxes still referenced by an enabled Gmail trigger are retried.
-    Returns the number of registration attempts. Registration retries are
-    gated on ``XAGENT_GMAIL_WATCH_ENABLED`` (like the renewal scan), so this
-    function re-registers nothing while the feature is switched off.
-    Trigger-status reconciliation runs either way, though: it does not touch
-    the cloud, and skipping it while disabled would leave disabled/expired
-    statuses frozen instead of observable through the trigger API.
+    Cleanup retries run even when watch registration is disabled because they
+    remove delivery resources rather than create them. Registration retries
+    remain gated on ``XAGENT_GMAIL_WATCH_ENABLED`` and cover only mailboxes
+    referenced by enabled Gmail triggers. Returns the total recovery attempts.
+    Trigger-status reconciliation runs either way so disabled or expired
+    states remain observable through the trigger API.
     """
+    batch_size = max(1, min(limit, 500))
+    cleanup_candidates = (
+        db.query(GmailWatchState.oauth_account_id)
+        .filter(
+            GmailWatchState.status == TriggerProvisioningStatus.FAILED.value,
+            GmailWatchState.last_error.like(f"{GMAIL_WATCH_CLEANUP_PENDING_PREFIX}%"),
+        )
+        .order_by(GmailWatchState.updated_at.asc(), GmailWatchState.id.asc())
+        .limit(batch_size)
+        .all()
+    )
+    cleanup_attempts = 0
+    for (oauth_account_id,) in cleanup_candidates:
+        release_gmail_mailbox_if_unused(
+            db,
+            int(oauth_account_id),
+            service_factory=service_factory,
+            publisher_factory=publisher_factory,
+            subscriber_factory=subscriber_factory,
+        )
+        cleanup_attempts += 1
+
     if not get_gmail_watch_enabled():
-        reconcile_gmail_trigger_provisioning(db, batch_size=max(1, min(limit, 500)))
-        return 0
+        reconcile_gmail_trigger_provisioning(db, batch_size=batch_size)
+        return cleanup_attempts
 
     scan_time = now or _now()
     stale_before = scan_time - timedelta(seconds=stale_pending_seconds)
-    batch_size = max(1, min(limit, 500))
     retryable = or_(
         GmailWatchState.status == TriggerProvisioningStatus.FAILED.value,
         and_(
@@ -1615,7 +1660,7 @@ def sweep_gmail_provisioning(
     # are not sweep candidates, so the trigger-facing status is reconciled
     # here unconditionally, paged by the sweep's own limit.
     reconcile_gmail_trigger_provisioning(db, batch_size=max(1, min(limit, 500)))
-    return attempts
+    return cleanup_attempts + attempts
 
 
 def best_effort_provision_gmail_watches_for_user(

--- a/src/xagent/web/services/gmail_provisioning.py
+++ b/src/xagent/web/services/gmail_provisioning.py
@@ -1414,6 +1414,65 @@ def _reconcile_gmail_trigger_batch(
     return updated
 
 
+def request_gmail_oauth_accounts_deletion(
+    db: Session,
+    oauth_account_ids: Sequence[int],
+) -> bool:
+    """Retain OAuth accounts until all unreferenced watches are cleaned up.
+
+    Returns ``True`` when no watch state remains and the caller may delete the
+    accounts. Otherwise, first verifies that none of the selected watches is
+    referenced, then marks every selected state for the scheduled cleanup sweep
+    in one transaction and returns ``False``.
+    """
+    account_ids = tuple(dict.fromkeys(int(value) for value in oauth_account_ids))
+    if not account_ids:
+        return True
+    states = (
+        db.query(GmailWatchState)
+        .filter(GmailWatchState.oauth_account_id.in_(account_ids))
+        .with_for_update()
+        .all()
+    )
+    if not states:
+        return True
+
+    referenced_ids = _referenced_gmail_oauth_account_ids(
+        db,
+        [
+            (
+                int(state.oauth_account_id),
+                int(state.user_id),
+                str(state.email or "").strip().lower(),
+            )
+            for state in states
+        ],
+    )
+    if referenced_ids:
+        raise GmailProvisioningError(
+            "Remove or disable this account's Gmail triggers before disconnecting it"
+        )
+
+    for state in states:
+        setattr(state, "status", TriggerProvisioningStatus.FAILED.value)
+        setattr(
+            state,
+            "last_error",
+            f"{GMAIL_WATCH_CLEANUP_PENDING_PREFIX} OAuth account deletion requested",
+        )
+        db.add(state)
+    db.commit()
+    return False
+
+
+def request_gmail_oauth_account_deletion(
+    db: Session,
+    oauth_account_id: int,
+) -> bool:
+    """Request durable cleanup for one ordinary Gmail OAuth account."""
+    return request_gmail_oauth_accounts_deletion(db, [oauth_account_id])
+
+
 def release_gmail_mailbox_if_unused(
     db: Session,
     oauth_account_id: int,

--- a/src/xagent/web/services/gmail_provisioning.py
+++ b/src/xagent/web/services/gmail_provisioning.py
@@ -304,12 +304,27 @@ def _is_already_exists(exc: Exception) -> bool:
 
 
 def _is_not_found(exc: Exception) -> bool:
+    """Recognize NotFound from both Pub/Sub and Gmail's REST transport."""
     try:
         from google.api_core.exceptions import NotFound
 
-        return isinstance(exc, NotFound)
+        if isinstance(exc, NotFound):
+            return True
     except ImportError:  # pragma: no cover
-        return type(exc).__name__ == "NotFound"
+        if type(exc).__name__ == "NotFound":
+            return True
+
+    response = getattr(exc, "response", None)
+    status_code = getattr(response, "status_code", None)
+    if status_code is None:
+        response = getattr(exc, "resp", None)
+        status_code = getattr(response, "status", None)
+    if status_code is None:
+        return False
+    try:
+        return int(status_code) == 404
+    except (TypeError, ValueError):
+        return False
 
 
 def _validate_provisioning_config() -> tuple[str, str, str]:

--- a/src/xagent/web/services/gmail_triggers.py
+++ b/src/xagent/web/services/gmail_triggers.py
@@ -124,6 +124,15 @@ class _GmailUsersResource:
             json=body,
         )
 
+    def stop(self, *, userId: str) -> _GmailApiRequest:
+        """Stop push delivery for the selected Gmail mailbox."""
+        user_id = quote(userId, safe="")
+        return _GmailApiRequest(
+            self._session,
+            "POST",
+            f"{GMAIL_API_ROOT}/users/{user_id}/stop",
+        )
+
     def history(self) -> _GmailHistoryResource:
         return _GmailHistoryResource(self._session, self._user_id)
 

--- a/src/xagent/web/services/gmail_triggers.py
+++ b/src/xagent/web/services/gmail_triggers.py
@@ -14,8 +14,8 @@ from google.auth.transport.requests import (
     Request,
 )
 from google.oauth2.credentials import Credentials
-from sqlalchemy import case, or_
-from sqlalchemy.orm import Session
+from sqlalchemy import and_, case, or_
+from sqlalchemy.orm import Session, aliased
 
 from ...config import (
     get_gmail_watch_enabled,
@@ -26,7 +26,12 @@ from ..models.gmail_watch import GmailWatchState
 from ..models.oauth_provider import OAuthProvider
 from ..models.trigger import AgentTrigger, TriggerProvisioningStatus, TriggerType
 from ..models.user_oauth import UserOAuth
+from .ops_signals import (
+    GMAIL_OAUTH_OWNERSHIP_MISMATCH,
+    register_degradation,
+)
 from .time_utils import coerce_utc as _coerce_utc
+from .user_oauth import get_scoped_user_oauth_account, user_oauth_owner_clause
 
 logger = logging.getLogger(__name__)
 
@@ -190,7 +195,11 @@ def _credentials_expiry(value: datetime | None) -> datetime | None:
 
 
 def build_gmail_service(db: Session, oauth_account: UserOAuth) -> Any:
-    """Build an authenticated Gmail API client for a connected Gmail account."""
+    """Build Gmail trigger access for one ordinary connected account."""
+    if oauth_account.resource_owner_key is not None:
+        raise GmailWatchConfigurationError(
+            "actor-owned OAuth credentials cannot back Gmail triggers"
+        )
     client_id, client_secret = _get_google_oauth_config(db)
     if not client_id or not client_secret:
         raise GmailWatchConfigurationError("Google OAuth configuration missing")
@@ -308,6 +317,80 @@ def _renew_watch_for_account(
     return state
 
 
+def _trigger_oauth_account_id(config: Any) -> int | None:
+    """Return an explicit trigger binding, or None for legacy fallback."""
+    value = config.get("oauth_account_id") if isinstance(config, dict) else None
+    try:
+        return int(value) if value is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _enabled_gmail_account_references(db: Session) -> tuple[set[int], set[int]]:
+    """Return valid and invalid account IDs referenced by enabled triggers."""
+    trigger_rows = (
+        db.query(AgentTrigger.user_id, AgentTrigger.config, AgentTrigger.resource_id)
+        .filter(
+            AgentTrigger.type == TriggerType.GMAIL.value,
+            AgentTrigger.enabled.is_(True),
+        )
+        .all()
+    )
+    explicit_users: dict[int, set[int]] = {}
+    legacy_keys: set[tuple[int, str]] = set()
+    unscoped_legacy_users: set[int] = set()
+    for user_id, config, resource_id in trigger_rows:
+        account_id = _trigger_oauth_account_id(config)
+        if account_id is not None:
+            explicit_users.setdefault(account_id, set()).add(int(user_id))
+            continue
+        email = str(resource_id or "").strip().lower()
+        if email:
+            legacy_keys.add((int(user_id), email))
+        else:
+            # Pre-binding triggers had neither an account id nor a mailbox
+            # resource. Preserve their user-wide renewal behavior.
+            unscoped_legacy_users.add(int(user_id))
+
+    candidate_filter = []
+    if explicit_users:
+        candidate_filter.append(UserOAuth.id.in_(explicit_users))
+    legacy_user_ids = {
+        user_id for user_id, _email in legacy_keys
+    } | unscoped_legacy_users
+    if legacy_user_ids:
+        candidate_filter.append(UserOAuth.user_id.in_(legacy_user_ids))
+    accounts = (
+        db.query(UserOAuth).filter(or_(*candidate_filter)).all()
+        if candidate_filter
+        else []
+    )
+
+    valid: set[int] = set()
+    invalid: set[int] = set(explicit_users)
+    for account in accounts:
+        account_id = int(account.id)
+        account_user_id = int(account.user_id)
+        ordinary_gmail = (
+            account.provider == "gmail" and account.resource_owner_key is None
+        )
+        explicitly_referenced = account_user_id in explicit_users.get(account_id, ())
+        legacy_referenced = (
+            account_user_id in unscoped_legacy_users
+            or (
+                account_user_id,
+                str(account.email or "").strip().lower(),
+            )
+            in legacy_keys
+        )
+        if (explicitly_referenced or legacy_referenced) and ordinary_gmail:
+            valid.add(account_id)
+        elif account_id in explicit_users or legacy_referenced:
+            invalid.add(account_id)
+    invalid.difference_update(valid)
+    return valid, invalid
+
+
 def scan_due_gmail_watch_renewals(
     db: Session,
     *,
@@ -321,28 +404,81 @@ def scan_due_gmail_watch_renewals(
     scan_time = _coerce_utc(now) or datetime.now(timezone.utc)
     renew_before = scan_time + timedelta(seconds=get_gmail_watch_renewal_lead_seconds())
     batch_size = max(1, min(int(limit), 500))
-    enabled_gmail_users = (
-        db.query(AgentTrigger.user_id.label("user_id"))
+    valid_account_ids, invalid_account_ids = _enabled_gmail_account_references(db)
+    referenced_account_ids = valid_account_ids | invalid_account_ids
+    if not referenced_account_ids:
+        return 0
+
+    due_watch = or_(
+        GmailWatchState.watch_expiration.is_(None),
+        GmailWatchState.watch_expiration <= renew_before,
+    )
+    invalid_states = (
+        db.query(GmailWatchState)
+        .outerjoin(
+            UserOAuth,
+            UserOAuth.id == GmailWatchState.oauth_account_id,
+        )
         .filter(
-            AgentTrigger.type == TriggerType.GMAIL.value,
-            AgentTrigger.enabled.is_(True),
+            GmailWatchState.oauth_account_id.in_(referenced_account_ids),
+            due_watch,
+            ~and_(
+                GmailWatchState.status == TriggerProvisioningStatus.FAILED.value,
+                GmailWatchState.last_error.like(
+                    "Gmail watch OAuth ownership mismatch:%"
+                ),
+            ),
+            or_(
+                UserOAuth.id.is_(None),
+                UserOAuth.user_id != GmailWatchState.user_id,
+                UserOAuth.provider != "gmail",
+                UserOAuth.resource_owner_key.is_not(None),
+            ),
         )
         .distinct()
-        .subquery()
+        .order_by(GmailWatchState.watch_expiration, GmailWatchState.id)
+        .limit(batch_size)
+        .all()
+    )
+    if invalid_states:
+        from .gmail_provisioning import register_gmail_watch_ownership_mismatch
+
+        for invalid_state in invalid_states:
+            detail = register_gmail_watch_ownership_mismatch(invalid_state)
+            setattr(
+                invalid_state,
+                "status",
+                TriggerProvisioningStatus.FAILED.value,
+            )
+            setattr(invalid_state, "last_error", detail)
+            db.add(invalid_state)
+        db.commit()
+
+    any_watch_state_alias = aliased(GmailWatchState)
+    any_watch_state = (
+        db.query(any_watch_state_alias.id)
+        .filter(any_watch_state_alias.oauth_account_id == UserOAuth.id)
+        .correlate(UserOAuth)
+        .exists()
     )
     rows = (
         db.query(UserOAuth, GmailWatchState)
-        .join(enabled_gmail_users, enabled_gmail_users.c.user_id == UserOAuth.user_id)
         .outerjoin(
             GmailWatchState,
-            GmailWatchState.oauth_account_id == UserOAuth.id,
+            and_(
+                GmailWatchState.oauth_account_id == UserOAuth.id,
+                GmailWatchState.user_id == UserOAuth.user_id,
+            ),
         )
-        .filter(UserOAuth.provider == "gmail")
+        .filter(
+            UserOAuth.id.in_(valid_account_ids),
+            UserOAuth.provider == "gmail",
+            user_oauth_owner_clause(None),
+        )
         .filter(
             or_(
-                GmailWatchState.id.is_(None),
-                GmailWatchState.watch_expiration.is_(None),
-                GmailWatchState.watch_expiration <= renew_before,
+                and_(GmailWatchState.id.is_not(None), due_watch),
+                and_(GmailWatchState.id.is_(None), ~any_watch_state),
             )
         )
         .order_by(
@@ -538,10 +674,25 @@ async def collect_gmail_pubsub_events(
     if not email_address or not notification.history_id:
         return GmailPubsubEventCollection(events=[], skipped=1)
 
-    oauth_account = (
-        db.query(UserOAuth).filter(UserOAuth.id == int(state.oauth_account_id)).first()
+    oauth_account = get_scoped_user_oauth_account(
+        db,
+        user_id=int(state.user_id),
+        account_id=int(state.oauth_account_id),
+        resource_owner_key=None,
     )
     if oauth_account is None:
+        logger.warning(
+            "Skipping Gmail callback for watch state %s: OAuth account %s is "
+            "missing or not ordinary for user %s",
+            state.id,
+            state.oauth_account_id,
+            state.user_id,
+        )
+        register_degradation(
+            GMAIL_OAUTH_OWNERSHIP_MISMATCH,
+            f"Gmail watch state {state.id} cannot resolve ordinary OAuth "
+            f"account {state.oauth_account_id} for user {state.user_id}",
+        )
         return GmailPubsubEventCollection(events=[], skipped=1)
 
     state_id = int(state.id)
@@ -620,15 +771,20 @@ async def collect_gmail_pubsub_events(
             raise GmailTriggerError(error_message) from watch_exc
         return GmailPubsubEventCollection(events=[], skipped=1)
 
-    triggers = (
-        db.query(AgentTrigger)
-        .filter(
-            AgentTrigger.user_id == int(state.user_id),
-            AgentTrigger.type == TriggerType.GMAIL.value,
-            AgentTrigger.enabled.is_(True),
+    triggers = [
+        trigger
+        for trigger in (
+            db.query(AgentTrigger)
+            .filter(
+                AgentTrigger.user_id == int(state.user_id),
+                AgentTrigger.type == TriggerType.GMAIL.value,
+                AgentTrigger.enabled.is_(True),
+            )
+            .all()
         )
-        .all()
-    )
+        if (bound_account_id := _trigger_oauth_account_id(trigger.config)) is None
+        or bound_account_id == int(state.oauth_account_id)
+    ]
 
     events: list[GmailCollectedEvent] = []
     skipped = 0

--- a/src/xagent/web/services/gmail_triggers.py
+++ b/src/xagent/web/services/gmail_triggers.py
@@ -794,6 +794,21 @@ async def collect_gmail_pubsub_events(
         )
         if _trigger_targets_watch(trigger, state)
     ]
+    resource_updated = False
+    for trigger in triggers:
+        if _trigger_oauth_account_id(trigger.config) is None:
+            continue
+        if str(trigger.resource_id or "").strip().lower() == email_address:
+            continue
+        # The exact account binding selected this trigger, and the callback's
+        # mailbox came from the verified watch state rather than the Pub/Sub
+        # payload. Keep the redundant resource field synchronized before the
+        # generic pipeline checks persisted resource identity.
+        setattr(trigger, "resource_id", email_address)
+        db.add(trigger)
+        resource_updated = True
+    if resource_updated:
+        db.commit()
 
     events: list[GmailCollectedEvent] = []
     skipped = 0

--- a/src/xagent/web/services/gmail_triggers.py
+++ b/src/xagent/web/services/gmail_triggers.py
@@ -200,6 +200,10 @@ def build_gmail_service(db: Session, oauth_account: UserOAuth) -> Any:
         raise GmailWatchConfigurationError(
             "actor-owned OAuth credentials cannot back Gmail triggers"
         )
+    if str(oauth_account.provider) != "gmail":
+        raise GmailWatchConfigurationError(
+            "Gmail watch access requires an ordinary Gmail OAuth account"
+        )
     client_id, client_secret = _get_google_oauth_config(db)
     if not client_id or not client_secret:
         raise GmailWatchConfigurationError("Google OAuth configuration missing")
@@ -326,6 +330,20 @@ def _trigger_oauth_account_id(config: Any) -> int | None:
         return None
 
 
+def _trigger_targets_watch(
+    trigger: AgentTrigger,
+    state: GmailWatchState,
+) -> bool:
+    """Match a trigger to one watch by account ID or its legacy mailbox."""
+    bound_account_id = _trigger_oauth_account_id(trigger.config)
+    if bound_account_id is not None:
+        return bound_account_id == int(state.oauth_account_id)
+    watched_email = str(state.email or "").strip().lower()
+    return bool(watched_email) and (
+        str(trigger.resource_id or "").strip().lower() == watched_email
+    )
+
+
 def _enabled_gmail_account_references(db: Session) -> tuple[set[int], set[int]]:
     """Return valid and invalid account IDs referenced by enabled triggers."""
     trigger_rows = (
@@ -338,7 +356,6 @@ def _enabled_gmail_account_references(db: Session) -> tuple[set[int], set[int]]:
     )
     explicit_users: dict[int, set[int]] = {}
     legacy_keys: set[tuple[int, str]] = set()
-    unscoped_legacy_users: set[int] = set()
     for user_id, config, resource_id in trigger_rows:
         account_id = _trigger_oauth_account_id(config)
         if account_id is not None:
@@ -347,17 +364,11 @@ def _enabled_gmail_account_references(db: Session) -> tuple[set[int], set[int]]:
         email = str(resource_id or "").strip().lower()
         if email:
             legacy_keys.add((int(user_id), email))
-        else:
-            # Pre-binding triggers had neither an account id nor a mailbox
-            # resource. Preserve their user-wide renewal behavior.
-            unscoped_legacy_users.add(int(user_id))
 
     candidate_filter = []
     if explicit_users:
         candidate_filter.append(UserOAuth.id.in_(explicit_users))
-    legacy_user_ids = {
-        user_id for user_id, _email in legacy_keys
-    } | unscoped_legacy_users
+    legacy_user_ids = {user_id for user_id, _email in legacy_keys}
     if legacy_user_ids:
         candidate_filter.append(UserOAuth.user_id.in_(legacy_user_ids))
     accounts = (
@@ -376,13 +387,9 @@ def _enabled_gmail_account_references(db: Session) -> tuple[set[int], set[int]]:
         )
         explicitly_referenced = account_user_id in explicit_users.get(account_id, ())
         legacy_referenced = (
-            account_user_id in unscoped_legacy_users
-            or (
-                account_user_id,
-                str(account.email or "").strip().lower(),
-            )
-            in legacy_keys
-        )
+            account_user_id,
+            str(account.email or "").strip().lower(),
+        ) in legacy_keys
         if (explicitly_referenced or legacy_referenced) and ordinary_gmail:
             valid.add(account_id)
         elif account_id in explicit_users or legacy_referenced:
@@ -422,9 +429,11 @@ def scan_due_gmail_watch_renewals(
         .filter(
             GmailWatchState.oauth_account_id.in_(referenced_account_ids),
             due_watch,
-            ~and_(
-                GmailWatchState.status == TriggerProvisioningStatus.FAILED.value,
-                GmailWatchState.last_error.like(
+            or_(
+                GmailWatchState.status.is_(None),
+                GmailWatchState.status != TriggerProvisioningStatus.FAILED.value,
+                GmailWatchState.last_error.is_(None),
+                ~GmailWatchState.last_error.like(
                     "Gmail watch OAuth ownership mismatch:%"
                 ),
             ),
@@ -679,6 +688,7 @@ async def collect_gmail_pubsub_events(
         user_id=int(state.user_id),
         account_id=int(state.oauth_account_id),
         resource_owner_key=None,
+        provider="gmail",
     )
     if oauth_account is None:
         logger.warning(
@@ -782,8 +792,7 @@ async def collect_gmail_pubsub_events(
             )
             .all()
         )
-        if (bound_account_id := _trigger_oauth_account_id(trigger.config)) is None
-        or bound_account_id == int(state.oauth_account_id)
+        if _trigger_targets_watch(trigger, state)
     ]
 
     events: list[GmailCollectedEvent] = []

--- a/src/xagent/web/services/ops_signals.py
+++ b/src/xagent/web/services/ops_signals.py
@@ -24,6 +24,9 @@ GMAIL_OIDC_SERVICE_ACCOUNT_UNVERIFIED = "gmail_oidc_service_account_unverified"
 # are disabled, so Gmail triggers report failed provisioning and existing
 # watches expire unrenewed.
 GMAIL_WATCH_REGISTRATION_DISABLED = "gmail_watch_registration_disabled"
+# Set when persisted Gmail watch ownership no longer matches an ordinary OAuth
+# account. The mismatch requires data repair, so no request path clears it.
+GMAIL_OAUTH_OWNERSHIP_MISMATCH = "gmail_oauth_ownership_mismatch"
 CHECKPOINT_DECODE_FALLBACK = "checkpoint_decode_fallback"
 CHECKPOINT_LEGACY_POINTER_AMBIGUOUS = "checkpoint_legacy_pointer_ambiguous"
 CHECKPOINT_LOAD_UNAVAILABLE = "checkpoint_load_unavailable"

--- a/src/xagent/web/services/trigger_providers/gmail.py
+++ b/src/xagent/web/services/trigger_providers/gmail.py
@@ -37,6 +37,7 @@ from ..ops_signals import (
     clear_degradation,
     register_degradation,
 )
+from ..user_oauth import get_scoped_user_oauth_account
 from .base import (
     CallbackRequestContext,
     TriggerConfigError,
@@ -515,6 +516,19 @@ class GmailProvider:
         _ = (trigger, events)
         state = _watch_state_for_callback(db, context.callback_id)
         if state is None:
+            return
+        if (
+            get_scoped_user_oauth_account(
+                db,
+                user_id=int(state.user_id),
+                account_id=int(state.oauth_account_id),
+                resource_owner_key=None,
+            )
+            is None
+        ):
+            # parse_events acknowledges ownership mismatches without fetching
+            # Gmail history. Preserve the previous cursor so a repaired
+            # ordinary account can consume the missed range on a later push.
             return
         if (
             str(state.status) == TriggerProvisioningStatus.FAILED.value

--- a/src/xagent/web/services/trigger_providers/gmail.py
+++ b/src/xagent/web/services/trigger_providers/gmail.py
@@ -460,13 +460,32 @@ class GmailProvider:
         )
 
     async def unregister(self, db: Session, trigger: AgentTrigger, config: Any) -> None:
-        # The binding must come from config: CRUD passes the trigger's
-        # previous config, and on delete the trigger row no longer exists.
+        # Modern bindings come from the previous config because CRUD may have
+        # already rebound or deleted the trigger row. Supported legacy rows
+        # carry only the mailbox resource, so resolve every watch for that
+        # user's mailbox and let reference-counted release decide which one is
+        # now unused.
         oauth_account_id = _binding_oauth_account_id(config)
         if oauth_account_id is not None:
-            await asyncio.to_thread(
-                release_gmail_mailbox_if_unused, db, oauth_account_id
-            )
+            account_ids = [oauth_account_id]
+        else:
+            mailbox = _normalized_email(trigger.resource_id)
+            if not mailbox:
+                return
+            account_ids = [
+                int(row.oauth_account_id)
+                for row in (
+                    db.query(GmailWatchState.oauth_account_id)
+                    .filter(
+                        GmailWatchState.user_id == int(trigger.user_id),
+                        func.lower(GmailWatchState.email) == mailbox,
+                    )
+                    .order_by(GmailWatchState.oauth_account_id.asc())
+                    .all()
+                )
+            ]
+        for account_id in account_ids:
+            await asyncio.to_thread(release_gmail_mailbox_if_unused, db, account_id)
 
     async def parse_events(
         self,

--- a/src/xagent/web/services/trigger_providers/gmail.py
+++ b/src/xagent/web/services/trigger_providers/gmail.py
@@ -523,6 +523,7 @@ class GmailProvider:
                 user_id=int(state.user_id),
                 account_id=int(state.oauth_account_id),
                 resource_owner_key=None,
+                provider="gmail",
             )
             is None
         ):

--- a/src/xagent/web/services/triggers.py
+++ b/src/xagent/web/services/triggers.py
@@ -34,7 +34,6 @@ from ..models.trigger import (
     TriggerType,
 )
 from ..models.user import User
-from ..models.user_oauth import UserOAuth
 from ..models.workforce import Workforce
 from .agent_team_scope import get_agent_team_scope, owned_agent_clause
 from .background_jobs import create_background_job, enqueue_background_job
@@ -61,6 +60,7 @@ from .trigger_providers.schemas import (
     normalize_weekdays,
     parse_trigger_config,
 )
+from .user_oauth import get_scoped_user_oauth_account
 
 logger = logging.getLogger(__name__)
 
@@ -600,8 +600,13 @@ def _resolve_gmail_resource(
     """Validate the bound Gmail account and return the normalized mailbox."""
     if oauth_account_id is None:
         raise TriggerServiceError("gmail trigger requires oauth_account_id")
-    account = db.query(UserOAuth).filter(UserOAuth.id == int(oauth_account_id)).first()
-    if account is None or int(account.user_id) != int(user_id):
+    account = get_scoped_user_oauth_account(
+        db,
+        user_id=user_id,
+        account_id=oauth_account_id,
+        resource_owner_key=None,
+    )
+    if account is None:
         raise TriggerServiceError("Gmail account not found")
     if str(account.provider) != "gmail":
         raise TriggerServiceError("Selected account is not a Gmail account")

--- a/src/xagent/web/services/user_oauth.py
+++ b/src/xagent/web/services/user_oauth.py
@@ -13,6 +13,7 @@ from typing import Any
 from sqlalchemy.orm import Query, Session
 from sqlalchemy.sql.elements import ColumnElement
 
+from ..models.gmail_watch import GmailWatchState
 from ..models.user_oauth import (
     USER_OAUTH_RESOURCE_OWNER_KEY_MAX_LENGTH,
     UserOAuth,
@@ -131,14 +132,32 @@ def delete_scoped_user_oauth_accounts(
     An empty sequence deletes nothing. Requiring explicit provider names keeps
     a missing or falsy filter from becoming a namespace-wide deletion.
     Transaction ownership remains with the caller; this function never
-    commits. Callers must not retain matching identity-mapped rows because the
-    bulk delete does not synchronize those in-memory objects.
+    commits. Ordinary Gmail rows with retained watch state are rejected so a
+    caller cannot cascade away durable cleanup handles; callers must request
+    Gmail cleanup before retrying the deletion. Callers must not retain
+    matching identity-mapped rows because the bulk delete does not synchronize
+    those in-memory objects.
     """
     if isinstance(providers, str):
         raise TypeError("providers must be a sequence, not a string")
     provider_keys = tuple(dict.fromkeys(str(provider) for provider in providers))
     if not provider_keys:
         return 0
+    if resource_owner_key is None and "gmail" in provider_keys:
+        protected_watch = (
+            db.query(GmailWatchState.id)
+            .join(UserOAuth, UserOAuth.id == GmailWatchState.oauth_account_id)
+            .filter(
+                UserOAuth.user_id == int(user_id),
+                UserOAuth.provider == "gmail",
+                UserOAuth.resource_owner_key.is_(None),
+            )
+            .first()
+        )
+        if protected_watch is not None:
+            raise RuntimeError(
+                "Gmail watch cleanup must complete before deleting its OAuth account"
+            )
     query = scoped_user_oauth_query(
         db,
         user_id=user_id,

--- a/src/xagent/web/services/user_oauth.py
+++ b/src/xagent/web/services/user_oauth.py
@@ -83,18 +83,17 @@ def get_scoped_user_oauth_account(
     user_id: int,
     account_id: int,
     resource_owner_key: str | None,
+    provider: str | None = None,
 ) -> UserOAuth | None:
-    """Get a credential by ID only when the expected owner also matches."""
-    return (
-        scoped_user_oauth_query(
-            db,
-            user_id=user_id,
-            resource_owner_key=resource_owner_key,
-        )
-        .filter(UserOAuth.id == int(account_id))
-        .populate_existing()
-        .first()
-    )
+    """Get a credential that matches its user, owner, and optional provider."""
+    query = scoped_user_oauth_query(
+        db,
+        user_id=user_id,
+        resource_owner_key=resource_owner_key,
+    ).filter(UserOAuth.id == int(account_id))
+    if provider is not None:
+        query = query.filter(UserOAuth.provider == provider)
+    return query.populate_existing().first()
 
 
 def get_user_oauth_account_by_id(
@@ -102,23 +101,22 @@ def get_user_oauth_account_by_id(
     *,
     account_id: int,
     resource_owner_key: str | None,
+    provider: str | None = None,
 ) -> UserOAuth | None:
     """Get a foreign-key-addressed credential in one owner namespace.
 
-    Internal Gmail watch rows already bind a globally unique OAuth primary key
-    and may not have an independently trusted account id at every reload site.
-    This shape preserves that existing lookup while centralizing its owner
-    namespace predicate.
+    Internal watch rows bind a globally unique OAuth primary key but do not
+    always have an independently trusted user ID at reload sites. The optional
+    provider predicate keeps provider-specific consumers on their own account
+    type while this helper centralizes the owner namespace predicate.
     """
-    return (
-        db.query(UserOAuth)
-        .filter(
-            UserOAuth.id == int(account_id),
-            user_oauth_owner_clause(resource_owner_key),
-        )
-        .populate_existing()
-        .first()
+    query = db.query(UserOAuth).filter(
+        UserOAuth.id == int(account_id),
+        user_oauth_owner_clause(resource_owner_key),
     )
+    if provider is not None:
+        query = query.filter(UserOAuth.provider == provider)
+    return query.populate_existing().first()
 
 
 def delete_scoped_user_oauth_accounts(

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3169,7 +3169,8 @@ class WebToolConfig(BaseToolConfig):
             if not is_valid:
                 logger.warning(
                     "OAUTH CONFIG: Token for '%s' is invalid and could not be refreshed. "
-                    "Deleting OAuth record to prompt user for reconnection.",
+                    "Disconnecting the OAuth record or preserving Gmail cleanup "
+                    "ownership for reconnection.",
                     provider_name,
                 )
                 # A failed flush leaves the transaction unusable. Roll it back,
@@ -3182,6 +3183,26 @@ class WebToolConfig(BaseToolConfig):
                     resource_owner_key=None,
                 )
                 if oauth_account is not None:
+                    if str(oauth_account.provider) == "gmail":
+                        from ..services.gmail_provisioning import (
+                            GmailProvisioningError,
+                            request_gmail_oauth_account_deletion,
+                        )
+
+                        try:
+                            ready_to_delete = request_gmail_oauth_account_deletion(
+                                oauth_db,
+                                account_id,
+                            )
+                        except GmailProvisioningError:
+                            # Keep the account and watch handles so a later
+                            # reconnect can restore credentials in place.
+                            ready_to_delete = False
+                        if not ready_to_delete:
+                            return _LegacyOAuthTokenResolution(
+                                access_token=None,
+                                refresh_failed=True,
+                            )
                     oauth_db.delete(oauth_account)
                     oauth_db.commit()
                 return _LegacyOAuthTokenResolution(

--- a/tests/web/api/test_gmail_auto_triggers.py
+++ b/tests/web/api/test_gmail_auto_triggers.py
@@ -27,6 +27,7 @@ from xagent.web.models.trigger import (
 )
 from xagent.web.models.user import User
 from xagent.web.models.user_oauth import UserOAuth
+from xagent.web.services import ops_signals
 from xagent.web.services.gmail_provisioning import (
     GMAIL_WATCH_DISABLED_ERROR,
     gmail_topic_path,
@@ -1403,6 +1404,50 @@ def test_best_effort_provisioning_targets_only_referenced_mailboxes(
         db.close()
 
 
+def test_collect_gmail_pubsub_events_warns_for_nonordinary_watch_account(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    signal_name = "gmail_oauth_ownership_mismatch"
+    ops_signals.clear_degradation(signal_name)
+    db = _direct_db_session()
+    try:
+        user = _create_user(db, "gmail-owner-mismatch")
+        oauth = _create_gmail_oauth(db, user)
+        state = GmailWatchState(
+            user_id=int(user.id),
+            oauth_account_id=int(oauth.id),
+            email="codeacme17@gmail.com",
+            history_id="100",
+            topic_name="projects/demo/topics/xagent-gmail",
+        )
+        setattr(oauth, "resource_owner_key", "actor:alice")
+        db.add_all([oauth, state])
+        db.commit()
+
+        with caplog.at_level("WARNING"):
+            result = asyncio.run(
+                collect_gmail_pubsub_events(
+                    db,
+                    GmailPubsubNotification(
+                        email_address="codeacme17@gmail.com",
+                        history_id="222",
+                        pubsub_message_id="pubsub-owner-mismatch",
+                    ),
+                    state=state,
+                )
+            )
+
+        assert result.events == []
+        assert result.skipped == 1
+        assert "Skipping Gmail callback" in caplog.text
+        assert str(state.id) in caplog.text
+        assert str(oauth.id) in caplog.text
+        assert signal_name in ops_signals.active_degradations()
+    finally:
+        ops_signals.clear_degradation(signal_name)
+        db.close()
+
+
 def test_collect_gmail_pubsub_events_collects_matching_trigger_events() -> None:
     db = _direct_db_session()
     try:
@@ -1476,6 +1521,81 @@ def test_collect_gmail_pubsub_events_collects_matching_trigger_events() -> None:
         # does, only after all events fired.
         db.refresh(state)
         assert state.history_id == "100"
+    finally:
+        db.close()
+
+
+def test_collect_gmail_pubsub_events_targets_exact_bound_account() -> None:
+    db = _direct_db_session()
+    try:
+        user = _create_user(db, "gmail-exact-bound-account-user")
+        watched_account = _create_gmail_oauth(db, user)
+        other_account = UserOAuth(
+            user_id=int(user.id),
+            provider="gmail",
+            access_token="other-access-token",
+            refresh_token="other-refresh-token",
+            provider_user_id="other-provider-user",
+            email="codeacme17@gmail.com",
+        )
+        db.add(other_account)
+        db.commit()
+        db.refresh(other_account)
+        watched_trigger = _mark_unified_gmail_trigger(
+            db,
+            _create_gmail_trigger(
+                db,
+                user,
+                config={
+                    "watch_label": "INBOX",
+                    "oauth_account_id": int(watched_account.id),
+                },
+            ),
+        )
+        _mark_unified_gmail_trigger(
+            db,
+            _create_gmail_trigger(
+                db,
+                user,
+                config={
+                    "watch_label": "INBOX",
+                    "oauth_account_id": int(other_account.id),
+                },
+            ),
+            callback_id="other-trigger-callback",
+        )
+        state = GmailWatchState(
+            user_id=int(user.id),
+            oauth_account_id=int(watched_account.id),
+            email="codeacme17@gmail.com",
+            history_id="100",
+            topic_name="projects/demo/topics/xagent-gmail",
+        )
+        db.add(state)
+        db.commit()
+        fake_service = _FakeGmailService(
+            history_response={
+                "history": [{"messagesAdded": [{"message": {"id": "msg-bound"}}]}]
+            },
+            messages={"msg-bound": _gmail_message("msg-bound")},
+        )
+
+        result = asyncio.run(
+            collect_gmail_pubsub_events(
+                db,
+                GmailPubsubNotification(
+                    email_address="codeacme17@gmail.com",
+                    history_id="222",
+                    pubsub_message_id="pubsub-bound",
+                ),
+                state=state,
+                service_factory=lambda _db, _oauth: fake_service,
+            )
+        )
+
+        assert [event.trigger_id for event in result.events] == [
+            int(watched_trigger.id)
+        ]
     finally:
         db.close()
 
@@ -2094,6 +2214,51 @@ def test_collect_gmail_pubsub_events_retains_reregistration_failure_detail(
         assert state.status == TriggerProvisioningStatus.FAILED.value
         assert "renewal backend unavailable" in str(state.last_error)
     finally:
+        db.close()
+
+
+def test_gmail_unified_callback_preserves_cursor_for_nonordinary_watch_account() -> (
+    None
+):
+    """Acknowledged ownership mismatches must not consume Gmail history."""
+    signal_name = "gmail_oauth_ownership_mismatch"
+    ops_signals.clear_degradation(signal_name)
+    db = _direct_db_session()
+    try:
+        user = _create_user(db, "gmail-owner-mismatch-route-user")
+        oauth = _create_gmail_oauth(db, user)
+        _mark_unified_gmail_trigger(db, _create_gmail_trigger(db, user))
+        state = _create_gmail_watch_state(
+            db, user, oauth, callback_id="cb-owner-mismatch-route"
+        )
+        setattr(oauth, "resource_owner_key", "actor:alice")
+        db.add(oauth)
+        db.commit()
+
+        def fake_verify(_token: str, audience: str) -> dict[str, object]:
+            return {"iss": "https://accounts.google.com", "aud": audience}
+
+        register_trigger_provider(
+            GmailProvider(oidc_verifier=fake_verify),
+            replace=True,
+        )
+
+        response = client.post(
+            "/api/triggers/callback/gmail/cb-owner-mismatch-route",
+            headers={"Authorization": "Bearer oidc-token"},
+            content=_gmail_pubsub_push_body(
+                claimed_email="codeacme17@gmail.com",
+                message_id="pubsub-owner-mismatch-route",
+            ),
+        )
+
+        assert response.status_code == 200, response.text
+        db.refresh(state)
+        assert state.history_id == "100"
+        assert signal_name in ops_signals.active_degradations()
+    finally:
+        register_trigger_provider(GmailProvider(), replace=True)
+        ops_signals.clear_degradation(signal_name)
         db.close()
 
 

--- a/tests/web/api/test_gmail_auto_triggers.py
+++ b/tests/web/api/test_gmail_auto_triggers.py
@@ -899,6 +899,67 @@ def test_gmail_unified_callback_ingests_history_filters_and_deduplicates(
         db.close()
 
 
+def test_gmail_exact_account_callback_repairs_stale_mailbox_and_fires(
+    mock_bg_scheduler,
+) -> None:
+    """The exact account binding stays authoritative after an email rename."""
+    db = _direct_db_session()
+    try:
+        user = _create_user(db, "gmail-exact-binding-user")
+        oauth = _create_gmail_oauth(db, user)
+        trigger = _mark_unified_gmail_trigger(
+            db,
+            _create_gmail_trigger(db, user, oauth_account=oauth),
+            resource_id="stale@old.example",
+        )
+        state = _create_gmail_watch_state(
+            db,
+            user,
+            oauth,
+            callback_id="cb-exact-binding",
+            email="renamed@gmail.example",
+        )
+        fake_service = _FakeGmailService(
+            history_response={
+                "history": [{"messagesAdded": [{"message": {"id": "msg-exact"}}]}]
+            },
+            messages={"msg-exact": _gmail_message("msg-exact")},
+        )
+        register_trigger_provider(
+            GmailProvider(
+                service_factory=lambda _db, _oauth: fake_service,
+                oidc_verifier=lambda _token, audience: {
+                    "iss": "https://accounts.google.com",
+                    "aud": audience,
+                },
+            ),
+            replace=True,
+        )
+
+        response = client.post(
+            "/api/triggers/callback/gmail/cb-exact-binding",
+            headers={"Authorization": "Bearer oidc-token"},
+            content=_gmail_pubsub_push_body(
+                claimed_email="attacker@example.com",
+                message_id="pubsub-exact",
+            ),
+        )
+
+        assert response.status_code == 200, response.text
+        assert response.json()["outcome"] == "accepted"
+        assert len(response.json()["trigger_run_ids"]) == 1
+        run = db.query(TriggerRun).filter(TriggerRun.trigger_id == trigger.id).one()
+        assert run.source_event_id == "gmail:msg-exact"
+        db.refresh(trigger)
+        assert trigger.resource_id == "renamed@gmail.example"
+        db.refresh(state)
+        assert state.history_id == "222"
+        assert mock_bg_scheduler.call_count == 1
+    finally:
+        register_trigger_provider(GmailProvider(), replace=True)
+        db.close()
+
+
 def test_gmail_unified_callback_holds_history_cursor_when_execution_fails() -> None:
     db = _direct_db_session()
     try:

--- a/tests/web/api/test_gmail_auto_triggers.py
+++ b/tests/web/api/test_gmail_auto_triggers.py
@@ -269,6 +269,7 @@ def _create_gmail_trigger(
     *,
     enabled: bool = True,
     config: dict[str, object] | None = None,
+    oauth_account: UserOAuth | None = None,
 ) -> AgentTrigger:
     agent = Agent(
         user_id=int(user.id),
@@ -281,14 +282,22 @@ def _create_gmail_trigger(
     db.commit()
     db.refresh(agent)
 
+    resolved_config = dict(config or {"watch_label": "INBOX"})
+    if oauth_account is not None:
+        resolved_config.setdefault("oauth_account_id", int(oauth_account.id))
     trigger = AgentTrigger(
         user_id=int(user.id),
         agent_id=int(agent.id),
         type=TriggerType.GMAIL.value,
         name="Gmail inbox",
         enabled=enabled,
-        config=config or {"watch_label": "INBOX"},
+        config=resolved_config,
         prompt_template="Handle {{payload}}",
+        resource_id=(
+            str(oauth_account.email).strip().lower()
+            if oauth_account is not None
+            else None
+        ),
     )
     db.add(trigger)
     db.commit()
@@ -1031,7 +1040,7 @@ def test_gmail_oidc_verifier_allows_clock_skew() -> None:
     assert mock_verify.call_args.kwargs["clock_skew_in_seconds"] > 0
 
 
-def test_gmail_unified_callback_rejects_resource_mismatch_without_trusting_payload_email(
+def test_gmail_unified_callback_does_not_route_a_legacy_mailbox_mismatch(
     mock_bg_scheduler,
 ) -> None:
     db = _direct_db_session()
@@ -1068,16 +1077,13 @@ def test_gmail_unified_callback_rejects_resource_mismatch_without_trusting_paylo
         )
 
         assert response.status_code == 200, response.text
-        assert response.json()["outcome"] == "rejected_resource"
+        assert response.json()["outcome"] == "accepted"
         assert db.query(TriggerRun).count() == 0
-        audit = (
-            db.query(TriggerAudit)
-            .filter(TriggerAudit.outcome == "rejected_resource")
-            .one()
-        )
-        assert audit.trigger_id == trigger.id
-        assert audit.detail["attested_resource_id"] == "codeacme17@gmail.com"
-        assert audit.detail["trigger_resource_id"] == "other@example.com"
+        audit = db.query(TriggerAudit).one()
+        assert audit.outcome == "accepted"
+        assert audit.trigger_id == int(trigger.id)
+        assert audit.detail["run_ids"] == []
+        assert trigger.resource_id == "other@example.com"
         assert mock_bg_scheduler.call_count == 0
     finally:
         register_trigger_provider(GmailProvider(), replace=True)
@@ -1149,6 +1155,24 @@ def test_gmail_oauth_config_falls_back_to_env_when_db_provider_is_blank(
         db.commit()
 
         assert _get_google_oauth_config(db) == ("env-client-id", "env-client-secret")
+    finally:
+        db.close()
+
+
+def test_build_gmail_service_rejects_a_non_gmail_account() -> None:
+    db = _direct_db_session()
+    try:
+        user = _create_user(db, "non-gmail-service-user")
+        oauth = _create_gmail_oauth(db, user)
+        setattr(oauth, "provider", "google-drive")
+        db.add(oauth)
+        db.commit()
+
+        with pytest.raises(
+            GmailWatchConfigurationError,
+            match="requires an ordinary Gmail OAuth account",
+        ):
+            build_gmail_service(db, oauth)
     finally:
         db.close()
 
@@ -1453,7 +1477,7 @@ def test_collect_gmail_pubsub_events_collects_matching_trigger_events() -> None:
     try:
         user = _create_user(db, "gmail-history-user")
         oauth = _create_gmail_oauth(db, user)
-        trigger = _create_gmail_trigger(db, user)
+        trigger = _create_gmail_trigger(db, user, oauth_account=oauth)
         state = GmailWatchState(
             user_id=int(user.id),
             oauth_account_id=int(oauth.id),
@@ -1605,7 +1629,12 @@ def test_collect_gmail_pubsub_events_skips_label_mismatch() -> None:
     try:
         user = _create_user(db, "gmail-label-mismatch-user")
         oauth = _create_gmail_oauth(db, user)
-        _create_gmail_trigger(db, user, config={"watch_label": "INBOX"})
+        _create_gmail_trigger(
+            db,
+            user,
+            config={"watch_label": "INBOX"},
+            oauth_account=oauth,
+        )
         state = GmailWatchState(
             user_id=int(user.id),
             oauth_account_id=int(oauth.id),
@@ -1653,7 +1682,12 @@ def test_collect_gmail_pubsub_events_accepts_case_insensitive_all_label() -> Non
     try:
         user = _create_user(db, "gmail-all-label-user")
         oauth = _create_gmail_oauth(db, user)
-        trigger = _create_gmail_trigger(db, user, config={"watch_label": "All"})
+        trigger = _create_gmail_trigger(
+            db,
+            user,
+            config={"watch_label": "All"},
+            oauth_account=oauth,
+        )
         state = GmailWatchState(
             user_id=int(user.id),
             oauth_account_id=int(oauth.id),
@@ -1701,7 +1735,12 @@ def test_collect_gmail_pubsub_events_accepts_wildcard_star_label() -> None:
     try:
         user = _create_user(db, "gmail-star-label-user")
         oauth = _create_gmail_oauth(db, user)
-        trigger = _create_gmail_trigger(db, user, config={"watch_label": "*"})
+        trigger = _create_gmail_trigger(
+            db,
+            user,
+            config={"watch_label": "*"},
+            oauth_account=oauth,
+        )
         state = GmailWatchState(
             user_id=int(user.id),
             oauth_account_id=int(oauth.id),
@@ -1756,7 +1795,12 @@ def test_collect_gmail_pubsub_events_wildcard_label_excludes_non_incoming_mail()
     try:
         user = _create_user(db, "gmail-star-excludes-sent-user")
         oauth = _create_gmail_oauth(db, user)
-        trigger = _create_gmail_trigger(db, user, config={"watch_label": "*"})
+        trigger = _create_gmail_trigger(
+            db,
+            user,
+            config={"watch_label": "*"},
+            oauth_account=oauth,
+        )
         state = GmailWatchState(
             user_id=int(user.id),
             oauth_account_id=int(oauth.id),
@@ -1815,7 +1859,12 @@ def test_collect_gmail_pubsub_events_specific_label_also_excludes_non_incoming_m
     try:
         user = _create_user(db, "gmail-specific-label-excludes-sent-user")
         oauth = _create_gmail_oauth(db, user)
-        trigger = _create_gmail_trigger(db, user, config={"watch_label": "Support"})
+        trigger = _create_gmail_trigger(
+            db,
+            user,
+            config={"watch_label": "Support"},
+            oauth_account=oauth,
+        )
         state = GmailWatchState(
             user_id=int(user.id),
             oauth_account_id=int(oauth.id),
@@ -1880,7 +1929,12 @@ def test_collect_gmail_pubsub_events_whitespace_only_label_falls_back_to_inbox()
     try:
         user = _create_user(db, "gmail-whitespace-label-user")
         oauth = _create_gmail_oauth(db, user)
-        trigger = _create_gmail_trigger(db, user, config={"watch_label": "   "})
+        trigger = _create_gmail_trigger(
+            db,
+            user,
+            config={"watch_label": "   "},
+            oauth_account=oauth,
+        )
         state = GmailWatchState(
             user_id=int(user.id),
             oauth_account_id=int(oauth.id),
@@ -2424,7 +2478,7 @@ def test_collect_gmail_pubsub_events_skips_deleted_message_without_failing_batch
     try:
         user = _create_user(db, "gmail-message-error-user")
         oauth = _create_gmail_oauth(db, user)
-        trigger = _create_gmail_trigger(db, user)
+        trigger = _create_gmail_trigger(db, user, oauth_account=oauth)
         state = GmailWatchState(
             user_id=int(user.id),
             oauth_account_id=int(oauth.id),
@@ -2493,7 +2547,7 @@ def test_collect_gmail_pubsub_events_skips_forbidden_message_without_failing_bat
     try:
         user = _create_user(db, "gmail-forbidden-message-user")
         oauth = _create_gmail_oauth(db, user)
-        trigger = _create_gmail_trigger(db, user)
+        trigger = _create_gmail_trigger(db, user, oauth_account=oauth)
         state = GmailWatchState(
             user_id=int(user.id),
             oauth_account_id=int(oauth.id),
@@ -2551,7 +2605,7 @@ def test_collect_gmail_pubsub_events_fails_batch_on_transient_message_error_and_
     try:
         user = _create_user(db, "gmail-transient-message-error-user")
         oauth = _create_gmail_oauth(db, user)
-        _create_gmail_trigger(db, user)
+        _create_gmail_trigger(db, user, oauth_account=oauth)
         state = GmailWatchState(
             user_id=int(user.id),
             oauth_account_id=int(oauth.id),
@@ -2606,7 +2660,7 @@ def test_collect_gmail_pubsub_events_holds_cursor_on_rate_limited_message() -> N
     try:
         user = _create_user(db, "gmail-rate-limited-message-user")
         oauth = _create_gmail_oauth(db, user)
-        _create_gmail_trigger(db, user)
+        _create_gmail_trigger(db, user, oauth_account=oauth)
         state = GmailWatchState(
             user_id=int(user.id),
             oauth_account_id=int(oauth.id),
@@ -2662,7 +2716,7 @@ def test_scan_due_gmail_watch_renewals_respects_enabled_flag_and_expiration(
     try:
         user = _create_user(db, "gmail-renewal-user")
         oauth = _create_gmail_oauth(db, user)
-        _create_gmail_trigger(db, user)
+        _create_gmail_trigger(db, user, oauth_account=oauth)
         fake_service = _FakeGmailService(
             {"historyId": "789", "expiration": "1782864000000"}
         )
@@ -2724,8 +2778,8 @@ def test_scan_due_gmail_watch_renewals_applies_batch_limit(
     try:
         users = [_create_user(db, f"gmail-renewal-limit-{idx}") for idx in range(3)]
         oauth_accounts = [_create_gmail_oauth(db, user) for user in users]
-        for user in users:
-            _create_gmail_trigger(db, user)
+        for user, oauth_account in zip(users, oauth_accounts, strict=True):
+            _create_gmail_trigger(db, user, oauth_account=oauth_account)
         fake_service = _FakeGmailService(
             {"historyId": "789", "expiration": "1782864000000"}
         )
@@ -2759,7 +2813,7 @@ def test_scan_due_gmail_watch_renewals_prioritizes_missing_and_earliest_expirati
         later_user = _create_user(db, "gmail-renewal-later-user")
         later_oauth = _create_gmail_oauth(db, later_user)
         later_oauth.email = "later@example.com"
-        _create_gmail_trigger(db, later_user)
+        _create_gmail_trigger(db, later_user, oauth_account=later_oauth)
         later_state = GmailWatchState(
             user_id=int(later_user.id),
             oauth_account_id=int(later_oauth.id),
@@ -2772,7 +2826,11 @@ def test_scan_due_gmail_watch_renewals_prioritizes_missing_and_earliest_expirati
         missing_expiration_user = _create_user(db, "gmail-renewal-missing-user")
         missing_expiration_oauth = _create_gmail_oauth(db, missing_expiration_user)
         missing_expiration_oauth.email = "missing@example.com"
-        _create_gmail_trigger(db, missing_expiration_user)
+        _create_gmail_trigger(
+            db,
+            missing_expiration_user,
+            oauth_account=missing_expiration_oauth,
+        )
         missing_expiration_state = GmailWatchState(
             user_id=int(missing_expiration_user.id),
             oauth_account_id=int(missing_expiration_oauth.id),
@@ -2819,7 +2877,7 @@ def test_scan_due_gmail_watch_renewals_records_failure_and_continues(
         first_user = _create_user(db, "gmail-renewal-fails-user")
         first_oauth = _create_gmail_oauth(db, first_user)
         first_oauth.email = "first@example.com"
-        _create_gmail_trigger(db, first_user)
+        _create_gmail_trigger(db, first_user, oauth_account=first_oauth)
         first_state = GmailWatchState(
             user_id=int(first_user.id),
             oauth_account_id=int(first_oauth.id),
@@ -2832,7 +2890,7 @@ def test_scan_due_gmail_watch_renewals_records_failure_and_continues(
         second_user = _create_user(db, "gmail-renewal-continues-user")
         second_oauth = _create_gmail_oauth(db, second_user)
         second_oauth.email = "second@example.com"
-        _create_gmail_trigger(db, second_user)
+        _create_gmail_trigger(db, second_user, oauth_account=second_oauth)
         second_state = GmailWatchState(
             user_id=int(second_user.id),
             oauth_account_id=int(second_oauth.id),
@@ -3061,4 +3119,153 @@ def test_collect_uses_the_callback_watch_state_not_email_lookup() -> None:
         db.refresh(state_a)
         assert state_a.history_id == "100"
     finally:
+        db.close()
+
+
+def test_collect_legacy_trigger_matches_the_watch_mailbox_by_email() -> None:
+    db = _direct_db_session()
+    try:
+        user = _create_user(db, "gmail-legacy-mailbox-routing")
+        watched_account = _create_gmail_oauth(db, user)
+        setattr(watched_account, "email", "watched@gmail.example")
+        other_account = UserOAuth(
+            user_id=int(user.id),
+            provider="gmail",
+            access_token="other-access-token",
+            provider_user_id="other-provider-user",
+            email="other@gmail.example",
+        )
+        db.add_all([watched_account, other_account])
+        db.commit()
+        db.refresh(watched_account)
+        db.refresh(other_account)
+        watched_trigger = _mark_unified_gmail_trigger(
+            db,
+            _create_gmail_trigger(db, user),
+            resource_id=str(watched_account.email),
+            callback_id="legacy-watched-trigger",
+        )
+        other_trigger = _mark_unified_gmail_trigger(
+            db,
+            _create_gmail_trigger(db, user),
+            resource_id=str(other_account.email),
+            callback_id="legacy-other-trigger",
+        )
+        state = _create_gmail_watch_state(
+            db,
+            user,
+            watched_account,
+            email=str(watched_account.email),
+        )
+        service = _FakeGmailService(
+            history_response={
+                "history": [{"messagesAdded": [{"message": {"id": "legacy-message"}}]}]
+            },
+            messages={"legacy-message": _gmail_message("legacy-message")},
+        )
+
+        result = asyncio.run(
+            collect_gmail_pubsub_events(
+                db,
+                GmailPubsubNotification(
+                    email_address=str(watched_account.email),
+                    history_id="222",
+                    pubsub_message_id="legacy-push",
+                ),
+                state=state,
+                service_factory=lambda *_args: service,
+            )
+        )
+
+        assert [event.trigger_id for event in result.events] == [
+            int(watched_trigger.id)
+        ]
+        assert int(other_trigger.id) not in {
+            event.trigger_id for event in result.events
+        }
+    finally:
+        db.close()
+
+
+def test_collect_does_not_route_an_unbound_legacy_trigger() -> None:
+    db = _direct_db_session()
+    try:
+        user = _create_user(db, "gmail-unbound-legacy-routing")
+        oauth = _create_gmail_oauth(db, user)
+        _mark_unified_gmail_trigger(
+            db,
+            _create_gmail_trigger(db, user),
+            resource_id="",
+        )
+        state = _create_gmail_watch_state(db, user, oauth)
+        service = _FakeGmailService(
+            history_response={
+                "history": [{"messagesAdded": [{"message": {"id": "unbound-message"}}]}]
+            },
+            messages={"unbound-message": _gmail_message("unbound-message")},
+        )
+
+        result = asyncio.run(
+            collect_gmail_pubsub_events(
+                db,
+                GmailPubsubNotification(
+                    email_address=str(oauth.email),
+                    history_id="222",
+                    pubsub_message_id="unbound-push",
+                ),
+                state=state,
+                service_factory=lambda *_args: service,
+            )
+        )
+
+        assert result.events == []
+    finally:
+        db.close()
+
+
+def test_gmail_callback_preserves_cursor_for_a_non_gmail_watch_account() -> None:
+    signal_name = "gmail_oauth_ownership_mismatch"
+    ops_signals.clear_degradation(signal_name)
+    db = _direct_db_session()
+    try:
+        user = _create_user(db, "gmail-non-gmail-route-user")
+        oauth = _create_gmail_oauth(db, user)
+        _mark_unified_gmail_trigger(db, _create_gmail_trigger(db, user))
+        state = _create_gmail_watch_state(
+            db,
+            user,
+            oauth,
+            callback_id="cb-non-gmail-route",
+        )
+        setattr(oauth, "provider", "google-drive")
+        db.add(oauth)
+        db.commit()
+
+        def fake_verify(_token: str, audience: str) -> dict[str, object]:
+            return {"iss": "https://accounts.google.com", "aud": audience}
+
+        register_trigger_provider(
+            GmailProvider(
+                service_factory=lambda *_args: pytest.fail("Gmail API was called"),
+                oidc_verifier=fake_verify,
+            ),
+            replace=True,
+        )
+
+        response = client.post(
+            "/api/triggers/callback/gmail/cb-non-gmail-route",
+            headers={"Authorization": "Bearer oidc-token"},
+            content=_gmail_pubsub_push_body(
+                claimed_email=str(oauth.email),
+                message_id="pubsub-non-gmail-route",
+            ),
+        )
+
+        assert response.status_code == 200, response.text
+        db.refresh(state)
+        assert state.history_id == "100"
+        assert signal_name in ops_signals.active_degradations()
+    finally:
+        register_trigger_provider(GmailProvider(), replace=True)
+        ops_signals.clear_degradation(signal_name)
         db.close()

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -38,10 +38,13 @@ from xagent.web.api.mcp import (
 )
 from xagent.web.models import MCPOAuthClient, MCPOAuthFlowState, MCPOAuthGrant
 from xagent.web.models.database import Base
+from xagent.web.models.gmail_watch import GmailWatchState
 from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.mcp_oauth import mcp_oauth_client_registration_lookup_hash
 from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
+from xagent.web.models.user_oauth import UserOAuth
+from xagent.web.services import connector_team_scope
 from xagent.web.services import mcp_oauth as mcp_oauth_service
 from xagent.web.services.mcp_oauth import (
     MCP_OAUTH_PERSISTED_VALUE_MAX_LENGTH,
@@ -2094,6 +2097,125 @@ async def test_local_mcp_oauth_listing_omits_auth_type_when_deactivated(db_sessi
         if a["id"] == "records"
     )
     assert "auth_type" not in records
+
+
+@pytest.mark.asyncio
+async def test_delete_mcp_server_preserves_gmail_watch_cleanup_handles(
+    db_session,
+) -> None:
+    db, user, _other_user = db_session
+    server = _add_mcp_oauth_server(
+        db,
+        user,
+        name="Gmail",
+        transport="oauth",
+    )
+    db.add(
+        PublicMCPApp(
+            app_id="gmail",
+            name="Gmail",
+            description="Gmail app",
+            transport="oauth",
+            provider_name="gmail",
+            launch_config={},
+        )
+    )
+    account = UserOAuth(
+        user_id=int(user.id),
+        provider="gmail",
+        resource_owner_key=None,
+        provider_user_id="gmail-user",
+        email="owner@gmail.example",
+        access_token="gmail-token",
+    )
+    db.add(account)
+    db.commit()
+    db.refresh(account)
+    state = GmailWatchState(
+        user_id=int(user.id),
+        oauth_account_id=int(account.id),
+        email="owner@gmail.example",
+        history_id="1",
+        topic_name="gmail-topic",
+        subscription_name="gmail-subscription",
+    )
+    db.add(state)
+    db.commit()
+    state_id = int(state.id)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await delete_mcp_server(int(server.id), current_user=user, db=db)
+
+    assert exc_info.value.status_code == 409
+    assert db.get(UserOAuth, int(account.id)) is account
+    retained_state = db.get(GmailWatchState, state_id)
+    assert retained_state is not None
+    assert str(retained_state.last_error).startswith("Gmail watch cleanup pending:")
+    assert db.get(MCPServer, int(server.id)) is server
+
+
+@pytest.mark.asyncio
+async def test_denied_team_mcp_delete_does_not_schedule_gmail_cleanup(
+    db_session,
+) -> None:
+    db, user, _other_user = db_session
+    server = _add_mcp_oauth_server(
+        db,
+        user,
+        name="Gmail",
+        transport="oauth",
+    )
+    db.add(
+        PublicMCPApp(
+            app_id="gmail",
+            name="Gmail",
+            description="Gmail app",
+            transport="oauth",
+            provider_name="gmail",
+            launch_config={},
+        )
+    )
+    account = UserOAuth(
+        user_id=int(user.id),
+        provider="gmail",
+        resource_owner_key=None,
+        provider_user_id="gmail-user",
+        email="owner@gmail.example",
+        access_token="gmail-token",
+    )
+    db.add(account)
+    db.commit()
+    db.refresh(account)
+    state = GmailWatchState(
+        user_id=int(user.id),
+        oauth_account_id=int(account.id),
+        email="owner@gmail.example",
+        history_id="1",
+        topic_name="gmail-topic",
+        subscription_name="gmail-subscription",
+    )
+    db.add(state)
+    db.commit()
+    state_id = int(state.id)
+
+    connector_team_scope.set_connector_team_hooks(
+        deleted=lambda *_args: connector_team_scope.ConnectorDeleteDecision(
+            team_owned=True,
+            authorized=False,
+        )
+    )
+    try:
+        with pytest.raises(HTTPException) as exc_info:
+            await delete_mcp_server(int(server.id), current_user=user, db=db)
+    finally:
+        connector_team_scope.set_connector_team_hooks()
+
+    assert exc_info.value.status_code == 403
+    retained_state = db.get(GmailWatchState, state_id)
+    assert retained_state is not None
+    assert retained_state.last_error is None
+    assert db.get(UserOAuth, int(account.id)) is account
+    assert db.get(MCPServer, int(server.id)) is server
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_gmail_provisioning.py
+++ b/tests/web/services/test_gmail_provisioning.py
@@ -132,6 +132,7 @@ def test_provisioning_captures_account_identity_before_transition_commit(
 
     class Account:
         id = 7
+        provider = "gmail"
         resource_owner_key = None
         expired = False
 
@@ -168,10 +169,11 @@ def test_provisioning_captures_account_identity_before_transition_commit(
         lambda _db, _account_id: TransitionLock(),
     )
 
-    def get_account(_db, *, user_id, account_id, resource_owner_key):
+    def get_account(_db, *, user_id, account_id, resource_owner_key, provider):
         assert _db is transition_db
         assert account_id == 7
         assert resource_owner_key is None
+        assert provider == "gmail"
         captured_user_ids.append(user_id)
         return transition_account
 
@@ -402,6 +404,49 @@ def _create_gmail_trigger(
     db.commit()
     db.refresh(trigger)
     return trigger
+
+
+def test_provisioning_rejects_an_ordinary_non_gmail_account(
+    db_session: Session,
+) -> None:
+    user = _create_user(db_session)
+    account = _create_oauth(db_session, user)
+    setattr(account, "provider", "google-drive")
+    db_session.add(account)
+    db_session.commit()
+
+    with pytest.raises(
+        gmail_provisioning.GmailProvisioningError,
+        match="requires an ordinary Gmail OAuth account",
+    ):
+        ensure_gmail_mailbox_provisioned(
+            db_session,
+            account,
+            service_factory=lambda *_args: pytest.fail("Gmail API was called"),
+            publisher_factory=lambda: pytest.fail("Pub/Sub API was called"),
+            subscriber_factory=lambda: pytest.fail("Pub/Sub API was called"),
+        )
+
+
+def test_watch_relationship_excludes_an_ordinary_non_gmail_account(
+    db_session: Session,
+) -> None:
+    user = _create_user(db_session)
+    account = _create_oauth(db_session, user)
+    setattr(account, "provider", "google-drive")
+    state = GmailWatchState(
+        user_id=int(user.id),
+        oauth_account_id=int(account.id),
+        email=str(account.email),
+        history_id="history",
+        topic_name="topic",
+        status=TriggerProvisioningStatus.ACTIVE.value,
+    )
+    db_session.add_all([account, state])
+    db_session.commit()
+    db_session.expire(state, ["oauth_account"])
+
+    assert state.oauth_account is None
 
 
 def test_provisioning_creates_deterministic_resources_and_active_state(
@@ -642,6 +687,60 @@ def test_sweep_warns_when_watch_account_is_not_ordinary(
     assert str(state.id) in caplog.text
     assert str(account.id) in caplog.text
     assert gmail_ownership_mismatch_signal in ops_signals.active_degradations()
+
+
+def test_sweep_mismatch_does_not_starve_a_valid_candidate(
+    db_session: Session,
+) -> None:
+    user = _create_user(db_session)
+    agent = _create_agent(db_session, user)
+    invalid_account = _create_oauth(
+        db_session,
+        user,
+        email="invalid@gmail.example",
+    )
+    valid_account = _create_oauth(
+        db_session,
+        user,
+        email="valid@gmail.example",
+    )
+    _create_gmail_trigger(db_session, user, agent, invalid_account)
+    _create_gmail_trigger(db_session, user, agent, valid_account)
+    now = datetime.now(timezone.utc)
+    invalid_state = GmailWatchState(
+        user_id=int(user.id),
+        oauth_account_id=int(invalid_account.id),
+        email=str(invalid_account.email),
+        history_id="old-invalid",
+        topic_name="invalid-topic",
+        status=TriggerProvisioningStatus.FAILED.value,
+        updated_at=now - timedelta(hours=2),
+    )
+    valid_state = GmailWatchState(
+        user_id=int(user.id),
+        oauth_account_id=int(valid_account.id),
+        email=str(valid_account.email),
+        history_id="old-valid",
+        topic_name="valid-topic",
+        status=TriggerProvisioningStatus.FAILED.value,
+        updated_at=now - timedelta(hours=1),
+    )
+    setattr(invalid_account, "resource_owner_key", "actor:alice")
+    db_session.add_all([invalid_account, invalid_state, valid_state])
+    db_session.commit()
+
+    attempts = sweep_gmail_provisioning(
+        db_session,
+        limit=1,
+        service_factory=lambda *_args: FakeGmailService(history_id="renewed"),
+        publisher_factory=lambda: FakePublisher(),
+        subscriber_factory=lambda: FakeSubscriber(),
+    )
+
+    assert attempts == 1
+    db_session.refresh(valid_state)
+    assert valid_state.history_id == "renewed"
+    assert valid_state.status == TriggerProvisioningStatus.ACTIVE.value
 
 
 def test_sweep_matches_duplicate_mailboxes_by_oauth_account_id(
@@ -1265,6 +1364,27 @@ def test_reconcile_matches_gmail_trigger_by_account_id_when_email_diverges(
     assert trigger.provisioning_error is None
 
 
+def test_reconcile_unbound_legacy_trigger_marks_configuration_failed(
+    db_session: Session,
+) -> None:
+    user = _create_user(db_session)
+    agent = _create_agent(db_session, user)
+    account = _create_oauth(db_session, user)
+    trigger = _create_gmail_trigger(db_session, user, agent, account)
+    setattr(trigger, "config", {"watch_label": "INBOX"})
+    setattr(trigger, "resource_id", "")
+    setattr(trigger, "provisioning_status", TriggerProvisioningStatus.ACTIVE.value)
+    db_session.add(trigger)
+    db_session.commit()
+
+    updated = reconcile_gmail_trigger_provisioning(db_session, [trigger])
+
+    assert updated == 1
+    db_session.refresh(trigger)
+    assert trigger.provisioning_status == TriggerProvisioningStatus.FAILED.value
+    assert "no OAuth account or mailbox binding" in str(trigger.provisioning_error)
+
+
 def test_reconcile_legacy_trigger_without_account_binding_matches_by_email(
     db_session: Session,
 ) -> None:
@@ -1519,6 +1639,37 @@ def test_release_warns_when_watch_account_is_not_ordinary(
     assert "Cannot stop Gmail watch" in caplog.text
     assert str(state.id) in caplog.text
     assert str(account.id) in caplog.text
+    assert gmail_ownership_mismatch_signal in ops_signals.active_degradations()
+
+
+def test_release_preserves_handles_for_a_non_gmail_watch_account(
+    db_session: Session,
+    gmail_ownership_mismatch_signal: str,
+) -> None:
+    user = _create_user(db_session)
+    account = _create_oauth(db_session, user)
+    state = GmailWatchState(
+        user_id=int(user.id),
+        oauth_account_id=int(account.id),
+        email=str(account.email),
+        history_id="history",
+        topic_name="topic",
+        status=TriggerProvisioningStatus.ACTIVE.value,
+    )
+    setattr(account, "provider", "google-drive")
+    db_session.add_all([account, state])
+    db_session.commit()
+
+    released = release_gmail_mailbox_if_unused(
+        db_session,
+        int(account.id),
+        service_factory=lambda *_args: pytest.fail("Gmail API was called"),
+        publisher_factory=lambda: pytest.fail("Pub/Sub API was called"),
+        subscriber_factory=lambda: pytest.fail("Pub/Sub API was called"),
+    )
+
+    assert released is False
+    assert db_session.get(GmailWatchState, int(state.id)) is state
     assert gmail_ownership_mismatch_signal in ops_signals.active_degradations()
 
 
@@ -2103,6 +2254,45 @@ def test_existing_subscription_resyncs_a_stale_oidc_audience(
     assert second.status == TriggerProvisioningStatus.ACTIVE.value
     assert len(subscriber.modify_calls) == 1
     assert subscription["push_config"]["oidc_token"]["audience"] == second.push_audience
+
+
+@pytest.mark.parametrize(
+    ("provider", "resource_owner_key"),
+    [("gmail", "actor:alice"), ("google-drive", None)],
+)
+def test_endpoint_reconciliation_skips_nonordinary_watch_accounts(
+    db_session: Session,
+    provider: str,
+    resource_owner_key: str | None,
+) -> None:
+    user = _create_user(db_session)
+    agent = _create_agent(db_session, user)
+    account = _create_oauth(db_session, user)
+    _create_gmail_trigger(db_session, user, agent, account)
+    state = GmailWatchState(
+        user_id=int(user.id),
+        oauth_account_id=int(account.id),
+        email=str(account.email),
+        history_id="old",
+        topic_name="projects/demo-project/topics/xagent-gmail-owner",
+        status=TriggerProvisioningStatus.ACTIVE.value,
+        callback_id="owner-callback",
+        subscription_name=("projects/demo-project/subscriptions/xagent-gmail-owner"),
+        push_audience="https://old.example/callback",
+    )
+    setattr(account, "provider", provider)
+    setattr(account, "resource_owner_key", resource_owner_key)
+    db_session.add_all([account, state])
+    db_session.commit()
+
+    result = reconcile_gmail_push_endpoints(
+        db_session,
+        execute=False,
+        subscriber_factory=lambda: pytest.fail("Pub/Sub API was called"),
+    )
+
+    assert result.scanned == 0
+    assert result.failed == 0
 
 
 def test_reconcile_push_endpoint_uses_s2s_base_without_reregistering_watch(
@@ -3129,6 +3319,34 @@ def test_reconciliation_rejects_watch_state_owned_by_another_user(
     assert gmail_ownership_mismatch_signal in ops_signals.active_degradations()
 
 
+def test_reconciliation_rejects_a_non_gmail_watch_account(
+    db_session: Session,
+    gmail_ownership_mismatch_signal: str,
+) -> None:
+    owner = _create_user(db_session)
+    agent = _create_agent(db_session, owner)
+    account = _create_oauth(db_session, owner)
+    trigger = _create_gmail_trigger(db_session, owner, agent, account)
+    state = GmailWatchState(
+        user_id=int(owner.id),
+        oauth_account_id=int(account.id),
+        email=str(account.email),
+        history_id="old",
+        topic_name="old-topic",
+        status=TriggerProvisioningStatus.ACTIVE.value,
+    )
+    setattr(account, "provider", "google-drive")
+    db_session.add_all([account, state])
+    db_session.commit()
+
+    assert reconcile_gmail_trigger_provisioning(db_session, [trigger]) == 1
+
+    db_session.refresh(trigger)
+    assert trigger.provisioning_status == TriggerProvisioningStatus.FAILED.value
+    assert "ownership mismatch" in str(trigger.provisioning_error).lower()
+    assert gmail_ownership_mismatch_signal in ops_signals.active_degradations()
+
+
 def test_renewal_scan_marks_nonordinary_watch_account_failed(
     db_session: Session,
     monkeypatch: pytest.MonkeyPatch,
@@ -3162,6 +3380,43 @@ def test_renewal_scan_marks_nonordinary_watch_account_failed(
     assert renewed == 0
     db_session.refresh(state)
     assert state.status == TriggerProvisioningStatus.FAILED.value
+    assert "ownership mismatch" in str(state.last_error).lower()
+    assert gmail_ownership_mismatch_signal in ops_signals.active_degradations()
+
+
+def test_renewal_scan_classifies_a_failed_mismatch_with_no_error(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    gmail_ownership_mismatch_signal: str,
+) -> None:
+    from xagent.web.services.gmail_triggers import scan_due_gmail_watch_renewals
+
+    monkeypatch.setenv("XAGENT_GMAIL_WATCH_ENABLED", "true")
+    owner = _create_user(db_session)
+    agent = _create_agent(db_session, owner)
+    account = _create_oauth(db_session, owner)
+    _create_gmail_trigger(db_session, owner, agent, account)
+    state = GmailWatchState(
+        user_id=int(owner.id),
+        oauth_account_id=int(account.id),
+        email=str(account.email),
+        history_id="old",
+        topic_name="old-topic",
+        watch_expiration=datetime.now(timezone.utc) - timedelta(hours=1),
+        status=TriggerProvisioningStatus.FAILED.value,
+        last_error=None,
+    )
+    setattr(account, "resource_owner_key", "actor:alice")
+    db_session.add_all([account, state])
+    db_session.commit()
+
+    renewed = scan_due_gmail_watch_renewals(
+        db_session,
+        service_factory=lambda *_args: pytest.fail("Gmail API was called"),
+    )
+
+    assert renewed == 0
+    db_session.refresh(state)
     assert "ownership mismatch" in str(state.last_error).lower()
     assert gmail_ownership_mismatch_signal in ops_signals.active_degradations()
 

--- a/tests/web/services/test_gmail_provisioning.py
+++ b/tests/web/services/test_gmail_provisioning.py
@@ -1180,6 +1180,49 @@ def test_release_treats_an_already_stopped_gmail_watch_as_converged(
     assert db_session.get(GmailWatchState, state_id) is None
 
 
+def test_oauth_account_deletion_waits_for_durable_watch_cleanup(
+    db_session: Session,
+) -> None:
+    request_deletion = getattr(
+        gmail_provisioning,
+        "request_gmail_oauth_account_deletion",
+        None,
+    )
+    assert callable(request_deletion)
+
+    user = _create_user(db_session)
+    account = _create_oauth(db_session, user)
+    publisher = FakePublisher()
+    subscriber = FakeSubscriber()
+    service = FakeGmailService()
+    state = ensure_gmail_mailbox_provisioned(
+        db_session,
+        account,
+        service_factory=lambda _db, _account: service,
+        publisher_factory=lambda: publisher,
+        subscriber_factory=lambda: subscriber,
+    )
+    state_id = int(state.id)
+
+    assert request_deletion(db_session, int(account.id)) is False
+    db_session.refresh(state)
+    assert state.status == TriggerProvisioningStatus.FAILED.value
+    assert str(state.last_error).startswith("Gmail watch cleanup pending:")
+    assert db_session.get(UserOAuth, int(account.id)) is account
+
+    assert (
+        sweep_gmail_provisioning(
+            db_session,
+            service_factory=lambda _db, _account: service,
+            publisher_factory=lambda: publisher,
+            subscriber_factory=lambda: subscriber,
+        )
+        == 1
+    )
+    assert db_session.get(GmailWatchState, state_id) is None
+    assert request_deletion(db_session, int(account.id)) is True
+
+
 def test_release_converges_when_production_gmail_stop_returns_http_404(
     db_session: Session,
 ) -> None:

--- a/tests/web/services/test_gmail_provisioning.py
+++ b/tests/web/services/test_gmail_provisioning.py
@@ -1018,6 +1018,167 @@ def test_unregister_preserves_cleanup_handles_when_remote_stop_fails(
     assert publisher.deleted_topics == []
 
 
+def test_sweep_retries_unreferenced_cleanup_after_remote_stop_failure(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FlakyStop:
+        def __init__(self) -> None:
+            self.stop_attempts = 0
+
+        def users(self) -> FlakyStop:
+            return self
+
+        def stop(self, *, userId: str) -> FlakyStop:
+            assert userId == "me"
+            return self
+
+        def execute(self) -> dict[str, object]:
+            self.stop_attempts += 1
+            if self.stop_attempts == 1:
+                raise RuntimeError("remote stop failed")
+            return {}
+
+    user = _create_user(db_session)
+    account = _create_oauth(db_session, user)
+    publisher = FakePublisher()
+    subscriber = FakeSubscriber()
+    service = FlakyStop()
+    state = ensure_gmail_mailbox_provisioned(
+        db_session,
+        account,
+        service_factory=lambda _db, _account: FakeGmailService(),
+        publisher_factory=lambda: publisher,
+        subscriber_factory=lambda: subscriber,
+    )
+    state_id = int(state.id)
+
+    assert (
+        release_gmail_mailbox_if_unused(
+            db_session,
+            int(account.id),
+            service_factory=lambda _db, _account: service,
+            publisher_factory=lambda: publisher,
+            subscriber_factory=lambda: subscriber,
+        )
+        is False
+    )
+    db_session.refresh(state)
+    assert state.status == TriggerProvisioningStatus.FAILED.value
+    assert str(state.last_error).startswith("Gmail watch cleanup pending:")
+
+    monkeypatch.setenv("XAGENT_GMAIL_WATCH_ENABLED", "false")
+    assert (
+        sweep_gmail_provisioning(
+            db_session,
+            service_factory=lambda _db, _account: service,
+            publisher_factory=lambda: publisher,
+            subscriber_factory=lambda: subscriber,
+        )
+        == 1
+    )
+    assert service.stop_attempts == 2
+    assert subscriber.deleted_subscriptions == [state.subscription_name]
+    assert publisher.deleted_topics == [state.topic_name]
+    assert db_session.get(GmailWatchState, state_id) is None
+
+
+def test_sweep_retries_cleanup_when_pubsub_deletion_fails(
+    db_session: Session,
+) -> None:
+    class FlakySubscriber(FakeSubscriber):
+        def __init__(self) -> None:
+            super().__init__()
+            self.delete_attempts = 0
+
+        def delete_subscription(self, *, request: dict[str, str]) -> None:
+            self.delete_attempts += 1
+            if self.delete_attempts == 1:
+                raise RuntimeError("subscription deletion failed")
+            super().delete_subscription(request=request)
+
+    user = _create_user(db_session)
+    account = _create_oauth(db_session, user)
+    publisher = FakePublisher()
+    subscriber = FlakySubscriber()
+    service = FakeGmailService()
+    state = ensure_gmail_mailbox_provisioned(
+        db_session,
+        account,
+        service_factory=lambda _db, _account: service,
+        publisher_factory=lambda: publisher,
+        subscriber_factory=lambda: subscriber,
+    )
+    state_id = int(state.id)
+
+    assert (
+        release_gmail_mailbox_if_unused(
+            db_session,
+            int(account.id),
+            service_factory=lambda _db, _account: service,
+            publisher_factory=lambda: publisher,
+            subscriber_factory=lambda: subscriber,
+        )
+        is False
+    )
+    db_session.refresh(state)
+    assert state.status == TriggerProvisioningStatus.FAILED.value
+    assert "subscription deletion failed" in str(state.last_error)
+
+    assert (
+        sweep_gmail_provisioning(
+            db_session,
+            service_factory=lambda _db, _account: service,
+            publisher_factory=lambda: publisher,
+            subscriber_factory=lambda: subscriber,
+        )
+        == 1
+    )
+    assert subscriber.delete_attempts == 2
+    assert db_session.get(GmailWatchState, state_id) is None
+
+
+def test_release_treats_an_already_stopped_gmail_watch_as_converged(
+    db_session: Session,
+) -> None:
+    from google.api_core.exceptions import NotFound
+
+    class AlreadyStopped:
+        def users(self) -> AlreadyStopped:
+            return self
+
+        def stop(self, *, userId: str) -> AlreadyStopped:
+            assert userId == "me"
+            return self
+
+        def execute(self) -> NoReturn:
+            raise NotFound("watch is already absent")
+
+    user = _create_user(db_session)
+    account = _create_oauth(db_session, user)
+    publisher = FakePublisher()
+    subscriber = FakeSubscriber()
+    state = ensure_gmail_mailbox_provisioned(
+        db_session,
+        account,
+        service_factory=lambda _db, _account: FakeGmailService(),
+        publisher_factory=lambda: publisher,
+        subscriber_factory=lambda: subscriber,
+    )
+    state_id = int(state.id)
+
+    assert release_gmail_mailbox_if_unused(
+        db_session,
+        int(account.id),
+        service_factory=lambda _db, _account: AlreadyStopped(),
+        publisher_factory=lambda: publisher,
+        subscriber_factory=lambda: subscriber,
+    )
+    assert subscriber.deleted_subscriptions == [state.subscription_name]
+    assert publisher.deleted_topics == [state.topic_name]
+    assert db_session.get(GmailWatchState, state_id) is None
+
+
 async def test_gmail_provider_register_unregister_offload_sync_sdk_work(
     db_session: Session, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1077,6 +1238,46 @@ async def test_gmail_provider_register_unregister_offload_sync_sdk_work(
         "to_thread:fake_release",
         f"release:{account.id}",
     ]
+
+
+async def test_gmail_provider_unregister_resolves_legacy_mailbox_binding(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.services.trigger_providers.gmail import GmailProvider
+
+    user = _create_user(db_session)
+    agent = _create_agent(db_session, user)
+    account = _create_oauth(db_session, user)
+    trigger = _create_gmail_trigger(db_session, user, agent, account)
+    setattr(trigger, "config", {"watch_label": "INBOX"})
+    db_session.add(trigger)
+    db_session.commit()
+    ensure_gmail_mailbox_provisioned(
+        db_session,
+        account,
+        service_factory=lambda _db, _account: FakeGmailService(),
+        publisher_factory=FakePublisher,
+        subscriber_factory=FakeSubscriber,
+    )
+    released: list[int] = []
+
+    monkeypatch.setattr(
+        "xagent.web.services.trigger_providers.gmail.release_gmail_mailbox_if_unused",
+        lambda _db, account_id: released.append(int(account_id)),
+    )
+
+    async def run_inline(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(
+        "xagent.web.services.trigger_providers.gmail.asyncio.to_thread",
+        run_inline,
+    )
+
+    await GmailProvider().unregister(db_session, trigger, dict(trigger.config))
+
+    assert released == [int(account.id)]
 
 
 def test_slow_registration_returns_pending_then_reconciles_to_active(

--- a/tests/web/services/test_gmail_provisioning.py
+++ b/tests/web/services/test_gmail_provisioning.py
@@ -29,7 +29,7 @@ from xagent.web.models.trigger import (
 )
 from xagent.web.models.user import User
 from xagent.web.models.user_oauth import UserOAuth
-from xagent.web.services import gmail_provisioning
+from xagent.web.services import gmail_provisioning, ops_signals
 from xagent.web.services.gmail_provisioning import (
     GMAIL_PUSH_PUBLISHER,
     GMAIL_WATCH_DISABLED_ERROR,
@@ -94,6 +94,107 @@ def test_transition_lock_yields_the_database_session(
         oauth_account_id=7,
     ) as transition_db:
         assert transition_db is db_session
+
+
+def test_background_provisioning_warns_when_ordinary_account_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class FakeSession:
+        closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    db = FakeSession()
+    monkeypatch.setattr(
+        "xagent.web.models.database.get_session_local",
+        lambda: lambda: db,
+    )
+    monkeypatch.setattr(
+        gmail_provisioning,
+        "get_user_oauth_account_by_id",
+        lambda *_args, **_kwargs: None,
+    )
+    caplog.set_level(logging.WARNING, logger=gmail_provisioning.__name__)
+
+    gmail_provisioning._provision_in_fresh_session(47)
+
+    assert "Cannot provision Gmail watch without ordinary OAuth account" in caplog.text
+    assert "47" in caplog.text
+    assert db.closed is True
+
+
+def test_provisioning_captures_account_identity_before_transition_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The lock may commit and expire the caller's ORM identity map."""
+
+    class Account:
+        id = 7
+        resource_owner_key = None
+        expired = False
+
+        @property
+        def user_id(self) -> int:
+            if self.expired:
+                raise AssertionError("expired account identity was lazy-loaded")
+            return 11
+
+    class CallerSession:
+        expired_all = False
+
+        def expire_all(self) -> None:
+            self.expired_all = True
+
+    class TransitionLock:
+        def __enter__(self):
+            account.expired = True
+            return transition_db
+
+        def __exit__(self, *_args) -> None:
+            return None
+
+    account = Account()
+    caller_db = CallerSession()
+    transition_db = object()
+    transition_account = object()
+    state = object()
+    captured_user_ids: list[int] = []
+
+    monkeypatch.setattr(
+        gmail_provisioning,
+        "_gmail_watch_transition_lock",
+        lambda _db, _account_id: TransitionLock(),
+    )
+
+    def get_account(_db, *, user_id, account_id, resource_owner_key):
+        assert _db is transition_db
+        assert account_id == 7
+        assert resource_owner_key is None
+        captured_user_ids.append(user_id)
+        return transition_account
+
+    monkeypatch.setattr(
+        gmail_provisioning,
+        "get_scoped_user_oauth_account",
+        get_account,
+    )
+    monkeypatch.setattr(
+        gmail_provisioning,
+        "_ensure_gmail_mailbox_provisioned_locked",
+        lambda db, oauth_account, **_kwargs: (
+            state
+            if db is transition_db and oauth_account is transition_account
+            else pytest.fail("unexpected transition arguments")
+        ),
+    )
+
+    result = ensure_gmail_mailbox_provisioned(caller_db, account)
+
+    assert result is state
+    assert captured_user_ids == [11]
+    assert caller_db.expired_all is True
 
 
 def test_postgresql_transition_uses_only_the_lock_owning_connection(
@@ -460,6 +561,89 @@ def test_sweep_retries_stale_failed_referenced_mailbox(db_session: Session) -> N
     assert refreshed.last_error is None
 
 
+@pytest.fixture
+def gmail_ownership_mismatch_signal() -> str:
+    name = "gmail_oauth_ownership_mismatch"
+    ops_signals.clear_degradation(name)
+    yield name
+    ops_signals.clear_degradation(name)
+
+
+def test_provisioning_rejects_watch_state_owned_by_another_user(
+    db_session: Session,
+    gmail_ownership_mismatch_signal: str,
+) -> None:
+    owner = _create_user(db_session)
+    account = _create_oauth(db_session, owner)
+    other_user = User(
+        username="other-owner",
+        email="other-owner@example.com",
+        password_hash="hash",
+    )
+    db_session.add(other_user)
+    db_session.commit()
+    state = GmailWatchState(
+        user_id=int(other_user.id),
+        oauth_account_id=int(account.id),
+        email="other@gmail.example",
+        history_id="old",
+        topic_name="old-topic",
+        status=TriggerProvisioningStatus.ACTIVE.value,
+    )
+    db_session.add(state)
+    db_session.commit()
+
+    with pytest.raises(
+        gmail_provisioning.GmailProvisioningError,
+        match="ownership mismatch",
+    ):
+        ensure_gmail_mailbox_provisioned(
+            db_session,
+            account,
+            service_factory=lambda *_args: pytest.fail("Gmail API was called"),
+            publisher_factory=lambda: pytest.fail("Pub/Sub API was called"),
+            subscriber_factory=lambda: pytest.fail("Pub/Sub API was called"),
+        )
+
+    db_session.refresh(state)
+    assert state.user_id == int(other_user.id)
+    assert state.email == "other@gmail.example"
+    assert state.status == TriggerProvisioningStatus.ACTIVE.value
+    assert gmail_ownership_mismatch_signal in ops_signals.active_degradations()
+
+
+def test_sweep_warns_when_watch_account_is_not_ordinary(
+    db_session: Session,
+    caplog: pytest.LogCaptureFixture,
+    gmail_ownership_mismatch_signal: str,
+) -> None:
+    user = _create_user(db_session)
+    agent = _create_agent(db_session, user)
+    account = _create_oauth(db_session, user)
+    _create_gmail_trigger(db_session, user, agent, account)
+    state = GmailWatchState(
+        user_id=int(user.id),
+        oauth_account_id=int(account.id),
+        email="owner@gmail.example",
+        history_id="",
+        topic_name="",
+        status=TriggerProvisioningStatus.FAILED.value,
+        updated_at=datetime.now(timezone.utc) - timedelta(minutes=10),
+    )
+    setattr(account, "resource_owner_key", "actor:alice")
+    db_session.add_all([account, state])
+    db_session.commit()
+
+    with caplog.at_level(logging.WARNING):
+        attempts = sweep_gmail_provisioning(db_session)
+
+    assert attempts == 0
+    assert "Skipping Gmail provisioning sweep" in caplog.text
+    assert str(state.id) in caplog.text
+    assert str(account.id) in caplog.text
+    assert gmail_ownership_mismatch_signal in ops_signals.active_degradations()
+
+
 def test_sweep_matches_duplicate_mailboxes_by_oauth_account_id(
     db_session: Session,
 ) -> None:
@@ -660,6 +844,79 @@ def test_unregister_releases_mailbox_only_after_last_enabled_trigger_is_deleted(
     assert subscriber.deleted_subscriptions == [state.subscription_name]
     assert publisher.deleted_topics == [state.topic_name]
     assert db_session.query(GmailWatchState).count() == 0
+
+
+def test_unregister_ignores_same_mailbox_trigger_for_another_account(
+    db_session: Session,
+) -> None:
+    user = _create_user(db_session)
+    target_account = _create_oauth(db_session, user)
+    other_account = _create_oauth(db_session, user)
+    agent = _create_agent(db_session, user)
+    _create_gmail_trigger(db_session, user, agent, other_account)
+    publisher = FakePublisher()
+    subscriber = FakeSubscriber()
+    gmail = FakeGmailService()
+    state = ensure_gmail_mailbox_provisioned(
+        db_session,
+        target_account,
+        service_factory=lambda _db, _account: gmail,
+        publisher_factory=lambda: publisher,
+        subscriber_factory=lambda: subscriber,
+    )
+
+    assert release_gmail_mailbox_if_unused(
+        db_session,
+        int(target_account.id),
+        service_factory=lambda _db, _account: gmail,
+        publisher_factory=lambda: publisher,
+        subscriber_factory=lambda: subscriber,
+    )
+    assert gmail.stop_calls == [{"userId": "me"}]
+    assert subscriber.deleted_subscriptions == [state.subscription_name]
+    assert publisher.deleted_topics == [state.topic_name]
+    assert db_session.get(GmailWatchState, int(state.id)) is None
+
+
+def test_unregister_preserves_cleanup_handles_when_remote_stop_fails(
+    db_session: Session,
+) -> None:
+    class StopFailure:
+        def users(self) -> StopFailure:
+            return self
+
+        def stop(self, *, userId: str) -> StopFailure:
+            assert userId == "me"
+            return self
+
+        def execute(self) -> NoReturn:
+            raise RuntimeError("remote stop failed")
+
+    user = _create_user(db_session)
+    account = _create_oauth(db_session, user)
+    publisher = FakePublisher()
+    subscriber = FakeSubscriber()
+    state = ensure_gmail_mailbox_provisioned(
+        db_session,
+        account,
+        service_factory=lambda _db, _account: FakeGmailService(),
+        publisher_factory=lambda: publisher,
+        subscriber_factory=lambda: subscriber,
+    )
+
+    assert (
+        release_gmail_mailbox_if_unused(
+            db_session,
+            int(account.id),
+            service_factory=lambda _db, _account: StopFailure(),
+            publisher_factory=lambda: publisher,
+            subscriber_factory=lambda: subscriber,
+        )
+        is False
+    )
+    assert db_session.get(GmailWatchState, int(state.id)) is state
+    assert subscriber.deleted_subscriptions == []
+    assert publisher.deleted_topics == []
 
 
 async def test_gmail_provider_register_unregister_offload_sync_sdk_work(
@@ -1227,6 +1484,44 @@ def test_unbind_releases_old_mailbox_while_flag_is_off(
     assert "disabled" in str(trigger.provisioning_error)
 
 
+def test_release_warns_when_watch_account_is_not_ordinary(
+    db_session: Session,
+    caplog: pytest.LogCaptureFixture,
+    gmail_ownership_mismatch_signal: str,
+) -> None:
+    user = _create_user(db_session)
+    account = _create_oauth(db_session, user)
+    state = GmailWatchState(
+        user_id=int(user.id),
+        oauth_account_id=int(account.id),
+        email="owner@gmail.example",
+        history_id="history",
+        topic_name="topic",
+        status=TriggerProvisioningStatus.ACTIVE.value,
+    )
+    setattr(account, "resource_owner_key", "actor:alice")
+    db_session.add_all([account, state])
+    db_session.commit()
+
+    def forbidden_cleanup_client() -> NoReturn:
+        raise AssertionError("cloud cleanup must wait for ownership remediation")
+
+    with caplog.at_level(logging.WARNING):
+        released = release_gmail_mailbox_if_unused(
+            db_session,
+            int(account.id),
+            publisher_factory=forbidden_cleanup_client,
+            subscriber_factory=forbidden_cleanup_client,
+        )
+
+    assert released is False
+    assert db_session.get(GmailWatchState, int(state.id)) is state
+    assert "Cannot stop Gmail watch" in caplog.text
+    assert str(state.id) in caplog.text
+    assert str(account.id) in caplog.text
+    assert gmail_ownership_mismatch_signal in ops_signals.active_degradations()
+
+
 def test_provision_gmail_trigger_disabled_reports_failed_without_registering(
     db_session: Session, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -1290,6 +1585,51 @@ def test_provision_gmail_trigger_disabled_mentions_project_id_when_also_missing(
     assert "XAGENT_GMAIL_WATCH_ENABLED" in str(other_trigger.provisioning_error)
     assert "XAGENT_GMAIL_PUBSUB_PROJECT_ID" in str(other_trigger.provisioning_error)
     assert db_session.query(GmailWatchState).count() == 0
+
+
+def test_provision_gmail_trigger_disabled_rejects_cross_user_watch_state(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    gmail_ownership_mismatch_signal: str,
+) -> None:
+    from xagent.web.services.gmail_provisioning import provision_gmail_trigger
+
+    monkeypatch.setenv("XAGENT_GMAIL_WATCH_ENABLED", "false")
+    owner = _create_user(db_session)
+    agent = _create_agent(db_session, owner)
+    account = _create_oauth(db_session, owner)
+    trigger = _create_gmail_trigger(db_session, owner, agent, account)
+    other_user = User(
+        username="disabled-other-owner",
+        email="disabled-other-owner@example.com",
+        password_hash="hash",
+    )
+    db_session.add(other_user)
+    db_session.commit()
+    db_session.add(
+        GmailWatchState(
+            user_id=int(other_user.id),
+            oauth_account_id=int(account.id),
+            email="owner@gmail.example",
+            history_id="hist-1",
+            topic_name="old-topic",
+            status=TriggerProvisioningStatus.ACTIVE.value,
+            watch_expiration=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+    )
+    db_session.commit()
+
+    status = provision_gmail_trigger(
+        db_session,
+        trigger,
+        run_in_thread=lambda _account_id: pytest.fail(
+            "provisioning thread must not start while disabled"
+        ),
+    )
+
+    assert status == TriggerProvisioningStatus.FAILED.value
+    assert "ownership mismatch" in str(trigger.provisioning_error).lower()
+    assert gmail_ownership_mismatch_signal in ops_signals.active_degradations()
 
 
 def test_provision_gmail_trigger_disabled_reports_existing_watch_state(
@@ -2754,6 +3094,301 @@ def test_iam_grant_appends_to_existing_publisher_binding(
     ]
 
 
+def test_reconciliation_rejects_watch_state_owned_by_another_user(
+    db_session: Session,
+    gmail_ownership_mismatch_signal: str,
+) -> None:
+    owner = _create_user(db_session)
+    agent = _create_agent(db_session, owner)
+    account = _create_oauth(db_session, owner)
+    trigger = _create_gmail_trigger(db_session, owner, agent, account)
+    other_user = User(
+        username="reconcile-other-owner",
+        email="reconcile-other-owner@example.com",
+        password_hash="hash",
+    )
+    db_session.add(other_user)
+    db_session.commit()
+    db_session.add(
+        GmailWatchState(
+            user_id=int(other_user.id),
+            oauth_account_id=int(account.id),
+            email="owner@gmail.example",
+            history_id="old",
+            topic_name="old-topic",
+            status=TriggerProvisioningStatus.ACTIVE.value,
+        )
+    )
+    db_session.commit()
+
+    assert reconcile_gmail_trigger_provisioning(db_session, [trigger]) == 1
+
+    db_session.refresh(trigger)
+    assert trigger.provisioning_status == TriggerProvisioningStatus.FAILED.value
+    assert "ownership mismatch" in str(trigger.provisioning_error).lower()
+    assert gmail_ownership_mismatch_signal in ops_signals.active_degradations()
+
+
+def test_renewal_scan_marks_nonordinary_watch_account_failed(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    gmail_ownership_mismatch_signal: str,
+) -> None:
+    from xagent.web.services.gmail_triggers import scan_due_gmail_watch_renewals
+
+    monkeypatch.setenv("XAGENT_GMAIL_WATCH_ENABLED", "true")
+    owner = _create_user(db_session)
+    agent = _create_agent(db_session, owner)
+    account = _create_oauth(db_session, owner)
+    _create_gmail_trigger(db_session, owner, agent, account)
+    state = GmailWatchState(
+        user_id=int(owner.id),
+        oauth_account_id=int(account.id),
+        email="owner@gmail.example",
+        history_id="old",
+        topic_name="old-topic",
+        watch_expiration=datetime.now(timezone.utc) - timedelta(hours=1),
+        status=TriggerProvisioningStatus.ACTIVE.value,
+    )
+    setattr(account, "resource_owner_key", "actor:alice")
+    db_session.add_all([account, state])
+    db_session.commit()
+
+    renewed = scan_due_gmail_watch_renewals(
+        db_session,
+        service_factory=lambda *_args: pytest.fail("Gmail API was called"),
+    )
+
+    assert renewed == 0
+    db_session.refresh(state)
+    assert state.status == TriggerProvisioningStatus.FAILED.value
+    assert "ownership mismatch" in str(state.last_error).lower()
+    assert gmail_ownership_mismatch_signal in ops_signals.active_degradations()
+
+
+def test_renewal_scan_does_not_count_owner_mismatches_against_batch_limit(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    gmail_ownership_mismatch_signal: str,
+) -> None:
+    from xagent.web.services import gmail_provisioning
+    from xagent.web.services.gmail_triggers import scan_due_gmail_watch_renewals
+
+    monkeypatch.setenv("XAGENT_GMAIL_WATCH_ENABLED", "true")
+    owner = _create_user(db_session)
+    agent = _create_agent(db_session, owner)
+    invalid_account = _create_oauth(
+        db_session,
+        owner,
+        email="invalid@gmail.example",
+    )
+    valid_account = _create_oauth(
+        db_session,
+        owner,
+        email="valid@gmail.example",
+    )
+    _create_gmail_trigger(db_session, owner, agent, invalid_account)
+    _create_gmail_trigger(db_session, owner, agent, valid_account)
+    invalid_state = GmailWatchState(
+        user_id=int(owner.id),
+        oauth_account_id=int(invalid_account.id),
+        email="invalid@gmail.example",
+        history_id="old-invalid",
+        topic_name="old-invalid-topic",
+        watch_expiration=datetime.now(timezone.utc) - timedelta(hours=2),
+        status=TriggerProvisioningStatus.ACTIVE.value,
+    )
+    valid_state = GmailWatchState(
+        user_id=int(owner.id),
+        oauth_account_id=int(valid_account.id),
+        email="valid@gmail.example",
+        history_id="old-valid",
+        topic_name="old-valid-topic",
+        watch_expiration=datetime.now(timezone.utc) - timedelta(hours=1),
+        status=TriggerProvisioningStatus.ACTIVE.value,
+    )
+    setattr(invalid_account, "resource_owner_key", "actor:alice")
+    db_session.add_all([invalid_account, invalid_state, valid_state])
+    db_session.commit()
+    monkeypatch.setattr(
+        gmail_provisioning,
+        "_default_publisher",
+        lambda: FakePublisher(),
+    )
+    monkeypatch.setattr(
+        gmail_provisioning,
+        "_default_subscriber",
+        lambda: FakeSubscriber(),
+    )
+
+    renewed = scan_due_gmail_watch_renewals(
+        db_session,
+        service_factory=lambda *_args: FakeGmailService(history_id="renewed"),
+        limit=1,
+    )
+
+    assert renewed == 1
+    db_session.refresh(invalid_state)
+    db_session.refresh(valid_state)
+    assert invalid_state.status == TriggerProvisioningStatus.FAILED.value
+    assert valid_state.status == TriggerProvisioningStatus.ACTIVE.value
+    assert valid_state.history_id == "renewed"
+    assert gmail_ownership_mismatch_signal in ops_signals.active_degradations()
+
+
+def test_renewal_scan_does_not_count_cross_user_states_against_batch_limit(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    gmail_ownership_mismatch_signal: str,
+) -> None:
+    from xagent.web.services import gmail_provisioning
+    from xagent.web.services.gmail_triggers import scan_due_gmail_watch_renewals
+
+    monkeypatch.setenv("XAGENT_GMAIL_WATCH_ENABLED", "true")
+    owner = _create_user(db_session)
+    other_user = User(
+        username="renewal-other-owner",
+        email="renewal-other-owner@example.com",
+        password_hash="hash",
+    )
+    db_session.add(other_user)
+    db_session.commit()
+    agent = _create_agent(db_session, owner)
+    mismatched_account = _create_oauth(
+        db_session,
+        owner,
+        email="mismatched@gmail.example",
+    )
+    valid_account = _create_oauth(
+        db_session,
+        owner,
+        email="valid-cross-user@gmail.example",
+    )
+    _create_gmail_trigger(db_session, owner, agent, mismatched_account)
+    _create_gmail_trigger(db_session, owner, agent, valid_account)
+    mismatched_state = GmailWatchState(
+        user_id=int(other_user.id),
+        oauth_account_id=int(mismatched_account.id),
+        email="mismatched@gmail.example",
+        history_id="old-mismatched",
+        topic_name="old-mismatched-topic",
+        watch_expiration=datetime.now(timezone.utc) - timedelta(hours=2),
+        status=TriggerProvisioningStatus.ACTIVE.value,
+    )
+    valid_state = GmailWatchState(
+        user_id=int(owner.id),
+        oauth_account_id=int(valid_account.id),
+        email="valid-cross-user@gmail.example",
+        history_id="old-valid",
+        topic_name="old-valid-topic",
+        watch_expiration=datetime.now(timezone.utc) - timedelta(hours=1),
+        status=TriggerProvisioningStatus.ACTIVE.value,
+    )
+    db_session.add_all([mismatched_state, valid_state])
+    db_session.commit()
+    monkeypatch.setattr(
+        gmail_provisioning,
+        "_default_publisher",
+        lambda: FakePublisher(),
+    )
+    monkeypatch.setattr(
+        gmail_provisioning,
+        "_default_subscriber",
+        lambda: FakeSubscriber(),
+    )
+
+    renewed = scan_due_gmail_watch_renewals(
+        db_session,
+        service_factory=lambda *_args: FakeGmailService(history_id="renewed"),
+        limit=1,
+    )
+
+    assert renewed == 1
+    db_session.refresh(mismatched_state)
+    db_session.refresh(valid_state)
+    assert mismatched_state.status == TriggerProvisioningStatus.FAILED.value
+    assert valid_state.status == TriggerProvisioningStatus.ACTIVE.value
+    assert valid_state.history_id == "renewed"
+    assert gmail_ownership_mismatch_signal in ops_signals.active_degradations()
+
+
+def test_renewal_scan_renews_only_accounts_bound_to_enabled_triggers(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from xagent.web.services import gmail_triggers
+
+    monkeypatch.setenv("XAGENT_GMAIL_WATCH_ENABLED", "true")
+    owner = _create_user(db_session)
+    agent = _create_agent(db_session, owner)
+    _create_oauth(db_session, owner, email="unbound@gmail.example")
+    bound_account = _create_oauth(db_session, owner, email="bound@gmail.example")
+    _create_gmail_trigger(db_session, owner, agent, bound_account)
+    renewed_account_ids: list[int] = []
+
+    def record_renewal(_db, account, *, service_factory):
+        renewed_account_ids.append(int(account.id))
+
+    monkeypatch.setattr(gmail_triggers, "_renew_watch_for_account", record_renewal)
+
+    renewed = gmail_triggers.scan_due_gmail_watch_renewals(
+        db_session,
+        service_factory=lambda *_args: pytest.fail("Gmail API was called"),
+        limit=1,
+    )
+
+    assert renewed == 1
+    assert renewed_account_ids == [int(bound_account.id)]
+
+
+def test_renewal_scan_progresses_through_recorded_owner_mismatches(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+    gmail_ownership_mismatch_signal: str,
+) -> None:
+    from xagent.web.services.gmail_triggers import scan_due_gmail_watch_renewals
+
+    monkeypatch.setenv("XAGENT_GMAIL_WATCH_ENABLED", "true")
+    owner = _create_user(db_session)
+    agent = _create_agent(db_session, owner)
+    accounts = [
+        _create_oauth(db_session, owner, email=f"invalid-{index}@gmail.example")
+        for index in range(2)
+    ]
+    states = []
+    for index, account in enumerate(accounts):
+        _create_gmail_trigger(db_session, owner, agent, account)
+        state = GmailWatchState(
+            user_id=int(owner.id),
+            oauth_account_id=int(account.id),
+            email=str(account.email),
+            history_id=f"old-{index}",
+            topic_name=f"old-topic-{index}",
+            watch_expiration=datetime.now(timezone.utc) - timedelta(hours=index + 1),
+            status=TriggerProvisioningStatus.ACTIVE.value,
+        )
+        setattr(account, "resource_owner_key", f"actor:{index}")
+        states.append(state)
+    db_session.add_all([*accounts, *states])
+    db_session.commit()
+
+    for _ in states:
+        assert (
+            scan_due_gmail_watch_renewals(
+                db_session,
+                service_factory=lambda *_args: pytest.fail("Gmail API was called"),
+                limit=1,
+            )
+            == 0
+        )
+
+    for state in states:
+        db_session.refresh(state)
+        assert state.status == TriggerProvisioningStatus.FAILED.value
+        assert "ownership mismatch" in str(state.last_error).lower()
+    assert gmail_ownership_mismatch_signal in ops_signals.active_degradations()
+
+
 def test_renewal_scan_uses_per_mailbox_provisioning_when_project_configured(
     db_session: Session, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -3105,6 +3740,63 @@ def test_concurrent_first_time_creations_race_on_the_unique_constraint(
     assert rows[0].email == "owner@gmail.example"
 
 
+def test_wrong_user_trigger_does_not_reference_watch_lifecycle(
+    db_session: Session,
+) -> None:
+    owner = _create_user(db_session)
+    account = _create_oauth(db_session, owner)
+    other_user = User(
+        username="wrong-trigger-owner",
+        email="wrong-trigger-owner@example.com",
+        password_hash="hash",
+    )
+    db_session.add(other_user)
+    db_session.commit()
+    other_agent = _create_agent(db_session, other_user)
+    _create_gmail_trigger(db_session, other_user, other_agent, account)
+    state = GmailWatchState(
+        user_id=int(owner.id),
+        oauth_account_id=int(account.id),
+        email=str(account.email),
+        history_id="old",
+        topic_name="old-topic",
+        status=TriggerProvisioningStatus.FAILED.value,
+        updated_at=datetime.now(timezone.utc) - timedelta(minutes=10),
+    )
+    db_session.add(state)
+    db_session.commit()
+
+    assert (
+        sweep_gmail_provisioning(
+            db_session,
+            service_factory=lambda *_args: pytest.fail("Gmail API was called"),
+            publisher_factory=lambda: pytest.fail("Pub/Sub API was called"),
+            subscriber_factory=lambda: pytest.fail("Pub/Sub API was called"),
+        )
+        == 0
+    )
+
+    setattr(state, "status", TriggerProvisioningStatus.ACTIVE.value)
+    setattr(
+        state,
+        "watch_expiration",
+        datetime.now(timezone.utc) - timedelta(hours=1),
+    )
+    setattr(state, "last_error", None)
+    db_session.add(state)
+    db_session.commit()
+
+    from xagent.web.services.gmail_triggers import scan_due_gmail_watch_renewals
+
+    assert scan_due_gmail_watch_renewals(db_session, limit=1) == 0
+    db_session.refresh(state)
+    assert state.status == TriggerProvisioningStatus.ACTIVE.value
+    assert state.last_error is None
+
+    result = reconcile_gmail_push_endpoints(db_session)
+    assert result.scanned == 0
+
+
 @pytest.mark.postgresql
 def test_gmail_trigger_lookup_resolves_bindings_on_postgresql(
     pg_session: Session,
@@ -3127,7 +3819,7 @@ def test_gmail_trigger_lookup_resolves_bindings_on_postgresql(
 
     referenced = gmail_provisioning._referenced_gmail_oauth_account_ids(
         db,
-        [(int(account.id), str(account.email or ""))],
+        [(int(account.id), int(account.user_id), str(account.email or ""))],
     )
 
     assert referenced == {int(account.id)}

--- a/tests/web/services/test_gmail_provisioning.py
+++ b/tests/web/services/test_gmail_provisioning.py
@@ -7,6 +7,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, NoReturn
 
 import pytest
+from requests import HTTPError
 from sqlalchemy import create_engine, event
 from sqlalchemy import text as sql_text
 from sqlalchemy.exc import OperationalError
@@ -29,7 +30,7 @@ from xagent.web.models.trigger import (
 )
 from xagent.web.models.user import User
 from xagent.web.models.user_oauth import UserOAuth
-from xagent.web.services import gmail_provisioning, ops_signals
+from xagent.web.services import gmail_provisioning, gmail_triggers, ops_signals
 from xagent.web.services.gmail_provisioning import (
     GMAIL_PUSH_PUBLISHER,
     GMAIL_WATCH_DISABLED_ERROR,
@@ -1174,6 +1175,65 @@ def test_release_treats_an_already_stopped_gmail_watch_as_converged(
         publisher_factory=lambda: publisher,
         subscriber_factory=lambda: subscriber,
     )
+    assert subscriber.deleted_subscriptions == [state.subscription_name]
+    assert publisher.deleted_topics == [state.topic_name]
+    assert db_session.get(GmailWatchState, state_id) is None
+
+
+def test_release_converges_when_production_gmail_stop_returns_http_404(
+    db_session: Session,
+) -> None:
+    """Exercise the same REST request and HTTP error surface used in production."""
+
+    class MissingResponse:
+        status_code = 404
+        content = b""
+
+        def raise_for_status(self) -> NoReturn:
+            error = HTTPError("404 Client Error: Not Found")
+            error.response = self  # type: ignore[assignment]
+            raise error
+
+    class RecordingSession:
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, str]] = []
+
+        def request(
+            self,
+            method: str,
+            url: str,
+            *,
+            timeout: int,
+            **_kwargs: Any,
+        ) -> MissingResponse:
+            assert timeout == 10
+            self.calls.append((method, url))
+            return MissingResponse()
+
+    user = _create_user(db_session)
+    account = _create_oauth(db_session, user)
+    publisher = FakePublisher()
+    subscriber = FakeSubscriber()
+    state = ensure_gmail_mailbox_provisioned(
+        db_session,
+        account,
+        service_factory=lambda _db, _account: FakeGmailService(),
+        publisher_factory=lambda: publisher,
+        subscriber_factory=lambda: subscriber,
+    )
+    state_id = int(state.id)
+    session = RecordingSession()
+
+    assert release_gmail_mailbox_if_unused(
+        db_session,
+        int(account.id),
+        service_factory=lambda _db, _account: gmail_triggers._GmailApiService(session),
+        publisher_factory=lambda: publisher,
+        subscriber_factory=lambda: subscriber,
+    )
+    assert session.calls == [
+        ("POST", "https://gmail.googleapis.com/gmail/v1/users/me/stop")
+    ]
     assert subscriber.deleted_subscriptions == [state.subscription_name]
     assert publisher.deleted_topics == [state.topic_name]
     assert db_session.get(GmailWatchState, state_id) is None

--- a/tests/web/services/test_user_oauth_ownership.py
+++ b/tests/web/services/test_user_oauth_ownership.py
@@ -5,6 +5,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
 from xagent.web.models.database import Base
+from xagent.web.models.gmail_watch import GmailWatchState
 from xagent.web.models.user import User
 from xagent.web.models.user_oauth import UserOAuth
 from xagent.web.services.user_oauth import (
@@ -65,6 +66,56 @@ def _db(tmp_path):
     for row in rows:
         db.refresh(row)
     return engine, db, user, rows
+
+
+def test_gmail_watch_relationship_requires_matching_ordinary_owner(tmp_path) -> None:
+    engine, db, user, rows = _db(tmp_path)
+    other_user = User(username="other-watch-owner", password_hash="hash")
+    db.add(other_user)
+    db.commit()
+    db.refresh(other_user)
+    foreign_account = UserOAuth(
+        user_id=int(other_user.id),
+        provider="gmail",
+        provider_user_id="foreign",
+        access_token="foreign",
+    )
+    db.add(foreign_account)
+    db.commit()
+    db.refresh(foreign_account)
+
+    states = [
+        GmailWatchState(
+            user_id=int(user.id),
+            oauth_account_id=int(rows[0].id),
+            email="ordinary@example.com",
+            history_id="1",
+            topic_name="ordinary",
+        ),
+        GmailWatchState(
+            user_id=int(user.id),
+            oauth_account_id=int(rows[1].id),
+            email="actor@example.com",
+            history_id="2",
+            topic_name="actor",
+        ),
+        GmailWatchState(
+            user_id=int(user.id),
+            oauth_account_id=int(foreign_account.id),
+            email="foreign@example.com",
+            history_id="3",
+            topic_name="foreign",
+        ),
+    ]
+    db.add_all(states)
+    db.commit()
+    try:
+        assert states[0].oauth_account is rows[0]
+        assert states[1].oauth_account is None
+        assert states[2].oauth_account is None
+    finally:
+        db.close()
+        engine.dispose()
 
 
 def test_listing_never_crosses_owner_namespaces(tmp_path) -> None:

--- a/tests/web/services/test_user_oauth_ownership.py
+++ b/tests/web/services/test_user_oauth_ownership.py
@@ -343,6 +343,36 @@ def test_string_provider_filter_is_rejected(tmp_path) -> None:
         engine.dispose()
 
 
+def test_bulk_deletion_cannot_cascade_an_ordinary_gmail_watch(tmp_path) -> None:
+    engine, db, user, rows = _db(tmp_path)
+    ordinary = rows[0]
+    state = GmailWatchState(
+        user_id=int(user.id),
+        oauth_account_id=int(ordinary.id),
+        email="ordinary@example.com",
+        history_id="1",
+        topic_name="ordinary-topic",
+    )
+    db.add(state)
+    db.commit()
+    state_id = int(state.id)
+
+    try:
+        with pytest.raises(RuntimeError, match="Gmail watch cleanup"):
+            delete_scoped_user_oauth_accounts(
+                db,
+                user_id=int(user.id),
+                resource_owner_key=None,
+                providers=["gmail"],
+            )
+
+        assert db.get(UserOAuth, int(ordinary.id)) is ordinary
+        assert db.get(GmailWatchState, state_id) is state
+    finally:
+        db.close()
+        engine.dispose()
+
+
 def test_actor_revocation_leaves_ordinary_and_other_actor_rows(tmp_path) -> None:
     engine, db, user, _rows = _db(tmp_path)
     try:

--- a/tests/web/test_meta_oauth.py
+++ b/tests/web/test_meta_oauth.py
@@ -13,10 +13,13 @@ from sqlalchemy.orm import sessionmaker
 from xagent.core.utils.encryption import encrypt_value
 from xagent.web.api import auth as auth_api
 from xagent.web.api.auth import create_access_token, generic_oauth_callback
+from xagent.web.models.agent import Agent
 from xagent.web.models.database import Base
+from xagent.web.models.gmail_watch import GmailWatchState
 from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.oauth_provider import OAuthProvider
 from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.trigger import AgentTrigger, TriggerType
 from xagent.web.models.user import User
 from xagent.web.models.user_oauth import UserOAuth
 from xagent.web.services import gmail_provisioning
@@ -162,6 +165,141 @@ def test_gmail_callback_best_effort_registers_watch_after_oauth_commit(
     )
     assert oauth_account.email == "alice@gmail.com"
     assert calls == [int(user.id)]
+
+
+def test_gmail_reconnect_preserves_account_id_watch_and_sibling_accounts(
+    db_session, monkeypatch
+):
+    """Reconnect must refresh one Gmail row without invalidating its bindings."""
+    db, user = db_session
+    account = UserOAuth(
+        user_id=int(user.id),
+        provider="gmail",
+        access_token="old-token",
+        provider_user_id="google-user-1",
+        email="old@gmail.com",
+    )
+    sibling = UserOAuth(
+        user_id=int(user.id),
+        provider="gmail",
+        access_token="sibling-token",
+        provider_user_id="google-user-2",
+        email="sibling@gmail.com",
+    )
+    unrelated = UserOAuth(
+        user_id=int(user.id),
+        provider="google-drive",
+        access_token="drive-token",
+        provider_user_id="google-user-1",
+        email="old@gmail.com",
+    )
+    db.add_all([account, sibling, unrelated])
+    db.commit()
+    db.refresh(account)
+    db.refresh(sibling)
+    account_id = int(account.id)
+    sibling_id = int(sibling.id)
+
+    agent = Agent(user_id=int(user.id), name="Gmail reconnect agent")
+    db.add(agent)
+    db.commit()
+    db.refresh(agent)
+    trigger = AgentTrigger(
+        user_id=int(user.id),
+        agent_id=int(agent.id),
+        type=TriggerType.GMAIL.value,
+        name="Gmail inbox",
+        enabled=True,
+        provider=TriggerType.GMAIL.value,
+        resource_id="old@gmail.com",
+        config={"oauth_account_id": account_id, "watch_label": "INBOX"},
+    )
+    watch = GmailWatchState(
+        user_id=int(user.id),
+        oauth_account_id=account_id,
+        email="old@gmail.com",
+        history_id="history-1",
+        topic_name="projects/test/topics/gmail-old",
+        callback_id="callback-old",
+        status="active",
+    )
+    db.add_all([trigger, watch])
+    db.commit()
+    db.refresh(trigger)
+    db.refresh(watch)
+    watch_id = int(watch.id)
+
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "google",
+            "app_id": "gmail",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "gmail-code", "state": state})
+    monkeypatch.setattr(
+        auth_api.requests,
+        "post",
+        Mock(
+            return_value=MockResponse(
+                {
+                    "access_token": "refreshed-token",
+                    "refresh_token": "refreshed-refresh",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                    "scope": "https://www.googleapis.com/auth/gmail.modify",
+                }
+            )
+        ),
+    )
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(
+            return_value=MockResponse(
+                {"sub": "google-user-1", "email": "renamed@gmail.com"}
+            )
+        ),
+    )
+    provisioned_users: list[int] = []
+    monkeypatch.setattr(
+        gmail_provisioning,
+        "best_effort_provision_gmail_watches_for_user",
+        lambda _db, *, user_id, context: provisioned_users.append(int(user_id)),
+    )
+
+    response = generic_oauth_callback("google", request, db, _google_provider())
+
+    assert response.status_code == 200
+    refreshed = (
+        db.query(UserOAuth)
+        .filter(
+            UserOAuth.user_id == int(user.id),
+            UserOAuth.provider == "gmail",
+            UserOAuth.provider_user_id == "google-user-1",
+        )
+        .one()
+    )
+    assert int(refreshed.id) == account_id
+    assert refreshed.email == "renamed@gmail.com"
+    assert refreshed.access_token == "refreshed-token"
+    assert {
+        int(row.id)
+        for row in db.query(UserOAuth).filter(UserOAuth.provider == "gmail").all()
+    } == {account_id, sibling_id}
+    assert (
+        db.query(GmailWatchState)
+        .filter(
+            GmailWatchState.id == watch_id,
+            GmailWatchState.oauth_account_id == account_id,
+        )
+        .one()
+    )
+    db.refresh(trigger)
+    assert trigger.config["oauth_account_id"] == account_id
+    assert provisioned_users == [int(user.id)]
 
 
 def test_gmail_callback_succeeds_when_best_effort_watch_provisioning_raises(

--- a/tests/web/test_trigger_dispatcher_gmail_gate.py
+++ b/tests/web/test_trigger_dispatcher_gmail_gate.py
@@ -8,7 +8,7 @@ from xagent.web import app as app_module
 
 
 @pytest.mark.asyncio
-async def test_trigger_dispatcher_skips_gmail_scan_when_watch_disabled(
+async def test_trigger_dispatcher_runs_cleanup_sweep_when_watch_disabled(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     calls: list[str] = []
@@ -21,6 +21,9 @@ async def test_trigger_dispatcher_skips_gmail_scan_when_watch_disabled(
         return FakeSession
 
     def fake_scan_due_gmail_watch_renewals(_db) -> int:
+        return 0
+
+    def fake_sweep_gmail_provisioning(_db) -> int:
         return 0
 
     def fake_scan_due_scheduled_triggers(_db):
@@ -49,6 +52,10 @@ async def test_trigger_dispatcher_skips_gmail_scan_when_watch_disabled(
         fake_scan_due_gmail_watch_renewals,
     )
     monkeypatch.setattr(
+        "xagent.web.services.gmail_provisioning.sweep_gmail_provisioning",
+        fake_sweep_gmail_provisioning,
+    )
+    monkeypatch.setattr(
         "xagent.web.services.triggers.scan_due_scheduled_triggers",
         fake_scan_due_scheduled_triggers,
     )
@@ -71,10 +78,11 @@ async def test_trigger_dispatcher_skips_gmail_scan_when_watch_disabled(
             batch_size=25,
         )
 
-    # Scheduled triggers are scanned in-process every tick (no Celery needed),
-    # but the Gmail watch-renewal scan stays gated off when watch is disabled.
+    # Scheduled triggers and cleanup run in-process every tick (no Celery
+    # needed), but Gmail watch renewal stays gated when registration is off.
     assert "_scan_due_scheduled_triggers_tick" in calls
     assert "_scan_due_gmail_watch_renewals_tick" not in calls
+    assert "_sweep_gmail_provisioning_tick" in calls
     assert "_reap_stale_preview_workforce_runs_tick" in calls
 
 

--- a/tests/web/test_user_oauth_ordinary_consumers.py
+++ b/tests/web/test_user_oauth_ordinary_consumers.py
@@ -13,6 +13,11 @@ from xagent.web.api.cloud_storage import (
 from xagent.web.models.database import Base
 from xagent.web.models.user import User
 from xagent.web.models.user_oauth import UserOAuth
+from xagent.web.services.gmail_provisioning import (
+    GmailProvisioningError,
+    ensure_gmail_mailbox_provisioned,
+)
+from xagent.web.services.triggers import TriggerServiceError, _resolve_gmail_resource
 
 ACTOR = "toby:slack:41:UALICE"
 
@@ -43,12 +48,20 @@ def oauth_rows(tmp_path):
         email="actor@example.com",
         access_token="actor",
     )
-    db.add_all([ordinary, actor])
+    actor_gmail = UserOAuth(
+        user_id=int(user.id),
+        provider="gmail",
+        resource_owner_key=ACTOR,
+        provider_user_id="actor-gmail",
+        email="actor@gmail.example",
+        access_token="actor-gmail",
+    )
+    db.add_all([ordinary, actor, actor_gmail])
     db.commit()
-    for row in (ordinary, actor):
+    for row in (ordinary, actor, actor_gmail):
         db.refresh(row)
     try:
-        yield db, user, ordinary, actor
+        yield db, user, ordinary, actor, actor_gmail
     finally:
         db.close()
         engine.dispose()
@@ -56,7 +69,7 @@ def oauth_rows(tmp_path):
 
 @pytest.mark.asyncio
 async def test_cloud_account_listing_contains_only_ordinary_rows(oauth_rows) -> None:
-    db, user, ordinary, _actor = oauth_rows
+    db, user, ordinary, _actor, _actor_gmail = oauth_rows
 
     accounts = await list_connected_accounts(provider=None, db=db, user=user)
 
@@ -65,7 +78,7 @@ async def test_cloud_account_listing_contains_only_ordinary_rows(oauth_rows) -> 
 
 @pytest.mark.asyncio
 async def test_cloud_account_delete_cannot_address_an_actor_row(oauth_rows) -> None:
-    db, user, _ordinary, actor = oauth_rows
+    db, user, _ordinary, actor, _actor_gmail = oauth_rows
 
     with pytest.raises(HTTPException) as exc_info:
         await delete_connected_account(int(actor.id), db=db, user=user)
@@ -75,9 +88,27 @@ async def test_cloud_account_delete_cannot_address_an_actor_row(oauth_rows) -> N
 
 
 def test_cloud_credentials_cannot_select_an_actor_row_by_id(oauth_rows) -> None:
-    db, user, _ordinary, actor = oauth_rows
+    db, user, _ordinary, actor, _actor_gmail = oauth_rows
 
     with pytest.raises(HTTPException) as exc_info:
         get_google_credentials(int(user.id), db, int(actor.id))
 
     assert exc_info.value.status_code == 404
+
+
+def test_gmail_watch_provisioning_rejects_an_actor_row(oauth_rows) -> None:
+    db, _user, _ordinary, _actor, actor_gmail = oauth_rows
+
+    with pytest.raises(GmailProvisioningError, match="actor-owned"):
+        ensure_gmail_mailbox_provisioned(db, actor_gmail)
+
+
+def test_gmail_trigger_binding_rejects_an_actor_row(oauth_rows) -> None:
+    db, user, _ordinary, _actor, actor_gmail = oauth_rows
+
+    with pytest.raises(TriggerServiceError, match="Gmail account not found"):
+        _resolve_gmail_resource(
+            db,
+            user_id=int(user.id),
+            oauth_account_id=int(actor_gmail.id),
+        )

--- a/tests/web/test_user_oauth_ordinary_consumers.py
+++ b/tests/web/test_user_oauth_ordinary_consumers.py
@@ -11,6 +11,7 @@ from xagent.web.api.cloud_storage import (
     list_connected_accounts,
 )
 from xagent.web.models.database import Base
+from xagent.web.models.gmail_watch import GmailWatchState
 from xagent.web.models.user import User
 from xagent.web.models.user_oauth import UserOAuth
 from xagent.web.services.gmail_provisioning import (
@@ -85,6 +86,42 @@ async def test_cloud_account_delete_cannot_address_an_actor_row(oauth_rows) -> N
 
     assert exc_info.value.status_code == 404
     assert db.get(UserOAuth, int(actor.id)) is not None
+
+
+@pytest.mark.asyncio
+async def test_cloud_gmail_account_delete_preserves_cleanup_handles(oauth_rows) -> None:
+    db, user, _ordinary, _actor, _actor_gmail = oauth_rows
+    gmail = UserOAuth(
+        user_id=int(user.id),
+        provider="gmail",
+        resource_owner_key=None,
+        provider_user_id="ordinary-gmail",
+        email="ordinary@gmail.example",
+        access_token="ordinary-gmail",
+    )
+    db.add(gmail)
+    db.commit()
+    db.refresh(gmail)
+    state = GmailWatchState(
+        user_id=int(user.id),
+        oauth_account_id=int(gmail.id),
+        email="ordinary@gmail.example",
+        history_id="1",
+        topic_name="gmail-topic",
+        subscription_name="gmail-subscription",
+    )
+    db.add(state)
+    db.commit()
+    state_id = int(state.id)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await delete_connected_account(int(gmail.id), db=db, user=user)
+
+    assert exc_info.value.status_code == 409
+    assert db.get(UserOAuth, int(gmail.id)) is gmail
+    retained_state = db.get(GmailWatchState, state_id)
+    assert retained_state is not None
+    assert str(retained_state.last_error).startswith("Gmail watch cleanup pending:")
 
 
 def test_cloud_credentials_cannot_select_an_actor_row_by_id(oauth_rows) -> None:

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -16,6 +16,7 @@ from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRuntimeEr
 from xagent.core.tools.adapters.vibe.mcp_adapter import MCPToolAdapter
 from xagent.core.utils.encryption import encrypt_value
 from xagent.web.models.database import Base
+from xagent.web.models.gmail_watch import GmailWatchState
 from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.oauth_provider import OAuthProvider
 from xagent.web.models.public_mcp import PublicMCPApp
@@ -894,6 +895,65 @@ async def test_user_oauth_refresh_failure_retains_unavailable_and_deletes_invali
             .first()
             is None
         )
+
+
+@pytest.mark.asyncio
+async def test_invalid_gmail_token_preserves_watch_cleanup_ownership(
+    db_session,
+    monkeypatch,
+):
+    db, user = db_session
+    oauth_server = _add_oauth_server(
+        db,
+        user,
+        name="Gmail",
+        app_id="resolver-gmail",
+        provider="gmail",
+        launch_config=_launch_config(),
+    )
+    oauth_account = _add_user_oauth(
+        db,
+        user,
+        provider="gmail",
+        access_token="expired-secret-token",
+    )
+    account_id = int(oauth_account.id)
+    state = GmailWatchState(
+        user_id=int(user.id),
+        oauth_account_id=account_id,
+        email="owner@gmail.example",
+        history_id="1",
+        topic_name="gmail-topic",
+        subscription_name="gmail-subscription",
+    )
+    db.add(state)
+    db.commit()
+    state_id = int(state.id)
+    isolated_session_factory = sessionmaker(
+        bind=db.get_bind(), autoflush=False, autocommit=False
+    )
+
+    async def fail_refresh(*args, **kwargs):
+        return False
+
+    monkeypatch.setattr(web_tools_config, "refresh_oauth_token_if_needed", fail_refresh)
+
+    configs = await _tool_config(
+        db, user, db_factory=isolated_session_factory
+    ).get_mcp_server_configs()
+
+    assert [config["name"] for config in configs] == [oauth_server.name]
+    _assert_unavailable_mcp_config(
+        configs[0],
+        oauth_server,
+        reason="oauth_token_refresh_failed",
+        oauth_token_required=True,
+    )
+    with isolated_session_factory() as verification_db:
+        assert verification_db.get(UserOAuth, account_id) is not None
+        retained_state = verification_db.get(GmailWatchState, state_id)
+        assert retained_state is not None
+        assert str(retained_state.last_error).startswith("Gmail watch cleanup pending:")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- move Gmail OAuth lookup, trigger binding, scan, provisioning, callback, release, and reconciliation paths to the ordinary owner namespace
- require a matching user, `provider = "gmail"`, and `resource_owner_key IS NULL` across Gmail lifecycle operations
- route current callbacks by exact OAuth account ID and supported legacy callbacks by normalized mailbox email
- fail closed for triggers that have neither an account binding nor a mailbox resource
- preserve Gmail history cursors and cleanup handles when ownership validation or remote watch cleanup fails
- prevent invalid ownership rows from consuming valid provisioning retry capacity
- handle nullable renewal mismatch fields explicitly
- run the Gmail watch integrity gate before workers restart during rollout

## Context

This is the upstream version of [bsbds/xagent#82](https://github.com/bsbds/xagent/pull/82). The owner-aware OAuth foundation in #1588 is merged into `main`.

## Verification

- 306 focused Gmail, trigger, OAuth ownership, and ordinary-consumer tests passed
- 4 PostgreSQL-only tests skipped because `XAGENT_TEST_POSTGRES_URL` was not available locally
- full pre-commit suite passed, including Ruff, mypy, Alembic checks, frontend lint, and frontend type-check
- `git diff --check` passed
- an independent final code review found no remaining findings

Live Gmail, Pub/Sub, and PostgreSQL integration behavior was not exercised locally.

## Rollout

Use PostgreSQL for production. Run the Gmail watch integrity query in `docs/deployment.md` after migration and require a zero result before worker restart. This change adds no environment variable or dependency.
