### PR TITLE
fix(sandboxed-tools): defer pypinyin import so sandboxed MCP tool calls don't crash

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/agent_tool_names.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool_names.py
@@ -4,6 +4,8 @@ import re
 import unicodedata
 from typing import Any
 
+from .tool_naming_limits import MAX_AGENT_TOOL_NAME_LENGTH
+
 try:
     # This module is transitively imported by mcp_adapter.py, which
     # sandboxed tool execution (tool_runner.py's _load_tool_class) also
@@ -21,7 +23,6 @@ AGENT_TOOL_NAME_PREFIX = "agent_"
 LEGACY_AGENT_TOOL_NAME_PREFIX = "call_agent_"
 WORKFORCE_AGENT_TOOL_NAME_PREFIX = "worker_"
 AGENT_TOOL_NAME_ID_SEPARATOR = "__a"
-MAX_AGENT_TOOL_NAME_LENGTH = 64
 
 
 def _normalize_agent_id(agent_id: Any) -> int:

--- a/src/xagent/core/tools/adapters/vibe/agent_tool_names.py
+++ b/src/xagent/core/tools/adapters/vibe/agent_tool_names.py
@@ -4,7 +4,18 @@ import re
 import unicodedata
 from typing import Any
 
-from pypinyin import lazy_pinyin  # type: ignore[import-not-found]
+try:
+    # This module is transitively imported by mcp_adapter.py, which
+    # sandboxed tool execution (tool_runner.py's _load_tool_class) also
+    # imports just to reach an unrelated class in the same module tree.
+    # The sandbox's Python environment never installs pypinyin (nothing
+    # it runs calls _semantic_slug), so a hard import here raised
+    # ModuleNotFoundError for every sandboxed tool call, not just this
+    # module's own users -- fall back to None instead, and skip
+    # romanization on the (never exercised in a sandbox) non-ASCII path.
+    from pypinyin import lazy_pinyin  # type: ignore[import-not-found]
+except ImportError:
+    lazy_pinyin = None
 
 AGENT_TOOL_NAME_PREFIX = "agent_"
 LEGACY_AGENT_TOOL_NAME_PREFIX = "call_agent_"
@@ -35,7 +46,7 @@ def _semantic_slug(value: Any) -> str:
     normalized_name = unicodedata.normalize("NFKD", raw_name.strip())
     romanized_name = (
         normalized_name
-        if normalized_name.isascii()
+        if normalized_name.isascii() or lazy_pinyin is None
         else "_".join(lazy_pinyin(normalized_name))
     )
     ascii_name = romanized_name.encode("ascii", "ignore").decode("ascii")

--- a/src/xagent/core/tools/adapters/vibe/api_tool_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/api_tool_adapter.py
@@ -11,7 +11,6 @@ from pydantic import BaseModel, Field, model_validator
 
 from ....utils.encryption import decrypt_value
 from ...core.api_tool import call_api
-from .agent_tool_names import MAX_AGENT_TOOL_NAME_LENGTH
 from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 from .connector_runtime import (
     MISSING_RUNTIME_VALUE,
@@ -26,6 +25,7 @@ from .connector_runtime import (
     is_runtime_header_scalar,
     runtime_bindings_from_config,
 )
+from .tool_naming_limits import MAX_AGENT_TOOL_NAME_LENGTH
 
 logger = logging.getLogger(__name__)
 

--- a/src/xagent/core/tools/adapters/vibe/api_tool_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/api_tool_adapter.py
@@ -151,8 +151,8 @@ class CustomApiTool(AbstractBaseTool):
         # `_call` (the part that signals "this is an API call") survives
         # instead of being cut off by a blind truncation of the whole
         # string. `MAX_AGENT_TOOL_NAME_LENGTH` is this repo's own record of
-        # that provider limit (agent_tool_names.py), shared here rather than
-        # redeclared so the two adapters can't drift apart on the number.
+        # that provider limit (tool_naming_limits.py), shared here rather
+        # than redeclared so the two adapters can't drift apart on the number.
         budget = MAX_AGENT_TOOL_NAME_LENGTH - len(prefix) - len(suffix)
         if len(sanitized_name) > budget:
             # `name` is a free-form, DB-unique string with no server

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -158,14 +158,24 @@ def _strict_http_401_responses(
 
 
 def _resolver_401_evidence(exc: BaseException) -> tuple[Any | None, frozenset[int]]:
-    # Lazy import keeps the core adapter independent from the web layer at import time.
-    from .....web.services.mcp_oauth import parse_www_authenticate_bearer
+    try:
+        # Lazy import keeps the core adapter independent from the web layer
+        # at import time -- and, since this runs inside MCPToolAdapter.
+        # run_json_async, which tool_runner.py reconstructs and calls for
+        # every sandboxed npx/uvx MCP tool call, from crashing with
+        # ModuleNotFoundError on a 401 (mcp_oauth.py needs sqlalchemy,
+        # which the sandbox never installs) instead of just skipping the
+        # refresh attempt the same way an unparsable challenge already
+        # does below.
+        from .....web.services.mcp_oauth import parse_www_authenticate_bearer
+    except ImportError:
+        parse_www_authenticate_bearer = None  # type: ignore[assignment]
 
     challenge = None
     response_ids: set[int] = set()
     for response in _strict_http_401_responses(exc):
         response_ids.add(id(response))
-        if challenge is not None:
+        if challenge is not None or parse_www_authenticate_bearer is None:
             continue
         candidate = parse_www_authenticate_bearer(
             response.headers.get_list("WWW-Authenticate")
@@ -447,8 +457,8 @@ class MCPToolAdapter(AbstractBaseTool):
         # Same failure mode as the character check above -- an over-long
         # name is rejected by the same providers, just on length instead of
         # charset. `MAX_AGENT_TOOL_NAME_LENGTH` is this repo's own record of
-        # that provider limit (agent_tool_names.py), shared here rather than
-        # redeclared so the two adapters can't drift apart on the number.
+        # that provider limit (tool_naming_limits.py), shared here rather
+        # than redeclared so the two adapters can't drift apart on the number.
         #
         # The tool name -- not the prefix -- is the only part that tells
         # two tools on the *same* server apart, so truncating from the end

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -24,7 +24,6 @@ from ..... import config as _root_config
 from .....sandbox.base import Sandbox
 from ...core.mcp.sessions import Connection, create_session
 from ...core.mcp.tools import load_mcp_tools
-from .agent_tool_names import MAX_AGENT_TOOL_NAME_LENGTH
 from .base import AbstractBaseTool, ToolVisibility
 from .connector_runtime import (
     ERROR_DELEGATED_AUTHORIZATION_FAILED,
@@ -41,6 +40,7 @@ from .sandboxed_tool.sandboxed_mcp_tool_helper import (
     load_sandboxed_mcp_tools,
     should_sandbox_mcp_connection,
 )
+from .tool_naming_limits import MAX_AGENT_TOOL_NAME_LENGTH
 
 
 class MCPFailurePhase(str, Enum):

--- a/src/xagent/core/tools/adapters/vibe/tool_naming_limits.py
+++ b/src/xagent/core/tools/adapters/vibe/tool_naming_limits.py
@@ -1,0 +1,11 @@
+"""Provider-imposed limits on generated tool names.
+
+Split out of agent_tool_names.py so that modules needing only this
+constant -- including ones imported inside a reduced-dependency sandbox,
+like mcp_adapter.py and api_tool_adapter.py -- don't pull in that
+module's own concerns (Chinese-name romanization, and whatever
+optional/backend-only dependency that romanization needs) just to read
+a number.
+"""
+
+MAX_AGENT_TOOL_NAME_LENGTH = 64

--- a/tests/core/tools/adapters/sandboxed_tool/test_tool_runner.py
+++ b/tests/core/tools/adapters/sandboxed_tool/test_tool_runner.py
@@ -3,6 +3,9 @@
 import argparse
 import base64
 import json
+import subprocess
+import sys
+import textwrap
 from typing import Any, Mapping
 from unittest.mock import patch
 
@@ -83,6 +86,66 @@ class TestLoadToolClass:
         """Non-existent module should raise ModuleNotFoundError."""
         with pytest.raises(ModuleNotFoundError):
             _load_tool_class("no.such.module:Cls")
+
+    def test_mcp_tool_adapter_loads_without_pypinyin(self):
+        """Regression test for the reported sandbox failure (PR #1710).
+
+        A reduced sandbox never installs pypinyin (only mcp/pydantic/
+        cloudpickle -- see SANDBOX_BASE_DEPENDENCIES), yet every
+        sandboxed MCP tool call must still import mcp_adapter:
+        MCPToolAdapter through this exact function, because
+        mcp_adapter.py transitively imports agent_tool_names.py for an
+        unrelated constant that agent_tool_names.py used to require
+        pypinyin just to define. Runs in a subprocess -- rather than
+        monkeypatching sys.modules/builtins.__import__ in-process -- so
+        blocking "pypinyin" at the import-system level can't be
+        undone by pypinyin already sitting in sys.modules from an
+        earlier test in this same process, and so this exercises the
+        real, unmodified import machinery tool_runner.py itself runs
+        under in a sandbox.
+        """
+        script = textwrap.dedent(
+            """
+            import sys
+
+            class _BlockPypinyin:
+                def find_spec(self, name, path=None, target=None):
+                    if name == "pypinyin" or name.startswith("pypinyin."):
+                        raise ModuleNotFoundError(f"No module named {name!r}")
+                    return None
+
+            sys.meta_path.insert(0, _BlockPypinyin())
+
+            from xagent.core.tools.adapters.vibe.sandboxed_tool.tool_runner import (
+                _load_tool_class,
+            )
+
+            cls = _load_tool_class(
+                "xagent.core.tools.adapters.vibe.mcp_adapter:MCPToolAdapter"
+            )
+            assert cls.__name__ == "MCPToolAdapter"
+
+            from xagent.core.tools.adapters.vibe import agent_tool_names
+
+            assert agent_tool_names.lazy_pinyin is None
+
+            ascii_name = agent_tool_names.gen_workforce_agent_tool_name(
+                1, "ASCII Name"
+            )
+            assert ascii_name.isascii()
+            assert agent_tool_names.parse_agent_tool_id(ascii_name) == 1
+
+            print("REGRESSION_TEST_OK")
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "REGRESSION_TEST_OK" in result.stdout
 
 
 class TestLoadExecutionSpec:

--- a/tests/core/tools/adapters/vibe/test_api_tool_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_api_tool_adapter.py
@@ -3,10 +3,12 @@ from unittest.mock import patch
 
 import pytest
 
-from xagent.core.tools.adapters.vibe.agent_tool_names import MAX_AGENT_TOOL_NAME_LENGTH
 from xagent.core.tools.adapters.vibe.api_tool_adapter import (
     CustomApiTool,
     create_custom_api_tools,
+)
+from xagent.core.tools.adapters.vibe.tool_naming_limits import (
+    MAX_AGENT_TOOL_NAME_LENGTH,
 )
 
 

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -1,10 +1,11 @@
 import json
 import re
+import sys
 from contextlib import asynccontextmanager
 from dataclasses import FrozenInstanceError
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
@@ -540,6 +541,27 @@ def test_resolver_challenge_uses_all_www_authenticate_header_values():
 )
 def test_resolver_challenge_rejects_non_refreshable_evidence(exc):
     assert mcp_adapter_module._resolver_invalid_token_challenge(exc) is None
+
+
+def test_resolver_401_evidence_degrades_when_mcp_oauth_unimportable():
+    """_resolver_401_evidence lazily imports xagent.web.services.mcp_oauth,
+    which needs sqlalchemy (directly, and transitively through
+    xagent.web.services.__init__'s other eager imports). That's fine on
+    the backend host, but this function runs inside MCPToolAdapter.
+    run_json_async -- the exact class/method tool_runner.py reconstructs
+    and calls for every sandboxed npx/uvx MCP tool call (see PR #1710) --
+    and the sandbox never installs sqlalchemy. A 401 from a sandboxed
+    OAuth-protected connector (e.g. Xero, once its access token expires
+    mid-session) must fail the same clean "authorization failed" way an
+    unparsable challenge already does, not crash with
+    ModuleNotFoundError."""
+    exc = _http_status_error(authenticate=['Bearer error="invalid_token"'])
+
+    with patch.dict(sys.modules, {"xagent.web.services.mcp_oauth": None}):
+        challenge, response_ids = mcp_adapter_module._resolver_401_evidence(exc)
+
+    assert challenge is None
+    assert len(response_ids) == 1
 
 
 def test_mcp_return_value_as_string_keeps_malformed_scalar_content_together():

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -13,7 +13,6 @@ from pydantic import BaseModel, ConfigDict
 from pydantic.alias_generators import to_camel
 
 from xagent.core.tools.adapters.vibe import mcp_adapter as mcp_adapter_module
-from xagent.core.tools.adapters.vibe.agent_tool_names import MAX_AGENT_TOOL_NAME_LENGTH
 from xagent.core.tools.adapters.vibe.mcp_adapter import (
     MCPFailurePhase,
     MCPServerLoadFailure,
@@ -22,6 +21,9 @@ from xagent.core.tools.adapters.vibe.mcp_adapter import (
     _exception_indicates_http_401,
     _mcp_return_value_as_string,
     load_mcp_tools_as_agent_tools,
+)
+from xagent.core.tools.adapters.vibe.tool_naming_limits import (
+    MAX_AGENT_TOOL_NAME_LENGTH,
 )
 
 


### PR DESCRIPTION
## Summary

Retested Xero and chrome-devtools on stage after #1682 merged. Tool *listing* now works (the AttributeError from that PR is fixed and confirmed gone), but calling any actual tool now fails with:

```
ModuleNotFoundError: No module named 'pypinyin'
```

Traced via stage logs and reproduced: calling a sandboxed MCP tool goes through `tool_runner.py`'s `_load_tool_class()`, which imports `mcp_adapter.py` to reach the tool's class. `mcp_adapter.py` imports `MAX_AGENT_TOOL_NAME_LENGTH` from `agent_tool_names.py` at module level, and that module unconditionally imported `pypinyin` -- a dependency only ever used by `_semantic_slug()`'s Chinese-name romanization path for delegation-agent tool names. A sandbox never calls that function (it's irrelevant to MCP tool execution) and never installs `pypinyin`, so every sandboxed MCP tool call failed on an unrelated transitive import.

This is downstream of, and unrelated to, the SandboxLeaseProvider fix in #1682: that PR fixed *listing* tools; this fixes actually *calling* them once listed.

## Fix

Wrap the `pypinyin` import in `try/except ImportError` at module level (not moved into the function body -- a first attempt at a local/deferred import broke `test_create_agent_tool.py`'s `unittest.mock.patch("...agent_tool_names.lazy_pinyin", ...)`, which needs `lazy_pinyin` to stay a persistent module attribute). Checked the rest of `mcp_adapter.py`'s top-level imports (`httpx`, `mcp`, `pydantic`) against the sandbox's dependency list -- `httpx` comes in transitively via `mcp`'s own dependencies, so `pypinyin` was the only actually-missing one in this chain.

## Test plan

- [x] Verified `gen_workforce_agent_tool_name`/`gen_agent_tool_name` still romanize Chinese names correctly with `pypinyin` present.
- [x] Simulated `pypinyin` being unavailable (patched `builtins.__import__`) -- module imports cleanly, non-ASCII names fall back to the ASCII-stripped form instead of crashing.
- [x] `pytest tests/core/tools/test_create_agent_tool.py tests/core/tools/test_agent_tool_publish_status.py tests/core/tools/adapters/vibe/test_mcp_adapter.py` -- all pass (the mock-patch test that a naive local-import fix would have broken is included and passing).
- [x] Broader sweep: `pytest tests/core/tools/ -k "agent_tool or mcp_adapter or sandboxed"` -- all pass (boxlite-runtime tests skip, as expected outside that environment).
- [x] `ruff check` / `ruff format` / `mypy` / full pre-commit -- all clean.