### PR TITLE
fix(files): log the provider cause behind durable-storage faults

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
@@ -121,8 +121,10 @@ async def _create_knowledge_base_from_file_impl(
         from .....web.models.database import get_db
         from .....web.models.uploaded_file import UploadedFile
         from .....web.services.managed_file_ref import (
+            DurableObjectIntegrityError,
             DurableStorageOperationError,
             ensure_uploaded_file_local_path,
+            log_durable_storage_fault,
         )
         from ...core.RAG_tools.core.schemas import (
             DEFAULT_EMBEDDING_MODEL_ID,
@@ -187,9 +189,34 @@ async def _create_knowledge_base_from_file_impl(
         for record in file_records:
             try:
                 source_path = ensure_uploaded_file_local_path(record)
-            except DurableStorageOperationError as exc:
+            except DurableObjectIntegrityError:
+                # Must precede the parent arm below, which this subclasses. A
+                # checksum mismatch is permanent corruption, already recorded
+                # at ERROR with both checksums by ``_raise_integrity_error``.
+                # Routing it through the durable-fault logger would add a
+                # "Durable storage unavailable" WARNING on top, which reads as
+                # a transient outage and can trip the alerts that watch for one
+                # -- burying the corruption diagnosis under a wrong one.
                 errors.append(
-                    f"Failed to restore {record.filename} from durable storage: {exc}"
+                    f"Stored copy of {record.filename} failed its integrity "
+                    "check and must be re-uploaded"
+                )
+                continue
+            except DurableStorageOperationError as exc:
+                log_durable_storage_fault(
+                    logger,
+                    "knowledge-base file restore",
+                    exc,
+                    file_id=record.file_id,
+                )
+                # Deliberately does NOT interpolate ``exc``. This string is
+                # joined into the tool result, so it reaches the model and the
+                # conversation transcript -- and ``str(exc)`` is the wrap's
+                # message, which carries the storage key, whose scope segments
+                # encode the owning user's id. The provider detail belongs in
+                # the log line above, which is server-side only.
+                errors.append(
+                    f"Failed to restore {record.filename} from durable storage"
                 )
                 continue
             if not source_path.exists():
@@ -211,10 +238,18 @@ async def _create_knowledge_base_from_file_impl(
             try:
                 request_context = copy_context()
                 result = await loop.run_in_executor(None, request_context.run, func)
-            except Exception as exc:
-                errors.append(
-                    f"Failed to ingest {record.filename} due to unexpected error: {exc}"
-                )
+            except Exception:
+                # Deliberately does NOT interpolate the exception, for the same
+                # reason as the durable arm above: this string is joined into the
+                # tool result, so it reaches the model and the conversation
+                # transcript. ``HashComputationError`` wraps an OSError whose
+                # message embeds the absolute upload path, and
+                # ``DocumentValidationError`` renders "Source path does not
+                # exist: <path>" -- both under users/<user_id>/uploads/..., so
+                # both carry the owning user's id. The filename is the only part
+                # the model needs; the traceback below keeps everything else,
+                # server-side.
+                errors.append(f"Failed to ingest {record.filename}")
                 logger.exception(
                     "Unexpected error ingesting file %s",
                     record.filename,

--- a/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/file_ingestion_tool.py
@@ -211,10 +211,11 @@ async def _create_knowledge_base_from_file_impl(
                 )
                 # Deliberately does NOT interpolate ``exc``. This string is
                 # joined into the tool result, so it reaches the model and the
-                # conversation transcript -- and ``str(exc)`` is the wrap's
-                # message, which carries the storage key, whose scope segments
-                # encode the owning user's id. The provider detail belongs in
-                # the log line above, which is server-side only.
+                # conversation transcript, and the provider detail belongs in
+                # the log line above, which is server-side only. (Since #1643
+                # the storage key is on ``storage_key`` rather than in the
+                # message, so it is the provider text -- not the key -- that
+                # interpolating would expose here.)
                 errors.append(
                     f"Failed to restore {record.filename} from durable storage"
                 )

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -1361,7 +1361,13 @@ class TaskWorkspace:
                 if should_close:
                     db.close()
         except Exception as e:
-            logger.warning(f"Failed to resolve file_id from database: {e}")
+            # ``exc_info`` because this fault is swallowed -- the caller only
+            # sees ``None`` -- so this is its only record. A durable-storage
+            # fault arrives here from ``materialize()`` carrying just the
+            # storage key; its cause lives in ``__cause__`` (#1467).
+            logger.warning(
+                f"Failed to resolve file_id from database: {e}", exc_info=True
+            )
             return None
 
     def _file_operation_path_in_authorized_storage(self, path: Path) -> bool:

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -2906,7 +2906,14 @@ class AgentServiceManager:
                     await self._load_persisted_execution_context(task_id, db)
 
             except Exception as e:
-                logger.error(f"Failed to create AgentService for task {task_id}: {e}")
+                # ``exc_info`` because this arm absorbs any wrapped fault --
+                # a durable-storage one from attachment restore included --
+                # whose provider cause lives only in ``__cause__`` (#1467).
+                # It re-raises, so nothing but the log line changes.
+                logger.error(
+                    f"Failed to create AgentService for task {task_id}: {e}",
+                    exc_info=True,
+                )
                 # Re-raise the exception - no fallback logic allowed
                 raise
 

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -115,11 +115,6 @@ logger = logging.getLogger(__name__)
 file_router = APIRouter(prefix="/api/files", tags=["files"])
 
 
-# Faults the delete-cleanup arm must let propagate instead of folding into the
-# retryable 503 (#1473): the namespace-authority family, plus ValueError from
-# ``normalize_storage_key`` for a structurally-invalid persisted key. A named
-# tuple constant rather than ``(*..., ValueError)`` inline: mypy only accepts
-# a name or a tuple display of types in an ``except`` clause.
 def _raise_durable_storage_unavailable(
     exc: Exception, operation: str, **fields: object
 ) -> NoReturn:

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -659,6 +659,21 @@ async def store_uploaded_files(
                 await drain_async_task_cancellation_safe(cleanup_task)
             except asyncio.CancelledError:
                 raise
+            except DurableStorageOperationError as exc:
+                # The double fault: the upload already failed against durable
+                # storage, and compensating against the same backend failed
+                # too -- the shape of the incident this reporting exists for.
+                # The generic arm below would log it, but without the fields
+                # that let a burst be aggregated, so it is named here instead.
+                # It stays swallowed: best-effort cleanup inside the
+                # ``finally`` of a request that is already failing.
+                log_durable_storage_fault(
+                    logger,
+                    "upload compensation",
+                    exc,
+                    user_id=user_id,
+                    task_id=parsed_task_id,
+                )
             except Exception:
                 logger.exception("Failed to compensate cancelled/failed upload")
 

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -37,7 +37,7 @@ from ...config import (
     get_uploads_dir,
 )
 from ...core.execution_scope import resolve_execution_scope
-from ...core.file_storage import get_user_file_storage
+from ...core.file_storage import get_user_file_storage, normalize_storage_key
 from ...core.tools.adapters.vibe.file_tool import read_file
 from ...core.tools.core.file_analysis import collect_pptx_slide_blocks
 from ...core.utils.svg import rasterize_svg_bytes
@@ -114,17 +114,12 @@ logger = logging.getLogger(__name__)
 
 file_router = APIRouter(prefix="/api/files", tags=["files"])
 
+
 # Faults the delete-cleanup arm must let propagate instead of folding into the
 # retryable 503 (#1473): the namespace-authority family, plus ValueError from
 # ``normalize_storage_key`` for a structurally-invalid persisted key. A named
 # tuple constant rather than ``(*..., ValueError)`` inline: mypy only accepts
 # a name or a tuple display of types in an ``except`` clause.
-_PERMANENT_CLEANUP_FAULTS: tuple[type[BaseException], ...] = (
-    *NAMESPACE_AUTHORITY_ERRORS,
-    ValueError,
-)
-
-
 def _raise_durable_storage_unavailable(
     exc: Exception, operation: str, **fields: object
 ) -> NoReturn:
@@ -136,10 +131,11 @@ def _raise_durable_storage_unavailable(
     lost, which is the bug #1467 was filed for). The 503 body is deliberately
     detail-free, which is what makes the log the only record.
 
-    ``exc``'s text carries the storage key, whose scope segments can encode
-    end-user identity, so it is only ever logged -- never returned to the
-    client. Pass request identifiers as ``fields``, and keep ``operation`` a
-    bounded label so it stays aggregatable.
+    The 503 body carries no detail from ``exc``. The storage key rides on the
+    exception's ``storage_key`` attribute rather than its message (#1643), so
+    the log line renders it as a field while ``str(exc)`` stays safe wherever
+    it escapes. Pass request identifiers as ``fields``, and keep ``operation``
+    a bounded label so it stays aggregatable.
 
     ``exc`` is ``Exception``, not ``BaseException``, so mypy rejects a caller
     that hands over an ``asyncio.CancelledError`` or ``KeyboardInterrupt``:
@@ -2193,22 +2189,22 @@ async def delete_file(
         storage_key = str(file_record.storage_key or "")
         storage_status = str(file_record.storage_status or "")
         if storage_key and storage_status == "available":
+            # Validate the persisted key *before* the try. A malformed one
+            # (null byte, empty, ``.``/``..`` segment -- rejected even in
+            # tolerant mode) is permanent, and no retry clears it, which is
+            # the half of #1473 about ``ValueError``. Doing it here rather
+            # than catching ``ValueError`` around the call is what keeps a
+            # *backend* ``ValueError`` -- ``fs.exists``/``fs.rm`` raise it
+            # too -- on the retryable path below where it belongs.
+            normalize_storage_key(storage_key, strict=False)
             try:
                 get_user_file_storage(_file_user_id_value(file_record)).delete(
                     storage_key
                 )
-            except _PERMANENT_CLEANUP_FAULTS:
-                # Permanent faults, not outages: folding either into the
-                # retryable 503 below is what #1473 tracked. A containment
-                # violation propagates to its dedicated handler in web/app.py,
-                # consistent with every other site in this file. A ValueError
-                # from ``normalize_storage_key`` (null byte, empty key, ``.``/
-                # ``..`` segment -- raised even in tolerant mode) means the
-                # persisted key itself is malformed, which no retry can clear;
-                # it has no dedicated handler, so it surfaces as the generic
-                # 500. The arm deliberately admits any ValueError from the
-                # call -- there is no narrower type to name, and none of them
-                # is an outage.
+            except NAMESPACE_AUTHORITY_ERRORS:
+                # A containment violation is permanent too, and has its own
+                # handler in web/app.py -- consistent with every other site in
+                # this file.
                 raise
             except Exception as exc:
                 _raise_durable_storage_unavailable(

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -69,8 +69,8 @@ from ..services.db_runtime import (
 )
 from ..services.kb_file_service import aggregate_uploaded_file_statuses
 from ..services.managed_file_ref import (
-    _NAMESPACE_AUTHORITY_ERRORS,
     FILE_INTEGRITY_REUPLOAD_MESSAGE,
+    NAMESPACE_AUTHORITY_ERRORS,
     DurableObjectIntegrityError,
     DurableObjectMissingError,
     DurableStorageOperationError,
@@ -113,6 +113,16 @@ except ImportError:
 logger = logging.getLogger(__name__)
 
 file_router = APIRouter(prefix="/api/files", tags=["files"])
+
+# Faults the delete-cleanup arm must let propagate instead of folding into the
+# retryable 503 (#1473): the namespace-authority family, plus ValueError from
+# ``normalize_storage_key`` for a structurally-invalid persisted key. A named
+# tuple constant rather than ``(*..., ValueError)`` inline: mypy only accepts
+# a name or a tuple display of types in an ``except`` clause.
+_PERMANENT_CLEANUP_FAULTS: tuple[type[BaseException], ...] = (
+    *NAMESPACE_AUTHORITY_ERRORS,
+    ValueError,
+)
 
 
 def _raise_durable_storage_unavailable(
@@ -2172,11 +2182,18 @@ async def delete_file(
                 get_user_file_storage(_file_user_id_value(file_record)).delete(
                     storage_key
                 )
-            except _NAMESPACE_AUTHORITY_ERRORS:
-                # A containment violation is a permanent authority fault, not
-                # an outage: folding it into the retryable 503 below is what
-                # #1473 tracked. It propagates to the dedicated handler in
-                # web/app.py, consistent with every other site in this file.
+            except _PERMANENT_CLEANUP_FAULTS:
+                # Permanent faults, not outages: folding either into the
+                # retryable 503 below is what #1473 tracked. A containment
+                # violation propagates to its dedicated handler in web/app.py,
+                # consistent with every other site in this file. A ValueError
+                # from ``normalize_storage_key`` (null byte, empty key, ``.``/
+                # ``..`` segment -- raised even in tolerant mode) means the
+                # persisted key itself is malformed, which no retry can clear;
+                # it has no dedicated handler, so it surfaces as the generic
+                # 500. The arm deliberately admits any ValueError from the
+                # call -- there is no narrower type to name, and none of them
+                # is an outage.
                 raise
             except Exception as exc:
                 _raise_durable_storage_unavailable(

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -4,7 +4,7 @@ import os
 from datetime import timedelta
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Dict, NamedTuple, Optional, Tuple, cast
+from typing import Any, Dict, NamedTuple, NoReturn, Optional, Tuple, cast
 from urllib.parse import quote
 from uuid import uuid4
 
@@ -69,12 +69,14 @@ from ..services.db_runtime import (
 )
 from ..services.kb_file_service import aggregate_uploaded_file_statuses
 from ..services.managed_file_ref import (
+    _NAMESPACE_AUTHORITY_ERRORS,
     FILE_INTEGRITY_REUPLOAD_MESSAGE,
     DurableObjectIntegrityError,
     DurableObjectMissingError,
     DurableStorageOperationError,
     ManagedFileRef,
     guess_media_type,
+    log_durable_storage_fault,
 )
 from ..services.uploaded_file_store import (
     LocalUploadRegistration,
@@ -113,11 +115,32 @@ logger = logging.getLogger(__name__)
 file_router = APIRouter(prefix="/api/files", tags=["files"])
 
 
-def _durable_storage_unavailable() -> HTTPException:
-    return HTTPException(
+def _raise_durable_storage_unavailable(
+    exc: Exception, operation: str, **fields: object
+) -> NoReturn:
+    """Log the durable-storage fault, then raise the retryable 503.
+
+    ``NoReturn`` rather than a factory returning the exception: logging and
+    raising are one step, so the type forbids a caller that logs without
+    raising (a phantom fault in the log) or raises without logging (the cause
+    lost, which is the bug #1467 was filed for). The 503 body is deliberately
+    detail-free, which is what makes the log the only record.
+
+    ``exc``'s text carries the storage key, whose scope segments can encode
+    end-user identity, so it is only ever logged -- never returned to the
+    client. Pass request identifiers as ``fields``, and keep ``operation`` a
+    bounded label so it stays aggregatable.
+
+    ``exc`` is ``Exception``, not ``BaseException``, so mypy rejects a caller
+    that hands over an ``asyncio.CancelledError`` or ``KeyboardInterrupt``:
+    a cancelled request has not shown the object store to be unwell, and 503
+    would tell the client to retry something deliberately stopped.
+    """
+    log_durable_storage_fault(logger, operation, exc, **fields)
+    raise HTTPException(
         status_code=503,
         detail="Durable storage is temporarily unavailable",
-    )
+    ) from exc
 
 
 def _file_integrity_failed() -> HTTPException:
@@ -305,7 +328,9 @@ def _durable_redirect_response(
     except DurableObjectIntegrityError as exc:
         raise _file_integrity_failed() from exc
     except DurableStorageOperationError as exc:
-        raise _durable_storage_unavailable() from exc
+        _raise_durable_storage_unavailable(
+            exc, "signed durable redirect", file_id=file_ref.record.file_id
+        )
 
     if not signed_url:
         return None
@@ -588,15 +613,13 @@ async def store_uploaded_files(
             )
         completed = True
     except DurableStorageOperationError as exc:
-        # The wrap carries the key on the exception rather than in its message
-        # (see DurableStorageOperationError), so render it explicitly -- this
-        # line is what operators grep during an outage and must not lose it.
-        logger.warning(
-            "Durable storage unavailable during upload: %s; storage_key=%s",
-            exc,
-            exc.storage_key,
+        # No single ``file_id``: this is a batch registration, and any of the
+        # files in it may be the one that failed. Tenant and task still
+        # correlate a 503 burst to who and what was affected, which is the
+        # question asked first during an outage.
+        _raise_durable_storage_unavailable(
+            exc, "upload", user_id=user_id, task_id=parsed_task_id
         )
-        raise _durable_storage_unavailable() from exc
     finally:
         if not completed:
 
@@ -1467,7 +1490,7 @@ async def download_file(
                     },
                 )
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable() from exc
+                _raise_durable_storage_unavailable(exc, "download", file_id=file_id)
     else:
         # For legacy files without records, check ownership
         if owner_user_id != _user_id_value(user) and not _is_admin_user(user):
@@ -1776,7 +1799,7 @@ async def preview_file(
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable() from exc
+                _raise_durable_storage_unavailable(exc, "preview", file_id=file_id)
             except DurableObjectMissingError:
                 materialized_path = file_ref.local_path
                 _ensure_under_uploads(materialized_path, owner_user_id)
@@ -1865,7 +1888,7 @@ async def preview_pptx_as_pdf(
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable() from exc
+                _raise_durable_storage_unavailable(exc, "pptx preview", file_id=file_id)
             except DurableObjectMissingError:
                 # Durable record points at nothing; fall back to whatever
                 # is on disk (or 404 below if it's gone too).
@@ -1957,7 +1980,9 @@ async def public_download_file(
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable() from exc
+                _raise_durable_storage_unavailable(
+                    exc, "public download", file_id=file_id
+                )
             except DurableObjectMissingError:
                 target_path = file_ref.local_path
         else:
@@ -2023,7 +2048,9 @@ async def public_preview_file(
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable() from exc
+                _raise_durable_storage_unavailable(
+                    exc, "public preview", file_id=file_id
+                )
             except DurableObjectMissingError:
                 target_path = file_ref.local_path
                 _ensure_under_uploads(target_path, owner_user_id)
@@ -2067,7 +2094,16 @@ async def public_preview_file(
             except DurableObjectIntegrityError as exc:
                 raise _file_integrity_failed() from exc
             except DurableStorageOperationError as exc:
-                raise _durable_storage_unavailable() from exc
+                # ``asset_record`` is a different row from the route's
+                # ``file_id``: the base record is the document, this is the
+                # preview asset registered under it, and it is the asset's
+                # restore that failed. Logging the route parameter here named an
+                # object that is fine.
+                _raise_durable_storage_unavailable(
+                    exc,
+                    "public preview task asset",
+                    file_id=asset_record.file_id,
+                )
             except DurableObjectMissingError:
                 target_path = asset_ref.local_path
             _ensure_under_uploads(target_path, owner_user_id)
@@ -2136,12 +2172,19 @@ async def delete_file(
                 get_user_file_storage(_file_user_id_value(file_record)).delete(
                     storage_key
                 )
+            except _NAMESPACE_AUTHORITY_ERRORS:
+                # A containment violation is a permanent authority fault, not
+                # an outage: folding it into the retryable 503 below is what
+                # #1473 tracked. It propagates to the dedicated handler in
+                # web/app.py, consistent with every other site in this file.
+                raise
             except Exception as exc:
-                logger.warning(
-                    "Failed to clean up durable file before deleting row: %s",
-                    storage_key,
+                _raise_durable_storage_unavailable(
+                    exc,
+                    "durable cleanup before row delete",
+                    file_id=file_id,
+                    storage_key=storage_key,
                 )
-                raise _durable_storage_unavailable() from exc
 
         db.delete(file_record)
         db.commit()

--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -2759,6 +2759,9 @@ def _refresh_existing_file_if_changed(
         except DurableObjectMissingError:
             return None
         except Exception as exc:  # noqa: BLE001
+            # ``exc_info`` because this fault is swallowed -- the caller only
+            # sees ``None`` -- so this line is its only record, and ``error=%s``
+            # alone drops the exception class and the cause chain (#1467).
             logger.warning(
                 "Failed to restore durable web-ingestion file before refresh: "
                 "url=%s, file_id=%s, context=%s, error=%s",
@@ -2766,6 +2769,7 @@ def _refresh_existing_file_if_changed(
                 existing_record.file_id,
                 context,
                 exc,
+                exc_info=exc,
             )
             return None
 

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -76,7 +76,11 @@ from ...services.hot_path_cache import (
     task_snapshot_key,
     task_steps_key,
 )
-from ...services.managed_file_ref import DurableStorageOperationError
+from ...services.managed_file_ref import (
+    DurableObjectIntegrityError,
+    DurableStorageOperationError,
+    log_durable_storage_fault,
+)
 from ...services.task_interaction_read import get_pending_interaction_question
 from ...services.task_orchestrator import (
     TaskTurnError,
@@ -228,8 +232,32 @@ def _resolve_turn_files_or_400(
             db=db,
             task_id=task_id,
         )
+    except DurableObjectIntegrityError:
+        # Precedes the parent arm: permanent corruption, already logged at
+        # ERROR with both checksums where it is raised. The envelope below is
+        # left as-is deliberately -- reclassifying it for the SDK is a
+        # compatibility change, not a logging one -- but it must not also emit
+        # a transient-outage warning.
+        raise V1ApiError(
+            V1ErrorCode.INTERNAL_ERROR,
+            503,
+            message="File storage is temporarily unavailable.",
+        ) from None
     except DurableStorageOperationError as exc:
         # Transient storage fault, not a client error -- 503 so SDK can retry.
+        # The V1ApiError envelope reaches the client without a traceback, so
+        # this log line is the only record of the provider fault (#1467).
+        # ``task_id`` is None on the create path -- one of this function's two
+        # callers, not an edge case -- so the owner and the requested ids carry
+        # the identification there.
+        log_durable_storage_fault(
+            logger,
+            "turn attachment resolution",
+            exc,
+            task_id=task_id,
+            owner_user_id=owner_user_id,
+            file_ids=",".join(file_ids),
+        )
         raise V1ApiError(
             V1ErrorCode.INTERNAL_ERROR,
             503,

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -183,11 +183,7 @@ async def upload_task_files(
         # stable {"error": {"code": ...}} shape. 503 (durable storage) stays 503 so
         # callers can retry; 413 (too large) stays 413; other client errors -> 400.
         if exc.status_code == 503:
-            raise V1ApiError(
-                V1ErrorCode.INTERNAL_ERROR,
-                503,
-                message="File storage is temporarily unavailable.",
-            ) from exc
+            _raise_v1_storage_unavailable(exc)
         if 400 <= exc.status_code < 500:
             raise V1ApiError(
                 V1ErrorCode.INVALID_INPUT,
@@ -232,17 +228,13 @@ def _resolve_turn_files_or_400(
             db=db,
             task_id=task_id,
         )
-    except DurableObjectIntegrityError:
+    except DurableObjectIntegrityError as exc:
         # Precedes the parent arm: permanent corruption, already logged at
-        # ERROR with both checksums where it is raised. The envelope below is
-        # left as-is deliberately -- reclassifying it for the SDK is a
-        # compatibility change, not a logging one -- but it must not also emit
-        # a transient-outage warning.
-        raise V1ApiError(
-            V1ErrorCode.INTERNAL_ERROR,
-            503,
-            message="File storage is temporarily unavailable.",
-        ) from None
+        # ERROR with both checksums where it is raised. The envelope is left
+        # as-is deliberately -- reclassifying it for the SDK is a compatibility
+        # change, not a logging one -- but it must not also emit a
+        # transient-outage warning.
+        _raise_v1_storage_unavailable(exc)
     except DurableStorageOperationError as exc:
         # Transient storage fault, not a client error -- 503 so SDK can retry.
         # The V1ApiError envelope reaches the client without a traceback, so
@@ -258,11 +250,7 @@ def _resolve_turn_files_or_400(
             owner_user_id=owner_user_id,
             file_ids=",".join(file_ids),
         )
-        raise V1ApiError(
-            V1ErrorCode.INTERNAL_ERROR,
-            503,
-            message="File storage is temporarily unavailable.",
-        ) from exc
+        _raise_v1_storage_unavailable(exc)
     if missing:
         raise V1ApiError(
             V1ErrorCode.INVALID_INPUT,
@@ -287,6 +275,22 @@ def _turn_payload(content: str, file_infos: list[dict[str, Any]]) -> TaskTurnPay
         attachments=normalize_attachments_for_persistence(file_infos) or None,
         file_ids=tuple(str(info["file_id"]) for info in file_infos),
     )
+
+
+def _raise_v1_storage_unavailable(exc: Exception) -> NoReturn:
+    """The retryable-503 envelope every durable-fault arm in this module answers with.
+
+    One helper rather than the envelope inline at each arm, matching this
+    module's other ``_raise_v1_*`` helpers. It always chains ``from exc``: the
+    ``v1_api_error_handler`` does not render ``exc_info`` today, so no arm loses
+    anything by chaining, and an arm that dropped the cause would lose it
+    silently the day that boundary starts logging one (#1521).
+    """
+    raise V1ApiError(
+        V1ErrorCode.INTERNAL_ERROR,
+        503,
+        message="File storage is temporarily unavailable.",
+    ) from exc
 
 
 def _raise_v1_file_binding_error(exc: TaskTurnFileBindingError) -> NoReturn:

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -112,6 +112,10 @@ def log_durable_storage_fault(
     ``target_logger`` is the caller's logger rather than this module's, so a
     line stays attributed to the endpoint or tool that produced it.
 
+    Translation stays per call site while #1521 (ASGI boundary handler vs.
+    per-site arms) is undecided; this helper is the shared half either answer
+    keeps.
+
     Field values are escaped and bounded, because some are client-supplied.
     That covers the fields *this* function renders -- it does **not** make the
     record as a whole unforgeable: the formatter renders ``exc_info`` verbatim,
@@ -127,27 +131,15 @@ def log_durable_storage_fault(
     passed that way would be invisible in exactly the logs an incident is
     diagnosed from.
     """
-    # One record per fault instance, whatever the nesting. A durable fault can
-    # pass through more than one handler that legitimately wants to report it --
-    # a request-scoped arm that answers the client, and an endpoint-scoped arm
-    # that catches whatever escaped -- and both calling this would log the same
-    # cause twice. Marking the exception is what makes each arm safe to write
-    # independently, instead of every new arm having to know which other arm
-    # might already have run.
-    #
-    # Only this module's own wraps are marked, and that is what makes the mark
-    # need no guarding. A wrap is what traverses several arms, so it is where
-    # dedup is needed; the raw provider exception the delete path hands over is
-    # reported by one site by definition. Restricting the mark also keeps this
-    # from setting a private attribute on an object the module does not own,
-    # where neither the read nor the write is safe in principle -- ``getattr``'s
-    # default absorbs ``AttributeError`` only -- and an exception escaping here,
-    # inside an ``except`` block, would replace a handled 503-with-a-log with an
-    # unhandled 500 that loses the fault, which is #1467's own failure mode.
+    # One record per fault instance: a wrap can traverse more than one arm
+    # that legitimately reports it -- a request-scoped arm that answers the
+    # client, then an endpoint-scoped arm that catches whatever escaped --
+    # and the mark is what makes each arm safe to write independently. Only
+    # this module's own wraps are marked (the attribute is declared on the
+    # class), so no guard is needed around the read or the write.
     if isinstance(exc, DurableStorageOperationError):
         if exc._durable_fault_logged:
             return
-        exc._durable_fault_logged = True
         # The wraps carry the key on the exception rather than in its message,
         # so ``str(exc)`` is safe wherever it escapes. Rendering it here is what
         # keeps that from costing the log anything: the key reaches this line
@@ -164,6 +156,11 @@ def log_durable_storage_fault(
     target_logger.warning(
         "Durable storage unavailable during %s%s", operation, rendered, exc_info=exc
     )
+    # Marked only after the record is emitted: if emission raised, the fault
+    # would stay unmarked for a later arm to report, instead of being
+    # permanently recorded as logged by an attempt that never wrote.
+    if isinstance(exc, DurableStorageOperationError):
+        exc._durable_fault_logged = True
 
 
 class DurableStorageOperationError(RuntimeError):
@@ -227,7 +224,7 @@ class DurableObjectIntegrityError(DurableStorageOperationError):
 # once, at the application boundary (see the handlers registered in
 # ``web/app.py``), instead of being reported as an outage an operator would
 # retry.
-_NAMESPACE_AUTHORITY_ERRORS: tuple[type[BaseException], ...] = (
+NAMESPACE_AUTHORITY_ERRORS: tuple[type[BaseException], ...] = (
     StorageKeyScopeError,
     ExecutionScopeAuthorityError,
     ExecutionScopeResolverContractError,
@@ -525,7 +522,7 @@ class ManagedFileRef:
         except DurableObjectIntegrityError:
             temp_path.unlink(missing_ok=True)
             raise
-        except _NAMESPACE_AUTHORITY_ERRORS:
+        except NAMESPACE_AUTHORITY_ERRORS:
             temp_path.unlink(missing_ok=True)
             raise
         except Exception as exc:
@@ -556,7 +553,7 @@ class ManagedFileRef:
                 last_integrity_error = exc
                 if materialized_path is not None:
                     materialized_path.unlink(missing_ok=True)
-            except _NAMESPACE_AUTHORITY_ERRORS:
+            except NAMESPACE_AUTHORITY_ERRORS:
                 raise
             except Exception as exc:
                 raise DurableStorageOperationError(
@@ -592,7 +589,7 @@ class ManagedFileRef:
                 content_type=content_type,
                 content_disposition=content_disposition,
             )
-        except _NAMESPACE_AUTHORITY_ERRORS:
+        except NAMESPACE_AUTHORITY_ERRORS:
             raise
         except Exception as exc:
             raise DurableStorageOperationError(
@@ -644,7 +641,7 @@ class ManagedFileRef:
                 resolved_key,
                 mime_type or getattr(self.record, "mime_type", None),
             )
-        except _NAMESPACE_AUTHORITY_ERRORS:
+        except NAMESPACE_AUTHORITY_ERRORS:
             raise
         except Exception as exc:
             raise DurableStorageOperationError(
@@ -664,7 +661,7 @@ class ManagedFileRef:
             stored_object = self._bound_storage().stat(expected_key)
         except FileNotFoundError:
             return "missing"
-        except _NAMESPACE_AUTHORITY_ERRORS:
+        except NAMESPACE_AUTHORITY_ERRORS:
             raise
         except Exception as exc:
             raise DurableStorageOperationError(
@@ -686,7 +683,7 @@ class ManagedFileRef:
             if not checksum:
                 try:
                     checksum = self._bound_storage().content_hash(expected_key)
-                except _NAMESPACE_AUTHORITY_ERRORS:
+                except NAMESPACE_AUTHORITY_ERRORS:
                     # The rule holds at every site in this module, not only
                     # where a downstream call happens to raise the same class
                     # again: relying on that would make this a silent swallow
@@ -709,7 +706,7 @@ class ManagedFileRef:
         if not checksum:
             try:
                 checksum = self._bound_storage().content_hash(expected_key)
-            except _NAMESPACE_AUTHORITY_ERRORS:
+            except NAMESPACE_AUTHORITY_ERRORS:
                 raise
             except Exception as exc:
                 raise DurableStorageOperationError(
@@ -769,7 +766,7 @@ class ManagedFileRef:
 
         try:
             actual_checksum = self._bound_storage().content_hash(self.storage_key)
-        except _NAMESPACE_AUTHORITY_ERRORS:
+        except NAMESPACE_AUTHORITY_ERRORS:
             # A permanent authority fault must not be reported as "checksum
             # unavailable", which reads as a transient reason to fall back to
             # backend-mediated access.

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -47,6 +47,125 @@ class DurableObjectMissingError(FileNotFoundError):
     """Raised when a registered file has no local copy or durable object."""
 
 
+# Rendered fields sit in a plain-text log line, so a value carrying a newline
+# would start what reads as a new, fully-formatted record (CWE-117). Some of
+# these values are client-supplied -- ``/v1/*`` passes the ``files`` list from
+# the request body, which is an unvalidated ``list[str]`` -- so a caller cannot
+# be relied on to have checked. Sanitising here covers every field at every
+# site, including ones added later.
+_LOG_VALUE_TRANSLATION = str.maketrans({"\n": "\\n", "\r": "\\r", "\t": "\\t"})
+
+# Long enough for a UUID list of realistic size, short enough that one field
+# cannot crowd out the rest of the line.
+_MAX_LOG_VALUE_LENGTH = 256
+
+
+def _sanitize_log_value(value: object) -> str:
+    """Flatten a field value to one bounded, single-line token.
+
+    Contract: callers filter ``None`` out before rendering -- a ``None`` field
+    is dropped from the line entirely, never rendered as ``None`` or ``""``
+    (whether it should render instead is #1642's open question). A new caller
+    must keep that filter; this function does not decide the policy.
+    """
+    text = str(value).translate(_LOG_VALUE_TRANSLATION)
+    if len(text) > _MAX_LOG_VALUE_LENGTH:
+        return f"{text[:_MAX_LOG_VALUE_LENGTH]}...[truncated]"
+    return text
+
+
+def log_durable_storage_fault(
+    target_logger: logging.Logger,
+    operation: str,
+    exc: Exception,
+    **fields: object,
+) -> None:
+    """Record a durable-storage fault with its full cause chain.
+
+    The single implementation for every site that reports a durable-storage
+    fault *as such*, so none of them can log it without its cause.
+
+    That is narrower than "every consumer of ``DurableStorageOperationError``",
+    and the difference matters: the class is a ``RuntimeError``, so broad
+    ``except Exception`` / ``except RuntimeError`` arms elsewhere absorb it
+    without ever naming it -- agent-service setup in web/api/chat.py,
+    knowledge-base refresh in web/api/kb.py, and workspace file resolution in
+    core/workspace.py. Those arms cannot route through this function, because
+    they handle every exception type; each carries ``exc_info`` so the chain
+    survives there, but none of them produces the fields this function renders.
+
+    So the accurate claim is about *naming*, not about coverage: a site that
+    reports this fault as a durable-storage fault does it here, and a site that
+    merely absorbs it keeps its own traceback. Anything added later in the first
+    category belongs here. Do not restate this as "every consumer" -- that was
+    the wording it replaced, and it was false.
+
+    The wraps in this module keep the storage key on the exception rather than
+    in its message (see ``DurableStorageOperationError``); the provider error
+    class, the
+    HTTP status, and throttle vs. timeout vs. rejected credentials live in
+    ``__cause__`` and nowhere else, and none of the envelopes these faults
+    become -- FastAPI's ``HTTPException``, the ``/v1/*`` error body, a tool
+    result -- carries a traceback. ``exc_info`` is the only thing that gets the
+    chain into a log (#1467).
+
+    ``target_logger`` is the caller's logger rather than this module's, so a
+    line stays attributed to the endpoint or tool that produced it.
+
+    Field values are escaped and bounded, because some are client-supplied.
+    That covers the fields *this* function renders -- it does **not** make the
+    record as a whole unforgeable: the formatter renders ``exc_info`` verbatim,
+    so a newline in a provider exception message still produces a physical
+    continuation line. Closing that needs the formatter itself and is tracked in
+    #1516; do not read the sanitising below as a stronger guarantee than it is.
+
+    ``operation`` must be a bounded label -- a small fixed set of values, so it
+    stays aggregatable. Per-request identifiers belong in ``fields``, which is
+    rendered as ``key=value`` pairs *in the message*: the deployed formatter is
+    ``"%(asctime)s %(levelname)-8s %(name)s - %(message)s"``
+    (see web/logging_config.py), which never renders ``extra``, so anything
+    passed that way would be invisible in exactly the logs an incident is
+    diagnosed from.
+    """
+    # One record per fault instance, whatever the nesting. A durable fault can
+    # pass through more than one handler that legitimately wants to report it --
+    # a request-scoped arm that answers the client, and an endpoint-scoped arm
+    # that catches whatever escaped -- and both calling this would log the same
+    # cause twice. Marking the exception is what makes each arm safe to write
+    # independently, instead of every new arm having to know which other arm
+    # might already have run.
+    #
+    # Only this module's own wraps are marked, and that is what makes the mark
+    # need no guarding. A wrap is what traverses several arms, so it is where
+    # dedup is needed; the raw provider exception the delete path hands over is
+    # reported by one site by definition. Restricting the mark also keeps this
+    # from setting a private attribute on an object the module does not own,
+    # where neither the read nor the write is safe in principle -- ``getattr``'s
+    # default absorbs ``AttributeError`` only -- and an exception escaping here,
+    # inside an ``except`` block, would replace a handled 503-with-a-log with an
+    # unhandled 500 that loses the fault, which is #1467's own failure mode.
+    if isinstance(exc, DurableStorageOperationError):
+        if exc._durable_fault_logged:
+            return
+        exc._durable_fault_logged = True
+        # The wraps carry the key on the exception rather than in its message,
+        # so ``str(exc)`` is safe wherever it escapes. Rendering it here is what
+        # keeps that from costing the log anything: the key reaches this line
+        # from every site, including ones that never passed it as a field.
+        # An explicit field wins, so a caller can still name a different key.
+        if exc.storage_key and "storage_key" not in fields:
+            fields = {**fields, "storage_key": exc.storage_key}
+
+    rendered = "".join(
+        f" {name}={_sanitize_log_value(value)}"
+        for name, value in fields.items()
+        if value is not None
+    )
+    target_logger.warning(
+        "Durable storage unavailable during %s%s", operation, rendered, exc_info=exc
+    )
+
+
 class DurableStorageOperationError(RuntimeError):
     """Raised when durable object storage is unavailable for an operation.
 
@@ -64,17 +183,22 @@ class DurableStorageOperationError(RuntimeError):
     carries other identifiers (it has no storage key) in its own message
     (#1642).
 
-    What this costs, stated so it is not overread: the one log line that
-    renders ``str(exc)`` today (the upload warning in ``web/api/files.py``)
-    is updated to render the attribute alongside it. Other absorbers of
-    ``str(exc)`` -- the KB ingestion tool's error text, the WebSocket
-    ``except RuntimeError`` arm -- lose the key from their output until they
-    read the attribute, which is #1515's scope.
+    ``log_durable_storage_fault`` renders the attribute as a field, so every
+    line that reports the fault *as such* still carries the key. The broad
+    absorbers that render ``str(e)`` -- chat.py, kb.py, core/workspace.py --
+    lose it from their lines until they read the attribute, which is #1515's
+    scope.
 
     ``storage_key`` is required (still nullable) so an omission is a type
     error at the call site rather than a silently ``None`` attribute --
     pass ``storage_key=None`` only where there genuinely is no key yet.
     """
+
+    # Set by ``log_durable_storage_fault`` so one fault yields one record even
+    # when several arms legitimately report it. Declared here rather than
+    # attached dynamically so it is typed, discoverable, and always present to
+    # read -- the reason that function needs no guard around the mark.
+    _durable_fault_logged: bool = False
 
     def __init__(self, message: str, *, storage_key: str | None) -> None:
         super().__init__(message)
@@ -651,12 +775,18 @@ class ManagedFileRef:
             # backend-mediated access.
             raise
         except Exception as exc:
+            # ``exc_info`` for the same reason as everywhere else on this
+            # path: this fault is swallowed -- the caller only sees ``False``
+            # and silently falls back to backend-mediated delivery -- so this
+            # line is the only record of it, and ``error=%s`` alone drops the
+            # exception class and the cause chain (#1467).
             logger.warning(
                 "Falling back to backend-mediated durable access because content "
                 "hash is unavailable: file_id=%s storage_key=%s error=%s",
                 getattr(self.record, "file_id", None),
                 self.storage_key,
                 exc,
+                exc_info=exc,
             )
             return False
 

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -48,13 +48,16 @@ class DurableObjectMissingError(FileNotFoundError):
     """Raised when a registered file has no local copy or durable object."""
 
 
-# Rendered fields sit in a plain-text log line, so a value carrying a newline
-# would start what reads as a new, fully-formatted record (CWE-117). Some of
-# these values are client-supplied -- ``/v1/*`` passes the ``files`` list from
-# the request body, which is an unvalidated ``list[str]`` -- so a caller cannot
-# be relied on to have checked. Sanitising here covers every field at every
-# site, including ones added later.
+# Field values are rendered into a plain-text ``key=value`` line, so a value
+# must stay one token: whitespace in it would let a client-supplied string put
+# what reads as further fields on the same record (CWE-117). Quoting is not
+# enough -- it only protects consumers that honour quotes, and the deployed
+# logs are read by whitespace tokenizers -- so whitespace is escaped instead.
+# Some of these values are client-supplied (``/v1/*`` renders the request's
+# ``files`` list, an unvalidated ``list[str]``), so a caller cannot be relied
+# on to have checked.
 _LOG_VALUE_TRANSLATION = str.maketrans({"\n": "\\n", "\r": "\\r", "\t": "\\t"})
+_LOG_VALUE_WHITESPACE = re.compile(r"\s")
 
 # Long enough for a UUID list of realistic size, short enough that one field
 # cannot crowd out the rest of the line.
@@ -62,52 +65,35 @@ _MAX_LOG_VALUE_LENGTH = 256
 
 # The stable prefix every durable-fault line starts with, and the anchor the
 # operational note tells alerts to key on. Public because tests assert on its
-# *absence* to prove an integrity fault was not reported as an outage -- with
-# the string inlined there, rewording this message would leave those
-# assertions passing vacuously against text that no longer exists.
+# *absence* to prove an integrity fault was not reported as an outage, and an
+# inlined copy there would pass vacuously once this text changed.
 DURABLE_FAULT_LOG_PREFIX = "Durable storage unavailable during"
 
-# Whitespace -- not a newline -- is what lets a client-supplied value forge a
-# *second field on the same line*: ``file_ids=abc user_id=999`` reads as two
-# fields to anything that splits on whitespace, no line break required. A value
-# carrying any is therefore quoted. Conditional, because every field rendered
-# today (ids, keys, counts) has no whitespace and stays bare and greppable.
-_LOG_VALUE_NEEDS_QUOTING = re.compile(r"\s")
+
+def _escape_whitespace(match: re.Match[str]) -> str:
+    """Render one whitespace character as an unambiguous escape."""
+    code = ord(match.group())
+    return f"\\x{code:02x}" if code <= 0xFF else f"\\u{code:04x}"
 
 
 def _sanitize_log_value(value: object) -> str:
-    """Flatten a field value to one bounded, single-line, single-*field* token.
+    """Flatten a field value to one bounded, single-token string.
 
-    Contract: callers filter ``None`` out before rendering -- a ``None`` field
-    is dropped from the line entirely, never rendered as ``None`` or ``""``
-    (whether it should render instead is #1642's open question). A new caller
-    must keep that filter; this function does not decide the policy.
+    Callers filter ``None`` out before rendering; a ``None`` field is dropped
+    from the line entirely (whether it should render instead is #1642).
 
-    The escaping is unconditional and the quoting is not, so one value has one
-    encoding either way: a reader unescapes always, and strips the quotes when
-    they are there. (Escaping only inside the quoted branch would give
-    ``a\\nb`` two different renderings depending on whether the value happened
-    to carry a space elsewhere -- same input, two encodings, decodable by
-    nothing.)
-
-    Quoting closes same-line field forgery only. It does not make the value
-    unbreakable to a naive reader: a raw ``\\v``/``\\f``/U+2028 still splits a
-    line visually because it is not in the escape table above (#1519), and the
-    record as a whole stays forgeable through ``exc_info`` text (#1516).
-
-    ``_MAX_LOG_VALUE_LENGTH`` bounds the value *before* escaping; escaping can
-    at most double it and quoting adds two, so the rendered token is bounded
-    too, just not by that number exactly.
+    The escape character goes first so the result stays decodable: ``\\\\``
+    is a literal backslash, ``\\n`` a newline, ``\\x20`` a space. What this
+    does not do is make the whole *record* unforgeable -- ``exc_info`` text is
+    rendered verbatim by the formatter (#1516), and ESC is not whitespace so it
+    still passes through (#1519).
     """
-    text = str(value).translate(_LOG_VALUE_TRANSLATION)
+    text = str(value).replace("\\", "\\\\")
+    text = text.translate(_LOG_VALUE_TRANSLATION)
+    text = _LOG_VALUE_WHITESPACE.sub(_escape_whitespace, text)
     if len(text) > _MAX_LOG_VALUE_LENGTH:
-        text = f"{text[:_MAX_LOG_VALUE_LENGTH]}...[truncated]"
-    # The closer and the escape character itself, so a quoted value cannot end
-    # its own region and resume as bare text.
-    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
-    if _LOG_VALUE_NEEDS_QUOTING.search(text):
-        return f'"{escaped}"'
-    return escaped
+        return f"{text[:_MAX_LOG_VALUE_LENGTH]}...[truncated]"
+    return text
 
 
 def log_durable_storage_fault(
@@ -119,67 +105,38 @@ def log_durable_storage_fault(
     """Record a durable-storage fault with its full cause chain.
 
     The single implementation for every site that reports a durable-storage
-    fault *as such*, so none of them can log it without its cause.
+    fault *as such*. That is narrower than every consumer of the class: it is
+    a ``RuntimeError``, so broad ``except Exception``/``except RuntimeError``
+    arms (chat.py, kb.py, core/workspace.py) absorb it without naming it, and
+    each keeps its own ``exc_info`` instead of the fields rendered here.
 
-    That is narrower than "every consumer of ``DurableStorageOperationError``",
-    and the difference matters: the class is a ``RuntimeError``, so broad
-    ``except Exception`` / ``except RuntimeError`` arms elsewhere absorb it
-    without ever naming it -- agent-service setup in web/api/chat.py,
-    knowledge-base refresh in web/api/kb.py, and workspace file resolution in
-    core/workspace.py. Those arms cannot route through this function, because
-    they handle every exception type; each carries ``exc_info`` so the chain
-    survives there, but none of them produces the fields this function renders.
+    The provider class, HTTP status, and throttle-vs-timeout-vs-credentials
+    distinction live only in ``__cause__``, and none of the envelopes these
+    faults become -- ``HTTPException``, the ``/v1/*`` body, a tool result --
+    carries a traceback, so ``exc_info`` is what gets them into a log (#1467).
 
-    So the accurate claim is about *naming*, not about coverage: a site that
-    reports this fault as a durable-storage fault does it here, and a site that
-    merely absorbs it keeps its own traceback. Anything added later in the first
-    category belongs here. Do not restate this as "every consumer" -- that was
-    the wording it replaced, and it was false.
+    ``target_logger`` is the caller's, so a line stays attributed to the
+    endpoint or tool that produced it. ``operation`` must be a bounded label,
+    a small fixed set of values, so it stays aggregatable; per-request
+    identifiers belong in ``fields``.
 
-    The wraps in this module keep the storage key on the exception rather than
-    in its message (see ``DurableStorageOperationError``); the provider error
-    class, the
-    HTTP status, and throttle vs. timeout vs. rejected credentials live in
-    ``__cause__`` and nowhere else, and none of the envelopes these faults
-    become -- FastAPI's ``HTTPException``, the ``/v1/*`` error body, a tool
-    result -- carries a traceback. ``exc_info`` is the only thing that gets the
-    chain into a log (#1467).
-
-    ``target_logger`` is the caller's logger rather than this module's, so a
-    line stays attributed to the endpoint or tool that produced it.
-
-    Translation stays per call site while #1521 (ASGI boundary handler vs.
-    per-site arms) is undecided; this helper is the shared half either answer
-    keeps.
-
-    Field values are escaped and bounded, because some are client-supplied.
-    That covers the fields *this* function renders -- it does **not** make the
-    record as a whole unforgeable: the formatter renders ``exc_info`` verbatim,
-    so a newline in a provider exception message still produces a physical
-    continuation line. Closing that needs the formatter itself and is tracked in
-    #1516; do not read the sanitising below as a stronger guarantee than it is.
-
-    ``operation`` must be a bounded label -- a small fixed set of values, so it
-    stays aggregatable. Per-request identifiers belong in ``fields``, which is
-    rendered as ``key=value`` pairs *in the message*: the deployed formatter is
-    ``"%(asctime)s %(levelname)-8s %(name)s - %(message)s"``
-    (see web/logging_config.py), which never renders ``extra``, so anything
-    passed that way would be invisible in exactly the logs an incident is
-    diagnosed from.
+    Fields are rendered as ``key=value`` *in the message*, not via ``extra=``:
+    the deployed formatter (``web/logging_config.py``) renders only
+    ``%(message)s``, so anything passed as ``extra`` is invisible in exactly
+    the logs an incident is read from. Values are escaped and bounded because
+    some are client-supplied; that bounds the fields, not the whole record,
+    whose ``exc_info`` text the formatter still renders verbatim (#1516).
     """
-    # One record per fault instance: a wrap can traverse more than one arm
-    # that legitimately reports it -- a request-scoped arm that answers the
-    # client, then an endpoint-scoped arm that catches whatever escaped --
-    # and the mark is what makes each arm safe to write independently. Only
-    # this module's own wraps are marked (the attribute is declared on the
-    # class), so no guard is needed around the read or the write.
+    # One record per fault instance: a wrap can cross several arms that each
+    # legitimately report it, and the mark is what makes them safe to write
+    # independently. Only this module's wraps are marked, and the attribute is
+    # declared on the class, so neither the read nor the write needs a guard.
     if isinstance(exc, DurableStorageOperationError):
         if exc._durable_fault_logged:
             return
-        # The wraps carry the key on the exception rather than in its message,
-        # so ``str(exc)`` is safe wherever it escapes. Rendering it here is what
-        # keeps that from costing the log anything: the key reaches this line
-        # from every site, including ones that never passed it as a field.
+        # The key rides on the exception, not in its message (#1643), so it
+        # reaches this line from every site -- including ones that never pass
+        # it as a field -- while ``str(exc)`` stays safe wherever it escapes.
         # An explicit field wins, so a caller can still name a different key.
         if exc.storage_key and "storage_key" not in fields:
             fields = {**fields, "storage_key": exc.storage_key}

--- a/src/xagent/web/services/managed_file_ref.py
+++ b/src/xagent/web/services/managed_file_ref.py
@@ -5,6 +5,7 @@ import binascii
 import hashlib
 import logging
 import mimetypes
+import re
 import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -59,19 +60,54 @@ _LOG_VALUE_TRANSLATION = str.maketrans({"\n": "\\n", "\r": "\\r", "\t": "\\t"})
 # cannot crowd out the rest of the line.
 _MAX_LOG_VALUE_LENGTH = 256
 
+# The stable prefix every durable-fault line starts with, and the anchor the
+# operational note tells alerts to key on. Public because tests assert on its
+# *absence* to prove an integrity fault was not reported as an outage -- with
+# the string inlined there, rewording this message would leave those
+# assertions passing vacuously against text that no longer exists.
+DURABLE_FAULT_LOG_PREFIX = "Durable storage unavailable during"
+
+# Whitespace -- not a newline -- is what lets a client-supplied value forge a
+# *second field on the same line*: ``file_ids=abc user_id=999`` reads as two
+# fields to anything that splits on whitespace, no line break required. A value
+# carrying any is therefore quoted. Conditional, because every field rendered
+# today (ids, keys, counts) has no whitespace and stays bare and greppable.
+_LOG_VALUE_NEEDS_QUOTING = re.compile(r"\s")
+
 
 def _sanitize_log_value(value: object) -> str:
-    """Flatten a field value to one bounded, single-line token.
+    """Flatten a field value to one bounded, single-line, single-*field* token.
 
     Contract: callers filter ``None`` out before rendering -- a ``None`` field
     is dropped from the line entirely, never rendered as ``None`` or ``""``
     (whether it should render instead is #1642's open question). A new caller
     must keep that filter; this function does not decide the policy.
+
+    The escaping is unconditional and the quoting is not, so one value has one
+    encoding either way: a reader unescapes always, and strips the quotes when
+    they are there. (Escaping only inside the quoted branch would give
+    ``a\\nb`` two different renderings depending on whether the value happened
+    to carry a space elsewhere -- same input, two encodings, decodable by
+    nothing.)
+
+    Quoting closes same-line field forgery only. It does not make the value
+    unbreakable to a naive reader: a raw ``\\v``/``\\f``/U+2028 still splits a
+    line visually because it is not in the escape table above (#1519), and the
+    record as a whole stays forgeable through ``exc_info`` text (#1516).
+
+    ``_MAX_LOG_VALUE_LENGTH`` bounds the value *before* escaping; escaping can
+    at most double it and quoting adds two, so the rendered token is bounded
+    too, just not by that number exactly.
     """
     text = str(value).translate(_LOG_VALUE_TRANSLATION)
     if len(text) > _MAX_LOG_VALUE_LENGTH:
-        return f"{text[:_MAX_LOG_VALUE_LENGTH]}...[truncated]"
-    return text
+        text = f"{text[:_MAX_LOG_VALUE_LENGTH]}...[truncated]"
+    # The closer and the escape character itself, so a quoted value cannot end
+    # its own region and resume as bare text.
+    escaped = text.replace("\\", "\\\\").replace('"', '\\"')
+    if _LOG_VALUE_NEEDS_QUOTING.search(text):
+        return f'"{escaped}"'
+    return escaped
 
 
 def log_durable_storage_fault(
@@ -153,6 +189,11 @@ def log_durable_storage_fault(
         for name, value in fields.items()
         if value is not None
     )
+    # The prefix stays a literal in the template, not an argument: this repo
+    # reads ``record.msg`` as the event's identity, and ``"%s %s%s"`` identifies
+    # nothing. ``DURABLE_FAULT_LOG_PREFIX`` is the same text for callers and
+    # tests to match on, pinned against this line by
+    # ``test_the_exported_prefix_is_the_one_the_helper_emits``.
     target_logger.warning(
         "Durable storage unavailable during %s%s", operation, rendered, exc_info=exc
     )

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -1384,8 +1384,10 @@ async def test_create_kb_from_file_durable_fault_logs_cause_and_hides_storage_ke
     * the provider fault only exists in ``__cause__``, and no envelope this
       path produces carries a traceback, so the log line is its only record;
     * the error string is joined into the tool result, so it reaches the model
-      and the conversation transcript -- and the wrap's message embeds the
-      storage key, whose scope segments encode the owning user's id.
+      and the conversation transcript, and provider text does not belong
+      there. (The storage key itself moved onto ``storage_key`` in #1643, so
+      what interpolation would expose today is the provider detail, not the
+      key -- the redaction obligation is the same either way.)
 
     Interpolating the exception into that string satisfied the first obligation
     while violating the second.

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -602,10 +602,15 @@ async def test_create_kb_from_file_continues_after_unexpected_ingest_error(tmp_p
     assert result["success"] is True
     assert result["collection_name"] == "agent_file_kb"
     assert result["files_ingested"] == 1
-    assert (
-        "Failed to ingest bad.txt due to unexpected error: parser exploded"
-        in result["message"]
-    )
+    # The failing file is named, so the model can tell the user which one to
+    # retry -- but not why, because this string is joined into the tool result
+    # and reaches the conversation transcript. The exceptions reachable here
+    # (``HashComputationError`` wrapping an OSError, ``DocumentValidationError``)
+    # render the absolute upload path, which sits under users/<user_id>/uploads
+    # and so carries the owning user's id. This assertion used to require the
+    # exception text, which pinned that disclosure in place.
+    assert "Failed to ingest bad.txt" in result["message"]
+    assert "parser exploded" not in result["message"]
     service.refresh_collection_metadata.assert_awaited_once_with("agent_file_kb")
     # One file landed, so the collection is real: cleaning it up would delete it.
     service.cleanup_failed_collection.assert_not_awaited()
@@ -1364,3 +1369,183 @@ async def test_agent_publish_of_a_new_collection_survives_a_config_read_failure(
     assert json.loads(save_kwargs["config_json"])["embedding_model_id"] == (
         DEFAULT_EMBEDDING_MODEL_ID
     )
+
+
+@pytest.mark.asyncio
+async def test_create_kb_from_file_durable_fault_logs_cause_and_hides_storage_key(
+    tmp_path,
+    caplog,
+    monkeypatch,
+):
+    """A restore failure must reach the log in full and the model in redacted form.
+
+    Two separate obligations meet in this one except-branch (#1467):
+
+    * the provider fault only exists in ``__cause__``, and no envelope this
+      path produces carries a traceback, so the log line is its only record;
+    * the error string is joined into the tool result, so it reaches the model
+      and the conversation transcript -- and the wrap's message embeds the
+      storage key, whose scope segments encode the owning user's id.
+
+    Interpolating the exception into that string satisfied the first obligation
+    while violating the second.
+    """
+    import logging
+
+    from xagent.core.tools.core.RAG_tools import kb as kb_module
+    from xagent.web.services.managed_file_ref import DurableStorageOperationError
+
+    storage_key = "users/7/uploads/file-1/notes.txt"
+    provider_message = "SlowDown: Please reduce your request rate (status 503)"
+
+    class _ProviderThrottled(RuntimeError):
+        pass
+
+    def fail_restore(_record):
+        provider_exc = _ProviderThrottled(provider_message)
+        raise DurableStorageOperationError(
+            "Failed to restore durable object", storage_key=storage_key
+        ) from provider_exc
+
+    source_file = tmp_path / "notes.txt"
+    source_file.write_text("hello", encoding="utf-8")
+    file_record = SimpleNamespace(
+        user_id=7,
+        filename="notes.txt",
+        storage_path=str(source_file),
+        file_id="file-1",
+    )
+
+    query = MagicMock()
+    query.filter.return_value = query
+    query.all.return_value = [file_record]
+    db = MagicMock()
+    db.query.return_value = query
+
+    def fake_get_db():
+        yield from _fake_db_generator(db)
+
+    # Same isolation as the sibling tests in this file. Without it the test
+    # still passes, but only because ``agent_collection_exists`` swallows
+    # non-``ValueError`` exceptions and reports True -- i.e. it would be
+    # leaning on real KB storage being unreachable rather than on a stub.
+    metadata_store = _FakeMetadataStore(CollectionInfo(name="agent_file_kb"))
+    coordinator = KBCoordinator(
+        storage_shim=_FakeStorageShim(metadata_store),
+        operation_compatibility=_RecordingOperationFacade(),
+    )
+    monkeypatch.setattr(kb_module, "get_kb_coordinator", lambda: coordinator)
+
+    logger_name = "xagent.core.tools.adapters.vibe.file_ingestion_tool"
+    with (
+        patch("xagent.web.models.database.get_db", side_effect=fake_get_db),
+        patch(
+            "xagent.web.services.managed_file_ref.ensure_uploaded_file_local_path",
+            side_effect=fail_restore,
+        ),
+        caplog.at_level(logging.WARNING, logger=logger_name),
+    ):
+        tool = CreateKnowledgeBaseFromFileTool(user_id=7, is_admin=False)
+        result = await tool.run_json_async(
+            {"file_ids": ["file-1"], "collection_name": "agent_file_kb"}
+        )
+
+    assert result["success"] is False
+
+    # The model-facing half: named, but stripped of anything identifying.
+    assert "Failed to restore notes.txt from durable storage" in result["message"]
+    assert storage_key not in result["message"]
+    assert "users/7" not in result["message"]
+    assert provider_message not in result["message"]
+
+    # The log half: the whole chain, provider class included.
+    records = [
+        logging.Formatter("%(message)s").format(record)
+        for record in caplog.records
+        if record.name == logger_name and record.levelno == logging.WARNING
+    ]
+    assert len(records) == 1, caplog.records
+    rendered = records[0]
+    assert "during knowledge-base file restore" in rendered
+    assert "file_id=file-1" in rendered
+    assert storage_key in rendered
+    assert "_ProviderThrottled" in rendered
+    assert provider_message in rendered
+
+
+@pytest.mark.asyncio
+async def test_create_kb_from_file_integrity_failure_is_not_an_outage_warning(
+    tmp_path,
+    caplog,
+    monkeypatch,
+):
+    """A checksum mismatch must not be reported as a transient outage.
+
+    ``DurableObjectIntegrityError`` subclasses ``DurableStorageOperationError``,
+    so a parent-only catch sends permanent corruption through the durable-fault
+    logger and adds a "Durable storage unavailable" WARNING on top of the
+    integrity ERROR already recorded where it is raised. That reads as an outage
+    to whatever watches for one, and buries the real diagnosis.
+    """
+    import logging
+
+    from xagent.core.tools.core.RAG_tools import kb as kb_module
+    from xagent.web.services.managed_file_ref import (
+        FILE_INTEGRITY_REUPLOAD_MESSAGE,
+        DurableObjectIntegrityError,
+    )
+
+    def fail_restore(_record):
+        raise DurableObjectIntegrityError(
+            FILE_INTEGRITY_REUPLOAD_MESSAGE,
+            storage_key="users/7/uploads/8ac1f2/corrupt.txt",
+        )
+
+    source_file = tmp_path / "notes.txt"
+    source_file.write_text("hello", encoding="utf-8")
+    file_record = SimpleNamespace(
+        user_id=7,
+        filename="notes.txt",
+        storage_path=str(source_file),
+        file_id="file-1",
+    )
+    query = MagicMock()
+    query.filter.return_value = query
+    query.all.return_value = [file_record]
+    db = MagicMock()
+    db.query.return_value = query
+
+    def fake_get_db():
+        yield from _fake_db_generator(db)
+
+    metadata_store = _FakeMetadataStore(CollectionInfo(name="agent_file_kb"))
+    coordinator = KBCoordinator(
+        storage_shim=_FakeStorageShim(metadata_store),
+        operation_compatibility=_RecordingOperationFacade(),
+    )
+    monkeypatch.setattr(kb_module, "get_kb_coordinator", lambda: coordinator)
+
+    logger_name = "xagent.core.tools.adapters.vibe.file_ingestion_tool"
+    with (
+        patch("xagent.web.models.database.get_db", side_effect=fake_get_db),
+        patch(
+            "xagent.web.services.managed_file_ref.ensure_uploaded_file_local_path",
+            side_effect=fail_restore,
+        ),
+        caplog.at_level(logging.WARNING, logger=logger_name),
+    ):
+        tool = CreateKnowledgeBaseFromFileTool(user_id=7, is_admin=False)
+        result = await tool.run_json_async(
+            {"file_ids": ["file-1"], "collection_name": "agent_file_kb"}
+        )
+
+    assert result["success"] is False
+    assert "integrity check" in result["message"]
+
+    outage_lines = [
+        entry
+        for entry in caplog.records
+        if entry.name == logger_name
+        and "Durable storage unavailable" in entry.getMessage()
+    ]
+    assert outage_lines == [], "permanent corruption must not read as an outage"

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -1491,6 +1491,7 @@ async def test_create_kb_from_file_integrity_failure_is_not_an_outage_warning(
 
     from xagent.core.tools.core.RAG_tools import kb as kb_module
     from xagent.web.services.managed_file_ref import (
+        DURABLE_FAULT_LOG_PREFIX,
         FILE_INTEGRITY_REUPLOAD_MESSAGE,
         DurableObjectIntegrityError,
     )
@@ -1545,7 +1546,6 @@ async def test_create_kb_from_file_integrity_failure_is_not_an_outage_warning(
     outage_lines = [
         entry
         for entry in caplog.records
-        if entry.name == logger_name
-        and "Durable storage unavailable" in entry.getMessage()
+        if entry.name == logger_name and DURABLE_FAULT_LOG_PREFIX in entry.getMessage()
     ]
     assert outage_lines == [], "permanent corruption must not read as an outage"

--- a/tests/web/api/test_durable_storage_fault_logging.py
+++ b/tests/web/api/test_durable_storage_fault_logging.py
@@ -29,6 +29,7 @@ from xagent.web.api.v1.errors import V1ApiError
 from xagent.web.models.user import User
 from xagent.web.services.managed_file_ref import (
     _MAX_LOG_VALUE_LENGTH,
+    DURABLE_FAULT_LOG_PREFIX,
     DurableStorageOperationError,
     ManagedFileRef,
     log_durable_storage_fault,
@@ -399,7 +400,7 @@ def test_v1_turn_attachment_integrity_fault_is_not_reported_as_an_outage(
     assert not [
         line
         for line in _warnings(caplog, v1_tasks.logger.name)
-        if "Durable storage unavailable" in line
+        if DURABLE_FAULT_LOG_PREFIX in line
     ], "an integrity fault emitted an outage warning -- the arms are misordered"
 
 
@@ -435,6 +436,18 @@ def _module_ast(module: Any) -> ast.Module:
     return ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
 
 
+def _callee_name(call: ast.Call) -> str | None:
+    """The function name a call targets, bare or qualified."""
+    return _exception_name(call.func)
+
+
+def _operation_label_node(call: ast.Call) -> ast.expr | None:
+    """The expression a call passes as ``operation``, positional or keyword."""
+    if len(call.args) > 1:
+        return call.args[1]
+    return next((kw.value for kw in call.keywords if kw.arg == "operation"), None)
+
+
 def _operation_label_of(call: ast.Call, where: str) -> str:
     """The call's operation label, which must be a string literal.
 
@@ -442,11 +455,7 @@ def _operation_label_of(call: ast.Call, where: str) -> str:
     must fail with "not a literal", never silently drop out of a drift
     comparison or die on an IndexError.
     """
-    node = (
-        call.args[1]
-        if len(call.args) > 1
-        else next((kw.value for kw in call.keywords if kw.arg == "operation"), None)
-    )
+    node = _operation_label_node(call)
     assert isinstance(node, ast.Constant) and isinstance(node.value, str), (
         f"{where}:{call.lineno}: the operation label must be a string "
         f"literal (positional or operation=); got {ast.unparse(call)[:90]!r}"
@@ -454,13 +463,53 @@ def _operation_label_of(call: ast.Call, where: str) -> str:
     return node.value
 
 
+def _package_modules(package_root: Path) -> list[Path]:
+    """Every module the repo-wide sweeps below walk, in a stable order."""
+    return sorted(package_root.rglob("*.py"))
+
+
+def _parse_module_file(path: Path) -> ast.Module:
+    """Parse a source file, naming it if it cannot be read or parsed.
+
+    The sweeps walk the whole package, so an unrelated unparsable or
+    non-UTF-8 file would otherwise fail them with a traceback that names
+    neither the file nor why this test touched it.
+    """
+    try:
+        return ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    except (SyntaxError, UnicodeDecodeError) as exc:
+        raise AssertionError(
+            f"{path} could not be parsed while sweeping the package for "
+            f"durable-fault sites ({exc.__class__.__name__}: {exc}). This is "
+            "not a durable-storage failure -- fix or exclude that file."
+        ) from exc
+
+
+def _exception_name(node: ast.expr) -> str | None:
+    """The class name an ``except`` operand refers to, bare or qualified.
+
+    ``ast.Attribute`` counts: a module refactored to ``except mfr.Durable...``
+    would otherwise drop out of every sweep below with nothing failing.
+    """
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        return node.attr
+    return None
+
+
 def _handler_types(handler: ast.ExceptHandler) -> list[str]:
     """The exception class names an ``except`` arm names, tuple or not."""
-    if isinstance(handler.type, ast.Name):
-        return [handler.type.id]
+    if handler.type is None:
+        return []
     if isinstance(handler.type, ast.Tuple):
-        return [e.id for e in handler.type.elts if isinstance(e, ast.Name)]
-    return []
+        return [
+            name
+            for name in (_exception_name(element) for element in handler.type.elts)
+            if name is not None
+        ]
+    name = _exception_name(handler.type)
+    return [name] if name is not None else []
 
 
 def _durable_arm_pairs(tree: ast.Module) -> list[ast.Try]:
@@ -617,52 +666,96 @@ _MODULES_WITH_DURABLE_ARM_PAIRS = (
 )
 
 
-# The two sites that call the shared helper directly, without files.py's
-# ``_raise_durable_storage_unavailable`` wrapper, and therefore sit outside
-# the files.py sweep above. Same contract: a bounded literal label and a
-# declared field set.
-_DIRECT_HELPER_SITES = (
-    ("web/api/v1/tasks.py", lambda: v1_tasks, "turn attachment resolution"),
-    (
-        "core/tools/adapters/vibe/file_ingestion_tool.py",
-        lambda: _file_ingestion_tool(),
-        "knowledge-base file restore",
-    ),
+# Every direct ``log_durable_storage_fault`` call in the tree, by module and
+# bounded label. "Direct" means not through files.py's
+# ``_raise_durable_storage_unavailable`` wrapper, whose own forwarding call
+# passes its caller's label along as a parameter -- the one site whose label
+# is legitimately not a literal, pinned by the files.py sweep instead.
+_DIRECT_HELPER_SITES = frozenset(
+    {
+        ("web/api/files.py", "upload compensation"),
+        ("web/api/v1/tasks.py", "turn attachment resolution"),
+        (
+            "core/tools/adapters/vibe/file_ingestion_tool.py",
+            "knowledge-base file restore",
+        ),
+    }
 )
 
+# Labels that are legitimately not string literals, by module and the name
+# they are passed as, each with what keeps the value bounded. A label must be
+# a literal *or* appear here -- "not a literal" alone is not a licence, or a
+# future site passing an unbounded variable would be waved through as if it
+# were one of these.
+_BOUNDED_NON_LITERAL_LABELS = {
+    # The wrapper forwarding its caller's label; the literals live at its
+    # callers, where the files.py sweep above checks them.
+    ("web/api/files.py", "operation"),
+}
 
-@pytest.mark.parametrize(
-    ("label", "loader", "expected_operation"), _DIRECT_HELPER_SITES
-)
-def test_direct_helper_sites_keep_a_bounded_literal_label(
-    label: str, loader: Any, expected_operation: str
-) -> None:
-    """The two non-files.py reporting sites are held to the same label rules.
 
-    The files.py sweep cannot see them -- they call the shared helper
-    directly -- so without this, a rewrite of either label to an f-string
-    (the leak-and-cardinality class the sweep exists to prevent) would land
-    unchecked.
+def test_every_direct_helper_site_is_declared_with_a_bounded_label() -> None:
+    """Discovered, not declared: a new direct reporting site cannot go unswept.
+
+    The files.py sweep only sees calls through the ``NoReturn`` wrapper, so a
+    site calling the shared helper directly is outside it. Previously this was
+    a hardcoded pair of modules, which could only check the sites someone
+    remembered to list -- a third would have gone unscanned. Now the tree is
+    walked, and every direct call must carry a string-literal label declared
+    above, so an f-string label (the leak-and-cardinality class this exists to
+    prevent) fails wherever it appears.
     """
-    tree = _module_ast(loader())
-    calls = [
-        node
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Call)
-        and isinstance(node.func, ast.Name)
-        and node.func.id == "log_durable_storage_fault"
-    ]
-    assert len(calls) == 1, (
-        f"{label}: expected exactly one direct helper call, found {len(calls)} "
-        "-- add the new site here with its label"
+    package_root = Path(files_api.__file__).parents[2]
+    found: set[tuple[str, str]] = set()
+    forwarding: list[str] = []
+    for path in _package_modules(package_root):
+        module_label = path.relative_to(package_root).as_posix()
+        tree = _parse_module_file(path)
+        for node in ast.walk(tree):
+            if not (
+                isinstance(node, ast.Call)
+                and _callee_name(node) == "log_durable_storage_fault"
+            ):
+                continue
+            label_node = _operation_label_node(node)
+            if isinstance(label_node, ast.Constant) and isinstance(
+                label_node.value, str
+            ):
+                # Only the reporting sites: the wrapper below forwards its
+                # caller's ``**fields`` by design, and its callers' field names
+                # are what the files.py sweep checks.
+                assert all(kw.arg is not None for kw in node.keywords), (
+                    f"{module_label}:{node.lineno} passes **kwargs to the "
+                    "helper, so its field names are not checkable here"
+                )
+                found.add((module_label, label_node.value))
+            elif (
+                isinstance(label_node, ast.Name)
+                and (module_label, label_node.id) in _BOUNDED_NON_LITERAL_LABELS
+            ):
+                # Declared above with the mechanism that bounds it.
+                forwarding.append(f"{module_label}:{label_node.id}")
+            else:
+                raise AssertionError(
+                    f"{module_label}:{node.lineno} passes a label that is "
+                    "neither a string literal nor a declared bounded variable: "
+                    f"{ast.unparse(node)[:90]!r}. A bounded literal keeps the "
+                    "label aggregatable; add it to _DIRECT_HELPER_SITES, or -- "
+                    "if it is a variable something else bounds -- to "
+                    "_BOUNDED_NON_LITERAL_LABELS with that reason."
+                )
+
+    assert found == set(_DIRECT_HELPER_SITES), (
+        f"direct helper sites changed: {found ^ set(_DIRECT_HELPER_SITES)} -- "
+        "declare the new site with its bounded label, or fix a label that "
+        "stopped being a string literal"
     )
-    operation = _operation_label_of(calls[0], label)
-    assert operation == expected_operation, (
-        f"{label}: the operation label must stay the bounded literal "
-        f"{expected_operation!r}; got {operation!r}"
+    assert set(forwarding) == {
+        f"{module}:{name}" for module, name in _BOUNDED_NON_LITERAL_LABELS
+    }, (
+        "the declared bounded-variable labels and the ones actually passed "
+        f"disagree: {sorted(forwarding)} vs {sorted(_BOUNDED_NON_LITERAL_LABELS)}"
     )
-    for keyword in calls[0].keywords:
-        assert keyword.arg is not None, f"{label} passes **kwargs to the helper"
 
 
 def test_every_module_with_an_arm_pair_is_in_the_table() -> None:
@@ -676,9 +769,8 @@ def test_every_module_with_an_arm_pair_is_in_the_table() -> None:
     """
     package_root = Path(files_api.__file__).parents[2]
     found = set()
-    for path in package_root.rglob("*.py"):
-        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
-        if _durable_arm_pairs(tree):
+    for path in _package_modules(package_root):
+        if _durable_arm_pairs(_parse_module_file(path)):
             found.add(path.relative_to(package_root).as_posix())
 
     declared = {label for label, _, _ in _MODULES_WITH_DURABLE_ARM_PAIRS}
@@ -701,19 +793,26 @@ def _file_ingestion_tool() -> Any:
 def test_the_integrity_arm_precedes_its_parent_at_every_site(
     label: str, expected: int, loader: Any
 ) -> None:
-    """Checked at all nine pairs, because only two have real end-to-end cover.
+    """Checked at all nine pairs, because three of them have no other guard.
 
-    The integrity subclass goes through a real call path at two of the nine:
-    ``file_ingestion_tool`` (via ``test_kb_creation_tools``) and ``v1/tasks.py``
-    (the resolver test above). At the other seven -- all in ``files.py`` -- the
-    tests either drive the shared helper directly with a pre-built exception or
-    inject only the parent class, so a swapped ordering would change behaviour
-    silently at seven of the nine.
+    Measured, not estimated -- an earlier version of this docstring claimed
+    seven of the nine were unguarded, which was more than twice the truth.
+    Neutralising each integrity arm in turn and running the suite shows six
+    pairs are caught behaviourally: ``_durable_redirect_response``,
+    ``download_file``, ``preview_file`` and the first ``public_preview_file``
+    pair (by the five ``*_checksum_mismatch_asks_user_to_reupload`` tests),
+    plus ``v1/tasks.py`` and ``file_ingestion_tool`` (by the real-path
+    injections in this file and ``test_kb_creation_tools``).
 
-    This does not replace those tests: it proves ordering, not that each arm
-    produces the right answer. What it does is make the one regression that
-    silently breaks the property at every site impossible to land. Real
-    end-to-end coverage for the ``files.py`` seven is #1522.
+    The three where a swapped or deleted arm changes behaviour with no
+    behavioural test failing are ``preview_pptx_as_pdf``,
+    ``public_download_file``, and the second ``public_preview_file`` pair --
+    the task-asset one. Those are what this check is load-bearing for; giving
+    them real end-to-end coverage is #1522.
+
+    This does not replace the behavioural tests: it proves ordering, not that
+    each arm answers correctly. What it adds is that the one regression which
+    breaks the property at every site at once cannot land anywhere.
     """
     tree = _module_ast(loader())
     pairs = _durable_arm_pairs(tree)
@@ -800,6 +899,99 @@ def test_field_values_cannot_forge_a_log_record(
     assert not any(line.startswith("2026-01-01") for line in rendered.splitlines()), (
         "the injected text must not stand as its own record"
     )
+    # It carries whitespace, so it is also quoted -- see the same-line forgery
+    # test below for why that half matters independently.
+    assert 'file_ids="' in message_line
+
+
+def test_a_field_value_cannot_forge_a_second_field_on_the_same_line(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Whitespace, not a newline, is the cheaper forgery -- close that too.
+
+    Escaping line breaks stops a value from fabricating a whole *record*, and
+    nothing stopped it fabricating a *field*: rendered bare, a client-supplied
+    ``abc user_id=999`` put two more ``key=value`` pairs on the line, indistin-
+    guishable from the ones the helper renders itself. An operator reading the
+    line -- or anything parsing it -- would attribute the fault to another
+    tenant and another file. No line break needed, so neither the escape table
+    (#1519) nor the ``exc_info`` channel (#1516) covers it.
+    """
+    forged = "abc user_id=999 file_id=someone-elses"
+
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        with pytest.raises(HTTPException):
+            files_api._raise_durable_storage_unavailable(
+                _wrapped_fault(), "upload", file_ids=forged
+            )
+
+    message_line = _sole_warning(caplog, files_api.logger.name).splitlines()[0]
+    # The whole value is one quoted token, so the forged pairs are inside it.
+    assert f'file_ids="{forged}"' in message_line
+    # And no bare forged field stands on its own next to the real ones.
+    assert " user_id=999" not in message_line.replace(f'"{forged}"', "")
+    assert " file_id=someone-elses" not in message_line.replace(f'"{forged}"', "")
+    # The real fields stay bare and greppable -- quoting is conditional.
+    assert f"storage_key={_STORAGE_KEY}" in message_line
+
+
+def test_the_exported_prefix_is_the_one_the_helper_emits(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The constant the other suites match on must track the real message.
+
+    Four negative assertions elsewhere prove an integrity fault emitted *no*
+    outage line by looking for this text. They previously inlined it, so a
+    reworded message would have left them passing against text that no longer
+    exists. Importing the constant only moves that risk unless the constant
+    itself is pinned to what the helper emits -- which is what this does.
+    """
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        log_durable_storage_fault(files_api.logger, "download", _wrapped_fault())
+
+    rendered = _sole_warning(caplog, files_api.logger.name).splitlines()[0]
+    assert rendered.startswith(f"{DURABLE_FAULT_LOG_PREFIX} download"), rendered
+
+
+def test_one_value_has_one_encoding_whether_or_not_it_is_quoted() -> None:
+    """Escaping is unconditional; only the quoting is conditional.
+
+    The first version escaped inside the quoted branch only, so ``a\\nb``
+    rendered as ``a\\nb`` bare but as ``a\\\\nb`` once any space elsewhere in
+    the value triggered quoting -- the same input with two encodings, which a
+    consumer cannot decode. Quoting may frame the value; it may not change it.
+    """
+    from xagent.web.services.managed_file_ref import _sanitize_log_value
+
+    bare = _sanitize_log_value("a\nb")
+    quoted = _sanitize_log_value("a\nb c")
+
+    assert not bare.startswith('"')
+    assert quoted.startswith('"') and quoted.endswith('"')
+    # The quoted rendering is the bare one, framed and with the space -- not a
+    # differently-escaped string.
+    assert quoted[1:-1] == f"{bare} c"
+
+
+def test_a_quoted_value_cannot_end_its_own_quoting(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The escape of the closer is what makes the quoting load-bearing.
+
+    Without escaping ``"`` (and the escape character itself), a value can close
+    the quoted region early and resume as bare text -- forging fields again,
+    one level down.
+    """
+    forged = 'abc" user_id=999'
+
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        with pytest.raises(HTTPException):
+            files_api._raise_durable_storage_unavailable(
+                _wrapped_fault(), "upload", file_ids=forged
+            )
+
+    message_line = _sole_warning(caplog, files_api.logger.name).splitlines()[0]
+    assert 'file_ids="abc\\" user_id=999"' in message_line
 
 
 @pytest.mark.parametrize("length", [_MAX_LOG_VALUE_LENGTH - 1, _MAX_LOG_VALUE_LENGTH])

--- a/tests/web/api/test_durable_storage_fault_logging.py
+++ b/tests/web/api/test_durable_storage_fault_logging.py
@@ -1,0 +1,747 @@
+"""Every durable-storage fault must reach the log with its provider cause.
+
+The envelopes these paths return are deliberately detail-free, and neither
+FastAPI's ``HTTPException`` handler nor the ``/v1/*`` error handler logs a
+traceback for the exception it translates -- so the log line is the *only*
+record of what actually failed. ``ManagedFileRef`` wraps provider faults into
+``DurableStorageOperationError`` carrying just the storage key, which means a
+log line without ``exc_info`` leaves an operator unable to tell a throttle from
+a timeout from rejected credentials. That is the gap that blocked an incident
+investigation in #1467.
+"""
+
+from __future__ import annotations
+
+import ast
+import io
+import logging
+from pathlib import Path
+from typing import Any, Iterator, cast
+
+import pytest
+from fastapi import HTTPException
+from fastapi.datastructures import UploadFile
+
+from xagent.core.file_storage.factory import get_unscoped_file_storage
+from xagent.web.api import files as files_api
+from xagent.web.api.v1 import tasks as v1_tasks
+from xagent.web.api.v1.errors import V1ApiError
+from xagent.web.models.user import User
+from xagent.web.services.managed_file_ref import (
+    _MAX_LOG_VALUE_LENGTH,
+    DurableStorageOperationError,
+    ManagedFileRef,
+    log_durable_storage_fault,
+)
+
+from .conftest import _direct_db_session, _setup_admin
+
+# Not module-wide: only the end-to-end upload test touches the database. The
+# other tests drive the helper directly and would pay a schema create/drop for
+# nothing.
+
+
+@pytest.fixture()
+def isolated_upload_storage(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> Iterator[Path]:
+    """Point staging and the object store at ``tmp_path``.
+
+    Kept local rather than shared with ``test_upload_connection_boundary``:
+    this suite's conftest deliberately exposes helpers by explicit import and
+    keeps fixtures out of it, and no fixture-sharing module exists for the
+    upload paths yet. The durable write is patched to fail before it reaches
+    the object store, but the store is still redirected so a regression that
+    lets the write through cannot touch a real backend.
+    """
+    upload_root = tmp_path / "uploads"
+    object_root = tmp_path / "objects"
+    upload_root.mkdir()
+    monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", object_root.as_uri())
+    get_unscoped_file_storage.cache_clear()
+    monkeypatch.setattr(files_api, "get_uploads_dir", lambda: upload_root)
+    try:
+        yield upload_root
+    finally:
+        get_unscoped_file_storage.cache_clear()
+
+
+def _stage_under(root: Path, user_id: int):
+    """A deterministic staging-path chooser scoped to ``root``."""
+
+    def get_upload_path(
+        filename: str,
+        task_id: str | None,
+        folder: str | None,
+        requested_user_id: int,
+    ) -> Path:
+        del task_id, folder
+        assert requested_user_id == user_id
+        path = root / f"user_{user_id}" / Path(filename).name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return path
+
+    return get_upload_path
+
+
+_FILENAME = "quarterly-report.txt"
+_STORAGE_KEY = f"users/7/uploads/8ac1f2/{_FILENAME}"
+_PROVIDER_MESSAGE = "SlowDown: Please reduce your request rate (status 503)"
+_UNAVAILABLE_DETAIL = "Durable storage is temporarily unavailable"
+
+
+class _ProviderThrottled(RuntimeError):
+    """Stand-in for the boto/S3 error class the wrap discards."""
+
+
+def _wrapped_fault() -> DurableStorageOperationError:
+    """Build a fault shaped exactly like ``ManagedFileRef``'s wraps.
+
+    The key rides on ``storage_key``, not in the message, because ``str(exc)``
+    escapes to places the raise site does not control. Keeping this replica in
+    the production shape is the point: with the key in the message it would test
+    a shape nothing raises, and the log assertions would pass for the wrong
+    reason -- from the message text rather than from the rendered field.
+
+    Everything an operator needs to classify the failure lives in ``__cause__``.
+    Assigning it directly is what ``raise ... from exc`` does, and it survives a
+    later bare ``raise`` of this object.
+    """
+    fault = DurableStorageOperationError(
+        "Failed to write durable object", storage_key=_STORAGE_KEY
+    )
+    fault.__cause__ = _ProviderThrottled(_PROVIDER_MESSAGE)
+    return fault
+
+
+def _rendered(record: logging.LogRecord) -> str:
+    """Render a record the way a handler would, ``exc_info`` included."""
+    return logging.Formatter("%(message)s").format(record)
+
+
+def _warnings(caplog: pytest.LogCaptureFixture, logger_name: str) -> list[str]:
+    return [
+        _rendered(record)
+        for record in caplog.records
+        if record.name == logger_name and record.levelno == logging.WARNING
+    ]
+
+
+def _sole_warning(caplog: pytest.LogCaptureFixture, logger_name: str) -> str:
+    """The one warning a direct helper call may emit."""
+    rendered = _warnings(caplog, logger_name)
+    assert len(rendered) == 1, f"expected exactly one warning, got {rendered}"
+    return rendered[0]
+
+
+def _warning_matching(
+    caplog: pytest.LogCaptureFixture, logger_name: str, needle: str
+) -> str:
+    """Pick the fault line out of an endpoint's warnings.
+
+    Not ``_sole_warning``: the request paths under test also run best-effort
+    cleanup that logs to this same logger when it cannot remove a staged file
+    (``_delete_staged_upload``), and an unrelated second warning must not read
+    as a failure of the line this test is about.
+    """
+    matches = [line for line in _warnings(caplog, logger_name) if needle in line]
+    assert len(matches) == 1, f"expected one warning matching {needle!r}: {matches}"
+    return matches[0]
+
+
+def _assert_cause_chain_recorded(rendered: str, *, wrap_key: bool = True) -> None:
+    """The provider fault -- class and message -- must be in the log text.
+
+    ``wrap_key=False`` where the wrap's own storage key should not appear: the
+    delete path hands over a raw provider exception that has none, and a caller
+    passing an explicit ``storage_key`` field deliberately overrides it.
+    """
+    assert _ProviderThrottled.__name__ in rendered
+    assert _PROVIDER_MESSAGE in rendered
+    if wrap_key:
+        # The key is the anchor an operator greps for. It is no longer in the
+        # message -- ``str(exc)`` escapes to clients -- so this asserts the
+        # helper renders it from the exception instead of losing it.
+        assert f"storage_key={_STORAGE_KEY}" in rendered
+
+
+def test_durable_storage_unavailable_logs_cause_and_keeps_body_detail_free(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The shared 503 helper is where all nine file-API sites get their log.
+
+    Asserting on the helper rather than on each endpoint is deliberate: the
+    exception is a required positional argument and the helper is ``NoReturn``,
+    so a call site can neither skip the cause nor log without raising. That
+    leaves the helper's own body as the only place the chain can be dropped.
+    """
+    fault = _wrapped_fault()
+
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        with pytest.raises(HTTPException) as raised:
+            files_api._raise_durable_storage_unavailable(fault, "download")
+
+    assert raised.value.status_code == 503
+    # Scope segments in the key can encode end-user identity, so the body
+    # stays the fixed message -- the detail is server-side only.
+    assert raised.value.detail == _UNAVAILABLE_DETAIL
+    assert _STORAGE_KEY not in str(raised.value.detail)
+    assert _PROVIDER_MESSAGE not in str(raised.value.detail)
+    assert raised.value.__cause__ is fault
+
+    rendered = _sole_warning(caplog, files_api.logger.name)
+    assert "Durable storage unavailable during download" in rendered
+    _assert_cause_chain_recorded(rendered)
+
+
+def test_durable_storage_unavailable_accepts_an_unwrapped_provider_error(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The delete path hands over the raw provider exception, not a wrap.
+
+    ``delete_file`` catches ``Exception`` around the durable cleanup rather
+    than a ``DurableStorageOperationError``, so the helper has to log something
+    that was never wrapped by ``ManagedFileRef``. Before #1467 that site logged
+    the storage key and discarded the exception entirely.
+    """
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        with pytest.raises(HTTPException) as raised:
+            files_api._raise_durable_storage_unavailable(
+                _ProviderThrottled(_PROVIDER_MESSAGE),
+                "durable cleanup before row delete",
+                storage_key=_STORAGE_KEY,
+            )
+
+    assert raised.value.status_code == 503
+    rendered = _sole_warning(caplog, files_api.logger.name)
+    assert "durable cleanup before row delete" in rendered
+    # The key is a named field, not part of the bounded operation label.
+    assert f"storage_key={_STORAGE_KEY}" in rendered
+    _assert_cause_chain_recorded(rendered, wrap_key=False)
+
+
+def test_one_wrap_yields_one_record_however_many_arms_report_it(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A fault crossing several handlers is recorded once.
+
+    Two arms legitimately report the same fault -- the request-scoped one that
+    answers the client, and the endpoint-scoped one that catches whatever
+    escaped -- and neither can know whether the other ran. So the wrap carries
+    the fact that it has been logged. Without this, sustained-outage logs
+    duplicate every fault, and the duplicate looks like a second failure.
+    """
+    fault = _wrapped_fault()
+
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        log_durable_storage_fault(
+            files_api.logger, "turn preparation", fault, task_id=42
+        )
+        log_durable_storage_fault(
+            files_api.logger, "endpoint recovery", fault, task_id=42
+        )
+
+    # The first arm to report wins, which is the innermost -- the one that knows
+    # what it was doing. The coarser endpoint label is the one dropped.
+    rendered = _sole_warning(caplog, files_api.logger.name)
+    assert "during turn preparation" in rendered
+    _assert_cause_chain_recorded(rendered)
+
+
+def test_an_unwrapped_provider_error_is_not_marked(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Dedup is scoped to this module's wraps, and only they carry the mark.
+
+    Setting a private attribute on a foreign exception is not safe in principle
+    -- it may reject the write, and reading it back is not guaranteed either --
+    and it buys nothing: an unwrapped provider error reaches exactly one
+    reporting site, so there is nothing to deduplicate.
+    """
+    raw = _ProviderThrottled(_PROVIDER_MESSAGE)
+
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        log_durable_storage_fault(files_api.logger, "download", raw)
+        log_durable_storage_fault(files_api.logger, "preview", raw)
+
+    assert len(_warnings(caplog, files_api.logger.name)) == 2
+    assert not hasattr(raw, "_durable_fault_logged")
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("_test_db")
+async def test_upload_durable_write_failure_logs_the_provider_cause(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+    isolated_upload_storage: Path,
+) -> None:
+    """End to end on the incident path: a failed durable write, one 503, one log.
+
+    ``store_uploaded_files`` backs ``/api/files/upload`` and both public-chat
+    upload entry points (share and widget), so this covers every route where
+    the reported 503 bursts were observed.
+    """
+    upload_root = isolated_upload_storage
+    # Side effect only: lays down the admin row the upload is attributed to.
+    _setup_admin()
+    db = _direct_db_session()
+    try:
+        user_id = int(db.query(User.id).filter(User.username == "admin").scalar())
+    finally:
+        db.close()
+    monkeypatch.setattr(
+        files_api, "get_upload_path", _stage_under(upload_root, user_id)
+    )
+
+    def fail_sync(_self: ManagedFileRef, *_args: Any, **_kwargs: Any) -> None:
+        raise _wrapped_fault()
+
+    monkeypatch.setattr(ManagedFileRef, "sync_to_durable", fail_sync)
+    upload = UploadFile(
+        filename=_FILENAME,
+        file=io.BytesIO(b"payload"),
+        headers={"content-type": "text/plain"},
+    )
+
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        with pytest.raises(HTTPException) as raised:
+            await files_api.store_uploaded_files(
+                upload_items=[upload],
+                task_type="general",
+                task_id=None,
+                folder=None,
+                user_id=user_id,
+                single_file_mode=True,
+            )
+
+    assert raised.value.status_code == 503
+    assert raised.value.detail == _UNAVAILABLE_DETAIL
+    # The cause chain still reaches the client-facing exception too.
+    assert isinstance(raised.value.__cause__, DurableStorageOperationError)
+
+    rendered = _warning_matching(
+        caplog, files_api.logger.name, "Durable storage unavailable during upload"
+    )
+    _assert_cause_chain_recorded(rendered)
+
+
+def test_v1_turn_attachment_durable_fault_logs_the_provider_cause(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The SDK path returns its own 503 envelope and needs its own log line."""
+
+    def fail_resolve(**_kwargs: Any) -> None:
+        raise _wrapped_fault()
+
+    monkeypatch.setattr(v1_tasks, "resolve_turn_file_infos", fail_resolve)
+
+    with caplog.at_level(logging.WARNING, logger=v1_tasks.logger.name):
+        with pytest.raises(V1ApiError) as raised:
+            v1_tasks._resolve_turn_files_or_400(
+                file_ids=["8ac1f2"],
+                owner_user_id=7,
+                db=cast(Any, None),
+                task_id=42,
+            )
+
+    assert raised.value.http_status == 503
+    assert _STORAGE_KEY not in raised.value.message
+    assert _PROVIDER_MESSAGE not in raised.value.message
+
+    rendered = _warning_matching(
+        caplog, v1_tasks.logger.name, "during turn attachment resolution"
+    )
+    assert "task_id=42" in rendered
+    # The create path has task_id=None, so these carry identification there.
+    assert "owner_user_id=7" in rendered
+    assert "file_ids=8ac1f2" in rendered
+    _assert_cause_chain_recorded(rendered)
+
+
+def test_v1_turn_attachment_integrity_fault_is_not_reported_as_an_outage(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The integrity subclass through the real cascade, not just the parent.
+
+    The test above injects only ``DurableStorageOperationError``, so it would
+    pass with the two arms swapped -- the parent would catch the subclass and
+    this site would report permanent corruption as a retryable outage. That is
+    the safety property the ordering exists for, and injecting the subclass is
+    what actually exercises it.
+    """
+    from xagent.web.services.managed_file_ref import (
+        FILE_INTEGRITY_REUPLOAD_MESSAGE,
+        DurableObjectIntegrityError,
+    )
+
+    def fail_resolve(**_kwargs: Any) -> None:
+        raise DurableObjectIntegrityError(
+            FILE_INTEGRITY_REUPLOAD_MESSAGE,
+            storage_key="users/7/uploads/8ac1f2/corrupt.txt",
+        )
+
+    monkeypatch.setattr(v1_tasks, "resolve_turn_file_infos", fail_resolve)
+
+    with caplog.at_level(logging.WARNING, logger=v1_tasks.logger.name):
+        with pytest.raises(V1ApiError) as raised:
+            v1_tasks._resolve_turn_files_or_400(
+                file_ids=["8ac1f2"],
+                owner_user_id=7,
+                db=cast(Any, None),
+                task_id=42,
+            )
+
+    assert raised.value.http_status == 503
+    # The envelope is deliberately unchanged; what must not happen is a second,
+    # contradicting record calling permanent corruption a transient outage.
+    assert not [
+        line
+        for line in _warnings(caplog, v1_tasks.logger.name)
+        if "Durable storage unavailable" in line
+    ], "an integrity fault emitted an outage warning -- the arms are misordered"
+
+
+# Every ``_raise_durable_storage_unavailable`` call site in files.py, with the
+# fields it is expected to carry. N2 in review -- the signed-redirect site
+# shipping with no identifier -- was invisible because only two sites had
+# assertions; this sweep is what makes the set itself the contract.
+_FAULT_SITES = (
+    ("signed durable redirect", ("file_id",)),
+    ("upload", ("user_id", "task_id")),
+    ("download", ("file_id",)),
+    ("preview", ("file_id",)),
+    ("pptx preview", ("file_id",)),
+    ("public download", ("file_id",)),
+    ("public preview", ("file_id",)),
+    ("public preview task asset", ("file_id",)),
+    ("durable cleanup before row delete", ("file_id", "storage_key")),
+)
+
+
+# --- shared AST primitives -------------------------------------------------
+#
+# Several contracts in this file can only be checked against source: which
+# call sites exist, what they bind, which arms come first, and whether a
+# handler re-raises. Each started as its own hand-rolled walk; these are the
+# pieces they share, and the checks themselves stay separate because they
+# assert different things.
+
+
+def _module_ast(module: Any) -> ast.Module:
+    """Parse an imported module's own source."""
+    return ast.parse(Path(module.__file__).read_text(encoding="utf-8"))
+
+
+def _handler_types(handler: ast.ExceptHandler) -> list[str]:
+    """The exception class names an ``except`` arm names, tuple or not."""
+    if isinstance(handler.type, ast.Name):
+        return [handler.type.id]
+    if isinstance(handler.type, ast.Tuple):
+        return [e.id for e in handler.type.elts if isinstance(e, ast.Name)]
+    return []
+
+
+def _durable_arm_pairs(tree: ast.Module) -> list[ast.Try]:
+    """Every ``try`` that handles both the integrity subclass and its parent."""
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Try)
+        and any(
+            "DurableObjectIntegrityError" in _handler_types(h) for h in node.handlers
+        )
+        and any(
+            "DurableStorageOperationError" in _handler_types(h) for h in node.handlers
+        )
+    ]
+
+
+def _identifiers(expression: ast.expr) -> set[str]:
+    """Every name and attribute the expression reads.
+
+    ``file_ref.record.file_id`` yields ``file_ref``, ``record`` and ``file_id``,
+    so a field may be bound to a bare variable or reached through attributes.
+    """
+    found: set[str] = set()
+    for node in ast.walk(expression):
+        if isinstance(node, ast.Name):
+            found.add(node.id)
+        elif isinstance(node, ast.Attribute):
+            found.add(node.attr)
+    return found
+
+
+def _binds_a_matching_name(field: str, expression: ast.expr) -> bool:
+    """Whether the expression reads an identifier plausibly holding ``field``.
+
+    A qualifier prefix is allowed -- ``task_id=parsed_task_id`` and
+    ``user_id=owner_user_id`` name the thing they carry -- while an unrelated
+    name is rejected, which is what catches ``file_id=storage_key``.
+
+    The prefix must end at an underscore. A bare suffix test would admit
+    ``file_id=profile_id``, since ``"profile_id".endswith("file_id")`` -- an
+    unrelated identifier passing on a coincidental substring, which is the
+    opposite of the point.
+
+    **This checks spelling, not referent, and that is a real limit.** The
+    "public preview task asset" site shipped with ``file_id=file_id`` where the
+    failing object was ``asset_record`` -- a different row from the route's
+    ``file_id``, so the one line meant to identify the failure named an object
+    that was fine. This check passed it, because the spelling was right. Only a
+    test that drives the endpoint distinguishes those, which is #1522; do not
+    read a green run here as "every site logs the right object".
+    """
+    return any(
+        identifier == field or identifier.endswith(f"_{field}")
+        for identifier in _identifiers(expression)
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "source", "accepted"),
+    [
+        ("file_id", "file_id", True),
+        ("file_id", "file_ref.record.file_id", True),
+        ("task_id", "parsed_task_id", True),
+        ("user_id", "owner_user_id", True),
+        ("file_id", "storage_key", False),
+        # A coincidental suffix, not a qualified name: the underscore boundary
+        # is the whole difference, and without it this passes.
+        ("file_id", "profile_id", False),
+    ],
+)
+def test_the_binding_check_accepts_qualified_names_and_rejects_unrelated_ones(
+    field: str, source: str, accepted: bool
+) -> None:
+    """The rule the site sweep leans on, pinned on its own.
+
+    Asserted here rather than only through the sweep because the sweep can only
+    fail on the sites that exist: a rule too loose to reject anything would
+    still pass it. ``profile_id`` is the case that made this necessary.
+    """
+    expression = ast.parse(source, mode="eval").body
+    assert _binds_a_matching_name(field, expression) is accepted
+
+
+def test_every_fault_site_label_is_bounded_and_reaches_the_log() -> None:
+    """The nine labels are a closed set of bounded, aggregatable values.
+
+    ``upload`` carries no ``file_id`` by design -- it is a batch-registration
+    path, and any file in the batch may be the one that failed -- but it does
+    carry tenant and task, which is what correlates a 503 burst. Every other
+    site identifies its subject.
+    """
+    tree = _module_ast(files_api)
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_raise_durable_storage_unavailable"
+    ]
+    # Parsed rather than grepped: a substring count also matches the ``def``
+    # line, and a label is only a contract if the count is exact.
+    assert len(calls) == len(_FAULT_SITES), (
+        f"{len(calls)} call sites but {len(_FAULT_SITES)} labels declared -- "
+        "add the new site to _FAULT_SITES with the fields it should carry"
+    )
+
+    declared = {label for label, _ in _FAULT_SITES}
+    passed = {
+        node.args[1].value
+        for node in calls
+        if len(node.args) > 1 and isinstance(node.args[1], ast.Constant)
+    }
+    # Every label is a plain literal, so it stays a bounded, aggregatable value
+    # -- an f-string here is how the storage key first became part of a label.
+    assert passed == declared, f"labels drifted: {passed ^ declared}"
+
+    for node in calls:
+        label = node.args[1].value
+        expected = dict(_FAULT_SITES)[label]
+        assert tuple(kw.arg for kw in node.keywords) == expected, (
+            f"site {label!r} passes "
+            f"{[kw.arg for kw in node.keywords]}, expected {list(expected)}"
+        )
+        # Names alone are not the contract. ``file_id=storage_key`` declares the
+        # right field and renders the wrong value, which is invisible both here
+        # and to the sweep below -- that one supplies its own placeholder values
+        # and never reads the call site. Requiring the bound expression to read
+        # something of the same name is what ties the label to the variable.
+        for keyword in node.keywords:
+            assert keyword.arg is not None, f"site {label!r} uses **kwargs"
+            assert _binds_a_matching_name(keyword.arg, keyword.value), (
+                f"site {label!r} binds {keyword.arg}= to "
+                f"{ast.unparse(keyword.value)!r}, which never reads "
+                f"{keyword.arg} -- the field name and the value must agree"
+            )
+
+
+# The counts are part of the contract: the walker can only check the pairs it
+# finds, so a deleted integrity arm removes its pair from sight rather than
+# failing the ordering assert. Pinning how many pairs each module carries is
+# what turns that silent disappearance into a failure. (A ``try`` with only
+# the parent arm is legitimately not a pair -- ``store_uploaded_files`` is one,
+# where the subclass is unreachable -- which is why the count must be declared,
+# not derived.)
+_MODULES_WITH_DURABLE_ARM_PAIRS = (
+    ("files.py", 7, lambda: files_api),
+    ("v1/tasks.py", 1, lambda: v1_tasks),
+    ("file_ingestion_tool.py", 1, lambda: _file_ingestion_tool()),
+)
+
+
+def _file_ingestion_tool() -> Any:
+    from xagent.core.tools.adapters.vibe import file_ingestion_tool
+
+    return file_ingestion_tool
+
+
+@pytest.mark.parametrize(
+    ("label", "expected", "loader"), _MODULES_WITH_DURABLE_ARM_PAIRS
+)
+def test_the_integrity_arm_precedes_its_parent_at_every_site(
+    label: str, expected: int, loader: Any
+) -> None:
+    """Checked at all nine pairs, because only two have real end-to-end cover.
+
+    The integrity subclass goes through a real call path at two of the nine:
+    ``file_ingestion_tool`` (via ``test_kb_creation_tools``) and ``v1/tasks.py``
+    (the resolver test above). At the other seven -- all in ``files.py`` -- the
+    tests either drive the shared helper directly with a pre-built exception or
+    inject only the parent class, so a swapped ordering would change behaviour
+    silently at seven of the nine.
+
+    This does not replace those tests: it proves ordering, not that each arm
+    produces the right answer. What it does is make the one regression that
+    silently breaks the property at every site impossible to land. Real
+    end-to-end coverage for the ``files.py`` seven is #1522.
+    """
+    tree = _module_ast(loader())
+    pairs = _durable_arm_pairs(tree)
+    assert len(pairs) == expected, (
+        f"{label}: expected {expected} integrity/parent pair(s), found "
+        f"{len(pairs)} at lines {sorted(p.lineno for p in pairs)} -- a pair was "
+        "added or removed. Update _MODULES_WITH_DURABLE_ARM_PAIRS and give the "
+        "changed site its coverage story; a deleted integrity arm is invisible "
+        "to the ordering check below, which is what this count exists to catch."
+    )
+
+    for node in pairs:
+        integrity_at = min(
+            handler.lineno
+            for handler in node.handlers
+            if "DurableObjectIntegrityError" in _handler_types(handler)
+        )
+        parent_at = min(
+            handler.lineno
+            for handler in node.handlers
+            if "DurableStorageOperationError" in _handler_types(handler)
+        )
+        assert integrity_at < parent_at, (
+            f"{label}: the try at line {node.lineno} catches "
+            f"DurableStorageOperationError (line {parent_at}) before its "
+            f"subclass DurableObjectIntegrityError (line {integrity_at}), which "
+            "makes the integrity arm dead and reports corruption as an outage"
+        )
+
+
+@pytest.mark.parametrize(("label", "expected_fields"), _FAULT_SITES)
+def test_fault_site_renders_its_label_and_fields(
+    caplog: pytest.LogCaptureFixture,
+    label: str,
+    expected_fields: tuple[str, ...],
+) -> None:
+    """Each site's label and field set must survive into the log line."""
+    fields = {name: f"value-for-{name}" for name in expected_fields}
+
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        with pytest.raises(HTTPException) as raised:
+            files_api._raise_durable_storage_unavailable(
+                _wrapped_fault(), label, **fields
+            )
+
+    assert raised.value.status_code == 503
+    rendered = _sole_warning(caplog, files_api.logger.name)
+    assert f"during {label}" in rendered
+    for name in expected_fields:
+        assert f"{name}=value-for-{name}" in rendered
+    # A site that names its own storage_key overrides the wrap's, so the wrap's
+    # key is legitimately absent there -- that precedence is the point.
+    _assert_cause_chain_recorded(
+        rendered, wrap_key="storage_key" not in expected_fields
+    )
+
+
+def test_field_values_cannot_forge_a_log_record(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A newline in a client-supplied field must not start a new record.
+
+    ``/v1/*`` renders the request's ``files`` list, an unvalidated ``list[str]``,
+    so a caller cannot be relied on to have checked (CWE-117).
+    """
+    forged = "ok,\n2026-01-01 00:00:00 ERROR    xagent.web - FABRICATED entry"
+
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        with pytest.raises(HTTPException):
+            files_api._raise_durable_storage_unavailable(
+                _wrapped_fault(), "upload", file_ids=forged
+            )
+
+    rendered = _sole_warning(caplog, files_api.logger.name)
+    message_line = rendered.splitlines()[0]
+    assert "FABRICATED" in message_line, "the value must survive, escaped"
+    assert "\\n" in message_line
+    assert not any(line.startswith("2026-01-01") for line in rendered.splitlines()), (
+        "the injected text must not stand as its own record"
+    )
+
+
+@pytest.mark.parametrize("length", [_MAX_LOG_VALUE_LENGTH - 1, _MAX_LOG_VALUE_LENGTH])
+def test_a_field_value_at_or_under_the_bound_is_kept_whole(
+    caplog: pytest.LogCaptureFixture, length: int
+) -> None:
+    """The bound is inclusive, so neither of these may be marked truncated."""
+    value = "v" * length
+
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        with pytest.raises(HTTPException):
+            files_api._raise_durable_storage_unavailable(
+                _wrapped_fault(), "upload", file_ids=value
+            )
+
+    rendered = _sole_warning(caplog, files_api.logger.name)
+    assert f"file_ids={value} " in f"{rendered.splitlines()[0]} "
+    assert "truncated" not in rendered.splitlines()[0]
+
+
+def test_an_overlong_field_value_is_truncated(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """One field must not be able to crowd out the rest of the line.
+
+    Pins the boundary rather than only the marker: with the length unasserted
+    this passed for any bound at all, so a change from 256 to 4096 would have
+    kept a green run while one field again took over the line.
+    """
+    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
+        with pytest.raises(HTTPException):
+            files_api._raise_durable_storage_unavailable(
+                _wrapped_fault(), "upload", file_ids="x" * 5000
+            )
+
+    message_line = _sole_warning(caplog, files_api.logger.name).splitlines()[0]
+    # The retained part is the intact leading prefix, at exactly the bound --
+    # one character more is the off-by-one this pins.
+    assert f"file_ids={'x' * _MAX_LOG_VALUE_LENGTH}...[truncated]" in message_line
+    assert "x" * (_MAX_LOG_VALUE_LENGTH + 1) not in message_line
+    assert len(message_line) < 1000
+    # The magnitude is part of the contract too, not just the mechanics: the
+    # cap exists so one field cannot crowd out the rest of the line, and the
+    # assertions above are all written against the constant, so they would stay
+    # green if it were raised to a value that defeats that. A ceiling rather
+    # than an equality, so the number stays tunable within its purpose.
+    assert _MAX_LOG_VALUE_LENGTH <= 512

--- a/tests/web/api/test_durable_storage_fault_logging.py
+++ b/tests/web/api/test_durable_storage_fault_logging.py
@@ -431,7 +431,27 @@ _FAULT_SITES = (
 
 def _module_ast(module: Any) -> ast.Module:
     """Parse an imported module's own source."""
-    return ast.parse(Path(module.__file__).read_text(encoding="utf-8"))
+    source_path = Path(module.__file__)
+    return ast.parse(source_path.read_text(encoding="utf-8"), filename=str(source_path))
+
+
+def _operation_label_of(call: ast.Call, where: str) -> str:
+    """The call's operation label, which must be a string literal.
+
+    Positional or ``operation=`` keyword -- a site refactored to keyword form
+    must fail with "not a literal", never silently drop out of a drift
+    comparison or die on an IndexError.
+    """
+    node = (
+        call.args[1]
+        if len(call.args) > 1
+        else next((kw.value for kw in call.keywords if kw.arg == "operation"), None)
+    )
+    assert isinstance(node, ast.Constant) and isinstance(node.value, str), (
+        f"{where}:{call.lineno}: the operation label must be a string "
+        f"literal (positional or operation=); got {ast.unparse(call)[:90]!r}"
+    )
+    return node.value
 
 
 def _handler_types(handler: ast.ExceptHandler) -> list[str]:
@@ -549,28 +569,28 @@ def test_every_fault_site_label_is_bounded_and_reaches_the_log() -> None:
     )
 
     declared = {label for label, _ in _FAULT_SITES}
-    passed = {
-        node.args[1].value
-        for node in calls
-        if len(node.args) > 1 and isinstance(node.args[1], ast.Constant)
-    }
+
     # Every label is a plain literal, so it stays a bounded, aggregatable value
     # -- an f-string here is how the storage key first became part of a label.
+    passed = {_operation_label_of(node, "files.py") for node in calls}
     assert passed == declared, f"labels drifted: {passed ^ declared}"
 
     for node in calls:
-        label = node.args[1].value
+        label = _operation_label_of(node, "files.py")
         expected = dict(_FAULT_SITES)[label]
-        assert tuple(kw.arg for kw in node.keywords) == expected, (
+        field_keywords = [kw for kw in node.keywords if kw.arg != "operation"]
+        # Set comparison: the field names are the contract, their order is not.
+        assert {kw.arg for kw in field_keywords} == set(expected), (
             f"site {label!r} passes "
-            f"{[kw.arg for kw in node.keywords]}, expected {list(expected)}"
+            f"{sorted(str(kw.arg) for kw in field_keywords)}, "
+            f"expected {sorted(expected)}"
         )
         # Names alone are not the contract. ``file_id=storage_key`` declares the
         # right field and renders the wrong value, which is invisible both here
         # and to the sweep below -- that one supplies its own placeholder values
         # and never reads the call site. Requiring the bound expression to read
         # something of the same name is what ties the label to the variable.
-        for keyword in node.keywords:
+        for keyword in field_keywords:
             assert keyword.arg is not None, f"site {label!r} uses **kwargs"
             assert _binds_a_matching_name(keyword.arg, keyword.value), (
                 f"site {label!r} binds {keyword.arg}= to "
@@ -587,10 +607,86 @@ def test_every_fault_site_label_is_bounded_and_reaches_the_log() -> None:
 # where the subclass is unreachable -- which is why the count must be declared,
 # not derived.)
 _MODULES_WITH_DURABLE_ARM_PAIRS = (
-    ("files.py", 7, lambda: files_api),
-    ("v1/tasks.py", 1, lambda: v1_tasks),
-    ("file_ingestion_tool.py", 1, lambda: _file_ingestion_tool()),
+    ("web/api/files.py", 7, lambda: files_api),
+    ("web/api/v1/tasks.py", 1, lambda: v1_tasks),
+    (
+        "core/tools/adapters/vibe/file_ingestion_tool.py",
+        1,
+        lambda: _file_ingestion_tool(),
+    ),
 )
+
+
+# The two sites that call the shared helper directly, without files.py's
+# ``_raise_durable_storage_unavailable`` wrapper, and therefore sit outside
+# the files.py sweep above. Same contract: a bounded literal label and a
+# declared field set.
+_DIRECT_HELPER_SITES = (
+    ("web/api/v1/tasks.py", lambda: v1_tasks, "turn attachment resolution"),
+    (
+        "core/tools/adapters/vibe/file_ingestion_tool.py",
+        lambda: _file_ingestion_tool(),
+        "knowledge-base file restore",
+    ),
+)
+
+
+@pytest.mark.parametrize(
+    ("label", "loader", "expected_operation"), _DIRECT_HELPER_SITES
+)
+def test_direct_helper_sites_keep_a_bounded_literal_label(
+    label: str, loader: Any, expected_operation: str
+) -> None:
+    """The two non-files.py reporting sites are held to the same label rules.
+
+    The files.py sweep cannot see them -- they call the shared helper
+    directly -- so without this, a rewrite of either label to an f-string
+    (the leak-and-cardinality class the sweep exists to prevent) would land
+    unchecked.
+    """
+    tree = _module_ast(loader())
+    calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "log_durable_storage_fault"
+    ]
+    assert len(calls) == 1, (
+        f"{label}: expected exactly one direct helper call, found {len(calls)} "
+        "-- add the new site here with its label"
+    )
+    operation = _operation_label_of(calls[0], label)
+    assert operation == expected_operation, (
+        f"{label}: the operation label must stay the bounded literal "
+        f"{expected_operation!r}; got {operation!r}"
+    )
+    for keyword in calls[0].keywords:
+        assert keyword.arg is not None, f"{label} passes **kwargs to the helper"
+
+
+def test_every_module_with_an_arm_pair_is_in_the_table() -> None:
+    """The table above is discovered, not merely declared.
+
+    A closed list can only check the modules someone remembered to add: a new
+    module introducing a misordered pair elsewhere would be invisible to the
+    per-module sweep. This walks every module under ``src/xagent`` and requires
+    the set of modules carrying an integrity/parent pair to equal the table, so
+    a new pair anywhere fails here with directions instead of going unchecked.
+    """
+    package_root = Path(files_api.__file__).parents[2]
+    found = set()
+    for path in package_root.rglob("*.py"):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        if _durable_arm_pairs(tree):
+            found.add(path.relative_to(package_root).as_posix())
+
+    declared = {label for label, _, _ in _MODULES_WITH_DURABLE_ARM_PAIRS}
+    assert found == declared, (
+        f"modules with integrity/parent arm pairs changed: {found ^ declared} "
+        "-- add the module to _MODULES_WITH_DURABLE_ARM_PAIRS with its pair "
+        "count so its ordering is swept, or remove the stale row"
+    )
 
 
 def _file_ingestion_tool() -> Any:
@@ -654,7 +750,13 @@ def test_fault_site_renders_its_label_and_fields(
     label: str,
     expected_fields: tuple[str, ...],
 ) -> None:
-    """Each site's label and field set must survive into the log line."""
+    """The helper renders each declared label and field set into the line.
+
+    Helper rendering only, with synthetic values: this never executes a real
+    ``files.py`` call site. What ties each site to its declared label, fields,
+    and bindings is the AST sweep above; what this pins is that the declared
+    shape, once passed, survives into the rendered record.
+    """
     fields = {name: f"value-for-{name}" for name in expected_fields}
 
     with caplog.at_level(logging.WARNING, logger=files_api.logger.name):

--- a/tests/web/api/test_durable_storage_fault_logging.py
+++ b/tests/web/api/test_durable_storage_fault_logging.py
@@ -899,9 +899,6 @@ def test_field_values_cannot_forge_a_log_record(
     assert not any(line.startswith("2026-01-01") for line in rendered.splitlines()), (
         "the injected text must not stand as its own record"
     )
-    # It carries whitespace, so it is also quoted -- see the same-line forgery
-    # test below for why that half matters independently.
-    assert 'file_ids="' in message_line
 
 
 def test_a_field_value_cannot_forge_a_second_field_on_the_same_line(
@@ -909,13 +906,19 @@ def test_a_field_value_cannot_forge_a_second_field_on_the_same_line(
 ) -> None:
     """Whitespace, not a newline, is the cheaper forgery -- close that too.
 
-    Escaping line breaks stops a value from fabricating a whole *record*, and
-    nothing stopped it fabricating a *field*: rendered bare, a client-supplied
-    ``abc user_id=999`` put two more ``key=value`` pairs on the line, indistin-
-    guishable from the ones the helper renders itself. An operator reading the
-    line -- or anything parsing it -- would attribute the fault to another
-    tenant and another file. No line break needed, so neither the escape table
-    (#1519) nor the ``exc_info`` channel (#1516) covers it.
+    Escaping line breaks stops a value fabricating a whole *record*, and
+    nothing stopped it fabricating a *field*: rendered with its spaces intact,
+    a client-supplied ``abc user_id=999`` put two more ``key=value`` pairs on
+    the line, and an operator -- or anything parsing it -- would attribute the
+    fault to another tenant and another file.
+
+    Asserted through the tokenizer a consumer actually uses, not against the
+    escaping this file happens to do. The first attempt at this quoted the
+    value instead, and asserted by stripping the quoted substring before
+    looking -- which proved the quoting existed, not that anything downstream
+    was safe. It was not: a whitespace tokenizer splits ``file_ids="abc`` from
+    ``user_id=999`` and reads the forgery as real, because nothing obliges a
+    log reader to honour quotes.
     """
     forged = "abc user_id=999 file_id=someone-elses"
 
@@ -926,13 +929,16 @@ def test_a_field_value_cannot_forge_a_second_field_on_the_same_line(
             )
 
     message_line = _sole_warning(caplog, files_api.logger.name).splitlines()[0]
-    # The whole value is one quoted token, so the forged pairs are inside it.
-    assert f'file_ids="{forged}"' in message_line
-    # And no bare forged field stands on its own next to the real ones.
-    assert " user_id=999" not in message_line.replace(f'"{forged}"', "")
-    assert " file_id=someone-elses" not in message_line.replace(f'"{forged}"', "")
-    # The real fields stay bare and greppable -- quoting is conditional.
-    assert f"storage_key={_STORAGE_KEY}" in message_line
+
+    # The consumer: split on whitespace, then on the first ``=``. This is what
+    # awk, a kv filter, and a grep pipeline all do.
+    fields = dict(token.split("=", 1) for token in message_line.split() if "=" in token)
+    assert set(fields) == {"file_ids", "storage_key"}, fields
+    assert "user_id" not in fields and "file_id" not in fields
+    # The value survives whole in the one field it belongs to, escaped.
+    assert fields["file_ids"].replace("\\x20", " ") == forged
+    # Fields the helper renders itself stay untouched and greppable.
+    assert fields["storage_key"] == _STORAGE_KEY
 
 
 def test_the_exported_prefix_is_the_one_the_helper_emits(
@@ -951,47 +957,6 @@ def test_the_exported_prefix_is_the_one_the_helper_emits(
 
     rendered = _sole_warning(caplog, files_api.logger.name).splitlines()[0]
     assert rendered.startswith(f"{DURABLE_FAULT_LOG_PREFIX} download"), rendered
-
-
-def test_one_value_has_one_encoding_whether_or_not_it_is_quoted() -> None:
-    """Escaping is unconditional; only the quoting is conditional.
-
-    The first version escaped inside the quoted branch only, so ``a\\nb``
-    rendered as ``a\\nb`` bare but as ``a\\\\nb`` once any space elsewhere in
-    the value triggered quoting -- the same input with two encodings, which a
-    consumer cannot decode. Quoting may frame the value; it may not change it.
-    """
-    from xagent.web.services.managed_file_ref import _sanitize_log_value
-
-    bare = _sanitize_log_value("a\nb")
-    quoted = _sanitize_log_value("a\nb c")
-
-    assert not bare.startswith('"')
-    assert quoted.startswith('"') and quoted.endswith('"')
-    # The quoted rendering is the bare one, framed and with the space -- not a
-    # differently-escaped string.
-    assert quoted[1:-1] == f"{bare} c"
-
-
-def test_a_quoted_value_cannot_end_its_own_quoting(
-    caplog: pytest.LogCaptureFixture,
-) -> None:
-    """The escape of the closer is what makes the quoting load-bearing.
-
-    Without escaping ``"`` (and the escape character itself), a value can close
-    the quoted region early and resume as bare text -- forging fields again,
-    one level down.
-    """
-    forged = 'abc" user_id=999'
-
-    with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
-        with pytest.raises(HTTPException):
-            files_api._raise_durable_storage_unavailable(
-                _wrapped_fault(), "upload", file_ids=forged
-            )
-
-    message_line = _sole_warning(caplog, files_api.logger.name).splitlines()[0]
-    assert 'file_ids="abc\\" user_id=999"' in message_line
 
 
 @pytest.mark.parametrize("length", [_MAX_LOG_VALUE_LENGTH - 1, _MAX_LOG_VALUE_LENGTH])

--- a/tests/web/services/test_managed_file_ref.py
+++ b/tests/web/services/test_managed_file_ref.py
@@ -705,3 +705,167 @@ def test_no_wrap_site_interpolates_into_the_message():
         f"{checked} -- a construction was added, removed, aliased, or moved "
         "behind a helper; update this count deliberately"
     )
+
+
+class _SentinelProviderFault(RuntimeError):
+    """The provider error a wrap must keep reachable through ``__cause__``."""
+
+
+_REMOTE_CHECKSUM = sha256(b"durable bytes").hexdigest()
+
+
+class _ProviderFaultStorage:
+    """Raise ``fault`` from one named backend call; let the others succeed.
+
+    Only the call under test may fail. If everything raised, a site could pass
+    by wrapping some *earlier* call's fault, which is the opposite of what these
+    cases pin down.
+
+    ``materialize`` and ``signed_url`` raise on their success path because no
+    case reaches them successfully; a path change that starts calling one shows
+    up as a failure instead of passing on a fault nobody meant to test.
+    """
+
+    def __init__(
+        self,
+        fault: Exception,
+        failing: str,
+        *,
+        remote_checksum: str = _REMOTE_CHECKSUM,
+        remote_size: int = 0,
+    ):
+        self.fault = fault
+        self.failing = failing
+        self.remote_checksum = remote_checksum
+        self.remote_size = remote_size
+
+    def _maybe_fail(self, name: str) -> None:
+        if name == self.failing:
+            raise self.fault
+
+    def _stored(self, key: str) -> StoredObject:
+        return StoredObject(
+            backend="s3",
+            key=key,
+            uri=f"s3://bucket/{key}",
+            size=self.remote_size,
+            checksum=self.remote_checksum,
+            etag="etag",
+        )
+
+    def copy_to_path(self, key, target_path):
+        self._maybe_fail("copy_to_path")
+        Path(target_path).write_bytes(b"durable bytes")
+
+    def materialize(self, key, filename=None):
+        self._maybe_fail("materialize")
+        raise AssertionError("unreachable in these cases")
+
+    def put_file(self, source, key, content_type=None):
+        self._maybe_fail("put_file")
+        return self._stored(key)
+
+    def signed_url(self, key, *, expires, content_type=None, content_disposition=None):
+        self._maybe_fail("signed_url")
+        raise AssertionError("unreachable in these cases")
+
+    def content_hash(self, key):
+        self._maybe_fail("content_hash")
+        return self.remote_checksum
+
+    def stat(self, key):
+        self._maybe_fail("stat")
+        return self._stored(key)
+
+
+def _durable_record(tmp_path, *, local_bytes: bytes | None, **overrides):
+    local_path = tmp_path / "uploads" / "payload.txt"
+    local_path.parent.mkdir(parents=True, exist_ok=True)
+    if local_bytes is not None:
+        local_path.write_bytes(local_bytes)
+    return _record(
+        local_path,
+        storage_backend="s3",
+        storage_key="users/7/uploads/file-123/payload.txt",
+        storage_status="available",
+        **overrides,
+    )
+
+
+def _drive_ensure_local(tmp_path, storage):
+    ref = ManagedFileRef(_durable_record(tmp_path, local_bytes=None), storage=storage)
+    return ref.ensure_local
+
+
+def _drive_materialize(tmp_path, storage):
+    ref = ManagedFileRef(_durable_record(tmp_path, local_bytes=None), storage=storage)
+    return ref.materialize
+
+
+def _drive_signed_access_url(tmp_path, storage):
+    # The signing call is reached only past the checksum gate, so the DB
+    # checksum has to agree with what ``content_hash`` reports.
+    record = _durable_record(tmp_path, local_bytes=None, checksum=_REMOTE_CHECKSUM)
+    ref = ManagedFileRef(record, storage=storage)
+    return lambda: ref.signed_access_url(expires=60)
+
+
+def _drive_sync_to_durable(tmp_path, storage):
+    ref = ManagedFileRef(
+        _durable_record(tmp_path, local_bytes=b"local bytes"), storage=storage
+    )
+    return ref.sync_to_durable
+
+
+def _drive_adopt(tmp_path, storage):
+    """Both ``adopt_existing_object`` wraps, selected by which call fails.
+
+    With no local copy, failing ``stat`` hits the metadata wrap directly; letting
+    ``stat`` succeed while reporting no checksum falls through to the second
+    ``content_hash`` lookup, which is wrapped separately a few lines further on.
+    """
+    record = _durable_record(tmp_path, local_bytes=None)
+    ref = ManagedFileRef(record, storage=storage)
+    return lambda: ref.adopt_existing_object(record.storage_key)
+
+
+@pytest.mark.parametrize(
+    ("failing", "expected_message", "driver", "storage_kwargs"),
+    [
+        ("copy_to_path", "restore durable object", _drive_ensure_local, {}),
+        ("materialize", "materialize durable object", _drive_materialize, {}),
+        ("signed_url", "sign durable object URL", _drive_signed_access_url, {}),
+        ("put_file", "write durable object", _drive_sync_to_durable, {}),
+        ("stat", "inspect durable object metadata", _drive_adopt, {}),
+        (
+            "content_hash",
+            "inspect durable object metadata",
+            _drive_adopt,
+            {"remote_checksum": ""},
+        ),
+    ],
+)
+def test_every_wrap_keeps_the_provider_fault_as_its_cause(
+    tmp_path, failing, expected_message, driver, storage_kwargs
+):
+    """``from exc`` at each real wrap site, asserted on a real raise.
+
+    The fault-logging suite builds its wraps by assigning ``__cause__`` on a
+    hand-made exception, so it proves what the logger does with a chain that is
+    already there -- not that these sites still produce one. Dropping ``from
+    exc`` at any wrap below would leave every assertion over there passing while
+    #1467 silently reopened: the provider class, the HTTP status and throttle vs.
+    timeout vs. rejected credentials live in ``__cause__`` and nowhere else.
+
+    Each case fails exactly one backend call and asserts the wrap raised for
+    *that* call carries *that* fault instance -- identity, not just type, so a
+    wrap re-raising some other error cannot pass.
+    """
+    fault = _SentinelProviderFault("SlowDown: reduce your request rate")
+    storage = _ProviderFaultStorage(fault, failing, **storage_kwargs)
+
+    with pytest.raises(DurableStorageOperationError) as raised:
+        driver(tmp_path, storage)()
+
+    assert expected_message in str(raised.value)
+    assert raised.value.__cause__ is fault

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -1585,6 +1585,63 @@ class TestFileManagement:
         finally:
             db.close()
 
+    def test_delete_file_malformed_key_is_not_reported_as_an_outage(
+        self, client, test_db, temp_uploads_dir, auth_headers, caplog
+    ):
+        """The other half of #1473: a structurally-invalid persisted key.
+
+        ``ScopedFileStorage.delete`` normalizes the key even in tolerant mode,
+        and ``normalize_storage_key`` raises ``ValueError`` for a ``..`` path
+        segment (also a null byte or an empty key). That is data-level
+        corruption in the row itself -- no retry can clear it -- so the
+        cleanup arm must let it propagate rather than fold it into the
+        retryable 503 with a transient-outage warning, which is exactly the
+        failure #1473 describes: the row becomes undeletable through the API
+        while the client is told to retry forever.
+        """
+        admin_user, test_app = test_db
+        upload_response = client.post(
+            "/api/files/upload",
+            files={"file": ("malformed-key.txt", b"malformed key", "text/plain")},
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert upload_response.status_code == 200
+        file_id = upload_response.json()["file_id"]
+
+        # Corrupt the persisted key the way a bad migration or adopt would:
+        # structurally invalid, not merely out of scope.
+        db = next(test_app.dependency_overrides[get_db]())
+        try:
+            record = (
+                db.query(UploadedFile).filter(UploadedFile.file_id == file_id).one()
+            )
+            record.storage_key = f"users/{admin_user.id}/uploads/../{file_id}"
+            db.commit()
+        finally:
+            db.close()
+
+        with caplog.at_level(logging.WARNING, logger="xagent.web.api.files"):
+            with pytest.raises(ValueError, match="Invalid storage key"):
+                client.delete(f"/api/files/{file_id}", headers=auth_headers)
+
+        # No outage warning: the fault is permanent, not a durable outage.
+        assert not [
+            entry
+            for entry in caplog.records
+            if entry.name == "xagent.web.api.files"
+            and "Durable storage unavailable" in entry.getMessage()
+        ], "a malformed persisted key was reported as a durable-storage outage"
+        # The row survives, same as any failed cleanup.
+        db = next(test_app.dependency_overrides[get_db]())
+        try:
+            assert (
+                db.query(UploadedFile).filter(UploadedFile.file_id == file_id).first()
+                is not None
+            )
+        finally:
+            db.close()
+
     def test_delete_file_scope_violation_is_not_reported_as_an_outage(
         self, client, test_db, temp_uploads_dir, auth_headers, monkeypatch, caplog
     ):

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -1643,6 +1643,51 @@ class TestFileManagement:
         finally:
             db.close()
 
+    def test_delete_file_backend_value_error_is_still_a_retryable_outage(
+        self, client, test_db, temp_uploads_dir, auth_headers, monkeypatch, caplog
+    ):
+        """A ValueError from the backend is an outage, not a malformed key.
+
+        ``ScopedFileStorage.delete`` normalizes and then calls ``fs.exists`` /
+        ``fs.rm``, and those raise ``ValueError`` for their own reasons. The
+        malformed-key half of #1473 must not swallow that case: catching
+        ``ValueError`` around the whole call made every backend one permanent,
+        bypassing both the durable-outage log and the retryable 503. The key
+        is validated before the call now, so only the normalization boundary
+        is permanent.
+        """
+        from xagent.core.file_storage.storage import FsspecFileStorage
+
+        _, test_app = test_db
+        upload_response = client.post(
+            "/api/files/upload",
+            files={"file": ("backend-value-error.txt", b"payload", "text/plain")},
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert upload_response.status_code == 200
+        file_id = upload_response.json()["file_id"]
+
+        def backend_value_error(self, key):
+            raise ValueError("backend rejected the request")
+
+        monkeypatch.setattr(FsspecFileStorage, "delete", backend_value_error)
+
+        with caplog.at_level(logging.WARNING, logger="xagent.web.api.files"):
+            response = client.delete(f"/api/files/{file_id}", headers=auth_headers)
+
+        # Retryable, not the permanent 500 a malformed key produces.
+        assert response.status_code == 503, response.text
+        # And it is reported as a durable-storage fault, with its cause.
+        fault_lines = [
+            entry.getMessage()
+            for entry in caplog.records
+            if entry.name == "xagent.web.api.files"
+            and DURABLE_FAULT_LOG_PREFIX in entry.getMessage()
+        ]
+        assert len(fault_lines) == 1, caplog.records
+        assert "durable cleanup before row delete" in fault_lines[0]
+
     def test_delete_file_scope_violation_is_not_reported_as_an_outage(
         self, client, test_db, temp_uploads_dir, auth_headers, monkeypatch, caplog
     ):

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -20,6 +20,7 @@ from xagent.web.models import database as database_module
 from xagent.web.models.database import Base, get_db
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
+from xagent.web.services.managed_file_ref import DURABLE_FAULT_LOG_PREFIX
 
 
 @pytest.fixture(scope="function")
@@ -1630,7 +1631,7 @@ class TestFileManagement:
             entry
             for entry in caplog.records
             if entry.name == "xagent.web.api.files"
-            and "Durable storage unavailable" in entry.getMessage()
+            and DURABLE_FAULT_LOG_PREFIX in entry.getMessage()
         ], "a malformed persisted key was reported as a durable-storage outage"
         # The row survives, same as any failed cleanup.
         db = next(test_app.dependency_overrides[get_db]())
@@ -1690,7 +1691,7 @@ class TestFileManagement:
             entry
             for entry in caplog.records
             if entry.name == "xagent.web.api.files"
-            and "Durable storage unavailable" in entry.getMessage()
+            and DURABLE_FAULT_LOG_PREFIX in entry.getMessage()
         ], "a scope violation was reported as a durable-storage outage"
         # The row survives, same as any failed cleanup.
         db = next(test_app.dependency_overrides[get_db]())

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -1,5 +1,6 @@
 """Test file upload API functionality - Fixed for multi-tenant architecture"""
 
+import logging
 import os
 import tempfile
 from pathlib import Path
@@ -1510,7 +1511,7 @@ class TestFileManagement:
         assert unrelated_cache.exists()
 
     def test_delete_file_keeps_record_when_durable_cleanup_fails(
-        self, client, test_db, temp_uploads_dir, auth_headers, monkeypatch
+        self, client, test_db, temp_uploads_dir, auth_headers, monkeypatch, caplog
     ):
         """Durable cleanup failure should not orphan the object by deleting the row."""
         from xagent.core.file_storage.storage import FsspecFileStorage
@@ -1549,10 +1550,92 @@ class TestFileManagement:
 
         monkeypatch.setattr(FsspecFileStorage, "delete", fail_target_delete)
 
-        response = client.delete(f"/api/files/{file_id}", headers=auth_headers)
+        with caplog.at_level(logging.WARNING, logger="xagent.web.api.files"):
+            response = client.delete(f"/api/files/{file_id}", headers=auth_headers)
 
         assert response.status_code == 503
         assert local_path.exists()
+
+        # End-to-end on the message this endpoint actually composes (#1467).
+        # Asserting through the request rather than by calling the helper with a
+        # hand-built label is the point: a drift in what the endpoint passes --
+        # a wrong variable, a dropped field -- would otherwise be invisible.
+        fault_lines = [
+            logging.Formatter("%(message)s").format(entry)
+            for entry in caplog.records
+            if entry.name == "xagent.web.api.files"
+            and entry.levelno == logging.WARNING
+            and "durable cleanup before row delete" in entry.getMessage()
+        ]
+        assert len(fault_lines) == 1, caplog.records
+        rendered = fault_lines[0]
+        assert f"file_id={file_id}" in rendered
+        assert f"storage_key={storage_key}" in rendered
+        # The cause chain, not just its str(), so the provider class survives.
+        assert "RuntimeError" in rendered
+        assert "simulated durable delete failure" in rendered
+        # The 503 body stays detail-free: the key must not reach the client.
+        assert storage_key not in response.text
+        db = next(test_app.dependency_overrides[get_db]())
+        try:
+            assert (
+                db.query(UploadedFile).filter(UploadedFile.file_id == file_id).first()
+                is not None
+            )
+        finally:
+            db.close()
+
+    def test_delete_file_scope_violation_is_not_reported_as_an_outage(
+        self, client, test_db, temp_uploads_dir, auth_headers, monkeypatch, caplog
+    ):
+        """A containment violation is a permanent authority fault, not a 503.
+
+        ``ScopedFileStorage.delete`` raises ``StorageKeyScopeError`` before it
+        reaches the backend when the key falls outside the bound prefix. The
+        cleanup arm must let it propagate -- retrying cannot clear an
+        authority fault, and the outage warning would point an operator at the
+        wrong subsystem. This was #1473.
+
+        This fixture's app is a bare router with no application-level
+        handlers, so "propagate" here means the exception escapes the
+        endpoint. In production it reaches the dedicated handler registered in
+        ``web/app.py`` (a permanent 500 with a fixed body), whose contract is
+        pinned by ``test_storage_namespace_authority_handler.py``.
+        """
+        from xagent.core.file_storage.scoped import (
+            ScopedFileStorage,
+            StorageKeyScopeError,
+        )
+
+        admin_user, test_app = test_db
+        upload_response = client.post(
+            "/api/files/upload",
+            files={"file": ("scope-violation.txt", b"scope violation", "text/plain")},
+            data={"task_type": "general"},
+            headers=auth_headers,
+        )
+        assert upload_response.status_code == 200
+        file_id = upload_response.json()["file_id"]
+
+        def scope_violating_delete(self, key):
+            raise StorageKeyScopeError(
+                f"Storage key '{key}' is outside the bound prefix"
+            )
+
+        monkeypatch.setattr(ScopedFileStorage, "delete", scope_violating_delete)
+
+        with caplog.at_level(logging.WARNING, logger="xagent.web.api.files"):
+            with pytest.raises(StorageKeyScopeError):
+                client.delete(f"/api/files/{file_id}", headers=auth_headers)
+
+        # No outage warning: the fault is not a durable-storage outage.
+        assert not [
+            entry
+            for entry in caplog.records
+            if entry.name == "xagent.web.api.files"
+            and "Durable storage unavailable" in entry.getMessage()
+        ], "a scope violation was reported as a durable-storage outage"
+        # The row survives, same as any failed cleanup.
         db = next(test_app.dependency_overrides[get_db]())
         try:
             assert (


### PR DESCRIPTION
Split 2/3 of #1476, executing the maintainer's re-slicing ruling. Closes the logging half of #1467. Closes #1473.

**Now based directly on `main`** — the storage-key slice (#1643) merged, this branch is rebased on top of it, and the diff shows only this slice. Code is the nine-round-hardened state from #1476 (`a17c7d1a`), plus two additions: the #1473 fix below, and `storage_key=` at the test constructions that #1643's now-required parameter demands.

## Problem

When a durable-storage operation failed, the only diagnostic reaching the logs was a truncated warning with no `exc_info` — and `files.py:590` was the *only* site that logged anything; the other eight `DurableStorageOperationError` handlers went straight to a 503 with no log line, as did the `/v1/*` resolver. The provider error class, the HTTP status, and throttle vs. timeout vs. rejected credentials existed only in `__cause__`, which every consumer discarded. During the incident behind #1467 we saw bursts of 503s on the upload endpoints and could not determine the cause.

## Change

One shared `log_durable_storage_fault` in `managed_file_ref.py`, beside the exception it reports: the caller's logger (lines stay attributed), a bounded `operation` label, per-request identifiers as `key=value` fields in the message (the deployed formatter never renders `extra=`), escaped and capped at 256 chars against log injection (CWE-117), and a per-instance dedup mark so several arms report one fault once.

In `files.py`, `_raise_durable_storage_unavailable(exc, operation, **fields) -> NoReturn` logs and raises `from exc` internally, so a caller cannot log without raising or raise without logging. Sites: nine in `files.py`, the `/v1/*` turn-attachment resolver, and the KB ingestion tool — whose model-facing message no longer interpolates the exception. Broad absorbers that catch every type (`chat.py` agent-service setup, `kb.py` refresh, `core/workspace.py` resolution) now carry `exc_info` of their own; two of them swallow the fault, so that line is its only record.

**Integrity stays distinct from outage:** `DurableObjectIntegrityError` subclasses `DurableStorageOperationError`, so a parent-first catch would report permanent checksum corruption as a transient outage. The subclass is handled first at all nine pairs here, pinned by an AST test with a closed per-module pair count, with real-path subclass injection at the `/v1/*` resolver and the KB tool.

**#1473, fixed here:** the delete-cleanup arm caught bare `Exception`, folding a permanent `StorageKeyScopeError` into the retryable 503. It now re-raises `_NAMESPACE_AUTHORITY_ERRORS` first, consistent with the rest of the file; a regression pins that a scope violation produces no outage warning and keeps the row.

## Operational note — log messages change

| Before | Now |
| --- | --- |
| `Failed to clean up durable file before deleting row: <key>` (exception discarded) | `Durable storage unavailable during durable cleanup before row delete file_id=<id> storage_key=<key>` |
| *(no log)* at eight `files.py` sites and `/v1/*` | `Durable storage unavailable during <operation> key=value…` |

Key alerts on the stable prefix plus the operation label, not on the field set. `Durable storage unavailable during upload` is unchanged as a substring.

## Tests

`test_durable_storage_fault_logging.py`: the shared helper's chain/503 contract; end-to-end on the incident path via `store_uploaded_files`; a parametrized sweep over all nine `files.py` sites pinning each label and field set, with AST binding checks (`file_id=storage_key` — right keyword, wrong variable — fails); injection and truncation behaviour; real-path integrity at `/v1/*`. `test_managed_file_ref.py`: a case per real wrap site asserting the raised wrap carries *that fault instance* as `__cause__` — dropping `from exc` from all six wraps fails six tests. The KB branch asserts the log carries the chain and the model-facing string carries no key. Every assertion was verified red by mutation.

## Out of scope

#1515 (routing broad absorbers through classification), #1516 (records forgeable via exception text), #1519 (sanitiser character set), #1520 (helper signature hardening), #1521 (ASGI boundary vs. per-site — undecided), #1522 (end-to-end coverage for the seven proxy-covered `files.py` sites), #1642 (residual minors), #1489. WebSocket consumers are split 3/3.

