### PR TITLE
fix(context): render the injected agent clock in the caller's timezone

### DIFF
--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 import json
 from collections import Counter
 from dataclasses import dataclass, field, replace
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any
 from uuid import uuid4
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from ...context_ref import (
     CONTEXT_REFS_KEY,
@@ -60,6 +61,10 @@ COMPACT_DROPPED_TOOL_NAME_MAX_CHARS = 64
 # nothing a dropped observation held.
 NON_EVIDENCE_TOOL_NAMES = CONTROL_TOOL_NAMES | {LOAD_SKILL_TOOL_NAME}
 COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES = 20
+
+# Wire name: request_context keys reach metadata verbatim, so renaming this
+# breaks the clients that populate it.
+CLOCK_TIMEZONE_METADATA_KEY = "timezone"
 
 
 def _utcnow() -> datetime:
@@ -441,10 +446,41 @@ class ExecutionContext:
                 messages.insert(0, {"role": "system", "content": system_content})
         return messages
 
+    def clock_zone(self) -> ZoneInfo | None:
+        """The end user's timezone, or None when none was supplied or the name
+        is unusable. The value is caller-controlled, so an unparsable name
+        degrades to the UTC wording instead of failing the run."""
+        name = self.metadata.get(CLOCK_TIMEZONE_METADATA_KEY)
+        if not isinstance(name, str) or not name.strip():
+            return None
+        try:
+            return ZoneInfo(name.strip())
+        except (ZoneInfoNotFoundError, ValueError, OSError, TypeError, KeyError):
+            # OSError is an over-long name, ValueError a path-shaped one; both
+            # are reachable because the name comes from the client.
+            return None
+
+    def _current_clock_text(self) -> str:
+        utc_stamp = self.created_at.astimezone(timezone.utc).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )
+        zone = self.clock_zone()
+        if zone is None:
+            return utc_stamp
+        local = self.created_at.astimezone(zone)
+        offset = local.utcoffset() or timedelta(0)
+        sign = "-" if offset < timedelta(0) else "+"
+        hours, remainder = divmod(abs(offset), timedelta(hours=1))
+        minutes = remainder // timedelta(minutes=1)
+        return (
+            f"{local.strftime('%Y-%m-%d %H:%M:%S')} "
+            f"({zone.key}, UTC{sign}{hours:02d}:{minutes:02d}), "
+            f"which is {utc_stamp}"
+        )
+
     def _current_time_context(self) -> str:
         return (
-            "Current date and time: "
-            f"{self.created_at.astimezone(timezone.utc).strftime('%Y-%m-%d %H:%M:%S UTC')}. "
+            f"Current date and time: {self._current_clock_text()}. "
             "Use this as the reference for relative dates such as today, recent, "
             "latest, yesterday, and tomorrow."
         )

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -837,9 +837,13 @@ class ReActPattern(AgentPattern):
             can_lookup_output_files = (
                 WORKSPACE_OUTPUT_FILES_TOOL_NAME in active_tool_names
             )
+            clock_zone = context.clock_zone()
             current_date = (
-                context.created_at.astimezone(timezone.utc).date().isoformat()
+                context.created_at.astimezone(clock_zone or timezone.utc)
+                .date()
+                .isoformat()
             )
+            clock_zone_label = clock_zone.key if clock_zone is not None else "UTC"
             instruction = (
                 "Use available tools when the user asks you to generate, compute, run, "
                 "execute, inspect, read, write, or otherwise produce a concrete result "
@@ -863,7 +867,7 @@ class ReActPattern(AgentPattern):
                 "When writing any final user-facing response, including plain "
                 "assistant text: "
                 f"{final_deliverable_file_reference_instructions(can_lookup=can_lookup_output_files, include_heading=False)}\n\n"
-                f"Current date (UTC): {current_date}. "
+                f"Current date ({clock_zone_label}): {current_date}. "
                 "For recent, latest, current, or time-sensitive requests, use this "
                 "date when forming search queries and judging source relevance. Only call "
                 "tools that are present in the current tool schema for this LLM call; "

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from dataclasses import replace
+from datetime import datetime, timezone
 
 import pytest
 
@@ -20,6 +21,7 @@ from xagent.core.agent.context.enrichment import (
     _lookup_relevant_memories_with_context,
     enrich_context_with_memory,
 )
+from xagent.core.agent.context.execution import CLOCK_TIMEZONE_METADATA_KEY
 from xagent.core.agent.language import (
     OUTPUT_LANGUAGE_METADATA_KEY,
     detect_prose_script_mismatch,
@@ -1712,3 +1714,94 @@ def test_system_context_renders_memory_persistence_guidance() -> None:
     assert "Memory persistence:" in with_flag
     assert "store_memory" in with_flag
     assert "update_memory" in with_flag
+
+
+def _clock_context(timezone_name: str | None) -> ExecutionContext:
+    """Context frozen at the ShiftCare incident instant: 2026-08-24 22:03:37 UTC
+    was already 2026-08-25 in Melbourne."""
+    context = ExecutionContext(
+        created_at=datetime(2026, 8, 24, 22, 3, 37, tzinfo=timezone.utc)
+    )
+    if timezone_name is not None:
+        context.metadata[CLOCK_TIMEZONE_METADATA_KEY] = timezone_name
+    context.add_user_message("how many shifts do we have on tomorrow?")
+    return context
+
+
+UTC_ONLY_CLOCK_LINE = (
+    "Current date and time: 2026-08-24 22:03:37 UTC. Use this as the reference "
+    "for relative dates such as today, recent, latest, yesterday, and tomorrow."
+)
+
+
+def test_clock_line_is_byte_identical_to_utc_wording_without_a_timezone() -> None:
+    assert _clock_context(None)._current_time_context() == UTC_ONLY_CLOCK_LINE
+
+
+def test_clock_line_leads_with_local_date_for_a_caller_timezone() -> None:
+    line = _clock_context("Australia/Melbourne")._current_time_context()
+
+    assert line.startswith(
+        "Current date and time: 2026-08-25 08:03:37 "
+        "(Australia/Melbourne, UTC+10:00), which is 2026-08-24 22:03:37 UTC."
+    )
+    # The wrong answer in production came from the model reading 08-24 as today.
+    assert not line.startswith("Current date and time: 2026-08-24")
+
+
+def test_clock_line_renders_a_half_hour_offset() -> None:
+    assert "(Asia/Kolkata, UTC+05:30)" in (
+        _clock_context("Asia/Kolkata")._current_time_context()
+    )
+
+
+def test_clock_line_follows_daylight_saving_for_the_same_zone() -> None:
+    winter = _clock_context("Australia/Melbourne")._current_time_context()
+    summer = ExecutionContext(
+        created_at=datetime(2026, 12, 24, 22, 3, 37, tzinfo=timezone.utc),
+        metadata={CLOCK_TIMEZONE_METADATA_KEY: "Australia/Melbourne"},
+    )._current_time_context()
+
+    assert "UTC+10:00" in winter
+    assert "UTC+11:00" in summer
+    assert "2026-12-25 09:03:37" in summer
+
+
+def test_clock_line_renders_a_negative_offset() -> None:
+    assert "(America/New_York, UTC-04:00)" in (
+        _clock_context("America/New_York")._current_time_context()
+    )
+
+
+@pytest.mark.parametrize(
+    "supplied",
+    [
+        "Not/AZone",
+        "",
+        "   ",
+        "Australia/Melbourne\x00",
+        42,
+        None,
+        "A" * 5000,
+        "../../../etc/passwd",
+        "/etc/passwd",
+        "Australia/../../etc/hosts",
+    ],
+)
+def test_unusable_timezone_degrades_to_utc_wording(supplied: object) -> None:
+    context = _clock_context(None)
+    context.metadata[CLOCK_TIMEZONE_METADATA_KEY] = supplied
+
+    assert context.clock_zone() is None
+    assert context._current_time_context() == UTC_ONLY_CLOCK_LINE
+
+
+def test_clock_timezone_survives_serialization_and_child_contexts() -> None:
+    context = _clock_context("Australia/Melbourne")
+
+    restored = ExecutionContext.from_dict(context.to_dict())
+    assert restored.clock_zone() is not None
+    assert restored.clock_zone().key == "Australia/Melbourne"
+
+    child = context.create_child_context(task="sub-task")
+    assert child.clock_zone().key == "Australia/Melbourne"

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any, cast
+from zoneinfo import ZoneInfo
 
 import pytest
 
@@ -348,6 +351,87 @@ async def test_execution_adapter_routes_react_to_react() -> None:
     assert result["metadata"]["execution_type"] == "agent_react"
     assert result["agent_result"]["pattern"] == "ReActPattern"
     assert llm.calls[0]["tools"] is not None
+
+
+@pytest.mark.asyncio
+async def test_request_context_timezone_reaches_both_prompt_clocks() -> None:
+    """Covers the transport the renderer depends on: request context ->
+    metadata["request_context"] -> _apply_request_context -> metadata. The
+    renderer's own formatting is unit-tested in tests/core/agent/test_context.py.
+    """
+    llm = FakeLLM(["tz done"])
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="tz",
+            pattern="react",
+            llm=llm,
+            tools=[FakeTool()],
+            service_id="tz-service",
+            skill_manager=NoSkillManager(),
+        )
+    )
+
+    result = await adapter.execute(
+        task="how many shifts do we have on tomorrow?",
+        task_id="tz-exec",
+        context={"timezone": "Australia/Melbourne"},
+    )
+
+    assert result["success"] is True
+    system_prompt = next(
+        message["content"]
+        for message in llm.calls[0]["messages"]
+        if message["role"] == "system"
+    )
+
+    # created_at is a dataclass default_factory, so it cannot be monkeypatched
+    # from here. Reading the UTC stamp back out of the prompt pins the pair
+    # without a wall-clock race.
+    stamped_utc = re.search(
+        r"which is (\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) UTC\.", system_prompt
+    )
+    assert stamped_utc is not None, system_prompt
+    expected_local = (
+        datetime.strptime(stamped_utc.group(1), "%Y-%m-%d %H:%M:%S")
+        .replace(tzinfo=timezone.utc)
+        .astimezone(ZoneInfo("Australia/Melbourne"))
+    )
+
+    assert (
+        f"Current date and time: {expected_local.strftime('%Y-%m-%d %H:%M:%S')} "
+        f"(Australia/Melbourne, UTC+" in system_prompt
+    )
+    assert (
+        f"Current date (Australia/Melbourne): {expected_local.date().isoformat()}. "
+        in system_prompt
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_context_without_timezone_keeps_utc_clocks() -> None:
+    llm = FakeLLM(["utc done"])
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="utc",
+            pattern="react",
+            llm=llm,
+            tools=[FakeTool()],
+            service_id="utc-service",
+            skill_manager=NoSkillManager(),
+        )
+    )
+
+    result = await adapter.execute(task="Say done", task_id="utc-exec", context={})
+
+    assert result["success"] is True
+    system_prompt = next(
+        message["content"]
+        for message in llm.calls[0]["messages"]
+        if message["role"] == "system"
+    )
+    assert "Current date (UTC): " in system_prompt
+    assert " UTC. Use this as the reference for relative dates" in system_prompt
+    assert "which is" not in system_prompt
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import logging
 import re
+from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
 
@@ -20,6 +21,7 @@ from xagent.core.agent import (
     ToolCallInterrupted,
     ToolCallRecord,
 )
+from xagent.core.agent.context.execution import CLOCK_TIMEZONE_METADATA_KEY
 from xagent.core.agent.result import tool_result_succeeded
 from xagent.core.file_ref import WORKSPACE_OUTPUT_FILES_TOOL_NAME
 from xagent.core.model.chat.basic.router import RouterLLM
@@ -6131,3 +6133,31 @@ async def test_blank_streaming_arguments_flow_from_adapter_into_react(mocker) ->
     assert result["success"] is True
     assert result["response"] == "gpt-4o"
     assert tool.calls == [{}]
+
+
+def _react_clock_prompt(timezone_name: str | None) -> str:
+    context = ExecutionContext(
+        created_at=datetime(2026, 8, 24, 22, 3, 37, tzinfo=timezone.utc)
+    )
+    if timezone_name is not None:
+        context.metadata[CLOCK_TIMEZONE_METADATA_KEY] = timezone_name
+    context.add_user_message("how many shifts do we have on tomorrow?")
+
+    messages = ReActPattern()._messages_for_llm(context, has_tools=True)
+    return messages[0]["content"]
+
+
+def test_tool_call_date_line_keeps_utc_wording_without_a_timezone() -> None:
+    assert "Current date (UTC): 2026-08-24. " in _react_clock_prompt(None)
+
+
+def test_tool_call_date_line_uses_the_caller_timezone() -> None:
+    prompt = _react_clock_prompt("Australia/Melbourne")
+
+    assert "Current date (Australia/Melbourne): 2026-08-25. " in prompt
+    # The UTC date is what produced the wrong "tomorrow" in production.
+    assert "Current date (UTC)" not in prompt
+
+
+def test_tool_call_date_line_degrades_to_utc_for_an_unusable_timezone() -> None:
+    assert "Current date (UTC): 2026-08-24. " in _react_clock_prompt("Not/AZone")

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -6147,17 +6147,35 @@ def _react_clock_prompt(timezone_name: str | None) -> str:
     return messages[0]["content"]
 
 
+# Verbatim pre-PR sentence, so a change to any part of the fallback instruction
+# fails rather than only a change to its "Current date" prefix.
+UTC_DATE_INSTRUCTION = (
+    "Current date (UTC): 2026-08-24. "
+    "For recent, latest, current, or time-sensitive requests, use this "
+    "date when forming search queries and judging source relevance."
+)
+
+
+def _date_instruction(prompt: str) -> str:
+    start = prompt.index("Current date (")
+    end = prompt.index("source relevance.", start) + len("source relevance.")
+    return prompt[start:end]
+
+
 def test_tool_call_date_line_keeps_utc_wording_without_a_timezone() -> None:
-    assert "Current date (UTC): 2026-08-24. " in _react_clock_prompt(None)
+    assert _date_instruction(_react_clock_prompt(None)) == UTC_DATE_INSTRUCTION
 
 
 def test_tool_call_date_line_uses_the_caller_timezone() -> None:
     prompt = _react_clock_prompt("Australia/Melbourne")
 
-    assert "Current date (Australia/Melbourne): 2026-08-25. " in prompt
+    assert _date_instruction(prompt) == UTC_DATE_INSTRUCTION.replace(
+        "Current date (UTC): 2026-08-24. ",
+        "Current date (Australia/Melbourne): 2026-08-25. ",
+    )
     # The UTC date is what produced the wrong "tomorrow" in production.
     assert "Current date (UTC)" not in prompt
 
 
 def test_tool_call_date_line_degrades_to_utc_for_an_unusable_timezone() -> None:
-    assert "Current date (UTC): 2026-08-24. " in _react_clock_prompt("Not/AZone")
+    assert _date_instruction(_react_clock_prompt("Not/AZone")) == UTC_DATE_INSTRUCTION


### PR DESCRIPTION
Refs #1675 — this is the backend half only; the issue stays open until the frontend and widget report a timezone.

## Invariant

This PR guarantees only:

When `ExecutionContext.metadata["timezone"]` carries a resolvable IANA timezone name, both prompt injection points render local time in that zone. When the key is absent or its value cannot be resolved, the output is byte-identical to before this PR.

## Entry points in scope

- `ExecutionContext._current_time_context` (`core/agent/context/execution.py`)
- The tool-schema date line in `ReActPattern._messages_for_llm` (`core/agent/pattern/react/react.py`)

## Why

An end user at UTC+10 asked "how many shifts do we have on tomorrow?" at 08:03 local on 2026-08-25. The injected clock read `2026-08-24 22:03:37 UTC`, so the model resolved "tomorrow" to 08-25 and answered from the wrong day; the user corrected it in the next message. For UTC+10 the failure window is local 00:00–10:00, ten hours a day.

## How

The timezone reaches `metadata` through `request_context`, which already writes every key into `context.metadata` verbatim, and `metadata` already travels through `to_dict` / `from_dict` / `create_child_context`. So this adds **no `ExecutionContext` field and no serialization change**.

```
Without a timezone (unchanged):
  Current date and time: 2026-08-24 22:03:37 UTC. Use this as the reference…
  Current date (UTC): 2026-08-24.

With a timezone:
  Current date and time: 2026-08-25 08:03:37 (Australia/Melbourne, UTC+10:00),
  which is 2026-08-24 22:03:37 UTC. Use this as the reference…
  Current date (Australia/Melbourne): 2026-08-25.
```

UTC stays alongside for log correlation, for search tools that filter in UTC, and so the model can reason about the day boundary itself.

## Known trade-offs

1. **A zero-offset zone prints the same stamp twice**, e.g. `(Europe/London, UTC+00:00), which is …`. Correct but redundant; a third branch is not worth it.
2. **`context.clock_zone()` is called unconditionally in `react.py`**, where the parameter is annotated `Any`. The same function already uses `context.created_at` and `context.get_messages_for_llm()` unconditionally, and all three call sites pass an `ExecutionContext`. No `getattr` guard for hypothetical callers.
3. **`normalize_schedule_timezone` in the `web` layer is not reused.** Both injection points live in `core`, and `core` must not depend on `web`. Lifting that helper would disturb the existing trigger tests for the sake of five lines.
4. **The timezone name is untrusted input**, since `request_context` applies no key allowlist. `clock_zone()` catches `OSError` (over-long name) and `ValueError` (path-shaped key) and degrades to UTC instead of failing the run. Covered for `"A" * 5000`, `../../../etc/passwd`, `/etc/passwd`.

## Unaffected

- **The prefix-cache optimization from #636.** Both points still use `context.created_at`; only the rendering zone changes. The timezone is constant for a task's lifetime, so the system-prompt prefix stays byte-identical across iterations.

## Explicit non-goals

- This PR does not make the frontend or the embeddable widget report a timezone (follow-up). Until then no client populates the key and behavior stays pure UTC.
- This PR does not address the timestamp being frozen within a turn, nor add a current-time tool (#1676).
- This PR does not touch the third injection point at `utils/context_builder.py:586`, which calls bare `datetime.now()` and emits unlabelled server-local time. `ContextBuilder` has no caller under `src/` and is not on a live path.
- This PR does not wire up scheduled-trigger timezones. Only `daily`/`weekly`/`monthly` configs store one, and its semantics are "the zone the schedule is expressed in", which is not necessarily the end user's zone.
- This PR does not add an account-level timezone setting.
- Adjacent pre-existing issues should be tracked as follow-ups rather than implemented here.

## Blocking criteria

This PR should be blocked only when:
1. it introduces a regression;
2. the stated invariant can still be broken; or
3. it materially worsens a pre-existing problem.

## Tests

19 new tests; tests are 73% of this PR's added lines (source +45/-5, tests +123).

Every guard is mutation-verified — eight mutations (ignore metadata, invert the offset sign, drop the minutes component, swap DST-aware conversion for a fixed offset, remove `OSError` from the catch, revert react to UTC, hardcode the label, remove the unresolvable-name fallback) were each caught by at least one test.

Coverage: byte-identical UTC wording · the production input (08-24 22:03 UTC + Melbourne → 08-25) · negative offset · half-hour offset (`Asia/Kolkata`, +05:30) · DST within one zone (Melbourne +10:00 winter / +11:00 summer) · ten unusable inputs · `to_dict`/`from_dict` round-trip and child-context inheritance.

`tests/core/agent` passes in full.

