### PR TITLE
fix(frontend): preserve taskless Session file rejection

### DIFF
--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -136,6 +136,7 @@ vi.mock("sonner", () => ({
 import {
   AppProvider,
   extractTaskControlEnvelope,
+  type AppProviderTransportConfig,
   useApp,
 } from "./app-context-chat"
 import { ChatStartScreen } from "@/components/chat/ChatStartScreen"
@@ -3126,6 +3127,58 @@ describe("AppProvider websocket message routing", () => {
       "First Session turn"
     )
     expect(apiRequestMock).not.toHaveBeenCalled()
+  })
+
+  it("forwards taskless Session files so unsupported delivery rejects instead of sending text alone", async () => {
+    const transport = makeSessionTransport()
+    // Exercise the branch-level contract independently from today's
+    // intentionally literal-disabled Session descriptor.
+    const enabledTransport = {
+      ...transport,
+      session: {
+        ...transport.session,
+        files: "enabled",
+      },
+    } as unknown as AppProviderTransportConfig
+    const file = new File(["secret"], "secret.txt", { type: "text/plain" })
+    const deliveryError = Object.assign(
+      new Error("File delivery is not supported for this connection."),
+      { disposition: "not_sent" as const },
+    )
+    sendChatMessageMock.mockImplementationOnce(async (_message: string, files?: File[]) => {
+      if (files?.length) throw deliveryError
+      return {
+        client_message_id: "session-file-turn",
+        turn_id: "session-file-turn",
+      }
+    })
+
+    render(
+      <AppProvider token="token" transport={enabledTransport}>
+        <SessionControlsProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    expect(screen.getByTestId("files-disabled").textContent).toBe("false")
+    await expect(
+      getSessionControls().sendMessage(
+        "Read the attached file",
+        { clientMessageId: "session-file-turn" },
+        [file],
+      )
+    ).rejects.toMatchObject({ disposition: "not_sent" })
+    expect(sendChatMessageMock).toHaveBeenCalledWith(
+      "Read the attached file",
+      [file],
+      undefined,
+      "session-file-turn",
+    )
+    expect(apiRequestMock).not.toHaveBeenCalled()
+    expect(transport.uploadFiles).not.toHaveBeenCalled()
+    expect(screen.getByTestId("messages").textContent).not.toContain(
+      "Read the attached file"
+    )
   })
 
   it("applies explicit public transport capabilities without disabling public files", () => {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -5992,7 +5992,7 @@ export function AppProvider({
       try {
         await sendChatMessage(
           message,
-          undefined,
+          files,
           config?.force,
           clientMessageId,
         )

--- a/frontend/src/hooks/use-websocket.test.ts
+++ b/frontend/src/hooks/use-websocket.test.ts
@@ -2359,9 +2359,12 @@ describe("useWebSocket normalized connections", () => {
     act(() => socket.open())
 
     const file = new File(["secret"], "secret.txt", { type: "text/plain" })
-    await expect(result.current.sendChatMessage("with file", [file])).rejects.toThrow(
-      "not supported",
-    )
+    await expect(
+      result.current.sendChatMessage("with file", [file])
+    ).rejects.toMatchObject({
+      message: "File delivery is not supported for this connection.",
+      disposition: "not_sent",
+    })
     expect(uploadFiles).not.toHaveBeenCalled()
     expect(socket.send).not.toHaveBeenCalled()
   })


### PR DESCRIPTION
## Summary
- forward taskless Session files into the existing WebSocket delivery contract instead of erasing the attachment argument
- preserve the transport-level not_sent rejection when taskless delivery cannot carry files
- add a regression test for a future Session file-capability enablement

## Tests
- npm run test:run -- src/contexts/app-context-chat.test.tsx src/hooks/use-websocket.test.ts
- npm run type-check
- eslint src/contexts/app-context-chat.test.tsx

Closes #1470