### PR TITLE
fix(web): name and contain durable-storage faults on the WebSocket paths

### DIFF
--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -126,6 +126,11 @@ from ..services.hot_path_cache import (
     task_cache_ttl_seconds,
     web_task_history_key,
 )
+from ..services.managed_file_ref import (
+    DurableObjectIntegrityError,
+    DurableStorageOperationError,
+    log_durable_storage_fault,
+)
 from ..services.task_command_transport import (
     COMMAND_FAILED,
     COMMAND_ID_PATTERN,
@@ -5935,6 +5940,55 @@ async def _handle_chat_message_unserialized(
             )
         return not delivery_failure_pool_timeout
 
+    async def answer_durable_turn_failure(ack_message: str) -> bool:
+        """Answer a durable turn failure, addressing each audience as #1514 does.
+
+        The two audiences differ deliberately: the sender's rejection ack (and
+        the detail bubble that stands in for it when the ack is suppressed)
+        carries ``ack_message``, while the task-wide broadcast -- which reaches
+        anonymous widget and share guests -- carries the fixed
+        ``CLIENT_SAFE_TASK_FAILURE``.
+
+        The durable arms below precede the ``RuntimeError`` arm they subclass.
+        On main those faults reached that arm and were broadcast from it, so
+        answering with the ack alone would quietly stop notifying the task.
+        This keeps that notification while giving the sender the specific
+        wording each fault deserves.
+
+        Used only by the arms this change adds. The pre-existing arms keep
+        their inline bodies: they landed with #1514, and rewriting them here
+        would re-open reviewed code to no benefit.
+
+        Returns ``False`` when the delivery layer says the caller must stop.
+        """
+        if not await finish_delivery_failure(ack_message):
+            return False
+        timestamp = datetime.now(timezone.utc).timestamp()
+        if authorized_task_id is not None:
+            error_payload = await _read_task_error_payload_offloop(
+                authorized_task_id,
+                CLIENT_SAFE_TASK_FAILURE,
+            )
+            await manager.broadcast_to_task(
+                {**error_payload, "timestamp": timestamp},
+                authorized_task_id,
+            )
+            if suppress_delivery_ack:
+                await manager.send_personal_message(
+                    {
+                        "type": "error",
+                        "message": ack_message,
+                        "timestamp": timestamp,
+                    },
+                    websocket,
+                )
+        else:
+            await manager.send_personal_message(
+                {"type": "error", "message": ack_message, "timestamp": timestamp},
+                websocket,
+            )
+        return True
+
     async def finish_existing_delivery(
         claim: Union[UserMessageDeliveryClaim, _UserMessageDeliverySnapshot],
     ) -> None:
@@ -6679,6 +6733,47 @@ async def _handle_chat_message_unserialized(
                     },
                     websocket,
                 )
+        except DurableObjectIntegrityError:
+            # Precedes the durable-fault arm below, which this subclasses. A
+            # checksum mismatch is permanent corruption, already recorded at
+            # ERROR with both checksums where it is raised, so it must not also
+            # be logged as a transient outage. It still owes the client an
+            # answer, and a distinct one: retrying cannot help, the stored copy
+            # has to be replaced.
+            #
+            # The message is a fixed literal, so it is safe for both audiences
+            # and needs no ``client_safe_error_message`` pass.
+            # Spelled out rather than shared with the outer arm's copy: the
+            # client-safe guard in test_websocket_client_safe_errors resolves a
+            # producer's message only as a literal, a traceable local, or a
+            # forwarded parameter -- a module constant reads as unresolvable
+            # and fails it. The duplication is the price of that check.
+            if not await answer_durable_turn_failure(
+                "A stored file for this message failed its integrity check "
+                "and must be re-uploaded."
+            ):
+                return
+        except DurableStorageOperationError as exc:
+            # Must precede the RuntimeError arm below, which this subclasses.
+            # This is the selected-file attachment path: the fault arrives here
+            # first, is answered to the client, and is swallowed -- so this is
+            # both the only place its provider cause can be recorded and the
+            # last place its text could escape.
+            #
+            # Fixed literal outbound rather than ``str(exc)``: the wrap's own
+            # text is not what a client should read, and this arm is also the
+            # sole logging owner for this path -- the fault does not re-raise,
+            # so the endpoint-level arm never sees it and cannot double-record.
+            log_durable_storage_fault(
+                logger,
+                "websocket agent execution",
+                exc,
+                task_id=authorized_task_id,
+            )
+            if not await answer_durable_turn_failure(
+                "A stored file for this message could not be read. Please try again."
+            ):
+                return
         except RuntimeError as e:
             # Runtime error. The sender's rejection ack keeps the wording
             # (#1479 contract); the task-wide broadcast reaches anonymous
@@ -6743,6 +6838,44 @@ async def _handle_chat_message_unserialized(
     except (ConnectionError, WebSocketDisconnect) as e:
         # Connection error
         logger.error("Connection error handling chat message: %s", e)
+        raise
+    except DurableObjectIntegrityError:
+        # Attachment preparation runs in this outer scope (see the
+        # ``_prepare_websocket_turn_sync`` call above), *before* the inner
+        # agent-execution try. So a stored-file fault surfaces here, not in the
+        # arms guarding that inner block -- which is why the fixed detail has to
+        # be applied at this level too.
+        #
+        # Corruption is permanent: the copy has to be replaced, so the client is
+        # told that rather than to retry. No exception text goes outbound; the
+        # integrity ERROR with both checksums is already logged where it is
+        # raised.
+        # Literal for the same reason as the inner arm above: the client-safe
+        # guard resolves only literals, traceable locals, and parameters.
+        await finish_delivery_failure(
+            "A stored file for this message failed its integrity check "
+            "and must be re-uploaded."
+        )
+        raise
+    except DurableStorageOperationError as exc:
+        # Same scope reasoning as above. ``str(exc)`` is the wrap's message and
+        # carries the storage key, whose scope segments encode the owning user's
+        # id -- it must not reach a socket frame, a persisted rejection, or a
+        # broadcast, any more than it may reach an HTTP body or a model (#1467).
+        #
+        # Logging here rather than leaving it to the endpoint arm: the
+        # durable-command route invokes this handler directly and never reaches
+        # that arm. Double-recording is prevented at the logger, which marks the
+        # fault, so both arms are safe to write independently.
+        log_durable_storage_fault(
+            logger,
+            "websocket chat turn preparation",
+            exc,
+            task_id=task_id,
+        )
+        await finish_delivery_failure(
+            "File storage is temporarily unavailable. Please try again."
+        )
         raise
     except Exception as e:
         # Other errors, re-raise
@@ -7602,6 +7735,36 @@ async def handle_status_request(
     await send_historical_data_as_stream(websocket, task_id, user)
 
 
+# Operation labels for the endpoint-level fault arms, keyed by message type.
+# A closed map rather than interpolation: ``type`` is client-supplied, and
+# ``operation`` is meant to be a bounded, aggregatable value -- it is also not
+# sanitised the way rendered fields are (#1520), so a client must not be able to
+# reach it.
+#
+# Only the message types whose handler lets a fault propagate are listed.
+# ``execute_task`` and ``intervention`` end in ``except RuntimeError``
+# with no re-raise, so a durable fault from either is swallowed there and can
+# never reach the arms below; giving them a label would claim a reachability
+# that does not exist, and the label would read as covered while never being
+# emitted. Making them reachable means giving those two handlers a durable arm
+# of their own, which is absorber work and belongs to #1515 -- at which point
+# they get a label here. ``_SWALLOWED_DISPATCH_TYPES`` in the tests pins the
+# omission against the handlers, so this cannot silently become wrong.
+# ``chat`` is absent for a third reason, distinct from the two above: every
+# fault arm of its handler that re-raises reports through
+# ``log_durable_storage_fault`` first, and the logger marks the instance, so
+# the call here is a no-op rather than a second record. A label for it would
+# name a line that is never emitted.
+# ``test_chat_is_unlabelled_only_because_its_arms_report_first`` pins the
+# report-before-re-raise half against the handler's own arms.
+_DISPATCH_OPERATIONS = {
+    "status_request": "websocket status request",
+    "pause_task": "websocket pause_task",
+    "resume_task": "websocket resume_task",
+}
+_UNKNOWN_DISPATCH_OPERATION = "websocket unknown message type"
+
+
 @ws_router.websocket("/ws/chat/{task_id}")
 async def websocket_chat_endpoint(
     websocket: WebSocket,
@@ -7620,6 +7783,13 @@ async def websocket_chat_endpoint(
 
     await manager.connect(websocket, task_id)
 
+    # Which message the loop is currently applying, for the fault arms below:
+    # they guard the whole dispatch, so a fixed label would report a resume or
+    # an execute_task fault as a chat turn in the one line meant to name it.
+    # Initialised here, not in the loop, because the initial status request runs
+    # before the first message is ever parsed.
+    dispatching = "websocket initial status request"
+
     try:
         # Send initial state
         await handle_status_request(websocket, task_id, user)
@@ -7636,6 +7806,15 @@ async def websocket_chat_endpoint(
             # Add user info to message data
             message_data["user_id"] = user.id
             message_data["user"] = user
+
+            # ``str()`` before the lookup, not for the ``None`` case -- a
+            # missing type misses the map either way -- but because ``type``
+            # is client-supplied and need not be hashable: ``{"type": []}``
+            # would raise ``TypeError`` from ``dict.get`` itself. Every value
+            # that does not name a handler lands on the bounded fallback.
+            dispatching = _DISPATCH_OPERATIONS.get(
+                str(message_data.get("type")), _UNKNOWN_DISPATCH_OPERATION
+            )
 
             if message_data.get("type") == "chat":
                 await handle_chat_message(websocket, task_id, message_data)
@@ -7657,6 +7836,20 @@ async def websocket_chat_endpoint(
 
     except WebSocketDisconnect:
         pass
+    except DurableObjectIntegrityError:
+        # Precedes the parent arm: permanent corruption, already recorded at
+        # ERROR with both checksums where it is raised, so it must not also be
+        # logged as a transient outage. Swallowed exactly as the parent arm
+        # swallows -- the socket is going away either way.
+        pass
+    except DurableStorageOperationError as exc:
+        # Must precede the RuntimeError arm below, which this subclasses. A
+        # storage fault reaching here would otherwise be logged as "Connection
+        # error in WebSocket" and swallowed -- mislabelled and cause-less on
+        # the very path #1467 was filed about. Still swallowed, as before:
+        # the socket is going away regardless and the client has already been
+        # answered; only the diagnosis changes.
+        log_durable_storage_fault(logger, dispatching, exc, task_id=task_id)
     except (ConnectionError, RuntimeError) as e:
         # Connection error
         logger.error(f"Connection error in WebSocket: {e}")

--- a/tests/web/api/test_durable_storage_fault_logging.py
+++ b/tests/web/api/test_durable_storage_fault_logging.py
@@ -24,6 +24,7 @@ from fastapi.datastructures import UploadFile
 
 from xagent.core.file_storage.factory import get_unscoped_file_storage
 from xagent.web.api import files as files_api
+from xagent.web.api import websocket as websocket_api
 from xagent.web.api.v1 import tasks as v1_tasks
 from xagent.web.api.v1.errors import V1ApiError
 from xagent.web.models.user import User
@@ -236,16 +237,16 @@ def test_one_wrap_yields_one_record_however_many_arms_report_it(
 
     with caplog.at_level(logging.WARNING, logger=files_api.logger.name):
         log_durable_storage_fault(
-            files_api.logger, "turn preparation", fault, task_id=42
+            files_api.logger, "websocket chat turn preparation", fault, task_id=42
         )
         log_durable_storage_fault(
-            files_api.logger, "endpoint recovery", fault, task_id=42
+            files_api.logger, "websocket chat turn", fault, task_id=42
         )
 
     # The first arm to report wins, which is the innermost -- the one that knows
     # what it was doing. The coarser endpoint label is the one dropped.
     rendered = _sole_warning(caplog, files_api.logger.name)
-    assert "during turn preparation" in rendered
+    assert "during websocket chat turn preparation" in rendered
     _assert_cause_chain_recorded(rendered)
 
 
@@ -425,8 +426,9 @@ _FAULT_SITES = (
 #
 # Several contracts in this file can only be checked against source: which
 # call sites exist, what they bind, which arms come first, and whether a
-# handler re-raises. Each started as its own hand-rolled walk; these are the
-# pieces they share, and the checks themselves stay separate because they
+# handler re-raises. Each of those started as its own hand-rolled walk, and
+# four near-identical parse-and-search blocks were three too many. These are
+# the pieces they share; the checks themselves stay separate because they
 # assert different things.
 
 
@@ -498,6 +500,16 @@ def _exception_name(node: ast.expr) -> str | None:
     return None
 
 
+def _function_named(tree: ast.Module, name: str) -> ast.AST:
+    """The (async) function definition called ``name``, anywhere in ``tree``."""
+    return next(
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef))
+        and node.name == name
+    )
+
+
 def _handler_types(handler: ast.ExceptHandler) -> list[str]:
     """The exception class names an ``except`` arm names, tuple or not."""
     if handler.type is None:
@@ -510,6 +522,17 @@ def _handler_types(handler: ast.ExceptHandler) -> list[str]:
         ]
     name = _exception_name(handler.type)
     return [name] if name is not None else []
+
+
+def _arms_catching(func: ast.AST, exc_name: str) -> list[ast.ExceptHandler]:
+    """Every ``except`` arm under ``func`` that names ``exc_name``, tuple or not."""
+    return [
+        arm
+        for try_node in ast.walk(func)
+        if isinstance(try_node, ast.Try)
+        for arm in try_node.handlers
+        if exc_name in _handler_types(arm)
+    ]
 
 
 def _durable_arm_pairs(tree: ast.Module) -> list[ast.Try]:
@@ -648,6 +671,246 @@ def test_every_fault_site_label_is_bounded_and_reaches_the_log() -> None:
             )
 
 
+@pytest.mark.parametrize(
+    "hostile_type",
+    [None, [], {}, {"nested": 1}, 42, ["chat"]],
+    ids=["missing", "list", "dict", "mapping", "int", "list-of-valid"],
+)
+def test_an_unhashable_or_absent_message_type_still_resolves_to_a_label(
+    hostile_type: object,
+) -> None:
+    """The dispatch lookup must survive a ``type`` the client chose freely.
+
+    ``message_data`` is decoded JSON, so ``type`` can be any JSON value --
+    including an unhashable one. ``dict.get([])`` raises ``TypeError``, inside
+    the endpoint's message loop, which is why the lookup coerces with ``str()``
+    first. A review read that coercion as a ``None``-to-``"None"`` bug; it is
+    not, because no coerced value names a handler, but nothing pinned the
+    property it actually protects.
+    """
+    resolved = websocket_api._DISPATCH_OPERATIONS.get(
+        str(hostile_type), websocket_api._UNKNOWN_DISPATCH_OPERATION
+    )
+
+    assert resolved in set(websocket_api._DISPATCH_OPERATIONS.values()) | {
+        websocket_api._UNKNOWN_DISPATCH_OPERATION
+    }
+    # A client-chosen value never becomes the label itself.
+    assert str(hostile_type) not in resolved
+
+
+def test_no_client_supplied_message_type_can_become_an_operation_label() -> None:
+    """The label must be a literal from the map, never built from the input.
+
+    ``operation`` is rendered into the message and, unlike the fields beside it,
+    is not escaped or bounded (#1520), so the received ``type`` reaching it would
+    reintroduce the injection this PR closed for fields.
+
+    Asserted against the **call site**, not by re-evaluating the lookup: an
+    earlier version of this test called ``_DISPATCH_OPERATIONS.get(hostile, ...)``
+    itself and claimed that pinned the property. It did not -- rewriting the call
+    site to ``f"websocket {message_data.get('type')}"`` would have left it green,
+    which is the exact leak class it claimed to guard.
+    """
+    endpoint = _function_named(_module_ast(websocket_api), "websocket_chat_endpoint")
+
+    assignments = [
+        node
+        for node in ast.walk(endpoint)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(target, ast.Name) and target.id == "dispatching"
+            for target in node.targets
+        )
+    ]
+    assert assignments, "no assignment to `dispatching` -- the label plumbing moved"
+
+    for node in assignments:
+        value = node.value
+        if isinstance(value, ast.Constant):
+            assert isinstance(value.value, str)
+            continue
+        assert isinstance(value, ast.Call) and isinstance(value.func, ast.Attribute), (
+            f"line {node.lineno}: `dispatching` is built by "
+            f"{ast.unparse(value)!r}; it must be a literal or a lookup in "
+            "_DISPATCH_OPERATIONS, never composed from the received type"
+        )
+        assert value.func.attr == "get"
+        assert (
+            isinstance(value.func.value, ast.Name)
+            and value.func.value.id == "_DISPATCH_OPERATIONS"
+        ), f"line {node.lineno}: lookup is not against _DISPATCH_OPERATIONS"
+        fallback = value.args[1] if len(value.args) > 1 else None
+        assert isinstance(fallback, ast.Name) and fallback.id == (
+            "_UNKNOWN_DISPATCH_OPERATION"
+        ), f"line {node.lineno}: unknown types must fall back to a fixed label"
+
+    # And the values a client can select between are bounded literals.
+    labels = set(websocket_api._DISPATCH_OPERATIONS.values())
+    labels.add(websocket_api._UNKNOWN_DISPATCH_OPERATION)
+    for label in labels:
+        assert label == label.strip()
+        assert not any(char in label for char in "\n\r\t")
+        assert len(label) < 64
+
+
+def test_every_dispatched_message_type_has_a_label() -> None:
+    """The map and the dispatch cascade must not drift apart.
+
+    They are two switches on the same value, kept in step by hand: a seventh
+    handler added to the cascade without a label would log its faults as
+    "unknown message type", which is silent and exactly the mislabelling the
+    map was added to fix.
+    """
+    endpoint = _function_named(_module_ast(websocket_api), "websocket_chat_endpoint")
+    dispatched = {
+        comparator.value
+        for node in ast.walk(endpoint)
+        if isinstance(node, ast.Compare)
+        and isinstance(node.left, ast.Call)
+        and isinstance(node.left.func, ast.Attribute)
+        and node.left.func.attr == "get"
+        and [getattr(arg, "value", None) for arg in node.left.args] == ["type"]
+        for comparator in node.comparators
+        if isinstance(comparator, ast.Constant)
+    }
+
+    assert dispatched, "found no dispatch branches -- the parse assumption broke"
+    labelled = set(websocket_api._DISPATCH_OPERATIONS)
+    unlabelled = _SWALLOWED_DISPATCH_TYPES | _INNER_REPORTED_DISPATCH_TYPES
+    assert dispatched == labelled | unlabelled, (
+        "dispatch cascade and label map disagree: "
+        f"{dispatched ^ (labelled | unlabelled)}"
+    )
+    assert not (labelled & unlabelled), (
+        "a type cannot be both labelled and declared unreachable: "
+        f"{labelled & unlabelled}"
+    )
+    assert not (_SWALLOWED_DISPATCH_TYPES & _INNER_REPORTED_DISPATCH_TYPES), (
+        "a type cannot be declared unlabelled for two different reasons -- "
+        "each omission is pinned by its own test, and they disagree about the "
+        "handler's shape: "
+        f"{_SWALLOWED_DISPATCH_TYPES & _INNER_REPORTED_DISPATCH_TYPES}"
+    )
+
+
+# Message types deliberately absent from the label map because their handler
+# swallows the fault before it can reach the endpoint arm. Declared, not
+# assumed: the test below reads the handlers to confirm it.
+_SWALLOWED_DISPATCH_TYPES = {"execute_task", "intervention"}
+
+# Absent for a different reason: every fault arm of the handler that
+# re-raises reports first, and the shared logger marks the instance, so the
+# endpoint-level call is a no-op. Two tests split that claim between them:
+# ``test_one_wrap_yields_one_record_however_many_arms_report_it`` pins the
+# marker, and ``test_chat_is_unlabelled_only_because_its_arms_report_first``
+# pins the report-before-re-raise shape against the handler's own arms.
+_INNER_REPORTED_DISPATCH_TYPES = {"chat"}
+_SWALLOWING_HANDLERS = {
+    "execute_task": "handle_execute_task",
+    "intervention": "handle_intervention",
+}
+
+
+def test_chat_is_unlabelled_only_because_its_arms_report_first() -> None:
+    """The omission above must stay true of the handler, not just of a comment.
+
+    Leaving ``chat`` out of the label map is only correct while every
+    ``DurableStorageOperationError`` arm in ``_handle_chat_message_unserialized``
+    that re-raises calls ``log_durable_storage_fault`` first: the logger marks
+    the instance, so the endpoint-level call stays a no-op. If an arm stops
+    logging before its bare ``raise``, the fault reaches the endpoint arm
+    unmarked and renders under the fallback label "websocket unknown message
+    type" -- a worse mislabel than the dead ``chat`` entry this omission
+    replaced -- and this test is what says the label must come back.
+
+    Scope, stated so it is not overread: this pins the shape of the arms that
+    re-raise. The marker behaviour itself is pinned by
+    ``test_one_wrap_yields_one_record_however_many_arms_report_it``, and neither
+    test proves that every statement of the handler sits inside a durable
+    ``try``.
+    """
+    func = _function_named(
+        _module_ast(websocket_api), "_handle_chat_message_unserialized"
+    )
+    durable_arms = _arms_catching(func, "DurableStorageOperationError")
+    assert durable_arms, (
+        "_handle_chat_message_unserialized no longer has a "
+        "DurableStorageOperationError arm, so a chat fault reaches the endpoint "
+        "arm unreported and 'chat' needs a label in _DISPATCH_OPERATIONS again"
+    )
+
+    for arm in durable_arms:
+        bare_raises = [
+            node
+            for node in ast.walk(arm)
+            if isinstance(node, ast.Raise) and node.exc is None
+        ]
+        if not bare_raises:
+            # A swallowing arm cannot hand the fault onward to the endpoint.
+            continue
+        log_calls = [
+            node
+            for node in ast.walk(arm)
+            if isinstance(node, ast.Call)
+            and (
+                (
+                    isinstance(node.func, ast.Name)
+                    and node.func.id == "log_durable_storage_fault"
+                )
+                or (
+                    isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "log_durable_storage_fault"
+                )
+            )
+        ]
+        assert log_calls and min(c.lineno for c in log_calls) < min(
+            r.lineno for r in bare_raises
+        ), (
+            f"the DurableStorageOperationError arm at line {arm.lineno} re-raises "
+            "without logging first, so the fault reaches the endpoint arm "
+            "unmarked and renders as 'websocket unknown message type' -- either "
+            "restore the log call before the raise or give 'chat' a label in "
+            "_DISPATCH_OPERATIONS"
+        )
+
+
+@pytest.mark.parametrize(
+    ("dispatch_type", "handler"), sorted(_SWALLOWING_HANDLERS.items())
+)
+def test_a_type_is_unlabelled_only_because_its_handler_swallows(
+    dispatch_type: str, handler: str
+) -> None:
+    """The omission above must stay true of the code, not just of a comment.
+
+    Leaving these two out of the label map is only correct while their handlers
+    end in ``except RuntimeError`` without re-raising, because that is what stops
+    a durable fault ever reaching the arm that would use the label. If someone
+    adds a re-raise -- or a durable arm, which is the #1515 work -- the type
+    becomes reachable and needs a label, and this is what says so.
+    """
+    func = _function_named(_module_ast(websocket_api), handler)
+    # ``_arms_catching`` also sees tuple arms (``except (A, RuntimeError)``),
+    # which the hand-rolled predecessor of this walk missed.
+    runtime_arms = _arms_catching(func, "RuntimeError")
+
+    assert runtime_arms, f"{handler} no longer has an except RuntimeError arm"
+    for arm in runtime_arms:
+        reraises = any(
+            isinstance(node, ast.Raise) and node.exc is None for node in ast.walk(arm)
+        )
+        assert not reraises, (
+            f"{handler}'s RuntimeError arm now re-raises, so {dispatch_type!r} "
+            "can reach the endpoint fault arm and needs a label in "
+            "_DISPATCH_OPERATIONS"
+        )
+
+
+# Every module carrying an integrity/parent arm pair. The ordering below is a
+# safety property, not a style rule: ``DurableObjectIntegrityError`` subclasses
+# ``DurableStorageOperationError``, so a parent arm placed first makes the child
+# arm dead and reports permanent corruption as a retryable outage -- loud enough
+# to trip the alerts that watch for one, and burying the real diagnosis.
 # The counts are part of the contract: the walker can only check the pairs it
 # finds, so a deleted integrity arm removes its pair from sight rather than
 # failing the ordering assert. Pinning how many pairs each module carries is
@@ -657,6 +920,7 @@ def test_every_fault_site_label_is_bounded_and_reaches_the_log() -> None:
 # not derived.)
 _MODULES_WITH_DURABLE_ARM_PAIRS = (
     ("web/api/files.py", 7, lambda: files_api),
+    ("web/api/websocket.py", 3, lambda: websocket_api),
     ("web/api/v1/tasks.py", 1, lambda: v1_tasks),
     (
         "core/tools/adapters/vibe/file_ingestion_tool.py",
@@ -671,13 +935,29 @@ _MODULES_WITH_DURABLE_ARM_PAIRS = (
 # ``_raise_durable_storage_unavailable`` wrapper, whose own forwarding call
 # passes its caller's label along as a parameter -- the one site whose label
 # is legitimately not a literal, pinned by the files.py sweep instead.
+# Each direct site by module, label, and the fields it must carry. The fields
+# are part of the contract, not decoration: a label without its correlators
+# cannot be joined to the request that produced it, and a review found the
+# compensation site could have lost or swapped ``user_id``/``task_id`` while
+# a label-only table stayed green.
 _DIRECT_HELPER_SITES = frozenset(
     {
-        ("web/api/files.py", "upload compensation"),
-        ("web/api/v1/tasks.py", "turn attachment resolution"),
+        ("web/api/files.py", "upload compensation", ("user_id", "task_id")),
+        (
+            "web/api/v1/tasks.py",
+            "turn attachment resolution",
+            ("task_id", "owner_user_id", "file_ids"),
+        ),
+        (
+            "web/api/websocket.py",
+            "websocket chat turn preparation",
+            ("task_id",),
+        ),
+        ("web/api/websocket.py", "websocket agent execution", ("task_id",)),
         (
             "core/tools/adapters/vibe/file_ingestion_tool.py",
             "knowledge-base file restore",
+            ("file_id",),
         ),
     }
 )
@@ -691,6 +971,11 @@ _BOUNDED_NON_LITERAL_LABELS = {
     # The wrapper forwarding its caller's label; the literals live at its
     # callers, where the files.py sweep above checks them.
     ("web/api/files.py", "operation"),
+    # The endpoint fault arm's dispatch label. Bounded by ``_DISPATCH_OPERATIONS``
+    # being a closed map with a fixed fallback -- a client-supplied ``type``
+    # cannot reach it -- which ``test_no_client_supplied_message_type_can_become
+    # _an_operation_label`` pins at the call site itself.
+    ("web/api/websocket.py", "dispatching"),
 }
 
 
@@ -706,8 +991,9 @@ def test_every_direct_helper_site_is_declared_with_a_bounded_label() -> None:
     prevent) fails wherever it appears.
     """
     package_root = Path(files_api.__file__).parents[2]
-    found: set[tuple[str, str]] = set()
+    found: set[tuple[str, str, tuple[str, ...]]] = set()
     forwarding: list[str] = []
+    seen_calls: list[str] = []
     for path in _package_modules(package_root):
         module_label = path.relative_to(package_root).as_posix()
         tree = _parse_module_file(path)
@@ -728,7 +1014,20 @@ def test_every_direct_helper_site_is_declared_with_a_bounded_label() -> None:
                     f"{module_label}:{node.lineno} passes **kwargs to the "
                     "helper, so its field names are not checkable here"
                 )
-                found.add((module_label, label_node.value))
+                seen_calls.append(f"{module_label}:{node.lineno}")
+                fields = tuple(str(kw.arg) for kw in node.keywords)
+                # Names alone are not the contract: ``task_id=user_id`` would
+                # declare the right field and render the wrong value. The
+                # binding check is the same one the files.py sweep applies.
+                for keyword in node.keywords:
+                    assert keyword.arg is not None and _binds_a_matching_name(
+                        keyword.arg, keyword.value
+                    ), (
+                        f"{module_label}:{node.lineno} binds {keyword.arg}= to "
+                        f"{ast.unparse(keyword.value)!r}, which never reads "
+                        f"{keyword.arg}"
+                    )
+                found.add((module_label, label_node.value, fields))
             elif (
                 isinstance(label_node, ast.Name)
                 and (module_label, label_node.id) in _BOUNDED_NON_LITERAL_LABELS
@@ -747,8 +1046,15 @@ def test_every_direct_helper_site_is_declared_with_a_bounded_label() -> None:
 
     assert found == set(_DIRECT_HELPER_SITES), (
         f"direct helper sites changed: {found ^ set(_DIRECT_HELPER_SITES)} -- "
-        "declare the new site with its bounded label, or fix a label that "
-        "stopped being a string literal"
+        "declare the new site with its bounded label and the fields it must "
+        "carry, or fix a site whose label or field set drifted"
+    )
+    # An exact count on top of the set comparison: a second call with a label
+    # and fields already declared would collapse into the same set element and
+    # go unnoticed otherwise.
+    assert len(seen_calls) == len(_DIRECT_HELPER_SITES), (
+        f"{len(seen_calls)} direct helper calls but "
+        f"{len(_DIRECT_HELPER_SITES)} declared: {sorted(seen_calls)}"
     )
     assert set(forwarding) == {
         f"{module}:{name}" for module, name in _BOUNDED_NON_LITERAL_LABELS
@@ -756,6 +1062,54 @@ def test_every_direct_helper_site_is_declared_with_a_bounded_label() -> None:
         "the declared bounded-variable labels and the ones actually passed "
         f"disagree: {sorted(forwarding)} vs {sorted(_BOUNDED_NON_LITERAL_LABELS)}"
     )
+
+
+def test_the_inner_durable_arms_still_notify_the_task() -> None:
+    """The arms this change inserts must not drop the notification they intercept.
+
+    ``DurableStorageOperationError`` and ``DurableObjectIntegrityError`` both
+    subclass ``RuntimeError``, so before these arms existed such a fault
+    reached the ``RuntimeError`` arm below them, which acknowledges the sender
+    *and* broadcasts ``CLIENT_SAFE_TASK_FAILURE`` to the task. Answering with
+    the acknowledgement alone would quietly stop notifying that audience --
+    which is why both arms go through ``answer_durable_turn_failure``, and why
+    that helper is the only thing standing between them and the regression.
+
+    Structural, and deliberately labelled as such: the inner agent-execution
+    block has no behavioural harness in this suite (it is one of the pairs
+    #1522 covers), so this pins the routing rather than the frames. It fails
+    if an arm reverts to calling ``finish_delivery_failure`` directly.
+    """
+    func = _function_named(
+        _module_ast(websocket_api), "_handle_chat_message_unserialized"
+    )
+    inner_arms = [
+        arm
+        for arm in _arms_catching(func, "DurableStorageOperationError")
+        + _arms_catching(func, "DurableObjectIntegrityError")
+        # The outer arms re-raise; the inner ones swallow, and only those
+        # inherit the broadcast the RuntimeError arm used to perform.
+        if not any(
+            isinstance(node, ast.Raise) and node.exc is None for node in ast.walk(arm)
+        )
+    ]
+    assert len(inner_arms) == 2, (
+        f"expected the two swallowing durable arms, found {len(inner_arms)} -- "
+        "an arm changed between re-raising and swallowing, which changes "
+        "whether it owes the task a broadcast"
+    )
+    for arm in inner_arms:
+        answered = [
+            node
+            for node in ast.walk(arm)
+            if isinstance(node, ast.Call)
+            and _callee_name(node) == "answer_durable_turn_failure"
+        ]
+        assert answered, (
+            f"the durable arm at line {arm.lineno} answers without "
+            "answer_durable_turn_failure, so the task-wide broadcast the "
+            "RuntimeError arm performs is silently dropped for this fault"
+        )
 
 
 def test_every_module_with_an_arm_pair_is_in_the_table() -> None:
@@ -793,22 +1147,24 @@ def _file_ingestion_tool() -> Any:
 def test_the_integrity_arm_precedes_its_parent_at_every_site(
     label: str, expected: int, loader: Any
 ) -> None:
-    """Checked at all nine pairs, because three of them have no other guard.
+    """Checked at all twelve pairs, because five of them have no other guard.
 
-    Measured, not estimated -- an earlier version of this docstring claimed
-    seven of the nine were unguarded, which was more than twice the truth.
-    Neutralising each integrity arm in turn and running the suite shows six
-    pairs are caught behaviourally: ``_durable_redirect_response``,
-    ``download_file``, ``preview_file`` and the first ``public_preview_file``
-    pair (by the five ``*_checksum_mismatch_asks_user_to_reupload`` tests),
-    plus ``v1/tasks.py`` and ``file_ingestion_tool`` (by the real-path
-    injections in this file and ``test_kb_creation_tools``).
+    Measured, not estimated -- an earlier version of this docstring put the
+    unguarded count at more than twice the truth. Neutralising each integrity
+    arm in turn and running the suite shows seven pairs are caught
+    behaviourally: ``_durable_redirect_response``, ``download_file``,
+    ``preview_file`` and the first ``public_preview_file`` pair (by the five
+    ``*_checksum_mismatch_asks_user_to_reupload`` tests), ``v1/tasks.py`` and
+    ``file_ingestion_tool`` (by the real-path injections in this file and
+    ``test_kb_creation_tools``), and the outer ``websocket.py`` pair (by
+    ``test_a_durable_integrity_fault_is_answered_as_corruption_not_an_outage``).
 
-    The three where a swapped or deleted arm changes behaviour with no
+    The five where a swapped or deleted arm changes behaviour with no
     behavioural test failing are ``preview_pptx_as_pdf``,
-    ``public_download_file``, and the second ``public_preview_file`` pair --
-    the task-asset one. Those are what this check is load-bearing for; giving
-    them real end-to-end coverage is #1522.
+    ``public_download_file``, the second ``public_preview_file`` pair (the
+    task-asset one), and the two remaining ``websocket.py`` pairs -- the inner
+    agent-execution one and the endpoint-level one. Those are what this check
+    is load-bearing for; giving them real end-to-end coverage is #1522.
 
     This does not replace the behavioural tests: it proves ordering, not that
     each arm answers correctly. What it adds is that the one regression which

--- a/tests/web/api/test_upload_connection_boundary.py
+++ b/tests/web/api/test_upload_connection_boundary.py
@@ -28,6 +28,7 @@ from xagent.web.api.public_chat_access import (
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
 from xagent.web.services.managed_file_ref import (
+    DURABLE_FAULT_LOG_PREFIX,
     DurableStorageOperationError,
     ManagedFileRef,
 )
@@ -811,6 +812,7 @@ async def test_cancel_after_upload_registration_compensates_metadata_and_bytes(
 async def test_failed_compensation_does_not_skip_request_local_cleanup(
     monkeypatch: pytest.MonkeyPatch,
     isolated_upload_storage,
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     _upload_root, _object_root = isolated_upload_storage
     _admin_headers()
@@ -860,6 +862,21 @@ async def test_failed_compensation_does_not_skip_request_local_cleanup(
 
     assert local_paths
     assert all(not path.exists() for path in local_paths)
+
+    # The double fault -- the upload failed against durable storage and
+    # compensating against it failed too -- is the incident this reporting
+    # exists for, so it must not be recorded as an unlabelled traceback. The
+    # AST sweep pins that the site declares these fields; this pins that the
+    # record actually carries them, with the values from this request.
+    fault_lines = [
+        record.getMessage()
+        for record in caplog.records
+        if record.name == "xagent.web.api.files"
+        and DURABLE_FAULT_LOG_PREFIX in record.getMessage()
+    ]
+    assert len(fault_lines) == 1, caplog.records
+    assert "upload compensation" in fault_lines[0]
+    assert f"user_id={user_id}" in fault_lines[0]
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -3934,3 +3934,270 @@ async def test_resume_non_owner_non_admin_is_refused(db_session) -> None:
     # Authorized away before any runtime is built; an error is sent back.
     assert "task_owner_user_id" not in captured
     ws_manager.send_personal_message.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_durable_attachment_failure_keeps_the_storage_key_off_the_socket(
+    db_session,
+    caplog,
+) -> None:
+    """A stored-file fault must not send the storage key to the client.
+
+    Attachment preparation runs in the handler's *outer* scope, so this fault
+    surfaces before the inner agent-execution arms and was answered with
+    ``str(exc)``, which then read
+    ``Failed to restore durable object: users/<id>/uploads/...`` and embedded the
+    owning user's id. Same defect as the model-facing leak in #1467, one
+    transport over.
+
+    The key has since moved off the message onto ``storage_key``, so ``str(exc)``
+    no longer carries it and this arm is no longer the only thing standing
+    between the fault and the client. Both still matter: this pins the arm's
+    fixed message, and ``test_the_wrap_keeps_the_storage_key_out_of_its_own_message``
+    pins the exception. Neither alone would have caught both rounds of this.
+
+    What this proves is the *rejection frame*: it asserts one was sent, so the
+    negative assertions below cannot pass over an empty list. The broadcast
+    assertion is defence in depth -- this path does not broadcast, so it holds
+    vacuously and exists to fail if a future edit starts. The persisted
+    rejection is not reached: ``finish_delivery_failure`` only writes when
+    ``delivery_claimed`` is set, and that comes from
+    ``preparation.delivery_claimed``, which never gets assigned when preparation
+    is what raised. Do not read this test as covering all three egresses.
+    """
+    import logging
+
+    from xagent.web.services.managed_file_ref import DurableStorageOperationError
+
+    owner = _user(db_session, "durable-leak-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.COMPLETED)
+    owner_id = int(owner.id)
+    task_id = int(task.id)
+    db_session.close()
+
+    storage_key = f"users/{owner_id}/uploads/8ac1f2/quarterly-report.xlsx"
+
+    class _ProviderThrottled(RuntimeError):
+        pass
+
+    def failing_prepare(**_kwargs):
+        wrap = DurableStorageOperationError(
+            "Failed to restore durable object", storage_key=storage_key
+        )
+        wrap.__cause__ = _ProviderThrottled("SlowDown: reduce your request rate")
+        raise wrap
+
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    logger_name = "xagent.web.api.websocket"
+
+    with (
+        patch(
+            "xagent.web.api.websocket._prepare_websocket_turn_sync",
+            side_effect=failing_prepare,
+        ),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        caplog.at_level(logging.WARNING, logger=logger_name),
+    ):
+        with pytest.raises(DurableStorageOperationError):
+            await _handle_chat_message_unserialized(
+                MagicMock(),
+                task_id,
+                {
+                    "message": "with an attachment",
+                    "client_message_id": "durable-leak-probe",
+                    "user": SimpleNamespace(id=owner_id, is_admin=False),
+                    "files": ["8ac1f2"],
+                },
+            )
+
+    # The rejection frame must actually have gone out, or every negative
+    # assertion below would hold over nothing and this test would pass while
+    # answering the client with anything at all.
+    frames = [str(call) for call in ws_manager.send_personal_message.await_args_list]
+    assert any("message_rejected" in frame for frame in frames), frames
+
+    # Every outbound egress: nothing may carry the key or the provider text.
+    outbound = frames + [
+        str(call) for call in ws_manager.broadcast_to_task.await_args_list
+    ]
+    for payload in outbound:
+        assert storage_key not in payload
+        assert f"users/{owner_id}" not in payload
+        assert "Failed to restore durable object" not in payload
+        assert "SlowDown" not in payload
+
+    # The server-side record keeps the whole chain, exactly once.
+    fault_lines = [
+        logging.Formatter("%(message)s").format(entry)
+        for entry in caplog.records
+        if entry.name == logger_name
+        and "Durable storage unavailable" in entry.getMessage()
+    ]
+    assert len(fault_lines) == 1, fault_lines
+    assert "during websocket chat turn preparation" in fault_lines[0]
+    assert storage_key in fault_lines[0]
+    assert "_ProviderThrottled" in fault_lines[0]
+
+
+@pytest.mark.asyncio
+async def test_a_dispatch_fault_is_labelled_with_the_message_that_failed(
+    db_session,
+    caplog,
+) -> None:
+    """The endpoint arm must name the message it was applying, not "chat turn".
+
+    That arm guards the whole receive-loop dispatch, so it sees faults from
+    every message type whose handler lets one through. It logged a fixed
+    ``"websocket chat turn"``, mislabelling all of them in the single line meant
+    to be authoritative about what failed.
+
+    ``resume_task`` rather than ``execute_task``, and the difference matters:
+    ``handle_execute_task`` ends in ``except RuntimeError`` with no re-raise, so
+    a durable fault there never reaches this arm at all. An earlier version of
+    this test mocked that handler and asserted a label for a path production
+    cannot take -- green, and describing nothing.
+    ``handle_resume_task`` propagates, so mocking it to raise stands in for a
+    real fault, and
+    ``test_a_type_is_unlabelled_only_because_its_handler_swallows`` is what keeps
+    that distinction true rather than remembered.
+
+    Driven through the real endpoint, because neither the label map nor its
+    agreement with the cascade would notice this arm going back to a constant.
+    """
+    import json
+    import logging
+
+    from fastapi import WebSocketDisconnect
+
+    from xagent.web.services.managed_file_ref import DurableStorageOperationError
+
+    owner = _user(db_session, "dispatch-label-owner")
+    task = _task(db_session, owner.id)
+    owner_id = int(owner.id)
+    task_id = int(task.id)
+    db_session.close()
+
+    websocket = MagicMock()
+    websocket.receive_text = AsyncMock(
+        side_effect=[json.dumps({"type": "resume_task"}), WebSocketDisconnect()]
+    )
+    ws_manager = MagicMock(
+        connect=AsyncMock(),
+        disconnect=MagicMock(),
+        send_personal_message=AsyncMock(),
+        broadcast_to_task=AsyncMock(),
+    )
+    logger_name = "xagent.web.api.websocket"
+
+    with (
+        patch.object(websocket_api, "manager", ws_manager),
+        patch.object(
+            websocket_api,
+            "get_authenticated_user",
+            AsyncMock(return_value=SimpleNamespace(id=owner_id, is_admin=False)),
+        ),
+        patch.object(websocket_api, "handle_status_request", AsyncMock()),
+        patch.object(
+            websocket_api,
+            "handle_resume_task",
+            AsyncMock(
+                side_effect=DurableStorageOperationError(
+                    "Failed to restore durable object",
+                    storage_key=f"users/{owner_id}/uploads/a/b.txt",
+                )
+            ),
+        ),
+        caplog.at_level(logging.WARNING, logger=logger_name),
+    ):
+        await websocket_api.websocket_chat_endpoint(websocket, task_id, None)
+
+    fault_lines = [
+        entry.getMessage()
+        for entry in caplog.records
+        if entry.name == logger_name
+        and "Durable storage unavailable" in entry.getMessage()
+    ]
+    assert len(fault_lines) == 1, fault_lines
+    assert "during websocket resume_task" in fault_lines[0]
+    assert "chat turn" not in fault_lines[0]
+    # The key still reaches the log, from the attribute rather than the message.
+    assert f"storage_key=users/{owner_id}/uploads/a/b.txt" in fault_lines[0]
+
+
+@pytest.mark.asyncio
+async def test_a_durable_integrity_fault_is_answered_as_corruption_not_an_outage(
+    db_session,
+    caplog,
+) -> None:
+    """The integrity subclass through the real cascade, not just the parent.
+
+    ``test_durable_attachment_failure_keeps_the_storage_key_off_the_socket``
+    injects only ``DurableStorageOperationError``, so it would pass with these
+    two arms swapped -- the parent would catch the subclass and tell the client
+    to retry something retrying cannot fix, while emitting a transient-outage
+    warning over the permanent-corruption ERROR already logged upstream.
+
+    Ordering is checked across all twelve pairs by
+    ``test_the_integrity_arm_precedes_its_parent_at_every_site``; this is what
+    proves this pair's arms also produce the right answers.
+    """
+    import logging
+
+    from xagent.web.services.managed_file_ref import (
+        FILE_INTEGRITY_REUPLOAD_MESSAGE,
+        DurableObjectIntegrityError,
+    )
+
+    owner = _user(db_session, "integrity-answer-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.COMPLETED)
+    owner_id = int(owner.id)
+    task_id = int(task.id)
+    db_session.close()
+
+    def failing_prepare(**_kwargs):
+        raise DurableObjectIntegrityError(
+            FILE_INTEGRITY_REUPLOAD_MESSAGE,
+            storage_key="users/7/uploads/8ac1f2/corrupt.txt",
+        )
+
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    logger_name = "xagent.web.api.websocket"
+
+    with (
+        patch(
+            "xagent.web.api.websocket._prepare_websocket_turn_sync",
+            side_effect=failing_prepare,
+        ),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        caplog.at_level(logging.WARNING, logger=logger_name),
+    ):
+        with pytest.raises(DurableObjectIntegrityError):
+            await _handle_chat_message_unserialized(
+                MagicMock(),
+                task_id,
+                {
+                    "message": "with a corrupted attachment",
+                    "client_message_id": "integrity-probe",
+                    "user": SimpleNamespace(id=owner_id, is_admin=False),
+                    "files": ["8ac1f2"],
+                },
+            )
+
+    frames = [str(call) for call in ws_manager.send_personal_message.await_args_list]
+    assert any("message_rejected" in frame for frame in frames), frames
+    # Told to re-upload, not to retry: retrying cannot repair corruption.
+    assert any("integrity check" in frame for frame in frames), frames
+    assert not any("temporarily unavailable" in frame for frame in frames), frames
+
+    assert not [
+        entry
+        for entry in caplog.records
+        if entry.name == logger_name
+        and "Durable storage unavailable" in entry.getMessage()
+    ], "an integrity fault emitted an outage warning -- the arms are misordered"


### PR DESCRIPTION
The WebSocket half of #1467, now based directly on `main` after #1644 merged. Reconciled with #1514, which landed first and rewrote the same failure arms — see below, that reconciliation is the part most worth reviewing.

## Problem

A durable fault on the chat-attachment path — the incident path of #1467 — was caught by the terminal `except (ConnectionError, RuntimeError)` arm, logged as `"Connection error in WebSocket"` with no `exc_info`, and swallowed: mislabelled and cause-less, on exactly the path the issue was filed about. `DurableStorageOperationError` is a `RuntimeError`, so nothing named it.

## Change

- The chat handler gets `DurableObjectIntegrityError` and `DurableStorageOperationError` arms ahead of the `RuntimeError` arm they subclass, in both the outer (attachment preparation) and inner (agent execution) scopes. Each answers the client with a fixed literal — an integrity fault says re-upload, because retrying cannot repair corruption — and the durable arms log through the shared helper. The inner arms are the sole logging owner for their path, since they do not re-raise.
- The endpoint-level arm derives its label from the dispatched message through a **closed** `_DISPATCH_OPERATIONS` map: `type` is client-supplied and `operation` is a bounded aggregation key, so a client must not be able to mint labels. Types absent from the map are absent for a declared reason — their handler swallows, or an inner arm already reported — and the tests read those handlers rather than trusting the comment.

## Reconciliation with #1514

This branch previously carried an `answer_turn_failure` extraction over all four failure arms. **It is gone**, because #1514 made those arms deliberately asymmetric: the sender's rejection ack keeps the specific wording while the task-wide broadcast — which reaches anonymous widget and share guests — carries the fixed `CLIENT_SAFE_TASK_FAILURE`. The extraction broadcast each arm's own message, so re-applying it on top of #1514 would have flattened that asymmetry and re-opened the leak #1514 closed. The pre-existing arms keep their inline bodies untouched.

The two arms this PR adds do need that notification, though: on `main` those faults reached the `RuntimeError` arm and were broadcast from it, so answering with the ack alone would quietly stop notifying the task. They go through `answer_durable_turn_failure`, which encodes the asymmetry explicitly — ack varies, broadcast is always the fixed string — and is used only by the arms added here.

**This branch deletes nothing from `main`'s production code.**

## Tests

The chat-attachment regression asserts the rejection frame carries neither the storage key nor provider text; an integrity fault is answered as corruption rather than outage; a `resume_task` fault is labelled with the message that failed (its handler propagates, unlike `execute_task`'s, and a test reads both so that distinction cannot rot); the label call site is pinned by AST against interpolating the client's `type`; and the integrity-ordering table extends to all twelve pairs across four modules, with the measured behavioural-vs-structural split stated in its docstring.

Also folded in from #1644's review: the direct-helper site table now declares each site's fields, checks their bindings and counts occurrences, with a real `caplog` assertion on the compensation record (R1-7); and the dispatch lookup's `str()` coercion is documented for what it actually guards — an unhashable client-supplied `type`, which would raise `TypeError` from `dict.get` itself — with a parametrized test.

## Out of scope

#1515 (`execute_task`/`intervention` durable arms), #1479 (pause/resume surfacing `RuntimeError` text — a pinned tested contract), #1522 (behavioural coverage for the inner agent-execution pair and the endpoint-level pair; the routing that keeps their broadcast is pinned structurally here), #1718, #1642.
