### PR TITLE
fix(frontend): report the browser timezone with each chat message

### DIFF
--- a/frontend/src/hooks/use-websocket.test.ts
+++ b/frontend/src/hooks/use-websocket.test.ts
@@ -591,6 +591,125 @@ describe("useWebSocket normalized connections", () => {
     }
   })
 
+  it("keeps a same-id retry bound to the zone of its first attempt", async () => {
+    const resolvedOptions = vi
+      .spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions")
+      .mockReturnValue({ timeZone: "Australia/Melbourne" } as Intl.ResolvedDateTimeFormatOptions)
+    try {
+      const { result } = renderHook(() => useWebSocket({
+        url: "ws://localhost",
+        taskId: 7,
+      }))
+      await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+      const socket = MockWebSocket.instances[0]
+      act(() => socket.open())
+
+      const first = result.current.sendChatMessage("same", undefined, false, "retry-id")
+      expect(JSON.parse(socket.send.mock.calls[0][0]).context)
+        .toEqual({ timezone: "Australia/Melbourne" })
+      // Unknown outcome: the command may already be executing server-side, so
+      // the client retries under the same id.
+      act(() => socket.receive({
+        type: "message_rejected",
+        client_message_id: "retry-id",
+        message: "connection lost",
+      }))
+      await expect(first).rejects.toThrow()
+
+      resolvedOptions.mockReturnValue(
+        { timeZone: "America/New_York" } as Intl.ResolvedDateTimeFormatOptions,
+      )
+
+      const retry = result.current.sendChatMessage("same", undefined, true, "retry-id")
+      expect(JSON.parse(socket.send.mock.calls[1][0]).context)
+        .toEqual({ timezone: "Australia/Melbourne" })
+      act(() => socket.receive({
+        type: "message_accepted",
+        client_message_id: "retry-id",
+      }))
+      await retry
+
+      // A genuinely new id picks up the current zone.
+      const fresh = result.current.sendChatMessage("next", undefined, false, "fresh-id")
+      expect(JSON.parse(socket.send.mock.calls[2][0]).context)
+        .toEqual({ timezone: "America/New_York" })
+      act(() => socket.receive({
+        type: "message_accepted",
+        client_message_id: "fresh-id",
+      }))
+      await fresh
+    } finally {
+      resolvedOptions.mockRestore()
+    }
+  })
+
+  it("keeps a same-id retry context-free when the first attempt had no zone", async () => {
+    const resolvedOptions = vi
+      .spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions")
+      .mockReturnValue({ timeZone: "" } as Intl.ResolvedDateTimeFormatOptions)
+    try {
+      const { result } = renderHook(() => useWebSocket({
+        url: "ws://localhost",
+        taskId: 7,
+      }))
+      await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+      const socket = MockWebSocket.instances[0]
+      act(() => socket.open())
+
+      const first = result.current.sendChatMessage("same", undefined, false, "omit-id")
+      expect("context" in JSON.parse(socket.send.mock.calls[0][0])).toBe(false)
+      act(() => socket.receive({
+        type: "message_rejected",
+        client_message_id: "omit-id",
+        message: "connection lost",
+      }))
+      await expect(first).rejects.toThrow()
+
+      resolvedOptions.mockReturnValue(
+        { timeZone: "America/New_York" } as Intl.ResolvedDateTimeFormatOptions,
+      )
+
+      const retry = result.current.sendChatMessage("same", undefined, true, "omit-id")
+      expect("context" in JSON.parse(socket.send.mock.calls[1][0])).toBe(false)
+      act(() => socket.receive({
+        type: "message_accepted",
+        client_message_id: "omit-id",
+      }))
+      await retry
+    } finally {
+      resolvedOptions.mockRestore()
+    }
+  })
+
+  it("sends without a context when Intl itself throws", async () => {
+    const resolvedOptions = vi
+      .spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions")
+      .mockImplementation(() => {
+        throw new RangeError("ICU unavailable")
+      })
+    try {
+      const { result } = renderHook(() => useWebSocket({
+        url: "ws://localhost",
+        taskId: 7,
+      }))
+      await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+      const socket = MockWebSocket.instances[0]
+      act(() => socket.open())
+
+      const delivery = result.current.sendChatMessage("hi", undefined, false, "throw-turn")
+      const sent = JSON.parse(socket.send.mock.calls[0][0])
+      expect("context" in sent).toBe(false)
+      expect(sent.message).toBe("hi")
+      act(() => socket.receive({
+        type: "message_accepted",
+        client_message_id: "throw-turn",
+      }))
+      await delivery
+    } finally {
+      resolvedOptions.mockRestore()
+    }
+  })
+
   it("treats an explicit null connection as disabled even when legacy inputs exist", async () => {
     renderHook(() => useWebSocket({
       url: "ws://localhost",

--- a/frontend/src/hooks/use-websocket.test.ts
+++ b/frontend/src/hooks/use-websocket.test.ts
@@ -528,12 +528,60 @@ describe("useWebSocket normalized connections", () => {
       message: "legacy",
       task_id: 7,
       client_message_id: "legacy-turn",
+      context: { timezone: expect.any(String) },
     })
     act(() => socket.receive({
       type: "message_accepted",
       client_message_id: "legacy-turn",
     }))
     await delivery
+  })
+
+  it("reports the browser timezone so the agent clock can render local time", async () => {
+    const { result } = renderHook(() => useWebSocket({
+      url: "ws://localhost",
+      taskId: 7,
+    }))
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+    const socket = MockWebSocket.instances[0]
+    act(() => socket.open())
+
+    const delivery = result.current.sendChatMessage("what is tomorrow", undefined, false, "tz-turn")
+    const sent = JSON.parse(socket.send.mock.calls[0][0])
+    expect(sent.context).toEqual({
+      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+    })
+    act(() => socket.receive({
+      type: "message_accepted",
+      client_message_id: "tz-turn",
+    }))
+    await delivery
+  })
+
+  it("omits the context entirely when the browser cannot resolve a timezone", async () => {
+    const resolvedOptions = vi
+      .spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions")
+      .mockReturnValue({ timeZone: "" } as Intl.ResolvedDateTimeFormatOptions)
+    try {
+      const { result } = renderHook(() => useWebSocket({
+        url: "ws://localhost",
+        taskId: 7,
+      }))
+      await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+      const socket = MockWebSocket.instances[0]
+      act(() => socket.open())
+
+      const delivery = result.current.sendChatMessage("hi", undefined, false, "no-tz-turn")
+      const sent = JSON.parse(socket.send.mock.calls[0][0])
+      expect("context" in sent).toBe(false)
+      act(() => socket.receive({
+        type: "message_accepted",
+        client_message_id: "no-tz-turn",
+      }))
+      await delivery
+    } finally {
+      resolvedOptions.mockRestore()
+    }
   })
 
   it("treats an explicit null connection as disabled even when legacy inputs exist", async () => {
@@ -706,6 +754,7 @@ describe("useWebSocket normalized connections", () => {
     expect(sent).toEqual({
       type: "chat",
       message: "create lazily",
+      context: { timezone: expect.any(String) },
       client_message_id: "session-turn-1",
     })
 

--- a/frontend/src/hooks/use-websocket.test.ts
+++ b/frontend/src/hooks/use-websocket.test.ts
@@ -538,24 +538,31 @@ describe("useWebSocket normalized connections", () => {
   })
 
   it("reports the browser timezone so the agent clock can render local time", async () => {
-    const { result } = renderHook(() => useWebSocket({
-      url: "ws://localhost",
-      taskId: 7,
-    }))
-    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
-    const socket = MockWebSocket.instances[0]
-    act(() => socket.open())
+    // Pinned, not read back from Intl: asserting against the same source the
+    // code reads makes the test tautological on a UTC host.
+    const resolvedOptions = vi
+      .spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions")
+      .mockReturnValue({ timeZone: "America/New_York" } as Intl.ResolvedDateTimeFormatOptions)
+    try {
+      const { result } = renderHook(() => useWebSocket({
+        url: "ws://localhost",
+        taskId: 7,
+      }))
+      await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+      const socket = MockWebSocket.instances[0]
+      act(() => socket.open())
 
-    const delivery = result.current.sendChatMessage("what is tomorrow", undefined, false, "tz-turn")
-    const sent = JSON.parse(socket.send.mock.calls[0][0])
-    expect(sent.context).toEqual({
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-    })
-    act(() => socket.receive({
-      type: "message_accepted",
-      client_message_id: "tz-turn",
-    }))
-    await delivery
+      const delivery = result.current.sendChatMessage("what is tomorrow", undefined, false, "tz-turn")
+      const sent = JSON.parse(socket.send.mock.calls[0][0])
+      expect(sent.context).toEqual({ timezone: "America/New_York" })
+      act(() => socket.receive({
+        type: "message_accepted",
+        client_message_id: "tz-turn",
+      }))
+      await delivery
+    } finally {
+      resolvedOptions.mockRestore()
+    }
   })
 
   it("omits the context entirely when the browser cannot resolve a timezone", async () => {

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -329,6 +329,11 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
   const tokenRef = useRef(token !== undefined ? token : authToken)
   const pendingDeliveriesRef = useRef(new Map<string, PendingDelivery>())
   const preparationsRef = useRef(new Map<string, MessagePreparationClaim>())
+  // Keyed by the logical client_message_id, not by physical send. The durable
+  // transport compares the whole payload, so a same-id retry that re-resolved
+  // the zone would be rejected as different content while the first command may
+  // still be executing. Cleared on either terminal ack below.
+  const attemptTimezonesRef = useRef(new Map<string, string | undefined>())
   const recentMessagesRef = useRef<RecentMessage[]>([])
   const callbacksRef = useRef<WebSocketCallbacks>({
     onConnectionClose,
@@ -885,6 +890,14 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
             ) {
               clearTimeout(pending.timeout)
               pendingDeliveriesRef.current.delete(clientMessageId)
+              if (
+                data.type === 'message_accepted'
+                || data.rejection_outcome === "not_accepted"
+              ) {
+                // Terminal for this id: accepted, or rejected without a
+                // same-id retry. An unknown outcome keeps the binding.
+                attemptTimezonesRef.current.delete(clientMessageId)
+              }
               if (data.type === 'message_accepted') {
                 pending.resolve({
                   client_message_id: clientMessageId,
@@ -1174,7 +1187,10 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
     preparationsRef.current.set(clientMessageId, claim)
 
     try {
-      const browserTimezone = resolveBrowserTimezone()
+      if (!attemptTimezonesRef.current.has(clientMessageId)) {
+        attemptTimezonesRef.current.set(clientMessageId, resolveBrowserTimezone())
+      }
+      const browserTimezone = attemptTimezonesRef.current.get(clientMessageId)
       const messageData: Record<string, unknown> = {
         type: 'chat',
         message,

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -67,6 +67,16 @@ export class MessageDeliveryError extends Error {
   }
 }
 
+const resolveBrowserTimezone = (): string | undefined => {
+  try {
+    // Defensive: neither a throwing Intl nor an empty resolved zone may block
+    // the send. The caller's truthiness check drops "".
+    return Intl.DateTimeFormat().resolvedOptions().timeZone
+  } catch {
+    return undefined
+  }
+}
+
 const deliveryError = (
   message: string,
   disposition: MessageDeliveryDisposition,
@@ -1164,10 +1174,12 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
     preparationsRef.current.set(clientMessageId, claim)
 
     try {
+      const browserTimezone = resolveBrowserTimezone()
       const messageData: Record<string, unknown> = {
         type: 'chat',
         message,
         client_message_id: clientMessageId,
+        ...(browserTimezone ? { context: { timezone: browserTimezone } } : {}),
         ...(connection.chatTaskIdMode === "required" ? { task_id: currentTaskId } : {}),
       }
 


### PR DESCRIPTION
Refs #1675 — frontend half; pairs with #1709.

## Invariant

This PR guarantees only:

Every `type: "chat"` websocket frame carries `context.timezone` holding the IANA zone name the browser resolves. When the browser cannot resolve one — `Intl` throws, or the resolved zone is `""` — the `context` key is absent entirely.

## Entry points in scope

- `sendChatMessage` in `useWebSocket` (`frontend/src/hooks/use-websocket.ts`)

## Why here

The main frontend and the embeddable widget both reach the same `sendChatMessage` through `useApp().sendMessage`, and `messageData` has exactly one construction site in the frontend. Changing it covers both clients, so **`widget.js` needs no change** — the widget page runs inside an iframe where `Intl` is directly available.

The backend already defaults `raw_context = message_data.get("context", {})`, and every key in `request_context` is written into `context.metadata` verbatim, so this key needs no backend change to arrive.

## Merge order

**Either PR can merge first; there is no hard dependency.**

- This one first: the timezone reaches `context.metadata["timezone"]`, nothing reads it yet, behavior unchanged.
- #1709 first: no client populates the key, rendering stays pure UTC.

Only with both merged does "tomorrow" resolve against local date for a UTC+10 user.

## Known trade-offs

1. **Two existing contract assertions are updated.** `toEqual` pins the whole chat payload shape, so a new field must be reflected there or those tests fail. That is the normal cost of a contract test, not a bypass.
2. **No `data-timezone` embed attribute here.** It is a separate change, in #1713 stacked on this branch. This PR is browser-resolved zones only.
3. **The empty-string check exists in exactly one place.** `resolveBrowserTimezone` originally guarded `""` twice — via `|| undefined` and via the caller's truthiness check. Mutation testing showed the former is undetectable (removing it keeps every test green) because the caller already covers it, so the redundant guard is gone.
4. **The zone is resolved once per logical message, not per physical send** (~40 bytes on the wire either way). `Intl` is consulted only for a `client_message_id` not seen before; the result is held in a ref map and reused by every same-id retry, then dropped on a terminal ack (accepted, or rejected with `rejection_outcome === "not_accepted"`). An unknown outcome deliberately keeps the binding, because that is the case `ChatInput` retries under the same id.

   This is load-bearing, not an optimization. `websocket.py:5321` copies the whole frame into the durable payload — excluding only `user`, `user_id`, and `_durable_*`, so `context` is included — and `task_command_transport.py:240` compares it with `_canonical_payload` in full. `ChatInput.tsx:725-737` reuses `client_message_id` whenever its `deliveryKey` (message text, runtime extensions, file identity — no zone) matches. So a retry that re-resolved the zone would carry different content under the same id, `payload_matches` would be false, and `websocket.py:5186` would answer `retry_with_new_id` while the first command may still be pending or executing — a duplicate-execution path. Before this PR every field in a chat frame was stable across physical sends; `context.timezone` is the first one that is not. Caught in review by @rogercloud; fixed in 4d385b0d.

   No cross-task caching: the zone can legitimately change between messages (travel, a system settings change), and a genuinely new id picks up the current value.

## Explicit non-goals

- This PR does not touch the legacy `type: "execute_task"` command path, which is not live user input and carries different timezone semantics.
- This PR does not add an account-level timezone setting or an embedder override attribute.
- This PR does not include the backend rendering (#1709).
- This PR does not address the timestamp being frozen within a turn, nor add a current-time tool (#1676).
- Adjacent pre-existing issues should be tracked as follow-ups rather than implemented here.

## Blocking criteria

As in #1709: this PR should be blocked only when it introduces a regression, the stated invariant can still be broken, or it materially worsens a pre-existing problem.

## Tests

5 new tests, 2 existing contract assertions updated. Source +21/-2, tests +157 (88% tests).

Mutation-verified, all caught:

| Mutation | Result |
| --- | --- |
| Drop the timezone from the frame entirely | 3 failed |
| Hardcode `"UTC"` as the resolved zone | 2 failed |
| Relax the truthiness check to `!== undefined` so `""` is sent | 1 failed |
| Resolve per physical send instead of per logical attempt | 2 failed |
| Also clear the attempt binding on an unknown outcome | 2 failed |
| Narrow the catch so an `Intl` throw propagates | 1 failed |

The first assertion originally read its expectation back from `Intl`, which made it tautological on a UTC host: the hardcoded-`"UTC"` mutation was caught under `TZ=Asia/Shanghai` (2 failed) but survived one test under `TZ=UTC` (1 failed). Pinning the zone to `America/New_York` makes both environments identical. Caught in review by @gemini-code-assist.

Coverage: the reported value equals the resolved zone · the `context` key is absent when the resolved zone is empty · absent when `Intl` throws · a same-id retry stays bound to its first attempt's zone while a new id adopts the current one · a same-id retry stays context-free when the first attempt resolved no zone.

319 tests pass across `src/hooks`, `src/components/widget`, and `src/lib/chat-response.test.ts`. `tsc --noEmit` and `eslint` clean on the touched files.

**Pre-existing local failure, unrelated to this PR:** `tsc --noEmit` reports four `yaml` module errors in `src/ci/frontend-test-manifest.test.ts`. `yaml` is declared at `package.json:90` but was not installed locally; CI's `npm ci` is unaffected. Installing it locally brings tsc to zero errors, with no change to `package.json` or `package-lock.json`.
