### PR TITLE
feat(files): share the canonical markdown file-reference parser

### DIFF
--- a/src/xagent/web/services/file_reference_output_service.py
+++ b/src/xagent/web/services/file_reference_output_service.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import logging
 import re
 from collections import defaultdict
+from collections.abc import Callable, Iterator
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Sequence
 
@@ -107,6 +109,10 @@ logger = logging.getLogger(__name__)
 # future change piping reconciled text into one of them should update it
 # to match this pattern (or route through a shared parsing helper) rather
 # than silently mis-parsing a title clause as part of the id/label.
+# ``iter_markdown_file_references`` /
+# ``replace_markdown_file_references`` below are that shared helper: a
+# consumer needing to read or rewrite this format goes through them, so
+# there is one pattern to keep correct rather than one per consumer.
 _MARKDOWN_FILE_REFERENCE_RE = re.compile(
     r"(?P<image>!)?\[(?P<label>(?>[^\]]*))\]\("
     r"(?P<target>(?>file:[^)\s]+))"
@@ -131,6 +137,222 @@ def _parsed_title(match: re.Match[str]) -> str | None:
     if stitle is not None:
         return stitle
     return match.group("ptitle")
+
+
+@dataclass(frozen=True)
+class MarkdownFileReference:
+    """One parsed ``[label](file:id ["title"])`` reference.
+
+    The public, structured view of a single ``_MARKDOWN_FILE_REFERENCE_RE``
+    match, so a consumer outside this module can read a reference's parts
+    without owning a second copy of the grammar. ``file_id`` is already
+    through ``parse_file_id_ref``, so a real ``file:///path`` URI never
+    reaches a consumer as a handle.
+
+    ``span`` indexes the *original* string, which is what makes a
+    replacement-by-span rewrite possible; ``text`` is the matched substring,
+    so a consumer that decides to leave a reference alone can put back
+    exactly what was written.
+
+    **Caller-facing contract details that are easy to get wrong:**
+
+    * ``label`` can be the empty string -- ``[](file:id)`` is a well-formed
+      match. Every existing consumer in this repo substitutes something
+      (``label or "image"``, ``label or "file"``); a caller that renders it
+      bare gets an empty link text.
+    * ``file_id`` is percent-*decoded* (``parse_file_id_ref`` runs
+      ``unquote``), so it is not necessarily a literal substring of
+      ``content``: ``[a](file:a%20b)`` yields ``file_id="a b"``. A caller
+      re-emitting a target MUST go through ``build_file_id_ref`` to
+      re-encode it -- ``f"file:{reference.file_id}"`` can produce a target
+      that no longer matches this module's own regex.
+    * ``title`` is raw: backslash escapes inside it are not decoded.
+    * ``junk`` is the reference's trailing unparsable prose -- see below.
+      A caller that rewrites a reference without consulting it will delete
+      that prose from the output.
+    """
+
+    file_id: str
+    label: str
+    title: str | None
+    is_image: bool
+    span: tuple[int, int]
+    text: str
+    # Trailing content inside the parens that parsed as neither destination
+    # nor title -- ``[the docs](file:id for more details)`` yields
+    # ``" for more details"``.
+    #
+    # Exposed because a caller cannot otherwise tell this case apart from an
+    # ordinary untitled reference (``title`` is ``None`` either way), and the
+    # difference decides whether rewriting is lossless. The regex matched
+    # that text as link syntax, but it is ordinary prose the model wrote:
+    # replacing the whole match discards it permanently. That is the
+    # destructive-loss class issue #1202 asked this module to eliminate, and
+    # ``reconcile_assistant_file_references`` guards it by falling back to
+    # ``match.group(0)`` whenever a reference carrying non-blank junk turns
+    # out to be unrecoverable.
+    #
+    # This function cannot make that call itself: whether a reference is
+    # recoverable depends on the caller's own lookup (the sibling has the
+    # database; this has a callback). So the decision is handed over rather
+    # than guessed -- see ``replace_markdown_file_references``, which
+    # defaults to preserving.
+    junk: str = ""
+
+
+def iter_markdown_file_references(content: str) -> Iterator[MarkdownFileReference]:
+    """Every internal ``file:`` reference in ``content``, in order.
+
+    The reading half of this module's canonical parser. The comment above
+    ``_MARKDOWN_FILE_REFERENCE_RE`` asks a consumer that needs to match this
+    format to route through a shared helper rather than fork the pattern;
+    until now there was no such helper, so the only options were forking it
+    or importing a private constant. A fork drifts silently -- a title-blind
+    copy reads a title clause as part of the id, and a copy without the
+    ``junk`` alternative fails to match shapes this one recovers -- and the
+    drift only shows up as a mangled reference in somebody's transcript.
+
+    See ``MarkdownFileReference`` for the contract details a caller has to
+    handle: an empty ``label``, a percent-decoded ``file_id``, and ``junk``.
+
+    Targets that are not internal handles are skipped rather than yielded
+    with an empty id: whether a ``file:`` target is a handle at all is
+    ``parse_file_id_ref``'s decision, and a consumer should not have to
+    re-make it.
+
+    Content with no ``file:`` substring is skipped without running the regex.
+    That is correctness-preserving (every match contains the literal), and it
+    is here for cost: the pattern's atomic label group makes ``finditer``
+    explore bracket-run candidates, and ``"[" * 100000 + "]"`` measures at
+    ~1.5s without the precheck and is instant with it.
+
+    It is a common-case optimisation, **not** a defence against adversarial
+    input: one ``file:`` anywhere in the content passes the precheck and the
+    same pathological cost returns (``"file:" + "[" * 100000 + "]"`` measures
+    ~2s either way). Hardening that would mean changing the pattern, which
+    this addition deliberately does not touch.
+
+    Deliberately *not* guarded on ``isinstance(content, str)``, unlike
+    ``reconcile_assistant_file_references``: a non-string must still raise --
+    once iterated. This is a generator, so no body runs until the first
+    ``next()``; an unconsumed ``iter_markdown_file_references(None)`` raises
+    nothing. Returning early instead would turn bad input into an empty
+    iteration a caller cannot tell apart from "no references".
+
+    The precheck is therefore ordered *after* a ``str``-only operation, not
+    before one. ``"file:" not in content`` is true for a ``list``/``tuple``/
+    ``set``/``dict`` of strings as readily as for text, so testing it first
+    would swallow exactly the bad input this contract promises to reject --
+    ``finditer`` used to raise on those and must keep doing so.
+    """
+    if not isinstance(content, str):
+        raise TypeError(f"content must be a str, got {type(content).__name__}")
+    if "file:" not in content:
+        return
+    for match in _MARKDOWN_FILE_REFERENCE_RE.finditer(content):
+        reference = _reference_from_match(match)
+        if reference is not None:
+            yield reference
+
+
+def _reference_from_match(match: re.Match[str]) -> MarkdownFileReference | None:
+    """One match as a reference, or ``None`` if its target is not a handle.
+
+    Shared by both public entry points so they cannot disagree about what a
+    reference is, or about which matches are skipped.
+    """
+    file_id = parse_file_id_ref(match.group("target"))
+    if not file_id:
+        return None
+    return MarkdownFileReference(
+        file_id=file_id,
+        label=match.group("label"),
+        title=_parsed_title(match),
+        is_image=bool(match.group("image")),
+        span=match.span(),
+        text=match.group(0),
+        junk=match.group("junk") or "",
+    )
+
+
+def replace_markdown_file_references(
+    content: str,
+    replace: Callable[[MarkdownFileReference], str],
+    *,
+    rewrite_junk_references: bool = False,
+) -> str:
+    """Rewrite every internal ``file:`` reference through ``replace``.
+
+    The writing half, for a consumer whose job is to *remove* the ``file:``
+    scheme rather than canonicalize it -- a chat channel whose client cannot
+    resolve the handle, say. ``reconcile_assistant_file_references`` does not
+    serve that consumer: it is the function that puts canonical ``file:``
+    links *into* content.
+
+    Non-handle targets are left exactly as written, for the same reason they
+    are skipped by ``iter_markdown_file_references``.
+
+    **A reference carrying non-blank junk is left untouched by default.**
+    ``[the docs](file:id for more details)`` matches because the regex's
+    ``junk`` alternative accepts trailing unparsable content, but that
+    content is ordinary prose the model wrote, not link syntax -- rewriting
+    the whole match deletes a fragment of the user's sentence. That is the
+    destructive-content-loss class issue #1202 closed on the reconcile path,
+    and defaulting to "rewrite" here would reopen it for every consumer that
+    did not know to ask.
+
+    ``reconcile_assistant_file_references`` makes this call conditionally:
+    junk is discardable when the id *resolves* to a record, and preserved
+    when the reference is unrecoverable. This function cannot decide that
+    itself -- recoverability lives in the caller's lookup, not here -- so the
+    conservative half is the default and ``rewrite_junk_references=True``
+    opts into the other. A caller that opts in should consult
+    ``MarkdownFileReference.junk`` and re-emit the prose it is about to
+    consume; returning ``reference.text`` from ``replace`` is the equivalent
+    of leaving one such reference alone case by case.
+
+    Substitution runs through ``re.sub``, so the output is built in one pass
+    and a replacement's length cannot disturb a later reference's position.
+    ``re.sub`` calls the callback in *forward* order, once per match.
+
+    ``replace`` must return a ``str``. A callback that returns ``None`` -- an
+    accidentally missing ``return`` is the realistic way this happens --
+    raises ``TypeError`` here rather than being honoured: ``re.sub`` treats a
+    ``None`` replacement as the empty string and would *silently delete*
+    every reference it was handed, which is the same destructive-content-loss
+    outcome the junk guard above exists to prevent. A callback that *raises*
+    is left alone: the exception propagates and ``content`` is unmutated,
+    because ``re.sub`` builds the result separately.
+    """
+
+    def _substitute(match: re.Match[str]) -> str:
+        reference = _reference_from_match(match)
+        if reference is None:
+            # Not an internal handle. Put back exactly what was written --
+            # deciding that is ``parse_file_id_ref``'s job, not this one's.
+            return match.group(0)
+        if reference.junk.strip() and not rewrite_junk_references:
+            return match.group(0)
+        replacement = replace(reference)
+        if not isinstance(replacement, str):
+            raise TypeError(
+                "replace must return a str; got "
+                f"{type(replacement).__name__} for file reference "
+                f"{reference.file_id!r}"
+            )
+        return replacement
+
+    if not isinstance(content, str):
+        # See ``iter_markdown_file_references``: the type rejection has to
+        # precede the containment test, which a container of strings passes.
+        raise TypeError(f"content must be a str, got {type(content).__name__}")
+    if "file:" not in content:
+        # Same short-circuit and the same reasoning as
+        # ``iter_markdown_file_references``. Returning ``content`` is exact:
+        # with no ``file:`` there is no match, so ``sub`` would return it
+        # unchanged anyway.
+        return content
+    return _MARKDOWN_FILE_REFERENCE_RE.sub(_substitute, content)
 
 
 # ``artifact_type_for_filename`` only knows image/video/office extensions

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -1,6 +1,7 @@
 import time
 from unittest.mock import patch
 
+import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 
@@ -11,7 +12,9 @@ from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
 from xagent.web.services.file_reference_output_service import (
     _AUDIO_EXTENSIONS,
+    iter_markdown_file_references,
     reconcile_assistant_file_references,
+    replace_markdown_file_references,
 )
 
 
@@ -1297,3 +1300,384 @@ def test_reconcile_reuses_prefetched_records_without_querying():
         assert content == "[generated_video.mp4](file:real-id)"
     finally:
         db.close()
+
+
+# -- the shared parsing helper -------------------------------------------------
+#
+# These pin the two properties a consumer outside this module relies on when it
+# routes through the helper instead of forking ``_MARKDOWN_FILE_REFERENCE_RE``:
+# that a titled reference parses as one reference (a title-blind fork reads the
+# title as part of the id), and that a non-handle ``file:`` target is left
+# exactly as written.
+
+
+def test_iter_markdown_file_references_reads_a_plain_reference():
+    (reference,) = list(iter_markdown_file_references("see [chart.png](file:abc-123)"))
+
+    assert reference.file_id == "abc-123"
+    assert reference.label == "chart.png"
+    assert reference.title is None
+    assert reference.is_image is False
+    assert reference.text == "[chart.png](file:abc-123)"
+
+
+def test_iter_markdown_file_references_reads_an_image_reference():
+    (reference,) = list(iter_markdown_file_references("![chart.png](file:abc-123)"))
+
+    assert reference.is_image is True
+    assert reference.file_id == "abc-123"
+
+
+def test_iter_markdown_file_references_reads_all_three_title_forms():
+    """The whole reason a consumer must not fork the pattern: a title-blind
+    copy folds the title clause into the id and resolves nothing."""
+    content = "[a](file:id-d \"d.mp4\") [b](file:id-s 's.mp4') [c](file:id-p (p.mp4))"
+
+    parsed = [
+        (reference.file_id, reference.title)
+        for reference in iter_markdown_file_references(content)
+    ]
+
+    assert parsed == [("id-d", "d.mp4"), ("id-s", "s.mp4"), ("id-p", "p.mp4")]
+
+
+def test_iter_markdown_file_references_skips_a_real_file_uri():
+    """``parse_file_id_ref`` owns that decision, and the helper defers to it
+    rather than handing a consumer an empty id to re-decide."""
+    assert list(iter_markdown_file_references("[passwd](file:///etc/passwd)")) == []
+
+
+def test_iter_markdown_file_references_spans_index_the_original():
+    content = "before [a](file:id-a) after"
+    (reference,) = list(iter_markdown_file_references(content))
+    start, end = reference.span
+
+    assert content[start:end] == "[a](file:id-a)"
+
+
+def test_iter_markdown_file_references_spans_index_every_reference():
+    """The single-reference case cannot catch an offset bug on the second.
+
+    ``span`` is documented as indexing the original string; with more than one
+    reference an off-by-one in later spans would still slice *something*, so
+    each is checked against the text it claims to cover."""
+    content = "x [a](file:id-a) y [b](file:id-b) z ![c](file:id-c)"
+    references = list(iter_markdown_file_references(content))
+
+    assert [content[s:e] for s, e in (r.span for r in references)] == [
+        "[a](file:id-a)",
+        "[b](file:id-b)",
+        "![c](file:id-c)",
+    ]
+
+
+def test_iter_markdown_file_references_percent_decodes_the_id():
+    """Documented hazard: ``file_id`` is not a literal substring of content.
+
+    ``parse_file_id_ref`` runs ``unquote``, so a caller rebuilding a target
+    with an f-string produces one this module's own regex would not match --
+    which is why the docstring points at ``build_file_id_ref``."""
+    (reference,) = list(iter_markdown_file_references("[a](file:a%20b)"))
+
+    assert reference.file_id == "a b"
+
+
+def test_iter_markdown_file_references_reports_an_empty_label_unchanged():
+    """Documented hazard: ``label`` can be ``''``.
+
+    ``[](file:id-a)`` is a well-formed match. The parser reports it as written
+    rather than substituting a placeholder; every consumer in this repo
+    supplies its own fallback."""
+    (reference,) = list(iter_markdown_file_references("[](file:id-a)"))
+
+    assert reference.label == ""
+
+
+def test_iter_markdown_file_references_leaves_title_escapes_raw():
+    """Documented hazard: ``title`` is not unescaped.
+
+    The regex accepts a backslash escape inside a quoted title, but the value
+    handed back is the raw matched text -- a consumer that renders it is
+    responsible for decoding."""
+    (reference,) = list(
+        iter_markdown_file_references(r'[a](file:id-a "sales \"Q3\".pdf")')
+    )
+
+    assert reference.title == r"sales \"Q3\".pdf"
+
+
+def test_replace_markdown_file_references_rewrites_every_reference():
+    content = "![a.png](file:id-a) then [b.csv](file:id-b)"
+
+    rewritten = replace_markdown_file_references(
+        content, lambda reference: reference.label
+    )
+
+    assert rewritten == "a.png then b.csv"
+
+
+def test_replace_markdown_file_references_can_put_the_original_back():
+    """A consumer that decides to leave one reference alone gets the exact
+    original text back, not a re-rendered approximation of it."""
+    content = '[a](file:id-a "a.mp4") and [b](file:id-b)'
+
+    rewritten = replace_markdown_file_references(
+        content,
+        lambda reference: reference.text if reference.file_id == "id-a" else "gone",
+    )
+
+    assert rewritten == '[a](file:id-a "a.mp4") and gone'
+
+
+def test_replace_markdown_file_references_leaves_a_real_file_uri_alone():
+    content = "[passwd](file:///etc/passwd)"
+
+    assert replace_markdown_file_references(content, lambda _: "rewritten") == content
+
+
+def test_replace_markdown_file_references_offsets_survive_a_longer_replacement():
+    """A replacement longer than what it replaced must not disturb the next
+    reference's position.
+
+    The docstring here used to say back-to-front substitution was what made
+    this safe. That described the by-span loop this function no longer uses:
+    ``re.sub`` walks matches *forward* and builds the output in one pass, so
+    positions are resolved against the original string and never shift. The
+    property under test is unchanged and still worth pinning -- only the
+    mechanism differs, and a wrong description of it must not be what a
+    future reader reasons from."""
+    content = "[a](file:id-a) [b](file:id-b)"
+
+    rewritten = replace_markdown_file_references(
+        content, lambda reference: f"<<{reference.file_id}>>"
+    )
+
+    assert rewritten == "<<id-a>> <<id-b>>"
+
+
+def test_iter_markdown_file_references_exposes_trailing_junk():
+    """The field that lets a caller tell this apart from an untitled
+    reference -- ``title`` is ``None`` in both cases, so without ``junk``
+    the difference between "safe to rewrite" and "rewriting deletes a
+    fragment of the user's sentence" is invisible."""
+    (reference,) = list(
+        iter_markdown_file_references(
+            "Check [the docs](file:nonexistent for more details) later"
+        )
+    )
+
+    assert reference.junk == " for more details"
+    assert reference.title is None
+    assert reference.label == "the docs"
+
+
+def test_iter_markdown_file_references_reports_no_junk_for_a_clean_reference():
+    (plain,) = list(iter_markdown_file_references("[a](file:id-a)"))
+    (titled,) = list(iter_markdown_file_references('[a](file:id-a "clip.mp4")'))
+
+    assert plain.junk == ""
+    assert titled.junk == ""
+
+
+def test_replace_markdown_file_references_preserves_trailing_junk_prose():
+    """Regression for the destructive-content-loss class of issue #1202.
+
+    ``[the docs](file:id for more details)`` matches only because the
+    regex's ``junk`` alternative accepts trailing unparsable content -- but
+    that content is ordinary prose the model wrote, not link syntax.
+    Rewriting the whole match deletes a fragment of the user's sentence.
+    ``reconcile_assistant_file_references`` has guarded this since #1202
+    (see test_reconcile_keeps_junk_untouched_when_id_does_not_resolve); this
+    function defaulted to deleting it, which reopened the bug for every
+    consumer that did not know to ask."""
+    content = "Check [the docs](file:nonexistent for more details) later"
+
+    assert (
+        replace_markdown_file_references(content, lambda reference: reference.label)
+        == content
+    )
+
+
+def test_the_junk_opt_in_still_leaves_a_non_handle_target_alone():
+    """Opting into junk rewriting must not also opt into rewriting non-handles.
+
+    These are two independent reasons ``_substitute`` returns the original
+    match, and only their combination was untested: a real ``file:///`` URI
+    carrying trailing junk hits the non-handle branch first, which
+    ``rewrite_junk_references`` has no bearing on."""
+    content = "see [passwd](file:///etc/passwd and more) here"
+
+    rewritten = replace_markdown_file_references(
+        content, lambda reference: "REPLACED", rewrite_junk_references=True
+    )
+
+    assert rewritten == content
+
+
+def test_the_replace_callback_sees_the_image_flag():
+    """``is_image`` is what a consumer needs to know a reference renders inline.
+
+    Asserted from inside the callback rather than only off the dataclass: the
+    rewrite path builds its own reference, so a consumer choosing markup by
+    ``is_image`` depends on it being right *there*."""
+    seen: list[tuple[str, bool]] = []
+
+    def record(reference):
+        seen.append((reference.file_id, reference.is_image))
+        return reference.label
+
+    replace_markdown_file_references("![a](file:id-a) and [b](file:id-b)", record)
+
+    assert seen == [("id-a", True), ("id-b", False)]
+
+
+def test_replace_markdown_file_references_can_opt_into_rewriting_junk():
+    """The sibling discards junk when the id *resolves* -- recoverability is
+    the caller's lookup, not this function's, so the conservative half is the
+    default and this is the opt-in."""
+    content = "Check [the docs](file:real-id for more details) later"
+
+    rewritten = replace_markdown_file_references(
+        content, lambda reference: reference.label, rewrite_junk_references=True
+    )
+
+    assert rewritten == "Check the docs later"
+
+
+def test_replace_markdown_file_references_junk_guard_is_per_reference():
+    """One junk-carrying reference must not stop the clean ones around it
+    from being rewritten -- a whole-content bail would be its own kind of
+    silent failure."""
+    content = "[a](file:id-a) then [the docs](file:id-b for more) then [c](file:id-c)"
+
+    rewritten = replace_markdown_file_references(
+        content, lambda reference: reference.label
+    )
+
+    assert rewritten == "a then [the docs](file:id-b for more) then c"
+
+
+def test_replace_markdown_file_references_rewrites_whitespace_only_junk():
+    """``junk.strip()``, not ``junk`` -- whitespace the regex swept up is not
+    prose worth preserving, and guarding on it would leave ordinary
+    references untouched. Matches the condition
+    ``reconcile_assistant_file_references`` uses (``if junk and
+    junk.strip()``), so the two functions agree on what counts as junk."""
+    content = "[a](file:id-a  )"
+
+    assert (
+        replace_markdown_file_references(content, lambda reference: reference.label)
+        == "a"
+    )
+
+
+def test_replace_markdown_file_references_handles_content_with_no_references():
+    assert replace_markdown_file_references("", lambda reference: "X") == ""
+    assert (
+        replace_markdown_file_references("plain text", lambda reference: "X")
+        == "plain text"
+    )
+
+
+def test_replace_markdown_file_references_handles_adjacent_references():
+    """No separator between them: the shape most likely to expose an
+    off-by-one in a span-based rewrite, and the one ``re.sub`` makes
+    structurally impossible."""
+    content = "[a](file:id-a)[b](file:id-b)"
+
+    rewritten = replace_markdown_file_references(
+        content, lambda reference: f"<{reference.label}>"
+    )
+
+    assert rewritten == "<a><b>"
+
+
+def test_replace_markdown_file_references_rejects_a_callback_returning_none():
+    """A missing ``return`` must not silently delete every reference.
+
+    ``re.sub`` treats a ``None`` replacement as the empty string --
+    ``re.sub(r"a", lambda m: None, "xax")`` is ``"xx"``, verified -- so an
+    accidentally-non-returning callback would erase content rather than
+    failing. That is the same destructive-content-loss outcome the junk guard
+    exists to prevent, arriving by a different route, and it is why this is a
+    ``TypeError`` rather than a documented quirk."""
+    with pytest.raises(TypeError, match="replace must return a str"):
+        replace_markdown_file_references("[a](file:id-a)", lambda reference: None)
+
+
+def test_replace_markdown_file_references_names_the_offending_reference():
+    """The error has to say which callback contract broke and on what, or a
+    caller with several references is left bisecting."""
+    with pytest.raises(TypeError) as caught:
+        replace_markdown_file_references("[a](file:id-a)", lambda reference: 42)
+
+    assert "int" in str(caught.value)
+    assert "id-a" in str(caught.value)
+
+
+def test_replace_markdown_file_references_propagates_a_raising_callback():
+    """The behaviour that was already correct, pinned so the ``None`` fix
+    above cannot quietly change it: a callback that *raises* is not caught,
+    and ``content`` is left unmutated because ``re.sub`` builds its result
+    separately."""
+    content = "[a](file:id-a) and [b](file:id-b)"
+
+    class _Boom(Exception):
+        pass
+
+    def _explode(reference):
+        raise _Boom("callback failed")
+
+    with pytest.raises(_Boom):
+        replace_markdown_file_references(content, _explode)
+
+    assert content == "[a](file:id-a) and [b](file:id-b)"
+
+
+def test_the_parsers_skip_content_without_the_file_literal():
+    """A cheap containment check in front of a pattern whose atomic label
+    group explores bracket-run candidates.
+
+    ``"[" * 100000 + "]"`` measures at ~1.5s through ``finditer`` and is
+    instant with the precheck. Asserted as a time bound rather than by
+    inspection because the cost is the whole point; the threshold is two
+    orders of magnitude below the unguarded figure, so it cannot flake on a
+    slow machine while still failing outright if the precheck is removed."""
+    pathological = "[" * 100_000 + "]"
+
+    started = time.perf_counter()
+    assert list(iter_markdown_file_references(pathological)) == []
+    assert replace_markdown_file_references(pathological, lambda _: "X") == pathological
+    elapsed = time.perf_counter() - started
+
+    assert elapsed < 0.2, f"the file: precheck is not short-circuiting ({elapsed:.3f}s)"
+
+
+def test_a_non_string_still_raises_rather_than_yielding_nothing():
+    """The precheck must not become the sibling's ``isinstance`` guard.
+
+    Returning early for a non-string would turn bad input into an empty
+    iteration a caller cannot distinguish from "no references found", which
+    is a worse failure than raising."""
+    with pytest.raises(TypeError):
+        list(iter_markdown_file_references(None))
+
+
+@pytest.mark.parametrize(
+    "container",
+    [["file:id-a"], ("file:id-a",), {"file:id-a"}, {"file:id-a": 1}],
+    ids=["list", "tuple", "set", "dict"],
+)
+def test_a_container_of_strings_raises_rather_than_reading_as_empty(container):
+    """A container passes ``"file:" not in content``, so ordering matters.
+
+    ``None`` alone does not pin this: it fails the containment test too, so a
+    precheck placed *before* the type rejection still raises for it. A list of
+    strings is the input that separates the two orders -- ``"file:" not in
+    ["file:id-a"]`` is ``True``, so a containment-first precheck returns empty
+    where ``finditer`` used to raise, silently losing the contract this
+    module's docstring promises."""
+    with pytest.raises(TypeError):
+        list(iter_markdown_file_references(container))
+    with pytest.raises(TypeError):
+        replace_markdown_file_references(container, lambda reference: "x")


### PR DESCRIPTION
## The problem

`_MARKDOWN_FILE_REFERENCE_RE` in `file_reference_output_service.py` is the canonical parser for the `[label](file:id ["title"])` format, and the comment above it says so — along with an instruction for anyone else who needs to match that format:

> a future change piping reconciled text into one of them should update it to match this pattern (**or route through a shared parsing helper**) rather than silently mis-parsing a title clause as part of the id/label.

There was no such helper. A consumer outside this module had two options: fork the pattern, or import a private constant. Both drift, and the drift is silent — a title-blind fork reads a title clause as part of the id and resolves nothing; a fork without the `junk` alternative fails to match shapes this one recovers; a fork without the atomic groups reintroduces the quadratic-blowup failure the comment documents. In every case the symptom is a mangled reference in somebody's persisted transcript, found by a support ticket rather than by a test.

**Correcting an inaccurate claim in the original description of this PR:** it said a Slack delivery path in *this* repo had forked the pattern. That is wrong, and @rogercloud was right to check it — nothing in `xagent` has ever forked `_MARKDOWN_FILE_REFERENCE_RE`. The channel utils (`slack/utils.py`, `telegram/utils.py`) use generic markdown-link regexes with no `file:` literal, and they predate this PR.

The real forker was **xorbitsai/xagent-saas#752's earlier revision**, which hand-rolled a simplified `_FILE_LINK_RE` for Toby's Slack delivery path and consequently matched *no* titled reference at all — the exact shape `reconcile_assistant_file_references` emits. This helper exists to replace that fork, and #752's current revision consumes it.

Separately, the title-blindness the comment warns about **is** a live bug on the channel paths, just not by forking this pattern: filed as #1725 (titled references get their link text deleted and a garbage id surfaced). This PR does not touch those files.

## The change

The helper the comment already points at, in two halves, added next to the pattern it wraps:

**`iter_markdown_file_references(content)`** yields each reference as a structured `MarkdownFileReference`:

- `file_id` — already through `parse_file_id_ref`, so a real `file:///path` URI is never handed over as a handle. It is percent-**decoded**, so it is not necessarily a literal substring of the input; a caller re-emitting a target must use `build_file_id_ref`.
- `label` (which can be `''`), `title` (raw — backslash escapes not decoded), `is_image`
- `span` into the original string, `text` — the matched substring, so a consumer that leaves a reference alone can put back exactly what was written
- `junk` — the trailing unparsable prose, see below

**`replace_markdown_file_references(content, replace, *, rewrite_junk_references=False)`** rewrites through a callback, via `re.sub` so the output is built in one pass.

The writing half exists for the consumer `reconcile_assistant_file_references` cannot serve: one whose job is to **remove** the `file:` scheme — for a chat client that cannot resolve the handle — rather than canonicalize links into content. That function is the one that puts canonical `file:` links *in*.

## Junk is preserved by default

`[the docs](file:id for more details)` matches only because the regex's `junk` alternative accepts trailing unparsable content. But that content is ordinary prose the model wrote, not link syntax — rewriting the whole match deletes a fragment of the user's sentence. That is the destructive-content-loss class issue #1202 closed on the reconcile path, and the first revision of this PR reopened it for every consumer that did not know to ask.

`reconcile_assistant_file_references` makes the call **conditionally**: junk is discardable when the id *resolves* to a record, and preserved when the reference is unrecoverable. This function cannot decide that itself — recoverability lives in the caller's lookup, not here — so it takes the conservative half as the default, exposes `junk` so a caller can see the case at all (`title` is `None` either way), and offers `rewrite_junk_references=True` to opt into the other.

## Scope

Pure addition. No existing behaviour changes and `reconcile_assistant_file_references` is untouched — it keeps using the pattern directly, which is why the two can never disagree about what a reference is.

## Tests

17 tests in `tests/web/services/test_file_reference_output_service.py`, all 64 in the file passing. The junk coverage mirrors the reconcile path's own #1202 regressions: junk preserved by default, the opt-in, per-reference isolation (one junk reference must not stop the clean ones around it), and whitespace-only junk still rewritten (matching the sibling's `junk and junk.strip()` condition). Plus empty content, adjacent references with no separator, all three title delimiter forms, non-handle targets, span-indexes-the-original, and put-the-original-back.

Six mutations verified to fail a specific test: removing the junk guard (the shipped bug), guarding on `junk` instead of `junk.strip()`, flipping the default, never populating `junk`, replacing non-handle targets, and returning `""` from the guard.
