### PR TITLE
chore(ci): move dev and CI PostgreSQL images from 16 to 17

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -627,7 +627,7 @@ jobs:
         shell: bash
         run: |
           set -e
-          .github/scripts/docker-pull-retry.sh minio/minio postgres:16-bookworm
+          .github/scripts/docker-pull-retry.sh minio/minio postgres:17-bookworm
 
       - name: Run e2e tests
         shell: bash

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -236,7 +236,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16-bookworm
+        image: postgres:17-bookworm
         env:
           POSTGRES_USER: xagent
           POSTGRES_PASSWORD: xagent

--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,6 @@ fenixaos_web.db
 
 # Per-developer local frontend env
 frontend/.env.local
+
+# Database dumps written by the docker/README.md backup steps
+/backup.sql

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
 
   # PostgreSQL Database
   postgres:
-    image: postgres:17-bookworm
+    image: postgres:${POSTGRES_IMAGE_TAG:-17-bookworm}
     container_name: xagent_postgres
     restart: unless-stopped
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -143,7 +143,7 @@ services:
 
   # PostgreSQL Database
   postgres:
-    image: postgres:16-bookworm
+    image: postgres:17-bookworm
     container_name: xagent_postgres
     restart: unless-stopped
     environment:

--- a/docker/README.md
+++ b/docker/README.md
@@ -572,11 +572,13 @@ docker compose exec -T postgres psql -U xagent xagent < backup.sql
 
 The bundled `postgres` service defaults to `postgres:17-bookworm`. PostgreSQL never upgrades a data directory across major versions: a v17 server refuses to open a directory initialized by v16, exits with `FATAL: database files are incompatible with server`, and — under `restart: unless-stopped` — restart-loops as `unhealthy`, which blocks `backend`, `worker`, and `scheduler` because they wait for `service_healthy`.
 
-Nothing is written to the old directory when this happens, so the situation is recoverable by pinning the previous tag. The migration itself still has to be performed deliberately, using the steps below.
+Nothing is written to the old directory when this happens, so the situation is recoverable by pinning the previous tag with `POSTGRES_IMAGE_TAG`. The migration itself still has to be performed deliberately.
 
-This section holds the executable commands. The release-level rollout contract for this change — impact, prerequisites, verification queries, and rollback — is the dated entry in [`docs/deployment.md`](../docs/deployment.md).
+The outline below is the standard PostgreSQL major-version path: dump under v16, initialize a fresh v17 cluster, restore. It is a general method, not a procedure that fits every deployment. Data size, uptime requirements, extensions, and what "verified" means for your data are yours to decide — **use the backup and verification process you already trust for this database, and rehearse the whole thing against a copy before running it on production.** The commands here illustrate each phase; they are not a substitute for that.
 
-> **Data loss warning:** `docker compose down -v`, `docker volume rm <project>_postgres_data`, and any other form of "recreating the volume" destroy the database irreversibly. None of them is an upgrade step.
+The release-level rollout context for this change — impact, prerequisites, and rollback — is the dated entry in [`docs/deployment.md`](../docs/deployment.md).
+
+> **Data loss warning:** `docker compose down -v`, removing the live `<project>_postgres_data` volume, and any other form of "recreating the volume" destroy the database irreversibly. None of them is an upgrade step. Removing the separate `_pg16_backup` copy that step 5 creates is a different thing, and is expected.
 
 > **Sandbox overlays:** a deployment started with `-f docker/docker-compose.sandbox.*.yml` must keep those `-f` arguments on every Compose command below. A bare `docker compose up -d` recreates `backend`, `worker`, and `scheduler` without the overlay and silently returns the deployment to non-sandboxed operation.
 
@@ -587,7 +589,7 @@ PGVOL=xagent_postgres_data
 BACKUP="$HOME/xagent-pg16-backup.sql"
 ```
 
-**1. Pin the current major version and confirm the deployment is healthy before changing anything.**
+**1. Pin the current major version and confirm the deployment is healthy before changing anything.** Compose reads `POSTGRES_IMAGE_TAG` from the shell environment in preference to `.env`, so an exported value silently overrides every edit below — `unset POSTGRES_IMAGE_TAG` first if one is set.
 
 ```bash
 printf '\nPOSTGRES_IMAGE_TAG="16-bookworm"\n' >> .env
@@ -601,7 +603,7 @@ docker compose exec postgres psql -U xagent -d xagent -tAc 'SHOW server_version'
 docker compose stop backend worker scheduler
 ```
 
-**3. Back up, and verify the backup is complete.** An interrupted `pg_dump` still leaves a plausible-looking file, so check for the completion marker and record the values you will compare against after the restore.
+**3. Back up.** Run your own backup process here; the dump below is the minimum, not the whole of it. Check the result before continuing — an interrupted `pg_dump` still leaves a plausible-looking file — and record whatever you intend to compare against after the restore.
 
 ```bash
 docker compose exec -T postgres pg_dump -U xagent -d xagent > "$BACKUP"
@@ -609,7 +611,6 @@ grep -q 'PostgreSQL database dump complete' "$BACKUP" \
   && echo "backup complete" \
   || echo "BACKUP INCOMPLETE - do not proceed"
 docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SELECT version_num FROM alembic_version'
-docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SELECT count(*) FROM tasks; SELECT count(*) FROM users'
 ```
 
 **4. Stop the stack, keeping the volumes.** Do not pass `-v`. The longer stop timeout lets Postgres finish its shutdown checkpoint, so step 5 copies a cleanly-closed directory rather than a crash-consistent one.
@@ -618,27 +619,31 @@ docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SELECT count(*) F
 docker compose down -t 60
 ```
 
-**5. Copy the v16 volume so rollback never depends on the dump alone.**
+**5. Copy the v16 volume so rollback never depends on the dump alone.** The destination has to be a clean volume: `cp -a` merges rather than mirrors, so a copy left behind by an earlier attempt must be removed rather than copied into.
 
 ```bash
-docker volume rm -f "${PGVOL}_pg16_backup" 2>/dev/null || true   # a copy left by an earlier attempt would merge, not mirror
+docker volume rm "${PGVOL}_pg16_backup" 2>/dev/null   # absent on a first attempt
 docker volume create "${PGVOL}_pg16_backup"
 docker run --rm -v "$PGVOL":/from:ro -v "${PGVOL}_pg16_backup":/to alpine sh -c 'cp -a /from/. /to/'
 docker run --rm -v "${PGVOL}_pg16_backup":/d alpine cat /d/pgdata/PG_VERSION   # expect: 16
 ```
 
-**6. Remove the v16 data directory from the live volume and start v17,** which initializes a fresh cluster. Dropping the `POSTGRES_IMAGE_TAG` line added in step 1 restores the v17 default. The destructive command is guarded by both preconditions rather than by the advisory prints above, so an incomplete dump or a bad volume copy leaves the data directory untouched. `pg_isready` needs `-h 127.0.0.1`: while the official image initializes a cluster it runs a temporary server on the Unix socket only, and a socket-based check reports that one as ready.
+**6. Remove the v16 data directory from the live volume.** The guard keeps the destructive command from running unless the dump completed and the volume copy really is v16.
 
 ```bash
 if grep -q 'PostgreSQL database dump complete' "$BACKUP" \
    && [ "$(docker run --rm -v "${PGVOL}_pg16_backup":/d alpine cat /d/pgdata/PG_VERSION)" = 16 ]; then
   docker run --rm -v "$PGVOL":/d alpine sh -c 'rm -rf /d/pgdata'
-  sed -i.envupgrade.bak '/^POSTGRES_IMAGE_TAG=/d' .env && rm -f .env.envupgrade.bak
-  docker compose up -d postgres
-  docker compose exec postgres pg_isready -h 127.0.0.1 -U xagent -d xagent
 else
   echo 'PRECONDITIONS NOT MET - nothing changed; do not continue'
 fi
+```
+
+**Then delete the `POSTGRES_IMAGE_TAG` line added in step 1 from `.env`** so the v17 default applies again, and start `postgres`, which initializes a fresh cluster. `pg_isready` needs `-h 127.0.0.1`: while the official image initializes a cluster it runs a temporary server on the Unix socket only, and a socket-based check reports that one as ready.
+
+```bash
+docker compose up -d postgres
+docker compose exec postgres pg_isready -h 127.0.0.1 -U xagent -d xagent
 ```
 
 **7. Restore and verify.** `ON_ERROR_STOP=1` makes a partial restore fail loudly instead of leaving a half-populated database.
@@ -647,32 +652,38 @@ fi
 docker compose exec -T postgres psql -U xagent -d xagent -v ON_ERROR_STOP=1 < "$BACKUP"
 docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SHOW server_version'
 docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SELECT version_num FROM alembic_version'
-docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SELECT count(*) FROM tasks; SELECT count(*) FROM users'
 ```
 
-The reported version must be 17.x, and every value must match what step 3 recorded. `pg_dump` does not carry optimizer statistics across, so rebuild them before the writers return:
+The reported version must be 17.x and `alembic_version` must match what step 3 recorded. Those two only establish that the schema arrived; what proves the *data* arrived is specific to your deployment, so run the checks that matter for it — row counts on the tables you care about, spot checks against recent records, an application smoke test. `pg_dump` does not carry optimizer statistics across, so rebuild them before the writers return:
 
 ```bash
 docker compose exec -T postgres vacuumdb -U xagent --all --analyze-in-stages
 ```
 
-**8. Only after verification passes, bring the writers back.**
+**8. Bring the writers back, only after your verification passes.**
 
 ```bash
 docker compose up -d
 ```
 
-**Rollback.** If any step fails, the volume copy from step 5 was never written to by v17:
+**Rollback — valid only until step 8 restarts the writers.** Until that point nothing has written to the v16 copy from step 5, so it is still a complete picture of the database. Confirm it exists and really is v16 *before* removing anything: `docker run -v` creates a named volume that does not exist, so an unchecked copy-back from a missing volume restores nothing over a directory it has already deleted.
 
 ```bash
-docker compose down
-docker run --rm -v "$PGVOL":/d alpine sh -c 'rm -rf /d/pgdata'
-docker run --rm -v "${PGVOL}_pg16_backup":/from:ro -v "$PGVOL":/to alpine sh -c 'cp -a /from/. /to/'
-printf '\nPOSTGRES_IMAGE_TAG="16-bookworm"\n' >> .env
-docker compose up -d
+docker compose down -t 60
+if docker volume inspect "${PGVOL}_pg16_backup" >/dev/null 2>&1 \
+   && [ "$(docker run --rm -v "${PGVOL}_pg16_backup":/d alpine cat /d/pgdata/PG_VERSION)" = 16 ]; then
+  docker run --rm -v "$PGVOL":/d alpine sh -c 'rm -rf /d/pgdata'
+  docker run --rm -v "${PGVOL}_pg16_backup":/from:ro -v "$PGVOL":/to alpine sh -c 'cp -a /from/. /to/'
+  printf '\nPOSTGRES_IMAGE_TAG="16-bookworm"\n' >> .env
+  docker compose up -d
+else
+  echo "BACKUP VOLUME MISSING OR NOT v16 - live data untouched; restore from $BACKUP instead"
+fi
 ```
 
-Keep `${PGVOL}_pg16_backup` until the v17 deployment has been running to your satisfaction, then remove it with `docker volume rm`.
+Once v17 has accepted writes, that copy is stale and copying it back discards everything written since the cutover. From that point recovery means taking a fresh v17 backup and reconciling the two, not a copy-back.
+
+Keep `${PGVOL}_pg16_backup` while you are still deciding whether the upgrade held, then remove it with `docker volume rm "${PGVOL}_pg16_backup"`.
 
 ## Troubleshooting
 
@@ -709,9 +720,10 @@ PostgreSQL 17 refuses to open the directory rather than modifying it, so the v16
 
 ```bash
 printf '\nPOSTGRES_IMAGE_TAG="16-bookworm"\n' >> .env
-docker compose config | grep 'image: postgres:'   # expect: postgres:16-bookworm
 docker compose up -d postgres
 ```
+
+If `postgres` still starts on 17 after this, a `POSTGRES_IMAGE_TAG` exported in the shell is overriding `.env`; `unset` it and retry.
 
 ### Rebuild After Code Changes
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -570,26 +570,23 @@ docker compose exec -T postgres psql -U xagent xagent < backup.sql
 
 ### PostgreSQL major version upgrade (16 to 17)
 
-The bundled `postgres` service defaults to `postgres:17-bookworm`. PostgreSQL never upgrades a data directory across major versions: a v17 server refuses to open a directory initialized by v16, exits with `FATAL: database files are incompatible with server`, and — under `restart: unless-stopped` — restart-loops as `unhealthy`, which blocks `backend`, `worker`, and `scheduler` because they wait for `service_healthy`.
+The bundled `postgres` service defaults to `postgres:17-bookworm`. PostgreSQL never upgrades a data directory across major versions: a v17 server refuses to open a v16 directory, exits with `FATAL: database files are incompatible with server`, and restart-loops as `unhealthy`, which blocks `backend`, `worker`, and `scheduler`. It does not modify the directory, so pinning `POSTGRES_IMAGE_TAG="16-bookworm"` restores service at any point.
 
-Nothing is written to the old directory when this happens, so the situation is recoverable by pinning the previous tag with `POSTGRES_IMAGE_TAG`. The migration itself still has to be performed deliberately.
+The steps below are the standard major-version path — dump under v16, initialize a fresh v17 cluster, restore. **This is a general method, not a procedure tuned to your deployment: use the backup and verification process you already trust for this database, and rehearse it against a copy first.** Release-level context is the dated entry in [`docs/deployment.md`](../docs/deployment.md).
 
-The outline below is the standard PostgreSQL major-version path: dump under v16, initialize a fresh v17 cluster, restore. It is a general method, not a procedure that fits every deployment. Data size, uptime requirements, extensions, and what "verified" means for your data are yours to decide — **use the backup and verification process you already trust for this database, and rehearse the whole thing against a copy before running it on production.** The commands here illustrate each phase; they are not a substitute for that.
+> **Data loss warning:** `docker compose down -v` and removing the live `<project>_postgres_data` volume destroy the database irreversibly. Neither is an upgrade step. Removing the separate `_pg16_backup` copy created in step 4 is expected.
 
-The release-level rollout context for this change — impact, prerequisites, and rollback — is the dated entry in [`docs/deployment.md`](../docs/deployment.md).
+> **Sandbox overlays:** keep the `-f docker/docker-compose.sandbox.*.yml` arguments on every Compose command below, or `backend`, `worker`, and `scheduler` come back without the overlay.
 
-> **Data loss warning:** `docker compose down -v`, removing the live `<project>_postgres_data` volume, and any other form of "recreating the volume" destroy the database irreversibly. None of them is an upgrade step. Removing the separate `_pg16_backup` copy that step 5 creates is a different thing, and is expected.
-
-> **Sandbox overlays:** a deployment started with `-f docker/docker-compose.sandbox.*.yml` must keep those `-f` arguments on every Compose command below. A bare `docker compose up -d` recreates `backend`, `worker`, and `scheduler` without the overlay and silently returns the deployment to non-sandboxed operation.
-
-Throughout, `PGVOL` is the Compose-prefixed volume name and `BACKUP` is the dump path. Find the volume with `docker volume ls | grep postgres_data`; for the default project name it is `xagent_postgres_data`. Keep the dump outside the checkout — it carries password hashes, OAuth tokens, and encrypted provider credentials.
+Set up. `PGVOL` is the Compose-prefixed volume name — find it with `docker volume ls | grep postgres_data`. Keep `BACKUP` outside the checkout; the dump carries password hashes, OAuth tokens, and encrypted provider credentials.
 
 ```bash
 PGVOL=xagent_postgres_data
 BACKUP="$HOME/xagent-pg16-backup.sql"
+unset POSTGRES_IMAGE_TAG   # Compose prefers a shell value over .env
 ```
 
-**1. Pin the current major version and confirm the deployment is healthy before changing anything.** Compose reads `POSTGRES_IMAGE_TAG` from the shell environment in preference to `.env`, so an exported value silently overrides every edit below — `unset POSTGRES_IMAGE_TAG` first if one is set.
+**1. Pin v16 and confirm the deployment is healthy.**
 
 ```bash
 printf '\nPOSTGRES_IMAGE_TAG="16-bookworm"\n' >> .env
@@ -597,38 +594,31 @@ docker compose up -d postgres
 docker compose exec postgres psql -U xagent -d xagent -tAc 'SHOW server_version'
 ```
 
-**2. Stop every writer, leaving `postgres` running.** `nginx` and `frontend` keep serving and will return errors for the whole window; stop them too if user-visible errors are unacceptable.
+**2. Stop the writers**, leaving `postgres` running. `nginx` and `frontend` keep serving errors for the whole window; stop them too if that is unacceptable.
 
 ```bash
 docker compose stop backend worker scheduler
 ```
 
-**3. Back up.** Run your own backup process here; the dump below is the minimum, not the whole of it. Check the result before continuing — an interrupted `pg_dump` still leaves a plausible-looking file — and record whatever you intend to compare against after the restore.
+**3. Back up and record what you will compare against.** An interrupted `pg_dump` still leaves a plausible-looking file, so check the result.
 
 ```bash
 docker compose exec -T postgres pg_dump -U xagent -d xagent > "$BACKUP"
-grep -q 'PostgreSQL database dump complete' "$BACKUP" \
-  && echo "backup complete" \
-  || echo "BACKUP INCOMPLETE - do not proceed"
+grep -q 'PostgreSQL database dump complete' "$BACKUP" && echo OK || echo 'INCOMPLETE - do not proceed'
 docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SELECT version_num FROM alembic_version'
 ```
 
-**4. Stop the stack, keeping the volumes.** Do not pass `-v`. The longer stop timeout lets Postgres finish its shutdown checkpoint, so step 5 copies a cleanly-closed directory rather than a crash-consistent one.
+**4. Stop the stack and copy the v16 volume**, so rollback never depends on the dump alone. No `-v`; `-t 60` lets Postgres finish its shutdown checkpoint. The destination must be a fresh volume, because `cp -a` merges rather than mirrors.
 
 ```bash
 docker compose down -t 60
-```
-
-**5. Copy the v16 volume so rollback never depends on the dump alone.** The destination has to be a clean volume: `cp -a` merges rather than mirrors, so a copy left behind by an earlier attempt must be removed rather than copied into.
-
-```bash
 docker volume rm "${PGVOL}_pg16_backup" 2>/dev/null   # absent on a first attempt
 docker volume create "${PGVOL}_pg16_backup"
 docker run --rm -v "$PGVOL":/from:ro -v "${PGVOL}_pg16_backup":/to alpine sh -c 'cp -a /from/. /to/'
 docker run --rm -v "${PGVOL}_pg16_backup":/d alpine cat /d/pgdata/PG_VERSION   # expect: 16
 ```
 
-**6. Remove the v16 data directory from the live volume.** The guard keeps the destructive command from running unless the dump completed and the volume copy really is v16.
+**5. Remove the v16 data directory from the live volume.** The guard blocks the destructive command unless the dump completed and the copy really is v16.
 
 ```bash
 if grep -q 'PostgreSQL database dump complete' "$BACKUP" \
@@ -639,26 +629,23 @@ else
 fi
 ```
 
-**Then delete the `POSTGRES_IMAGE_TAG` line added in step 1 from `.env`** so the v17 default applies again, and start `postgres`, which initializes a fresh cluster. `pg_isready` needs `-h 127.0.0.1`: while the official image initializes a cluster it runs a temporary server on the Unix socket only, and a socket-based check reports that one as ready.
+**6. Delete the `POSTGRES_IMAGE_TAG` line from `.env`** and start `postgres`, which initializes a fresh v17 cluster. `pg_isready` needs `-h 127.0.0.1`: during initialization the image runs a temporary server on the Unix socket only, which a socket check reports as ready.
 
 ```bash
 docker compose up -d postgres
 docker compose exec postgres pg_isready -h 127.0.0.1 -U xagent -d xagent
 ```
 
-**7. Restore and verify.** `ON_ERROR_STOP=1` makes a partial restore fail loudly instead of leaving a half-populated database.
+**7. Restore and verify.** `ON_ERROR_STOP=1` fails loudly instead of leaving a half-populated database.
 
 ```bash
 docker compose exec -T postgres psql -U xagent -d xagent -v ON_ERROR_STOP=1 < "$BACKUP"
-docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SHOW server_version'
-docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SELECT version_num FROM alembic_version'
-```
-
-The reported version must be 17.x and `alembic_version` must match what step 3 recorded. Those two only establish that the schema arrived; what proves the *data* arrived is specific to your deployment, so run the checks that matter for it — row counts on the tables you care about, spot checks against recent records, an application smoke test. `pg_dump` does not carry optimizer statistics across, so rebuild them before the writers return:
-
-```bash
+docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SHOW server_version'                        # expect: 17.x
+docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SELECT version_num FROM alembic_version'    # expect: the step 3 value
 docker compose exec -T postgres vacuumdb -U xagent --all --analyze-in-stages
 ```
+
+Those two queries establish only that the schema arrived. Run whatever proves the *data* arrived for your deployment — row counts on the tables you care about, spot checks against recent records, an application smoke test. `vacuumdb` rebuilds the optimizer statistics that `pg_dump` does not carry across.
 
 **8. Bring the writers back, only after your verification passes.**
 
@@ -666,7 +653,7 @@ docker compose exec -T postgres vacuumdb -U xagent --all --analyze-in-stages
 docker compose up -d
 ```
 
-**Rollback — valid only until step 8 restarts the writers.** Until that point nothing has written to the v16 copy from step 5, so it is still a complete picture of the database. Confirm it exists and really is v16 *before* removing anything: `docker run -v` creates a named volume that does not exist, so an unchecked copy-back from a missing volume restores nothing over a directory it has already deleted.
+**Rollback — valid only until step 8 restarts the writers.** Until then nothing has written to the v16 copy from step 4. Confirm it exists and really is v16 *before* removing anything: `docker run -v` creates a named volume that does not exist, so an unchecked copy-back from a missing volume restores nothing over a directory it has already deleted.
 
 ```bash
 docker compose down -t 60
@@ -681,9 +668,7 @@ else
 fi
 ```
 
-Once v17 has accepted writes, that copy is stale and copying it back discards everything written since the cutover. From that point recovery means taking a fresh v17 backup and reconciling the two, not a copy-back.
-
-Keep `${PGVOL}_pg16_backup` while you are still deciding whether the upgrade held, then remove it with `docker volume rm "${PGVOL}_pg16_backup"`.
+After v17 accepts writes the copy is stale, and copying it back discards everything written since the cutover; recovery from that point means a fresh v17 backup plus reconciliation. Keep the copy while you are still deciding whether the upgrade held, then remove it with `docker volume rm "${PGVOL}_pg16_backup"`.
 
 ## Troubleshooting
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,9 @@ Compose overlays, including sandbox runtime options, live in this directory.
 
 - **Frontend**: Next.js standalone build served by nginx
 - **Backend**: FastAPI with Python 3.11, Node.js 22, Playwright, LibreOffice
-- **PostgreSQL**: PostgreSQL 17 database. The image tag is overridable via `POSTGRES_IMAGE_TAG`. A deployment whose `postgres_data` volume was initialized by PostgreSQL 16 cannot be switched to 17 in place; see [PostgreSQL major version upgrade (16 to 17)](#postgresql-major-version-upgrade-16-to-17).
+- **PostgreSQL**: PostgreSQL 17 database; the image tag is overridable via `POSTGRES_IMAGE_TAG`
+
+> **Required action on upgrade:** A `postgres_data` volume initialized by PostgreSQL 16 cannot be switched to 17 in place. PostgreSQL 17 refuses to open it and exits, so `postgres` restart-loops and `backend`, `worker`, and `scheduler` never start. Pin `POSTGRES_IMAGE_TAG="16-bookworm"` to defer, then migrate with [PostgreSQL major version upgrade (16 to 17)](#postgresql-major-version-upgrade-16-to-17). Fresh installations are unaffected.
 
 ## Quick Start
 
@@ -540,6 +542,10 @@ Key production variables:
 # Database (set via docker-compose.yml)
 DATABASE_URL="postgresql://xagent:password@postgres:5432/xagent"
 
+# Image tag of the bundled postgres service (default: 17-bookworm).
+# Pin "16-bookworm" for a postgres_data volume that v16 initialized.
+POSTGRES_IMAGE_TAG="17-bookworm"
+
 # Security
 ENCRYPTION_KEY="your-encryption-key"
 ```
@@ -568,23 +574,28 @@ The bundled `postgres` service defaults to `postgres:17-bookworm`. PostgreSQL ne
 
 Nothing is written to the old directory when this happens, so the situation is recoverable by pinning the previous tag. The migration itself still has to be performed deliberately, using the steps below.
 
+This section holds the executable commands. The release-level rollout contract for this change — impact, prerequisites, verification queries, and rollback — is the dated entry in [`docs/deployment.md`](../docs/deployment.md).
+
 > **Data loss warning:** `docker compose down -v`, `docker volume rm <project>_postgres_data`, and any other form of "recreating the volume" destroy the database irreversibly. None of them is an upgrade step.
 
-Throughout, `PGVOL` is the Compose-prefixed volume name. Find it with `docker volume ls | grep postgres_data`; for the default project name it is `xagent_postgres_data`.
+> **Sandbox overlays:** a deployment started with `-f docker/docker-compose.sandbox.*.yml` must keep those `-f` arguments on every Compose command below. A bare `docker compose up -d` recreates `backend`, `worker`, and `scheduler` without the overlay and silently returns the deployment to non-sandboxed operation.
+
+Throughout, `PGVOL` is the Compose-prefixed volume name and `BACKUP` is the dump path. Find the volume with `docker volume ls | grep postgres_data`; for the default project name it is `xagent_postgres_data`. Keep the dump outside the checkout — it carries password hashes, OAuth tokens, and encrypted provider credentials.
 
 ```bash
 PGVOL=xagent_postgres_data
+BACKUP="$HOME/xagent-pg16-backup.sql"
 ```
 
 **1. Pin the current major version and confirm the deployment is healthy before changing anything.**
 
 ```bash
-echo 'POSTGRES_IMAGE_TAG="16-bookworm"' >> .env
+printf '\nPOSTGRES_IMAGE_TAG="16-bookworm"\n' >> .env
 docker compose up -d postgres
 docker compose exec postgres psql -U xagent -d xagent -tAc 'SHOW server_version'
 ```
 
-**2. Stop every writer, leaving `postgres` running.**
+**2. Stop every writer, leaving `postgres` running.** `nginx` and `frontend` keep serving and will return errors for the whole window; stop them too if user-visible errors are unacceptable.
 
 ```bash
 docker compose stop backend worker scheduler
@@ -593,45 +604,57 @@ docker compose stop backend worker scheduler
 **3. Back up, and verify the backup is complete.** An interrupted `pg_dump` still leaves a plausible-looking file, so check for the completion marker and record the values you will compare against after the restore.
 
 ```bash
-docker compose exec -T postgres pg_dump -U xagent -d xagent > backup.sql
-grep -q 'PostgreSQL database dump complete' backup.sql \
+docker compose exec -T postgres pg_dump -U xagent -d xagent > "$BACKUP"
+grep -q 'PostgreSQL database dump complete' "$BACKUP" \
   && echo "backup complete" \
   || echo "BACKUP INCOMPLETE - do not proceed"
 docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SELECT version_num FROM alembic_version'
+docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SELECT count(*) FROM tasks; SELECT count(*) FROM users'
 ```
 
-**4. Stop the stack, keeping the volumes.** Do not pass `-v`.
+**4. Stop the stack, keeping the volumes.** Do not pass `-v`. The longer stop timeout lets Postgres finish its shutdown checkpoint, so step 5 copies a cleanly-closed directory rather than a crash-consistent one.
 
 ```bash
-docker compose down
+docker compose down -t 60
 ```
 
 **5. Copy the v16 volume so rollback never depends on the dump alone.**
 
 ```bash
+docker volume rm -f "${PGVOL}_pg16_backup" 2>/dev/null || true   # a copy left by an earlier attempt would merge, not mirror
 docker volume create "${PGVOL}_pg16_backup"
 docker run --rm -v "$PGVOL":/from:ro -v "${PGVOL}_pg16_backup":/to alpine sh -c 'cp -a /from/. /to/'
 docker run --rm -v "${PGVOL}_pg16_backup":/d alpine cat /d/pgdata/PG_VERSION   # expect: 16
 ```
 
-**6. Remove the v16 data directory from the live volume and start v17,** which initializes a fresh cluster. Dropping the `POSTGRES_IMAGE_TAG` line added in step 1 restores the v17 default.
+**6. Remove the v16 data directory from the live volume and start v17,** which initializes a fresh cluster. Dropping the `POSTGRES_IMAGE_TAG` line added in step 1 restores the v17 default. The destructive command is guarded by both preconditions rather than by the advisory prints above, so an incomplete dump or a bad volume copy leaves the data directory untouched. `pg_isready` needs `-h 127.0.0.1`: while the official image initializes a cluster it runs a temporary server on the Unix socket only, and a socket-based check reports that one as ready.
 
 ```bash
-docker run --rm -v "$PGVOL":/d alpine sh -c 'rm -rf /d/pgdata'
-sed -i.bak '/^POSTGRES_IMAGE_TAG=/d' .env && rm -f .env.bak   # .env.bak is not gitignored
-docker compose up -d postgres
-docker compose exec postgres pg_isready -U xagent -d xagent
+if grep -q 'PostgreSQL database dump complete' "$BACKUP" \
+   && [ "$(docker run --rm -v "${PGVOL}_pg16_backup":/d alpine cat /d/pgdata/PG_VERSION)" = 16 ]; then
+  docker run --rm -v "$PGVOL":/d alpine sh -c 'rm -rf /d/pgdata'
+  sed -i.envupgrade.bak '/^POSTGRES_IMAGE_TAG=/d' .env && rm -f .env.envupgrade.bak
+  docker compose up -d postgres
+  docker compose exec postgres pg_isready -h 127.0.0.1 -U xagent -d xagent
+else
+  echo 'PRECONDITIONS NOT MET - nothing changed; do not continue'
+fi
 ```
 
 **7. Restore and verify.** `ON_ERROR_STOP=1` makes a partial restore fail loudly instead of leaving a half-populated database.
 
 ```bash
-docker compose exec -T postgres psql -U xagent -d xagent -v ON_ERROR_STOP=1 < backup.sql
+docker compose exec -T postgres psql -U xagent -d xagent -v ON_ERROR_STOP=1 < "$BACKUP"
 docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SHOW server_version'
 docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SELECT version_num FROM alembic_version'
+docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SELECT count(*) FROM tasks; SELECT count(*) FROM users'
 ```
 
-The reported version must be 17.x, and the schema-level checks must match what step 3 recorded.
+The reported version must be 17.x, and every value must match what step 3 recorded. `pg_dump` does not carry optimizer statistics across, so rebuild them before the writers return:
+
+```bash
+docker compose exec -T postgres vacuumdb -U xagent --all --analyze-in-stages
+```
 
 **8. Only after verification passes, bring the writers back.**
 
@@ -645,7 +668,7 @@ docker compose up -d
 docker compose down
 docker run --rm -v "$PGVOL":/d alpine sh -c 'rm -rf /d/pgdata'
 docker run --rm -v "${PGVOL}_pg16_backup":/from:ro -v "$PGVOL":/to alpine sh -c 'cp -a /from/. /to/'
-echo 'POSTGRES_IMAGE_TAG="16-bookworm"' >> .env
+printf '\nPOSTGRES_IMAGE_TAG="16-bookworm"\n' >> .env
 docker compose up -d
 ```
 
@@ -685,7 +708,8 @@ DETAIL:  The data directory was initialized by PostgreSQL version 16, which is n
 PostgreSQL 17 refuses to open the directory rather than modifying it, so the v16 data is intact. Pin the previous major version to restore service immediately, then upgrade deliberately using [PostgreSQL major version upgrade (16 to 17)](#postgresql-major-version-upgrade-16-to-17).
 
 ```bash
-echo 'POSTGRES_IMAGE_TAG="16-bookworm"' >> .env
+printf '\nPOSTGRES_IMAGE_TAG="16-bookworm"\n' >> .env
+docker compose config | grep 'image: postgres:'   # expect: postgres:16-bookworm
 docker compose up -d postgres
 ```
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,7 @@ Compose overlays, including sandbox runtime options, live in this directory.
 
 - **Frontend**: Next.js standalone build served by nginx
 - **Backend**: FastAPI with Python 3.11, Node.js 22, Playwright, LibreOffice
-- **PostgreSQL**: PostgreSQL 17 database (Note: Upgrading an existing self-hosted deployment from v16 to v17 requires manual database migration or volume recreation, as PostgreSQL does not automatically upgrade data directories between major versions.)
+- **PostgreSQL**: PostgreSQL 17 database. The image tag is overridable via `POSTGRES_IMAGE_TAG`. A deployment whose `postgres_data` volume was initialized by PostgreSQL 16 cannot be switched to 17 in place; see [PostgreSQL major version upgrade (16 to 17)](#postgresql-major-version-upgrade-16-to-17).
 
 ## Quick Start
 
@@ -562,6 +562,95 @@ docker compose exec postgres pg_dump -U xagent xagent > backup.sql
 docker compose exec -T postgres psql -U xagent xagent < backup.sql
 ```
 
+### PostgreSQL major version upgrade (16 to 17)
+
+The bundled `postgres` service defaults to `postgres:17-bookworm`. PostgreSQL never upgrades a data directory across major versions: a v17 server refuses to open a directory initialized by v16, exits with `FATAL: database files are incompatible with server`, and — under `restart: unless-stopped` — restart-loops as `unhealthy`, which blocks `backend`, `worker`, and `scheduler` because they wait for `service_healthy`.
+
+Nothing is written to the old directory when this happens, so the situation is recoverable by pinning the previous tag. The migration itself still has to be performed deliberately, using the steps below.
+
+> **Data loss warning:** `docker compose down -v`, `docker volume rm <project>_postgres_data`, and any other form of "recreating the volume" destroy the database irreversibly. None of them is an upgrade step.
+
+Throughout, `PGVOL` is the Compose-prefixed volume name. Find it with `docker volume ls | grep postgres_data`; for the default project name it is `xagent_postgres_data`.
+
+```bash
+PGVOL=xagent_postgres_data
+```
+
+**1. Pin the current major version and confirm the deployment is healthy before changing anything.**
+
+```bash
+echo 'POSTGRES_IMAGE_TAG="16-bookworm"' >> .env
+docker compose up -d postgres
+docker compose exec postgres psql -U xagent -d xagent -tAc 'SHOW server_version'
+```
+
+**2. Stop every writer, leaving `postgres` running.**
+
+```bash
+docker compose stop backend worker scheduler
+```
+
+**3. Back up, and verify the backup is complete.** An interrupted `pg_dump` still leaves a plausible-looking file, so check for the completion marker and record the values you will compare against after the restore.
+
+```bash
+docker compose exec -T postgres pg_dump -U xagent -d xagent > backup.sql
+grep -q 'PostgreSQL database dump complete' backup.sql \
+  && echo "backup complete" \
+  || echo "BACKUP INCOMPLETE - do not proceed"
+docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SELECT version_num FROM alembic_version'
+```
+
+**4. Stop the stack, keeping the volumes.** Do not pass `-v`.
+
+```bash
+docker compose down
+```
+
+**5. Copy the v16 volume so rollback never depends on the dump alone.**
+
+```bash
+docker volume create "${PGVOL}_pg16_backup"
+docker run --rm -v "$PGVOL":/from:ro -v "${PGVOL}_pg16_backup":/to alpine sh -c 'cp -a /from/. /to/'
+docker run --rm -v "${PGVOL}_pg16_backup":/d alpine cat /d/pgdata/PG_VERSION   # expect: 16
+```
+
+**6. Remove the v16 data directory from the live volume and start v17,** which initializes a fresh cluster. Dropping the `POSTGRES_IMAGE_TAG` line added in step 1 restores the v17 default.
+
+```bash
+docker run --rm -v "$PGVOL":/d alpine sh -c 'rm -rf /d/pgdata'
+sed -i.bak '/^POSTGRES_IMAGE_TAG=/d' .env && rm -f .env.bak   # .env.bak is not gitignored
+docker compose up -d postgres
+docker compose exec postgres pg_isready -U xagent -d xagent
+```
+
+**7. Restore and verify.** `ON_ERROR_STOP=1` makes a partial restore fail loudly instead of leaving a half-populated database.
+
+```bash
+docker compose exec -T postgres psql -U xagent -d xagent -v ON_ERROR_STOP=1 < backup.sql
+docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SHOW server_version'
+docker compose exec -T postgres psql -U xagent -d xagent -tAc 'SELECT version_num FROM alembic_version'
+```
+
+The reported version must be 17.x, and the schema-level checks must match what step 3 recorded.
+
+**8. Only after verification passes, bring the writers back.**
+
+```bash
+docker compose up -d
+```
+
+**Rollback.** If any step fails, the volume copy from step 5 was never written to by v17:
+
+```bash
+docker compose down
+docker run --rm -v "$PGVOL":/d alpine sh -c 'rm -rf /d/pgdata'
+docker run --rm -v "${PGVOL}_pg16_backup":/from:ro -v "$PGVOL":/to alpine sh -c 'cp -a /from/. /to/'
+echo 'POSTGRES_IMAGE_TAG="16-bookworm"' >> .env
+docker compose up -d
+```
+
+Keep `${PGVOL}_pg16_backup` until the v17 deployment has been running to your satisfaction, then remove it with `docker volume rm`.
+
 ## Troubleshooting
 
 ### Container Won't Start
@@ -582,6 +671,22 @@ docker compose exec postgres pg_isready -U xagent
 
 # Check database logs
 docker compose logs postgres
+```
+
+### PostgreSQL Won't Start After an Upgrade
+
+`docker compose ps` reports `postgres` as `restarting` and `unhealthy`, and `backend`, `worker`, and `scheduler` never start because they wait for `service_healthy`. A data directory initialized by an older major version produces this in `docker compose logs postgres`:
+
+```
+FATAL:  database files are incompatible with server
+DETAIL:  The data directory was initialized by PostgreSQL version 16, which is not compatible with this version 17.11 (Debian 17.11-1.pgdg12+2).
+```
+
+PostgreSQL 17 refuses to open the directory rather than modifying it, so the v16 data is intact. Pin the previous major version to restore service immediately, then upgrade deliberately using [PostgreSQL major version upgrade (16 to 17)](#postgresql-major-version-upgrade-16-to-17).
+
+```bash
+echo 'POSTGRES_IMAGE_TAG="16-bookworm"' >> .env
+docker compose up -d postgres
 ```
 
 ### Rebuild After Code Changes

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,7 @@ Compose overlays, including sandbox runtime options, live in this directory.
 
 - **Frontend**: Next.js standalone build served by nginx
 - **Backend**: FastAPI with Python 3.11, Node.js 22, Playwright, LibreOffice
-- **PostgreSQL**: PostgreSQL 17 database
+- **PostgreSQL**: PostgreSQL 17 database (Note: Upgrading an existing self-hosted deployment from v16 to v17 requires manual database migration or volume recreation, as PostgreSQL does not automatically upgrade data directories between major versions.)
 
 ## Quick Start
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -18,7 +18,7 @@ Compose overlays, including sandbox runtime options, live in this directory.
 
 - **Frontend**: Next.js standalone build served by nginx
 - **Backend**: FastAPI with Python 3.11, Node.js 22, Playwright, LibreOffice
-- **PostgreSQL**: PostgreSQL 16 database
+- **PostgreSQL**: PostgreSQL 17 database
 
 ## Quick Start
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -200,3 +200,87 @@ Because this release cannot create actor-owned rows, the downgrade remains avail
 SQLite can commit each schema operation separately during a batch-table rebuild. If a downgrade fails, do not retry against the changed database. For a disposable local database, delete and recreate it through normal application startup. Otherwise, restore the verified backup. Make sure that `alembic current` reports the owner-aware revision before you retry the downgrade.
 
 The migration refuses the downgrade if a non-null owner row exists. If a caller created such a row, disable that caller. Revoke and remove the credential with an approved procedure. Then retry the downgrade.
+
+## 2026-08-26 — PostgreSQL 17 default for the bundled Compose database
+
+### Deployment impact
+
+The bundled `postgres` service in `docker-compose.yml` now defaults to `postgres:17-bookworm`. This aligns self-hosted deployments with the PostgreSQL 17 major that production runs and that CI validates against.
+
+PostgreSQL never upgrades a data directory across major versions. A `postgres_data` volume initialized by PostgreSQL 16 does not open under a PostgreSQL 17 server. The server exits with `FATAL: database files are incompatible with server` and does not modify the directory, so the v16 data stays intact and the failure is recoverable by pinning the previous tag.
+
+Under `restart: unless-stopped` the container restart-loops as `unhealthy`. `backend`, `worker`, and `scheduler` wait for `service_healthy` and never start. Treat an unplanned upgrade of an existing v16 deployment as a full outage until the tag is pinned back or the migration below completes.
+
+Fresh installations are unaffected. They initialize directly under v17. Deployments whose `DATABASE_URL` points at an external or managed PostgreSQL are unaffected, because the bundled service is not in their path.
+
+This change has no Alembic revision, no schema change, and no application-code change. The migration is a data-directory migration only.
+
+### Prerequisites and configuration
+
+This release adds one environment variable. `POSTGRES_IMAGE_TAG` sets the tag of the bundled `postgres` image and defaults to `17-bookworm`. `example.env` documents it. Set it to `16-bookworm` to keep an existing v16 volume running until it is migrated.
+
+Before migrating, confirm the deployment uses the bundled `postgres` service rather than an external database. Identify the Compose-prefixed volume name with `docker volume ls | grep postgres_data`. For the default project name it is `xagent_postgres_data`.
+
+Reserve a maintenance window. The database is unavailable from the point writers stop until verification passes. `nginx` and `frontend` keep serving during that window and return errors to users. Stop them as well when user-visible errors are unacceptable.
+
+Do not run `docker compose down -v` or `docker volume rm` at any point in this procedure. Both destroy the database irreversibly. Neither is an upgrade step.
+
+### Deployment and migration steps
+
+The executable commands for every step below are the [PostgreSQL major version upgrade (16 to 17)](../docker/README.md#postgresql-major-version-upgrade-16-to-17) runbook in `docker/README.md`. Run one runbook step per numbered step here, in order.
+
+A deployment that uses a sandbox runtime overlay must keep its `-f` overlay arguments on every Compose command in that runbook. A bare `docker compose up -d` recreates `backend`, `worker`, and `scheduler` without the overlay and silently returns the deployment to non-sandboxed operation.
+
+1. Pin `POSTGRES_IMAGE_TAG` to `16-bookworm` and confirm the deployment is healthy on v16 before anything else changes.
+2. Stop `backend`, `worker`, and `scheduler`. Leave `postgres` running.
+3. Take a dump and verify it is complete. An interrupted `pg_dump` still leaves a plausible file. Record the values that the verification section compares after the restore.
+4. Stop the stack without `-v`.
+5. Copy the v16 volume to a separate volume, so rollback never depends on the dump alone. Remove any copy left by an earlier attempt before creating it.
+6. Remove the v16 data directory from the live volume, unpin `POSTGRES_IMAGE_TAG`, and start `postgres` on v17, which initializes a fresh cluster.
+7. Restore the dump with `ON_ERROR_STOP=1`, then run the verification below.
+8. Start the remaining services only after verification passes.
+
+Keep the v16 volume copy until the v17 deployment has run to your satisfaction. Then remove it with `docker volume rm`.
+
+### Verification and monitoring
+
+Run the version query after the restore:
+
+```sql
+SHOW server_version;
+```
+
+The result must report a 17.x version.
+
+Run the remaining queries against v16 before step 4 and against v17 after the restore, and compare the two results:
+
+```sql
+SELECT version_num FROM alembic_version;
+```
+
+The result must equal the value recorded before the migration. This is a schema check only. A restore that stopped early does not change this value.
+
+```sql
+SELECT count(*) FROM tasks;
+SELECT count(*) FROM users;
+```
+
+Each count must equal the value recorded before the migration. These are the row-level checks. The two checks above do not prove that the data restored.
+
+After verification passes, run `vacuumdb --all --analyze-in-stages` inside the `postgres` container. `pg_dump` does not carry optimizer statistics across a restore, and a restored cluster plans queries badly until statistics exist.
+
+Confirm that `docker compose ps` reports `postgres` as `healthy`, and that `docker compose logs postgres` shows a startup with no `FATAL` line, before you start the writers.
+
+### Rollback
+
+A v17 server never opened the volume copy taken in step 5, so rollback restores that copy directly instead of replaying the dump.
+
+1. Stop the stack without `-v`.
+2. Remove the data directory from the live volume.
+3. Copy the preserved v16 volume back over it.
+4. Pin `POSTGRES_IMAGE_TAG` to `16-bookworm`.
+5. Start the stack and confirm that `SHOW server_version` reports a 16.x version.
+
+Roll back rather than repair in place when verification fails after a partial restore under v17. A cluster left half-populated by an interrupted restore is not a state to diagnose during an outage.
+
+If the v16 volume copy is unavailable, restore the verified dump from step 3 onto a v16 cluster initialized from `16-bookworm`.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -205,87 +205,56 @@ The migration refuses the downgrade if a non-null owner row exists. If a caller 
 
 ### Deployment impact
 
-The bundled `postgres` service in `docker-compose.yml` now defaults to `postgres:17-bookworm`. This aligns self-hosted deployments with the PostgreSQL 17 major that production runs and that CI validates against.
+The bundled `postgres` service in `docker-compose.yml` now defaults to `postgres:17-bookworm`, aligning self-hosted deployments with the PostgreSQL 17 major that production runs and CI validates against. There is no Alembic revision, no schema change, and no application-code change. This is a data-directory migration only.
 
-PostgreSQL never upgrades a data directory across major versions. A `postgres_data` volume initialized by PostgreSQL 16 does not open under a PostgreSQL 17 server. The server exits with `FATAL: database files are incompatible with server` and does not modify the directory, so the v16 data stays intact and the failure is recoverable by pinning the previous tag.
+PostgreSQL never upgrades a data directory across major versions. A `postgres_data` volume initialized by PostgreSQL 16 does not open under a PostgreSQL 17 server: the server exits with `FATAL: database files are incompatible with server` without modifying the directory, restart-loops as `unhealthy`, and `backend`, `worker`, and `scheduler` never start because they wait for `service_healthy`. The v16 data stays intact, so pinning the previous tag restores service. Treat an unplanned upgrade of an existing v16 deployment as a full outage until that happens or the migration below completes.
 
-Under `restart: unless-stopped` the container restart-loops as `unhealthy`. `backend`, `worker`, and `scheduler` wait for `service_healthy` and never start. Treat an unplanned upgrade of an existing v16 deployment as a full outage until the tag is pinned back or the migration below completes.
-
-Fresh installations are unaffected. They initialize directly under v17. Deployments whose `DATABASE_URL` points at an external or managed PostgreSQL are unaffected, because the bundled service is not in their path.
-
-This change has no Alembic revision, no schema change, and no application-code change. The migration is a data-directory migration only.
+Fresh installations are unaffected, because they initialize directly under v17. So are deployments whose `DATABASE_URL` points at an external or managed PostgreSQL, because the bundled service is not in their path.
 
 ### Prerequisites and configuration
 
-This release adds one environment variable. `POSTGRES_IMAGE_TAG` sets the tag of the bundled `postgres` image and defaults to `17-bookworm`. `example.env` documents it. Set it to `16-bookworm` to keep an existing v16 volume running until it is migrated.
+`POSTGRES_IMAGE_TAG` is new in this release. It sets the tag of the bundled `postgres` image, defaults to `17-bookworm`, and is documented in `example.env`. Set it to `16-bookworm` to keep an existing v16 volume running until it is migrated.
 
-Before migrating, confirm the deployment uses the bundled `postgres` service rather than an external database. Identify the Compose-prefixed volume name with `docker volume ls | grep postgres_data`. For the default project name it is `xagent_postgres_data`.
+Before migrating, confirm the deployment uses the bundled `postgres` service rather than an external database, and identify the Compose-prefixed volume name with `docker volume ls | grep postgres_data`. Reserve a maintenance window: the database is unavailable from the point writers stop until verification passes, and `nginx` and `frontend` keep serving errors to users for that whole window.
 
-Reserve a maintenance window. The database is unavailable from the point writers stop until verification passes. `nginx` and `frontend` keep serving during that window and return errors to users. Stop them as well when user-visible errors are unacceptable.
-
-Do not run `docker compose down -v`, and do not remove the live `postgres_data` volume, at any point in this procedure. Both destroy the database irreversibly. Neither is an upgrade step. Removing the separate `_pg16_backup` copy that the runbook creates is a different operation and is expected, before a retry and after the upgrade is accepted.
+Never run `docker compose down -v` or remove the live `postgres_data` volume. Both destroy the database irreversibly and neither is an upgrade step. Removing the separate `_pg16_backup` copy that the runbook creates is a different operation and is expected.
 
 The runbook is a general method, not a procedure tuned to any one deployment. Use the backup and verification process you already trust for this database, and rehearse the migration against a copy before running it on production.
 
 ### Deployment and migration steps
 
-The executable commands for every step below are the [PostgreSQL major version upgrade (16 to 17)](../docker/README.md#postgresql-major-version-upgrade-16-to-17) runbook in `docker/README.md`. Run one runbook step per numbered step here, in order.
+The executable commands are the [PostgreSQL major version upgrade (16 to 17)](../docker/README.md#postgresql-major-version-upgrade-16-to-17) runbook in `docker/README.md`; each numbered step below is one runbook step, in order. A deployment that uses a sandbox runtime overlay must keep its `-f` overlay arguments on every Compose command, or `backend`, `worker`, and `scheduler` come back without the overlay.
 
-A deployment that uses a sandbox runtime overlay must keep its `-f` overlay arguments on every Compose command in that runbook. A bare `docker compose up -d` recreates `backend`, `worker`, and `scheduler` without the overlay and silently returns the deployment to non-sandboxed operation.
-
-1. Pin `POSTGRES_IMAGE_TAG` to `16-bookworm` and confirm the deployment is healthy on v16 before anything else changes.
-2. Stop `backend`, `worker`, and `scheduler`. Leave `postgres` running.
-3. Run your backup process and verify its result. An interrupted `pg_dump` still leaves a plausible file. Record the values you will compare after the restore.
-4. Stop the stack without `-v`.
-5. Copy the v16 volume to a separate volume, so rollback never depends on the dump alone. Remove any copy left by an earlier attempt before creating it.
-6. Remove the v16 data directory from the live volume, unpin `POSTGRES_IMAGE_TAG`, and start `postgres` on v17, which initializes a fresh cluster.
+1. Pin `POSTGRES_IMAGE_TAG` to `16-bookworm` and confirm the deployment is healthy on v16.
+2. Stop `backend`, `worker`, and `scheduler`, leaving `postgres` running.
+3. Run your backup process, verify its result, and record the values you will compare after the restore.
+4. Stop the stack without `-v` and copy the v16 volume to a separate volume, so rollback never depends on the dump alone.
+5. Remove the v16 data directory from the live volume, guarded on the dump being complete and the copy being v16.
+6. Unpin `POSTGRES_IMAGE_TAG` and start `postgres` on v17, which initializes a fresh cluster.
 7. Restore the dump with `ON_ERROR_STOP=1`, then run the verification below.
 8. Start the remaining services only after verification passes.
 
-Keep the v16 volume copy while you are still deciding whether the upgrade held. Then remove it with `docker volume rm`.
+Keep the v16 volume copy while you are still deciding whether the upgrade held, then remove it with `docker volume rm`.
 
 ### Verification and monitoring
 
-Run the version query after the restore:
+After the restore, `SHOW server_version` must report a 17.x version, and `SELECT version_num FROM alembic_version` must equal the value recorded in step 3. The second check is schema-only: a restore that stopped early does not change that value.
 
-```sql
-SHOW server_version;
-```
+Those two establish that the schema arrived. What proves the data arrived depends on the deployment, so run the checks that matter for yours — row counts on the tables you care about, spot checks against recent records, an application smoke test.
 
-The result must report a 17.x version.
+Then run `vacuumdb --all --analyze-in-stages` inside the `postgres` container. `pg_dump` does not carry optimizer statistics across a restore, and a restored cluster plans queries badly until they exist.
 
-Run this against v16 before step 4 and against v17 after the restore, and compare:
-
-```sql
-SELECT version_num FROM alembic_version;
-```
-
-The result must equal the value recorded before the migration. This is a schema check only. A restore that stopped early does not change this value.
-
-Those two establish that the schema arrived. What proves the data arrived depends on the deployment, so run the checks that matter for yours — row counts on the tables you care about, spot checks against recent records, an application smoke test. Counts on `tasks` and `users` are a reasonable minimum:
-
-```sql
-SELECT count(*) FROM tasks;
-SELECT count(*) FROM users;
-```
-
-After verification passes, run `vacuumdb --all --analyze-in-stages` inside the `postgres` container. `pg_dump` does not carry optimizer statistics across a restore, and a restored cluster plans queries badly until statistics exist.
-
-Confirm that `docker compose ps` reports `postgres` as `healthy`, and that `docker compose logs postgres` shows a startup with no `FATAL` line, before you start the writers.
+Before starting the writers, confirm that `docker compose ps` reports `postgres` as `healthy` and that `docker compose logs postgres` shows a startup with no `FATAL` line.
 
 ### Rollback
 
-This procedure is valid only until step 8 restarts the writers. Until that point a v17 server has never opened the volume copy taken in step 5, so it is still a complete picture of the database and rollback restores it directly instead of replaying the dump.
+Valid only until step 8 restarts the writers. Until that point a v17 server has never opened the volume copy taken in step 4, so it is still a complete picture of the database and rollback restores it directly instead of replaying the dump.
 
 1. Stop the stack without `-v`.
-2. Confirm the preserved v16 volume exists and reports `PG_VERSION` 16. Do this before removing anything: Docker creates a named volume that does not exist, so an unchecked copy-back from a missing volume restores nothing over a directory it has already deleted.
-3. Remove the data directory from the live volume.
-4. Copy the preserved v16 volume back over it.
-5. Pin `POSTGRES_IMAGE_TAG` to `16-bookworm`.
-6. Start the stack and confirm that `SHOW server_version` reports a 16.x version.
+2. Confirm the preserved v16 volume exists and reports `PG_VERSION` 16, before removing anything. Docker creates a named volume that does not exist, so an unchecked copy-back from a missing volume restores nothing over a directory it has already deleted.
+3. Remove the data directory from the live volume and copy the preserved v16 volume back over it.
+4. Pin `POSTGRES_IMAGE_TAG` to `16-bookworm`, start the stack, and confirm that `SHOW server_version` reports a 16.x version.
 
-Roll back rather than repair in place when verification fails after a partial restore under v17. A cluster left half-populated by an interrupted restore is not a state to diagnose during an outage.
+Roll back rather than repair in place when verification fails after a partial restore under v17. A cluster left half-populated by an interrupted restore is not a state to diagnose during an outage. If the v16 volume copy is unavailable, restore the verified dump from step 3 onto a v16 cluster initialized from `16-bookworm`.
 
-Once v17 has accepted writes, the volume copy is stale and restoring it discards everything written since the cutover. Recovery from that point means taking a fresh v17 backup and reconciling the two, not a copy-back.
-
-If the v16 volume copy is unavailable, restore the verified dump from step 3 onto a v16 cluster initialized from `16-bookworm`.
+After v17 accepts writes the volume copy is stale, and restoring it discards everything written since the cutover. Recovery from that point means taking a fresh v17 backup and reconciling the two, not a copy-back.

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -223,7 +223,9 @@ Before migrating, confirm the deployment uses the bundled `postgres` service rat
 
 Reserve a maintenance window. The database is unavailable from the point writers stop until verification passes. `nginx` and `frontend` keep serving during that window and return errors to users. Stop them as well when user-visible errors are unacceptable.
 
-Do not run `docker compose down -v` or `docker volume rm` at any point in this procedure. Both destroy the database irreversibly. Neither is an upgrade step.
+Do not run `docker compose down -v`, and do not remove the live `postgres_data` volume, at any point in this procedure. Both destroy the database irreversibly. Neither is an upgrade step. Removing the separate `_pg16_backup` copy that the runbook creates is a different operation and is expected, before a retry and after the upgrade is accepted.
+
+The runbook is a general method, not a procedure tuned to any one deployment. Use the backup and verification process you already trust for this database, and rehearse the migration against a copy before running it on production.
 
 ### Deployment and migration steps
 
@@ -233,14 +235,14 @@ A deployment that uses a sandbox runtime overlay must keep its `-f` overlay argu
 
 1. Pin `POSTGRES_IMAGE_TAG` to `16-bookworm` and confirm the deployment is healthy on v16 before anything else changes.
 2. Stop `backend`, `worker`, and `scheduler`. Leave `postgres` running.
-3. Take a dump and verify it is complete. An interrupted `pg_dump` still leaves a plausible file. Record the values that the verification section compares after the restore.
+3. Run your backup process and verify its result. An interrupted `pg_dump` still leaves a plausible file. Record the values you will compare after the restore.
 4. Stop the stack without `-v`.
 5. Copy the v16 volume to a separate volume, so rollback never depends on the dump alone. Remove any copy left by an earlier attempt before creating it.
 6. Remove the v16 data directory from the live volume, unpin `POSTGRES_IMAGE_TAG`, and start `postgres` on v17, which initializes a fresh cluster.
 7. Restore the dump with `ON_ERROR_STOP=1`, then run the verification below.
 8. Start the remaining services only after verification passes.
 
-Keep the v16 volume copy until the v17 deployment has run to your satisfaction. Then remove it with `docker volume rm`.
+Keep the v16 volume copy while you are still deciding whether the upgrade held. Then remove it with `docker volume rm`.
 
 ### Verification and monitoring
 
@@ -252,7 +254,7 @@ SHOW server_version;
 
 The result must report a 17.x version.
 
-Run the remaining queries against v16 before step 4 and against v17 after the restore, and compare the two results:
+Run this against v16 before step 4 and against v17 after the restore, and compare:
 
 ```sql
 SELECT version_num FROM alembic_version;
@@ -260,12 +262,12 @@ SELECT version_num FROM alembic_version;
 
 The result must equal the value recorded before the migration. This is a schema check only. A restore that stopped early does not change this value.
 
+Those two establish that the schema arrived. What proves the data arrived depends on the deployment, so run the checks that matter for yours — row counts on the tables you care about, spot checks against recent records, an application smoke test. Counts on `tasks` and `users` are a reasonable minimum:
+
 ```sql
 SELECT count(*) FROM tasks;
 SELECT count(*) FROM users;
 ```
-
-Each count must equal the value recorded before the migration. These are the row-level checks. The two checks above do not prove that the data restored.
 
 After verification passes, run `vacuumdb --all --analyze-in-stages` inside the `postgres` container. `pg_dump` does not carry optimizer statistics across a restore, and a restored cluster plans queries badly until statistics exist.
 
@@ -273,14 +275,17 @@ Confirm that `docker compose ps` reports `postgres` as `healthy`, and that `dock
 
 ### Rollback
 
-A v17 server never opened the volume copy taken in step 5, so rollback restores that copy directly instead of replaying the dump.
+This procedure is valid only until step 8 restarts the writers. Until that point a v17 server has never opened the volume copy taken in step 5, so it is still a complete picture of the database and rollback restores it directly instead of replaying the dump.
 
 1. Stop the stack without `-v`.
-2. Remove the data directory from the live volume.
-3. Copy the preserved v16 volume back over it.
-4. Pin `POSTGRES_IMAGE_TAG` to `16-bookworm`.
-5. Start the stack and confirm that `SHOW server_version` reports a 16.x version.
+2. Confirm the preserved v16 volume exists and reports `PG_VERSION` 16. Do this before removing anything: Docker creates a named volume that does not exist, so an unchecked copy-back from a missing volume restores nothing over a directory it has already deleted.
+3. Remove the data directory from the live volume.
+4. Copy the preserved v16 volume back over it.
+5. Pin `POSTGRES_IMAGE_TAG` to `16-bookworm`.
+6. Start the stack and confirm that `SHOW server_version` reports a 16.x version.
 
 Roll back rather than repair in place when verification fails after a partial restore under v17. A cluster left half-populated by an interrupted restore is not a state to diagnose during an outage.
+
+Once v17 has accepted writes, the volume copy is stale and restoring it discards everything written since the cutover. Recovery from that point means taking a fresh v17 backup and reconciling the two, not a copy-back.
 
 If the v16 volume copy is unavailable, restore the verified dump from step 3 onto a v16 cluster initialized from `16-bookworm`.

--- a/example.env
+++ b/example.env
@@ -13,6 +13,11 @@
 # POSTGRES_PASSWORD is used by both postgres and xagent services.
 POSTGRES_PASSWORD="xagent_password"
 
+# PostgreSQL image tag for the bundled postgres service (default: 17-bookworm).
+# A postgres_data volume initialized by v16 must pin "16-bookworm" until it is
+# migrated. See the upgrade runbook in docker/README.md.
+# POSTGRES_IMAGE_TAG="16-bookworm"
+
 # Web service port (default: 80)
 # Frontend and backend are both accessible through this single port
 # nginx will route /api/* to backend and others to frontend

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -981,9 +981,15 @@ def stage_interaction_request(
     call's pre-read and its own INSERT. Under REPEATABLE READ or
     SERIALIZABLE the re-read reuses this transaction's original snapshot,
     does not see that row, and classifies a legitimate replay as
-    ``InteractionSlotTaken`` -- measured on PostgreSQL 16 at both levels.
-    That is a degradation, not a corruption: ``InteractionSlotTaken`` is
-    swallowed, so the caller's turn survives and the question is lost.
+    ``InteractionSlotTaken`` -- measured at both levels. No PostgreSQL
+    version is named because none is load-bearing: a query in such a
+    transaction sees a snapshot as of the start of the transaction's
+    first non-transaction-control statement rather than of the current
+    statement, which is the documented behavior of those levels and not a
+    version quirk, so the re-read cannot see a row committed after that
+    point. That is a degradation, not a corruption:
+    ``InteractionSlotTaken`` is swallowed, so the caller's turn survives
+    and the question is lost.
     READ COMMITTED is PostgreSQL's default and this codebase sets no
     ``isolation_level`` on its engine. Both halves of that are asserted,
     not assumed: one test reads the server's effective

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -981,12 +981,10 @@ def stage_interaction_request(
     call's pre-read and its own INSERT. Under REPEATABLE READ or
     SERIALIZABLE the re-read reuses this transaction's original snapshot,
     does not see that row, and classifies a legitimate replay as
-    ``InteractionSlotTaken`` -- measured at both levels. No PostgreSQL
-    version is named because none is load-bearing: a query in such a
+    ``InteractionSlotTaken`` at both levels: a query in such a
     transaction sees a snapshot as of the start of the transaction's
     first non-transaction-control statement rather than of the current
-    statement, which is the documented behavior of those levels and not a
-    version quirk, so the re-read cannot see a row committed after that
+    statement, so the re-read cannot see a row committed after that
     point. That is a degradation, not a corruption:
     ``InteractionSlotTaken`` is swallowed, so the caller's turn survives
     and the question is lost.

--- a/tests/e2e/test_minio_harness_ports.py
+++ b/tests/e2e/test_minio_harness_ports.py
@@ -101,7 +101,7 @@ def test_unpublished_port_raises_and_removes_the_container(
     with pytest.raises(RuntimeError, match="did not publish a host port"):
         run_container_with_dynamic_ports(
             client,
-            "postgres:16-bookworm",
+            "postgres:17-bookworm",
             name="fixture-container",
             container_ports=("5432/tcp",),
         )

--- a/tests/e2e/test_skill_runtime_session_postgres.py
+++ b/tests/e2e/test_skill_runtime_session_postgres.py
@@ -42,6 +42,9 @@ pytestmark = [pytest.mark.e2e, pytest.mark.docker]
 
 POSTGRES_PASSWORD = "xagent_test"
 POSTGRES_DATABASE = "xagent_test"
+# WHY: the image tag is a floating major, so a drifted pull would otherwise keep
+# this suite green while silently testing against PostgreSQL 16.
+MIN_SERVER_VERSION_NUM = 170000
 SKILL_INDEX_SENTINEL = "Pool handoff regression fixture"
 QUESTION = "Which deployment target should I use?"
 EXPECTED_SKILL_INDEX_LINE = (
@@ -109,7 +112,15 @@ def postgres_url() -> Iterator[str]:
             except psycopg2.OperationalError:
                 time.sleep(0.25)
             else:
+                with connection.cursor() as cursor:
+                    cursor.execute("SHOW server_version_num")
+                    server_version_num = int(cursor.fetchone()[0])
                 connection.close()
+                if server_version_num < MIN_SERVER_VERSION_NUM:
+                    raise RuntimeError(
+                        "e2e fixture requires PostgreSQL 17 or newer, got "
+                        f"server_version_num={server_version_num}"
+                    )
                 break
         else:
             raise RuntimeError("PostgreSQL did not become ready")

--- a/tests/e2e/test_skill_runtime_session_postgres.py
+++ b/tests/e2e/test_skill_runtime_session_postgres.py
@@ -79,7 +79,7 @@ def postgres_url() -> Iterator[str]:
     client = _docker_client()
     container, host_ports = run_container_with_dynamic_ports(
         client,
-        "postgres:16-bookworm",
+        "postgres:17-bookworm",
         name=f"xagent-postgres-e2e-{uuid4().hex[:12]}",
         container_ports=("5432/tcp",),
         tmpfs={"/var/lib/postgresql/data": "rw,size=256m"},


### PR DESCRIPTION
## What & why

Two weeks ago the SaaS deployment moved off PostgreSQL 16 onto **RDS PostgreSQL 17.10**. This repository did not follow: every PostgreSQL it starts was still `postgres:16-bookworm`, so local development, the migration suite, and the e2e suite were all validating against a major version production no longer runs. Anything that changed between 16 and 17 — planner behavior, a deprecated setting, an extension version — would have been caught only in production.

An audit found PostgreSQL 16 declared in **seven** places, four of which actually start or pull a container.

## Change

**The four real call sites** — all move to `postgres:17-bookworm`:

| File | Role |
|---|---|
| `docker-compose.yml` | the `postgres` service for local dev and self-hosted deployment |
| `.github/workflows/test-migrations.yml` | the service container backing **every** Postgres-only migration test (all 15 `XAGENT_TEST_POSTGRES_URL` steps) |
| `tests/e2e/test_skill_runtime_session_postgres.py` | e2e fixture, starts a real container per run |
| `.github/workflows/ci.yml` | the e2e pre-pull; must match the fixture tag above or the pre-pull silently stops warming the right image |

**Two cosmetic sites** — `tests/e2e/test_minio_harness_ports.py` (a string literal passed to a fake Docker client; never pulled) and the `docker/README.md` service list.

**One version stamp in a docstring** — `src/xagent/web/services/task_interaction_staging.py`. The isolation-level note recorded its REPEATABLE READ / SERIALIZABLE degradation as "measured on PostgreSQL 16 at both levels". That degradation follows from documented snapshot semantics, not from anything specific to 16, so the note now states the mechanism — a query in such a transaction sees a snapshot as of the start of the transaction's first non-transaction-control statement, not of the current statement — and names no version. This stops the comment from needing a re-stamp on every upgrade. The behavior was nonetheless re-measured on 17.11 before de-versioning it (see Verification).

## Decisions

**Floating `17-bookworm`, not a pinned `17.10-bookworm`.** Pinning would mirror RDS exactly, and both tags exist on Docker Hub. Floating won for three reasons:

1. `docker-compose.yml` is a **shipped self-host deployment artifact**, not only a test fixture. Official Postgres minor tags stop being rebuilt once superseded, so a pinned `17.10-bookworm` would leave self-hosters on a Postgres that never receives another PostgreSQL or Debian base patch. [PostgreSQL 17.11](https://www.postgresql.org/about/news/postgresql-186-1711-1615-1519-1424-and-19-beta-3-released-3365/) alone closes 20+ CVEs, eight of them CVSS 8.8 (`CVE-2026-14664` regexp heap overflow → arbitrary code execution, `CVE-2026-15741` SQL injection via `EXTRACT`, and others).
2. It matches the convention already in the tree — the previous value was `16-bookworm`, a floating major, not a pinned minor.
3. CI running one minor **ahead** of production is the safe direction: it exercises the next RDS minor before RDS offers it, rather than after.

The counter-case for pinning — making CI a bit-exact production replica — only has force for the one version-sensitive assertion in the tree, and that assertion is now explicitly version-independent (above) and re-measured.

**Note that `17-bookworm` currently resolves to 17.11**, one minor ahead of production. This is intentional per (3), and worth stating plainly rather than leaving as a surprise.

**The tag is duplicated across four files with no shared constant.** Two are YAML (a compose file and a workflow), one is a workflow shell line, one is Python, so there is no mechanism that could hold them together. Left as-is deliberately rather than adding indirection that spans three languages; the coupling between the `ci.yml` pre-pull and the e2e fixture is the one that matters and both are changed here.

## Operational follow-up (not in this PR)

RDS does not yet offer 17.11 — per the [RDS PostgreSQL release notes](https://docs.aws.amazon.com/AmazonRDS/latest/PostgreSQLReleaseNotes/postgresql-versions.html), 17.10 is still the newest PostgreSQL 17 minor available, so **production is currently as patched as RDS allows**. Given the CVE count in 17.11, the SaaS instance is worth upgrading promptly once AWS ships it. That is an infrastructure action with no counterpart in this repository (there is no IaC here).

## Verification

Docker daemon local, `postgres:17-bookworm` resolving to `PostgreSQL 17.11 (Debian 17.11-1.pgdg12+2)`.

- **The full `test-postgresql-migrations` job, reproduced locally against 17.11 — 19/19 steps pass.** Every step of that job in order: `upgrade`, `idempotence`, `incremental`, `downgrade`, then all 15 Postgres-only pytest steps (owner-aware OAuth migrations, gmail provisioning, runtime-key transition, task command transport, task status storage, both `task_interaction_requests` alembic + parity pairs, monitor JSON extraction, interaction staging primitives, protocol_version alembic + parity, interaction lifecycle view, trace `json`→`jsonb`, interaction close rowcount grid, supersede savepoint isolation).
- **The de-versioned docstring claim, re-measured on 17.11.** A three-way probe reproduces the original measurement exactly: after a savepoint rollback, the identity re-read finds the concurrently-committed row under READ COMMITTED (→ REPLAY, correct) and misses it under both REPEATABLE READ and SERIALIZABLE (→ `InteractionSlotTaken`, the documented degradation). `default_transaction_isolation` on 17.11 is still `read committed`. The claim holds unchanged, which is what licenses removing the version from it.
- **e2e:** `tests/e2e/test_skill_runtime_session_postgres.py` + `tests/e2e/test_minio_harness_ports.py --run-special` — 8 passed. The first genuinely starts a `postgres:17-bookworm` container.
- **Compose:** `docker compose config --quiet` passes on the base file and on both sandbox overlays (`boxlite`, `docker`); the resolved `postgres` service shows `image: postgres:17-bookworm`.
- **Lint:** `pre-commit run --files` over all seven changed files — ruff, ruff-format, **mypy**, isort, codespell all pass.
- **Audit:** a repo-wide search for `postgres.16`, `pg16`, `postgres:16`, and `PostgreSQL 16` now returns nothing.

This PR touches both `.github/workflows/test-migrations.yml` and `src/xagent/web/services/task_interaction_staging.py`, which are both on the `detect-migration-changes` path list — so the PostgreSQL migration job **will** run here rather than skipping, and CI will re-execute the battery above against 17 on its own runners.
