### PR TITLE
fix(openrouter): drop require_parameters from official-provider pinning

### DIFF
--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -18,8 +18,8 @@ OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 _DEEPSEEK_FUNCTION_PREFIX_ERROR = "function call should not be used with prefix"
 
 # Pinning to these provider slugs via `only` + `allow_fallbacks: False` routes
-# every request for the author to that single official endpoint. Before adding
-# an author here, confirm its official OpenRouter endpoint actually supports
+# every request for the author to one of the listed official endpoints. Before
+# adding an author here, confirm each of its official endpoints actually supports
 # every parameter this client can send (tools, tool_choice, response_format,
 # structured outputs, temperature) — an unsupported parameter is now silently
 # ignored by the endpoint rather than rejected, so a wrong entry degrades

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -17,6 +17,13 @@ logger = logging.getLogger(__name__)
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 _DEEPSEEK_FUNCTION_PREFIX_ERROR = "function call should not be used with prefix"
 
+# Pinning to these provider slugs via `only` + `allow_fallbacks: False` routes
+# every request for the author to that single official endpoint. Before adding
+# an author here, confirm its official OpenRouter endpoint actually supports
+# every parameter this client can send (tools, tool_choice, response_format,
+# structured outputs, temperature) — an unsupported parameter is now silently
+# ignored by the endpoint rather than rejected, so a wrong entry degrades
+# request semantics instead of failing loudly.
 _OPENROUTER_OFFICIAL_PROVIDERS_BY_AUTHOR: dict[str, tuple[str, ...]] = {
     "anthropic": ("anthropic",),
     "deepseek": ("deepseek",),
@@ -348,7 +355,6 @@ class OpenRouterLLM(OpenAILLM):
             "provider": {
                 "only": list(official_providers),
                 "allow_fallbacks": False,
-                "require_parameters": True,
             },
         }
 

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -523,7 +523,6 @@ async def test_openrouter_deepseek_uses_official_provider(
     assert call_kwargs["extra_body"]["provider"] == {
         "only": ["deepseek"],
         "allow_fallbacks": False,
-        "require_parameters": True,
     }
 
 
@@ -550,9 +549,10 @@ def test_openrouter_official_provider_mapping_covers_auto_router_authors(
 
         extra_body = llm._prepare_extra_body({})
 
-        assert extra_body["provider"]["only"] == expected_providers
-        assert extra_body["provider"]["allow_fallbacks"] is False
-        assert extra_body["provider"]["require_parameters"] is True
+        assert extra_body["provider"] == {
+            "only": expected_providers,
+            "allow_fallbacks": False,
+        }
 
 
 @pytest.mark.asyncio
@@ -901,7 +901,6 @@ async def test_openrouter_stream_deepseek_uses_official_provider(mocker, monkeyp
     assert call_kwargs["extra_body"]["provider"] == {
         "only": ["deepseek"],
         "allow_fallbacks": False,
-        "require_parameters": True,
     }
 
 


### PR DESCRIPTION
## What

`OpenRouterLLM._prepare_extra_body` no longer sets `require_parameters` when it pins a request to an author's official provider. The injected block is now:

```python
"provider": {
    "only": list(official_providers),
    "allow_fallbacks": False,
}
```

## Why

`require_parameters: true` instructs OpenRouter to discard every endpoint that does not declare support for *each* parameter present in the request. Together with `only: [<official provider>]` and `allow_fallbacks: false` the candidate set is already a single endpoint, so one unsupported parameter empties the set entirely and the request comes back as a 404 reading `No endpoints found that can handle the requested parameters`. A parameter the endpoint could simply have ignored takes down the whole call instead.

Dropping the flag restores OpenRouter's default semantics for that endpoint: a parameter it does not implement is ignored rather than turned into a routing failure. This is the same treatment a request already gets when official-provider pinning is switched off, so the change narrows a behavioural difference rather than widening one. The pinning itself is unchanged — `only` still confines routing to the official provider and `allow_fallbacks: false` still forbids quietly routing elsewhere.

The trade-off is worth stating plainly: an unsupported parameter is now dropped by the endpoint instead of failing loudly, so a wrong entry in the author-to-provider map degrades request semantics quietly instead of erroring. A comment on `_OPENROUTER_OFFICIAL_PROVIDERS_BY_AUTHOR` records the maintenance requirement this creates — before adding an author, confirm its official OpenRouter endpoint actually supports every parameter this client can send (`tools`, `tool_choice`, `response_format`, structured outputs, `temperature`).

Fixes #1575

## Testing

Three assertions in `tests/core/model/chat/basic/test_openrouter.py` covered the pinned `provider` block — the non-streaming path, the author-map coverage test, and the streaming path. All three now assert the complete dictionary instead of individual keys, so a reintroduced key fails the test rather than slipping past an unasserted field.

`uv run pytest tests/core/model/chat/basic/test_openrouter.py` — 48 passed.
