### PR TITLE
fix(agent): strip final_answer bundled with work tool calls in ReAct

### DIFF
--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -12,9 +12,29 @@ flag never changes observable results, only latency:
   including failures.
 - I3 (ledger order): ``tool_ledger`` insertion order matches input order after a
   batch, because the consecutive-count walks read it in reverse insertion order.
-- I4 (control short-circuit): a control tool (final_answer / send_message /
-  ask_user_question) owns its segment and ends the turn's tool execution; later
-  tool calls in the same turn do not run.
+- I4 (control segment): a control tool (final_answer / send_message /
+  ask_user_question) owns its segment and never shares a concurrent batch.
+  What happens to the rest of the batch depends on the control result:
+    * final_answer with answer text finalizes the run and clears the queue;
+    * final_answer with an empty answer is rejected instead - the call gets a
+      failure result, every sibling still queued is cancelled with a result of
+      its own, and the next turn is forced back to final_answer;
+    * ask_user_question, and send_message with expect_response=True, suspend
+      for the user and discard the rest of the plan;
+    * send_message with expect_response=False returns "message_sent" and
+      execution continues with the next segment.
+  So every branch except the last ends the turn's tool execution. The reject,
+  suspend, and message branches settle every queued sibling with a result of
+  its own; the finalize branch does not - it clears the queue without
+  cancelling siblings, which is exactly why the strip removes a bundled
+  final_answer before the batch is recorded.
+
+  A batch that arrives here from a fresh LLM response carries no final_answer
+  alongside a work tool: response normalization removes it first, because its
+  answer text was written before those tools ran. That holds for fresh
+  responses only - pending_tool_calls restored from a checkpoint are replayed
+  without re-normalization, so a batch written by an earlier build can still
+  reach this loop carrying one, and takes the branches above unchanged.
 - I5 (interrupt / resume): an interrupt during a concurrent batch preserves
   calls that already completed and leaves only interrupted calls pending. A
   cancelled call may still have committed externally before cancellation was
@@ -96,6 +116,11 @@ REACT_DECISION_FINAL_ANSWER = "final_answer"
 USER_INTERACTION_CONTROL_TOOL_NAMES = CONTROL_TOOL_NAMES - {REACT_DECISION_FINAL_ANSWER}
 REACT_DECISION_TOOL_CALL = "tool_call"
 UNGROUPED_TOOL_DECISION_CATEGORIES = frozenset({"basic", "other"})
+# Bounds for the final_answer-strip warning's tool-name list. Tool names come
+# straight from the model, so the log line is shaped like the rest of this
+# module's untrusted-input logging: bounded length, escaped, never raw.
+STRIP_LOG_MAX_TOOL_NAMES = 8
+STRIP_LOG_MAX_TOOL_NAME_CHARS = 64
 REACT_RESPONSE_LANGUAGE_DESCRIPTION = (
     "Target natural language for user-facing prose in this ReAct response, "
     "for example English, Simplified Chinese, Traditional Chinese, or Spanish. "
@@ -676,6 +701,30 @@ class ReActPattern(AgentPattern):
                             self._empty_final_answer_call(normalized) is not None
                         ),
                     )
+            original_tool_calls = normalized.get("tool_calls") or []
+            kept_tool_calls, stripped_final_answers = (
+                self._strip_final_answer_bundled_with_work_tools(original_tool_calls)
+            )
+            if stripped_final_answers:
+                logger.warning(
+                    "ReAct discarding %d final_answer call(s) bundled with work "
+                    "tools; the answer text predates their results. "
+                    "iteration=%s model=%s batch_size=%d tools=[%s]",
+                    len(stripped_final_answers),
+                    iteration,
+                    llm_metadata.get("selected_model"),
+                    len(original_tool_calls),
+                    self._tool_names_for_log(original_tool_calls),
+                )
+                normalized["tool_calls"] = kept_tool_calls
+                if answer_streamer is not None:
+                    # The discarded text may already be streaming to the UI.
+                    # Nothing downstream closes that stream once the batch no
+                    # longer carries a final_answer, so close it here.
+                    await answer_streamer.fail(
+                        "discarded an answer that arrived together with tool "
+                        "calls; answering again once the tools have run"
+                    )
             if force_final_answer_now and not normalized.get("tool_calls"):
                 normalized["done"] = True
 
@@ -863,8 +912,10 @@ class ReActPattern(AgentPattern):
                 "final answer on the latest tool result instead of repeating the same "
                 "tool work. When the current task is complete, call the final_answer "
                 "tool exactly once instead of calling another work tool or returning "
-                "plain assistant text. Do not write assistant text in the same "
-                "response as a work tool call; call the tool directly. "
+                "plain assistant text. Never put final_answer in the same response "
+                "as any other tool call: run the work tools first, then answer on a "
+                "later turn from their results. Do not write assistant text in the "
+                "same response as a work tool call; call the tool directly. "
                 f"{missing_information_instruction}"
                 "If the latest user "
                 "message explicitly asks you to call a named available tool, call "
@@ -1078,6 +1129,15 @@ class ReActPattern(AgentPattern):
                 continue
             if force_final_answer and tool_call.get("name") != "final_answer":
                 return True
+        if self._batch_carries_work_tool(tool_calls):
+            # A final_answer sharing the batch with a work tool is removed by
+            # _strip_final_answer_bundled_with_work_tools before the batch is
+            # recorded, so its answer field never reaches the user and cannot
+            # be a reason to discard the whole response. Discarding here would
+            # take the work calls with it - the exact behavior this guard is
+            # not allowed to reintroduce. The empty-answer repair owns
+            # responses whose only calls are control tools.
+            return False
         return self._empty_final_answer_call(normalized) is not None
 
     def _empty_final_answer_call(
@@ -1100,6 +1160,85 @@ class ReActPattern(AgentPattern):
             if not self._final_answer_text(tool_call.get("args")).strip():
                 return tool_call
         return None
+
+    def _batch_carries_work_tool(self, tool_calls: list[dict[str, Any]]) -> bool:
+        """Whether a tool-call batch contains at least one non-control tool.
+
+        The single predicate for "this batch does real work", shared by the
+        final_answer strip and the empty-answer guard so the two cannot
+        disagree about which batches the strip owns.
+        """
+
+        control_tool_names = self._control_tool_names()
+        return any(
+            isinstance(tool_call, dict)
+            and tool_call.get("name") not in control_tool_names
+            for tool_call in tool_calls
+        )
+
+    def _strip_final_answer_bundled_with_work_tools(
+        self,
+        tool_calls: list[dict[str, Any]],
+    ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Split a batch that mixes ``final_answer`` with real work tools.
+
+        Returns ``(kept, removed)``. A ``final_answer`` sharing a response with
+        a work tool was written before that tool ran, so its text cannot
+        describe the result it claims to summarize. Dropping it lets the work
+        tools execute and the next iteration answer from real results.
+
+        Must run before the batch reaches ``add_assistant_message``. A
+        ``final_answer`` recorded in the message history never receives a tool
+        result, and ``ExecutionContext._sanitize_tool_message_pairs`` then drops
+        the whole assistant block together with the work-tool results the model
+        needs on the next turn.
+
+        Control-only batches are returned unchanged. ``send_message`` with
+        ``expect_response=False`` continues the turn by design, and a batch
+        with no work tool carries no result the answer could be missing.
+        """
+
+        if not self._batch_carries_work_tool(tool_calls):
+            return tool_calls, []
+        kept: list[dict[str, Any]] = []
+        removed: list[dict[str, Any]] = []
+        for tool_call in tool_calls:
+            if isinstance(tool_call, dict) and tool_call.get("name") == "final_answer":
+                removed.append(tool_call)
+            else:
+                kept.append(tool_call)
+        return kept, removed
+
+    def _tool_names_for_log(self, tool_calls: list[dict[str, Any]]) -> str:
+        """Render a batch's tool names for a log line, bounded and escaped.
+
+        Names are model-controlled strings with no length or character limit of
+        their own, so they are truncated and ``repr``-escaped before reaching
+        the log: a newline inside a name would otherwise split the record.
+        Order is preserved and duplicates are kept - a batch calling the same
+        tool three times is the fact worth reading. Non-mapping entries are
+        rendered as a placeholder instead of raising, matching the
+        ``isinstance(tool_call, dict)`` defense in ``_batch_carries_work_tool``
+        and ``_strip_final_answer_bundled_with_work_tools``: this method must
+        not be the one place in the strip path that crashes the run on a
+        malformed batch it is only trying to log. That branch is
+        defense-in-depth: ``_normalize_tool_calls`` currently emits only dict
+        entries with non-empty names, so no production input reaches it today.
+        """
+
+        names = [
+            repr(
+                (
+                    str(tool_call.get("name"))
+                    if isinstance(tool_call, dict)
+                    else f"<non-mapping tool_call: {type(tool_call).__name__}>"
+                )[:STRIP_LOG_MAX_TOOL_NAME_CHARS]
+            )
+            for tool_call in tool_calls[:STRIP_LOG_MAX_TOOL_NAMES]
+        ]
+        overflow = len(tool_calls) - len(names)
+        rendered = ", ".join(names)
+        return f"{rendered} (+{overflow} more)" if overflow > 0 else rendered
 
     def _final_answer_text(self, args: Any) -> str:
         """Coerce a ``final_answer`` argument payload into its answer text.
@@ -1722,9 +1861,12 @@ class ReActPattern(AgentPattern):
                         "unfinished, or outcome=blocked when no further progress is "
                         "possible without user input or an external state change. "
                         "Never mark an answer completed when it admits work is "
-                        "unfinished. Do not call additional tools after this. Set "
-                        "response_language to the target output language for this "
-                        "answer. "
+                        "unfinished. Call this tool alone: never place it in the "
+                        "same response as any other tool call, and do not call "
+                        "additional tools after it. An answer written in the same "
+                        "response as a tool call cannot describe that tool's "
+                        "result. Set response_language to the target output "
+                        "language for this answer. "
                         f"{final_answer_language_rule()}"
                     ),
                     "parameters": {
@@ -2095,9 +2237,14 @@ class ReActPattern(AgentPattern):
     ) -> None:
         """Refuse to finalize on an empty ``final_answer`` and re-request one.
 
-        ``_response_requires_tool_protocol_retry`` catches this on the turn the
-        model produces it, so this guard covers the paths that reach the handler
-        without passing through response normalization — most importantly a
+        For a batch whose only calls are control tools,
+        ``_response_requires_tool_protocol_retry`` still catches this on the
+        turn the model produces it, discarding the whole response before it is
+        recorded. For a batch that also carries a work tool, the fresh path
+        strips the ``final_answer`` call regardless of whether its answer is
+        empty, so the work tool runs and this handler never sees that batch
+        either. This guard is left covering the one path that reaches the
+        handler without passing through response normalization at all — a
         checkpoint resume that restores ``pending_tool_calls`` verbatim.
 
         Returning ``None`` keeps the run in the loop; ``force_final_answer_next``
@@ -2106,13 +2253,15 @@ class ReActPattern(AgentPattern):
 
         Two deliberate differences from the fresh-turn path.
 
-        Sibling calls still pending are discarded, matching the fresh path's
-        whole-response rejection for the order that matters: a resumed
-        ``[final_answer(""), work_tool]`` batch would otherwise execute a
-        side-effecting tool that the fresh path never runs. The match is not
-        exact in the reverse order - in ``[work_tool, final_answer("")]`` the
-        work tool has already executed by the time this runs, and nothing here
-        undoes it.
+        Sibling calls still pending are discarded regardless of order, because
+        by the time a resume reaches this point the assistant envelope for the
+        batch is already recorded in history (see
+        ``_ensure_pending_tool_call_envelope``), so an undiscarded sibling
+        would be left queued with no result of its own. This diverges from the
+        fresh path, which now runs the work tool instead of discarding it: the
+        fresh path can still drop ``final_answer`` before anything is
+        recorded, while a resumed batch can only cancel calls that are already
+        committed to history.
 
         And the next turn is forced to ``final_answer`` alone, where the fresh
         path restores the full tool set. That bounds the run: a second empty

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -3992,6 +3992,10 @@ async def test_react_pattern_reserves_control_tool_names_in_schema() -> None:
     )
     assert "tool names mentioned in memory" in system_prompt
     assert "call the final_answer tool exactly once" in system_prompt
+    assert (
+        "Never put final_answer in the same response as any other tool call"
+        in system_prompt
+    )
     final_answer_schema = next(
         schema
         for schema in llm.calls[0]["tools"]
@@ -4000,6 +4004,10 @@ async def test_react_pattern_reserves_control_tool_names_in_schema() -> None:
     assert (
         "same natural language as the current user request"
         in final_answer_schema["description"]
+    )
+    assert (
+        "Call this tool alone: never place it in the same response as any "
+        "other tool call" in final_answer_schema["description"]
     )
     assert "response_language" in final_answer_schema["parameters"]["required"]
     assert "outcome" in final_answer_schema["parameters"]["required"]

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -331,6 +331,12 @@ class FakeLLM:
         return self.responses.pop(0)
 
 
+class FakeNamedLLM(FakeLLM):
+    """FakeLLM carrying a ``model_name``, for tests that assert on it in logs."""
+
+    model_name = "fake-model"
+
+
 class StreamingFinalAnswerLLM:
     def __init__(self) -> None:
         self.calls: list[dict[str, Any]] = []
@@ -697,29 +703,116 @@ class StreamingFinalAnswerToolLLM:
 
 
 class StreamingMixedFinalAnswerAndToolLLM:
+    """First call bundles final_answer with a work tool; the retry answers for real."""
+
+    def __init__(self) -> None:
+        self.stream_calls: list[dict[str, Any]] = []
+
     async def chat(self, **kwargs: Any) -> Any:
         raise AssertionError("streaming mixed tool path should not call chat()")
 
     async def stream_chat(self, **kwargs: Any) -> Any:
+        self.stream_calls.append(kwargs)
+        if len(self.stream_calls) == 1:
+            yield StreamChunk(
+                type=ChunkType.TOOL_CALL,
+                tool_calls=[
+                    {
+                        "index": 0,
+                        "id": "call_final",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"Candidate"}',
+                        },
+                    },
+                    {
+                        "index": 1,
+                        "id": "call_calc",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    },
+                ],
+            )
+            yield StreamChunk(type=ChunkType.END)
+            return
         yield StreamChunk(
             type=ChunkType.TOOL_CALL,
             tool_calls=[
                 {
-                    "index": 0,
-                    "id": "call_final",
+                    "id": "call_final_2",
                     "function": {
                         "name": "final_answer",
-                        "arguments": '{"answer":"Candidate"}',
+                        "arguments": '{"answer":"4"}',
                     },
-                },
+                }
+            ],
+        )
+        yield StreamChunk(type=ChunkType.END)
+
+
+class StreamingAnswerThenWorkToolLLM:
+    """Streams a final_answer candidate before the batch also names a work tool.
+
+    Exercises the case where the answer streamer has already emitted content
+    by the time the work tool's name shows up in a later chunk of the same
+    response, so the strip point is the only place left to close the stream.
+    """
+
+    def __init__(self) -> None:
+        self.stream_calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> Any:
+        raise AssertionError("streaming answer-then-tool path should not call chat()")
+
+    async def stream_chat(self, **kwargs: Any) -> Any:
+        self.stream_calls.append(kwargs)
+        if len(self.stream_calls) == 1:
+            prefix = '{"answer":"'
+            for arguments in [
+                prefix + "Looking",
+                prefix + "Looking that up now.",
+                prefix + 'Looking that up now."}',
+            ]:
+                yield StreamChunk(
+                    type=ChunkType.TOOL_CALL,
+                    tool_calls=[
+                        {
+                            "index": 0,
+                            "id": "call_final",
+                            "function": {
+                                "name": "final_answer",
+                                "arguments": arguments,
+                            },
+                        }
+                    ],
+                )
+            yield StreamChunk(
+                type=ChunkType.TOOL_CALL,
+                tool_calls=[
+                    {
+                        "index": 1,
+                        "id": "call_calc",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    }
+                ],
+            )
+            yield StreamChunk(type=ChunkType.END)
+            return
+        yield StreamChunk(
+            type=ChunkType.TOOL_CALL,
+            tool_calls=[
                 {
-                    "index": 1,
-                    "id": "call_calc",
+                    "id": "call_final_2",
                     "function": {
-                        "name": "calculator",
-                        "arguments": '{"expression":"2+2"}',
+                        "name": "final_answer",
+                        "arguments": '{"answer":"4"}',
                     },
-                },
+                }
             ],
         )
         yield StreamChunk(type=ChunkType.END)
@@ -1587,24 +1680,811 @@ async def test_react_pattern_streams_final_answer_control_tool() -> None:
 
 
 @pytest.mark.asyncio
-async def test_react_pattern_does_not_stream_mixed_final_answer_candidate() -> None:
+async def test_react_strips_final_answer_bundled_before_work_tool() -> None:
+    """I-2: a final_answer bundled before a work tool is stripped too - the
+    work tool is no longer silently discarded, and the candidate answer text
+    is never streamed to the frontend."""
+
     llm = StreamingMixedFinalAnswerAndToolLLM()
-    pattern = ReActPattern(max_iterations=1)
+    pattern = ReActPattern(max_iterations=3)
     context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
     context.add_user_message("Calculate 2+2")
     outbound = OutboundCollector()
     runtime = PatternRuntime(execution_id="task-1", outbound_message_handler=outbound)
+    tool = FakeTool()
 
     result = await pattern.run(
         context=context,
-        tools=[FakeTool()],
+        tools=[tool],
         llm=llm,
         runtime=runtime,
     )
 
     assert result["success"] is True
-    assert result["response"] == "Candidate"
-    assert outbound.events == []
+    assert result["response"] == "4"
+    assert tool.calls == [{"expression": "2+2"}]
+    assert not any(
+        event.get("content") == "Candidate" or event.get("delta") == "Candidate"
+        for event in outbound.events
+    )
+
+
+@pytest.mark.asyncio
+async def test_react_strips_final_answer_bundled_after_work_tool(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """I-1/I-3/I-5: a final_answer bundled after a work tool is stripped, the
+    work tool executes and its result reaches the next turn, and the strip is
+    logged once with the model name and the pre-strip tool list, bounded and
+    escaped."""
+
+    llm = FakeNamedLLM(
+        responses=[
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_calc",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    },
+                    {
+                        "id": "call_final",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"Looking that up now."}',
+                        },
+                    },
+                ],
+            },
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_final_2",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"4"}',
+                        },
+                    }
+                ],
+            },
+        ]
+    )
+    tool = FakeTool()
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Calculate 2+2")
+    runtime = PatternRuntime(execution_id="task-1")
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.agent.pattern.react.react"
+    ):
+        result = await pattern.run(
+            context=context,
+            tools=[tool],
+            llm=llm,
+            runtime=runtime,
+        )
+
+    assert result["success"] is True
+    assert result["response"] == "4"
+    assert tool.calls == [{"expression": "2+2"}]
+
+    # I-3: the stripped final_answer leaves no trace in the assistant
+    # message, the tool-result messages, or the ledger.
+    assistant_messages = context.get_messages_by_role("assistant")
+    first_turn_tool_names = [
+        call["function"]["name"] for call in (assistant_messages[0].tool_calls or [])
+    ]
+    assert first_turn_tool_names == ["calculator"]
+    tool_result_ids = {
+        message.tool_call_id for message in context.get_messages_by_role("tool")
+    }
+    assert "call_final" not in tool_result_ids
+    assert "call_final" not in pattern.tool_ledger
+
+    # Regression-only guard, not a mutation-effective assertion on its own:
+    # no orphaned tool_call may ever appear in history.
+    assistant_tool_call_ids = {
+        call["id"]
+        for message in assistant_messages
+        for call in (message.tool_calls or [])
+    }
+    assert assistant_tool_call_ids == tool_result_ids
+
+    all_content = json.dumps(
+        [message.content for message in context.messages], default=str
+    )
+    assert "Looking that up now." not in all_content
+
+    assert len(llm.calls) == 2
+    assert llm.calls[1]["messages"][-1]["role"] == "tool"
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert len(messages) == 1
+    assert "final_answer" in messages[0]
+    assert "calculator" in messages[0]
+    assert "fake-model" in messages[0]
+
+    # I-5 (bound): the tool-name list in the warning is capped, escaped, and
+    # never exposes an unbounded or unescaped model-controlled string.
+    caplog.clear()
+    long_name = "x" * 200 + "\n" + "y"
+    overflow_tool_calls = [
+        {"id": "call_long", "function": {"name": long_name, "arguments": "{}"}},
+        *(
+            {
+                "id": f"call_work_{index}",
+                "function": {"name": f"work_tool_{index}", "arguments": "{}"},
+            }
+            for index in range(10)
+        ),
+        {
+            "id": "call_overflow_final",
+            "function": {
+                "name": "final_answer",
+                "arguments": '{"answer":"Looking that up now."}',
+            },
+        },
+    ]
+    overflow_llm = FakeNamedLLM(responses=[{"tool_calls": overflow_tool_calls}])
+    overflow_pattern = ReActPattern(max_iterations=1)
+    overflow_context = ExecutionContext(
+        system_prompt="You are helpful.", execution_id="task-2"
+    )
+    overflow_context.add_user_message("Run many tools")
+    overflow_runtime = PatternRuntime(execution_id="task-2")
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.agent.pattern.react.react"
+    ):
+        await overflow_pattern.run(
+            context=overflow_context,
+            tools=[],
+            llm=overflow_llm,
+            runtime=overflow_runtime,
+        )
+
+    overflow_messages = [record.getMessage() for record in caplog.records]
+    assert len(overflow_messages) == 1
+    overflow_message = overflow_messages[0]
+    assert "(+4 more)" in overflow_message
+    assert "\n" not in overflow_message
+    assert ("x" * 64) in overflow_message
+    assert ("x" * 65) not in overflow_message
+
+
+def test_tool_names_for_log_tolerates_non_mapping_entries() -> None:
+    """Matches the isinstance(dict) defense in _batch_carries_work_tool and
+    _strip_final_answer_bundled_with_work_tools: a non-mapping batch entry
+    must render a placeholder instead of crashing the log line it appears
+    in."""
+
+    pattern = ReActPattern()
+
+    rendered = pattern._tool_names_for_log(
+        [
+            {"id": "call_1", "name": "calculator"},
+            "not-a-tool-call",
+            None,
+        ]
+    )
+
+    assert "calculator" in rendered
+    assert "non-mapping tool_call: str" in rendered
+    assert "non-mapping tool_call: NoneType" in rendered
+
+
+@pytest.mark.asyncio
+async def test_react_strips_every_final_answer_in_a_mixed_batch() -> None:
+    """I-4: every final_answer in a batch is stripped, not only the first."""
+
+    llm = FakeLLM(
+        responses=[
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_final_a",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"A"}',
+                        },
+                    },
+                    {
+                        "id": "call_calc",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    },
+                    {
+                        "id": "call_final_b",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"B"}',
+                        },
+                    },
+                ],
+            },
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_final_2",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"4"}',
+                        },
+                    }
+                ],
+            },
+        ]
+    )
+    tool = FakeTool()
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Calculate 2+2")
+    runtime = PatternRuntime(execution_id="task-1")
+
+    result = await pattern.run(
+        context=context,
+        tools=[tool],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["response"] not in {"A", "B"}
+    assert result["response"] == "4"
+    assistant_messages = context.get_messages_by_role("assistant")
+    first_turn_tool_calls = assistant_messages[0].tool_calls or []
+    assert len(first_turn_tool_calls) == 1
+    assert first_turn_tool_calls[0]["function"]["name"] == "calculator"
+
+
+@pytest.mark.asyncio
+async def test_react_closes_open_answer_stream_when_bundled_final_answer_is_stripped() -> (
+    None
+):
+    """I-6: an answer stream already open when the batch turns out to bundle
+    a work tool is closed explicitly instead of left open forever, and it is
+    never closed as though the candidate text were the real final answer."""
+
+    llm = StreamingAnswerThenWorkToolLLM()
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Calculate 2+2")
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(execution_id="task-1", outbound_message_handler=outbound)
+    tool = FakeTool()
+
+    result = await pattern.run(
+        context=context,
+        tools=[tool],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "4"
+    assert tool.calls == [{"expression": "2+2"}]
+
+    started_id = next(
+        event["message_id"]
+        for event in outbound.events
+        if event["type"] == "final_answer_start"
+    )
+    first_stream_events = []
+    for event in outbound.events:
+        if event.get("message_id") != started_id:
+            continue
+        first_stream_events.append(event)
+        if event["type"] == "final_answer_error":
+            break
+
+    assert [event["type"] for event in first_stream_events] == [
+        "final_answer_start",
+        "final_answer_delta",
+        "final_answer_delta",
+        "final_answer_error",
+    ]
+    assert not any(
+        event["type"] == "final_answer_end"
+        and event.get("content") == "Looking that up now."
+        for event in outbound.events
+    )
+    assert outbound.events[-1]["type"] == "final_answer_end"
+    assert outbound.events[-1]["content"] == "4"
+
+
+@pytest.mark.asyncio
+async def test_react_keeps_send_message_bundled_with_work_tool(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Guards against a future change that widens the strip from final_answer
+    to every control tool. This test stays green if the strip is removed
+    entirely - it pins behavior that must not change, not behavior this fix
+    introduces."""
+
+    llm = FakeLLM(
+        responses=[
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_message",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": (
+                                '{"message":"Still working",'
+                                '"message_type":"progress","expect_response":false}'
+                            ),
+                        },
+                    },
+                    {
+                        "id": "call_calc",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    },
+                ],
+            },
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_final",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"4"}',
+                        },
+                    }
+                ],
+            },
+        ]
+    )
+    tool = FakeTool()
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Calculate 2+2")
+    runtime = PatternRuntime(execution_id="task-1")
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.agent.pattern.react.react"
+    ):
+        result = await pattern.run(
+            context=context,
+            tools=[tool],
+            llm=llm,
+            runtime=runtime,
+        )
+
+    assert result["success"] is True
+    assert result["response"] == "4"
+    assert tool.calls == [{"expression": "2+2"}]
+    assert len(runtime.outbound_messages) == 1
+    assert runtime.outbound_messages[0]["message"] == "Still working"
+    assert caplog.records == []
+
+
+@pytest.mark.asyncio
+async def test_react_keeps_control_only_final_answer_batch(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Same guard shape as the send_message case: a batch of control tools
+    only has no result the answer could be missing, so the strip must not
+    touch it. Green with or without the strip."""
+
+    llm = FakeLLM(
+        responses=[
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_message",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": (
+                                '{"message":"Still working",'
+                                '"message_type":"progress","expect_response":false}'
+                            ),
+                        },
+                    },
+                    {
+                        "id": "call_final",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"Done."}',
+                        },
+                    },
+                ],
+            },
+        ]
+    )
+    pattern = ReActPattern(max_iterations=1)
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Do the thing")
+    runtime = PatternRuntime(execution_id="task-1")
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.agent.pattern.react.react"
+    ):
+        result = await pattern.run(
+            context=context,
+            tools=[],
+            llm=llm,
+            runtime=runtime,
+        )
+
+    assert result["success"] is True
+    assert result["response"] == "Done."
+    assert caplog.records == []
+
+
+@pytest.mark.asyncio
+async def test_react_forced_final_answer_recovers_full_tool_set_after_mixed_batch(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """I-9a: guards the forced-final-answer turn's existing recovery path.
+    This test stays green if the strip is removed entirely - it pins
+    behavior that must not change, not behavior this fix introduces."""
+
+    llm = FakeLLM(
+        responses=[
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_calc_1",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    },
+                    {
+                        "id": "call_final_1",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"Looking that up now."}',
+                        },
+                    },
+                ],
+            },
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_calc_2",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    }
+                ],
+            },
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_final_2",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"4"}',
+                        },
+                    }
+                ],
+            },
+        ]
+    )
+    tool = FakeTool()
+    pattern = ReActPattern(max_iterations=3)
+    pattern.force_final_answer_next = True
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Calculate 2+2")
+    runtime = PatternRuntime(execution_id="task-1")
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.agent.pattern.react.react"
+    ):
+        result = await pattern.run(
+            context=context,
+            tools=[tool],
+            llm=llm,
+            runtime=runtime,
+        )
+
+    assert result["success"] is True
+    assert result["response"] == "4"
+    second_call_tool_names = {
+        schema["function"]["name"] for schema in llm.calls[1]["tools"]
+    }
+    assert "calculator" in second_call_tool_names
+    assert pattern.force_final_answer_next is False
+    assert tool.calls == [{"expression": "2+2"}]
+    assert caplog.records == []
+
+
+@pytest.mark.asyncio
+async def test_react_forced_final_answer_fails_when_recovery_retry_bundles_again(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """I-9b: anchor test - pins the strip's position, not its existence.
+    Deleting the strip helper entirely leaves this green. Moving the strip
+    call to run ahead of either tool-protocol-retry guard check instead of
+    after both turns it red: on the first guard, because the strip fires and
+    logs before that response is discarded wholesale for an unrelated reason,
+    leaving a stray "discarding" warning behind; on the second (retry) guard,
+    because stripping the retried batch's final_answer erases the very
+    mixed-call shape that guard exists to reject, so the run no longer fails
+    at all - it runs the retried calculator and needs a third response the
+    fixture never provides."""
+
+    llm = FakeLLM(
+        responses=[
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_calc_1",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    },
+                    {
+                        "id": "call_final_1",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"Looking that up now."}',
+                        },
+                    },
+                ],
+            },
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_calc_2",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    },
+                    {
+                        "id": "call_final_2",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"Looking that up now."}',
+                        },
+                    },
+                ],
+            },
+        ]
+    )
+    tool = FakeTool()
+    pattern = ReActPattern(max_iterations=3)
+    pattern.force_final_answer_next = True
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Calculate 2+2")
+    runtime = PatternRuntime(execution_id="task-1")
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.agent.pattern.react.react"
+    ):
+        result = await pattern.run(
+            context=context,
+            tools=[tool],
+            llm=llm,
+            runtime=runtime,
+        )
+
+    assert result["success"] is False
+    assert result["status"] == "invalid_tool_protocol"
+    assert tool.calls == []
+    # The run fails through the existing invalid-protocol path, which logs
+    # its own unrelated warning; only the strip's warning must be absent.
+    assert not any("discarding" in record.getMessage() for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_react_strips_empty_final_answer_from_a_retried_batch_when_not_reforcing() -> (
+    None
+):
+    """Guards the retry recheck's accepted behavior change: a retried batch
+    that is neither a forced turn nor itself rejecting mixed control calls
+    (reject_mixed_control_calls=False from a provider protocol error on the
+    first response, force_final_answer=False because this was never a forced
+    turn) now lets a bundled empty final_answer strip and the work tool run,
+    instead of hard-failing as "invalid tool protocol after retry". The
+    first response's provider-level protocol error is what puts the run on
+    the retry path at all; the retried response is the one carrying the
+    mixed batch this test is pinning."""
+
+    llm = FakeLLM(
+        responses=[
+            tool_protocol_error_response(
+                ToolProtocolViolation(
+                    provider="deepseek",
+                    code="serialized_tool_call_content",
+                    message="Invalid provider tool protocol.",
+                )
+            ),
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_work",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    },
+                    {
+                        "id": "call_final",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":""}',
+                        },
+                    },
+                ],
+            },
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_final_2",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"4"}',
+                        },
+                    }
+                ],
+            },
+        ]
+    )
+    tool = FakeTool()
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Calculate 2+2")
+    runtime = PatternRuntime(execution_id="task-1")
+
+    result = await pattern.run(
+        context=context,
+        tools=[tool],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["response"] == "4"
+    assert tool.calls == [{"expression": "2+2"}]
+    assert len(llm.calls) == 3
+
+
+@pytest.mark.asyncio
+async def test_react_strips_empty_final_answer_bundled_with_work_tool(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """I-11: an empty-answer final_answer bundled with a work tool is
+    stripped like any other bundled final_answer, instead of discarding the
+    whole response the way a control-only empty answer does."""
+
+    llm = FakeLLM(
+        responses=[
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_calc",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    },
+                    {
+                        "id": "call_final",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":""}',
+                        },
+                    },
+                ],
+            },
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_final_2",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"4"}',
+                        },
+                    }
+                ],
+            },
+        ]
+    )
+    tool = FakeTool()
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Calculate 2+2")
+    runtime = PatternRuntime(execution_id="task-1")
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.agent.pattern.react.react"
+    ):
+        result = await pattern.run(
+            context=context,
+            tools=[tool],
+            llm=llm,
+            runtime=runtime,
+        )
+
+    assert result["success"] is True
+    assert result["response"] == "4"
+    assert tool.calls == [{"expression": "2+2"}]
+    assert len(llm.calls) == 2
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert not any("carried no answer text" in message for message in messages)
+    assert any(
+        "final_answer" in message and "calculator" in message for message in messages
+    )
+
+
+@pytest.mark.asyncio
+async def test_react_pauses_for_user_after_stripping_bundled_final_answer() -> None:
+    """I-12: a batch that turns out to need user input after the bundled
+    final_answer is stripped still pauses cleanly, with the unexecuted work
+    tool cancelled rather than silently dropped."""
+
+    llm = FakeLLM(
+        responses=[
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_final",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"Done."}',
+                        },
+                    },
+                    {
+                        "id": "call_ask",
+                        "function": {
+                            "name": "ask_user_question",
+                            "arguments": '{"message":"Which one?"}',
+                        },
+                    },
+                    {
+                        "id": "call_calc",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    },
+                ],
+            },
+        ]
+    )
+    tool = FakeTool()
+    pattern = ReActPattern(max_iterations=1)
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Calculate 2+2 then ask me something")
+    runtime = PatternRuntime(execution_id="task-1")
+
+    result = await pattern.run(
+        context=context,
+        tools=[tool],
+        llm=llm,
+        runtime=runtime,
+    )
+
+    assert result["status"] == "waiting_for_user"
+    assert tool.calls == []
+    assert "call_final" not in pattern.tool_ledger
+    assert pattern.tool_ledger["call_calc"].status == "cancelled"
+    assert pattern.tool_ledger["call_ask"].status == "completed"
+
+    assistant_messages = context.get_messages_by_role("assistant")
+    assistant_tool_call_ids = {
+        call["id"]
+        for message in assistant_messages
+        for call in (message.tool_calls or [])
+    }
+    tool_result_ids = {
+        message.tool_call_id for message in context.get_messages_by_role("tool")
+    }
+    assert assistant_tool_call_ids == {"call_ask", "call_calc"}
+    assert assistant_tool_call_ids <= tool_result_ids
 
 
 @pytest.mark.asyncio
@@ -3206,6 +4086,11 @@ async def test_react_pattern_can_finish_with_final_answer_tool() -> None:
 async def test_react_pattern_final_answer_clears_trailing_pending_before_checkpoint() -> (
     None
 ):
+    # The trailing call is another control tool (send_message), not a work
+    # tool: a work tool here would instead be stripped from the batch before
+    # final_answer ever reaches this point (see the strip tests above), which
+    # would defeat what this test is pinning - that a control result of
+    # "completed" clears whatever is still queued behind it.
     llm = FakeLLM(
         responses=[
             {
@@ -3218,10 +4103,13 @@ async def test_react_pattern_final_answer_clears_trailing_pending_before_checkpo
                         },
                     },
                     {
-                        "id": "call_calc",
+                        "id": "call_message",
                         "function": {
-                            "name": "calculator",
-                            "arguments": '{"expression":"9+1"}',
+                            "name": "send_message",
+                            "arguments": (
+                                '{"message":"Still working",'
+                                '"message_type":"progress","expect_response":false}'
+                            ),
                         },
                     },
                 ],
@@ -5349,8 +6237,10 @@ async def test_react_retries_final_answer_that_omits_the_answer_field() -> None:
 
 
 @pytest.mark.asyncio
-async def test_react_discards_empty_final_answer_with_trailing_work_call() -> None:
-    """Discard the invalid response so retry feedback survives sanitization."""
+async def test_react_strips_empty_final_answer_with_trailing_work_call() -> None:
+    """An empty-answer final_answer bundled with a work tool is stripped like
+    any other bundled final_answer: the work tool executes instead of being
+    discarded along with the empty answer (I-11, streaming path)."""
 
     llm = StreamingEmptyFinalAnswerLLM(trailing_work_tool=True)
     pattern, context, runtime, _outbound, _tracer = _react_empty_final_answer_fixture()
@@ -5365,12 +6255,8 @@ async def test_react_discards_empty_final_answer_with_trailing_work_call() -> No
 
     assert result["success"] is True
     assert result["response"] == "The result is 4."
-    assert tool.calls == []
+    assert tool.calls == [{"expression": "2+2"}]
     assert len(llm.stream_calls) == 2
-    assert (
-        "previous response called final_answer with an empty answer"
-        in (llm.stream_calls[1]["messages"][0]["content"])
-    )
 
     assistant_tool_call_ids = {
         tool_call["id"]
@@ -5380,7 +6266,8 @@ async def test_react_discards_empty_final_answer_with_trailing_work_call() -> No
     tool_result_ids = {
         message.tool_call_id for message in context.messages if message.role == "tool"
     }
-    assert assistant_tool_call_ids == {"call_final_1"}
+    assert "call_final_0" not in assistant_tool_call_ids
+    assert "call_final_0" not in pattern.tool_ledger
     assert assistant_tool_call_ids <= tool_result_ids
 
 
@@ -5582,12 +6469,14 @@ def test_empty_final_answer_call_detects_blank_answers() -> None:
 
 @pytest.mark.asyncio
 async def test_react_discards_rest_of_resumed_batch_after_empty_final_answer() -> None:
-    """A rejected resume batch must not run work the fresh path would discard.
+    """A rejected resume batch cancels its still-pending sibling calls.
 
-    The fresh-turn path throws away the whole offending response, so a
-    ``[final_answer(""), work_tool]`` batch never executes the work tool. A
-    resumed batch has to match, or a pre-fix checkpoint replays a side effect
-    that the same model output would never have produced on a live turn.
+    On resume the whole batch's assistant envelope is already recorded in
+    history before execution starts, so every queued call must end with a
+    result row; the only safe outcome for siblings behind a rejected empty
+    ``final_answer`` is cancellation. A fresh-turn ``[final_answer(""),
+    work_tool]`` batch instead strips the ``final_answer`` before anything
+    is recorded and runs the work tool, so the two paths diverge on purpose.
     """
 
     llm = StreamingEmptyFinalAnswerLLM()
@@ -5775,9 +6664,11 @@ async def test_react_resumed_empty_final_answer_abandons_after_forced_retry() ->
 async def test_react_resumed_reverse_batch_order_cannot_undo_an_executed_tool() -> None:
     """Pins the documented limit of the resume guard's batch discard.
 
-    In ``[work_tool, final_answer("")]`` the work tool has already executed by
-    the time the rejection runs, so the match with the fresh path's
-    whole-response rejection is exact only when the empty answer comes first.
+    In ``[work_tool, final_answer("")]`` restored onto ``pending_tool_calls``,
+    the work tool has already executed by the time the rejection runs, so
+    discarding the rest of the batch cannot reach back and undo it - the
+    resume guard can only cancel calls still queued, never ones already
+    committed.
     """
 
     llm = StreamingEmptyFinalAnswerLLM()


### PR DESCRIPTION
## Summary

A response whose `tool_calls` bundle `final_answer` with work tools previously ended the turn with the pre-written answer text: with `final_answer` last, executed work-tool results were discarded unseen; with it first, the remaining work calls were silently dropped without executing. In both orders the answer text predates the bundled tools' results, so it can never be based on them (#1664).

Response normalization now strips every `final_answer` that shares a batch with a work tool before the batch is recorded, executes the remaining tools normally, and lets a later turn answer from their real results.

## Behavior changes

- `[work_tool, final_answer]` (either order): the work tools run, their results reach the model, and the bundled answer text is discarded with one bounded WARNING (model name, escaped and truncated tool names, batch size).
- `[work_tool, final_answer("")]`: the empty-answer guard previously discarded the whole response, taking the work tool with it; such a batch is now stripped like any other. The same applies at the protocol-retry re-check, where this shape previously hard-failed.
- An answer stream already opened for the discarded text is closed explicitly instead of being left dangling.
- Control-only batches are untouched: `send_message` with `expect_response=false` bundled with a work tool keeps continuing the turn, and forced-final-answer turns keep their existing recovery semantics.
- `final_answer`'s tool description and the system prompt now state that it must be called alone, after tool results are available.

## Verification

- `tests/core/agent/test_react.py`: 139 passed (128 at base). One test that asserted the old bundling behavior was rewritten, and `test_react_pattern_does_not_stream_mixed_final_answer_candidate` was deleted: its first half pinned the old behavior, and its never-streamed half now lives in `test_react_strips_final_answer_bundled_before_work_tool`. 12 tests added covering both bundle orders, multi-`final_answer` batches, empty-answer bundles on the fresh and retry paths, stream closure, log bounds and escaping, `send_message` bundling, control-only batches, forced-turn anchors, and the pause path.
- New assertions were mutation-checked: reverting the strip, narrowing it to the first entry, removing the log bounds, removing the stream closure, or moving the strip point each turns the corresponding tests red.
- `pre-commit` (ruff, mypy, isort, codespell) clean on the changed files.

Closes #1664

