### PR TITLE
fix(openrouter): retry provider-compat 4xx in the client for every entrypoint

### DIFF
--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -1,6 +1,8 @@
 import logging
 from typing import Any, AsyncIterator, Callable, Dict, List, Optional
 
+import openai
+
 from .....config import get_openrouter_official_providers_only
 from ..error import retry_on
 from ..exceptions import LLMRetryableError, LLMToolProtocolError
@@ -17,6 +19,18 @@ logger = logging.getLogger(__name__)
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 _DEEPSEEK_FUNCTION_PREFIX_ERROR = "function call should not be used with prefix"
+
+# OpenAILLM.chat/stream_chat normally convert every openai.BadRequestError into
+# a RuntimeError before returning. Their response_format pop-and-retry path is
+# an exception, though: it re-issues the request from inside its own
+# ``except openai.BadRequestError`` block, and if that retried call also fails
+# with a BadRequestError, nothing wraps the second failure -- it escapes as a
+# bare SDK exception. openai.BadRequestError's MRO does not include
+# RuntimeError, so the compat retry loops below must catch both explicitly to
+# keep covering that case. The historical implementation caught bare
+# ``Exception`` here; this tuple is the precise, intentionally narrowed
+# replacement.
+_COMPAT_RETRYABLE_ERRORS = (RuntimeError, openai.BadRequestError)
 
 # Pinning to these provider slugs via `only` + `allow_fallbacks: False` routes
 # every request for the author to one of the listed official endpoints. Before
@@ -203,16 +217,23 @@ def _next_compat_adjustment(
 ) -> tuple[Optional[str | Dict[str, Any]], Optional[Dict[str, Any]], str, str] | None:
     """Pick the next OpenRouter provider-compatibility adjustment for a failure.
 
-    Rules are checked strictest-first (relax tool_choice, then disable
-    thinking, then enable thinking): a message that happens to match more than
-    one predicate is resolved by its most specific cause instead of by
-    declaration order. A rule that matches but would leave the actually
-    rendered request unchanged compared to the current ``(tool_choice,
-    render(thinking))`` state is a no-op and is skipped without spending its
-    retry budget, so a rule that cannot fix anything does not block a later
-    rule that can. A rule whose action was already attempted stops the search
-    outright: the same shared one-attempt-per-action budget this logic
-    replaces (router.py's ``attempted_retry_actions``) applies here too.
+    Candidates are checked strictest-first (relax tool_choice, then disable
+    thinking, then enable thinking) and tried in that written order: the
+    first candidate whose predicate matches and would actually change the
+    rendered request wins. Order is the mechanism here, not a side detail --
+    this deliberately reverses the candidate order used by the predecessor
+    implementation this logic replaces. Pairing strictest-first with the
+    no-op skip below means that when a failure message matches more than one
+    predicate, every matching rule can still be tried in turn rather than the
+    first match blocking the rest; reordering the ``candidates`` tuple
+    changes which adjustment fires first and is not a safe refactor. A rule
+    that matches but would leave the actually rendered request unchanged
+    compared to the current ``(tool_choice, render(thinking))`` state is a
+    no-op and is skipped without spending its retry budget, so a rule that
+    cannot fix anything does not block a later rule that can. A rule whose
+    action was already attempted stops the search outright: the same shared
+    one-attempt-per-action budget this logic replaces (router.py's
+    ``attempted_retry_actions``) applies here too.
     """
     current_state = (tool_choice, render(thinking))
     candidates: tuple[
@@ -362,7 +383,12 @@ class OpenRouterLLM(OpenAILLM):
         **kwargs: Any,
     ) -> Any:
         # Vision requests carry no DeepSeek prefix-retry need, so the inner
-        # call goes straight to the OpenAI implementation.
+        # call goes straight to the OpenAI implementation. This also skips
+        # chat()'s DeepSeek tool-protocol handling (_force_single_required_
+        # deepseek_tool, normalize_deepseek_response, the protocol-error
+        # retry), which is a deliberate omission rather than an oversight:
+        # those branches only take effect when tools are passed, and no
+        # current caller passes tools into vision_chat.
         return await self._run_chat_with_compat_retry(
             super().vision_chat,
             messages,
@@ -458,10 +484,14 @@ class OpenRouterLLM(OpenAILLM):
         ``sanitize_messages=True``) and ``vision_chat`` (wrapping the
         inherited ``OpenAILLM.vision_chat`` directly, which has no
         ``sanitized_out`` parameter and must never receive one). A retryable
-        error raised by the inner call (e.g. the DeepSeek tool-protocol error
-        surfaced after prefix retry, or a wrapped 429/5xx recognized by
-        ``retry_on``) is left for the shared LLM retry wrapper and is never
-        treated as a compat adjustment opportunity.
+        error raised by the inner call (e.g. ``LLMEmptyContentError`` after an
+        empty-content response, or a ``RuntimeError`` wrapping a rate-limit or
+        5xx error that ``retry_on`` recognizes via ``__cause__``) is left for
+        the shared LLM retry wrapper and is never treated as a compat
+        adjustment opportunity. A single ``call`` invocation may itself issue
+        up to one additional upstream request: ``OpenAILLM.chat``'s
+        response_format pop-and-retry path can resend once internally before
+        returning or raising.
 
         Known limitation: ``OpenAILLM.chat``'s structured-output degrade path
         can rewrite ``thinking`` internally (disabling it after a non-JSON
@@ -506,7 +536,7 @@ class OpenRouterLLM(OpenAILLM):
                 return await call(current_messages, **call_kwargs)
             except LLMRetryableError:
                 raise
-            except RuntimeError as exc:
+            except _COMPAT_RETRYABLE_ERRORS as exc:
                 if retry_on(exc):
                     raise
 
@@ -683,7 +713,7 @@ class OpenRouterLLM(OpenAILLM):
                 return
             except LLMRetryableError:
                 raise
-            except RuntimeError as exc:
+            except _COMPAT_RETRYABLE_ERRORS as exc:
                 if has_yielded:
                     raise
                 if retry_on(exc):

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -2,6 +2,7 @@ import logging
 from typing import Any, AsyncIterator, Callable, Dict, List, Optional
 
 from .....config import get_openrouter_official_providers_only
+from ..error import retry_on
 from ..exceptions import LLMRetryableError, LLMToolProtocolError
 from ..timeout_config import TimeoutConfig
 from ..tool_protocol import TOOL_PROTOCOL_ERROR_KEY, get_tool_protocol_error
@@ -337,6 +338,7 @@ class OpenRouterLLM(OpenAILLM):
             thinking=thinking,
             output_config=output_config,
             kwargs=kwargs,
+            sanitize_messages=True,
         )
 
         if not self._uses_deepseek_tool_protocol:
@@ -384,8 +386,17 @@ class OpenRouterLLM(OpenAILLM):
         response_format: Optional[Dict[str, Any]] = None,
         thinking: Optional[Dict[str, Any]] = None,
         output_config: Optional[Dict[str, Any]] = None,
+        sanitized_out: Optional[List[List[Dict[str, Any]]]] = None,
         **kwargs: Any,
     ) -> Any:
+        """Send ``messages``, retrying once with DeepSeek's prefix stripped.
+
+        ``sanitized_out``, when given, receives the sanitized message list at
+        the moment a prefix retry fires, so a caller looping over repeated
+        provider-compat errors (see ``_run_chat_with_compat_retry``) can reuse
+        the already-sanitized messages instead of re-triggering this same
+        prefix rejection on every iteration.
+        """
         try:
             response = await super().chat(
                 messages=messages,
@@ -404,6 +415,9 @@ class OpenRouterLLM(OpenAILLM):
             )
             if sanitized_messages is None:
                 raise
+
+            if sanitized_out is not None:
+                sanitized_out.append(sanitized_messages)
 
             logger.info(
                 "OpenRouter DeepSeek rejected function-call history with an "
@@ -436,23 +450,37 @@ class OpenRouterLLM(OpenAILLM):
         thinking: Optional[Dict[str, Any]],
         output_config: Optional[Dict[str, Any]],
         kwargs: Dict[str, Any],
+        sanitize_messages: bool = False,
     ) -> Any:
         """Retry ``call`` once per matching OpenRouter provider-compat rule.
 
-        Shared by ``chat`` (wrapping ``_chat_with_prefix_retry``) and
-        ``vision_chat`` (wrapping the inherited ``OpenAILLM.vision_chat``
-        directly). A retryable error raised by the inner call (e.g. the
-        DeepSeek tool-protocol error surfaced after prefix retry) is left for
-        the shared LLM retry wrapper and is never treated as a compat
-        adjustment opportunity.
+        Shared by ``chat`` (wrapping ``_chat_with_prefix_retry``, with
+        ``sanitize_messages=True``) and ``vision_chat`` (wrapping the
+        inherited ``OpenAILLM.vision_chat`` directly, which has no
+        ``sanitized_out`` parameter and must never receive one). A retryable
+        error raised by the inner call (e.g. the DeepSeek tool-protocol error
+        surfaced after prefix retry, or a wrapped 429/5xx recognized by
+        ``retry_on``) is left for the shared LLM retry wrapper and is never
+        treated as a compat adjustment opportunity.
+
+        Known limitation: ``OpenAILLM.chat``'s structured-output degrade path
+        can rewrite ``thinking`` internally (disabling it after a non-JSON
+        response) without reporting the change back here, so
+        ``current_thinking`` does not necessarily reflect what was actually
+        sent on that path. No caller in this repository currently passes
+        ``response_format`` into ``chat``, so this gap has no live caller
+        today.
         """
         current_tool_choice = tool_choice
         current_thinking = thinking
+        current_messages = messages
         attempted: set[str] = set()
 
         def render(candidate_thinking: Optional[Dict[str, Any]]) -> Dict[str, Any]:
             return self._prepare_provider_reasoning_extra_body(
-                extra_body={},
+                extra_body=self._prepare_extra_body(
+                    dict(kwargs.get("extra_body") or {})
+                ),
                 thinking=candidate_thinking,
                 tools=tools,
                 response_format=response_format,
@@ -461,21 +489,27 @@ class OpenRouterLLM(OpenAILLM):
             )
 
         while True:
+            sanitized_out: List[List[Dict[str, Any]]] = []
+            call_kwargs: Dict[str, Any] = dict(
+                temperature=temperature,
+                max_tokens=max_tokens,
+                tools=tools,
+                tool_choice=current_tool_choice,
+                response_format=response_format,
+                thinking=current_thinking,
+                output_config=output_config,
+                **kwargs,
+            )
+            if sanitize_messages:
+                call_kwargs["sanitized_out"] = sanitized_out
             try:
-                return await call(
-                    messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    tools=tools,
-                    tool_choice=current_tool_choice,
-                    response_format=response_format,
-                    thinking=current_thinking,
-                    output_config=output_config,
-                    **kwargs,
-                )
+                return await call(current_messages, **call_kwargs)
             except LLMRetryableError:
                 raise
             except RuntimeError as exc:
+                if retry_on(exc):
+                    raise
+
                 adjustment = _next_compat_adjustment(
                     exc,
                     tools=tools,
@@ -491,6 +525,8 @@ class OpenRouterLLM(OpenAILLM):
                     adjustment
                 )
                 attempted.add(action_key)
+                if sanitized_out:
+                    current_messages = sanitized_out[-1]
                 logger.info(log_message)
 
     async def _stream_chat_with_prefix_retry(
@@ -503,8 +539,15 @@ class OpenRouterLLM(OpenAILLM):
         response_format: Optional[Dict[str, Any]] = None,
         thinking: Optional[Dict[str, Any]] = None,
         output_config: Optional[Dict[str, Any]] = None,
+        sanitized_out: Optional[List[List[Dict[str, Any]]]] = None,
         **kwargs: Any,
     ) -> AsyncIterator[StreamChunk]:
+        """Streaming counterpart of ``_chat_with_prefix_retry``.
+
+        ``sanitized_out`` carries the same contract as the non-streaming
+        version: when the prefix retry fires, the sanitized messages are
+        appended to it so a caller looping over compat errors can reuse them.
+        """
         has_yielded = False
         try:
             async for chunk in super().stream_chat(
@@ -527,6 +570,9 @@ class OpenRouterLLM(OpenAILLM):
             )
             if has_yielded or sanitized_messages is None:
                 raise
+
+        if sanitized_out is not None:
+            sanitized_out.append(sanitized_messages)
 
         logger.info(
             "OpenRouter DeepSeek rejected streaming function-call history with an "
@@ -593,16 +639,23 @@ class OpenRouterLLM(OpenAILLM):
         DeepSeek dict-tool_choice path ``call`` (``_stream_chat_inner``)
         buffers chunks internally until the tool protocol is validated, so an
         inner chunk being produced is not the same thing as one having been
-        yielded from here.
+        yielded from here. ``call`` is always ``_stream_chat_inner``, which
+        forwards its ``**kwargs`` straight through to
+        ``_stream_chat_with_prefix_retry``, so the ``sanitized_out`` list
+        built here reaches that function's out-param without either function
+        needing to know about it explicitly.
         """
         has_yielded = False
         current_tool_choice = tool_choice
         current_thinking = thinking
+        current_messages = messages
         attempted: set[str] = set()
 
         def render(candidate_thinking: Optional[Dict[str, Any]]) -> Dict[str, Any]:
             return self._prepare_provider_reasoning_extra_body(
-                extra_body={},
+                extra_body=self._prepare_extra_body(
+                    dict(kwargs.get("extra_body") or {})
+                ),
                 thinking=candidate_thinking,
                 tools=tools,
                 response_format=response_format,
@@ -611,9 +664,10 @@ class OpenRouterLLM(OpenAILLM):
             )
 
         while True:
+            sanitized_out: List[List[Dict[str, Any]]] = []
             try:
                 async for chunk in call(
-                    messages,
+                    current_messages,
                     temperature=temperature,
                     max_tokens=max_tokens,
                     tools=tools,
@@ -621,6 +675,7 @@ class OpenRouterLLM(OpenAILLM):
                     response_format=response_format,
                     thinking=current_thinking,
                     output_config=output_config,
+                    sanitized_out=sanitized_out,
                     **kwargs,
                 ):
                     has_yielded = True
@@ -630,6 +685,8 @@ class OpenRouterLLM(OpenAILLM):
                 raise
             except RuntimeError as exc:
                 if has_yielded:
+                    raise
+                if retry_on(exc):
                     raise
 
                 adjustment = _next_compat_adjustment(
@@ -647,6 +704,8 @@ class OpenRouterLLM(OpenAILLM):
                     adjustment
                 )
                 attempted.add(action_key)
+                if sanitized_out:
+                    current_messages = sanitized_out[-1]
                 logger.info(log_message)
 
     async def _stream_chat_inner(

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -184,10 +184,7 @@ def _should_retry_without_thinking(
     # follow-up tracking issue lands.
     exc_msg = str(exc).lower()
     return (
-        (thinking is None or isinstance(thinking, dict))
-        and tool_choice is not None
-        and "thinking" in exc_msg
-        and "tool_choice" in exc_msg
+        tool_choice is not None and "thinking" in exc_msg and "tool_choice" in exc_msg
     )
 
 
@@ -222,20 +219,16 @@ def _next_compat_adjustment(
     Candidates are checked strictest-first (relax tool_choice, then disable
     thinking, then enable thinking) and tried in that written order: the
     first candidate whose predicate matches and would actually change the
-    rendered request wins. Order is the mechanism here, not a side detail --
-    this deliberately reverses the candidate order used by the predecessor
-    implementation this logic replaces. Pairing strictest-first with the
-    no-op skip below means that when a failure message matches more than one
-    predicate, every matching rule can still be tried in turn rather than the
-    first match blocking the rest; reordering the ``candidates`` tuple
-    changes which adjustment fires first and is not a safe refactor. A rule
-    that matches but would leave the actually rendered request unchanged
-    compared to the current ``(tool_choice, render(thinking))`` state is a
-    no-op and is skipped without spending its retry budget, so a rule that
-    cannot fix anything does not block a later rule that can. A rule whose
-    action was already attempted stops the search outright: the same shared
-    one-attempt-per-action budget this logic replaces (router.py's
-    ``attempted_retry_actions``) applies here too.
+    rendered request wins. Order is the mechanism here, not a side detail:
+    reordering the ``candidates`` tuple changes which adjustment fires first
+    and is not a safe refactor. A rule that matches but would leave the
+    actually rendered request unchanged compared to the current
+    ``(tool_choice, render(thinking))`` state is a no-op and is skipped
+    without spending its retry budget, so a rule that cannot fix anything
+    does not block a later rule that can. A rule whose action was already
+    attempted stops the search outright, even if a later, not-yet-attempted
+    rule would also match: one exhausted rule ends the whole search rather
+    than yielding to the next candidate.
     """
     current_state = (tool_choice, render(thinking))
     candidates: tuple[
@@ -348,6 +341,14 @@ class OpenRouterLLM(OpenAILLM):
         output_config: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> Any:
+        """Send a chat completion through OpenRouter.
+
+        Applies DeepSeek-specific request shaping and DeepSeek tool-protocol
+        handling, plus OpenRouter provider-compatibility retries: a retry may
+        relax a strict ``tool_choice`` down to ``"auto"``, or flip
+        ``thinking`` between enabled and disabled, each adjustment at most
+        once per call (see ``_next_compat_adjustment``).
+        """
         if self._uses_deepseek_tool_protocol:
             tool_choice = _force_single_required_deepseek_tool(tools, tool_choice)
         response = await self._run_chat_with_compat_retry(
@@ -384,6 +385,15 @@ class OpenRouterLLM(OpenAILLM):
         output_config: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> Any:
+        """Send a vision-capable chat completion through OpenRouter.
+
+        Applies the same OpenRouter provider-compatibility retries as
+        ``chat``: a retry may relax a strict ``tool_choice`` down to
+        ``"auto"``, or flip ``thinking`` between enabled and disabled, each
+        adjustment at most once per call. Unlike ``chat``, this skips
+        DeepSeek prefix retries and DeepSeek tool-protocol handling entirely
+        (see the comment below).
+        """
         # Vision requests carry no DeepSeek prefix-retry need, so the inner
         # call goes straight to the OpenAI implementation. This also skips
         # chat()'s DeepSeek tool-protocol handling (_force_single_required_
@@ -491,24 +501,57 @@ class OpenRouterLLM(OpenAILLM):
         5xx error that ``retry_on`` recognizes via ``__cause__``) is left for
         the shared LLM retry wrapper and is never treated as a compat
         adjustment opportunity. A single ``call`` invocation may itself issue
-        up to one additional upstream request: the response_format
-        pop-and-retry path in ``OpenAILLM.chat`` and ``vision_chat`` (both
-        served by this helper) can resend once internally before returning or
-        raising.
+        one additional upstream request through the response_format
+        pop-and-retry path shared by ``OpenAILLM.chat`` and ``vision_chat``,
+        but the two behave differently on a successful resend: ``chat``'s
+        branch returns the processed result of the resent call, or lets that
+        second call's failure propagate uncaught; ``vision_chat``'s
+        same-named branch does neither on a successful resend -- it falls
+        out of the ``except`` block with no ``return`` statement, so the
+        call implicitly yields ``None`` instead of the resent response
+        (tracked by #1650). No caller in this repository currently passes
+        ``response_format`` into ``chat``; the one caller that does supply
+        it in this repository (``vision_tool.py``) calls ``vision_chat``.
 
         Known limitation: ``OpenAILLM.chat``'s structured-output degrade path
         can rewrite ``thinking`` internally (disabling it after a non-JSON
         response) without reporting the change back here, so
         ``current_thinking`` does not necessarily reflect what was actually
-        sent on that path. No caller in this repository currently passes
-        ``response_format`` into ``chat``, so this gap has no live caller
-        today.
+        sent on that path.
+
+        Upstream request bounds for one logical call (one ``chat``/
+        ``vision_chat`` invocation, i.e. one attempt as seen by the
+        per-model ``RetryWrapper`` around this class): the compat-retry loop
+        below tries the initial request plus at most one attempt per
+        distinct action (``relax_tool_choice``, ``disable_thinking``,
+        ``enable_thinking``), so at most 4 requests come from this loop
+        itself. Without ``response_format``, ``chat``'s ``call`` adds at
+        most 1 more request in total (not per loop iteration) from
+        ``_chat_with_prefix_retry``'s DeepSeek function-call-prefix resend,
+        since the sanitized messages carry forward into later iterations
+        instead of re-triggering the same prefix rejection -- at most 5
+        upstream requests per logical call. With ``response_format``
+        supplied (``vision_chat`` today), the inner pop-and-retry can instead
+        fire independently on every one of the up to 4 loop iterations,
+        since each iteration's ``tool_choice``/``thinking`` differs -- at
+        most 8 upstream requests per logical call. Under
+        ``ModelConfig.max_retries``'s default outer budget of 10 attempts, a
+        run whose errors keep alternating between a compat-fixable shape and
+        an outer-retryable one can reach at most 50 upstream requests without
+        ``response_format`` or 80 with it.
         """
         current_tool_choice = tool_choice
         current_thinking = thinking
         current_messages = messages
         attempted: set[str] = set()
 
+        # ``render`` only models extra_body. Thinking also reaches the request
+        # through ``_build_request_messages(messages, thinking=...)``, which
+        # ``render`` never sees; that second path is a no-op today only because
+        # this class's MRO resolves to ``OpenAILLM._prepare_messages_for_request``
+        # (ignores ``thinking``), not ``DeepSeekLLM``'s rewrite. If a class on
+        # this MRO ever starts consuming ``thinking`` there, this no-op
+        # comparison must model the message body too, not just extra_body.
         def render(candidate_thinking: Optional[Dict[str, Any]]) -> Dict[str, Any]:
             return self._prepare_provider_reasoning_extra_body(
                 extra_body=self._prepare_extra_body(
@@ -636,6 +679,16 @@ class OpenRouterLLM(OpenAILLM):
         output_config: Optional[Dict[str, Any]] = None,
         **kwargs: Any,
     ) -> AsyncIterator[StreamChunk]:
+        """Stream a chat completion through OpenRouter.
+
+        Applies the same OpenRouter provider-compatibility retries as
+        ``chat``: a retry may relax a strict ``tool_choice`` down to
+        ``"auto"``, or flip ``thinking`` between enabled and disabled, each
+        adjustment at most once per call. Once the first chunk has been
+        yielded to the caller, no further compat retry happens: a later
+        error on that same stream is raised as-is, since replaying it would
+        duplicate output already sent.
+        """
         async for chunk in self._run_stream_chat_with_compat_retry(
             self._stream_chat_inner,
             messages,
@@ -684,6 +737,9 @@ class OpenRouterLLM(OpenAILLM):
         current_messages = messages
         attempted: set[str] = set()
 
+        # ``render`` only models extra_body, not the thinking that also flows
+        # into ``_build_request_messages``'s messages -- see the ``render``
+        # closure in ``_run_chat_with_compat_retry`` for why that is safe today.
         def render(candidate_thinking: Optional[Dict[str, Any]]) -> Dict[str, Any]:
             return self._prepare_provider_reasoning_extra_body(
                 extra_body=self._prepare_extra_body(

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -20,16 +20,18 @@ logger = logging.getLogger(__name__)
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 _DEEPSEEK_FUNCTION_PREFIX_ERROR = "function call should not be used with prefix"
 
-# OpenAILLM.chat/stream_chat normally convert every openai.BadRequestError into
-# a RuntimeError before returning. Their response_format pop-and-retry path is
-# an exception, though: it re-issues the request from inside its own
+# OpenAILLM.chat/vision_chat normally convert every openai.BadRequestError
+# into a RuntimeError before returning. Their response_format pop-and-retry
+# path is an exception, though: it re-issues the request from inside its own
 # ``except openai.BadRequestError`` block, and if that retried call also fails
 # with a BadRequestError, nothing wraps the second failure -- it escapes as a
-# bare SDK exception. openai.BadRequestError's MRO does not include
-# RuntimeError, so the compat retry loops below must catch both explicitly to
-# keep covering that case. The historical implementation caught bare
-# ``Exception`` here; this tuple is the precise, intentionally narrowed
-# replacement.
+# bare SDK exception. (stream_chat is not affected: its resend sits in a
+# nested try, so the outer handler still wraps a second failure; the streaming
+# loop catches the tuple for symmetry and defense.) openai.BadRequestError's
+# MRO does not include RuntimeError, so the compat retry loops below must
+# catch both explicitly to keep covering that case. The historical
+# implementation caught bare ``Exception`` here; this tuple is the precise,
+# intentionally narrowed replacement.
 _COMPAT_RETRYABLE_ERRORS = (RuntimeError, openai.BadRequestError)
 
 # Pinning to these provider slugs via `only` + `allow_fallbacks: False` routes
@@ -489,9 +491,10 @@ class OpenRouterLLM(OpenAILLM):
         5xx error that ``retry_on`` recognizes via ``__cause__``) is left for
         the shared LLM retry wrapper and is never treated as a compat
         adjustment opportunity. A single ``call`` invocation may itself issue
-        up to one additional upstream request: ``OpenAILLM.chat``'s
-        response_format pop-and-retry path can resend once internally before
-        returning or raising.
+        up to one additional upstream request: the response_format
+        pop-and-retry path in ``OpenAILLM.chat`` and ``vision_chat`` (both
+        served by this helper) can resend once internally before returning or
+        raising.
 
         Known limitation: ``OpenAILLM.chat``'s structured-output degrade path
         can rewrite ``thinking`` internally (disabling it after a non-JSON

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, AsyncIterator, Dict, List, Optional
+from typing import Any, AsyncIterator, Callable, Dict, List, Optional
 
 from .....config import get_openrouter_official_providers_only
 from ..exceptions import LLMRetryableError, LLMToolProtocolError
@@ -126,6 +126,148 @@ def _deepseek_tool_protocol_retry_error(response: Any) -> LLMRetryableError | No
     )
 
 
+# Normalized intents translated into OpenRouter's reasoning/thinking request body.
+_DISABLE_DOWNSTREAM_THINKING = {"type": "disabled", "enable": False}
+_ENABLE_DOWNSTREAM_THINKING = {"type": "enabled", "enable": True}
+
+_ACTION_ENABLE_THINKING = "enable_thinking"
+_ACTION_DISABLE_THINKING = "disable_thinking"
+_ACTION_RELAX_TOOL_CHOICE = "relax_tool_choice"
+
+
+def _should_retry_with_thinking(
+    exc: Exception,
+    *,
+    thinking: Optional[Dict[str, Any]],
+) -> bool:
+    # This is the primary stop condition after a retry swaps in enabled thinking;
+    # retry-action tracking remains defense in depth for the shared retry loop.
+    if isinstance(thinking, dict) and (
+        thinking.get("type") == "enabled" or thinking.get("enable") is True
+    ):
+        return False
+
+    # OpenRouter currently exposes this provider constraint only through an
+    # untyped 400 response. Retry the same selected model once with reasoning
+    # enabled instead of repeating the rejected payload or rerouting.
+    # Replace string matching with typed provider errors when available.
+    exc_msg = str(exc).lower()
+    return "reasoning is mandatory" in exc_msg and "cannot be disabled" in exc_msg
+
+
+def _should_retry_without_thinking(
+    exc: Exception,
+    *,
+    thinking: Optional[Dict[str, Any]],
+    tool_choice: Optional[str | Dict[str, Any]],
+) -> bool:
+    # Deliberate OpenRouter/DeepSeek compatibility bridge: the provider returns
+    # an OpenAI-compatible 400 without a typed error for this thinking/tool_choice
+    # conflict. Replace this with provider-owned typed exceptions once the
+    # follow-up tracking issue lands.
+    exc_msg = str(exc).lower()
+    return (
+        (thinking is None or isinstance(thinking, dict))
+        and tool_choice is not None
+        and "thinking" in exc_msg
+        and "tool_choice" in exc_msg
+    )
+
+
+def _should_retry_with_relaxed_tool_choice(
+    exc: Exception,
+    *,
+    tools: Optional[List[Dict[str, Any]]],
+    tool_choice: Optional[str | Dict[str, Any]],
+) -> bool:
+    if not tools or tool_choice in (None, "auto", "none"):
+        return False
+
+    # Deliberate OpenRouter compatibility bridge: official provider routing can
+    # reject strict tool_choice values before selecting an endpoint. This
+    # degrades forced tool use to "auto" instead of failing the whole agent run.
+    # Replace string matching with typed provider errors when available.
+    exc_msg = str(exc).lower()
+    return "no endpoints found" in exc_msg and "tool_choice" in exc_msg
+
+
+def _next_compat_adjustment(
+    exc: Exception,
+    *,
+    tools: Optional[List[Dict[str, Any]]],
+    tool_choice: Optional[str | Dict[str, Any]],
+    thinking: Optional[Dict[str, Any]],
+    attempted: set[str],
+    render: Callable[[Optional[Dict[str, Any]]], Dict[str, Any]],
+) -> tuple[Optional[str | Dict[str, Any]], Optional[Dict[str, Any]], str, str] | None:
+    """Pick the next OpenRouter provider-compatibility adjustment for a failure.
+
+    Rules are checked strictest-first (relax tool_choice, then disable
+    thinking, then enable thinking): a message that happens to match more than
+    one predicate is resolved by its most specific cause instead of by
+    declaration order. A rule that matches but would leave the actually
+    rendered request unchanged compared to the current ``(tool_choice,
+    render(thinking))`` state is a no-op and is skipped without spending its
+    retry budget, so a rule that cannot fix anything does not block a later
+    rule that can. A rule whose action was already attempted stops the search
+    outright: the same shared one-attempt-per-action budget this logic
+    replaces (router.py's ``attempted_retry_actions``) applies here too.
+    """
+    current_state = (tool_choice, render(thinking))
+    candidates: tuple[
+        tuple[Optional[str | Dict[str, Any]], Optional[Dict[str, Any]], str, str]
+        | None,
+        ...,
+    ] = (
+        (
+            (
+                "auto",
+                thinking,
+                "selected OpenRouter endpoint rejected tool_choice; retrying with tool_choice=auto",
+                _ACTION_RELAX_TOOL_CHOICE,
+            )
+            if _should_retry_with_relaxed_tool_choice(
+                exc, tools=tools, tool_choice=tool_choice
+            )
+            else None
+        ),
+        (
+            (
+                tool_choice,
+                _DISABLE_DOWNSTREAM_THINKING,
+                "selected model rejected thinking with tool_choice; retrying without thinking",
+                _ACTION_DISABLE_THINKING,
+            )
+            if _should_retry_without_thinking(
+                exc, thinking=thinking, tool_choice=tool_choice
+            )
+            else None
+        ),
+        (
+            (
+                tool_choice,
+                _ENABLE_DOWNSTREAM_THINKING,
+                "selected model requires reasoning; retrying with thinking enabled",
+                _ACTION_ENABLE_THINKING,
+            )
+            if _should_retry_with_thinking(exc, thinking=thinking)
+            else None
+        ),
+    )
+
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        next_tool_choice, next_thinking, _log_message, action_key = candidate
+        if (next_tool_choice, render(next_thinking)) == current_state:
+            continue
+        if action_key in attempted:
+            return None
+        return candidate
+
+    return None
+
+
 class OpenRouterLLM(OpenAILLM):
     """OpenRouter client using the OpenAI SDK with OpenRouter-specific options."""
 
@@ -184,6 +326,66 @@ class OpenRouterLLM(OpenAILLM):
     ) -> Any:
         if self._uses_deepseek_tool_protocol:
             tool_choice = _force_single_required_deepseek_tool(tools, tool_choice)
+        response = await self._run_chat_with_compat_retry(
+            self._chat_with_prefix_retry,
+            messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools,
+            tool_choice=tool_choice,
+            response_format=response_format,
+            thinking=thinking,
+            output_config=output_config,
+            kwargs=kwargs,
+        )
+
+        if not self._uses_deepseek_tool_protocol:
+            return response
+        response = normalize_deepseek_response(response, tools=tools)
+        retry_error = _deepseek_tool_protocol_retry_error(response)
+        if retry_error is not None:
+            raise retry_error
+        return response
+
+    async def vision_chat(
+        self,
+        messages: List[Dict[str, Any]],
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tool_choice: Optional[str | Dict[str, Any]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
+        thinking: Optional[Dict[str, Any]] = None,
+        output_config: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> Any:
+        # Vision requests carry no DeepSeek prefix-retry need, so the inner
+        # call goes straight to the OpenAI implementation.
+        return await self._run_chat_with_compat_retry(
+            super().vision_chat,
+            messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools,
+            tool_choice=tool_choice,
+            response_format=response_format,
+            thinking=thinking,
+            output_config=output_config,
+            kwargs=kwargs,
+        )
+
+    async def _chat_with_prefix_retry(
+        self,
+        messages: List[Dict[str, Any]],
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tool_choice: Optional[str | Dict[str, Any]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
+        thinking: Optional[Dict[str, Any]] = None,
+        output_config: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> Any:
         try:
             response = await super().chat(
                 messages=messages,
@@ -219,13 +421,77 @@ class OpenRouterLLM(OpenAILLM):
                 **kwargs,
             )
 
-        if not self._uses_deepseek_tool_protocol:
-            return response
-        response = normalize_deepseek_response(response, tools=tools)
-        retry_error = _deepseek_tool_protocol_retry_error(response)
-        if retry_error is not None:
-            raise retry_error
         return response
+
+    async def _run_chat_with_compat_retry(
+        self,
+        call: Callable[..., Any],
+        messages: List[Dict[str, Any]],
+        *,
+        temperature: Optional[float],
+        max_tokens: Optional[int],
+        tools: Optional[List[Dict[str, Any]]],
+        tool_choice: Optional[str | Dict[str, Any]],
+        response_format: Optional[Dict[str, Any]],
+        thinking: Optional[Dict[str, Any]],
+        output_config: Optional[Dict[str, Any]],
+        kwargs: Dict[str, Any],
+    ) -> Any:
+        """Retry ``call`` once per matching OpenRouter provider-compat rule.
+
+        Shared by ``chat`` (wrapping ``_chat_with_prefix_retry``) and
+        ``vision_chat`` (wrapping the inherited ``OpenAILLM.vision_chat``
+        directly). A retryable error raised by the inner call (e.g. the
+        DeepSeek tool-protocol error surfaced after prefix retry) is left for
+        the shared LLM retry wrapper and is never treated as a compat
+        adjustment opportunity.
+        """
+        current_tool_choice = tool_choice
+        current_thinking = thinking
+        attempted: set[str] = set()
+
+        def render(candidate_thinking: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+            return self._prepare_provider_reasoning_extra_body(
+                extra_body={},
+                thinking=candidate_thinking,
+                tools=tools,
+                response_format=response_format,
+                output_config=output_config,
+                is_streaming=False,
+            )
+
+        while True:
+            try:
+                return await call(
+                    messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                    tool_choice=current_tool_choice,
+                    response_format=response_format,
+                    thinking=current_thinking,
+                    output_config=output_config,
+                    **kwargs,
+                )
+            except LLMRetryableError:
+                raise
+            except RuntimeError as exc:
+                adjustment = _next_compat_adjustment(
+                    exc,
+                    tools=tools,
+                    tool_choice=current_tool_choice,
+                    thinking=current_thinking,
+                    attempted=attempted,
+                    render=render,
+                )
+                if adjustment is None:
+                    raise
+
+                current_tool_choice, current_thinking, log_message, action_key = (
+                    adjustment
+                )
+                attempted.add(action_key)
+                logger.info(log_message)
 
     async def _stream_chat_with_prefix_retry(
         self,
@@ -280,6 +546,110 @@ class OpenRouterLLM(OpenAILLM):
             yield chunk
 
     async def stream_chat(
+        self,
+        messages: List[Dict[str, Any]],
+        temperature: Optional[float] = None,
+        max_tokens: Optional[int] = None,
+        tools: Optional[List[Dict[str, Any]]] = None,
+        tool_choice: Optional[str | Dict[str, Any]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
+        thinking: Optional[Dict[str, Any]] = None,
+        output_config: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> AsyncIterator[StreamChunk]:
+        async for chunk in self._run_stream_chat_with_compat_retry(
+            self._stream_chat_inner,
+            messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            tools=tools,
+            tool_choice=tool_choice,
+            response_format=response_format,
+            thinking=thinking,
+            output_config=output_config,
+            kwargs=kwargs,
+        ):
+            yield chunk
+
+    async def _run_stream_chat_with_compat_retry(
+        self,
+        call: Callable[..., AsyncIterator[StreamChunk]],
+        messages: List[Dict[str, Any]],
+        *,
+        temperature: Optional[float],
+        max_tokens: Optional[int],
+        tools: Optional[List[Dict[str, Any]]],
+        tool_choice: Optional[str | Dict[str, Any]],
+        response_format: Optional[Dict[str, Any]],
+        thinking: Optional[Dict[str, Any]],
+        output_config: Optional[Dict[str, Any]],
+        kwargs: Dict[str, Any],
+    ) -> AsyncIterator[StreamChunk]:
+        """Streaming counterpart of ``_run_chat_with_compat_retry``.
+
+        Only retries while nothing has reached the caller yet: once a chunk
+        has actually been yielded, replaying the request would duplicate
+        output, so any later error is raised as-is. Note that for the
+        DeepSeek dict-tool_choice path ``call`` (``_stream_chat_inner``)
+        buffers chunks internally until the tool protocol is validated, so an
+        inner chunk being produced is not the same thing as one having been
+        yielded from here.
+        """
+        has_yielded = False
+        current_tool_choice = tool_choice
+        current_thinking = thinking
+        attempted: set[str] = set()
+
+        def render(candidate_thinking: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+            return self._prepare_provider_reasoning_extra_body(
+                extra_body={},
+                thinking=candidate_thinking,
+                tools=tools,
+                response_format=response_format,
+                output_config=output_config,
+                is_streaming=True,
+            )
+
+        while True:
+            try:
+                async for chunk in call(
+                    messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                    tool_choice=current_tool_choice,
+                    response_format=response_format,
+                    thinking=current_thinking,
+                    output_config=output_config,
+                    **kwargs,
+                ):
+                    has_yielded = True
+                    yield chunk
+                return
+            except LLMRetryableError:
+                raise
+            except RuntimeError as exc:
+                if has_yielded:
+                    raise
+
+                adjustment = _next_compat_adjustment(
+                    exc,
+                    tools=tools,
+                    tool_choice=current_tool_choice,
+                    thinking=current_thinking,
+                    attempted=attempted,
+                    render=render,
+                )
+                if adjustment is None:
+                    raise
+
+                current_tool_choice, current_thinking, log_message, action_key = (
+                    adjustment
+                )
+                attempted.add(action_key)
+                logger.info(log_message)
+
+    async def _stream_chat_inner(
         self,
         messages: List[Dict[str, Any]],
         temperature: Optional[float] = None,

--- a/src/xagent/core/model/chat/basic/router.py
+++ b/src/xagent/core/model/chat/basic/router.py
@@ -283,10 +283,16 @@ class RouterLLM(BaseLLM):
 
         The returned wrapper dispatches directly to the selected downstream
         model without routing a second time, and carries the selected model's
-        context window from xrouter's model profile catalog. Provider-compat
-        retries (a rejected tool_choice, a thinking/tool_choice conflict, a
-        model that mandates reasoning) are the downstream OpenRouter client's
-        own responsibility, not this router's.
+        context window from xrouter's model profile catalog. Both resolver
+        branches in ``_resolve_route`` currently build an ``OpenRouterLLM``
+        client for the chosen slug (the injected ``_downstream_resolver`` in
+        practice, and the ``create_base_llm`` fallback always, since it is
+        given ``model_provider="openrouter"``), so provider-compat retries (a
+        rejected tool_choice, a thinking/tool_choice conflict, a model that
+        mandates reasoning) are that client's own responsibility today, not
+        this router's. ``_downstream_resolver`` is typed as
+        ``Callable[[str], BaseLLM]``, not ``OpenRouterLLM``, so this is a
+        statement about current call sites, not a type-level guarantee.
 
         ``preferred_input_modalities`` supplied by the caller (task runtime
         extensions) is *advisory*: a router that cannot honour it degrades by

--- a/src/xagent/core/model/chat/basic/router.py
+++ b/src/xagent/core/model/chat/basic/router.py
@@ -32,7 +32,7 @@ import inspect
 import logging
 import os
 import threading
-from typing import Any, AsyncIterator, Callable, List, Optional, cast
+from typing import Any, AsyncIterator, Callable, List, Optional
 
 from ....context_ref import CONTEXT_REFS_KEY, normalize_context_references
 from ....model import ChatModelConfig
@@ -45,9 +45,6 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_ROUTER_ABILITIES = ["chat", "tool_calling"]
 _UNROUTED_ROUTER_ABILITIES = {"vision", "thinking_mode"}
-# Normalized intents translated into OpenRouter's reasoning/thinking request body.
-_DISABLE_DOWNSTREAM_THINKING = {"type": "disabled", "enable": False}
-_ENABLE_DOWNSTREAM_THINKING = {"type": "enabled", "enable": True}
 _CONTENT_PART_MODALITIES = {
     "audio": "audio",
     "audio_url": "audio",
@@ -71,98 +68,6 @@ _MODALITY_ABILITIES = {
 
 class RouterModalityRoutingError(RuntimeError):
     """The installed router cannot enforce required input modalities."""
-
-
-def _should_retry_with_thinking(
-    exc: Exception,
-    *,
-    thinking: dict[str, Any] | None,
-) -> bool:
-    # This is the primary stop condition after a retry swaps in enabled thinking;
-    # retry-action tracking remains defense in depth for the shared retry loop.
-    if isinstance(thinking, dict) and (
-        thinking.get("type") == "enabled" or thinking.get("enable") is True
-    ):
-        return False
-
-    # OpenRouter currently exposes this provider constraint only through an
-    # untyped 400 response. Retry the same selected model once with reasoning
-    # enabled instead of repeating the rejected payload or rerouting.
-    # Replace string matching with typed provider errors when available.
-    exc_msg = str(exc).lower()
-    return "reasoning is mandatory" in exc_msg and "cannot be disabled" in exc_msg
-
-
-def _should_retry_without_thinking(
-    exc: Exception,
-    *,
-    thinking: dict[str, Any] | None,
-    tool_choice: str | dict[str, Any] | None,
-) -> bool:
-    # Deliberate OpenRouter/DeepSeek compatibility bridge: the provider returns
-    # an OpenAI-compatible 400 without a typed error for this thinking/tool_choice
-    # conflict. Replace this with provider-owned typed exceptions once the
-    # follow-up tracking issue lands.
-    exc_msg = str(exc).lower()
-    return (
-        (thinking is None or isinstance(thinking, dict))
-        and tool_choice is not None
-        and "thinking" in exc_msg
-        and "tool_choice" in exc_msg
-    )
-
-
-def _should_retry_with_relaxed_tool_choice(
-    exc: Exception,
-    *,
-    tools: list[dict[str, Any]] | None,
-    tool_choice: str | dict[str, Any] | None,
-) -> bool:
-    if not tools or tool_choice in (None, "auto", "none"):
-        return False
-
-    # Deliberate OpenRouter compatibility bridge: official provider routing can
-    # reject strict tool_choice values before selecting an endpoint. This
-    # degrades forced tool use to "auto" instead of failing the whole agent run.
-    # Replace string matching with typed provider errors when available.
-    exc_msg = str(exc).lower()
-    return "no endpoints found" in exc_msg and "tool_choice" in exc_msg
-
-
-def _next_retry_state(
-    exc: Exception,
-    *,
-    tools: list[dict[str, Any]] | None,
-    thinking: dict[str, Any] | None,
-    tool_choice: str | dict[str, Any] | None,
-) -> tuple[str | dict[str, Any] | None, dict[str, Any] | None, str, str] | None:
-    if _should_retry_with_thinking(exc, thinking=thinking):
-        return (
-            tool_choice,
-            _ENABLE_DOWNSTREAM_THINKING,
-            "selected model requires reasoning; retrying with thinking enabled",
-            "enable_thinking",
-        )
-
-    if _should_retry_without_thinking(exc, thinking=thinking, tool_choice=tool_choice):
-        return (
-            tool_choice,
-            _DISABLE_DOWNSTREAM_THINKING,
-            "selected model rejected thinking with tool_choice; retrying without thinking",
-            "disable_thinking",
-        )
-
-    if _should_retry_with_relaxed_tool_choice(
-        exc, tools=tools, tool_choice=tool_choice
-    ):
-        return (
-            "auto",
-            thinking,
-            "selected OpenRouter endpoint rejected tool_choice; retrying with tool_choice=auto",
-            "relax_tool_choice",
-        )
-
-    return None
 
 
 class _NullStore:
@@ -291,57 +196,6 @@ class RouterLLM(BaseLLM):
     def supports_thinking_mode(self) -> bool:
         return "thinking_mode" in self._abilities
 
-    async def _run_non_streaming_with_provider_retry(
-        self,
-        method: Callable[..., Any],
-        messages: list[dict[str, Any]],
-        *,
-        temperature: float | None,
-        max_tokens: int | None,
-        tools: list[dict[str, Any]] | None,
-        tool_choice: str | dict[str, Any] | None,
-        response_format: dict[str, Any] | None,
-        thinking: dict[str, Any] | None,
-        output_config: dict[str, Any] | None,
-        kwargs: dict[str, Any],
-    ) -> str | dict[str, Any]:
-        current_tool_choice = tool_choice
-        current_thinking = thinking
-        attempted_retry_actions: set[str] = set()
-
-        while True:
-            try:
-                result = await method(
-                    messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    tools=tools,
-                    tool_choice=current_tool_choice,
-                    response_format=response_format,
-                    thinking=current_thinking,
-                    output_config=output_config,
-                    **kwargs,
-                )
-                return cast(str | dict[str, Any], result)
-            except Exception as exc:  # noqa: BLE001 - inspect a provider compatibility error.
-                retry_state = _next_retry_state(
-                    exc,
-                    tools=tools,
-                    thinking=current_thinking,
-                    tool_choice=current_tool_choice,
-                )
-                if retry_state is None:
-                    raise
-
-                next_tool_choice, next_thinking, log_message, action_key = retry_state
-                if action_key in attempted_retry_actions:
-                    raise
-
-                attempted_retry_actions.add(action_key)
-                logger.info(log_message)
-                current_tool_choice = next_tool_choice
-                current_thinking = next_thinking
-
     async def chat(
         self,
         messages: list[dict[str, str]],
@@ -418,63 +272,6 @@ class RouterLLM(BaseLLM):
         ):
             yield chunk
 
-    async def _run_streaming_with_provider_retry(
-        self,
-        llm: BaseLLM,
-        messages: list[dict[str, Any]],
-        *,
-        temperature: float | None,
-        max_tokens: int | None,
-        tools: list[dict[str, Any]] | None,
-        tool_choice: str | dict[str, Any] | None,
-        response_format: dict[str, Any] | None,
-        thinking: dict[str, Any] | None,
-        output_config: dict[str, Any] | None,
-        kwargs: dict[str, Any],
-    ) -> AsyncIterator[StreamChunk]:
-        has_yielded = False
-        current_tool_choice = tool_choice
-        current_thinking = thinking
-        attempted_retry_actions: set[str] = set()
-
-        while True:
-            try:
-                async for chunk in llm.stream_chat(
-                    messages,
-                    temperature=temperature,
-                    max_tokens=max_tokens,
-                    tools=tools,
-                    tool_choice=current_tool_choice,
-                    response_format=response_format,
-                    thinking=current_thinking,
-                    output_config=output_config,
-                    **kwargs,
-                ):
-                    has_yielded = True
-                    yield chunk
-                return
-            except Exception as exc:  # noqa: BLE001 - inspect a provider compatibility error.
-                if has_yielded:
-                    raise
-
-                retry_state = _next_retry_state(
-                    exc,
-                    tools=tools,
-                    thinking=current_thinking,
-                    tool_choice=current_tool_choice,
-                )
-                if retry_state is None:
-                    raise
-
-                next_tool_choice, next_thinking, log_message, action_key = retry_state
-                if action_key in attempted_retry_actions:
-                    raise
-
-                attempted_retry_actions.add(action_key)
-                logger.info(log_message)
-                current_tool_choice = next_tool_choice
-                current_thinking = next_thinking
-
     # ---- Routing ------------------------------------------------------------
     async def prepare_for_call(
         self,
@@ -484,9 +281,12 @@ class RouterLLM(BaseLLM):
     ) -> BaseLLM:
         """Resolve one xrouter decision into a reusable per-call LLM.
 
-        The returned wrapper keeps RouterLLM's compatibility retries without
-        routing a second time, and carries the selected model's context window
-        from xrouter's model profile catalog.
+        The returned wrapper dispatches directly to the selected downstream
+        model without routing a second time, and carries the selected model's
+        context window from xrouter's model profile catalog. Provider-compat
+        retries (a rejected tool_choice, a thinking/tool_choice conflict, a
+        model that mandates reasoning) are the downstream OpenRouter client's
+        own responsibility, not this router's.
 
         ``preferred_input_modalities`` supplied by the caller (task runtime
         extensions) is *advisory*: a router that cannot honour it degrades by
@@ -805,8 +605,7 @@ class _ResolvedRouterLLM(BaseLLM):
         output_config: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> str | dict[str, Any]:
-        return await self._router._run_non_streaming_with_provider_retry(
-            self._downstream.chat,
+        return await self._downstream.chat(
             messages,
             temperature=temperature,
             max_tokens=max_tokens,
@@ -815,7 +614,7 @@ class _ResolvedRouterLLM(BaseLLM):
             response_format=response_format,
             thinking=thinking,
             output_config=output_config,
-            kwargs=kwargs,
+            **kwargs,
         )
 
     async def vision_chat(
@@ -830,8 +629,7 @@ class _ResolvedRouterLLM(BaseLLM):
         output_config: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> str | dict[str, Any]:
-        return await self._router._run_non_streaming_with_provider_retry(
-            self._downstream.vision_chat,
+        return await self._downstream.vision_chat(
             messages,
             temperature=temperature,
             max_tokens=max_tokens,
@@ -840,7 +638,7 @@ class _ResolvedRouterLLM(BaseLLM):
             response_format=response_format,
             thinking=thinking,
             output_config=output_config,
-            kwargs=kwargs,
+            **kwargs,
         )
 
     async def stream_chat(
@@ -855,8 +653,7 @@ class _ResolvedRouterLLM(BaseLLM):
         output_config: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> AsyncIterator[StreamChunk]:
-        async for chunk in self._router._run_streaming_with_provider_retry(
-            self._downstream,
+        async for chunk in self._downstream.stream_chat(
             messages,
             temperature=temperature,
             max_tokens=max_tokens,
@@ -865,6 +662,6 @@ class _ResolvedRouterLLM(BaseLLM):
             response_format=response_format,
             thinking=thinking,
             output_config=output_config,
-            kwargs=kwargs,
+            **kwargs,
         ):
             yield chunk

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -1337,19 +1337,29 @@ async def test_openrouter_stream_error_after_first_chunk_not_retried(mocker):
 
 @pytest.mark.asyncio
 async def test_openrouter_compat_retry_does_not_catch_llm_retryable_error(mocker):
-    """A retryable protocol error from the inner call is never a compat adjustment."""
+    """A retryable protocol error is re-raised even when its text matches a rule.
+
+    The error message deliberately matches the relaxed-tool_choice predicate
+    and the call carries tools with tool_choice="required": without the
+    LLMRetryableError guard the compat retry would swallow the error and
+    replay the request, so the single-call assertion pins the guard itself.
+    """
     protocol_error = LLMToolProtocolError(
         provider="deepseek",
         code="malformed_tool_arguments",
-        message="DeepSeek returned malformed arguments.",
+        message=("No endpoints found that support the provided 'tool_choice' value."),
     )
     llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
     prefix_retry_mock = mocker.patch.object(
         llm, "_chat_with_prefix_retry", side_effect=protocol_error
     )
 
-    with pytest.raises(LLMToolProtocolError, match="malformed arguments"):
-        await llm.chat([{"role": "user", "content": "score?"}])
+    with pytest.raises(LLMToolProtocolError, match="No endpoints found"):
+        await llm.chat(
+            [{"role": "user", "content": "score?"}],
+            tools=_two_tool_schema(),
+            tool_choice="required",
+        )
 
     assert prefix_retry_mock.call_count == 1
 

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -1250,6 +1250,48 @@ async def test_openrouter_direct_relaxes_tool_choice_after_bare_bad_request_erro
 
 
 @pytest.mark.asyncio
+async def test_openrouter_vision_relaxes_tool_choice_after_bare_bad_request_error(
+    mock_chat_completion, mocker
+):
+    """The vision path recovers from the bare BadRequestError escape too.
+
+    ``vision_chat`` is the entrypoint with a live response_format producer in
+    this repository, so the escape guarded here is reachable in production:
+    ``OpenAILLM.vision_chat``'s pop-and-retry resend sits inside its own
+    ``except openai.BadRequestError`` block and a second failure escapes
+    unwrapped, exactly like ``chat``'s.
+    """
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        _bad_request_error(
+            "the model does not support response_format for this request"
+        ),
+        _bad_request_error(_OPENROUTER_TOOL_CHOICE_ERROR),
+        mock_chat_completion,
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(
+        model_name="z-ai/glm-5.2",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "vision"],
+    )
+
+    await llm.vision_chat(
+        [{"role": "user", "content": "score?"}],
+        tools=_two_tool_schema(),
+        tool_choice="required",
+        response_format={"type": "json_object"},
+    )
+
+    assert mock_client.chat.completions.create.await_count == 3
+    final_call = mock_client.chat.completions.create.call_args_list[2].kwargs
+    assert final_call["tool_choice"] == "auto"
+
+
+@pytest.mark.asyncio
 async def test_openrouter_direct_does_not_repeat_mandatory_reasoning_retry(mocker):
     """Each compat action fires at most once per call, even across a 3-error run."""
     mock_client = mocker.AsyncMock()
@@ -1857,6 +1899,8 @@ async def test_openrouter_stream_thinking_retry_changes_rendered_extra_body(mock
     assert extra_bodies[0] != extra_bodies[1]
     assert extra_bodies[0]["thinking"] == {"type": "disabled"}
     assert extra_bodies[1]["thinking"] == {"type": "enabled"}
+    for call in mock_client.chat.completions.create.call_args_list:
+        assert "sanitized_out" not in call.kwargs
 
 
 @pytest.mark.asyncio

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -1522,11 +1522,11 @@ async def test_openrouter_vision_chat_retries_mandatory_reasoning(mocker):
     that happens to go through vision_chat. The spies pin both directions of
     the fork: OpenAILLM.vision_chat must be the method that actually issues
     the request, and OpenRouterLLM.chat / _chat_with_prefix_retry (the
-    DeepSeek prefix-retry path) must never run for a vision call. Mutation
-    check performed by hand: temporarily making OpenRouterLLM.vision_chat
-    call super().chat(...) instead of super().vision_chat(...) turns this red
-    (chat_spy and prefix_retry_spy stop being zero), confirming the
-    assertions actually discriminate between the two dispatch paths.
+    DeepSeek prefix-retry path) must never run for a vision call. Rewiring
+    vision_chat to super().chat(...) turns this red via the vision_chat spy
+    dropping to zero (super() bypasses the OpenRouterLLM.chat spy), while
+    rewiring it to self.chat(...) is caught by the chat and prefix-retry
+    spies — together the spies discriminate both dispatch mistakes.
     """
     success_response = SimpleNamespace(
         choices=[
@@ -1580,6 +1580,8 @@ async def test_openrouter_vision_chat_retries_mandatory_reasoning(mocker):
     assert vision_chat_spy.call_count == 2
     assert chat_spy.call_count == 0
     assert prefix_retry_spy.call_count == 0
+    for call in mock_client.chat.completions.create.call_args_list:
+        assert "sanitized_out" not in call.kwargs
 
 
 @pytest.mark.asyncio

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -1480,3 +1480,159 @@ async def test_openrouter_deepseek_no_op_thinking_retry_falls_through_to_next_ru
     assert mock_client.chat.completions.create.await_count == 2
     second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
     assert second_call["extra_body"]["thinking"] == {"type": "enabled"}
+
+
+# ==========================================================================
+# Client-layer equivalents of the RouterLLM-level retry tests that used to
+# live in tests/core/model/test_router_provider_config.py (moved here because
+# RouterLLM no longer retries on its own; see router.py).
+# ==========================================================================
+
+
+@pytest.mark.asyncio
+async def test_openrouter_direct_disables_thinking_for_tool_choice_conflict(mocker):
+    """chat: a thinking/tool_choice 400 retries once with thinking disabled.
+
+    Starting from an already-enabled thinking value keeps the disable
+    adjustment a real change (not a no-op), isolating this single rule.
+    """
+    calls: list[dict] = []
+
+    async def fake_inner(messages, **kwargs):
+        del messages
+        calls.append(kwargs)
+        if len(calls) == 1:
+            raise RuntimeError(_THINKING_TOOL_CHOICE_ERROR)
+        return "ok"
+
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+    mocker.patch.object(llm, "_chat_with_prefix_retry", side_effect=fake_inner)
+
+    result = await llm.chat(
+        [{"role": "user", "content": "score?"}],
+        tool_choice="required",
+        thinking={"type": "enabled", "enable": True},
+    )
+
+    assert result == "ok"
+    assert len(calls) == 2
+    assert calls[0]["tool_choice"] == "required"
+    assert calls[0]["thinking"] == {"type": "enabled", "enable": True}
+    assert calls[1]["tool_choice"] == "required"
+    assert calls[1]["thinking"] == openrouter_module._DISABLE_DOWNSTREAM_THINKING
+
+
+@pytest.mark.asyncio
+async def test_openrouter_stream_disables_thinking_for_tool_choice_conflict(mocker):
+    """stream_chat: same rule as above, exercised on the streaming entrypoint."""
+    calls: list[dict] = []
+
+    async def rejects(**_kwargs):
+        if False:
+            yield None
+        raise RuntimeError(_THINKING_TOOL_CHOICE_ERROR)
+
+    async def succeeds(**_kwargs):
+        yield StreamChunk(type=ChunkType.TOKEN, content="ok", delta="ok")
+
+    def fake_inner(messages, **kwargs):
+        del messages
+        calls.append(kwargs)
+        return rejects() if len(calls) == 1 else succeeds()
+
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+    mocker.patch.object(llm, "_stream_chat_inner", side_effect=fake_inner)
+
+    chunks = [
+        chunk
+        async for chunk in llm.stream_chat(
+            [{"role": "user", "content": "score?"}],
+            tool_choice="required",
+            thinking={"type": "enabled", "enable": True},
+        )
+    ]
+
+    assert [chunk.delta for chunk in chunks] == ["ok"]
+    assert len(calls) == 2
+    assert calls[0]["tool_choice"] == "required"
+    assert calls[0]["thinking"] == {"type": "enabled", "enable": True}
+    assert calls[1]["tool_choice"] == "required"
+    assert calls[1]["thinking"] == openrouter_module._DISABLE_DOWNSTREAM_THINKING
+
+
+@pytest.mark.asyncio
+async def test_openrouter_stream_disables_thinking_when_unspecified_non_deepseek(
+    mocker,
+):
+    """stream_chat: an unspecified (None) thinking value still gets a real
+    disable retry for a non-DeepSeek model.
+
+    DeepSeek's None default already renders as disabled (see the no-op test
+    below), so this covers the case where starting from None is a genuine
+    adjustment: any non-DeepSeek slug, where an unset thinking value renders
+    as an empty extra_body rather than an explicit disabled one.
+    """
+    calls: list[dict] = []
+
+    async def rejects(**_kwargs):
+        if False:
+            yield None
+        raise RuntimeError(_THINKING_TOOL_CHOICE_ERROR)
+
+    async def succeeds(**_kwargs):
+        yield StreamChunk(type=ChunkType.TOKEN, content="ok", delta="ok")
+
+    def fake_inner(messages, **kwargs):
+        del messages
+        calls.append(kwargs)
+        return rejects() if len(calls) == 1 else succeeds()
+
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+    mocker.patch.object(llm, "_stream_chat_inner", side_effect=fake_inner)
+
+    chunks = [
+        chunk
+        async for chunk in llm.stream_chat(
+            [{"role": "user", "content": "score?"}],
+            tool_choice="required",
+        )
+    ]
+
+    assert [chunk.delta for chunk in chunks] == ["ok"]
+    assert len(calls) == 2
+    assert calls[0]["thinking"] is None
+    assert calls[1]["tool_choice"] == "required"
+    assert calls[1]["thinking"] == openrouter_module._DISABLE_DOWNSTREAM_THINKING
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_stream_no_op_thinking_default_propagates(mocker):
+    """stream_chat: DeepSeek's unspecified (None) thinking already renders
+    disabled, so a thinking/tool_choice 400 is a no-op for rule 2; with no
+    other rule matching this text, the error surfaces after exactly one call
+    instead of wasting a retry replaying an unchanged request.
+    """
+    calls = 0
+
+    async def rejects():
+        if False:
+            yield None
+        raise RuntimeError(_THINKING_TOOL_CHOICE_ERROR)
+
+    def fake_inner(*_args, **kwargs):
+        nonlocal calls
+        del kwargs
+        calls += 1
+        return rejects()
+
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+    mocker.patch.object(llm, "_stream_chat_inner", side_effect=fake_inner)
+
+    with pytest.raises(RuntimeError, match="Thinking mode does not support"):
+        async for _chunk in llm.stream_chat(
+            [{"role": "user", "content": "score?"}],
+            tool_choice="required",
+        ):
+            pass
+
+    assert calls == 1

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -1144,3 +1144,339 @@ async def test_structured_output_retry_disables_openrouter_reasoning(
     second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
     assert second_call["extra_body"]["reasoning"] == {"enabled": False}
     assert second_call["extra_body"]["thinking"] == {"type": "disabled"}
+
+
+# ==========================================================================
+# Provider-compatibility retries owned by the client (direct-slug entrypoints)
+# ==========================================================================
+
+_MANDATORY_REASONING_ERROR = (
+    "Reasoning is mandatory for this endpoint and cannot be disabled."
+)
+_THINKING_TOOL_CHOICE_ERROR = "Thinking mode does not support this tool_choice"
+_OPENROUTER_TOOL_CHOICE_ERROR = (
+    "No endpoints found that support the provided 'tool_choice' value."
+)
+
+
+def _two_tool_schema() -> list[dict]:
+    return [
+        _single_tool_schema("answer")[0],
+        _single_tool_schema("skip")[0],
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openrouter_direct_relaxes_tool_choice_on_endpoint_404(
+    mock_chat_completion, mocker
+):
+    """A direct (non-auto) OpenRouter slug retries a rejected tool_choice itself."""
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        RuntimeError(_OPENROUTER_TOOL_CHOICE_ERROR),
+        mock_chat_completion,
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+
+    result = await llm.chat(
+        [{"role": "user", "content": "score?"}],
+        tools=_two_tool_schema(),
+        tool_choice="required",
+    )
+
+    assert result["content"] == "Hello World"
+    assert mock_client.chat.completions.create.await_count == 2
+    second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
+    assert second_call["tool_choice"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_direct_does_not_repeat_mandatory_reasoning_retry(mocker):
+    """Each compat action fires at most once per call, even across a 3-error run."""
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        RuntimeError(_MANDATORY_REASONING_ERROR),
+        RuntimeError(_THINKING_TOOL_CHOICE_ERROR),
+        RuntimeError(_MANDATORY_REASONING_ERROR),
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+
+    with pytest.raises(RuntimeError, match="Reasoning is mandatory"):
+        await llm.chat(
+            [{"role": "user", "content": "score?"}],
+            tools=_two_tool_schema(),
+            tool_choice="required",
+            thinking={"type": "disabled", "enable": False},
+        )
+
+    assert mock_client.chat.completions.create.await_count == 3
+    thinking_values = [
+        call.kwargs["extra_body"].get("thinking")
+        for call in mock_client.chat.completions.create.call_args_list
+    ]
+    assert thinking_values == [
+        {"type": "disabled"},
+        {"type": "enabled"},
+        {"type": "disabled"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openrouter_direct_chains_thinking_and_tool_choice_retries(mocker):
+    """A thinking-conflict 400 followed by a tool_choice 404 chains two adjustments."""
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        RuntimeError(_THINKING_TOOL_CHOICE_ERROR),
+        RuntimeError(_OPENROUTER_TOOL_CHOICE_ERROR),
+        SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content="ok", tool_calls=None, reasoning_content=None
+                    )
+                )
+            ],
+            usage=None,
+            model_dump=lambda: {"id": "openrouter-chain"},
+        ),
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+
+    result = await llm.chat(
+        [{"role": "user", "content": "score?"}],
+        tools=_two_tool_schema(),
+        tool_choice="required",
+        thinking={"type": "enabled", "enable": True},
+    )
+
+    assert result["content"] == "ok"
+    tool_choices = [
+        call.kwargs["tool_choice"]
+        for call in mock_client.chat.completions.create.call_args_list
+    ]
+    assert tool_choices == ["required", "required", "auto"]
+
+
+@pytest.mark.asyncio
+async def test_openrouter_stream_relaxes_tool_choice_before_first_chunk(mocker):
+    """Streaming retries the same compat rules while nothing has been yielded yet."""
+    attempts = 0
+
+    async def rejects_tool_choice():
+        if False:
+            yield None
+        raise RuntimeError(_OPENROUTER_TOOL_CHOICE_ERROR)
+
+    async def succeeds():
+        yield StreamChunk(type=ChunkType.TOKEN, content="ok", delta="ok")
+
+    def fake_stream(*_args, **kwargs):
+        nonlocal attempts
+        del kwargs
+        attempts += 1
+        return rejects_tool_choice() if attempts == 1 else succeeds()
+
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+    mocker.patch.object(llm, "_stream_chat_inner", side_effect=fake_stream)
+
+    chunks = [
+        chunk
+        async for chunk in llm.stream_chat(
+            [{"role": "user", "content": "score?"}],
+            tools=_two_tool_schema(),
+            tool_choice="required",
+        )
+    ]
+
+    assert [chunk.delta for chunk in chunks] == ["ok"]
+    assert attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_openrouter_stream_error_after_first_chunk_not_retried(mocker):
+    """Once a chunk has actually reached the caller, a later error is never retried."""
+    attempts = 0
+
+    async def yields_then_fails():
+        nonlocal attempts
+        attempts += 1
+        yield StreamChunk(type=ChunkType.TOKEN, content="partial", delta="partial")
+        raise RuntimeError(_OPENROUTER_TOOL_CHOICE_ERROR)
+
+    def fake_stream(*_args, **kwargs):
+        del kwargs
+        return yields_then_fails()
+
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+    mocker.patch.object(llm, "_stream_chat_inner", side_effect=fake_stream)
+
+    received = []
+    with pytest.raises(RuntimeError, match="No endpoints found"):
+        async for chunk in llm.stream_chat(
+            [{"role": "user", "content": "score?"}],
+            tools=_two_tool_schema(),
+            tool_choice="required",
+        ):
+            received.append(chunk)
+
+    assert [chunk.delta for chunk in received] == ["partial"]
+    assert attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_openrouter_compat_retry_does_not_catch_llm_retryable_error(mocker):
+    """A retryable protocol error from the inner call is never a compat adjustment."""
+    protocol_error = LLMToolProtocolError(
+        provider="deepseek",
+        code="malformed_tool_arguments",
+        message="DeepSeek returned malformed arguments.",
+    )
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+    prefix_retry_mock = mocker.patch.object(
+        llm, "_chat_with_prefix_retry", side_effect=protocol_error
+    )
+
+    with pytest.raises(LLMToolProtocolError, match="malformed arguments"):
+        await llm.chat([{"role": "user", "content": "score?"}])
+
+    assert prefix_retry_mock.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_openrouter_direct_thinking_retry_changes_rendered_extra_body(mocker):
+    """A thinking-rule retry (rules 1/2) must change what is actually sent."""
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        RuntimeError(_MANDATORY_REASONING_ERROR),
+        SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content="ok", tool_calls=None, reasoning_content=None
+                    )
+                )
+            ],
+            usage=None,
+            model_dump=lambda: {"id": "openrouter-thinking"},
+        ),
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+
+    await llm.chat(
+        [{"role": "user", "content": "score?"}],
+        thinking={"type": "disabled", "enable": False},
+    )
+
+    extra_bodies = [
+        call.kwargs["extra_body"]
+        for call in mock_client.chat.completions.create.call_args_list
+    ]
+    assert extra_bodies[0] != extra_bodies[1]
+    assert extra_bodies[0]["thinking"] == {"type": "disabled"}
+    assert extra_bodies[1]["thinking"] == {"type": "enabled"}
+
+
+@pytest.mark.asyncio
+async def test_openrouter_vision_chat_retries_mandatory_reasoning(mocker):
+    """vision_chat shares the same compat retry as chat, with no prefix retry."""
+    success_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="Hello World", tool_calls=None, reasoning_content=None
+                )
+            )
+        ],
+        usage=None,
+        model_dump=lambda: {"id": "openrouter-vision"},
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        RuntimeError(_MANDATORY_REASONING_ERROR),
+        success_response,
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(
+        model_name="z-ai/glm-5.2",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "vision"],
+    )
+
+    result = await llm.vision_chat(
+        [{"role": "user", "content": "describe this image"}],
+        thinking={"type": "disabled", "enable": False},
+    )
+
+    assert result["content"] == "Hello World"
+    assert mock_client.chat.completions.create.await_count == 2
+    second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
+    assert second_call["extra_body"]["thinking"] == {"type": "enabled"}
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_no_op_thinking_retry_falls_through_to_next_rule(
+    mocker,
+):
+    """A no-op disable-thinking match is skipped so a real fix (enable) still fires."""
+    combined_error = (
+        "Reasoning is mandatory for this endpoint and cannot be disabled, "
+        "and thinking conflicts with tool_choice here."
+    )
+    success_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="ok", tool_calls=None, reasoning_content=None
+                )
+            )
+        ],
+        usage=None,
+        model_dump=lambda: {"id": "openrouter-noop"},
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        RuntimeError(combined_error),
+        success_response,
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+    )
+
+    # deepseek's default (thinking=None) already renders as disabled, so the
+    # "disable thinking" rule (2) would be a no-op against this error; the
+    # aggregator must fall through to rule 1 (enable thinking) instead of
+    # wasting the retry budget replaying an unchanged request.
+    result = await llm.chat(
+        [{"role": "user", "content": "score?"}],
+        tools=_two_tool_schema(),
+        tool_choice="required",
+    )
+
+    assert result["content"] == "ok"
+    assert mock_client.chat.completions.create.await_count == 2
+    second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
+    assert second_call["extra_body"]["thinking"] == {"type": "enabled"}

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -1195,6 +1195,60 @@ async def test_openrouter_direct_relaxes_tool_choice_on_endpoint_404(
     assert second_call["tool_choice"] == "auto"
 
 
+def _bad_request_error(message: str) -> openai.BadRequestError:
+    return openai.BadRequestError(
+        f"Error code: 400 - {{'error': {{'message': '{message}'}}}}",
+        response=httpx.Response(
+            400,
+            request=httpx.Request(
+                "POST", "https://openrouter.ai/api/v1/chat/completions"
+            ),
+        ),
+        body={"error": {"message": message, "code": 400}},
+    )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_direct_relaxes_tool_choice_after_bare_bad_request_error(
+    mock_chat_completion, mocker
+):
+    """A bare ``openai.BadRequestError`` must still reach the compat retry loop.
+
+    ``OpenAILLM.chat`` normally converts every ``openai.BadRequestError`` into
+    a ``RuntimeError`` before returning, but its response_format pop-and-retry
+    path (openai.py's ``except openai.BadRequestError`` block) re-issues the
+    request from inside that except clause: if the retried call also raises
+    ``openai.BadRequestError``, that second error is not wrapped by anything
+    and escapes as a bare SDK exception. The compat retry loop must catch it
+    the same way it catches the RuntimeError case, not just replay-fail.
+    """
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        _bad_request_error(
+            "the model does not support response_format for this request"
+        ),
+        _bad_request_error(_OPENROUTER_TOOL_CHOICE_ERROR),
+        mock_chat_completion,
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+
+    result = await llm.chat(
+        [{"role": "user", "content": "score?"}],
+        tools=_two_tool_schema(),
+        tool_choice="required",
+        response_format={"type": "json_object"},
+    )
+
+    assert result["content"] == "Hello World"
+    assert mock_client.chat.completions.create.await_count == 3
+    final_call = mock_client.chat.completions.create.call_args_list[2].kwargs
+    assert final_call["tool_choice"] == "auto"
+
+
 @pytest.mark.asyncio
 async def test_openrouter_direct_does_not_repeat_mandatory_reasoning_retry(mocker):
     """Each compat action fires at most once per call, even across a 3-error run."""
@@ -1273,7 +1327,7 @@ async def test_openrouter_direct_chains_thinking_and_tool_choice_retries(mocker)
 @pytest.mark.asyncio
 async def test_openrouter_stream_relaxes_tool_choice_before_first_chunk(mocker):
     """Streaming retries the same compat rules while nothing has been yielded yet."""
-    attempts = 0
+    calls: list[dict] = []
 
     async def rejects_tool_choice():
         if False:
@@ -1284,10 +1338,8 @@ async def test_openrouter_stream_relaxes_tool_choice_before_first_chunk(mocker):
         yield StreamChunk(type=ChunkType.TOKEN, content="ok", delta="ok")
 
     def fake_stream(*_args, **kwargs):
-        nonlocal attempts
-        del kwargs
-        attempts += 1
-        return rejects_tool_choice() if attempts == 1 else succeeds()
+        calls.append(kwargs)
+        return rejects_tool_choice() if len(calls) == 1 else succeeds()
 
     llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
     mocker.patch.object(llm, "_stream_chat_inner", side_effect=fake_stream)
@@ -1302,7 +1354,8 @@ async def test_openrouter_stream_relaxes_tool_choice_before_first_chunk(mocker):
     ]
 
     assert [chunk.delta for chunk in chunks] == ["ok"]
-    assert attempts == 2
+    assert len(calls) == 2
+    assert [call["tool_choice"] for call in calls] == ["required", "auto"]
 
 
 @pytest.mark.asyncio
@@ -1755,6 +1808,93 @@ async def test_openrouter_stream_disables_thinking_when_unspecified_non_deepseek
     assert calls[0]["thinking"] is None
     assert calls[1]["tool_choice"] == "required"
     assert calls[1]["thinking"] == openrouter_module._DISABLE_DOWNSTREAM_THINKING
+
+
+@pytest.mark.asyncio
+async def test_openrouter_stream_thinking_retry_changes_rendered_extra_body(mocker):
+    """stream_chat: same rule as the chat-path test, exercised on streaming.
+
+    A mandatory-reasoning 400 (rule 3) retries once with thinking enabled,
+    and the retried request's ``extra_body`` must actually reflect that
+    change, not just the ``thinking`` kwarg passed to the inner call.
+
+    The retry's success is mocked as an empty stream (the same convention
+    ``test_openrouter_deepseek_stream_retries_prefix_error_before_first_chunk``
+    uses): the raw OpenAI SDK chunk shape this mock would otherwise need to
+    produce is unrelated to what this test is pinning, which is the request
+    actually sent on retry.
+    """
+
+    async def empty_stream():
+        if False:
+            yield None
+
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        RuntimeError(_MANDATORY_REASONING_ERROR),
+        empty_stream(),
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+
+    chunks = [
+        chunk
+        async for chunk in llm.stream_chat(
+            [{"role": "user", "content": "score?"}],
+            thinking={"type": "disabled", "enable": False},
+        )
+    ]
+
+    assert chunks == []
+    assert mock_client.chat.completions.create.await_count == 2
+    extra_bodies = [
+        call.kwargs["extra_body"]
+        for call in mock_client.chat.completions.create.call_args_list
+    ]
+    assert extra_bodies[0] != extra_bodies[1]
+    assert extra_bodies[0]["thinking"] == {"type": "disabled"}
+    assert extra_bodies[1]["thinking"] == {"type": "enabled"}
+
+
+@pytest.mark.asyncio
+async def test_openrouter_stream_does_not_repeat_mandatory_reasoning_retry(mocker):
+    """stream_chat: each compat action fires at most once per call, even
+    across a 3-error run, mirroring the chat-path budget guarantee.
+    """
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        RuntimeError(_MANDATORY_REASONING_ERROR),
+        RuntimeError(_THINKING_TOOL_CHOICE_ERROR),
+        RuntimeError(_MANDATORY_REASONING_ERROR),
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+
+    with pytest.raises(RuntimeError, match="Reasoning is mandatory"):
+        async for _chunk in llm.stream_chat(
+            [{"role": "user", "content": "score?"}],
+            tools=_two_tool_schema(),
+            tool_choice="required",
+            thinking={"type": "disabled", "enable": False},
+        ):
+            pass
+
+    assert mock_client.chat.completions.create.await_count == 3
+    thinking_values = [
+        call.kwargs["extra_body"].get("thinking")
+        for call in mock_client.chat.completions.create.call_args_list
+    ]
+    assert thinking_values == [
+        {"type": "disabled"},
+        {"type": "enabled"},
+        {"type": "disabled"},
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -8,6 +8,7 @@ import pytest
 
 from xagent.core.model.chat.basic import openrouter as openrouter_module
 from xagent.core.model.chat.basic.base import BaseLLM
+from xagent.core.model.chat.basic.openai import OpenAILLM
 from xagent.core.model.chat.basic.openrouter import OpenRouterLLM
 from xagent.core.model.chat.error import retry_on
 from xagent.core.model.chat.exceptions import (
@@ -1365,6 +1366,41 @@ async def test_openrouter_compat_retry_does_not_catch_llm_retryable_error(mocker
 
 
 @pytest.mark.asyncio
+async def test_openrouter_compat_retry_skips_retryable_error_hidden_in_cause(mocker):
+    """Ordering contract: retry_on() wins over compat-rule text matching.
+
+    A plain RuntimeError whose ``__cause__`` is an ``openai.RateLimitError``
+    is not an ``LLMRetryableError`` instance, so the existing
+    ``except LLMRetryableError: raise`` guard does not catch it — only
+    ``retry_on()``'s ``__cause__`` inspection recognizes it as retryable. The
+    error text is deliberately built to also match the relaxed-tool_choice
+    compat rule ("no endpoints found" / "tool_choice"), so without checking
+    retry_on() first the compat loop would treat this retryable error as an
+    OpenRouter compatibility quirk and replay the request instead of leaving
+    it for the shared LLM retry wrapper.
+    """
+    cause = openai.RateLimitError("rate limited", response=mocker.Mock(), body=None)
+    try:
+        raise RuntimeError(_OPENROUTER_TOOL_CHOICE_ERROR) from cause
+    except RuntimeError as exc:
+        wrapped_rate_limit_error = exc
+
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+    prefix_retry_mock = mocker.patch.object(
+        llm, "_chat_with_prefix_retry", side_effect=wrapped_rate_limit_error
+    )
+
+    with pytest.raises(RuntimeError, match="No endpoints found"):
+        await llm.chat(
+            [{"role": "user", "content": "score?"}],
+            tools=_two_tool_schema(),
+            tool_choice="required",
+        )
+
+    assert prefix_retry_mock.call_count == 1
+
+
+@pytest.mark.asyncio
 async def test_openrouter_direct_thinking_retry_changes_rendered_extra_body(mocker):
     """A thinking-rule retry (rules 1/2) must change what is actually sent."""
     mock_client = mocker.AsyncMock()
@@ -1402,9 +1438,96 @@ async def test_openrouter_direct_thinking_retry_changes_rendered_extra_body(mock
     assert extra_bodies[1]["thinking"] == {"type": "enabled"}
 
 
+_DISABLE_THINKING_MATCHING_EXTRA_BODY = {
+    "reasoning": {"enabled": False},
+    "thinking": {"type": "disabled"},
+}
+
+
+@pytest.mark.asyncio
+async def test_openrouter_direct_thinking_rule_skipped_when_render_unchanged(
+    mocker, monkeypatch
+):
+    """A disable-thinking match that renders no real change is a no-op.
+
+    The caller already sends ``extra_body`` with thinking disabled, so
+    replaying with ``_DISABLE_DOWNSTREAM_THINKING`` would produce a
+    byte-identical request. The no-op check inside ``_next_compat_adjustment``
+    only catches this when ``render()`` starts from the caller's actual
+    extra_body instead of a synthetic empty one, so with the fix the rule is
+    skipped and the error surfaces after exactly one call.
+    """
+    monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = RuntimeError(
+        _THINKING_TOOL_CHOICE_ERROR
+    )
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+
+    with pytest.raises(RuntimeError, match="Thinking mode does not support"):
+        await llm.chat(
+            [{"role": "user", "content": "score?"}],
+            tool_choice="required",
+            thinking=None,
+            extra_body=dict(_DISABLE_THINKING_MATCHING_EXTRA_BODY),
+        )
+
+    assert mock_client.chat.completions.create.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_openrouter_stream_thinking_rule_skipped_when_render_unchanged(
+    mocker, monkeypatch
+):
+    """Streaming counterpart of the no-op disable-thinking skip above."""
+    monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
+    calls = 0
+
+    async def rejects():
+        if False:
+            yield None
+        raise RuntimeError(_THINKING_TOOL_CHOICE_ERROR)
+
+    def fake_inner(*_args, **kwargs):
+        nonlocal calls
+        del kwargs
+        calls += 1
+        return rejects()
+
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+    mocker.patch.object(llm, "_stream_chat_inner", side_effect=fake_inner)
+
+    with pytest.raises(RuntimeError, match="Thinking mode does not support"):
+        async for _chunk in llm.stream_chat(
+            [{"role": "user", "content": "score?"}],
+            tool_choice="required",
+            thinking=None,
+            extra_body=dict(_DISABLE_THINKING_MATCHING_EXTRA_BODY),
+        ):
+            pass
+
+    assert calls == 1
+
+
 @pytest.mark.asyncio
 async def test_openrouter_vision_chat_retries_mandatory_reasoning(mocker):
-    """vision_chat shares the same compat retry as chat, with no prefix retry."""
+    """vision_chat shares the same compat retry as chat, with no prefix retry.
+
+    The message carries a real multimodal content list (text + image_url) so
+    this exercises the actual vision dispatch, not just a plain-text payload
+    that happens to go through vision_chat. The spies pin both directions of
+    the fork: OpenAILLM.vision_chat must be the method that actually issues
+    the request, and OpenRouterLLM.chat / _chat_with_prefix_retry (the
+    DeepSeek prefix-retry path) must never run for a vision call. Mutation
+    check performed by hand: temporarily making OpenRouterLLM.vision_chat
+    call super().chat(...) instead of super().vision_chat(...) turns this red
+    (chat_spy and prefix_retry_spy stop being zero), confirming the
+    assertions actually discriminate between the two dispatch paths.
+    """
     success_response = SimpleNamespace(
         choices=[
             SimpleNamespace(
@@ -1430,9 +1553,23 @@ async def test_openrouter_vision_chat_retries_mandatory_reasoning(mocker):
         api_key="test-key",
         abilities=["chat", "tool_calling", "vision"],
     )
+    vision_chat_spy = mocker.spy(OpenAILLM, "vision_chat")
+    chat_spy = mocker.spy(OpenRouterLLM, "chat")
+    prefix_retry_spy = mocker.spy(llm, "_chat_with_prefix_retry")
 
     result = await llm.vision_chat(
-        [{"role": "user", "content": "describe this image"}],
+        [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe this image"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/cat.png"},
+                    },
+                ],
+            }
+        ],
         thinking={"type": "disabled", "enable": False},
     )
 
@@ -1440,6 +1577,9 @@ async def test_openrouter_vision_chat_retries_mandatory_reasoning(mocker):
     assert mock_client.chat.completions.create.await_count == 2
     second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
     assert second_call["extra_body"]["thinking"] == {"type": "enabled"}
+    assert vision_chat_spy.call_count == 2
+    assert chat_spy.call_count == 0
+    assert prefix_retry_spy.call_count == 0
 
 
 @pytest.mark.asyncio

--- a/tests/core/model/chat/basic/test_router.py
+++ b/tests/core/model/chat/basic/test_router.py
@@ -552,9 +552,10 @@ async def test_sandwiched_pure_404_bounds_total_upstream_calls(monkeypatch, mock
             tool_choice="required",
         )
 
-    # Upper bound, not the exact value: 1 original + at most 3 compat
-    # adjustments (one per rule) is this layer's per-call ceiling.
-    assert mock_client.chat.completions.create.await_count <= 4
+    # 1 original call + 1 tool_choice relaxation: the second identical 404
+    # then fails rule 3's own precondition (tool_choice is already "auto"),
+    # so no further adjustment is possible and the exact count is pinned.
+    assert mock_client.chat.completions.create.await_count == 2
 
 
 @pytest.mark.asyncio
@@ -709,4 +710,7 @@ async def test_sandwiched_deepseek_prefix_sanitizes_messages_once(monkeypatch, m
 
     assert result["content"] == "ok"
     assert prefix_error_count == 1
-    assert mock_client.chat.completions.create.await_count <= 5
+    # 1 prefix rejection + 1 sanitized-but-mandatory-reasoning failure + 1
+    # sanitized success: the sanitized messages carry over across compat
+    # iterations, so the prefix rejection never fires a second time.
+    assert mock_client.chat.completions.create.await_count == 3

--- a/tests/core/model/chat/basic/test_router.py
+++ b/tests/core/model/chat/basic/test_router.py
@@ -1,4 +1,9 @@
-"""Tests for RouterLLM provider compatibility retries."""
+"""Tests for RouterLLM's xrouter routing and per-call dispatch.
+
+Provider-compatibility retries used to live here too; they are now owned by
+OpenRouterLLM itself (see test_openrouter.py) since RouterLLM no longer
+retries the downstream call on its own.
+"""
 
 from __future__ import annotations
 
@@ -8,90 +13,16 @@ import pytest
 
 from xagent.core.context_ref import CONTEXT_REFS_KEY, ContextReference
 from xagent.core.model.chat.basic.base import BaseLLM
+from xagent.core.model.chat.basic.openrouter import OpenRouterLLM
 from xagent.core.model.chat.basic.router import (
     RouterLLM,
     RouterModalityRoutingError,
 )
+from xagent.core.model.chat.error import retry_on
+from xagent.core.model.chat.exceptions import LLMToolProtocolError
 from xagent.core.model.chat.types import ChunkType, StreamChunk
-
-_OPENROUTER_TOOL_CHOICE_ERROR = (
-    "OpenAI API error (404): Error code: 404 - {'error': {'message': "
-    "\"No endpoints found that support the provided 'tool_choice' value.\"}}"
-)
-_THINKING_TOOL_CHOICE_ERROR = (
-    "OpenAI bad request (400): Thinking mode does not support this tool_choice"
-)
-_MANDATORY_REASONING_ERROR = (
-    "OpenAI bad request (400): Reasoning is mandatory for this endpoint "
-    "and cannot be disabled."
-)
-
-
-def _tool_schema() -> dict[str, Any]:
-    return {
-        "type": "function",
-        "function": {
-            "name": "answer",
-            "description": "Answer the user",
-            "parameters": {"type": "object", "properties": {}},
-        },
-    }
-
-
-class _ToolChoiceRetryLLM(BaseLLM):
-    def __init__(self) -> None:
-        self.chat_tool_choices: list[str | dict[str, Any] | None] = []
-        self.stream_tool_choices: list[str | dict[str, Any] | None] = []
-
-    @property
-    def abilities(self) -> list[str]:
-        return ["chat", "tool_calling"]
-
-    @property
-    def model_name(self) -> str:
-        return "z-ai/glm-5.2"
-
-    @property
-    def supports_thinking_mode(self) -> bool:
-        return False
-
-    async def chat(
-        self,
-        messages: list[dict[str, Any]],
-        temperature: float | None = None,
-        max_tokens: int | None = None,
-        tools: list[dict[str, Any]] | None = None,
-        tool_choice: str | dict[str, Any] | None = None,
-        response_format: dict[str, Any] | None = None,
-        thinking: dict[str, Any] | None = None,
-        output_config: dict[str, Any] | None = None,
-        **kwargs: Any,
-    ) -> str | dict[str, Any]:
-        del messages, temperature, max_tokens, tools, response_format
-        del thinking, output_config, kwargs
-        self.chat_tool_choices.append(tool_choice)
-        if tool_choice == "required":
-            raise RuntimeError(_OPENROUTER_TOOL_CHOICE_ERROR)
-        return "ok"
-
-    async def stream_chat(
-        self,
-        messages: list[dict[str, str]],
-        temperature: float | None = None,
-        max_tokens: int | None = None,
-        tools: list[dict[str, Any]] | None = None,
-        tool_choice: str | dict[str, Any] | None = None,
-        response_format: dict[str, Any] | None = None,
-        thinking: dict[str, Any] | None = None,
-        output_config: dict[str, Any] | None = None,
-        **kwargs: Any,
-    ) -> AsyncIterator[StreamChunk]:
-        del messages, temperature, max_tokens, tools, response_format
-        del thinking, output_config, kwargs
-        self.stream_tool_choices.append(tool_choice)
-        if tool_choice == "required":
-            raise RuntimeError(_OPENROUTER_TOOL_CHOICE_ERROR)
-        yield StreamChunk(type=ChunkType.TOKEN, content="ok", delta="ok")
+from xagent.core.retry.strategy import FixedDelay
+from xagent.core.retry.wrapper import create_retry_wrapper
 
 
 class _ScriptedChatLLM(BaseLLM):
@@ -151,10 +82,6 @@ class _ScriptedChatLLM(BaseLLM):
         if self.errors:
             raise RuntimeError(self.errors.pop(0))
         yield StreamChunk(type=ChunkType.TOKEN, content="ok", delta="ok")
-
-
-async def _select_glm(_prompt: str) -> str:
-    return "z-ai/glm-5.2"
 
 
 @pytest.mark.asyncio
@@ -532,177 +459,126 @@ def test_profile_context_window_returns_none_when_catalog_lookup_fails(
     assert "Could not resolve xrouter context window for test/model" in caplog.text
 
 
-@pytest.mark.asyncio
-async def test_router_chat_relaxes_required_tool_choice_on_openrouter_endpoint_error(
-    monkeypatch,
-):
-    llm = _ToolChoiceRetryLLM()
-    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
+async def _select_glm(_prompt: str) -> str:
+    return "z-ai/glm-5.2"
 
-    async def select_model(_prompt: str) -> str:
-        return "z-ai/glm-5.2"
 
-    monkeypatch.setattr(router, "_select_model", select_model)
+def _tool_schema() -> dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": "answer",
+            "description": "Answer the user",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
 
-    result = await router.chat(
-        [{"role": "user", "content": "score?"}],
-        tools=[_tool_schema()],
-        tool_choice="required",
+
+# ==========================================================================
+# Three-layer sandwich: RouterLLM -> create_retry_wrapper -> OpenRouterLLM.
+#
+# RouterLLM itself no longer retries (see router.py); OpenRouterLLM owns the
+# provider-compat retry, and create_retry_wrapper (adapter.py's usual wrapping
+# of a downstream model) owns the outer retry-on-retryable-error budget. This
+# pins the combined upper bound on upstream calls so the two layers cannot
+# compound into an unbounded retry storm.
+# ==========================================================================
+
+_PURE_TOOL_CHOICE_404 = (
+    "No endpoints found that support the provided 'tool_choice' value."
+)
+_THINKING_ONLY_CONFLICT = "Thinking mode does not support this tool_choice"
+_MANDATORY_REASONING_ONLY = (
+    "Reasoning is mandatory for this endpoint and cannot be disabled."
+)
+
+
+def _sandwiched_openrouter_llm(mocker, *, side_effect, max_retries: int):
+    """RouterLLM wired to create_retry_wrapper(OpenRouterLLM), matching how
+    adapter.py wraps a resolved downstream model in production."""
+    inner = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+    mocker.patch.object(inner, "_chat_with_prefix_retry", side_effect=side_effect)
+    wrapped = create_retry_wrapper(
+        inner,
+        BaseLLM,  # type: ignore[type-abstract]
+        retry_methods={"chat"},
+        strategy=FixedDelay(delay_ms=0),
+        max_retries=max_retries,
+        retry_on=retry_on,
     )
-
-    assert result == "ok"
-    assert llm.chat_tool_choices == ["required", "auto"]
-
-
-@pytest.mark.asyncio
-async def test_router_stream_relaxes_required_tool_choice_before_first_chunk(
-    monkeypatch,
-):
-    llm = _ToolChoiceRetryLLM()
-    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
-
-    async def select_model(_prompt: str) -> str:
-        return "z-ai/glm-5.2"
-
-    monkeypatch.setattr(router, "_select_model", select_model)
-
-    chunks = [
-        chunk
-        async for chunk in router.stream_chat(
-            [{"role": "user", "content": "score?"}],
-            tools=[_tool_schema()],
-            tool_choice="required",
-        )
-    ]
-
-    assert [chunk.delta for chunk in chunks] == ["ok"]
-    assert llm.stream_tool_choices == ["required", "auto"]
+    router = RouterLLM(downstream_resolver=lambda _model_id: wrapped)
+    return router
 
 
 @pytest.mark.asyncio
-async def test_router_chat_does_not_relax_auto_tool_choice_on_openrouter_error(
-    monkeypatch,
-):
-    llm = _ScriptedChatLLM([_OPENROUTER_TOOL_CHOICE_ERROR])
-    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
+async def test_sandwiched_pure_404_bounds_total_upstream_calls(monkeypatch, mocker):
+    """A persistent tool_choice 404 never compounds past the documented bound.
+
+    OpenRouterLLM's own rule 3 relaxes tool_choice to "auto" once; a second
+    identical 404 then fails rule 3's own precondition (tool_choice is no
+    longer a strict value), so the compat retry gives up with a plain
+    RuntimeError that create_retry_wrapper's retry_on() does not retry.
+    """
+    calls = 0
+
+    async def fake_inner(messages, **kwargs):
+        nonlocal calls
+        del messages, kwargs
+        calls += 1
+        raise RuntimeError(_PURE_TOOL_CHOICE_404)
+
+    router = _sandwiched_openrouter_llm(mocker, side_effect=fake_inner, max_retries=2)
     monkeypatch.setattr(router, "_select_model", _select_glm)
 
     with pytest.raises(RuntimeError, match="No endpoints found"):
         await router.chat(
             [{"role": "user", "content": "score?"}],
             tools=[_tool_schema()],
-            tool_choice="auto",
-        )
-
-    assert llm.tool_choices == ["auto"]
-
-
-@pytest.mark.asyncio
-async def test_router_chat_propagates_non_matching_errors_without_retry(monkeypatch):
-    llm = _ScriptedChatLLM(["different provider error"])
-    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
-    monkeypatch.setattr(router, "_select_model", _select_glm)
-
-    with pytest.raises(RuntimeError, match="different provider error"):
-        await router.chat(
-            [{"role": "user", "content": "score?"}],
-            tools=[_tool_schema()],
             tool_choice="required",
         )
 
-    assert llm.tool_choices == ["required"]
+    # Upper bound, not the exact value: 1 original + at most 3 compat
+    # adjustments (one per rule) is this layer's per-call ceiling.
+    assert calls <= 4
 
 
-@pytest.mark.parametrize(
-    "thinking",
-    [None, {"type": "disabled", "enable": False}],
-    ids=["unspecified", "disabled"],
-)
 @pytest.mark.asyncio
-async def test_router_chat_enables_thinking_when_selected_model_requires_it(
-    monkeypatch, thinking
+async def test_sandwiched_alternating_errors_bounds_total_upstream_calls(
+    monkeypatch, mocker
 ):
-    llm = _ScriptedChatLLM([_MANDATORY_REASONING_ERROR])
-    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
-    monkeypatch.setattr(router, "_select_model", _select_glm)
+    """A worst-case chain (all 3 compat rules fire, then a wrapper-retryable
+    error) repeats at most once per wrapper attempt, bounding total upstream
+    calls at wrapper_budget * 4 (1 original + 3 adjustments per attempt).
+    """
+    calls = 0
 
-    result = await router.chat(
-        [{"role": "user", "content": "score?"}],
-        tools=[_tool_schema()],
-        tool_choice="required",
-        thinking=thinking,
+    async def fake_inner(messages, **kwargs):
+        nonlocal calls
+        del messages, kwargs
+        calls += 1
+        position = (calls - 1) % 4
+        if position == 0:
+            raise RuntimeError(_PURE_TOOL_CHOICE_404)
+        if position == 1:
+            raise RuntimeError(_THINKING_ONLY_CONFLICT)
+        if position == 2:
+            raise RuntimeError(_MANDATORY_REASONING_ONLY)
+        # The 4th call in each attempt: every compat rule has already fired
+        # once this call, so this retryable error is what escapes to the
+        # outer wrapper and decides whether to spend another whole attempt.
+        raise LLMToolProtocolError(
+            provider="deepseek",
+            code="model_output_boundary",
+            message="retryable boundary condition",
+        )
+
+    wrapper_budget = 2
+    router = _sandwiched_openrouter_llm(
+        mocker, side_effect=fake_inner, max_retries=wrapper_budget
     )
-
-    assert result == "ok"
-    assert llm.thinking_values == [
-        thinking,
-        {"type": "enabled", "enable": True},
-    ]
-    assert llm.tool_choices == ["required", "required"]
-
-
-@pytest.mark.asyncio
-async def test_router_stream_enables_thinking_when_selected_model_requires_it(
-    monkeypatch,
-):
-    llm = _ScriptedChatLLM([_MANDATORY_REASONING_ERROR])
-    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
     monkeypatch.setattr(router, "_select_model", _select_glm)
 
-    chunks = [
-        chunk
-        async for chunk in router.stream_chat(
-            [{"role": "user", "content": "score?"}],
-            tools=[_tool_schema()],
-            tool_choice="required",
-            thinking={"type": "disabled", "enable": False},
-        )
-    ]
-
-    assert [chunk.delta for chunk in chunks] == ["ok"]
-    assert llm.thinking_values == [
-        {"type": "disabled", "enable": False},
-        {"type": "enabled", "enable": True},
-    ]
-
-
-@pytest.mark.asyncio
-async def test_router_does_not_repeat_mandatory_reasoning_retry(monkeypatch):
-    llm = _ScriptedChatLLM(
-        [
-            _MANDATORY_REASONING_ERROR,
-            _THINKING_TOOL_CHOICE_ERROR,
-            _MANDATORY_REASONING_ERROR,
-        ]
-    )
-    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
-    monkeypatch.setattr(router, "_select_model", _select_glm)
-
-    with pytest.raises(RuntimeError, match="Reasoning is mandatory"):
-        await router.chat(
-            [{"role": "user", "content": "score?"}],
-            tools=[_tool_schema()],
-            tool_choice="required",
-            thinking={"type": "disabled", "enable": False},
-        )
-
-    assert llm.thinking_values == [
-        {"type": "disabled", "enable": False},
-        {"type": "enabled", "enable": True},
-        {"type": "disabled", "enable": False},
-    ]
-    assert llm.tool_choices == ["required", "required", "required"]
-
-
-@pytest.mark.asyncio
-async def test_router_does_not_retry_mandatory_reasoning_when_already_enabled(
-    monkeypatch,
-):
-    llm = _ScriptedChatLLM([_MANDATORY_REASONING_ERROR])
-    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
-    monkeypatch.setattr(router, "_select_model", _select_glm)
-
-    with pytest.raises(RuntimeError, match="Reasoning is mandatory"):
+    with pytest.raises(LLMToolProtocolError, match="retryable boundary"):
         await router.chat(
             [{"role": "user", "content": "score?"}],
             tools=[_tool_schema()],
@@ -710,48 +586,4 @@ async def test_router_does_not_retry_mandatory_reasoning_when_already_enabled(
             thinking={"type": "enabled", "enable": True},
         )
 
-    assert llm.thinking_values == [{"type": "enabled", "enable": True}]
-    assert llm.tool_choices == ["required"]
-
-
-@pytest.mark.asyncio
-async def test_router_chat_does_not_retry_same_action_twice(monkeypatch):
-    llm = _ScriptedChatLLM([_THINKING_TOOL_CHOICE_ERROR, _THINKING_TOOL_CHOICE_ERROR])
-    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
-    monkeypatch.setattr(router, "_select_model", _select_glm)
-
-    with pytest.raises(RuntimeError, match="Thinking mode does not support"):
-        await router.chat(
-            [{"role": "user", "content": "score?"}],
-            tools=[_tool_schema()],
-            tool_choice="required",
-            thinking={"type": "disabled", "enable": False},
-        )
-
-    assert llm.tool_choices == ["required", "required"]
-    assert llm.thinking_values == [
-        {"type": "disabled", "enable": False},
-        {"type": "disabled", "enable": False},
-    ]
-
-
-@pytest.mark.asyncio
-async def test_router_chat_can_chain_thinking_and_tool_choice_retries(monkeypatch):
-    llm = _ScriptedChatLLM([_THINKING_TOOL_CHOICE_ERROR, _OPENROUTER_TOOL_CHOICE_ERROR])
-    router = RouterLLM(downstream_resolver=lambda _model_id: llm)
-    monkeypatch.setattr(router, "_select_model", _select_glm)
-
-    result = await router.chat(
-        [{"role": "user", "content": "score?"}],
-        tools=[_tool_schema()],
-        tool_choice="required",
-        thinking={"type": "enabled", "enable": True},
-    )
-
-    assert result == "ok"
-    assert llm.tool_choices == ["required", "required", "auto"]
-    assert llm.thinking_values == [
-        {"type": "enabled", "enable": True},
-        {"type": "disabled", "enable": False},
-        {"type": "disabled", "enable": False},
-    ]
+    assert calls <= wrapper_budget * 4

--- a/tests/core/model/chat/basic/test_router.py
+++ b/tests/core/model/chat/basic/test_router.py
@@ -7,8 +7,11 @@ retries the downstream call on its own.
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, AsyncIterator
 
+import httpx
+import openai
 import pytest
 
 from xagent.core.context_ref import CONTEXT_REFS_KEY, ContextReference
@@ -493,11 +496,27 @@ _MANDATORY_REASONING_ONLY = (
 )
 
 
-def _sandwiched_openrouter_llm(mocker, *, side_effect, max_retries: int):
+def _sandwiched_openrouter_llm(
+    mocker,
+    *,
+    side_effect,
+    max_retries: int,
+    model_name: str = "z-ai/glm-5.2",
+):
     """RouterLLM wired to create_retry_wrapper(OpenRouterLLM), matching how
-    adapter.py wraps a resolved downstream model in production."""
-    inner = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
-    mocker.patch.object(inner, "_chat_with_prefix_retry", side_effect=side_effect)
+    adapter.py wraps a resolved downstream model in production.
+
+    The OpenAI client itself is mocked (not ``_chat_with_prefix_retry``), so
+    ``mock_client.chat.completions.create.await_count`` reflects the real
+    number of upstream requests OpenRouterLLM actually issues.
+    """
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = side_effect
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    inner = OpenRouterLLM(model_name=model_name, api_key="test-key")
     wrapped = create_retry_wrapper(
         inner,
         BaseLLM,  # type: ignore[type-abstract]
@@ -507,7 +526,7 @@ def _sandwiched_openrouter_llm(mocker, *, side_effect, max_retries: int):
         retry_on=retry_on,
     )
     router = RouterLLM(downstream_resolver=lambda _model_id: wrapped)
-    return router
+    return router, mock_client
 
 
 @pytest.mark.asyncio
@@ -519,15 +538,11 @@ async def test_sandwiched_pure_404_bounds_total_upstream_calls(monkeypatch, mock
     longer a strict value), so the compat retry gives up with a plain
     RuntimeError that create_retry_wrapper's retry_on() does not retry.
     """
-    calls = 0
-
-    async def fake_inner(messages, **kwargs):
-        nonlocal calls
-        del messages, kwargs
-        calls += 1
-        raise RuntimeError(_PURE_TOOL_CHOICE_404)
-
-    router = _sandwiched_openrouter_llm(mocker, side_effect=fake_inner, max_retries=2)
+    router, mock_client = _sandwiched_openrouter_llm(
+        mocker,
+        side_effect=RuntimeError(_PURE_TOOL_CHOICE_404),
+        max_retries=2,
+    )
     monkeypatch.setattr(router, "_select_model", _select_glm)
 
     with pytest.raises(RuntimeError, match="No endpoints found"):
@@ -539,7 +554,7 @@ async def test_sandwiched_pure_404_bounds_total_upstream_calls(monkeypatch, mock
 
     # Upper bound, not the exact value: 1 original + at most 3 compat
     # adjustments (one per rule) is this layer's per-call ceiling.
-    assert calls <= 4
+    assert mock_client.chat.completions.create.await_count <= 4
 
 
 @pytest.mark.asyncio
@@ -552,9 +567,9 @@ async def test_sandwiched_alternating_errors_bounds_total_upstream_calls(
     """
     calls = 0
 
-    async def fake_inner(messages, **kwargs):
+    def fake_create(*_args, **kwargs):
         nonlocal calls
-        del messages, kwargs
+        del kwargs
         calls += 1
         position = (calls - 1) % 4
         if position == 0:
@@ -573,8 +588,8 @@ async def test_sandwiched_alternating_errors_bounds_total_upstream_calls(
         )
 
     wrapper_budget = 2
-    router = _sandwiched_openrouter_llm(
-        mocker, side_effect=fake_inner, max_retries=wrapper_budget
+    router, mock_client = _sandwiched_openrouter_llm(
+        mocker, side_effect=fake_create, max_retries=wrapper_budget
     )
     monkeypatch.setattr(router, "_select_model", _select_glm)
 
@@ -586,4 +601,112 @@ async def test_sandwiched_alternating_errors_bounds_total_upstream_calls(
             thinking={"type": "enabled", "enable": True},
         )
 
-    assert calls <= wrapper_budget * 4
+    assert mock_client.chat.completions.create.await_count <= wrapper_budget * 4
+
+
+def _deepseek_prefix_error() -> openai.BadRequestError:
+    return openai.BadRequestError(
+        "Error code: 400 - {'error': {'message': 'Provider returned error'}}",
+        response=httpx.Response(
+            400,
+            request=httpx.Request(
+                "POST", "https://openrouter.ai/api/v1/chat/completions"
+            ),
+        ),
+        body={
+            "error": {
+                "message": "Provider returned error",
+                "code": 400,
+                "metadata": {
+                    "provider_name": "DeepSeek",
+                    "raw": (
+                        '{"error":{"message":'
+                        '"Function call should not be used with prefix"}}'
+                    ),
+                },
+            }
+        },
+    )
+
+
+def _deepseek_tool_call_history() -> list[dict]:
+    return [
+        {"role": "user", "content": "Generate music"},
+        {
+            "role": "assistant",
+            "content": "I will generate the music first.",
+            "tool_calls": [
+                {
+                    "id": "call_music",
+                    "type": "function",
+                    "function": {
+                        "name": "generate_music",
+                        "arguments": '{"prompt":"intro"}',
+                    },
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_music", "content": '{"success":true}'},
+    ]
+
+
+async def _select_deepseek(_prompt: str) -> str:
+    return "deepseek/deepseek-v4-flash"
+
+
+@pytest.mark.asyncio
+async def test_sandwiched_deepseek_prefix_sanitizes_messages_once(monkeypatch, mocker):
+    """A DeepSeek prefix rejection sanitizes messages once per call, not once
+    per compat iteration.
+
+    Before the out-param fix, ``_run_chat_with_compat_retry`` replayed the
+    same unsanitized messages on every compat iteration, so a DeepSeek model
+    chaining a prefix rejection with a compat-adjustable error re-triggered
+    the prefix rejection (and its sanitize-and-retry) on every iteration
+    too, doubling the real upstream call count. With the fix, the sanitized
+    messages from the first iteration carry over, so the prefix rejection
+    only ever fires once and the total call count stays bounded.
+    """
+    calls = 0
+    prefix_error_count = 0
+    post_sanitize_calls = 0
+    success_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="ok", tool_calls=None, reasoning_content=None
+                )
+            )
+        ],
+        usage=None,
+        model_dump=lambda: {"id": "openrouter-sandwiched-deepseek"},
+    )
+
+    def fake_create(*_args, **kwargs):
+        nonlocal calls, prefix_error_count, post_sanitize_calls
+        calls += 1
+        messages = kwargs["messages"]
+        assistant_message = next(
+            message for message in messages if message.get("tool_calls")
+        )
+        if assistant_message.get("content"):
+            prefix_error_count += 1
+            raise _deepseek_prefix_error()
+        post_sanitize_calls += 1
+        if post_sanitize_calls == 1:
+            raise RuntimeError(_MANDATORY_REASONING_ONLY)
+        return success_response
+
+    router, mock_client = _sandwiched_openrouter_llm(
+        mocker,
+        side_effect=fake_create,
+        max_retries=2,
+        model_name="deepseek/deepseek-v4-flash",
+    )
+    monkeypatch.setattr(router, "_select_model", _select_deepseek)
+
+    result = await router.chat(_deepseek_tool_call_history())
+
+    assert result["content"] == "ok"
+    assert prefix_error_count == 1
+    assert mock_client.chat.completions.create.await_count <= 5

--- a/tests/core/model/test_router_provider_config.py
+++ b/tests/core/model/test_router_provider_config.py
@@ -9,7 +9,6 @@ from xagent.core.model.chat.basic.router import RouterLLM
 from xagent.core.model.chat.types import ChunkType, StreamChunk
 
 _THINKING_TOOL_CHOICE_ERROR = "Thinking mode does not support this tool_choice"
-_DISABLE_DOWNSTREAM_THINKING = {"type": "disabled", "enable": False}
 
 
 class _RejectThinkingToolChoiceLLM:
@@ -198,98 +197,6 @@ async def test_router_dispatches_chosen_slug_through_downstream_resolver():
     assert seen["slug"] == "anthropic/claude-opus-4.8"
     assert result.model_name == "anthropic/claude-opus-4.8"
     assert result._downstream == "DOWNSTREAM_LLM"
-
-
-async def test_router_retries_chat_without_thinking_for_tool_choice_error():
-    downstream = _RejectThinkingToolChoiceLLM()
-    selected: list[str] = []
-
-    llm = RouterLLM(model_name="auto", downstream_resolver=lambda _s: downstream)
-
-    async def fake_select(prompt: str) -> str:
-        selected.append(prompt)
-        return "deepseek/deepseek-v4-flash"
-
-    llm._select_model = fake_select  # type: ignore[assignment]
-
-    result = await llm.chat(
-        [{"role": "user", "content": "hi"}],
-        tool_choice="required",
-        thinking={"type": "disabled", "enable": False},
-    )
-
-    assert result == "ok"
-    assert selected == ["hi"]
-    assert len(downstream.chat_calls) == 2
-    assert downstream.chat_calls[0]["tool_choice"] == "required"
-    assert downstream.chat_calls[0]["thinking"] == {
-        "type": "disabled",
-        "enable": False,
-    }
-    assert downstream.chat_calls[1]["tool_choice"] == "required"
-    assert downstream.chat_calls[1]["thinking"] == _DISABLE_DOWNSTREAM_THINKING
-    assert "extra_body" not in downstream.chat_calls[1]
-
-
-async def test_router_retries_stream_without_thinking_for_tool_choice_error():
-    downstream = _RejectThinkingToolChoiceLLM()
-    selected: list[str] = []
-
-    llm = RouterLLM(model_name="auto", downstream_resolver=lambda _s: downstream)
-
-    async def fake_select(prompt: str) -> str:
-        selected.append(prompt)
-        return "deepseek/deepseek-v4-flash"
-
-    llm._select_model = fake_select  # type: ignore[assignment]
-
-    chunks = [
-        chunk
-        async for chunk in llm.stream_chat(
-            [{"role": "user", "content": "hi"}],
-            tool_choice="required",
-            thinking={"type": "disabled", "enable": False},
-        )
-    ]
-
-    assert [chunk.delta for chunk in chunks] == ["ok"]
-    assert selected == ["hi"]
-    assert len(downstream.stream_calls) == 2
-    assert downstream.stream_calls[0]["tool_choice"] == "required"
-    assert downstream.stream_calls[0]["thinking"] == {
-        "type": "disabled",
-        "enable": False,
-    }
-    assert downstream.stream_calls[1]["tool_choice"] == "required"
-    assert downstream.stream_calls[1]["thinking"] == _DISABLE_DOWNSTREAM_THINKING
-    assert "extra_body" not in downstream.stream_calls[1]
-
-
-async def test_router_retries_stream_without_explicit_thinking_for_tool_choice_error():
-    downstream = _RejectThinkingToolChoiceLLM()
-
-    llm = RouterLLM(model_name="auto", downstream_resolver=lambda _s: downstream)
-
-    async def fake_select(_prompt: str) -> str:
-        return "deepseek/deepseek-v4-flash"
-
-    llm._select_model = fake_select  # type: ignore[assignment]
-
-    chunks = [
-        chunk
-        async for chunk in llm.stream_chat(
-            [{"role": "user", "content": "hi"}],
-            tool_choice="required",
-        )
-    ]
-
-    assert [chunk.delta for chunk in chunks] == ["ok"]
-    assert len(downstream.stream_calls) == 2
-    assert downstream.stream_calls[0]["tool_choice"] == "required"
-    assert downstream.stream_calls[0]["thinking"] is None
-    assert downstream.stream_calls[1]["tool_choice"] == "required"
-    assert downstream.stream_calls[1]["thinking"] == _DISABLE_DOWNSTREAM_THINKING
-    assert "extra_body" not in downstream.stream_calls[1]
 
 
 async def test_router_does_not_retry_unrelated_errors():


### PR DESCRIPTION
## What

The three OpenRouter provider-compatibility retries now live in `OpenRouterLLM` and apply to all three entrypoints — `chat`, `vision_chat` (newly overridden) and `stream_chat`. `RouterLLM`'s own copy of the retry loop is removed.

The rules themselves are carried over unchanged, and are tried strictest-first:

| Order | Failure it recognises | Adjustment on retry |
|---|---|---|
| 1 | `no endpoints found` + `tool_choice`, with tools present and a strict `tool_choice` | resend with `tool_choice="auto"` |
| 2 | `thinking` + `tool_choice` | resend with thinking disabled |
| 3 | `reasoning is mandatory` + `cannot be disabled` | resend with thinking enabled |

Each action fires at most once per call, so a call that hits two different failures can still apply two different adjustments, while a repeating failure cannot loop.

## Why

These rules only ever ran inside `RouterLLM`, which is constructed exclusively for the OpenRouter `auto` model name. A model configured with a concrete OpenRouter slug is served by a bare `OpenRouterLLM`, and the shared retry wrapper around it treats only timeouts, 429 and 5xx as retryable — a 4xx arrives as a plain `RuntimeError` and is not retried. The result was a split in behaviour with no principle behind it: the same provider quirk that the router path recovered from silently failed the task outright on the direct-slug path, on the very first error.

OpenRouter's provider routing can move a slug onto an endpoint that rejects or does not implement a parameter the request carries, and it surfaces that only as an untyped 4xx. Recovering from that is the OpenRouter client's concern. The router's job is choosing a model; it merely happened to be the one place that had wrapped a call in this handling. With the rules moved down to the client, every entrypoint gets them regardless of whether a router sits in front.

Fixes #1576

### A rule that would change nothing is skipped without spending its budget

If a rule matches the error text but its adjustment would leave the request unchanged as actually rendered, it is skipped and its action is *not* marked as used. The comparison is made on the pair `(tool_choice, rendered reasoning body)` rather than on the raw thinking argument, because different thinking values can render to the same request.

This matters when one error message matches more than one rule. DeepSeek models already render with thinking disabled by default, so against a `thinking` + `tool_choice` 400 the disable-thinking rule would resend a byte-identical request. Skipping it lets the enable-thinking rule run instead of the call spending its budget replaying an unchanged payload.

### Log lines keep their text but change logger

The three retry log messages are unchanged word for word. They are now emitted by the `xagent.core.model.chat.basic.openrouter` logger instead of `xagent.core.model.chat.basic.router`. Any saved log query or alert that filters on the router logger name needs to be updated to match.

### Retry upper bounds

Worst-case upstream request counts, so the ceiling is explicit for operations. Two mechanics explain the table: a bare compat 4xx does not trigger the outer retry wrapper (its classification treats 4xx as non-retryable), so the multiplied rows apply only when compat 4xx errors alternate with transient wrapper-retryable failures; and when that alternation happens, the outer wrapper replays the original call arguments — a compat adjustment discovered mid-call is discarded and has to be rediscovered on the next attempt. This is an accepted tradeoff of keeping the two retry families separate; #1654 tracks the structural alternative.

| Shape | Bound |
|---|---|
| Final shape, errors are consistently 404 | 5 (one original, at most one DeepSeek prefix-sanitization resend, and at most one retry per rule; the outer wrapper does not replay a 404) |
| Final shape, errors alternate between compat 4xx and wrapper-retryable | outer wrapper budget (10 by default) x 5 = 50 |
| Final shape, response_format-bearing call (the base client's pop-and-retry can resend once per compat iteration) | 8, or wrapper budget x 8 = 80 when errors alternate |
| Second commit reverted, so both layers retry, consistently 404 | 20 |
| Second commit reverted, errors alternate | 200 |

The last two rows exist because the change is split so that reverting only the second commit restores the previous two-layer arrangement; they describe that fallback state, not the state this PR lands in.

### Known boundary (structured-output fallback)

`OpenAILLM.chat`'s structured-output fallback can silently resend a request with reasoning disabled without reporting that state to the compatibility loop, so the loop's view of the thinking state can go stale on that path. No production caller passes `response_format` to `chat` today (the only structured-output producer goes through `vision_chat`; correction: `vision_chat` has an equivalent fallback branch too — its result handling is fixed under #1650), and the suppressed retry would be re-degraded internally and fail identically, so this is documented on the retry helper rather than special-cased.

### Known boundary (DeepSeek reasoning replay)

On an endpoint that mandates reasoning, the enable-thinking rule gets a DeepSeek model past the first call, but a subsequent turn in a tool chain still fails with a 400 because `reasoning_content` is not sent back. That is a separate gap tracked by #1537; this change turns an immediate failure into a working first call, and does not claim to close it.

### Why RouterLLM's loop is removed

#1576 suggested leaving the router call path untouched. This PR removes its retry loop anyway, in its own commit: once the client owns the compat retries, the router copy is permanently redundant, and keeping both layers multiplies the worst-case bounds (the 20/200 rows above quantify exactly that two-layer state, which reverting the removal commit restores). Both downstream-resolver branches construct the OpenRouter client, so no other downstream loses coverage by the removal.

## Testing

Behaviour that moved took its tests with it:

- `tests/core/model/chat/basic/test_router.py` loses the `RouterLLM`-level retry cases, since that layer no longer retries. Two new tests replace them, pinning the combined upper bound for the `RouterLLM` -> retry wrapper -> `OpenRouterLLM` composition so the wrapper's budget and the client's compat retries cannot compound unbounded.
- `tests/core/model/test_router_provider_config.py` loses three cases that asserted `RouterLLM` itself retried a stub downstream; the equivalent coverage now sits at the client layer in `test_openrouter.py`, including a real DeepSeek default where that same retry is correctly a no-op.
- `tests/core/model/chat/basic/test_openrouter.py` gains the client-layer suite: per-entrypoint compat retries, the one-attempt-per-action budget, chained adjustments across two different failures, the no-op skip, the streaming guard that refuses to retry once a chunk has reached the caller, and re-raising a retryable protocol error even when its text happens to match a rule.

`uv run pytest tests/core/model/chat/basic/test_openrouter.py tests/core/model/chat/basic/test_router.py tests/core/model/test_router_provider_config.py` — 95 passed.




