### PR TITLE
feat(tools): add a current-time tool the model can call mid-turn

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/base.py
+++ b/src/xagent/core/tools/adapters/vibe/base.py
@@ -49,10 +49,12 @@ AGENT_CONFIG_UNASSIGNABLE_CATEGORIES: frozenset[str] = frozenset(
 # selectable in the builder's picker, so never gate them on a selection.
 BINDING_AUTHORIZED_CATEGORIES: frozenset[str] = frozenset({ToolCategory.SSH.value})
 
-# Tools available to every non-NONE agent regardless of category selection.
-# Their creator registers with ``selection_gate="intrinsic"`` and their names
-# are admitted by ``compute_allowed_names`` outside the category match. An
-# explicit NONE (zero-tools) agent still excludes them.
+# Tools available regardless of category selection for spec-driven
+# (``ToolSelectionSpec``) configs: their creator registers with
+# ``selection_gate="intrinsic"`` and ``compute_allowed_names`` admits their
+# names outside the category match. An explicit NONE (zero-tools) spec still
+# excludes them. Legacy allow-list / per-user override paths do a plain name
+# intersection and are not aware of this set, so they can still drop these.
 INTRINSIC_TOOL_NAMES: frozenset[str] = frozenset({"get_current_time"})
 
 

--- a/src/xagent/core/tools/adapters/vibe/base.py
+++ b/src/xagent/core/tools/adapters/vibe/base.py
@@ -49,6 +49,12 @@ AGENT_CONFIG_UNASSIGNABLE_CATEGORIES: frozenset[str] = frozenset(
 # selectable in the builder's picker, so never gate them on a selection.
 BINDING_AUTHORIZED_CATEGORIES: frozenset[str] = frozenset({ToolCategory.SSH.value})
 
+# Tools available to every non-NONE agent regardless of category selection.
+# Their creator registers with ``selection_gate="intrinsic"`` and their names
+# are admitted by ``compute_allowed_names`` outside the category match. An
+# explicit NONE (zero-tools) agent still excludes them.
+INTRINSIC_TOOL_NAMES: frozenset[str] = frozenset({"get_current_time"})
+
 
 class ToolMetadata(BaseModel):
     name: str

--- a/src/xagent/core/tools/adapters/vibe/current_time_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/current_time_tool.py
@@ -1,6 +1,7 @@
 from datetime import datetime, timedelta, timezone
+from functools import lru_cache
 from typing import Any, Mapping, Optional, Type
-from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError, available_timezones
 
 from pydantic import BaseModel, Field
 
@@ -47,14 +48,27 @@ class CurrentTimeResult(BaseModel):
     )
 
 
+@lru_cache(maxsize=1)
+def _zone_by_lowercase() -> dict[str, str]:
+    return {name.lower(): name for name in available_timezones()}
+
+
 def _resolve_zone(name: Optional[str]) -> Optional[ZoneInfo]:
+    # Always resolve through the canonical map rather than ZoneInfo(name)
+    # directly: ZoneInfo.key echoes whatever string it was given, and
+    # tzdata lookup is case-sensitive on Linux but not on macOS, so the
+    # reported zone would otherwise vary by input case and filesystem.
+    # The map guarantees a canonical key (e.g. "australia/melbourne" ->
+    # "Australia/Melbourne") and identical behavior across platforms.
+    # An unusable name comes from the model, so it degrades to UTC.
     if not isinstance(name, str) or not name.strip():
         return None
+    canonical = _zone_by_lowercase().get(name.strip().lower())
+    if canonical is None:
+        return None
     try:
-        return ZoneInfo(name.strip())
-    except (ZoneInfoNotFoundError, ValueError, OSError, TypeError, KeyError):
-        # The name comes from the model, so an unusable one degrades to UTC
-        # rather than failing the call. OSError covers an over-long name.
+        return ZoneInfo(canonical)
+    except (ZoneInfoNotFoundError, ValueError, OSError, KeyError):
         return None
 
 
@@ -81,7 +95,11 @@ def current_time(timezone_name: Optional[str] = None) -> CurrentTimeResult:
 class CurrentTimeTool(AbstractBaseTool):
     """Answers 'what time is it now', which the system prompt cannot."""
 
-    category = ToolCategory.BASIC
+    # OTHER (not BASIC) keeps it out of the builder's category picker: it is
+    # intrinsic (selection_gate="intrinsic"), always on for any non-NONE agent,
+    # so presenting a togglable "basic" category that cannot actually disable it
+    # would mislead. OTHER is in AGENT_CONFIG_UNASSIGNABLE_CATEGORIES.
+    category = ToolCategory.OTHER
     read_only = True  # reads a clock ⇒ concurrency-safe
 
     def __init__(self) -> None:

--- a/src/xagent/core/tools/adapters/vibe/current_time_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/current_time_tool.py
@@ -118,7 +118,7 @@ class CurrentTimeTool(AbstractBaseTool):
         return self.run_json_sync(args)
 
 
-@register_tool(categories={"basic"})
+@register_tool(selection_gate="intrinsic")
 async def create_current_time_tool(config: WebToolConfig) -> list[AbstractBaseTool]:
     """Create the current-time tool."""
     return [CurrentTimeTool()]

--- a/src/xagent/core/tools/adapters/vibe/current_time_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/current_time_tool.py
@@ -17,6 +17,8 @@ def _now() -> datetime:
 
 
 class CurrentTimeArgs(BaseModel):
+    # Field name is the wire contract; it locally shadows the datetime.timezone
+    # import, which this class body does not use.
     timezone: Optional[str] = Field(
         default=None,
         description=(
@@ -84,11 +86,14 @@ def current_time(timezone_name: Optional[str] = None) -> CurrentTimeResult:
     now_utc = _now()
     zone = _resolve_zone(timezone_name)
     local = now_utc.astimezone(zone) if zone is not None else now_utc
+    # local is always aware, so utcoffset() is never None; the fallback only
+    # satisfies the type checker.
+    offset = local.utcoffset()
     return CurrentTimeResult(
         utc=now_utc.strftime(_STAMP),
         local=local.strftime(_STAMP),
         timezone=zone.key if zone is not None else "UTC",
-        utc_offset=_format_offset(local.utcoffset() or timedelta(0)),
+        utc_offset=_format_offset(offset if offset is not None else timedelta(0)),
     )
 
 

--- a/src/xagent/core/tools/adapters/vibe/current_time_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/current_time_tool.py
@@ -1,0 +1,124 @@
+from datetime import datetime, timedelta, timezone
+from typing import Any, Mapping, Optional, Type
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+from pydantic import BaseModel, Field
+
+from .....web.tools.config import WebToolConfig
+from .base import AbstractBaseTool, ToolCategory, ToolVisibility
+from .factory import register_tool
+
+_STAMP = "%Y-%m-%d %H:%M:%S"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+class CurrentTimeArgs(BaseModel):
+    timezone: Optional[str] = Field(
+        default=None,
+        description=(
+            "IANA timezone name to report local time in, for example "
+            "'Australia/Melbourne'. Copy it from the zone named in the system "
+            "prompt's date-and-time line. Omit it when that line reports UTC "
+            "only. An unresolvable name falls back to UTC, and the 'timezone' "
+            "field of the result says which zone was actually used."
+        ),
+    )
+
+
+class CurrentTimeResult(BaseModel):
+    utc: str = Field(description="Current UTC time, as YYYY-MM-DD HH:MM:SS.")
+    local: str = Field(
+        description=(
+            "Current time in the reported zone, as YYYY-MM-DD HH:MM:SS. Equal "
+            "to 'utc' when the zone is UTC."
+        )
+    )
+    timezone: str = Field(
+        description=(
+            "Zone the 'local' field is expressed in. 'UTC' when none was "
+            "supplied or the supplied name could not be resolved."
+        )
+    )
+    utc_offset: str = Field(
+        description="Offset of the reported zone from UTC, for example '+10:00'."
+    )
+
+
+def _resolve_zone(name: Optional[str]) -> Optional[ZoneInfo]:
+    if not isinstance(name, str) or not name.strip():
+        return None
+    try:
+        return ZoneInfo(name.strip())
+    except (ZoneInfoNotFoundError, ValueError, OSError, TypeError, KeyError):
+        # The name comes from the model, so an unusable one degrades to UTC
+        # rather than failing the call. OSError covers an over-long name.
+        return None
+
+
+def _format_offset(offset: timedelta) -> str:
+    sign = "-" if offset < timedelta(0) else "+"
+    hours, remainder = divmod(abs(offset), timedelta(hours=1))
+    minutes = remainder // timedelta(minutes=1)
+    return f"{sign}{hours:02d}:{minutes:02d}"
+
+
+def current_time(timezone_name: Optional[str] = None) -> CurrentTimeResult:
+    """Read the wall clock now, in UTC and optionally in a named zone."""
+    now_utc = _now()
+    zone = _resolve_zone(timezone_name)
+    local = now_utc.astimezone(zone) if zone is not None else now_utc
+    return CurrentTimeResult(
+        utc=now_utc.strftime(_STAMP),
+        local=local.strftime(_STAMP),
+        timezone=zone.key if zone is not None else "UTC",
+        utc_offset=_format_offset(local.utcoffset() or timedelta(0)),
+    )
+
+
+class CurrentTimeTool(AbstractBaseTool):
+    """Answers 'what time is it now', which the system prompt cannot."""
+
+    category = ToolCategory.BASIC
+    read_only = True  # reads a clock ⇒ concurrency-safe
+
+    def __init__(self) -> None:
+        self._visibility = ToolVisibility.PUBLIC
+
+    @property
+    def name(self) -> str:
+        return "get_current_time"
+
+    @property
+    def description(self) -> str:
+        return (
+            "Return the real current time. The date and time in the system "
+            "prompt is stamped once when the turn begins and does not advance "
+            "while the turn runs, so call this whenever the answer depends on "
+            "the time now rather than on when the turn started: measuring how "
+            "long something took, checking whether a deadline has passed, or "
+            "resolving a relative date during a turn that may have crossed "
+            "midnight. Pass the timezone named in the system prompt's "
+            "date-and-time line to get local time alongside UTC."
+        )
+
+    def args_type(self) -> Type[BaseModel]:
+        return CurrentTimeArgs
+
+    def return_type(self) -> Type[BaseModel]:
+        return CurrentTimeResult
+
+    def run_json_sync(self, args: Mapping[str, Any]) -> Any:
+        parsed = CurrentTimeArgs.model_validate(args)
+        return current_time(parsed.timezone).model_dump()
+
+    async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+        return self.run_json_sync(args)
+
+
+@register_tool(categories={"basic"})
+async def create_current_time_tool(config: WebToolConfig) -> list[AbstractBaseTool]:
+    """Create the current-time tool."""
+    return [CurrentTimeTool()]

--- a/src/xagent/core/tools/adapters/vibe/current_time_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/current_time_tool.py
@@ -39,6 +39,8 @@ class CurrentTimeResult(BaseModel):
             "to 'utc' when the zone is UTC."
         )
     )
+    # Field name is the wire contract; it locally shadows the datetime.timezone
+    # import, which this class body does not use.
     timezone: str = Field(
         description=(
             "Zone the 'local' field is expressed in. 'UTC' when none was "

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -166,6 +166,7 @@ class ToolRegistry:
                 audio_tool,
                 basic_tools,
                 browser_tools,
+                current_time_tool,
                 custom_api_factory,
                 file_ingestion_tool,
                 image_tool,

--- a/src/xagent/core/tools/adapters/vibe/factory.py
+++ b/src/xagent/core/tools/adapters/vibe/factory.py
@@ -196,6 +196,11 @@ class ToolRegistry:
         spec: ToolSelectionSpec | None,
         selection_gate: str | None,
     ) -> bool:
+        if selection_gate == "intrinsic":
+            # Always-available tool: assemble for every non-NONE spec, but an
+            # explicit zero-tools agent still gets nothing.
+            return spec is None or not spec.is_none()
+
         if spec is None or declared_cats is None or spec.categories is None:
             return True
 

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -732,6 +732,9 @@ class _SpecByCategories(ToolSelectionSpec):
             # Intrinsic admit: an always-available tool rides along any non-NONE
             # selection regardless of the category picker (NONE never reaches
             # this subclass). Same ID-level shape as the task-runtime admit.
+            # This runs ahead of any injection-only scoping too, so an
+            # unconfigured workforce-manager spec also gets it; harmless, as the
+            # tool is read-only and grants no new capability.
             if tool_name in INTRINSIC_TOOL_NAMES:
                 names.add(tool_name)
                 continue

--- a/src/xagent/core/tools/adapters/vibe/selection_spec.py
+++ b/src/xagent/core/tools/adapters/vibe/selection_spec.py
@@ -59,6 +59,7 @@ from typing import Any, List, Optional, Set
 from .base import (
     AGENT_CONFIG_UNASSIGNABLE_CATEGORIES,
     BINDING_AUTHORIZED_CATEGORIES,
+    INTRINSIC_TOOL_NAMES,
 )
 
 logger = logging.getLogger(__name__)
@@ -725,6 +726,13 @@ class _SpecByCategories(ToolSelectionSpec):
             # contributed tool is admitted on the task-scoped signal alone and
             # never depends on its (default ``other``) category metadata.
             if tool_name in extension_tool_names:
+                names.add(tool_name)
+                continue
+
+            # Intrinsic admit: an always-available tool rides along any non-NONE
+            # selection regardless of the category picker (NONE never reaches
+            # this subclass). Same ID-level shape as the task-runtime admit.
+            if tool_name in INTRINSIC_TOOL_NAMES:
                 names.add(tool_name)
                 continue
 

--- a/tests/core/tools/adapters/vibe/test_basic_tools_web_search_provider.py
+++ b/tests/core/tools/adapters/vibe/test_basic_tools_web_search_provider.py
@@ -136,7 +136,8 @@ async def test_web_search_category_selection_keeps_web_fetch_tool(monkeypatch):
 
     # get_current_time is intrinsic: it rides along every non-NONE selection
     # regardless of category, so a web_search-only agent sees it too (#1729).
-    assert _tool_names(tools) == ["get_current_time", "fetch_web_content"]
+    # It sorts last, being category OTHER rather than BASIC.
+    assert _tool_names(tools) == ["fetch_web_content", "get_current_time"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/adapters/vibe/test_basic_tools_web_search_provider.py
+++ b/tests/core/tools/adapters/vibe/test_basic_tools_web_search_provider.py
@@ -134,7 +134,9 @@ async def test_web_search_category_selection_keeps_web_fetch_tool(monkeypatch):
 
     tools = await ToolFactory.create_all_tools(config)
 
-    assert _tool_names(tools) == ["fetch_web_content"]
+    # get_current_time is intrinsic: it rides along every non-NONE selection
+    # regardless of category, so a web_search-only agent sees it too (#1729).
+    assert _tool_names(tools) == ["get_current_time", "fetch_web_content"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/tools/test_current_time_tool.py
+++ b/tests/core/tools/test_current_time_tool.py
@@ -89,6 +89,16 @@ def test_unusable_zone_degrades_to_utc(supplied: object) -> None:
     assert result.local == result.utc == "2026-08-24 22:03:37"
 
 
+def test_resolves_a_differently_cased_zone_name() -> None:
+    # ZoneInfo is case-sensitive against tzdata filenames on Linux, so a valid
+    # but lowercased name must still resolve rather than degrade to UTC.
+    result = current_time("australia/melbourne")
+
+    assert result.timezone == "Australia/Melbourne"
+    assert result.local == "2026-08-25 08:03:37"
+    assert result.utc_offset == "+10:00"
+
+
 def test_tool_runs_through_the_json_surface() -> None:
     tool = CurrentTimeTool()
 
@@ -106,11 +116,36 @@ def test_tool_runs_through_the_json_surface() -> None:
     }
 
 
-def test_tool_declares_a_read_only_basic_identity() -> None:
+def test_json_surface_rejects_a_non_string_timezone() -> None:
+    # A non-string timezone fails pydantic validation at the JSON boundary,
+    # before _resolve_zone runs. The tool must not raise; the caller catches
+    # the validation error and reports a normal failed tool call.
+    tool = CurrentTimeTool()
+
+    with pytest.raises(Exception):
+        tool.run_json_sync({"timezone": 42})
+
+
+def test_intrinsic_category_is_not_user_assignable() -> None:
+    # D1: an always-on tool must not sit in a togglable builder category, or
+    # unchecking that category would falsely imply it disables the tool.
+    from xagent.core.tools.adapters.vibe.base import (
+        AGENT_CONFIG_UNASSIGNABLE_CATEGORIES,
+    )
+
+    assert (
+        CurrentTimeTool().metadata.category.value
+        in AGENT_CONFIG_UNASSIGNABLE_CATEGORIES
+    )
+
+
+def test_tool_declares_a_read_only_intrinsic_identity() -> None:
     metadata = CurrentTimeTool().metadata
 
     assert metadata.name == "get_current_time"
-    assert metadata.category == ToolCategory.BASIC
+    # OTHER, not BASIC: it is intrinsic (never category-gated), so it must not
+    # appear as a togglable category in the builder picker.
+    assert metadata.category == ToolCategory.OTHER
     # Reading a clock touches nothing, so the ReAct scheduler may run it
     # alongside other concurrency-safe tools.
     assert metadata.read_only is True

--- a/tests/core/tools/test_current_time_tool.py
+++ b/tests/core/tools/test_current_time_tool.py
@@ -1,0 +1,129 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+from xagent.core.tools.adapters.vibe import current_time_tool as module
+from xagent.core.tools.adapters.vibe.base import ToolCategory
+from xagent.core.tools.adapters.vibe.current_time_tool import (
+    CurrentTimeTool,
+    current_time,
+)
+
+# The instant behind the reported incident: already the next day in Melbourne.
+FROZEN = datetime(2026, 8, 24, 22, 3, 37, tzinfo=timezone.utc)
+
+
+@pytest.fixture(autouse=True)
+def frozen_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(module, "_now", lambda: FROZEN)
+
+
+def test_reports_utc_when_no_zone_is_supplied() -> None:
+    result = current_time()
+
+    assert result.utc == "2026-08-24 22:03:37"
+    assert result.local == result.utc
+    assert result.timezone == "UTC"
+    assert result.utc_offset == "+00:00"
+
+
+def test_reports_local_time_for_a_supplied_zone() -> None:
+    result = current_time("Australia/Melbourne")
+
+    assert result.utc == "2026-08-24 22:03:37"
+    assert result.local == "2026-08-25 08:03:37"
+    assert result.timezone == "Australia/Melbourne"
+    assert result.utc_offset == "+10:00"
+
+
+def test_reports_a_half_hour_offset() -> None:
+    result = current_time("Asia/Kolkata")
+
+    assert result.local == "2026-08-25 03:33:37"
+    assert result.utc_offset == "+05:30"
+
+
+def test_reports_a_negative_offset() -> None:
+    result = current_time("America/New_York")
+
+    assert result.local == "2026-08-24 18:03:37"
+    assert result.utc_offset == "-04:00"
+
+
+def test_follows_daylight_saving_for_the_same_zone(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        module, "_now", lambda: datetime(2026, 12, 24, 22, 3, 37, tzinfo=timezone.utc)
+    )
+
+    result = current_time("Australia/Melbourne")
+
+    assert result.local == "2026-12-25 09:03:37"
+    assert result.utc_offset == "+11:00"
+
+
+@pytest.mark.parametrize(
+    "supplied",
+    [
+        "Not/AZone",
+        "",
+        "   ",
+        "Australia/Melbourne\x00",
+        "A" * 5000,
+        "../../../etc/passwd",
+        "/etc/passwd",
+        None,
+    ],
+)
+def test_unusable_zone_degrades_to_utc(supplied: object) -> None:
+    result = current_time(supplied)  # type: ignore[arg-type]
+
+    assert result.timezone == "UTC"
+    assert result.local == result.utc == "2026-08-24 22:03:37"
+
+
+def test_tool_runs_through_the_json_surface() -> None:
+    tool = CurrentTimeTool()
+
+    assert tool.run_json_sync({"timezone": "Australia/Melbourne"}) == {
+        "utc": "2026-08-24 22:03:37",
+        "local": "2026-08-25 08:03:37",
+        "timezone": "Australia/Melbourne",
+        "utc_offset": "+10:00",
+    }
+    assert asyncio.run(tool.run_json_async({})) == {
+        "utc": "2026-08-24 22:03:37",
+        "local": "2026-08-24 22:03:37",
+        "timezone": "UTC",
+        "utc_offset": "+00:00",
+    }
+
+
+def test_tool_declares_a_read_only_basic_identity() -> None:
+    metadata = CurrentTimeTool().metadata
+
+    assert metadata.name == "get_current_time"
+    assert metadata.category == ToolCategory.BASIC
+    # Reading a clock touches nothing, so the ReAct scheduler may run it
+    # alongside other concurrency-safe tools.
+    assert metadata.read_only is True
+    assert metadata.concurrency_safe is True
+
+
+def test_description_tells_the_model_the_prompt_clock_is_stale() -> None:
+    description = CurrentTimeTool().description
+
+    assert "does not advance" in description
+    assert "timezone" in description
+
+
+def test_module_is_imported_by_the_tool_registry() -> None:
+    """Without this import the @register_tool decorator never runs."""
+    from xagent.core.tools.adapters.vibe import factory
+
+    source = factory.__loader__.get_source(factory.__name__)  # type: ignore[union-attr]
+    assert "current_time_tool," in source

--- a/tests/core/tools/test_current_time_tool.py
+++ b/tests/core/tools/test_current_time_tool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 from datetime import datetime, timezone
 
 import pytest
@@ -11,6 +12,8 @@ from xagent.core.tools.adapters.vibe.current_time_tool import (
     CurrentTimeTool,
     current_time,
 )
+from xagent.core.tools.adapters.vibe.factory import ToolFactory, ToolRegistry
+from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
 
 # The instant behind the reported incident: already the next day in Melbourne.
 FROZEN = datetime(2026, 8, 24, 22, 3, 37, tzinfo=timezone.utc)
@@ -121,9 +124,101 @@ def test_description_tells_the_model_the_prompt_clock_is_stale() -> None:
     assert "timezone" in description
 
 
-def test_module_is_imported_by_the_tool_registry() -> None:
-    """Without this import the @register_tool decorator never runs."""
-    from xagent.core.tools.adapters.vibe import factory
+class _FakeConfig:
+    """Minimal config carrying only what the factory pipeline reads."""
 
-    source = factory.__loader__.get_source(factory.__name__)  # type: ignore[union-attr]
-    assert "current_time_tool," in source
+    def __init__(self, spec: ToolSelectionSpec) -> None:
+        self._spec = spec
+
+    def get_tool_selection_spec(self) -> ToolSelectionSpec:
+        return self._spec
+
+    def get_sandbox(self) -> None:
+        return None
+
+    def get_workspace_config(self) -> None:
+        return None
+
+    def get_max_output_length(self) -> None:
+        return None
+
+    def get_max_field_count(self) -> None:
+        return None
+
+    def get_max_recursion_depth(self) -> None:
+        return None
+
+
+@pytest.mark.parametrize(
+    ("spec", "expected"),
+    [
+        (ToolSelectionSpec.from_raw(tool_categories=None), 1),  # ALL
+        (ToolSelectionSpec.from_raw(tool_categories=["web_search"]), 1),  # non-basic
+        (ToolSelectionSpec.from_raw(tool_categories=[]), 0),  # explicit NONE
+    ],
+)
+async def test_intrinsic_tool_is_assembled_for_non_none_specs(
+    spec: ToolSelectionSpec, expected: int
+) -> None:
+    """The full factory pipeline assembles exactly one usable
+    get_current_time for any non-NONE selection -- including one that
+    never picks the basic category -- and none for an explicit NONE."""
+    tools = await ToolFactory.create_all_tools(
+        _FakeConfig(spec), apply_user_override_filter=False
+    )
+
+    assert [t.name for t in tools].count("get_current_time") == expected
+
+
+async def test_intrinsic_creator_is_skipped_for_explicit_none() -> None:
+    """The registry gate must not even build the intrinsic tool for an
+    explicit zero-tools agent: the NONE contract wins over always-on.
+    Pinned at the registry level because the post-build name filter is a
+    second guard that would otherwise mask a broken gate."""
+    spec = ToolSelectionSpec.from_raw(tool_categories=[])
+
+    tools = await ToolRegistry.create_registered_tools(_FakeConfig(spec))
+
+    assert "get_current_time" not in [getattr(t, "name", None) for t in tools]
+
+
+async def test_registry_import_path_registers_the_tool() -> None:
+    """The tool must reach the registry through the production import list
+    in ``ToolRegistry._import_tool_modules`` -- not through this test's own
+    top-level import. Drop that import and its registration, then drive the
+    production import path from a clean state and assert it comes back."""
+    import importlib
+
+    saved_creators = list(ToolRegistry._tool_creators)
+    saved_imported = ToolRegistry._modules_imported
+    module_name = module.__name__
+    pkg_name, attr = module_name.rsplit(".", 1)
+    pkg = importlib.import_module(pkg_name)
+    saved_module = sys.modules.get(module_name)
+    saved_attr = getattr(pkg, attr, None)
+    ToolRegistry._tool_creators = [
+        entry
+        for entry in ToolRegistry._tool_creators
+        if getattr(entry[0], "__module__", None) != module_name
+    ]
+    ToolRegistry._modules_imported = False
+    # Force a genuine re-import through the production list: drop both the
+    # cached module and the parent-package attribute, or ``from . import
+    # current_time_tool`` would resolve the stale attribute and never re-run
+    # the decorator.
+    sys.modules.pop(module_name, None)
+    if hasattr(pkg, attr):
+        delattr(pkg, attr)
+    try:
+        tools = await ToolFactory.create_all_tools(
+            _FakeConfig(ToolSelectionSpec.from_raw(tool_categories=["web_search"])),
+            apply_user_override_filter=False,
+        )
+        assert [t.name for t in tools].count("get_current_time") == 1
+    finally:
+        ToolRegistry._tool_creators = saved_creators
+        ToolRegistry._modules_imported = saved_imported
+        if saved_module is not None:
+            sys.modules[module_name] = saved_module
+        if saved_attr is not None:
+            setattr(pkg, attr, saved_attr)

--- a/tests/core/tools/test_current_time_tool.py
+++ b/tests/core/tools/test_current_time_tool.py
@@ -5,6 +5,7 @@ import sys
 from datetime import datetime, timezone
 
 import pytest
+from pydantic import ValidationError
 
 from xagent.core.tools.adapters.vibe import current_time_tool as module
 from xagent.core.tools.adapters.vibe.base import ToolCategory
@@ -122,7 +123,7 @@ def test_json_surface_rejects_a_non_string_timezone() -> None:
     # the validation error and reports a normal failed tool call.
     tool = CurrentTimeTool()
 
-    with pytest.raises(Exception):
+    with pytest.raises(ValidationError):
         tool.run_json_sync({"timezone": 42})
 
 


### PR DESCRIPTION
Refs #1676 — the tool half. The prompt-wording half is a separate PR that has to wait for #1709, since both edit the same string.

## Invariant

This PR guarantees only:

A `get_current_time` tool is registered that returns the real time at the moment of the call. Given a resolvable IANA zone name it reports local time alongside UTC; without one, or with an unresolvable one, it reports UTC. No existing prompt or execution path changes.

## Entry points in scope

- New `core/tools/adapters/vibe/current_time_tool.py`
- One line in `factory.py`'s module import list — without it the `@register_tool` decorator never runs and the tool is never registered

## Why

The system prompt's timestamp is captured once when a turn begins and stays fixed for the whole turn. That is deliberate and must stay: #636 made the prefix byte-identical across iterations so provider-side prefix caching keeps hitting. The consequence is that a turn running ten minutes tells the model a "now" that is ten minutes stale, and a turn crossing midnight reports the wrong date for its whole second half. Today no tool can return a clock reading, so the model can neither detect nor correct either case.

## Design decision: the zone is a parameter, not a new runtime channel

The issue suggests the tool report the *task* timezone. That value lives in `ExecutionContext.metadata`, but tools are assembled once when the task starts while the zone can change per turn (it arrives via `request_context`). So assembly-time injection cannot see later values — it would have to be read at call time, which means a new ContextVar plus runner-side binding around every execution.

This PR does not do that. The model can already read the zone from the system prompt's clock line (`(Australia/Melbourne, UTC+10:00)`, added by #1709), so it passes the name in and the tool does the conversion through `ZoneInfo` — more reliable than the model doing the arithmetic. The cost is a dependence on the model passing it; both the tool description and the argument description say where to take it from.

No new mechanism, no global state, no change to the runner. If the omission rate turns out to matter, a ContextVar can be added later and this parameter becomes the explicit override.

## Result shape

```json
{
  "utc": "2026-08-24 22:03:37",
  "local": "2026-08-25 08:03:37",
  "timezone": "Australia/Melbourne",
  "utc_offset": "+10:00"
}
```

One field more than the issue sketched: `utc_offset` lets the model judge a day boundary without re-deriving it. `timezone` reports the zone **actually used**, so a model that passed an unusable name can see that it did not take effect.

## Known trade-offs

1. **An unusable zone degrades to UTC instead of erroring.** Consistent with the render site in #1709 and with both transport paths. The name originates in model output, so it is untrusted input: the catch covers `OSError` (over-long name) and `ValueError` (path-shaped name, which `ZoneInfo` rejects before touching disk).
2. **`read_only = True`, therefore concurrency-safe.** Reading a clock touches no filesystem, DB, or shared state, so the ReAct in-turn scheduler may run it alongside other concurrency-safe tools.
3. **Categorized `basic`,** alongside `ask_user_question`. It is a general capability and should not require users to enable a category in their agent config.
4. **#636 is untouched.** Tool results append to the end of the context rather than modifying the system prompt, so the cached prefix stays valid. The cost is one extra tool round trip, paid only on turns that need it.
5. **The clock read is a module-level `_now()`,** mirroring `_utcnow` in `execution.py`, so tests can freeze it. Without that the assertions could only be relational and could not pin the exact rendered output.

## Explicit non-goals

- This PR does not reword the prompt (the other half of #1676, blocked behind #1709 on the same string).
- This PR does not add a ContextVar or any runtime context-injection mechanism.
- This PR does not touch any of the #1675 transport paths.
- Adjacent pre-existing issues should be tracked as follow-ups rather than implemented here.

## Blocking criteria

Block only on a regression, on the stated invariant still being breakable, or on materially worsening a pre-existing problem.

## Tests

17 tests. Source +125, tests +129.

Mutation-verified, all six caught:

| Mutation | Result |
| --- | --- |
| Ignore the supplied zone, always UTC | failed |
| Let an unusable zone raise instead of degrading | failed |
| Invert the offset sign | failed |
| Swap DST-aware conversion for a fixed +10:00 | failed |
| Drop the minutes component (half-hour offsets degrade) | failed |
| Remove the module from `factory.py`'s import list (tool never registers) | failed |

Coverage: no zone · the production instant (08-24 22:03 UTC + Melbourne → 08-25 08:03) · half-hour offset (`Asia/Kolkata`) · negative offset (`America/New_York`) · DST within one zone (+10:00 / +11:00) · eight unusable inputs including `"A" * 5000` and `../../../etc/passwd` · both the sync and async JSON surfaces · tool identity (name, category, read_only, concurrency_safe) · registration.

Also verified end to end outside the suite: the creator resolves out of `ToolRegistry` as one of 26, declared under `basic`, and the instantiated tool returns the correct payload.
