### PR TITLE
fix(openai): wrap the response_format resend and return the vision result

### DIFF
--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -473,7 +473,30 @@ class OpenAICompatibleLLM(BaseLLM):
 
         try:
             # Make the API call
-            response = await _make_api_call()
+            try:
+                response = await _make_api_call()
+            except openai.BadRequestError as e:
+                # Check if error is related to response_format
+                error_msg = _format_openai_error("OpenAI bad request", e)
+                if (
+                    "response_format" in error_msg.lower()
+                    and "response_format" in completion_params
+                ):
+                    # Remove response_format and retry
+                    logger.warning(
+                        f"API doesn't support response_format, retrying without it. Error: {error_msg}"
+                    )
+                    completion_params.pop("response_format")
+
+                    # Retry without response_format. A BadRequestError raised
+                    # here is not caught by this clause -- it propagates to
+                    # the outer ``except openai.BadRequestError`` below, which
+                    # wraps it into RuntimeError like every other failure path.
+                    response = await _make_api_call()
+                    return _process_response(response)
+
+                raise
+
             result = _process_response(response)
 
             # Provider reasoning can corrupt structured JSON on some compatible
@@ -516,25 +539,9 @@ class OpenAICompatibleLLM(BaseLLM):
             raise
 
         except openai.BadRequestError as e:
-            # Handle bad request errors
-            error_msg = _format_openai_error("OpenAI bad request", e)
-
-            # Check if error is related to response_format
-            if (
-                "response_format" in error_msg.lower()
-                and "response_format" in completion_params
-            ):
-                # Remove response_format and retry
-                logger.warning(
-                    f"API doesn't support response_format, retrying without it. Error: {error_msg}"
-                )
-                completion_params.pop("response_format")
-
-                # Retry the API call without response_format
-                response = await _make_api_call()
-                return _process_response(response)
-
-            raise RuntimeError(error_msg) from e
+            # Handle bad request errors, including a response_format resend
+            # that failed again (see the nested try/except above).
+            raise RuntimeError(_format_openai_error("OpenAI bad request", e)) from e
 
         except openai.APITimeoutError as e:
             # Handle timeout errors
@@ -669,14 +676,42 @@ class OpenAICompatibleLLM(BaseLLM):
 
         try:
             # Make the API call with extra_body if needed
-            if extra_body:
-                response = await self._client.chat.completions.create(
-                    extra_body=extra_body, **completion_params
-                )
-            else:
-                response = await self._client.chat.completions.create(
-                    **completion_params
-                )
+            try:
+                if extra_body:
+                    response = await self._client.chat.completions.create(
+                        extra_body=extra_body, **completion_params
+                    )
+                else:
+                    response = await self._client.chat.completions.create(
+                        **completion_params
+                    )
+            except openai.BadRequestError as e:
+                # Check if error is related to response_format
+                error_msg = _format_openai_error("OpenAI bad request", e)
+                if (
+                    "response_format" in error_msg.lower()
+                    and "response_format" in completion_params
+                ):
+                    # Remove response_format and retry
+                    logger.warning(
+                        f"API doesn't support response_format, retrying without it. Error: {error_msg}"
+                    )
+                    completion_params.pop("response_format")
+
+                    # Retry without response_format. A BadRequestError raised
+                    # here is not caught by this clause -- it propagates to
+                    # the outer ``except openai.BadRequestError`` below, which
+                    # wraps it into RuntimeError like every other failure path.
+                    if extra_body:
+                        response = await self._client.chat.completions.create(
+                            extra_body=extra_body, **completion_params
+                        )
+                    else:
+                        response = await self._client.chat.completions.create(
+                            **completion_params
+                        )
+                else:
+                    raise
 
             # Validate response
             if not hasattr(response, "choices") or not response.choices:
@@ -800,31 +835,9 @@ class OpenAICompatibleLLM(BaseLLM):
             raise RuntimeError(f"OpenAI authentication failed: {e.message}") from e
 
         except openai.BadRequestError as e:
-            # Handle bad request errors
-            error_msg = _format_openai_error("OpenAI bad request", e)
-
-            # Check if error is related to response_format
-            if (
-                "response_format" in error_msg.lower()
-                and "response_format" in completion_params
-            ):
-                # Remove response_format and retry
-                logger.warning(
-                    f"API doesn't support response_format, retrying without it. Error: {error_msg}"
-                )
-                completion_params.pop("response_format")
-
-                # Retry the API call without response_format
-                if extra_body:
-                    response = await self._client.chat.completions.create(
-                        extra_body=extra_body, **completion_params
-                    )
-                else:
-                    response = await self._client.chat.completions.create(
-                        **completion_params
-                    )
-            else:
-                raise RuntimeError(error_msg) from e
+            # Handle bad request errors, including a response_format resend
+            # that failed again (see the nested try/except above).
+            raise RuntimeError(_format_openai_error("OpenAI bad request", e)) from e
 
         except openai.APIError as e:
             # Handle OpenAI API errors

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -678,17 +678,18 @@ class OpenAICompatibleLLM(BaseLLM):
             is_streaming=False,
         )
 
+        async def _make_api_call() -> Any:
+            assert self._client is not None
+            if extra_body:
+                return await self._client.chat.completions.create(
+                    extra_body=extra_body, **completion_params
+                )
+            return await self._client.chat.completions.create(**completion_params)
+
         try:
             # Make the API call with extra_body if needed
             try:
-                if extra_body:
-                    response = await self._client.chat.completions.create(
-                        extra_body=extra_body, **completion_params
-                    )
-                else:
-                    response = await self._client.chat.completions.create(
-                        **completion_params
-                    )
+                response = await _make_api_call()
             except openai.BadRequestError as e:
                 # Check if error is related to response_format
                 error_msg = _format_openai_error("OpenAI bad request", e)
@@ -706,14 +707,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     # here is not caught by this clause -- it propagates to
                     # the outer ``except openai.BadRequestError`` below, which
                     # wraps it into RuntimeError like every other failure path.
-                    if extra_body:
-                        response = await self._client.chat.completions.create(
-                            extra_body=extra_body, **completion_params
-                        )
-                    else:
-                        response = await self._client.chat.completions.create(
-                            **completion_params
-                        )
+                    response = await _make_api_call()
                 else:
                     raise
 

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -487,15 +487,19 @@ class OpenAICompatibleLLM(BaseLLM):
                         f"API doesn't support response_format, retrying without it. Error: {error_msg}"
                     )
                     completion_params.pop("response_format")
+                    response_format = None
 
-                    # Retry without response_format. A BadRequestError raised
-                    # here is not caught by this clause -- it propagates to
-                    # the outer ``except openai.BadRequestError`` below, which
-                    # wraps it into RuntimeError like every other failure path.
+                    # Retry without response_format and fall through to the
+                    # main flow (the structured-output degrade check below is
+                    # gated on response_format, now None). A BadRequestError
+                    # raised here is not caught by this clause -- it
+                    # propagates to the outer ``except openai.BadRequestError``
+                    # below, which wraps it into RuntimeError like every other
+                    # failure path.
                     response = await _make_api_call()
-                    return _process_response(response)
 
-                raise
+                else:
+                    raise
 
             result = _process_response(response)
 

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -20,18 +20,16 @@ logger = logging.getLogger(__name__)
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
 _DEEPSEEK_FUNCTION_PREFIX_ERROR = "function call should not be used with prefix"
 
-# OpenAILLM.chat/vision_chat normally convert every openai.BadRequestError
-# into a RuntimeError before returning. Their response_format pop-and-retry
-# path is an exception, though: it re-issues the request from inside its own
-# ``except openai.BadRequestError`` block, and if that retried call also fails
-# with a BadRequestError, nothing wraps the second failure -- it escapes as a
-# bare SDK exception. (stream_chat is not affected: its resend sits in a
-# nested try, so the outer handler still wraps a second failure; the streaming
-# loop catches the tuple for symmetry and defense.) openai.BadRequestError's
-# MRO does not include RuntimeError, so the compat retry loops below must
-# catch both explicitly to keep covering that case. The historical
-# implementation caught bare ``Exception`` here; this tuple is the precise,
-# intentionally narrowed replacement.
+# OpenAILLM.chat/vision_chat/stream_chat convert every openai.BadRequestError
+# into a RuntimeError before returning, including the response_format
+# pop-and-retry resend (its second failure is re-raised inside the outer
+# try and wrapped like any other provider failure). openai.BadRequestError
+# stays in this tuple as defense in depth: its MRO does not include
+# RuntimeError, so if any base-client path ever leaks the bare SDK
+# exception again, the compat retry loops below keep covering it instead
+# of letting the call hard-fail. The historical implementation caught bare
+# ``Exception`` here; this tuple is the precise, intentionally narrowed
+# replacement.
 _COMPAT_RETRYABLE_ERRORS = (RuntimeError, openai.BadRequestError)
 
 # Pinning to these provider slugs via `only` + `allow_fallbacks: False` routes

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -501,13 +501,12 @@ class OpenRouterLLM(OpenAILLM):
         adjustment opportunity. A single ``call`` invocation may itself issue
         one additional upstream request through the response_format
         pop-and-retry path shared by ``OpenAILLM.chat`` and ``vision_chat``,
-        but the two behave differently on a successful resend: ``chat``'s
-        branch returns the processed result of the resent call, or lets that
-        second call's failure propagate uncaught; ``vision_chat``'s
-        same-named branch does neither on a successful resend -- it falls
-        out of the ``except`` block with no ``return`` statement, so the
-        call implicitly yields ``None`` instead of the resent response
-        (tracked by #1650). No caller in this repository currently passes
+        and the two behave identically: a successful resend flows through
+        the method's normal response processing and is returned, while a
+        resend that fails again is wrapped into ``RuntimeError`` by the
+        outer handler like every other failure path, so no bare
+        ``openai.BadRequestError`` reaches this loop from either
+        entrypoint. No caller in this repository currently passes
         ``response_format`` into ``chat``; the one caller that does supply
         it in this repository (``vision_tool.py``) calls ``vision_chat``.
 

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -30,6 +30,8 @@ _DEEPSEEK_FUNCTION_PREFIX_ERROR = "function call should not be used with prefix"
 # of letting the call hard-fail. The historical implementation caught bare
 # ``Exception`` here; this tuple is the precise, intentionally narrowed
 # replacement.
+# No production path currently produces a bare ``openai.BadRequestError``
+# here; the only coverage is a stub test that patches an internal method.
 _COMPAT_RETRYABLE_ERRORS = (RuntimeError, openai.BadRequestError)
 
 # Pinning to these provider slugs via `only` + `allow_fallbacks: False` routes

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -5,6 +5,8 @@ import json
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+import httpx
+import openai
 import pytest
 
 from xagent.core.model.chat.basic.base import BaseLLM
@@ -36,6 +38,18 @@ def _tool_call_delta(index, call_id, name, arguments, call_type="function"):
         id=call_id,
         type=call_type,
         function=SimpleNamespace(name=name, arguments=arguments),
+    )
+
+
+def _response_format_bad_request(message: str) -> openai.BadRequestError:
+    """A 400 whose text matches the response_format fallback's trigger check."""
+    return openai.BadRequestError(
+        f"Error code: 400 - {{'error': {{'message': '{message}'}}}}",
+        response=httpx.Response(
+            400,
+            request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+        ),
+        body={"error": {"message": message, "code": 400}},
     )
 
 
@@ -1278,3 +1292,125 @@ class TestOpenAILLM:
 
         assert final_chunk is not None
         assert final_chunk.tool_calls[0]["function"]["arguments"] == expected
+
+    @pytest.mark.asyncio
+    async def test_chat_response_format_retry_failure_wraps_runtime_error(
+        self, openai_llm_config, mocker
+    ):
+        """A second BadRequestError from the response_format resend must be
+        wrapped into RuntimeError, not escape as a bare SDK exception, just
+        like every other ``chat()`` failure path."""
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _response_format_bad_request(
+                "the model does not support response_format for this request"
+            ),
+            _response_format_bad_request(
+                "the model does not support response_format for this request"
+            ),
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+        llm = OpenAILLM(**openai_llm_config)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await llm.chat(
+                [{"role": "user", "content": "hi"}],
+                response_format={"type": "json_object"},
+            )
+
+        assert isinstance(exc_info.value.__cause__, openai.BadRequestError)
+        assert mock_client.chat.completions.create.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_chat_response_format_retry_success_returns_result(
+        self, openai_llm_config, mock_chat_completion, mocker
+    ):
+        """When the resend succeeds, ``chat()`` already returns the processed
+        result today; this pins that behavior against the same failure-path
+        restructuring."""
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _response_format_bad_request(
+                "the model does not support response_format for this request"
+            ),
+            mock_chat_completion,
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+        llm = OpenAILLM(**openai_llm_config)
+
+        result = await llm.chat(
+            [{"role": "user", "content": "hi"}],
+            response_format={"type": "json_object"},
+        )
+
+        assert result.get("content") == "Hello World"
+        assert mock_client.chat.completions.create.await_count == 2
+        second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
+        assert "response_format" not in second_call
+
+    @pytest.mark.asyncio
+    async def test_vision_chat_response_format_retry_failure_wraps_runtime_error(
+        self, openai_llm_config, mocker
+    ):
+        """Same guarantee as ``chat()``: the vision path must not leak a bare
+        BadRequestError when the response_format resend also fails."""
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _response_format_bad_request(
+                "the model does not support response_format for this request"
+            ),
+            _response_format_bad_request(
+                "the model does not support response_format for this request"
+            ),
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+        llm = OpenAILLM(**openai_llm_config, abilities=["chat", "vision"])
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await llm.vision_chat(
+                [{"role": "user", "content": "describe this"}],
+                response_format={"type": "json_object"},
+            )
+
+        assert isinstance(exc_info.value.__cause__, openai.BadRequestError)
+        assert mock_client.chat.completions.create.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_vision_chat_response_format_retry_success_returns_result(
+        self, openai_llm_config, mock_chat_completion, mocker
+    ):
+        """A successful resend must return the processed result, not fall
+        through to an implicit ``None`` (the vision_chat() half of #1650)."""
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _response_format_bad_request(
+                "the model does not support response_format for this request"
+            ),
+            mock_chat_completion,
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+        llm = OpenAILLM(**openai_llm_config, abilities=["chat", "vision"])
+
+        result = await llm.vision_chat(
+            [{"role": "user", "content": "describe this"}],
+            response_format={"type": "json_object"},
+        )
+
+        assert result is not None
+        assert result.get("type") == "text"
+        assert result.get("content") == "Hello World"
+        assert mock_client.chat.completions.create.await_count == 2
+        second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
+        assert "response_format" not in second_call

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -53,6 +53,13 @@ def _response_format_bad_request(message: str) -> openai.BadRequestError:
     )
 
 
+def _api_timeout_error() -> openai.APITimeoutError:
+    """The SDK's timeout error, as raised by a request that never answered."""
+    return openai.APITimeoutError(
+        request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions")
+    )
+
+
 class TestOpenAILLM:
     """Test cases for OpenAI LLM implementation."""
 
@@ -1299,16 +1306,18 @@ class TestOpenAILLM:
     ):
         """A second BadRequestError from the response_format resend must be
         wrapped into RuntimeError, not escape as a bare SDK exception, just
-        like every other ``chat()`` failure path."""
+        like every other ``chat()`` failure path. This pins WHICH of the two
+        errors becomes ``__cause__``: it must be the resend's own failure,
+        not the first attempt's, and the wrapped message must carry the
+        resend's text."""
+        first_error = _response_format_bad_request(
+            "the model does not support response_format on the first attempt"
+        )
+        second_error = _response_format_bad_request(
+            "the model still rejects response_format on the resend"
+        )
         mock_client = mocker.AsyncMock()
-        mock_client.chat.completions.create.side_effect = [
-            _response_format_bad_request(
-                "the model does not support response_format for this request"
-            ),
-            _response_format_bad_request(
-                "the model does not support response_format for this request"
-            ),
-        ]
+        mock_client.chat.completions.create.side_effect = [first_error, second_error]
         mocker.patch(
             "xagent.core.model.chat.basic.openai.AsyncOpenAI",
             return_value=mock_client,
@@ -1321,7 +1330,8 @@ class TestOpenAILLM:
                 response_format={"type": "json_object"},
             )
 
-        assert isinstance(exc_info.value.__cause__, openai.BadRequestError)
+        assert exc_info.value.__cause__ is second_error
+        assert "on the resend" in str(exc_info.value)
         assert mock_client.chat.completions.create.await_count == 2
 
     @pytest.mark.asyncio
@@ -1359,16 +1369,18 @@ class TestOpenAILLM:
         self, openai_llm_config, mocker
     ):
         """Same guarantee as ``chat()``: the vision path must not leak a bare
-        BadRequestError when the response_format resend also fails."""
+        BadRequestError when the response_format resend also fails. This
+        pins WHICH of the two errors becomes ``__cause__``: it must be the
+        resend's own failure, not the first attempt's, and the wrapped
+        message must carry the resend's text."""
+        first_error = _response_format_bad_request(
+            "the model does not support response_format on the first attempt"
+        )
+        second_error = _response_format_bad_request(
+            "the model still rejects response_format on the resend"
+        )
         mock_client = mocker.AsyncMock()
-        mock_client.chat.completions.create.side_effect = [
-            _response_format_bad_request(
-                "the model does not support response_format for this request"
-            ),
-            _response_format_bad_request(
-                "the model does not support response_format for this request"
-            ),
-        ]
+        mock_client.chat.completions.create.side_effect = [first_error, second_error]
         mocker.patch(
             "xagent.core.model.chat.basic.openai.AsyncOpenAI",
             return_value=mock_client,
@@ -1381,7 +1393,8 @@ class TestOpenAILLM:
                 response_format={"type": "json_object"},
             )
 
-        assert isinstance(exc_info.value.__cause__, openai.BadRequestError)
+        assert exc_info.value.__cause__ is second_error
+        assert "on the resend" in str(exc_info.value)
         assert mock_client.chat.completions.create.await_count == 2
 
     @pytest.mark.asyncio
@@ -1411,6 +1424,163 @@ class TestOpenAILLM:
         assert result is not None
         assert result.get("type") == "text"
         assert result.get("content") == "Hello World"
+        assert mock_client.chat.completions.create.await_count == 2
+        second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
+        assert "response_format" not in second_call
+
+    @pytest.mark.asyncio
+    async def test_chat_response_format_resend_timeout_wraps_runtime_error(
+        self, openai_llm_config, mocker
+    ):
+        """Before this PR the response_format resend lived directly inside
+        the ``except openai.BadRequestError`` clause, so a non-BadRequestError
+        failure from that resend escaped unwrapped. The nested-try
+        restructuring routes it to ``chat()``'s own
+        ``except openai.APITimeoutError`` handler instead; this path is
+        newly correct and was previously untested."""
+        timeout_error = _api_timeout_error()
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _response_format_bad_request(
+                "the model does not support response_format for this request"
+            ),
+            timeout_error,
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+        llm = OpenAILLM(**openai_llm_config)
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await llm.chat(
+                [{"role": "user", "content": "hi"}],
+                response_format={"type": "json_object"},
+            )
+
+        assert "OpenAI API timeout" in str(exc_info.value)
+        assert exc_info.value.__cause__ is timeout_error
+        assert mock_client.chat.completions.create.await_count == 2
+        second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
+        assert "response_format" not in second_call
+
+    @pytest.mark.asyncio
+    async def test_vision_chat_response_format_resend_timeout_wraps_runtime_error(
+        self, openai_llm_config, mocker
+    ):
+        """Before this PR the response_format resend lived directly inside
+        the ``except openai.BadRequestError`` clause, so a non-BadRequestError
+        failure from that resend escaped unwrapped. The nested-try
+        restructuring routes it to ``vision_chat()``'s own
+        ``except openai.APITimeoutError`` handler instead; this path is
+        newly correct and was previously untested."""
+        timeout_error = _api_timeout_error()
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _response_format_bad_request(
+                "the model does not support response_format for this request"
+            ),
+            timeout_error,
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+        llm = OpenAILLM(**openai_llm_config, abilities=["chat", "vision"])
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await llm.vision_chat(
+                [{"role": "user", "content": "describe this"}],
+                response_format={"type": "json_object"},
+            )
+
+        assert "OpenAI API timeout" in str(exc_info.value)
+        assert exc_info.value.__cause__ is timeout_error
+        assert mock_client.chat.completions.create.await_count == 2
+        second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
+        assert "response_format" not in second_call
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_response_format_resend_timeout_is_retryable(
+        self, openai_llm_config, mocker
+    ):
+        """``stream_chat`` already had this nested-try shape before this PR;
+        its diff is untouched here. This test pins the sibling contract that
+        ``test_chat_...`` and ``test_vision_chat_...`` above were aligned
+        to: ``stream_chat`` classifies the same response_format-resend
+        timeout as ``LLMRetryableError`` rather than ``RuntimeError``."""
+        timeout_error = _api_timeout_error()
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _response_format_bad_request(
+                "the model does not support response_format for this request"
+            ),
+            timeout_error,
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+        llm = OpenAILLM(**openai_llm_config)
+
+        with pytest.raises(LLMRetryableError) as exc_info:
+            _ = [
+                chunk
+                async for chunk in llm.stream_chat(
+                    [{"role": "user", "content": "hi"}],
+                    response_format={"type": "json_object"},
+                )
+            ]
+
+        assert "OpenAI API timeout" in str(exc_info.value)
+        assert exc_info.value.__cause__ is timeout_error
+        assert mock_client.chat.completions.create.await_count == 2
+        second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
+        assert "response_format" not in second_call
+
+    @pytest.mark.asyncio
+    async def test_vision_chat_empty_content_after_resend_raises_empty_content_error(
+        self, openai_llm_config, mocker
+    ):
+        """Pins ``vision_chat()``'s empty-content contract, which had zero
+        tests of its own (``chat()`` has ``test_empty_content_response``;
+        ``vision_chat()`` had nothing). The response_format resend is the
+        carrier here because falling through to the normal processing path
+        is what makes this outcome reachable on the resend at all: before
+        this PR, a successful resend short-circuited to ``None`` instead of
+        running that processing path."""
+        mock_choice = MagicMock()
+        mock_choice.finish_reason = "stop"
+        mock_message = MagicMock()
+        mock_message.content = ""
+        mock_message.tool_calls = None
+        mock_message.reasoning_content = None
+        mock_choice.message = mock_message
+        empty_response = MagicMock()
+        empty_response.choices = [mock_choice]
+
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _response_format_bad_request(
+                "the model does not support response_format for this request"
+            ),
+            empty_response,
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+        llm = OpenAILLM(**openai_llm_config, abilities=["chat", "vision"])
+
+        with pytest.raises(
+            LLMEmptyContentError,
+            match="LLM returned empty content and no tool calls",
+        ):
+            await llm.vision_chat(
+                [{"role": "user", "content": "describe this"}],
+                response_format={"type": "json_object"},
+            )
+
         assert mock_client.chat.completions.create.await_count == 2
         second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
         assert "response_format" not in second_call

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -1209,7 +1209,7 @@ def _bad_request_error(message: str) -> openai.BadRequestError:
 
 
 @pytest.mark.asyncio
-async def test_openrouter_direct_relaxes_tool_choice_after_bare_bad_request_error(
+async def test_openrouter_direct_relaxes_tool_choice_after_wrapped_resend_failure(
     mock_chat_completion, mocker
 ):
     """The compat retry recovers when the response_format resend also 400s.
@@ -1248,7 +1248,7 @@ async def test_openrouter_direct_relaxes_tool_choice_after_bare_bad_request_erro
 
 
 @pytest.mark.asyncio
-async def test_openrouter_vision_relaxes_tool_choice_after_bare_bad_request_error(
+async def test_openrouter_vision_relaxes_tool_choice_after_wrapped_resend_failure(
     mock_chat_completion, mocker
 ):
     """The vision path recovers when the response_format resend also 400s.
@@ -1287,6 +1287,38 @@ async def test_openrouter_vision_relaxes_tool_choice_after_bare_bad_request_erro
     assert mock_client.chat.completions.create.await_count == 3
     final_call = mock_client.chat.completions.create.call_args_list[2].kwargs
     assert final_call["tool_choice"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_compat_loop_catches_bare_sdk_bad_request(mocker):
+    """A bare ``openai.BadRequestError`` reaching the compat loop is handled.
+
+    The base client wraps provider 4xx failures into ``RuntimeError`` on
+    every known path, so this pin drives the loop directly: the inner call
+    raises the bare SDK error once, and the loop must treat it as a compat
+    adjustment opportunity rather than let it escape. This is the only test
+    that fails when ``openai.BadRequestError`` is removed from
+    ``_COMPAT_RETRYABLE_ERRORS``.
+    """
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+    prefix_retry_mock = mocker.patch.object(
+        llm,
+        "_chat_with_prefix_retry",
+        side_effect=[
+            _bad_request_error(_OPENROUTER_TOOL_CHOICE_ERROR),
+            {"type": "text", "content": "Hello World", "tool_calls": None},
+        ],
+    )
+
+    result = await llm.chat(
+        [{"role": "user", "content": "score?"}],
+        tools=_two_tool_schema(),
+        tool_choice="required",
+    )
+
+    assert result["content"] == "Hello World"
+    assert prefix_retry_mock.call_count == 2
+    assert prefix_retry_mock.call_args_list[1].kwargs["tool_choice"] == "auto"
 
 
 @pytest.mark.asyncio

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -1298,7 +1298,9 @@ async def test_openrouter_compat_loop_catches_bare_sdk_bad_request(mocker):
     raises the bare SDK error once, and the loop must treat it as a compat
     adjustment opportunity rather than let it escape. This is the only test
     that fails when ``openai.BadRequestError`` is removed from
-    ``_COMPAT_RETRYABLE_ERRORS``.
+    ``_COMPAT_RETRYABLE_ERRORS``. The streaming compat loop in
+    ``_run_stream_chat_with_compat_retry`` consumes the same tuple but has
+    no equivalent bare-error stub coverage yet.
     """
     llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
     prefix_retry_mock = mocker.patch.object(

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -1212,15 +1212,13 @@ def _bad_request_error(message: str) -> openai.BadRequestError:
 async def test_openrouter_direct_relaxes_tool_choice_after_bare_bad_request_error(
     mock_chat_completion, mocker
 ):
-    """A bare ``openai.BadRequestError`` must still reach the compat retry loop.
+    """The compat retry recovers when the response_format resend also 400s.
 
-    ``OpenAILLM.chat`` normally converts every ``openai.BadRequestError`` into
-    a ``RuntimeError`` before returning, but its response_format pop-and-retry
-    path (openai.py's ``except openai.BadRequestError`` block) re-issues the
-    request from inside that except clause: if the retried call also raises
-    ``openai.BadRequestError``, that second error is not wrapped by anything
-    and escapes as a bare SDK exception. The compat retry loop must catch it
-    the same way it catches the RuntimeError case, not just replay-fail.
+    ``OpenAILLM.chat`` converts every ``openai.BadRequestError`` into a
+    ``RuntimeError``, including a failure of its response_format pop-and-retry
+    resend, so the compat loop sees the wrapped form here. The loop's catch
+    tuple still includes the bare SDK exception as defense in depth for any
+    future base-client path that leaks one unwrapped.
     """
     mock_client = mocker.AsyncMock()
     mock_client.chat.completions.create.side_effect = [
@@ -1253,13 +1251,13 @@ async def test_openrouter_direct_relaxes_tool_choice_after_bare_bad_request_erro
 async def test_openrouter_vision_relaxes_tool_choice_after_bare_bad_request_error(
     mock_chat_completion, mocker
 ):
-    """The vision path recovers from the bare BadRequestError escape too.
+    """The vision path recovers when the response_format resend also 400s.
 
     ``vision_chat`` is the entrypoint with a live response_format producer in
-    this repository, so the escape guarded here is reachable in production:
-    ``OpenAILLM.vision_chat``'s pop-and-retry resend sits inside its own
-    ``except openai.BadRequestError`` block and a second failure escapes
-    unwrapped, exactly like ``chat``'s.
+    this repository, so this recovery is reachable in production. A failed
+    resend arrives here wrapped as ``RuntimeError`` by the base client; the
+    compat loop's catch tuple keeps the bare SDK exception as defense in
+    depth.
     """
     mock_client = mocker.AsyncMock()
     mock_client.chat.completions.create.side_effect = [

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -1257,7 +1257,13 @@ async def test_openrouter_vision_relaxes_tool_choice_after_wrapped_resend_failur
     this repository, so this recovery is reachable in production. A failed
     resend arrives here wrapped as ``RuntimeError`` by the base client; the
     compat loop's catch tuple keeps the bare SDK exception as defense in
-    depth.
+    depth. The value asserted below reaches the caller from the THIRD
+    upstream call, which succeeds on its first attempt after the compat loop
+    relaxed ``tool_choice`` -- it does not come through a successful resend.
+    So this pins that ``vision_chat``'s processed result survives the
+    OpenRouter compat loop; the successful-resend return itself is pinned
+    directly by ``test_vision_chat_response_format_retry_success_returns_result``
+    in ``tests/core/model/chat/basic/test_openai.py``.
     """
     mock_client = mocker.AsyncMock()
     mock_client.chat.completions.create.side_effect = [
@@ -1277,13 +1283,15 @@ async def test_openrouter_vision_relaxes_tool_choice_after_wrapped_resend_failur
         abilities=["chat", "tool_calling", "vision"],
     )
 
-    await llm.vision_chat(
+    result = await llm.vision_chat(
         [{"role": "user", "content": "score?"}],
         tools=_two_tool_schema(),
         tool_choice="required",
         response_format={"type": "json_object"},
     )
 
+    assert result["type"] == "text"
+    assert result["content"] == "Hello World"
     assert mock_client.chat.completions.create.await_count == 3
     final_call = mock_client.chat.completions.create.call_args_list[2].kwargs
     assert final_call["tool_choice"] == "auto"


### PR DESCRIPTION
## What

`OpenAILLM.chat` and `OpenAILLM.vision_chat` now issue their response_format pop-and-retry resend inside a nested try, matching `stream_chat`'s existing shape, and `vision_chat` returns the processed result of a successful resend instead of falling off the end of the method.

## Why

Two defects lived in the resend path:

- The resend was issued from inside the `except openai.BadRequestError` handler, so a second failure escaped as a bare SDK exception instead of the wrapped `RuntimeError` every other failure path produces — invisible to callers that classify provider failures by `RuntimeError`, including the provider-compat retries.
- `vision_chat` assigned a successful resend to a variable and never processed or returned it, implicitly returning `None`. The repository's only `response_format` producer calls `vision_chat`, and its type checks turn that `None` into a silent success-with-empty-results.

What the resend sends is unchanged, and a successful resend behaves as before apart from `vision_chat` now returning its result. The exception flow changes in one more place than the two bullets above describe, on a narrow path in `chat`: the structured-output degrade check — it fires only when the caller passed `response_format`, the model declares `thinking_mode`, and the first response came back carrying reasoning content but non-JSON text — issues its own resend with thinking disabled. If that resend is rejected with a `response_format` 400, the old outer handler still owned the pop-and-retry logic, so it dropped `response_format` and made a third attempt that could succeed. The new outer handler wraps that 400 into `RuntimeError` and makes no further attempt. No caller in this repository reaches the path today: the only `response_format` producer, `VisionCore.detect_objects`, calls `vision_chat`, which has no degrade check. The successful resend now flows through the method's single inline processing path, so response handling (including provider-state capture) is not duplicated. The OpenRouter compat-retry notes that described the old bare-escape behavior are updated in the same change; the compat catch tuple keeps `openai.BadRequestError` as defense in depth.

Fixes #1650

## Testing

- `chat` and `vision_chat` double-failure scenarios assert the wrapped `RuntimeError` and that its `__cause__` is the *second* SDK error rather than the first; the two errors now carry distinct messages so the test can tell them apart.
- `vision_chat` successful-resend asserts the real processed result (mutation-checked: removing the return turns it red); `chat` successful-resend pinned as regression cover.
- Resend-timeout pins for `chat`, `vision_chat` and `stream_chat`: an `openai.APITimeoutError` raised by the resend now reaches each method's own timeout handler — `RuntimeError` for the first two, `LLMRetryableError` for `stream_chat` — instead of escaping unwrapped as it did when the resend lived inside the `except openai.BadRequestError` clause.
- A `vision_chat` resend that succeeds with empty content raises `LLMEmptyContentError`, pinning that method's empty-content contract, which had no test of its own.
- The OpenRouter vision compat-retry test now captures `vision_chat`'s return value and asserts the processed text envelope.
- A comment at `openrouter.py`'s `_COMPAT_RETRYABLE_ERRORS` records that the `openai.BadRequestError` member has no production producer and that its coverage is a stub.
- Full openai + openrouter suites: 117 passed; pre-commit clean.

