### PR TITLE
feat(web): add external-scoped task cancel command handling

### DIFF
--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -98,6 +98,11 @@ from ..services.db_runtime import (
     propagate_deferred_cancellation,
     run_db_io_cancellation_safe,
 )
+from ..services.external_task_cancel import (
+    EXTERNAL_COMMAND_SCOPE,
+    EXTERNAL_TURN_INTERRUPTED_MESSAGE,
+    cancel_external_task_unserialized,
+)
 from ..services.file_reference_output_service import (
     load_assistant_file_reference_records,
     reconcile_assistant_file_references,
@@ -400,14 +405,22 @@ def client_safe_error_message(error: BaseException) -> str:
 
 
 def client_safe_task_command_failure(
-    kind: TaskCommandKind, error: BaseException
+    kind: TaskCommandKind, error: BaseException, *, scope: str | None = None
 ) -> str:
     """Terminal command failure: server-owned kind prefix + redacted detail.
 
     The frontend renders ``message`` verbatim for ``agent_error``, so dropping
     the prefix entirely removed user-visible context. The kind comes from our
     own enum, never from the exception, which is what makes the prefix safe.
+
+    An external-scope cancel is the one command a task's audience issues
+    without any account behind it, and its whole meaning is "stop this
+    response". Whatever exhausted the command's budget, the audience gets the
+    same sentence the terminal event carries, with no command identity or
+    exception detail attached.
     """
+    if kind == TaskCommandKind.CANCEL and scope == EXTERNAL_COMMAND_SCOPE:
+        return EXTERNAL_TURN_INTERRUPTED_MESSAGE
     return f"Task command {kind.value} failed: {client_safe_error_message(error)}"
 
 
@@ -8445,8 +8458,6 @@ async def _execute_durable_task_command(
                     message_data,
                 )
             elif command.kind == TaskCommandKind.CANCEL:
-                from .a2a import _cancel_task_unserialized
-
                 agent_id_value = message_data.get("agent_id")
                 if agent_id_value is None:
                     raise ValueError(
@@ -8469,13 +8480,27 @@ async def _execute_durable_task_command(
                         "state-version target",
                         reason="stale_run",
                     )
+                # The A2A execution core loads its target as an A2A task, so
+                # a cancel for any other task source needs its own core. The
+                # scope names which one; a payload without it is an A2A
+                # cancel, the only shape this command had before.
                 async with task_execution_controller.command(command.task_id):
-                    await _cancel_task_unserialized(
-                        task_id=command.task_id,
-                        agent_id=agent_id,
-                        expected_run_id=command.target_run_id,
-                        expected_state_version=target_state_version,
-                    )
+                    if message_data.get("scope") == EXTERNAL_COMMAND_SCOPE:
+                        await cancel_external_task_unserialized(
+                            task_id=command.task_id,
+                            agent_id=agent_id,
+                            expected_run_id=command.target_run_id,
+                            expected_state_version=target_state_version,
+                        )
+                    else:
+                        from .a2a import _cancel_task_unserialized
+
+                        await _cancel_task_unserialized(
+                            task_id=command.task_id,
+                            agent_id=agent_id,
+                            expected_run_id=command.target_run_id,
+                            expected_state_version=target_state_version,
+                        )
             else:  # pragma: no cover - enum construction rejects this earlier
                 raise ValueError(f"Unsupported task command kind: {command.kind}")
         except StaleTaskRunError as exc:
@@ -8490,6 +8515,13 @@ async def _execute_durable_task_command(
     }
 
 
+def _command_scope(command: ClaimedTaskCommand) -> str | None:
+    """The scope a command payload names, or ``None`` when it names none."""
+
+    scope = command.payload.get("scope")
+    return scope if isinstance(scope, str) else None
+
+
 async def _broadcast_terminal_command_error(
     command: ClaimedTaskCommand,
     error: BaseException,
@@ -8500,7 +8532,14 @@ async def _broadcast_terminal_command_error(
             # A blessed constructor rather than an f-string at the call
             # site: the guard cannot see inside an interpolation. The kind
             # also travels as a structured field for consumers that want it.
-            "message": client_safe_task_command_failure(command.kind, error),
+            # The scope goes with it because the audience of an
+            # external-scope command is not the audience the default
+            # wording was written for.
+            "message": client_safe_task_command_failure(
+                command.kind,
+                error,
+                scope=_command_scope(command),
+            ),
             "command_kind": command.kind.value,
             "task_id": command.task_id,
             "command_id": command.command_id,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -100,8 +100,8 @@ from ..services.db_runtime import (
 )
 from ..services.external_task_cancel import (
     EXTERNAL_COMMAND_SCOPE,
-    EXTERNAL_TURN_INTERRUPTED_MESSAGE,
     cancel_external_task_unserialized,
+    external_cancel_exhausted_message,
 )
 from ..services.file_reference_output_service import (
     load_assistant_file_reference_records,
@@ -405,7 +405,11 @@ def client_safe_error_message(error: BaseException) -> str:
 
 
 def client_safe_task_command_failure(
-    kind: TaskCommandKind, error: BaseException, *, scope: str | None = None
+    kind: TaskCommandKind,
+    error: BaseException,
+    *,
+    scope: str | None = None,
+    task_status: TaskStatus | None = None,
 ) -> str:
     """Terminal command failure: server-owned kind prefix + redacted detail.
 
@@ -415,12 +419,15 @@ def client_safe_task_command_failure(
 
     An external-scope cancel is the one command a task's audience issues
     without any account behind it, and its whole meaning is "stop this
-    response". Whatever exhausted the command's budget, the audience gets the
-    same sentence the terminal event carries, with no command identity or
-    exception detail attached.
+    response". That audience gets neither the command identity nor the
+    exception detail - and it gets a sentence about the turn rather than
+    about the command, which is why the caller reads the task and hands the
+    status in. Saying the response was interrupted when the task is still
+    running would be false, and the visitor would keep waiting on a turn
+    nobody stopped.
     """
     if kind == TaskCommandKind.CANCEL and scope == EXTERNAL_COMMAND_SCOPE:
-        return EXTERNAL_TURN_INTERRUPTED_MESSAGE
+        return external_cancel_exhausted_message(task_status)
     return f"Task command {kind.value} failed: {client_safe_error_message(error)}"
 
 
@@ -8482,15 +8489,37 @@ async def _execute_durable_task_command(
                     )
                 # The A2A execution core loads its target as an A2A task, so
                 # a cancel for any other task source needs its own core. The
-                # scope names which one; a payload without it is an A2A
-                # cancel, the only shape this command had before.
+                # scope names which one, and the absence of the key is itself
+                # a value: it is the only shape this command had before the
+                # external core existed, so it stays on the A2A path. Any
+                # other value names a core that does not exist here, and
+                # silently running the A2A one against it would cancel
+                # nothing while reporting success.
+                if "scope" not in message_data:
+                    scope_value = EXTERNAL_COMMAND_SCOPE_ABSENT
+                else:
+                    scope_value = message_data["scope"]
+                # Identity and equality checks rather than set membership:
+                # an unhashable payload value (a dict or list) must land in
+                # the same terminal rejection, not raise ``TypeError`` into
+                # the retry path.
+                if (
+                    scope_value is not EXTERNAL_COMMAND_SCOPE_ABSENT
+                    and scope_value != EXTERNAL_COMMAND_SCOPE
+                ):
+                    raise TaskCommandRejected(
+                        f"Cancel command {command.command_id} names task scope "
+                        f"{scope_value!r}, which has no execution core",
+                        reason="unsupported_scope",
+                    )
                 async with task_execution_controller.command(command.task_id):
-                    if message_data.get("scope") == EXTERNAL_COMMAND_SCOPE:
+                    if scope_value == EXTERNAL_COMMAND_SCOPE:
                         await cancel_external_task_unserialized(
                             task_id=command.task_id,
                             agent_id=agent_id,
                             expected_run_id=command.target_run_id,
                             expected_state_version=target_state_version,
+                            turn_id=_command_turn_id(command.task_id, message_data),
                         )
                     else:
                         from .a2a import _cancel_task_unserialized
@@ -8515,6 +8544,12 @@ async def _execute_durable_task_command(
     }
 
 
+# "no scope key at all" needs a value the scope check can compare against
+# and no payload can ever carry. A JSON payload cannot hold this object, so
+# a producer cannot forge the pre-external shape by writing a string.
+EXTERNAL_COMMAND_SCOPE_ABSENT = object()
+
+
 def _command_scope(command: ClaimedTaskCommand) -> str | None:
     """The scope a command payload names, or ``None`` when it names none."""
 
@@ -8522,23 +8557,79 @@ def _command_scope(command: ClaimedTaskCommand) -> str | None:
     return scope if isinstance(scope, str) else None
 
 
+def _command_turn_id(task_id: int, message_data: dict[str, Any]) -> str | None:
+    """The turn a command names, or ``None`` when it names none usably.
+
+    The value only picks which delivery row a cancel closes. A producer that
+    writes something other than a non-empty string is a bug, but refusing
+    the stop over it would leave the visitor's turn running, so the target
+    falls back to the running turn and the bug is logged rather than raised.
+    """
+
+    if "turn_id" not in message_data:
+        return None
+    raw = message_data["turn_id"]
+    if isinstance(raw, str) and raw.strip():
+        return raw.strip()
+    logger.warning(
+        "task %s cancel command carries an unusable turn_id of type %s; "
+        "falling back to the running turn's delivery row",
+        task_id,
+        type(raw).__name__,
+    )
+    return None
+
+
+def _is_external_cancel(command: ClaimedTaskCommand) -> bool:
+    """Whether this command is a stop issued by a task's external audience."""
+
+    return (
+        command.kind == TaskCommandKind.CANCEL
+        and _command_scope(command) == EXTERNAL_COMMAND_SCOPE
+    )
+
+
 async def _broadcast_terminal_command_error(
     command: ClaimedTaskCommand,
     error: BaseException,
 ) -> None:
+    scope = _command_scope(command)
+    # Two things separate an external-scope cancel from every other command
+    # that exhausts its budget, and both come from who reads the frame. The
+    # wording has to be true about the turn, which takes reading the task.
+    # And ``command_kind``/``command_id`` are operator handles: an anonymous
+    # visitor cannot act on them and should not be shown the durable command
+    # identity of a task they do not own. Two payload literals rather than
+    # one built and trimmed: the client-safe guard only inspects dict
+    # literals passed straight to the sink, and a payload assembled in a
+    # variable would drop this site out of its view entirely.
+    if _is_external_cancel(command):
+        task_status = await _load_terminal_command_task_status(command.task_id)
+        await manager.broadcast_to_task(
+            {
+                "type": "agent_error",
+                "message": client_safe_task_command_failure(
+                    command.kind,
+                    error,
+                    scope=scope,
+                    task_status=task_status,
+                ),
+                "task_id": command.task_id,
+                "timestamp": datetime.now(timezone.utc).timestamp(),
+            },
+            command.task_id,
+        )
+        return
     await manager.broadcast_to_task(
         {
             "type": "agent_error",
             # A blessed constructor rather than an f-string at the call
             # site: the guard cannot see inside an interpolation. The kind
             # also travels as a structured field for consumers that want it.
-            # The scope goes with it because the audience of an
-            # external-scope command is not the audience the default
-            # wording was written for.
             "message": client_safe_task_command_failure(
                 command.kind,
                 error,
-                scope=_command_scope(command),
+                scope=scope,
             ),
             "command_kind": command.kind.value,
             "task_id": command.task_id,
@@ -8604,6 +8695,36 @@ def _load_command_task_run_id(task_id: int) -> str | None:
         if task is None:
             raise ValueError(f"Task {task_id} no longer exists")
         return str(task.run_id) if task.run_id is not None else None
+
+
+async def _load_terminal_command_task_status(task_id: int) -> TaskStatus | None:
+    """The task's status right now, or ``None`` when it cannot be read.
+
+    This read only chooses wording for a notification that is already the
+    last act of a terminal command, and it runs inside the ``except`` bodies
+    of ``execute_durable_task_command``. An exception raised here would
+    replace the failure that dispatcher is handling, turning "the command
+    failed" into "the database failed", so an unreadable row - deleted, pool
+    exhausted, database down - is answered as ``None`` and logged.
+    ``CancelledError`` is deliberately not caught: a cancelled dispatcher
+    still has to unwind.
+    """
+
+    def _read() -> TaskStatus | None:
+        SessionLocal = get_session_local()
+        with SessionLocal() as db:
+            task = db.query(Task).filter(Task.id == task_id).first()
+            return task.status if task is not None else None
+
+    try:
+        return await run_db_io_cancellation_safe(_read)
+    except Exception:
+        logger.warning(
+            "could not read task %s status while wording a terminal command broadcast",
+            task_id,
+            exc_info=True,
+        )
+        return None
 
 
 @ws_router.websocket("/ws/build/chat")

--- a/src/xagent/web/services/external_task_cancel.py
+++ b/src/xagent/web/services/external_task_cancel.py
@@ -4,7 +4,7 @@ The durable command channel already carries A2A cancels; its execution core
 (``a2a.py``) loads its target with ``Task.source == "a2a"``, so an external
 task cannot travel through it. This module is that core's external-scope
 counterpart: the same load / hard-cancel / fenced-finalize shape against
-``Task.source == "external"`` rows, with three differences the external
+``Task.source == "external"`` rows, with the differences the external
 surface needs.
 
   - The visitor has no other channel to learn the turn ended, so the core
@@ -18,6 +18,10 @@ surface needs.
     command is terminal without a client-visible error frame, which is the
     outcome an anonymous visitor should get for a stop that no longer has a
     target.
+  - The finalize commits more than the terminal row: the interruption
+    transcript line the visitor reads and the stopped turn's delivery row
+    are staged in the same transaction, and the shared task cache is
+    invalidated once that commit lands.
 """
 
 from __future__ import annotations
@@ -34,6 +38,7 @@ from .chat_history_service import (
     DELIVERY_DISPATCHED,
     DELIVERY_PENDING,
     mark_user_message_delivery,
+    persist_assistant_message_no_commit,
 )
 from .db_runtime import run_db_io_cancellation_safe
 from .task_command_transport import TaskCommandRejected
@@ -49,14 +54,22 @@ EXTERNAL_COMMAND_SCOPE = "external"
 
 _TERMINAL_STATUSES = {TaskStatus.COMPLETED, TaskStatus.FAILED}
 
-# Cancellation waits for the run coroutine to unwind, per handle, so one
-# external cancel occupies a dispatcher slot for up to twice this value
-# (the running handle plus the resume coordinator). It is deliberately far
-# above the A2A path's 0.5s: whichever writer lands first owns the terminal
-# row, and letting the cancelled coroutine settle first keeps its lease and
-# delivery reconciliation in the hands of the coroutine that ran the turn.
-# Raising it raises the worst-case queueing delay for every other command on
-# this process; lowering it makes the overlap window more likely.
+# Cancellation waits for the run coroutine to unwind, once per handle - the
+# running handle and the resume coordinator - so the nominal cost of one
+# external cancel is twice this value. Nominal, not bounded:
+# ``BackgroundTaskManager.cancel_task`` waits with ``asyncio.wait_for``,
+# which on timeout cancels the coroutine and then waits for that
+# cancellation to finish, and the coroutine's cleanup drains uninterruptible
+# database work in a worker thread before it lets the cancellation through
+# (``run_db_io_cancellation_safe``). A slow database therefore extends the
+# hold past this value with no hard upper bound.
+#
+# The value is deliberately far above the A2A path's 0.5s: whichever writer
+# lands first owns the terminal row, and letting the cancelled coroutine
+# settle first keeps its lease and delivery reconciliation in the hands of
+# the coroutine that ran the turn. Raising it raises the typical queueing
+# delay for every other command on this process; lowering it makes the
+# overlap window more likely.
 EXTERNAL_CANCEL_WAIT_SECONDS = 5.0
 
 # A cancelled turn and a worker shutting down both cut the response short,
@@ -67,6 +80,45 @@ EXTERNAL_TURN_INTERRUPTED_MESSAGE = "This response was interrupted."
 # Written to the durable row only when a cancel command actually applied,
 # which is what keeps the two causes apart for whoever reads the row later.
 EXTERNAL_CANCEL_ERROR_MESSAGE = "Stopped by the visitor."
+
+# Broadcast, never stored. An exhausted cancel command whose target is
+# still alive has to say so, and the sentence has to be actionable: the
+# visitor can press stop again. Writing it to ``task.error_message`` would
+# put a text the replay judgement does not recognise on a live row, so this
+# constant has exactly one consumer - the terminal command broadcast.
+EXTERNAL_CANCEL_NOT_APPLIED_MESSAGE = (
+    "Stopping this response didn't go through — please try again."
+)
+
+
+def external_cancel_exhausted_message(task_status: TaskStatus | None) -> str:
+    """Wording for a cancel command that ran out of budget, by what happened.
+
+    ``EXTERNAL_TURN_INTERRUPTED_MESSAGE`` asserts the response is over, so it
+    is only true once the task reached ``COMPLETED`` or ``FAILED``. ``PAUSED``
+    and ``WAITING_FOR_USER`` look stopped to the frontend - its
+    ``isStoppedTaskStatus`` counts them, because that function answers
+    "should the spinner stop" - but the run behind them can still produce
+    more output, so on those the stop did not take.
+
+    ``None`` means the status could not be read: the row is gone, or the
+    database did not answer. The sentence that asserts nothing about the
+    turn is the safe one there too.
+    """
+
+    if task_status in _TERMINAL_STATUSES:
+        return EXTERNAL_TURN_INTERRUPTED_MESSAGE
+    return EXTERNAL_CANCEL_NOT_APPLIED_MESSAGE
+
+
+# The two sentences a cancelled external turn can be settled with: this
+# module's own finalize writes the first, the cancelled run's settlement
+# writes the second (``task_orchestrator`` derives it from the task
+# source). A row carrying neither was failed by something other than a
+# cancel, and this command has no claim on it.
+_SETTLED_BY_CANCEL_MESSAGES = frozenset(
+    {EXTERNAL_CANCEL_ERROR_MESSAGE, EXTERNAL_TURN_INTERRUPTED_MESSAGE}
+)
 
 
 def _task_run_id(task: Task) -> str | None:
@@ -100,12 +152,21 @@ def _is_settled_external_cancel_target(
 ) -> bool:
     """Report whether this exact target already reached its cancel outcome.
 
-    The judgement is the durable state tuple, not a marker column: the same
-    command replayed after its own finalize, and the settlement of the run
-    this command cancelled, both leave the exact target run FAILED at the
-    command's own state version or one past it. Either way the turn this
-    command targeted is over, which is what the command asked for, so the
-    replay is answered without writing anything.
+    The judgement is the durable state tuple plus the settling sentence, not
+    a marker column: the same command replayed after its own finalize, and
+    the settlement of the run this command cancelled, both leave the exact
+    target run FAILED at the command's own state version or one past it,
+    carrying one of the two texts only a cancellation writes.
+
+    The sentence is load bearing, not decoration. Without it the same tuple
+    also describes a run that failed on its own - a provider timeout, a
+    setup error - and this command would report that failure as a
+    cancellation it had performed, and broadcast a terminal event claiming
+    the visitor's stop had landed. A tuple that matches with any other text
+    falls through to ``_assert_external_cancel_target``, which rejects it as
+    ``stale_run`` (the version has moved, or the task is already terminal),
+    writing nothing and broadcasting nothing; that run's own settlement owns
+    its transcript and its event.
     """
 
     return (
@@ -113,6 +174,7 @@ def _is_settled_external_cancel_target(
         and _task_run_id(task) == expected_run_id
         and int(task.state_version or 0)
         in {expected_state_version, expected_state_version + 1}
+        and task.error_message in _SETTLED_BY_CANCEL_MESSAGES
     )
 
 
@@ -165,40 +227,105 @@ def _load_cancelable_external_task_sync(
         return False
 
 
-def _mark_cancelled_turn_delivery_dispatched(db: Session, task_id: int) -> None:
+def _mark_cancelled_turn_delivery_dispatched(
+    db: Session, task_id: int, *, turn_id: str | None
+) -> None:
     """Close the cancelled turn's delivery row without committing ``db``.
 
     A delivery row is closed by whichever coroutine settles the turn it
     belongs to. When this finalize wins that race the settlement is fenced
     out, so nothing else ever moves the row off ``pending`` and every later
     resend of the same client message id is refused forever.
-    ``dispatched`` rather than ``failed`` is the
-    honest target: the run had already started, so the message may have been
-    consumed and a retry invitation could double-execute it.
+    ``dispatched`` rather than ``failed`` is the honest target: the run had
+    already started, so the message may have been consumed and a retry
+    invitation could double-execute it.
 
-    The turn is identified as the newest pending user row on the task, since
-    the command carries a task-state target and no turn id. A cancel applies
-    to the turn that is running, which is the turn that owns that row.
+    ``turn_id`` names the exact row when the command carries one, which is
+    the only way to be certain the row closed belongs to the turn the stop
+    was aimed at. It is a producer-reported value, not an authorization
+    fact: even a value forged for another task falls through the
+    ``task_id`` filter in ``mark_user_message_delivery`` and lands nothing,
+    the same way ``end_user_id`` is audit data only.
+
+    Without one the target is the newest pending user row on the task. That
+    fallback is only sound because a task cannot take a new turn while it is
+    running: ``_claim_turn_no_commit`` in ``task_orchestrator`` filters an
+    APPEND on ``_APPENDABLE_STATUSES`` - COMPLETED, FAILED, PAUSED - which
+    excludes RUNNING, so a cancel target that is still running has at most
+    one pending user row and "newest" and "the running turn's" name the same
+    row. If that filter ever admits RUNNING, this fallback starts closing
+    another turn's row and every caller must pass ``turn_id``.
     """
 
-    row = (
-        db.query(TaskChatMessage.turn_id)
-        .filter(
-            TaskChatMessage.task_id == task_id,
-            TaskChatMessage.role == "user",
-            TaskChatMessage.delivery_status == DELIVERY_PENDING,
+    if turn_id is None:
+        row = (
+            db.query(TaskChatMessage.turn_id)
+            .filter(
+                TaskChatMessage.task_id == task_id,
+                TaskChatMessage.role == "user",
+                TaskChatMessage.delivery_status == DELIVERY_PENDING,
+            )
+            .order_by(TaskChatMessage.id.desc())
+            .first()
         )
-        .order_by(TaskChatMessage.id.desc())
-        .first()
-    )
-    if row is None or row[0] is None:
-        return
+        if row is None or row[0] is None:
+            return
+        turn_id = str(row[0])
     mark_user_message_delivery(
         db,
         task_id=task_id,
-        turn_id=str(row[0]),
+        turn_id=turn_id,
         status=DELIVERY_DISPATCHED,
     )
+
+
+def _persist_interruption_transcript_no_commit(db: Session, task: Task) -> None:
+    """Stage the one assistant line the stopped turn owes its reader.
+
+    Exactly one writer produces it. When the cancelled run's settlement
+    wins the race it writes the line itself (``settle_task_lease_isolated``
+    in ``task_orchestrator``), and this finalize never runs its fenced
+    UPDATE, so it writes nothing. When this finalize wins, the settlement's
+    UPDATE requires ``status == RUNNING`` and matches no row, so it skips
+    its own write and this line is the only one. The replay short circuit
+    above returns before reaching here, so a redelivered command adds none.
+
+    The row mirrors the settlement's exactly - same content, same
+    ``chat_response`` type, no turn id - so the reader cannot tell which
+    writer won. ``content_is_reconciled`` is set because the content is a
+    server-owned constant with no file references to resolve.
+
+    A task row without an owner gets no line from either writer: the
+    settlement guards on ``task.user_id is not None`` and so does this.
+    External rows are created with the agent owner's id and never hit that
+    branch; it is a guard against a NULL column, not a normal path.
+    """
+
+    if task.user_id is None:
+        return
+    persist_assistant_message_no_commit(
+        db,
+        task_id=int(task.id),
+        user_id=int(task.user_id),
+        content=EXTERNAL_TURN_INTERRUPTED_MESSAGE,
+        message_type="chat_response",
+        content_is_reconciled=True,
+    )
+
+
+def _invalidate_task_cache_after_commit(task_id: int) -> None:
+    """Drop the task's cached projections once its terminal row is committed.
+
+    The import is deferred because ``task_orchestrator`` imports this module
+    at module level for the settlement text; a module-level import back
+    would close the cycle. The orchestrator's own wrapper is the one called
+    rather than ``hot_path_cache.invalidate_task_cache`` directly, so a cache
+    outage stays non-fatal here exactly as it is on the settlement path.
+    """
+
+    from .task_orchestrator import invalidate_task_cache_best_effort
+
+    invalidate_task_cache_best_effort(task_id)
 
 
 def _finalize_external_cancel_sync(
@@ -207,6 +334,7 @@ def _finalize_external_cancel_sync(
     agent_id: int,
     expected_run_id: str | None,
     expected_state_version: int,
+    turn_id: str | None,
 ) -> None:
     """Atomically persist cancellation for one exact task-state target."""
 
@@ -260,8 +388,10 @@ def _finalize_external_cancel_sync(
                 f"{expected_run_id}/{expected_state_version}",
                 reason="stale_run",
             )
-        _mark_cancelled_turn_delivery_dispatched(db, task_id)
+        _persist_interruption_transcript_no_commit(db, updated)
+        _mark_cancelled_turn_delivery_dispatched(db, task_id, turn_id=turn_id)
         db.commit()
+        _invalidate_task_cache_after_commit(task_id)
 
 
 async def _broadcast_external_cancel_terminal_event(task_id: int) -> None:
@@ -292,6 +422,7 @@ async def cancel_external_task_unserialized(
     agent_id: int,
     expected_run_id: str | None,
     expected_state_version: int,
+    turn_id: str | None = None,
 ) -> None:
     """Cancel one exact durable-command target while the caller owns its gate."""
 
@@ -316,6 +447,7 @@ async def cancel_external_task_unserialized(
                 agent_id=agent_id,
                 expected_run_id=expected_run_id,
                 expected_state_version=expected_state_version,
+                turn_id=turn_id,
             )
         )
     await _broadcast_external_cancel_terminal_event(task_id)

--- a/src/xagent/web/services/external_task_cancel.py
+++ b/src/xagent/web/services/external_task_cancel.py
@@ -1,0 +1,321 @@
+"""Cancel execution of one external-source task turn.
+
+The durable command channel already carries A2A cancels; its execution core
+(``a2a.py``) loads its target with ``Task.source == "a2a"``, so an external
+task cannot travel through it. This module is that core's external-scope
+counterpart: the same load / hard-cancel / fenced-finalize shape against
+``Task.source == "external"`` rows, with three differences the external
+surface needs.
+
+  - The visitor has no other channel to learn the turn ended, so the core
+    broadcasts the terminal event itself once its finalize commits. The
+    settlement path in ``task_orchestrator`` broadcasts only for setup/run
+    errors, never for a cancellation.
+  - The wait for the running coroutine is longer than the A2A one, because
+    the external turn's finalize races the settlement that the cancelled
+    coroutine is about to perform. See ``EXTERNAL_CANCEL_WAIT_SECONDS``.
+  - Every expected failure leaves as ``TaskCommandRejected``. A rejected
+    command is terminal without a client-visible error frame, which is the
+    outcome an anonymous visitor should get for a stop that no longer has a
+    target.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import func, update
+from sqlalchemy.orm import Session
+
+from ..models.chat_message import TaskChatMessage
+from ..models.database import get_session_local
+from ..models.task import Task, TaskStatus
+from .chat_history_service import (
+    DELIVERY_DISPATCHED,
+    DELIVERY_PENDING,
+    mark_user_message_delivery,
+)
+from .db_runtime import run_db_io_cancellation_safe
+from .task_command_transport import TaskCommandRejected
+from .task_execution_controller import TaskControlState
+
+logger = logging.getLogger(__name__)
+
+EXTERNAL_TASK_SOURCE = "external"
+
+# Command payload scope that routes a CANCEL command to this core. A command
+# without it keeps the A2A execution path it has always had.
+EXTERNAL_COMMAND_SCOPE = "external"
+
+_TERMINAL_STATUSES = {TaskStatus.COMPLETED, TaskStatus.FAILED}
+
+# Cancellation waits for the run coroutine to unwind, per handle, so one
+# external cancel occupies a dispatcher slot for up to twice this value
+# (the running handle plus the resume coordinator). It is deliberately far
+# above the A2A path's 0.5s: whichever writer lands first owns the terminal
+# row, and letting the cancelled coroutine settle first keeps its lease and
+# delivery reconciliation in the hands of the coroutine that ran the turn.
+# Raising it raises the worst-case queueing delay for every other command on
+# this process; lowering it makes the overlap window more likely.
+EXTERNAL_CANCEL_WAIT_SECONDS = 5.0
+
+# A cancelled turn and a worker shutting down both cut the response short,
+# so the text every consumer of the interruption sees states the outcome
+# without claiming a cause.
+EXTERNAL_TURN_INTERRUPTED_MESSAGE = "This response was interrupted."
+
+# Written to the durable row only when a cancel command actually applied,
+# which is what keeps the two causes apart for whoever reads the row later.
+EXTERNAL_CANCEL_ERROR_MESSAGE = "Stopped by the visitor."
+
+
+def _task_run_id(task: Task) -> str | None:
+    run_id = getattr(task, "run_id", None)
+    return str(run_id) if run_id is not None else None
+
+
+def _load_external_task(db: Session, *, task_id: int, agent_id: int) -> Task:
+    task = (
+        db.query(Task)
+        .filter(
+            Task.id == task_id,
+            Task.agent_id == agent_id,
+            Task.source == EXTERNAL_TASK_SOURCE,
+        )
+        .first()
+    )
+    if task is None:
+        raise TaskCommandRejected(
+            f"task {task_id} is not an external task of agent {agent_id}",
+            reason="task_not_found",
+        )
+    return task
+
+
+def _is_settled_external_cancel_target(
+    task: Task,
+    *,
+    expected_run_id: str | None,
+    expected_state_version: int,
+) -> bool:
+    """Report whether this exact target already reached its cancel outcome.
+
+    The judgement is the durable state tuple, not a marker column: the same
+    command replayed after its own finalize, and the settlement of the run
+    this command cancelled, both leave the exact target run FAILED at the
+    command's own state version or one past it. Either way the turn this
+    command targeted is over, which is what the command asked for, so the
+    replay is answered without writing anything.
+    """
+
+    return (
+        task.status == TaskStatus.FAILED
+        and _task_run_id(task) == expected_run_id
+        and int(task.state_version or 0)
+        in {expected_state_version, expected_state_version + 1}
+    )
+
+
+def _assert_external_cancel_target(
+    task: Task,
+    *,
+    expected_run_id: str | None,
+    expected_state_version: int,
+) -> None:
+    """Reject a cancel command whose immutable task-state target is stale."""
+
+    current_run_id = _task_run_id(task)
+    current_state_version = int(task.state_version or 0)
+    if (
+        current_run_id != expected_run_id
+        or current_state_version != expected_state_version
+        or task.status in _TERMINAL_STATUSES
+    ):
+        raise TaskCommandRejected(
+            f"task {task.id} changed from run/version "
+            f"{expected_run_id}/{expected_state_version} to "
+            f"{current_run_id}/{current_state_version}/{task.status.value}",
+            reason="stale_run",
+        )
+
+
+def _load_cancelable_external_task_sync(
+    *,
+    task_id: int,
+    agent_id: int,
+    expected_run_id: str | None,
+    expected_state_version: int,
+) -> bool:
+    """Return whether the exact cancel target is already settled."""
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = _load_external_task(db, task_id=task_id, agent_id=agent_id)
+        if _is_settled_external_cancel_target(
+            task,
+            expected_run_id=expected_run_id,
+            expected_state_version=expected_state_version,
+        ):
+            return True
+        _assert_external_cancel_target(
+            task,
+            expected_run_id=expected_run_id,
+            expected_state_version=expected_state_version,
+        )
+        return False
+
+
+def _mark_cancelled_turn_delivery_dispatched(db: Session, task_id: int) -> None:
+    """Close the cancelled turn's delivery row without committing ``db``.
+
+    A delivery row is closed by whichever coroutine settles the turn it
+    belongs to. When this finalize wins that race the settlement is fenced
+    out, so nothing else ever moves the row off ``pending`` and every later
+    resend of the same client message id is refused forever.
+    ``dispatched`` rather than ``failed`` is the
+    honest target: the run had already started, so the message may have been
+    consumed and a retry invitation could double-execute it.
+
+    The turn is identified as the newest pending user row on the task, since
+    the command carries a task-state target and no turn id. A cancel applies
+    to the turn that is running, which is the turn that owns that row.
+    """
+
+    row = (
+        db.query(TaskChatMessage.turn_id)
+        .filter(
+            TaskChatMessage.task_id == task_id,
+            TaskChatMessage.role == "user",
+            TaskChatMessage.delivery_status == DELIVERY_PENDING,
+        )
+        .order_by(TaskChatMessage.id.desc())
+        .first()
+    )
+    if row is None or row[0] is None:
+        return
+    mark_user_message_delivery(
+        db,
+        task_id=task_id,
+        turn_id=str(row[0]),
+        status=DELIVERY_DISPATCHED,
+    )
+
+
+def _finalize_external_cancel_sync(
+    *,
+    task_id: int,
+    agent_id: int,
+    expected_run_id: str | None,
+    expected_state_version: int,
+) -> None:
+    """Atomically persist cancellation for one exact task-state target."""
+
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        task = _load_external_task(db, task_id=task_id, agent_id=agent_id)
+        if _is_settled_external_cancel_target(
+            task,
+            expected_run_id=expected_run_id,
+            expected_state_version=expected_state_version,
+        ):
+            return
+        _assert_external_cancel_target(
+            task,
+            expected_run_id=expected_run_id,
+            expected_state_version=expected_state_version,
+        )
+
+        statement = (
+            update(Task)
+            .where(
+                Task.id == task_id,
+                Task.agent_id == agent_id,
+                Task.source == EXTERNAL_TASK_SOURCE,
+                func.coalesce(Task.state_version, 0) == expected_state_version,
+                Task.status.notin_(_TERMINAL_STATUSES),
+            )
+            .values(
+                status=TaskStatus.FAILED,
+                control_state=TaskControlState.FAILED.value,
+                state_version=expected_state_version + 1,
+                runner_id=None,
+                lease_attempt_id=None,
+                lease_expires_at=None,
+                last_heartbeat_at=None,
+                error_message=EXTERNAL_CANCEL_ERROR_MESSAGE,
+            )
+        )
+        if expected_run_id is None:
+            statement = statement.where(Task.run_id.is_(None))
+        else:
+            statement = statement.where(Task.run_id == expected_run_id)
+
+        updated = db.execute(
+            statement.returning(Task).execution_options(synchronize_session=False)
+        ).scalar_one_or_none()
+        if updated is None:
+            db.rollback()
+            raise TaskCommandRejected(
+                f"task {task_id} changed while finalizing cancel target "
+                f"{expected_run_id}/{expected_state_version}",
+                reason="stale_run",
+            )
+        _mark_cancelled_turn_delivery_dispatched(db, task_id)
+        db.commit()
+
+
+async def _broadcast_external_cancel_terminal_event(task_id: int) -> None:
+    from ..api.websocket import create_terminal_task_error_event
+    from ..api.websocket import manager as websocket_manager
+
+    try:
+        await websocket_manager.broadcast_to_task(
+            create_terminal_task_error_event(
+                task_id,
+                EXTERNAL_TURN_INTERRUPTED_MESSAGE,
+            ),
+            task_id,
+        )
+    except Exception:
+        # The terminal row is already committed; a failed notification must
+        # not turn that durable success into a retried command.
+        logger.warning(
+            "task %s cancellation was committed but its terminal broadcast failed",
+            task_id,
+            exc_info=True,
+        )
+
+
+async def cancel_external_task_unserialized(
+    *,
+    task_id: int,
+    agent_id: int,
+    expected_run_id: str | None,
+    expected_state_version: int,
+) -> None:
+    """Cancel one exact durable-command target while the caller owns its gate."""
+
+    already_settled = await run_db_io_cancellation_safe(
+        lambda: _load_cancelable_external_task_sync(
+            task_id=task_id,
+            agent_id=agent_id,
+            expected_run_id=expected_run_id,
+            expected_state_version=expected_state_version,
+        )
+    )
+    if not already_settled:
+        from ..api.websocket import background_task_manager
+
+        await background_task_manager.cancel_task(
+            task_id,
+            timeout_seconds=EXTERNAL_CANCEL_WAIT_SECONDS,
+        )
+        await run_db_io_cancellation_safe(
+            lambda: _finalize_external_cancel_sync(
+                task_id=task_id,
+                agent_id=agent_id,
+                expected_run_id=expected_run_id,
+                expected_state_version=expected_state_version,
+            )
+        )
+    await _broadcast_external_cancel_terminal_event(task_id)

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -71,6 +71,10 @@ from .db_runtime import (
     is_database_pool_timeout,
     run_db_io_cancellation_safe,
 )
+from .external_task_cancel import (
+    EXTERNAL_TASK_SOURCE,
+    EXTERNAL_TURN_INTERRUPTED_MESSAGE,
+)
 from .file_turn import bind_turn_files_no_commit
 from .hot_path_cache import invalidate_task_cache
 from .task_execution_controller import (
@@ -1788,7 +1792,17 @@ def _schedule_bg(
                     task_id,
                 )
             except asyncio.CancelledError:
-                settlement_error = "task execution cancelled"
+                # Settlement text lands in ``task.error_message`` and, for a
+                # task with an owner, in the transcript as an assistant
+                # message. An external task's transcript is read by the
+                # visitor who asked the question, so that audience gets a
+                # sentence written for it instead of the operator wording
+                # every other source keeps.
+                settlement_error = (
+                    EXTERNAL_TURN_INTERRUPTED_MESSAGE
+                    if task_source == EXTERNAL_TASK_SOURCE
+                    else "task execution cancelled"
+                )
                 raise
             except Exception as setup_or_run_err:
                 if is_database_pool_timeout(setup_or_run_err):

--- a/tests/web/api/test_external_task_cancel.py
+++ b/tests/web/api/test_external_task_cancel.py
@@ -28,6 +28,7 @@ from xagent.web.services.chat_history_service import (
 )
 from xagent.web.services.external_task_cancel import (
     EXTERNAL_CANCEL_ERROR_MESSAGE,
+    EXTERNAL_CANCEL_NOT_APPLIED_MESSAGE,
     EXTERNAL_CANCEL_WAIT_SECONDS,
     EXTERNAL_TURN_INTERRUPTED_MESSAGE,
     cancel_external_task_unserialized,
@@ -157,6 +158,22 @@ def _delivery_status(task_id: int, turn_id: str) -> str | None:
         db.close()
 
 
+def _interruption_transcript_count(task_id: int) -> int:
+    db = _direct_db_session()
+    try:
+        return (
+            db.query(TaskChatMessage)
+            .filter(
+                TaskChatMessage.task_id == task_id,
+                TaskChatMessage.role == "assistant",
+                TaskChatMessage.content == EXTERNAL_TURN_INTERRUPTED_MESSAGE,
+            )
+            .count()
+        )
+    finally:
+        db.close()
+
+
 def _broadcast_manager(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     manager = MagicMock()
     manager.broadcast_to_task = AsyncMock()
@@ -273,21 +290,175 @@ async def test_settlement_text_by_task_source(
 
 
 @pytest.mark.asyncio
+async def test_interrupted_transcript_finalize_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The stopped turn gets exactly one AI-side explanation line.
+
+    When this finalize's fenced UPDATE wins the race, the settlement's own
+    UPDATE requires ``status == RUNNING`` and matches no row, so it skips
+    its own write. This finalize is then the only writer, and it must not
+    leave the reader without any explanation.
+    """
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="interruption transcript finalize wins",
+    )
+    _broadcast_manager(monkeypatch)
+    monkeypatch.setattr(
+        websocket_api.background_task_manager,
+        "cancel_task",
+        AsyncMock(return_value=MagicMock(requested=False)),
+    )
+
+    await cancel_external_task_unserialized(
+        task_id=task_id,
+        agent_id=agent_id,
+        expected_run_id="run-external",
+        expected_state_version=4,
+    )
+
+    assert _interruption_transcript_count(task_id) == 1
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskChatMessage)
+            .filter(
+                TaskChatMessage.task_id == task_id,
+                TaskChatMessage.role == "assistant",
+                TaskChatMessage.content == EXTERNAL_TURN_INTERRUPTED_MESSAGE,
+            )
+            .one()
+        )
+        assert row.message_type == "chat_response"
+        assert row.turn_id is None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_interrupted_transcript_settlement_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A settlement that beats this finalize still leaves exactly one line.
+
+    Reuses ``test_settlement_text_by_task_source``'s driving shape: a real
+    background run is cancelled and its own settlement writes the
+    interruption line before this core is ever asked to finalize anything.
+    The exact target this core is handed afterwards is the run/version pair
+    the settlement raced against, so the replay judgement must recognise it
+    as already settled and add nothing.
+    """
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="interruption transcript settlement wins",
+        source="external",
+        run_id=None,
+        state_version=0,
+    )
+    _broadcast_manager(monkeypatch)
+    execution_started = asyncio.Event()
+
+    async def block_until_cancelled(**_kwargs: object) -> None:
+        execution_started.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(websocket_api, "execute_task_background", block_until_cancelled)
+    monkeypatch.setattr(
+        task_orchestrator,
+        "load_task_setup_snapshot_sync",
+        lambda *_args, **_kwargs: SimpleNamespace(task=SimpleNamespace(id=task_id)),
+    )
+    monkeypatch.setattr(task_orchestrator, "_get_agent_manager", MagicMock())
+
+    bg_task = task_orchestrator._schedule_bg(
+        task_id=task_id,
+        task_owner_user_id=owner_user_id,
+        task_source="external",
+        payload=TaskTurnPayload("stop me"),
+        force_fresh=False,
+        context=None,
+    )
+    try:
+        await asyncio.wait_for(execution_started.wait(), timeout=5)
+        before_cancel = _load_task(task_id)
+        bg_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await bg_task
+    finally:
+        websocket_api.background_task_manager.running_tasks.pop(task_id, None)
+
+    settled = _load_task(task_id)
+    assert settled.error_message == EXTERNAL_TURN_INTERRUPTED_MESSAGE
+    assert _interruption_transcript_count(task_id) == 1
+
+    await cancel_external_task_unserialized(
+        task_id=task_id,
+        agent_id=agent_id,
+        expected_run_id=before_cancel.run_id,
+        expected_state_version=before_cancel.state_version,
+    )
+
+    assert _interruption_transcript_count(task_id) == 1
+    assert _load_task(task_id).error_message == EXTERNAL_TURN_INTERRUPTED_MESSAGE
+
+
+@pytest.mark.asyncio
+async def test_interrupted_transcript_replayed_after_finalize(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A redelivery of the same command after its own finalize adds nothing."""
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="interruption transcript replayed",
+    )
+    _broadcast_manager(monkeypatch)
+    monkeypatch.setattr(
+        websocket_api.background_task_manager,
+        "cancel_task",
+        AsyncMock(return_value=MagicMock(requested=False)),
+    )
+
+    for _ in range(2):
+        await cancel_external_task_unserialized(
+            task_id=task_id,
+            agent_id=agent_id,
+            expected_run_id="run-external",
+            expected_state_version=4,
+        )
+
+    assert _interruption_transcript_count(task_id) == 1
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "expected_state_version",
     [5, 4],
-    ids=["own_finalize_replayed", "run_settled_first"],
+    ids=["same_version_terminal", "one_version_past"],
+)
+@pytest.mark.parametrize(
+    "settled_by_the_run",
+    [EXTERNAL_CANCEL_ERROR_MESSAGE, EXTERNAL_TURN_INTERRUPTED_MESSAGE],
+    ids=["own_finalize_message", "settlement_message"],
 )
 async def test_external_cancel_finalize_replay_idempotent(
     monkeypatch: pytest.MonkeyPatch,
+    settled_by_the_run: str,
     expected_state_version: int,
 ) -> None:
-    """A replay reads the state tuple and writes nothing.
+    """A replay reads the state tuple and the settling sentence, and writes nothing.
 
     The same command redelivered after its own finalize finds its own state
     version; the settlement of the run it cancelled leaves the same terminal
     tuple one version further on. Both are the outcome the command asked
-    for, so neither may rewrite the row.
+    for, so neither may rewrite the row - but only when the row also
+    carries one of the two sentences a cancellation writes, not any text.
     """
     agent_id, owner_user_id = _create_agent()
     manager = _broadcast_manager(monkeypatch)
@@ -295,7 +466,6 @@ async def test_external_cancel_finalize_replay_idempotent(
     monkeypatch.setattr(
         websocket_api.background_task_manager, "cancel_task", cancel_task
     )
-    settled_by_the_run = "settled elsewhere"
     task_id = _create_task(
         agent_id=agent_id,
         owner_user_id=owner_user_id,
@@ -322,6 +492,57 @@ async def test_external_cancel_finalize_replay_idempotent(
     # event still goes out: the attempt that settled it may have died
     # before broadcasting.
     assert len(_broadcast_payloads(manager)) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "expected_state_version",
+    [4, 5],
+    ids=["version_moved", "same_version_terminal"],
+)
+async def test_replay_judgement_ignores_a_genuine_failure(
+    monkeypatch: pytest.MonkeyPatch,
+    expected_state_version: int,
+) -> None:
+    """A tuple match with an unrelated failure text is not a settled cancel.
+
+    A run that failed on its own - a provider timeout, a setup error -
+    leaves the same durable tuple a cancellation would. Without checking
+    the text, this command would report someone else's failure as a
+    cancellation it performed and broadcast a false terminal event.
+    """
+    agent_id, owner_user_id = _create_agent()
+    manager = _broadcast_manager(monkeypatch)
+    cancel_task = AsyncMock(return_value=MagicMock(requested=False))
+    monkeypatch.setattr(
+        websocket_api.background_task_manager, "cancel_task", cancel_task
+    )
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="genuinely failed task",
+        status=TaskStatus.FAILED,
+        control_state=TaskControlState.FAILED.value,
+        state_version=5,
+        error_message="setup/run error: provider timeout",
+    )
+
+    with pytest.raises(TaskCommandRejected) as raised:
+        await cancel_external_task_unserialized(
+            task_id=task_id,
+            agent_id=agent_id,
+            expected_run_id="run-external",
+            expected_state_version=expected_state_version,
+        )
+
+    assert raised.value.reason == "stale_run"
+    untouched = _load_task(task_id)
+    assert untouched.status == TaskStatus.FAILED
+    assert untouched.state_version == 5
+    assert untouched.error_message == "setup/run error: provider timeout"
+    assert cancel_task.await_count == 0
+    assert len(_broadcast_payloads(manager)) == 0
+    assert _interruption_transcript_count(task_id) == 0
 
 
 @pytest.mark.asyncio
@@ -370,11 +591,101 @@ async def test_external_cancel_marks_delivery_dispatched_on_timeout(
 
 
 @pytest.mark.asyncio
+async def test_external_cancel_closes_the_named_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A command carrying a turn id closes exactly that row, not the newest.
+
+    Without a turn id the fallback closes the newest pending user row, which
+    only happens to be the running turn's row because a task cannot take a
+    new turn while it is running. A caller that does know the turn must not
+    be at the mercy of that fallback.
+    """
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="named turn delivery row",
+    )
+    _seed_pending_user_message(
+        task_id=task_id, owner_user_id=owner_user_id, turn_id="turn-older"
+    )
+    _seed_pending_user_message(
+        task_id=task_id, owner_user_id=owner_user_id, turn_id="turn-newer"
+    )
+    _broadcast_manager(monkeypatch)
+    monkeypatch.setattr(
+        websocket_api.background_task_manager,
+        "cancel_task",
+        AsyncMock(return_value=MagicMock(requested=False)),
+    )
+
+    await cancel_external_task_unserialized(
+        task_id=task_id,
+        agent_id=agent_id,
+        expected_run_id="run-external",
+        expected_state_version=4,
+        turn_id="turn-older",
+    )
+
+    assert _delivery_status(task_id, "turn-older") == DELIVERY_DISPATCHED
+    assert _delivery_status(task_id, "turn-newer") == DELIVERY_PENDING
+
+
+@pytest.mark.asyncio
+async def test_cancel_command_turn_id_reaches_the_core(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The dispatcher threads a payload ``turn_id`` through to the core.
+
+    ``_execute_durable_task_command`` is the only caller of the external
+    core, so this is the site that must translate the payload's turn id
+    into the keyword argument the core closes a delivery row with.
+    """
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="turn id threaded through the dispatcher",
+    )
+    _broadcast_manager(monkeypatch)
+    observed: list[dict[str, Any]] = []
+
+    async def record_target(**kwargs: Any) -> None:
+        observed.append(kwargs)
+
+    monkeypatch.setattr(
+        websocket_api, "cancel_external_task_unserialized", record_target
+    )
+
+    await websocket_api._execute_durable_task_command(
+        ClaimedTaskCommand(
+            id=4,
+            task_id=task_id,
+            actor_user_id=None,
+            command_id=f"cancel:{task_id}:4",
+            kind=TaskCommandKind.CANCEL,
+            payload={
+                "agent_id": agent_id,
+                "target_state_version": 4,
+                "scope": "external",
+                "turn_id": "turn-older",
+            },
+            target_run_id="run-external",
+            attempt_count=1,
+        )
+    )
+
+    assert len(observed) == 1
+    assert observed[0]["turn_id"] == "turn-older"
+
+
+@pytest.mark.asyncio
 async def test_cancel_wait_constants_isolated(monkeypatch: pytest.MonkeyPatch) -> None:
     """The longer external wait stays on the external path.
 
     The wait occupies a dispatcher slot per handle, so leaking the external
-    value onto the A2A path would multiply every A2A cancel's worst case.
+    value onto the A2A path would multiply every A2A cancel's hold time.
     """
     agent_id, owner_user_id = _create_agent()
     external_task_id = _create_task(
@@ -421,6 +732,100 @@ async def test_cancel_wait_constants_isolated(monkeypatch: pytest.MonkeyPatch) -
     assert waits == [EXTERNAL_CANCEL_WAIT_SECONDS, None]
     assert EXTERNAL_CANCEL_WAIT_SECONDS == 5.0
     assert a2a_default.default == 0.5
+
+
+@pytest.mark.asyncio
+async def test_external_cancel_invalidates_the_task_cache_on_finalize_commit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A finalize that actually writes the terminal row invalidates the cache.
+
+    The invalidation must run only after the write it is protecting against
+    staleness has committed, so a reader racing the cache never sees a
+    pre-cancel projection after the row is already durably FAILED.
+    """
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="cache invalidated on finalize commit",
+    )
+    _broadcast_manager(monkeypatch)
+    monkeypatch.setattr(
+        websocket_api.background_task_manager,
+        "cancel_task",
+        AsyncMock(return_value=MagicMock(requested=False)),
+    )
+    invalidated = MagicMock()
+    monkeypatch.setattr(
+        task_orchestrator, "invalidate_task_cache_best_effort", invalidated
+    )
+
+    await cancel_external_task_unserialized(
+        task_id=task_id,
+        agent_id=agent_id,
+        expected_run_id="run-external",
+        expected_state_version=4,
+    )
+
+    invalidated.assert_called_once_with(task_id)
+
+
+@pytest.mark.asyncio
+async def test_external_cancel_replay_short_circuit_skips_cache_invalidation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A finalize that discovers the target already settled writes nothing.
+
+    The race is settled between the two reads: the initial check sees the
+    task still RUNNING, but by the time finalize re-checks (after awaiting
+    the cancel), the target has already reached its cancel outcome
+    elsewhere. Nothing this finalize writes, so no cache invalidation is
+    owed either - only a write this core performed should trigger one.
+    """
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="settled during the wait",
+    )
+    _broadcast_manager(monkeypatch)
+    invalidated = MagicMock()
+    monkeypatch.setattr(
+        task_orchestrator, "invalidate_task_cache_best_effort", invalidated
+    )
+
+    async def settle_during_the_wait(*_args: object, **_kwargs: object) -> MagicMock:
+        db = _direct_db_session()
+        try:
+            db.query(Task).filter(Task.id == task_id).update(
+                {
+                    "status": TaskStatus.FAILED,
+                    "control_state": TaskControlState.FAILED.value,
+                    "state_version": 5,
+                    "error_message": EXTERNAL_CANCEL_ERROR_MESSAGE,
+                    "run_id": "run-external",
+                }
+            )
+            db.commit()
+        finally:
+            db.close()
+        return MagicMock(requested=False)
+
+    monkeypatch.setattr(
+        websocket_api.background_task_manager,
+        "cancel_task",
+        settle_during_the_wait,
+    )
+
+    await cancel_external_task_unserialized(
+        task_id=task_id,
+        agent_id=agent_id,
+        expected_run_id="run-external",
+        expected_state_version=4,
+    )
+
+    invalidated.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -481,7 +886,9 @@ async def test_terminal_command_error_text_external(
     Driven by a deleted task row, which is a real raise site outside the
     external core: the failure budget runs out and the broadcast reaches the
     visitor's conversation, where the default wording would carry command
-    and exception detail.
+    and exception detail. The row being gone means the status read cannot
+    answer, so the wording is the conservative "didn't go through" sentence,
+    not the terminal one - the deletion is not proof the turn is over.
     """
     agent_id, owner_user_id = _create_agent()
     task_id = _create_task(
@@ -518,9 +925,71 @@ async def test_terminal_command_error_text_external(
 
     payloads = _broadcast_payloads(manager)
     assert [payload["type"] for payload in payloads] == ["agent_error"]
-    assert payloads[0]["message"] == EXTERNAL_TURN_INTERRUPTED_MESSAGE
+    assert payloads[0]["message"] == EXTERNAL_CANCEL_NOT_APPLIED_MESSAGE
+    assert "command_kind" not in payloads[0]
+    assert "command_id" not in payloads[0]
     assert str(raised.value) not in repr(payloads)
-    assert command.command_id not in repr(payloads[0]["message"])
+    assert command.command_id not in repr(payloads)
+    assert set(payloads[0]) == {"type", "message", "task_id", "timestamp"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("task_status", "expected_message"),
+    [
+        (TaskStatus.RUNNING, EXTERNAL_CANCEL_NOT_APPLIED_MESSAGE),
+        (TaskStatus.FAILED, EXTERNAL_TURN_INTERRUPTED_MESSAGE),
+        (TaskStatus.COMPLETED, EXTERNAL_TURN_INTERRUPTED_MESSAGE),
+        (TaskStatus.PAUSED, EXTERNAL_CANCEL_NOT_APPLIED_MESSAGE),
+    ],
+    ids=[
+        "still_running",
+        "already_failed",
+        "already_completed",
+        "paused_is_still_alive",
+    ],
+)
+async def test_terminal_command_error_text_follows_the_task_state(
+    monkeypatch: pytest.MonkeyPatch,
+    task_status: TaskStatus,
+    expected_message: str,
+) -> None:
+    """The exhausted-cancel wording asserts only what the task's state proves.
+
+    ``PAUSED`` looks stopped to the frontend's spinner logic, but the run
+    behind it can still produce more output on resume, so the terminal
+    sentence would be false there just as it would be on ``RUNNING``.
+    """
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="terminal wording by task state",
+        status=task_status,
+        control_state=TaskControlState.RUNNING.value,
+    )
+    manager = _broadcast_manager(monkeypatch)
+    command = ClaimedTaskCommand(
+        id=1,
+        task_id=task_id,
+        actor_user_id=None,
+        command_id=f"cancel:{task_id}:4",
+        kind=TaskCommandKind.CANCEL,
+        payload={
+            "agent_id": agent_id,
+            "target_state_version": 4,
+            "scope": "external",
+        },
+        target_run_id="run-external",
+        attempt_count=1,
+    )
+
+    await websocket_api._broadcast_terminal_command_error(
+        command, RuntimeError(f"lease lost at {task_id}")
+    )
+
+    payloads = _broadcast_payloads(manager)
+    assert payloads[0]["message"] == expected_message
 
 
 @pytest.mark.asyncio
@@ -616,3 +1085,67 @@ async def test_cancel_without_scope_stays_on_the_a2a_core(
     assert cancelled.status == TaskStatus.FAILED
     assert cancelled.error_message == "Task canceled by A2A client."
     assert cancelled.agent_config["a2a_state"] == "TASK_STATE_CANCELED"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scope",
+    ["foo", "", 123, None, {"scope": "external"}],
+    ids=[
+        "unknown_string",
+        "empty_string",
+        "non_string",
+        "explicit_none",
+        "unhashable",
+    ],
+)
+async def test_cancel_rejects_an_unknown_scope(
+    monkeypatch: pytest.MonkeyPatch,
+    scope: Any,
+) -> None:
+    """A scope naming neither core is rejected before either core runs.
+
+    A payload without the ``scope`` key at all keeps the pre-external A2A
+    shape; every other value - including an explicit ``None`` - names a
+    core that does not exist, and silently defaulting to the A2A core would
+    cancel nothing while reporting success.
+    """
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="unknown scope cancel",
+    )
+    _broadcast_manager(monkeypatch)
+    external_core = AsyncMock()
+    monkeypatch.setattr(
+        websocket_api, "cancel_external_task_unserialized", external_core
+    )
+    a2a_core = AsyncMock()
+    monkeypatch.setattr(a2a_api, "_cancel_task_unserialized", a2a_core)
+
+    with pytest.raises(TaskCommandRejected) as raised:
+        await websocket_api._execute_durable_task_command(
+            ClaimedTaskCommand(
+                id=5,
+                task_id=task_id,
+                actor_user_id=None,
+                command_id=f"cancel:{task_id}:4",
+                kind=TaskCommandKind.CANCEL,
+                payload={
+                    "agent_id": agent_id,
+                    "target_state_version": 4,
+                    "scope": scope,
+                },
+                target_run_id="run-external",
+                attempt_count=1,
+            )
+        )
+
+    assert raised.value.reason == "unsupported_scope"
+    assert external_core.await_count == 0
+    assert a2a_core.await_count == 0
+    untouched = _load_task(task_id)
+    assert untouched.status == TaskStatus.RUNNING
+    assert untouched.state_version == 4
+    assert untouched.error_message is None

--- a/tests/web/api/test_external_task_cancel.py
+++ b/tests/web/api/test_external_task_cancel.py
@@ -1,0 +1,618 @@
+"""External-scope cancel: its own execution core, its own wording.
+
+Every test here drives one invariant of the external cancel path: the
+terminal event the visitor needs, the two texts the two writers own, the
+replay judgement, the delivery row the finalize closes, the wait constant
+that must not travel to the A2A path, the failure classification, and the
+routing that keeps a scopeless cancel on the A2A core.
+"""
+
+import asyncio
+import inspect
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from xagent.web.api import a2a as a2a_api
+from xagent.web.api import websocket as websocket_api
+from xagent.web.models.agent import Agent
+from xagent.web.models.chat_message import TaskChatMessage
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.services import external_task_cancel, task_orchestrator
+from xagent.web.services.chat_history_service import (
+    DELIVERY_DISPATCHED,
+    DELIVERY_PENDING,
+)
+from xagent.web.services.external_task_cancel import (
+    EXTERNAL_CANCEL_ERROR_MESSAGE,
+    EXTERNAL_CANCEL_WAIT_SECONDS,
+    EXTERNAL_TURN_INTERRUPTED_MESSAGE,
+    cancel_external_task_unserialized,
+)
+from xagent.web.services.task_command_transport import (
+    MAX_COMMAND_FAILURES,
+    ClaimedTaskCommand,
+    TaskCommandKind,
+    TaskCommandRejected,
+)
+from xagent.web.services.task_execution_controller import TaskControlState
+from xagent.web.services.task_orchestrator import TaskTurnPayload
+
+from .conftest import _admin_headers, _direct_db_session, client
+
+pytestmark = pytest.mark.usefixtures("_test_db")
+
+
+def _create_agent() -> tuple[int, int]:
+    """One agent plus its owner id, the pair every task row here needs."""
+    headers = _admin_headers()
+    response = client.post(
+        "/api/agents",
+        headers=headers,
+        json={
+            "name": "External cancel agent",
+            "description": "External cancel test agent",
+            "instructions": "You are an external cancel test agent.",
+            "execution_mode": "balanced",
+        },
+    )
+    assert response.status_code == 200, response.text
+    agent_id = int(response.json()["id"])
+    db = _direct_db_session()
+    try:
+        owner_user_id = int(db.query(Agent).filter(Agent.id == agent_id).one().user_id)
+    finally:
+        db.close()
+    return agent_id, owner_user_id
+
+
+def _create_task(
+    *,
+    agent_id: int,
+    owner_user_id: int,
+    title: str,
+    source: str = "external",
+    status: TaskStatus = TaskStatus.RUNNING,
+    control_state: str = TaskControlState.RUNNING.value,
+    run_id: str | None = "run-external",
+    state_version: int = 4,
+    error_message: str | None = None,
+    runner_id: str | None = None,
+    agent_config: dict[str, Any] | None = None,
+) -> int:
+    db = _direct_db_session()
+    try:
+        task = Task(
+            user_id=owner_user_id,
+            title=title,
+            status=status,
+            control_state=control_state,
+            run_id=run_id,
+            state_version=state_version,
+            runner_id=runner_id,
+            lease_attempt_id="attempt-external" if runner_id else None,
+            lease_expires_at=(
+                datetime.now(UTC) + timedelta(minutes=1) if runner_id else None
+            ),
+            last_heartbeat_at=datetime.now(UTC) if runner_id else None,
+            agent_id=agent_id,
+            source=source,
+            is_visible=False,
+            error_message=error_message,
+            agent_config=agent_config,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        return int(task.id)
+    finally:
+        db.close()
+
+
+def _load_task(task_id: int) -> Task:
+    db = _direct_db_session()
+    try:
+        return db.query(Task).filter(Task.id == task_id).one()
+    finally:
+        db.close()
+
+
+def _seed_pending_user_message(
+    *, task_id: int, owner_user_id: int, turn_id: str
+) -> None:
+    db = _direct_db_session()
+    try:
+        db.add(
+            TaskChatMessage(
+                task_id=task_id,
+                user_id=owner_user_id,
+                role="user",
+                content="stop this one",
+                message_type="user_message",
+                turn_id=turn_id,
+                delivery_status=DELIVERY_PENDING,
+            )
+        )
+        db.commit()
+    finally:
+        db.close()
+
+
+def _delivery_status(task_id: int, turn_id: str) -> str | None:
+    db = _direct_db_session()
+    try:
+        message = (
+            db.query(TaskChatMessage)
+            .filter(
+                TaskChatMessage.task_id == task_id,
+                TaskChatMessage.turn_id == turn_id,
+            )
+            .one()
+        )
+        return str(message.delivery_status)
+    finally:
+        db.close()
+
+
+def _broadcast_manager(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    manager = MagicMock()
+    manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", manager)
+    return manager
+
+
+def _broadcast_payloads(manager: MagicMock) -> list[dict]:
+    return [call.args[0] for call in manager.broadcast_to_task.await_args_list]
+
+
+@pytest.mark.asyncio
+async def test_external_cancel_broadcasts_terminal_frame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The visitor learns the turn ended from the core, not from settlement.
+
+    The cancelled coroutine's settlement broadcasts only for setup/run
+    errors, so without this frame the widget keeps waiting forever.
+    """
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="external cancel broadcast",
+    )
+    manager = _broadcast_manager(monkeypatch)
+    monkeypatch.setattr(
+        websocket_api.background_task_manager,
+        "cancel_task",
+        AsyncMock(return_value=MagicMock(requested=False)),
+    )
+
+    await cancel_external_task_unserialized(
+        task_id=task_id,
+        agent_id=agent_id,
+        expected_run_id="run-external",
+        expected_state_version=4,
+    )
+
+    payloads = _broadcast_payloads(manager)
+    assert [payload["type"] for payload in payloads] == ["task_error"]
+    assert payloads[0]["message"] == EXTERNAL_TURN_INTERRUPTED_MESSAGE
+    assert payloads[0]["task"]["status"] == TaskStatus.FAILED.value
+    cancelled = _load_task(task_id)
+    assert cancelled.status == TaskStatus.FAILED
+    assert cancelled.control_state == TaskControlState.FAILED.value
+    assert cancelled.state_version == 5
+    assert cancelled.error_message == EXTERNAL_CANCEL_ERROR_MESSAGE
+    assert cancelled.runner_id is None
+    assert cancelled.lease_expires_at is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("task_source", "expected_error"),
+    [
+        ("external", EXTERNAL_TURN_INTERRUPTED_MESSAGE),
+        ("widget", "task execution cancelled"),
+    ],
+)
+async def test_settlement_text_by_task_source(
+    monkeypatch: pytest.MonkeyPatch,
+    task_source: str,
+    expected_error: str,
+) -> None:
+    """Settlement text is derived from the task source, for that audience.
+
+    The settlement of a cancelled run writes its text to the durable row and
+    to the transcript, so an external visitor must not read the operator
+    wording every other source keeps.
+    """
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="settlement text",
+        source=task_source,
+        run_id=None,
+        state_version=0,
+    )
+    _broadcast_manager(monkeypatch)
+    execution_started = asyncio.Event()
+
+    async def block_until_cancelled(**_kwargs: object) -> None:
+        execution_started.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(websocket_api, "execute_task_background", block_until_cancelled)
+    monkeypatch.setattr(
+        task_orchestrator,
+        "load_task_setup_snapshot_sync",
+        lambda *_args, **_kwargs: SimpleNamespace(task=SimpleNamespace(id=task_id)),
+    )
+    monkeypatch.setattr(task_orchestrator, "_get_agent_manager", MagicMock())
+
+    bg_task = task_orchestrator._schedule_bg(
+        task_id=task_id,
+        task_owner_user_id=owner_user_id,
+        task_source=task_source,
+        payload=TaskTurnPayload("stop me"),
+        force_fresh=False,
+        context=None,
+    )
+    try:
+        await asyncio.wait_for(execution_started.wait(), timeout=5)
+        bg_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await bg_task
+    finally:
+        websocket_api.background_task_manager.running_tasks.pop(task_id, None)
+
+    assert _load_task(task_id).error_message == expected_error
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "expected_state_version",
+    [5, 4],
+    ids=["own_finalize_replayed", "run_settled_first"],
+)
+async def test_external_cancel_finalize_replay_idempotent(
+    monkeypatch: pytest.MonkeyPatch,
+    expected_state_version: int,
+) -> None:
+    """A replay reads the state tuple and writes nothing.
+
+    The same command redelivered after its own finalize finds its own state
+    version; the settlement of the run it cancelled leaves the same terminal
+    tuple one version further on. Both are the outcome the command asked
+    for, so neither may rewrite the row.
+    """
+    agent_id, owner_user_id = _create_agent()
+    manager = _broadcast_manager(monkeypatch)
+    cancel_task = AsyncMock(return_value=MagicMock(requested=False))
+    monkeypatch.setattr(
+        websocket_api.background_task_manager, "cancel_task", cancel_task
+    )
+    settled_by_the_run = "settled elsewhere"
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="settled cancel target",
+        status=TaskStatus.FAILED,
+        control_state=TaskControlState.FAILED.value,
+        state_version=5,
+        error_message=settled_by_the_run,
+    )
+
+    await cancel_external_task_unserialized(
+        task_id=task_id,
+        agent_id=agent_id,
+        expected_run_id="run-external",
+        expected_state_version=expected_state_version,
+    )
+
+    replayed = _load_task(task_id)
+    assert replayed.status == TaskStatus.FAILED
+    assert replayed.state_version == 5
+    assert replayed.error_message == settled_by_the_run
+    assert cancel_task.await_count == 0
+    # A settled target is not cancelled a second time, but the terminal
+    # event still goes out: the attempt that settled it may have died
+    # before broadcasting.
+    assert len(_broadcast_payloads(manager)) == 1
+
+
+@pytest.mark.asyncio
+async def test_external_cancel_marks_delivery_dispatched_on_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A finalize that outruns the settlement closes the delivery row itself.
+
+    The delivery row is closed by whichever coroutine settles the turn. When
+    the wait expires and this finalize wins, nothing else will ever move the
+    row off ``pending`` and every resend of that client message id would be
+    refused forever.
+    """
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="delivery row after timeout",
+    )
+    _seed_pending_user_message(
+        task_id=task_id, owner_user_id=owner_user_id, turn_id="turn-timeout"
+    )
+    _broadcast_manager(monkeypatch)
+    monkeypatch.setattr(external_task_cancel, "EXTERNAL_CANCEL_WAIT_SECONDS", 0.05)
+
+    async def unwind_past_the_wait() -> None:
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            await asyncio.sleep(0.2)
+
+    unwinding = asyncio.create_task(unwind_past_the_wait())
+    websocket_api.background_task_manager.register_task(task_id, unwinding)
+    try:
+        await cancel_external_task_unserialized(
+            task_id=task_id,
+            agent_id=agent_id,
+            expected_run_id="run-external",
+            expected_state_version=4,
+        )
+    finally:
+        websocket_api.background_task_manager.running_tasks.pop(task_id, None)
+
+    assert _load_task(task_id).status == TaskStatus.FAILED
+    assert _delivery_status(task_id, "turn-timeout") == DELIVERY_DISPATCHED
+
+
+@pytest.mark.asyncio
+async def test_cancel_wait_constants_isolated(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The longer external wait stays on the external path.
+
+    The wait occupies a dispatcher slot per handle, so leaking the external
+    value onto the A2A path would multiply every A2A cancel's worst case.
+    """
+    agent_id, owner_user_id = _create_agent()
+    external_task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="external wait",
+    )
+    a2a_task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="a2a wait",
+        source="a2a",
+        agent_config={"a2a_context_id": "ctx-external-wait"},
+    )
+    _broadcast_manager(monkeypatch)
+    waits: list[float | None] = []
+
+    async def record_wait(
+        _task_id: int, timeout_seconds: float | None = None
+    ) -> MagicMock:
+        waits.append(timeout_seconds)
+        return MagicMock(requested=False)
+
+    monkeypatch.setattr(
+        websocket_api.background_task_manager, "cancel_task", record_wait
+    )
+
+    await cancel_external_task_unserialized(
+        task_id=external_task_id,
+        agent_id=agent_id,
+        expected_run_id="run-external",
+        expected_state_version=4,
+    )
+    await a2a_api._cancel_task_unserialized(
+        task_id=a2a_task_id,
+        agent_id=agent_id,
+        expected_run_id="run-external",
+        expected_state_version=4,
+    )
+
+    a2a_default = inspect.signature(
+        websocket_api.BackgroundTaskManager.cancel_task
+    ).parameters["timeout_seconds"]
+    assert waits == [EXTERNAL_CANCEL_WAIT_SECONDS, None]
+    assert EXTERNAL_CANCEL_WAIT_SECONDS == 5.0
+    assert a2a_default.default == 0.5
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("expected_run_id", "expected_state_version", "wrong_agent"),
+    [
+        ("run-external", 4, True),
+        ("run-rotated", 4, False),
+        ("run-external", 9, False),
+    ],
+    ids=["not_this_agents_task", "run_rotated", "state_version_moved"],
+)
+async def test_external_cancel_failures_classified_rejected(
+    monkeypatch: pytest.MonkeyPatch,
+    expected_run_id: str,
+    expected_state_version: int,
+    wrong_agent: bool,
+) -> None:
+    """Every expected failure leaves the core as a rejection.
+
+    A rejection is terminal without an error frame, which is the outcome an
+    anonymous visitor should get for a stop whose target is gone. A plain
+    exception would instead retry and then render as an error bubble.
+    """
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="rejected cancel",
+    )
+    _broadcast_manager(monkeypatch)
+    monkeypatch.setattr(
+        websocket_api.background_task_manager,
+        "cancel_task",
+        AsyncMock(return_value=MagicMock(requested=False)),
+    )
+
+    with pytest.raises(TaskCommandRejected):
+        await cancel_external_task_unserialized(
+            task_id=task_id,
+            agent_id=agent_id + 1 if wrong_agent else agent_id,
+            expected_run_id=expected_run_id,
+            expected_state_version=expected_state_version,
+        )
+
+    untouched = _load_task(task_id)
+    assert untouched.status == TaskStatus.RUNNING
+    assert untouched.state_version == 4
+    assert untouched.error_message is None
+
+
+@pytest.mark.asyncio
+async def test_terminal_command_error_text_external(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An exhausted external cancel broadcasts the neutral sentence.
+
+    Driven by a deleted task row, which is a real raise site outside the
+    external core: the failure budget runs out and the broadcast reaches the
+    visitor's conversation, where the default wording would carry command
+    and exception detail.
+    """
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="deleted before cancel",
+    )
+    db = _direct_db_session()
+    try:
+        db.query(Task).filter(Task.id == task_id).delete()
+        db.commit()
+    finally:
+        db.close()
+    manager = _broadcast_manager(monkeypatch)
+    command = ClaimedTaskCommand(
+        id=1,
+        task_id=task_id,
+        actor_user_id=None,
+        command_id=f"cancel:{task_id}:4",
+        kind=TaskCommandKind.CANCEL,
+        payload={
+            "agent_id": agent_id,
+            "target_state_version": 4,
+            "scope": "external",
+            "end_user_id": "visitor-1",
+        },
+        target_run_id="run-external",
+        attempt_count=MAX_COMMAND_FAILURES,
+        failure_count=MAX_COMMAND_FAILURES - 1,
+    )
+
+    with pytest.raises(ValueError) as raised:
+        await websocket_api.execute_durable_task_command(command)
+
+    payloads = _broadcast_payloads(manager)
+    assert [payload["type"] for payload in payloads] == ["agent_error"]
+    assert payloads[0]["message"] == EXTERNAL_TURN_INTERRUPTED_MESSAGE
+    assert str(raised.value) not in repr(payloads)
+    assert command.command_id not in repr(payloads[0]["message"])
+
+
+@pytest.mark.asyncio
+async def test_cancel_payload_audit_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    """``end_user_id`` is audit data: nothing on this path reads it.
+
+    It is a value the producer reports about itself, not an authorization
+    fact, so the same command with and without it must hand the core exactly
+    the same target.
+    """
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="audit field only",
+    )
+    _broadcast_manager(monkeypatch)
+    observed: list[dict[str, Any]] = []
+
+    async def record_target(**kwargs: Any) -> None:
+        observed.append(kwargs)
+
+    monkeypatch.setattr(
+        websocket_api, "cancel_external_task_unserialized", record_target
+    )
+    payloads: list[dict[str, Any]] = [
+        {"agent_id": agent_id, "target_state_version": 4, "scope": "external"},
+        {
+            "agent_id": agent_id,
+            "target_state_version": 4,
+            "scope": "external",
+            "end_user_id": "visitor-1",
+        },
+    ]
+
+    for payload in payloads:
+        await websocket_api._execute_durable_task_command(
+            ClaimedTaskCommand(
+                id=2,
+                task_id=task_id,
+                actor_user_id=None,
+                command_id=f"cancel:{task_id}:4",
+                kind=TaskCommandKind.CANCEL,
+                payload=payload,
+                target_run_id="run-external",
+                attempt_count=1,
+            )
+        )
+
+    assert len(observed) == len(payloads)
+    assert observed[0] == observed[1]
+
+
+@pytest.mark.asyncio
+async def test_cancel_without_scope_stays_on_the_a2a_core(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A payload with no scope reaches the A2A core exactly as before."""
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_task(
+        agent_id=agent_id,
+        owner_user_id=owner_user_id,
+        title="scopeless cancel",
+        source="a2a",
+        agent_config={"a2a_context_id": "ctx-scopeless"},
+    )
+    _broadcast_manager(monkeypatch)
+    monkeypatch.setattr(
+        websocket_api.background_task_manager,
+        "cancel_task",
+        AsyncMock(return_value=MagicMock(requested=False)),
+    )
+    external_core = AsyncMock()
+    monkeypatch.setattr(
+        websocket_api, "cancel_external_task_unserialized", external_core
+    )
+
+    await websocket_api._execute_durable_task_command(
+        ClaimedTaskCommand(
+            id=3,
+            task_id=task_id,
+            actor_user_id=owner_user_id,
+            command_id=f"cancel:{task_id}:4",
+            kind=TaskCommandKind.CANCEL,
+            payload={"agent_id": agent_id, "target_state_version": 4},
+            target_run_id="run-external",
+            attempt_count=1,
+        )
+    )
+
+    cancelled = _load_task(task_id)
+    assert external_core.await_count == 0
+    assert cancelled.status == TaskStatus.FAILED
+    assert cancelled.error_message == "Task canceled by A2A client."
+    assert cancelled.agent_config["a2a_state"] == "TASK_STATE_CANCELED"

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -890,7 +890,10 @@ async def test_terminal_command_failure_keeps_context_and_redacts_detail() -> No
     connection_manager = MagicMock()
     connection_manager.broadcast_to_task = AsyncMock()
     command = SimpleNamespace(
-        kind=websocket_api.TaskCommandKind.PAUSE, task_id=7, command_id="cmd-7"
+        kind=websocket_api.TaskCommandKind.PAUSE,
+        task_id=7,
+        command_id="cmd-7",
+        payload={},
     )
     with patch.object(websocket_api, "manager", connection_manager):
         await websocket_api._broadcast_terminal_command_error(


### PR DESCRIPTION
Part of #1673.

## What changes

- A `CANCEL` task command may now carry `scope: "external"` in its payload. Such a command runs a dedicated execution core targeting `Task.source == "external"` rows; the existing A2A core loads its target with `Task.source == "a2a"` and can never reach an external task. A command without a scope keeps the A2A path unchanged.
- The external core loads the target by task id, agent id, and source, verifies the expected `run_id` / `state_version`, hard-cancels the running turn with its own 5-second wait (the A2A wait stays at the 0.5-second default), commits a fenced terminal row (`FAILED`, lease columns cleared, `state_version` bumped), closes the cancelled turn's pending delivery row as `dispatched`, and broadcasts the terminal `task_error` event itself. The broadcast lives here because a cancelled run's own settlement never broadcasts: `broadcast_error_message` is assigned only on the setup/run exception path, not on cancellation.
- A replay of the same command is answered from the durable state tuple (already `FAILED`, same `run_id`, `state_version` at or one past the target) without writing anything. Every expected failure — missing or foreign task, changed run or state version — leaves the core as a command rejection.
- Cancellation text follows its audience. A cancelled external turn settles with "This response was interrupted." (an external task's transcript is read by the end visitor), while every other source keeps the existing operator wording. The task's `error_message` records "Stopped by the visitor." only when the cancel command itself finalized the row, so an operator can tell a visitor-initiated stop from any other interruption. An exhausted external cancel command broadcasts the same neutral sentence instead of command identity and exception detail.

## Why

Embedded chat surfaces need a way to stop a running turn (#1673). The missing server half is a cancel path that can reach `source == "external"` tasks; this change provides it behind the durable command channel, which already owns idempotency, ordering, and delivery to the process holding the task lease. Nothing in this repository produces external-scope commands yet, so runtime behavior is unchanged until a producer enqueues one.

## Verification

- `pytest tests/web/api/test_external_task_cancel.py` — pins: terminal broadcast and terminal row shape; settlement text per task source; replay idempotency from the state tuple; delivery-row closure on the cancel-wait timeout path; wait-constant isolation (external 5.0s vs A2A default 0.5s); rejection classification for every expected failure; neutral broadcast on command-budget exhaustion, driven by a deleted task row; the `end_user_id` payload field being audit-only (never read by the executor); and scope-less commands staying on the A2A core with unchanged behavior.
- `pytest tests/web/api tests/web/services tests/architecture -m "not postgresql"` — no new failures against the base revision.
- `pre-commit run` passes on all changed files.

## Review follow-up

The second commit closes the races the review confirmed: the finalize stages the visitor-facing interruption transcript line and the stopped turn's delivery row in the same transaction as the fenced terminal write (an optional `turn_id` in the command payload targets the exact row); the replay judgement additionally requires one of the two cancel-written sentences on the durable row, so a run that failed on its own is never claimed as a cancellation; an exhausted cancel command is worded by the task's live status and never asserts an interruption that has not happened; unknown explicit scopes are rejected terminally instead of falling through to the A2A core; the external-scope terminal broadcast carries an allowlisted payload without internal command identity; and the shared task cache is invalidated once the finalize commits.
