### PR TITLE
refactor(chat): serialize attachment uploads

### DIFF
--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -1529,6 +1529,122 @@ describe("ChatInput", () => {
     expect(container.querySelector('button[type="submit"]')).toBeDisabled()
   })
 
+  it("cancels the selected duplicate file upload", async () => {
+    let firstSignal: AbortSignal | undefined
+    const first = new File(["one"], "duplicate.txt", {
+      type: "text/plain",
+      lastModified: 1,
+    })
+    const second = new File(["two"], "duplicate.txt", {
+      type: "text/plain",
+      lastModified: 1,
+    })
+
+    apiRequestMock.mockImplementation((url: string, init?: RequestInit) => {
+      if (url === "http://upload.local/api/files/upload") {
+        firstSignal ??= init?.signal ?? undefined
+        return new Promise<Response>(() => {})
+      }
+      return Promise.resolve(emptyJsonResponse())
+    })
+
+    function Harness() {
+      const [files, setFiles] = React.useState<File[]>([])
+
+      return (
+        <ChatInput
+          hideConfig
+          inputValue=""
+          files={files}
+          onFilesChange={setFiles}
+          onInputChange={vi.fn()}
+          onSend={vi.fn()}
+        />
+      )
+    }
+
+    const { container } = render(<Harness />)
+    const fileInput = container.querySelector("input[type=\"file\"]") as HTMLInputElement
+
+    fireEvent.change(fileInput, { target: { files: [first] } })
+    await waitFor(() => {
+      expect(firstSignal).toBeDefined()
+    })
+
+    fireEvent.change(fileInput, { target: { files: [second] } })
+    fireEvent.click(screen.getAllByTitle("common.cancel")[0])
+
+    expect(firstSignal?.aborted).toBe(true)
+  })
+
+  it("serializes files within and across selections", async () => {
+    let resolveFirst!: (value: { file_id: string }) => void
+    let resolveSecond!: (value: { file_id: string }) => void
+    const firstUpload = new Promise<{ file_id: string }>((resolve) => {
+      resolveFirst = resolve
+    })
+    const secondUpload = new Promise<{ file_id: string }>((resolve) => {
+      resolveSecond = resolve
+    })
+    const uploadFile = vi.fn()
+      .mockReturnValueOnce(firstUpload)
+      .mockReturnValueOnce(secondUpload)
+      .mockResolvedValueOnce({ file_id: "file-3" })
+    const first = new File(["one"], "one.txt", { type: "text/plain" })
+    const second = new File(["two"], "two.txt", { type: "text/plain" })
+    const third = new File(["three"], "three.txt", { type: "text/plain" })
+
+    function Harness() {
+      const [files, setFiles] = React.useState<File[]>([])
+
+      return (
+        <ChatInput
+          hideConfig
+          inputValue=""
+          files={files}
+          onFilesChange={setFiles}
+          onInputChange={vi.fn()}
+          onSend={vi.fn()}
+          uploadFile={uploadFile}
+        />
+      )
+    }
+
+    const { container } = render(<Harness />)
+    const fileInput = container.querySelector("input[type=\"file\"]") as HTMLInputElement
+
+    fireEvent.change(fileInput, { target: { files: [first, second] } })
+    await waitFor(() => {
+      expect(uploadFile).toHaveBeenCalledWith(
+        first,
+        expect.objectContaining({ taskType: "task" }),
+      )
+    })
+
+    fireEvent.change(fileInput, { target: { files: [third] } })
+
+    expect(uploadFile).toHaveBeenCalledOnce()
+
+    resolveFirst({ file_id: "file-1" })
+
+    await waitFor(() => {
+      expect(uploadFile).toHaveBeenCalledWith(
+        second,
+        expect.objectContaining({ taskType: "task" }),
+      )
+    })
+    expect(uploadFile).toHaveBeenCalledTimes(2)
+
+    resolveSecond({ file_id: "file-2" })
+
+    await waitFor(() => {
+      expect(uploadFile).toHaveBeenCalledWith(
+        third,
+        expect.objectContaining({ taskType: "task" }),
+      )
+    })
+  })
+
   it("keeps pause hidden while running draft files are still uploading", async () => {
     const onPause = vi.fn()
     const uploadFile = vi.fn(() => new Promise<{ file_id: string }>(() => {}))

--- a/frontend/src/components/chat/ChatInput.test.tsx
+++ b/frontend/src/components/chat/ChatInput.test.tsx
@@ -1645,6 +1645,102 @@ describe("ChatInput", () => {
     })
   })
 
+  it("serializes default upload requests within and across selections", async () => {
+    let resolveFirst!: (response: Response) => void
+    let resolveSecond!: (response: Response) => void
+    const firstUpload = new Promise<Response>((resolve) => {
+      resolveFirst = resolve
+    })
+    const secondUpload = new Promise<Response>((resolve) => {
+      resolveSecond = resolve
+    })
+    const uploadUrl = "http://upload.local/api/files/upload"
+    const first = new File(["one"], "one.txt", { type: "text/plain" })
+    const second = new File(["two"], "two.txt", { type: "text/plain" })
+    const third = new File(["three"], "three.txt", { type: "text/plain" })
+
+    apiRequestMock.mockImplementation((url: string) => {
+      if (url !== uploadUrl) {
+        return Promise.resolve(emptyJsonResponse())
+      }
+
+      const uploadCount = apiRequestMock.mock.calls.filter(
+        ([requestUrl]) => requestUrl === uploadUrl,
+      ).length
+      if (uploadCount === 1) {
+        return firstUpload
+      }
+      if (uploadCount === 2) {
+        return secondUpload
+      }
+      return Promise.resolve(new Response(JSON.stringify({
+        success: true,
+        file_id: "file-3",
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }))
+    })
+
+    function Harness() {
+      const [files, setFiles] = React.useState<File[]>([])
+
+      return (
+        <ChatInput
+          hideConfig
+          inputValue=""
+          files={files}
+          onFilesChange={setFiles}
+          onInputChange={vi.fn()}
+          onSend={vi.fn()}
+        />
+      )
+    }
+
+    const { container } = render(<Harness />)
+    const fileInput = container.querySelector("input[type=\"file\"]") as HTMLInputElement
+    const uploadCalls = () => apiRequestMock.mock.calls.filter(
+      ([url]) => url === uploadUrl,
+    )
+
+    fireEvent.change(fileInput, { target: { files: [first, second] } })
+    await waitFor(() => {
+      expect(uploadCalls()).toHaveLength(1)
+    })
+    expect(((uploadCalls()[0][1] as RequestInit).body as FormData).get("file")).toBe(first)
+
+    fireEvent.change(fileInput, { target: { files: [third] } })
+
+    expect(uploadCalls()).toHaveLength(1)
+    expect(container.querySelector('button[type="submit"]')).toBeDisabled()
+
+    resolveFirst(new Response(JSON.stringify({ success: true, file_id: "file-1" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+
+    await waitFor(() => {
+      expect(uploadCalls()).toHaveLength(2)
+    })
+    expect(((uploadCalls()[1][1] as RequestInit).body as FormData).get("file")).toBe(second)
+
+    resolveSecond(new Response(JSON.stringify({ success: true, file_id: "file-2" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+
+    await waitFor(() => {
+      expect(uploadCalls()).toHaveLength(3)
+    })
+    expect(((uploadCalls()[2][1] as RequestInit).body as FormData).get("file")).toBe(third)
+    await waitFor(() => {
+      expect((first as File & { file_id?: string }).file_id).toBe("file-1")
+      expect((second as File & { file_id?: string }).file_id).toBe("file-2")
+      expect((third as File & { file_id?: string }).file_id).toBe("file-3")
+      expect(container.querySelector('button[type="submit"]')).toBeEnabled()
+    })
+  })
+
   it("keeps pause hidden while running draft files are still uploading", async () => {
     const onPause = vi.fn()
     const uploadFile = vi.fn(() => new Promise<{ file_id: string }>(() => {}))

--- a/frontend/src/components/chat/ChatInput.tsx
+++ b/frontend/src/components/chat/ChatInput.tsx
@@ -245,7 +245,8 @@ export function ChatInput({
 
   // Track files for async operations
   const filesRef = useRef(enabledFiles);
-  const uploadAbortControllersRef = useRef<Map<string, AbortController>>(new Map());
+  const uploadAbortControllersRef = useRef<Map<File, AbortController>>(new Map());
+  const uploadQueueRef = useRef<Promise<void>>(Promise.resolve());
 
   useEffect(() => {
     filesRef.current = enabledFiles;
@@ -315,7 +316,7 @@ export function ChatInput({
   const [models, setModels] = useState<ModelRecord[]>([]);
 
   // State to track files currently being uploaded
-  const [uploadingFiles, setUploadingFiles] = useState<Set<string>>(new Set());
+  const [uploadingFiles, setUploadingFiles] = useState<Set<File>>(new Set());
 
   const extractDroppedFiles = (dataTransfer: DataTransfer) => {
     const itemFiles = Array.from(dataTransfer.items || [])
@@ -346,32 +347,33 @@ export function ChatInput({
     setIsDraggingFiles(false);
   }, [filesDisabled]);
 
-  // Helper to upload files immediately
-  const uploadFiles = async (newFiles: File[]) => {
-    if (filesDisabled || newFiles.length === 0) return;
-
-    // Mark as uploading (use name + lastModified as rough unique ID)
-    const fileIds = newFiles.map(f => `${f.name}-${f.lastModified}`);
-    setUploadingFiles(prev => {
-      const next = new Set(prev);
-      fileIds.forEach(id => next.add(id));
-      return next;
-    });
+  const runFileUploads = async (newFiles: File[]) => {
+    if (filesDisabled || newFiles.length === 0) {
+      return;
+    }
 
     const failedFiles = new Set<File>();
     let uploadErrorMessage: string | null = null;
 
-    // Upload files individually to ensure better reliability and progress tracking
-    await Promise.all(newFiles.map(async (file) => {
-      const fileId = `${file.name}-${file.lastModified}`;
-      const controller = new AbortController();
-      uploadAbortControllersRef.current.set(fileId, controller);
+    for (const file of newFiles) {
+      const controller = uploadAbortControllersRef.current.get(file);
+      if (!controller || controller.signal.aborted) {
+        setUploadingFiles(prev => {
+          const next = new Set(prev);
+          next.delete(file);
+          return next;
+        });
+        continue;
+      }
 
       try {
         const currentTaskType = mode || 'task';
 
         if (uploadFile) {
           const result = await uploadFile(file, { taskType: currentTaskType });
+          if (controller.signal.aborted) {
+            continue;
+          }
           if (result && typeof result.file_id === 'string') {
             (file as File & { file_id?: string }).file_id = result.file_id;
           } else {
@@ -380,7 +382,6 @@ export function ChatInput({
         } else {
           const formData = new FormData();
           formData.append('file', file);
-          // Default to task mode if not specified
           formData.append('task_type', currentTaskType);
 
           const response = await apiRequest(`${getUploadApiUrl()}/api/files/upload`, {
@@ -394,7 +395,6 @@ export function ChatInput({
           if (response.ok && isJsonRecord(parsed.data)) {
             const data = parsed.data;
             if (data.success && typeof data.file_id === 'string') {
-              // Attach file_id to the File object
               (file as File & { file_id?: string }).file_id = data.file_id;
             } else {
               failedFiles.add(file);
@@ -416,22 +416,37 @@ export function ChatInput({
           uploadErrorMessage = uploadErrorMessage || (error instanceof Error ? error.message : null);
         }
       } finally {
-        uploadAbortControllersRef.current.delete(fileId);
+        if (uploadAbortControllersRef.current.get(file) === controller) {
+          uploadAbortControllersRef.current.delete(file);
+        }
         setUploadingFiles(prev => {
           const next = new Set(prev);
-          next.delete(fileId);
+          next.delete(file);
           return next;
         });
       }
-    }));
+    }
 
-    // Handle failed files
     if (failedFiles.size > 0) {
       toast.error(uploadErrorMessage || t("files.uploadFailed") || "Failed to upload some files");
       if (onFilesChange) {
         onFilesChange(filesRef.current.filter(f => !failedFiles.has(f)));
       }
     }
+  };
+
+  const uploadFiles = (newFiles: File[]) => {
+    if (filesDisabled || newFiles.length === 0) {
+      return;
+    }
+
+    newFiles.forEach(file => {
+      uploadAbortControllersRef.current.set(file, new AbortController());
+    });
+    setUploadingFiles(prev => new Set([...prev, ...newFiles]));
+
+    const scheduled = uploadQueueRef.current.then(() => runFileUploads(newFiles));
+    uploadQueueRef.current = scheduled.catch(() => undefined);
   };
 
   const appendFiles = (newFiles: File[]) => {
@@ -874,11 +889,10 @@ export function ChatInput({
   const removeFile = (index: number) => {
     const fileToRemove = enabledFiles[index];
     if (fileToRemove) {
-      const fileId = `${fileToRemove.name}-${fileToRemove.lastModified}`;
-      const controller = uploadAbortControllersRef.current.get(fileId);
+      const controller = uploadAbortControllersRef.current.get(fileToRemove);
       if (controller) {
         controller.abort();
-        uploadAbortControllersRef.current.delete(fileId);
+        uploadAbortControllersRef.current.delete(fileToRemove);
       }
     }
     onFilesChange?.(enabledFiles.filter((_, i) => i !== index));
@@ -976,7 +990,7 @@ export function ChatInput({
           {enabledFiles.length > 0 && (
             <div className="flex flex-wrap gap-2 px-4 pt-3">
               {enabledFiles.map((file, index) => {
-                const isUploading = uploadingFiles.has(`${file.name}-${file.lastModified}`);
+                const isUploading = uploadingFiles.has(file);
                 return (
                   <div
                     key={index}

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -713,6 +713,39 @@ describe("PublicAgentChatPage", () => {
     expect(app.setTaskId).not.toHaveBeenCalledWith(99, { navigate: false })
   })
 
+  it("serializes public transport uploads", async () => {
+    let resolveFirst!: (response: Response) => void
+    const firstResponse = new Promise<Response>((resolve) => {
+      resolveFirst = resolve
+    })
+    const first = new File(["one"], "one.txt", { type: "text/plain" })
+    const second = new File(["two"], "two.txt", { type: "text/plain" })
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(successfulAgentAuth))
+      .mockReturnValueOnce(firstResponse)
+      .mockResolvedValueOnce(jsonResponse({ success: true, file_id: "file-2" }))
+
+    renderWidgetPage({ widgetKey: "widget-secret" })
+
+    await screen.findByRole("button", { name: "start:Support Agent" })
+    const uploaded = app.provider?.transport?.uploadFiles?.(
+      [first, second],
+      { taskId: 42, taskType: "task" },
+    )
+
+    expect(uploaded).toBeDefined()
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+
+    resolveFirst(jsonResponse({ success: true, file_id: "file-1" }))
+
+    await expect(uploaded).resolves.toEqual([
+      expect.objectContaining({ file_id: "file-1" }),
+      expect.objectContaining({ file_id: "file-2" }),
+    ])
+    expect(fetchMock).toHaveBeenCalledTimes(3)
+  })
+
   it("clears a stale task when the server denies access for this guest", async () => {
     localStorage.clear()
     const token = makeShareJwt({ guest_id: "guest-A", exp: futureExp() })

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -20,6 +20,7 @@ const app = vi.hoisted(() => ({
     transport?: AppProviderTransportConfig
   },
   startScreenProps: null as null | {
+    onSend: (message: string, files: File[], config?: Record<string, string>) => Promise<void>
     voiceInputEnabled?: boolean
   },
 }))
@@ -548,6 +549,63 @@ describe("PublicAgentChatPage", () => {
     )
     await waitFor(() => {
       expect(localStorage.getItem("widget_task_wf8_guest-1")).toBe("43")
+    })
+  })
+
+  it("uploads workforce opening attachments serially before creating a task", async () => {
+    let resolveFirst!: (response: Response) => void
+    let resolveSecond!: (response: Response) => void
+    const firstUpload = new Promise<Response>((resolve) => {
+      resolveFirst = resolve
+    })
+    const secondUpload = new Promise<Response>((resolve) => {
+      resolveSecond = resolve
+    })
+    const first = new File(["one"], "one.txt", { type: "text/plain" })
+    const second = new File(["two"], "two.txt", { type: "text/plain" })
+
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(successfulWorkforceAuth))
+      .mockReturnValueOnce(firstUpload)
+      .mockReturnValueOnce(secondUpload)
+      .mockResolvedValueOnce(jsonResponse(widgetTaskResponse(44, "running")))
+
+    renderWidgetPage({ searchAgentId: null, widgetKey: "widget-secret" })
+
+    await screen.findByRole("button", { name: "start:Support Workforce" })
+    const opening = app.startScreenProps!.onSend(
+      "opening message",
+      [first, second],
+      { mode: "balanced" },
+    )
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      "https://api.example/api/widget/files/upload",
+    )
+    const firstRequest = fetchMock.mock.calls[1][1] as RequestInit
+    expect((firstRequest.body as FormData).get("file")).toBe(first)
+
+    resolveFirst(jsonResponse({ success: true, file_id: "file-1" }))
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(3)
+    })
+    expect(fetchMock.mock.calls[2][0]).toBe(
+      "https://api.example/api/widget/files/upload",
+    )
+    const secondRequest = fetchMock.mock.calls[2][1] as RequestInit
+    expect((secondRequest.body as FormData).get("file")).toBe(second)
+
+    resolveSecond(jsonResponse({ success: true, file_id: "file-2" }))
+
+    await opening
+    expect(fetchMock).toHaveBeenCalledTimes(4)
+    const taskRequest = fetchMock.mock.calls[3][1] as RequestInit
+    expect(JSON.parse(taskRequest.body as string)).toEqual({
+      title: "opening message",
+      description: "opening message",
+      files: ["file-1", "file-2"],
     })
   })
 

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -7,7 +7,7 @@ import { TaskConversationPanel } from "@/components/task/task-conversation-panel
 import { AppProvider, useApp, type AppProviderTransportConfig } from "@/contexts/app-context-chat"
 import { usePublicFileAccessPolicy } from "@/contexts/file-access-context"
 import { useI18n } from "@/contexts/i18n-context"
-import { uploadPublicChatFile } from "@/lib/public-chat-file-upload"
+import { uploadPublicChatFiles } from "@/lib/public-chat-file-upload"
 import { normalizeTaskStatus } from "@/lib/task-status"
 import {
   getApiUrl,
@@ -274,13 +274,13 @@ function PublicConversationContent({
       // exists yet) and threaded in as file ids BEFORE the run begins;
       // otherwise the first turn never sees them.
       if (workforceId && files?.length) {
-        const uploaded = await Promise.all(files.map((file) => uploadPublicChatFile({
+        const uploaded = await uploadPublicChatFiles({
           url: `${getApiUrl()}${publicApiPrefix}/files/upload`,
           accessToken,
-          file,
+          files,
           taskType: "task",
           fallbackError: t("files.uploadFailed"),
-        })))
+        })
         taskPayload.files = uploaded.map((item) => item.file_id)
       }
 
@@ -601,16 +601,14 @@ export function PublicAgentChatPage({
       `${baseUrl}/${authMode === "share" ? "api/share" : "api/widget"}/chat/ws/${taskId}${token ? `?token=${token}` : ""}`,
     fileAccess,
     uploadFiles: (files, params) =>
-      Promise.all(files.map((file) =>
-        uploadPublicChatFile({
-          url: `${getApiUrl()}/${authMode === "share" ? "api/share" : "api/widget"}/files/upload`,
-          accessToken: publicAccessToken,
-          file,
-          taskType: params.taskType,
-          taskId: params.taskId,
-          fallbackError: t("files.uploadFailed"),
-        }),
-      )),
+      uploadPublicChatFiles({
+        url: `${getApiUrl()}/${authMode === "share" ? "api/share" : "api/widget"}/files/upload`,
+        accessToken: publicAccessToken,
+        files,
+        taskType: params.taskType,
+        taskId: params.taskId,
+        fallbackError: t("files.uploadFailed"),
+      }),
   }), [authMode, fileAccess, publicAccessToken, t])
 
   if (isInitializing) {

--- a/frontend/src/lib/public-chat-file-upload.test.ts
+++ b/frontend/src/lib/public-chat-file-upload.test.ts
@@ -1,6 +1,9 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 
-import { uploadPublicChatFile } from "./public-chat-file-upload"
+import {
+  uploadPublicChatFile,
+  uploadPublicChatFiles,
+} from "./public-chat-file-upload"
 
 describe("uploadPublicChatFile", () => {
   afterEach(() => {
@@ -56,5 +59,70 @@ describe("uploadPublicChatFile", () => {
       size: 4,
       type: "text/plain",
     })
+  })
+
+  it("uploads files one at a time in source order", async () => {
+    let resolveFirst!: (response: Response) => void
+    const firstResponse = new Promise<Response>((resolve) => {
+      resolveFirst = resolve
+    })
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockReturnValueOnce(firstResponse)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true, file_id: "file-2" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+    const first = new File(["one"], "one.txt", { type: "text/plain" })
+    const second = new File(["two"], "two.txt", { type: "text/plain" })
+    const uploaded = uploadPublicChatFiles({
+      url: "http://api.local/api/share/files/upload",
+      accessToken: "guest-token",
+      files: [first, second],
+      taskType: "task",
+      fallbackError: "Upload failed",
+    })
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+
+    resolveFirst(new Response(JSON.stringify({ success: true, file_id: "file-1" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+
+    await expect(uploaded).resolves.toEqual([
+      expect.objectContaining({ file_id: "file-1" }),
+      expect.objectContaining({ file_id: "file-2" }),
+    ])
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+  })
+
+  it("does not start a later file after an upload failure", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch")
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ detail: "File is too large" }), {
+          status: 413,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ success: true, file_id: "file-2" }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      )
+    await expect(uploadPublicChatFiles({
+      url: "http://api.local/api/share/files/upload",
+      accessToken: "guest-token",
+      files: [
+        new File(["oversize"], "large.txt", { type: "text/plain" }),
+        new File(["next"], "next.txt", { type: "text/plain" }),
+      ],
+      taskType: "task",
+      fallbackError: "Upload failed",
+    })).rejects.toThrow("File is too large")
+
+    expect(fetchMock).toHaveBeenCalledOnce()
   })
 })

--- a/frontend/src/lib/public-chat-file-upload.ts
+++ b/frontend/src/lib/public-chat-file-upload.ts
@@ -21,6 +21,18 @@ interface PublicChatUploadResponse {
   message?: unknown
 }
 
+export async function uploadPublicChatFiles(
+  { files, ...options }: Omit<UploadPublicChatFileOptions, "file"> & { files: File[] },
+): Promise<PublicChatUploadedFile[]> {
+  const uploadedFiles: PublicChatUploadedFile[] = []
+
+  for (const file of files) {
+    uploadedFiles.push(await uploadPublicChatFile({ ...options, file }))
+  }
+
+  return uploadedFiles
+}
+
 export async function uploadPublicChatFile({
   url,
   accessToken,

--- a/frontend/vitest.widget.config.ts
+++ b/frontend/vitest.widget.config.ts
@@ -28,6 +28,7 @@ const widgetConfig = mergeConfig(baseConfig, defineConfig({
         "src/lib/api-wrapper.ts",
         "src/lib/auth-cache.ts",
         "src/lib/files-disabled-presentation.ts",
+        "src/lib/public-chat-file-upload.ts",
         "src/contexts/presentation-capabilities.tsx",
         "src/app/settings/page.tsx",
         "src/components/layout/sidebar.tsx",
@@ -66,6 +67,9 @@ const widgetConfig = mergeConfig(baseConfig, defineConfig({
           statements: 85, branches: 80, functions: 90, lines: 85,
         },
         "src/lib/auth-cache.ts": { statements: 90, branches: 80, functions: 90, lines: 90 },
+        "src/lib/public-chat-file-upload.ts": {
+          statements: 90, branches: 80, functions: 100, lines: 90,
+        },
         "src/contexts/presentation-capabilities.tsx": {
           statements: 100, branches: 100, functions: 100, lines: 100,
         },
@@ -142,6 +146,7 @@ export default defineConfig({
       "src/components/widget/widget-session.test.ts",
       "src/components/widget/public-agent-chat-page.test.tsx",
       "src/components/widget/session-agent-chat-page.test.tsx",
+      "src/lib/public-chat-file-upload.test.ts",
       "src/components/widget/session-agent-chat-page.integration.test.tsx",
       "src/components/widget/use-widget-session.test.tsx",
       "src/contexts/app-context-chat.test.tsx",


### PR DESCRIPTION
## Summary
- Serialize public-chat attachments through the existing single-file API.
- Queue ChatInput uploads across file selections.
- Track cancellation by File object identity.
- Add required widget-lane coverage for public upload serialization.

## Public upload failure policy
Public uploads fail fast: the first failed request stops later selected files.
A retry starts a new client upload attempt. The client does not continue queued
files or compensate for earlier successful requests.

## Tests
- `npm run test:run -- src/lib/public-chat-file-upload.test.ts src/components/chat/ChatInput.test.tsx src/components/widget/public-agent-chat-page.test.tsx`
- `npm run test:widget`
- `npm run test:widget:coverage`
- `npm run type-check`
- `npm run lint`

## Validation limitation
`pre-commit run --all-files` passes every hook except the existing Alembic bootstrap. It uses CPython 3.13, but `onnxruntime==1.19.2` has no cp313 wheel.