### PR TITLE
fix(files): carry the storage key on the exception, not in its message

### DIFF
--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -592,7 +592,7 @@ async def store_uploaded_files(
         # (see DurableStorageOperationError), so render it explicitly -- this
         # line is what operators grep during an outage and must not lose it.
         logger.warning(
-            "Durable storage unavailable during upload: %s storage_key=%s",
+            "Durable storage unavailable during upload: %s; storage_key=%s",
             exc,
             exc.storage_key,
         )

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -588,7 +588,14 @@ async def store_uploaded_files(
             )
         completed = True
     except DurableStorageOperationError as exc:
-        logger.warning("Durable storage unavailable during upload: %s", exc)
+        # The wrap carries the key on the exception rather than in its message
+        # (see DurableStorageOperationError), so render it explicitly -- this
+        # line is what operators grep during an outage and must not lose it.
+        logger.warning(
+            "Durable storage unavailable during upload: %s storage_key=%s",
+            exc,
+            exc.storage_key,
+        )
         raise _durable_storage_unavailable() from exc
     finally:
         if not completed:

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -48,7 +48,25 @@ class DurableObjectMissingError(FileNotFoundError):
 
 
 class DurableStorageOperationError(RuntimeError):
-    """Raised when durable object storage is unavailable for an operation."""
+    """Raised when durable object storage is unavailable for an operation.
+
+    **The storage key belongs in ``storage_key``, never in the message.** Its
+    scope segments encode the owning user's id, and ``str(exc)`` on this class
+    reaches places this module does not control: a bare ``raise`` from a
+    WebSocket fault arm carries it into a task-wide broadcast and into a
+    persisted command row, and broad ``except RuntimeError`` arms interpolate
+    it straight into client-facing text (#1497). Redacting those egresses one
+    at a time is how the leak kept returning under new names; with the key off
+    the message, ``str(exc)`` is safe by construction and a new egress cannot
+    reintroduce it.
+
+    Operators lose nothing: a consumer that wants the key in a log line reads
+    it from ``storage_key``.
+    """
+
+    def __init__(self, message: str, *, storage_key: str | None = None) -> None:
+        super().__init__(message)
+        self.storage_key = storage_key
 
 
 class DurableObjectIntegrityError(DurableStorageOperationError):
@@ -377,7 +395,8 @@ class ManagedFileRef:
         except Exception as exc:
             temp_path.unlink(missing_ok=True)
             raise DurableStorageOperationError(
-                f"Failed to restore durable object: {self.storage_key}"
+                "Failed to restore durable object",
+                storage_key=self.storage_key,
             ) from exc
 
     def materialize(self, *, allow_existing_local: bool = True) -> Path:
@@ -405,13 +424,15 @@ class ManagedFileRef:
                 raise
             except Exception as exc:
                 raise DurableStorageOperationError(
-                    f"Failed to materialize durable object: {self.storage_key}"
+                    "Failed to materialize durable object",
+                    storage_key=self.storage_key,
                 ) from exc
 
         if last_integrity_error is not None:
             raise last_integrity_error
         raise DurableStorageOperationError(
-            f"Failed to materialize durable object: {self.storage_key}"
+            "Failed to materialize durable object",
+            storage_key=self.storage_key,
         )
 
     def open_read(self) -> BinaryIO:
@@ -439,7 +460,8 @@ class ManagedFileRef:
             raise
         except Exception as exc:
             raise DurableStorageOperationError(
-                f"Failed to sign durable object URL: {self.storage_key}"
+                "Failed to sign durable object URL",
+                storage_key=self.storage_key,
             ) from exc
 
     def sync_to_durable(
@@ -490,7 +512,8 @@ class ManagedFileRef:
             raise
         except Exception as exc:
             raise DurableStorageOperationError(
-                f"Failed to write durable object: {resolved_key}"
+                "Failed to write durable object",
+                storage_key=resolved_key,
             ) from exc
         self.apply_stored_object(stored_object)
         setattr(self.record, "file_size", path.stat().st_size)
@@ -509,7 +532,8 @@ class ManagedFileRef:
             raise
         except Exception as exc:
             raise DurableStorageOperationError(
-                f"Failed to inspect durable object metadata: {expected_key}"
+                "Failed to inspect durable object metadata",
+                storage_key=expected_key,
             ) from exc
 
         checksum = stored_object.checksum
@@ -553,7 +577,8 @@ class ManagedFileRef:
                 raise
             except Exception as exc:
                 raise DurableStorageOperationError(
-                    f"Failed to inspect durable object metadata: {expected_key}"
+                    "Failed to inspect durable object metadata",
+                    storage_key=expected_key,
                 ) from exc
 
         self.apply_stored_object(

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -57,8 +57,12 @@ class DurableStorageOperationError(RuntimeError):
     persisted command row, and broad ``except RuntimeError`` arms interpolate
     it straight into client-facing text (#1497). Redacting those egresses one
     at a time is how the leak kept returning under new names; with the key off
-    the message, ``str(exc)`` is safe by construction and a new egress cannot
-    reintroduce it.
+    the message at every construction in this module -- enforced by the purity
+    test in ``tests/web/services/test_managed_file_ref.py`` -- no ``str(exc)``
+    egress can reintroduce it from here. The guarantee is module-scoped: that
+    scan does not cover other modules, and ``uploaded_file_store.py`` still
+    carries other identifiers (it has no storage key) in its own message
+    (#1642).
 
     What this costs, stated so it is not overread: the one log line that
     renders ``str(exc)`` today (the upload warning in ``web/api/files.py``)

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -60,11 +60,19 @@ class DurableStorageOperationError(RuntimeError):
     the message, ``str(exc)`` is safe by construction and a new egress cannot
     reintroduce it.
 
-    Operators lose nothing: a consumer that wants the key in a log line reads
-    it from ``storage_key``.
+    What this costs, stated so it is not overread: the one log line that
+    renders ``str(exc)`` today (the upload warning in ``web/api/files.py``)
+    is updated to render the attribute alongside it. Other absorbers of
+    ``str(exc)`` -- the KB ingestion tool's error text, the WebSocket
+    ``except RuntimeError`` arm -- lose the key from their output until they
+    read the attribute, which is #1515's scope.
+
+    ``storage_key`` is required (still nullable) so an omission is a type
+    error at the call site rather than a silently ``None`` attribute --
+    pass ``storage_key=None`` only where there genuinely is no key yet.
     """
 
-    def __init__(self, message: str, *, storage_key: str | None = None) -> None:
+    def __init__(self, message: str, *, storage_key: str | None) -> None:
         super().__init__(message)
         self.storage_key = storage_key
 
@@ -664,7 +672,9 @@ class ManagedFileRef:
             expected_checksum,
             actual_checksum,
         )
-        raise DurableObjectIntegrityError(FILE_INTEGRITY_REUPLOAD_MESSAGE)
+        raise DurableObjectIntegrityError(
+            FILE_INTEGRITY_REUPLOAD_MESSAGE, storage_key=self.storage_key
+        )
 
 
 def managed_file_from_record(file_record: UploadedFile) -> ManagedFileRef:

--- a/src/xagent/web/services/uploaded_file_store.py
+++ b/src/xagent/web/services/uploaded_file_store.py
@@ -1261,8 +1261,12 @@ def compensate_registered_uploads_sync(
 
     if unresolved:
         failed_ids = ", ".join(claim.file_id for claim in unresolved)
+        # No single key: this is a batch compensation failure. The file ids in
+        # the message are #1642's scope, alongside widening the purity scan to
+        # this module.
         raise DurableStorageOperationError(
-            f"Failed to compensate durable uploads: {failed_ids}"
+            f"Failed to compensate durable uploads: {failed_ids}",
+            storage_key=None,
         )
 
 

--- a/tests/web/api/test_upload_connection_boundary.py
+++ b/tests/web/api/test_upload_connection_boundary.py
@@ -827,7 +827,9 @@ async def test_failed_compensation_does_not_skip_request_local_cleanup(
         raise RuntimeError("registration failed")
 
     def fail_compensation(_claims) -> None:  # type: ignore[no-untyped-def]
-        raise DurableStorageOperationError("storage cleanup unavailable")
+        raise DurableStorageOperationError(
+            "storage cleanup unavailable", storage_key=None
+        )
 
     monkeypatch.setattr(
         files_api,

--- a/tests/web/services/test_managed_file_ref.py
+++ b/tests/web/services/test_managed_file_ref.py
@@ -621,23 +621,40 @@ def test_no_wrap_site_interpolates_into_the_message():
     version read only the positional slot, so ``message=...`` slipped past as
     a keyword; it is looked up in both places now, and a ``**`` unpacking --
     which no static check can see through -- fails outright rather than being
-    skipped. What the whitelist still cannot see: a name bound to dynamically
-    built text one statement earlier. That indirection would need assignment
-    tracing to catch; this test does not claim to.
+    skipped. Calls are matched by bare name and by attribute
+    (``module.DurableStorageOperationError(...)``), with the guarded name set
+    derived from the class hierarchy so a future subclass is covered without
+    editing this test. What the whitelist still cannot see: a name bound to
+    dynamically built text one statement earlier, or a construction hidden
+    behind an alias -- which is what the exact count below turns into a
+    failure instead of a silent skip.
     """
     import ast
 
     from xagent.web.services import managed_file_ref
 
+    def _hierarchy_names(cls: type) -> set[str]:
+        names = {cls.__name__}
+        for sub in cls.__subclasses__():
+            names |= _hierarchy_names(sub)
+        return names
+
+    guarded = _hierarchy_names(DurableStorageOperationError)
+
     tree = ast.parse(Path(managed_file_ref.__file__).read_text(encoding="utf-8"))
     checked = 0
     for node in ast.walk(tree):
-        if not (
-            isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Name)
-            and node.func.id
-            in {"DurableStorageOperationError", "DurableObjectIntegrityError"}
-        ):
+        if not isinstance(node, ast.Call):
+            continue
+        callee = node.func
+        callee_name = (
+            callee.id
+            if isinstance(callee, ast.Name)
+            else callee.attr
+            if isinstance(callee, ast.Attribute)
+            else None
+        )
+        if callee_name not in guarded:
             continue
         assert not any(kw.arg is None for kw in node.keywords), (
             f"managed_file_ref.py:{node.lineno} constructs via ** unpacking, "
@@ -662,4 +679,15 @@ def test_no_wrap_site_interpolates_into_the_message():
             "module constant -- the identifier belongs in storage_key= so "
             "str(exc) stays safe"
         )
-    assert checked, "found no constructions -- the parse assumption broke"
+    # The count is part of the contract, same as the pair-count tables in the
+    # fault-logging suite: consolidating constructions into a helper would
+    # leave only the helper's own body visible to this walk while every real
+    # call site goes dark, and an aliased construction is invisible to the
+    # name match -- both would silently shrink coverage. A changed count means
+    # a construction was added, removed, or hidden: update it deliberately and
+    # give the new site its coverage story.
+    assert checked == 8, (
+        f"expected 8 constructions (7 wraps + the integrity raise), found "
+        f"{checked} -- a construction was added, removed, aliased, or moved "
+        "behind a helper; update this count deliberately"
+    )

--- a/tests/web/services/test_managed_file_ref.py
+++ b/tests/web/services/test_managed_file_ref.py
@@ -581,3 +581,54 @@ def test_adopt_existing_object_refreshes_same_size_checksum_mismatch_from_local_
     assert storage.stat_calls == [record.storage_key]
     assert storage.put_calls == [(local_path, record.storage_key)]
     assert record.checksum == sha256(b"new-data").hexdigest()
+
+
+def test_the_wrap_keeps_the_storage_key_out_of_its_own_message(tmp_path):
+    """``str(exc)`` is the value that escapes; it must not carry the key.
+
+    The key's scope segments encode the owning user's id, and ``str(exc)`` on
+    these classes reaches places the raise site does not control: a bare
+    ``raise`` from a WebSocket fault arm carries it into a task-wide broadcast
+    and a persisted command row, and broad ``except RuntimeError`` arms
+    interpolate it into client-facing text (#1497). The invariant therefore
+    has to hold at the exception, not at each egress.
+    """
+    source = tmp_path / "uploads" / "leak-probe.txt"
+    source.parent.mkdir()
+    source.write_text("leak probe", encoding="utf-8")
+    record = _record(source, file_size=source.stat().st_size)
+
+    with pytest.raises(DurableStorageOperationError) as raised:
+        ManagedFileRef(record, storage=FailingStorage()).sync_to_durable()
+
+    fault = raised.value
+    assert fault.storage_key, "the wrap must carry the key on the attribute"
+    assert fault.storage_key not in str(fault)
+    assert "users/" not in str(fault)
+
+
+def test_no_wrap_site_interpolates_into_the_message():
+    """Every construction of these classes, not just the one driven above.
+
+    A new wrap site that puts the key back into the message would reopen the
+    leak at every ``str(exc)`` egress at once, and no runtime test can drive a
+    site that does not exist yet. Parsing the module is what closes that gap.
+    """
+    import ast
+
+    from xagent.web.services import managed_file_ref
+
+    tree = ast.parse(Path(managed_file_ref.__file__).read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id
+            in {"DurableStorageOperationError", "DurableObjectIntegrityError"}
+        ):
+            continue
+        message = node.args[0] if node.args else None
+        assert not isinstance(message, ast.JoinedStr), (
+            f"managed_file_ref.py:{node.lineno} interpolates into the message; "
+            "the identifier belongs in storage_key= so str(exc) stays safe"
+        )

--- a/tests/web/services/test_managed_file_ref.py
+++ b/tests/web/services/test_managed_file_ref.py
@@ -614,6 +614,11 @@ def test_no_wrap_site_interpolates_into_the_message():
     leak at every ``str(exc)`` egress at once, and no runtime test can drive a
     site that does not exist yet. Parsing the module is what closes that gap.
 
+    It also asserts ``storage_key=`` is present at every site: the invariant
+    is the key off the message *and* on the attribute, and mypy enforcing the
+    required keyword elsewhere is not a reason to leave the second half
+    unpinned here.
+
     The message must be a string literal or a bare name (a module constant
     like ``FILE_INTEGRITY_REUPLOAD_MESSAGE``) -- a whitelist, because the
     first version of this test blacklisted f-strings only, and ``"..." + key``,
@@ -661,6 +666,16 @@ def test_no_wrap_site_interpolates_into_the_message():
             "which this check cannot see through; spell the arguments out so "
             "the message stays statically checkable"
         )
+        # The invariant has two halves: the key is off the message AND on the
+        # attribute. mypy enforces the required keyword, but pin it here too so
+        # a site that regressed to a message-only construction fails on this
+        # assertion rather than on a type-check that runs elsewhere. storage_key
+        # is keyword-only, so it can only appear as a keyword.
+        assert any(kw.arg == "storage_key" for kw in node.keywords), (
+            f"managed_file_ref.py:{node.lineno} constructs "
+            f"{callee_name} without storage_key=; the key must ride the "
+            "attribute, not just be absent from the message"
+        )
         if node.args:
             message = node.args[0]
         else:
@@ -679,13 +694,12 @@ def test_no_wrap_site_interpolates_into_the_message():
             "module constant -- the identifier belongs in storage_key= so "
             "str(exc) stays safe"
         )
-    # The count is part of the contract, same as the pair-count tables in the
-    # fault-logging suite: consolidating constructions into a helper would
-    # leave only the helper's own body visible to this walk while every real
-    # call site goes dark, and an aliased construction is invisible to the
-    # name match -- both would silently shrink coverage. A changed count means
-    # a construction was added, removed, or hidden: update it deliberately and
-    # give the new site its coverage story.
+    # The count is part of the contract: consolidating constructions into a
+    # helper would leave only the helper's own body visible to this walk while
+    # every real call site goes dark, and an aliased construction is invisible
+    # to the name match -- both would silently shrink coverage. A changed count
+    # means a construction was added, removed, or hidden: update it
+    # deliberately and give the new site its coverage story.
     assert checked == 8, (
         f"expected 8 constructions (7 wraps + the integrity raise), found "
         f"{checked} -- a construction was added, removed, aliased, or moved "

--- a/tests/web/services/test_managed_file_ref.py
+++ b/tests/web/services/test_managed_file_ref.py
@@ -617,10 +617,13 @@ def test_no_wrap_site_interpolates_into_the_message():
     The message must be a string literal or a bare name (a module constant
     like ``FILE_INTEGRITY_REUPLOAD_MESSAGE``) -- a whitelist, because the
     first version of this test blacklisted f-strings only, and ``"..." + key``,
-    ``"%s" % key``, and ``"{}".format(key)`` all walked past it. What the
-    whitelist still cannot see: a name bound to dynamically built text one
-    statement earlier. That indirection would need assignment tracing to
-    catch; this test does not claim to.
+    ``"%s" % key``, and ``"{}".format(key)`` all walked past it. The second
+    version read only the positional slot, so ``message=...`` slipped past as
+    a keyword; it is looked up in both places now, and a ``**`` unpacking --
+    which no static check can see through -- fails outright rather than being
+    skipped. What the whitelist still cannot see: a name bound to dynamically
+    built text one statement earlier. That indirection would need assignment
+    tracing to catch; this test does not claim to.
     """
     import ast
 
@@ -636,7 +639,17 @@ def test_no_wrap_site_interpolates_into_the_message():
             in {"DurableStorageOperationError", "DurableObjectIntegrityError"}
         ):
             continue
-        message = node.args[0] if node.args else None
+        assert not any(kw.arg is None for kw in node.keywords), (
+            f"managed_file_ref.py:{node.lineno} constructs via ** unpacking, "
+            "which this check cannot see through; spell the arguments out so "
+            "the message stays statically checkable"
+        )
+        if node.args:
+            message = node.args[0]
+        else:
+            message = next(
+                (kw.value for kw in node.keywords if kw.arg == "message"), None
+            )
         if message is None:
             continue
         checked += 1

--- a/tests/web/services/test_managed_file_ref.py
+++ b/tests/web/services/test_managed_file_ref.py
@@ -613,12 +613,21 @@ def test_no_wrap_site_interpolates_into_the_message():
     A new wrap site that puts the key back into the message would reopen the
     leak at every ``str(exc)`` egress at once, and no runtime test can drive a
     site that does not exist yet. Parsing the module is what closes that gap.
+
+    The message must be a string literal or a bare name (a module constant
+    like ``FILE_INTEGRITY_REUPLOAD_MESSAGE``) -- a whitelist, because the
+    first version of this test blacklisted f-strings only, and ``"..." + key``,
+    ``"%s" % key``, and ``"{}".format(key)`` all walked past it. What the
+    whitelist still cannot see: a name bound to dynamically built text one
+    statement earlier. That indirection would need assignment tracing to
+    catch; this test does not claim to.
     """
     import ast
 
     from xagent.web.services import managed_file_ref
 
     tree = ast.parse(Path(managed_file_ref.__file__).read_text(encoding="utf-8"))
+    checked = 0
     for node in ast.walk(tree):
         if not (
             isinstance(node, ast.Call)
@@ -628,7 +637,16 @@ def test_no_wrap_site_interpolates_into_the_message():
         ):
             continue
         message = node.args[0] if node.args else None
-        assert not isinstance(message, ast.JoinedStr), (
-            f"managed_file_ref.py:{node.lineno} interpolates into the message; "
-            "the identifier belongs in storage_key= so str(exc) stays safe"
+        if message is None:
+            continue
+        checked += 1
+        is_literal = isinstance(message, ast.Constant) and isinstance(
+            message.value, str
         )
+        assert is_literal or isinstance(message, ast.Name), (
+            f"managed_file_ref.py:{node.lineno} builds the message dynamically "
+            f"({ast.unparse(message)!r}); it must be a string literal or a "
+            "module constant -- the identifier belongs in storage_key= so "
+            "str(exc) stays safe"
+        )
+    assert checked, "found no constructions -- the parse assumption broke"


### PR DESCRIPTION
Split 1/3 of #1476, executing the maintainer's re-slicing ruling. The code is unchanged from #1476's nine-round-hardened head (`a17c7d1a`), re-cut into independently reviewable slices; this one lands first, and the cause-logging slice stacks on it.

## Problem

`str(exc)` on `DurableStorageOperationError` escapes to places the raise site does not control — the task-wide broadcast in `_broadcast_terminal_command_error`, the persisted `TaskExecutionCommand.error` column, and broad `except RuntimeError` arms that interpolate exception text into client-facing frames — and the message carried the storage key, whose scope segments encode the owning user's id (#1497). The #1476 review spent four rounds redacting these egresses one at a time; each round found another.

## Change

The seven wrap constructions in `managed_file_ref.py` keep a static message and carry the key as a structured attribute:

```python
raise DurableStorageOperationError(
    "Failed to restore durable object", storage_key=self.storage_key
) from exc
```

`str(exc)` therefore cannot carry the key wherever it escapes, including egresses nobody has enumerated.

**`storage_key` is a required keyword-only parameter** (still nullable), per review: an omission is a mypy `call-arg` error at commit time and a `TypeError` at runtime, not a silently-`None` attribute. The integrity raise now passes its real key (closing that #1642 bullet); the batch-compensation site in `uploaded_file_store.py` has no single key and says `storage_key=None` explicitly.

**What this costs, stated precisely** (an earlier revision said "operators lose nothing", which overreached): the one log line that renders `str(exc)` today — the `files.py` upload warning — is updated here to render the attribute alongside it. Other absorbers of `str(exc)` (the KB ingestion tool's error text, the WebSocket `except RuntimeError` arm) lose the key from their output after this merges, until the cause-logging slice's shared helper (which renders the attribute at every reporting site) and #1515 (the remaining broad absorbers) restore it.

## Tests

One test drives a real wrap and asserts `str(exc)` carries no `users/` segment while the attribute does; one parses `managed_file_ref.py` and enforces the message shape at every construction: string literal or module constant only (concatenation, `%`-formatting, `.format()`, and f-strings all fail), found in the positional slot or the `message=` keyword, with `**`-unpacking refused outright, calls matched by bare name and attribute form, the guarded class set derived from the hierarchy, and an exact construction count (8) so consolidation behind a helper or an aliased construction fails instead of silently shrinking coverage. Every predicate verified red by mutation; the residual the walk cannot see (a name bound to dynamically built text one statement earlier) is stated in the docstring rather than implied covered.

## Out of scope

- #1489 — `delete_durable` never wraps provider faults.
- `uploaded_file_store.py:1264` still carries `file_ids` in its message (no storage key), and the purity scan covers only `managed_file_ref.py` — #1642.
