### PR TITLE
fix(trace): cap event payload rendering in ConsoleTraceHandler

### DIFF
--- a/example.env
+++ b/example.env
@@ -423,7 +423,9 @@ LANGFUSE_SECRET_KEY="secret key"
 # Per-field byte cap for the LLM I/O audit trace written to trace_events
 # (data.messages / data.response / etc.). Anything larger is truncated with a
 # "[truncated N chars]" suffix. A long DAG task hitting all audit sites can
-# otherwise write multi-MB rows. Default: 50000 (~50KB).
+# otherwise write multi-MB rows. Also bounds the rendered size of every
+# trace category's console log line (not just LLM audit events). Default:
+# 50000 (~50KB).
 # XAGENT_MAX_TRACE_PAYLOAD_BYTES="50000"
 
 # Web Search API Keys

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -2809,9 +2809,10 @@ def get_max_trace_payload_bytes() -> int:
     """Max byte size for individual trace payload fields (e.g. data.messages,
     data.response) before truncation.
 
-    Applies to the LLM I/O audit trace added in fix/llm-trace-coverage. A
-    long DAG task hitting all 9 audit sites can otherwise write multi-MB
-    rows into trace_events.
+    Applies to the LLM I/O audit trace: a long DAG task hitting all 9 audit
+    sites can otherwise write multi-MB rows into trace_events. Also bounds
+    the rendered size of every trace category's console log line, not only
+    LLM audit events.
 
     Priority:
         1. XAGENT_MAX_TRACE_PAYLOAD_BYTES env var

--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -890,6 +890,11 @@ _LOG_SCALAR_COST = 16
 _QUOTE_COST = 2
 
 
+def _rendered_width(text: str) -> int:
+    """UTF-8 byte width of ``text`` as it will appear in the rendered log."""
+    return len(text.encode("utf-8", errors="replace"))
+
+
 def _shrink_within_budget(value: Any, budget: int) -> Any:
     """Copy ``value`` while spending a single shared byte budget.
 
@@ -926,7 +931,7 @@ def _shrink_node(value: Any, remaining: List[int], depth: int) -> Any:
         return _LOG_BUDGET_SPENT
     if depth >= _MAX_TRACE_DEPTH:
         too_deep = f"...[truncated: depth exceeds {_MAX_TRACE_DEPTH}]"
-        remaining[0] -= len(too_deep) + _QUOTE_COST
+        remaining[0] -= _rendered_width(too_deep) + _QUOTE_COST
         return too_deep
 
     if isinstance(value, str):
@@ -943,7 +948,7 @@ def _shrink_node(value: Any, remaining: List[int], depth: int) -> Any:
             "utf-8", errors="ignore"
         )
         marked = f"{head}...[truncated {len(value) - len(head)} chars]"
-        remaining[0] -= len(marked.encode("utf-8")) + _QUOTE_COST
+        remaining[0] -= _rendered_width(marked) + _QUOTE_COST
         return marked
 
     if isinstance(value, dict):
@@ -953,7 +958,7 @@ def _shrink_node(value: Any, remaining: List[int], depth: int) -> Any:
             if remaining[0] <= 0:
                 shrunk[_LOG_OMITTED_KEYS_KEY] = f"{len(value) - len(shrunk)} more keys"
                 break
-            remaining[0] -= len(f"{key!r}: , ")
+            remaining[0] -= _rendered_width(f"{key!r}: , ")
             shrunk[key] = _shrink_node(item, remaining, depth + 1)
         return shrunk
 
@@ -1007,9 +1012,13 @@ def _render_event_data_for_log(data: Any, max_bytes: Optional[int] = None) -> st
         return f"{data}"
 
     rendered = f"{_shrink_within_budget(data, max_bytes)}"
-    if len(rendered) <= max_bytes:
+    encoded = rendered.encode("utf-8", errors="replace")
+    if len(encoded) <= max_bytes:
         return rendered
-    return f"{rendered[:max_bytes]}...[truncated {len(rendered) - max_bytes} chars]"
+    # Slice on a byte boundary and drop an incomplete trailing multi-byte
+    # char, matching the string-leaf truncation above.
+    head = encoded[:max_bytes].decode("utf-8", errors="ignore")
+    return f"{head}...[truncated {len(rendered) - len(head)} chars]"
 
 
 class ConsoleTraceHandler(BaseTraceHandler):

--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -6,7 +6,7 @@ import logging
 from abc import ABC, abstractmethod
 from datetime import datetime, timezone
 from enum import Enum
-from typing import Any, Callable, Dict, List, Optional, cast
+from typing import Any, Callable, Dict, List, Optional, Set, cast
 from uuid import uuid4
 
 from ..utils.security import redact_sensitive_text
@@ -594,10 +594,14 @@ def normalize_llm_trace_payload(
     return out
 
 
-# Bound on recursion depth inside `_trim_subtree`. LLM payloads we care
-# about (messages[*].content, tool_calls) nest at most 4-5 levels; 50 is
-# well above that and well below Python's default 1000-frame limit, so a
-# pathological payload can't blow the stack via this helper.
+# Bound on recursion depth for both walks that share it: `_trim_subtree`
+# (per-leaf budget, LLM payloads) and `_shrink_node` (shared budget,
+# console log line). LLM payloads nest at most 4-5 levels
+# (messages[*].content, tool_calls); checkpoint snapshots handed to the
+# console renderer nest deeper (snapshot.context.messages[*].context_refs[*]),
+# which is why one bound covers both. 50 is well above both profiles and
+# well below Python's default 1000-frame limit, so a pathological payload
+# can't blow the stack via either helper.
 _MAX_TRACE_DEPTH = 50
 
 
@@ -882,17 +886,55 @@ class BaseTraceHandler(TraceHandler):
 _LOG_BUDGET_SPENT = "...[truncated: log budget exhausted]"
 _LOG_OMITTED_KEYS_KEY = "__omitted_keys__"
 
-# Nominal budget charged per non-container leaf. Roughly the rendered
-# width of a small number or ``None`` plus its separator.
-_LOG_SCALAR_COST = 16
+# Stands in for a container that is already on the current walk path.
+# ``repr`` marks a back-reference with ``{...}``; this walk rebuilds
+# containers by hand, so it needs a marker of its own.
+_LOG_CYCLE_MARKER = "...[cyclic reference]"
 
-# Quotes a rendered repr puts around a nested string.
-_QUOTE_COST = 2
+# Budget held back from every container so the ``__omitted_keys__`` /
+# ``...[N more items]`` marker that closes a truncated container still fits
+# inside the caller's byte bound. The markers are written after the budget
+# is spent, so without this reserve the shrunk copy overshoots by one
+# marker per ancestor level and the overshoot lands in
+# ``_render_event_data_for_log``'s hard byte cut, which slices mid-value
+# instead of on a container boundary.
+_LOG_CONTAINER_SLACK = 256
+
+# Fit passes for a string leaf that has to be truncated. The slice is taken
+# in raw bytes but charged in rendered bytes, and ``repr`` escaping expands
+# a raw byte by at most 4x (ASCII control chars render as ``\xNN``).
+# Scaling the slice down by the measured expansion ratio converges within
+# three passes when escapes are spread roughly evenly through the string
+# (0 of 7,200 random escape-heavy payloads needed more). A string whose
+# escapes are concentrated in a long run at its head overstates the
+# expansion of the tail, which can take five or six passes to converge;
+# after three the leaf may still overshoot, and the final hard cut in
+# ``_render_event_data_for_log`` bounds the output.
+_LOG_TRUNCATE_FIT_PASSES = 3
 
 
 def _rendered_width(text: str) -> int:
     """UTF-8 byte width of ``text`` as it will appear in the rendered log."""
     return len(text.encode("utf-8", errors="replace"))
+
+
+def _leaf_text(value: Any, depth: int) -> str:
+    """The exact text a leaf contributes to the rendered log line.
+
+    ``_render_event_data_for_log`` renders the whole payload with a single
+    ``f"{...}"``, so a leaf that *is* the payload goes through ``str()`` --
+    a bare string keeps neither quotes nor escapes. Every deeper leaf is
+    rendered by its container's ``repr()``, which adds the quotes and turns
+    a newline into two characters. Charging the wrong one of these is what
+    made a wide scalar container over-truncate and an escape-heavy string
+    container overshoot.
+    """
+    return f"{value}" if depth == 0 else repr(value)
+
+
+def _leaf_width(value: Any, depth: int) -> int:
+    """Rendered byte width of a leaf sitting at ``depth``."""
+    return _rendered_width(_leaf_text(value, depth))
 
 
 def _shrink_within_budget(value: Any, budget: int) -> Any:
@@ -907,8 +949,16 @@ def _shrink_within_budget(value: Any, budget: int) -> Any:
     therefore a bounded rendered length.
 
     Containers are rebuilt with their keys and order intact and leaves are
-    reused as-is, so a payload that fits the budget renders exactly as the
-    original would.
+    reused as-is, and every node is charged what it actually renders as, so
+    a payload whose rendered width leaves ``_LOG_CONTAINER_SLACK`` bytes of
+    the budget unspent renders exactly as the original would. The reserve
+    is what the omission markers are written out of; a payload that fills
+    the budget to within that reserve loses its last few entries to a
+    marker instead.
+
+    Cycles are not expanded: a container that points back at one of its own
+    ancestors becomes ``_LOG_CYCLE_MARKER``. The same acyclic subtree
+    referenced from two places is still rendered in both.
 
     Args:
         value: Original event payload.
@@ -917,67 +967,138 @@ def _shrink_within_budget(value: Any, budget: int) -> Any:
     Returns:
         The original value or a bounded copy of it.
     """
-    remaining = [budget]
-    return _shrink_node(value, remaining, 0)
+    # Capped at 1/8 of the budget so a small configured budget (e.g.
+    # XAGENT_MAX_TRACE_PAYLOAD_BYTES=200) doesn't have most of its bytes
+    # eaten by the reserve before any payload data gets a chance to render.
+    # At the default 50,000 this is a no-op: min(256, 6,250) is 256.
+    slack = min(_LOG_CONTAINER_SLACK, max(0, budget // 8))
+    return _shrink_node(value, [budget], 0, set(), slack)
 
 
-def _shrink_node(value: Any, remaining: List[int], depth: int) -> Any:
+def _shrink_string_leaf(
+    value: str, remaining: List[int], depth: int, slack: int
+) -> str:
+    """Charge a string leaf its rendered width, truncating it if it doesn't fit.
+
+    The leaf is charged what it renders as, ``repr`` escaping included, so a
+    container of escape-heavy strings -- tracebacks, code snippets -- stays
+    within the budget when escapes are spread through the string; a long
+    escape run concentrated at the head can defeat the refit loop and falls
+    to the final hard cut (see ``_LOG_TRUNCATE_FIT_PASSES``). A nested leaf
+    leaves ``slack``
+    bytes behind for its ancestors' omission markers; a top-level leaf is
+    the whole log line, so nothing can follow it and it may spend
+    everything.
+    """
+    spendable = remaining[0] if depth == 0 else remaining[0] - slack
+    width = _leaf_width(value, depth)
+    if width <= spendable:
+        remaining[0] -= width
+        return value
+
+    # The slice is taken in raw bytes but charged in rendered bytes, so
+    # measure the marked result and scale the slice down until it fits.
+    # Slicing on a byte boundary and decoding with errors="ignore" drops an
+    # incomplete trailing multi-byte char, so the reported char count stays
+    # accurate.
+    encoded = value.encode("utf-8", errors="replace")
+    marker_slack = min(30, max(8, spendable // 4))
+    allowance = max(0, spendable - marker_slack)
+    # The slice can never usefully exceed the string's own byte length --
+    # without this cap, a string shorter than ``allowance`` (rendered width
+    # inflated past the budget by repr escaping alone) starts the fit loop
+    # with a slice that cuts nothing, wasting a pass on a no-op and, worse,
+    # tacking a "...[truncated 0 chars]" marker onto the untouched string.
+    cut = min(allowance, len(encoded))
+    marked = ""
+    for _ in range(_LOG_TRUNCATE_FIT_PASSES):
+        head = encoded[:cut].decode("utf-8", errors="ignore")
+        marked = f"{head}...[truncated {len(value) - len(head)} chars]"
+        marked_width = _leaf_width(marked, depth)
+        if marked_width <= spendable or cut == 0:
+            break
+        cut = min(len(encoded), max(0, (cut * allowance) // marked_width))
+    remaining[0] -= _leaf_width(marked, depth)
+    return marked
+
+
+def _shrink_node(
+    value: Any,
+    remaining: List[int],
+    depth: int,
+    seen: Set[int],
+    slack: int,
+) -> Any:
     """Recursive worker for :func:`_shrink_within_budget`.
 
     ``remaining`` is a single-element list used as a mutable counter so
-    every branch of the walk draws from the same budget.
+    every branch of the walk draws from the same budget. ``seen`` holds the
+    ids of the containers on the path from the root to here -- ids go in on
+    the way down and come out on the way up -- so a back-reference is
+    replaced by a marker while a shared acyclic subtree is still rendered
+    at each of its positions. ``slack`` is the budget held back for the
+    omission markers.
     """
     if remaining[0] <= 0:
         return _LOG_BUDGET_SPENT
     if depth >= _MAX_TRACE_DEPTH:
         too_deep = f"...[truncated: depth exceeds {_MAX_TRACE_DEPTH}]"
-        remaining[0] -= _rendered_width(too_deep) + _QUOTE_COST
+        remaining[0] -= _leaf_width(too_deep, depth)
         return too_deep
 
     if isinstance(value, str):
-        # ``_QUOTE_COST`` accounts for the quotes the rendered repr adds
-        # around a nested string; without it a container of many short
-        # strings renders a few hundred bytes over the budget.
-        encoded = value.encode("utf-8", errors="replace")
-        if len(encoded) + _QUOTE_COST <= remaining[0]:
-            remaining[0] -= len(encoded) + _QUOTE_COST
-            return value
-        # Slice on a byte boundary and drop an incomplete trailing
-        # multi-byte char, so the reported char count stays accurate.
-        head = encoded[: max(0, remaining[0] - _QUOTE_COST)].decode(
-            "utf-8", errors="ignore"
-        )
-        marked = f"{head}...[truncated {len(value) - len(head)} chars]"
-        remaining[0] -= _rendered_width(marked) + _QUOTE_COST
-        return marked
+        return _shrink_string_leaf(value, remaining, depth, slack)
 
     if isinstance(value, dict):
+        node_id = id(value)
+        if node_id in seen:
+            remaining[0] -= _leaf_width(_LOG_CYCLE_MARKER, depth)
+            return _LOG_CYCLE_MARKER
+        seen.add(node_id)
         shrunk: Dict[Any, Any] = {}
         remaining[0] -= 2  # rendered braces
         for key, item in value.items():
-            if remaining[0] <= 0:
-                shrunk[_LOG_OMITTED_KEYS_KEY] = f"{len(value) - len(shrunk)} more keys"
+            key_cost = _rendered_width(f"{key!r}: , ")
+            # A key is charged in full and can't be truncated, so decide
+            # before spending: stopping here instead of after keeps the copy
+            # inside the budget even when one key is wider than what's left.
+            if remaining[0] - key_cost <= slack:
+                # Don't clobber a real payload key that happens to carry the
+                # sentinel's name -- the omission count is worth less than
+                # the data it would overwrite.
+                if _LOG_OMITTED_KEYS_KEY not in shrunk:
+                    shrunk[_LOG_OMITTED_KEYS_KEY] = (
+                        f"{len(value) - len(shrunk)} more keys"
+                    )
                 break
-            remaining[0] -= _rendered_width(f"{key!r}: , ")
-            shrunk[key] = _shrink_node(item, remaining, depth + 1)
+            remaining[0] -= key_cost
+            shrunk[key] = _shrink_node(item, remaining, depth + 1, seen, slack)
+        seen.discard(node_id)
         return shrunk
 
     if isinstance(value, list):
+        node_id = id(value)
+        if node_id in seen:
+            remaining[0] -= _leaf_width(_LOG_CYCLE_MARKER, depth)
+            return _LOG_CYCLE_MARKER
+        seen.add(node_id)
         items: List[Any] = []
         remaining[0] -= 2  # rendered brackets
         for item in value:
-            if remaining[0] <= 0:
+            if remaining[0] - 2 <= slack:
                 items.append(f"...[{len(value) - len(items)} more items]")
                 break
             remaining[0] -= 2  # rendered separator
-            items.append(_shrink_node(item, remaining, depth + 1))
+            items.append(_shrink_node(item, remaining, depth + 1, seen, slack))
+        seen.discard(node_id)
         return items
 
-    # Numbers, bools, None and anything else: reused as-is, charged a
-    # nominal cost so a wide container of scalars still exhausts the
-    # budget. An unusually long repr is caught by the final string cap in
-    # ``_render_event_data_for_log``.
-    remaining[0] -= _LOG_SCALAR_COST
+    # Numbers, bools, None and anything else: reused as-is and charged what
+    # they render as, so a wide container of scalars spends the budget at
+    # the rate the log line actually grows. A single leaf whose repr is
+    # wider than the whole budget is still left alone here and caught by the
+    # final string cap in ``_render_event_data_for_log``.
+    remaining[0] -= _leaf_width(value, depth)
     return value
 
 

--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -1039,6 +1039,14 @@ def _shrink_node(
     at each of its positions. ``slack`` is the budget held back for the
     omission markers.
     """
+    # Unreachable through the current call graph: the top-level call from
+    # _shrink_within_budget only runs when _render_event_data_for_log has
+    # already rejected max_bytes <= 0, so the root starts with
+    # remaining[0] > 0; and every recursive call from the dict/list
+    # branches below only fires after checking remaining[0] - cost > slack
+    # (slack >= 0) and then deducting cost, so remaining[0] is still > 0
+    # at the callee's entry. Kept as a guard for a future direct caller of
+    # _shrink_within_budget that passes a non-positive budget.
     if remaining[0] <= 0:
         return _LOG_BUDGET_SPENT
     if depth >= _MAX_TRACE_DEPTH:

--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -879,31 +879,170 @@ class BaseTraceHandler(TraceHandler):
         pass
 
 
+_LOG_BUDGET_SPENT = "...[truncated: log budget exhausted]"
+_LOG_OMITTED_KEYS_KEY = "__omitted_keys__"
+
+# Nominal budget charged per non-container leaf. Roughly the rendered
+# width of a small number or ``None`` plus its separator.
+_LOG_SCALAR_COST = 16
+
+# Quotes a rendered repr puts around a nested string.
+_QUOTE_COST = 2
+
+
+def _shrink_within_budget(value: Any, budget: int) -> Any:
+    """Copy ``value`` while spending a single shared byte budget.
+
+    ``truncate_for_trace`` gives every leaf its own slice of the budget,
+    so its result still grows with the number of leaves: a payload with a
+    few thousand message entries stays in the hundreds of kilobytes even
+    after per-leaf trimming. Here the budget is shared across the whole
+    walk instead — once it is spent, the remaining keys and list items are
+    replaced by a short marker — so the copy has a bounded node count and
+    therefore a bounded rendered length.
+
+    Containers are rebuilt with their keys and order intact and leaves are
+    reused as-is, so a payload that fits the budget renders exactly as the
+    original would.
+
+    Args:
+        value: Original event payload.
+        budget: Total byte budget for the whole subtree; must be > 0.
+
+    Returns:
+        The original value or a bounded copy of it.
+    """
+    remaining = [budget]
+    return _shrink_node(value, remaining, 0)
+
+
+def _shrink_node(value: Any, remaining: List[int], depth: int) -> Any:
+    """Recursive worker for :func:`_shrink_within_budget`.
+
+    ``remaining`` is a single-element list used as a mutable counter so
+    every branch of the walk draws from the same budget.
+    """
+    if remaining[0] <= 0:
+        return _LOG_BUDGET_SPENT
+    if depth >= _MAX_TRACE_DEPTH:
+        too_deep = f"...[truncated: depth exceeds {_MAX_TRACE_DEPTH}]"
+        remaining[0] -= len(too_deep) + _QUOTE_COST
+        return too_deep
+
+    if isinstance(value, str):
+        # ``_QUOTE_COST`` accounts for the quotes the rendered repr adds
+        # around a nested string; without it a container of many short
+        # strings renders a few hundred bytes over the budget.
+        encoded = value.encode("utf-8", errors="replace")
+        if len(encoded) + _QUOTE_COST <= remaining[0]:
+            remaining[0] -= len(encoded) + _QUOTE_COST
+            return value
+        # Slice on a byte boundary and drop an incomplete trailing
+        # multi-byte char, so the reported char count stays accurate.
+        head = encoded[: max(0, remaining[0] - _QUOTE_COST)].decode(
+            "utf-8", errors="ignore"
+        )
+        marked = f"{head}...[truncated {len(value) - len(head)} chars]"
+        remaining[0] -= len(marked.encode("utf-8")) + _QUOTE_COST
+        return marked
+
+    if isinstance(value, dict):
+        shrunk: Dict[Any, Any] = {}
+        remaining[0] -= 2  # rendered braces
+        for key, item in value.items():
+            if remaining[0] <= 0:
+                shrunk[_LOG_OMITTED_KEYS_KEY] = f"{len(value) - len(shrunk)} more keys"
+                break
+            remaining[0] -= len(f"{key!r}: , ")
+            shrunk[key] = _shrink_node(item, remaining, depth + 1)
+        return shrunk
+
+    if isinstance(value, list):
+        items: List[Any] = []
+        remaining[0] -= 2  # rendered brackets
+        for item in value:
+            if remaining[0] <= 0:
+                items.append(f"...[{len(value) - len(items)} more items]")
+                break
+            remaining[0] -= 2  # rendered separator
+            items.append(_shrink_node(item, remaining, depth + 1))
+        return items
+
+    # Numbers, bools, None and anything else: reused as-is, charged a
+    # nominal cost so a wide container of scalars still exhausts the
+    # budget. An unusually long repr is caught by the final string cap in
+    # ``_render_event_data_for_log``.
+    remaining[0] -= _LOG_SCALAR_COST
+    return value
+
+
+def _render_event_data_for_log(data: Any, max_bytes: Optional[int] = None) -> str:
+    """Render ``event.data`` into a size-bounded string for console logging.
+
+    This is the log-rendering sink only. Trace payloads are not capped per
+    category at the tracer boundary (only LLM events go through
+    ``normalize_llm_trace_payload``), and checkpoint events carry a full
+    execution snapshot, so interpolating ``event.data`` straight into a log
+    line produces multi-megabyte lines on long-context tasks.
+
+    Persistence paths must keep the full payload — truncating a durable
+    checkpoint record would break task recovery — so the bound lives here,
+    at the point where the string is built, and nowhere else.
+
+    Args:
+        data: The event payload to render.
+        max_bytes: Byte bound for the rendered string. When ``None``, reads
+            ``XAGENT_MAX_TRACE_PAYLOAD_BYTES`` (default 50_000, 0 disables).
+
+    Returns:
+        A string no longer than ``max_bytes`` plus a truncation marker.
+    """
+    if max_bytes is None:
+        # Local import to avoid circular dependency at module load
+        from ...config import get_max_trace_payload_bytes
+
+        max_bytes = get_max_trace_payload_bytes()
+
+    if max_bytes <= 0:
+        return f"{data}"
+
+    rendered = f"{_shrink_within_budget(data, max_bytes)}"
+    if len(rendered) <= max_bytes:
+        return rendered
+    return f"{rendered[:max_bytes]}...[truncated {len(rendered) - max_bytes} chars]"
+
+
 class ConsoleTraceHandler(BaseTraceHandler):
-    """Trace handler that logs events to console with clear scope information."""
+    """Trace handler that logs events to console with clear scope information.
+
+    Payloads are rendered through ``_render_event_data_for_log`` so a large
+    event (a checkpoint snapshot, for instance) cannot turn into a
+    multi-megabyte log line. This handler is observational only; the
+    persistence handlers keep the untrimmed payload.
+    """
 
     async def _handle_task_event(self, event: TraceEvent) -> None:
         """Handle task-level events."""
         logger.info(
-            f"[TASK] {event.event_type.action.value.upper()} {event.event_type.category.value.upper()} - Task {event.task_id} - {event.data}"
+            f"[TASK] {event.event_type.action.value.upper()} {event.event_type.category.value.upper()} - Task {event.task_id} - {_render_event_data_for_log(event.data)}"
         )
 
     async def _handle_step_event(self, event: TraceEvent) -> None:
         """Handle step-level events."""
         logger.info(
-            f"[STEP] {event.event_type.action.value.upper()} {event.event_type.category.value.upper()} - Step {event.step_id} - {event.data}"
+            f"[STEP] {event.event_type.action.value.upper()} {event.event_type.category.value.upper()} - Step {event.step_id} - {_render_event_data_for_log(event.data)}"
         )
 
     async def _handle_action_event(self, event: TraceEvent) -> None:
         """Handle action-level events."""
         logger.info(
-            f"[ACTION] {event.event_type.action.value.upper()} {event.event_type.category.value.upper()} - Step {event.step_id} - {event.data}"
+            f"[ACTION] {event.event_type.action.value.upper()} {event.event_type.category.value.upper()} - Step {event.step_id} - {_render_event_data_for_log(event.data)}"
         )
 
     async def _handle_system_event(self, event: TraceEvent) -> None:
         """Handle system-level events."""
         logger.info(
-            f"[SYSTEM] {event.event_type.action.value.upper()} {event.event_type.category.value.upper()} - {event.data}"
+            f"[SYSTEM] {event.event_type.action.value.upper()} {event.event_type.category.value.upper()} - {_render_event_data_for_log(event.data)}"
         )
 
 

--- a/src/xagent/core/agent/trace.py
+++ b/src/xagent/core/agent/trace.py
@@ -1117,8 +1117,11 @@ def _render_event_data_for_log(data: Any, max_bytes: Optional[int] = None) -> st
 
     Args:
         data: The event payload to render.
-        max_bytes: Byte bound for the rendered string. When ``None``, reads
-            ``XAGENT_MAX_TRACE_PAYLOAD_BYTES`` (default 50_000, 0 disables).
+        max_bytes: Byte bound for the rendered string. A value of 0 or
+            less disables truncation. When ``None``, reads
+            ``XAGENT_MAX_TRACE_PAYLOAD_BYTES`` (default 50_000; that path
+            accepts 0 to disable but rejects negatives, falling back to
+            the default).
 
     Returns:
         A string no longer than ``max_bytes`` plus a truncation marker.

--- a/tests/core/agent/pattern/test_llm_trace_audit.py
+++ b/tests/core/agent/pattern/test_llm_trace_audit.py
@@ -785,7 +785,8 @@ def test_render_event_data_bounds_multi_megabyte_checkpoint(
     out = _render_event_data_for_log(payload, max_bytes=50_000)
 
     # Slack covers the trailing "...[truncated N chars]" marker.
-    assert len(out) <= 50_000 + 100, f"log render not bounded: {len(out)}"
+    out_bytes = len(out.encode("utf-8"))
+    assert out_bytes <= 50_000 + 100, f"log render not bounded: {out_bytes}"
     assert out.startswith("{'checkpoint_type': 'step_complete'")
 
 
@@ -809,11 +810,110 @@ def test_render_event_data_bounds_wide_dict() -> None:
     assert len(f"{truncate_for_trace(payload, max_bytes=50_000)}") > 1_000_000
 
     out = _render_event_data_for_log(payload, max_bytes=50_000)
-    assert len(out) <= 50_000 + 100, f"log render not bounded: {len(out)}"
+    out_bytes = len(out.encode("utf-8"))
+    assert out_bytes <= 50_000 + 100, f"log render not bounded: {out_bytes}"
 
     # The dropped keys are accounted for, not silently swallowed.
     shrunk = _shrink_within_budget(payload, 50_000)
     assert "more keys" in shrunk["snapshot"]["__omitted_keys__"]
+
+
+def _chinese_step_results_payload(n_steps: int, id_len: int) -> Dict[str, Any]:
+    """A checkpoint-shaped payload with Chinese plan step ids as dict keys.
+
+    Mirrors ``step_results`` in a real execution checkpoint, where each key
+    is the plan's own step id — often a short Chinese phrase — rather than
+    an ASCII index.
+    """
+    return {
+        "checkpoint_type": "step_complete",
+        "step_results": {
+            f"步骤{i}-{'验证与执行' * id_len}": {
+                "status": "done",
+                "output": "结果" * 50,
+            }
+            for i in range(n_steps)
+        },
+    }
+
+
+def test_render_event_data_bounds_wide_chinese_keyed_dict() -> None:
+    """A dict with many Chinese keys must stay within the byte budget.
+
+    ``_shrink_node`` charges each dict key's rendered width with
+    ``len(f"{key!r}: , ")``, which counts Python characters, not the UTF-8
+    bytes the log line actually spends once encoded. Before the fix this
+    payload rendered 144,594 bytes against a 50,000 byte budget — a 189%
+    overrun — because every 200-character Chinese key was charged as if it
+    cost 200 bytes when it actually costs about 600.
+
+    ``_shrink_within_budget`` is asserted on directly (not only through
+    ``_render_event_data_for_log``) because the final hard byte-cut in
+    ``_render_event_data_for_log`` bounds total output size on its own —
+    it would mask a regression in the per-key accounting. Checking the
+    shrink step's own output is what actually pins the accounting fix.
+    """
+    from xagent.core.agent.trace import (
+        _render_event_data_for_log,
+        _shrink_within_budget,
+    )
+
+    payload = {f"键{i}" + "中" * 200: "v" for i in range(3_000)}
+
+    shrunk = _shrink_within_budget(payload, 50_000)
+    shrunk_bytes = len(f"{shrunk}".encode("utf-8"))
+    assert shrunk_bytes <= 50_000 + 1_000, (
+        f"per-key byte accounting broken: {shrunk_bytes}"
+    )
+
+    out = _render_event_data_for_log(payload, max_bytes=50_000)
+    out_bytes = len(out.encode("utf-8"))
+    assert out_bytes <= 50_000 + 100, f"log render not bounded: {out_bytes}"
+
+
+def test_render_event_data_bounds_chinese_step_results_checkpoint() -> None:
+    """A checkpoint-shaped payload with Chinese plan step ids as dict keys
+    renders within the byte budget end to end, matching the shape a real
+    execution checkpoint produces once a plan's step ids are Chinese text.
+    """
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    payload = _chinese_step_results_payload(n_steps=800, id_len=8)
+
+    out = _render_event_data_for_log(payload, max_bytes=50_000)
+    out_bytes = len(out.encode("utf-8"))
+    assert out_bytes <= 50_000 + 100, f"log render not bounded: {out_bytes}"
+
+
+def test_render_event_data_bounds_chinese_tuple_payload() -> None:
+    """Tuples are not walked by ``_shrink_node`` — only str/dict/list are —
+    so they pass through unshrunk and the final byte-domain hard cut in
+    ``_render_event_data_for_log`` is the only thing bounding them.
+
+    Before the fix this payload rendered 135,743 bytes against a 50,000
+    byte budget because the cap sliced with ``rendered[:max_bytes]``, a
+    Python character offset, instead of a UTF-8 byte offset.
+    """
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    payload = tuple("中文内容测试" * 4 for _ in range(20_000))
+
+    out = _render_event_data_for_log(payload, max_bytes=50_000)
+    out_bytes = len(out.encode("utf-8"))
+    assert out_bytes <= 50_000 + 100, f"log render not bounded: {out_bytes}"
+
+
+def test_render_event_data_bounds_chinese_set_payload() -> None:
+    """Sets take the same unshrunk path as tuples, so the byte-domain hard
+    cut must bound them too.
+    """
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    payload = {f"中文集合元素{i}" * 4 for i in range(20_000)}
+
+    out = _render_event_data_for_log(payload, max_bytes=50_000)
+    out_bytes = len(out.encode("utf-8"))
+    assert out_bytes <= 50_000 + 100, f"log render not bounded: {out_bytes}"
 
 
 @pytest.mark.parametrize(
@@ -878,5 +978,6 @@ async def test_console_handler_caps_every_scope(
 
     assert len(caplog.records) == 1
     message = caplog.records[0].getMessage()
-    assert len(message) <= 50_000 + 200, f"log line not bounded: {len(message)}"
+    message_bytes = len(message.encode("utf-8"))
+    assert message_bytes <= 50_000 + 200, f"log line not bounded: {message_bytes}"
     assert "[truncated" in message

--- a/tests/core/agent/pattern/test_llm_trace_audit.py
+++ b/tests/core/agent/pattern/test_llm_trace_audit.py
@@ -708,3 +708,175 @@ class _RecordingTracer:
             }
         )
         return "evt"
+
+
+# ---------------------------------------------------------------------------
+# ConsoleTraceHandler log-render cap
+# ---------------------------------------------------------------------------
+
+
+def _checkpoint_payload(n_messages: int, chars_per_message: int) -> Dict[str, Any]:
+    """A checkpoint-shaped payload: bulky content nested under ``snapshot``.
+
+    Mirrors what ``TraceCheckpointStore`` emits — the top-level keys carry
+    no truncatable field name, so the LLM-payload normalizer leaves this
+    shape untouched and the console renderer is the only thing standing
+    between it and the log line.
+    """
+    return {
+        "checkpoint_type": "step_complete",
+        "sequence": 42,
+        "snapshot": {
+            "task_id": 12345,
+            "context": {
+                "messages": [
+                    {"role": "assistant", "content": "y" * chars_per_message}
+                    for _ in range(n_messages)
+                ],
+                "variables": {"scratch": "z" * chars_per_message},
+            },
+        },
+    }
+
+
+def test_render_event_data_small_payload_unchanged() -> None:
+    """A payload inside the budget renders exactly as plain interpolation."""
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    payload = {
+        "step": 3,
+        "status": "running",
+        "tool": "search",
+        "args": {"q": "hello"},
+        "history": [1, 2, [3, 4]],
+    }
+    assert _render_event_data_for_log(payload, max_bytes=50_000) == f"{payload}"
+
+
+def test_render_event_data_multibyte_small_payload_unchanged() -> None:
+    """Multi-byte content inside the budget is not sliced."""
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    payload = {"content": "中文测试" * 20}
+    assert _render_event_data_for_log(payload, max_bytes=50_000) == f"{payload}"
+
+
+@pytest.mark.parametrize(
+    "n_messages,chars_per_message",
+    [
+        (20, 200_000),  # few very large messages
+        (2_000, 2_000),  # many medium messages
+        (50_000, 100),  # very wide message list
+    ],
+)
+def test_render_event_data_bounds_multi_megabyte_checkpoint(
+    n_messages: int, chars_per_message: int
+) -> None:
+    """Multi-MB checkpoint payloads render within the cap.
+
+    Covers the shape ``truncate_for_trace`` alone cannot bound: it splits
+    the budget per leaf, so a wide message list still renders megabytes.
+    """
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    payload = _checkpoint_payload(n_messages, chars_per_message)
+    assert len(f"{payload}") > 500_000, "fixture should be far over the cap"
+
+    out = _render_event_data_for_log(payload, max_bytes=50_000)
+
+    # Slack covers the trailing "...[truncated N chars]" marker.
+    assert len(out) <= 50_000 + 100, f"log render not bounded: {len(out)}"
+    assert out.startswith("{'checkpoint_type': 'step_complete'")
+
+
+def test_render_event_data_bounds_wide_dict() -> None:
+    """Key-count explosion is bounded too: the budget is shared, so the
+    remaining keys collapse into one marker instead of each getting a
+    minimum slice of their own.
+
+    ``truncate_for_trace`` cannot do this — its per-leaf split gives every
+    one of the 100k keys a floor of its own, so its output stays in the
+    megabytes.
+    """
+    from xagent.core.agent.trace import (
+        _render_event_data_for_log,
+        _shrink_within_budget,
+        truncate_for_trace,
+    )
+
+    payload = {"snapshot": {f"k{i}": "v" * 200 for i in range(100_000)}}
+
+    assert len(f"{truncate_for_trace(payload, max_bytes=50_000)}") > 1_000_000
+
+    out = _render_event_data_for_log(payload, max_bytes=50_000)
+    assert len(out) <= 50_000 + 100, f"log render not bounded: {len(out)}"
+
+    # The dropped keys are accounted for, not silently swallowed.
+    shrunk = _shrink_within_budget(payload, 50_000)
+    assert "more keys" in shrunk["snapshot"]["__omitted_keys__"]
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [None, "plain string", 42, [], {}, object(), {"obj": object()}, ("a", "b")],
+)
+def test_render_event_data_tolerates_unusual_payloads(payload: Any) -> None:
+    """Non-dict and non-serializable payloads render without raising."""
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    assert isinstance(_render_event_data_for_log(payload, max_bytes=50_000), str)
+
+
+def test_render_event_data_zero_cap_disables_truncation() -> None:
+    """``XAGENT_MAX_TRACE_PAYLOAD_BYTES=0`` keeps the old behaviour."""
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    payload = _checkpoint_payload(5, 10_000)
+    assert _render_event_data_for_log(payload, max_bytes=0) == f"{payload}"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scope_kwargs",
+    [
+        {"scope": "TASK", "action": "START", "task_id": "t1"},
+        {"scope": "STEP", "action": "UPDATE", "step_id": "s1"},
+        {"scope": "ACTION", "action": "INFO", "step_id": "s1"},
+        {"scope": "SYSTEM", "action": "UPDATE"},
+    ],
+)
+async def test_console_handler_caps_every_scope(
+    scope_kwargs: Dict[str, Any], caplog: pytest.LogCaptureFixture
+) -> None:
+    """All four ConsoleTraceHandler scopes cap the payload they log."""
+    import logging
+
+    from xagent.core.agent.trace import (
+        ConsoleTraceHandler,
+        TraceAction,
+        TraceCategory,
+        TraceEvent,
+        TraceEventType,
+        TraceScope,
+    )
+
+    attribution = dict(scope_kwargs)
+    scope_name = attribution.pop("scope")
+    action_name = attribution.pop("action")
+
+    event_type = TraceEventType(
+        getattr(TraceScope, scope_name),
+        getattr(TraceAction, action_name),
+        TraceCategory.GENERAL,
+    )
+    event = TraceEvent(
+        event_type, data=_checkpoint_payload(2_000, 2_000), **attribution
+    )
+
+    with caplog.at_level(logging.INFO, logger="xagent.core.agent.trace"):
+        await ConsoleTraceHandler().handle_event(event)
+
+    assert len(caplog.records) == 1
+    message = caplog.records[0].getMessage()
+    assert len(message) <= 50_000 + 200, f"log line not bounded: {len(message)}"
+    assert "[truncated" in message

--- a/tests/core/agent/pattern/test_llm_trace_audit.py
+++ b/tests/core/agent/pattern/test_llm_trace_audit.py
@@ -12,7 +12,7 @@ The v2-runtime audit injection (centralized in
 follow-up PR.
 """
 
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
 
 import pytest
 
@@ -885,9 +885,17 @@ def test_render_event_data_bounds_chinese_step_results_checkpoint() -> None:
     assert out_bytes <= 50_000 + 100, f"log render not bounded: {out_bytes}"
 
 
-def test_render_event_data_bounds_chinese_tuple_payload() -> None:
-    """Tuples are not walked by ``_shrink_node`` — only str/dict/list are —
-    so they pass through unshrunk and the final byte-domain hard cut in
+@pytest.mark.parametrize(
+    "payload",
+    [
+        tuple("中文内容测试" * 4 for _ in range(20_000)),
+        {f"中文集合元素{i}" * 4 for i in range(20_000)},
+    ],
+    ids=["tuple", "set"],
+)
+def test_render_event_data_bounds_chinese_unwalked_container(payload: Any) -> None:
+    """Tuples and sets are not walked by ``_shrink_node`` — only str/dict/list
+    are — so they pass through unshrunk and the final byte-domain hard cut in
     ``_render_event_data_for_log`` is the only thing bounding them.
 
     Before the fix this payload rendered 135,743 bytes against a 50,000
@@ -896,35 +904,278 @@ def test_render_event_data_bounds_chinese_tuple_payload() -> None:
     """
     from xagent.core.agent.trace import _render_event_data_for_log
 
-    payload = tuple("中文内容测试" * 4 for _ in range(20_000))
-
-    out = _render_event_data_for_log(payload, max_bytes=50_000)
-    out_bytes = len(out.encode("utf-8"))
-    assert out_bytes <= 50_000 + 100, f"log render not bounded: {out_bytes}"
-
-
-def test_render_event_data_bounds_chinese_set_payload() -> None:
-    """Sets take the same unshrunk path as tuples, so the byte-domain hard
-    cut must bound them too.
-    """
-    from xagent.core.agent.trace import _render_event_data_for_log
-
-    payload = {f"中文集合元素{i}" * 4 for i in range(20_000)}
-
     out = _render_event_data_for_log(payload, max_bytes=50_000)
     out_bytes = len(out.encode("utf-8"))
     assert out_bytes <= 50_000 + 100, f"log render not bounded: {out_bytes}"
 
 
 @pytest.mark.parametrize(
-    "payload",
-    [None, "plain string", 42, [], {}, object(), {"obj": object()}, ("a", "b")],
+    "payload,check",
+    [
+        (None, lambda out: out == "None"),
+        ("plain string", lambda out: out == "plain string"),
+        (42, lambda out: out == "42"),
+        ([], lambda out: out == "[]"),
+        ({}, lambda out: out == "{}"),
+        (
+            object(),
+            lambda out: out.startswith("<object object at ") and out.endswith(">"),
+        ),
+        (
+            {"obj": object()},
+            lambda out: (
+                out.startswith("{'obj': <object object at ") and out.endswith(">}")
+            ),
+        ),
+        (("a", "b"), lambda out: out == "('a', 'b')"),
+    ],
 )
-def test_render_event_data_tolerates_unusual_payloads(payload: Any) -> None:
-    """Non-dict and non-serializable payloads render without raising."""
+def test_render_event_data_tolerates_unusual_payloads(
+    payload: Any, check: Callable[[str], bool]
+) -> None:
+    """Non-dict and non-serializable payloads render to their exact expected
+    text, not just to *some* string.
+
+    A bare payload at depth 0 renders through ``str()`` (no quotes, no
+    escapes); ``object()`` two levels above depth 0 renders through the
+    container's ``repr()``. The ``object()`` cases use ``startswith`` /
+    ``endswith`` because the memory address in the default ``repr`` varies
+    per run.
+    """
     from xagent.core.agent.trace import _render_event_data_for_log
 
-    assert isinstance(_render_event_data_for_log(payload, max_bytes=50_000), str)
+    out = _render_event_data_for_log(payload, max_bytes=50_000)
+    assert check(out), out
+
+
+def test_render_event_data_keeps_wide_scalar_dict_verbatim() -> None:
+    """A dict of many small-int leaves that fits the budget must render
+    byte-identical to plain interpolation.
+
+    Before the fix, the scalar branch charged a flat 16 bytes per leaf
+    regardless of what the leaf actually renders as, so this 45,780-byte
+    payload — inside the 50,000 byte budget — was shrunk down to 23,378
+    bytes with 2,107 keys collapsed into ``__omitted_keys__``.
+    """
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    payload = {i: i for i in range(4_000)}
+    assert len(f"{payload}".encode("utf-8")) == 45_780
+    assert _render_event_data_for_log(payload, max_bytes=50_000) == f"{payload}"
+
+
+def test_render_event_data_keeps_llm_call_records_verbatim() -> None:
+    """The real ``llm_calls`` shape from ``ExecutionContext.to_dict()`` —
+    a list of dicts of six integer fields plus an ISO timestamp string —
+    must render verbatim when it fits the budget.
+
+    Before the fix this 39,918-byte payload was shrunk to 36,267 bytes by
+    the same flat per-leaf charge as the scalar dict case above.
+    """
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    payload = {
+        "checkpoint_type": "step_complete",
+        "snapshot": {
+            "context": {
+                "llm_calls": [
+                    {
+                        "input_tokens": 12_000 + i,
+                        "output_tokens": 300 + i,
+                        "total_tokens": 12_300 + 2 * i,
+                        "message_index": i,
+                        "prompt_message_count": i % 40,
+                        "prompt_content_chars": 48_000 + i,
+                        "timestamp": "2026-08-24T05:33:21.123456+00:00",
+                    }
+                    for i in range(200)
+                ]
+            }
+        },
+    }
+    assert len(f"{payload}".encode("utf-8")) == 39_918
+    assert _render_event_data_for_log(payload, max_bytes=50_000) == f"{payload}"
+
+
+def test_render_event_data_bounds_escape_heavy_strings() -> None:
+    """A dict of many multi-line traceback strings must fit the budget in
+    the shrink step itself, so the final hard cut never fires.
+
+    Before the fix, a string leaf was charged its raw UTF-8 length while
+    the log line renders it through ``repr()`` escaping, so this payload's
+    shrunk copy reached 52,501 bytes against the same 50,000 byte budget
+    and the final hard cut landed in the middle of a string value instead
+    of on a container boundary.
+    """
+    from xagent.core.agent.trace import (
+        _render_event_data_for_log,
+        _shrink_within_budget,
+    )
+
+    traceback_text = (
+        "Traceback (most recent call last):\n"
+        '  File "/a/b/c.py", line 42, in run\n'
+        "    raise ValueError('boom')\n"
+        "ValueError: boom\n"
+    ) * 2
+    payload = {f"e{i}": traceback_text for i in range(400)}
+
+    shrunk = _shrink_within_budget(payload, 50_000)
+    shrunk_bytes = len(f"{shrunk}".encode("utf-8"))
+    assert shrunk_bytes <= 50_000, f"escape-heavy accounting broken: {shrunk_bytes}"
+
+    # No hard cut fired, so the output is exactly the shrunk copy's
+    # rendering -- a truncation marker sliced mid-marker is not possible.
+    out = _render_event_data_for_log(payload, max_bytes=50_000)
+    assert out == f"{shrunk}", "hard cut fired: the shrunk copy overshot the budget"
+
+
+def test_render_event_data_fits_single_leaf_inflated_by_escaping() -> None:
+    """A single string leaf whose raw byte length is well inside the budget
+    but whose ``repr()``-escaped rendering is not must still fit, and the
+    fit loop's first slice must not be wider than the string itself.
+
+    ``"\\x00" * 20_000`` is only 20,000 raw bytes, but every ``\\x00`` repr's
+    as the four-character escape ``\\x00``, so the escaped rendering (about
+    80,000 bytes) is the one that overflows the budget. The fit loop's
+    starting slice was computed from the *budget*, not from the string's
+    own length: when the budget-derived slice was wider than the 20,000
+    raw bytes available, slicing did nothing, and the loop appended a
+    truncation marker reporting 0 chars removed onto the untouched string
+    -- an internally contradictory result that also overshot the budget
+    (the escaped string plus the marker suffix is wider than either alone).
+    """
+    from xagent.core.agent.trace import (
+        _render_event_data_for_log,
+        _shrink_within_budget,
+    )
+
+    payload = {"blob": "\x00" * 20_000, "step": "s3"}
+
+    shrunk = _shrink_within_budget(payload, 50_000)
+    shrunk_bytes = len(f"{shrunk}".encode("utf-8"))
+    assert shrunk_bytes <= 50_000, f"single-leaf accounting broken: {shrunk_bytes}"
+    assert "truncated 0 chars" not in f"{shrunk}", (
+        "marker claims nothing was cut from a leaf that had to be cut"
+    )
+
+    out = _render_event_data_for_log(payload, max_bytes=50_000)
+    assert out == f"{shrunk}", "hard cut fired: the shrunk copy overshot the budget"
+
+
+def test_render_event_data_marks_cyclic_dict() -> None:
+    """A dict that references one of its own ancestors must be replaced by
+    a cycle marker instead of being re-expanded.
+
+    Before the fix there was no cycle detection: this self-referential dict
+    rendered at 967 bytes (plain ``repr()`` renders the same dict at 23
+    bytes, marking the cycle with ``{...}``).
+    """
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    payload: Dict[str, Any] = {"a": 1}
+    payload["self"] = payload
+
+    out = _render_event_data_for_log(payload, max_bytes=50_000)
+    assert "...[cyclic reference]" in out
+    assert len(out.encode("utf-8")) < 200, len(out.encode("utf-8"))
+    assert "depth exceeds" not in out, "cycle should be caught before the depth guard"
+
+
+def test_render_event_data_marks_cyclic_list() -> None:
+    """A list that contains itself must be replaced by a cycle marker.
+
+    Before the fix this rendered at 5,266 bytes instead of being cut short.
+    """
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    payload: List[Any] = ["x" * 100]
+    payload.append(payload)
+
+    out = _render_event_data_for_log(payload, max_bytes=50_000)
+    assert "...[cyclic reference]" in out
+    assert len(out.encode("utf-8")) < 300, len(out.encode("utf-8"))
+
+
+def test_render_event_data_marks_mutually_referencing_dicts() -> None:
+    """Two dicts that reference each other must be replaced by a cycle
+    marker on the back-edge, not re-expanded indefinitely.
+
+    Before the fix this rendered at 1,215 bytes instead of being cut short.
+    """
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    first: Dict[str, Any] = {"name": "a"}
+    second: Dict[str, Any] = {"name": "b", "peer": first}
+    first["peer"] = second
+
+    out = _render_event_data_for_log(first, max_bytes=50_000)
+    assert "...[cyclic reference]" in out
+    assert len(out.encode("utf-8")) < 200, len(out.encode("utf-8"))
+
+
+def test_render_event_data_renders_shared_subtree_at_every_position() -> None:
+    """The same acyclic container referenced from two places is not a
+    cycle -- both positions must render it in full.
+
+    This is the reverse guard for cycle detection: a "visited" set that
+    only ever grows (instead of dropping ids on the way back up) would
+    mistake this shape for a cycle at the second occurrence.
+    """
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    shared = {"x": 1, "y": "hello"}
+    payload = {"first": shared, "second": shared}
+    assert _render_event_data_for_log(payload, max_bytes=50_000) == f"{payload}"
+
+    message = {"role": "user", "content": "hi"}
+    wide = {"messages": [message] * 500, "tail": "END"}
+    out = _render_event_data_for_log(wide, max_bytes=50_000)
+    assert "...[cyclic reference]" not in out
+    assert "'tail'" in out
+
+
+def test_render_event_data_keeps_real_omitted_keys_key() -> None:
+    """A real payload key literally named ``__omitted_keys__`` must survive
+    truncation instead of being overwritten by the omission-count sentinel.
+
+    Real ``event.data`` keys are the tracer's own literals
+    (``checkpoint_type``, ``snapshot``, ``sequence``), so this is a
+    defensive guard against a payload the tracer doesn't control, not a
+    scenario observed in production. Data outranks the omission count: if
+    the sentinel key already holds real payload data, no omission count is
+    reported at all.
+    """
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    payload = {
+        "__omitted_keys__": "REAL DATA",
+        "big": "x" * 100_000,
+        "z": "zz",
+    }
+    out = _render_event_data_for_log(payload, max_bytes=50_000)
+    assert "REAL DATA" in out, "sentinel clobbered a real payload key"
+
+
+@pytest.mark.parametrize(
+    "payload",
+    ["z" * 49_999, "a\n" * 24_999],
+    ids=["plain", "newlines"],
+)
+def test_render_event_data_keeps_top_level_string_verbatim(payload: str) -> None:
+    """A bare string payload renders through ``str()``, not ``repr()``, so
+    it must be charged without the quotes and escapes ``repr()`` would add.
+
+    Before the fix, a top-level string was charged as if it would be
+    wrapped in quotes like a nested one: ``"z" * 49_999`` (49,999 bytes,
+    inside the budget) was charged as ``49,999 + 2 = 50,001`` bytes,
+    truncated, and then truncated again by the final hard cut, ending up
+    at 50,023 bytes even though ``f"{data}"`` renders it whole.
+    """
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    assert len(payload.encode("utf-8")) <= 50_000
+    assert _render_event_data_for_log(payload, max_bytes=50_000) == payload
 
 
 def test_render_event_data_zero_cap_disables_truncation() -> None:

--- a/tests/core/agent/pattern/test_llm_trace_audit.py
+++ b/tests/core/agent/pattern/test_llm_trace_audit.py
@@ -13,6 +13,7 @@ follow-up PR.
 """
 
 import copy
+import re
 from typing import Any, Callable, Dict, List
 
 import pytest
@@ -762,6 +763,34 @@ def test_render_event_data_multibyte_small_payload_unchanged() -> None:
     assert _render_event_data_for_log(payload, max_bytes=50_000) == f"{payload}"
 
 
+def test_render_event_data_multibyte_dict_verbatim_at_budget_boundary() -> None:
+    """Pins byte-accurate accounting for a multi-byte payload sitting just
+    under the budget, where a char-count-based width estimate would wrongly
+    truncate it.
+
+    Each ``中`` char is 3 UTF-8 bytes. A dict holding 16,500 of them renders
+    to 49,515 bytes -- inside the 50,000 byte budget with the
+    ``_LOG_CONTAINER_SLACK`` reserve (256 bytes) still unspent (probed
+    boundary: this shape stays verbatim through 16,575 chars / 49,740
+    bytes and starts truncating at 16,576 chars / 49,743 bytes). This test
+    pins that a payload comfortably inside that boundary renders
+    byte-for-byte identical to plain interpolation.
+
+    This is a regression guard for charging a multi-byte leaf's width by
+    Python character count instead of UTF-8 byte count -- e.g. estimating
+    non-ASCII text at up to 4 bytes/char, which would count this payload
+    as needing far more than the budget and truncate it hard even though
+    it fits with room to spare. Verified by temporarily changing
+    ``_rendered_width`` to ``len(text) * 4``: this payload's rendered
+    output then shrinks from the true 49,515 bytes down to 37,204 bytes
+    and this assertion goes red.
+    """
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    payload = {"content": "中" * 16_500}
+    assert _render_event_data_for_log(payload, max_bytes=50_000) == f"{payload}"
+
+
 @pytest.mark.parametrize(
     "n_messages,chars_per_message",
     [
@@ -777,8 +806,18 @@ def test_render_event_data_bounds_multi_megabyte_checkpoint(
 
     Covers the shape ``truncate_for_trace`` alone cannot bound: it splits
     the budget per leaf, so a wide message list still renders megabytes.
+
+    Also pins the list-omission marker itself: the omitted count is not
+    just "some number" but exactly the messages dropped from the list,
+    i.e. the original length minus however many entries the shrink walk
+    kept before the budget ran out. Probed real values for the three
+    parametrizations above: (20, 200_000) omits 19, (2_000, 2_000) omits
+    1_974, (50_000, 100) omits 49_645.
     """
-    from xagent.core.agent.trace import _render_event_data_for_log
+    from xagent.core.agent.trace import (
+        _render_event_data_for_log,
+        _shrink_within_budget,
+    )
 
     payload = _checkpoint_payload(n_messages, chars_per_message)
     assert len(f"{payload}") > 500_000, "fixture should be far over the cap"
@@ -789,6 +828,25 @@ def test_render_event_data_bounds_multi_megabyte_checkpoint(
     out_bytes = len(out.encode("utf-8"))
     assert out_bytes <= 50_000 + 100, f"log render not bounded: {out_bytes}"
     assert out.startswith("{'checkpoint_type': 'step_complete'")
+
+    # The dropped messages are accounted for, not silently swallowed: the
+    # last list entry is the "...[N more items]" marker, and N must equal
+    # the original message count minus however many messages were kept
+    # ahead of it.
+    shrunk_messages = _shrink_within_budget(payload, 50_000)["snapshot"]["context"][
+        "messages"
+    ]
+    marker = shrunk_messages[-1]
+    assert isinstance(marker, str) and marker.startswith("...["), (
+        f"expected a list-omission marker as the last entry, got {marker!r}"
+    )
+    match = re.fullmatch(r"\.\.\.\[(\d+) more items\]", marker)
+    assert match, f"expected '...[N more items]' marker, got {marker!r}"
+    kept = len(shrunk_messages) - 1
+    assert int(match.group(1)) == n_messages - kept, (
+        f"omitted count {match.group(1)} should equal "
+        f"{n_messages} total - {kept} kept = {n_messages - kept}"
+    )
 
 
 def test_render_event_data_bounds_wide_dict() -> None:
@@ -803,13 +861,15 @@ def test_render_event_data_bounds_wide_dict() -> None:
     from xagent.core.agent.trace import (
         _render_event_data_for_log,
         _shrink_within_budget,
-        truncate_for_trace,
     )
 
     payload = {"snapshot": {f"k{i}": "v" * 200 for i in range(100_000)}}
 
-    assert len(f"{truncate_for_trace(payload, max_bytes=50_000)}") > 1_000_000
-
+    # truncate_for_trace's per-leaf budget gives every one of the 100k keys
+    # a floor of its own, so it renders this payload at well over 1 MB --
+    # this is the reason _shrink_within_budget (a shared, not per-leaf,
+    # budget) exists. Consolidating the two helpers is tracked in #623 and
+    # is out of scope here.
     out = _render_event_data_for_log(payload, max_bytes=50_000)
     out_bytes = len(out.encode("utf-8"))
     assert out_bytes <= 50_000 + 100, f"log render not bounded: {out_bytes}"
@@ -1210,14 +1270,22 @@ def test_render_event_data_small_budget_hard_cut() -> None:
     ``...[truncated N chars]`` marker, and the marker itself is what pushes
     the result over budget -- measured at 222 bytes for this fixture, 22
     bytes over the 200-byte budget.
+
+    The lower-bound assertion checks for the hard-cut marker itself, not
+    the overshoot amount: if the overshoot is ever fixed so the result
+    lands at or under 200 bytes, this test should not go red for no
+    longer overshooting -- only for the marker disappearing.
     """
     from xagent.core.agent.trace import _render_event_data_for_log
 
     payload = {"a": "x" * 1000, "b": "y" * 1000, "c": "z" * 1000}
     out = _render_event_data_for_log(payload, max_bytes=200)
     out_bytes = len(out.encode("utf-8"))
-    assert 200 < out_bytes <= 230, (
-        f"expected the hard-cut marker overshoot to land in (200, 230], got {out_bytes}"
+    assert out_bytes <= 230, (
+        f"expected the hard cut to stay near budget, got {out_bytes}"
+    )
+    assert re.search(r"\.\.\.\[truncated \d+ chars\]$", out), (
+        f"expected the hard-cut marker at the end of the output, got {out!r}"
     )
 
 

--- a/tests/core/agent/pattern/test_llm_trace_audit.py
+++ b/tests/core/agent/pattern/test_llm_trace_audit.py
@@ -12,6 +12,7 @@ The v2-runtime audit injection (centralized in
 follow-up PR.
 """
 
+import copy
 from typing import Any, Callable, Dict, List
 
 import pytest
@@ -960,7 +961,12 @@ def test_render_event_data_keeps_wide_scalar_dict_verbatim() -> None:
     from xagent.core.agent.trace import _render_event_data_for_log
 
     payload = {i: i for i in range(4_000)}
-    assert len(f"{payload}".encode("utf-8")) == 45_780
+    # Precise byte count (45,780) is pinned in this test's docstring above;
+    # the check here only needs to confirm the fixture is inside the
+    # budget, since the fixture's exact repr length is CPython-format
+    # dependent and the byte-for-byte equality assertion below is what
+    # actually catches the regression.
+    assert len(f"{payload}".encode("utf-8")) < 50_000
     assert _render_event_data_for_log(payload, max_bytes=50_000) == f"{payload}"
 
 
@@ -993,7 +999,12 @@ def test_render_event_data_keeps_llm_call_records_verbatim() -> None:
             }
         },
     }
-    assert len(f"{payload}".encode("utf-8")) == 39_918
+    # Precise byte count (39,918) is pinned in this test's docstring above;
+    # the check here only needs to confirm the fixture is inside the
+    # budget, since the fixture's exact repr length is CPython-format
+    # dependent and the byte-for-byte equality assertion below is what
+    # actually catches the regression.
+    assert len(f"{payload}".encode("utf-8")) < 50_000
     assert _render_event_data_for_log(payload, max_bytes=50_000) == f"{payload}"
 
 
@@ -1184,6 +1195,104 @@ def test_render_event_data_zero_cap_disables_truncation() -> None:
 
     payload = _checkpoint_payload(5, 10_000)
     assert _render_event_data_for_log(payload, max_bytes=0) == f"{payload}"
+
+
+def test_render_event_data_small_budget_hard_cut() -> None:
+    """This is the only case in this file that runs with a budget below
+    the default 50_000 -- everything else exercises the shrink walk at
+    production scale. A ``max_bytes=200`` budget against a dict with
+    several 1000-char string fields is too small for ``_shrink_node`` to
+    land under the cap on its own (each field's own truncation marker,
+    plus the ``__omitted_keys__`` marker for the fields it can't fit at
+    all, already eats past 200 bytes), so ``_render_event_data_for_log``'s
+    final hard byte-cut fires on top of the shrink pass. That hard cut
+    slices the rendered string to ``max_bytes`` and appends its own
+    ``...[truncated N chars]`` marker, and the marker itself is what pushes
+    the result over budget -- measured at 222 bytes for this fixture, 22
+    bytes over the 200-byte budget.
+    """
+    from xagent.core.agent.trace import _render_event_data_for_log
+
+    payload = {"a": "x" * 1000, "b": "y" * 1000, "c": "z" * 1000}
+    out = _render_event_data_for_log(payload, max_bytes=200)
+    out_bytes = len(out.encode("utf-8"))
+    assert 200 < out_bytes <= 230, (
+        f"expected the hard-cut marker overshoot to land in (200, 230], got {out_bytes}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_console_cap_does_not_shrink_the_persisted_payload(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """The safety promise this PR exists to guarantee: the byte cap applies
+    only to the string the console handler builds for its own log line. Any
+    other handler on the same ``Tracer`` -- a database writer, a checkpoint
+    store, a websocket broadcaster -- must still receive ``event.data``
+    exactly as it was passed in, unshrunk.
+
+    Wires a real ``Tracer`` with two handlers, ``ConsoleTraceHandler`` and a
+    recording handler standing in for a persistence sink, and fires one
+    event with a payload whose rendered width is far past the 50_000-byte
+    console budget. The recording handler's copy of ``event.data`` must be
+    the identical object (not a shrunk copy) and equal to the original, and
+    the console log line must still have been capped.
+    """
+    import logging
+
+    from xagent.core.agent.trace import (
+        SYSTEM_INFO,
+        BaseTraceHandler,
+        ConsoleTraceHandler,
+        Tracer,
+    )
+
+    class _RecordingPersistenceHandler(BaseTraceHandler):
+        """Stands in for a database/checkpoint handler: keeps whatever
+        ``event.data`` object it was handed, unmodified."""
+
+        def __init__(self) -> None:
+            super().__init__()
+            self.received: List[Any] = []
+
+        async def _handle_system_event(self, event: Any) -> None:
+            self.received.append(event.data)
+
+    monkeypatch.setenv("XAGENT_MAX_TRACE_PAYLOAD_BYTES", "50000")
+
+    tracer = Tracer()
+    tracer.add_handler(ConsoleTraceHandler())
+    persistence_handler = _RecordingPersistenceHandler()
+    tracer.add_handler(persistence_handler)
+
+    original_payload = {"snapshot": {f"k{i}": "v" * 200 for i in range(2_000)}}
+    assert len(f"{original_payload}".encode("utf-8")) > 50_000, (
+        "fixture should be far over the console budget"
+    )
+    # Snapshot the content BEFORE dispatch: the tracer passes ``data`` by
+    # reference, so comparing received[0] against original_payload would be
+    # comparing an object with itself and could never catch an in-place
+    # mutation by the console handler.
+    expected_content = copy.deepcopy(original_payload)
+
+    with caplog.at_level(logging.INFO, logger="xagent.core.agent.trace"):
+        await tracer.trace_event(SYSTEM_INFO, data=original_payload)
+
+    # Persistence side: same object, untouched.
+    assert len(persistence_handler.received) == 1
+    assert persistence_handler.received[0] is original_payload
+    assert persistence_handler.received[0] == expected_content
+
+    # Console side: the log line is still capped. ``Tracer.trace_event``
+    # itself logs several diagnostic lines through the same module logger
+    # (dispatch bookkeeping), so filter down to the one line
+    # ``ConsoleTraceHandler._handle_system_event`` actually renders.
+    console_records = [
+        r for r in caplog.records if r.getMessage().startswith("[SYSTEM]")
+    ]
+    assert len(console_records) == 1
+    message_bytes = len(console_records[0].getMessage().encode("utf-8"))
+    assert message_bytes <= 50_000 + 30, f"log line not bounded: {message_bytes}"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #1626

## Problem

`ConsoleTraceHandler` interpolates `event.data` directly into f-strings in all four `_handle_*` methods. Checkpoint events (`SYSTEM/UPDATE/GENERAL`) carry the full execution snapshot nested under `snapshot.context.messages`, and the `XAGENT_MAX_TRACE_PAYLOAD_BYTES` cap never applies to them: the runtime gates normalization to `TraceCategory.LLM` only, and `normalize_llm_trace_payload` scans only top-level keys. The result is that every checkpoint save of a long-context task renders the entire context into a single multi-megabyte log line, paying the full serialization cost in memory each time.

## Fix

Bound the rendering at the console logging sink. A new `_render_event_data_for_log` helper deep-shrinks the payload to the `XAGENT_MAX_TRACE_PAYLOAD_BYTES` budget (default 50 KB, `0` disables, matching the existing knob) before any f-string interpolation, so the oversized string is never built. All four `_handle_*` methods route through it.

Reusing `truncate_for_trace` alone was measured and rejected: it allocates a per-leaf budget and keeps every key, so wide payloads stay unbounded. Measured on synthetic checkpoint-shaped payloads (budget 50,000 bytes):

| Payload shape | Raw f-string | `truncate_for_trace` only | This PR's renderer |
|---|---|---|---|
| 20 messages × 200k chars | 4,221,862 | 9,366 | 50,024 |
| 2,000 messages × 2k chars | 4,142,662 | 205,902 | 49,783 |
| 50,000 messages × 100 chars | 8,020,762 | 4,904,002 | 46,114 |
| 100,000 integer keys | 1,677,794 | 1,677,794 (untouched) | 26,262 |

The new renderer walks the tree with a single shared budget and collapses the remainder into short markers (`__omitted_keys__`, `...[N more items]`) once the budget is spent, with a final hard cut on the rendered string as a backstop for pathologically long single-object reprs.

Scope guarantees:

- Truncation applies **only** to the console logging sink. `DatabaseTraceHandler`, `WebSocketTraceHandler`, and `TraceCheckpointStore` are untouched — durable checkpoint records used for task recovery keep the full payload.
- Small payloads render byte-for-byte identically to the previous output when their rendered width stays at least `_LOG_CONTAINER_SLACK` (256 bytes) under the budget — measured cutoff 49,742 bytes at the 50,000 default; within that reserve band the payload may already be shrunk.
- `XAGENT_MAX_TRACE_PAYLOAD_BYTES=0` preserves the exact pre-change behavior.

## Tests

New unit tests in `tests/core/agent/pattern/test_llm_trace_audit.py` (alongside the existing truncation tests), grown across review rounds: byte-identical rendering for small payloads (including multi-byte text), bounded output for three multi-megabyte checkpoint shapes, bounded output for key-explosion payloads (with a regression assertion that `truncate_for_trace` alone exceeds 1 MB on that shape), `cap=0` passthrough, non-dict/unusual payloads (`None`, strings, `object()`, tuples), and per-scope log-line bounds for all four handler methods.

Full trace/checkpoint-related suite passes: 161 tests, 0 failures. `pre-commit` (ruff, mypy, isort, codespell) clean.



## Known gaps deferred to issues

- **#1634** — `_shrink_node` walks only `str`/`dict`/`list`. Any other container (tuple, set, non-dict Mapping, bytes, large-repr objects) is charged but never walked: the emitted line stays bounded by the final byte cut, but the value's full repr is still materialized to measure it, an oversized value can starve trailing sibling keys out of the line, and the cut lands mid-repr. Deliberately excluded here: the fix needs a rendering-semantics decision (type-name preservation) that belongs to that issue.
- **#1655** — the same `event.data` still reaches the database sink and the tracer's own INFO key-listing line unbounded; only the console sink is capped by this PR.
- **#623** — this module now carries several structurally similar truncation implementations; consolidation is tracked there.
