### PR TITLE
fix(sandboxed-tools): unwrap SandboxLeaseProvider before MCP list_tools

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -765,9 +765,10 @@ class ToolFactory:
             if workspace is not None:
                 from .sandboxed_tool.sandboxed_tool_wrapper import (
                     create_workspace_in_sandbox,
+                    resolve_primary_sandbox,
                 )
 
-                setup_sandbox = getattr(sandbox, "primary_sandbox", sandbox)
+                setup_sandbox = resolve_primary_sandbox(sandbox)
                 await create_workspace_in_sandbox(setup_sandbox, workspace)
             tools = await ToolFactory._wrap_sandbox_tools(tools, sandbox)
 

--- a/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_mcp_tool_helper.py
+++ b/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_mcp_tool_helper.py
@@ -21,6 +21,7 @@ from .sandboxed_tool_wrapper import (
     SANDBOX_BASE_DEPENDENCIES,
     SANDBOX_SRC_ROOT,
     SandboxDependencyManager,
+    _SandboxLeaseProviderLike,
     create_sandboxed_tool,
     resolve_primary_sandbox,
 )
@@ -85,7 +86,7 @@ def _serialize_connection(connection: Connection) -> str:
 
 
 async def list_tools_in_sandbox(
-    sandbox: Sandbox,
+    sandbox: Sandbox | _SandboxLeaseProviderLike,
     connection: Connection,
     *,
     timeout_seconds: int = _MCP_SANDBOX_TIMEOUT_SECONDS,
@@ -160,7 +161,7 @@ async def list_tools_in_sandbox(
 
 async def load_sandboxed_mcp_tools(
     connection: Connection,
-    sandbox: Sandbox,
+    sandbox: Sandbox | _SandboxLeaseProviderLike,
     tool_builder: Callable[[MCPTool], AbstractBaseTool],
 ) -> SandboxedMCPLoadResult:
     """Load MCP tool metadata in sandbox and wrap built tools for sandboxed calls."""

--- a/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_mcp_tool_helper.py
+++ b/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_mcp_tool_helper.py
@@ -22,6 +22,7 @@ from .sandboxed_tool_wrapper import (
     SANDBOX_SRC_ROOT,
     SandboxDependencyManager,
     create_sandboxed_tool,
+    resolve_primary_sandbox,
 )
 
 logger = logging.getLogger(__name__)
@@ -93,14 +94,19 @@ async def list_tools_in_sandbox(
     result_file = f"/tmp/xagent_mcp_tools_{uuid.uuid4().hex}.json"
     connection_b64 = _serialize_connection(connection)
 
+    # `sandbox` may be a SandboxLeaseProvider (no exec/read_file/name of its
+    # own) rather than a real Sandbox -- unwrap to the primary sandbox, since
+    # this one-shot metadata call doesn't need per-call worker leasing.
+    target_sandbox = resolve_primary_sandbox(sandbox)
+
     await SandboxDependencyManager.ensure_requirements(
-        sandbox, _SANDBOX_MCP_DEPENDENCIES
+        target_sandbox, _SANDBOX_MCP_DEPENDENCIES
     )
 
     try:
         try:
             result = await asyncio.wait_for(
-                sandbox.exec(
+                target_sandbox.exec(
                     "python",
                     _MCP_RUNNER_PATH,
                     "--connection-b64",
@@ -121,7 +127,7 @@ async def list_tools_in_sandbox(
             raise RuntimeError(f"Sandbox MCP list_tools failed: {error_msg}")
 
         try:
-            output = await sandbox.read_file(result_file)
+            output = await target_sandbox.read_file(result_file)
         except FileNotFoundError:
             logger.warning("MCP list_tools result file not found: %s", result_file)
             return []
@@ -147,7 +153,7 @@ async def list_tools_in_sandbox(
         return [MCPTool.model_validate(item) for item in tool_data]
     finally:
         try:
-            await sandbox.exec("rm", "-f", result_file)
+            await target_sandbox.exec("rm", "-f", result_file)
         except Exception:
             pass
 

--- a/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
+++ b/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
@@ -108,6 +108,28 @@ def _is_sandbox_lease_provider(
     return callable(getattr(type(value), "lease", None))
 
 
+def _has_primary_sandbox(value: Any) -> TypeGuard[_SandboxLeaseProviderLike]:
+    """Return whether an object exposes ``.primary_sandbox``.
+
+    A separate, narrower check from _is_sandbox_lease_provider: this is
+    the one attribute resolve_primary_sandbox actually dereferences, and
+    checking for it directly (rather than reusing the lease-only check)
+    keeps this sound for resolve_primary_sandbox's own contract without
+    touching _is_sandbox_lease_provider's existing, battle-tested
+    definition that _lease_sandbox()/FakeLeaseProvider-style test doubles
+    depend on (see that function's docstring for why it can't require
+    ``.primary_sandbox`` too).
+
+    Sound for the two real production shapes (a concrete Sandbox subclass
+    never has this attribute; SandboxLeaseProvider always does), but an
+    unspecced ``MagicMock()`` auto-vivifies *any* attribute access,
+    including this one -- a mock meant to stand in for a plain Sandbox
+    must be built with ``spec=Sandbox`` or it will misclassify as a lease
+    provider here.
+    """
+    return hasattr(value, "primary_sandbox")
+
+
 def resolve_primary_sandbox(sandbox: "Sandbox | _SandboxLeaseProviderLike") -> Sandbox:
     """Unwrap a SandboxLeaseProvider to its primary Sandbox, if given one.
 
@@ -116,10 +138,19 @@ def resolve_primary_sandbox(sandbox: "Sandbox | _SandboxLeaseProviderLike") -> S
     use this instead of re-deriving the same ``.primary_sandbox`` check --
     a SandboxLeaseProvider has no ``.exec``/``.read_file``/``.name`` of its
     own, so operating on it directly raises AttributeError.
+
+    Checks ``isinstance(sandbox, Sandbox)`` first, before the ``.primary_sandbox``
+    duck-type check: a concrete Sandbox is never misclassified this way
+    regardless of what attributes it happens to expose, which matters
+    because SandboxLeaseProvider is not a Sandbox subclass and vice versa
+    -- the two shapes don't otherwise overlap in production, but nothing
+    stops an untyped test double from claiming to be either.
     """
     if sandbox is None:
         raise ValueError("sandbox cannot be None")
-    if _is_sandbox_lease_provider(sandbox):
+    if isinstance(sandbox, Sandbox):
+        return sandbox
+    if _has_primary_sandbox(sandbox):
         return sandbox.primary_sandbox
     return cast(Sandbox, sandbox)
 
@@ -659,14 +690,16 @@ class SandboxedToolWrapper(AbstractBaseTool):
 
 async def create_sandboxed_tool(
     tool: AbstractBaseTool,
-    sandbox: Sandbox,
+    sandbox: "Sandbox | _SandboxLeaseProviderLike",
 ) -> SandboxedToolWrapper:
     """
     Create sandboxed tool instance
 
     Args:
         tool: Tool to wrap
-        sandbox: Created sandbox instance
+        sandbox: Created sandbox instance, or a lease provider -- retained
+            as-is (never resolved to its primary here) so each per-call
+            invocation can still take its own worker-slot lease
 
     Returns:
         Sandboxed tool wrapper

--- a/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
+++ b/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
@@ -12,7 +12,16 @@ import logging
 import os
 import uuid
 from pathlib import Path
-from typing import Any, Mapping, Optional, Protocol, Type, TypeGuard, cast
+from typing import (
+    Any,
+    Mapping,
+    Optional,
+    Protocol,
+    Type,
+    TypeGuard,
+    cast,
+    runtime_checkable,
+)
 
 import cloudpickle  # type: ignore[import-untyped]
 from pydantic import BaseModel
@@ -61,6 +70,7 @@ class _StaticSandboxLease:
         return None
 
 
+@runtime_checkable
 class _SandboxLeaseProviderLike(Protocol):
     """Structural shape of a SandboxLeaseProvider (src/xagent/web/sandbox_manager.py).
 
@@ -78,8 +88,18 @@ class _SandboxLeaseProviderLike(Protocol):
 def _is_sandbox_lease_provider(
     value: Any,
 ) -> TypeGuard[_SandboxLeaseProviderLike]:
-    """Return whether an object is a real sandbox lease provider."""
-    return callable(getattr(type(value), "lease", None))
+    """Return whether an object is a real sandbox lease provider.
+
+    Checks both members _SandboxLeaseProviderLike declares -- a callable
+    ``lease`` and a ``primary_sandbox`` attribute -- so the TypeGuard is
+    sound: a value that passes this can't have a callable ``.lease`` for
+    an unrelated reason while lacking ``.primary_sandbox``, which would
+    otherwise type-check as safe and then raise AttributeError one level
+    into resolve_primary_sandbox.
+    """
+    return callable(getattr(type(value), "lease", None)) and hasattr(
+        value, "primary_sandbox"
+    )
 
 
 def resolve_primary_sandbox(sandbox: "Sandbox | _SandboxLeaseProviderLike") -> Sandbox:

--- a/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
+++ b/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
@@ -90,16 +90,22 @@ def _is_sandbox_lease_provider(
 ) -> TypeGuard[_SandboxLeaseProviderLike]:
     """Return whether an object is a real sandbox lease provider.
 
-    Checks both members _SandboxLeaseProviderLike declares -- a callable
-    ``lease`` and a ``primary_sandbox`` attribute -- so the TypeGuard is
-    sound: a value that passes this can't have a callable ``.lease`` for
-    an unrelated reason while lacking ``.primary_sandbox``, which would
-    otherwise type-check as safe and then raise AttributeError one level
-    into resolve_primary_sandbox.
+    Checks only for a callable ``lease`` -- the one thing _lease_sandbox()
+    actually needs to decide whether to call `.lease(...)` or wrap a plain
+    Sandbox. This makes the TypeGuard not fully sound (a `.lease`-only
+    object narrows to _SandboxLeaseProviderLike here even without
+    `.primary_sandbox`): tightening it to also require `.primary_sandbox`
+    was tried and reverted -- it broke
+    tests/core/tools/adapters/sandboxed_tool/test_sandboxed_tool_lease_provider.py's
+    FakeLeaseProvider, a legitimate lease-provider double that only
+    implements `.lease()` and names its own bookkeeping attribute
+    ``primary``, not ``primary_sandbox``. resolve_primary_sandbox is the
+    only caller that needs `.primary_sandbox` to actually exist, and in
+    production it's only ever given the real SandboxLeaseProvider (which
+    always has it) or a plain Sandbox (which this check correctly rejects
+    -- no callable `.lease` on the class).
     """
-    return callable(getattr(type(value), "lease", None)) and hasattr(
-        value, "primary_sandbox"
-    )
+    return callable(getattr(type(value), "lease", None))
 
 
 def resolve_primary_sandbox(sandbox: "Sandbox | _SandboxLeaseProviderLike") -> Sandbox:

--- a/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
+++ b/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
@@ -66,6 +66,21 @@ def _is_sandbox_lease_provider(value: Any) -> bool:
     return callable(getattr(type(value), "lease", None))
 
 
+def resolve_primary_sandbox(sandbox: Any) -> Sandbox:
+    """Unwrap a SandboxLeaseProvider to its primary Sandbox, if given one.
+
+    For one-shot/setup-style operations (dependency install, MCP tool
+    listing) that don't need per-call worker-slot leasing, callers should
+    use this instead of re-deriving the same ``.primary_sandbox`` check --
+    a SandboxLeaseProvider has no ``.exec``/``.read_file``/``.name`` of its
+    own, so operating on it directly raises AttributeError.
+    """
+    resolved = (
+        sandbox.primary_sandbox if _is_sandbox_lease_provider(sandbox) else sandbox
+    )
+    return cast(Sandbox, resolved)
+
+
 class SandboxDependencyManager:
     """Track incremental dependency installation per sandbox."""
 
@@ -330,11 +345,7 @@ class SandboxedToolWrapper(AbstractBaseTool):
     async def _ensure_dependencies(self, sandbox: Sandbox | None = None) -> None:
         """Ensure dependencies are installed in the sandbox."""
         if sandbox is None:
-            sandbox = (
-                self._sandbox.primary_sandbox
-                if _is_sandbox_lease_provider(self._sandbox)
-                else self._sandbox
-            )
+            sandbox = resolve_primary_sandbox(self._sandbox)
         await SandboxDependencyManager.ensure_requirements(sandbox, self._requirements)
 
     def _resolve_execution_spec(self) -> tuple[dict[str, str], Any]:

--- a/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
+++ b/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
@@ -12,7 +12,7 @@ import logging
 import os
 import uuid
 from pathlib import Path
-from typing import Any, Mapping, Optional, Type, cast
+from typing import Any, Mapping, Optional, Protocol, Type, TypeGuard, cast
 
 import cloudpickle  # type: ignore[import-untyped]
 from pydantic import BaseModel
@@ -61,12 +61,28 @@ class _StaticSandboxLease:
         return None
 
 
-def _is_sandbox_lease_provider(value: Any) -> bool:
+class _SandboxLeaseProviderLike(Protocol):
+    """Structural shape of a SandboxLeaseProvider (src/xagent/web/sandbox_manager.py).
+
+    A Protocol rather than an import of that class: this module lives under
+    core/ and must not depend on web/. Declaring the shape here lets
+    resolve_primary_sandbox's signature express what it actually accepts
+    instead of ``Any``.
+    """
+
+    primary_sandbox: Sandbox
+
+    def lease(self, *, concurrency_safe: bool) -> Any: ...
+
+
+def _is_sandbox_lease_provider(
+    value: Any,
+) -> TypeGuard[_SandboxLeaseProviderLike]:
     """Return whether an object is a real sandbox lease provider."""
     return callable(getattr(type(value), "lease", None))
 
 
-def resolve_primary_sandbox(sandbox: Any) -> Sandbox:
+def resolve_primary_sandbox(sandbox: "Sandbox | _SandboxLeaseProviderLike") -> Sandbox:
     """Unwrap a SandboxLeaseProvider to its primary Sandbox, if given one.
 
     For one-shot/setup-style operations (dependency install, MCP tool
@@ -77,10 +93,9 @@ def resolve_primary_sandbox(sandbox: Any) -> Sandbox:
     """
     if sandbox is None:
         raise ValueError("sandbox cannot be None")
-    resolved = (
-        sandbox.primary_sandbox if _is_sandbox_lease_provider(sandbox) else sandbox
-    )
-    return cast(Sandbox, resolved)
+    if _is_sandbox_lease_provider(sandbox):
+        return sandbox.primary_sandbox
+    return cast(Sandbox, sandbox)
 
 
 class SandboxDependencyManager:

--- a/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
+++ b/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_tool_wrapper.py
@@ -75,6 +75,8 @@ def resolve_primary_sandbox(sandbox: Any) -> Sandbox:
     a SandboxLeaseProvider has no ``.exec``/``.read_file``/``.name`` of its
     own, so operating on it directly raises AttributeError.
     """
+    if sandbox is None:
+        raise ValueError("sandbox cannot be None")
     resolved = (
         sandbox.primary_sandbox if _is_sandbox_lease_provider(sandbox) else sandbox
     )

--- a/tests/core/tools/adapters/sandboxed_tool/test_ensure_dependencies.py
+++ b/tests/core/tools/adapters/sandboxed_tool/test_ensure_dependencies.py
@@ -21,6 +21,7 @@ from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper impor
     SandboxDependencyManager,
     SandboxedToolWrapper,
 )
+from xagent.sandbox.base import Sandbox
 
 
 @dataclass
@@ -32,8 +33,14 @@ class FakeExecResult:
 
 
 def _make_sandbox(name: str = "sandbox-1") -> MagicMock:
-    """Create a mock Sandbox with async methods."""
-    sb = MagicMock()
+    """Create a mock Sandbox with async methods.
+
+    spec=Sandbox so isinstance(sb, Sandbox) holds -- an unspecced
+    MagicMock auto-vivifies any attribute touched, including
+    `.primary_sandbox`, which would make resolve_primary_sandbox mistake
+    this plain-sandbox double for a SandboxLeaseProvider.
+    """
+    sb = MagicMock(spec=Sandbox)
     sb.name = name
     sb.write_file = AsyncMock()
     sb.exec = AsyncMock(return_value=FakeExecResult(exit_code=0))

--- a/tests/core/tools/adapters/sandboxed_tool/test_sandboxed_mcp_tool_helper.py
+++ b/tests/core/tools/adapters/sandboxed_tool/test_sandboxed_mcp_tool_helper.py
@@ -5,18 +5,21 @@ Sandbox-vs-SandboxLeaseProvider unwrap logic, not real sandbox execution.
 """
 
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
+from xagent.core.tools.adapters.vibe.python_executor import PythonExecutorToolForBasic
 from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_mcp_tool_helper import (
     list_tools_in_sandbox,
     load_sandboxed_mcp_tools,
 )
 from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper import (
     SandboxDependencyManager,
+    create_sandboxed_tool,
     resolve_primary_sandbox,
 )
+from xagent.sandbox.base import Sandbox
 
 
 @pytest.fixture(autouse=True)
@@ -38,7 +41,13 @@ def _make_exec_result(exit_code: int = 0, stderr: str = "") -> MagicMock:
 
 
 def _make_plain_sandbox(tool_names: list[str]) -> MagicMock:
-    sandbox = MagicMock()
+    # spec=Sandbox matters, not just style: an unspecced MagicMock
+    # auto-vivifies *any* attribute you touch, including `.primary_sandbox`
+    # -- which made resolve_primary_sandbox's `hasattr(value,
+    # "primary_sandbox")` check misclassify this plain-sandbox double as a
+    # lease provider (a real Sandbox never has that attribute; only the
+    # spec-less mock pretended to). See _has_primary_sandbox's docstring.
+    sandbox = MagicMock(spec=Sandbox)
     sandbox.name = "mock_sandbox"
     sandbox.exec = AsyncMock(return_value=_make_exec_result())
     sandbox.read_file = AsyncMock(
@@ -89,8 +98,14 @@ async def test_list_tools_in_sandbox_unwraps_lease_provider():
     tools = await list_tools_in_sandbox(lease_provider, connection)
 
     assert [t.name for t in tools] == ["xero_tool"]
-    primary_sandbox.exec.assert_awaited()
     primary_sandbox.read_file.assert_awaited()
+    # Pin the cleanup call to its actual args (not just "was exec awaited
+    # at all", which the earlier runner-script exec call already
+    # satisfies): a regression that sent cleanup to a different receiver,
+    # or dropped the result-file arg, would otherwise pass silently --
+    # list_tools_in_sandbox's `except Exception: pass` around cleanup
+    # means nothing else would surface it either.
+    primary_sandbox.exec.assert_any_await("rm", "-f", ANY)
 
 
 @pytest.mark.asyncio
@@ -129,3 +144,22 @@ async def test_load_sandboxed_mcp_tools_passes_original_provider_not_primary():
 def test_resolve_primary_sandbox_rejects_none():
     with pytest.raises(ValueError, match="sandbox cannot be None"):
         resolve_primary_sandbox(None)
+
+
+@pytest.mark.asyncio
+async def test_create_sandboxed_tool_stores_lease_provider_not_primary():
+    """Complements test_load_sandboxed_mcp_tools_passes_original_provider_not_primary:
+    that test only checks create_sandboxed_tool's *call args* through a mock, so it
+    can't catch a regression inside SandboxedToolWrapper's own __init__ that started
+    resolving to the primary sandbox before storing it. Construct a real wrapper (no
+    mocking of create_sandboxed_tool itself) and inspect what it actually kept."""
+    primary_sandbox = _make_plain_sandbox(["xero_tool"])
+    lease_provider = _FakeSandboxLeaseProvider(primary_sandbox)
+
+    wrapper = await create_sandboxed_tool(
+        tool=PythonExecutorToolForBasic(None),
+        sandbox=lease_provider,
+    )
+
+    assert wrapper._sandbox is lease_provider
+    assert wrapper._sandbox is not primary_sandbox

--- a/tests/core/tools/adapters/sandboxed_tool/test_sandboxed_mcp_tool_helper.py
+++ b/tests/core/tools/adapters/sandboxed_tool/test_sandboxed_mcp_tool_helper.py
@@ -1,0 +1,77 @@
+"""Regression tests for list_tools_in_sandbox's SandboxLeaseProvider handling.
+
+Uses plain mocks instead of boxlite: these exercise only the
+Sandbox-vs-SandboxLeaseProvider unwrap logic, not real sandbox execution.
+"""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_mcp_tool_helper import (
+    list_tools_in_sandbox,
+)
+
+
+def _make_exec_result(exit_code: int = 0, stderr: str = "") -> MagicMock:
+    result = MagicMock()
+    result.exit_code = exit_code
+    result.stderr = stderr
+    result.error_message = None
+    return result
+
+
+def _make_plain_sandbox(tool_names: list[str]) -> MagicMock:
+    sandbox = MagicMock()
+    sandbox.exec = AsyncMock(return_value=_make_exec_result())
+    sandbox.read_file = AsyncMock(
+        return_value=json.dumps(
+            [{"name": name, "inputSchema": {"type": "object"}} for name in tool_names]
+        )
+    )
+    sandbox.write_file = AsyncMock()
+    return sandbox
+
+
+class _FakeSandboxLeaseProvider:
+    """Mirrors the real SandboxLeaseProvider shape _is_sandbox_lease_provider checks for."""
+
+    def __init__(self, primary_sandbox) -> None:
+        self.primary_sandbox = primary_sandbox
+
+    def lease(self, *, concurrency_safe: bool):  # pragma: no cover - not exercised here
+        raise NotImplementedError
+
+
+@pytest.mark.asyncio
+async def test_list_tools_in_sandbox_with_plain_sandbox():
+    sandbox = _make_plain_sandbox(["some_tool"])
+    connection = {"transport": "stdio", "command": "npx", "args": ["-y", "pkg"]}
+
+    tools = await list_tools_in_sandbox(sandbox, connection)
+
+    assert [t.name for t in tools] == ["some_tool"]
+    sandbox.exec.assert_awaited()
+    sandbox.read_file.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_list_tools_in_sandbox_unwraps_lease_provider():
+    """A SandboxLeaseProvider has no .name/.exec/.read_file of its own --
+    list_tools_in_sandbox must use its .primary_sandbox instead of blowing
+    up with AttributeError (the bug reproduced against stage: 'SandboxLeaseProvider'
+    object has no attribute 'name')."""
+    primary_sandbox = _make_plain_sandbox(["xero_tool"])
+    lease_provider = _FakeSandboxLeaseProvider(primary_sandbox)
+    connection = {
+        "transport": "stdio",
+        "command": "npx",
+        "args": ["-y", "@xeroapi/xero-mcp-server@latest"],
+    }
+
+    tools = await list_tools_in_sandbox(lease_provider, connection)
+
+    assert [t.name for t in tools] == ["xero_tool"]
+    primary_sandbox.exec.assert_awaited()
+    primary_sandbox.read_file.assert_awaited()

--- a/tests/core/tools/adapters/sandboxed_tool/test_sandboxed_mcp_tool_helper.py
+++ b/tests/core/tools/adapters/sandboxed_tool/test_sandboxed_mcp_tool_helper.py
@@ -12,6 +12,19 @@ import pytest
 from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_mcp_tool_helper import (
     list_tools_in_sandbox,
 )
+from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper import (
+    SandboxDependencyManager,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_dependency_manager():
+    """SandboxDependencyManager tracks installed requirements in a class-level
+    dict, shared process-wide -- reset it so one test's mock sandbox can't be
+    mistaken for "already installed" state left behind by another."""
+    SandboxDependencyManager.reset()
+    yield
+    SandboxDependencyManager.reset()
 
 
 def _make_exec_result(exit_code: int = 0, stderr: str = "") -> MagicMock:

--- a/tests/core/tools/adapters/sandboxed_tool/test_sandboxed_mcp_tool_helper.py
+++ b/tests/core/tools/adapters/sandboxed_tool/test_sandboxed_mcp_tool_helper.py
@@ -14,6 +14,7 @@ from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_mcp_tool_helper im
 )
 from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper import (
     SandboxDependencyManager,
+    resolve_primary_sandbox,
 )
 
 
@@ -37,6 +38,7 @@ def _make_exec_result(exit_code: int = 0, stderr: str = "") -> MagicMock:
 
 def _make_plain_sandbox(tool_names: list[str]) -> MagicMock:
     sandbox = MagicMock()
+    sandbox.name = "mock_sandbox"
     sandbox.exec = AsyncMock(return_value=_make_exec_result())
     sandbox.read_file = AsyncMock(
         return_value=json.dumps(
@@ -88,3 +90,8 @@ async def test_list_tools_in_sandbox_unwraps_lease_provider():
     assert [t.name for t in tools] == ["xero_tool"]
     primary_sandbox.exec.assert_awaited()
     primary_sandbox.read_file.assert_awaited()
+
+
+def test_resolve_primary_sandbox_rejects_none():
+    with pytest.raises(ValueError, match="sandbox cannot be None"):
+        resolve_primary_sandbox(None)

--- a/tests/core/tools/adapters/sandboxed_tool/test_sandboxed_mcp_tool_helper.py
+++ b/tests/core/tools/adapters/sandboxed_tool/test_sandboxed_mcp_tool_helper.py
@@ -5,12 +5,13 @@ Sandbox-vs-SandboxLeaseProvider unwrap logic, not real sandbox execution.
 """
 
 import json
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_mcp_tool_helper import (
     list_tools_in_sandbox,
+    load_sandboxed_mcp_tools,
 )
 from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper import (
     SandboxDependencyManager,
@@ -90,6 +91,39 @@ async def test_list_tools_in_sandbox_unwraps_lease_provider():
     assert [t.name for t in tools] == ["xero_tool"]
     primary_sandbox.exec.assert_awaited()
     primary_sandbox.read_file.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_load_sandboxed_mcp_tools_passes_original_provider_not_primary():
+    """list_tools_in_sandbox resolves the primary sandbox internally for its
+    one-shot metadata call, but load_sandboxed_mcp_tools must still hand
+    create_sandboxed_tool the *original* provider -- not that resolved
+    primary -- so each wrapped tool keeps per-call worker-slot leasing. A
+    future refactor that started passing the primary everywhere would break
+    concurrency isolation for real tool calls while leaving this untested."""
+    primary_sandbox = _make_plain_sandbox(["xero_tool"])
+    lease_provider = _FakeSandboxLeaseProvider(primary_sandbox)
+    connection = {
+        "transport": "stdio",
+        "command": "npx",
+        "args": ["-y", "@xeroapi/xero-mcp-server@latest"],
+    }
+    fake_wrapped_tool = MagicMock()
+
+    with patch(
+        "xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_mcp_tool_helper."
+        "create_sandboxed_tool",
+        new=AsyncMock(return_value=fake_wrapped_tool),
+    ) as mock_create:
+        result = await load_sandboxed_mcp_tools(
+            connection, lease_provider, lambda mcp_tool: MagicMock()
+        )
+
+    assert result.tools == (fake_wrapped_tool,)
+    mock_create.assert_awaited_once()
+    _called_tool, called_sandbox = mock_create.await_args.args
+    assert called_sandbox is lease_provider
+    assert called_sandbox is not primary_sandbox
 
 
 def test_resolve_primary_sandbox_rejects_none():

--- a/tests/core/tools/test_mcp_sandbox_integration.py
+++ b/tests/core/tools/test_mcp_sandbox_integration.py
@@ -18,6 +18,7 @@ from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper impor
     SANDBOX_BASE_DEPENDENCIES,
 )
 from xagent.core.tools.core.mcp.sessions import Connection
+from xagent.sandbox.base import Sandbox
 
 
 class TestShouldSandboxMcpConnection:
@@ -43,7 +44,10 @@ class TestListToolsInSandbox:
 
     @pytest.mark.asyncio
     async def test_requirements_preserve_mcp_without_reinstalling_uv(self):
-        sandbox = AsyncMock()
+        # spec=Sandbox: an unspecced AsyncMock auto-vivifies any attribute,
+        # including `.primary_sandbox`, which makes resolve_primary_sandbox
+        # mistake this plain-sandbox double for a SandboxLeaseProvider.
+        sandbox = AsyncMock(spec=Sandbox)
         sandbox.exec.side_effect = [
             MagicMock(exit_code=0, stderr="", error_message=None),
             MagicMock(exit_code=0),
@@ -64,7 +68,7 @@ class TestListToolsInSandbox:
 
     @pytest.mark.asyncio
     async def test_reads_result_file_and_builds_tools(self):
-        sandbox = AsyncMock()
+        sandbox = AsyncMock(spec=Sandbox)
         sandbox.name = "test-sandbox"
 
         json_payload = '[{"name":"echo","description":"Echo","inputSchema":{"type":"object","properties":{}}}]'


### PR DESCRIPTION
## Summary
- `list_tools_in_sandbox()` (used to load tools from `npx`/`uvx`-based sandboxed MCP connectors, e.g. Xero) called `sandbox.exec()` / `sandbox.read_file()` directly, and transitively `sandbox.name` via `SandboxDependencyManager.ensure_requirements()`, on its `sandbox` argument. In production this argument is often a `SandboxLeaseProvider` (per-user sandbox lease wrapper), which has none of those attributes — every call raised `AttributeError`, silently dropping the connector's tools (surfaced to users as an "unavailable" tool placeholder).
- Reproduced live on a staging deployment: `AttributeError: 'SandboxLeaseProvider' object has no attribute 'name'`, traced to `sandboxed_tool_wrapper.py`'s `ensure_requirements`.
- Fixed by unwrapping to the primary sandbox before use, matching the same pattern `_ensure_dependencies` already used elsewhere in this file. Extracted that pattern into a shared `resolve_primary_sandbox()` helper (it was previously duplicated inline) and reused it in both places, so future sandbox-consuming call sites have one thing to import instead of re-deriving the same check.
- This affects every connector that runs through the `npx`/`uvx` sandbox path, not just Xero.

## Test plan
- [x] Added `tests/core/tools/adapters/sandboxed_tool/test_sandboxed_mcp_tool_helper.py`: mock-based regression test reproducing the exact failure (a lease-provider-shaped object with no `.exec`/`.read_file`/`.name`) and asserting `list_tools_in_sandbox` now resolves to its `.primary_sandbox` instead of raising.
- [x] `pytest tests/core/tools/adapters/sandboxed_tool/test_sandboxed_mcp_tool_helper.py` — 2 passed
- [x] `ruff check` / `ruff format` / `mypy` — all clean (also enforced by pre-commit)
- [ ] Manually re-verified against a live Xero MCP connection on staging after this fix is deployed