### PR TITLE
feat: add DOCX generation support to sandbox

### DIFF
--- a/docker/Dockerfile.sandbox
+++ b/docker/Dockerfile.sandbox
@@ -56,7 +56,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         -r /tmp/sandbox-requirements.txt \
     && rm /tmp/sandbox-requirements.txt \
     && uvx --version \
-    && python -c "import cloudpickle, fsspec, matplotlib, mcp; import numpy, openpyxl, pandas, pydantic, pydantic_settings"
+    && python -c "import cloudpickle, docx, fsspec, matplotlib, mcp; import numpy, openpyxl, pandas, pydantic, pydantic_settings"
 
 # Allow pip install without --break-system-packages globally. Sandboxed tools
 # can install their explicitly declared runtime dependencies as an unprivileged

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ sandbox = [
   "numpy>=1.21.0",
   "matplotlib>=3.5.0",
   "openpyxl>=3.1.0",
+  "python-docx>=1.1.0",
   "fsspec>=2024.0.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,6 +227,7 @@ test = [
   "copilotkit==0.1.69",
   "langgraph-prebuilt<1.0.9",
   "openpyxl>=3.1.5",
+  "python-docx>=1.1.0",
   "asyncssh>=2.14.0",
 ]
 

--- a/src/xagent/core/tools/adapters/vibe/python_executor.py
+++ b/src/xagent/core/tools/adapters/vibe/python_executor.py
@@ -141,6 +141,7 @@ class PythonExecutorTool(AbstractBaseTool):
         "numpy>=1.21.0",
         "matplotlib>=3.5.0",
         "openpyxl>=3.1.0",  # required by the xlsx-financial-report skill
+        "python-docx>=1.1.0",  # required by the docx-report-editorial skill
     ]
 )
 class PythonExecutorToolForBasic(PythonExecutorTool):

--- a/src/xagent/skills/builtin/docx-report-editorial/SKILL.md
+++ b/src/xagent/skills/builtin/docx-report-editorial/SKILL.md
@@ -1,0 +1,368 @@
+---
+name: docx-report-editorial
+description: |
+  A native .docx styled as an editorial report: "Word report", "Word 文档",
+  "memo", "proposal", "研究报告". Opens cleanly in Word / Google Docs /
+  Pages with real heading styles and a cover page.
+when_to_use: |
+  A polished .docx meant to be read as a document and further edited in
+  Word. Use pdf-report-editorial when the deliverable is a fixed printable
+  PDF, and pptx-editorial when the user wants slides.
+tags:
+  - docx
+  - word
+  - report
+  - document
+  - editorial
+---
+
+# Editorial Report (.docx)
+
+You will generate one `.docx` file via python-docx by writing a Python
+program and running it through the `execute_python_code` tool. Save to
+the workspace, then report the path + a 1-line content summary.
+
+## 📦 Required runtime packages
+
+The sandboxed `execute_python_code` ships with `pandas`, `numpy`,
+`matplotlib`, `openpyxl`, and **`python-docx>=1.1.0`** preinstalled — no
+extra installation step is needed. The import name is **`docx`**, not
+`python_docx`:
+
+```python
+from docx import Document          # ✅ correct
+import python_docx                 # ❌ ModuleNotFoundError
+```
+
+> **Note:** `execute_python_code` accepts only `code` and
+> `capture_output` arguments; there is no `packages` parameter.
+> All required libraries are already available in the sandbox image.
+
+## 💾 How to save the file
+
+`execute_python_code` already runs with the task's output directory as
+the current working directory. Save the document with a **plain
+filename** (no path), e.g.:
+
+```python
+doc.save("market_expansion_report.docx")   # ✅ correct
+```
+
+Do NOT use:
+- `doc.save("/workspace/foo.docx")` — `/workspace` does not exist on this host
+- `doc.save("output/foo.docx")` — there is no nested `output/` subdir
+- BytesIO + base64 round-trips — just save to disk directly.
+
+Verify with `os.path.getsize("market_expansion_report.docx")` before
+declaring success. A real python-docx document is **always >10 KB** —
+if your saved file is under 5 KB it's broken or empty.
+
+### 🔗 Make it clickable in chat — REQUIRED
+
+The Python executor returns a `markdown_link` field in its response for
+every workspace file it generated (or a `file_refs[]` array with one
+entry per file). **Read the tool's response** and use the returned
+`markdown_link` string verbatim. In your final answer, the **first line
+MUST be that chip link itself** — bare markdown, NOT inside backticks,
+NOT presented as "file_id: UUID":
+
+✅ **CORRECT** (renders as clickable chip — chat UI looks for this exact pattern):
+
+    [market_expansion_report.docx](file:20fae785-3823-4906-b385-d0e8a7807dc8)
+
+The UUID comes from the executor response. Do not fabricate one.
+
+❌ **WRONG — common failure that renders as plain text**:
+
+    已生成报告:
+    - 文件名: `market_expansion_report.docx`
+    - file_id: `20fae785-3823-4906-b385-d0e8a7807dc8`
+
+❌ **ALSO WRONG — chip link inside a code fence**: ` ```[name](file:UUID)``` `
+   suppresses markdown so the link won't render as a chip.
+
+❌ **ALSO WRONG — calling `get_file_info(...)` to "fetch" the file_id**.
+   Its `FileInfo` return shape does not include `file_id`; the chip
+   reference is already on the executor result.
+
+## ⚠️ Hard rules — NO exceptions
+
+0. **MATCH THE USER'S LANGUAGE.** If the prompt is Chinese (中文), ALL
+   document text (cover kicker, headings, body, table headers, captions,
+   footer) must be in Chinese. Translate template phrases like
+   `EXECUTIVE SUMMARY` → `摘要`, `FINDINGS` → `调查结果`,
+   `RECOMMENDATIONS` → `建议`, `As of YYYY-MM-DD` → `截至 YYYY-MM-DD`.
+   Never leave English kickers in a Chinese report.
+1. **One palette only.** Pick one of the 5 palettes below; use only its
+   **4 hex values** (`ink`, `paper`, `paper_tint`, `ink_tint`). Define a
+   `palette = {...}` dict ONCE at the top of the script and reference
+   `palette["ink"]` etc. everywhere — do not copy literal hex values into
+   individual styling calls.
+2. **Two fonts only.** Headings = `Georgia` (serif, present on all OSes).
+   Body = `Calibri` (sans, Word default). No custom fonts — recipients
+   won't have them and Word falls back to Times.
+   **For Chinese documents**: both render Chinese via system fallback
+   (PingFang on macOS, Microsoft YaHei on Windows) — do not switch fonts.
+3. **Use real Word styles, not manual formatting.** Headings must use the
+   built-in `Heading 1` / `Heading 2` / `Heading 3` styles so Word's
+   navigation pane and auto table-of-contents work. A document where every
+   heading is just bold 18pt body text is broken — it has no outline.
+4. **Forbidden:**
+   - WordArt, drop shadows, glow, 3-D effects, gradient fills
+   - clipart, emoji as decoration, stock-photo placeholders
+   - centered body paragraphs (left-align / justify only)
+   - all-caps body text (kickers and labels only)
+   - colored hyperlinks other than `ink` (links = ink + underline)
+   - more than one heading font
+   - Comic Sans, Arial Black, Times New Roman as a deliberate choice
+5. **Real content only.** No lorem ipsum, no `[Title here]` placeholders,
+   no fabricated statistics, no fake citations. If a section has no user
+   data, drop the section rather than padding it.
+6. **Failure honesty — NEVER fake the deliverable.**
+   - If `execute_python_code` raises after multiple retries, STOP and report
+     the actual error. Do not write a stub file like
+     `write_file("report.docx", "placeholder")` to make the chip appear.
+   - The final answer must reflect what was actually written. Do not
+     describe sections or tables that aren't in the saved `.docx`.
+
+## 🎨 Palettes — pick ONE
+
+Same palettes as `pdf-report-editorial` and `pptx-editorial` — keep the
+editorial family visually consistent. Each: `ink` (body text + rules),
+`paper` (page / cell background), `paper-tint` (table band + callout bg),
+`ink-tint` (kickers, captions, footer).
+
+- **Monocle** (default / business / tech / policy)
+  ink `0A0A0B` · paper `F1EFEA` · paper-tint `E8E5DE` · ink-tint `18181A`
+- **Indigo Porcelain** (research / data-heavy)
+  ink `0A1F3D` · paper `F1F3F5` · paper-tint `E4E8EC` · ink-tint `152A4A`
+- **Forest Ink** (sustainability / impact)
+  ink `1A2E1F` · paper `F5F1E8` · paper-tint `ECE7DA` · ink-tint `253D2C`
+- **Kraft Paper** (humanities / qualitative)
+  ink `2A1E13` · paper `EEDFC7` · paper-tint `E0D0B6` · ink-tint `3A2A1D`
+- **Dune** (art / design / fashion criticism)
+  ink `1F1A14` · paper `F0E6D2` · paper-tint `E3D7BF` · ink-tint `2D2620`
+
+python-docx takes hex without the `#` prefix, via
+`RGBColor.from_string(palette["ink"])`.
+
+## ✒️ Typography (python-docx Pt sizes)
+
+| Role | Style | Family | Size | Weight |
+|---|---|---|---|---|
+| Cover title | `Title` | Georgia | 40pt | regular |
+| Cover subtitle / dek | body run | Calibri | 14pt | italic |
+| Kicker (small caps label) | body run | Calibri | 9pt, uppercase | bold, ink-tint |
+| H1 section | `Heading 1` | Georgia | 22pt | regular |
+| H2 subsection | `Heading 2` | Georgia | 16pt | regular |
+| H3 sub-subsection | `Heading 3` | Calibri | 12pt | bold |
+| Body paragraph | `Normal` | Calibri | 11pt | regular, line 1.4 |
+| Pull quote | `Intense Quote` | Georgia | 14pt | italic |
+| Table header | table run | Calibri | 10pt | bold, paper on ink |
+| Table body | table run | Calibri | 10pt | regular |
+| Caption / footnote | `Caption` | Calibri | 9pt | italic, ink-tint |
+
+## 📐 Page setup
+
+Set margins, size and orientation on each `section` before adding content.
+
+```python
+from docx import Document
+from docx.shared import Pt, Cm, RGBColor
+from docx.enum.section import WD_ORIENT, WD_SECTION
+
+doc = Document()
+sec = doc.sections[0]
+
+# A4 portrait with editorial margins
+sec.page_width, sec.page_height = Cm(21.0), Cm(29.7)
+sec.orientation = WD_ORIENT.PORTRAIT
+sec.top_margin, sec.bottom_margin = Cm(2.5), Cm(2.5)
+sec.left_margin, sec.right_margin = Cm(2.2), Cm(2.2)
+```
+
+⚠️ **Orientation gotcha:** setting `sec.orientation = WD_ORIENT.LANDSCAPE`
+does NOT swap the page dimensions — Word reads the width/height, not the
+flag. You must swap them yourself:
+
+```python
+sec.orientation = WD_ORIENT.LANDSCAPE
+sec.page_width, sec.page_height = Cm(29.7), Cm(21.0)   # swap explicitly
+```
+
+Set the default body font once on the `Normal` style so every paragraph
+inherits it (including CJK, which needs the `eastAsia` attribute):
+
+```python
+from docx.oxml.ns import qn
+
+normal = doc.styles["Normal"]
+normal.font.name = "Calibri"
+normal.font.size = Pt(11)
+normal.font.color.rgb = RGBColor.from_string(palette["ink"])
+normal.element.rPr.rFonts.set(qn("w:eastAsia"), "Microsoft YaHei")
+normal.paragraph_format.line_spacing = 1.4
+normal.paragraph_format.space_after = Pt(8)
+```
+
+## 🏛️ Cover page pattern
+
+The cover is its own section so the body can restart page numbering and
+use different headers. Structure: kicker → title → dek → rule → meta row.
+
+```python
+from docx.enum.text import WD_ALIGN_PARAGRAPH, WD_BREAK
+
+def add_kicker(doc, text):
+    p = doc.add_paragraph()
+    run = p.add_run(text.upper())
+    run.font.name, run.font.size, run.font.bold = "Calibri", Pt(9), True
+    run.font.color.rgb = RGBColor.from_string(palette["ink_tint"])
+    return p
+
+# --- cover ---
+doc.add_paragraph().paragraph_format.space_after = Pt(160)  # vertical push
+add_kicker(doc, "Research Brief")
+
+title = doc.add_paragraph(style="Title")
+title_run = title.add_run("Agent Infrastructure in 2026")
+title_run.font.name, title_run.font.size = "Georgia", Pt(40)
+title_run.font.color.rgb = RGBColor.from_string(palette["ink"])
+
+dek = doc.add_paragraph()
+dek_run = dek.add_run("Market shape, adoption curves, and the shift to "
+                      "production-grade systems.")
+dek_run.font.name, dek_run.font.size, dek_run.font.italic = "Calibri", Pt(14), True
+
+meta = doc.add_paragraph()
+meta_run = meta.add_run("Xagent Team · 2026-05-14")   # middle dot, not hyphen
+meta_run.font.size = Pt(10)
+meta_run.font.color.rgb = RGBColor.from_string(palette["ink_tint"])
+
+# Page break -> body starts on page 2
+doc.add_paragraph().add_run().add_break(WD_BREAK.PAGE)
+```
+
+## 🔠 Heading hierarchy
+
+Always use the built-in styles, then restyle the style object once — not
+each heading individually:
+
+```python
+for name, family, size in (("Heading 1", "Georgia", 22),
+                           ("Heading 2", "Georgia", 16),
+                           ("Heading 3", "Calibri", 12)):
+    st = doc.styles[name]
+    st.font.name, st.font.size = family, Pt(size)
+    st.font.color.rgb = RGBColor.from_string(palette["ink"])
+    st.font.bold = (name == "Heading 3")
+    st.paragraph_format.space_before = Pt(18)
+    st.paragraph_format.space_after = Pt(6)
+
+doc.add_heading("Executive Summary", level=1)
+doc.add_paragraph("...")
+doc.add_heading("Market Size", level=2)
+```
+
+⚠️ `doc.add_heading(..., level=0)` applies the `Title` style, not a
+heading — use it only on the cover. Body sections start at `level=1`.
+
+## 📊 Table styling
+
+python-docx has no API for cell shading or borders, so both need raw
+OOXML. These two helpers are the whole toolkit — copy them verbatim.
+
+```python
+from docx.oxml.ns import qn
+from docx.oxml import OxmlElement
+
+def shade_cell(cell, hex_fill):
+    """Solid background fill for one table cell."""
+    tcPr = cell._tc.get_or_add_tcPr()
+    shd = OxmlElement("w:shd")
+    shd.set(qn("w:val"), "clear")
+    shd.set(qn("w:color"), "auto")
+    shd.set(qn("w:fill"), hex_fill)
+    tcPr.append(shd)
+
+def set_row_border(row, edge, hex_color, sz=8):
+    """Horizontal hairline on a row: edge is 'top' or 'bottom'. sz is 1/8 pt."""
+    for cell in row.cells:
+        tcPr = cell._tc.get_or_add_tcPr()
+        borders = tcPr.find(qn("w:tcBorders"))
+        if borders is None:
+            borders = OxmlElement("w:tcBorders")
+            tcPr.append(borders)
+        el = OxmlElement(f"w:{edge}")
+        el.set(qn("w:val"), "single")
+        el.set(qn("w:sz"), str(sz))          # 8 = 1pt
+        el.set(qn("w:color"), hex_color)
+        borders.append(el)
+```
+
+Editorial table rules — **horizontal rules only, no vertical borders**:
+
+```python
+from docx.enum.table import WD_TABLE_ALIGNMENT
+
+rows = [("Region", "Revenue", "YoY"),
+        ("North America", "4.2M", "+18%"),
+        ("EMEA", "2.8M", "+11%")]
+
+table = doc.add_table(rows=len(rows), cols=3)
+table.style = "Table Grid"          # then strip verticals via borders
+table.alignment = WD_TABLE_ALIGNMENT.CENTER
+table.autofit = True
+
+for r, record in enumerate(rows):
+    for c, value in enumerate(record):
+        cell = table.cell(r, c)
+        cell.text = str(value)
+        para = cell.paragraphs[0]
+        # numbers right-aligned, text left-aligned
+        para.alignment = (WD_ALIGN_PARAGRAPH.RIGHT if c > 0 and r > 0
+                          else WD_ALIGN_PARAGRAPH.LEFT)
+        run = para.runs[0]
+        run.font.name, run.font.size = "Calibri", Pt(10)
+        if r == 0:                                   # header row
+            run.font.bold = True
+            run.font.color.rgb = RGBColor.from_string(palette["paper"])
+            shade_cell(cell, palette["ink"])         # ink header band
+        elif r % 2 == 0:                             # zebra band
+            shade_cell(cell, palette["paper_tint"])
+            run.font.color.rgb = RGBColor.from_string(palette["ink"])
+        else:
+            run.font.color.rgb = RGBColor.from_string(palette["ink"])
+
+set_row_border(table.rows[-1], "bottom", palette["ink"])
+
+caption = doc.add_paragraph(style="Caption")
+caption_run = caption.add_run("Table 1 — Revenue by region, FY2026.")
+caption_run.font.size, caption_run.font.italic = Pt(9), True
+caption_run.font.color.rgb = RGBColor.from_string(palette["ink_tint"])
+```
+
+Repeat the header row across page breaks for tables longer than a page:
+
+```python
+trPr = table.rows[0]._tr.get_or_add_trPr()
+trPr.append(OxmlElement("w:tblHeader"))
+```
+
+## 📝 Output checklist
+
+- [ ] `from docx import Document` (import name is `docx`, not `python_docx`)
+- [ ] LANGUAGE matches the user's prompt — no English kickers in a ZH report
+- [ ] One palette, only its 4 hex values appear anywhere
+- [ ] Only Georgia + Calibri; `Normal` style carries the body font + eastAsia
+- [ ] Real `Heading 1/2/3` styles used (Word navigation pane shows an outline)
+- [ ] Page size, margins, and orientation set explicitly on the section
+      (landscape = swap width/height, not just the orientation flag)
+- [ ] Cover page present, followed by an explicit page break
+- [ ] Tables: ink header band, `paper_tint` zebra rows, horizontal rules only,
+      numbers right-aligned, caption below
+- [ ] No fabricated data, no lorem ipsum, no placeholder headings
+- [ ] File saved with a plain filename and verified >10 KB via `os.path.getsize`
+- [ ] **Final answer FIRST LINE is `[filename](file:UUID)`** as bare markdown
+
+Then write the .docx and report path + which palette + which sections.

--- a/src/xagent/skills/builtin/docx-report-editorial/SKILL.md
+++ b/src/xagent/skills/builtin/docx-report-editorial/SKILL.md
@@ -217,28 +217,33 @@ sec.page_width, sec.page_height = Cm(29.7), Cm(21.0)   # swap explicitly
 ```
 
 Set the default body font once on the `Normal` style so every paragraph
-inherits it (including CJK, which needs the `eastAsia` attribute):
+inherits it:
 
 ```python
-from docx.oxml.ns import qn
+from docx.shared import Pt, RGBColor
 
 normal = doc.styles["Normal"]
 normal.font.name = "Calibri"
 normal.font.size = Pt(11)
 normal.font.color.rgb = RGBColor.from_string(palette["ink"])
-rpr = normal.element.get_or_add_rPr()
-rpr.get_or_add_rFonts().set(qn("w:eastAsia"), "Microsoft YaHei")
 normal.paragraph_format.line_spacing = 1.4
 normal.paragraph_format.space_after = Pt(8)
 ```
 
+Do not pin `w:eastAsia` to a named CJK face. Rule 2 is that Chinese renders
+through each platform's own fallback — writing `Microsoft YaHei` into the
+style hard-codes a font that is absent on macOS and Linux, which is the
+substitution the rule exists to prevent. Leaving the attribute unset is what
+lets Word pick PingFang, YaHei or Noto per platform.
+
 ## 🏛️ Cover page pattern
 
 The cover is its own section so the body can restart page numbering and
-use different headers. Structure: kicker → title → dek → rule → meta row.
+use different headers. Structure: kicker → title → dek → meta row.
 
 ```python
-from docx.enum.text import WD_ALIGN_PARAGRAPH, WD_BREAK
+from docx.shared import Pt, RGBColor
+
 
 def add_kicker(doc, text):
     p = doc.add_paragraph()
@@ -378,6 +383,8 @@ Editorial table rules — **horizontal rules only, no vertical borders**:
 
 ```python
 from docx.enum.table import WD_TABLE_ALIGNMENT
+from docx.enum.text import WD_ALIGN_PARAGRAPH
+from docx.shared import Pt, RGBColor
 
 rows = [("Region", "Revenue", "YoY"),
         ("North America", "4.2M", "+18%"),
@@ -442,7 +449,8 @@ trPr.append(OxmlElement("w:tblHeader"))
 - [ ] `from docx import Document` (import name is `docx`, not `python_docx`)
 - [ ] LANGUAGE matches the user's prompt — no English kickers in a ZH report
 - [ ] One palette, only its 4 hex values appear anywhere
-- [ ] Only Georgia + Calibri; `Normal` style carries the body font + eastAsia
+- [ ] Only Georgia + Calibri; `Normal` carries the body font, and no named
+      CJK face is pinned to `w:eastAsia`
 - [ ] Real `Heading 1/2/3` styles used (Word navigation pane shows an outline)
 - [ ] Page size, margins, and orientation set explicitly on the section
       (landscape = swap width/height, not just the orientation flag)

--- a/src/xagent/skills/builtin/docx-report-editorial/SKILL.md
+++ b/src/xagent/skills/builtin/docx-report-editorial/SKILL.md
@@ -200,7 +200,8 @@ normal = doc.styles["Normal"]
 normal.font.name = "Calibri"
 normal.font.size = Pt(11)
 normal.font.color.rgb = RGBColor.from_string(palette["ink"])
-normal.element.rPr.rFonts.set(qn("w:eastAsia"), "Microsoft YaHei")
+rpr = normal.element.get_or_add_rPr()
+rpr.get_or_add_rFonts().set(qn("w:eastAsia"), "Microsoft YaHei")
 normal.paragraph_format.line_spacing = 1.4
 normal.paragraph_format.space_after = Pt(8)
 ```
@@ -277,27 +278,44 @@ from docx.oxml.ns import qn
 from docx.oxml import OxmlElement
 
 def shade_cell(cell, hex_fill):
-    """Solid background fill for one table cell."""
+    """Solid background fill for one table cell. Replaces any existing fill --
+    w:tcPr allows at most one w:shd, and a second one corrupts the cell."""
     tcPr = cell._tc.get_or_add_tcPr()
+    for stale in tcPr.findall(qn("w:shd")):
+        tcPr.remove(stale)
     shd = OxmlElement("w:shd")
     shd.set(qn("w:val"), "clear")
     shd.set(qn("w:color"), "auto")
     shd.set(qn("w:fill"), hex_fill)
     tcPr.append(shd)
 
+# w:tcBorders is an ordered sequence -- Word rejects the part if the children
+# come out of order, so insert at the schema position instead of appending.
+_BORDER_ORDER = ("top", "left", "bottom", "right", "insideH", "insideV")
+
+
 def set_row_border(row, edge, hex_color, sz=8):
-    """Horizontal hairline on a row: edge is 'top' or 'bottom'. sz is 1/8 pt."""
+    """Horizontal hairline on a row: edge is 'top' or 'bottom'. sz is 1/8 pt.
+    Re-styling an edge replaces it -- one w:<edge> per w:tcBorders."""
     for cell in row.cells:
         tcPr = cell._tc.get_or_add_tcPr()
         borders = tcPr.find(qn("w:tcBorders"))
         if borders is None:
             borders = OxmlElement("w:tcBorders")
             tcPr.append(borders)
+        for stale in borders.findall(qn(f"w:{edge}")):
+            borders.remove(stale)
         el = OxmlElement(f"w:{edge}")
         el.set(qn("w:val"), "single")
         el.set(qn("w:sz"), str(sz))          # 8 = 1pt
         el.set(qn("w:color"), hex_color)
-        borders.append(el)
+        rank = _BORDER_ORDER.index(edge)
+        later = [child for child in borders
+                 if _BORDER_ORDER.index(child.tag.split("}")[1]) > rank]
+        if later:
+            later[0].addprevious(el)
+        else:
+            borders.append(el)
 ```
 
 Editorial table rules — **horizontal rules only, no vertical borders**:

--- a/src/xagent/skills/builtin/docx-report-editorial/SKILL.md
+++ b/src/xagent/skills/builtin/docx-report-editorial/SKILL.md
@@ -61,7 +61,18 @@ Re-open the file and count what you wrote:
 from docx import Document
 
 check = Document("market_expansion_report.docx")
-assert len(check.paragraphs) > 10 and len(check.tables) >= 1
+assert any(p.text.strip() for p in check.paragraphs), "document has no text"
+```
+
+Assert the shape the request actually asked for, never a fixed minimum. A
+multi-section report should also check its tables and headings; a one-page
+memo or letter legitimately has neither, and padding it to satisfy a
+threshold breaks the no-fabricated-content rule above.
+
+```python
+# only for a document the request asked to be structured this way
+assert len(check.tables) >= 1
+assert any(p.style.name.startswith("Heading") for p in check.paragraphs)
 ```
 
 ### 🔗 Make it clickable in chat — REQUIRED
@@ -415,6 +426,9 @@ caption_run.font.color.rgb = RGBColor.from_string(palette["ink_tint"])
 Repeat the header row across page breaks for tables longer than a page:
 
 ```python
+from docx.oxml.ns import qn
+from docx.oxml import OxmlElement
+
 # w:trPr allows at most one w:tblHeader, so replace rather than append -- a
 # second one is schema-invalid, and a loop over tables would add one per pass.
 trPr = table.rows[0]._tr.get_or_add_trPr()
@@ -432,12 +446,15 @@ trPr.append(OxmlElement("w:tblHeader"))
 - [ ] Real `Heading 1/2/3` styles used (Word navigation pane shows an outline)
 - [ ] Page size, margins, and orientation set explicitly on the section
       (landscape = swap width/height, not just the orientation flag)
-- [ ] Cover page present, followed by an explicit page break
+- [ ] Cover page present, followed by a `WD_SECTION.NEW_PAGE` section break
+      (not an extra page break as well — that leaves a blank page)
 - [ ] Tables: ink header band, `paper_tint` zebra rows, horizontal rules only,
       numbers right-aligned, caption below
 - [ ] No fabricated data, no lorem ipsum, no placeholder headings
-- [ ] File saved with a plain filename, then re-opened and its paragraph /
-      table counts asserted (byte size proves nothing — empty is ~36 KB)
+- [ ] File saved with a plain filename, then re-opened and asserted non-empty
+      (byte size proves nothing — an empty document is already ~36 KB)
+- [ ] Any structural assertion matches what was requested — no fixed minimum
+      that a legitimate one-page memo or letter would fail
 - [ ] **Final answer FIRST LINE is `[filename](file:UUID)`** as bare markdown
 
 Then write the .docx and report path + which palette + which sections.

--- a/src/xagent/skills/builtin/docx-report-editorial/SKILL.md
+++ b/src/xagent/skills/builtin/docx-report-editorial/SKILL.md
@@ -53,9 +53,16 @@ Do NOT use:
 - `doc.save("output/foo.docx")` — there is no nested `output/` subdir
 - BytesIO + base64 round-trips — just save to disk directly.
 
-Verify with `os.path.getsize("market_expansion_report.docx")` before
-declaring success. A real python-docx document is **always >10 KB** —
-if your saved file is under 5 KB it's broken or empty.
+Verify the content, not the byte count: an empty `Document()` already saves
+at ~36 KB, so a size threshold cannot tell a real report from a blank one.
+Re-open the file and count what you wrote:
+
+```python
+from docx import Document
+
+check = Document("market_expansion_report.docx")
+assert len(check.paragraphs) > 10 and len(check.tables) >= 1
+```
 
 ### 🔗 Make it clickable in chat — REQUIRED
 
@@ -129,19 +136,27 @@ The UUID comes from the executor response. Do not fabricate one.
 
 Same palettes as `pdf-report-editorial` and `pptx-editorial` — keep the
 editorial family visually consistent. Each: `ink` (body text + rules),
-`paper` (page / cell background), `paper-tint` (table band + callout bg),
-`ink-tint` (kickers, captions, footer).
+`paper` (page / cell background), `paper_tint` (table band + callout bg),
+`ink_tint` (kickers, captions, footer). The keys are underscored — the dict
+below is what every snippet indexes into.
 
 - **Monocle** (default / business / tech / policy)
-  ink `0A0A0B` · paper `F1EFEA` · paper-tint `E8E5DE` · ink-tint `18181A`
+  ink `0A0A0B` · paper `F1EFEA` · paper_tint `E8E5DE` · ink_tint `18181A`
 - **Indigo Porcelain** (research / data-heavy)
-  ink `0A1F3D` · paper `F1F3F5` · paper-tint `E4E8EC` · ink-tint `152A4A`
+  ink `0A1F3D` · paper `F1F3F5` · paper_tint `E4E8EC` · ink_tint `152A4A`
 - **Forest Ink** (sustainability / impact)
-  ink `1A2E1F` · paper `F5F1E8` · paper-tint `ECE7DA` · ink-tint `253D2C`
+  ink `1A2E1F` · paper `F5F1E8` · paper_tint `ECE7DA` · ink_tint `253D2C`
 - **Kraft Paper** (humanities / qualitative)
-  ink `2A1E13` · paper `EEDFC7` · paper-tint `E0D0B6` · ink-tint `3A2A1D`
+  ink `2A1E13` · paper `EEDFC7` · paper_tint `E0D0B6` · ink_tint `3A2A1D`
 - **Dune** (art / design / fashion criticism)
-  ink `1F1A14` · paper `F0E6D2` · paper-tint `E3D7BF` · ink-tint `2D2620`
+  ink `1F1A14` · paper `F0E6D2` · paper_tint `E3D7BF` · ink_tint `2D2620`
+
+Define it once at the top of the script, then index it everywhere:
+
+```python
+palette = {"ink": "0A0A0B", "paper": "F1EFEA",
+           "paper_tint": "E8E5DE", "ink_tint": "18181A"}   # Monocle
+```
 
 python-docx takes hex without the `#` prefix, via
 `RGBColor.from_string(palette["ink"])`.
@@ -152,7 +167,7 @@ python-docx takes hex without the `#` prefix, via
 |---|---|---|---|---|
 | Cover title | `Title` | Georgia | 40pt | regular |
 | Cover subtitle / dek | body run | Calibri | 14pt | italic |
-| Kicker (small caps label) | body run | Calibri | 9pt, uppercase | bold, ink-tint |
+| Kicker (small caps label) | body run | Calibri | 9pt, uppercase | bold, ink_tint |
 | H1 section | `Heading 1` | Georgia | 22pt | regular |
 | H2 subsection | `Heading 2` | Georgia | 16pt | regular |
 | H3 sub-subsection | `Heading 3` | Calibri | 12pt | bold |
@@ -160,7 +175,7 @@ python-docx takes hex without the `#` prefix, via
 | Pull quote | `Intense Quote` | Georgia | 14pt | italic |
 | Table header | table run | Calibri | 10pt | bold, paper on ink |
 | Table body | table run | Calibri | 10pt | regular |
-| Caption / footnote | `Caption` | Calibri | 9pt | italic, ink-tint |
+| Caption / footnote | `Caption` | Calibri | 9pt | italic, ink_tint |
 
 ## 📐 Page setup
 
@@ -169,7 +184,7 @@ Set margins, size and orientation on each `section` before adding content.
 ```python
 from docx import Document
 from docx.shared import Pt, Cm, RGBColor
-from docx.enum.section import WD_ORIENT, WD_SECTION
+from docx.enum.section import WD_ORIENT
 
 doc = Document()
 sec = doc.sections[0]
@@ -240,8 +255,11 @@ meta_run = meta.add_run("Xagent Team · 2026-05-14")   # middle dot, not hyphen
 meta_run.font.size = Pt(10)
 meta_run.font.color.rgb = RGBColor.from_string(palette["ink_tint"])
 
-# Page break -> body starts on page 2
-doc.add_paragraph().add_run().add_break(WD_BREAK.PAGE)
+# A new section — not just a page break — is what lets the body restart page
+# numbering and carry its own header/footer.
+from docx.enum.section import WD_SECTION
+
+body = doc.add_section(WD_SECTION.NEW_PAGE)
 ```
 
 ## 🔠 Heading hierarchy
@@ -268,6 +286,17 @@ doc.add_heading("Market Size", level=2)
 ⚠️ `doc.add_heading(..., level=0)` applies the `Title` style, not a
 heading — use it only on the cover. Body sections start at `level=1`.
 
+Pull quotes use the built-in style too, so they stay in the outline-free
+body flow:
+
+```python
+quote = doc.add_paragraph(style="Intense Quote")
+quote_run = quote.add_run("Adoption is no longer the constraint; "
+                          "operating cost is.")
+quote_run.font.name, quote_run.font.size = "Georgia", Pt(14)
+quote_run.font.italic = True
+```
+
 ## 📊 Table styling
 
 python-docx has no API for cell shading or borders, so both need raw
@@ -277,45 +306,61 @@ OOXML. These two helpers are the whole toolkit — copy them verbatim.
 from docx.oxml.ns import qn
 from docx.oxml import OxmlElement
 
+# Both w:tcPr and w:tcBorders are ordered sequences: Word rejects the part when
+# children appear out of order, and each tag may appear at most once. Appending
+# is wrong on both counts, so everything below inserts at the schema position.
+_TCPR_ORDER = ("cnfStyle", "tcW", "gridSpan", "hMerge", "vMerge", "tcBorders",
+               "shd", "noWrap", "tcMar", "textDirection", "tcFitText",
+               "vAlign", "hideMark")
+_BORDER_ORDER = ("top", "left", "bottom", "right", "insideH", "insideV",
+                 "tl2br", "tr2bl")
+
+
+def _put(parent, tag, order):
+    """Replace parent's <w:{tag}> child, keeping the schema's element order."""
+    for stale in parent.findall(qn(f"w:{tag}")):
+        parent.remove(stale)
+    el = OxmlElement(f"w:{tag}")
+    rank = order.index(tag)
+    later = [child for child in parent
+             if child.tag.split("}")[1] in order
+             and order.index(child.tag.split("}")[1]) > rank]
+    if later:
+        later[0].addprevious(el)
+    else:
+        parent.append(el)
+    return el
+
+
 def shade_cell(cell, hex_fill):
-    """Solid background fill for one table cell. Replaces any existing fill --
-    w:tcPr allows at most one w:shd, and a second one corrupts the cell."""
+    """Solid background fill for one table cell."""
     tcPr = cell._tc.get_or_add_tcPr()
-    for stale in tcPr.findall(qn("w:shd")):
-        tcPr.remove(stale)
-    shd = OxmlElement("w:shd")
+    shd = _put(tcPr, "shd", _TCPR_ORDER)
     shd.set(qn("w:val"), "clear")
     shd.set(qn("w:color"), "auto")
     shd.set(qn("w:fill"), hex_fill)
-    tcPr.append(shd)
-
-# w:tcBorders is an ordered sequence -- Word rejects the part if the children
-# come out of order, so insert at the schema position instead of appending.
-_BORDER_ORDER = ("top", "left", "bottom", "right", "insideH", "insideV")
-
 
 def set_row_border(row, edge, hex_color, sz=8):
-    """Horizontal hairline on a row: edge is 'top' or 'bottom'. sz is 1/8 pt.
-    Re-styling an edge replaces it -- one w:<edge> per w:tcBorders."""
+    """Hairline on one edge of every cell in a row, e.g. 'top' or 'bottom'.
+    sz is in 1/8 pt. Re-styling the same edge replaces it."""
     for cell in row.cells:
         tcPr = cell._tc.get_or_add_tcPr()
         borders = tcPr.find(qn("w:tcBorders"))
         if borders is None:
-            borders = OxmlElement("w:tcBorders")
-            tcPr.append(borders)
-        for stale in borders.findall(qn(f"w:{edge}")):
-            borders.remove(stale)
-        el = OxmlElement(f"w:{edge}")
+            borders = _put(tcPr, "tcBorders", _TCPR_ORDER)
+        el = _put(borders, edge, _BORDER_ORDER)
         el.set(qn("w:val"), "single")
         el.set(qn("w:sz"), str(sz))          # 8 = 1pt
         el.set(qn("w:color"), hex_color)
-        rank = _BORDER_ORDER.index(edge)
-        later = [child for child in borders
-                 if _BORDER_ORDER.index(child.tag.split("}")[1]) > rank]
-        if later:
-            later[0].addprevious(el)
-        else:
-            borders.append(el)
+
+
+def clear_cell_border(cell, edge):
+    """Remove one edge, e.g. the verticals a full-grid table style draws."""
+    tcPr = cell._tc.get_or_add_tcPr()
+    borders = tcPr.find(qn("w:tcBorders"))
+    if borders is None:
+        borders = _put(tcPr, "tcBorders", _TCPR_ORDER)
+    _put(borders, edge, _BORDER_ORDER).set(qn("w:val"), "nil")
 ```
 
 Editorial table rules — **horizontal rules only, no vertical borders**:
@@ -328,7 +373,7 @@ rows = [("Region", "Revenue", "YoY"),
         ("EMEA", "2.8M", "+11%")]
 
 table = doc.add_table(rows=len(rows), cols=3)
-table.style = "Table Grid"          # then strip verticals via borders
+table.style = "Table Grid"          # verticals stripped per cell below
 table.alignment = WD_TABLE_ALIGNMENT.CENTER
 table.autofit = True
 
@@ -352,6 +397,13 @@ for r, record in enumerate(rows):
         else:
             run.font.color.rgb = RGBColor.from_string(palette["ink"])
 
+# "Table Grid" draws a full grid; nil out the verticals to keep it editorial.
+for table_row in table.rows:
+    for table_cell in table_row.cells:
+        for vertical in ("left", "right", "insideV"):
+            clear_cell_border(table_cell, vertical)
+
+set_row_border(table.rows[0], "bottom", palette["ink"])
 set_row_border(table.rows[-1], "bottom", palette["ink"])
 
 caption = doc.add_paragraph(style="Caption")
@@ -363,7 +415,11 @@ caption_run.font.color.rgb = RGBColor.from_string(palette["ink_tint"])
 Repeat the header row across page breaks for tables longer than a page:
 
 ```python
+# w:trPr allows at most one w:tblHeader, so replace rather than append -- a
+# second one is schema-invalid, and a loop over tables would add one per pass.
 trPr = table.rows[0]._tr.get_or_add_trPr()
+for stale in trPr.findall(qn("w:tblHeader")):
+    trPr.remove(stale)
 trPr.append(OxmlElement("w:tblHeader"))
 ```
 
@@ -380,7 +436,8 @@ trPr.append(OxmlElement("w:tblHeader"))
 - [ ] Tables: ink header band, `paper_tint` zebra rows, horizontal rules only,
       numbers right-aligned, caption below
 - [ ] No fabricated data, no lorem ipsum, no placeholder headings
-- [ ] File saved with a plain filename and verified >10 KB via `os.path.getsize`
+- [ ] File saved with a plain filename, then re-opened and its paragraph /
+      table counts asserted (byte size proves nothing — empty is ~36 KB)
 - [ ] **Final answer FIRST LINE is `[filename](file:UUID)`** as bare markdown
 
 Then write the .docx and report path + which palette + which sections.

--- a/tests/skills/test_builtin_docx_report_editorial.py
+++ b/tests/skills/test_builtin_docx_report_editorial.py
@@ -9,6 +9,8 @@ skill actually documents and assert the invariants Word enforces.
 
 from __future__ import annotations
 
+import ast
+import builtins
 import re
 import tempfile
 from pathlib import Path
@@ -202,6 +204,109 @@ def test_the_validation_snippet_accepts_a_one_page_memo() -> None:
         source.replace('"market_expansion_report.docx"', repr(str(MEMO_PATH))),
         namespace,
     )
+
+
+def test_every_self_contained_fence_imports_what_it_uses() -> None:
+    """A fence that opens with its own import line reads as copy-and-run, so
+    its import list has to be complete. Listing some of what it uses is the
+    worst shape: it looks self-contained and fails at the missing name. Two
+    rounds of review found one each (the repeat-header block, then the cover
+    block, which imported the two enums it had stopped using and omitted the
+    Pt and RGBColor it still called).
+
+    Fences that continue from earlier ones are exempt -- they legitimately
+    build on `doc`, `sec`, `table` and `palette` -- so the check is scoped to
+    fences that declare imports of their own.
+    """
+    fences = re.findall(r"^```python\n(.*?)^```", SKILL_MD.read_text(), re.S | re.M)
+    carried_over = {"doc", "sec", "table", "row", "cell", "check", "palette"}
+    # Helpers an earlier fence defines are carried forward the same way the
+    # document objects are -- the skill tells the model to copy them once.
+    carried_over |= {
+        node.name
+        for fence in fences
+        for node in ast.walk(ast.parse(fence))
+        if isinstance(node, ast.FunctionDef)
+    }
+
+    # Static analysis rather than exec: running a fence against stub objects
+    # raises AttributeError on the first stub call, which masks every missing
+    # name after it. The point is the whole import list, not the first line.
+    offenders = []
+    for fence in fences:
+        if not re.match(r"\s*(from|import)\s", fence):
+            continue  # a continuation fence, not advertised as standalone
+        tree = ast.parse(fence)
+        bound = set(dir(builtins)) | carried_over
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Import, ast.ImportFrom)):
+                bound |= {a.asname or a.name.split(".")[0] for a in node.names}
+            elif isinstance(node, ast.Name) and isinstance(node.ctx, ast.Store):
+                bound.add(node.id)
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                bound.add(node.name)
+                bound |= {a.arg for a in node.args.args}
+            elif isinstance(node, ast.ExceptHandler) and node.name:
+                bound.add(node.name)
+            elif isinstance(node, ast.comprehension):
+                bound |= {
+                    n.id for n in ast.walk(node.target) if isinstance(n, ast.Name)
+                }
+        used = {
+            n.id
+            for n in ast.walk(tree)
+            if isinstance(n, ast.Name) and isinstance(n.ctx, ast.Load)
+        }
+        missing = sorted(used - bound)
+        if missing:
+            offenders.append((fence.strip().splitlines()[0], missing))
+
+    assert not offenders, f"fences missing imports: {offenders}"
+
+
+def test_the_prose_does_not_promise_what_the_snippets_omit() -> None:
+    """Four rounds of review found prose describing behaviour the code below
+    it did not have: a page break where the code opens a section, verticals
+    "stripped" by a call that was not there, a cover rule with no rule, an
+    eastAsia font pinned against the rule forbidding it. Each was found by
+    reading. These pin the ones that are mechanically checkable.
+    """
+    text = SKILL_MD.read_text()
+    fences = "\n".join(re.findall(r"^```python\n(.*?)^```", text, re.S | re.M))
+
+    # The cover: prose names the section break, so the code must open one.
+    assert "add_section" in fences
+    assert "WD_BREAK.PAGE" not in fences, (
+        "a page break next to the section break is the blank-page trap"
+    )
+
+    # The table: prose says horizontal rules only, so the verticals the
+    # "Table Grid" style draws have to actually be cleared.
+    if '"Table Grid"' in fences:
+        # A call, not a mention: the helper's own definition contains each edge
+        # name, so searching the text passes even with every call deleted.
+        sample = next(
+            f
+            for f in re.findall(r"^```python\n(.*?)^```", text, re.S | re.M)
+            if '"Table Grid"' in f
+        )
+        calls = [
+            node
+            for node in ast.walk(ast.parse(sample))
+            if isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "clear_cell_border"
+        ]
+        assert calls, "the sample never clears the grid's verticals"
+        cleared = " ".join(ast.dump(c) for c in calls) + sample
+        for vertical in ("left", "right", "insideV"):
+            assert vertical in cleared, f"{vertical} border never cleared"
+
+    # Rule 2 puts CJK on platform fallback, so no named face may be pinned.
+    assert 'qn("w:eastAsia")' not in fences, "rule 2 forbids pinning a CJK face"
+
+    # The validation snippet must not reimpose a shape floor.
+    assert "len(check.paragraphs) > 10" not in fences
 
 
 def test_the_repeat_header_snippet_stays_single(helpers) -> None:

--- a/tests/skills/test_builtin_docx_report_editorial.py
+++ b/tests/skills/test_builtin_docx_report_editorial.py
@@ -1,0 +1,200 @@
+"""The docx skill's helpers are executed, not just read.
+
+Two rounds of review found OOXML schema defects in these snippets that every
+existing check missed: python-docx accepts out-of-order and duplicated
+children without complaint, and the resulting file is still a valid zip, so
+"the snippet ran and saved" proves nothing. These tests run the helpers the
+skill actually documents and assert the invariants Word enforces.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from docx import Document
+from docx.enum.table import WD_CELL_VERTICAL_ALIGNMENT
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
+
+SKILL_MD = (
+    Path(__file__).parents[2]
+    / "src"
+    / "xagent"
+    / "skills"
+    / "builtin"
+    / "docx-report-editorial"
+    / "SKILL.md"
+)
+
+# w:tcPr / w:tcBorders / w:trPr child order, per ECMA-376 CT_TcPr, CT_TcBorders
+# and CT_TrPr. python-docx encodes the same sequences in its _tag_seq tuples.
+TCPR_ORDER = (
+    "cnfStyle",
+    "tcW",
+    "gridSpan",
+    "hMerge",
+    "vMerge",
+    "tcBorders",
+    "shd",
+    "noWrap",
+    "tcMar",
+    "textDirection",
+    "tcFitText",
+    "vAlign",
+    "hideMark",
+)
+BORDER_ORDER = (
+    "top",
+    "left",
+    "bottom",
+    "right",
+    "insideH",
+    "insideV",
+    "tl2br",
+    "tr2bl",
+)
+
+
+def _helpers() -> dict:
+    """Execute the skill's own helper snippet and hand back what it defines.
+
+    Reading the code out of SKILL.md is the point: a fix applied to the test
+    but not to the documented snippet cannot pass, and agents copy the
+    snippet, not this file.
+    """
+    blocks = re.findall(r"^```python\n(.*?)^```", SKILL_MD.read_text(), re.S | re.M)
+    source = next(b for b in blocks if "def shade_cell" in b)
+    assert "def set_row_border" in source, "helpers must stay in one block"
+    namespace: dict = {}
+    exec(source, namespace)  # noqa: S102 - executing our own documented snippet
+    return namespace
+
+
+def _child_tags(element) -> list[str]:
+    return [child.tag.split("}")[1] for child in element]
+
+
+def _assert_ordered(element, order: tuple[str, ...], label: str) -> None:
+    tags = [t for t in _child_tags(element) if t in order]
+    ranks = [order.index(t) for t in tags]
+    assert ranks == sorted(ranks), f"{label} out of schema order: {tags}"
+    assert len(tags) == len(set(tags)), f"{label} has duplicate children: {tags}"
+
+
+@pytest.fixture(scope="module")
+def helpers() -> dict:
+    return _helpers()
+
+
+def test_shading_then_bordering_one_cell_keeps_tcpr_ordered(helpers) -> None:
+    """The order the skill's own sample table uses: zebra-shade the cells,
+    then rule the row. w:tcBorders must precede w:shd; appending gave
+    ['tcW', 'shd', 'tcBorders'], which Word rejects."""
+    table = Document().add_table(rows=3, cols=2)
+    cell = table.cell(2, 0)
+
+    helpers["shade_cell"](cell, "E8E5DE")
+    helpers["set_row_border"](table.rows[2], "bottom", "0A0A0B")
+
+    tcPr = cell._tc.get_or_add_tcPr()
+    _assert_ordered(tcPr, TCPR_ORDER, "w:tcPr")
+    tags = _child_tags(tcPr)
+    assert tags.index("tcBorders") < tags.index("shd")
+
+
+def test_bordering_then_shading_one_cell_keeps_tcpr_ordered(helpers) -> None:
+    """The reverse order has to hold too -- the helpers must not depend on
+    the caller happening to pick the sequence that works."""
+    table = Document().add_table(rows=2, cols=2)
+    cell = table.cell(0, 0)
+
+    helpers["set_row_border"](table.rows[0], "top", "0A0A0B")
+    helpers["shade_cell"](cell, "E8E5DE")
+
+    _assert_ordered(cell._tc.get_or_add_tcPr(), TCPR_ORDER, "w:tcPr")
+
+
+def test_shading_lands_before_a_later_sibling_already_present(helpers) -> None:
+    """shade_cell has to place w:shd correctly on its own, not lean on
+    set_row_border's insert to fix the order afterwards. Vertically centring
+    a cell first writes w:vAlign, which the schema puts after w:shd."""
+    table = Document().add_table(rows=1, cols=1)
+    cell = table.cell(0, 0)
+    cell.vertical_alignment = WD_CELL_VERTICAL_ALIGNMENT.CENTER
+
+    helpers["shade_cell"](cell, "0A0A0B")
+
+    tcPr = cell._tc.get_or_add_tcPr()
+    _assert_ordered(tcPr, TCPR_ORDER, "w:tcPr")
+    tags = _child_tags(tcPr)
+    assert tags.index("shd") < tags.index("vAlign")
+
+
+def test_repeated_calls_replace_rather_than_stack(helpers) -> None:
+    """Restyling is idempotent: w:tcPr allows one w:shd and w:tcBorders one
+    child per edge, and the last write is what survives."""
+    table = Document().add_table(rows=2, cols=2)
+    cell = table.cell(1, 0)
+
+    helpers["shade_cell"](cell, "E8E5DE")
+    helpers["shade_cell"](cell, "0A0A0B")
+    helpers["set_row_border"](table.rows[1], "bottom", "111111")
+    helpers["set_row_border"](table.rows[1], "bottom", "FF0000")
+
+    tcPr = cell._tc.get_or_add_tcPr()
+    _assert_ordered(tcPr, TCPR_ORDER, "w:tcPr")
+    assert tcPr.find(qn("w:shd")).get(qn("w:fill")) == "0A0A0B"
+
+    borders = tcPr.find(qn("w:tcBorders"))
+    _assert_ordered(borders, BORDER_ORDER, "w:tcBorders")
+    assert borders.find(qn("w:bottom")).get(qn("w:color")) == "FF0000"
+
+
+def test_every_documented_edge_is_settable(helpers) -> None:
+    """Including the diagonals: keying the insert on a tuple that omitted
+    tl2br/tr2bl raised ValueError from tuple.index instead of setting them."""
+    table = Document().add_table(rows=1, cols=1)
+
+    for edge in BORDER_ORDER:
+        helpers["set_row_border"](table.rows[0], edge, "0A0A0B")
+
+    borders = table.cell(0, 0)._tc.get_or_add_tcPr().find(qn("w:tcBorders"))
+    _assert_ordered(borders, BORDER_ORDER, "w:tcBorders")
+    assert set(_child_tags(borders)) == set(BORDER_ORDER)
+
+
+def test_clearing_a_border_nils_it_in_place(helpers) -> None:
+    """Stripping the verticals a full-grid style draws must not disturb the
+    horizontal rules already set, nor the element order."""
+    table = Document().add_table(rows=1, cols=1)
+    cell = table.cell(0, 0)
+
+    helpers["set_row_border"](table.rows[0], "bottom", "0A0A0B")
+    helpers["clear_cell_border"](cell, "left")
+    helpers["clear_cell_border"](cell, "right")
+
+    borders = cell._tc.get_or_add_tcPr().find(qn("w:tcBorders"))
+    _assert_ordered(borders, BORDER_ORDER, "w:tcBorders")
+    assert borders.find(qn("w:left")).get(qn("w:val")) == "nil"
+    assert borders.find(qn("w:bottom")).get(qn("w:color")) == "0A0A0B"
+
+
+def test_the_repeat_header_snippet_stays_single(helpers) -> None:
+    """w:trPr permits at most one w:tblHeader; the snippet ran twice -- an
+    agent looping over tables or retrying -- used to leave two behind."""
+    blocks = re.findall(r"^```python\n(.*?)^```", SKILL_MD.read_text(), re.S | re.M)
+    source = next(b for b in blocks if "w:tblHeader" in b)
+
+    document = Document()
+    namespace = {
+        "table": document.add_table(rows=2, cols=2),
+        "qn": qn,
+        "OxmlElement": OxmlElement,
+    }
+    exec(source, namespace)  # noqa: S102 - executing our own documented snippet
+    exec(source, namespace)  # noqa: S102 - a retry must not stack a second one
+
+    trPr = namespace["table"].rows[0]._tr.get_or_add_trPr()
+    assert len(trPr.findall(qn("w:tblHeader"))) == 1

--- a/tests/skills/test_builtin_docx_report_editorial.py
+++ b/tests/skills/test_builtin_docx_report_editorial.py
@@ -10,13 +10,15 @@ skill actually documents and assert the invariants Word enforces.
 from __future__ import annotations
 
 import re
+import tempfile
 from pathlib import Path
 
 import pytest
 from docx import Document
 from docx.enum.table import WD_CELL_VERTICAL_ALIGNMENT
-from docx.oxml import OxmlElement
 from docx.oxml.ns import qn
+
+MEMO_PATH = Path(tempfile.gettempdir()) / "docx_skill_memo_check.docx"
 
 SKILL_MD = (
     Path(__file__).parents[2]
@@ -67,6 +69,7 @@ def _helpers() -> dict:
     blocks = re.findall(r"^```python\n(.*?)^```", SKILL_MD.read_text(), re.S | re.M)
     source = next(b for b in blocks if "def shade_cell" in b)
     assert "def set_row_border" in source, "helpers must stay in one block"
+    # Empty namespace on purpose — the fence has to carry its own imports.
     namespace: dict = {}
     exec(source, namespace)  # noqa: S102 - executing our own documented snippet
     return namespace
@@ -181,18 +184,37 @@ def test_clearing_a_border_nils_it_in_place(helpers) -> None:
     assert borders.find(qn("w:bottom")).get(qn("w:color")) == "0A0A0B"
 
 
+def test_the_validation_snippet_accepts_a_one_page_memo() -> None:
+    """The skill advertises memos and letters and forbids padding, so the
+    documented check cannot impose a shape minimum: a >10-paragraph or
+    >=1-table assertion turns a legitimate short document into an executor
+    failure, and the only way to satisfy it is fabricated content."""
+    blocks = re.findall(r"^```python\n(.*?)^```", SKILL_MD.read_text(), re.S | re.M)
+    source = next(b for b in blocks if "check = Document(" in b)
+
+    memo = Document()
+    memo.add_heading("Q3 headcount freeze", level=1)
+    memo.add_paragraph("Hiring pauses on 1 October and resumes in January.")
+    memo.save(str(MEMO_PATH))
+
+    namespace = {"Document": Document}
+    exec(  # noqa: S102 - executing our own documented snippet
+        source.replace('"market_expansion_report.docx"', repr(str(MEMO_PATH))),
+        namespace,
+    )
+
+
 def test_the_repeat_header_snippet_stays_single(helpers) -> None:
     """w:trPr permits at most one w:tblHeader; the snippet ran twice -- an
     agent looping over tables or retrying -- used to leave two behind."""
     blocks = re.findall(r"^```python\n(.*?)^```", SKILL_MD.read_text(), re.S | re.M)
     source = next(b for b in blocks if "w:tblHeader" in b)
 
+    # Only `table` is supplied: an agent copying this fence gets whatever the
+    # fence itself imports and nothing else. Injecting qn/OxmlElement here is
+    # what let a NameError in the published snippet pass review twice.
     document = Document()
-    namespace = {
-        "table": document.add_table(rows=2, cols=2),
-        "qn": qn,
-        "OxmlElement": OxmlElement,
-    }
+    namespace = {"table": document.add_table(rows=2, cols=2)}
     exec(source, namespace)  # noqa: S102 - executing our own documented snippet
     exec(source, namespace)  # noqa: S102 - a retry must not stack a second one
 

--- a/tests/test_docker_workflow_versions.py
+++ b/tests/test_docker_workflow_versions.py
@@ -24,6 +24,7 @@ SANDBOX_DISTRIBUTION_IMPORTS = {
     "numpy": "numpy",
     "matplotlib": "matplotlib",
     "openpyxl": "openpyxl",
+    "python-docx": "docx",
     "fsspec": "fsspec",
 }
 SANDBOX_DIRECT_REQUIREMENTS = {
@@ -35,6 +36,7 @@ SANDBOX_DIRECT_REQUIREMENTS = {
     "numpy": "numpy>=1.21.0",
     "matplotlib": "matplotlib>=3.5.0",
     "openpyxl": "openpyxl>=3.1.0",
+    "python-docx": "python-docx>=1.1.0",
     "fsspec": "fsspec>=2024.0.0",
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -7937,6 +7937,7 @@ dev = [
     { name = "pytest-socket" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
+    { name = "python-docx" },
     { name = "ruff" },
     { name = "types-docker" },
     { name = "types-openpyxl" },
@@ -7980,6 +7981,7 @@ test = [
     { name = "pytest-socket" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
+    { name = "python-docx" },
 ]
 
 [package.metadata]
@@ -8135,6 +8137,7 @@ dev = [
     { name = "pytest-socket", specifier = ">=0.7.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.0" },
+    { name = "python-docx", specifier = ">=1.1.0" },
     { name = "ruff", specifier = ">=0.12.3" },
     { name = "types-docker", specifier = ">=7.1.0.20251009" },
     { name = "types-openpyxl", specifier = ">=3.1.5" },
@@ -8178,6 +8181,7 @@ test = [
     { name = "pytest-socket", specifier = ">=0.7.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.0" },
+    { name = "python-docx", specifier = ">=1.1.0" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -4064,9 +4064,9 @@ name = "ocrmac"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "sys_platform == 'darwin'" },
-    { name = "pillow", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-vision", marker = "sys_platform == 'darwin'" },
+    { name = "click" },
+    { name = "pillow" },
+    { name = "pyobjc-framework-vision" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/07/3e15ab404f75875c5e48c47163300eb90b7409044d8711fc3aaf52503f2e/ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9", size = 1454317, upload-time = "2026-01-08T16:44:26.412Z" }
 wheels = [
@@ -5404,7 +5404,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -5421,8 +5421,8 @@ name = "pyobjc-framework-coreml"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/2d/baa9ea02cbb1c200683cb7273b69b4bee5070e86f2060b77e6a27c2a9d7e/pyobjc_framework_coreml-12.1.tar.gz", hash = "sha256:0d1a4216891a18775c9e0170d908714c18e4f53f9dc79fb0f5263b2aa81609ba", size = 40465, upload-time = "2025-11-14T10:14:02.265Z" }
 wheels = [
@@ -5439,8 +5439,8 @@ name = "pyobjc-framework-quartz"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
 wheels = [
@@ -5457,10 +5457,10 @@ name = "pyobjc-framework-vision"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-coreml", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreml" },
+    { name = "pyobjc-framework-quartz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/5a/08bb3e278f870443d226c141af14205ff41c0274da1e053b72b11dfc9fb2/pyobjc_framework_vision-12.1.tar.gz", hash = "sha256:a30959100e85dcede3a786c544e621ad6eb65ff6abf85721f805822b8c5fe9b0", size = 59538, upload-time = "2025-11-14T10:23:21.979Z" }
 wheels = [
@@ -6897,13 +6897,13 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin'" },
-    { name = "networkx", marker = "sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "sys_platform == 'darwin'" },
-    { name = "sympy", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:10802fd383bbfed646212e765a72c37d2185205d4f26eb197a254e8ac7ddcb25", upload-time = "2026-05-12T16:20:07Z" },
@@ -6931,13 +6931,13 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "sys_platform != 'darwin'" },
-    { name = "networkx", marker = "sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "sys_platform != 'darwin'" },
-    { name = "sympy", marker = "sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:aaa9c1f5e8c518d7be1e3c3e1b090ca7d63b6e353a1abd6cfdaf902405093467", upload-time = "2026-05-12T23:16:01Z" },
@@ -6981,9 +6981,9 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
-    { name = "pillow", marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:df0c166b6bdf7c47f88e81e8b43bc085451d5c50d0c5d1691bc474c1227d6fed", upload-time = "2026-05-12T16:20:37Z" },
@@ -7011,9 +7011,9 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'darwin'" },
-    { name = "pillow", marker = "sys_platform != 'darwin'" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:99d05d071ff34305334ee1854f5edf7c2767b96ba59fe92e76d84a1fa72c8e06", upload-time = "2026-05-12T16:20:36Z" },
@@ -7954,6 +7954,7 @@ sandbox = [
     { name = "pandas" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-docx" },
 ]
 static-type-check = [
     { name = "types-docker" },
@@ -8151,6 +8152,7 @@ sandbox = [
     { name = "pandas", specifier = ">=1.3.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings" },
+    { name = "python-docx", specifier = ">=1.1.0" },
 ]
 static-type-check = [
     { name = "types-docker", specifier = ">=7.1.0.20251009" },


### PR DESCRIPTION
## What

Enable DOCX file generation in the sandbox. Together with the existing PPTX (pptxgenjs / pptx-editorial), XLSX (openpyxl / xlsx-financial-report) and PDF (browser_pdf / pdf-report-editorial) paths, this completes the document-generation coverage for Word documents.

- **pyproject.toml**: add `python-docx>=1.1.0` to the `sandbox` dependency group (same constraint already used by `backend-image`) and relock. The sandbox image previously shipped openpyxl but not python-docx, so `import docx` failed inside `execute_python_code`.
- **docker/Dockerfile.sandbox**: extend the runtime import smoke check with `docx` so a missing package fails the image build.
- **skills/builtin/docx-report-editorial**: new builtin skill for editorial `.docx` reports, mirroring the structure of `xlsx-financial-report` (same `execute_python_code` mechanism and frontmatter shape) and reusing the palette shared by `pdf-report-editorial` / `pptx-editorial`. Covers page setup, heading hierarchy, table styling (OOXML shading/border helpers) and a cover-page pattern.

Builtin skills are discovered by directory scan (`skills/library.py`), so no registration code is needed.

## Notes

- The `uv.lock` diff beyond the two python-docx lines is marker re-simplification only: `uv export --locked --all-groups` output is byte-identical before and after apart from python-docx/lxml, and no package version changed.
- Every code snippet in the new SKILL.md was executed against python-docx 1.2.0 (the version the lock resolves); the generated document was inspected to confirm real heading outline, header-cell shading, zebra bands and `tblHeader` repetition.
- Not verified here: the sandbox image build itself; the added import check covers it in CI/publish.
