### PR TITLE
fix(mcp): stop gating the connector ownership badge on connection state

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "test:kb-components": "vitest run --config vitest.config.ts src/components/kb",
     "test:ci-manifest": "vitest run --config vitest.config.ts src/ci/frontend-test-manifest.test.ts",
     "test:app-pages": "vitest run --config vitest.config.ts src/app",
-    "test:home-build-contracts": "vitest run --config vitest.config.ts src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts",
+    "test:home-build-contracts": "vitest run --config vitest.config.ts src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts src/lib/team-sharing-sanitizers.test.ts",
     "test:widget": "vitest run --config vitest.widget.config.ts",
     "test:widget:coverage": "vitest run --config vitest.widget.config.ts --coverage"
   },

--- a/frontend/src/app/tools/page.test.tsx
+++ b/frontend/src/app/tools/page.test.tsx
@@ -158,15 +158,41 @@ describe("ToolsPage official settings dialog ownership badge (#1623)", () => {
       dialog = screen.getByRole("dialog")
     })
     expect(within(dialog!).getByText("tools.mcp.sharing.shared")).toBeInTheDocument()
+    // Spreading the sanitized status onto this entry has a second consumer
+    // besides the badge: the share-toggle button reads app.shared to decide
+    // its own label and the direction it POSTs (handleToggleShare's share
+    // argument is !app.shared). Before this change app.shared was always
+    // undefined here, so this button read "Share" even for an
+    // already-shared connector -- pinning the correct "Unshare" direction.
+    expect(
+      within(dialog!).getByRole("button", { name: "tools.mcp.sharing.unshare" }),
+    ).toBeInTheDocument()
+  })
+
+  it("shows the private label and the share direction for an unshared server", async () => {
+    installApiMock({ "mcp:9": { shared: false, is_owner: true, needs_config: false } })
+    await renderPage()
+
+    fireEvent.click(screen.getByText("Records MCP"))
+
+    let dialog: HTMLElement
+    await waitFor(() => {
+      dialog = screen.getByRole("dialog")
+    })
+    expect(within(dialog!).getByText("tools.mcp.sharing.private")).toBeInTheDocument()
+    expect(
+      within(dialog!).getByRole("button", { name: "tools.mcp.sharing.share" }),
+    ).toBeInTheDocument()
   })
 
   it("shows no ownership label when the sharing status is malformed", async () => {
     // shared is not a boolean. is_owner: true and needs_config: false keep
-    // the card's own (unsanitized, F1 sub-decision a) isNonOwnedTeamTool
-    // check reading this as the viewer's own tool (card stays clickable) and
-    // keep the badge div's needs_config suffix from ever appending -- both
-    // deliberate, so this isolates the assertion to the dialog's sanitized
-    // lookup, which must reject the whole entry and withhold its badge.
+    // the card's own isNonOwnedTeamTool check (which reads the raw status
+    // and is deliberately left alone by this change) reading this as the
+    // viewer's own tool, so the card stays clickable, and keep the badge
+    // div's needs_config suffix from ever appending -- both deliberate, so
+    // this isolates the assertion to the dialog's sanitized lookup, which
+    // must reject the whole entry and withhold its badge.
     installApiMock({ "mcp:9": { shared: "yes", is_owner: true, needs_config: false } })
     await renderPage()
 

--- a/frontend/src/app/tools/page.test.tsx
+++ b/frontend/src/app/tools/page.test.tsx
@@ -1,0 +1,185 @@
+import React from "react"
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const apiRequestMock = vi.hoisted(() => vi.fn())
+const routerReplaceMock = vi.hoisted(() => vi.fn())
+const routerPushMock = vi.hoisted(() => vi.fn())
+const searchParamsMock = vi.hoisted(() => ({ value: new URLSearchParams() }))
+// Stable across renders on purpose: the page has a useEffect keyed on
+// [isAdmin, user] (loadConfigurableTools/loadSqlConnections). A mock that
+// returns a fresh object literal on every call gives that effect a new
+// `user` reference every render, which never stabilizes -- each run sets
+// state, which re-renders, which calls this mock again, forever.
+const routerMock = vi.hoisted(() => ({ replace: routerReplaceMock, push: routerPushMock }))
+const authValue = vi.hoisted(() => ({
+  token: "token",
+  inTeam: true,
+  user: { is_admin: true },
+}))
+const mcpAppsValue = vi.hoisted(() => ({ getAppIcon: () => null, apps: [] }))
+// t/tDynamic must be stable function references, not freshly-created
+// closures: ConnectMcpDialog (mounted unconditionally by this page, gated
+// closed via its own `open` prop) has a useEffect keyed on [open, t,
+// selectedMcpServers]. A `t` that is a new function every render never lets
+// that effect settle, and its close-branch cleanup (clearMcpOauthPollState)
+// unconditionally calls setLoadingApps(new Set()) -- an unstable `t` alone
+// is enough to spin that into an infinite render loop.
+const translate = vi.hoisted(
+  () => (key: string, vars?: Record<string, string | number>) =>
+    vars ? `${key}:${JSON.stringify(vars)}` : key,
+)
+const translateDynamic = vi.hoisted(() => (_key: string, fallback: string) => fallback)
+const i18nValue = vi.hoisted(() => ({ t: translate, tDynamic: translateDynamic, locale: "en" }))
+
+// ./page.tsx has no top-level React import (it relies on the automatic JSX
+// runtime everywhere else in this app config), but this harness's esbuild
+// transform for .tsx test-reachable modules resolves classic-mode
+// React.createElement calls against a global binding. vi.hoisted runs before
+// any static import in this file, including the one that pulls in ./page, so
+// this is the only point at which the binding can be supplied.
+vi.hoisted(() => {
+  ;(globalThis as unknown as { React: unknown }).React = require("react")
+})
+
+vi.mock("@/lib/api-wrapper", () => ({ apiRequest: apiRequestMock }))
+
+vi.mock("@/lib/utils", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/utils")>("@/lib/utils")
+  return { ...actual, getApiUrl: () => "http://api.local" }
+})
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => routerMock,
+  useSearchParams: () => searchParamsMock.value,
+}))
+
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => authValue,
+}))
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => i18nValue,
+}))
+
+vi.mock("@/contexts/mcp-apps-context", () => ({
+  useMcpApps: () => mcpAppsValue,
+}))
+
+vi.mock("@/components/ui/sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}))
+
+vi.mock("@/components/ui/dialog", () => ({
+  Dialog: ({ open, children }: { open: boolean; children: React.ReactNode }) =>
+    open ? <div role="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h1>{children}</h1>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}))
+
+import ToolsPage from "./page"
+import type { MCPServer } from "./page"
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json" },
+  })
+}
+
+// The one server shape handleEditMcpServer's official branch requires:
+// transport === 'oauth'.
+function officialMcpServer(overrides: Partial<MCPServer> = {}): MCPServer {
+  return {
+    id: 9,
+    user_id: 1,
+    name: "Records MCP",
+    transport: "oauth",
+    description: "",
+    config: {},
+    is_active: true,
+    is_default: false,
+    transport_display: "OAuth",
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  }
+}
+
+/** Dispatches the page's five mount fetches by URL. */
+function installApiMock(connectorStatus: unknown = {}) {
+  apiRequestMock.mockImplementation(async (url: string) => {
+    if (url.endsWith("/api/tools/available")) return jsonResponse({ tools: [] })
+    if (url.endsWith("/api/mcp/servers")) return jsonResponse([officialMcpServer()])
+    if (url.endsWith("/api/connectors/status")) return jsonResponse(connectorStatus)
+    if (url.endsWith("/api/tools/configurable")) return jsonResponse({ tools: [] })
+    if (url.endsWith("/api/tools/sql-connections")) return jsonResponse({ connections: [] })
+    throw new Error(`Unexpected request: ${url}`)
+  })
+}
+
+async function renderPage() {
+  render(<ToolsPage />)
+  await waitFor(() => {
+    expect(screen.getByText("Records MCP")).toBeInTheDocument()
+  })
+}
+
+beforeEach(() => {
+  apiRequestMock.mockReset()
+  routerReplaceMock.mockReset()
+  routerPushMock.mockReset()
+  searchParamsMock.value = new URLSearchParams()
+})
+
+afterEach(cleanup)
+
+describe("ToolsPage official settings dialog ownership badge (#1623)", () => {
+  it("shows the matching three-way label when the server carries a real sharing status", async () => {
+    // is_owner: true, not false: the card's own (unrelated, untouched)
+    // isNonOwnedTeamTool check reads a team-shared entry the viewer does not
+    // own as unclickable, which would silently skip the dialog entirely
+    // while still leaving the *card's* own badge in the document to satisfy
+    // an unscoped query -- scoping to the dialog below is what would have
+    // caught that.
+    installApiMock({ "mcp:9": { shared: true, is_owner: true, needs_config: false } })
+    await renderPage()
+
+    fireEvent.click(screen.getByText("Records MCP"))
+
+    let dialog: HTMLElement
+    await waitFor(() => {
+      dialog = screen.getByRole("dialog")
+    })
+    expect(within(dialog!).getByText("tools.mcp.sharing.shared")).toBeInTheDocument()
+  })
+
+  it("shows no ownership label when the sharing status is malformed", async () => {
+    // shared is not a boolean. is_owner: true and needs_config: false keep
+    // the card's own (unsanitized, F1 sub-decision a) isNonOwnedTeamTool
+    // check reading this as the viewer's own tool (card stays clickable) and
+    // keep the badge div's needs_config suffix from ever appending -- both
+    // deliberate, so this isolates the assertion to the dialog's sanitized
+    // lookup, which must reject the whole entry and withhold its badge.
+    installApiMock({ "mcp:9": { shared: "yes", is_owner: true, needs_config: false } })
+    await renderPage()
+
+    fireEvent.click(screen.getByText("Records MCP"))
+
+    let dialog: HTMLElement
+    await waitFor(() => {
+      dialog = screen.getByRole("dialog")
+    })
+    // Scoped to the dialog: the card behind it renders its own (unsanitized,
+    // untouched) badge off the same malformed status and would otherwise
+    // make this assertion about a different element entirely.
+    const dialogQueries = within(dialog!)
+    expect(dialogQueries.queryByText("tools.mcp.sharing.private")).toBeNull()
+    expect(dialogQueries.queryByText("tools.mcp.sharing.shared")).toBeNull()
+    expect(dialogQueries.queryByText("tools.mcp.sharing.teamTool")).toBeNull()
+  })
+})

--- a/frontend/src/app/tools/page.test.tsx
+++ b/frontend/src/app/tools/page.test.tsx
@@ -33,14 +33,12 @@ const translateDynamic = vi.hoisted(() => (_key: string, fallback: string) => fa
 const i18nValue = vi.hoisted(() => ({ t: translate, tDynamic: translateDynamic, locale: "en" }))
 
 // ./page.tsx has no top-level React import (it relies on the automatic JSX
-// runtime everywhere else in this app config), but this harness's esbuild
-// transform for .tsx test-reachable modules resolves classic-mode
-// React.createElement calls against a global binding. vi.hoisted runs before
-// any static import in this file, including the one that pulls in ./page, so
-// this is the only point at which the binding can be supplied.
-vi.hoisted(() => {
-  ;(globalThis as unknown as { React: unknown }).React = require("react")
-})
+// runtime everywhere else in this app config), while this harness's esbuild
+// transform resolves its React.createElement calls against a global binding.
+// The binding is read when the component renders, not when the module is
+// imported, so stubbing it per test is early enough -- and vi.stubGlobal is
+// tracked, so the afterEach below restores the global instead of leaving one
+// behind for the other files sharing this worker.
 
 vi.mock("@/lib/api-wrapper", () => ({ apiRequest: apiRequestMock }))
 
@@ -130,13 +128,17 @@ async function renderPage() {
 }
 
 beforeEach(() => {
+  vi.stubGlobal("React", React)
   apiRequestMock.mockReset()
   routerReplaceMock.mockReset()
   routerPushMock.mockReset()
   searchParamsMock.value = new URLSearchParams()
 })
 
-afterEach(cleanup)
+afterEach(() => {
+  cleanup()
+  vi.unstubAllGlobals()
+})
 
 describe("ToolsPage official settings dialog ownership badge (#1623)", () => {
   it("shows the matching three-way label when the server carries a real sharing status", async () => {

--- a/frontend/src/app/tools/page.test.tsx
+++ b/frontend/src/app/tools/page.test.tsx
@@ -153,11 +153,8 @@ describe("ToolsPage official settings dialog ownership badge (#1623)", () => {
 
     fireEvent.click(screen.getByText("Records MCP"))
 
-    let dialog: HTMLElement
-    await waitFor(() => {
-      dialog = screen.getByRole("dialog")
-    })
-    expect(within(dialog!).getByText("tools.mcp.sharing.shared")).toBeInTheDocument()
+    const dialog = await screen.findByRole("dialog")
+    expect(within(dialog).getByText("tools.mcp.sharing.shared")).toBeInTheDocument()
     // Spreading the sanitized status onto this entry has a second consumer
     // besides the badge: the share-toggle button reads app.shared to decide
     // its own label and the direction it POSTs (handleToggleShare's share
@@ -165,7 +162,7 @@ describe("ToolsPage official settings dialog ownership badge (#1623)", () => {
     // undefined here, so this button read "Share" even for an
     // already-shared connector -- pinning the correct "Unshare" direction.
     expect(
-      within(dialog!).getByRole("button", { name: "tools.mcp.sharing.unshare" }),
+      within(dialog).getByRole("button", { name: "tools.mcp.sharing.unshare" }),
     ).toBeInTheDocument()
   })
 
@@ -175,13 +172,10 @@ describe("ToolsPage official settings dialog ownership badge (#1623)", () => {
 
     fireEvent.click(screen.getByText("Records MCP"))
 
-    let dialog: HTMLElement
-    await waitFor(() => {
-      dialog = screen.getByRole("dialog")
-    })
-    expect(within(dialog!).getByText("tools.mcp.sharing.private")).toBeInTheDocument()
+    const dialog = await screen.findByRole("dialog")
+    expect(within(dialog).getByText("tools.mcp.sharing.private")).toBeInTheDocument()
     expect(
-      within(dialog!).getByRole("button", { name: "tools.mcp.sharing.share" }),
+      within(dialog).getByRole("button", { name: "tools.mcp.sharing.share" }),
     ).toBeInTheDocument()
   })
 
@@ -198,14 +192,11 @@ describe("ToolsPage official settings dialog ownership badge (#1623)", () => {
 
     fireEvent.click(screen.getByText("Records MCP"))
 
-    let dialog: HTMLElement
-    await waitFor(() => {
-      dialog = screen.getByRole("dialog")
-    })
+    const dialog = await screen.findByRole("dialog")
     // Scoped to the dialog: the card behind it renders its own (unsanitized,
     // untouched) badge off the same malformed status and would otherwise
     // make this assertion about a different element entirely.
-    const dialogQueries = within(dialog!)
+    const dialogQueries = within(dialog)
     expect(dialogQueries.queryByText("tools.mcp.sharing.private")).toBeNull()
     expect(dialogQueries.queryByText("tools.mcp.sharing.shared")).toBeNull()
     expect(dialogQueries.queryByText("tools.mcp.sharing.teamTool")).toBeNull()

--- a/frontend/src/app/tools/page.test.tsx
+++ b/frontend/src/app/tools/page.test.tsx
@@ -200,5 +200,33 @@ describe("ToolsPage official settings dialog ownership badge (#1623)", () => {
     expect(dialogQueries.queryByText("tools.mcp.sharing.private")).toBeNull()
     expect(dialogQueries.queryByText("tools.mcp.sharing.shared")).toBeNull()
     expect(dialogQueries.queryByText("tools.mcp.sharing.teamTool")).toBeNull()
+    // The badge labels above pass whether or not the sanitizer runs -- both
+    // a rejected entry and a never-spread one leave app.shared undefined,
+    // so a malformed entry alone can't tell the two apart. The share
+    // button's direction can: it reads app.shared for truthiness, so an
+    // unsanitized "yes" would read truthy and show "Unshare" here instead.
+    expect(
+      within(dialog).getByRole("button", { name: "tools.mcp.sharing.share" }),
+    ).toBeInTheDocument()
+  })
+
+  it("shows no ownership label when needs_config is not a boolean", async () => {
+    // needs_config: "yes" is the only malformed field here; shared and
+    // is_owner are well-formed. sanitizeConnectorStatusEntry rejects the
+    // whole entry when any one field fails its boolean check, so this pins
+    // that field-level rejection is entry-wide, not per-field.
+    installApiMock({ "mcp:9": { shared: true, is_owner: true, needs_config: "yes" } })
+    await renderPage()
+
+    fireEvent.click(screen.getByText("Records MCP"))
+
+    const dialog = await screen.findByRole("dialog")
+    const dialogQueries = within(dialog)
+    expect(dialogQueries.queryByText("tools.mcp.sharing.private")).toBeNull()
+    expect(dialogQueries.queryByText("tools.mcp.sharing.shared")).toBeNull()
+    expect(dialogQueries.queryByText("tools.mcp.sharing.teamTool")).toBeNull()
+    // Positive anchor: the dialog did render past the malformed status,
+    // it just withheld every sharing badge.
+    expect(dialogQueries.getByRole("button", { name: "tools.mcp.sharing.share" })).toBeInTheDocument()
   })
 })

--- a/frontend/src/app/tools/page.tsx
+++ b/frontend/src/app/tools/page.tsx
@@ -39,6 +39,7 @@ import { getApiUrl, cn } from "@/lib/utils"
 import { apiRequest } from "@/lib/api-wrapper"
 import { ConnectMcpDialog, AppIntegration } from "@/components/mcp/connect-mcp-dialog"
 import { OfficialMcpSettingsDialog } from "@/components/mcp/official-mcp-settings-dialog"
+import { sanitizeConnectorStatusEntry } from "@/lib/team-sharing-sanitizers"
 import { CustomApiForm, MCPServerFormData } from "@/components/mcp/custom-api-form"
 import { CustomMcpForm } from "@/components/mcp/custom-mcp-form"
 import {
@@ -583,6 +584,13 @@ function ToolsPageContent() {
       // We need to fetch the icon or use a generic one
       let icon = getAppIcon(server.name) || "";
 
+      // Same key derivation the card uses to read connectorStatus, so the
+      // settings dialog shows the same ownership label as the card it was
+      // opened from. Sanitized so the dialog's badge gate (which requires
+      // app.shared !== undefined) only ever sees a well-formed answer.
+      const connType = server.transport === 'custom_api' ? 'custom_api' : 'mcp'
+      const sharingStatus = sanitizeConnectorStatusEntry(connectorStatus[`${connType}:${server.id}`])
+
       // Create an AppIntegration-like object for the dialog
       setEditingOfficialApp({
         id: appId, // Store the app ID for OAuth flow
@@ -597,7 +605,8 @@ function ToolsPageContent() {
         // This reconstruction path is only reached for oauth servers (gated
         // above); set auth_type explicitly so the settings dialog's isKeyBased
         // check stays correct if this path is ever reused for other transports.
-        auth_type: "builtin_oauth"
+        auth_type: "builtin_oauth",
+        ...(sharingStatus ?? {}),
       })
       setIsOfficialAppDialogOpen(true)
     } else if (server.transport === "custom_api") {

--- a/frontend/src/app/tools/page.tsx
+++ b/frontend/src/app/tools/page.tsx
@@ -594,8 +594,13 @@ function ToolsPageContent() {
       const connType = 'mcp'
       const sharingStatus = sanitizeConnectorStatusEntry(connectorStatus[`${connType}:${server.id}`])
 
-      // Create an AppIntegration-like object for the dialog
+      // Create an AppIntegration-like object for the dialog. The sanitized
+      // sharing status is spread FIRST: today it carries exactly the three
+      // sharing keys, but spreading it last would let any extra key a future
+      // sanitizer change lets through silently override the identity fields
+      // set below (server_id, is_connected, auth_type).
       setEditingOfficialApp({
+        ...(sharingStatus ?? {}),
         id: appId, // Store the app ID for OAuth flow
         server_id: server.id, // Store the actual server ID for disconnect
         name: server.name,
@@ -609,7 +614,6 @@ function ToolsPageContent() {
         // above); set auth_type explicitly so the settings dialog's isKeyBased
         // check stays correct if this path is ever reused for other transports.
         auth_type: "builtin_oauth",
-        ...(sharingStatus ?? {}),
       })
       setIsOfficialAppDialogOpen(true)
     } else if (server.transport === "custom_api") {

--- a/frontend/src/app/tools/page.tsx
+++ b/frontend/src/app/tools/page.tsx
@@ -587,8 +587,11 @@ function ToolsPageContent() {
       // Same key derivation the card uses to read connectorStatus, so the
       // settings dialog shows the same ownership label as the card it was
       // opened from. Sanitized so the dialog's badge gate (which requires
-      // app.shared !== undefined) only ever sees a well-formed answer.
-      const connType = server.transport === 'custom_api' ? 'custom_api' : 'mcp'
+      // app.shared to be a real boolean) only ever sees a well-formed answer.
+      // This branch only runs for isOfficial servers, which are always
+      // transport === 'oauth' (see the isOfficial check above), so the key
+      // prefix here is always 'mcp'.
+      const connType = 'mcp'
       const sharingStatus = sanitizeConnectorStatusEntry(connectorStatus[`${connType}:${server.id}`])
 
       // Create an AppIntegration-like object for the dialog

--- a/frontend/src/ci/frontend-test-manifest.test.ts
+++ b/frontend/src/ci/frontend-test-manifest.test.ts
@@ -23,7 +23,7 @@ const pagesCommand =
 const kbComponentsCommand = "vitest run --config vitest.config.ts src/components/kb"
 const appPagesCommand = "vitest run --config vitest.config.ts src/app"
 const homeBuildContractsCommand =
-  "vitest run --config vitest.config.ts src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts"
+  "vitest run --config vitest.config.ts src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts src/lib/team-sharing-sanitizers.test.ts"
 const ciSummaryCondition =
   "always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)"
 const frontendSummaryCheckCommand =

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -2153,6 +2153,118 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     within(screen.getByTestId("connector-card-records")).getByTestId("connected-check")
   })
 
+  it("shows the team-ownership badge for a hook-resolved connector that lists as unconnected (#1623)", async () => {
+    useAuthMock.mockReturnValue({ token: "token", inTeam: true })
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.includes("/api/mcp/apps?")) {
+        return Promise.resolve({ ok: true, json: async () => [hookResolvedCustomMcp()] })
+      }
+      if (url.endsWith("/api/connectors/status")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ "mcp:9": { shared: true, is_owner: false, needs_config: false } }),
+        })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+
+    renderDialog()
+    await screen.findByText("Records MCP")
+
+    await waitFor(() => {
+      within(screen.getByTestId("connector-card-records")).getByText(
+        "tools.mcp.sharing.teamTool",
+      )
+    })
+  })
+
+  it("withholds the ownership badge when the sharing route does not answer for an entry (#1623)", async () => {
+    useAuthMock.mockReturnValue({ token: "token", inTeam: true })
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.includes("/api/mcp/apps?")) {
+        return Promise.resolve({ ok: true, json: async () => [hookResolvedCustomMcp()] })
+      }
+      if (url.endsWith("/api/connectors/status")) {
+        return Promise.resolve({ ok: false, status: 500, json: async () => ({}) })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+
+    renderDialog()
+    await screen.findByText("Records MCP")
+
+    // The status request must actually have been issued -- a pure negative
+    // here would also pass if the fixture lost its server_id or the route
+    // was never called.
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        "http://api.local/api/connectors/status",
+        expect.objectContaining({ method: "POST" }),
+      )
+    })
+
+    const card = within(screen.getByTestId("connector-card-records"))
+    expect(card.queryByText("tools.mcp.sharing.private")).toBeNull()
+    expect(card.queryByText("tools.mcp.sharing.shared")).toBeNull()
+    expect(card.queryByText("tools.mcp.sharing.teamTool")).toBeNull()
+
+    // Same withholding when the route answers 200 but the payload for this
+    // ref is malformed (needs_config is not a boolean) -- distinct from the
+    // non-ok case above, and the one that actually depends on the merge
+    // going through sanitizeConnectorStatus rather than a raw cast.
+    cleanup()
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.includes("/api/mcp/apps?")) {
+        return Promise.resolve({ ok: true, json: async () => [hookResolvedCustomMcp()] })
+      }
+      if (url.endsWith("/api/connectors/status")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ "mcp:9": { shared: true, is_owner: false, needs_config: "no" } }),
+        })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+
+    renderDialog()
+    await screen.findByText("Records MCP")
+    await waitFor(() => {
+      expect(apiRequestMock).toHaveBeenCalledWith(
+        "http://api.local/api/connectors/status",
+        expect.objectContaining({ method: "POST" }),
+      )
+    })
+
+    const cardAfterMalformedAnswer = within(screen.getByTestId("connector-card-records"))
+    expect(cardAfterMalformedAnswer.queryByText("tools.mcp.sharing.private")).toBeNull()
+    expect(cardAfterMalformedAnswer.queryByText("tools.mcp.sharing.shared")).toBeNull()
+    expect(cardAfterMalformedAnswer.queryByText("tools.mcp.sharing.teamTool")).toBeNull()
+  })
+
+  it("shows no ownership badge for a listing entry carrying shared but no connector id (#1623)", async () => {
+    useAuthMock.mockReturnValue({ token: "token", inTeam: true })
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.includes("/api/mcp/apps?")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => [{ ...mcpOauthApp(), shared: true, is_owner: false }],
+        })
+      }
+      if (url.endsWith("/api/connectors/status")) {
+        return Promise.resolve({ ok: true, json: async () => ({}) })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+
+    renderDialog()
+    await screen.findByText("Granola")
+
+    const card = within(screen.getByTestId("connector-card-granola"))
+    expect(card.queryByText("tools.mcp.sharing.private")).toBeNull()
+    expect(card.queryByText("tools.mcp.sharing.shared")).toBeNull()
+    expect(card.queryByText("tools.mcp.sharing.teamTool")).toBeNull()
+  })
+
   it("offers Authorize, and refuses selection, for a connector whose consent was never started (#1323)", async () => {
     // The fail-early half of #1347: attaching this connector would load zero
     // tools, so the card is not selectable -- but the flow repaired in #1323

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -2178,6 +2178,35 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     })
   })
 
+  it("shows the private badge for an answered shared:false status (#1623)", async () => {
+    // The only positive pin on this gate's Private arm: every other fixture in
+    // this file answers shared: true or a malformed shape, so a gate that
+    // regressed to truthiness (rendering nothing for shared: false) would pass
+    // all of them.
+    useAuthMock.mockReturnValue({ token: "token", inTeam: true })
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url.includes("/api/mcp/apps?")) {
+        return Promise.resolve({ ok: true, json: async () => [hookResolvedCustomMcp()] })
+      }
+      if (url.endsWith("/api/connectors/status")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ "mcp:9": { shared: false, is_owner: true, needs_config: false } }),
+        })
+      }
+      throw new Error(`Unexpected request: ${url}`)
+    })
+
+    renderDialog()
+    await screen.findByText("Records MCP")
+
+    await waitFor(() => {
+      within(screen.getByTestId("connector-card-records")).getByText(
+        "tools.mcp.sharing.private",
+      )
+    })
+  })
+
   it("withholds the ownership badge when the sharing route does not answer for an entry (#1623)", async () => {
     useAuthMock.mockReturnValue({ token: "token", inTeam: true })
     apiRequestMock.mockImplementation((url: string) => {

--- a/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.test.tsx
@@ -2195,7 +2195,8 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
 
     // The status request must actually have been issued -- a pure negative
     // here would also pass if the fixture lost its server_id or the route
-    // was never called.
+    // was never called. This is the only case in this test, so a match here
+    // can only come from this test's own mock.
     await waitFor(() => {
       expect(apiRequestMock).toHaveBeenCalledWith(
         "http://api.local/api/connectors/status",
@@ -2207,12 +2208,14 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
     expect(card.queryByText("tools.mcp.sharing.private")).toBeNull()
     expect(card.queryByText("tools.mcp.sharing.shared")).toBeNull()
     expect(card.queryByText("tools.mcp.sharing.teamTool")).toBeNull()
+  })
 
-    // Same withholding when the route answers 200 but the payload for this
-    // ref is malformed (needs_config is not a boolean) -- distinct from the
-    // non-ok case above, and the one that actually depends on the merge
-    // going through sanitizeConnectorStatus rather than a raw cast.
-    cleanup()
+  it("withholds the ownership badge when the sharing route answers with a malformed entry (#1623)", async () => {
+    // Distinct from the non-ok case above, and the one that actually depends
+    // on the merge going through sanitizeConnectorStatus rather than a raw
+    // cast: needs_config is not a boolean, so the whole entry must be
+    // dropped, not just the one field.
+    useAuthMock.mockReturnValue({ token: "token", inTeam: true })
     apiRequestMock.mockImplementation((url: string) => {
       if (url.includes("/api/mcp/apps?")) {
         return Promise.resolve({ ok: true, json: async () => [hookResolvedCustomMcp()] })
@@ -2228,6 +2231,10 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
 
     renderDialog()
     await screen.findByText("Records MCP")
+
+    // Own test, own mock, own call history (this file's beforeEach resets
+    // apiRequestMock before every test) -- so this can only be satisfied by
+    // the request this test's own render issued.
     await waitFor(() => {
       expect(apiRequestMock).toHaveBeenCalledWith(
         "http://api.local/api/connectors/status",
@@ -2235,10 +2242,10 @@ describe("ConnectMcpDialog Custom API detail loading", () => {
       )
     })
 
-    const cardAfterMalformedAnswer = within(screen.getByTestId("connector-card-records"))
-    expect(cardAfterMalformedAnswer.queryByText("tools.mcp.sharing.private")).toBeNull()
-    expect(cardAfterMalformedAnswer.queryByText("tools.mcp.sharing.shared")).toBeNull()
-    expect(cardAfterMalformedAnswer.queryByText("tools.mcp.sharing.teamTool")).toBeNull()
+    const card = within(screen.getByTestId("connector-card-records"))
+    expect(card.queryByText("tools.mcp.sharing.private")).toBeNull()
+    expect(card.queryByText("tools.mcp.sharing.shared")).toBeNull()
+    expect(card.queryByText("tools.mcp.sharing.teamTool")).toBeNull()
   })
 
   it("shows no ownership badge for a listing entry carrying shared but no connector id (#1623)", async () => {

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -1491,10 +1491,12 @@ export function ConnectMcpDialog({
                                     connectorRef(app) requires the entry to have a sharing identity
                                     at all (a numeric server_id); without it an unconnected catalog
                                     entry would render "Private" from a shared field nobody set.
-                                    app.shared !== undefined holds only once the sharing route has
-                                    actually answered for this ref, because the merge above only
-                                    ever writes a sanitized triple -- so this term can never be true
-                                    from a guess. */}
+                                    app.shared !== undefined holds for a well-formed answer from the
+                                    sharing route (the merge above only ever writes a sanitized
+                                    triple), or for a shared field the /api/mcp/apps listing itself
+                                    chose to supply -- sanitizeAppIntegrations does not strip unknown
+                                    fields. connectorRef(app) is what keeps that second case from
+                                    rendering a badge on an entry with no sharing identity at all. */}
                                 {inTeam && connectorRef(app) && app.shared !== undefined && (
                                   <Badge variant="secondary" className={`font-medium px-2 py-0.5 rounded-md border shadow-none ${app.shared ? 'bg-blue-50 text-blue-700 border-blue-200' : 'bg-slate-100 text-slate-600 border-slate-200'}`}>
                                     {!app.shared

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -1491,13 +1491,14 @@ export function ConnectMcpDialog({
                                     connectorRef(app) requires the entry to have a sharing identity
                                     at all (a numeric server_id); without it an unconnected catalog
                                     entry would render "Private" from a shared field nobody set.
-                                    app.shared !== undefined holds for a well-formed answer from the
-                                    sharing route (the merge above only ever writes a sanitized
-                                    triple), or for a shared field the /api/mcp/apps listing itself
-                                    chose to supply -- sanitizeAppIntegrations does not strip unknown
-                                    fields. connectorRef(app) is what keeps that second case from
-                                    rendering a badge on an entry with no sharing identity at all. */}
-                                {inTeam && connectorRef(app) && app.shared !== undefined && (
+                                    typeof app.shared === "boolean" holds for a well-formed answer
+                                    from the sharing route (the merge above only ever writes a
+                                    sanitized triple), or for a shared field the /api/mcp/apps
+                                    listing itself chose to supply -- sanitizeAppIntegrations does
+                                    not strip unknown fields. connectorRef(app) is what keeps that
+                                    second case from rendering a badge on an entry with no sharing
+                                    identity at all. */}
+                                {inTeam && connectorRef(app) && typeof app.shared === "boolean" && (
                                   <Badge variant="secondary" className={`font-medium px-2 py-0.5 rounded-md border shadow-none ${app.shared ? 'bg-blue-50 text-blue-700 border-blue-200' : 'bg-slate-100 text-slate-600 border-slate-200'}`}>
                                     {!app.shared
                                       ? t('tools.mcp.sharing.private')

--- a/frontend/src/components/mcp/connect-mcp-dialog.tsx
+++ b/frontend/src/components/mcp/connect-mcp-dialog.tsx
@@ -38,7 +38,7 @@ import { Textarea } from "@/components/ui/textarea"
 import { Label } from "@/components/ui/label"
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group"
 import { useEffect } from "react"
-import { sanitizeAppIntegrations } from "@/lib/team-sharing-sanitizers"
+import { sanitizeAppIntegrations, sanitizeConnectorStatus } from "@/lib/team-sharing-sanitizers"
 
 import {
   isValidMcpName,
@@ -357,8 +357,7 @@ export function ConnectMcpDialog({
         body: JSON.stringify({ refs }),
       })
       if (!response.ok) return
-      const status: Record<string, { shared: boolean; is_owner: boolean; needs_config: boolean }> =
-        await response.json()
+      const status = sanitizeConnectorStatus(await response.json())
       setApps((prev) =>
         prev.map((app) => {
           const ref = connectorRef(app)
@@ -1487,7 +1486,16 @@ export function ConnectMcpDialog({
                                   {app.is_local ? <Home className="h-3 w-3 mr-1.5 text-slate-400" /> : <Globe className="h-3 w-3 mr-1.5 text-slate-400" />}
                                   {app.is_local ? t('tools.mcp.dialog.local') : t('tools.mcp.dialog.remote')}
                                 </Badge>
-                                {inTeam && isGloballyConnected && connectorRef(app) && (
+                                {/* The ownership badge reports team-sharing status, which is not a
+                                    credential fact, so it does not gate on isGloballyConnected.
+                                    connectorRef(app) requires the entry to have a sharing identity
+                                    at all (a numeric server_id); without it an unconnected catalog
+                                    entry would render "Private" from a shared field nobody set.
+                                    app.shared !== undefined holds only once the sharing route has
+                                    actually answered for this ref, because the merge above only
+                                    ever writes a sanitized triple -- so this term can never be true
+                                    from a guess. */}
+                                {inTeam && connectorRef(app) && app.shared !== undefined && (
                                   <Badge variant="secondary" className={`font-medium px-2 py-0.5 rounded-md border shadow-none ${app.shared ? 'bg-blue-50 text-blue-700 border-blue-200' : 'bg-slate-100 text-slate-600 border-slate-200'}`}>
                                     {!app.shared
                                       ? t('tools.mcp.sharing.private')

--- a/frontend/src/components/mcp/official-mcp-settings-dialog.test.tsx
+++ b/frontend/src/components/mcp/official-mcp-settings-dialog.test.tsx
@@ -230,6 +230,11 @@ describe("OfficialMcpSettingsDialog connected-state actions", () => {
       isGloballyConnected: true,
     })
 
+    // Anchor: proves the dialog actually rendered its content, so the three
+    // negatives below aren't trivially satisfied by an empty document (the
+    // component's own `if (!app) return null` is the failure mode this
+    // guards against).
+    expect(screen.getByText("Chrome")).toBeInTheDocument()
     expect(screen.queryByText("tools.mcp.sharing.private")).toBeNull()
     expect(screen.queryByText("tools.mcp.sharing.shared")).toBeNull()
     expect(screen.queryByText("tools.mcp.sharing.teamTool")).toBeNull()

--- a/frontend/src/components/mcp/official-mcp-settings-dialog.test.tsx
+++ b/frontend/src/components/mcp/official-mcp-settings-dialog.test.tsx
@@ -203,6 +203,37 @@ describe("OfficialMcpSettingsDialog connected-state actions", () => {
 
     expect(screen.queryByRole("button", { name: "tools.mcp.dialog.configure" })).toBeNull()
   })
+
+  it("shows the ownership badge for an unconnected entry that carries a sharing status (#1623)", () => {
+    authState.inTeam = true
+    renderDialog({
+      app: app({
+        auth_type: "mcp_oauth",
+        is_custom: true,
+        server_id: 9,
+        shared: true,
+        is_owner: false,
+        needs_config: false,
+      }),
+      isGloballyConnected: false,
+    })
+
+    expect(screen.getByText("tools.mcp.sharing.teamTool")).toBeInTheDocument()
+  })
+
+  it("withholds the ownership badge for an entry with no sharing status (#1623)", () => {
+    authState.inTeam = true
+    // The Tools page's hand-built shape: a server_id, isGloballyConnected
+    // true, and no shared/is_owner/needs_config at all.
+    renderDialog({
+      app: app({ auth_type: "builtin_oauth", server_id: 9 }),
+      isGloballyConnected: true,
+    })
+
+    expect(screen.queryByText("tools.mcp.sharing.private")).toBeNull()
+    expect(screen.queryByText("tools.mcp.sharing.shared")).toBeNull()
+    expect(screen.queryByText("tools.mcp.sharing.teamTool")).toBeNull()
+  })
 })
 
 describe("OfficialMcpSettingsDialog connect trigger", () => {

--- a/frontend/src/components/mcp/official-mcp-settings-dialog.test.tsx
+++ b/frontend/src/components/mcp/official-mcp-settings-dialog.test.tsx
@@ -239,6 +239,24 @@ describe("OfficialMcpSettingsDialog connected-state actions", () => {
     expect(screen.queryByText("tools.mcp.sharing.shared")).toBeNull()
     expect(screen.queryByText("tools.mcp.sharing.teamTool")).toBeNull()
   })
+
+  it("withholds the ownership badge for a team entry with no connector id (#1623)", () => {
+    authState.inTeam = true
+    // A well-formed sharing triple, but no server_id at all -- the factory
+    // default carries none -- so the badge must stay withheld regardless of
+    // shared/is_owner/needs_config.
+    renderDialog({
+      app: app({ auth_type: "mcp_oauth", shared: true, is_owner: false, needs_config: false }),
+      isGloballyConnected: true,
+    })
+
+    // Anchor: proves the dialog actually rendered its content before the
+    // three negatives below are checked.
+    expect(screen.getByText("Chrome")).toBeInTheDocument()
+    expect(screen.queryByText("tools.mcp.sharing.private")).toBeNull()
+    expect(screen.queryByText("tools.mcp.sharing.shared")).toBeNull()
+    expect(screen.queryByText("tools.mcp.sharing.teamTool")).toBeNull()
+  })
 })
 
 describe("OfficialMcpSettingsDialog connect trigger", () => {

--- a/frontend/src/components/mcp/official-mcp-settings-dialog.tsx
+++ b/frontend/src/components/mcp/official-mcp-settings-dialog.tsx
@@ -218,7 +218,18 @@ export function OfficialMcpSettingsDialog({
             </div>
           )}
 
-          {inTeam && isGloballyConnected && Number.isInteger(app.server_id) && (
+          {/* The ownership badge reports team-sharing status, which is not a
+              credential fact, so it does not gate on isGloballyConnected.
+              Number.isInteger(app.server_id) requires the entry to have a
+              sharing identity at all; without it an entry with no connector id
+              would render "Private" from a shared field nobody set.
+              app.shared !== undefined holds only once the sharing route has
+              actually answered for this entry -- the picker's merge only ever
+              writes a sanitized triple, and the Tools page only spreads
+              shared/is_owner/needs_config here when its own lookup through the
+              same sanitizer survives -- so this term can never be true from a
+              guess. */}
+          {inTeam && Number.isInteger(app.server_id) && app.shared !== undefined && (
             <div className={`mb-4 inline-flex items-center px-3 py-1 rounded-full text-sm font-medium border ${app.shared ? 'bg-blue-50 border-blue-100 text-blue-700' : 'bg-slate-50 border-slate-200 text-slate-600'}`}>
               {!app.shared
                 ? t('tools.mcp.sharing.private')

--- a/frontend/src/components/mcp/official-mcp-settings-dialog.tsx
+++ b/frontend/src/components/mcp/official-mcp-settings-dialog.tsx
@@ -223,12 +223,14 @@ export function OfficialMcpSettingsDialog({
               Number.isInteger(app.server_id) requires the entry to have a
               sharing identity at all; without it an entry with no connector id
               would render "Private" from a shared field nobody set.
-              app.shared !== undefined holds only once the sharing route has
-              actually answered for this entry -- the picker's merge only ever
-              writes a sanitized triple, and the Tools page only spreads
-              shared/is_owner/needs_config here when its own lookup through the
-              same sanitizer survives -- so this term can never be true from a
-              guess. */}
+              app.shared !== undefined holds for a well-formed answer from the
+              sharing route -- the picker's merge and the Tools page's own
+              lookup both only ever write a sanitized triple -- or for a
+              shared field the /api/mcp/apps listing itself chose to supply
+              (sanitizeAppIntegrations does not strip unknown fields).
+              Number.isInteger(app.server_id) is what keeps that second case
+              from rendering a badge on an entry with no sharing identity at
+              all. */}
           {inTeam && Number.isInteger(app.server_id) && app.shared !== undefined && (
             <div className={`mb-4 inline-flex items-center px-3 py-1 rounded-full text-sm font-medium border ${app.shared ? 'bg-blue-50 border-blue-100 text-blue-700' : 'bg-slate-50 border-slate-200 text-slate-600'}`}>
               {!app.shared

--- a/frontend/src/components/mcp/official-mcp-settings-dialog.tsx
+++ b/frontend/src/components/mcp/official-mcp-settings-dialog.tsx
@@ -223,15 +223,19 @@ export function OfficialMcpSettingsDialog({
               Number.isInteger(app.server_id) requires the entry to have a
               sharing identity at all; without it an entry with no connector id
               would render "Private" from a shared field nobody set.
-              app.shared !== undefined holds for a well-formed answer from the
-              sharing route -- the picker's merge and the Tools page's own
-              lookup both only ever write a sanitized triple -- or for a
+              typeof app.shared === "boolean" holds for a well-formed answer
+              from the sharing route -- the picker's merge and the Tools page's
+              own lookup both only ever write a sanitized triple -- or for a
               shared field the /api/mcp/apps listing itself chose to supply
               (sanitizeAppIntegrations does not strip unknown fields).
               Number.isInteger(app.server_id) is what keeps that second case
               from rendering a badge on an entry with no sharing identity at
-              all. */}
-          {inTeam && Number.isInteger(app.server_id) && app.shared !== undefined && (
+              all. The button gate below (isNonOwnedTeamTool) deliberately
+              keeps reading app.shared for truthiness rather than matching
+              this boolean check -- that gate only needs to know whether
+              sharing is active at all, not whether the field is well-formed,
+              so the mismatch with this badge condition is intentional. */}
+          {inTeam && Number.isInteger(app.server_id) && typeof app.shared === "boolean" && (
             <div className={`mb-4 inline-flex items-center px-3 py-1 rounded-full text-sm font-medium border ${app.shared ? 'bg-blue-50 border-blue-100 text-blue-700' : 'bg-slate-50 border-slate-200 text-slate-600'}`}>
               {!app.shared
                 ? t('tools.mcp.sharing.private')

--- a/frontend/src/lib/team-sharing-sanitizers.test.ts
+++ b/frontend/src/lib/team-sharing-sanitizers.test.ts
@@ -53,6 +53,12 @@ describe("team sharing response sanitizers", () => {
     expect(
       sanitizeConnectorStatusEntry({ shared: "yes", is_owner: false, needs_config: false }),
     ).toBeNull()
+    expect(
+      sanitizeConnectorStatusEntry({ shared: true, is_owner: "yes", needs_config: false }),
+    ).toBeNull()
+    expect(
+      sanitizeConnectorStatusEntry({ shared: true, is_owner: false, needs_config: "no" }),
+    ).toBeNull()
     expect(sanitizeConnectorStatusEntry("bad")).toBeNull()
     expect(sanitizeConnectorStatusEntry(null)).toBeNull()
   })

--- a/frontend/src/lib/team-sharing-sanitizers.test.ts
+++ b/frontend/src/lib/team-sharing-sanitizers.test.ts
@@ -77,5 +77,7 @@ describe("team sharing response sanitizers", () => {
     })
     expect(sanitizeConnectorStatus("bad")).toEqual({})
     expect(sanitizeConnectorStatus(null)).toEqual({})
+    expect(sanitizeConnectorStatus(undefined)).toEqual({})
+    expect(sanitizeConnectorStatus([1, 2])).toEqual({})
   })
 })

--- a/frontend/src/lib/team-sharing-sanitizers.test.ts
+++ b/frontend/src/lib/team-sharing-sanitizers.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from "vitest"
 
 import {
   sanitizeAppIntegrations,
+  sanitizeConnectorStatus,
+  sanitizeConnectorStatusEntry,
   sanitizeUnsharedConnectors,
   sanitizeUnsharedKnowledgeBases,
 } from "./team-sharing-sanitizers"
@@ -38,5 +40,36 @@ describe("team sharing response sanitizers", () => {
     }
     expect(sanitizeAppIntegrations([app, null, 1, { id: "missing-fields" }])).toEqual([app])
     expect(sanitizeAppIntegrations({ apps: [app] })).toEqual([])
+  })
+
+  it("keeps a connector status entry only when all three fields are real booleans", () => {
+    expect(
+      sanitizeConnectorStatusEntry({ shared: true, is_owner: false, needs_config: true }),
+    ).toEqual({ shared: true, is_owner: false, needs_config: true })
+    expect(sanitizeConnectorStatusEntry({ shared: true })).toBeNull()
+    expect(
+      sanitizeConnectorStatusEntry({ shared: null, is_owner: true, needs_config: false }),
+    ).toBeNull()
+    expect(
+      sanitizeConnectorStatusEntry({ shared: "yes", is_owner: false, needs_config: false }),
+    ).toBeNull()
+    expect(sanitizeConnectorStatusEntry("bad")).toBeNull()
+    expect(sanitizeConnectorStatusEntry(null)).toBeNull()
+  })
+
+  it("keeps only well-formed connector status entries, keyed as given", () => {
+    expect(
+      sanitizeConnectorStatus({
+        "mcp:1": { shared: true, is_owner: false, needs_config: true },
+        "mcp:2": { shared: true },
+        "mcp:3": { shared: null, is_owner: true, needs_config: false },
+        "mcp:4": { shared: "yes", is_owner: false, needs_config: false },
+        "mcp:5": "bad",
+      }),
+    ).toEqual({
+      "mcp:1": { shared: true, is_owner: false, needs_config: true },
+    })
+    expect(sanitizeConnectorStatus("bad")).toEqual({})
+    expect(sanitizeConnectorStatus(null)).toEqual({})
   })
 })

--- a/frontend/src/lib/team-sharing-sanitizers.ts
+++ b/frontend/src/lib/team-sharing-sanitizers.ts
@@ -52,3 +52,31 @@ export const sanitizeAppIntegrations = (value: unknown): AppIntegration[] => {
       typeof item.icon === "string",
   )
 }
+
+export interface ConnectorStatus {
+  shared: boolean
+  is_owner: boolean
+  needs_config: boolean
+}
+
+export const sanitizeConnectorStatusEntry = (value: unknown): ConnectorStatus | null => {
+  if (!isRecord(value)) return null
+  if (
+    typeof value.shared !== "boolean" ||
+    typeof value.is_owner !== "boolean" ||
+    typeof value.needs_config !== "boolean"
+  ) {
+    return null
+  }
+  return { shared: value.shared, is_owner: value.is_owner, needs_config: value.needs_config }
+}
+
+export const sanitizeConnectorStatus = (value: unknown): Record<string, ConnectorStatus> => {
+  if (!isRecord(value)) return {}
+  const result: Record<string, ConnectorStatus> = {}
+  for (const [key, entry] of Object.entries(value)) {
+    const sanitized = sanitizeConnectorStatusEntry(entry)
+    if (sanitized) result[key] = sanitized
+  }
+  return result
+}

--- a/frontend/src/lib/team-sharing-sanitizers.ts
+++ b/frontend/src/lib/team-sharing-sanitizers.ts
@@ -53,13 +53,13 @@ export const sanitizeAppIntegrations = (value: unknown): AppIntegration[] => {
   )
 }
 
-export interface ConnectorStatus {
+export interface ConnectorStatusEntry {
   shared: boolean
   is_owner: boolean
   needs_config: boolean
 }
 
-export const sanitizeConnectorStatusEntry = (value: unknown): ConnectorStatus | null => {
+export const sanitizeConnectorStatusEntry = (value: unknown): ConnectorStatusEntry | null => {
   if (!isRecord(value)) return null
   if (
     typeof value.shared !== "boolean" ||
@@ -71,9 +71,9 @@ export const sanitizeConnectorStatusEntry = (value: unknown): ConnectorStatus | 
   return { shared: value.shared, is_owner: value.is_owner, needs_config: value.needs_config }
 }
 
-export const sanitizeConnectorStatus = (value: unknown): Record<string, ConnectorStatus> => {
+export const sanitizeConnectorStatus = (value: unknown): Record<string, ConnectorStatusEntry> => {
   if (!isRecord(value)) return {}
-  const result: Record<string, ConnectorStatus> = {}
+  const result: Record<string, ConnectorStatusEntry> = {}
   for (const [key, entry] of Object.entries(value)) {
     const sanitized = sanitizeConnectorStatusEntry(entry)
     if (sanitized) result[key] = sanitized


### PR DESCRIPTION
## Problem

For a connector whose credentials arrive through the external OAuth token
resolver hook, `GET /api/mcp/apps` reports `is_connected: false` for as long as
the connector exists: no per-user `MCPOAuthGrant` is ever written, and
`_mcp_oauth_server_is_actually_connected` answers from grant state alone. That
is what the field means, and `can_attach` / `can_authorize` / `can_configure`
already carry the decisions that do depend on the hook.

The connector picker's team-ownership badge was gated on that field. A connector
shared with a team therefore showed only its transport badge ("Local") in the
"+ Connector" dialog, while the Tools page labelled the same connector "Team
tool" — two surfaces telling different stories about one server. The badge in
the connector detail dialog carried the same gate.

Team ownership is a fact about sharing, not about credentials, and the picker
already holds it: the sharing-status request is issued for every listed entry
that carries a `server_id`, connected or not.

## Change

Both ownership badges now render on the sharing facts alone:

- was `inTeam && isGloballyConnected && <has a connector reference>`
- now `inTeam && <has a connector reference> && typeof app.shared === "boolean"`

The connection term is gone. In its place is a term that was missing: the
sharing status must actually have been answered for this entry. `shared` is
optional and nothing defaulted it, so `undefined` means "the sharing route did
not answer", while the label expression treats `!app.shared` as "private" —
without the new term, a failed or partial response would have made the badge
assert "Private" about a team-owned connector.

To make that term mean what it says rather than "some producer set this field",
the sharing response is normalized at the boundary. `sanitizeConnectorStatus` /
`sanitizeConnectorStatusEntry` join the existing sanitizers in
`lib/team-sharing-sanitizers.ts` and keep only entries whose `shared`,
`is_owner` and `needs_config` are all real booleans. A partial, `null`-valued or
non-boolean answer is dropped, so the badge stays silent instead of guessing.

The Tools page builds its own entry for the detail dialog and attached no
sharing status, so that dialog printed "Private" for every server — including
one whose card said "Team tool" a click earlier. It now passes the status it
already holds, through the same sanitizer, so both surfaces agree. (From this
page's own entry point only the Private and Shared labels are reachable: the
card gate keeps a non-owned team tool unclickable, so its dialog never opens
here -- the Team tool arm is exercised from the picker's entry point.)

Everything that reports connection state keeps reading it: the connected
checkmark, the Authorize trigger's suppression on a connected entry, the
connected-account chip, and the Connect / Share / Disconnect gates.

## Behaviour

| Entry | Before | After |
|---|---|---|
| team-shared connector, no per-user grant, status answered | no badge | the matching label |
| any entry, status answered | as before | unchanged |
| connected entry, status failed, partial, or not about this entry | "Private" | no badge |
| entry with no connector reference (unconnected catalog entry) | no badge | no badge |
| viewer not in a team | no badge | no badge |
| Tools page detail dialog | "Private", always | the matching label, or nothing when unanswered |

Two further consequences, both intended and both stated here rather than left to
be discovered:

- On the Tools page, the detail dialog's share toggle reads
  `handleToggleShare(app, !app.shared)`. With `shared` never supplied on that
  path it always offered "Share", which for an already-shared connector was a
  no-op re-share. It now offers "Unshare" and revokes, which is what the button
  was written to do. Pinned in both directions by test.
- `isNonOwnedTeamTool` reads the same triple. Because a malformed answer is now
  dropped whole rather than partially merged, Configure / Share / Disconnect
  render on such an answer where a partial merge previously hid them. Those
  routes are enforced server-side and answer 403; this is reachable only from a
  response that violates the shape the client is given.

## Verification

```
$ cd frontend && npx vitest run --config vitest.config.ts src/components/mcp
Test Files  5 passed (5)        Tests  103 passed (103)

$ npx vitest run --config vitest.config.ts src/lib/team-sharing-sanitizers.test.ts
Test Files  1 passed (1)        Tests  5 passed (5)

$ npm run test:app-pages
Test Files  13 passed (13)      Tests  280 passed (280)

$ npx tsc --noEmit
(clean)

$ pre-commit run --files <the eight changed files>
fix end of files ... Passed / trim trailing whitespace ... Passed
codespell ... Passed / npm lint ... Passed / npm type-check ... Passed
```

Each new test was checked by reverting the thing it guards and confirming it
fails for the stated reason. Representative runs:

| Reverted | Fails |
|---|---|
| `isGloballyConnected` restored in the picker gate | the badge case, on `Unable to find ... tools.mcp.sharing.teamTool` |
| `isGloballyConnected` restored in the modal gate | the modal badge case |
| `typeof app.shared === "boolean"` dropped, picker | the no-answer case, on `expected <span ...> to be null` |
| `typeof app.shared === "boolean"` dropped, modal | the no-sharing-status case |
| `connectorRef(app)` dropped, picker | the listing-`shared`-without-`server_id` case |
| the sanitizer bypassed in the picker merge | the malformed-answer case, on `expected <span data-slot="badge" ...> to be null` |
| the status no longer passed to the Tools page entry | both Tools page label cases |
| the status passed unsanitized to the Tools page entry | the malformed-status case |

The `src/app/build/page.test.tsx` stderr output in the `test:app-pages` run is
pre-existing: those are that file's deliberate error-path cases, unchanged here.

## Notes

- Frontend only. No API field, response shape, or backend predicate changes.
- The issue offers an either/or: teach `is_connected` about the resolver hook,
  "or the ownership badge should not be gated on connection state at all — a
  connector's team ownership is a fact about sharing, not about credentials."
  This takes the second branch. The connected checkmark therefore stays absent
  for a hook-resolved connector, which is the correct rendering of
  `is_connected`: the hook is a deployment-level presence probe, so it can
  support `can_attach`'s deliberately loose "credentials will plausibly resolve"
  but not a checkmark asserting that a credential exists.
- The tests for the two dialogs live in `frontend/src/components/mcp/`, which
  none of the frontend job's six launchers covers, so they are maintained and
  run locally (`npx vitest run --config vitest.config.ts src/components/mcp`)
  rather than in CI. Wiring in a whole new directory like that one is a
  repository-level policy choice, left to be decided separately. The new
  `src/app/tools/page.test.tsx` cases do run in CI via `test:app-pages`.
- `src/lib/team-sharing-sanitizers.test.ts` had the same kind of gap: it
  predates this PR and sat in no frontend CI lane, so the blocking fix from
  the previous review round ran only locally, through the ad hoc command shown
  in Verification above. This round adds it to the existing
  `test:home-build-contracts` lane, and adds two more assertions to it
  (`sanitizeConnectorStatus(undefined)` and `sanitizeConnectorStatus([1, 2])`,
  both dropping to `{}`). That fix also shows the note above about
  `components/mcp` overstated the general cost of wiring a file into CI:
  adding a file to an *existing* lane costs two synced edits — the file list
  in `package.json` and the mirrored constant in
  `src/ci/frontend-test-manifest.test.ts` — and does not touch `ci.yml` at
  all. A brand-new lane, such as one for `components/mcp`, would still need
  both a `package.json` script and a `ci.yml` step.
- This round also strengthens the Tools-page malformed-status coverage. The
  existing case asserted only that the three badge labels were absent, which
  is true whether or not the sanitizer runs — a rejected entry and a
  never-populated one both leave `app.shared` undefined. Added an assertion on
  the share button's own label, which does distinguish the two: it reads
  `app.shared` for truthiness, so bypassing the sanitizer would flip it to
  "Unshare". A second case pins the same thing for a non-boolean
  `needs_config` with otherwise well-formed `shared` / `is_owner`, confirming
  rejection is entry-wide rather than per-field. Both new assertions were
  checked by temporarily reading the raw table entry in place of the
  sanitized call at `page.tsx`'s dialog-construction site: both went red on
  the button assertion, then the call was restored.
- #1403 overlaps this on one population. It closes #1387 — a team-shared
  *catalog* connector, which carries no `server_id` until connected, so its
  sharing status cannot be fetched at all; that genuinely needs the new backend
  field it adds. It also emits that field for local entries and renders a second,
  hardcoded "Team tool" badge next to this one, so for a team-shared local
  `mcp_oauth` connector the two changes address the same visible symptom by
  different means. They are not equivalent: that badge reads no `is_owner` term,
  so it can only ever print one of the three labels, and it does not touch the
  detail dialog. If both land, whichever is second should drop the redundant
  badge.
- The three-way label is spelled out at three call sites. With all three gates
  now agreeing in shape, extracting one helper becomes possible; left out here so
  this change stays to the sites that carried the defect.
- `app/tools/page.tsx` still assigns the sharing response into state unvalidated
  and its own card badge still shows "Private" when the status is unanswered.
  Only the value path feeding the detail dialog is normalized here.

Closes #1623

