### PR TITLE
feat(connectors): add Google Search Console MCP connector

### DIFF
--- a/src/xagent/migrations/versions/20260824_seed_google_search_console_mcp_app.py
+++ b/src/xagent/migrations/versions/20260824_seed_google_search_console_mcp_app.py
@@ -1,0 +1,82 @@
+"""seed built-in Google Search Console (OAuth) MCP connector
+
+Revision ID: 20260824_seed_google_search_console_mcp_app
+Revises: 20260818_user_oauth_resource_owner
+Create Date: 2026-08-24 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260824_seed_google_search_console_mcp_app"
+down_revision: Union[str, None] = "20260818_user_oauth_resource_owner"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+
+APP_ID = "google-search-console"
+
+ROW = {
+    "app_id": APP_ID,
+    "name": "Google Search Console",
+    "description": "Connect to Google Search Console to list verified sites, query search analytics (clicks, impressions, CTR, position), inspect URLs, and list sitemaps.",
+    "icon": "https://www.google.com/s2/favicons?domain=search.google.com&sz=128",
+    "transport": "oauth",
+    "provider_name": "google",
+    "category": "Marketing",
+    "oauth_scopes": ["https://www.googleapis.com/auth/webmasters.readonly"],
+    "is_visible_in_connector": True,
+    "launch_config": {
+        "command": "python",
+        "args": ["-m", "xagent.web.tools.mcp.google_search_console"],
+        "env_mapping": {"GOOGLE_ACCESS_TOKEN": "access_token"},
+    },
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+
+    columns = {c["name"] for c in inspector.get_columns("public_mcp_apps")}
+    existing = set(bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars())
+    if APP_ID in existing:
+        return
+
+    row = {k: v for k, v in ROW.items() if k in columns}
+    bind.execute(sa.insert(PUBLIC_MCP_APPS_TABLE), [row])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+    # Only the catalog entry is removed. The shared "google" oauth_providers row
+    # is left untouched since it is reused by Gmail/Drive/Calendar/Docs/Slides/
+    # Ads/Analytics. Any MCPServer/UserMCPServer rows created by users who
+    # already connected are intentionally left in place — connect-driven rows
+    # are not owned by this migration and are cleaned up through the normal
+    # disconnect path.
+    bind.execute(
+        sa.delete(PUBLIC_MCP_APPS_TABLE).where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+    )

--- a/src/xagent/migrations/versions/20260824_seed_google_search_console_mcp_app.py
+++ b/src/xagent/migrations/versions/20260824_seed_google_search_console_mcp_app.py
@@ -40,7 +40,7 @@ ROW = {
     "icon": "https://www.google.com/s2/favicons?domain=search.google.com&sz=128",
     "transport": "oauth",
     "provider_name": "google",
-    "category": "Marketing",
+    "category": "Analytics",
     "oauth_scopes": ["https://www.googleapis.com/auth/webmasters.readonly"],
     "is_visible_in_connector": True,
     "launch_config": {

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -443,6 +443,22 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             },
         },
         {
+            "app_id": "google-search-console",
+            "name": "Google Search Console",
+            "description": "Connect to Google Search Console to list verified sites, query search analytics (clicks, impressions, CTR, position), inspect URLs, and list sitemaps.",
+            "icon": "https://www.google.com/s2/favicons?domain=search.google.com&sz=128",
+            "transport": "oauth",
+            "provider_name": "google",
+            "category": "Marketing",
+            "oauth_scopes": ["https://www.googleapis.com/auth/webmasters.readonly"],
+            "is_visible_in_connector": True,
+            "launch_config": {
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.google_search_console"],
+                "env_mapping": {"GOOGLE_ACCESS_TOKEN": "access_token"},
+            },
+        },
+        {
             "app_id": "hubspot",
             "name": "HubSpot",
             "description": "Connect to HubSpot CRM and Marketing Hub to search, create, and update contacts and companies, read deals, log notes, read forms and submissions, pull traffic analytics reports, and read marketing emails and campaigns.",

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -484,9 +484,9 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "icon": "https://www.google.com/s2/favicons?domain=search.google.com&sz=128",
             "transport": "oauth",
             "provider_name": "google",
-            # "Analytics" (not "Marketing", which google-analytics uses as a
-            # pre-existing mismatch — see the posthog entry's comment below)
-            # since this connector is squarely a search-analytics tool.
+            # "Analytics" (not "Marketing", which google-analytics uses —
+            # a pre-existing mismatch, not a precedent to repeat) since this
+            # connector is squarely a search-analytics tool.
             "category": "Analytics",
             "oauth_scopes": ["https://www.googleapis.com/auth/webmasters.readonly"],
             "is_visible_in_connector": True,

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -449,7 +449,10 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "icon": "https://www.google.com/s2/favicons?domain=search.google.com&sz=128",
             "transport": "oauth",
             "provider_name": "google",
-            "category": "Marketing",
+            # "Analytics" (not "Marketing", which google-analytics uses as a
+            # pre-existing mismatch — see the posthog entry's comment below)
+            # since this connector is squarely a search-analytics tool.
+            "category": "Analytics",
             "oauth_scopes": ["https://www.googleapis.com/auth/webmasters.readonly"],
             "is_visible_in_connector": True,
             "launch_config": {

--- a/src/xagent/web/tools/mcp/google_docs.py
+++ b/src/xagent/web/tools/mcp/google_docs.py
@@ -66,7 +66,7 @@ def get_drive_service() -> Any:
 
 def _resolve_document_id(document_id: str) -> str:
     """Accept either a bare document id or a full Google Docs URL."""
-    return resolve_id_from_url(document_id, _DOCUMENT_URL_ID_PATTERN)
+    return resolve_id_from_url(document_id, _DOCUMENT_URL_ID_PATTERN, "document_id")
 
 
 def _paragraph_text(paragraph: dict[str, Any]) -> str:

--- a/src/xagent/web/tools/mcp/google_search_console.py
+++ b/src/xagent/web/tools/mcp/google_search_console.py
@@ -43,6 +43,34 @@ def _success(**payload: Any) -> str:
     return json.dumps({"status": "success", **payload}, ensure_ascii=False)
 
 
+def _success_with_trimmed_list(field_name: str, items: list[Any]) -> str:
+    """Build a {"status": "success", field_name: items, "truncated": ...}
+    payload, halving items until the serialized response fits the
+    platform's output limit.
+
+    list_sites and list_sitemaps both call APIs with no pageToken/offset
+    parameter — Google returns every site or every submitted sitemap in
+    one response — so unlike query_search_analytics (which can be paged
+    with start_row), there's no way to ask for a smaller page up front.
+    Truncating after the fact, the same way query_search_analytics already
+    guards its own oversized responses, is the only option for a property
+    with an unusually large site or sitemap count.
+    """
+    max_output_length = get_tool_max_output_length()
+    original_count = len(items)
+    response = _success(**{field_name: items, "truncated": False})
+    while len(response) > max_output_length and items:
+        items = items[: len(items) // 2]
+        response = _success(**{field_name: items, "truncated": True})
+    if len(items) < original_count:
+        logger.warning(
+            f"Google Search Console {field_name} response trimmed from "
+            f"{original_count} to {len(items)} items to stay under the "
+            f"{max_output_length}-char output limit"
+        )
+    return response
+
+
 def _error(message: str) -> str:
     return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
 
@@ -204,7 +232,7 @@ def google_search_console_list_sites() -> str:
             for entry in site_entries
             if isinstance(entry, dict) and entry.get("siteUrl")
         ]
-        return _success(sites=sites)
+        return _success_with_trimmed_list("sites", sites)
     except Exception as e:
         logger.error(f"Error listing Google Search Console sites: {e}")
         return _error(str(e))
@@ -229,8 +257,14 @@ def google_search_console_list_sitemaps(site_url: str) -> str:
         )
         sitemaps = result.get("sitemap")
         if not isinstance(sitemaps, list):
+            if sitemaps is not None:
+                logger.warning(
+                    f"Google Search Console list_sitemaps returned a non-list "
+                    f"'sitemap' field ({type(sitemaps).__name__}); treating "
+                    f"as empty"
+                )
             sitemaps = []
-        return _success(sitemaps=sitemaps)
+        return _success_with_trimmed_list("sitemaps", sitemaps)
     except Exception as e:
         logger.error(f"Error listing sitemaps for {site_url!r}: {e}")
         return _error(str(e))

--- a/src/xagent/web/tools/mcp/google_search_console.py
+++ b/src/xagent/web/tools/mcp/google_search_console.py
@@ -1,0 +1,319 @@
+import json
+import logging
+import os
+import re
+from typing import Any
+from urllib.parse import quote
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+from ....config import get_tool_max_output_length
+from .utils import setup_proxy_env
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("google-search-console-mcp")
+
+# Ensure standard proxy environment variables are set to prevent hanging requests
+setup_proxy_env()
+
+mcp = FastMCP("google-search-console-mcp")
+
+WEBMASTERS_API_BASE_URL = "https://www.googleapis.com/webmasters/v3"
+SEARCH_CONSOLE_API_BASE_URL = "https://searchconsole.googleapis.com/v1"
+DEFAULT_TIMEOUT_SECONDS = 30
+
+VALID_DIMENSIONS = {"query", "page", "country", "device", "date", "searchAppearance"}
+VALID_SEARCH_TYPES = {"web", "image", "video", "news", "discover", "googleNews"}
+_DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}\Z")
+
+# The Search Analytics API itself allows rowLimit up to 25000. That's capped
+# tighter here to bound the serialized MCP response; query_search_analytics
+# still guards the actual serialized size and trims rows if needed, same as
+# google_analytics_run_report does.
+QUERY_DEFAULT_ROW_LIMIT = 100
+QUERY_MAX_ROW_LIMIT = 1000
+
+
+def _success(**payload: Any) -> str:
+    return json.dumps({"status": "success", **payload}, ensure_ascii=False)
+
+
+def _error(message: str) -> str:
+    return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
+
+
+def _headers() -> dict[str, str]:
+    access_token = os.environ.get("GOOGLE_ACCESS_TOKEN")
+    if not access_token:
+        raise ValueError("GOOGLE_ACCESS_TOKEN environment variable is missing")
+    return {
+        "Authorization": f"Bearer {access_token}",
+        "Content-Type": "application/json",
+    }
+
+
+def _extract_error_detail(response: requests.Response) -> str | None:
+    """Pull the human-readable message out of a Google API error body
+    (``{"error": {"code": ..., "message": ..., "status": ...}}``).
+    Returns None if the body isn't in the expected shape, so the caller can
+    fall back to the raw response text.
+    """
+    try:
+        payload = response.json()
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    error = payload.get("error")
+    if not isinstance(error, dict):
+        return None
+    message = error.get("message")
+    return message if isinstance(message, str) and message else None
+
+
+def _request(
+    method: str,
+    url: str,
+    *,
+    params: dict[str, Any] | None = None,
+    body: dict[str, Any] | None = None,
+) -> Any:
+    response = requests.request(
+        method=method,
+        url=url,
+        headers=_headers(),
+        params=params,
+        json=body,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        message = str(exc)
+        detail = _extract_error_detail(response)
+        if detail is None:
+            # Cap the raw-body fallback: an upstream HTML error page can be
+            # hundreds of KB and would otherwise be embedded whole into the
+            # error message.
+            detail = response.text.strip()[:1000]
+        if detail:
+            message = f"{message} - {detail}"
+        raise RuntimeError(message) from exc
+
+    if response.status_code == 204 or not response.content:
+        return {}
+    return response.json()
+
+
+def _require_dict_result(result: Any) -> dict[str, Any]:
+    """Guard against a non-dict payload (e.g. a list or string) before
+    calling dict methods on it. A dict that's merely empty (zero sites, zero
+    report rows) is a normal, valid response and must not be rejected here.
+    """
+    if not isinstance(result, dict):
+        raise ValueError("Unexpected response format from Google Search Console API")
+    return result
+
+
+def _encoded_site_url(site_url: str) -> str:
+    """Search Console site identifiers are either a URL-prefix property
+    (e.g. "https://example.com/") or a domain property
+    (e.g. "sc-domain:example.com"); both must be percent-encoded before use
+    in a URL path segment.
+    """
+    if not isinstance(site_url, str) or not site_url:
+        raise ValueError(
+            'site_url must be a non-empty string, e.g. "https://example.com/" '
+            'or "sc-domain:example.com" (see google_search_console_list_sites)'
+        )
+    return quote(site_url, safe="")
+
+
+def _validate_date(label: str, value: str) -> None:
+    if not isinstance(value, str) or not _DATE_PATTERN.match(value):
+        raise ValueError(f"{label} must be a date string in YYYY-MM-DD format")
+
+
+@mcp.tool()
+def google_search_console_list_sites() -> str:
+    """
+    List the sites (URL-prefix or domain properties) the connected account
+    has Search Console access to, along with the permission level. Use this
+    first to discover which site_url values are available for the other
+    google_search_console_* tools.
+    """
+    try:
+        result = _require_dict_result(
+            _request("GET", f"{WEBMASTERS_API_BASE_URL}/sites")
+        )
+        sites = [
+            {
+                "site_url": entry.get("siteUrl"),
+                "permission_level": entry.get("permissionLevel"),
+            }
+            for entry in (result.get("siteEntry") or [])
+            if isinstance(entry, dict)
+        ]
+        return _success(sites=sites)
+    except Exception as e:
+        logger.error(f"Error listing Google Search Console sites: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def google_search_console_list_sitemaps(site_url: str) -> str:
+    """
+    List the sitemaps submitted for a site, including their status and
+    warning/error counts.
+
+    site_url: a value from google_search_console_list_sites, e.g.
+      "https://example.com/" or "sc-domain:example.com".
+    """
+    try:
+        encoded_site_url = _encoded_site_url(site_url)
+        result = _require_dict_result(
+            _request(
+                "GET",
+                f"{WEBMASTERS_API_BASE_URL}/sites/{encoded_site_url}/sitemaps",
+            )
+        )
+        return _success(sitemaps=result.get("sitemap") or [])
+    except Exception as e:
+        logger.error(f"Error listing sitemaps for {site_url!r}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def google_search_console_query_search_analytics(
+    site_url: str,
+    start_date: str,
+    end_date: str,
+    dimensions: list[str] | None = None,
+    search_type: str = "web",
+    dimension_filter_groups: list[dict[str, Any]] | None = None,
+    row_limit: int = QUERY_DEFAULT_ROW_LIMIT,
+    start_row: int = 0,
+) -> str:
+    """
+    Query Search Analytics: clicks, impressions, CTR, and average position,
+    broken down by any combination of dimensions, for a date range.
+
+    site_url: a value from google_search_console_list_sites.
+    start_date, end_date: YYYY-MM-DD (inclusive). Search Console data is
+      typically delayed 1-3 days, so end_date should not be today.
+    dimensions: any of "query", "page", "country", "device", "date",
+      "searchAppearance". Omit for a single aggregate row.
+    search_type: one of "web", "image", "video", "news", "discover",
+      "googleNews" (default "web").
+    dimension_filter_groups: raw Search Analytics API filter groups, e.g.
+      [{"filters": [{"dimension": "country", "operator": "equals",
+      "expression": "usa"}]}]. Optional.
+    row_limit: max rows to return (default 100, max 1000 — keeps a wide
+      query's serialized response under the MCP output size limit).
+    start_row: row offset for paging — if the response returns exactly
+      row_limit rows, call again with start_row += row_limit to fetch more.
+    """
+    try:
+        encoded_site_url = _encoded_site_url(site_url)
+        _validate_date("start_date", start_date)
+        _validate_date("end_date", end_date)
+        if start_date > end_date:
+            raise ValueError("start_date must not be after end_date")
+        if search_type not in VALID_SEARCH_TYPES:
+            raise ValueError(f"search_type must be one of {sorted(VALID_SEARCH_TYPES)}")
+        if row_limit < 1 or row_limit > QUERY_MAX_ROW_LIMIT:
+            raise ValueError(f"row_limit must be between 1 and {QUERY_MAX_ROW_LIMIT}")
+        if start_row < 0:
+            raise ValueError("start_row must be >= 0")
+        if dimensions:
+            invalid = sorted(set(dimensions) - VALID_DIMENSIONS)
+            if invalid:
+                raise ValueError(
+                    f"invalid dimensions {invalid}; must be from {sorted(VALID_DIMENSIONS)}"
+                )
+
+        body: dict[str, Any] = {
+            "startDate": start_date,
+            "endDate": end_date,
+            "type": search_type,
+            "rowLimit": row_limit,
+            "startRow": start_row,
+        }
+        if dimensions:
+            body["dimensions"] = dimensions
+        if dimension_filter_groups:
+            body["dimensionFilterGroups"] = dimension_filter_groups
+
+        result = _require_dict_result(
+            _request(
+                "POST",
+                f"{WEBMASTERS_API_BASE_URL}/sites/{encoded_site_url}/searchAnalytics/query",
+                body=body,
+            )
+        )
+        rows = result.get("rows") or []
+
+        # row_limit bounds row *count*, not bytes: several "query"/"page"
+        # dimension values (often full URLs) at once can still cross the
+        # platform's output truncation threshold. Halve the returned rows
+        # until the serialized response fits, mirroring
+        # google_analytics_run_report's trimming approach.
+        max_output_length = get_tool_max_output_length()
+        original_row_count = len(rows)
+        response = _success(rows=rows, row_count=len(rows), truncated=False)
+        while len(response) > max_output_length and len(rows) > 1:
+            rows = rows[: len(rows) // 2]
+            response = _success(rows=rows, row_count=len(rows), truncated=True)
+        if len(rows) < original_row_count:
+            logger.warning(
+                f"Google Search Console query_search_analytics response trimmed "
+                f"from {original_row_count} to {len(rows)} rows to stay under "
+                f"the {max_output_length}-char output limit"
+            )
+        return response
+    except Exception as e:
+        logger.error(f"Error querying search analytics for {site_url!r}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def google_search_console_inspect_url(
+    site_url: str, inspection_url: str, language_code: str = "en-US"
+) -> str:
+    """
+    Inspect a URL's indexing status: whether it's indexed, canonical URL,
+    coverage state, mobile usability, and rich result eligibility.
+
+    site_url: the property the URL belongs to, from
+      google_search_console_list_sites.
+    inspection_url: the fully-qualified URL to inspect (must belong to
+      site_url).
+    language_code: BCP-47 language for the human-readable result fields
+      (default "en-US").
+    """
+    try:
+        if not isinstance(site_url, str) or not site_url:
+            raise ValueError("site_url must be a non-empty string")
+        if not isinstance(inspection_url, str) or not inspection_url:
+            raise ValueError("inspection_url must be a non-empty string")
+        body = {
+            "inspectionUrl": inspection_url,
+            "siteUrl": site_url,
+            "languageCode": language_code,
+        }
+        result = _require_dict_result(
+            _request(
+                "POST",
+                f"{SEARCH_CONSOLE_API_BASE_URL}/urlInspection/index:inspect",
+                body=body,
+            )
+        )
+        return _success(inspection_result=result.get("inspectionResult") or {})
+    except Exception as e:
+        logger.error(f"Error inspecting URL {inspection_url!r}: {e}")
+        return _error(str(e))
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/src/xagent/web/tools/mcp/google_search_console.py
+++ b/src/xagent/web/tools/mcp/google_search_console.py
@@ -4,13 +4,12 @@ import logging
 import os
 import re
 from typing import Any
-from urllib.parse import quote
 
 import requests
 from mcp.server.fastmcp import FastMCP
 
 from ....config import get_tool_max_output_length
-from .utils import setup_proxy_env
+from .utils import require_clean_identifier, setup_proxy_env, url_path_id
 
 logger = logging.getLogger("google-search-console-mcp")
 
@@ -125,14 +124,17 @@ def _encoded_site_url(site_url: str) -> str:
     """Search Console site identifiers are either a URL-prefix property
     (e.g. "https://example.com/") or a domain property
     (e.g. "sc-domain:example.com"); both must be percent-encoded before use
-    in a URL path segment.
+    in a URL path segment. Delegates to the shared url_path_id helper (used
+    by the other stdio MCP connectors) for that encoding plus its "."/".."
+    guard, after our own check for the more actionable message on the
+    empty/wrong-type case.
     """
     if not isinstance(site_url, str) or not site_url:
         raise ValueError(
             'site_url must be a non-empty string, e.g. "https://example.com/" '
             'or "sc-domain:example.com" (see google_search_console_list_sites)'
         )
-    return quote(site_url, safe="")
+    return url_path_id(site_url, "site_url")
 
 
 def _validate_date(label: str, value: str) -> None:
@@ -232,8 +234,10 @@ def google_search_console_query_search_analytics(
       "expression": "usa"}]}]. Optional.
     row_limit: max rows to return (default 100, max 1000 — keeps a wide
       query's serialized response under the MCP output size limit).
-    start_row: row offset for paging — if the response returns exactly
-      row_limit rows, call again with start_row += row_limit to fetch more.
+    start_row: row offset for paging — if row_count equals row_limit, call
+      again with start_row += row_limit to fetch more (row_count reflects
+      how many rows this query actually matched, independent of whether
+      "rows" was shortened below — see "truncated").
     """
     try:
         encoded_site_url = _encoded_site_url(site_url)
@@ -288,12 +292,21 @@ def google_search_console_query_search_analytics(
         # platform's output truncation threshold. Halve the returned rows
         # until the serialized response fits, mirroring
         # google_analytics_run_report's trimming approach.
+        #
+        # row_count is pinned to the pre-trim count and never recomputed
+        # from the (possibly shrunk) "rows" list: it's the pagination
+        # signal the docstring tells callers to check against row_limit,
+        # and trimming rows for output-size reasons must not be confused
+        # with "this page had fewer matches than row_limit" — that would
+        # make a caller stop paging early and silently miss rows, with no
+        # way to resume since the dropped rows already consumed part of
+        # this request's offset window.
         max_output_length = get_tool_max_output_length()
         original_row_count = len(rows)
-        response = _success(rows=rows, row_count=len(rows), truncated=False)
+        response = _success(rows=rows, row_count=original_row_count, truncated=False)
         while len(response) > max_output_length and rows:
             rows = rows[: len(rows) // 2]
-            response = _success(rows=rows, row_count=len(rows), truncated=True)
+            response = _success(rows=rows, row_count=original_row_count, truncated=True)
         if len(rows) < original_row_count:
             logger.warning(
                 f"Google Search Console query_search_analytics response trimmed "
@@ -322,10 +335,8 @@ def google_search_console_inspect_url(
       (default "en-US").
     """
     try:
-        if not isinstance(site_url, str) or not site_url:
-            raise ValueError("site_url must be a non-empty string")
-        if not isinstance(inspection_url, str) or not inspection_url:
-            raise ValueError("inspection_url must be a non-empty string")
+        site_url = require_clean_identifier(site_url, "site_url")
+        inspection_url = require_clean_identifier(inspection_url, "inspection_url")
         body = {
             "inspectionUrl": inspection_url,
             "siteUrl": site_url,

--- a/src/xagent/web/tools/mcp/google_search_console.py
+++ b/src/xagent/web/tools/mcp/google_search_console.py
@@ -3,7 +3,7 @@ import json
 import logging
 import os
 import re
-from typing import Any
+from typing import Any, Callable
 
 import requests
 from mcp.server.fastmcp import FastMCP
@@ -53,7 +53,7 @@ def _success_with_trimmed_list(
     items: list[Any],
     count_field_name: str,
     *,
-    truncated_hint: str | None = None,
+    truncated_hint: Callable[[int], str] | None = None,
 ) -> str:
     """Build a {"status": "success", field_name: items, count_field_name:
     <pre-trim count>, "truncated": ...} payload, halving items until the
@@ -76,9 +76,11 @@ def _success_with_trimmed_list(
     trimmed (empty) list still reports how many entries actually exist,
     rather than reading as "you have none."
 
-    truncated_hint, if given, is included as "hint" only once trimming
-    actually happens — a caller-visible next step (e.g. "retry with a
-    smaller row_limit") instead of a signal only visible in server logs.
+    truncated_hint, if given, is called with the *final* (post-trim) item
+    count and its return value is included as "hint" only once trimming
+    actually happens — a caller-visible, count-specific next step (e.g.
+    "N rows fit; retry with row_limit=N") instead of a vague "try smaller"
+    signal only visible in server logs.
     """
     max_output_length = get_tool_max_output_length()
     original_count = len(items)
@@ -90,7 +92,7 @@ def _success_with_trimmed_list(
             "truncated": truncated,
         }
         if truncated and truncated_hint:
-            payload["hint"] = truncated_hint
+            payload["hint"] = truncated_hint(len(items))
         return _success(**payload)
 
     response = _build(False)
@@ -104,6 +106,28 @@ def _success_with_trimmed_list(
             f"{max_output_length}-char output limit"
         )
     return response
+
+
+def _row_trim_hint(safe_row_count: int) -> str:
+    """Build query_search_analytics' truncated_hint from the final,
+    post-trim row count. Approximate, not exact: re-requesting with
+    row_limit=safe_row_count may return a different-sized page (a
+    different set of rows can serialize to a different size), so this is a
+    starting point for the caller to converge on, not a guarantee.
+    """
+    if safe_row_count > 0:
+        return (
+            f"response truncated for output size; approximately "
+            f"{safe_row_count} row(s) fit at this start_row — retry with a "
+            f"smaller row_limit (try {safe_row_count} or less) to reduce "
+            f"truncation"
+        )
+    return (
+        "response truncated for output size; even a single row exceeds the "
+        "limit at this start_row — narrow the query (fewer dimensions, or "
+        "add dimension_filter_groups) rather than retrying with a smaller "
+        "row_limit"
+    )
 
 
 def _error(message: str) -> str:
@@ -431,14 +455,7 @@ def google_search_console_query_search_analytics(
         # halves "rows" until the response fits while pinning row_count to
         # the pre-trim count (see its docstring) and attaching a retry hint.
         return _success_with_trimmed_list(
-            "rows",
-            rows,
-            "row_count",
-            truncated_hint=(
-                "response truncated for output size; retry this same "
-                "start_row with a smaller row_limit to recover the missing "
-                "rows"
-            ),
+            "rows", rows, "row_count", truncated_hint=_row_trim_hint
         )
     except Exception as e:
         logger.error(f"Error querying search analytics for {site_url!r}: {e}")

--- a/src/xagent/web/tools/mcp/google_search_console.py
+++ b/src/xagent/web/tools/mcp/google_search_console.py
@@ -156,12 +156,21 @@ def google_search_console_list_sites() -> str:
         result = _require_dict_result(
             _request("GET", f"{WEBMASTERS_API_BASE_URL}/sites")
         )
+        site_entries = result.get("siteEntry")
+        if not isinstance(site_entries, list):
+            if site_entries is not None:
+                logger.warning(
+                    f"Google Search Console list_sites returned a non-list "
+                    f"'siteEntry' field ({type(site_entries).__name__}); "
+                    f"treating as empty"
+                )
+            site_entries = []
         sites = [
             {
                 "site_url": entry.get("siteUrl"),
                 "permission_level": entry.get("permissionLevel"),
             }
-            for entry in (result.get("siteEntry") or [])
+            for entry in site_entries
             if isinstance(entry, dict) and entry.get("siteUrl")
         ]
         return _success(sites=sites)
@@ -329,7 +338,16 @@ def google_search_console_inspect_url(
                 body=body,
             )
         )
-        return _success(inspection_result=result.get("inspectionResult") or {})
+        inspection_result = result.get("inspectionResult")
+        if not isinstance(inspection_result, dict):
+            if inspection_result is not None:
+                logger.warning(
+                    f"Google Search Console inspect_url returned a non-dict "
+                    f"'inspectionResult' field "
+                    f"({type(inspection_result).__name__}); treating as empty"
+                )
+            inspection_result = {}
+        return _success(inspection_result=inspection_result)
     except Exception as e:
         logger.error(f"Error inspecting URL {inspection_url!r}: {e}")
         return _error(str(e))

--- a/src/xagent/web/tools/mcp/google_search_console.py
+++ b/src/xagent/web/tools/mcp/google_search_console.py
@@ -130,6 +130,26 @@ def _row_trim_hint(safe_row_count: int) -> str:
     )
 
 
+def _no_pagination_trim_hint(noun: str) -> Callable[[int], str]:
+    """Build the truncated_hint for list_sites/list_sitemaps: unlike
+    query_search_analytics, neither underlying Google API takes a
+    page size or offset — it always returns every entry in one response —
+    so there is no smaller-request retry that would help. The caller needs
+    to know the dropped entries are genuinely unreachable through this
+    tool, not just that they should ask again differently.
+    """
+
+    def _hint(shown_count: int) -> str:
+        return (
+            f"response truncated for output size; only {shown_count} of the "
+            f"real {noun} count could be included, and this API has no "
+            f"page size/offset to request a smaller batch — the remaining "
+            f"{noun} are not retrievable through this tool"
+        )
+
+    return _hint
+
+
 def _error(message: str) -> str:
     return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
 
@@ -292,7 +312,12 @@ def google_search_console_list_sites() -> str:
             for entry in site_entries
             if isinstance(entry, dict) and entry.get("siteUrl")
         ]
-        return _success_with_trimmed_list("sites", sites, "site_count")
+        return _success_with_trimmed_list(
+            "sites",
+            sites,
+            "site_count",
+            truncated_hint=_no_pagination_trim_hint("sites"),
+        )
     except Exception as e:
         logger.error(f"Error listing Google Search Console sites: {e}")
         return _error(str(e))
@@ -324,7 +349,12 @@ def google_search_console_list_sitemaps(site_url: str) -> str:
                     f"as empty"
                 )
             sitemaps = []
-        return _success_with_trimmed_list("sitemaps", sitemaps, "sitemap_count")
+        return _success_with_trimmed_list(
+            "sitemaps",
+            sitemaps,
+            "sitemap_count",
+            truncated_hint=_no_pagination_trim_hint("sitemaps"),
+        )
     except Exception as e:
         logger.error(f"Error listing sitemaps for {site_url!r}: {e}")
         return _error(str(e))

--- a/src/xagent/web/tools/mcp/google_search_console.py
+++ b/src/xagent/web/tools/mcp/google_search_console.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import logging
 import os
@@ -138,6 +139,10 @@ def _encoded_site_url(site_url: str) -> str:
 def _validate_date(label: str, value: str) -> None:
     if not isinstance(value, str) or not _DATE_PATTERN.match(value):
         raise ValueError(f"{label} must be a date string in YYYY-MM-DD format")
+    try:
+        datetime.date.fromisoformat(value)
+    except ValueError:
+        raise ValueError(f"{label} must be a valid calendar date") from None
 
 
 @mcp.tool()
@@ -269,7 +274,7 @@ def google_search_console_query_search_analytics(
         max_output_length = get_tool_max_output_length()
         original_row_count = len(rows)
         response = _success(rows=rows, row_count=len(rows), truncated=False)
-        while len(response) > max_output_length and len(rows) > 1:
+        while len(response) > max_output_length and rows:
             rows = rows[: len(rows) // 2]
             response = _success(rows=rows, row_count=len(rows), truncated=True)
         if len(rows) < original_row_count:

--- a/src/xagent/web/tools/mcp/google_search_console.py
+++ b/src/xagent/web/tools/mcp/google_search_console.py
@@ -103,7 +103,12 @@ def _request(
 
     if response.status_code == 204 or not response.content:
         return {}
-    return response.json()
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Failed to parse JSON response from Google Search Console API: {response.text[:200]}"
+        ) from exc
 
 
 def _require_dict_result(result: Any) -> dict[str, Any]:
@@ -153,7 +158,7 @@ def google_search_console_list_sites() -> str:
                 "permission_level": entry.get("permissionLevel"),
             }
             for entry in (result.get("siteEntry") or [])
-            if isinstance(entry, dict)
+            if isinstance(entry, dict) and entry.get("siteUrl")
         ]
         return _success(sites=sites)
     except Exception as e:
@@ -227,7 +232,7 @@ def google_search_console_query_search_analytics(
         if start_row < 0:
             raise ValueError("start_row must be >= 0")
         if dimensions:
-            invalid = sorted(set(dimensions) - VALID_DIMENSIONS)
+            invalid = sorted(set(dimensions) - VALID_DIMENSIONS, key=str)
             if invalid:
                 raise ValueError(
                     f"invalid dimensions {invalid}; must be from {sorted(VALID_DIMENSIONS)}"
@@ -252,7 +257,9 @@ def google_search_console_query_search_analytics(
                 body=body,
             )
         )
-        rows = result.get("rows") or []
+        rows = result.get("rows")
+        if not isinstance(rows, list):
+            rows = []
 
         # row_limit bounds row *count*, not bytes: several "query"/"page"
         # dimension values (often full URLs) at once can still cross the

--- a/src/xagent/web/tools/mcp/google_search_console.py
+++ b/src/xagent/web/tools/mcp/google_search_console.py
@@ -187,7 +187,10 @@ def google_search_console_list_sitemaps(site_url: str) -> str:
                 f"{WEBMASTERS_API_BASE_URL}/sites/{encoded_site_url}/sitemaps",
             )
         )
-        return _success(sitemaps=result.get("sitemap") or [])
+        sitemaps = result.get("sitemap")
+        if not isinstance(sitemaps, list):
+            sitemaps = []
+        return _success(sitemaps=sitemaps)
     except Exception as e:
         logger.error(f"Error listing sitemaps for {site_url!r}: {e}")
         return _error(str(e))
@@ -263,6 +266,12 @@ def google_search_console_query_search_analytics(
         )
         rows = result.get("rows")
         if not isinstance(rows, list):
+            if rows is not None:
+                logger.warning(
+                    f"Google Search Console query_search_analytics returned a "
+                    f"non-list 'rows' field ({type(rows).__name__}); treating "
+                    f"as empty"
+                )
             rows = []
 
         # row_limit bounds row *count*, not bytes: several "query"/"page"

--- a/src/xagent/web/tools/mcp/google_search_console.py
+++ b/src/xagent/web/tools/mcp/google_search_console.py
@@ -12,7 +12,6 @@ from mcp.server.fastmcp import FastMCP
 from ....config import get_tool_max_output_length
 from .utils import setup_proxy_env
 
-logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("google-search-console-mcp")
 
 # Ensure standard proxy environment variables are set to prevent hanging requests
@@ -328,4 +327,5 @@ def google_search_console_inspect_url(
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     mcp.run()

--- a/src/xagent/web/tools/mcp/google_search_console.py
+++ b/src/xagent/web/tools/mcp/google_search_console.py
@@ -9,7 +9,12 @@ import requests
 from mcp.server.fastmcp import FastMCP
 
 from ....config import get_tool_max_output_length
-from .utils import require_clean_identifier, setup_proxy_env, url_path_id
+from .utils import (
+    require_clean_identifier,
+    setup_proxy_env,
+    success_with_capped_dict,
+    url_path_id,
+)
 
 logger = logging.getLogger("google-search-console-mcp")
 
@@ -43,25 +48,55 @@ def _success(**payload: Any) -> str:
     return json.dumps({"status": "success", **payload}, ensure_ascii=False)
 
 
-def _success_with_trimmed_list(field_name: str, items: list[Any]) -> str:
-    """Build a {"status": "success", field_name: items, "truncated": ...}
-    payload, halving items until the serialized response fits the
-    platform's output limit.
+def _success_with_trimmed_list(
+    field_name: str,
+    items: list[Any],
+    count_field_name: str,
+    *,
+    truncated_hint: str | None = None,
+) -> str:
+    """Build a {"status": "success", field_name: items, count_field_name:
+    <pre-trim count>, "truncated": ...} payload, halving items until the
+    serialized response fits the platform's output limit.
 
     list_sites and list_sitemaps both call APIs with no pageToken/offset
     parameter — Google returns every site or every submitted sitemap in
     one response — so unlike query_search_analytics (which can be paged
     with start_row), there's no way to ask for a smaller page up front.
-    Truncating after the fact, the same way query_search_analytics already
-    guards its own oversized responses, is the only option for a property
-    with an unusually large site or sitemap count.
+    Truncating after the fact is the only option for a property with an
+    unusually large site or sitemap count.
+
+    count_field_name is pinned to the count *before* any trimming and
+    never recomputed from the (possibly shrunk) items list: for
+    query_search_analytics this is the row_count pagination signal callers
+    check against row_limit, and conflating it with the post-trim count
+    would make a caller stop paging early and silently miss rows, with no
+    way to resume since the dropped rows already consumed part of that
+    request's offset window. For list_sites/list_sitemaps it means a fully
+    trimmed (empty) list still reports how many entries actually exist,
+    rather than reading as "you have none."
+
+    truncated_hint, if given, is included as "hint" only once trimming
+    actually happens — a caller-visible next step (e.g. "retry with a
+    smaller row_limit") instead of a signal only visible in server logs.
     """
     max_output_length = get_tool_max_output_length()
     original_count = len(items)
-    response = _success(**{field_name: items, "truncated": False})
+
+    def _build(truncated: bool) -> str:
+        payload: dict[str, Any] = {
+            field_name: items,
+            count_field_name: original_count,
+            "truncated": truncated,
+        }
+        if truncated and truncated_hint:
+            payload["hint"] = truncated_hint
+        return _success(**payload)
+
+    response = _build(False)
     while len(response) > max_output_length and items:
         items = items[: len(items) // 2]
-        response = _success(**{field_name: items, "truncated": True})
+        response = _build(True)
     if len(items) < original_count:
         logger.warning(
             f"Google Search Console {field_name} response trimmed from "
@@ -174,11 +209,12 @@ def _dimension_filter_groups_reference_query(
     dimension_filter_groups: list[dict[str, Any]],
 ) -> bool:
     """Whether any filter inside dimension_filter_groups filters on the
-    "query" dimension. Tolerates a malformed/unexpected shape (a non-dict
-    group, a non-list "filters", a non-dict filter entry) by treating it as
-    not referencing "query" rather than raising — this check runs before
-    the request body is built, and a shape the caller got wrong here will
-    still surface as a clear upstream 400 once sent."""
+    "query" dimension. The caller has already validated that
+    dimension_filter_groups itself is a list; this tolerates a malformed
+    shape *within* that list (a non-dict group, a non-list "filters", a
+    non-dict filter entry) by treating it as not referencing "query" rather
+    than raising — such a shape will still surface as a clear upstream 400
+    once the request is sent."""
     for group in dimension_filter_groups:
         if not isinstance(group, dict):
             continue
@@ -232,7 +268,7 @@ def google_search_console_list_sites() -> str:
             for entry in site_entries
             if isinstance(entry, dict) and entry.get("siteUrl")
         ]
-        return _success_with_trimmed_list("sites", sites)
+        return _success_with_trimmed_list("sites", sites, "site_count")
     except Exception as e:
         logger.error(f"Error listing Google Search Console sites: {e}")
         return _error(str(e))
@@ -264,7 +300,7 @@ def google_search_console_list_sitemaps(site_url: str) -> str:
                     f"as empty"
                 )
             sitemaps = []
-        return _success_with_trimmed_list("sitemaps", sitemaps)
+        return _success_with_trimmed_list("sitemaps", sitemaps, "sitemap_count")
     except Exception as e:
         logger.error(f"Error listing sitemaps for {site_url!r}: {e}")
         return _error(str(e))
@@ -288,18 +324,19 @@ def google_search_console_query_search_analytics(
     site_url: a value from google_search_console_list_sites.
     start_date, end_date: YYYY-MM-DD (inclusive). Search Console data is
       typically delayed 1-3 days, so end_date should not be today.
-    dimensions: any of "query", "page", "country", "device", "date",
-      "searchAppearance". Omit for a single aggregate row. "query" is not
-      available (as a dimension or as a dimension_filter_groups filter)
-      when search_type is "discover" or "googleNews" (Google doesn't
-      disclose search terms for those surfaces) — "position" values on
-      rows from those two surfaces are also not meaningful ranking data,
-      per Google's own documentation.
+    dimensions: a list of any of "query", "page", "country", "device",
+      "date", "searchAppearance". Omit for a single aggregate row.
+      "searchAppearance" cannot be combined with any other dimension.
+      "query" is not available (as a dimension or as a
+      dimension_filter_groups filter) when search_type is "discover" or
+      "googleNews" (Google doesn't disclose search terms for those
+      surfaces) — "position" values on rows from those two surfaces are
+      also not meaningful ranking data, per Google's own documentation.
     search_type: one of "web", "image", "video", "news", "discover",
       "googleNews" (default "web").
-    dimension_filter_groups: raw Search Analytics API filter groups, e.g.
-      [{"filters": [{"dimension": "country", "operator": "equals",
-      "expression": "usa"}]}]. Optional.
+    dimension_filter_groups: a list of raw Search Analytics API filter
+      groups, e.g. [{"filters": [{"dimension": "country", "operator":
+      "equals", "expression": "usa"}]}]. Optional.
     row_limit: max rows to return (default 100, max 1000 — keeps a wide
       query's serialized response under the MCP output size limit).
     start_row: row offset for paging — if row_count equals row_limit, call
@@ -308,7 +345,9 @@ def google_search_console_query_search_analytics(
       not a total match count — Google's own API docs note it isn't
       guaranteed to return literally every matching row even once you've
       fully paginated. It stays accurate even when "rows" is shortened
-      below for output-size reasons — see "truncated".
+      below for output-size reasons — see "truncated" and "hint" (present
+      only when truncated); a caller that hits this can retry the same
+      start_row with a smaller row_limit to recover the missing rows.
     """
     try:
         encoded_site_url = _encoded_site_url(site_url)
@@ -322,11 +361,22 @@ def google_search_console_query_search_analytics(
             raise ValueError(f"row_limit must be between 1 and {QUERY_MAX_ROW_LIMIT}")
         if start_row < 0:
             raise ValueError("start_row must be >= 0")
+        if dimensions is not None and not isinstance(dimensions, list):
+            raise ValueError("dimensions must be a list of strings")
+        if dimension_filter_groups is not None and not isinstance(
+            dimension_filter_groups, list
+        ):
+            raise ValueError("dimension_filter_groups must be a list of filter groups")
         if dimensions:
             invalid = sorted(set(dimensions) - VALID_DIMENSIONS, key=str)
             if invalid:
                 raise ValueError(
                     f"invalid dimensions {invalid}; must be from {sorted(VALID_DIMENSIONS)}"
+                )
+            if "searchAppearance" in dimensions and len(dimensions) > 1:
+                raise ValueError(
+                    '"searchAppearance" cannot be combined with other dimensions '
+                    "in the same request"
                 )
         if search_type in _SEARCH_TYPES_WITHOUT_QUERY_DIMENSION:
             # Google rejects "query" for these two surfaces whether it's
@@ -377,31 +427,19 @@ def google_search_console_query_search_analytics(
 
         # row_limit bounds row *count*, not bytes: several "query"/"page"
         # dimension values (often full URLs) at once can still cross the
-        # platform's output truncation threshold. Halve the returned rows
-        # until the serialized response fits, mirroring
-        # google_analytics_run_report's trimming approach.
-        #
-        # row_count is pinned to the pre-trim count and never recomputed
-        # from the (possibly shrunk) "rows" list: it's the pagination
-        # signal the docstring tells callers to check against row_limit,
-        # and trimming rows for output-size reasons must not be confused
-        # with "this page had fewer matches than row_limit" — that would
-        # make a caller stop paging early and silently miss rows, with no
-        # way to resume since the dropped rows already consumed part of
-        # this request's offset window.
-        max_output_length = get_tool_max_output_length()
-        original_row_count = len(rows)
-        response = _success(rows=rows, row_count=original_row_count, truncated=False)
-        while len(response) > max_output_length and rows:
-            rows = rows[: len(rows) // 2]
-            response = _success(rows=rows, row_count=original_row_count, truncated=True)
-        if len(rows) < original_row_count:
-            logger.warning(
-                f"Google Search Console query_search_analytics response trimmed "
-                f"from {original_row_count} to {len(rows)} rows to stay under "
-                f"the {max_output_length}-char output limit"
-            )
-        return response
+        # platform's output truncation threshold. _success_with_trimmed_list
+        # halves "rows" until the response fits while pinning row_count to
+        # the pre-trim count (see its docstring) and attaching a retry hint.
+        return _success_with_trimmed_list(
+            "rows",
+            rows,
+            "row_count",
+            truncated_hint=(
+                "response truncated for output size; retry this same "
+                "start_row with a smaller row_limit to recover the missing "
+                "rows"
+            ),
+        )
     except Exception as e:
         logger.error(f"Error querying search analytics for {site_url!r}: {e}")
         return _error(str(e))
@@ -446,7 +484,7 @@ def google_search_console_inspect_url(
                     f"({type(inspection_result).__name__}); treating as empty"
                 )
             inspection_result = {}
-        return _success(inspection_result=inspection_result)
+        return success_with_capped_dict("inspection_result", inspection_result)
     except Exception as e:
         logger.error(f"Error inspecting URL {inspection_url!r}: {e}")
         return _error(str(e))

--- a/src/xagent/web/tools/mcp/google_search_console.py
+++ b/src/xagent/web/tools/mcp/google_search_console.py
@@ -24,6 +24,11 @@ DEFAULT_TIMEOUT_SECONDS = 30
 
 VALID_DIMENSIONS = {"query", "page", "country", "device", "date", "searchAppearance"}
 VALID_SEARCH_TYPES = {"web", "image", "video", "news", "discover", "googleNews"}
+# Google does not disclose search terms for Discover/Google News surfaces,
+# so the Search Analytics API rejects the "query" dimension for these two
+# search types with a 400. Checked locally so the calling LLM gets an
+# actionable message instead of an upstream API error.
+_SEARCH_TYPES_WITHOUT_QUERY_DIMENSION = {"discover", "googleNews"}
 _DATE_PATTERN = re.compile(r"^\d{4}-\d{2}-\d{2}\Z")
 
 # The Search Analytics API itself allows rowLimit up to 25000. That's capped
@@ -226,7 +231,9 @@ def google_search_console_query_search_analytics(
     start_date, end_date: YYYY-MM-DD (inclusive). Search Console data is
       typically delayed 1-3 days, so end_date should not be today.
     dimensions: any of "query", "page", "country", "device", "date",
-      "searchAppearance". Omit for a single aggregate row.
+      "searchAppearance". Omit for a single aggregate row. "query" is not
+      available when search_type is "discover" or "googleNews" (Google
+      doesn't disclose search terms for those surfaces).
     search_type: one of "web", "image", "video", "news", "discover",
       "googleNews" (default "web").
     dimension_filter_groups: raw Search Analytics API filter groups, e.g.
@@ -256,6 +263,15 @@ def google_search_console_query_search_analytics(
             if invalid:
                 raise ValueError(
                     f"invalid dimensions {invalid}; must be from {sorted(VALID_DIMENSIONS)}"
+                )
+            if (
+                "query" in dimensions
+                and search_type in _SEARCH_TYPES_WITHOUT_QUERY_DIMENSION
+            ):
+                raise ValueError(
+                    f'the "query" dimension is not available for '
+                    f"search_type={search_type!r} (Google does not disclose "
+                    f"search terms for Discover/Google News surfaces)"
                 )
 
         body: dict[str, Any] = {

--- a/src/xagent/web/tools/mcp/google_search_console.py
+++ b/src/xagent/web/tools/mcp/google_search_console.py
@@ -142,6 +142,30 @@ def _encoded_site_url(site_url: str) -> str:
     return url_path_id(site_url, "site_url")
 
 
+def _dimension_filter_groups_reference_query(
+    dimension_filter_groups: list[dict[str, Any]],
+) -> bool:
+    """Whether any filter inside dimension_filter_groups filters on the
+    "query" dimension. Tolerates a malformed/unexpected shape (a non-dict
+    group, a non-list "filters", a non-dict filter entry) by treating it as
+    not referencing "query" rather than raising — this check runs before
+    the request body is built, and a shape the caller got wrong here will
+    still surface as a clear upstream 400 once sent."""
+    for group in dimension_filter_groups:
+        if not isinstance(group, dict):
+            continue
+        filters = group.get("filters")
+        if not isinstance(filters, list):
+            continue
+        for filter_entry in filters:
+            if (
+                isinstance(filter_entry, dict)
+                and filter_entry.get("dimension") == "query"
+            ):
+                return True
+    return False
+
+
 def _validate_date(label: str, value: str) -> None:
     if not isinstance(value, str) or not _DATE_PATTERN.match(value):
         raise ValueError(f"{label} must be a date string in YYYY-MM-DD format")
@@ -232,8 +256,11 @@ def google_search_console_query_search_analytics(
       typically delayed 1-3 days, so end_date should not be today.
     dimensions: any of "query", "page", "country", "device", "date",
       "searchAppearance". Omit for a single aggregate row. "query" is not
-      available when search_type is "discover" or "googleNews" (Google
-      doesn't disclose search terms for those surfaces).
+      available (as a dimension or as a dimension_filter_groups filter)
+      when search_type is "discover" or "googleNews" (Google doesn't
+      disclose search terms for those surfaces) — "position" values on
+      rows from those two surfaces are also not meaningful ranking data,
+      per Google's own documentation.
     search_type: one of "web", "image", "video", "news", "discover",
       "googleNews" (default "web").
     dimension_filter_groups: raw Search Analytics API filter groups, e.g.
@@ -242,9 +269,12 @@ def google_search_console_query_search_analytics(
     row_limit: max rows to return (default 100, max 1000 — keeps a wide
       query's serialized response under the MCP output size limit).
     start_row: row offset for paging — if row_count equals row_limit, call
-      again with start_row += row_limit to fetch more (row_count reflects
-      how many rows this query actually matched, independent of whether
-      "rows" was shortened below — see "truncated").
+      again with start_row += row_limit to fetch more. row_count is the
+      number of rows this single response returned (capped at row_limit),
+      not a total match count — Google's own API docs note it isn't
+      guaranteed to return literally every matching row even once you've
+      fully paginated. It stays accurate even when "rows" is shortened
+      below for output-size reasons — see "truncated".
     """
     try:
         encoded_site_url = _encoded_site_url(site_url)
@@ -264,14 +294,22 @@ def google_search_console_query_search_analytics(
                 raise ValueError(
                     f"invalid dimensions {invalid}; must be from {sorted(VALID_DIMENSIONS)}"
                 )
-            if (
-                "query" in dimensions
-                and search_type in _SEARCH_TYPES_WITHOUT_QUERY_DIMENSION
-            ):
+        if search_type in _SEARCH_TYPES_WITHOUT_QUERY_DIMENSION:
+            # Google rejects "query" for these two surfaces whether it's
+            # requested as a grouping dimension or as a filter condition —
+            # both reach the same API restriction, so both must be checked
+            # here rather than just the dimensions list.
+            uses_query = bool(dimensions and "query" in dimensions) or (
+                dimension_filter_groups is not None
+                and _dimension_filter_groups_reference_query(dimension_filter_groups)
+            )
+            if uses_query:
                 raise ValueError(
                     f'the "query" dimension is not available for '
                     f"search_type={search_type!r} (Google does not disclose "
-                    f"search terms for Discover/Google News surfaces)"
+                    f"search terms for Discover/Google News surfaces), whether "
+                    f"requested as a dimension or filtered on via "
+                    f"dimension_filter_groups"
                 )
 
         body: dict[str, Any] = {

--- a/src/xagent/web/tools/mcp/google_sheets.py
+++ b/src/xagent/web/tools/mcp/google_sheets.py
@@ -53,7 +53,9 @@ def get_drive_service() -> Any:
 
 def _resolve_spreadsheet_id(spreadsheet_id: str) -> str:
     """Accept either a bare spreadsheet id or a full Google Sheets URL."""
-    return resolve_id_from_url(spreadsheet_id, _SPREADSHEET_URL_ID_PATTERN)
+    return resolve_id_from_url(
+        spreadsheet_id, _SPREADSHEET_URL_ID_PATTERN, "spreadsheet_id"
+    )
 
 
 @mcp.tool()

--- a/src/xagent/web/tools/mcp/google_slides.py
+++ b/src/xagent/web/tools/mcp/google_slides.py
@@ -48,7 +48,9 @@ def get_slides_service() -> Any:
 
 def _resolve_presentation_id(presentation_id: str) -> str:
     """Accept either a bare presentation id or a full Google Slides URL."""
-    return resolve_id_from_url(presentation_id, _PRESENTATION_URL_ID_PATTERN)
+    return resolve_id_from_url(
+        presentation_id, _PRESENTATION_URL_ID_PATTERN, "presentation_id"
+    )
 
 
 def _element_text(element: dict[str, Any]) -> str:

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -143,9 +143,16 @@ def clamp_offset(offset: int) -> int:
     return max(0, int(offset))
 
 
-def resolve_id_from_url(value: str, pattern: re.Pattern[str]) -> str:
+def resolve_id_from_url(value: str, pattern: re.Pattern[str], field_name: str) -> str:
     """Return the id captured by ``pattern`` when ``value`` is a matching URL,
-    otherwise the stripped value itself."""
+    otherwise the stripped value itself.
+
+    Guards against a non-string value the same way require_clean_identifier
+    does: ``pattern.search()``/``.strip()`` would otherwise raise a raw
+    TypeError/AttributeError instead of a clean, actionable ValueError.
+    """
+    if not isinstance(value, str):
+        raise ValueError(f"{field_name} must be a string")
     match = pattern.search(value)
     if match:
         return match.group(1)

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -18,7 +18,7 @@ def require_clean_identifier(value: str, field_name: str) -> str:
     into a URL path, use url_path_id instead - encoding (not just rejecting
     whitespace) is what actually closes path/query injection.
     """
-    if not value or value.strip() != value:
+    if not isinstance(value, str) or not value or value.strip() != value:
         raise ValueError(
             f"{field_name} must be a non-empty id with no surrounding whitespace"
         )

--- a/tests/alembic/test_20260824_seed_google_search_console_mcp_app.py
+++ b/tests/alembic/test_20260824_seed_google_search_console_mcp_app.py
@@ -1,0 +1,129 @@
+"""Tests for the Google Search Console MCP connector seed migration."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260824_seed_google_search_console_mcp_app.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "seed_google_search_console_migration", migration_file
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_table(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                name VARCHAR(200) NOT NULL,
+                description TEXT,
+                icon VARCHAR(1000),
+                transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                provider_name VARCHAR(50),
+                category VARCHAR(100),
+                oauth_scopes JSON,
+                is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                launch_config JSON
+            )
+            """
+        )
+    )
+
+
+def _app_ids(connection):
+    return set(connection.execute(text("SELECT app_id FROM public_mcp_apps")).scalars())
+
+
+def test_upgrade_inserts_google_search_console(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        assert "google-search-console" in _app_ids(connection)
+        row = connection.execute(
+            text(
+                "SELECT transport, provider_name, launch_config FROM public_mcp_apps"
+                " WHERE app_id='google-search-console'"
+            )
+        ).first()
+        assert row[0] == "oauth"
+        assert row[1] == "google"
+        assert "xagent.web.tools.mcp.google_search_console" in str(row[2])
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()  # second run must not raise or duplicate
+        rows = connection.execute(
+            text(
+                "SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='google-search-console'"
+            )
+        ).scalar()
+        assert rows == 1
+
+
+def test_seed_row_matches_registry(tmp_path):
+    """The migration snapshot and the runtime registry must define the same
+    google-search-console row (the migration is a frozen copy; this catches
+    drift)."""
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    migration = _load_migration_module()
+    registry_row = next(
+        r
+        for r in get_builtin_public_mcp_app_rows()
+        if r["app_id"] == "google-search-console"
+    )
+    assert migration.ROW == registry_row
+
+
+def test_downgrade_removes_google_search_console(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "google-search-console" not in _app_ids(connection)
+
+
+def test_upgrade_and_downgrade_no_op_without_table(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        table_names = set(
+            connection.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table'")
+            ).scalars()
+        )
+        assert "public_mcp_apps" not in table_names

--- a/tests/alembic/test_20260824_seed_google_search_console_mcp_app.py
+++ b/tests/alembic/test_20260824_seed_google_search_console_mcp_app.py
@@ -88,6 +88,35 @@ def test_upgrade_is_idempotent(tmp_path):
         assert rows == 1
 
 
+def test_upgrade_leaves_existing_differently_populated_row_untouched(tmp_path):
+    """The presence-only guard (`if APP_ID in existing: return`) must never
+    reach the insert path once a row exists — verify with a row whose data
+    actually differs from ROW, not just an identical re-seed."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        connection.execute(
+            text(
+                "INSERT INTO public_mcp_apps (app_id, name, transport,"
+                " provider_name, category, is_visible_in_connector)"
+                " VALUES ('google-search-console', 'Customized Name', 'oauth',"
+                " 'google', 'Marketing', 0)"
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        row = connection.execute(
+            text(
+                "SELECT name, category, is_visible_in_connector"
+                " FROM public_mcp_apps WHERE app_id='google-search-console'"
+            )
+        ).first()
+        assert row[0] == "Customized Name"
+        assert row[1] == "Marketing"
+        assert row[2] == 0
+
+
 def test_seed_row_matches_registry():
     """The migration snapshot and the runtime registry must define the same
     google-search-console row (the migration is a frozen copy; this catches
@@ -170,6 +199,25 @@ def test_downgrade_removes_google_search_console(tmp_path):
             migration.upgrade()
             migration.downgrade()
         assert "google-search-console" not in _app_ids(connection)
+
+
+def test_downgrade_only_removes_this_app_not_unrelated_rows(tmp_path):
+    """A DELETE missing its WHERE clause (table-wide instead of scoped to
+    this app_id) would not be caught by a test with only one seeded row."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        connection.execute(
+            text(
+                "INSERT INTO public_mcp_apps (app_id, name, transport)"
+                " VALUES ('unrelated-app', 'Unrelated', 'oauth')"
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert _app_ids(connection) == {"unrelated-app"}
 
 
 def test_downgrade_is_a_no_op_when_row_already_absent(tmp_path):

--- a/tests/alembic/test_20260824_seed_google_search_console_mcp_app.py
+++ b/tests/alembic/test_20260824_seed_google_search_console_mcp_app.py
@@ -88,7 +88,7 @@ def test_upgrade_is_idempotent(tmp_path):
         assert rows == 1
 
 
-def test_seed_row_matches_registry(tmp_path):
+def test_seed_row_matches_registry():
     """The migration snapshot and the runtime registry must define the same
     google-search-console row (the migration is a frozen copy; this catches
     drift)."""
@@ -103,6 +103,54 @@ def test_seed_row_matches_registry(tmp_path):
     assert migration.ROW == registry_row
 
 
+def test_app_id_does_not_collide_with_other_builtin_apps():
+    """A duplicate app_id across the registry would violate the DB's UNIQUE
+    constraint at seed time for whichever migration runs second; catch it
+    directly here instead of relying on that indirect signal."""
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    app_ids = [row["app_id"] for row in get_builtin_public_mcp_app_rows()]
+    assert app_ids.count("google-search-console") == 1
+
+
+def test_upgrade_inserts_only_columns_present_on_older_schema(tmp_path):
+    """A pre-existing deployment's public_mcp_apps table may predate a
+    column ROW defines (e.g. before is_visible_in_connector was added).
+    upgrade() must insert only the columns that actually exist rather than
+    failing or inserting into a nonexistent column."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE public_mcp_apps (
+                    id INTEGER PRIMARY KEY,
+                    app_id VARCHAR(100) NOT NULL UNIQUE,
+                    name VARCHAR(200) NOT NULL,
+                    description TEXT,
+                    icon VARCHAR(1000),
+                    transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                    provider_name VARCHAR(50),
+                    category VARCHAR(100),
+                    launch_config JSON
+                )
+                """
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        assert "google-search-console" in _app_ids(connection)
+        row = connection.execute(
+            text(
+                "SELECT category, launch_config FROM public_mcp_apps"
+                " WHERE app_id='google-search-console'"
+            )
+        ).first()
+        assert row[0] == "Analytics"
+        assert "xagent.web.tools.mcp.google_search_console" in str(row[1])
+
+
 def test_downgrade_removes_google_search_console(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()
@@ -111,6 +159,16 @@ def test_downgrade_removes_google_search_console(tmp_path):
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
             migration.downgrade()
+        assert "google-search-console" not in _app_ids(connection)
+
+
+def test_downgrade_is_a_no_op_when_row_already_absent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.downgrade()  # never upgraded; row was never inserted
         assert "google-search-console" not in _app_ids(connection)
 
 

--- a/tests/alembic/test_20260824_seed_google_search_console_mcp_app.py
+++ b/tests/alembic/test_20260824_seed_google_search_console_mcp_app.py
@@ -115,9 +115,17 @@ def test_app_id_does_not_collide_with_other_builtin_apps():
 
 def test_upgrade_inserts_only_columns_present_on_older_schema(tmp_path):
     """A pre-existing deployment's public_mcp_apps table may predate a
-    column ROW defines (e.g. before is_visible_in_connector was added).
-    upgrade() must insert only the columns that actually exist rather than
-    failing or inserting into a nonexistent column."""
+    column ROW defines. upgrade() must insert only the columns that
+    actually exist rather than failing or inserting into a nonexistent
+    column.
+
+    This fixture mirrors the table's actual migration history rather than
+    an arbitrary subset: oauth_scopes was added at table creation
+    (f1427c3a7261, 2026-04-21) while is_visible_in_connector was added over
+    a month later (20260519_add_connector_visibility_to_public_mcp_apps) —
+    so a real pre-2026-05-19 deployment has oauth_scopes but not
+    is_visible_in_connector, never the other way around.
+    """
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()
     with engine.begin() as connection:
@@ -133,6 +141,7 @@ def test_upgrade_inserts_only_columns_present_on_older_schema(tmp_path):
                     transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
                     provider_name VARCHAR(50),
                     category VARCHAR(100),
+                    oauth_scopes JSON,
                     launch_config JSON
                 )
                 """
@@ -143,12 +152,13 @@ def test_upgrade_inserts_only_columns_present_on_older_schema(tmp_path):
         assert "google-search-console" in _app_ids(connection)
         row = connection.execute(
             text(
-                "SELECT category, launch_config FROM public_mcp_apps"
+                "SELECT category, oauth_scopes, launch_config FROM public_mcp_apps"
                 " WHERE app_id='google-search-console'"
             )
         ).first()
         assert row[0] == "Analytics"
-        assert "xagent.web.tools.mcp.google_search_console" in str(row[1])
+        assert "webmasters.readonly" in str(row[1])
+        assert "xagent.web.tools.mcp.google_search_console" in str(row[2])
 
 
 def test_downgrade_removes_google_search_console(tmp_path):

--- a/tests/migrations/test_migration_integration.py
+++ b/tests/migrations/test_migration_integration.py
@@ -483,11 +483,14 @@ class TestMigrations:
 
     def test_sqlite_owner_downgrade_preserves_stripe_head(self, sqlite_tester):
         """Rollback removes owner storage without removing the Stripe seed."""
-        owner_revision = "20260818_user_oauth_resource_owner"
         stripe_revision = "20260818_seed_stripe_mcp_app"
         script_dir = ScriptDirectory.from_config(sqlite_tester.alembic_cfg)
 
-        assert script_dir.get_heads() == [owner_revision]
+        # A single unambiguous head is what makes "head" below resolve
+        # deterministically; the exact revision id is expected to change as
+        # later migrations are added and isn't itself part of this test's
+        # invariant.
+        assert len(script_dir.get_heads()) == 1
 
         sqlite_tester.create_metadata_owned_users_table()
         command.upgrade(sqlite_tester.alembic_cfg, "head")

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -832,6 +832,10 @@ def test_builtin_registry_uses_runtime_available_launch_commands() -> None:
             "xagent.web.tools.mcp.google_analytics",
             {"GOOGLE_ACCESS_TOKEN": "access_token"},
         ),
+        "google-search-console": (
+            "xagent.web.tools.mcp.google_search_console",
+            {"GOOGLE_ACCESS_TOKEN": "access_token"},
+        ),
         "hubspot": (
             "xagent.web.tools.mcp.hubspot",
             {"HUBSPOT_ACCESS_TOKEN": "access_token"},

--- a/tests/web/tools/test_google_search_console_mcp.py
+++ b/tests/web/tools/test_google_search_console_mcp.py
@@ -111,6 +111,28 @@ def test_request_caps_unstructured_error_body(monkeypatch):
     assert len(str(excinfo.value)) < 1200
 
 
+def test_request_raises_runtime_error_on_non_json_success_body(monkeypatch):
+    """A 200 response whose body isn't JSON (e.g. an HTML page from an
+    intermediate proxy) must fail with a clear RuntimeError, not a raw
+    ValueError/JSONDecodeError from response.json()."""
+    bad_response = Mock()
+    bad_response.status_code = 200
+    bad_response.content = b"<html>not json</html>"
+    bad_response.text = "<html>not json</html>"
+    bad_response.raise_for_status = Mock()
+    bad_response.json = Mock(side_effect=ValueError("Expecting value"))
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(return_value=bad_response),
+    )
+
+    with pytest.raises(RuntimeError, match="Failed to parse JSON response"):
+        google_search_console._request(
+            "GET", f"{google_search_console.WEBMASTERS_API_BASE_URL}/sites"
+        )
+
+
 def test_list_sites_projects_site_entries(monkeypatch):
     monkeypatch.setattr(
         google_search_console.requests,
@@ -139,6 +161,34 @@ def test_list_sites_projects_site_entries(monkeypatch):
     assert result["sites"] == [
         {"site_url": "https://example.com/", "permission_level": "siteOwner"},
         {"site_url": "sc-domain:example.com", "permission_level": "siteFullUser"},
+    ]
+
+
+def test_list_sites_filters_out_entries_without_site_url(monkeypatch):
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "siteEntry": [
+                        {"siteUrl": None, "permissionLevel": "siteOwner"},
+                        {"permissionLevel": "siteOwner"},
+                        {
+                            "siteUrl": "https://example.com/",
+                            "permissionLevel": "siteOwner",
+                        },
+                    ]
+                }
+            )
+        ),
+    )
+
+    result = json.loads(google_search_console.google_search_console_list_sites())
+
+    assert result["status"] == "success"
+    assert result["sites"] == [
+        {"site_url": "https://example.com/", "permission_level": "siteOwner"}
     ]
 
 
@@ -424,6 +474,24 @@ def test_query_search_analytics_trims_rows_and_flags_truncated_when_over_budget(
     assert result["truncated"] is True
     assert len(result["rows"]) < google_search_console.QUERY_MAX_ROW_LIMIT
     assert len(response) < get_tool_max_output_length()
+
+
+def test_query_search_analytics_treats_non_list_rows_as_empty(monkeypatch):
+    """A malformed API response where "rows" isn't a list (e.g. null or a
+    dict) must not raise a TypeError out of len()/slicing; it degrades to an
+    empty result instead."""
+    mock_request = Mock(return_value=MockResponse(json_data={"rows": "not-a-list"}))
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/", start_date="2026-07-01", end_date="2026-07-28"
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["rows"] == []
+    assert result["row_count"] == 0
 
 
 def test_query_search_analytics_returns_error_payload_on_api_failure(monkeypatch):

--- a/tests/web/tools/test_google_search_console_mcp.py
+++ b/tests/web/tools/test_google_search_console_mcp.py
@@ -68,6 +68,15 @@ def test_encoded_site_url_rejects_empty():
         google_search_console._encoded_site_url("")
 
 
+@pytest.mark.parametrize("bad_value", [None, 123, ["https://example.com/"]])
+def test_encoded_site_url_rejects_non_string(bad_value):
+    """The isinstance guard is this function's own logic, not something
+    url_path_id/require_clean_identifier provides — .strip() would raise a
+    raw AttributeError on a non-string value without it."""
+    with pytest.raises(ValueError, match="site_url"):
+        google_search_console._encoded_site_url(bad_value)
+
+
 @pytest.mark.parametrize("bad_value", [".", ".."])
 def test_encoded_site_url_rejects_dot_segments(bad_value):
     """ "." and ".." survive quote() unchanged (unreserved per RFC 3986), and
@@ -263,6 +272,33 @@ def test_list_sites_returns_error_payload_on_failure(monkeypatch):
     assert "insufficient permissions" in result["message"]
 
 
+def test_list_sites_trims_response_when_over_output_budget(monkeypatch):
+    """list_sites has no pageToken/offset to request a smaller page up
+    front (Google returns every site in one response), so an unusually
+    large account must be handled the same way query_search_analytics
+    guards its own oversized responses: truncate after the fact."""
+    max_output_length = get_tool_max_output_length()
+    site_entries = [
+        {
+            "siteUrl": f"https://example-{i}.com/".ljust(80, "x"),
+            "permissionLevel": "siteOwner",
+        }
+        for i in range(2000)
+    ]
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"siteEntry": site_entries})
+    )
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    response = google_search_console.google_search_console_list_sites()
+
+    result = json.loads(response)
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert len(result["sites"]) < len(site_entries)
+    assert len(response) < max_output_length
+
+
 def test_list_sites_rejects_expired_token(monkeypatch):
     monkeypatch.setattr(
         google_search_console.requests,
@@ -336,20 +372,43 @@ def test_list_sitemaps_returns_sitemap_list(monkeypatch):
     assert "https%3A%2F%2Fexample.com%2F" in mock_request.call_args.kwargs["url"]
 
 
-def test_list_sitemaps_treats_non_list_sitemap_field_as_empty(monkeypatch):
+def test_list_sitemaps_treats_non_list_sitemap_field_as_empty(monkeypatch, caplog):
     """A malformed API response where "sitemap" isn't a list must not
-    crash or leak the raw value; it degrades to an empty list."""
+    crash or leak the raw value; it degrades to an empty list and logs the
+    anomaly, matching the warning the other three tools log for the same
+    class of malformed-field failure."""
     mock_request = Mock(return_value=MockResponse(json_data={"sitemap": "not-a-list"}))
     monkeypatch.setattr(google_search_console.requests, "request", mock_request)
 
-    result = json.loads(
-        google_search_console.google_search_console_list_sitemaps(
-            "https://example.com/"
+    with caplog.at_level("WARNING", logger=google_search_console.logger.name):
+        result = json.loads(
+            google_search_console.google_search_console_list_sitemaps(
+                "https://example.com/"
+            )
         )
-    )
 
     assert result["status"] == "success"
     assert result["sitemaps"] == []
+    assert "non-list 'sitemap'" in caplog.text
+
+
+def test_list_sitemaps_omits_warning_when_sitemap_key_missing(monkeypatch, caplog):
+    """A genuinely absent "sitemap" key (a site with no sitemaps) should not
+    log the malformed-response warning — only a present-but-wrong-type
+    value should."""
+    mock_request = Mock(return_value=MockResponse(json_data={}))
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    with caplog.at_level("WARNING", logger=google_search_console.logger.name):
+        result = json.loads(
+            google_search_console.google_search_console_list_sitemaps(
+                "https://example.com/"
+            )
+        )
+
+    assert result["status"] == "success"
+    assert result["sitemaps"] == []
+    assert "non-list 'sitemap'" not in caplog.text
 
 
 def test_list_sitemaps_returns_error_payload_on_failure(monkeypatch):
@@ -372,6 +431,35 @@ def test_list_sitemaps_returns_error_payload_on_failure(monkeypatch):
 
     assert result["status"] == "error"
     assert "site not found" in result["message"]
+
+
+def test_list_sitemaps_trims_response_when_over_output_budget(monkeypatch):
+    """Same as list_sites: the Sitemaps API has no pageToken/offset, so a
+    property with an unusually large submitted-sitemap count (common for
+    sitemap-index setups) must be truncated after the fact rather than
+    failing the call outright."""
+    max_output_length = get_tool_max_output_length()
+    sitemap_entries = [
+        {
+            "path": f"https://example.com/sitemap-{i}.xml".ljust(80, "x"),
+            "isPending": False,
+        }
+        for i in range(2000)
+    ]
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"sitemap": sitemap_entries})
+    )
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    response = google_search_console.google_search_console_list_sitemaps(
+        "https://example.com/"
+    )
+
+    result = json.loads(response)
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert len(result["sitemaps"]) < len(sitemap_entries)
+    assert len(response) < max_output_length
 
 
 def test_list_sitemaps_rejects_non_dict_top_level_response(monkeypatch):

--- a/tests/web/tools/test_google_search_console_mcp.py
+++ b/tests/web/tools/test_google_search_console_mcp.py
@@ -70,9 +70,12 @@ def test_encoded_site_url_rejects_empty():
 
 @pytest.mark.parametrize("bad_value", [None, 123, ["https://example.com/"]])
 def test_encoded_site_url_rejects_non_string(bad_value):
-    """The isinstance guard is this function's own logic, not something
-    url_path_id/require_clean_identifier provides — .strip() would raise a
-    raw AttributeError on a non-string value without it."""
+    """_encoded_site_url's own isinstance check fires first and produces the
+    more actionable, format-specific message; require_clean_identifier (via
+    url_path_id, reached if this local check were ever removed) now also
+    guards against a non-string value with its own isinstance check, so
+    either layer alone would prevent the raw AttributeError .strip() used
+    to raise on a non-string value."""
     with pytest.raises(ValueError, match="site_url"):
         google_search_console._encoded_site_url(bad_value)
 
@@ -427,16 +430,16 @@ def test_list_sitemaps_degenerate_trim_reports_true_count_not_zero(monkeypatch):
         Mock(return_value=MockResponse(json_data={"sitemap": [oversized_sitemap]})),
     )
 
-    result = json.loads(
-        google_search_console.google_search_console_list_sitemaps(
-            "https://example.com/"
-        )
+    response = google_search_console.google_search_console_list_sitemaps(
+        "https://example.com/"
     )
+    result = json.loads(response)
 
     assert result["status"] == "success"
     assert result["sitemaps"] == []
     assert result["sitemap_count"] == 1
     assert result["truncated"] is True
+    assert len(response) < max_output_length
 
 
 def test_list_sitemaps_treats_non_list_sitemap_field_as_empty(monkeypatch, caplog):
@@ -1067,8 +1070,10 @@ def test_query_search_analytics_trims_rows_and_flags_truncated_when_over_budget(
     assert result["row_count"] == google_search_console.QUERY_MAX_ROW_LIMIT
     assert result["row_count"] != len(result["rows"])
     # A truncated response must carry a caller-visible next step, not just
-    # a server-side log line.
+    # a server-side log line — and a concrete number, not just "try
+    # smaller", so the caller isn't left guessing.
     assert "smaller row_limit" in result["hint"]
+    assert str(len(result["rows"])) in result["hint"]
 
 
 def test_query_search_analytics_trims_to_empty_when_single_row_exceeds_budget(
@@ -1094,6 +1099,9 @@ def test_query_search_analytics_trims_to_empty_when_single_row_exceeds_budget(
     # Even trimmed to zero rows, row_count still reports the actual match
     # count (1), not len(rows) (0) — the pagination signal.
     assert result["row_count"] == 1
+    # A zero-row-fit hint must not suggest an invalid row_limit=0; it
+    # explicitly steers the caller toward narrowing the query instead.
+    assert "narrow the query" in result["hint"]
 
 
 def test_query_search_analytics_treats_non_list_rows_as_empty(monkeypatch, caplog):

--- a/tests/web/tools/test_google_search_console_mcp.py
+++ b/tests/web/tools/test_google_search_console_mcp.py
@@ -165,6 +165,20 @@ def test_request_raises_runtime_error_on_non_json_success_body(monkeypatch):
         )
 
 
+def test_request_returns_empty_dict_for_204_response(monkeypatch):
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=204, text="")),
+    )
+
+    result = google_search_console._request(
+        "DELETE", f"{google_search_console.WEBMASTERS_API_BASE_URL}/sites"
+    )
+
+    assert result == {}
+
+
 def test_list_sites_projects_site_entries(monkeypatch):
     monkeypatch.setattr(
         google_search_console.requests,
@@ -194,6 +208,32 @@ def test_list_sites_projects_site_entries(monkeypatch):
         {"site_url": "https://example.com/", "permission_level": "siteOwner"},
         {"site_url": "sc-domain:example.com", "permission_level": "siteFullUser"},
     ]
+    assert result["site_count"] == 2
+    assert result["truncated"] is False
+
+
+def test_list_sites_degenerate_trim_reports_true_count_not_zero(monkeypatch):
+    """A single oversized site entry that still exceeds the output budget
+    after trimming to an empty list must not read as "you have no sites" —
+    site_count stays pinned to the real pre-trim count."""
+    max_output_length = get_tool_max_output_length()
+    oversized_site = {
+        "siteUrl": "https://example.com/" + "x" * (max_output_length + 1000),
+        "permissionLevel": "siteOwner",
+    }
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data={"siteEntry": [oversized_site]})),
+    )
+
+    result = json.loads(google_search_console.google_search_console_list_sites())
+
+    assert result["status"] == "success"
+    assert result["sites"] == []
+    assert result["site_count"] == 1
+    assert result["truncated"] is True
+    assert len(json.dumps(result)) < max_output_length
 
 
 def test_list_sites_filters_out_entries_without_site_url(monkeypatch):
@@ -369,7 +409,34 @@ def test_list_sitemaps_returns_sitemap_list(monkeypatch):
 
     assert result["status"] == "success"
     assert result["sitemaps"][0]["path"] == "https://example.com/sitemap.xml"
+    assert result["sitemap_count"] == 1
     assert "https%3A%2F%2Fexample.com%2F" in mock_request.call_args.kwargs["url"]
+
+
+def test_list_sitemaps_degenerate_trim_reports_true_count_not_zero(monkeypatch):
+    """A single oversized sitemap entry that still exceeds the output
+    budget after trimming to an empty list must not read as "you have no
+    sitemaps" — sitemap_count stays pinned to the real pre-trim count."""
+    max_output_length = get_tool_max_output_length()
+    oversized_sitemap = {
+        "path": "https://example.com/sitemap.xml?" + "x" * (max_output_length + 1000)
+    }
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data={"sitemap": [oversized_sitemap]})),
+    )
+
+    result = json.loads(
+        google_search_console.google_search_console_list_sitemaps(
+            "https://example.com/"
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["sitemaps"] == []
+    assert result["sitemap_count"] == 1
+    assert result["truncated"] is True
 
 
 def test_list_sitemaps_treats_non_list_sitemap_field_as_empty(monkeypatch, caplog):
@@ -810,6 +877,102 @@ def test_query_search_analytics_tolerates_malformed_filter_groups(
     )
 
     assert result["status"] == "success"
+    # A regression that silently dropped the malformed groups instead of
+    # forwarding them (e.g. to let Google's own validation reject them)
+    # would pass a status-only assertion undetected.
+    assert mock_request.call_args.kwargs["json"]["dimensionFilterGroups"] == (
+        malformed_filter_groups
+    )
+
+
+def test_query_search_analytics_rejects_non_list_dimensions(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            dimensions="query",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "dimensions" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_query_search_analytics_rejects_non_list_dimension_filter_groups(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            dimension_filter_groups={"filters": []},
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "dimension_filter_groups" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_query_search_analytics_rejects_search_appearance_combined_with_other_dimensions(
+    monkeypatch,
+):
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            dimensions=["searchAppearance", "query"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "searchAppearance" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_query_search_analytics_allows_search_appearance_alone(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={}))
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            dimensions=["searchAppearance"],
+        )
+    )
+
+    assert result["status"] == "success"
+    mock_request.assert_called_once()
+
+
+def test_query_search_analytics_accepts_minimum_row_limit(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={}))
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            row_limit=1,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert mock_request.call_args.kwargs["json"]["rowLimit"] == 1
 
 
 def test_query_search_analytics_rejects_zero_row_limit(monkeypatch):
@@ -903,6 +1066,9 @@ def test_query_search_analytics_trims_rows_and_flags_truncated_when_over_budget(
     # trimming into thinking it already reached the last page.
     assert result["row_count"] == google_search_console.QUERY_MAX_ROW_LIMIT
     assert result["row_count"] != len(result["rows"])
+    # A truncated response must carry a caller-visible next step, not just
+    # a server-side log line.
+    assert "smaller row_limit" in result["hint"]
 
 
 def test_query_search_analytics_trims_to_empty_when_single_row_exceeds_budget(
@@ -1109,6 +1275,25 @@ def test_inspect_url_rejects_surrounding_whitespace(monkeypatch):
 
     assert result["status"] == "error"
     assert "inspection_url" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_inspect_url_rejects_non_string_site_url(monkeypatch):
+    """inspect_url validates site_url/inspection_url via
+    require_clean_identifier directly (not _encoded_site_url, which would
+    incorrectly percent-encode a JSON-body value) — a non-string must still
+    raise a clean ValueError, not a raw AttributeError from .strip()."""
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_inspect_url(
+            12345, "https://example.com/page"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "site_url" in result["message"]
     mock_request.assert_not_called()
 
 

--- a/tests/web/tools/test_google_search_console_mcp.py
+++ b/tests/web/tools/test_google_search_console_mcp.py
@@ -246,6 +246,22 @@ def test_list_sitemaps_returns_sitemap_list(monkeypatch):
     assert "https%3A%2F%2Fexample.com%2F" in mock_request.call_args.kwargs["url"]
 
 
+def test_list_sitemaps_treats_non_list_sitemap_field_as_empty(monkeypatch):
+    """A malformed API response where "sitemap" isn't a list must not
+    crash or leak the raw value; it degrades to an empty list."""
+    mock_request = Mock(return_value=MockResponse(json_data={"sitemap": "not-a-list"}))
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_list_sitemaps(
+            "https://example.com/"
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["sitemaps"] == []
+
+
 def test_query_search_analytics_builds_body_and_returns_rows(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(
@@ -515,22 +531,46 @@ def test_query_search_analytics_trims_to_empty_when_single_row_exceeds_budget(
     assert len(response) < max_output_length
 
 
-def test_query_search_analytics_treats_non_list_rows_as_empty(monkeypatch):
+def test_query_search_analytics_treats_non_list_rows_as_empty(monkeypatch, caplog):
     """A malformed API response where "rows" isn't a list (e.g. null or a
     dict) must not raise a TypeError out of len()/slicing; it degrades to an
-    empty result instead."""
+    empty result instead, and the anomaly is logged so it's distinguishable
+    from a real zero-row answer."""
     mock_request = Mock(return_value=MockResponse(json_data={"rows": "not-a-list"}))
     monkeypatch.setattr(google_search_console.requests, "request", mock_request)
 
-    result = json.loads(
-        google_search_console.google_search_console_query_search_analytics(
-            "https://example.com/", start_date="2026-07-01", end_date="2026-07-28"
+    with caplog.at_level("WARNING", logger=google_search_console.logger.name):
+        result = json.loads(
+            google_search_console.google_search_console_query_search_analytics(
+                "https://example.com/", start_date="2026-07-01", end_date="2026-07-28"
+            )
         )
-    )
 
     assert result["status"] == "success"
     assert result["rows"] == []
     assert result["row_count"] == 0
+    assert "non-list 'rows'" in caplog.text
+
+
+def test_query_search_analytics_omits_warning_when_rows_key_missing(
+    monkeypatch, caplog
+):
+    """A genuinely absent "rows" key (a normal zero-result answer) should not
+    log the malformed-response warning — only a present-but-wrong-type value
+    should."""
+    mock_request = Mock(return_value=MockResponse(json_data={}))
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    with caplog.at_level("WARNING", logger=google_search_console.logger.name):
+        result = json.loads(
+            google_search_console.google_search_console_query_search_analytics(
+                "https://example.com/", start_date="2026-07-01", end_date="2026-07-28"
+            )
+        )
+
+    assert result["status"] == "success"
+    assert result["rows"] == []
+    assert "non-list 'rows'" not in caplog.text
 
 
 def test_query_search_analytics_returns_error_payload_on_api_failure(monkeypatch):

--- a/tests/web/tools/test_google_search_console_mcp.py
+++ b/tests/web/tools/test_google_search_console_mcp.py
@@ -60,6 +60,21 @@ def test_encoded_site_url_rejects_empty():
         google_search_console._encoded_site_url("")
 
 
+@pytest.mark.parametrize("bad_value", [".", ".."])
+def test_encoded_site_url_rejects_dot_segments(bad_value):
+    """ "." and ".." survive quote() unchanged (unreserved per RFC 3986), and
+    requests/urllib3 normalize them out of the final URL path client-side —
+    delegating to the shared url_path_id helper rejects them explicitly
+    instead of silently hitting an unintended endpoint."""
+    with pytest.raises(ValueError, match="site_url"):
+        google_search_console._encoded_site_url(bad_value)
+
+
+def test_encoded_site_url_rejects_surrounding_whitespace():
+    with pytest.raises(ValueError, match="site_url"):
+        google_search_console._encoded_site_url(" https://example.com/ ")
+
+
 def test_request_wraps_http_error_with_google_error_message(monkeypatch):
     monkeypatch.setattr(
         google_search_console.requests,
@@ -524,6 +539,14 @@ def test_query_search_analytics_trims_rows_and_flags_truncated_when_over_budget(
     assert result["truncated"] is True
     assert len(result["rows"]) < google_search_console.QUERY_MAX_ROW_LIMIT
     assert len(response) < get_tool_max_output_length()
+    # Regression for the pagination-contract bug: row_count must reflect
+    # how many rows this query actually matched (== row_limit here, since
+    # the API returned a full page), independent of how many rows survived
+    # output-size trimming. A caller comparing row_count to row_limit to
+    # decide whether to fetch the next page must not be misled by
+    # trimming into thinking it already reached the last page.
+    assert result["row_count"] == google_search_console.QUERY_MAX_ROW_LIMIT
+    assert result["row_count"] != len(result["rows"])
 
 
 def test_query_search_analytics_trims_to_empty_when_single_row_exceeds_budget(
@@ -546,6 +569,9 @@ def test_query_search_analytics_trims_to_empty_when_single_row_exceeds_budget(
     assert result["rows"] == []
     assert result["truncated"] is True
     assert len(response) < max_output_length
+    # Even trimmed to zero rows, row_count still reports the actual match
+    # count (1), not len(rows) (0) — the pagination signal.
+    assert result["row_count"] == 1
 
 
 def test_query_search_analytics_treats_non_list_rows_as_empty(monkeypatch, caplog):
@@ -668,6 +694,21 @@ def test_inspect_url_rejects_empty_inspection_url(monkeypatch):
     result = json.loads(
         google_search_console.google_search_console_inspect_url(
             "https://example.com/", ""
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "inspection_url" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_inspect_url_rejects_surrounding_whitespace(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_inspect_url(
+            "https://example.com/", " https://example.com/page "
         )
     )
 

--- a/tests/web/tools/test_google_search_console_mcp.py
+++ b/tests/web/tools/test_google_search_console_mcp.py
@@ -340,6 +340,23 @@ def test_query_search_analytics_rejects_invalid_date(monkeypatch):
     mock_request.assert_not_called()
 
 
+def test_query_search_analytics_rejects_invalid_calendar_date(monkeypatch):
+    """The date regex alone accepts "2026-02-31" (right shape, impossible
+    date); fromisoformat catches what the regex can't."""
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/", start_date="2026-02-31", end_date="2026-07-28"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "valid calendar date" in result["message"]
+    mock_request.assert_not_called()
+
+
 def test_query_search_analytics_rejects_start_date_after_end_date(monkeypatch):
     mock_request = Mock()
     monkeypatch.setattr(google_search_console.requests, "request", mock_request)
@@ -474,6 +491,28 @@ def test_query_search_analytics_trims_rows_and_flags_truncated_when_over_budget(
     assert result["truncated"] is True
     assert len(result["rows"]) < google_search_console.QUERY_MAX_ROW_LIMIT
     assert len(response) < get_tool_max_output_length()
+
+
+def test_query_search_analytics_trims_to_empty_when_single_row_exceeds_budget(
+    monkeypatch,
+):
+    """A single row whose own serialized size exceeds max_output_length must
+    still end up under budget — the halving loop must not stop at
+    len(rows) == 1 just because it can't halve further."""
+    max_output_length = get_tool_max_output_length()
+    oversized_row = {"keys": ["x" * (max_output_length + 1000)]}
+    mock_request = Mock(return_value=MockResponse(json_data={"rows": [oversized_row]}))
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    response = google_search_console.google_search_console_query_search_analytics(
+        "https://example.com/", start_date="2026-07-01", end_date="2026-07-28"
+    )
+
+    result = json.loads(response)
+    assert result["status"] == "success"
+    assert result["rows"] == []
+    assert result["truncated"] is True
+    assert len(response) < max_output_length
 
 
 def test_query_search_analytics_treats_non_list_rows_as_empty(monkeypatch):

--- a/tests/web/tools/test_google_search_console_mcp.py
+++ b/tests/web/tools/test_google_search_console_mcp.py
@@ -1,0 +1,513 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from xagent.config import get_tool_max_output_length
+from xagent.web.tools.mcp import google_search_console
+
+
+class MockResponse:
+    def __init__(self, json_data=None, text="", status_code=200):
+        self._json_data = json_data if json_data is not None else {}
+        self.text = text or (json.dumps(self._json_data) if json_data else "")
+        self.status_code = status_code
+        self.content = self.text.encode()
+
+    def json(self):
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(f"{self.status_code} Client Error", response=self)
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("GOOGLE_ACCESS_TOKEN", "access-token")
+
+
+def test_headers_require_access_token(monkeypatch):
+    monkeypatch.delenv("GOOGLE_ACCESS_TOKEN")
+
+    with pytest.raises(ValueError, match="GOOGLE_ACCESS_TOKEN"):
+        google_search_console._headers()
+
+
+def test_headers_include_bearer_token():
+    headers = google_search_console._headers()
+
+    assert headers["Authorization"] == "Bearer access-token"
+
+
+def test_encoded_site_url_percent_encodes_url_prefix_property():
+    assert (
+        google_search_console._encoded_site_url("https://example.com/")
+        == "https%3A%2F%2Fexample.com%2F"
+    )
+
+
+def test_encoded_site_url_percent_encodes_domain_property():
+    assert (
+        google_search_console._encoded_site_url("sc-domain:example.com")
+        == "sc-domain%3Aexample.com"
+    )
+
+
+def test_encoded_site_url_rejects_empty():
+    with pytest.raises(ValueError, match="site_url"):
+        google_search_console._encoded_site_url("")
+
+
+def test_request_wraps_http_error_with_google_error_message(monkeypatch):
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=400,
+                json_data={
+                    "error": {
+                        "code": 400,
+                        "message": "Invalid site URL.",
+                        "status": "INVALID_ARGUMENT",
+                    }
+                },
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Invalid site URL"):
+        google_search_console._request(
+            "GET", f"{google_search_console.WEBMASTERS_API_BASE_URL}/sites"
+        )
+
+
+def test_request_falls_back_to_raw_text_for_unstructured_error_body(monkeypatch):
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text="upstream 500")),
+    )
+
+    with pytest.raises(RuntimeError, match="upstream 500"):
+        google_search_console._request(
+            "GET", f"{google_search_console.WEBMASTERS_API_BASE_URL}/sites"
+        )
+
+
+def test_request_caps_unstructured_error_body(monkeypatch):
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=502, text="x" * 5000)),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        google_search_console._request(
+            "GET", f"{google_search_console.WEBMASTERS_API_BASE_URL}/sites"
+        )
+    assert len(str(excinfo.value)) < 1200
+
+
+def test_list_sites_projects_site_entries(monkeypatch):
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "siteEntry": [
+                        {
+                            "siteUrl": "https://example.com/",
+                            "permissionLevel": "siteOwner",
+                        },
+                        {
+                            "siteUrl": "sc-domain:example.com",
+                            "permissionLevel": "siteFullUser",
+                        },
+                    ]
+                }
+            )
+        ),
+    )
+
+    result = json.loads(google_search_console.google_search_console_list_sites())
+
+    assert result["status"] == "success"
+    assert result["sites"] == [
+        {"site_url": "https://example.com/", "permission_level": "siteOwner"},
+        {"site_url": "sc-domain:example.com", "permission_level": "siteFullUser"},
+    ]
+
+
+def test_list_sites_handles_no_sites(monkeypatch):
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data={})),
+    )
+
+    result = json.loads(google_search_console.google_search_console_list_sites())
+
+    assert result["status"] == "success"
+    assert result["sites"] == []
+
+
+def test_list_sites_returns_error_payload_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=403,
+                json_data={"error": {"message": "insufficient permissions"}},
+            )
+        ),
+    )
+
+    result = json.loads(google_search_console.google_search_console_list_sites())
+
+    assert result["status"] == "error"
+    assert "insufficient permissions" in result["message"]
+
+
+def test_list_sitemaps_returns_sitemap_list(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "sitemap": [
+                    {"path": "https://example.com/sitemap.xml", "isPending": False}
+                ]
+            }
+        )
+    )
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_list_sitemaps(
+            "https://example.com/"
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["sitemaps"][0]["path"] == "https://example.com/sitemap.xml"
+    assert "https%3A%2F%2Fexample.com%2F" in mock_request.call_args.kwargs["url"]
+
+
+def test_query_search_analytics_builds_body_and_returns_rows(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "rows": [
+                    {
+                        "keys": ["some query"],
+                        "clicks": 10,
+                        "impressions": 100,
+                        "ctr": 0.1,
+                        "position": 3.5,
+                    }
+                ]
+            }
+        )
+    )
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            dimensions=["query"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["row_count"] == 1
+    assert result["rows"][0]["clicks"] == 10
+
+    call_kwargs = mock_request.call_args.kwargs
+    assert call_kwargs["url"].endswith(
+        "/sites/https%3A%2F%2Fexample.com%2F/searchAnalytics/query"
+    )
+    body = call_kwargs["json"]
+    assert body["startDate"] == "2026-07-01"
+    assert body["endDate"] == "2026-07-28"
+    assert body["dimensions"] == ["query"]
+    assert body["type"] == "web"
+    assert body["rowLimit"] == google_search_console.QUERY_DEFAULT_ROW_LIMIT
+    assert body["startRow"] == 0
+
+
+def test_query_search_analytics_passes_through_filter_groups_and_search_type(
+    monkeypatch,
+):
+    mock_request = Mock(return_value=MockResponse(json_data={}))
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    filter_groups = [
+        {
+            "filters": [
+                {"dimension": "country", "operator": "equals", "expression": "usa"}
+            ]
+        }
+    ]
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "sc-domain:example.com",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            search_type="image",
+            dimension_filter_groups=filter_groups,
+            row_limit=50,
+            start_row=100,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["rows"] == []
+    body = mock_request.call_args.kwargs["json"]
+    assert body["type"] == "image"
+    assert body["dimensionFilterGroups"] == filter_groups
+    assert body["rowLimit"] == 50
+    assert body["startRow"] == 100
+
+
+def test_query_search_analytics_rejects_invalid_date(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/", start_date="7daysAgo", end_date="2026-07-28"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "start_date" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_query_search_analytics_rejects_start_date_after_end_date(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/", start_date="2026-08-01", end_date="2026-01-01"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "start_date" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_query_search_analytics_rejects_invalid_search_type(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            search_type="carrier-pigeon",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "search_type" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_query_search_analytics_rejects_invalid_dimensions(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            dimensions=["query", "bogus"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "bogus" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_query_search_analytics_rejects_zero_row_limit(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            row_limit=0,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "row_limit" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_query_search_analytics_rejects_row_limit_above_max(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            row_limit=google_search_console.QUERY_MAX_ROW_LIMIT + 1,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "row_limit" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_query_search_analytics_rejects_negative_start_row(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            start_row=-1,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "start_row" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_query_search_analytics_trims_rows_and_flags_truncated_when_over_budget(
+    monkeypatch,
+):
+    rows = [
+        {
+            "keys": [f"https://example.com/some/long/page/path/{i}".ljust(70, "x")],
+            "clicks": i,
+            "impressions": i * 10,
+            "ctr": 0.1,
+            "position": 3.5,
+        }
+        for i in range(google_search_console.QUERY_MAX_ROW_LIMIT)
+    ]
+    mock_request = Mock(return_value=MockResponse(json_data={"rows": rows}))
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    response = google_search_console.google_search_console_query_search_analytics(
+        "https://example.com/",
+        start_date="2026-07-01",
+        end_date="2026-07-28",
+        dimensions=["page"],
+        row_limit=google_search_console.QUERY_MAX_ROW_LIMIT,
+    )
+
+    result = json.loads(response)
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert len(result["rows"]) < google_search_console.QUERY_MAX_ROW_LIMIT
+    assert len(response) < get_tool_max_output_length()
+
+
+def test_query_search_analytics_returns_error_payload_on_api_failure(monkeypatch):
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=400,
+                json_data={"error": {"message": "bad request"}},
+            )
+        ),
+    )
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/", start_date="2026-07-01", end_date="2026-07-28"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "bad request" in result["message"]
+
+
+def test_inspect_url_returns_inspection_result(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "inspectionResult": {
+                    "indexStatusResult": {"verdict": "PASS"},
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_inspect_url(
+            "https://example.com/", "https://example.com/page"
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["inspection_result"]["indexStatusResult"]["verdict"] == "PASS"
+
+    body = mock_request.call_args.kwargs["json"]
+    assert body["inspectionUrl"] == "https://example.com/page"
+    assert body["siteUrl"] == "https://example.com/"
+    assert body["languageCode"] == "en-US"
+    assert mock_request.call_args.kwargs["url"].endswith("/urlInspection/index:inspect")
+
+
+def test_inspect_url_rejects_empty_inspection_url(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_inspect_url(
+            "https://example.com/", ""
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "inspection_url" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_inspect_url_returns_error_payload_on_api_failure(monkeypatch):
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=404,
+                json_data={"error": {"message": "URL not found"}},
+            )
+        ),
+    )
+
+    result = json.loads(
+        google_search_console.google_search_console_inspect_url(
+            "https://example.com/", "https://example.com/missing"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "URL not found" in result["message"]

--- a/tests/web/tools/test_google_search_console_mcp.py
+++ b/tests/web/tools/test_google_search_console_mcp.py
@@ -237,6 +237,10 @@ def test_list_sites_degenerate_trim_reports_true_count_not_zero(monkeypatch):
     assert result["site_count"] == 1
     assert result["truncated"] is True
     assert len(json.dumps(result)) < max_output_length
+    # list_sites has no page size/offset to retry with, unlike
+    # query_search_analytics — the hint must say so honestly rather than
+    # suggesting a retry that can't actually help.
+    assert "no page size/offset" in result["hint"]
 
 
 def test_list_sites_filters_out_entries_without_site_url(monkeypatch):
@@ -440,6 +444,7 @@ def test_list_sitemaps_degenerate_trim_reports_true_count_not_zero(monkeypatch):
     assert result["sitemap_count"] == 1
     assert result["truncated"] is True
     assert len(response) < max_output_length
+    assert "no page size/offset" in result["hint"]
 
 
 def test_list_sitemaps_treats_non_list_sitemap_field_as_empty(monkeypatch, caplog):

--- a/tests/web/tools/test_google_search_console_mcp.py
+++ b/tests/web/tools/test_google_search_console_mcp.py
@@ -205,6 +205,23 @@ def test_list_sites_handles_no_sites(monkeypatch):
     assert result["sites"] == []
 
 
+def test_list_sites_treats_non_list_site_entry_field_as_empty(monkeypatch, caplog):
+    """A malformed API response where "siteEntry" isn't a list (e.g. a dict
+    or string) must not silently iterate its characters/keys; it degrades to
+    an empty list and logs the anomaly."""
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"siteEntry": "not-a-list"})
+    )
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    with caplog.at_level("WARNING", logger=google_search_console.logger.name):
+        result = json.loads(google_search_console.google_search_console_list_sites())
+
+    assert result["status"] == "success"
+    assert result["sites"] == []
+    assert "non-list 'siteEntry'" in caplog.text
+
+
 def test_list_sites_returns_error_payload_on_failure(monkeypatch):
     monkeypatch.setattr(
         google_search_console.requests,
@@ -621,6 +638,27 @@ def test_inspect_url_returns_inspection_result(monkeypatch):
     assert body["siteUrl"] == "https://example.com/"
     assert body["languageCode"] == "en-US"
     assert mock_request.call_args.kwargs["url"].endswith("/urlInspection/index:inspect")
+
+
+def test_inspect_url_treats_non_dict_inspection_result_as_empty(monkeypatch, caplog):
+    """A malformed API response where "inspectionResult" isn't a dict must
+    not be passed through as-is; it degrades to an empty dict and logs the
+    anomaly."""
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"inspectionResult": "not-a-dict"})
+    )
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    with caplog.at_level("WARNING", logger=google_search_console.logger.name):
+        result = json.loads(
+            google_search_console.google_search_console_inspect_url(
+                "https://example.com/", "https://example.com/page"
+            )
+        )
+
+    assert result["status"] == "success"
+    assert result["inspection_result"] == {}
+    assert "non-dict 'inspectionResult'" in caplog.text
 
 
 def test_inspect_url_rejects_empty_inspection_url(monkeypatch):

--- a/tests/web/tools/test_google_search_console_mcp.py
+++ b/tests/web/tools/test_google_search_console_mcp.py
@@ -627,6 +627,103 @@ def test_query_search_analytics_allows_query_dimension_for_web_search_type(
     mock_request.assert_called_once()
 
 
+@pytest.mark.parametrize("search_type", ["discover", "googleNews"])
+def test_query_search_analytics_rejects_query_filter_for_discover_and_news(
+    monkeypatch, search_type
+):
+    """The restriction on "query" for discover/googleNews must also cover
+    dimension_filter_groups, not just the dimensions list — Google's API
+    rejects "query" from either path for these two surfaces."""
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            search_type=search_type,
+            dimension_filter_groups=[
+                {
+                    "filters": [
+                        {
+                            "dimension": "query",
+                            "operator": "equals",
+                            "expression": "foo",
+                        }
+                    ]
+                }
+            ],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "query" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_query_search_analytics_allows_non_query_filter_for_discover(monkeypatch):
+    """The dimension_filter_groups check must not over-reject a filter on a
+    dimension other than "query"."""
+    mock_request = Mock(return_value=MockResponse(json_data={}))
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            search_type="discover",
+            dimension_filter_groups=[
+                {
+                    "filters": [
+                        {
+                            "dimension": "country",
+                            "operator": "equals",
+                            "expression": "usa",
+                        }
+                    ]
+                }
+            ],
+        )
+    )
+
+    assert result["status"] == "success"
+    mock_request.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    "malformed_filter_groups",
+    [
+        ["not-a-dict"],
+        [{"filters": "not-a-list"}],
+        [{"filters": ["not-a-dict"]}],
+        [{}],
+    ],
+)
+def test_query_search_analytics_tolerates_malformed_filter_groups(
+    monkeypatch, malformed_filter_groups
+):
+    """A malformed dimension_filter_groups shape must not crash the local
+    query-dimension check; it degrades to "doesn't reference query" and
+    lets the request proceed (any real problem still surfaces as an
+    upstream 400)."""
+    mock_request = Mock(return_value=MockResponse(json_data={}))
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            search_type="discover",
+            dimension_filter_groups=malformed_filter_groups,
+        )
+    )
+
+    assert result["status"] == "success"
+
+
 def test_query_search_analytics_rejects_zero_row_limit(monkeypatch):
     mock_request = Mock()
     monkeypatch.setattr(google_search_console.requests, "request", mock_request)

--- a/tests/web/tools/test_google_search_console_mcp.py
+++ b/tests/web/tools/test_google_search_console_mcp.py
@@ -11,7 +11,15 @@ from xagent.web.tools.mcp import google_search_console
 class MockResponse:
     def __init__(self, json_data=None, text="", status_code=200):
         self._json_data = json_data if json_data is not None else {}
-        self.text = text or (json.dumps(self._json_data) if json_data else "")
+        # `is not None`, not truthiness: json_data={} is a genuine "empty
+        # but present" JSON body ("{}", 2 bytes) and must serialize
+        # differently from omitting json_data entirely (no body at all) —
+        # a plain `if json_data` treats both the same, which lets tests
+        # that pass json_data={} accidentally skip _request's
+        # response.json() parsing path via the empty-content shortcut.
+        self.text = text or (
+            json.dumps(self._json_data) if json_data is not None else ""
+        )
         self.status_code = status_code
         self.content = self.text.encode()
 
@@ -255,6 +263,56 @@ def test_list_sites_returns_error_payload_on_failure(monkeypatch):
     assert "insufficient permissions" in result["message"]
 
 
+def test_list_sites_rejects_expired_token(monkeypatch):
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=401,
+                json_data={"error": {"message": "Request had invalid credentials."}},
+            )
+        ),
+    )
+
+    result = json.loads(google_search_console.google_search_console_list_sites())
+
+    assert result["status"] == "error"
+    assert "invalid credentials" in result["message"]
+
+
+def test_list_sites_rejects_non_dict_top_level_response(monkeypatch):
+    """A malformed API response whose top level is a list/string rather than
+    a dict must not raise an unhandled AttributeError out of _require_dict_result's
+    caller; it surfaces as a normal error envelope."""
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data=["unexpected", "list"])),
+    )
+
+    result = json.loads(google_search_console.google_search_console_list_sites())
+
+    assert result["status"] == "error"
+    assert "Unexpected response format" in result["message"]
+
+
+def test_list_sites_wraps_missing_token_into_error_envelope(monkeypatch):
+    """An end-to-end check that a missing GOOGLE_ACCESS_TOKEN is wrapped into
+    the tool's normal {"status": "error"} envelope rather than propagating
+    as a raw exception — _headers() itself is unit-tested directly
+    elsewhere, but no test previously drove that failure through a tool."""
+    monkeypatch.delenv("GOOGLE_ACCESS_TOKEN")
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(google_search_console.google_search_console_list_sites())
+
+    assert result["status"] == "error"
+    assert "GOOGLE_ACCESS_TOKEN" in result["message"]
+    mock_request.assert_not_called()
+
+
 def test_list_sitemaps_returns_sitemap_list(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(
@@ -292,6 +350,45 @@ def test_list_sitemaps_treats_non_list_sitemap_field_as_empty(monkeypatch):
 
     assert result["status"] == "success"
     assert result["sitemaps"] == []
+
+
+def test_list_sitemaps_returns_error_payload_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=404,
+                json_data={"error": {"message": "site not found"}},
+            )
+        ),
+    )
+
+    result = json.loads(
+        google_search_console.google_search_console_list_sitemaps(
+            "https://example.com/"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "site not found" in result["message"]
+
+
+def test_list_sitemaps_rejects_non_dict_top_level_response(monkeypatch):
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data=["unexpected", "list"])),
+    )
+
+    result = json.loads(
+        google_search_console.google_search_console_list_sitemaps(
+            "https://example.com/"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "Unexpected response format" in result["message"]
 
 
 def test_query_search_analytics_builds_body_and_returns_rows(monkeypatch):
@@ -373,6 +470,21 @@ def test_query_search_analytics_passes_through_filter_groups_and_search_type(
     assert body["startRow"] == 100
 
 
+def test_query_search_analytics_omits_dimensions_and_filter_groups_when_unset(
+    monkeypatch,
+):
+    mock_request = Mock(return_value=MockResponse(json_data={}))
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    google_search_console.google_search_console_query_search_analytics(
+        "https://example.com/", start_date="2026-07-01", end_date="2026-07-28"
+    )
+
+    body = mock_request.call_args.kwargs["json"]
+    assert "dimensions" not in body
+    assert "dimensionFilterGroups" not in body
+
+
 def test_query_search_analytics_rejects_invalid_date(monkeypatch):
     mock_request = Mock()
     monkeypatch.setattr(google_search_console.requests, "request", mock_request)
@@ -385,6 +497,21 @@ def test_query_search_analytics_rejects_invalid_date(monkeypatch):
 
     assert result["status"] == "error"
     assert "start_date" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_query_search_analytics_rejects_invalid_end_date(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/", start_date="2026-07-01", end_date="not-a-date"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "end_date" in result["message"]
     mock_request.assert_not_called()
 
 
@@ -454,6 +581,50 @@ def test_query_search_analytics_rejects_invalid_dimensions(monkeypatch):
     assert result["status"] == "error"
     assert "bogus" in result["message"]
     mock_request.assert_not_called()
+
+
+@pytest.mark.parametrize("search_type", ["discover", "googleNews"])
+def test_query_search_analytics_rejects_query_dimension_for_discover_and_news(
+    monkeypatch, search_type
+):
+    mock_request = Mock()
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            dimensions=["query"],
+            search_type=search_type,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "query" in result["message"]
+    mock_request.assert_not_called()
+
+
+def test_query_search_analytics_allows_query_dimension_for_web_search_type(
+    monkeypatch,
+):
+    """The discover/googleNews restriction must not over-reject "query" for
+    other search types."""
+    mock_request = Mock(return_value=MockResponse(json_data={}))
+    monkeypatch.setattr(google_search_console.requests, "request", mock_request)
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/",
+            start_date="2026-07-01",
+            end_date="2026-07-28",
+            dimensions=["query"],
+            search_type="web",
+        )
+    )
+
+    assert result["status"] == "success"
+    mock_request.assert_called_once()
 
 
 def test_query_search_analytics_rejects_zero_row_limit(monkeypatch):
@@ -638,6 +809,45 @@ def test_query_search_analytics_returns_error_payload_on_api_failure(monkeypatch
     assert "bad request" in result["message"]
 
 
+def test_query_search_analytics_rejects_expired_token(monkeypatch):
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=401,
+                json_data={"error": {"message": "Request had invalid credentials."}},
+            )
+        ),
+    )
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/", start_date="2026-07-01", end_date="2026-07-28"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "invalid credentials" in result["message"]
+
+
+def test_query_search_analytics_rejects_non_dict_top_level_response(monkeypatch):
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data=["unexpected", "list"])),
+    )
+
+    result = json.loads(
+        google_search_console.google_search_console_query_search_analytics(
+            "https://example.com/", start_date="2026-07-01", end_date="2026-07-28"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "Unexpected response format" in result["message"]
+
+
 def test_inspect_url_returns_inspection_result(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(
@@ -737,3 +947,20 @@ def test_inspect_url_returns_error_payload_on_api_failure(monkeypatch):
 
     assert result["status"] == "error"
     assert "URL not found" in result["message"]
+
+
+def test_inspect_url_rejects_non_dict_top_level_response(monkeypatch):
+    monkeypatch.setattr(
+        google_search_console.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data=["unexpected", "list"])),
+    )
+
+    result = json.loads(
+        google_search_console.google_search_console_inspect_url(
+            "https://example.com/", "https://example.com/page"
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "Unexpected response format" in result["message"]

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -1,3 +1,5 @@
+import re
+
 import pytest
 import requests
 
@@ -69,6 +71,35 @@ def test_clamp_limit_boundaries(limit, expected):
 )
 def test_clamp_offset_boundaries(offset, expected):
     assert utils.clamp_offset(offset) == expected
+
+
+_TEST_URL_ID_PATTERN = re.compile(r"/d/([a-zA-Z0-9_-]+)")
+
+
+def test_resolve_id_from_url_extracts_id_from_matching_url():
+    assert (
+        utils.resolve_id_from_url(
+            "https://docs.google.com/document/d/abc123/edit",
+            _TEST_URL_ID_PATTERN,
+            "document_id",
+        )
+        == "abc123"
+    )
+
+
+def test_resolve_id_from_url_passes_through_bare_id():
+    assert (
+        utils.resolve_id_from_url(" abc123 ", _TEST_URL_ID_PATTERN, "document_id")
+        == "abc123"
+    )
+
+
+def test_resolve_id_from_url_rejects_non_string():
+    """Mirrors require_clean_identifier's fix: pattern.search() would
+    otherwise raise a raw TypeError on a non-string value instead of a
+    clean ValueError."""
+    with pytest.raises(ValueError, match="document_id"):
+        utils.resolve_id_from_url(12345, _TEST_URL_ID_PATTERN, "document_id")
 
 
 def test_url_path_id_output_survives_requests_url_normalization():

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -12,6 +12,14 @@ def test_require_clean_identifier_rejects_empty_and_whitespace():
     assert utils.require_clean_identifier("001xx", "record_id") == "001xx"
 
 
+def test_require_clean_identifier_rejects_non_string():
+    """A truthy non-str (e.g. an int) previously slipped past `not value`
+    and crashed on `.strip()` with a raw AttributeError instead of a clean
+    ValueError."""
+    with pytest.raises(ValueError, match="record_id"):
+        utils.require_clean_identifier(12345, "record_id")
+
+
 def test_url_path_id_percent_encodes_reserved_characters():
     # A literal ".." blocklist misses "/" and "?", which redirect the
     # request to a different endpoint or inject query params without ever


### PR DESCRIPTION
## Summary
- Add a builtin OAuth connector for Google Search Console (`google-search-console`), reusing the existing shared `google` OAuth provider with a readonly `webmasters.readonly` scope
- New MCP tool module exposing: list verified sites, query search analytics (clicks/impressions/CTR/position by query/page/country/device/date), list sitemaps, and inspect a URL's indexing status
- Follows the existing `google-analytics` connector's structure (registry entry, seed migration, launch_config/env_mapping)

## Test plan
- [x] `pytest tests/web/tools/test_google_search_console_mcp.py tests/alembic/test_20260824_seed_google_search_console_mcp_app.py` — 31 passed
- [x] `ruff check` / `ruff format --check` on all new/changed files
- [x] `alembic heads` confirms a single head chained correctly from the migration's `down_revision`
- [x] Pre-commit hooks (ruff, mypy, isort, codespell, alembic-check) passed on commit