### PR TITLE
feat(openrouter): replay DeepSeek reasoning content on tool-call chains

### DIFF
--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -679,6 +679,10 @@ class ReActPattern(AgentPattern):
             assistant_content = normalized.get("content")
             tool_calls = normalized.get("tool_calls", [])
             if assistant_content is not None or normalized.get("tool_calls"):
+                # A tool-protocol error response never carries tool_calls (see
+                # tool_protocol_error_response), so this guard never mistakes
+                # a protocol violation for a real tool-call turn worth saving
+                # provider state for.
                 metadata = (
                     self._provider_state_for_context(normalized) if tool_calls else {}
                 )

--- a/src/xagent/core/model/chat/basic/base.py
+++ b/src/xagent/core/model/chat/basic/base.py
@@ -130,6 +130,28 @@ class BaseLLM(ABC):
         """
         return ability in self.abilities
 
+    def _strip_internal_message_keys(
+        self, messages: List[dict[str, Any]]
+    ) -> List[dict[str, Any]]:
+        """Remove Xagent-only message metadata before sending provider calls.
+
+        Every provider that forwards a message dict's keys through to its SDK
+        call largely unchanged (as opposed to rebuilding a provider-shaped
+        message field-by-field) must call this before the request leaves the
+        process, or an internal marker like ``_xagent_provider_state`` leaks
+        onto the wire.
+        """
+        sanitized: List[dict[str, Any]] = []
+        for message in messages:
+            sanitized.append(
+                {
+                    key: value
+                    for key, value in message.items()
+                    if not key.startswith("_xagent_")
+                }
+            )
+        return sanitized
+
     def _sanitize_unicode_content(self, content: Any) -> Any:
         """
         Sanitize content by removing or replacing invalid Unicode characters.

--- a/src/xagent/core/model/chat/basic/claude.py
+++ b/src/xagent/core/model/chat/basic/claude.py
@@ -287,6 +287,12 @@ class ClaudeLLM(BaseLLM):
         Returns:
             Tuple of (system_message, list of messages in Anthropic format)
         """
+        # No explicit ``_xagent_``-prefixed key stripping happens here: every
+        # output message below is rebuilt field-by-field (role/content/
+        # tool_use blocks), never a ``dict(msg)`` copy, so an internal
+        # marker like ``_xagent_provider_state`` on the input is never read
+        # and cannot leak into the Anthropic request. Switching any branch
+        # here to copy ``msg`` wholesale would reopen that leak.
         anthropic_messages: List[Dict[str, Any]] = []
         system_message = None
 

--- a/src/xagent/core/model/chat/basic/deepseek.py
+++ b/src/xagent/core/model/chat/basic/deepseek.py
@@ -153,7 +153,7 @@ class DeepSeekLLM(OpenAICompatibleLLM):
         ``restore_deepseek_reasoning_content`` for the exact rules.
         """
         _ = thinking
-        return restore_deepseek_reasoning_content(messages)
+        return restore_deepseek_reasoning_content(messages, model_name=self._model_name)
 
     def _response_provider_state(
         self,

--- a/src/xagent/core/model/chat/basic/deepseek.py
+++ b/src/xagent/core/model/chat/basic/deepseek.py
@@ -4,17 +4,20 @@ from typing import Any, AsyncIterator, Dict, List, Optional
 
 from ...providers import is_placeholder_api_key
 from .base import StreamChunk
-from .deepseek_tool_protocol import (
+from .deepseek_tool_protocol import (  # noqa: F401 - re-exported, see below
+    DEEPSEEK_PROVIDER_STATE_NAMESPACE,
+    DEEPSEEK_REASONING_CONTENT_STATE_KEY,
     adapt_deepseek_stream,
+    deepseek_reasoning_provider_state,
+    deepseek_reasoning_provider_state_payload,
     normalize_deepseek_response,
+    restore_deepseek_reasoning_content,
 )
 from .openai import PROVIDER_STATE_METADATA_KEY, OpenAICompatibleLLM
 
 logger = logging.getLogger(__name__)
 
 DEEPSEEK_DEFAULT_BASE_URL = "https://api.deepseek.com"
-DEEPSEEK_PROVIDER_STATE_NAMESPACE = "deepseek"
-DEEPSEEK_REASONING_CONTENT_STATE_KEY = "reasoning_content"
 DEEPSEEK_SUPPORTED_MODELS = (
     "deepseek-v4-flash",
     "deepseek-v4-pro",
@@ -144,44 +147,24 @@ class DeepSeekLLM(OpenAICompatibleLLM):
         """Preserve DeepSeek thinking metadata on assistant tool-call history.
 
         DeepSeek V4 requires assistant messages in a tool-call chain to replay
-        the exact ``reasoning_content`` returned by the provider. An explicit
-        empty string is semantically different from a missing field, so this
-        must use key presence rather than truthiness. If older context lacks
-        captured provider state, use an empty string fallback to keep assistant
-        tool-call history structurally valid for later DeepSeek requests.
+        the exact ``reasoning_content`` returned by the provider. Replay is
+        unconditional -- it does not depend on ``thinking`` -- and an older
+        message with no captured state falls back to an empty string; see
+        ``restore_deepseek_reasoning_content`` for the exact rules.
         """
-        prepared: List[Dict[str, Any]] = []
-        for message in messages:
-            prepared_message = dict(message)
-            provider_state = prepared_message.get(PROVIDER_STATE_METADATA_KEY)
-            if isinstance(provider_state, dict):
-                deepseek_metadata = provider_state.get(
-                    DEEPSEEK_PROVIDER_STATE_NAMESPACE
-                )
-                if (
-                    isinstance(deepseek_metadata, dict)
-                    and DEEPSEEK_REASONING_CONTENT_STATE_KEY in deepseek_metadata
-                ):
-                    prepared_message["reasoning_content"] = deepseek_metadata[
-                        DEEPSEEK_REASONING_CONTENT_STATE_KEY
-                    ]
-            if (
-                prepared_message.get("role") == "assistant"
-                and prepared_message.get("tool_calls")
-                and "reasoning_content" not in prepared_message
-            ):
-                prepared_message["reasoning_content"] = ""
-            prepared.append(prepared_message)
-        return prepared
+        _ = thinking
+        return restore_deepseek_reasoning_content(messages)
 
-    def _response_provider_state(self, result: Dict[str, Any]) -> Dict[str, Any]:
-        if "reasoning_content" not in result:
-            return {}
-        return {
-            DEEPSEEK_PROVIDER_STATE_NAMESPACE: {
-                DEEPSEEK_REASONING_CONTENT_STATE_KEY: result["reasoning_content"],
-            },
-        }
+    def _response_provider_state(
+        self,
+        result: Dict[str, Any],
+        *,
+        thinking: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        _ = thinking
+        return deepseek_reasoning_provider_state(
+            result, fields=(DEEPSEEK_REASONING_CONTENT_STATE_KEY,)
+        )
 
     def _attach_reasoning_content_to_raw(
         self,
@@ -196,11 +179,9 @@ class DeepSeekLLM(OpenAICompatibleLLM):
             has_reasoning_content=has_reasoning_content,
         )
         if has_reasoning_content and isinstance(raw_payload, dict):
-            raw_payload[PROVIDER_STATE_METADATA_KEY] = {
-                DEEPSEEK_PROVIDER_STATE_NAMESPACE: {
-                    DEEPSEEK_REASONING_CONTENT_STATE_KEY: reasoning_content,
-                },
-            }
+            raw_payload[PROVIDER_STATE_METADATA_KEY] = (
+                deepseek_reasoning_provider_state_payload(reasoning_content)
+            )
         return raw_payload
 
     def _normalize_response_format(

--- a/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
+++ b/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
@@ -12,9 +12,20 @@ from ..tool_protocol import (
     ToolProtocolViolation,
     tool_protocol_error_response,
 )
-from ..types import ChunkType, StreamChunk
+from ..types import PROVIDER_STATE_METADATA_KEY, ChunkType, StreamChunk
 
 _PROVIDER = "deepseek"
+
+# DeepSeek's mandatory reasoning-replay contract, shared by any client that
+# talks the DeepSeek tool protocol (``DeepSeekLLM`` directly, and
+# ``OpenRouterLLM`` for OpenRouter's deepseek-authored slugs): a response that
+# carries reasoning content on a tool-call message must have that exact
+# content replayed on the assistant message the next time it is sent back.
+# The namespace/key below are this client's own internal vocabulary for that
+# state, not necessarily the wire field name a given provider used to send it
+# (see ``deepseek_reasoning_provider_state``'s ``fields`` argument).
+DEEPSEEK_PROVIDER_STATE_NAMESPACE = "deepseek"
+DEEPSEEK_REASONING_CONTENT_STATE_KEY = "reasoning_content"
 _SERIALIZED_TOOL_CALL_RE = re.compile(
     r"<[^>\n]*dsml[^>\n]*tool_calls",
     re.IGNORECASE,
@@ -139,6 +150,128 @@ async def adapt_deepseek_stream(
 
     for chunk in usage_chunks:
         yield chunk
+
+
+def deepseek_reasoning_provider_state_payload(reasoning_content: Any) -> dict[str, Any]:
+    """Wrap already-extracted reasoning text in the shared provider-state shape."""
+    return {
+        DEEPSEEK_PROVIDER_STATE_NAMESPACE: {
+            DEEPSEEK_REASONING_CONTENT_STATE_KEY: reasoning_content,
+        },
+    }
+
+
+def deepseek_reasoning_provider_state(
+    result: dict[str, Any],
+    *,
+    fields: tuple[str, ...],
+) -> dict[str, Any]:
+    """Capture DeepSeek-protocol reasoning content into a provider-state payload.
+
+    ``fields`` lists the wire field spellings to look for, in precedence
+    order. Checks ``result`` itself first (the shape the transport layer
+    already normalizes onto), then falls back to the raw response's message
+    payload (``result["raw"]["choices"][0]["message"]``) for a provider whose
+    SDK preserves a field spelling the transport layer does not normalize.
+    A field counts as present only when its value is not ``None`` -- an
+    explicit empty string is a valid, must-preserve value; only genuine
+    absence should return ``{}``.
+
+    Direct DeepSeek only ever sends ``reasoning_content``, so it passes a
+    single-element ``fields`` tuple and the raw fallback is never reached in
+    practice; OpenRouter's deepseek-authored slugs may use either
+    ``reasoning_content`` or the ``reasoning`` alias, so it passes both.
+    """
+    value, found = _first_reasoning_value(result, fields)
+    if not found:
+        message = _raw_response_message(
+            result.get("raw") if isinstance(result, dict) else None
+        )
+        if message is not None:
+            value, found = _first_reasoning_value(message, fields)
+    if not found:
+        return {}
+    return deepseek_reasoning_provider_state_payload(value)
+
+
+def restore_deepseek_reasoning_content(
+    messages: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Replay captured DeepSeek reasoning content onto assistant history.
+
+    An assistant message that previously captured ``reasoning_content`` under
+    the shared provider-state marker gets it translated back to the
+    ``reasoning_content`` field DeepSeek's API expects. An assistant message
+    with tool calls but no captured state gets an empty-string fallback
+    instead, so the history stays structurally valid for a DeepSeek request
+    (older context may predate capture, or come from a rebuilt session).
+
+    This is unconditional: it does not look at whether thinking is enabled
+    for the *current* request, because the replay requirement is about the
+    history's own shape, not this call's configuration.
+    """
+    prepared: list[dict[str, Any]] = []
+    for message in messages:
+        prepared_message = dict(message)
+        provider_state = prepared_message.get(PROVIDER_STATE_METADATA_KEY)
+        if isinstance(provider_state, dict):
+            deepseek_metadata = provider_state.get(DEEPSEEK_PROVIDER_STATE_NAMESPACE)
+            if (
+                isinstance(deepseek_metadata, dict)
+                and DEEPSEEK_REASONING_CONTENT_STATE_KEY in deepseek_metadata
+            ):
+                prepared_message[DEEPSEEK_REASONING_CONTENT_STATE_KEY] = (
+                    deepseek_metadata[DEEPSEEK_REASONING_CONTENT_STATE_KEY]
+                )
+        if (
+            prepared_message.get("role") == "assistant"
+            and prepared_message.get("tool_calls")
+            and DEEPSEEK_REASONING_CONTENT_STATE_KEY not in prepared_message
+        ):
+            prepared_message[DEEPSEEK_REASONING_CONTENT_STATE_KEY] = ""
+        prepared.append(prepared_message)
+    return prepared
+
+
+def reasoning_field_names(result: Any) -> tuple[str, ...]:
+    """Return every reasoning-related key name observed on a captured result.
+
+    Checks the same two places ``deepseek_reasoning_provider_state`` does --
+    the ``result`` dict itself, then its raw response message -- and returns
+    the union of keys starting with ``"reasoning"`` found there. For
+    observability only: the caller logs these key *names*, never their
+    values, so a provider that renamed its reasoning field can be diagnosed
+    without ever putting reasoning content itself into a log line.
+    """
+    names: list[str] = []
+    if isinstance(result, dict):
+        names.extend(key for key in result if key.startswith("reasoning"))
+        message = _raw_response_message(result.get("raw"))
+        if message is not None:
+            names.extend(key for key in message if key.startswith("reasoning"))
+    return tuple(dict.fromkeys(names))
+
+
+def _first_reasoning_value(source: Any, fields: tuple[str, ...]) -> tuple[Any, bool]:
+    if not isinstance(source, dict):
+        return None, False
+    for field_name in fields:
+        if field_name in source and source[field_name] is not None:
+            return source[field_name], True
+    return None, False
+
+
+def _raw_response_message(raw: Any) -> dict[str, Any] | None:
+    if not isinstance(raw, dict):
+        return None
+    choices = raw.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return None
+    first_choice = choices[0]
+    if not isinstance(first_choice, dict):
+        return None
+    message = first_choice.get("message")
+    return message if isinstance(message, dict) else None
 
 
 def _response_violation(

--- a/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
+++ b/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import re
 from collections.abc import AsyncIterator
 from dataclasses import replace
@@ -13,6 +14,8 @@ from ..tool_protocol import (
     tool_protocol_error_response,
 )
 from ..types import PROVIDER_STATE_METADATA_KEY, ChunkType, StreamChunk
+
+logger = logging.getLogger(__name__)
 
 _PROVIDER = "deepseek"
 
@@ -196,6 +199,8 @@ def deepseek_reasoning_provider_state(
 
 def restore_deepseek_reasoning_content(
     messages: list[dict[str, Any]],
+    *,
+    model_name: str,
 ) -> list[dict[str, Any]]:
     """Replay captured DeepSeek reasoning content onto assistant history.
 
@@ -209,11 +214,23 @@ def restore_deepseek_reasoning_content(
     This is unconditional: it does not look at whether thinking is enabled
     for the *current* request, because the replay requirement is about the
     history's own shape, not this call's configuration.
+
+    Logs one INFO summary per call (only when at least one assistant
+    tool-call message actually needed replay) counting how many messages
+    replayed real captured content versus how many hit the empty-string
+    fallback. A rising fallback count is the signal that something upstream
+    is losing captured state (a rebuilt task history, a synthesized
+    tool-call message) before it reaches here -- that loss does not raise on
+    its own, since the fallback keeps the request valid. The log carries
+    only the counts and ``model_name``, never the reasoning text itself.
     """
     prepared: list[dict[str, Any]] = []
+    replayed_count = 0
+    fallback_count = 0
     for message in messages:
         prepared_message = dict(message)
         provider_state = prepared_message.get(PROVIDER_STATE_METADATA_KEY)
+        replayed_captured_content = False
         if isinstance(provider_state, dict):
             deepseek_metadata = provider_state.get(DEEPSEEK_PROVIDER_STATE_NAMESPACE)
             if (
@@ -223,13 +240,25 @@ def restore_deepseek_reasoning_content(
                 prepared_message[DEEPSEEK_REASONING_CONTENT_STATE_KEY] = (
                     deepseek_metadata[DEEPSEEK_REASONING_CONTENT_STATE_KEY]
                 )
-        if (
-            prepared_message.get("role") == "assistant"
-            and prepared_message.get("tool_calls")
-            and DEEPSEEK_REASONING_CONTENT_STATE_KEY not in prepared_message
+                replayed_captured_content = True
+        if prepared_message.get("role") == "assistant" and prepared_message.get(
+            "tool_calls"
         ):
-            prepared_message[DEEPSEEK_REASONING_CONTENT_STATE_KEY] = ""
+            if replayed_captured_content:
+                replayed_count += 1
+            elif DEEPSEEK_REASONING_CONTENT_STATE_KEY not in prepared_message:
+                prepared_message[DEEPSEEK_REASONING_CONTENT_STATE_KEY] = ""
+                fallback_count += 1
         prepared.append(prepared_message)
+    if replayed_count or fallback_count:
+        logger.info(
+            "DeepSeek reasoning replay for model %s: %d assistant message(s) "
+            "replayed captured reasoning content, %d used the empty-string "
+            "fallback",
+            model_name,
+            replayed_count,
+            fallback_count,
+        )
     return prepared
 
 

--- a/src/xagent/core/model/chat/basic/gemini.py
+++ b/src/xagent/core/model/chat/basic/gemini.py
@@ -308,6 +308,12 @@ class GeminiLLM(BaseLLM):
         self, messages: List[Dict[str, Any]]
     ) -> tuple[Optional[str], List[Dict[str, Any]]]:
         """Convert OpenAI format messages to Gemini format."""
+        # No explicit ``_xagent_``-prefixed key stripping happens here: every
+        # output message below is rebuilt field-by-field, never a
+        # ``dict(msg)`` copy, so an internal marker like
+        # ``_xagent_provider_state`` on the input is never read and cannot
+        # leak into the Gemini request. Switching any branch here to copy
+        # ``msg`` wholesale would reopen that leak.
         gemini_messages = []
         system_instruction = None
 

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -86,9 +86,13 @@ def _format_openai_error(prefix: str, error: BaseException) -> str:
 def field_content(message: Any, field_name: str) -> tuple[bool, Any]:
     """Return whether a provider message/delta explicitly set ``field_name``.
 
-    Checks, in order, a plain dict, a pydantic model's declared fields, its
-    ``model_extra`` (unknown fields the SDK still preserves), and finally
-    ``__dict__`` as a last resort for other object shapes.
+    Checks, in order, a plain dict, a pydantic model's declared fields, and
+    its ``model_extra`` (unknown fields the SDK still preserves). ``__dict__``
+    is only consulted for objects that are neither of those two shapes: on a
+    pydantic model every declared field sits in ``__dict__`` carrying its
+    default whether or not the provider actually sent it, so it cannot
+    distinguish "the provider sent this" from "the class declares it" and
+    must not be used as a fallback there.
 
     Public (not ``_``-prefixed) because it is a general-purpose probe over
     any OpenAI-SDK-shaped message or delta object, not an implementation
@@ -102,7 +106,8 @@ def field_content(message: Any, field_name: str) -> tuple[bool, Any]:
         return value is not None, value
 
     model_fields_set = getattr(message, "model_fields_set", None)
-    if isinstance(model_fields_set, set) and field_name in model_fields_set:
+    is_pydantic_model = isinstance(model_fields_set, set)
+    if is_pydantic_model and field_name in model_fields_set:  # type: ignore[operator]
         value = getattr(message, field_name, None)
         return value is not None, value
 
@@ -110,6 +115,13 @@ def field_content(message: Any, field_name: str) -> tuple[bool, Any]:
     if isinstance(model_extra, dict) and field_name in model_extra:
         value = model_extra.get(field_name)
         return value is not None, value
+
+    if is_pydantic_model:
+        # On a pydantic model every declared field sits in ``__dict__``
+        # carrying its default, set or not, so ``__dict__`` cannot tell
+        # "the provider sent this" from "the class declares it". The two
+        # checks above are the only ones that can.
+        return False, None
 
     message_attrs = getattr(message, "__dict__", {})
     if not isinstance(message_attrs, dict) or field_name not in message_attrs:
@@ -128,10 +140,11 @@ def _delta_field_names(delta: Any) -> tuple[str, ...]:
     """Return every field name actually set on a streaming delta object.
 
     Checks the same shapes ``field_content`` does -- a plain dict, a
-    pydantic model's declared fields, its ``model_extra``, and finally
-    ``__dict__`` -- but returns key names rather than one field's value.
-    Used to log which reasoning-like field (if any) a delta carried without
-    ever logging its content.
+    pydantic model's declared fields, and its ``model_extra`` -- but
+    collects key names rather than one field's value, so it falls back to
+    ``__dict__`` whenever both of those come up empty, even on a pydantic
+    model. Used to log which reasoning-like field (if any) a delta carried
+    without ever logging its content.
     """
     if isinstance(delta, dict):
         return tuple(delta.keys())

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -83,12 +83,17 @@ def _format_openai_error(prefix: str, error: BaseException) -> str:
     return formatted
 
 
-def _field_content(message: Any, field_name: str) -> tuple[bool, Any]:
+def field_content(message: Any, field_name: str) -> tuple[bool, Any]:
     """Return whether a provider message/delta explicitly set ``field_name``.
 
     Checks, in order, a plain dict, a pydantic model's declared fields, its
     ``model_extra`` (unknown fields the SDK still preserves), and finally
     ``__dict__`` as a last resort for other object shapes.
+
+    Public (not ``_``-prefixed) because it is a general-purpose probe over
+    any OpenAI-SDK-shaped message or delta object, not an implementation
+    detail private to this module: ``OpenRouterLLM`` reuses it as-is to
+    widen its own reasoning-field check across multiple wire spellings.
     """
     if isinstance(message, dict):
         if field_name not in message:
@@ -116,7 +121,33 @@ def _field_content(message: Any, field_name: str) -> tuple[bool, Any]:
 
 def _message_reasoning_content(message: Any) -> tuple[bool, Any]:
     """Return whether a provider explicitly included reasoning content."""
-    return _field_content(message, "reasoning_content")
+    return field_content(message, "reasoning_content")
+
+
+def _delta_field_names(delta: Any) -> tuple[str, ...]:
+    """Return every field name actually set on a streaming delta object.
+
+    Checks the same shapes ``field_content`` does -- a plain dict, a
+    pydantic model's declared fields, its ``model_extra``, and finally
+    ``__dict__`` -- but returns key names rather than one field's value.
+    Used to log which reasoning-like field (if any) a delta carried without
+    ever logging its content.
+    """
+    if isinstance(delta, dict):
+        return tuple(delta.keys())
+
+    names: set[str] = set()
+    model_fields_set = getattr(delta, "model_fields_set", None)
+    if isinstance(model_fields_set, set):
+        names.update(model_fields_set)
+    model_extra = getattr(delta, "model_extra", None)
+    if isinstance(model_extra, dict):
+        names.update(model_extra.keys())
+    if not names:
+        delta_attrs = getattr(delta, "__dict__", None)
+        if isinstance(delta_attrs, dict):
+            names.update(delta_attrs.keys())
+    return tuple(names)
 
 
 def _is_retryable_stream_transport_error(error: BaseException) -> bool:
@@ -244,6 +275,26 @@ class OpenAICompatibleLLM(BaseLLM):
         historical behavior exactly.
         """
         return _message_reasoning_content(delta)
+
+    def _check_stream_reasoning_capture(
+        self,
+        *,
+        thinking: Optional[Dict[str, Any]],
+        has_tool_calls: bool,
+        has_reasoning_content: bool,
+        observed_field_names: tuple[str, ...],
+    ) -> None:
+        """Hook called once after a stream ends, for a silent-capture check.
+
+        Mirrors ``_response_provider_state``'s non-streaming warning, but for
+        the streaming path: called with the whole stream's outcome (whether
+        any delta ever carried a recognized reasoning field, whether the
+        response ended with tool calls, and every field name -- never a
+        value -- seen on any delta), so a subclass can warn when thinking
+        was requested but nothing recognized was ever captured. Default is a
+        no-op; only ``OpenRouterLLM`` currently overrides it.
+        """
+        _ = thinking, has_tool_calls, has_reasoning_content, observed_field_names
 
     def _build_request_messages(
         self,
@@ -987,6 +1038,7 @@ class OpenAICompatibleLLM(BaseLLM):
             accumulated_tool_calls: Dict[str, Dict] = {}
             accumulated_reasoning_content = ""
             has_reasoning_content = False
+            observed_reasoning_field_names: set[str] = set()
             last_raw_chunk = None  # Track last raw chunk for usage extraction
             usage_received = False
 
@@ -1029,6 +1081,11 @@ class OpenAICompatibleLLM(BaseLLM):
                         accumulated_reasoning_content += str(
                             delta_reasoning_content or ""
                         )
+                    observed_reasoning_field_names.update(
+                        name
+                        for name in _delta_field_names(delta)
+                        if name.startswith("reasoning")
+                    )
 
                 chunk = self._parse_stream_chunk(
                     raw_chunk,
@@ -1040,6 +1097,17 @@ class OpenAICompatibleLLM(BaseLLM):
                     if chunk.is_usage():
                         usage_received = True
                     yield chunk
+
+            # One-time hook for a subclass to detect a silent streaming
+            # capture failure (thinking requested, tool calls in the
+            # response, but no recognized reasoning field ever captured).
+            # See ``_check_stream_reasoning_capture``'s docstring.
+            self._check_stream_reasoning_capture(
+                thinking=thinking,
+                has_tool_calls=bool(accumulated_tool_calls),
+                has_reasoning_content=has_reasoning_content,
+                observed_field_names=tuple(sorted(observed_reasoning_field_names)),
+            )
 
             # Fallback: Ensure usage chunk is always sent
             # If no usage chunk was received, try to extract from the last raw chunk

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -434,8 +434,18 @@ class OpenAICompatibleLLM(BaseLLM):
                 return await self._client.chat.completions.create(**completion_params)
 
         # Helper function to process response
-        def _process_response(resp: Any) -> Dict[str, Any]:
-            """Process the API response and return the result"""
+        def _process_response(
+            resp: Any, *, request_thinking: Optional[Dict[str, Any]]
+        ) -> Dict[str, Any]:
+            """Process the API response and return the result.
+
+            ``request_thinking`` is the thinking configuration that the
+            attempt producing ``resp`` actually sent. It is a parameter
+            rather than a closure read because this call can retry once
+            with thinking disabled (see the structured-output degrade
+            branch below): a closure read would judge the second response
+            by the first attempt's configuration.
+            """
             # Validate response
             if not hasattr(resp, "choices") or not resp.choices:
                 raise RuntimeError(
@@ -492,7 +502,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     result["reasoning_content"] = reasoning_content
                     result["reasoning"] = reasoning_content
                 provider_state = self._response_provider_state(
-                    result, thinking=thinking
+                    result, thinking=request_thinking
                 )
                 if provider_state:
                     result[PROVIDER_STATE_METADATA_KEY] = provider_state
@@ -582,7 +592,7 @@ class OpenAICompatibleLLM(BaseLLM):
                 else:
                     raise
 
-            result = _process_response(response)
+            result = _process_response(response, request_thinking=thinking)
 
             # Provider reasoning can corrupt structured JSON on some compatible
             # endpoints. Subclasses can disable provider reasoning for a retry.
@@ -607,16 +617,25 @@ class OpenAICompatibleLLM(BaseLLM):
                             "Model returned non-JSON content with response_format while thinking was enabled. "
                             "Retrying with thinking disabled."
                         )
+                        # One variable for both halves: what this retry
+                        # sends, and what the response hook is told it
+                        # sent. Two literals here would drift apart.
+                        retry_thinking: Dict[str, Any] = {
+                            "type": "disabled",
+                            "enable": False,
+                        }
                         extra_body = self._prepare_provider_reasoning_extra_body(
                             extra_body=extra_body,
-                            thinking={"type": "disabled", "enable": False},
+                            thinking=retry_thinking,
                             tools=tools,
                             response_format=response_format,
                             output_config=output_config,
                             is_streaming=False,
                         )
                         response = await _make_api_call()
-                        result = _process_response(response)
+                        result = _process_response(
+                            response, request_thinking=retry_thinking
+                        )
 
             return result
 

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -11,12 +11,14 @@ from ....utils.security import redact_sensitive_text
 from ..exceptions import LLMEmptyContentError, LLMRetryableError, LLMTimeoutError
 from ..timeout_config import TimeoutConfig
 from ..token_context import add_token_usage, extract_cached_input_tokens
-from ..types import ChunkType, StreamChunk
+from ..types import PROVIDER_STATE_METADATA_KEY, ChunkType, StreamChunk
 from .base import BaseLLM
 
 logger = logging.getLogger(__name__)
 
-PROVIDER_STATE_METADATA_KEY = "_xagent_provider_state"
+# ``PROVIDER_STATE_METADATA_KEY`` now lives in ``chat.types`` (see there for
+# why); imported here so existing code and tests that import it from this
+# transport module keep working unchanged.
 
 
 def _truncate_error_detail(value: Any, limit: int = 4000) -> str:
@@ -81,30 +83,40 @@ def _format_openai_error(prefix: str, error: BaseException) -> str:
     return formatted
 
 
-def _message_reasoning_content(message: Any) -> tuple[bool, Any]:
-    """Return whether a provider explicitly included reasoning content."""
+def _field_content(message: Any, field_name: str) -> tuple[bool, Any]:
+    """Return whether a provider message/delta explicitly set ``field_name``.
+
+    Checks, in order, a plain dict, a pydantic model's declared fields, its
+    ``model_extra`` (unknown fields the SDK still preserves), and finally
+    ``__dict__`` as a last resort for other object shapes.
+    """
     if isinstance(message, dict):
-        if "reasoning_content" not in message:
+        if field_name not in message:
             return False, None
-        value = message.get("reasoning_content")
+        value = message.get(field_name)
         return value is not None, value
 
     model_fields_set = getattr(message, "model_fields_set", None)
-    if isinstance(model_fields_set, set) and "reasoning_content" in model_fields_set:
-        value = getattr(message, "reasoning_content", None)
+    if isinstance(model_fields_set, set) and field_name in model_fields_set:
+        value = getattr(message, field_name, None)
         return value is not None, value
 
     model_extra = getattr(message, "model_extra", None)
-    if isinstance(model_extra, dict) and "reasoning_content" in model_extra:
-        value = model_extra.get("reasoning_content")
+    if isinstance(model_extra, dict) and field_name in model_extra:
+        value = model_extra.get(field_name)
         return value is not None, value
 
     message_attrs = getattr(message, "__dict__", {})
-    if not isinstance(message_attrs, dict) or "reasoning_content" not in message_attrs:
+    if not isinstance(message_attrs, dict) or field_name not in message_attrs:
         return False, None
 
-    value = message_attrs["reasoning_content"]
+    value = message_attrs[field_name]
     return value is not None, value
+
+
+def _message_reasoning_content(message: Any) -> tuple[bool, Any]:
+    """Return whether a provider explicitly included reasoning content."""
+    return _field_content(message, "reasoning_content")
 
 
 def _is_retryable_stream_transport_error(error: BaseException) -> bool:
@@ -210,25 +222,28 @@ class OpenAICompatibleLLM(BaseLLM):
         _ = thinking
         return messages
 
-    def _response_provider_state(self, result: Dict[str, Any]) -> Dict[str, Any]:
-        """Return opaque provider-owned message state for future LLM requests."""
-        _ = result
+    def _response_provider_state(
+        self,
+        result: Dict[str, Any],
+        *,
+        thinking: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        """Return opaque provider-owned message state for future LLM requests.
+
+        ``thinking`` is the request's thinking configuration, made available
+        so a subclass can tell whether reasoning content was actually asked
+        for (e.g. to decide whether an empty capture is worth a warning).
+        """
+        _ = result, thinking
         return {}
 
-    def _strip_internal_message_keys(
-        self, messages: List[Dict[str, Any]]
-    ) -> List[Dict[str, Any]]:
-        """Remove Xagent-only message metadata before sending provider calls."""
-        sanitized: List[Dict[str, Any]] = []
-        for message in messages:
-            sanitized.append(
-                {
-                    key: value
-                    for key, value in message.items()
-                    if not key.startswith("_xagent_")
-                }
-            )
-        return sanitized
+    def _delta_reasoning_content(self, delta: Any) -> tuple[bool, Any]:
+        """Hook for subclasses that watch additional reasoning field spellings.
+
+        Default implementation only recognizes ``reasoning_content``, matching
+        historical behavior exactly.
+        """
+        return _message_reasoning_content(delta)
 
     def _build_request_messages(
         self,
@@ -412,7 +427,9 @@ class OpenAICompatibleLLM(BaseLLM):
                 if has_reasoning_content:
                     result["reasoning_content"] = reasoning_content
                     result["reasoning"] = reasoning_content
-                provider_state = self._response_provider_state(result)
+                provider_state = self._response_provider_state(
+                    result, thinking=thinking
+                )
                 if provider_state:
                     result[PROVIDER_STATE_METADATA_KEY] = provider_state
                 return result
@@ -766,7 +783,9 @@ class OpenAICompatibleLLM(BaseLLM):
                 if has_reasoning_content:
                     result["reasoning_content"] = reasoning_content
                     result["reasoning"] = reasoning_content
-                provider_state = self._response_provider_state(result)
+                provider_state = self._response_provider_state(
+                    result, thinking=thinking
+                )
                 if provider_state:
                     result[PROVIDER_STATE_METADATA_KEY] = provider_state
                 return result
@@ -1003,7 +1022,7 @@ class OpenAICompatibleLLM(BaseLLM):
                 if hasattr(raw_chunk, "choices") and raw_chunk.choices:
                     delta = raw_chunk.choices[0].delta
                     delta_has_reasoning, delta_reasoning_content = (
-                        _message_reasoning_content(delta)
+                        self._delta_reasoning_content(delta)
                     )
                     if delta_has_reasoning:
                         has_reasoning_content = True

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -8,16 +8,33 @@ from ..error import retry_on
 from ..exceptions import LLMRetryableError, LLMToolProtocolError
 from ..timeout_config import TimeoutConfig
 from ..tool_protocol import TOOL_PROTOCOL_ERROR_KEY, get_tool_protocol_error
-from ..types import StreamChunk
+from ..types import PROVIDER_STATE_METADATA_KEY, StreamChunk
 from .deepseek_tool_protocol import (
+    DEEPSEEK_REASONING_CONTENT_STATE_KEY,
     adapt_deepseek_stream,
+    deepseek_reasoning_provider_state,
+    deepseek_reasoning_provider_state_payload,
     normalize_deepseek_response,
+    reasoning_field_names,
+    restore_deepseek_reasoning_content,
 )
-from .openai import OpenAILLM
+from .openai import OpenAILLM, _field_content
 
 logger = logging.getLogger(__name__)
 
 OPENROUTER_BASE_URL = "https://openrouter.ai/api/v1"
+
+# OpenRouter's own docs describe both ``reasoning_content`` (the field
+# DeepSeek's own API uses) and a ``reasoning`` alias as valid response
+# fields; which one a given deepseek-authored slug actually sends has not
+# been confirmed against a live response, so both are watched defensively.
+# A third documented field, ``reasoning_details`` (structured blocks), is
+# deliberately not handled: replaying it would need an ordered-array
+# accumulator this client does not have, and the WARNING logged when no
+# known field is captured (see ``_response_provider_state``) is the safety
+# net for that gap. Order here is precedence when a response carries more
+# than one of these fields.
+OPENROUTER_REASONING_FIELDS = (DEEPSEEK_REASONING_CONTENT_STATE_KEY, "reasoning")
 _DEEPSEEK_FUNCTION_PREFIX_ERROR = "function call should not be used with prefix"
 
 # OpenAILLM.chat/vision_chat/stream_chat convert every openai.BadRequestError
@@ -152,6 +169,13 @@ _ACTION_DISABLE_THINKING = "disable_thinking"
 _ACTION_RELAX_TOOL_CHOICE = "relax_tool_choice"
 
 
+def _thinking_requested(thinking: Optional[Dict[str, Any]]) -> bool:
+    """Return whether a request asked for thinking to be enabled."""
+    return isinstance(thinking, dict) and (
+        thinking.get("type") == "enabled" or thinking.get("enable") is True
+    )
+
+
 def _should_retry_with_thinking(
     exc: Exception,
     *,
@@ -159,9 +183,7 @@ def _should_retry_with_thinking(
 ) -> bool:
     # This is the primary stop condition after a retry swaps in enabled thinking;
     # retry-action tracking remains defense in depth for the shared retry loop.
-    if isinstance(thinking, dict) and (
-        thinking.get("type") == "enabled" or thinking.get("enable") is True
-    ):
+    if _thinking_requested(thinking):
         return False
 
     # OpenRouter currently exposes this provider constraint only through an
@@ -316,6 +338,94 @@ class OpenRouterLLM(OpenAILLM):
 
     def _is_official_openrouter_client(self) -> bool:
         return self.base_url.rstrip("/") == OPENROUTER_BASE_URL
+
+    def _prepare_messages_for_request(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        thinking: Optional[Dict[str, Any]],
+    ) -> List[Dict[str, Any]]:
+        """Replay captured DeepSeek reasoning content, deepseek slugs only.
+
+        Gated on ``_uses_deepseek_tool_protocol`` (the model-name author
+        check), the same gate every other DeepSeek-protocol branch on this
+        class uses -- not on abilities or config, so a non-deepseek slug's
+        request-building path is untouched.
+        """
+        if not self._uses_deepseek_tool_protocol:
+            return messages
+        return restore_deepseek_reasoning_content(messages)
+
+    def _response_provider_state(
+        self,
+        result: Dict[str, Any],
+        *,
+        thinking: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
+        if not self._uses_deepseek_tool_protocol:
+            return {}
+        provider_state = deepseek_reasoning_provider_state(
+            result, fields=OPENROUTER_REASONING_FIELDS
+        )
+        if (
+            not provider_state
+            and result.get("tool_calls")
+            and _thinking_requested(thinking)
+        ):
+            # Thinking was requested and the response is a tool call, but
+            # neither known reasoning field spelling was captured. This is
+            # the one silent-failure mode of the whole mechanism (see
+            # OPENROUTER_REASONING_FIELDS): the next request in this tool
+            # chain will 400 with no clue pointing back here, so log which
+            # reasoning-like keys (if any) actually showed up -- key names
+            # only, never their content.
+            logger.warning(
+                "OpenRouter deepseek model %s returned a tool call with "
+                "thinking requested, but no reasoning content was captured "
+                "under any known field spelling %s; observed reasoning-like "
+                "keys: %s",
+                self._model_name,
+                OPENROUTER_REASONING_FIELDS,
+                reasoning_field_names(result),
+            )
+        return provider_state
+
+    def _attach_reasoning_content_to_raw(
+        self,
+        raw_payload: Any,
+        reasoning_content: str,
+        *,
+        has_reasoning_content: bool = False,
+    ) -> Any:
+        raw_payload = super()._attach_reasoning_content_to_raw(
+            raw_payload,
+            reasoning_content,
+            has_reasoning_content=has_reasoning_content,
+        )
+        if (
+            self._uses_deepseek_tool_protocol
+            and has_reasoning_content
+            and isinstance(raw_payload, dict)
+        ):
+            raw_payload[PROVIDER_STATE_METADATA_KEY] = (
+                deepseek_reasoning_provider_state_payload(reasoning_content)
+            )
+        return raw_payload
+
+    def _delta_reasoning_content(self, delta: Any) -> tuple[bool, Any]:
+        """Widen the streaming reasoning-field check for deepseek slugs only.
+
+        Non-deepseek slugs get the base class's single-spelling check
+        unchanged; this only broadens what counts as reasoning content for
+        the protocol this class already special-cases everywhere else.
+        """
+        if not self._uses_deepseek_tool_protocol:
+            return super()._delta_reasoning_content(delta)
+        for field_name in OPENROUTER_REASONING_FIELDS:
+            found, value = _field_content(delta, field_name)
+            if found:
+                return True, value
+        return False, None
 
     def _deepseek_function_prefix_retry_messages(
         self,
@@ -546,11 +656,15 @@ class OpenRouterLLM(OpenAILLM):
 
         # ``render`` only models extra_body. Thinking also reaches the request
         # through ``_build_request_messages(messages, thinking=...)``, which
-        # ``render`` never sees; that second path is a no-op today only because
-        # this class's MRO resolves to ``OpenAILLM._prepare_messages_for_request``
-        # (ignores ``thinking``), not ``DeepSeekLLM``'s rewrite. If a class on
-        # this MRO ever starts consuming ``thinking`` there, this no-op
-        # comparison must model the message body too, not just extra_body.
+        # ``render`` never sees; that second path is a no-op comparison-wise
+        # not because it ignores ``thinking`` (this class's own
+        # ``_prepare_messages_for_request`` does replay reasoning content) but
+        # because its output depends only on ``messages``, never on
+        # ``thinking``: for one fixed ``messages`` list, any two candidate
+        # thinking values render byte-identical message bodies, so comparing
+        # extra_body alone is still sufficient. If that method ever starts
+        # branching on ``thinking``, this no-op comparison must model the
+        # message body too, not just extra_body.
         def render(candidate_thinking: Optional[Dict[str, Any]]) -> Dict[str, Any]:
             return self._prepare_provider_reasoning_extra_body(
                 extra_body=self._prepare_extra_body(

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -18,7 +18,7 @@ from .deepseek_tool_protocol import (
     reasoning_field_names,
     restore_deepseek_reasoning_content,
 )
-from .openai import OpenAILLM, _field_content
+from .openai import OpenAILLM, field_content
 
 logger = logging.getLogger(__name__)
 
@@ -354,7 +354,7 @@ class OpenRouterLLM(OpenAILLM):
         """
         if not self._uses_deepseek_tool_protocol:
             return messages
-        return restore_deepseek_reasoning_content(messages)
+        return restore_deepseek_reasoning_content(messages, model_name=self._model_name)
 
     def _response_provider_state(
         self,
@@ -422,10 +422,42 @@ class OpenRouterLLM(OpenAILLM):
         if not self._uses_deepseek_tool_protocol:
             return super()._delta_reasoning_content(delta)
         for field_name in OPENROUTER_REASONING_FIELDS:
-            found, value = _field_content(delta, field_name)
+            found, value = field_content(delta, field_name)
             if found:
                 return True, value
         return False, None
+
+    def _check_stream_reasoning_capture(
+        self,
+        *,
+        thinking: Optional[Dict[str, Any]],
+        has_tool_calls: bool,
+        has_reasoning_content: bool,
+        observed_field_names: tuple[str, ...],
+    ) -> None:
+        """Streaming counterpart of the WARNING in ``_response_provider_state``.
+
+        Same silent-failure mode, same gate (deepseek slugs only, thinking
+        requested, response ended with tool calls), just checked over the
+        whole stream's outcome instead of one non-streaming response body:
+        if no delta ever carried a recognized reasoning field, the next
+        request in this tool chain will 400 with nothing pointing back here.
+        """
+        if (
+            self._uses_deepseek_tool_protocol
+            and has_tool_calls
+            and _thinking_requested(thinking)
+            and not has_reasoning_content
+        ):
+            logger.warning(
+                "OpenRouter deepseek model %s streamed a tool call with "
+                "thinking requested, but no reasoning content was captured "
+                "under any known field spelling %s across the stream; "
+                "observed reasoning-like keys: %s",
+                self._model_name,
+                OPENROUTER_REASONING_FIELDS,
+                observed_field_names,
+            )
 
     def _deepseek_function_prefix_retry_messages(
         self,
@@ -1017,12 +1049,17 @@ class OpenRouterLLM(OpenAILLM):
         else:
             # DeepSeek-served endpoints can default to thinking mode, and once a
             # response carries reasoning_content they require it to be replayed
-            # verbatim on the next request of a tool-call chain — which this
-            # client does not do (#1537). Keep thinking off unless the caller
-            # asks for it, matching DeepSeekLLM's default. This deliberately
-            # ignores supports_thinking_mode: the blocker is the missing
-            # replay, not model capability, so a declared thinking_mode
-            # ability must not re-enable the failing default before #1537.
+            # verbatim on the next request of a tool-call chain. That replay is
+            # implemented (_prepare_messages_for_request, _response_provider_
+            # state, _attach_reasoning_content_to_raw below), so this is no
+            # longer the reason thinking stays off by default. It stays off
+            # here anyway, matching DeepSeekLLM's own default: turning
+            # thinking on changes token cost and response shape for every
+            # DeepSeek-authored slug on this client, which is a separate call
+            # from closing the replay gap and is left for a change that makes
+            # that call explicitly (#1537). This deliberately ignores
+            # supports_thinking_mode: a declared thinking_mode ability does
+            # not flip this default on its own.
             should_disable = self._uses_deepseek_tool_protocol
             should_enable = False
 

--- a/src/xagent/core/model/chat/basic/router.py
+++ b/src/xagent/core/model/chat/basic/router.py
@@ -176,11 +176,21 @@ class RouterLLM(BaseLLM):
         # A virtual router cannot advertise one candidate's dynamic abilities.
         # The resolved per-call wrapper derives those from the selected model's
         # profile after xrouter applies any input-modality preferences.
+        configured_abilities = (
+            list(abilities) if abilities else list(_DEFAULT_ROUTER_ABILITIES)
+        )
         self._abilities = [
             ability
-            for ability in (abilities or _DEFAULT_ROUTER_ABILITIES)
+            for ability in configured_abilities
             if ability not in _UNROUTED_ROUTER_ABILITIES
         ]
+        # Kept unfiltered (unlike ``self._abilities`` above) for the
+        # ``_resolve_route`` fallback branch: that branch builds a real
+        # downstream ``OpenRouterLLM`` from a ``ChatModelConfig``, and that
+        # client's own ``vision``/``thinking_mode`` support must reflect what
+        # the user actually configured, not this virtual router's
+        # deliberately-narrowed advertised abilities.
+        self._raw_abilities = configured_abilities
         self._fallback_model = os.getenv("XAGENT_ROUTER_FALLBACK_MODEL") or None
 
     # ---- BaseLLM interface --------------------------------------------------
@@ -373,7 +383,11 @@ class RouterLLM(BaseLLM):
             default_temperature=self.default_temperature,
             default_max_tokens=self.default_max_tokens,
             timeout=self.timeout,
-            abilities=self._abilities,
+            # Unfiltered abilities (see ``self._raw_abilities``): this builds
+            # a real downstream client, not the virtual router itself, so it
+            # must not inherit the router's own vision/thinking_mode
+            # exclusion.
+            abilities=self._raw_abilities,
         )
         return model_id, create_base_llm(config)
 
@@ -589,6 +603,13 @@ class _ResolvedRouterLLM(BaseLLM):
 
     @property
     def supports_thinking_mode(self) -> bool:
+        # Reads the virtual router's own abilities, which always exclude
+        # "thinking_mode" (see ``_UNROUTED_ROUTER_ABILITIES``), so this is
+        # always False even when ``self._downstream`` (the actually resolved
+        # model) does support thinking. No caller in this repository reads
+        # this property today, so the mismatch is latent; if a caller starts
+        # relying on it, read ``self._downstream.supports_thinking_mode``
+        # instead of changing what the router itself reports.
         return self._router.supports_thinking_mode
 
     @property

--- a/src/xagent/core/model/chat/basic/xinference.py
+++ b/src/xagent/core/model/chat/basic/xinference.py
@@ -249,7 +249,9 @@ class XinferenceLLM(BaseLLM):
             LLMTimeoutError: If the request times out
         """
         # Sanitize messages
-        sanitized_messages = self._sanitize_unicode_content(messages)
+        sanitized_messages = self._sanitize_unicode_content(
+            self._strip_internal_message_keys(messages)
+        )
 
         # Build generate config
         generate_config = self._build_generate_config(
@@ -476,7 +478,9 @@ class XinferenceLLM(BaseLLM):
             LLMTimeoutError: If timeout occurs
         """
         # Sanitize messages
-        sanitized_messages = self._sanitize_unicode_content(messages)
+        sanitized_messages = self._sanitize_unicode_content(
+            self._strip_internal_message_keys(messages)
+        )
 
         # Build generate config with streaming enabled
         stream_options = dict(kwargs.pop("stream_options", {}) or {})

--- a/src/xagent/core/model/chat/basic/zhipu.py
+++ b/src/xagent/core/model/chat/basic/zhipu.py
@@ -172,7 +172,9 @@ class ZhipuLLM(BaseLLM):
         # Prepare the completion parameters
         completion_params = {
             "model": self._model_name,
-            "messages": self._sanitize_unicode_content(messages),
+            "messages": self._sanitize_unicode_content(
+                self._strip_internal_message_keys(messages)
+            ),
             "max_tokens": max_tokens or self.default_max_tokens,
             "stream": False,  # We handle streaming separately if needed
             **kwargs,
@@ -445,7 +447,9 @@ class ZhipuLLM(BaseLLM):
         # Prepare the completion parameters
         completion_params = {
             "model": self._model_name,
-            "messages": self._sanitize_unicode_content(messages),
+            "messages": self._sanitize_unicode_content(
+                self._strip_internal_message_keys(messages)
+            ),
             "max_tokens": max_tokens or self.default_max_tokens,
             "stream": True,  # Enable streaming
             **kwargs,
@@ -816,7 +820,9 @@ class ZhipuLLM(BaseLLM):
         # Prepare the completion parameters
         completion_params = {
             "model": self._model_name,
-            "messages": self._sanitize_unicode_content(messages),
+            "messages": self._sanitize_unicode_content(
+                self._strip_internal_message_keys(messages)
+            ),
             "temperature": temperature or self.default_temperature,
             "max_tokens": max_tokens or self.default_max_tokens,
             "stream": False,  # We handle streaming separately if needed

--- a/src/xagent/core/model/chat/tool_protocol.py
+++ b/src/xagent/core/model/chat/tool_protocol.py
@@ -22,6 +22,10 @@ def tool_protocol_error_response(
     *,
     raw: Any = None,
 ) -> dict[str, Any]:
+    # ``tool_calls`` is always ``[]`` here, never the violating call: callers
+    # that only persist reasoning-replay state for tool-call turns (e.g.
+    # react.py's context guard) rely on this response never looking like a
+    # tool-call turn, so a protocol violation is never mistaken for one.
     response: dict[str, Any] = {
         "type": "tool_protocol_error",
         "content": "",

--- a/src/xagent/core/model/chat/types.py
+++ b/src/xagent/core/model/chat/types.py
@@ -4,6 +4,14 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Dict, List
 
+# Message-dict key under which a provider-owned, opaque round-trip payload
+# (e.g. DeepSeek's mandatory ``reasoning_content`` replay) is stashed between
+# an LLM response and the next request that carries that message back. Lives
+# here rather than in a transport module so protocol-rule modules (e.g.
+# ``basic.deepseek_tool_protocol``) can depend on it without reaching into a
+# transport implementation module.
+PROVIDER_STATE_METADATA_KEY = "_xagent_provider_state"
+
 
 class ChunkType(Enum):
     """Streaming response chunk types"""

--- a/tests/core/model/chat/basic/test_deepseek.py
+++ b/tests/core/model/chat/basic/test_deepseek.py
@@ -1,3 +1,4 @@
+import logging
 from types import SimpleNamespace
 
 import pytest
@@ -734,6 +735,73 @@ class TestDeepSeekLLM:
 
         call_messages = mock_client.chat.completions.create.call_args.kwargs["messages"]
         assert call_messages[0]["reasoning_content"] == ""
+
+    @pytest.mark.asyncio
+    async def test_replay_logs_info_summary_of_capture_vs_fallback_counts(
+        self, llm, mock_chat_completion, mocker, caplog
+    ):
+        """Design §6's second default observation: one INFO summary per
+        request counting how many assistant tool-call messages replayed
+        real captured reasoning content versus how many hit the
+        empty-string fallback. Two of the three tool-call messages below
+        carry captured provider state; the third does not.
+        """
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.return_value = mock_chat_completion
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        def _assistant_tool_call_message(call_id, *, reasoning_content=None):
+            message = {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": call_id,
+                        "type": "function",
+                        "function": {"name": "search", "arguments": "{}"},
+                    }
+                ],
+            }
+            if reasoning_content is not None:
+                message[PROVIDER_STATE_METADATA_KEY] = {
+                    DEEPSEEK_PROVIDER_STATE_NAMESPACE: {
+                        DEEPSEEK_REASONING_CONTENT_STATE_KEY: reasoning_content
+                    }
+                }
+            return message
+
+        messages = [
+            {"role": "user", "content": "Search xagent"},
+            _assistant_tool_call_message("call_1", reasoning_content="first thought"),
+            {"role": "tool", "tool_call_id": "call_1", "content": "result 1"},
+            _assistant_tool_call_message("call_2", reasoning_content="second thought"),
+            {"role": "tool", "tool_call_id": "call_2", "content": "result 2"},
+            _assistant_tool_call_message("call_3"),
+            {"role": "tool", "tool_call_id": "call_3", "content": "result 3"},
+        ]
+
+        with caplog.at_level(
+            logging.INFO,
+            logger="xagent.core.model.chat.basic.deepseek_tool_protocol",
+        ):
+            await llm.chat(messages)
+
+        summaries = [
+            record.getMessage()
+            for record in caplog.records
+            if "reasoning replay" in record.getMessage()
+        ]
+        assert len(summaries) == 1
+        summary = summaries[0]
+        assert llm.model_name in summary
+        assert "2 assistant message(s) replayed captured reasoning content" in summary
+        assert "1 used the empty-string fallback" in summary
+        # Only counts and the model name are logged, never the captured text.
+        assert "first thought" not in summary
+        assert "second thought" not in summary
 
     @pytest.mark.asyncio
     async def test_final_answer_call_replays_empty_reasoning_content_without_tools(

--- a/tests/core/model/chat/basic/test_deepseek.py
+++ b/tests/core/model/chat/basic/test_deepseek.py
@@ -840,9 +840,24 @@ class TestDeepSeekLLM:
         token_chunks = [chunk for chunk in chunks if chunk.type == ChunkType.TOKEN]
         assert [chunk.delta for chunk in token_chunks] == ["Final answer"]
         assert token_chunks[0].raw["reasoning_content"] == "Think first."
+        # Covers the provider-state branch of ``_attach_reasoning_content_to_raw``
+        # (deepseek.py), which the assertions above never exercised: they only
+        # checked the mirrored ``reasoning_content`` field the base class also
+        # sets, not the ``_xagent_provider_state`` marker DeepSeek's own
+        # streaming override adds on top of it.
+        assert token_chunks[0].raw[PROVIDER_STATE_METADATA_KEY] == {
+            DEEPSEEK_PROVIDER_STATE_NAMESPACE: {
+                DEEPSEEK_REASONING_CONTENT_STATE_KEY: "Think first."
+            }
+        }
 
         end_chunk = next(chunk for chunk in chunks if chunk.type == ChunkType.END)
         assert end_chunk.raw["reasoning_content"] == "Think first."
+        assert end_chunk.raw[PROVIDER_STATE_METADATA_KEY] == {
+            DEEPSEEK_PROVIDER_STATE_NAMESPACE: {
+                DEEPSEEK_REASONING_CONTENT_STATE_KEY: "Think first."
+            }
+        }
 
     @pytest.mark.asyncio
     async def test_list_available_models_returns_curated_v4_models(self):

--- a/tests/core/model/chat/basic/test_deepseek_tool_protocol.py
+++ b/tests/core/model/chat/basic/test_deepseek_tool_protocol.py
@@ -9,7 +9,11 @@ from xagent.core.model.chat.basic.deepseek_tool_protocol import (
     adapt_deepseek_stream,
     normalize_deepseek_response,
 )
-from xagent.core.model.chat.tool_protocol import get_tool_protocol_error
+from xagent.core.model.chat.tool_protocol import (
+    ToolProtocolViolation,
+    get_tool_protocol_error,
+    tool_protocol_error_response,
+)
 from xagent.core.model.chat.types import ChunkType, StreamChunk
 
 
@@ -437,6 +441,27 @@ def test_deepseek_codec_bounds_original_argument_diagnostics() -> None:
     assert details["original_arguments_length"] == len(original_arguments)
     assert len(details["original_arguments_preview"]) == 4096
     assert details["original_arguments_truncated"] is True
+
+
+def test_tool_protocol_error_response_never_carries_tool_calls() -> None:
+    """A protocol-error response is never mistaken for a real tool-call turn.
+
+    react.py's guard that saves reasoning provider state only does so
+    ``if tool_calls`` (see react.py's assistant-message save point); this
+    response shape is the reason that guard never fires on a violation --
+    ``tool_calls`` is unconditionally ``[]`` here, regardless of what the
+    violating response actually contained.
+    """
+    violation = ToolProtocolViolation(
+        provider="deepseek",
+        code="malformed_tool_arguments",
+        message="DeepSeek returned malformed arguments.",
+    )
+
+    response = tool_protocol_error_response(violation, raw={"tool_calls": [{"id": 1}]})
+
+    assert response["tool_calls"] == []
+    assert response["type"] == "tool_protocol_error"
 
 
 def test_deepseek_codec_is_inactive_without_requested_tools() -> None:

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -8,12 +8,15 @@ from unittest.mock import MagicMock
 import httpx
 import openai
 import pytest
+from openai.types.chat.chat_completion_chunk import ChoiceDelta
+from pydantic import BaseModel, ConfigDict
 
 from xagent.core.model.chat.basic.base import BaseLLM
 from xagent.core.model.chat.basic.openai import (
     PROVIDER_STATE_METADATA_KEY,
     OpenAILLM,
     _format_openai_error,
+    field_content,
 )
 from xagent.core.model.chat.error import retry_on
 from xagent.core.model.chat.exceptions import LLMEmptyContentError, LLMRetryableError
@@ -1584,3 +1587,31 @@ class TestOpenAILLM:
         assert mock_client.chat.completions.create.await_count == 2
         second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
         assert "response_format" not in second_call
+
+
+class TestFieldContent:
+    """``field_content`` must not mistake a pydantic model's declared default
+    for a value the provider actually sent."""
+
+    class _MessageWithDeclaredDefault(BaseModel):
+        model_config = ConfigDict(extra="allow")
+
+        reasoning_content: str = "sdk-default-not-from-provider"
+
+    def test_field_content_ignores_a_declared_default_on_a_pydantic_model(self):
+        message = self._MessageWithDeclaredDefault()
+
+        assert field_content(message, "reasoning_content") == (False, None)
+
+    def test_field_content_reads_a_value_passed_through_model_extra(self):
+        """The real-world path: the OpenAI SDK builds response and delta
+        objects through ``construct()``, which -- unlike a normal pydantic
+        ``__init__`` -- only adds explicitly-declared fields to
+        ``model_fields_set`` and routes every unrecognized field straight to
+        ``model_extra``. ``ChoiceDelta`` doesn't declare ``reasoning_content``,
+        so this is exactly how a provider's reasoning field actually arrives
+        on a streaming delta."""
+        delta = ChoiceDelta.construct(role="assistant", reasoning_content="step 1")
+
+        assert "reasoning_content" not in delta.model_fields_set
+        assert field_content(delta, "reasoning_content") == (True, "step 1")

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -8,6 +8,10 @@ import pytest
 
 from xagent.core.model.chat.basic import openrouter as openrouter_module
 from xagent.core.model.chat.basic.base import BaseLLM
+from xagent.core.model.chat.basic.deepseek_tool_protocol import (
+    DEEPSEEK_PROVIDER_STATE_NAMESPACE,
+    DEEPSEEK_REASONING_CONTENT_STATE_KEY,
+)
 from xagent.core.model.chat.basic.openai import OpenAILLM
 from xagent.core.model.chat.basic.openrouter import OpenRouterLLM
 from xagent.core.model.chat.error import retry_on
@@ -19,7 +23,11 @@ from xagent.core.model.chat.tool_protocol import (
     TOOL_PROTOCOL_ERROR_KEY,
     get_tool_protocol_error,
 )
-from xagent.core.model.chat.types import ChunkType, StreamChunk
+from xagent.core.model.chat.types import (
+    PROVIDER_STATE_METADATA_KEY,
+    ChunkType,
+    StreamChunk,
+)
 from xagent.core.retry.strategy import FixedDelay
 from xagent.core.retry.wrapper import create_retry_wrapper
 
@@ -2012,3 +2020,813 @@ async def test_openrouter_deepseek_stream_no_op_thinking_default_propagates(mock
             pass
 
     assert calls == 1
+
+
+# ---------------------------------------------------------------------------
+# DeepSeek reasoning-content replay on OpenRouter (issue #1537, PR-1).
+#
+# These cover the shared capture/replay mechanism now wired into
+# OpenRouterLLM via ``deepseek_tool_protocol``'s shared functions. Naming
+# follows the design's invariant table (I-1 .. I-12, I-18, I-19); I-13/I-14
+# live in test_deepseek.py (unchanged direct-DeepSeek coverage), I-15 is the
+# existing test_openai.py negative test, and I-16/I-17 (PR-2, default
+# thinking) are out of scope here.
+# ---------------------------------------------------------------------------
+
+
+def _deepseek_provider_state(reasoning_content: object) -> dict:
+    return {
+        DEEPSEEK_PROVIDER_STATE_NAMESPACE: {
+            DEEPSEEK_REASONING_CONTENT_STATE_KEY: reasoning_content
+        }
+    }
+
+
+def _openrouter_tool_call_response(
+    *,
+    reasoning_content: object = "unset",
+    raw_message_extra: dict | None = None,
+    tool_name: str = "search",
+) -> SimpleNamespace:
+    tool_call = SimpleNamespace(
+        id="call_1",
+        type="function",
+        function=SimpleNamespace(name=tool_name, arguments="{}"),
+    )
+    message_kwargs: dict = {"content": None, "tool_calls": [tool_call]}
+    if reasoning_content != "unset":
+        message_kwargs["reasoning_content"] = reasoning_content
+    message = SimpleNamespace(**message_kwargs)
+    raw_message = dict(raw_message_extra or {})
+    raw = {
+        "id": "openrouter-deepseek",
+        "choices": [{"message": raw_message}],
+    }
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message)],
+        usage=None,
+        model_dump=lambda: raw,
+    )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_captures_reasoning_provider_state(mocker):
+    """I-1: a deepseek-slug tool-call response captures reasoning_content."""
+    response = _openrouter_tool_call_response(
+        reasoning_content="Use the search tool first"
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = response
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+
+    result = await llm.chat(
+        [{"role": "user", "content": "Search xagent"}],
+        tools=_single_tool_schema("search"),
+        thinking={"type": "enabled"},
+    )
+
+    assert result[PROVIDER_STATE_METADATA_KEY] == _deepseek_provider_state(
+        "Use the search tool first"
+    )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_captures_empty_reasoning_content(mocker):
+    """I-2: an explicit empty-string reasoning_content is still captured."""
+    response = _openrouter_tool_call_response(reasoning_content="")
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = response
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+
+    result = await llm.chat(
+        [{"role": "user", "content": "Search xagent"}],
+        tools=_single_tool_schema("search"),
+        thinking={"type": "enabled"},
+    )
+
+    assert result[PROVIDER_STATE_METADATA_KEY] == _deepseek_provider_state("")
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_captures_reasoning_alias_from_raw(mocker):
+    """I-3: the ``reasoning`` alias is captured from the raw response body
+    when the SDK message object never surfaced ``reasoning_content`` at all.
+
+    This is the defensive-merge branch from the design's V4 decision (no
+    live OpenRouter response was available to confirm which spelling a
+    deepseek slug actually sends).
+    """
+    response = _openrouter_tool_call_response(
+        reasoning_content="unset",
+        raw_message_extra={"reasoning": "alt-spelling-thinking"},
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = response
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+
+    result = await llm.chat(
+        [{"role": "user", "content": "Search xagent"}],
+        tools=_single_tool_schema("search"),
+        thinking={"type": "enabled"},
+    )
+
+    # The base class's own message-level mirrors never fired (the SDK
+    # message object had no ``reasoning_content`` attribute at all) -- only
+    # the provider-state capture, which additionally consults raw, sees it.
+    assert "reasoning_content" not in result
+    assert result[PROVIDER_STATE_METADATA_KEY] == _deepseek_provider_state(
+        "alt-spelling-thinking"
+    )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_replays_reasoning_content(
+    mocker, mock_chat_completion
+):
+    """I-4: captured provider state is translated back to ``reasoning_content``
+    on the next request, and the internal marker never reaches the wire.
+    """
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = mock_chat_completion
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+    messages = [
+        {"role": "user", "content": "Search xagent"},
+        {
+            "role": "assistant",
+            "content": "",
+            PROVIDER_STATE_METADATA_KEY: _deepseek_provider_state("prior thought"),
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+    ]
+
+    await llm.chat(messages)
+
+    call_messages = mock_client.chat.completions.create.call_args.kwargs["messages"]
+    assert call_messages[1]["reasoning_content"] == "prior thought"
+    assert PROVIDER_STATE_METADATA_KEY not in call_messages[1]
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_replays_empty_reasoning_fallback(
+    mocker, mock_chat_completion
+):
+    """I-5: an assistant tool-call message with no captured state gets the
+    empty-string fallback so the history stays structurally valid.
+    """
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = mock_chat_completion
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+    messages = [
+        {"role": "user", "content": "Search xagent"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+    ]
+
+    await llm.chat(messages)
+
+    call_messages = mock_client.chat.completions.create.call_args.kwargs["messages"]
+    assert call_messages[1]["reasoning_content"] == ""
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_replays_when_thinking_disabled(
+    mocker, mock_chat_completion
+):
+    """I-6: replay happens regardless of this call's own thinking setting."""
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = mock_chat_completion
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+    messages = [
+        {"role": "user", "content": "Search xagent"},
+        {
+            "role": "assistant",
+            "content": "",
+            PROVIDER_STATE_METADATA_KEY: _deepseek_provider_state("prior thought"),
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+    ]
+
+    await llm.chat(messages, thinking={"type": "disabled"})
+
+    call_messages = mock_client.chat.completions.create.call_args.kwargs["messages"]
+    assert call_messages[1]["reasoning_content"] == "prior thought"
+
+
+def _reasoning_delta_chunk(
+    *,
+    reasoning_content: object = None,
+    reasoning: object = "unset",
+    finish_reason: object = None,
+) -> SimpleNamespace:
+    delta_kwargs: dict = {
+        "content": None,
+        "tool_calls": None,
+        "reasoning_content": reasoning_content,
+    }
+    if reasoning != "unset":
+        delta_kwargs["reasoning"] = reasoning
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(**delta_kwargs),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=None,
+        model_dump=lambda: {"id": "reasoning-delta"},
+    )
+
+
+def _tool_call_delta_chunk(
+    *,
+    call_id: object,
+    index: int,
+    name: object = None,
+    arguments: str = "",
+    finish_reason: object = None,
+) -> SimpleNamespace:
+    tool_call = SimpleNamespace(
+        id=call_id,
+        index=index,
+        function=SimpleNamespace(name=name, arguments=arguments),
+    )
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                delta=SimpleNamespace(
+                    content=None,
+                    tool_calls=[tool_call],
+                    reasoning_content=None,
+                ),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=None,
+        model_dump=lambda: {"id": "tool-call-delta"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_stream_captures_reasoning_provider_state(mocker):
+    """I-7: streamed reasoning content accumulates onto the tool-call chunk's
+    raw payload as captured provider state.
+    """
+
+    async def stream():
+        yield _reasoning_delta_chunk(reasoning_content="Think first.")
+        yield _tool_call_delta_chunk(
+            call_id="call_1",
+            index=0,
+            name="search",
+            arguments='{"query":"xagent"}',
+            finish_reason="tool_calls",
+        )
+
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = stream()
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+
+    chunks = [
+        chunk
+        async for chunk in llm.stream_chat(
+            [{"role": "user", "content": "Search xagent"}],
+            tools=_single_tool_schema("search"),
+        )
+    ]
+
+    tool_chunks = [chunk for chunk in chunks if chunk.is_tool_call()]
+    assert tool_chunks, "expected at least one tool-call chunk"
+    assert tool_chunks[-1].raw[PROVIDER_STATE_METADATA_KEY] == (
+        _deepseek_provider_state("Think first.")
+    )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_stream_captures_reasoning_alias_delta(mocker):
+    """Streaming counterpart of I-3: a delta using the ``reasoning`` alias
+    (never ``reasoning_content``) must still be captured -- this is the
+    branch ``_delta_reasoning_content``'s override exists for; the base
+    class's own delta check only ever recognizes ``reasoning_content``.
+    """
+
+    async def stream():
+        yield _reasoning_delta_chunk(reasoning_content=None, reasoning="Alt thinking.")
+        yield _tool_call_delta_chunk(
+            call_id="call_1",
+            index=0,
+            name="search",
+            arguments='{"query":"xagent"}',
+            finish_reason="tool_calls",
+        )
+
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = stream()
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+
+    chunks = [
+        chunk
+        async for chunk in llm.stream_chat(
+            [{"role": "user", "content": "Search xagent"}],
+            tools=_single_tool_schema("search"),
+        )
+    ]
+
+    tool_chunks = [chunk for chunk in chunks if chunk.is_tool_call()]
+    assert tool_chunks, "expected at least one tool-call chunk"
+    assert tool_chunks[-1].raw[PROVIDER_STATE_METADATA_KEY] == (
+        _deepseek_provider_state("Alt thinking.")
+    )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_stream_provider_state_survives_tool_truncation(
+    mocker,
+):
+    """I-8: when the protocol adapter withholds a partial-looking argument
+    tail (``_safe_streaming_tool_chunk``'s ``dataclasses.replace``), the
+    truncated chunk it immediately yields still carries the captured
+    provider state -- ``replace()`` only rewrites ``tool_calls``, never
+    ``raw``.
+    """
+
+    async def stream():
+        yield _reasoning_delta_chunk(reasoning_content="Think first.")
+        # The tail ``<dsml`` looks like the start of DeepSeek's serialized
+        # tool-call marker (see ``_PARTIAL_MARKER_TARGET``), so the adapter
+        # withholds it from this chunk instead of passing it through.
+        yield _tool_call_delta_chunk(
+            call_id="call_1", index=0, name="search", arguments='{"query":"xa<dsml'
+        )
+        yield _tool_call_delta_chunk(
+            call_id=None, index=0, arguments='ing"}', finish_reason="tool_calls"
+        )
+
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = stream()
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+
+    chunks = [
+        chunk
+        async for chunk in llm.stream_chat(
+            [{"role": "user", "content": "Search xagent"}],
+            tools=_single_tool_schema("search"),
+        )
+    ]
+
+    tool_chunks = [chunk for chunk in chunks if chunk.is_tool_call()]
+    assert tool_chunks, "expected at least one tool-call chunk"
+    assert all(
+        chunk.raw[PROVIDER_STATE_METADATA_KEY]
+        == _deepseek_provider_state("Think first.")
+        for chunk in tool_chunks
+    )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_default_first_turn_request_is_byte_identical(
+    mocker, mock_chat_completion
+):
+    """PR-1 must not change anything about the request OpenRouter already
+    sends today for the untouched default (thinking left unset, i.e.
+    ``thinking=None``, which still renders disabled -- that is PR-2's
+    concern, not this one's).
+
+    A first turn with no prior assistant tool-call message is the case
+    where the new ``_prepare_messages_for_request`` override has nothing to
+    rewrite (``restore_deepseek_reasoning_content`` only touches assistant
+    messages that already have ``tool_calls``): every message here is
+    exactly what was sent before this PR, and ``extra_body`` renders the
+    same disabled payload ``_prepare_provider_reasoning_extra_body``
+    produced before (that function is untouched by PR-1). This is the
+    concrete request-level counterpart of A-5's no-op-comparison reasoning
+    in the design and of the existing
+    ``test_openrouter_deepseek_defaults_to_disabled_thinking`` extra_body
+    check.
+    """
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = mock_chat_completion
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+
+    await llm.chat([{"role": "user", "content": "Hello"}])
+
+    call_kwargs = mock_client.chat.completions.create.call_args.kwargs
+    assert call_kwargs["messages"] == [{"role": "user", "content": "Hello"}]
+    assert call_kwargs["extra_body"] == {
+        "reasoning": {"enabled": False},
+        "thinking": {"type": "disabled"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_openrouter_non_deepseek_does_not_capture_or_replay_reasoning(mocker):
+    """I-9: a non-deepseek slug is untouched by any of the three hooks --
+    no capture (checked here against a response that *does* carry
+    reasoning_content on a tool call, so the gate is actually exercised, not
+    vacuously true because the response has nothing to capture), no replay,
+    and an upstream-supplied internal marker is still stripped by the shared
+    base-class sanitization (not by anything new here).
+    """
+    response = _openrouter_tool_call_response(
+        reasoning_content="should never be captured for this model"
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = response
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="anthropic/claude-sonnet-4.6", api_key="test-key")
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            PROVIDER_STATE_METADATA_KEY: _deepseek_provider_state("stale"),
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+    ]
+
+    result = await llm.chat(
+        messages, tools=_single_tool_schema("search"), thinking={"type": "enabled"}
+    )
+
+    call_messages = mock_client.chat.completions.create.call_args.kwargs["messages"]
+    assert PROVIDER_STATE_METADATA_KEY not in call_messages[0]
+    assert "reasoning_content" not in call_messages[0]
+    assert PROVIDER_STATE_METADATA_KEY not in result
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_round_trips_reasoning_across_two_calls(
+    mocker, mock_chat_completion
+):
+    """I-10: a full two-call chain -- capture on the first response, replay
+    of that exact content on the assistant history sent in the second call.
+    """
+    first_response = _openrouter_tool_call_response(
+        reasoning_content="Search first, then answer."
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = first_response
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+
+    first_result = await llm.chat(
+        [{"role": "user", "content": "Search xagent"}],
+        tools=_single_tool_schema("search"),
+        thinking={"type": "enabled"},
+    )
+
+    second_messages = [
+        {"role": "user", "content": "Search xagent"},
+        {
+            "role": "assistant",
+            "content": "",
+            PROVIDER_STATE_METADATA_KEY: first_result[PROVIDER_STATE_METADATA_KEY],
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "found it"},
+    ]
+    mock_client.chat.completions.create.return_value = mock_chat_completion
+
+    await llm.chat(second_messages, tools=_single_tool_schema("search"))
+
+    second_call_messages = mock_client.chat.completions.create.call_args.kwargs[
+        "messages"
+    ]
+    assert second_call_messages[1]["reasoning_content"] == "Search first, then answer."
+    assert PROVIDER_STATE_METADATA_KEY not in second_call_messages[1]
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_replays_reasoning_after_mandatory_reasoning_retry(
+    mocker, mock_chat_completion
+):
+    """I-11: after the enable-thinking compat retry recovers a mandatory-
+    reasoning 400, the captured content from that recovered call replays
+    correctly on a later request -- the #1621 "known boundary" this PR
+    closes.
+    """
+    first_response = _openrouter_tool_call_response(
+        reasoning_content="Reasoned after enabling thinking."
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        RuntimeError(
+            "OpenRouter bad request (400): reasoning is mandatory for this "
+            "model and cannot be disabled"
+        ),
+        first_response,
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+
+    result = await llm.chat(
+        [{"role": "user", "content": "Search xagent"}],
+        tools=_single_tool_schema("search"),
+    )
+
+    assert mock_client.chat.completions.create.await_count == 2
+    assert result[PROVIDER_STATE_METADATA_KEY] == _deepseek_provider_state(
+        "Reasoned after enabling thinking."
+    )
+
+    mock_client.chat.completions.create.side_effect = None
+    mock_client.chat.completions.create.return_value = mock_chat_completion
+
+    second_messages = [
+        {"role": "user", "content": "Search xagent"},
+        {
+            "role": "assistant",
+            "content": "",
+            PROVIDER_STATE_METADATA_KEY: result[PROVIDER_STATE_METADATA_KEY],
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "found it"},
+    ]
+    await llm.chat(second_messages, tools=_single_tool_schema("search"))
+
+    second_call_messages = mock_client.chat.completions.create.call_args.kwargs[
+        "messages"
+    ]
+    assert (
+        second_call_messages[1]["reasoning_content"]
+        == "Reasoned after enabling thinking."
+    )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_prefix_retry_preserves_provider_state(
+    mocker, mock_chat_completion
+):
+    """I-12: the prefix-stripping retry's ``dict(message)`` shallow copy
+    (``_strip_assistant_tool_call_prefixes``) keeps the provider-state
+    marker, so the retried request still replays reasoning correctly.
+    """
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        RuntimeError(openrouter_module._DEEPSEEK_FUNCTION_PREFIX_ERROR),
+        mock_chat_completion,
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+    messages = [
+        {"role": "user", "content": "Search xagent"},
+        {
+            "role": "assistant",
+            "content": "stray prefix text",
+            PROVIDER_STATE_METADATA_KEY: _deepseek_provider_state("prior thought"),
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+    ]
+
+    await llm.chat(messages, tools=_single_tool_schema("search"))
+
+    assert mock_client.chat.completions.create.await_count == 2
+    retried_messages = mock_client.chat.completions.create.call_args.kwargs["messages"]
+    assert retried_messages[1]["reasoning_content"] == "prior thought"
+    assert retried_messages[1]["content"] == ""
+    assert PROVIDER_STATE_METADATA_KEY not in retried_messages[1]
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_vision_captures_reasoning_provider_state(mocker):
+    """I-18: vision_chat inherits capture for free -- no deepseek-specific
+    override targets vision_chat, only the shared hooks the base class
+    already calls from both entrypoints.
+    """
+    response = _openrouter_tool_call_response(
+        reasoning_content="Looking at the image first."
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = response
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "vision"],
+    )
+
+    result = await llm.vision_chat(
+        [{"role": "user", "content": [{"type": "text", "text": "what is this?"}]}],
+        thinking={"type": "enabled"},
+    )
+
+    assert result[PROVIDER_STATE_METADATA_KEY] == _deepseek_provider_state(
+        "Looking at the image first."
+    )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_vision_replays_reasoning_content(
+    mocker, mock_chat_completion
+):
+    """I-19: vision_chat replays captured reasoning under the exact same
+    namespace/key as ``chat`` -- this is one shared mechanism, not two.
+    """
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = mock_chat_completion
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "vision"],
+    )
+    messages = [
+        {"role": "user", "content": [{"type": "text", "text": "what is this?"}]},
+        {
+            "role": "assistant",
+            "content": "",
+            PROVIDER_STATE_METADATA_KEY: _deepseek_provider_state("prior thought"),
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+    ]
+
+    # Replay does not look at whether thinking is enabled for this call.
+    await llm.vision_chat(messages, thinking={"type": "disabled"})
+
+    call_messages = mock_client.chat.completions.create.call_args.kwargs["messages"]
+    assert call_messages[1]["reasoning_content"] == "prior thought"
+    assert PROVIDER_STATE_METADATA_KEY not in call_messages[1]
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_warns_when_capture_misses_all_known_spellings(
+    mocker, caplog
+):
+    """V2-6: the WARNING that fires when thinking was requested, the
+    response is a tool call, but neither known reasoning spelling was
+    captured -- must only report key names via ``reasoning_field_names``,
+    never reasoning content.
+    """
+    import logging
+
+    response = _openrouter_tool_call_response(reasoning_content="unset")
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = response
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.model.chat.basic.openrouter"
+    ):
+        await llm.chat(
+            [{"role": "user", "content": "Search xagent"}],
+            tools=_single_tool_schema("search"),
+            thinking={"type": "enabled"},
+        )
+
+    assert any(
+        "no reasoning content was captured" in record.message
+        for record in caplog.records
+    )
+    assert not any("Search xagent" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_no_warning_when_thinking_not_requested(
+    mocker, caplog
+):
+    """The empty-capture WARNING must not fire on the ordinary path where
+    thinking was never requested (the current PR-1 default for every
+    deepseek slug): an empty capture there is expected, not a spelling-drift
+    signal, and this is also the highest-traffic path today -- misfiring
+    here would make the warning noise, not signal.
+    """
+    import logging
+
+    response = _openrouter_tool_call_response(reasoning_content="unset")
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = response
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.model.chat.basic.openrouter"
+    ):
+        await llm.chat(
+            [{"role": "user", "content": "Search xagent"}],
+            tools=_single_tool_schema("search"),
+        )
+
+    assert not any(
+        "no reasoning content was captured" in record.message
+        for record in caplog.records
+    )

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -2443,6 +2443,63 @@ async def test_openrouter_deepseek_stream_provider_state_survives_tool_truncatio
 
 
 @pytest.mark.asyncio
+async def test_openrouter_deepseek_stream_replays_reasoning_content(mocker):
+    """Streaming counterpart of I-4 (``test_openrouter_deepseek_replays_
+    reasoning_content``): ``stream_chat`` runs through the same
+    ``_build_request_messages`` / ``_prepare_messages_for_request`` path as
+    ``chat``, so captured provider state on a prior assistant tool-call
+    message must be translated back to ``reasoning_content`` on the request
+    the stream entry point actually sends, not just on the non-streaming
+    entry point.
+    """
+
+    async def stream():
+        yield _tool_call_delta_chunk(
+            call_id="call_2",
+            index=0,
+            name="search",
+            arguments='{"query":"xagent"}',
+            finish_reason="tool_calls",
+        )
+
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = stream()
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+    messages = [
+        {"role": "user", "content": "Search xagent"},
+        {
+            "role": "assistant",
+            "content": "",
+            PROVIDER_STATE_METADATA_KEY: _deepseek_provider_state("prior thought"),
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+    ]
+
+    chunks = [
+        chunk
+        async for chunk in llm.stream_chat(
+            messages, tools=_single_tool_schema("search")
+        )
+    ]
+
+    assert chunks, "expected at least one streamed chunk"
+    call_messages = mock_client.chat.completions.create.call_args.kwargs["messages"]
+    assert call_messages[1]["reasoning_content"] == "prior thought"
+    assert PROVIDER_STATE_METADATA_KEY not in call_messages[1]
+
+
+@pytest.mark.asyncio
 async def test_openrouter_deepseek_default_first_turn_request_is_byte_identical(
     mocker, mock_chat_completion
 ):
@@ -2826,6 +2883,104 @@ async def test_openrouter_deepseek_no_warning_when_thinking_not_requested(
             tools=_single_tool_schema("search"),
         )
 
+    assert not any(
+        "no reasoning content was captured" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_stream_warns_when_capture_misses_all_known_spellings(
+    mocker, caplog
+):
+    """Streaming counterpart of
+    ``test_openrouter_deepseek_warns_when_capture_misses_all_known_spellings``:
+    the non-streaming WARNING in ``_response_provider_state`` has no
+    streaming equivalent before this test -- ``_check_stream_reasoning_
+    capture`` closes that gap. Same gate, checked over the whole stream
+    instead of one response body: thinking requested, the stream ends with
+    a tool call, but no delta ever carried a recognized reasoning field.
+    """
+    import logging
+
+    async def stream():
+        yield _tool_call_delta_chunk(
+            call_id="call_1",
+            index=0,
+            name="search",
+            arguments='{"query":"xagent"}',
+            finish_reason="tool_calls",
+        )
+
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = stream()
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.model.chat.basic.openrouter"
+    ):
+        chunks = [
+            chunk
+            async for chunk in llm.stream_chat(
+                [{"role": "user", "content": "Search xagent"}],
+                tools=_single_tool_schema("search"),
+                thinking={"type": "enabled"},
+            )
+        ]
+
+    assert chunks
+    assert any(
+        "no reasoning content was captured" in record.message
+        for record in caplog.records
+    )
+    assert not any("Search xagent" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_stream_no_warning_when_thinking_not_requested(
+    mocker, caplog
+):
+    """Streaming counterpart of
+    ``test_openrouter_deepseek_no_warning_when_thinking_not_requested``: an
+    empty capture is expected (not a spelling-drift signal) on the ordinary
+    path where thinking was never requested -- the current PR-1 default for
+    every deepseek slug, and the highest-traffic streaming path today.
+    """
+    import logging
+
+    async def stream():
+        yield _tool_call_delta_chunk(
+            call_id="call_1",
+            index=0,
+            name="search",
+            arguments='{"query":"xagent"}',
+            finish_reason="tool_calls",
+        )
+
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = stream()
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.model.chat.basic.openrouter"
+    ):
+        chunks = [
+            chunk
+            async for chunk in llm.stream_chat(
+                [{"role": "user", "content": "Search xagent"}],
+                tools=_single_tool_schema("search"),
+            )
+        ]
+
+    assert chunks
     assert not any(
         "no reasoning content was captured" in record.message
         for record in caplog.records

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -2824,12 +2824,17 @@ async def test_openrouter_deepseek_warns_when_capture_misses_all_known_spellings
 ):
     """V2-6: the WARNING that fires when thinking was requested, the
     response is a tool call, but neither known reasoning spelling was
-    captured -- must only report key names via ``reasoning_field_names``,
-    never reasoning content.
+    captured -- must report the unrecognized key names it did observe
+    (its entire diagnostic value), never reasoning content.
     """
     import logging
 
-    response = _openrouter_tool_call_response(reasoning_content="unset")
+    response = _openrouter_tool_call_response(
+        reasoning_content="unset",
+        raw_message_extra={
+            "reasoning_details": [{"type": "reasoning.text", "text": "SECRET-THOUGHT"}]
+        },
+    )
     mock_client = mocker.AsyncMock()
     mock_client.chat.completions.create.return_value = response
     mocker.patch(
@@ -2847,11 +2852,16 @@ async def test_openrouter_deepseek_warns_when_capture_misses_all_known_spellings
             thinking={"type": "enabled"},
         )
 
-    assert any(
-        "no reasoning content was captured" in record.message
+    warning_messages = [
+        record.getMessage()
         for record in caplog.records
-    )
-    assert not any("Search xagent" in record.message for record in caplog.records)
+        if "no reasoning content was captured" in record.message
+    ]
+    assert warning_messages
+    assert any("reasoning_details" in message for message in warning_messages)
+    for record in caplog.records:
+        assert "SECRET-THOUGHT" not in record.getMessage()
+        assert "Search xagent" not in record.getMessage()
 
 
 @pytest.mark.asyncio
@@ -2904,13 +2914,17 @@ async def test_openrouter_deepseek_stream_warns_when_capture_misses_all_known_sp
     import logging
 
     async def stream():
-        yield _tool_call_delta_chunk(
+        chunk = _tool_call_delta_chunk(
             call_id="call_1",
             index=0,
             name="search",
             arguments='{"query":"xagent"}',
             finish_reason="tool_calls",
         )
+        chunk.choices[0].delta.reasoning_details = [
+            {"type": "reasoning.text", "text": "SECRET-THOUGHT"}
+        ]
+        yield chunk
 
     mock_client = mocker.AsyncMock()
     mock_client.chat.completions.create.return_value = stream()
@@ -2933,11 +2947,16 @@ async def test_openrouter_deepseek_stream_warns_when_capture_misses_all_known_sp
         ]
 
     assert chunks
-    assert any(
-        "no reasoning content was captured" in record.message
+    warning_messages = [
+        record.getMessage()
         for record in caplog.records
-    )
-    assert not any("Search xagent" in record.message for record in caplog.records)
+        if "no reasoning content was captured" in record.message
+    ]
+    assert warning_messages
+    assert any("reasoning_details" in message for message in warning_messages)
+    for record in caplog.records:
+        assert "SECRET-THOUGHT" not in record.getMessage()
+        assert "Search xagent" not in record.getMessage()
 
 
 @pytest.mark.asyncio
@@ -2977,6 +2996,50 @@ async def test_openrouter_deepseek_stream_no_warning_when_thinking_not_requested
             async for chunk in llm.stream_chat(
                 [{"role": "user", "content": "Search xagent"}],
                 tools=_single_tool_schema("search"),
+            )
+        ]
+
+    assert chunks
+    assert not any(
+        "no reasoning content was captured" in record.message
+        for record in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_non_deepseek_stream_no_capture_warning(mocker, caplog):
+    """The streaming capture sentinel is gated on deepseek-authored slugs:
+    a non-deepseek model streaming a tool call with thinking requested and
+    no reasoning field is that provider's normal shape, not spelling drift.
+    """
+    import logging
+
+    async def stream():
+        yield _tool_call_delta_chunk(
+            call_id="call_1",
+            index=0,
+            name="search",
+            arguments='{"query":"xagent"}',
+            finish_reason="tool_calls",
+        )
+
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = stream()
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="openai/gpt-5.6-sol", api_key="test-key")
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.model.chat.basic.openrouter"
+    ):
+        chunks = [
+            chunk
+            async for chunk in llm.stream_chat(
+                [{"role": "user", "content": "Search xagent"}],
+                tools=_single_tool_schema("search"),
+                thinking={"type": "enabled"},
             )
         ]
 

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -2791,6 +2791,7 @@ async def test_openrouter_deepseek_vision_captures_reasoning_provider_state(mock
 
     result = await llm.vision_chat(
         [{"role": "user", "content": [{"type": "text", "text": "what is this?"}]}],
+        tools=_single_tool_schema("search"),
         thinking={"type": "enabled"},
     )
 
@@ -2927,6 +2928,76 @@ async def test_openrouter_deepseek_no_warning_when_thinking_not_requested(
         "no reasoning content was captured" in record.message
         for record in caplog.records
     )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_no_capture_warning_after_thinking_disabled_retry(
+    mocker, caplog
+):
+    """The capture-miss WARNING judges each attempt by that attempt's own
+    thinking configuration.
+
+    ``chat`` retries once with thinking disabled when a structured-output
+    request came back as non-JSON while thinking was on. That retry really
+    does ask for no thinking, so an empty reasoning capture on its response
+    is the expected outcome -- not the silent-failure mode this warning
+    exists to report. Judging the retry by the first attempt's "thinking
+    enabled" would print a warning that sends a reader looking for a
+    renamed provider field that is not there.
+    """
+    import logging
+
+    non_json_message = SimpleNamespace(
+        content="Here is the answer, but it is not JSON.",
+        tool_calls=None,
+        reasoning_content="Thinking about the schema first.",
+    )
+    thinking_on_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=non_json_message)],
+        usage=None,
+        model_dump=lambda: {"id": "openrouter-deepseek-non-json"},
+    )
+    thinking_off_response = _openrouter_tool_call_response(reasoning_content="unset")
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        thinking_on_response,
+        thinking_off_response,
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "thinking_mode"],
+    )
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.model.chat.basic.openrouter"
+    ):
+        result = await llm.chat(
+            [{"role": "user", "content": "Search xagent"}],
+            tools=_single_tool_schema("search"),
+            response_format={"type": "json_object"},
+            thinking={"type": "enabled"},
+        )
+
+    # The retry really did go out with thinking off -- otherwise this test
+    # would be asserting silence on a request that never changed.
+    assert mock_client.chat.completions.create.await_count == 2
+    retry_extra_body = mock_client.chat.completions.create.call_args.kwargs[
+        "extra_body"
+    ]
+    assert retry_extra_body["thinking"] == {"type": "disabled"}
+    assert retry_extra_body["reasoning"] == {"enabled": False}
+    assert result["type"] == "tool_call"
+
+    assert not [
+        record.message
+        for record in caplog.records
+        if "no reasoning content was captured" in record.message
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -2023,14 +2023,15 @@ async def test_openrouter_deepseek_stream_no_op_thinking_default_propagates(mock
 
 
 # ---------------------------------------------------------------------------
-# DeepSeek reasoning-content replay on OpenRouter (issue #1537, PR-1).
+# DeepSeek reasoning-content replay on OpenRouter (issue #1537).
 #
 # These cover the shared capture/replay mechanism now wired into
-# OpenRouterLLM via ``deepseek_tool_protocol``'s shared functions. Naming
-# follows the design's invariant table (I-1 .. I-12, I-18, I-19); I-13/I-14
-# live in test_deepseek.py (unchanged direct-DeepSeek coverage), I-15 is the
-# existing test_openai.py negative test, and I-16/I-17 (PR-2, default
-# thinking) are out of scope here.
+# OpenRouterLLM via ``deepseek_tool_protocol``'s shared functions. The
+# direct-DeepSeek side of that same mechanism keeps its own coverage in
+# test_deepseek.py, and test_openai.py holds the negative case pinning that
+# a plain OpenAI-compatible client captures nothing. Whether thinking should
+# default to enabled for deepseek slugs is a separate question and is not
+# decided by any test here.
 # ---------------------------------------------------------------------------
 
 
@@ -2071,7 +2072,7 @@ def _openrouter_tool_call_response(
 
 @pytest.mark.asyncio
 async def test_openrouter_deepseek_captures_reasoning_provider_state(mocker):
-    """I-1: a deepseek-slug tool-call response captures reasoning_content."""
+    """A deepseek-slug tool-call response captures reasoning_content."""
     response = _openrouter_tool_call_response(
         reasoning_content="Use the search tool first"
     )
@@ -2096,7 +2097,11 @@ async def test_openrouter_deepseek_captures_reasoning_provider_state(mocker):
 
 @pytest.mark.asyncio
 async def test_openrouter_deepseek_captures_empty_reasoning_content(mocker):
-    """I-2: an explicit empty-string reasoning_content is still captured."""
+    """An explicit empty-string reasoning_content is still captured.
+
+    An empty string is a value the provider sent, not a missing field, so
+    it must round-trip like any other captured content.
+    """
     response = _openrouter_tool_call_response(reasoning_content="")
     mock_client = mocker.AsyncMock()
     mock_client.chat.completions.create.return_value = response
@@ -2117,12 +2122,13 @@ async def test_openrouter_deepseek_captures_empty_reasoning_content(mocker):
 
 @pytest.mark.asyncio
 async def test_openrouter_deepseek_captures_reasoning_alias_from_raw(mocker):
-    """I-3: the ``reasoning`` alias is captured from the raw response body
+    """The ``reasoning`` alias is captured from the raw response body
     when the SDK message object never surfaced ``reasoning_content`` at all.
 
-    This is the defensive-merge branch from the design's V4 decision (no
-    live OpenRouter response was available to confirm which spelling a
-    deepseek slug actually sends).
+    Capture checks both spellings on purpose: no live OpenRouter response
+    was available to confirm which one a deepseek slug actually sends, so
+    the raw body is consulted as a fallback for whichever spelling the
+    transport layer did not already normalize.
     """
     response = _openrouter_tool_call_response(
         reasoning_content="unset",
@@ -2155,7 +2161,7 @@ async def test_openrouter_deepseek_captures_reasoning_alias_from_raw(mocker):
 async def test_openrouter_deepseek_replays_reasoning_content(
     mocker, mock_chat_completion
 ):
-    """I-4: captured provider state is translated back to ``reasoning_content``
+    """Captured provider state is translated back to ``reasoning_content``
     on the next request, and the internal marker never reaches the wire.
     """
     mock_client = mocker.AsyncMock()
@@ -2193,7 +2199,7 @@ async def test_openrouter_deepseek_replays_reasoning_content(
 async def test_openrouter_deepseek_replays_empty_reasoning_fallback(
     mocker, mock_chat_completion
 ):
-    """I-5: an assistant tool-call message with no captured state gets the
+    """An assistant tool-call message with no captured state gets the
     empty-string fallback so the history stays structurally valid.
     """
     mock_client = mocker.AsyncMock()
@@ -2229,7 +2235,12 @@ async def test_openrouter_deepseek_replays_empty_reasoning_fallback(
 async def test_openrouter_deepseek_replays_when_thinking_disabled(
     mocker, mock_chat_completion
 ):
-    """I-6: replay happens regardless of this call's own thinking setting."""
+    """Replay happens regardless of this call's own thinking setting.
+
+    What the provider requires back is the reasoning content it produced
+    earlier in this tool chain, so whether thinking is requested again on
+    the current call cannot gate the replay.
+    """
     mock_client = mocker.AsyncMock()
     mock_client.chat.completions.create.return_value = mock_chat_completion
     mocker.patch(
@@ -2316,7 +2327,7 @@ def _tool_call_delta_chunk(
 
 @pytest.mark.asyncio
 async def test_openrouter_deepseek_stream_captures_reasoning_provider_state(mocker):
-    """I-7: streamed reasoning content accumulates onto the tool-call chunk's
+    """Streamed reasoning content accumulates onto the tool-call chunk's
     raw payload as captured provider state.
     """
 
@@ -2355,10 +2366,12 @@ async def test_openrouter_deepseek_stream_captures_reasoning_provider_state(mock
 
 @pytest.mark.asyncio
 async def test_openrouter_deepseek_stream_captures_reasoning_alias_delta(mocker):
-    """Streaming counterpart of I-3: a delta using the ``reasoning`` alias
-    (never ``reasoning_content``) must still be captured -- this is the
-    branch ``_delta_reasoning_content``'s override exists for; the base
-    class's own delta check only ever recognizes ``reasoning_content``.
+    """A streamed delta using the ``reasoning`` alias is captured too.
+
+    A delta that carries the alias and never ``reasoning_content`` must
+    still be recognized -- this is the branch ``_delta_reasoning_content``'s
+    override exists for, since the base class's own delta check only ever
+    recognizes ``reasoning_content``.
     """
 
     async def stream():
@@ -2398,11 +2411,13 @@ async def test_openrouter_deepseek_stream_captures_reasoning_alias_delta(mocker)
 async def test_openrouter_deepseek_stream_provider_state_survives_tool_truncation(
     mocker,
 ):
-    """I-8: when the protocol adapter withholds a partial-looking argument
-    tail (``_safe_streaming_tool_chunk``'s ``dataclasses.replace``), the
-    truncated chunk it immediately yields still carries the captured
-    provider state -- ``replace()`` only rewrites ``tool_calls``, never
-    ``raw``.
+    """Withholding a partial-looking argument tail preserves captured state.
+
+    When the protocol adapter holds back a tail that looks like the start of
+    a serialized tool-call marker (``_safe_streaming_tool_chunk``'s
+    ``dataclasses.replace``), the truncated chunk it yields in that moment
+    must still carry the captured provider state -- ``replace()`` only
+    rewrites ``tool_calls``, never ``raw``.
     """
 
     async def stream():
@@ -2444,13 +2459,13 @@ async def test_openrouter_deepseek_stream_provider_state_survives_tool_truncatio
 
 @pytest.mark.asyncio
 async def test_openrouter_deepseek_stream_replays_reasoning_content(mocker):
-    """Streaming counterpart of I-4 (``test_openrouter_deepseek_replays_
-    reasoning_content``): ``stream_chat`` runs through the same
-    ``_build_request_messages`` / ``_prepare_messages_for_request`` path as
-    ``chat``, so captured provider state on a prior assistant tool-call
-    message must be translated back to ``reasoning_content`` on the request
-    the stream entry point actually sends, not just on the non-streaming
-    entry point.
+    """``stream_chat``'s outbound request replays captured reasoning too.
+
+    ``stream_chat`` runs through the same ``_build_request_messages`` /
+    ``_prepare_messages_for_request`` path as ``chat``, so captured provider
+    state on a prior assistant tool-call message must be translated back to
+    ``reasoning_content`` on the request the streaming entry point actually
+    sends, not only on the non-streaming one.
     """
 
     async def stream():
@@ -2503,22 +2518,20 @@ async def test_openrouter_deepseek_stream_replays_reasoning_content(mocker):
 async def test_openrouter_deepseek_default_first_turn_request_is_byte_identical(
     mocker, mock_chat_completion
 ):
-    """PR-1 must not change anything about the request OpenRouter already
-    sends today for the untouched default (thinking left unset, i.e.
-    ``thinking=None``, which still renders disabled -- that is PR-2's
-    concern, not this one's).
+    """The default first-turn request is unchanged by reasoning replay.
 
-    A first turn with no prior assistant tool-call message is the case
-    where the new ``_prepare_messages_for_request`` override has nothing to
-    rewrite (``restore_deepseek_reasoning_content`` only touches assistant
-    messages that already have ``tool_calls``): every message here is
-    exactly what was sent before this PR, and ``extra_body`` renders the
-    same disabled payload ``_prepare_provider_reasoning_extra_body``
-    produced before (that function is untouched by PR-1). This is the
-    concrete request-level counterpart of A-5's no-op-comparison reasoning
-    in the design and of the existing
-    ``test_openrouter_deepseek_defaults_to_disabled_thinking`` extra_body
-    check.
+    With thinking left unset (``thinking=None``, which still renders
+    disabled) and no prior assistant tool-call message in the history, the
+    ``_prepare_messages_for_request`` override has nothing to rewrite --
+    ``restore_deepseek_reasoning_content`` only touches assistant messages
+    that already carry ``tool_calls``. So every message on the wire is
+    exactly what this client sent before replay existed, and ``extra_body``
+    renders the same disabled payload, because
+    ``_prepare_provider_reasoning_extra_body`` is not modified.
+
+    This is the request-level counterpart of the ``extra_body`` check in
+    ``test_openrouter_deepseek_defaults_to_disabled_thinking``: that one
+    pins the rendered reasoning payload, this one pins the whole request.
     """
     mock_client = mocker.AsyncMock()
     mock_client.chat.completions.create.return_value = mock_chat_completion
@@ -2540,12 +2553,14 @@ async def test_openrouter_deepseek_default_first_turn_request_is_byte_identical(
 
 @pytest.mark.asyncio
 async def test_openrouter_non_deepseek_does_not_capture_or_replay_reasoning(mocker):
-    """I-9: a non-deepseek slug is untouched by any of the three hooks --
-    no capture (checked here against a response that *does* carry
-    reasoning_content on a tool call, so the gate is actually exercised, not
-    vacuously true because the response has nothing to capture), no replay,
-    and an upstream-supplied internal marker is still stripped by the shared
-    base-class sanitization (not by anything new here).
+    """A non-deepseek slug is untouched by any of the three hooks.
+
+    No capture, no replay, and an upstream-supplied internal marker is still
+    stripped by the shared base-class sanitization rather than by anything
+    added here. The response used below deliberately *does* carry
+    reasoning_content on a tool call, so the model-name gate is actually
+    exercised instead of passing vacuously on a response with nothing to
+    capture.
     """
     response = _openrouter_tool_call_response(
         reasoning_content="should never be captured for this model"
@@ -2587,8 +2602,11 @@ async def test_openrouter_non_deepseek_does_not_capture_or_replay_reasoning(mock
 async def test_openrouter_deepseek_round_trips_reasoning_across_two_calls(
     mocker, mock_chat_completion
 ):
-    """I-10: a full two-call chain -- capture on the first response, replay
-    of that exact content on the assistant history sent in the second call.
+    """A full two-call chain captures then replays the same content.
+
+    Reasoning content is captured from the first response and replayed
+    verbatim on the assistant history sent in the second call -- the
+    end-to-end behavior the provider's 400 demands.
     """
     first_response = _openrouter_tool_call_response(
         reasoning_content="Search first, then answer."
@@ -2638,10 +2656,13 @@ async def test_openrouter_deepseek_round_trips_reasoning_across_two_calls(
 async def test_openrouter_deepseek_replays_reasoning_after_mandatory_reasoning_retry(
     mocker, mock_chat_completion
 ):
-    """I-11: after the enable-thinking compat retry recovers a mandatory-
-    reasoning 400, the captured content from that recovered call replays
-    correctly on a later request -- the #1621 "known boundary" this PR
-    closes.
+    """Reasoning captured by the enable-thinking retry replays later.
+
+    When the compat retry turns thinking on to recover a mandatory-reasoning
+    400, the content captured from that recovered call must replay correctly
+    on a later request. Recovering the first call was already possible; the
+    second call in the same tool chain used to fail anyway, and this pins
+    that it no longer does.
     """
     first_response = _openrouter_tool_call_response(
         reasoning_content="Reasoned after enabling thinking."
@@ -2704,9 +2725,11 @@ async def test_openrouter_deepseek_replays_reasoning_after_mandatory_reasoning_r
 async def test_openrouter_deepseek_prefix_retry_preserves_provider_state(
     mocker, mock_chat_completion
 ):
-    """I-12: the prefix-stripping retry's ``dict(message)`` shallow copy
-    (``_strip_assistant_tool_call_prefixes``) keeps the provider-state
-    marker, so the retried request still replays reasoning correctly.
+    """The prefix-stripping retry keeps the provider-state marker.
+
+    ``_strip_assistant_tool_call_prefixes`` rebuilds messages through a
+    ``dict(message)`` shallow copy, which must carry the provider-state
+    marker along so the retried request still replays reasoning correctly.
     """
     mock_client = mocker.AsyncMock()
     mock_client.chat.completions.create.side_effect = [
@@ -2746,9 +2769,10 @@ async def test_openrouter_deepseek_prefix_retry_preserves_provider_state(
 
 @pytest.mark.asyncio
 async def test_openrouter_deepseek_vision_captures_reasoning_provider_state(mocker):
-    """I-18: vision_chat inherits capture for free -- no deepseek-specific
-    override targets vision_chat, only the shared hooks the base class
-    already calls from both entrypoints.
+    """``vision_chat`` inherits reasoning capture with no vision-specific code.
+
+    Nothing here overrides ``vision_chat`` itself; capture works because the
+    base class calls the same shared hooks from both entrypoints.
     """
     response = _openrouter_tool_call_response(
         reasoning_content="Looking at the image first."
@@ -2779,8 +2803,10 @@ async def test_openrouter_deepseek_vision_captures_reasoning_provider_state(mock
 async def test_openrouter_deepseek_vision_replays_reasoning_content(
     mocker, mock_chat_completion
 ):
-    """I-19: vision_chat replays captured reasoning under the exact same
-    namespace/key as ``chat`` -- this is one shared mechanism, not two.
+    """``vision_chat`` replays captured reasoning exactly as ``chat`` does.
+
+    Both entrypoints read the same namespace and key, because this is one
+    shared mechanism rather than two parallel implementations.
     """
     mock_client = mocker.AsyncMock()
     mock_client.chat.completions.create.return_value = mock_chat_completion
@@ -2822,10 +2848,13 @@ async def test_openrouter_deepseek_vision_replays_reasoning_content(
 async def test_openrouter_deepseek_warns_when_capture_misses_all_known_spellings(
     mocker, caplog
 ):
-    """V2-6: the WARNING that fires when thinking was requested, the
-    response is a tool call, but neither known reasoning spelling was
-    captured -- must report the unrecognized key names it did observe
-    (its entire diagnostic value), never reasoning content.
+    """The capture-miss WARNING names the keys it saw, never their content.
+
+    It fires when thinking was requested and the response is a tool call but
+    neither known reasoning spelling was captured. Naming the unrecognized
+    keys it did observe is the warning's entire diagnostic value, since that
+    is what identifies a renamed provider field; the values behind those
+    keys must never reach a log line.
     """
     import logging
 
@@ -2868,11 +2897,12 @@ async def test_openrouter_deepseek_warns_when_capture_misses_all_known_spellings
 async def test_openrouter_deepseek_no_warning_when_thinking_not_requested(
     mocker, caplog
 ):
-    """The empty-capture WARNING must not fire on the ordinary path where
-    thinking was never requested (the current PR-1 default for every
-    deepseek slug): an empty capture there is expected, not a spelling-drift
-    signal, and this is also the highest-traffic path today -- misfiring
-    here would make the warning noise, not signal.
+    """The capture-miss WARNING stays silent when thinking was not requested.
+
+    Thinking is off by default for every deepseek slug, so this is the
+    highest-traffic path today. An empty capture there is the expected
+    outcome rather than a sign that the provider renamed its reasoning
+    field, and warning about it would turn the signal into noise.
     """
     import logging
 
@@ -2963,11 +2993,13 @@ async def test_openrouter_deepseek_stream_warns_when_capture_misses_all_known_sp
 async def test_openrouter_deepseek_stream_no_warning_when_thinking_not_requested(
     mocker, caplog
 ):
-    """Streaming counterpart of
+    """The streaming capture-miss WARNING is silent without thinking too.
+
+    Same rule as
     ``test_openrouter_deepseek_no_warning_when_thinking_not_requested``: an
-    empty capture is expected (not a spelling-drift signal) on the ordinary
-    path where thinking was never requested -- the current PR-1 default for
-    every deepseek slug, and the highest-traffic streaming path today.
+    empty capture is the expected outcome, not a sign of a renamed provider
+    field, on the path where thinking was never requested -- off by default
+    for every deepseek slug, and the highest-traffic streaming path today.
     """
     import logging
 

--- a/tests/core/model/chat/basic/test_provider_state_stripping.py
+++ b/tests/core/model/chat/basic/test_provider_state_stripping.py
@@ -165,15 +165,17 @@ _STRIP_GUARD_COVERED: frozenset[type] = frozenset(
 # for them rather than merely untested:
 _STRIP_GUARD_EXEMPT: dict[type, str] = {
     OpenAICompatibleLLM: (
-        "intermediate base for the OpenAI-protocol clients above; never "
-        "constructed directly as a provider, so it has no wire request of "
-        "its own to check."
+        "intermediate base that implements the stripping call itself; never "
+        "constructed directly as a provider, and its behavior is covered "
+        "transitively by the five registered concrete subclasses above -- "
+        "removing the stripping call turns their tests red."
     ),
     RouterLLM: (
         "the virtual auto-router: chat/vision_chat/stream_chat resolve a "
         "downstream BaseLLM and forward the same message list object to it "
-        "unchanged (see router.py); it never reads or copies a message "
-        "dict itself, so the downstream client's own guard is what runs."
+        "unchanged (see router.py); it reads message content for routing "
+        "but never constructs any provider-bound message dict itself, so "
+        "the downstream client's own guard is what runs."
     ),
     _ResolvedRouterLLM: (
         "a thin per-call wrapper around one resolved downstream client; "

--- a/tests/core/model/chat/basic/test_provider_state_stripping.py
+++ b/tests/core/model/chat/basic/test_provider_state_stripping.py
@@ -1,0 +1,119 @@
+"""Repository-level coverage for one shared invariant across non-OpenAI
+chat clients: no ``_xagent_``-prefixed internal message key ever reaches a
+provider's wire request.
+
+``_strip_internal_message_keys`` (now on ``BaseLLM``, see basic/base.py) is
+the mechanism for clients that forward a message dict's keys mostly
+unchanged (Zhipu, Xinference). Claude and Gemini take a different, equally
+valid path to the same result: their message-conversion functions rebuild
+each provider message field-by-field and never copy a message dict
+wholesale, so an internal key is simply never read in the first place. Each
+check below asserts the *result* (no leaked key), not the mechanism, so a
+provider that later switches mechanisms without breaking the outcome does
+not need this file to change.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xagent.core.model.chat.basic.claude import ClaudeLLM
+from xagent.core.model.chat.basic.gemini import GeminiLLM
+from xagent.core.model.chat.basic.xinference import XinferenceLLM
+from xagent.core.model.chat.basic.zhipu import ZhipuLLM
+from xagent.core.model.chat.types import PROVIDER_STATE_METADATA_KEY
+
+_MARKED_HISTORY: list[dict[str, Any]] = [
+    {"role": "user", "content": "Search xagent"},
+    {
+        "role": "assistant",
+        "content": "",
+        PROVIDER_STATE_METADATA_KEY: {"deepseek": {"reasoning_content": "prior"}},
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "search", "arguments": "{}"},
+            }
+        ],
+    },
+    {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+]
+
+
+def _assert_no_internal_keys(messages: list[dict[str, Any]]) -> None:
+    for message in messages:
+        for key in message:
+            assert not key.startswith("_xagent_"), (
+                f"leaked internal key {key!r} in outbound message {message!r}"
+            )
+
+
+def test_claude_message_conversion_drops_internal_keys(claude_llm_config):
+    """Claude: safety comes from rebuilding each message field-by-field, not
+    from an explicit strip call -- see the comment in
+    ``_convert_messages_to_anthropic_format``.
+    """
+    llm = ClaudeLLM(**claude_llm_config)
+
+    _system, anthropic_messages = llm._convert_messages_to_anthropic_format(
+        _MARKED_HISTORY
+    )
+
+    _assert_no_internal_keys(anthropic_messages)
+
+
+def test_gemini_message_conversion_drops_internal_keys(gemini_llm_config):
+    """Gemini: same field-by-field rebuild guarantee as Claude."""
+    llm = GeminiLLM(**gemini_llm_config)
+
+    _system, gemini_messages = llm._convert_messages_to_gemini_format(_MARKED_HISTORY)
+
+    _assert_no_internal_keys(gemini_messages)
+
+
+@pytest.mark.asyncio
+async def test_zhipu_chat_strips_internal_keys_before_the_sdk_call(mocker):
+    """Zhipu: forwards message dicts close to unchanged, so it needs (and
+    now has) an explicit ``_strip_internal_message_keys`` call.
+    """
+    mock_response = mocker.MagicMock()
+    mock_response.choices = [mocker.MagicMock()]
+    mock_response.choices[0].message.tool_calls = None
+    mock_response.choices[0].message.content = "done"
+    mock_response.usage = None
+    mock_client = mocker.MagicMock()
+    mock_client.chat.completions.create.return_value = mock_response
+    mocker.patch(
+        "xagent.core.model.chat.basic.zhipu.ZhipuAiClient",
+        return_value=mock_client,
+    )
+    llm = ZhipuLLM(api_key="test-key")
+
+    await llm.chat(_MARKED_HISTORY)
+
+    sent_messages = mock_client.chat.completions.create.call_args.kwargs["messages"]
+    _assert_no_internal_keys(sent_messages)
+
+
+@pytest.mark.asyncio
+async def test_xinference_chat_strips_internal_keys_before_the_sdk_call(mocker):
+    """Xinference: same wholesale-forwarding shape as Zhipu, same fix."""
+
+    class _ModelHandle:
+        async def chat(self, **kwargs: Any):
+            self.received_messages = kwargs["messages"]
+            return {
+                "choices": [{"message": {"content": "done"}, "finish_reason": "stop"}]
+            }
+
+    llm = XinferenceLLM(model_name="qwen3.8")
+    handle = _ModelHandle()
+    llm._client = mocker.MagicMock()
+    llm._model_handle = handle
+
+    await llm.chat(_MARKED_HISTORY)
+
+    _assert_no_internal_keys(handle.received_messages)

--- a/tests/core/model/chat/basic/test_provider_state_stripping.py
+++ b/tests/core/model/chat/basic/test_provider_state_stripping.py
@@ -109,6 +109,55 @@ async def test_zhipu_chat_strips_internal_keys_before_the_sdk_call(mocker):
 
 
 @pytest.mark.asyncio
+async def test_zhipu_vision_chat_strips_internal_keys_before_the_sdk_call(mocker):
+    """Zhipu: ``vision_chat`` assembles its own request instead of delegating
+    to ``chat``, so it carries its own strip call and needs its own check.
+    Registering the class once is not the same as exercising each entrypoint.
+    """
+    mock_response = mocker.MagicMock()
+    mock_response.choices = [mocker.MagicMock()]
+    mock_response.choices[0].message.tool_calls = None
+    mock_response.choices[0].message.content = "done"
+    mock_response.usage = None
+    mock_client = mocker.MagicMock()
+    mock_client.chat.completions.create.return_value = mock_response
+    mocker.patch(
+        "xagent.core.model.chat.basic.zhipu.ZhipuAiClient",
+        return_value=mock_client,
+    )
+    llm = ZhipuLLM(
+        model_name="glm-4.5v",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "vision"],
+    )
+
+    await llm.vision_chat(_MARKED_HISTORY)
+
+    sent_messages = mock_client.chat.completions.create.call_args.kwargs["messages"]
+    _assert_no_internal_keys(sent_messages)
+
+
+@pytest.mark.asyncio
+async def test_zhipu_stream_chat_strips_internal_keys_before_the_sdk_call(mocker):
+    """Zhipu: ``stream_chat`` is the third entrypoint that builds its own
+    request, on a separate producer-thread code path from ``chat``.
+    """
+    mock_client = mocker.MagicMock()
+    mock_client.chat.completions.create.return_value = []
+    mocker.patch(
+        "xagent.core.model.chat.basic.zhipu.ZhipuAiClient",
+        return_value=mock_client,
+    )
+    llm = ZhipuLLM(api_key="test-key")
+
+    async for _chunk in llm.stream_chat(_MARKED_HISTORY):
+        pass
+
+    sent_messages = mock_client.chat.completions.create.call_args.kwargs["messages"]
+    _assert_no_internal_keys(sent_messages)
+
+
+@pytest.mark.asyncio
 async def test_xinference_chat_strips_internal_keys_before_the_sdk_call(mocker):
     """Xinference: same wholesale-forwarding shape as Zhipu, same fix."""
 
@@ -125,6 +174,37 @@ async def test_xinference_chat_strips_internal_keys_before_the_sdk_call(mocker):
     llm._model_handle = handle
 
     await llm.chat(_MARKED_HISTORY)
+
+    _assert_no_internal_keys(handle.received_messages)
+
+
+@pytest.mark.asyncio
+async def test_xinference_stream_chat_strips_internal_keys_before_the_sdk_call(mocker):
+    """Xinference: ``stream_chat`` is a second wholesale-forwarding path with
+    its own strip call. ``vision_chat`` needs no separate check here -- it
+    delegates straight to ``chat`` (see xinference.py) rather than building
+    a request of its own.
+    """
+
+    class _EmptyStream:
+        def __aiter__(self) -> "_EmptyStream":
+            return self
+
+        async def __anext__(self) -> Any:
+            raise StopAsyncIteration
+
+    class _StreamHandle:
+        async def chat(self, **kwargs: Any) -> _EmptyStream:
+            self.received_messages = kwargs["messages"]
+            return _EmptyStream()
+
+    llm = XinferenceLLM(model_name="qwen3.8")
+    handle = _StreamHandle()
+    llm._client = mocker.MagicMock()
+    llm._model_handle = handle
+
+    async for _chunk in llm.stream_chat(_MARKED_HISTORY):
+        pass
 
     _assert_no_internal_keys(handle.received_messages)
 

--- a/tests/core/model/chat/basic/test_provider_state_stripping.py
+++ b/tests/core/model/chat/basic/test_provider_state_stripping.py
@@ -15,12 +15,22 @@ not need this file to change.
 
 from __future__ import annotations
 
+import importlib
+import pkgutil
 from typing import Any
 
 import pytest
 
+import xagent.core.model.chat.basic as basic_pkg
+from xagent.core.model.chat.basic.azure_openai import AzureOpenAILLM
+from xagent.core.model.chat.basic.base import BaseLLM
 from xagent.core.model.chat.basic.claude import ClaudeLLM
+from xagent.core.model.chat.basic.dashscope import DashScopeLLM
+from xagent.core.model.chat.basic.deepseek import DeepSeekLLM
 from xagent.core.model.chat.basic.gemini import GeminiLLM
+from xagent.core.model.chat.basic.openai import OpenAICompatibleLLM, OpenAILLM
+from xagent.core.model.chat.basic.openrouter import OpenRouterLLM
+from xagent.core.model.chat.basic.router import RouterLLM, _ResolvedRouterLLM
 from xagent.core.model.chat.basic.xinference import XinferenceLLM
 from xagent.core.model.chat.basic.zhipu import ZhipuLLM
 from xagent.core.model.chat.types import PROVIDER_STATE_METADATA_KEY
@@ -117,3 +127,115 @@ async def test_xinference_chat_strips_internal_keys_before_the_sdk_call(mocker):
     await llm.chat(_MARKED_HISTORY)
 
     _assert_no_internal_keys(handle.received_messages)
+
+
+# --- Discovery guard: every BaseLLM subclass must be accounted for ---------
+#
+# The tests above cover four clients by name. That list goes stale silently
+# the moment a new BaseLLM subclass is added and nobody remembers to give it
+# the same coverage. The two registries and the test below turn that into a
+# loud failure: every concrete BaseLLM subclass found anywhere under
+# ``xagent.core.model.chat.basic`` must appear in one of them, or the
+# discovery test fails and names the class that is missing.
+
+# Classes with a dedicated leak-guard test, here or elsewhere:
+#   - ClaudeLLM / GeminiLLM / ZhipuLLM / XinferenceLLM: the four tests above.
+#   - OpenAILLM: test_openai.py::test_internal_xagent_message_keys_are_stripped
+#     exercises _build_request_messages -> _strip_internal_message_keys
+#     directly.
+#   - DeepSeekLLM / OpenRouterLLM / AzureOpenAILLM / DashScopeLLM: none of
+#     these override _prepare_messages_for_request's sanitization step or
+#     _strip_internal_message_keys, so they run OpenAILLM's own
+#     _build_request_messages unchanged and are covered by the same test.
+_STRIP_GUARD_COVERED: frozenset[type] = frozenset(
+    {
+        ClaudeLLM,
+        GeminiLLM,
+        ZhipuLLM,
+        XinferenceLLM,
+        OpenAILLM,
+        DeepSeekLLM,
+        OpenRouterLLM,
+        AzureOpenAILLM,
+        DashScopeLLM,
+    }
+)
+
+# Classes deliberately excluded, with why leaking is structurally impossible
+# for them rather than merely untested:
+_STRIP_GUARD_EXEMPT: dict[type, str] = {
+    OpenAICompatibleLLM: (
+        "intermediate base for the OpenAI-protocol clients above; never "
+        "constructed directly as a provider, so it has no wire request of "
+        "its own to check."
+    ),
+    RouterLLM: (
+        "the virtual auto-router: chat/vision_chat/stream_chat resolve a "
+        "downstream BaseLLM and forward the same message list object to it "
+        "unchanged (see router.py); it never reads or copies a message "
+        "dict itself, so the downstream client's own guard is what runs."
+    ),
+    _ResolvedRouterLLM: (
+        "a thin per-call wrapper around one resolved downstream client; "
+        "same reasoning as RouterLLM above."
+    ),
+}
+
+
+def _all_basellm_subclasses() -> set[type]:
+    """Recursively discover every production BaseLLM subclass registered so far.
+
+    Imports every module under ``xagent.core.model.chat.basic`` first, so a
+    subclass defined in a module nothing else in this test file happens to
+    import still gets registered on ``BaseLLM.__subclasses__()`` before the
+    walk below runs.
+
+    ``BaseLLM.__subclasses__()`` is a process-wide registry: it also picks up
+    test-double subclasses defined inside other test modules once pytest has
+    collected them (e.g. a scripted fake LLM used to exercise the router).
+    Those are excluded by module, not by name, since this file has no way to
+    tell "a fake used only in one test" from "a real provider" other than
+    where the class is defined: only classes whose ``__module__`` lives
+    under ``xagent.core.model.chat.basic`` itself count as production
+    clients this guard is responsible for.
+    """
+    for _, module_name, _ in pkgutil.iter_modules(basic_pkg.__path__):
+        importlib.import_module(f"{basic_pkg.__name__}.{module_name}")
+
+    discovered: set[type] = set()
+
+    def _walk(cls: type) -> None:
+        for subclass in cls.__subclasses__():
+            if subclass in discovered:
+                continue
+            discovered.add(subclass)
+            _walk(subclass)
+
+    _walk(BaseLLM)
+    _production_prefix = f"{basic_pkg.__name__}."
+    return {
+        subclass
+        for subclass in discovered
+        if subclass.__module__.startswith(_production_prefix)
+    }
+
+
+def test_every_basellm_subclass_is_accounted_for_by_the_strip_guard():
+    """A newly added BaseLLM subclass with no leak-guard coverage must fail
+    here, not go unnoticed. This test does not re-verify the four dedicated
+    tests' outcome (they already do); it only verifies that every subclass
+    that exists is *known* to one of the two registries above.
+    """
+    discovered = _all_basellm_subclasses()
+    unaccounted = discovered - _STRIP_GUARD_COVERED - set(_STRIP_GUARD_EXEMPT)
+
+    assert not unaccounted, (
+        "New BaseLLM subclass(es) with no _xagent_ leak-guard coverage: "
+        f"{sorted(cls.__qualname__ for cls in unaccounted)}. Add a "
+        "dedicated test asserting no '_xagent_'-prefixed message key "
+        "reaches this client's wire request (see the ClaudeLLM/ZhipuLLM "
+        "tests above for the two known-good shapes) and add the class to "
+        "_STRIP_GUARD_COVERED, or if it never reads/copies a message dict "
+        "itself, add it to _STRIP_GUARD_EXEMPT with a comment explaining "
+        "why."
+    )

--- a/tests/core/model/chat/basic/test_router.py
+++ b/tests/core/model/chat/basic/test_router.py
@@ -23,7 +23,11 @@ from xagent.core.model.chat.basic.router import (
 )
 from xagent.core.model.chat.error import retry_on
 from xagent.core.model.chat.exceptions import LLMToolProtocolError
-from xagent.core.model.chat.types import ChunkType, StreamChunk
+from xagent.core.model.chat.types import (
+    PROVIDER_STATE_METADATA_KEY,
+    ChunkType,
+    StreamChunk,
+)
 from xagent.core.retry.strategy import FixedDelay
 from xagent.core.retry.wrapper import create_retry_wrapper
 
@@ -714,3 +718,128 @@ async def test_sandwiched_deepseek_prefix_sanitizes_messages_once(monkeypatch, m
     # sanitized success: the sanitized messages carry over across compat
     # iterations, so the prefix rejection never fires a second time.
     assert mock_client.chat.completions.create.await_count == 3
+
+
+# ---------------------------------------------------------------------------
+# ``_resolve_route``'s fallback branch (no injected ``downstream_resolver``):
+# the abilities passed to the ``ChatModelConfig`` it builds must be the
+# caller's original configuration, not ``RouterLLM._abilities`` (which always
+# excludes vision/thinking_mode -- see ``_UNROUTED_ROUTER_ABILITIES`` -- since
+# a virtual router cannot claim a candidate's dynamic abilities before
+# routing picks one). See the design's V2-2/V3 attack: before this fix, a
+# user-declared ``thinking_mode``/``vision`` ability was silently dropped
+# from the actually-constructed downstream client on this branch.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_router_fallback_downstream_supports_thinking_mode_matches_configured_abilities(
+    monkeypatch,
+):
+    router = RouterLLM(
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "thinking_mode"],
+    )
+    monkeypatch.setattr(router, "_select_model", _select_deepseek)
+
+    model_id, downstream = await router._resolve_route(
+        [{"role": "user", "content": "hi"}]
+    )
+
+    assert model_id == "deepseek/deepseek-v4-flash"
+    # The router's own advertised abilities never include thinking_mode...
+    assert router.supports_thinking_mode is False
+    # ...but the downstream client the fallback branch actually built must
+    # still see it, because that is what the user configured.
+    assert downstream.supports_thinking_mode is True
+
+
+@pytest.mark.asyncio
+async def test_router_fallback_downstream_has_ability_vision_matches_configured_abilities(
+    monkeypatch,
+):
+    router = RouterLLM(
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "vision"],
+    )
+    monkeypatch.setattr(router, "_select_model", _select_deepseek)
+
+    _model_id, downstream = await router._resolve_route(
+        [{"role": "user", "content": "hi"}]
+    )
+
+    assert router.has_ability("vision") is False
+    assert downstream.has_ability("vision") is True
+
+
+@pytest.mark.asyncio
+async def test_router_auto_fallback_vision_deepseek_round_trips_reasoning(
+    monkeypatch, mocker
+):
+    """I-20: auto routing's fallback branch, picking a deepseek model, on a
+    vision-input call -- the whole combination must still run end-to-end and
+    reasoning capture must still fire. This is the concrete scenario V2-1's
+    "vision inherits capture for free" and V2-2's "fallback abilities fix"
+    combine into: a user with an image in the conversation, no explicit
+    model chosen, routed by "auto" to a deepseek slug, on the code path with
+    no injected downstream_resolver.
+    """
+    tool_call = SimpleNamespace(
+        id="call_1",
+        type="function",
+        function=SimpleNamespace(name="search", arguments="{}"),
+    )
+    message = SimpleNamespace(
+        content=None,
+        tool_calls=[tool_call],
+        reasoning_content="Looking at the picture first.",
+    )
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=message)],
+        usage=None,
+        model_dump=lambda: {"id": "auto-fallback-vision-deepseek"},
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = response
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+
+    async def select_deepseek(_prompt: str, **_kwargs: Any) -> str:
+        return "deepseek/deepseek-v4-flash"
+
+    router = RouterLLM(
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "vision", "thinking_mode"],
+    )
+    monkeypatch.setattr(router, "_select_model", select_deepseek)
+    monkeypatch.setattr(router, "_profile_context_window", lambda _model_id: None)
+    monkeypatch.setattr(
+        RouterLLM,
+        "_profile_input_modalities",
+        staticmethod(lambda _model_id: ("image",)),
+    )
+
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "what is in this image?"},
+                {"type": "image_url", "image_url": {"url": "data:image/png;base64,x"}},
+            ],
+        }
+    ]
+
+    prepared = await router.prepare_for_call(messages)
+    # xrouter's profile reports this model supports the image modality, so
+    # the resolved wrapper's own abilities pick up "vision" too (separate
+    # from the fallback-construction fix above, but both must hold for this
+    # combined scenario to actually reach vision_chat successfully).
+    assert prepared.has_ability("vision") is True
+
+    result = await prepared.vision_chat(messages, thinking={"type": "enabled"})
+
+    assert result[PROVIDER_STATE_METADATA_KEY] == {
+        "deepseek": {"reasoning_content": "Looking at the picture first."}
+    }

--- a/tests/core/model/chat/basic/test_router.py
+++ b/tests/core/model/chat/basic/test_router.py
@@ -840,7 +840,11 @@ async def test_router_auto_fallback_vision_deepseek_round_trips_reasoning(
     # combined scenario to actually reach vision_chat successfully).
     assert prepared.has_ability("vision") is True
 
-    result = await prepared.vision_chat(messages, thinking={"type": "enabled"})
+    result = await prepared.vision_chat(
+        messages,
+        tools=[_tool_schema()],
+        thinking={"type": "enabled"},
+    )
 
     assert result[PROVIDER_STATE_METADATA_KEY] == {
         "deepseek": {"reasoning_content": "Looking at the picture first."}

--- a/tests/core/model/chat/basic/test_router.py
+++ b/tests/core/model/chat/basic/test_router.py
@@ -726,9 +726,9 @@ async def test_sandwiched_deepseek_prefix_sanitizes_messages_once(monkeypatch, m
 # caller's original configuration, not ``RouterLLM._abilities`` (which always
 # excludes vision/thinking_mode -- see ``_UNROUTED_ROUTER_ABILITIES`` -- since
 # a virtual router cannot claim a candidate's dynamic abilities before
-# routing picks one). See the design's V2-2/V3 attack: before this fix, a
-# user-declared ``thinking_mode``/``vision`` ability was silently dropped
-# from the actually-constructed downstream client on this branch.
+# routing picks one). Before this fix, a user-declared
+# ``thinking_mode``/``vision`` ability was silently dropped from the
+# actually-constructed downstream client on this branch.
 # ---------------------------------------------------------------------------
 
 
@@ -776,13 +776,15 @@ async def test_router_fallback_downstream_has_ability_vision_matches_configured_
 async def test_router_auto_fallback_vision_deepseek_round_trips_reasoning(
     monkeypatch, mocker
 ):
-    """I-20: auto routing's fallback branch, picking a deepseek model, on a
-    vision-input call -- the whole combination must still run end-to-end and
-    reasoning capture must still fire. This is the concrete scenario V2-1's
-    "vision inherits capture for free" and V2-2's "fallback abilities fix"
-    combine into: a user with an image in the conversation, no explicit
-    model chosen, routed by "auto" to a deepseek slug, on the code path with
-    no injected downstream_resolver.
+    """Auto routing to a deepseek model on a vision call still captures reasoning.
+
+    This is where two separate behaviors meet: ``vision_chat`` inheriting
+    reasoning capture, and the fallback branch building its downstream
+    client from the caller's configured abilities. The combination is a real
+    user situation -- an image in the conversation, no explicit model
+    chosen, routed by "auto" to a deepseek slug, on the code path with no
+    injected ``downstream_resolver`` -- so it must run end-to-end with
+    capture firing.
     """
     tool_call = SimpleNamespace(
         id="call_1",


### PR DESCRIPTION
Part of #1537.

DeepSeek's API requires that once a response carries `reasoning_content`, that exact
field is replayed on the corresponding assistant message of the next request in a
tool-call chain. `DeepSeekLLM` did this; `OpenRouterLLM` did not, so a DeepSeek-authored
slug served through OpenRouter with thinking enabled failed the second turn of every
tool-call chain with `400: The reasoning_content in the thinking mode must be passed
back to the API`.

This change extracts the mechanism out of `DeepSeekLLM` and wires it into
`OpenRouterLLM`. The default-disable in `_prepare_provider_reasoning_extra_body`
(added by #1532) is deliberately untouched here — flipping it changes token cost and
response shape for every DeepSeek-authored slug, so it is left to a change that makes
that call explicitly. The comment on that branch is rewritten, because it used to say
replay was unimplemented, which is no longer true.

This also closes the "Known boundary (DeepSeek reasoning replay)" that #1621 called out:
its compat retry got the first call of a mandatory-reasoning endpoint to succeed, but
the second call in a tool chain still failed.

### Behavior changes

**Reasoning replay on OpenRouter**

- `OpenRouterLLM` now implements the three DeepSeek-protocol hooks
  (`_response_provider_state`, `_prepare_messages_for_request`,
  `_attach_reasoning_content_to_raw`), gated on the model name's author segment —
  the same gate every other DeepSeek-protocol branch on this class already uses.
  A non-deepseek slug's request-building and response-capture paths are unchanged.
- Capture is defensive: no live OpenRouter response was available to confirm which
  field spelling a deepseek slug actually returns, so both `reasoning_content` and the
  documented `reasoning` alias are checked, consulting the raw response body as a
  fallback for whichever spelling the transport layer did not already normalize.
  Streaming gets the same widening through a new `_delta_reasoning_content` hook.
  Replay always writes `reasoning_content`, the field name DeepSeek's own 400 names.
- `vision_chat` inherits capture and replay with no vision-specific code.

**Shared mechanism**

- `deepseek_reasoning_provider_state`, `restore_deepseek_reasoning_content` and
  `reasoning_field_names` move into `deepseek_tool_protocol.py` as provider-agnostic
  functions. `DeepSeekLLM`'s three hooks become thin wrappers with zero behavior change.
- `PROVIDER_STATE_METADATA_KEY` moves to `chat/types.py` (re-exported from `openai.py`)
  so a protocol-rule module does not have to import a transport module to reach it.
- `_response_provider_state` now receives the request's thinking config, and
  `_delta_reasoning_content` is a new hook. Both are no-ops for every existing caller.
- `openai.py`'s `_field_content` is renamed to `field_content`: `OpenRouterLLM` imports
  it across a module boundary, so it is a shared utility, not a private detail.

**Internal-key leak guard**

- `_strip_internal_message_keys` moves from `OpenAICompatibleLLM` onto `BaseLLM`, and
  `ZhipuLLM` and `XinferenceLLM` now call it. Both forwarded message dicts to their SDK
  largely unchanged, so both would have sent `_xagent_`-prefixed keys — including the
  new `_xagent_provider_state` — straight to the provider.
- `ClaudeLLM` and `GeminiLLM` need no call: their conversion functions rebuild each
  provider message field-by-field rather than copying a message dict wholesale. Both get
  a comment recording that this is what keeps them safe, plus test coverage of the
  invariant across all four clients, checked at every entrypoint that assembles its
  own request: Zhipu `chat` / `vision_chat` / `stream_chat`, and Xinference `chat` /
  `stream_chat`. Xinference's `vision_chat` delegates straight to `chat`, so it has no
  request of its own to check.

**Auto-route fallback abilities**

- `RouterLLM._resolve_route`'s fallback branch (no downstream resolver injected) built
  the downstream `OpenRouterLLM` from the router's own advertised abilities, which always
  exclude `vision` and `thinking_mode` — a virtual router cannot claim a candidate's
  dynamic abilities before routing picks one. The constructed client therefore silently
  lost any `vision`/`thinking_mode` ability the user had configured. The caller's original
  abilities are now kept alongside the router's filtered set and used only at that one
  construction point.

**Observability**

- `restore_deepseek_reasoning_content` logs one INFO summary per call counting how many
  assistant tool-call messages replayed real captured reasoning content versus how many
  hit the empty-string fallback. A rising fallback count is the signal that something
  upstream is dropping captured state. The line carries counts and the model name only,
  never reasoning text.
- A WARNING fires when thinking was requested, the response is a tool call, and neither
  known field spelling was captured — the one silent-failure mode of the mechanism, since
  the resulting 400 arrives on the *next* request with nothing pointing back here. The
  warning reports the reasoning-like key *names* observed on the response, never their
  values, so a renamed provider field can be diagnosed without logging model reasoning.
  `stream_chat` tracks the same field names across the whole stream and calls a new
  `_check_stream_reasoning_capture` hook once the stream ends, giving the streaming path
  the same sentinel.
- `test_provider_state_stripping.py` gains a discovery test that walks every concrete
  `BaseLLM` subclass under `xagent.core.model.chat.basic` and fails, naming the class,
  if it is neither covered nor in the explicit exemption registry — so a newly added
  client with no leak-guard coverage is caught structurally rather than silently.

### Verification

| Check | Result |
|---|---|
| `pytest tests/core/model/chat/` | 482 passed |
| `pytest tests/core/model/chat/basic/test_openrouter.py` | 92 passed |
| `pytest tests/core/model/chat/basic/test_openai.py` | 50 passed |
| `pre-commit run --files <changed set>` | ruff check, ruff format, mypy, isort, codespell, end-of-file, trailing-whitespace all pass |

Two mutation spot-checks confirm the new coverage actually bites:

- Blanking `reasoning_field_names` so it reports no observed keys fails
  `test_openrouter_deepseek_warns_when_capture_misses_all_known_spellings` and nothing
  else (475 passed, 1 failed), pinning that the sentinel's diagnostic value is the key
  names it names.
- Removing `openai.BadRequestError` from `_COMPAT_RETRYABLE_ERRORS` fails
  `test_openrouter_compat_loop_catches_bare_sdk_bad_request` and nothing else, confirming
  the pre-existing stub coverage still holds under this change.

Four more mutations pin the review-driven additions:

- Reverting the structured-output retry's response processing to read the outer
  `thinking` instead of the per-attempt value fails
  `test_openrouter_deepseek_no_capture_warning_after_thinking_disabled_retry` and
  nothing else (1 failed, 91 passed).
- Removing the strip call from `ZhipuLLM.vision_chat` fails
  `test_zhipu_vision_chat_strips_internal_keys_before_the_sdk_call` and nothing else
  (1 failed, 7 passed in that file); removing it from `ZhipuLLM.stream_chat` fails
  `test_zhipu_stream_chat_strips_internal_keys_before_the_sdk_call` the same way.
- Removing the strip call from `XinferenceLLM.stream_chat` fails
  `test_xinference_stream_chat_strips_internal_keys_before_the_sdk_call` and nothing
  else (1 failed, 7 passed in that file).

### Size

Three-dot diff against `main`: 19 files, +2339 / -109.

| | Files | Added | Removed |
|---|---|---|---|
| `src/` | 13 | 600 | 106 |
| `tests/` | 6 | 1739 | 3 |



