### PR TITLE
feat: add built-in agent runtime

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ Xagent has one main entrypoint:
 - `runtime.py` - Cross-cutting pattern services: LLM calls, tool calls, tracing, checkpoints, outbound messages, and context compaction.
 - `context/` - Message and execution context management.
 - `pattern/` - Execution patterns: `single_call`, ReAct, DAG plan-execute, and auto routing.
+- `builtin/` - Restricted specs, registry, and executor for code-defined internal agents.
 - `checkpoint.py` - Trace-backed checkpoint persistence for resumable executions.
 
 There is no v1/v2 runtime switch. Do not add new code under `agent_v2` or `agent_runtime`; both concepts have been collapsed into `core.agent`.

--- a/src/xagent/core/agent/builtin/__init__.py
+++ b/src/xagent/core/agent/builtin/__init__.py
@@ -1,0 +1,35 @@
+"""Public API for code-defined built-in agents."""
+
+from .executor import (
+    BuiltinAgentCapabilityError,
+    BuiltinAgentExecutor,
+    BuiltinAgentModelUnavailableError,
+    BuiltinModelResolver,
+)
+from .registry import (
+    BUILTIN_AGENT_REGISTRY,
+    BuiltinAgentNotFoundError,
+    BuiltinAgentRegistrationError,
+    BuiltinAgentRegistry,
+)
+from .spec import (
+    BuiltinAgentPattern,
+    BuiltinAgentRunContext,
+    BuiltinAgentSpec,
+    BuiltinToolBuilder,
+)
+
+__all__ = [
+    "BUILTIN_AGENT_REGISTRY",
+    "BuiltinAgentCapabilityError",
+    "BuiltinAgentExecutor",
+    "BuiltinAgentModelUnavailableError",
+    "BuiltinAgentNotFoundError",
+    "BuiltinAgentPattern",
+    "BuiltinAgentRegistrationError",
+    "BuiltinAgentRegistry",
+    "BuiltinAgentRunContext",
+    "BuiltinAgentSpec",
+    "BuiltinModelResolver",
+    "BuiltinToolBuilder",
+]

--- a/src/xagent/core/agent/builtin/executor.py
+++ b/src/xagent/core/agent/builtin/executor.py
@@ -1,0 +1,154 @@
+"""Restricted execution path for code-defined built-in agents."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from typing import Any, TypeAlias, cast
+
+from ...model.chat.basic.base import BaseLLM
+from ...tools.adapters.vibe import Tool
+from ...tools.adapters.vibe.base import ToolCategory
+from ..service import AgentService
+from .registry import BUILTIN_AGENT_REGISTRY, BuiltinAgentRegistry
+from .spec import BuiltinAgentRunContext, BuiltinAgentSpec
+
+BuiltinModelResolverResult: TypeAlias = BaseLLM | Awaitable[BaseLLM | None] | None
+BuiltinModelResolver: TypeAlias = Callable[
+    [str, BuiltinAgentRunContext], BuiltinModelResolverResult
+]
+BuiltinServiceFactory: TypeAlias = Callable[..., AgentService]
+
+
+class BuiltinAgentModelUnavailableError(RuntimeError):
+    """Raised when no model is available for a built-in agent's model role."""
+
+
+class BuiltinAgentCapabilityError(ValueError):
+    """Raised when a built-in agent requests a forbidden capability."""
+
+
+class BuiltinAgentExecutor:
+    """Resolve and execute a registered built-in agent with least privilege."""
+
+    def __init__(
+        self,
+        *,
+        model_resolver: BuiltinModelResolver,
+        registry: BuiltinAgentRegistry = BUILTIN_AGENT_REGISTRY,
+        service_factory: BuiltinServiceFactory = AgentService,
+    ) -> None:
+        self._model_resolver = model_resolver
+        self._registry = registry
+        self._service_factory = service_factory
+
+    async def execute(
+        self,
+        name: str,
+        *,
+        task: str,
+        execution_id: str,
+        request_context: Mapping[str, Any] | None = None,
+        tracer: Any | None = None,
+        workspace_base_dir: str | None = None,
+    ) -> dict[str, Any]:
+        """Execute one built-in agent run without persistence or default tools."""
+
+        if not task.strip():
+            raise ValueError("Built-in agent task must not be empty")
+
+        spec = self._registry.require(name)
+        run_context = BuiltinAgentRunContext(
+            execution_id=execution_id,
+            request_context=dict(request_context or {}),
+            tracer=tracer,
+            workspace_base_dir=workspace_base_dir,
+        )
+        model = await self._resolve_model(spec, run_context)
+        tools = await self._build_tools(spec, run_context)
+        self._validate_tools(spec, tools)
+
+        metadata = {
+            "agent_type": "builtin",
+            "builtin_agent_name": spec.name,
+            "builtin_agent_version": spec.version,
+            "builtin_model_role": spec.model_role,
+        }
+        service_kwargs: dict[str, Any] = {
+            "name": f"builtin:{spec.name}",
+            "id": f"builtin:{spec.name}:{execution_id}",
+            "task_id": execution_id,
+            "pattern": spec.pattern,
+            "llm": model,
+            "tracer": tracer,
+            "system_prompt": spec.system_prompt,
+            "tools": tools,
+            "tools_initialized": True,
+            "tool_config": None,
+            "enable_default_tools": False,
+            "enable_workspace": spec.workspace_enabled,
+            "memory_enabled": spec.memory_enabled,
+            "skills_enabled": spec.skills_enabled,
+            "user_interaction_enabled": False,
+            "execution_metadata": metadata,
+            "agent_type": "builtin",
+        }
+        if workspace_base_dir is not None:
+            service_kwargs["workspace_base_dir"] = workspace_base_dir
+
+        service = self._service_factory(**service_kwargs)
+        execution_context = dict(run_context.request_context)
+        execution_context["builtin_agent"] = dict(metadata)
+        result = await service.execute_task(
+            task,
+            context=execution_context,
+            task_id=execution_id,
+        )
+        result_metadata = result.get("metadata")
+        if not isinstance(result_metadata, dict):
+            result_metadata = {}
+            result["metadata"] = result_metadata
+        result_metadata.update(metadata)
+        result["builtin_artifacts"] = dict(run_context.artifacts)
+        return result
+
+    async def _resolve_model(
+        self,
+        spec: BuiltinAgentSpec,
+        run_context: BuiltinAgentRunContext,
+    ) -> BaseLLM:
+        resolved = self._model_resolver(spec.model_role, run_context)
+        if inspect.isawaitable(resolved):
+            resolved = await resolved
+        if resolved is None:
+            raise BuiltinAgentModelUnavailableError(
+                f"No model is available for built-in agent '{spec.name}' "
+                f"with role '{spec.model_role}'"
+            )
+        return cast(BaseLLM, resolved)
+
+    async def _build_tools(
+        self,
+        spec: BuiltinAgentSpec,
+        run_context: BuiltinAgentRunContext,
+    ) -> list[Tool]:
+        if spec.build_tools is None:
+            return []
+        built = spec.build_tools(run_context)
+        if inspect.isawaitable(built):
+            built = await built
+        if isinstance(built, (str, bytes)) or not isinstance(built, Sequence):
+            raise TypeError(
+                f"Built-in agent '{spec.name}' tool builder must return a sequence"
+            )
+        return list(built)
+
+    def _validate_tools(self, spec: BuiltinAgentSpec, tools: list[Tool]) -> None:
+        for tool in tools:
+            metadata = getattr(tool, "metadata", None)
+            category = getattr(metadata, "category", None)
+            category_value = getattr(category, "value", category)
+            if category_value == ToolCategory.AGENT.value:
+                raise BuiltinAgentCapabilityError(
+                    f"Built-in agent '{spec.name}' cannot use agent delegation tools"
+                )

--- a/src/xagent/core/agent/builtin/executor.py
+++ b/src/xagent/core/agent/builtin/executor.py
@@ -91,7 +91,6 @@ class BuiltinAgentExecutor:
             "skills_enabled": spec.skills_enabled,
             "user_interaction_enabled": False,
             "execution_metadata": metadata,
-            "agent_type": "builtin",
         }
         if workspace_base_dir is not None:
             service_kwargs["workspace_base_dir"] = workspace_base_dir

--- a/src/xagent/core/agent/builtin/executor.py
+++ b/src/xagent/core/agent/builtin/executor.py
@@ -8,7 +8,10 @@ from typing import Any, TypeAlias, cast
 
 from ...model.chat.basic.base import BaseLLM
 from ...tools.adapters.vibe import Tool
-from ...tools.adapters.vibe.base import ToolCategory
+from ...tools.adapters.vibe.base import (
+    AGENT_CONFIG_UNASSIGNABLE_CATEGORIES,
+    ToolCategory,
+)
 from ..service import AgentService
 from .registry import BUILTIN_AGENT_REGISTRY, BuiltinAgentRegistry
 from .spec import BuiltinAgentRunContext, BuiltinAgentSpec
@@ -18,6 +21,10 @@ BuiltinModelResolver: TypeAlias = Callable[
     [str, BuiltinAgentRunContext], BuiltinModelResolverResult
 ]
 BuiltinServiceFactory: TypeAlias = Callable[..., AgentService]
+_BUILTIN_ALLOWED_TOOL_CATEGORIES = (
+    frozenset(category.value for category in ToolCategory)
+    - AGENT_CONFIG_UNASSIGNABLE_CATEGORIES
+)
 
 
 class BuiltinAgentModelUnavailableError(RuntimeError):
@@ -58,6 +65,13 @@ class BuiltinAgentExecutor:
             raise ValueError("Built-in agent task must not be empty")
 
         spec = self._registry.require(name)
+        if spec.workspace_enabled and (
+            workspace_base_dir is None or not workspace_base_dir.strip()
+        ):
+            raise BuiltinAgentCapabilityError(
+                f"Built-in agent '{spec.name}' must be given an explicit "
+                "workspace_base_dir when workspace access is enabled"
+            )
         run_context = BuiltinAgentRunContext(
             execution_id=execution_id,
             request_context=dict(request_context or {}),
@@ -76,7 +90,7 @@ class BuiltinAgentExecutor:
         }
         service_kwargs: dict[str, Any] = {
             "name": f"builtin:{spec.name}",
-            "id": f"builtin:{spec.name}:{execution_id}",
+            "id": f"builtin--{spec.name}--{execution_id}",
             "task_id": execution_id,
             "pattern": spec.pattern,
             "llm": model,
@@ -147,7 +161,8 @@ class BuiltinAgentExecutor:
             metadata = getattr(tool, "metadata", None)
             category = getattr(metadata, "category", None)
             category_value = getattr(category, "value", category)
-            if category_value == ToolCategory.AGENT.value:
+            if category_value not in _BUILTIN_ALLOWED_TOOL_CATEGORIES:
                 raise BuiltinAgentCapabilityError(
-                    f"Built-in agent '{spec.name}' cannot use agent delegation tools"
+                    f"Built-in agent '{spec.name}' cannot use tools without an "
+                    f"explicit assignable category (got {category_value!r})"
                 )

--- a/src/xagent/core/agent/builtin/executor.py
+++ b/src/xagent/core/agent/builtin/executor.py
@@ -21,10 +21,12 @@ BuiltinModelResolver: TypeAlias = Callable[
     [str, BuiltinAgentRunContext], BuiltinModelResolverResult
 ]
 BuiltinServiceFactory: TypeAlias = Callable[..., AgentService]
-_BUILTIN_ALLOWED_TOOL_CATEGORIES = (
-    frozenset(category.value for category in ToolCategory)
-    - AGENT_CONFIG_UNASSIGNABLE_CATEGORIES
+_BUILTIN_ALLOWED_TOOL_CATEGORIES = frozenset(
+    category
+    for category in ToolCategory
+    if category.value not in AGENT_CONFIG_UNASSIGNABLE_CATEGORIES
 )
+_BUILTIN_REQUEST_CONTEXT_KEY = "builtin_request_context"
 
 
 class BuiltinAgentModelUnavailableError(RuntimeError):
@@ -110,11 +112,11 @@ class BuiltinAgentExecutor:
             service_kwargs["workspace_base_dir"] = workspace_base_dir
 
         service = self._service_factory(**service_kwargs)
-        execution_context = dict(run_context.request_context)
-        execution_context["builtin_agent"] = dict(metadata)
         result = await service.execute_task(
             task,
-            context=execution_context,
+            context={
+                _BUILTIN_REQUEST_CONTEXT_KEY: dict(run_context.request_context),
+            },
             task_id=execution_id,
         )
         result_metadata = result.get("metadata")
@@ -138,6 +140,12 @@ class BuiltinAgentExecutor:
                 f"No model is available for built-in agent '{spec.name}' "
                 f"with role '{spec.model_role}'"
             )
+        if not callable(getattr(resolved, "chat", None)):
+            raise BuiltinAgentModelUnavailableError(
+                f"Model resolver for built-in agent '{spec.name}' returned an "
+                f"invalid model for role '{spec.model_role}': expected a callable "
+                "chat method"
+            )
         return cast(BaseLLM, resolved)
 
     async def _build_tools(
@@ -160,9 +168,11 @@ class BuiltinAgentExecutor:
         for tool in tools:
             metadata = getattr(tool, "metadata", None)
             category = getattr(metadata, "category", None)
-            category_value = getattr(category, "value", category)
-            if category_value not in _BUILTIN_ALLOWED_TOOL_CATEGORIES:
+            if (
+                not isinstance(category, ToolCategory)
+                or category not in _BUILTIN_ALLOWED_TOOL_CATEGORIES
+            ):
                 raise BuiltinAgentCapabilityError(
                     f"Built-in agent '{spec.name}' cannot use tools without an "
-                    f"explicit assignable category (got {category_value!r})"
+                    f"explicit assignable category (got {category!r})"
                 )

--- a/src/xagent/core/agent/builtin/registry.py
+++ b/src/xagent/core/agent/builtin/registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from threading import RLock
 
 from .spec import BuiltinAgentSpec
 
@@ -20,18 +21,25 @@ class BuiltinAgentRegistry:
 
     def __init__(self, specs: Iterable[BuiltinAgentSpec] = ()) -> None:
         self._specs: dict[str, BuiltinAgentSpec] = {}
+        self._lock = RLock()
         for spec in specs:
             self.register(spec)
 
     def register(self, spec: BuiltinAgentSpec) -> None:
-        if spec.name in self._specs:
+        if not isinstance(spec, BuiltinAgentSpec):
             raise BuiltinAgentRegistrationError(
-                f"Built-in agent '{spec.name}' is already registered"
+                "Built-in agent registry only accepts BuiltinAgentSpec instances"
             )
-        self._specs[spec.name] = spec
+        with self._lock:
+            if spec.name in self._specs:
+                raise BuiltinAgentRegistrationError(
+                    f"Built-in agent '{spec.name}' is already registered"
+                )
+            self._specs[spec.name] = spec
 
     def get(self, name: str) -> BuiltinAgentSpec | None:
-        return self._specs.get(name)
+        with self._lock:
+            return self._specs.get(name)
 
     def require(self, name: str) -> BuiltinAgentSpec:
         spec = self.get(name)
@@ -42,10 +50,12 @@ class BuiltinAgentRegistry:
         return spec
 
     def list_specs(self) -> tuple[BuiltinAgentSpec, ...]:
-        return tuple(self._specs.values())
+        with self._lock:
+            return tuple(self._specs.values())
 
     def __contains__(self, name: object) -> bool:
-        return name in self._specs
+        with self._lock:
+            return name in self._specs
 
 
 BUILTIN_AGENT_REGISTRY = BuiltinAgentRegistry()

--- a/src/xagent/core/agent/builtin/registry.py
+++ b/src/xagent/core/agent/builtin/registry.py
@@ -1,0 +1,51 @@
+"""Registry for code-defined built-in agent specifications."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from .spec import BuiltinAgentSpec
+
+
+class BuiltinAgentRegistrationError(ValueError):
+    """Raised when a built-in agent specification cannot be registered."""
+
+
+class BuiltinAgentNotFoundError(LookupError):
+    """Raised when a requested built-in agent has not been registered."""
+
+
+class BuiltinAgentRegistry:
+    """In-process registry whose entries are never persisted or user-edited."""
+
+    def __init__(self, specs: Iterable[BuiltinAgentSpec] = ()) -> None:
+        self._specs: dict[str, BuiltinAgentSpec] = {}
+        for spec in specs:
+            self.register(spec)
+
+    def register(self, spec: BuiltinAgentSpec) -> None:
+        if spec.name in self._specs:
+            raise BuiltinAgentRegistrationError(
+                f"Built-in agent '{spec.name}' is already registered"
+            )
+        self._specs[spec.name] = spec
+
+    def get(self, name: str) -> BuiltinAgentSpec | None:
+        return self._specs.get(name)
+
+    def require(self, name: str) -> BuiltinAgentSpec:
+        spec = self.get(name)
+        if spec is None:
+            raise BuiltinAgentNotFoundError(
+                f"Built-in agent '{name}' is not registered"
+            )
+        return spec
+
+    def list_specs(self) -> tuple[BuiltinAgentSpec, ...]:
+        return tuple(self._specs.values())
+
+    def __contains__(self, name: object) -> bool:
+        return name in self._specs
+
+
+BUILTIN_AGENT_REGISTRY = BuiltinAgentRegistry()

--- a/src/xagent/core/agent/builtin/spec.py
+++ b/src/xagent/core/agent/builtin/spec.py
@@ -16,6 +16,8 @@ BuiltinAgentPattern: TypeAlias = Literal[
     "auto",
 ]
 
+_BUILTIN_EXECUTION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+
 
 @dataclass(frozen=True, slots=True)
 class BuiltinAgentRunContext:
@@ -28,8 +30,11 @@ class BuiltinAgentRunContext:
     artifacts: dict[str, Any] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if not self.execution_id.strip():
-            raise ValueError("Built-in agent execution_id must not be empty")
+        if not _BUILTIN_EXECUTION_ID_RE.fullmatch(self.execution_id):
+            raise ValueError(
+                "Built-in agent execution_id must contain only letters, digits, "
+                "dots, colons, underscores, or hyphens"
+            )
 
 
 BuiltinToolBuilderResult: TypeAlias = Sequence[Tool] | Awaitable[Sequence[Tool]]

--- a/src/xagent/core/agent/builtin/spec.py
+++ b/src/xagent/core/agent/builtin/spec.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Any, Literal, TypeAlias
+from typing import Any, Literal, TypeAlias, get_args
 
 from ...tools.adapters.vibe import Tool
 
@@ -24,7 +24,8 @@ _BUILTIN_EXECUTION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
 class BuiltinAgentRunContext:
     """Execution-scoped dependencies available to built-in agent factories.
 
-    Identity and request inputs are immutable; ``artifacts`` is the deliberate
+    Identity and the top-level request mapping are immutable. Nested request
+    values remain trusted, code-owned inputs; ``artifacts`` is the deliberate
     mutable output channel shared with execution-scoped tool builders.
     """
 
@@ -52,8 +53,8 @@ BuiltinToolBuilder: TypeAlias = Callable[
     [BuiltinAgentRunContext], BuiltinToolBuilderResult
 ]
 
-_BUILTIN_AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]*$")
-_SUPPORTED_PATTERNS = frozenset({"single_call", "react", "dag_plan_execute", "auto"})
+_BUILTIN_AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
+_SUPPORTED_PATTERNS = frozenset(get_args(BuiltinAgentPattern))
 
 
 @dataclass(frozen=True, slots=True)
@@ -62,6 +63,10 @@ class BuiltinAgentSpec:
 
     Built-in agents are deliberately separate from database-backed agents and
     Agent Builder. Their capabilities are opt-in and disabled by default.
+    ``version`` is an opaque deployment/metadata label; the registry supports
+    one live specification per name, regardless of version. ``build_tools`` is
+    called once per execution and must return execution-owned stateful tools,
+    rather than sharing them between overlapping runs.
     """
 
     name: str
@@ -76,7 +81,7 @@ class BuiltinAgentSpec:
 
     def __post_init__(self) -> None:
         if not _BUILTIN_AGENT_NAME_RE.fullmatch(self.name):
-            raise ValueError("Built-in agent name must match ^[a-z][a-z0-9_-]*$")
+            raise ValueError("Built-in agent name must match ^[a-z][a-z0-9_-]{0,63}$")
         if not self.version.strip():
             raise ValueError("Built-in agent version must not be empty")
         if not self.system_prompt.strip():

--- a/src/xagent/core/agent/builtin/spec.py
+++ b/src/xagent/core/agent/builtin/spec.py
@@ -1,0 +1,72 @@
+"""Declarative specifications for code-defined built-in agents."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any, Literal, TypeAlias
+
+from ...tools.adapters.vibe import Tool
+
+BuiltinAgentPattern: TypeAlias = Literal[
+    "single_call",
+    "react",
+    "dag_plan_execute",
+    "auto",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class BuiltinAgentRunContext:
+    """Execution-scoped dependencies available to built-in agent factories."""
+
+    execution_id: str
+    request_context: Mapping[str, Any] = field(default_factory=dict)
+    tracer: Any | None = None
+    workspace_base_dir: str | None = None
+    artifacts: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.execution_id.strip():
+            raise ValueError("Built-in agent execution_id must not be empty")
+
+
+BuiltinToolBuilderResult: TypeAlias = Sequence[Tool] | Awaitable[Sequence[Tool]]
+BuiltinToolBuilder: TypeAlias = Callable[
+    [BuiltinAgentRunContext], BuiltinToolBuilderResult
+]
+
+_BUILTIN_AGENT_NAME_RE = re.compile(r"^[a-z][a-z0-9_-]*$")
+_SUPPORTED_PATTERNS = frozenset({"single_call", "react", "dag_plan_execute", "auto"})
+
+
+@dataclass(frozen=True, slots=True)
+class BuiltinAgentSpec:
+    """Immutable definition for an internal, code-owned agent.
+
+    Built-in agents are deliberately separate from database-backed agents and
+    Agent Builder. Their capabilities are opt-in and disabled by default.
+    """
+
+    name: str
+    version: str
+    system_prompt: str
+    pattern: BuiltinAgentPattern = "single_call"
+    model_role: str = "general"
+    build_tools: BuiltinToolBuilder | None = None
+    memory_enabled: bool = False
+    skills_enabled: bool = False
+    workspace_enabled: bool = False
+
+    def __post_init__(self) -> None:
+        if not _BUILTIN_AGENT_NAME_RE.fullmatch(self.name):
+            raise ValueError("Built-in agent name must match ^[a-z][a-z0-9_-]*$")
+        if not self.version.strip():
+            raise ValueError("Built-in agent version must not be empty")
+        if not self.system_prompt.strip():
+            raise ValueError("Built-in agent system_prompt must not be empty")
+        if self.pattern not in _SUPPORTED_PATTERNS:
+            raise ValueError(f"Unsupported built-in agent pattern: {self.pattern}")
+        if not self.model_role.strip():
+            raise ValueError("Built-in agent model_role must not be empty")

--- a/src/xagent/core/agent/builtin/spec.py
+++ b/src/xagent/core/agent/builtin/spec.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass, field
+from types import MappingProxyType
 from typing import Any, Literal, TypeAlias
 
 from ...tools.adapters.vibe import Tool
@@ -16,12 +17,16 @@ BuiltinAgentPattern: TypeAlias = Literal[
     "auto",
 ]
 
-_BUILTIN_EXECUTION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}$")
+_BUILTIN_EXECUTION_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
 
 
 @dataclass(frozen=True, slots=True)
 class BuiltinAgentRunContext:
-    """Execution-scoped dependencies available to built-in agent factories."""
+    """Execution-scoped dependencies available to built-in agent factories.
+
+    Identity and request inputs are immutable; ``artifacts`` is the deliberate
+    mutable output channel shared with execution-scoped tool builders.
+    """
 
     execution_id: str
     request_context: Mapping[str, Any] = field(default_factory=dict)
@@ -33,8 +38,13 @@ class BuiltinAgentRunContext:
         if not _BUILTIN_EXECUTION_ID_RE.fullmatch(self.execution_id):
             raise ValueError(
                 "Built-in agent execution_id must contain only letters, digits, "
-                "dots, colons, underscores, or hyphens"
+                "dots, underscores, or hyphens"
             )
+        object.__setattr__(
+            self,
+            "request_context",
+            MappingProxyType(dict(self.request_context)),
+        )
 
 
 BuiltinToolBuilderResult: TypeAlias = Sequence[Tool] | Awaitable[Sequence[Tool]]

--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -56,7 +56,10 @@ class AgentExecutionConfig:
     skill_manager: Any | None = None
     skill_scope_context: Any | None = None
     allowed_skills: list[str] | None = None
+    skills_enabled: bool = True
+    user_interaction_enabled: bool = True
     preferred_input_modalities: tuple[str, ...] = ()
+    execution_metadata: dict[str, Any] = field(default_factory=dict)
 
 
 class AgentExecutionAdapter:
@@ -240,6 +243,7 @@ class AgentExecutionAdapter:
         include_request_context: bool = False,
     ) -> dict[str, Any]:
         metadata: dict[str, Any] = {
+            **self.config.execution_metadata,
             "execution_type": execution_type,
             "pattern": self.config.pattern,
         }
@@ -257,8 +261,10 @@ class AgentExecutionAdapter:
 
     def _build_runner(self) -> tuple[AgentRunner, str]:
         pattern, execution_type = self._build_pattern()
-        skill_manager = self.config.skill_manager
-        if skill_manager is None:
+        skill_manager = (
+            self.config.skill_manager if self.config.skills_enabled else None
+        )
+        if self.config.skills_enabled and skill_manager is None:
             from ...skills.utils import create_skill_manager
 
             skill_manager = create_skill_manager(
@@ -271,7 +277,10 @@ class AgentExecutionAdapter:
             llm=self.config.llm,
             compact_llm=self.config.compact_llm,
             system_prompt=self.config.system_prompt,
-            metadata={"pattern": self.config.pattern},
+            metadata={
+                **self.config.execution_metadata,
+                "pattern": self.config.pattern,
+            },
             memory_store=self.config.memory_store,
             memory_similarity_threshold=self.config.memory_similarity_threshold,
             skill_manager=skill_manager,
@@ -295,6 +304,7 @@ class AgentExecutionAdapter:
                 DAGPattern(
                     LLMPlanGenerator(),
                     max_concurrency=self.config.dag_max_concurrency,
+                    user_interaction_enabled=self.config.user_interaction_enabled,
                 ),
                 "agent_dag",
             )
@@ -305,10 +315,12 @@ class AgentExecutionAdapter:
                         max_iterations=self.config.react_max_iterations,
                         tool_parallel_enabled=self.config.tool_parallel_enabled,
                         tool_max_concurrency=self.config.tool_max_concurrency,
+                        user_interaction_enabled=(self.config.user_interaction_enabled),
                     ),
                     dag_pattern=DAGPattern(
                         LLMPlanGenerator(),
                         max_concurrency=self.config.dag_max_concurrency,
+                        user_interaction_enabled=(self.config.user_interaction_enabled),
                     ),
                 ),
                 "agent_auto",
@@ -320,6 +332,7 @@ class AgentExecutionAdapter:
                     finalize_after_tool_result=True,
                     tool_parallel_enabled=self.config.tool_parallel_enabled,
                     tool_max_concurrency=self.config.tool_max_concurrency,
+                    user_interaction_enabled=self.config.user_interaction_enabled,
                 ),
                 "agent_single_call",
             )
@@ -328,6 +341,7 @@ class AgentExecutionAdapter:
                 max_iterations=self.config.react_max_iterations,
                 tool_parallel_enabled=self.config.tool_parallel_enabled,
                 tool_max_concurrency=self.config.tool_max_concurrency,
+                user_interaction_enabled=self.config.user_interaction_enabled,
             ),
             "agent_react",
         )
@@ -414,6 +428,7 @@ class AgentExecutionAdapter:
             "success": result.get("success", False),
             "error": result.get("error"),
             "metadata": {
+                **self.config.execution_metadata,
                 "agent_name": self.config.name,
                 "execution_type": execution_type,
                 "pattern": self.config.pattern,

--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -35,6 +35,7 @@ class AgentExecutionConfig:
     tracer: Any | None = None
     system_prompt: str | None = None
     workspace_base_dir: str = "workspace"
+    workspace_enabled: bool = True
     allowed_external_dirs: list[str] | None = None
     scope_segments: tuple[str, ...] = ()
     current_task_id: str | None = None
@@ -284,7 +285,9 @@ class AgentExecutionAdapter:
             memory_store=self.config.memory_store,
             memory_similarity_threshold=self.config.memory_similarity_threshold,
             skill_manager=skill_manager,
-            allowed_skills=self.config.allowed_skills,
+            allowed_skills=(
+                self.config.allowed_skills if self.config.skills_enabled else None
+            ),
         )
         return (
             AgentRunner(
@@ -292,6 +295,7 @@ class AgentExecutionAdapter:
                 tracer=self.config.tracer,
                 callbacks=[TraceEventCallback()],
                 workspace_base_dir=self.config.workspace_base_dir,
+                workspace_enabled=self.config.workspace_enabled,
                 scope_segments=self.config.scope_segments,
                 outbound_message_handler=self.config.outbound_message_handler,
             ),
@@ -315,12 +319,12 @@ class AgentExecutionAdapter:
                         max_iterations=self.config.react_max_iterations,
                         tool_parallel_enabled=self.config.tool_parallel_enabled,
                         tool_max_concurrency=self.config.tool_max_concurrency,
-                        user_interaction_enabled=(self.config.user_interaction_enabled),
+                        user_interaction_enabled=self.config.user_interaction_enabled,
                     ),
                     dag_pattern=DAGPattern(
                         LLMPlanGenerator(),
                         max_concurrency=self.config.dag_max_concurrency,
-                        user_interaction_enabled=(self.config.user_interaction_enabled),
+                        user_interaction_enabled=self.config.user_interaction_enabled,
                     ),
                 ),
                 "agent_auto",

--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -57,6 +57,7 @@ class AgentExecutionConfig:
     skill_manager: Any | None = None
     skill_scope_context: Any | None = None
     allowed_skills: list[str] | None = None
+    # Capability gate: False overrides an explicitly supplied manager/list.
     skills_enabled: bool = True
     user_interaction_enabled: bool = True
     preferred_input_modalities: tuple[str, ...] = ()

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -363,6 +363,7 @@ class DAGPattern(AgentPattern):
         | str = ReActReasoningMode.TOOL_CALLING,
         max_concurrency: int = 4,
         max_completion_replans: int = 3,
+        user_interaction_enabled: bool = True,
     ) -> None:
         self.plan_generator = (
             plan_generator
@@ -373,6 +374,7 @@ class DAGPattern(AgentPattern):
         self.react_reasoning_mode = ReActReasoningMode(react_reasoning_mode)
         self.max_concurrency = max(1, max_concurrency)
         self.max_completion_replans = max(0, max_completion_replans)
+        self.user_interaction_enabled = user_interaction_enabled
         self.status = "idle"
         self.plan: ExecutionPlan | None = None
         self.active_step_id: str | None = None
@@ -988,6 +990,7 @@ class DAGPattern(AgentPattern):
             max_iterations=self.react_max_iterations,
             reasoning_mode=self.react_reasoning_mode,
             finalize_after_tool_result=False,
+            user_interaction_enabled=self.user_interaction_enabled,
         )
         active_pattern_state = self.active_step_pattern_states.get(step.id)
         if active_pattern_state is not None:

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1904,6 +1904,17 @@ class ReActPattern(AgentPattern):
                 result={"success": False, "error": error},
                 tool_call_id=tool_call.get("id"),
             )
+            remaining = [
+                pending
+                for pending in self.pending_tool_calls
+                if pending is not tool_call
+            ]
+            self.pending_tool_calls = [tool_call]
+            self._cancel_tool_calls(
+                remaining,
+                context,
+                reason=f"Discarded because control tool '{name}' is disabled.",
+            )
             self.force_final_answer_next = True
             return None
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -93,6 +93,7 @@ DEFAULT_REPEATED_TOOL_DECISION_CONSECUTIVE_TOOL_CALLS = 4
 DEFAULT_REPEATED_TOOL_DECISION_CONSECUTIVE_WORK_TOOL_CALLS = 10
 REACT_DECISION_TOOL_NAME = "react_decision"
 REACT_DECISION_FINAL_ANSWER = "final_answer"
+USER_INTERACTION_CONTROL_TOOL_NAMES = CONTROL_TOOL_NAMES - {REACT_DECISION_FINAL_ANSWER}
 REACT_DECISION_TOOL_CALL = "tool_call"
 UNGROUPED_TOOL_DECISION_CATEGORIES = frozenset({"basic", "other"})
 REACT_RESPONSE_LANGUAGE_DESCRIPTION = (
@@ -846,6 +847,15 @@ class ReActPattern(AgentPattern):
                 .isoformat()
             )
             clock_zone_label = clock_zone.key if clock_zone is not None else "UTC"
+            missing_information_instruction = (
+                "If a tool needs missing information from the user, call "
+                "ask_user_question; do not ask the question as plain assistant "
+                "text. "
+                if self.user_interaction_enabled
+                else "If missing user information prevents completion, do not ask "
+                "the user or attempt an unavailable interaction tool; finish with "
+                "outcome=blocked and explain what is missing. "
+            )
             instruction = (
                 "Use available tools when the user asks you to generate, compute, run, "
                 "execute, inspect, read, write, or otherwise produce a concrete result "
@@ -854,9 +864,9 @@ class ReActPattern(AgentPattern):
                 "tool work. When the current task is complete, call the final_answer "
                 "tool exactly once instead of calling another work tool or returning "
                 "plain assistant text. Do not write assistant text in the same "
-                "response as a work tool call; call the tool directly. If a tool "
-                "needs missing information from the user, call ask_user_question; do "
-                "not ask the question as plain assistant text. If the latest user "
+                "response as a work tool call; call the tool directly. "
+                f"{missing_information_instruction}"
+                "If the latest user "
                 "message explicitly asks you to call a named available tool, call "
                 "that tool instead of paraphrasing the request. If a tool "
                 "fails, retry with a corrected call when possible; "
@@ -1699,7 +1709,7 @@ class ReActPattern(AgentPattern):
     def _builtin_tool_schemas(
         self, *, can_lookup_output_files: bool = False
     ) -> list[dict[str, Any]]:
-        schemas = [
+        schemas: list[dict[str, Any]] = [
             {
                 "type": "function",
                 "function": {
@@ -1852,7 +1862,12 @@ class ReActPattern(AgentPattern):
             },
         ]
         if not self.user_interaction_enabled:
-            return schemas[:1]
+            return [
+                schema
+                for schema in schemas
+                if schema.get("function", {}).get("name")
+                not in USER_INTERACTION_CONTROL_TOOL_NAMES
+            ]
         return schemas
 
     def _tool_schemas_with_builtin_controls(
@@ -1889,19 +1904,27 @@ class ReActPattern(AgentPattern):
         name = tool_call["name"]
         args = tool_call.get("args", {})
 
-        if not self.user_interaction_enabled and name in {
-            "send_message",
-            "ask_user_question",
-        }:
+        if (
+            not self.user_interaction_enabled
+            and name in USER_INTERACTION_CONTROL_TOOL_NAMES
+        ):
             error = f"Control tool '{name}' is disabled for this execution."
+            logger.warning(
+                "ReAct rejected disabled user-interaction control tool. "
+                "tool=%s tool_call_id=%s",
+                name,
+                tool_call.get("id"),
+            )
+            failure = {"success": False, "status": "error", "error": error}
             self._record_tool_call(
                 tool_call,
                 status="failed",
+                result=failure,
                 error=error,
             )
             context.add_tool_result(
                 tool_name=name,
-                result={"success": False, "error": error},
+                result=failure,
                 tool_call_id=tool_call.get("id"),
             )
             remaining = [
@@ -1915,6 +1938,7 @@ class ReActPattern(AgentPattern):
                 context,
                 reason=f"Discarded because control tool '{name}' is disabled.",
             )
+            self.status = "thinking"
             self.force_final_answer_next = True
             return None
 
@@ -2257,6 +2281,27 @@ class ReActPattern(AgentPattern):
     ) -> dict[str, Any]:
         """Publish tool-originated questions and checkpoint the suspended run."""
 
+        if not self.user_interaction_enabled:
+            tool_names = sorted(
+                {
+                    str(tool_call.get("name") or "unknown")
+                    for tool_call, _ in waiting_pairs
+                }
+            )
+            error = (
+                "Tool-requested user interaction is disabled for this execution: "
+                + ", ".join(tool_names)
+            )
+            logger.warning("ReAct rejected tool-requested user interaction: %s", error)
+            self.status = "failed"
+            self.waiting_for_user_request = None
+            return {
+                "success": False,
+                "status": "failed",
+                "error": error,
+                "context": context,
+            }
+
         requests: list[dict[str, Any]] = []
         interactions: list[dict[str, Any]] = []
         used_fields: set[str] = set()
@@ -2454,6 +2499,27 @@ class ReActPattern(AgentPattern):
         llm: Any,
         runtime: PatternRuntime,
     ) -> dict[str, Any] | None:
+        if not self.user_interaction_enabled:
+            disabled_index = next(
+                (
+                    index
+                    for index, pending in enumerate(self.pending_tool_calls)
+                    if pending.get("name") in USER_INTERACTION_CONTROL_TOOL_NAMES
+                ),
+                None,
+            )
+            if disabled_index:
+                preceding = self.pending_tool_calls[:disabled_index]
+                disabled_name = self.pending_tool_calls[disabled_index].get("name")
+                self.pending_tool_calls = self.pending_tool_calls[disabled_index:]
+                self._cancel_tool_calls(
+                    preceding,
+                    context,
+                    reason=(
+                        "Discarded because the response also called disabled "
+                        f"control tool '{disabled_name}'."
+                    ),
+                )
         successful_tool_result = False
         while self.pending_tool_calls:
             interrupted = await self._interrupt_if_requested(

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -208,6 +208,7 @@ class ReActPattern(AgentPattern):
         ),
         tool_parallel_enabled: bool = False,
         tool_max_concurrency: int = 3,
+        user_interaction_enabled: bool = True,
     ) -> None:
         self.llm = llm
         self.max_iterations = max_iterations
@@ -219,6 +220,7 @@ class ReActPattern(AgentPattern):
         # batch bounded by ``tool_max_concurrency``.
         self.tool_parallel_enabled = tool_parallel_enabled
         self.tool_max_concurrency = max(1, int(tool_max_concurrency))
+        self.user_interaction_enabled = user_interaction_enabled
         self.repeated_tool_decision_after_consecutive_tool_calls = (
             repeated_tool_decision_after_consecutive_tool_calls
         )
@@ -1697,7 +1699,7 @@ class ReActPattern(AgentPattern):
     def _builtin_tool_schemas(
         self, *, can_lookup_output_files: bool = False
     ) -> list[dict[str, Any]]:
-        return [
+        schemas = [
             {
                 "type": "function",
                 "function": {
@@ -1849,6 +1851,9 @@ class ReActPattern(AgentPattern):
                 },
             },
         ]
+        if not self.user_interaction_enabled:
+            return schemas[:1]
+        return schemas
 
     def _tool_schemas_with_builtin_controls(
         self,
@@ -1883,6 +1888,24 @@ class ReActPattern(AgentPattern):
     ) -> dict[str, Any] | None:
         name = tool_call["name"]
         args = tool_call.get("args", {})
+
+        if not self.user_interaction_enabled and name in {
+            "send_message",
+            "ask_user_question",
+        }:
+            error = f"Control tool '{name}' is disabled for this execution."
+            self._record_tool_call(
+                tool_call,
+                status="failed",
+                error=error,
+            )
+            context.add_tool_result(
+                tool_name=name,
+                result={"success": False, "error": error},
+                tool_call_id=tool_call.get("id"),
+            )
+            self.force_final_answer_next = True
+            return None
 
         if name == "final_answer":
             answer = self._final_answer_text(args)

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -2508,7 +2508,7 @@ class ReActPattern(AgentPattern):
                 ),
                 None,
             )
-            if disabled_index:
+            if disabled_index is not None:
                 preceding = self.pending_tool_calls[:disabled_index]
                 disabled_name = self.pending_tool_calls[disabled_index].get("name")
                 self.pending_tool_calls = self.pending_tool_calls[disabled_index:]

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -46,6 +46,7 @@ class AgentRunner:
         callbacks: list[Any] | None = None,
         context_manager: ContextManager | None = None,
         workspace_base_dir: str = "workspace",
+        workspace_enabled: bool = True,
         scope_segments: tuple[str, ...] = (),
         outbound_message_handler: Any | None = None,
     ) -> None:
@@ -56,6 +57,7 @@ class AgentRunner:
         self.callbacks = callbacks or []
         self.context_manager = context_manager or ContextManager()
         self.workspace_base_dir = workspace_base_dir
+        self.workspace_enabled = workspace_enabled
         self.scope_segments = scope_segments
         self.outbound_message_handler = outbound_message_handler
         self._active_controls: dict[str, ExecutionControl] = {}
@@ -191,7 +193,7 @@ class AgentRunner:
             interrupt_checker=interrupt_checker,
             outbound_message_handler=self.outbound_message_handler,
         )
-        if runtime.context_ref_resolver is None:
+        if self.workspace_enabled and runtime.context_ref_resolver is None:
             if workspace is None:
                 workspace_base = base_dir or self.workspace_base_dir
                 if context.workspace_path:
@@ -719,24 +721,30 @@ class AgentRunner:
         allowed_external_dirs: list[str] | None,
         base_dir: str | None,
         metadata: dict[str, Any] | None,
-    ) -> tuple[ExecutionContext, Any]:
-        workspace = self.workspace_manager.get_or_create_workspace(
-            base_dir=base_dir or self.workspace_base_dir,
-            task_id=workspace_id or execution_id,
-            allowed_external_dirs=allowed_external_dirs,
-            scope_segments=self.scope_segments,
-        )
-        if inspect.isawaitable(workspace):
-            workspace = await workspace
+    ) -> tuple[ExecutionContext, Any | None]:
+        workspace = None
+        context_kwargs: dict[str, Any] = {}
+        if self.workspace_enabled:
+            workspace = self.workspace_manager.get_or_create_workspace(
+                base_dir=base_dir or self.workspace_base_dir,
+                task_id=workspace_id or execution_id,
+                allowed_external_dirs=allowed_external_dirs,
+                scope_segments=self.scope_segments,
+            )
+            if inspect.isawaitable(workspace):
+                workspace = await workspace
+            context_kwargs = {
+                "workspace_id": workspace.id,
+                "workspace_path": str(workspace.workspace_dir),
+                "cwd": str(workspace.workspace_dir),
+                "workspace_state": self._workspace_state(workspace),
+            }
         context = self.context_manager.create_context(
             execution_id=execution_id,
             user_id=user_id,
             session_id=session_id,
             system_prompt=getattr(self.agent, "system_prompt", None),
-            workspace_id=workspace.id,
-            workspace_path=str(workspace.workspace_dir),
-            cwd=str(workspace.workspace_dir),
-            workspace_state=self._workspace_state(workspace),
+            **context_kwargs,
         )
         # Snapshotted at task start. On resume the context (and this threshold)
         # is restored verbatim from the checkpoint, so a context-window or ratio

--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -65,6 +65,10 @@ class AgentService:
         preferred_input_modalities: tuple[str, ...] | list[str] | None = None,
         tools_initialized: bool | None = None,
         react_max_iterations: int = 200,
+        enable_default_tools: bool = True,
+        skills_enabled: bool = True,
+        user_interaction_enabled: bool = True,
+        execution_metadata: dict[str, Any] | None = None,
         **agent_kwargs: Any,
     ) -> None:
         self.name = name
@@ -86,6 +90,10 @@ class AgentService:
         self.memory_similarity_threshold = memory_similarity_threshold
         self.memory_enabled = memory_enabled
         self.react_max_iterations = max(1, int(react_max_iterations))
+        self.enable_default_tools = enable_default_tools
+        self.skills_enabled = skills_enabled
+        self.user_interaction_enabled = user_interaction_enabled
+        self.execution_metadata = dict(execution_metadata or {})
         if tools is not None and tool_config is not None:
             handoff_factory_runtime = getattr(
                 tool_config, "handoff_factory_runtime", None
@@ -191,7 +199,7 @@ class AgentService:
         elif self.enable_workspace:
             self._setup_workspace()
 
-        if not self.tools and not self.tool_config:
+        if self.enable_default_tools and not self.tools and not self.tool_config:
             self.tool_config = self._create_default_tool_config()
             self.allowed_skills = self._get_allowed_skills_from_config(self.tool_config)
 
@@ -497,9 +505,14 @@ class AgentService:
                 self.memory if self.memory_enabled else None
             )
             self._execution_adapter.config.allowed_skills = self.allowed_skills
+            self._execution_adapter.config.skills_enabled = self.skills_enabled
+            self._execution_adapter.config.user_interaction_enabled = (
+                self.user_interaction_enabled
+            )
             self._execution_adapter.config.skill_scope_context = (
                 self.skill_scope_context
             )
+            self._execution_adapter.config.execution_metadata = self.execution_metadata
             self._execution_adapter.config.system_prompt = self.system_prompt
             self._execution_adapter.config.preferred_input_modalities = (
                 self.preferred_input_modalities
@@ -554,7 +567,10 @@ class AgentService:
                 memory_similarity_threshold=self.memory_similarity_threshold,
                 skill_scope_context=self.skill_scope_context,
                 allowed_skills=self.allowed_skills,
+                skills_enabled=self.skills_enabled,
+                user_interaction_enabled=self.user_interaction_enabled,
                 preferred_input_modalities=self.preferred_input_modalities,
+                execution_metadata=self.execution_metadata,
             )
         )
 

--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -506,13 +506,16 @@ class AgentService:
             )
             self._execution_adapter.config.allowed_skills = self.allowed_skills
             self._execution_adapter.config.skills_enabled = self.skills_enabled
+            self._execution_adapter.config.workspace_enabled = self.enable_workspace
             self._execution_adapter.config.user_interaction_enabled = (
                 self.user_interaction_enabled
             )
             self._execution_adapter.config.skill_scope_context = (
                 self.skill_scope_context
             )
-            self._execution_adapter.config.execution_metadata = self.execution_metadata
+            self._execution_adapter.config.execution_metadata = dict(
+                self.execution_metadata
+            )
             self._execution_adapter.config.system_prompt = self.system_prompt
             self._execution_adapter.config.preferred_input_modalities = (
                 self.preferred_input_modalities
@@ -553,6 +556,7 @@ class AgentService:
                 tracer=tracer,
                 system_prompt=self.system_prompt,
                 workspace_base_dir=self.workspace_base_dir,
+                workspace_enabled=self.enable_workspace,
                 allowed_external_dirs=self.allowed_external_dirs,
                 scope_segments=self.scope_segments,
                 current_task_id=self._current_task_id,
@@ -570,7 +574,7 @@ class AgentService:
                 skills_enabled=self.skills_enabled,
                 user_interaction_enabled=self.user_interaction_enabled,
                 preferred_input_modalities=self.preferred_input_modalities,
-                execution_metadata=self.execution_metadata,
+                execution_metadata=dict(self.execution_metadata),
             )
         )
 

--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -35,7 +35,15 @@ _UNSET = object()
 
 
 class AgentService:
-    """Service facade that executes tasks through agent only."""
+    """Service facade that executes tasks through agent only.
+
+    Capability controls are deny-capable overrides: ``enable_default_tools``
+    controls automatic tool construction, ``skills_enabled=False`` suppresses
+    supplied skill managers and allowlists, and ``user_interaction_enabled=False``
+    blocks outbound user-facing control calls and waits. ``execution_metadata``
+    is trusted internal metadata copied into runner and result records; untrusted
+    request data belongs in the separate task context passed to ``execute_task``.
+    """
 
     def __init__(
         self,

--- a/tests/core/agent/builtin/__init__.py
+++ b/tests/core/agent/builtin/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for code-defined built-in agents."""

--- a/tests/core/agent/builtin/test_executor.py
+++ b/tests/core/agent/builtin/test_executor.py
@@ -58,6 +58,21 @@ class AgentCategoryTool:
     )
 
 
+class OtherCategoryTool:
+    metadata = ToolMetadata(
+        name="uncategorized",
+        description="Tool without an assignable category.",
+    )
+
+
+class BasicCategoryTool:
+    metadata = ToolMetadata(
+        name="basic",
+        description="A normal built-in tool.",
+        category=ToolCategory.BASIC,
+    )
+
+
 def _registry(**overrides: Any) -> BuiltinAgentRegistry:
     values: dict[str, Any] = {
         "name": "internal_worker",
@@ -95,7 +110,7 @@ async def test_executor_builds_a_least_privilege_agent_and_stamps_metadata() -> 
     assert service_factory.service is not None
     init = service_factory.service.init_kwargs
     assert init["name"] == "builtin:internal_worker"
-    assert init["id"] == "builtin:internal_worker:run-1"
+    assert init["id"] == "builtin--internal_worker--run-1"
     assert init["pattern"] == "single_call"
     assert init["llm"] is model
     assert init["tools"] == []
@@ -125,7 +140,7 @@ async def test_executor_builds_a_least_privilege_agent_and_stamps_metadata() -> 
 
 @pytest.mark.asyncio
 async def test_executor_supports_execution_scoped_async_tool_builders() -> None:
-    tool = object()
+    tool = BasicCategoryTool()
     builder_execution_ids: list[str] = []
 
     async def build_tools(context: Any) -> list[Any]:
@@ -174,19 +189,63 @@ async def test_executor_fails_before_service_creation_when_model_is_unavailable(
 
 
 @pytest.mark.asyncio
-async def test_executor_rejects_agent_delegation_tools() -> None:
+@pytest.mark.parametrize(
+    "tool",
+    [AgentCategoryTool(), OtherCategoryTool(), object()],
+)
+async def test_executor_rejects_tools_without_an_assignable_category(
+    tool: Any,
+) -> None:
     executor = BuiltinAgentExecutor(
-        registry=_registry(build_tools=lambda _context: [AgentCategoryTool()]),
+        registry=_registry(build_tools=lambda _context: [tool]),
         model_resolver=cast(Any, lambda _role, _context: FakeLLM()),
         service_factory=cast(Any, RecordingServiceFactory()),
     )
 
-    with pytest.raises(BuiltinAgentCapabilityError, match="delegation"):
+    with pytest.raises(BuiltinAgentCapabilityError, match="assignable category"):
         await executor.execute(
             "internal_worker",
             task="Perform internal work",
             execution_id="run-delegation",
         )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("missing_root", [None, "", " "])
+async def test_executor_requires_an_explicit_root_for_workspace_access(
+    tmp_path: Any,
+    missing_root: str | None,
+) -> None:
+    service_factory = RecordingServiceFactory()
+    executor = BuiltinAgentExecutor(
+        registry=_registry(workspace_enabled=True),
+        model_resolver=cast(Any, lambda _role, _context: FakeLLM()),
+        service_factory=cast(Any, service_factory),
+    )
+
+    with pytest.raises(BuiltinAgentCapabilityError, match="workspace_base_dir"):
+        await executor.execute(
+            "internal_worker",
+            task="Perform internal work",
+            execution_id="run-workspace",
+            workspace_base_dir=missing_root,
+        )
+    assert service_factory.service is None
+
+    await executor.execute(
+        "internal_worker",
+        task="Perform internal work",
+        execution_id="run-workspace",
+        workspace_base_dir=str(tmp_path),
+    )
+
+    assert service_factory.service is not None
+    assert service_factory.service.init_kwargs["enable_workspace"] is True
+    assert service_factory.service.init_kwargs["workspace_base_dir"] == str(tmp_path)
+    assert (
+        service_factory.service.init_kwargs["id"]
+        == "builtin--internal_worker--run-workspace"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/builtin/test_executor.py
+++ b/tests/core/agent/builtin/test_executor.py
@@ -106,7 +106,7 @@ async def test_executor_builds_a_least_privilege_agent_and_stamps_metadata() -> 
     assert init["memory_enabled"] is False
     assert init["skills_enabled"] is False
     assert init["user_interaction_enabled"] is False
-    assert init["agent_type"] == "builtin"
+    assert "agent_type" not in init
 
     execute = service_factory.service.execute_kwargs
     assert execute is not None
@@ -190,7 +190,9 @@ async def test_executor_rejects_agent_delegation_tools() -> None:
 
 
 @pytest.mark.asyncio
-async def test_executor_runs_through_real_agent_service_without_default_tools() -> None:
+async def test_executor_runs_through_real_agent_service_without_default_tools(
+    tmp_path: Any,
+) -> None:
     model = FakeLLM(["work complete"])
     executor = BuiltinAgentExecutor(
         registry=_registry(),
@@ -201,6 +203,7 @@ async def test_executor_runs_through_real_agent_service_without_default_tools() 
         "internal_worker",
         task="Perform internal work",
         execution_id="run-real-service",
+        workspace_base_dir=str(tmp_path),
     )
 
     assert result["success"] is True
@@ -211,3 +214,4 @@ async def test_executor_runs_through_real_agent_service_without_default_tools() 
         tool["function"]["name"] for tool in model.calls[0].get("tools") or []
     }
     assert tool_names == {"final_answer"}
+    assert not any(path.name.startswith("builtin:") for path in tmp_path.iterdir())

--- a/tests/core/agent/builtin/test_executor.py
+++ b/tests/core/agent/builtin/test_executor.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from xagent.core.agent.builtin import (
+    BuiltinAgentCapabilityError,
+    BuiltinAgentExecutor,
+    BuiltinAgentModelUnavailableError,
+    BuiltinAgentRegistry,
+    BuiltinAgentSpec,
+)
+from xagent.core.tools.adapters.vibe.base import ToolCategory, ToolMetadata
+
+
+class FakeLLM:
+    model_name = "fake-model"
+
+    def __init__(self, responses: list[Any] | None = None) -> None:
+        self.responses = list(responses or [])
+        self.calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return self.responses.pop(0)
+
+
+class RecordingService:
+    def __init__(self, **kwargs: Any) -> None:
+        self.init_kwargs = kwargs
+        self.execute_kwargs: dict[str, Any] | None = None
+
+    async def execute_task(self, task: str, **kwargs: Any) -> dict[str, Any]:
+        self.execute_kwargs = {"task": task, **kwargs}
+        return {
+            "status": "completed",
+            "success": True,
+            "output": "done",
+            "metadata": {"pattern": self.init_kwargs["pattern"]},
+        }
+
+
+class RecordingServiceFactory:
+    def __init__(self) -> None:
+        self.service: RecordingService | None = None
+
+    def __call__(self, **kwargs: Any) -> RecordingService:
+        self.service = RecordingService(**kwargs)
+        return self.service
+
+
+class AgentCategoryTool:
+    metadata = ToolMetadata(
+        name="delegate",
+        description="Delegate work.",
+        category=ToolCategory.AGENT,
+    )
+
+
+def _registry(**overrides: Any) -> BuiltinAgentRegistry:
+    values: dict[str, Any] = {
+        "name": "internal_worker",
+        "version": "1",
+        "system_prompt": "Perform one internal task.",
+    }
+    values.update(overrides)
+    return BuiltinAgentRegistry([BuiltinAgentSpec(**values)])
+
+
+@pytest.mark.asyncio
+async def test_executor_builds_a_least_privilege_agent_and_stamps_metadata() -> None:
+    model = FakeLLM()
+    resolver_calls: list[tuple[str, str]] = []
+    service_factory = RecordingServiceFactory()
+
+    async def resolve_model(role: str, context: Any) -> FakeLLM:
+        resolver_calls.append((role, context.execution_id))
+        return model
+
+    executor = BuiltinAgentExecutor(
+        registry=_registry(),
+        model_resolver=cast(Any, resolve_model),
+        service_factory=cast(Any, service_factory),
+    )
+
+    result = await executor.execute(
+        "internal_worker",
+        task="Perform internal work",
+        execution_id="run-1",
+        request_context={"work_item_count": 3},
+    )
+
+    assert resolver_calls == [("general", "run-1")]
+    assert service_factory.service is not None
+    init = service_factory.service.init_kwargs
+    assert init["name"] == "builtin:internal_worker"
+    assert init["id"] == "builtin:internal_worker:run-1"
+    assert init["pattern"] == "single_call"
+    assert init["llm"] is model
+    assert init["tools"] == []
+    assert init["tools_initialized"] is True
+    assert init["tool_config"] is None
+    assert init["enable_default_tools"] is False
+    assert init["enable_workspace"] is False
+    assert init["memory_enabled"] is False
+    assert init["skills_enabled"] is False
+    assert init["user_interaction_enabled"] is False
+    assert init["agent_type"] == "builtin"
+
+    execute = service_factory.service.execute_kwargs
+    assert execute is not None
+    assert execute["task"] == "Perform internal work"
+    assert execute["task_id"] == "run-1"
+    assert execute["context"]["work_item_count"] == 3
+    assert execute["context"]["builtin_agent"] == {
+        "agent_type": "builtin",
+        "builtin_agent_name": "internal_worker",
+        "builtin_agent_version": "1",
+        "builtin_model_role": "general",
+    }
+    assert result["metadata"]["builtin_agent_name"] == "internal_worker"
+    assert result["metadata"]["builtin_agent_version"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_executor_supports_execution_scoped_async_tool_builders() -> None:
+    tool = object()
+    builder_execution_ids: list[str] = []
+
+    async def build_tools(context: Any) -> list[Any]:
+        builder_execution_ids.append(context.execution_id)
+        context.artifacts["built"] = True
+        return [tool]
+
+    service_factory = RecordingServiceFactory()
+    executor = BuiltinAgentExecutor(
+        registry=_registry(build_tools=build_tools),
+        model_resolver=cast(Any, lambda _role, _context: FakeLLM()),
+        service_factory=cast(Any, service_factory),
+    )
+
+    result = await executor.execute(
+        "internal_worker",
+        task="Perform internal work",
+        execution_id="run-tools",
+    )
+
+    assert builder_execution_ids == ["run-tools"]
+    assert service_factory.service is not None
+    assert service_factory.service.init_kwargs["tools"] == [tool]
+    assert result["builtin_artifacts"] == {"built": True}
+
+
+@pytest.mark.asyncio
+async def test_executor_fails_before_service_creation_when_model_is_unavailable() -> (
+    None
+):
+    service_factory = RecordingServiceFactory()
+    executor = BuiltinAgentExecutor(
+        registry=_registry(model_role="fast"),
+        model_resolver=lambda _role, _context: None,
+        service_factory=cast(Any, service_factory),
+    )
+
+    with pytest.raises(BuiltinAgentModelUnavailableError, match="role 'fast'"):
+        await executor.execute(
+            "internal_worker",
+            task="Perform internal work",
+            execution_id="run-no-model",
+        )
+
+    assert service_factory.service is None
+
+
+@pytest.mark.asyncio
+async def test_executor_rejects_agent_delegation_tools() -> None:
+    executor = BuiltinAgentExecutor(
+        registry=_registry(build_tools=lambda _context: [AgentCategoryTool()]),
+        model_resolver=cast(Any, lambda _role, _context: FakeLLM()),
+        service_factory=cast(Any, RecordingServiceFactory()),
+    )
+
+    with pytest.raises(BuiltinAgentCapabilityError, match="delegation"):
+        await executor.execute(
+            "internal_worker",
+            task="Perform internal work",
+            execution_id="run-delegation",
+        )
+
+
+@pytest.mark.asyncio
+async def test_executor_runs_through_real_agent_service_without_default_tools() -> None:
+    model = FakeLLM(["work complete"])
+    executor = BuiltinAgentExecutor(
+        registry=_registry(),
+        model_resolver=cast(Any, lambda _role, _context: model),
+    )
+
+    result = await executor.execute(
+        "internal_worker",
+        task="Perform internal work",
+        execution_id="run-real-service",
+    )
+
+    assert result["success"] is True
+    assert result["output"] == "work complete"
+    assert result["metadata"]["execution_type"] == "agent_single_call"
+    assert result["metadata"]["builtin_agent_name"] == "internal_worker"
+    tool_names = {
+        tool["function"]["name"] for tool in model.calls[0].get("tools") or []
+    }
+    assert tool_names == {"final_answer"}

--- a/tests/core/agent/builtin/test_executor.py
+++ b/tests/core/agent/builtin/test_executor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -73,6 +74,14 @@ class BasicCategoryTool:
     )
 
 
+class EnumLikeCategoryTool:
+    metadata = SimpleNamespace(
+        name="enum-like",
+        description="Malformed enum-like category.",
+        category=SimpleNamespace(value=ToolCategory.BASIC.value),
+    )
+
+
 def _registry(**overrides: Any) -> BuiltinAgentRegistry:
     values: dict[str, Any] = {
         "name": "internal_worker",
@@ -86,6 +95,7 @@ def _registry(**overrides: Any) -> BuiltinAgentRegistry:
 @pytest.mark.asyncio
 async def test_executor_builds_a_least_privilege_agent_and_stamps_metadata() -> None:
     model = FakeLLM()
+    tracer = object()
     resolver_calls: list[tuple[str, str]] = []
     service_factory = RecordingServiceFactory()
 
@@ -104,6 +114,7 @@ async def test_executor_builds_a_least_privilege_agent_and_stamps_metadata() -> 
         task="Perform internal work",
         execution_id="run-1",
         request_context={"work_item_count": 3},
+        tracer=tracer,
     )
 
     assert resolver_calls == [("general", "run-1")]
@@ -113,6 +124,7 @@ async def test_executor_builds_a_least_privilege_agent_and_stamps_metadata() -> 
     assert init["id"] == "builtin--internal_worker--run-1"
     assert init["pattern"] == "single_call"
     assert init["llm"] is model
+    assert init["tracer"] is tracer
     assert init["tools"] == []
     assert init["tools_initialized"] is True
     assert init["tool_config"] is None
@@ -127,12 +139,8 @@ async def test_executor_builds_a_least_privilege_agent_and_stamps_metadata() -> 
     assert execute is not None
     assert execute["task"] == "Perform internal work"
     assert execute["task_id"] == "run-1"
-    assert execute["context"]["work_item_count"] == 3
-    assert execute["context"]["builtin_agent"] == {
-        "agent_type": "builtin",
-        "builtin_agent_name": "internal_worker",
-        "builtin_agent_version": "1",
-        "builtin_model_role": "general",
+    assert execute["context"] == {
+        "builtin_request_context": {"work_item_count": 3},
     }
     assert result["metadata"]["builtin_agent_name"] == "internal_worker"
     assert result["metadata"]["builtin_agent_version"] == "1"
@@ -189,9 +197,55 @@ async def test_executor_fails_before_service_creation_when_model_is_unavailable(
 
 
 @pytest.mark.asyncio
+async def test_executor_rejects_invalid_sync_model_result() -> None:
+    service_factory = RecordingServiceFactory()
+    executor = BuiltinAgentExecutor(
+        registry=_registry(),
+        model_resolver=cast(Any, lambda _role, _context: object()),
+        service_factory=cast(Any, service_factory),
+    )
+
+    with pytest.raises(BuiltinAgentModelUnavailableError, match="invalid model"):
+        await executor.execute(
+            "internal_worker",
+            task="Perform internal work",
+            execution_id="run-invalid-model",
+        )
+
+    assert service_factory.service is None
+
+
+@pytest.mark.asyncio
+async def test_executor_rejects_invalid_async_model_result() -> None:
+    async def resolve_invalid_model(_role: str, _context: Any) -> object:
+        return object()
+
+    service_factory = RecordingServiceFactory()
+    executor = BuiltinAgentExecutor(
+        registry=_registry(),
+        model_resolver=cast(Any, resolve_invalid_model),
+        service_factory=cast(Any, service_factory),
+    )
+
+    with pytest.raises(BuiltinAgentModelUnavailableError, match="invalid model"):
+        await executor.execute(
+            "internal_worker",
+            task="Perform internal work",
+            execution_id="run-invalid-async-model",
+        )
+
+    assert service_factory.service is None
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "tool",
-    [AgentCategoryTool(), OtherCategoryTool(), object()],
+    [
+        AgentCategoryTool(),
+        OtherCategoryTool(),
+        EnumLikeCategoryTool(),
+        object(),
+    ],
 )
 async def test_executor_rejects_tools_without_an_assignable_category(
     tool: Any,
@@ -208,6 +262,31 @@ async def test_executor_rejects_tools_without_an_assignable_category(
             task="Perform internal work",
             execution_id="run-delegation",
         )
+
+
+@pytest.mark.asyncio
+async def test_executor_rejects_empty_tasks_and_invalid_tool_builder_results() -> None:
+    service_factory = RecordingServiceFactory()
+    executor = BuiltinAgentExecutor(
+        registry=_registry(build_tools=cast(Any, lambda _context: object())),
+        model_resolver=cast(Any, lambda _role, _context: FakeLLM()),
+        service_factory=cast(Any, service_factory),
+    )
+
+    with pytest.raises(ValueError, match="must not be empty"):
+        await executor.execute(
+            "internal_worker",
+            task=" ",
+            execution_id="run-empty",
+        )
+    with pytest.raises(TypeError, match="must return a sequence"):
+        await executor.execute(
+            "internal_worker",
+            task="Perform internal work",
+            execution_id="run-invalid-tools",
+        )
+
+    assert service_factory.service is None
 
 
 @pytest.mark.asyncio
@@ -262,6 +341,11 @@ async def test_executor_runs_through_real_agent_service_without_default_tools(
         "internal_worker",
         task="Perform internal work",
         execution_id="run-real-service",
+        request_context={
+            "system_prompt": "HOSTILE SYSTEM PROMPT",
+            "pattern": "spoofed-pattern",
+            "builtin_agent_name": "spoofed-name",
+        },
         workspace_base_dir=str(tmp_path),
     )
 
@@ -269,8 +353,45 @@ async def test_executor_runs_through_real_agent_service_without_default_tools(
     assert result["output"] == "work complete"
     assert result["metadata"]["execution_type"] == "agent_single_call"
     assert result["metadata"]["builtin_agent_name"] == "internal_worker"
+    context = result["agent_result"]["context"]
+    assert "HOSTILE SYSTEM PROMPT" not in context.system_prompt
+    assert context.metadata["pattern"] == "single_call"
+    assert context.metadata["builtin_agent_name"] == "internal_worker"
+    assert context.metadata["builtin_request_context"] == {
+        "system_prompt": "HOSTILE SYSTEM PROMPT",
+        "pattern": "spoofed-pattern",
+        "builtin_agent_name": "spoofed-name",
+    }
+    assert all(
+        "HOSTILE SYSTEM PROMPT" not in str(message.get("content") or "")
+        for message in model.calls[0]["messages"]
+    )
     tool_names = {
         tool["function"]["name"] for tool in model.calls[0].get("tools") or []
     }
     assert tool_names == {"final_answer"}
-    assert not any(path.name.startswith("builtin:") for path in tmp_path.iterdir())
+    assert not any(path.name.startswith("builtin--") for path in tmp_path.iterdir())
+
+
+@pytest.mark.asyncio
+async def test_executor_workspace_id_stays_within_component_limit(
+    tmp_path: Any,
+) -> None:
+    name = "a" * 64
+    execution_id = "e" * 128
+    workspace_id = f"builtin--{name}--{execution_id}"
+    executor = BuiltinAgentExecutor(
+        registry=_registry(name=name, workspace_enabled=True),
+        model_resolver=cast(Any, lambda _role, _context: FakeLLM(["done"])),
+    )
+
+    result = await executor.execute(
+        name,
+        task="Perform internal work",
+        execution_id=execution_id,
+        workspace_base_dir=str(tmp_path),
+    )
+
+    assert result["success"] is True
+    assert len(workspace_id.encode()) < 255
+    assert (tmp_path / workspace_id).is_dir()

--- a/tests/core/agent/builtin/test_registry.py
+++ b/tests/core/agent/builtin/test_registry.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+import pytest
+
+from xagent.core.agent.builtin import (
+    BuiltinAgentNotFoundError,
+    BuiltinAgentRegistrationError,
+    BuiltinAgentRegistry,
+    BuiltinAgentSpec,
+)
+
+
+def _spec(name: str, version: str = "1") -> BuiltinAgentSpec:
+    return BuiltinAgentSpec(
+        name=name,
+        version=version,
+        system_prompt=f"Run {name}.",
+    )
+
+
+def test_registry_registers_and_lists_code_defined_specs() -> None:
+    first = _spec("first")
+    second = _spec("second")
+    registry = BuiltinAgentRegistry([first])
+
+    registry.register(second)
+
+    assert registry.get("first") is first
+    assert registry.require("second") is second
+    assert registry.list_specs() == (first, second)
+    assert "first" in registry
+
+
+def test_registry_rejects_duplicate_names_even_across_versions() -> None:
+    registry = BuiltinAgentRegistry([_spec("worker", version="1")])
+
+    with pytest.raises(BuiltinAgentRegistrationError, match="already registered"):
+        registry.register(_spec("worker", version="2"))
+
+
+def test_registry_require_fails_for_unknown_agent() -> None:
+    with pytest.raises(BuiltinAgentNotFoundError, match="not registered"):
+        BuiltinAgentRegistry().require("missing")

--- a/tests/core/agent/builtin/test_registry.py
+++ b/tests/core/agent/builtin/test_registry.py
@@ -41,8 +41,11 @@ def test_registry_rejects_duplicate_names_even_across_versions() -> None:
 
 
 def test_registry_require_fails_for_unknown_agent() -> None:
+    registry = BuiltinAgentRegistry()
+
+    assert registry.get("missing") is None
     with pytest.raises(BuiltinAgentNotFoundError, match="not registered"):
-        BuiltinAgentRegistry().require("missing")
+        registry.require("missing")
 
 
 def test_registry_rejects_non_spec_entries() -> None:

--- a/tests/core/agent/builtin/test_registry.py
+++ b/tests/core/agent/builtin/test_registry.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, cast
+
 import pytest
 
 from xagent.core.agent.builtin import (
@@ -41,3 +43,8 @@ def test_registry_rejects_duplicate_names_even_across_versions() -> None:
 def test_registry_require_fails_for_unknown_agent() -> None:
     with pytest.raises(BuiltinAgentNotFoundError, match="not registered"):
         BuiltinAgentRegistry().require("missing")
+
+
+def test_registry_rejects_non_spec_entries() -> None:
+    with pytest.raises(BuiltinAgentRegistrationError, match="BuiltinAgentSpec"):
+        BuiltinAgentRegistry().register(cast(Any, object()))

--- a/tests/core/agent/builtin/test_spec.py
+++ b/tests/core/agent/builtin/test_spec.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
+from typing import Any, cast
+
 import pytest
 
 from xagent.core.agent.builtin import BuiltinAgentRunContext, BuiltinAgentSpec
@@ -26,6 +29,13 @@ def test_builtin_agent_spec_defaults_to_least_privilege() -> None:
     assert spec.workspace_enabled is False
 
 
+def test_builtin_agent_spec_is_immutable() -> None:
+    spec = _spec()
+
+    with pytest.raises(FrozenInstanceError):
+        setattr(spec, "name", "replacement")
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [
@@ -44,9 +54,22 @@ def test_builtin_agent_spec_rejects_invalid_identity_and_runtime_fields(
         _spec(**{field: value})
 
 
-@pytest.mark.parametrize("execution_id", [" ", "../escape", "nested/path"])
+@pytest.mark.parametrize("execution_id", [" ", "../escape", "nested/path", "run:1"])
 def test_builtin_agent_run_context_rejects_unsafe_execution_id(
     execution_id: str,
 ) -> None:
     with pytest.raises(ValueError, match="execution_id"):
         BuiltinAgentRunContext(execution_id=execution_id)
+
+
+def test_builtin_agent_run_context_copies_and_freezes_request_context() -> None:
+    source = {"tenant": "alpha"}
+    context = BuiltinAgentRunContext(
+        execution_id="run-1",
+        request_context=source,
+    )
+    source["tenant"] = "changed"
+
+    assert context.request_context == {"tenant": "alpha"}
+    with pytest.raises(TypeError):
+        cast(dict[str, Any], context.request_context)["tenant"] = "mutated"

--- a/tests/core/agent/builtin/test_spec.py
+++ b/tests/core/agent/builtin/test_spec.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from xagent.core.agent.builtin import BuiltinAgentRunContext, BuiltinAgentSpec
+
+
+def _spec(**overrides):
+    values = {
+        "name": "internal_worker",
+        "version": "1",
+        "system_prompt": "Perform one internal task.",
+    }
+    values.update(overrides)
+    return BuiltinAgentSpec(**values)
+
+
+def test_builtin_agent_spec_defaults_to_least_privilege() -> None:
+    spec = _spec()
+
+    assert spec.pattern == "single_call"
+    assert spec.model_role == "general"
+    assert spec.build_tools is None
+    assert spec.memory_enabled is False
+    assert spec.skills_enabled is False
+    assert spec.workspace_enabled is False
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("name", "Internal Worker"),
+        ("version", " "),
+        ("system_prompt", ""),
+        ("model_role", " "),
+        ("pattern", "unknown"),
+    ],
+)
+def test_builtin_agent_spec_rejects_invalid_identity_and_runtime_fields(
+    field: str,
+    value: str,
+) -> None:
+    with pytest.raises(ValueError):
+        _spec(**{field: value})
+
+
+def test_builtin_agent_run_context_requires_execution_id() -> None:
+    with pytest.raises(ValueError, match="execution_id"):
+        BuiltinAgentRunContext(execution_id=" ")

--- a/tests/core/agent/builtin/test_spec.py
+++ b/tests/core/agent/builtin/test_spec.py
@@ -44,6 +44,9 @@ def test_builtin_agent_spec_rejects_invalid_identity_and_runtime_fields(
         _spec(**{field: value})
 
 
-def test_builtin_agent_run_context_requires_execution_id() -> None:
+@pytest.mark.parametrize("execution_id", [" ", "../escape", "nested/path"])
+def test_builtin_agent_run_context_rejects_unsafe_execution_id(
+    execution_id: str,
+) -> None:
     with pytest.raises(ValueError, match="execution_id"):
-        BuiltinAgentRunContext(execution_id=" ")
+        BuiltinAgentRunContext(execution_id=execution_id)

--- a/tests/core/agent/builtin/test_spec.py
+++ b/tests/core/agent/builtin/test_spec.py
@@ -36,10 +36,15 @@ def test_builtin_agent_spec_is_immutable() -> None:
         setattr(spec, "name", "replacement")
 
 
+def test_builtin_agent_name_accepts_the_bounded_maximum() -> None:
+    assert _spec(name="a" * 64).name == "a" * 64
+
+
 @pytest.mark.parametrize(
     ("field", "value"),
     [
         ("name", "Internal Worker"),
+        ("name", "a" * 65),
         ("version", " "),
         ("system_prompt", ""),
         ("model_role", " "),

--- a/tests/core/agent/test_agent_service_tools_init.py
+++ b/tests/core/agent/test_agent_service_tools_init.py
@@ -96,3 +96,11 @@ def test_tools_list_is_copied_not_aliased():
     service = _make_service(tools=caller_list)
     caller_list.append(object())
     assert len(service.tools) == 1
+
+
+def test_default_tool_configuration_can_be_disabled() -> None:
+    service = _make_service(tools=[], enable_default_tools=False)
+
+    assert service.tools == []
+    assert service.tool_config is None
+    assert service.enable_default_tools is False

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -31,6 +31,7 @@ from xagent.core.agent.language import (
     OUTPUT_LANGUAGE_SOURCE_PLAN,
 )
 from xagent.core.agent.pattern.base import RequiredToolCallError
+from xagent.core.agent.pattern.dag import dag as dag_module
 from xagent.core.agent.pattern.dag.dag import _DAGStepRuntime
 from xagent.core.agent.pattern.dag.plan_generator import (
     PLAN_GENERATION_REQUIRED_TOOL_MESSAGE,
@@ -451,6 +452,34 @@ def test_dag_waiting_response_preserves_active_step_state() -> None:
         "forwarded_from_root": True,
         "dag_step_id": "confirm",
     }
+
+
+@pytest.mark.asyncio
+async def test_dag_forwards_disabled_interaction_policy_to_each_step(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed_policies: list[bool] = []
+    original_react_pattern = dag_module.ReActPattern
+
+    class RecordingReActPattern(original_react_pattern):
+        def __init__(self, *args: Any, **kwargs: Any) -> None:
+            observed_policies.append(kwargs["user_interaction_enabled"])
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(dag_module, "ReActPattern", RecordingReActPattern)
+    pattern = DAGPattern(
+        lambda **_: build_plan(PlanStep(id="answer", task="Answer")),
+        user_interaction_enabled=False,
+    )
+
+    result = await pattern.run(
+        context=ExecutionContext(execution_id="dag-no-interaction"),
+        tools=[],
+        llm=SequenceLLM([{"content": "done", "done": True}]),
+    )
+
+    assert result["success"] is True
+    assert observed_policies == [False]
 
 
 async def run_invalid_plan(plan: ExecutionPlan) -> dict[str, Any]:

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -129,6 +129,46 @@ class ReusedExecutionAdapter:
         return {"success": True}
 
 
+def test_execution_adapter_can_disable_skills_and_preserve_internal_metadata() -> None:
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="builtin:internal_worker",
+            pattern="single_call",
+            llm=FakeLLM([]),
+            skills_enabled=False,
+            user_interaction_enabled=False,
+            execution_metadata={
+                "agent_type": "builtin",
+                "builtin_agent_name": "internal_worker",
+            },
+        )
+    )
+
+    runner, execution_type = adapter._build_runner()
+    metadata = adapter._execution_metadata(execution_type=execution_type)
+    normalized = adapter._normalize_result(
+        result={"success": True, "output": "ok"},
+        execution_type=execution_type,
+        execution_id="run-1",
+    )
+
+    assert runner.agent.skill_manager is None
+    assert runner.agent.allowed_skills is None
+    assert [
+        schema["function"]["name"]
+        for schema in runner.agent.patterns[0]._builtin_tool_schemas()
+    ] == ["final_answer"]
+    assert runner.agent.metadata == {
+        "agent_type": "builtin",
+        "builtin_agent_name": "internal_worker",
+        "pattern": "single_call",
+    }
+    assert metadata["agent_type"] == "builtin"
+    assert metadata["builtin_agent_name"] == "internal_worker"
+    assert normalized["metadata"]["agent_type"] == "builtin"
+    assert normalized["metadata"]["builtin_agent_name"] == "internal_worker"
+
+
 def test_execution_metadata_carries_runtime_modality_preferences() -> None:
     adapter = AgentExecutionAdapter(
         AgentExecutionConfig(
@@ -1237,6 +1277,71 @@ async def test_execution_adapter_forwards_outbound_messages() -> None:
     assert outbound_message["expect_response"] is False
     assert outbound_message["visible"] is True
     assert outbound_message["step_id"] == outbound_message["metadata"]["step_id"]
+
+
+@pytest.mark.asyncio
+async def test_execution_adapter_rejects_outbound_control_calls_when_disabled() -> None:
+    sent_messages: list[dict[str, Any]] = []
+    llm = FakeLLM(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": "call-message",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": json.dumps(
+                                {
+                                    "message": "Should stay internal",
+                                    "message_type": "progress",
+                                    "expect_response": False,
+                                }
+                            ),
+                        },
+                    }
+                ]
+            },
+            {
+                "tool_calls": [
+                    {
+                        "id": "call-final",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": json.dumps(
+                                {
+                                    "response_language": "en",
+                                    "answer": "done",
+                                    "outcome": "completed",
+                                }
+                            ),
+                        },
+                    }
+                ]
+            },
+        ]
+    )
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="noninteractive",
+            pattern="single_call",
+            llm=llm,
+            outbound_message_handler=sent_messages.append,
+            skills_enabled=False,
+            user_interaction_enabled=False,
+        )
+    )
+
+    result = await adapter.execute(task="Stay internal", task_id="internal-exec")
+
+    assert result["success"] is True
+    assert result["output"] == "done"
+    assert sent_messages == []
+    assert [schema["function"]["name"] for schema in llm.calls[0]["tools"]] == [
+        "final_answer"
+    ]
+    assert [schema["function"]["name"] for schema in llm.calls[1]["tools"]] == [
+        "final_answer"
+    ]
 
 
 def test_execution_adapter_uses_last_assistant_message_when_output_missing() -> None:

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -135,6 +135,7 @@ def test_execution_adapter_can_disable_skills_and_preserve_internal_metadata() -
             name="builtin:internal_worker",
             pattern="single_call",
             llm=FakeLLM([]),
+            allowed_skills=["must-not-load"],
             skills_enabled=False,
             user_interaction_enabled=False,
             execution_metadata={

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -10,7 +10,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 
-from xagent.core.agent import AgentExecutionAdapter, AgentExecutionConfig
+from xagent.core.agent import AgentExecutionAdapter, AgentExecutionConfig, ReActPattern
 from xagent.core.agent.execution_adapter import INTERRUPTED_USER_MESSAGE
 from xagent.core.agent.result import NO_OUTPUT_PLACEHOLDER
 from xagent.core.agent.service import AgentService
@@ -1421,6 +1421,88 @@ async def test_execution_adapter_rejects_outbound_control_calls_when_disabled(
     }
     assert cancelled_work_ids == {"call-work-before", "call-work-after"}
     assert "call ask_user_question" not in llm.calls[0]["messages"][0]["content"]
+
+
+@pytest.mark.asyncio
+async def test_disabled_control_prescan_runs_when_control_is_first(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cancelled_batches: list[list[str]] = []
+    original_cancel = ReActPattern._cancel_tool_calls
+
+    def record_cancelled_batch(
+        self: ReActPattern,
+        tool_calls: list[dict[str, Any]],
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
+        cancelled_batches.append([str(call.get("id")) for call in tool_calls])
+        original_cancel(self, tool_calls, *args, **kwargs)
+
+    monkeypatch.setattr(ReActPattern, "_cancel_tool_calls", record_cancelled_batch)
+    work_tool = FakeTool()
+    llm = FakeLLM(
+        [
+            {
+                "tool_calls": [
+                    {
+                        "id": "call-control",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": json.dumps(
+                                {
+                                    "message": "Do not send",
+                                    "message_type": "progress",
+                                    "expect_response": False,
+                                }
+                            ),
+                        },
+                    },
+                    {
+                        "id": "call-work-after",
+                        "function": {
+                            "name": "noop",
+                            "arguments": json.dumps({"value": "must-not-run"}),
+                        },
+                    },
+                ]
+            },
+            {
+                "tool_calls": [
+                    {
+                        "id": "call-final",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": json.dumps(
+                                {
+                                    "response_language": "en",
+                                    "answer": "done",
+                                    "outcome": "completed",
+                                }
+                            ),
+                        },
+                    }
+                ]
+            },
+        ]
+    )
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="noninteractive",
+            pattern="single_call",
+            llm=llm,
+            tools=[work_tool],
+            skills_enabled=False,
+            user_interaction_enabled=False,
+        )
+    )
+
+    result = await adapter.execute(task="Stay internal", task_id="internal-exec")
+
+    assert result["success"] is True
+    assert work_tool.calls == []
+    assert cancelled_batches[0] == []
+    assert ["call-work-after"] in cancelled_batches
 
 
 def test_execution_adapter_uses_last_assistant_message_when_output_missing() -> None:

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -1282,6 +1282,7 @@ async def test_execution_adapter_forwards_outbound_messages() -> None:
 @pytest.mark.asyncio
 async def test_execution_adapter_rejects_outbound_control_calls_when_disabled() -> None:
     sent_messages: list[dict[str, Any]] = []
+    work_tool = FakeTool()
     llm = FakeLLM(
         [
             {
@@ -1298,7 +1299,14 @@ async def test_execution_adapter_rejects_outbound_control_calls_when_disabled() 
                                 }
                             ),
                         },
-                    }
+                    },
+                    {
+                        "id": "call-work",
+                        "function": {
+                            "name": "noop",
+                            "arguments": json.dumps({"value": "must-not-run"}),
+                        },
+                    },
                 ]
             },
             {
@@ -1325,6 +1333,7 @@ async def test_execution_adapter_rejects_outbound_control_calls_when_disabled() 
             name="noninteractive",
             pattern="single_call",
             llm=llm,
+            tools=[work_tool],
             outbound_message_handler=sent_messages.append,
             skills_enabled=False,
             user_interaction_enabled=False,
@@ -1336,12 +1345,20 @@ async def test_execution_adapter_rejects_outbound_control_calls_when_disabled() 
     assert result["success"] is True
     assert result["output"] == "done"
     assert sent_messages == []
+    assert work_tool.calls == []
     assert [schema["function"]["name"] for schema in llm.calls[0]["tools"]] == [
-        "final_answer"
+        "noop",
+        "final_answer",
     ]
     assert [schema["function"]["name"] for schema in llm.calls[1]["tools"]] == [
         "final_answer"
     ]
+    cancelled_work = next(
+        message
+        for message in llm.calls[1]["messages"]
+        if message.get("role") == "tool" and message.get("tool_call_id") == "call-work"
+    )
+    assert "cancelled" in cancelled_work["content"]
 
 
 def test_execution_adapter_uses_last_assistant_message_when_output_missing() -> None:

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -169,6 +169,31 @@ def test_execution_adapter_can_disable_skills_and_preserve_internal_metadata() -
     assert normalized["metadata"]["builtin_agent_name"] == "internal_worker"
 
 
+@pytest.mark.parametrize("pattern_name", ["dag_plan_execute", "auto"])
+def test_execution_adapter_propagates_interaction_policy_to_nested_patterns(
+    pattern_name: str,
+) -> None:
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="builtin:nested_worker",
+            pattern=pattern_name,
+            llm=FakeLLM([]),
+            skills_enabled=False,
+            user_interaction_enabled=False,
+        )
+    )
+
+    runner, _ = adapter._build_runner()
+    pattern = runner.agent.patterns[0]
+
+    assert runner.agent.skill_manager is None
+    if pattern_name == "dag_plan_execute":
+        assert pattern.user_interaction_enabled is False
+    else:
+        assert pattern.react_pattern.user_interaction_enabled is False
+        assert pattern.dag_pattern.user_interaction_enabled is False
+
+
 def test_execution_metadata_carries_runtime_modality_preferences() -> None:
     adapter = AgentExecutionAdapter(
         AgentExecutionConfig(
@@ -915,6 +940,10 @@ async def test_agent_service_refreshes_compact_llm_on_reused_execution_adapter()
             recovered_skill_context=None,
             memory_store=None,
             allowed_skills=None,
+            skills_enabled=True,
+            workspace_enabled=True,
+            user_interaction_enabled=True,
+            execution_metadata={"old": True},
         )
     )
     service = AgentService(
@@ -925,6 +954,10 @@ async def test_agent_service_refreshes_compact_llm_on_reused_execution_adapter()
         compact_llm=cast(Any, initial_compact_llm),
         tools=[],
         tool_config=None,
+        enable_workspace=False,
+        skills_enabled=False,
+        user_interaction_enabled=False,
+        execution_metadata={"agent_type": "builtin"},
     )
     service._execution_adapter = cast(Any, adapter)
 
@@ -939,6 +972,10 @@ async def test_agent_service_refreshes_compact_llm_on_reused_execution_adapter()
     assert adapter.config.current_task_id == "task-compact-refresh"
     assert adapter.config.llm is updated_llm
     assert adapter.config.compact_llm is updated_compact_llm
+    assert adapter.config.skills_enabled is False
+    assert adapter.config.workspace_enabled is False
+    assert adapter.config.user_interaction_enabled is False
+    assert adapter.config.execution_metadata == {"agent_type": "builtin"}
 
 
 @pytest.mark.asyncio
@@ -1280,7 +1317,30 @@ async def test_execution_adapter_forwards_outbound_messages() -> None:
 
 
 @pytest.mark.asyncio
-async def test_execution_adapter_rejects_outbound_control_calls_when_disabled() -> None:
+@pytest.mark.parametrize(
+    ("control_name", "control_args"),
+    [
+        (
+            "send_message",
+            {
+                "message": "Should stay internal",
+                "message_type": "progress",
+                "expect_response": False,
+            },
+        ),
+        (
+            "ask_user_question",
+            {
+                "message": "Should stay internal",
+                "interactions": [],
+            },
+        ),
+    ],
+)
+async def test_execution_adapter_rejects_outbound_control_calls_when_disabled(
+    control_name: str,
+    control_args: dict[str, Any],
+) -> None:
     sent_messages: list[dict[str, Any]] = []
     work_tool = FakeTool()
     llm = FakeLLM(
@@ -1288,20 +1348,21 @@ async def test_execution_adapter_rejects_outbound_control_calls_when_disabled() 
             {
                 "tool_calls": [
                     {
-                        "id": "call-message",
+                        "id": "call-work-before",
                         "function": {
-                            "name": "send_message",
-                            "arguments": json.dumps(
-                                {
-                                    "message": "Should stay internal",
-                                    "message_type": "progress",
-                                    "expect_response": False,
-                                }
-                            ),
+                            "name": "noop",
+                            "arguments": json.dumps({"value": "must-not-run"}),
                         },
                     },
                     {
-                        "id": "call-work",
+                        "id": "call-control",
+                        "function": {
+                            "name": control_name,
+                            "arguments": json.dumps(control_args),
+                        },
+                    },
+                    {
+                        "id": "call-work-after",
                         "function": {
                             "name": "noop",
                             "arguments": json.dumps({"value": "must-not-run"}),
@@ -1353,12 +1414,13 @@ async def test_execution_adapter_rejects_outbound_control_calls_when_disabled() 
     assert [schema["function"]["name"] for schema in llm.calls[1]["tools"]] == [
         "final_answer"
     ]
-    cancelled_work = next(
-        message
+    cancelled_work_ids = {
+        message.get("tool_call_id")
         for message in llm.calls[1]["messages"]
-        if message.get("role") == "tool" and message.get("tool_call_id") == "call-work"
-    )
-    assert "cancelled" in cancelled_work["content"]
+        if message.get("role") == "tool" and "cancelled" in message["content"]
+    }
+    assert cancelled_work_ids == {"call-work-before", "call-work-after"}
+    assert "call ask_user_question" not in llm.calls[0]["messages"][0]["content"]
 
 
 def test_execution_adapter_uses_last_assistant_message_when_output_missing() -> None:

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -4646,6 +4646,58 @@ async def test_react_pattern_skips_store_memory_tool_in_single_call_mode() -> No
 
 
 @pytest.mark.asyncio
+async def test_tool_result_user_interaction_fails_closed_when_disabled() -> None:
+    class WaitingTool:
+        metadata = SimpleNamespace(
+            name="approval_gate",
+            description="Request approval.",
+        )
+
+        def args_type(self) -> type[BaseModel]:
+            return CalculatorArgs
+
+        async def run_json_async(self, args: dict[str, Any]) -> dict[str, Any]:
+            return {
+                "success": False,
+                "status": "waiting_for_user",
+                "message": "Approve this action?",
+            }
+
+    pattern = ReActPattern(max_iterations=2, user_interaction_enabled=False)
+    runtime = PatternRuntime(execution_id="unattended-task")
+    context = ExecutionContext(execution_id="unattended-task")
+    context.add_user_message("Run unattended.")
+
+    result = await pattern.run(
+        context=context,
+        tools=[WaitingTool()],
+        llm=FakeLLM(
+            [
+                {
+                    "tool_calls": [
+                        {
+                            "id": "wait-call",
+                            "function": {
+                                "name": "approval_gate",
+                                "arguments": '{"expression":"2+2"}',
+                            },
+                        }
+                    ]
+                }
+            ]
+        ),
+        runtime=runtime,
+    )
+
+    assert result["success"] is False
+    assert result["status"] == "failed"
+    assert "interaction is disabled" in result["error"]
+    assert runtime.outbound_messages == []
+    assert pattern.status == "failed"
+    assert pattern.waiting_for_user_request is None
+
+
+@pytest.mark.asyncio
 async def test_tool_result_can_pause_and_resume_with_user_response() -> None:
     class ResumableTool:
         def __init__(self) -> None:


### PR DESCRIPTION
## Summary

- add immutable code-defined built-in agent specs, an in-process registry, and a restricted executor
- run built-in agents through AgentService with least-privilege defaults for tools, memory, skills, workspace, and user interaction
- propagate internal execution metadata and reject disabled outbound control calls
- cover registry validation, async model and tool resolution, capability isolation, and real AgentService execution

## Scope

This PR only adds the generic runtime. It does not register product-specific built-in agents or add Memory Dreaming policy, storage, APIs, or scheduling.

## Validation

- PYTHONPATH=$PWD/src python -X faulthandler -m pytest -q tests/core/agent
- ruff check on all changed Python files
- mypy on the built-in runtime, execution adapter, and AgentService
- commit hooks: ruff check, ruff format, mypy, isort, codespell, whitespace checks