### PR TITLE
fix(tasks): carry the caller timezone into turns that start at task creation

### DIFF
--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -237,6 +237,10 @@ describe("PublicAgentChatPage", () => {
     sessionStorage.clear()
     fetchMock.mockReset()
     vi.stubGlobal("fetch", fetchMock)
+    // Pinned so the create-body assertions below do not depend on the host zone.
+    vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue(
+      { timeZone: "Australia/Melbourne" } as Intl.ResolvedDateTimeFormatOptions,
+    )
   })
 
   afterEach(() => {
@@ -478,6 +482,7 @@ describe("PublicAgentChatPage", () => {
         body: JSON.stringify({
           title: "first message",
           description: "first message",
+          timezone: "Australia/Melbourne",
           agent_id: 17,
         }),
       },
@@ -502,6 +507,26 @@ describe("PublicAgentChatPage", () => {
 
     expect(await screen.findByTestId("conversation-panel")).toBeInTheDocument()
     expect(app.setTaskId).toHaveBeenCalledWith(42, { navigate: false })
+  })
+
+  it("omits the timezone from the opening turn when the browser resolves none", async () => {
+    vi.spyOn(Intl.DateTimeFormat.prototype, "resolvedOptions").mockReturnValue(
+      { timeZone: "" } as Intl.ResolvedDateTimeFormatOptions,
+    )
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(successfulWorkforceAuth))
+      .mockResolvedValueOnce(jsonResponse(widgetTaskResponse(44, "running")))
+
+    renderWidgetPage({ searchAgentId: null, widgetKey: "widget-secret" })
+
+    fireEvent.click(await screen.findByRole("button", { name: "start:Support Workforce" }))
+
+    await waitFor(() => {
+      expect(app.setTaskId).toHaveBeenCalledWith(44, { navigate: false })
+    })
+    const createBody = JSON.parse(fetchMock.mock.calls[1][1].body)
+    expect("timezone" in createBody).toBe(false)
+    expect(createBody.description).toBe("first message")
   })
 
   it("lets workforce task creation start the opening turn without sending it again", async () => {
@@ -543,6 +568,7 @@ describe("PublicAgentChatPage", () => {
         body: JSON.stringify({
           title: "first message",
           description: "first message",
+          timezone: "Australia/Melbourne",
         }),
       },
     )

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -5,6 +5,7 @@ import { Loader2, MessageSquarePlus } from "lucide-react"
 import { ChatStartScreen } from "@/components/chat/ChatStartScreen"
 import { TaskConversationPanel } from "@/components/task/task-conversation-panel"
 import { AppProvider, useApp, type AppProviderTransportConfig } from "@/contexts/app-context-chat"
+import { resolveReportedTimezone } from "@/hooks/use-websocket"
 import { usePublicFileAccessPolicy } from "@/contexts/file-access-context"
 import { useI18n } from "@/contexts/i18n-context"
 import { uploadPublicChatFile } from "@/lib/public-chat-file-upload"
@@ -262,6 +263,13 @@ function PublicConversationContent({
       const taskPayload: Record<string, string | number | string[]> = {
         title: message,
         description: message,
+      }
+      // Workforce opening turns start inside this request and never reach
+      // sendChatMessage, so the zone has to ride along here or the first
+      // answer is rendered against UTC.
+      const openingTimezone = resolveReportedTimezone()
+      if (openingTimezone) {
+        taskPayload.timezone = openingTimezone
       }
       if (agentId) {
         taskPayload.agent_id = agentId

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -77,7 +77,7 @@ export class MessageDeliveryError extends Error {
   }
 }
 
-const resolveReportedTimezone = (): string | undefined => {
+export const resolveReportedTimezone = (): string | undefined => {
   if (typeof window !== "undefined") {
     // widget.js copies data-timezone onto the iframe URL; an embedder that knows
     // its user's business zone outranks the machine zone.

--- a/frontend/src/lib/workforces-api.test.ts
+++ b/frontend/src/lib/workforces-api.test.ts
@@ -1,6 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
+const resolveTimezoneMock = vi.hoisted(() => vi.fn<() => string | undefined>())
+
+vi.mock("@/hooks/use-websocket", () => ({
+  resolveReportedTimezone: resolveTimezoneMock,
+}))
 
 vi.mock("@/lib/api-wrapper", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
@@ -25,6 +30,7 @@ import {
   listAgentOptions,
   listWorkforces,
   runWorkforce,
+  runWorkforcePreview,
   unarchiveWorkforce,
 } from "./workforces-api"
 
@@ -39,6 +45,8 @@ function jsonResponse(data: unknown, init?: ResponseInit) {
 describe("workforces-api", () => {
   beforeEach(() => {
     apiRequestMock.mockReset()
+    resolveTimezoneMock.mockReset()
+    resolveTimezoneMock.mockReturnValue(undefined)
   })
 
   it("uses the PR5 list pagination and visibility contract", async () => {
@@ -134,6 +142,78 @@ describe("workforces-api", () => {
       }),
     )
     expect(result.redirect_url).toBe("/task/10")
+  })
+
+  it("attaches the reported timezone to a workforce run opener", async () => {
+    resolveTimezoneMock.mockReturnValue("Australia/Melbourne")
+    apiRequestMock.mockResolvedValueOnce(
+      jsonResponse({
+        workforce_run_id: 9,
+        task_id: 10,
+        status: "running",
+        redirect_url: "/task/10",
+      }),
+    )
+
+    await runWorkforce(5, { message: "go", files: ["file-1"] })
+
+    const body = JSON.parse(apiRequestMock.mock.calls[0][1].body)
+    expect(body.timezone).toBe("Australia/Melbourne")
+  })
+
+  it("omits the timezone from a workforce run opener when none resolves", async () => {
+    resolveTimezoneMock.mockReturnValue(undefined)
+    apiRequestMock.mockResolvedValueOnce(
+      jsonResponse({
+        workforce_run_id: 9,
+        task_id: 10,
+        status: "running",
+        redirect_url: "/task/10",
+      }),
+    )
+
+    await runWorkforce(5, { message: "go" })
+
+    const body = JSON.parse(apiRequestMock.mock.calls[0][1].body)
+    expect("timezone" in body).toBe(false)
+  })
+
+  it("lets an explicit timezone on the payload win over the resolver", async () => {
+    resolveTimezoneMock.mockReturnValue("Australia/Melbourne")
+    apiRequestMock.mockResolvedValueOnce(
+      jsonResponse({
+        workforce_run_id: 9,
+        task_id: 10,
+        status: "running",
+        redirect_url: "/task/10",
+      }),
+    )
+
+    await runWorkforce(5, { message: "go", timezone: "Asia/Kolkata" })
+
+    const body = JSON.parse(apiRequestMock.mock.calls[0][1].body)
+    expect(body.timezone).toBe("Asia/Kolkata")
+  })
+
+  it("attaches the reported timezone to a workforce preview opener", async () => {
+    resolveTimezoneMock.mockReturnValue("Australia/Melbourne")
+    apiRequestMock.mockResolvedValueOnce(
+      jsonResponse({
+        workforce_run_id: 9,
+        task_id: 10,
+        status: "running",
+        redirect_url: "/task/10",
+      }),
+    )
+
+    await runWorkforcePreview({
+      manager_agent_id: 1,
+      workers: [{ agent_id: 2, assignment_instructions: "do it" }],
+      message: "go",
+    })
+
+    const body = JSON.parse(apiRequestMock.mock.calls[0][1].body)
+    expect(body.timezone).toBe("Australia/Melbourne")
   })
 
   it("loads one delegated Agent execution on demand", async () => {

--- a/frontend/src/lib/workforces-api.ts
+++ b/frontend/src/lib/workforces-api.ts
@@ -7,6 +7,7 @@ import {
   parseApiResponse,
 } from "@/lib/api-wrapper"
 import { getApiUrl } from "@/lib/utils"
+import { resolveReportedTimezone } from "@/hooks/use-websocket"
 import type {
   WorkforceAgentOption,
   WorkforceAgentExecution,
@@ -305,11 +306,23 @@ export async function removeWorkforceAgent(
   }
 }
 
+// The workforce opening turn starts inside this HTTP request and never reaches
+// the websocket send path, so the zone is attached here. An explicit value on
+// the payload wins; otherwise fall back to the browser/data-timezone resolution.
+function withReportedTimezone<T extends { timezone?: string }>(payload: T): T {
+  if (payload.timezone) return payload
+  const timezone = resolveReportedTimezone()
+  return timezone ? { ...payload, timezone } : payload
+}
+
+
 export async function runWorkforce(
   workforceId: number | string,
   payload: WorkforceRunPayload | string,
 ): Promise<WorkforceRunResponse> {
-  const body = typeof payload === "string" ? { message: payload } : payload
+  const body = withReportedTimezone(
+    typeof payload === "string" ? { message: payload } : payload,
+  )
   const response = await apiRequest(`${getApiUrl()}/api/workforces/${workforceId}/runs`, {
     method: "POST",
     headers: jsonHeaders(),
@@ -327,7 +340,7 @@ export async function runWorkforcePreview(
   const response = await apiRequest(`${getApiUrl()}/api/workforces/preview/runs`, {
     method: "POST",
     headers: jsonHeaders(),
-    body: JSON.stringify(payload),
+    body: JSON.stringify(withReportedTimezone(payload)),
   })
   if (!response.ok) {
     throw await parseApiError(response, "Failed to run workforce preview")

--- a/frontend/src/types/workforce.ts
+++ b/frontend/src/types/workforce.ts
@@ -199,6 +199,7 @@ export interface WorkforceRunPayload {
   execution_mode?: string | null
   is_preview?: boolean
   is_visible?: boolean
+  timezone?: string
 }
 
 export interface WorkforceRunResponse {
@@ -220,6 +221,7 @@ export interface WorkforcePreviewRunPayload {
   message: string
   files?: string[]
   execution_mode?: string | null
+  timezone?: string
 }
 
 export interface WorkforceShareLink {

--- a/src/xagent/web/api/public_chat_access.py
+++ b/src/xagent/web/api/public_chat_access.py
@@ -1007,6 +1007,7 @@ async def _create_workforce_widget_chat_task(
         workforce,
         message=request.description or "",
         selected_file_ids=request.files,
+        timezone=request.timezone,
         source="widget",
         is_visible=False,
         extra_agent_config={
@@ -1172,6 +1173,7 @@ async def _create_workforce_share_chat_task(
         workforce,
         message=request.description or "",
         selected_file_ids=request.files,
+        timezone=request.timezone,
         source="shared_link",
         is_visible=False,
         extra_agent_config={

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -665,6 +665,7 @@ async def create_chat_task(
                 actor_user_id=actor_user_id,
                 payload=prepared.payload,
                 claimed=prepared.claimed_turn,
+                context=({"timezone": request.timezone} if request.timezone else None),
             )
         except TaskTurnError as exc:
             pop_ephemeral_runtime_values(prepared.payload.turn_id)

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -93,6 +93,7 @@ from ...services.task_orchestrator import (
     _ClaimedTurn,
     _retire_turn_session_best_effort,
     commit_claimed_turn_or_reconcile,
+    timezone_schedule_context,
 )
 from . import _events_stream
 from ._step_mapping import map_trace_events_to_public_steps
@@ -665,7 +666,7 @@ async def create_chat_task(
                 actor_user_id=actor_user_id,
                 payload=prepared.payload,
                 claimed=prepared.claimed_turn,
-                context=({"timezone": request.timezone} if request.timezone else None),
+                context=timezone_schedule_context(request.timezone),
             )
         except TaskTurnError as exc:
             pop_ephemeral_runtime_values(prepared.payload.turn_id)

--- a/src/xagent/web/api/v1/workforces.py
+++ b/src/xagent/web/api/v1/workforces.py
@@ -142,6 +142,7 @@ async def create_workforce_run_endpoint(
             is_visible=False,
             source="sdk",
             idempotency_key=request.idempotency_key,
+            timezone=request.timezone,
         )
     except HTTPException as exc:
         _raise_v1_for_workforce_http_error(exc)

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -128,6 +128,10 @@ class WorkforceRunRequest(BaseModel):
     execution_mode: str | None = None
     is_preview: bool = False
     is_visible: bool = True
+    # Opening turn starts inside this request, so the zone rides here or the
+    # first answer renders against UTC. Unresolvable names degrade to UTC at
+    # the render site rather than 422 here.
+    timezone: str | None = None
 
 
 class WorkforcePreviewRunRequest(BaseModel):
@@ -138,6 +142,7 @@ class WorkforcePreviewRunRequest(BaseModel):
     message: str = Field(..., min_length=1)
     files: list[str] = Field(default_factory=list)
     execution_mode: str | None = None
+    timezone: str | None = None
 
 
 def _field_supplied(model: BaseModel, field_name: str) -> bool:
@@ -663,6 +668,7 @@ async def create_workforce_preview_run(
         message=request.message,
         selected_file_ids=request.files,
         execution_mode=request.execution_mode,
+        timezone=request.timezone,
     )
     return {
         "workforce_run_id": result.workforce_run.id,
@@ -1420,6 +1426,7 @@ async def create_workforce_run(
         execution_mode=request.execution_mode,
         is_preview=request.is_preview,
         is_visible=request.is_visible,
+        timezone=request.timezone,
     )
     return {
         "workforce_run_id": result.workforce_run.id,

--- a/src/xagent/web/api/workforces.py
+++ b/src/xagent/web/api/workforces.py
@@ -131,7 +131,7 @@ class WorkforceRunRequest(BaseModel):
     # Opening turn starts inside this request, so the zone rides here or the
     # first answer renders against UTC. Unresolvable names degrade to UTC at
     # the render site rather than 422 here.
-    timezone: str | None = None
+    timezone: str | None = Field(default=None, max_length=64)
 
 
 class WorkforcePreviewRunRequest(BaseModel):
@@ -142,7 +142,7 @@ class WorkforcePreviewRunRequest(BaseModel):
     message: str = Field(..., min_length=1)
     files: list[str] = Field(default_factory=list)
     execution_mode: str | None = None
-    timezone: str | None = None
+    timezone: str | None = Field(default=None, max_length=64)
 
 
 def _field_supplied(model: BaseModel, field_name: str) -> bool:

--- a/src/xagent/web/schemas/chat.py
+++ b/src/xagent/web/schemas/chat.py
@@ -88,7 +88,10 @@ class TaskCreateRequest(BaseModel):
     # Only consumed by entry points that start the first turn inside task
     # creation. Unresolvable names degrade to UTC at the render site rather
     # than 422 here, matching how the websocket path treats the same field.
-    timezone: Optional[str] = None  # IANA name for the caller's local clock
+    # max_length bounds this guest-reachable free-text field to IANA lengths.
+    timezone: Optional[str] = Field(
+        default=None, max_length=64
+    )  # IANA name for the caller's local clock
 
     # Execution mode field
     execution_mode: Optional[str] = None  # "flash", "balanced", "think", or "auto"

--- a/src/xagent/web/schemas/chat.py
+++ b/src/xagent/web/schemas/chat.py
@@ -85,6 +85,10 @@ class TaskCreateRequest(BaseModel):
     )
     is_preview: bool = False  # Backward-compatible alias for is_visible=False.
     is_visible: bool = True
+    # Only consumed by entry points that start the first turn inside task
+    # creation. Unresolvable names degrade to UTC at the render site rather
+    # than 422 here, matching how the websocket path treats the same field.
+    timezone: Optional[str] = None  # IANA name for the caller's local clock
 
     # Execution mode field
     execution_mode: Optional[str] = None  # "flash", "balanced", "think", or "auto"

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -496,6 +496,14 @@ class CreateWorkforceRunRequest(BaseModel):
             "the original run rather than creating a new one."
         ),
     )
+    timezone: Optional[str] = Field(
+        default=None,
+        description=(
+            "IANA timezone name for the end user's local clock, used to render "
+            "the date the workforce reasons from. Omit to keep UTC. An "
+            "unresolvable name degrades to UTC rather than failing the request."
+        ),
+    )
 
 
 class CreateWorkforceRunResponse(BaseModel):

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -117,6 +117,7 @@ class CreateTaskRequest(BaseModel):
     )
     timezone: Optional[str] = Field(
         default=None,
+        max_length=64,
         description=(
             "IANA timezone name for the end user's local clock, used to render "
             "the date the agent reasons from. Omit to keep UTC. An "

--- a/src/xagent/web/schemas/v1.py
+++ b/src/xagent/web/schemas/v1.py
@@ -115,6 +115,14 @@ class CreateTaskRequest(BaseModel):
             "validated and applied below the LLM/tool-argument layer."
         ),
     )
+    timezone: Optional[str] = Field(
+        default=None,
+        description=(
+            "IANA timezone name for the end user's local clock, used to render "
+            "the date the agent reasons from. Omit to keep UTC. An "
+            "unresolvable name degrades to UTC rather than failing the request."
+        ),
+    )
 
 
 class UploadedFileInfo(BaseModel):

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -56,6 +56,7 @@ from uuid import uuid4
 from sqlalchemy import func
 from sqlalchemy.orm import Session
 
+from ...core.agent.context.execution import CLOCK_TIMEZONE_METADATA_KEY
 from ...core.execution_scope import resolve_execution_scope
 from ...core.tools.adapters.vibe.config import RequiredMCPUnavailableError
 from ..models.task import Task, TaskStatus
@@ -110,6 +111,18 @@ _APPENDABLE_STATUSES = (
     TaskStatus.FAILED,
     TaskStatus.PAUSED,
 )
+
+
+def timezone_schedule_context(timezone: str | None) -> dict[str, Any] | None:
+    """Build the schedule ``context`` carrying the caller's clock timezone.
+
+    Shared by every create-first entry point (workforce widget/share, the
+    workforce SDK, and ``/v1/chat/tasks``) so blank normalization and the
+    metadata key stay identical across them. Whitespace-only degrades to
+    ``None`` so the renderer keeps UTC.
+    """
+    normalized = (timezone or "").strip()
+    return {CLOCK_TIMEZONE_METADATA_KEY: normalized} if normalized else None
 
 
 @dataclass(frozen=True)

--- a/src/xagent/web/services/workforce_runs.py
+++ b/src/xagent/web/services/workforce_runs.py
@@ -102,6 +102,7 @@ class _NormalizedWorkforceRunRequest:
     source: str
     idempotency_key: str | None
     extra_agent_config: dict[str, Any] | None
+    timezone: str | None
 
 
 def normalize_execution_mode(value: str | None) -> str:
@@ -181,6 +182,7 @@ def _normalize_workforce_run_request(
     source: str | None,
     idempotency_key: str | None,
     extra_agent_config: dict[str, Any] | None,
+    timezone: str | None = None,
 ) -> _NormalizedWorkforceRunRequest:
     """Normalize caller input once before either transaction owner runs."""
 
@@ -195,6 +197,7 @@ def _normalize_workforce_run_request(
         extra_agent_config=(
             dict(extra_agent_config) if extra_agent_config is not None else None
         ),
+        timezone=(timezone or "").strip() or None,
     )
 
 
@@ -727,6 +730,7 @@ async def _start_normalized_workforce_run(
             actor_user_id=user_id,
             payload=prepared.payload,
             claimed=prepared.claimed_turn,
+            context=({"timezone": request.timezone} if request.timezone else None),
         )
         return WorkforceRunStartResult(
             workforce_run=prepared.workforce_run,
@@ -753,6 +757,7 @@ async def create_workforce_run_by_id(
     source: str | None = None,
     idempotency_key: str | None = None,
     extra_agent_config: dict[str, Any] | None = None,
+    timezone: str | None = None,
 ) -> WorkforceRunStartResult:
     """Create a run from detached identities.
 
@@ -770,6 +775,7 @@ async def create_workforce_run_by_id(
         source=source,
         idempotency_key=idempotency_key,
         extra_agent_config=extra_agent_config,
+        timezone=timezone,
     )
     return await _start_normalized_workforce_run(
         user_id=int(user_id),
@@ -791,6 +797,7 @@ async def create_workforce_run(
     source: str | None = None,
     idempotency_key: str | None = None,
     extra_agent_config: dict[str, Any] | None = None,
+    timezone: str | None = None,
 ) -> WorkforceRunStartResult:
     """Compatibility entry point for callers that still own ORM identities."""
 
@@ -807,6 +814,7 @@ async def create_workforce_run(
         source=source,
         idempotency_key=idempotency_key,
         extra_agent_config=extra_agent_config,
+        timezone=timezone,
     )
     if not release_db_connection_if_clean(db):
         raise RuntimeError("request DB transaction is not clean at turn boundary")

--- a/src/xagent/web/services/workforce_runs.py
+++ b/src/xagent/web/services/workforce_runs.py
@@ -198,7 +198,7 @@ def _normalize_workforce_run_request(
         extra_agent_config=(
             dict(extra_agent_config) if extra_agent_config is not None else None
         ),
-        timezone=(timezone or "").strip() or None,
+        timezone=(timezone.strip() or None) if isinstance(timezone, str) else None,
     )
 
 

--- a/src/xagent/web/services/workforce_runs.py
+++ b/src/xagent/web/services/workforce_runs.py
@@ -31,6 +31,7 @@ from .task_orchestrator import (
     TaskTurnOrchestrator,
     TaskTurnPayload,
     _ClaimedTurn,
+    timezone_schedule_context,
 )
 from .workforce_access import ensure_workforce_access, get_workforce_policy
 from .workforce_errors import WorkforceRunError, WorkforceRunErrorCode
@@ -730,7 +731,7 @@ async def _start_normalized_workforce_run(
             actor_user_id=user_id,
             payload=prepared.payload,
             claimed=prepared.claimed_turn,
-            context=({"timezone": request.timezone} if request.timezone else None),
+            context=timezone_schedule_context(request.timezone),
         )
         return WorkforceRunStartResult(
             workforce_run=prepared.workforce_run,
@@ -837,6 +838,7 @@ async def create_preview_workforce_run(
     selected_file_ids: list[str] | None = None,
     execution_mode: str | None = None,
     source: str | None = None,
+    timezone: str | None = None,
 ) -> WorkforceRunStartResult:
     """Test-run an unsaved workforce draft: a manager + inline worker configs
     that were never persisted as a Workforce row.
@@ -863,6 +865,7 @@ async def create_preview_workforce_run(
         source=source,
         idempotency_key=None,
         extra_agent_config=None,
+        timezone=timezone,
     )
 
     async def _create_and_schedule() -> WorkforceRunStartResult:
@@ -882,6 +885,7 @@ async def create_preview_workforce_run(
             actor_user_id=user_id,
             payload=cast(TaskTurnPayload, prepared.payload),
             claimed=cast(_ClaimedTurn, prepared.claimed_turn),
+            context=timezone_schedule_context(request.timezone),
         )
         return WorkforceRunStartResult(
             workforce_run=prepared.workforce_run,

--- a/tests/web/api/conftest.py
+++ b/tests/web/api/conftest.py
@@ -345,7 +345,7 @@ def _install_one_slot_queue_pool(
     return engine
 
 
-def patch_schedule_bg(monkeypatch: pytest.MonkeyPatch) -> None:
+def patch_schedule_bg(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
     """Replace the leaf that starts a real background turn with a no-op task.
 
     The workforce guest create path reaches
@@ -362,10 +362,15 @@ def patch_schedule_bg(monkeypatch: pytest.MonkeyPatch) -> None:
     anyway.
     """
 
-    def fake_schedule_bg(**_kwargs: Any) -> "asyncio.Task[None]":
+    scheduled: dict[str, Any] = {}
+
+    def fake_schedule_bg(**kwargs: Any) -> "asyncio.Task[None]":
+        scheduled.update(kwargs)
+
         async def noop() -> None:
             return None
 
         return asyncio.create_task(noop())
 
     monkeypatch.setattr(task_orchestrator_service, "_schedule_bg", fake_schedule_bg)
+    return scheduled

--- a/tests/web/api/test_workforce_share_link.py
+++ b/tests/web/api/test_workforce_share_link.py
@@ -424,6 +424,47 @@ def test_disabled_workforce_share_invalidates_existing_guest_tokens() -> None:
 # ===== Guest task creation → create_workforce_run =====
 
 
+def test_share_task_create_forwards_timezone_to_the_opening_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Share opening turns start inside task creation, same as the widget."""
+    workforce_id = _create_workforce("Share Timezone Workforce")
+    token = _enable_share(workforce_id)
+    guest_headers = _authenticate_share_guest(token)
+    scheduled = patch_schedule_bg(monkeypatch)
+
+    response = client.post(
+        "/api/share/chat/task/create",
+        headers=guest_headers,
+        json={
+            "title": "how many shifts do we have on tomorrow?",
+            "description": "how many shifts do we have on tomorrow?",
+            "timezone": "Australia/Melbourne",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert scheduled["context"] == {"timezone": "Australia/Melbourne"}
+
+
+def test_share_task_create_without_timezone_sends_no_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workforce_id = _create_workforce("Share No Timezone Workforce")
+    token = _enable_share(workforce_id)
+    guest_headers = _authenticate_share_guest(token)
+    scheduled = patch_schedule_bg(monkeypatch)
+
+    response = client.post(
+        "/api/share/chat/task/create",
+        headers=guest_headers,
+        json={"title": "hello", "description": "hello"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert scheduled["context"] is None
+
+
 def test_share_task_create_starts_workforce_run(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/web/api/test_workforce_widget.py
+++ b/tests/web/api/test_workforce_widget.py
@@ -559,6 +559,48 @@ def test_disabled_widget_invalidates_existing_guest_tokens() -> None:
 # ===== Guest task creation → create_workforce_run =====
 
 
+def test_widget_task_create_forwards_timezone_to_the_opening_turn(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The widget opening turn starts inside this request and never reaches the
+    websocket chat frame, so the zone has to travel on the create body."""
+    workforce_id = _create_workforce("Widget Timezone Workforce")
+    key = _enable_widget(workforce_id)
+    guest_headers = _authenticate_widget_guest_by_key(key)
+    scheduled = patch_schedule_bg(monkeypatch)
+
+    response = client.post(
+        "/api/widget/chat/task/create",
+        headers=guest_headers,
+        json={
+            "title": "how many shifts do we have on tomorrow?",
+            "description": "how many shifts do we have on tomorrow?",
+            "timezone": "Australia/Melbourne",
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert scheduled["context"] == {"timezone": "Australia/Melbourne"}
+
+
+def test_widget_task_create_without_timezone_sends_no_context(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workforce_id = _create_workforce("Widget No Timezone Workforce")
+    key = _enable_widget(workforce_id)
+    guest_headers = _authenticate_widget_guest_by_key(key)
+    scheduled = patch_schedule_bg(monkeypatch)
+
+    response = client.post(
+        "/api/widget/chat/task/create",
+        headers=guest_headers,
+        json={"title": "hello", "description": "hello"},
+    )
+
+    assert response.status_code == 200, response.text
+    assert scheduled["context"] is None
+
+
 def test_widget_task_create_starts_workforce_run(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/web/api/test_workforces_api.py
+++ b/tests/web/api/test_workforces_api.py
@@ -2082,6 +2082,7 @@ def test_run_endpoint_delegates_to_run_service(monkeypatch: pytest.MonkeyPatch) 
         execution_mode: str | None = None,
         is_preview: bool = False,
         is_visible: bool = True,
+        timezone: str | None = None,
     ) -> Any:
         captured.update(
             {
@@ -2092,6 +2093,7 @@ def test_run_endpoint_delegates_to_run_service(monkeypatch: pytest.MonkeyPatch) 
                 "execution_mode": execution_mode,
                 "is_preview": is_preview,
                 "is_visible": is_visible,
+                "timezone": timezone,
             }
         )
         return SimpleNamespace(
@@ -2108,7 +2110,12 @@ def test_run_endpoint_delegates_to_run_service(monkeypatch: pytest.MonkeyPatch) 
     response = client.post(
         f"/api/workforces/{workforce['id']}/runs",
         headers=headers,
-        json={"message": "go", "files": ["file-1"], "execution_mode": "think"},
+        json={
+            "message": "go",
+            "files": ["file-1"],
+            "execution_mode": "think",
+            "timezone": "Australia/Melbourne",
+        },
     )
     assert response.status_code == 200, response.text
     assert response.json() == {
@@ -2125,6 +2132,7 @@ def test_run_endpoint_delegates_to_run_service(monkeypatch: pytest.MonkeyPatch) 
         "execution_mode": "think",
         "is_preview": False,
         "is_visible": True,
+        "timezone": "Australia/Melbourne",
     }
 
 
@@ -2152,6 +2160,7 @@ def test_preview_run_endpoint_delegates_to_run_service(
         message: str,
         selected_file_ids: list[str] | None = None,
         execution_mode: str | None = None,
+        timezone: str | None = None,
     ) -> Any:
         captured.update(
             {
@@ -2163,6 +2172,7 @@ def test_preview_run_endpoint_delegates_to_run_service(
                 "message": message,
                 "selected_file_ids": selected_file_ids,
                 "execution_mode": execution_mode,
+                "timezone": timezone,
             }
         )
         return SimpleNamespace(
@@ -2190,6 +2200,7 @@ def test_preview_run_endpoint_delegates_to_run_service(
             ],
             "message": "go",
             "files": ["file-1"],
+            "timezone": "Australia/Melbourne",
         },
     )
     assert response.status_code == 200, response.text
@@ -2218,6 +2229,7 @@ def test_preview_run_endpoint_delegates_to_run_service(
         "message": "go",
         "selected_file_ids": ["file-1"],
         "execution_mode": None,
+        "timezone": "Australia/Melbourne",
     }
 
 

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -262,6 +262,43 @@ def mock_start_task():
 # ===== POST /v1/chat/tasks =====
 
 
+def test_create_task_forwards_timezone_to_the_first_turn(mock_start_task):
+    """SDK callers have no websocket, so the create body is their only chance
+    to declare a zone for the turn that task creation starts."""
+    agent_id, full_key = _create_agent_with_key()
+
+    resp = client.post(
+        "/v1/chat/tasks",
+        headers=_bearer(full_key),
+        json={
+            "agent_id": agent_id,
+            "message": {"role": "user", "content": "how many shifts tomorrow?"},
+            "timezone": "Australia/Melbourne",
+        },
+    )
+
+    assert resp.status_code == 202, resp.text
+    assert mock_start_task.call_args.kwargs["context"] == {
+        "timezone": "Australia/Melbourne"
+    }
+
+
+def test_create_task_without_timezone_sends_no_context(mock_start_task):
+    agent_id, full_key = _create_agent_with_key()
+
+    resp = client.post(
+        "/v1/chat/tasks",
+        headers=_bearer(full_key),
+        json={
+            "agent_id": agent_id,
+            "message": {"role": "user", "content": "hello"},
+        },
+    )
+
+    assert resp.status_code == 202, resp.text
+    assert mock_start_task.call_args.kwargs["context"] is None
+
+
 def test_create_task_happy_path(mock_start_task):
     """Returns 202 + task_id, writes hidden SDK Task + input,
     persists first user message, kicks off background, and leaves the

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -299,6 +299,23 @@ def test_create_task_without_timezone_sends_no_context(mock_start_task):
     assert mock_start_task.call_args.kwargs["context"] is None
 
 
+def test_create_task_rejects_an_over_long_timezone(mock_start_task):
+    # Guest-reachable free-text field is bounded to IANA lengths (max_length=64).
+    agent_id, full_key = _create_agent_with_key()
+
+    resp = client.post(
+        "/v1/chat/tasks",
+        headers=_bearer(full_key),
+        json={
+            "agent_id": agent_id,
+            "message": {"role": "user", "content": "hello"},
+            "timezone": "A" * 65,
+        },
+    )
+
+    assert resp.status_code == 422, resp.text
+
+
 def test_create_task_treats_a_blank_timezone_as_absent(mock_start_task):
     # The shared helper normalizes whitespace-only to None, so the SDK path
     # matches the workforce path rather than sending {"timezone": "  "}.

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -299,6 +299,25 @@ def test_create_task_without_timezone_sends_no_context(mock_start_task):
     assert mock_start_task.call_args.kwargs["context"] is None
 
 
+def test_create_task_treats_a_blank_timezone_as_absent(mock_start_task):
+    # The shared helper normalizes whitespace-only to None, so the SDK path
+    # matches the workforce path rather than sending {"timezone": "  "}.
+    agent_id, full_key = _create_agent_with_key()
+
+    resp = client.post(
+        "/v1/chat/tasks",
+        headers=_bearer(full_key),
+        json={
+            "agent_id": agent_id,
+            "message": {"role": "user", "content": "hello"},
+            "timezone": "   ",
+        },
+    )
+
+    assert resp.status_code == 202, resp.text
+    assert mock_start_task.call_args.kwargs["context"] is None
+
+
 def test_create_task_happy_path(mock_start_task):
     """Returns 202 + task_id, writes hidden SDK Task + input,
     persists first user message, kicks off background, and leaves the

--- a/tests/web/api/v1/test_workforces.py
+++ b/tests/web/api/v1/test_workforces.py
@@ -186,6 +186,43 @@ def _manager_agent_id(workforce_id: int) -> int:
 # ===== POST /v1/workforces/{id}/runs =====
 
 
+def test_create_run_forwards_timezone_to_the_opening_turn(mock_schedule_bg):
+    """The workforce SDK opener starts its turn inside this HTTP request and
+    has no websocket, so the create body is its only way to declare a zone."""
+    headers = _admin_headers()
+    workforce_id = _create_active_workforce(headers)
+    full_key = _create_workforce_key(headers, workforce_id)
+
+    resp = client.post(
+        f"/v1/workforces/{workforce_id}/runs",
+        headers=_bearer(full_key),
+        json={
+            "message": {"role": "user", "content": "how many shifts tomorrow?"},
+            "timezone": "Australia/Melbourne",
+        },
+    )
+
+    assert resp.status_code == 202, resp.text
+    assert mock_schedule_bg.call_args.kwargs["context"] == {
+        "timezone": "Australia/Melbourne"
+    }
+
+
+def test_create_run_without_timezone_sends_no_context(mock_schedule_bg):
+    headers = _admin_headers()
+    workforce_id = _create_active_workforce(headers)
+    full_key = _create_workforce_key(headers, workforce_id)
+
+    resp = client.post(
+        f"/v1/workforces/{workforce_id}/runs",
+        headers=_bearer(full_key),
+        json={"message": {"role": "user", "content": "coordinate the work"}},
+    )
+
+    assert resp.status_code == 202, resp.text
+    assert mock_schedule_bg.call_args.kwargs["context"] is None
+
+
 def test_create_run_happy_path():
     headers = _admin_headers()
     workforce_id = _create_active_workforce(headers)

--- a/tests/web/test_workforce_run_service.py
+++ b/tests/web/test_workforce_run_service.py
@@ -222,6 +222,82 @@ def _workforce_runtime_with_worker_tools(*tool_names: str) -> WorkforceTaskRunti
 
 
 @pytest.mark.asyncio
+async def test_create_workforce_run_forwards_the_caller_timezone(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The opening turn starts inside task creation, so the zone has to ride
+    the create request; there is no chat frame to carry it."""
+    scheduled = _patch_schedule_bg(monkeypatch)
+
+    user = _create_user(db_session, "tz-owner")
+    manager = _create_agent(db_session, user, "Manager")
+    workforce = _create_workforce(db_session, user, manager)
+    _add_worker(db_session, user, workforce, _create_agent(db_session, user, "Analyst"))
+    db_session.commit()
+
+    result = await create_workforce_run(
+        db_session,
+        user,
+        workforce,
+        message="how many shifts do we have on tomorrow?",
+        timezone="Australia/Melbourne",
+    )
+    await result.background_task
+
+    assert scheduled["context"] == {"timezone": "Australia/Melbourne"}
+
+
+@pytest.mark.asyncio
+async def test_create_workforce_run_sends_no_context_without_a_timezone(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduled = _patch_schedule_bg(monkeypatch)
+
+    user = _create_user(db_session, "no-tz-owner")
+    manager = _create_agent(db_session, user, "Manager")
+    workforce = _create_workforce(db_session, user, manager)
+    _add_worker(db_session, user, workforce, _create_agent(db_session, user, "Analyst"))
+    db_session.commit()
+
+    result = await create_workforce_run(
+        db_session,
+        user,
+        workforce,
+        message="hello",
+    )
+    await result.background_task
+
+    assert scheduled["context"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_workforce_run_treats_a_blank_timezone_as_absent(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduled = _patch_schedule_bg(monkeypatch)
+
+    user = _create_user(db_session, "blank-tz-owner")
+    manager = _create_agent(db_session, user, "Manager")
+    workforce = _create_workforce(db_session, user, manager)
+    _add_worker(db_session, user, workforce, _create_agent(db_session, user, "Analyst"))
+    db_session.commit()
+
+    result = await create_workforce_run(
+        db_session,
+        user,
+        workforce,
+        message="hello",
+        timezone="   ",
+    )
+    await result.background_task
+
+    assert scheduled["context"] is None
+
+
+@pytest.mark.asyncio
 async def test_create_workforce_run_creates_task_run_and_starts_turn(
     db_session: Session,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/web/test_workforce_run_service.py
+++ b/tests/web/test_workforce_run_service.py
@@ -366,6 +366,71 @@ async def test_create_workforce_run_creates_task_run_and_starts_turn(
 
 
 @pytest.mark.asyncio
+async def test_create_preview_workforce_run_forwards_the_caller_timezone(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduled = _patch_schedule_bg(monkeypatch)
+
+    user = _create_user(db_session, "preview-tz-owner")
+    manager = _create_agent(db_session, user, "Draft Manager")
+    worker_agent = _create_agent(db_session, user, "Draft Analyst")
+    db_session.commit()
+
+    result = await create_preview_workforce_run(
+        db_session,
+        user_id=user.id,
+        name="Launch Team",
+        description=None,
+        manager_agent_id=manager.id,
+        workers=[
+            {
+                "agent_id": worker_agent.id,
+                "alias": "Analyst",
+                "assignment_instructions": "Do the work.",
+            }
+        ],
+        message="how many shifts do we have on tomorrow?",
+        timezone="Australia/Melbourne",
+    )
+    await result.background_task
+
+    assert scheduled["context"] == {"timezone": "Australia/Melbourne"}
+
+
+@pytest.mark.asyncio
+async def test_create_preview_workforce_run_sends_no_context_without_a_timezone(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    scheduled = _patch_schedule_bg(monkeypatch)
+
+    user = _create_user(db_session, "preview-no-tz-owner")
+    manager = _create_agent(db_session, user, "Draft Manager")
+    worker_agent = _create_agent(db_session, user, "Draft Analyst")
+    db_session.commit()
+
+    result = await create_preview_workforce_run(
+        db_session,
+        user_id=user.id,
+        name="Launch Team",
+        description=None,
+        manager_agent_id=manager.id,
+        workers=[
+            {
+                "agent_id": worker_agent.id,
+                "alias": "Analyst",
+                "assignment_instructions": "Do the work.",
+            }
+        ],
+        message="hello",
+    )
+    await result.background_task
+
+    assert scheduled["context"] is None
+
+
+@pytest.mark.asyncio
 async def test_create_preview_workforce_run_never_persists_a_workforce(
     db_session: Session,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
Refs #1675 — closes the last transport gap. Addresses finding **G1** from @rogercloud's review of #1712.

**Stacked on #1713 (which is stacked on #1712).** Cut from that branch, so the diff shown here includes their commits until they merge. Own increment: source +32/-1, tests +229/-2.

## Invariant

This PR guarantees only:

When a task-creation request carries a non-blank `timezone`, the turn that task creation itself starts receives it as `context={"timezone": ...}`, which #1709 renders as local time. When the field is absent or blank, the request behaves exactly as it does today and the turn renders UTC.

## Entry points in scope

- `POST /api/widget/chat/task/create` and `POST /api/share/chat/task/create` (workforce opening turns)
- `POST /v1/chat/tasks` (SDK/REST)
- `create_workforce_run` / `create_workforce_run_by_id`
- `public-agent-chat-page.tsx` opening-message submit

## Why #1712 was not enough

#1712 attaches the zone to `type: "chat"` websocket frames. Two paths never send one:

- **Workforce openers.** `public-agent-chat-page.tsx:336` sends the first message inside the create request and deliberately skips `sendMessage`, because `create_workforce_run` already starts that turn — resending it over the websocket would run the turn twice. So the opening question, the exact shape of the reported incident ("how many shifts do we have on tomorrow?"), was answered against UTC, and later turns cannot repair that first answer.
- **SDK/REST callers.** They have no websocket at all.

## How

The downstream pipe already existed and was simply never connected: `schedule_claimed_create_turn` has taken an optional `context` since before this work (`task_orchestrator.py:602`), and both workforce (`workforce_runs.py:730`) and SDK (`v1/tasks.py:636`) call sites just omitted it. So this is a transport wiring change, not new machinery:

```
TaskCreateRequest.timezone / CreateTaskRequest.timezone
      ↓
create_workforce_run(timezone=...) → _NormalizedWorkforceRunRequest.timezone
      ↓
schedule_claimed_create_turn(context={"timezone": ...})   ← param already existed
      ↓
(unchanged) → execute_task(context=) → metadata["request_context"] → metadata["timezone"]
      ↓
(unchanged, #1709) → both prompt clocks render local time
```

`TaskTurnPayload`, the orchestrator internals, the runner, and the injection points are untouched. Both transports converge on the same `metadata["timezone"]`, so a task that opens over HTTP and continues over websocket keeps one consistent zone.

## Known trade-offs

1. **No IANA validation at the schema layer.** #1709 already resolves through `ZoneInfo` and degrades to UTC on anything unresolvable, and the websocket path does not validate either. Validating here would make the same untrusted field 422 on HTTP but silently degrade on websocket. Blank/whitespace values are normalized to absent.
2. **`TaskCreateRequest.timezone` is inert on the plain-agent branch.** `create_public_chat_task` is a dispatcher: workforce requests are delegated, everything else returns without starting a turn, and the frontend then calls `sendMessage` (which #1712 covers). All three handlers share one request model, so the field is accepted there but unused. Adding a separate model to hide it would cost more than it buys.
3. **`create_pending_workforce_run` does not take the parameter.** It creates a committed PENDING record for a caller-owned dispatch phase and starts no turn, so a timezone there would be dead weight.
4. **`patch_schedule_bg` in `tests/web/api/conftest.py` now returns the captured kwargs.** Its docstring records that three suites previously kept drifting private copies, so the shared helper was extended rather than shadowed. Existing callers ignore the return value and are unaffected.
5. **`resolveReportedTimezone` is now exported** from `use-websocket.ts` so the opening-message path reuses the exact resolution order (`data-timezone` → browser → omitted) instead of growing a second implementation that would drift.

## Explicit non-goals

- This PR does not add an account-level timezone setting.
- This PR does not wire scheduled triggers, which store a zone with different semantics ("the zone the schedule is expressed in").
- This PR does not address #1676.
- Adjacent pre-existing issues should be tracked as follow-ups rather than implemented here.

## Blocking criteria

Block only on a regression, on the stated invariant still being breakable, or on materially worsening a pre-existing problem.

## Tests

9 new tests across four suites; two existing frontend contract assertions updated. Own increment is 88% tests.

Mutation-verified, all six caught:

| Mutation | Result |
| --- | --- |
| `workforce_runs` stops passing `context` | 3 failed |
| widget + share handlers stop passing `timezone` | 2 failed |
| SDK stops passing `context` | 1 failed |
| blank timezone no longer normalized to absent | 1 failed |
| frontend stops putting the zone on `taskPayload` | 2 failed |
| frontend sends an empty zone instead of omitting | 1 failed |

Coverage: widget opening turn · share opening turn · SDK create · service-level forwarding · blank-zone normalization · frontend opening body carries the zone while still not calling `sendMessage` · frontend omits the key when the browser resolves none.

221 tests pass across the four touched web suites; 341 across `src/hooks` and `src/components/widget`. `ruff`, `mypy`, `tsc`, and `eslint` clean on the touched files.

The two frontend contract assertions now pin `Intl` to `Australia/Melbourne` in `beforeEach` rather than asserting the host zone — the same tautology trap @gemini-code-assist caught in #1712.
