### PR TITLE
fix(frontend): surface the backend's real rejection reason in ClarificationForm

### DIFF
--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -527,6 +527,26 @@ describe("ClarificationForm delivery failures", () => {
     await waitFor(() => expect(screen.queryByRole("alert")).toBeNull())
   })
 
+  it("reads the reason off a failure that is not an Error instance", async () => {
+    // `onSend` belongs to arbitrary builder callbacks (#1485), so a rejection
+    // carrying the contract's fields need not be an `Error` subclass - the
+    // disposition is probed structurally and the reason has to match.
+    const onSend = vi.fn().mockRejectedValue({
+      message: "A previous guidance message is still being applied.",
+      disposition: "rejected",
+      userFacing: true,
+    })
+
+    await submitAnswer(onSend)
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "A previous guidance message is still being applied.",
+        { description: "chatPage.clarification.sendNotSent" },
+      )
+    })
+  })
+
   it("uses hint keys that resolve in both locale trees", () => {
     // The component tests stub t() as identity, so they pin the key strings
     // only against themselves. This binds them to the real trees: a typo'd

--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -9,6 +9,7 @@ import {
 } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { McpApp } from "@/contexts/mcp-apps-context"
+import { resolveTranslation } from "@/i18n/translations"
 
 const appContextMock = vi.hoisted(() => ({
   dispatch: vi.fn(),
@@ -386,5 +387,181 @@ describe("ClarificationForm connect_apps interaction", () => {
     expect(screen.queryByText(CONNECT_APPS_INTERACTION.label)).not.toBeInTheDocument()
     // An ordinary field's own persisted label is untouched by this.
     expect(screen.getByText("Note:")).toBeInTheDocument()
+  })
+})
+
+describe("ClarificationForm delivery failures", () => {
+  beforeEach(() => {
+    appContextMock.dispatch.mockReset()
+    appContextMock.filesDisabled = false
+    appContextMock.providerAvailable = true
+    appContextMock.sendMessage.mockReset()
+    toastErrorMock.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  const deliveryError = (
+    message: string,
+    disposition: string,
+    userFacing = false,
+  ) => Object.assign(new Error(message), { disposition, userFacing })
+
+  const submitAnswer = async (onSend: ReturnType<typeof vi.fn>) => {
+    render(
+      <ClarificationForm
+        interactions={[{ type: "text_input" as const, field: "city", label: "City" }]}
+        onSend={onSend}
+      />,
+    )
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+  }
+
+  it("surfaces the backend rejection reason instead of the generic toast", async () => {
+    const onSend = vi.fn().mockRejectedValue(deliveryError(
+      "A previous guidance message is still being applied. Please wait for it to finish.",
+      "rejected",
+      true,
+    ))
+
+    await submitAnswer(onSend)
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "A previous guidance message is still being applied. Please wait for it to finish.",
+        { description: "chatPage.clarification.sendNotSent" },
+      )
+    })
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "A previous guidance message is still being applied.",
+    )
+  })
+
+  it("keeps the form submittable after a failure that never reached the agent", async () => {
+    const onSend = vi.fn().mockRejectedValue(
+      deliveryError("Durable storage is temporarily unavailable", "not_sent", true),
+    )
+
+    await submitAnswer(onSend)
+
+    await waitFor(() => expect(toastErrorMock).toHaveBeenCalledWith(
+      "Durable storage is temporarily unavailable",
+      { description: "chatPage.clarification.sendNotSent" },
+    ))
+    const submit = screen.getByRole("button", {
+      name: "chatPage.clarification.submit",
+    })
+    expect(submit).toBeEnabled()
+    expect(screen.getByRole("textbox")).toHaveValue("Beijing")
+  })
+
+  it("warns before a resubmit when the delivery outcome is unknown", async () => {
+    // No resubmit guard exists in this component (a retry mints a fresh
+    // client message id today), so the copy must warn - not promise safety.
+    const onSend = vi.fn().mockRejectedValue(deliveryError(
+      "The task is busy applying an earlier answer.",
+      "outcome_unknown",
+      true,
+    ))
+
+    await submitAnswer(onSend)
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "The task is busy applying an earlier answer.",
+        { description: "chatPage.clarification.sendOutcomeUnknown" },
+      )
+    })
+    // Advisory only: the button stays enabled, exactly as it does today.
+    expect(screen.getByRole("button", {
+      name: "chatPage.clarification.submit",
+    })).toBeEnabled()
+  })
+
+  it("keeps connection plumbing diagnostics away from the visitor", async () => {
+    const onSend = vi.fn().mockRejectedValue(deliveryError(
+      "Message not sent: the connection changed before delivery.",
+      "not_sent",
+    ))
+
+    await submitAnswer(onSend)
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "chatPage.clarification.sendError",
+        { description: "chatPage.clarification.sendNotSent" },
+      )
+    })
+    expect(await screen.findByRole("alert")).not.toHaveTextContent(
+      "the connection changed before delivery",
+    )
+  })
+
+  it("falls back to the generic string when the failure carries no reason", async () => {
+    const onSend = vi.fn().mockRejectedValue(new Error("   "))
+
+    await submitAnswer(onSend)
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "chatPage.clarification.sendError",
+        undefined,
+      )
+    })
+  })
+
+  it("clears the failure once the visitor edits an answer", async () => {
+    const onSend = vi.fn().mockRejectedValue(
+      deliveryError("Durable storage is temporarily unavailable", "not_sent", true),
+    )
+
+    await submitAnswer(onSend)
+
+    await screen.findByRole("alert")
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Shanghai" } })
+    await waitFor(() => expect(screen.queryByRole("alert")).toBeNull())
+  })
+
+  it("uses hint keys that resolve in both locale trees", () => {
+    // The component tests stub t() as identity, so they pin the key strings
+    // only against themselves. This binds them to the real trees: a typo'd
+    // key would fall back to itself instead of a translated sentence.
+    for (const key of [
+      "chatPage.clarification.sendNotSent",
+      "chatPage.clarification.sendOutcomeUnknown",
+    ] as const) {
+      expect(resolveTranslation("en", key)).not.toBe(key)
+      expect(resolveTranslation("zh", key)).not.toBe(key)
+    }
+  })
+
+  it("clears a previous round's failure when the form is asked again", async () => {
+    // The live turn render path keeps one component instance across
+    // clarification rounds, so a stale round-1 alert would sit on top of
+    // round 2's question.
+    appContextMock.sendMessage.mockRejectedValue(deliveryError(
+      "Durable storage is temporarily unavailable",
+      "not_sent",
+      true,
+    ))
+    const interactions = [{ type: "text_input" as const, field: "city", label: "City" }]
+    const { rerender } = render(
+      <ClarificationForm interactions={interactions} active />,
+    )
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    await screen.findByRole("alert")
+
+    rerender(<ClarificationForm interactions={interactions} active={false} />)
+    rerender(<ClarificationForm interactions={interactions} active />)
+
+    expect(screen.queryByRole("alert")).toBeNull()
   })
 })

--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -32,10 +32,20 @@ vi.mock("@/contexts/app-context-chat", () => ({
   },
 }))
 
+// `translate` is a mutable box so a test can swap the active locale's `t` and
+// rerender, the way I18nProvider does - it changes its context value without
+// remounting consumers. `identity` is kept beside it as the single definition
+// the file-wide reset below restores.
+const i18nMock = vi.hoisted(() => {
+  const identity = (key: string, vars?: Record<string, string | number>) =>
+    vars ? `${key}:${JSON.stringify(vars)}` : key
+  return { identity, translate: identity }
+})
+
 vi.mock("@/contexts/i18n-context", () => ({
   useI18n: () => ({
     t: (key: string, vars?: Record<string, string | number>) =>
-      vars ? `${key}:${JSON.stringify(vars)}` : key,
+      i18nMock.translate(key, vars),
   }),
 }))
 
@@ -55,6 +65,12 @@ vi.mock("@/contexts/auth-context", () => ({
 }))
 
 import { ClarificationForm } from "./clarification-form"
+
+// Every describe in this file gets the identity translate back, so a locale
+// swapped by one test cannot leak into a suite added below it.
+beforeEach(() => {
+  i18nMock.translate = i18nMock.identity
+})
 
 describe("ClarificationForm Session file capability", () => {
   beforeEach(() => {
@@ -437,9 +453,13 @@ describe("ClarificationForm delivery failures", () => {
         { description: "chatPage.clarification.sendNotSent" },
       )
     })
-    expect(await screen.findByRole("alert")).toHaveTextContent(
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent(
       "A previous guidance message is still being applied.",
     )
+    // The hint lives in the alert too, not only in the toast - without this
+    // the inline hint could be deleted with every test still green.
+    expect(alert).toHaveTextContent("chatPage.clarification.sendNotSent")
   })
 
   it("keeps the form submittable after a failure that never reached the agent", async () => {
@@ -481,6 +501,9 @@ describe("ClarificationForm delivery failures", () => {
     expect(screen.getByRole("button", {
       name: "chatPage.clarification.submit",
     })).toBeEnabled()
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "chatPage.clarification.sendOutcomeUnknown",
+    )
   })
 
   it("keeps connection plumbing diagnostics away from the visitor", async () => {
@@ -545,6 +568,58 @@ describe("ClarificationForm delivery failures", () => {
         { description: "chatPage.clarification.sendNotSent" },
       )
     })
+  })
+
+  it("re-renders the visible failure in the new locale", async () => {
+    // I18nProvider swaps its context value on a locale change without
+    // remounting consumers, so an alert holding pre-translated strings would
+    // keep showing the previous language until it is cleared.
+    const onSend = vi.fn().mockRejectedValue(
+      deliveryError("Durable storage is temporarily unavailable", "not_sent", true),
+    )
+    const interactions = [{ type: "text_input" as const, field: "city", label: "City" }]
+    const { rerender } = render(
+      <ClarificationForm interactions={interactions} onSend={onSend} />,
+    )
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("chatPage.clarification.sendNotSent")
+
+    i18nMock.translate = (key: string) => `zh:${key}`
+    rerender(<ClarificationForm interactions={interactions} onSend={onSend} />)
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "zh:chatPage.clarification.sendNotSent",
+    )
+    // The backend's own reason is not ours to translate - it passes through.
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Durable storage is temporarily unavailable",
+    )
+  })
+
+  it("re-renders the generic fallback message in the new locale", async () => {
+    const onSend = vi.fn().mockRejectedValue(new Error("   "))
+    const interactions = [{ type: "text_input" as const, field: "city", label: "City" }]
+    const { rerender } = render(
+      <ClarificationForm interactions={interactions} onSend={onSend} />,
+    )
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    expect(await screen.findByRole("alert")).toHaveTextContent(
+      "chatPage.clarification.sendError",
+    )
+
+    i18nMock.translate = (key: string) => `zh:${key}`
+    rerender(<ClarificationForm interactions={interactions} onSend={onSend} />)
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "zh:chatPage.clarification.sendError",
+    )
   })
 
   it("uses hint keys that resolve in both locale trees", () => {

--- a/frontend/src/components/chat/clarification-form.tsx
+++ b/frontend/src/components/chat/clarification-form.tsx
@@ -71,6 +71,10 @@ const readSendDisposition = (error: unknown): MessageDeliveryDisposition | null 
  * shown as-is. Connection plumbing messages stay behind the localized string:
  * they are English diagnostics, and a widget visitor is not the audience for
  * them.
+ *
+ * The message is probed structurally for the same reason the disposition is:
+ * an `onSend` callback's rejection need not be an `Error` instance. Nothing
+ * new becomes displayable either way — `userFacing` still has to be set.
  */
 const readSendReason = (error: unknown): string => {
   if (
@@ -80,7 +84,8 @@ const readSendReason = (error: unknown): string => {
   ) {
     return ""
   }
-  return error instanceof Error ? error.message.trim() : ""
+  const message = (error as { message?: unknown }).message
+  return typeof message === "string" ? message.trim() : ""
 }
 
 // Interaction types that are "live widgets" reflecting external state (e.g.

--- a/frontend/src/components/chat/clarification-form.tsx
+++ b/frontend/src/components/chat/clarification-form.tsx
@@ -13,6 +13,7 @@ import { toast } from "@/components/ui/sonner"
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible"
 import { ChevronDown, ChevronRight, MessageSquare, Upload, File as FileIcon, X, Globe } from "lucide-react"
 import { ConnectAppsField } from "./connect-apps-field"
+import type { MessageDeliveryDisposition } from "@/hooks/use-websocket"
 
 interface ClarificationFormProps {
   message?: string
@@ -44,6 +45,43 @@ const isFileActionSelection = (
 ): boolean => option
   ? isFileActionOption(option)
   : isFileActionValue(value)
+
+/**
+ * Delivery failures carry whether the turn definitely never reached the agent.
+ * Plain errors (local validation, unexpected throws) carry nothing, and are
+ * left unqualified rather than guessed at: telling a visitor to resubmit a
+ * turn that may have landed is worse than saying nothing. Errors are probed
+ * structurally rather than by `instanceof`, because the `onSend` branch's
+ * failures come from arbitrary builder callbacks (see #1485).
+ */
+const readSendDisposition = (error: unknown): MessageDeliveryDisposition | null => {
+  if (typeof error !== "object" || error === null || !("disposition" in error)) {
+    return null
+  }
+  const disposition = (error as { disposition: unknown }).disposition
+  return disposition === "not_sent"
+    || disposition === "rejected"
+    || disposition === "outcome_unknown"
+    ? disposition
+    : null
+}
+
+/**
+ * Only the reasons the sender can act on — the backend's rejection text — are
+ * shown as-is. Connection plumbing messages stay behind the localized string:
+ * they are English diagnostics, and a widget visitor is not the audience for
+ * them.
+ */
+const readSendReason = (error: unknown): string => {
+  if (
+    typeof error !== "object"
+    || error === null
+    || (error as { userFacing?: unknown }).userFacing !== true
+  ) {
+    return ""
+  }
+  return error instanceof Error ? error.message.trim() : ""
+}
 
 // Interaction types that are "live widgets" reflecting external state (e.g.
 // useMcpApps()'s connection state), not a question with an answer to submit
@@ -103,11 +141,16 @@ export function ClarificationForm({
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isSubmitted, setIsSubmitted] = useState(!active && !isConnectAppsOnly)
   const [isOpen, setIsOpen] = useState(active || isConnectAppsOnly)
+  const [sendFailure, setSendFailure] = useState<{ message: string; hint: string | null } | null>(null)
 
   useEffect(() => {
     if (active) {
+      // A new clarification round reuses this component instance on the live
+      // turn render path, so a stale round-1 failure alert would sit on top
+      // of round 2's question.
       setIsSubmitted(false)
       setIsOpen(true)
+      setSendFailure(null)
     }
   }, [active])
 
@@ -189,6 +232,7 @@ export function ClarificationForm({
 
   const handleInputChange = (field: string, value: any) => {
     setFormState((prev) => ({ ...prev, [field]: value }))
+    setSendFailure(null)
   }
 
   const handleSubmit = async () => {
@@ -281,6 +325,7 @@ export function ClarificationForm({
 
     try {
       setIsSubmitting(true)
+      setSendFailure(null)
       // If textMessage is empty but we have files, send a generic message?
       const outboundFiles = filesDisabled ? [] : files
       const finalMessage = textMessage || (outboundFiles.length > 0 ? t("chatPage.clarification.uploadedFiles") : t("chatPage.clarification.confirmed"))
@@ -298,7 +343,24 @@ export function ClarificationForm({
       }
     } catch (error) {
       console.error("Failed to send clarification response", error)
-      toast.error(t("chatPage.clarification.sendError"))
+      // The rejection reason ("a previous guidance message is still being
+      // applied") is the only actionable part of the failure; the fixed
+      // string is a last resort.
+      const detail = readSendReason(error)
+      const disposition = readSendDisposition(error)
+      const failure = {
+        message: detail || t("chatPage.clarification.sendError"),
+        // The draft is preserved and Submit stays enabled in every case, so
+        // the copy may only warn, never promise: a resubmit after an unknown
+        // outcome mints a fresh delivery and could answer the question twice.
+        hint: disposition === "outcome_unknown"
+          ? t("chatPage.clarification.sendOutcomeUnknown")
+          : disposition === "not_sent" || disposition === "rejected"
+            ? t("chatPage.clarification.sendNotSent")
+            : null,
+      }
+      setSendFailure(failure)
+      toast.error(failure.message, failure.hint ? { description: failure.hint } : undefined)
     } finally {
       setIsSubmitting(false)
     }
@@ -581,6 +643,15 @@ export function ClarificationForm({
                 )
               ))}
             </div>
+
+            {sendFailure && (
+              <div role="alert" className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+                <div>{sendFailure.message}</div>
+                {sendFailure.hint && (
+                  <div className="mt-1 text-xs text-destructive/80">{sendFailure.hint}</div>
+                )}
+              </div>
+            )}
 
             <div className="pt-2 flex gap-2">
               <Button className="flex-1" size="sm" onClick={handleSubmit} disabled={!active || isSubmitting || isSubmitted}>

--- a/frontend/src/components/chat/clarification-form.tsx
+++ b/frontend/src/components/chat/clarification-form.tsx
@@ -14,6 +14,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { ChevronDown, ChevronRight, MessageSquare, Upload, File as FileIcon, X, Globe } from "lucide-react"
 import { ConnectAppsField } from "./connect-apps-field"
 import type { MessageDeliveryDisposition } from "@/hooks/use-websocket"
+import type { TranslationKey } from "@/i18n/translations"
 
 interface ClarificationFormProps {
   message?: string
@@ -88,6 +89,20 @@ const readSendReason = (error: unknown): string => {
   return typeof message === "string" ? message.trim() : ""
 }
 
+/**
+ * The hint that belongs with a disposition, as a key rather than a translated
+ * string: the toast needs it once at failure time, while the persistent alert
+ * has to re-resolve it on every render so a locale switch is not stuck behind
+ * whatever language was active when the send failed.
+ */
+const sendHintKey = (
+  disposition: MessageDeliveryDisposition | null,
+): TranslationKey | null => disposition === "outcome_unknown"
+  ? "chatPage.clarification.sendOutcomeUnknown"
+  : disposition === "not_sent" || disposition === "rejected"
+    ? "chatPage.clarification.sendNotSent"
+    : null
+
 // Interaction types that are "live widgets" reflecting external state (e.g.
 // useMcpApps()'s connection state), not a question with an answer to submit
 // - see the comment on isConnectAppsOnly below for why that distinction
@@ -146,7 +161,11 @@ export function ClarificationForm({
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isSubmitted, setIsSubmitted] = useState(!active && !isConnectAppsOnly)
   const [isOpen, setIsOpen] = useState(active || isConnectAppsOnly)
-  const [sendFailure, setSendFailure] = useState<{ message: string; hint: string | null } | null>(null)
+  // Raw evidence only. Translating at render (not at failure time) is what
+  // lets a locale switch reach an alert that is already on screen.
+  const [sendFailure, setSendFailure] = useState<
+    { detail: string; disposition: MessageDeliveryDisposition | null } | null
+  >(null)
 
   useEffect(() => {
     if (active) {
@@ -353,19 +372,18 @@ export function ClarificationForm({
       // string is a last resort.
       const detail = readSendReason(error)
       const disposition = readSendDisposition(error)
-      const failure = {
-        message: detail || t("chatPage.clarification.sendError"),
-        // The draft is preserved and Submit stays enabled in every case, so
-        // the copy may only warn, never promise: a resubmit after an unknown
-        // outcome mints a fresh delivery and could answer the question twice.
-        hint: disposition === "outcome_unknown"
-          ? t("chatPage.clarification.sendOutcomeUnknown")
-          : disposition === "not_sent" || disposition === "rejected"
-            ? t("chatPage.clarification.sendNotSent")
-            : null,
-      }
-      setSendFailure(failure)
-      toast.error(failure.message, failure.hint ? { description: failure.hint } : undefined)
+      setSendFailure({ detail, disposition })
+      // The toast is a snapshot - it keeps whatever language was active when
+      // it fired. The alert below is not, and re-resolves on every render.
+      // The draft is preserved and Submit stays enabled in every case, so the
+      // copy may only warn, never promise: a resubmit after an unknown
+      // outcome mints a fresh delivery and could answer the question twice.
+      const hintKey = sendHintKey(disposition)
+      const hint = hintKey ? t(hintKey) : null
+      toast.error(
+        detail || t("chatPage.clarification.sendError"),
+        hint ? { description: hint } : undefined,
+      )
     } finally {
       setIsSubmitting(false)
     }
@@ -593,6 +611,10 @@ export function ClarificationForm({
     }
   }
 
+  // Recomputed on every render, which is the point: a locale change re-renders
+  // this component without remounting it.
+  const sendFailureHintKey = sendFailure ? sendHintKey(sendFailure.disposition) : null
+
   return (
     <Collapsible
       open={isOpen}
@@ -651,9 +673,9 @@ export function ClarificationForm({
 
             {sendFailure && (
               <div role="alert" className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
-                <div>{sendFailure.message}</div>
-                {sendFailure.hint && (
-                  <div className="mt-1 text-xs text-destructive/80">{sendFailure.hint}</div>
+                <div>{sendFailure.detail || t("chatPage.clarification.sendError")}</div>
+                {sendFailureHintKey && (
+                  <div className="mt-1 text-xs text-destructive/80">{t(sendFailureHintKey)}</div>
                 )}
               </div>
             )}

--- a/frontend/src/hooks/use-websocket.test.ts
+++ b/frontend/src/hooks/use-websocket.test.ts
@@ -300,6 +300,72 @@ describe("useWebSocket message delivery", () => {
     })
   })
 
+  it("marks a rejection that carries the backend's reason as user facing", async () => {
+    // The clarification form only shows a rejection reason that is marked
+    // user facing; if this flag regresses, the visitor drops back to the
+    // generic "Failed to send response" toast.
+    const { result } = renderHook(() => useWebSocket({
+      url: "ws://localhost",
+      taskId: 1,
+    }))
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+    const socket = MockWebSocket.instances[0]
+    act(() => socket.open())
+
+    const delivery = result.current.sendChatMessage(
+      "answer",
+      undefined,
+      false,
+      "rejected-with-reason",
+    )
+    act(() => {
+      socket.receive({
+        type: "message_rejected",
+        client_message_id: "rejected-with-reason",
+        message: "A previous guidance message is still being applied. Please wait for it to finish.",
+        rejection_outcome: "not_accepted",
+      })
+    })
+
+    await expect(delivery).rejects.toMatchObject({
+      message: "A previous guidance message is still being applied. Please wait for it to finish.",
+      disposition: "rejected",
+      userFacing: true,
+    })
+  })
+
+  it("keeps a rejection without a backend reason marked as not user facing", async () => {
+    const { result } = renderHook(() => useWebSocket({
+      url: "ws://localhost",
+      taskId: 1,
+    }))
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+    const socket = MockWebSocket.instances[0]
+    act(() => socket.open())
+
+    const delivery = result.current.sendChatMessage(
+      "answer",
+      undefined,
+      false,
+      "rejected-no-reason",
+    )
+    act(() => {
+      socket.receive({
+        type: "message_rejected",
+        client_message_id: "rejected-no-reason",
+        rejection_outcome: "not_accepted",
+      })
+    })
+
+    await expect(delivery).rejects.toMatchObject({
+      message: "Message was rejected.",
+      disposition: "rejected",
+      userFacing: false,
+    })
+  })
+
   it("rejects concurrent reuse of a pending client message id without replacing its owner", async () => {
     const { result } = renderHook(() => useWebSocket({
       url: "ws://localhost",

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -54,16 +54,26 @@ export type MessageDeliveryDisposition = "not_sent" | "rejected" | "outcome_unkn
 export class MessageDeliveryError extends Error {
   readonly disposition: MessageDeliveryDisposition
   readonly retryWithNewId: boolean
+  /**
+   * Whether `message` explains the failure in terms the sender can act on —
+   * the server's rejection text. The remaining messages describe connection
+   * plumbing ("the connection changed before delivery") and are diagnostics:
+   * callers show their own localized string for those rather than putting
+   * internal English in front of a visitor.
+   */
+  readonly userFacing: boolean
 
   constructor(
     message: string,
     disposition: MessageDeliveryDisposition,
     retryWithNewId = false,
+    userFacing = false,
   ) {
     super(message)
     this.name = "MessageDeliveryError"
     this.disposition = disposition
     this.retryWithNewId = retryWithNewId
+    this.userFacing = userFacing
   }
 }
 
@@ -71,7 +81,8 @@ const deliveryError = (
   message: string,
   disposition: MessageDeliveryDisposition,
   retryWithNewId = false,
-) => new MessageDeliveryError(message, disposition, retryWithNewId)
+  userFacing = false,
+) => new MessageDeliveryError(message, disposition, retryWithNewId, userFacing)
 
 export type WebSocketCredentialOwner =
   | {
@@ -887,6 +898,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
                     ? "rejected"
                     : "outcome_unknown",
                   data.retry_with_new_id === true,
+                  typeof data.message === "string" && data.message.trim() !== "",
                 ))
               }
             }

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -332,6 +332,8 @@ const en = {
       confirmed: "Confirmed",
       sendFailed: "Failed to send clarification response",
       sendError: "Failed to send response",
+      sendNotSent: "Your answers were kept — you can submit again.",
+      sendOutcomeUnknown: "Your response may already have been submitted. Reload the conversation before submitting again.",
       selectOption: "Select an option",
       selectOptions: "Select options",
       acceptedFormats: "Accepted formats",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -332,6 +332,8 @@ const zh = {
       confirmed: "已确认",
       sendFailed: "发送澄清回复失败",
       sendError: "发送回复失败",
+      sendNotSent: "你填写的内容已保留，可以重新提交。",
+      sendOutcomeUnknown: "回复可能已经提交，请刷新会话后再重新提交。",
       selectOption: "请选择一个选项",
       selectOptions: "请选择选项",
       acceptedFormats: "支持的格式",

--- a/frontend/vitest.widget.config.ts
+++ b/frontend/vitest.widget.config.ts
@@ -10,6 +10,7 @@ const widgetConfig = mergeConfig(baseConfig, defineConfig({
         "src/app/widget/chat/[[]token[]]/page-client.tsx",
         "src/components/chat/ChatInput.tsx",
         "src/components/chat/ChatMessage.tsx",
+        "src/components/chat/clarification-form.tsx",
         "src/components/chat/TraceEventRenderer.tsx",
         "src/components/file/file-preview-content.tsx",
         "src/components/file/file-viewer.tsx",
@@ -88,6 +89,9 @@ const widgetConfig = mergeConfig(baseConfig, defineConfig({
         "src/components/pages/oidc-callback.tsx": { statements: 75, branches: 45, functions: 95, lines: 75 },
         "src/components/chat/ChatInput.tsx": { statements: 60, branches: 60, functions: 40, lines: 60 },
         "src/components/chat/ChatMessage.tsx": { statements: 50, branches: 50, functions: 40, lines: 50 },
+        "src/components/chat/clarification-form.tsx": {
+          statements: 76, branches: 68, functions: 62, lines: 76,
+        },
         "src/components/chat/TraceEventRenderer.tsx": {
           statements: 80, branches: 75, functions: 75, lines: 80,
         },


### PR DESCRIPTION
# fix(frontend): surface the backend's real rejection reason in ClarificationForm

Fixes leg 2 of #1468. Presentation-only re-slice of #1472, per the re-slicing rule: this PR carries the half of that work that drew zero unresolved blocking findings across five review rounds, and nothing else.

## What it does

When the backend rejects a clarification submission (e.g. *"A previous guidance message is still being applied. Please wait for it to finish."*), the form previously showed only a generic "Failed to send response" toast. Now:

- `MessageDeliveryError` gains a `userFacing` flag, set on the `message_rejected` ack path exactly when the backend supplied a non-empty message (`use-websocket.ts`). Connection-plumbing diagnostics stay `userFacing: false`.
- `ClarificationForm` reads the failure's disposition and user-facing reason, renders them in an inline `role="alert"` box plus the toast, and keys the hint on the disposition: `not_sent`/`rejected` → "Your answers were kept — you can submit again."; `outcome_unknown` → "Your response may already have been submitted. Reload the conversation before submitting again."; plain errors → generic string, no hint. The alert clears on edit and on a new clarification round.
- en/zh strings for the two hints; the widget CI lane now instruments `clarification-form.tsx` (`coverage.include` + per-file floor 76/68/62/76 against measured 79.71/71.65/66.66/79.71).

## Shape

+322/−2 over 7 files; 229 of 324 changed lines are tests. The hub edit (`use-websocket.ts`, 1460 lines) is 14 additive lines: one field, one constructor parameter, one line at the single producing call site.

## Design decision: no client-message-id reuse in this PR

#1472's form kept one client message id across retries so an `outcome_unknown` resubmit could not open a second turn. This PR deliberately does not carry that: on `main` today the submit button already re-enables after any failure and every retry mints a fresh id, so surfacing the reason adds no new duplicate-submit path — it makes an existing one visible and warns about it honestly. Consequently the `outcome_unknown` copy *warns* ("may already have been submitted, reload first") and the #1472 string that promised "submitting again … will not create a second answer" is not included — that promise is only true with id reuse, which belongs to the retry half (#1695).

## Review history of these exact lines (from #1472)

- The `userFacing` inference ("non-empty backend string ⇒ safe to display") was blocked in #1472 rounds 1–3 (N3) until the backend redaction chokepoint landed — that chokepoint merged as #1514, and rogercloud accepted the tracking split in rounds 4–5. The remaining raw-`str(e)` producers (including one `message_rejected` producer on the resume path) are tracked in #1696 and declared out of scope here.
- `userFacing` being inferred rather than signalled, and backend rejection text bypassing localization (P5), are tracked in #1479 (proposed fix: an error-code enum the client maps to i18n keys).

## Preflight findings, disclosed

An adversarial preflight (reviewer-style fan-out) ran on this exact diff before opening. Zero Critical/Major. Two minors, dispositioned:

- The batch-upload failure producer in `use-websocket.ts` still throws its `deliveryError(getUploadErrorMessage(...), "not_sent")` without `userFacing`, so a sender-actionable upload message ("File is too large…") stays behind the generic string in this form while ChatInput shows it raw. Deliberately not fixed by flipping the flag: `getUploadErrorMessage`'s last-resort branch returns raw response-body text, and a blanket `userFacing: true` there would hand raw proxy bodies to widget visitors. Recorded on #1479 (comment), whose error-code contract resolves both halves.
- The two new i18n keys were pinned to the real locale trees with a `resolveTranslation` test (the component tests stub `t()` as identity; the compiler already rejects typo'd keys via `TranslationKey`, this adds the vitest-level binding).

## Out of scope (pre-existing, tracked)

- #1695 — the retry half of #1468 (transient 503 upload retry), blocked on a server upload idempotency key; completed five-round work preserved on branch `fix/clarification-form-retry-surfacing-1468` @ `4dcfac1f`.
- #1696 — three backend producers can still send raw exception text to chat clients (mechanism left open by #1643); one of them can reach the `message_rejected` ack this PR renders.
- #1479 — `safe_for_display`/error-code contract; localization of backend rejection text; agent `RuntimeError` passthrough.
- #1471 — `transport.uploadFiles` has no cancellation hook.
- #1485 — `onSend` has no typed delivery contract (this PR probes errors structurally for exactly that reason), untyped `config`, untyped uploader result.
- #1470 — taskless Session send path can silently drop attachments.

## Verification

- All 9 new tests verified red against the unmodified code first, green after.
- `tsc --noEmit` clean; `eslint` on changed files: only the 11 pre-existing errors in `clarification-form.tsx` (count and composition unchanged vs `main`).
- Full frontend suite: 2398 tests, 1 failure — `PROVIDER_DISPLAY_NAMES` in `connect-apps-field.test.tsx`, which reproduces on a clean checkout of `upstream/main` (backend OAuth registry gained a provider with no frontend display name; being filed separately).
- Required `test:widget:coverage` lane green with the new per-file floor.
