### PR TITLE
fix: harden client-facing failure logging

### DIFF
--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -355,6 +355,11 @@ class ClientVisibleError(Exception):
     redacted, so forgetting the marker fails closed.
     """
 
+    def __init__(self, *args: object) -> None:
+        if type(self) is ClientVisibleError:
+            raise TypeError("ClientVisibleError must be subclassed")
+        super().__init__(*args)
+
 
 class ClientVisibleValidationError(ClientVisibleError, ValueError):
     """A validation failure whose text is safe to show the sender."""
@@ -392,11 +397,11 @@ def client_safe_error_message(error: BaseException) -> str:
     Read a passing sweep as "the recognized shapes are clean", never as
     "nothing reaches a client raw".
     """
-    return (
-        str(error)
-        if isinstance(error, ClientVisibleError)
-        else CLIENT_SAFE_VALIDATION_ERROR
-    )
+    if isinstance(error, ClientVisibleError):
+        message = str(error)
+        if message.strip():
+            return message
+    return CLIENT_SAFE_VALIDATION_ERROR
 
 
 def client_safe_task_command_failure(
@@ -423,10 +428,37 @@ def log_client_facing_failure(error: Exception, template: str, *args: object) ->
     ``template`` ends in the ``%s`` that receives ``error``; ``args`` fill the
     placeholders before it.
     """
+    rendered_message: str | None = None
+    try:
+        if str.endswith(template, "%s"):
+            rendered_message = str.__str__(template % (*args, error))
+    except Exception:
+        pass
+    if rendered_message is None:
+        safe_template = _safe_log_argument(template)
+        safe_args = tuple(_safe_log_argument(arg) for arg in args)
+        safe_error = _safe_log_argument(error)
+        logger.error(
+            "Malformed client-facing log template %r with args=%r; original error: %s",
+            safe_template,
+            safe_args,
+            safe_error,
+            exc_info=not isinstance(error, ClientVisibleError),
+        )
+        return
     if isinstance(error, ClientVisibleError):
-        logger.warning(template, *args, error)
+        logger.warning(rendered_message)
     else:
-        logger.error(template, *args, error, exc_info=True)
+        logger.error(rendered_message, exc_info=True)
+
+
+def _safe_log_argument(value: object) -> object:
+    if type(value) in (str, int, float, bytes):
+        return value
+    try:
+        return str.__str__(str(value))
+    except Exception as rendering_error:
+        return f"<unprintable {type(value).__name__}: {type(rendering_error).__name__}>"
 
 
 async def send_message_delivery(

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -438,12 +438,13 @@ def log_client_facing_failure(error: Exception, template: str, *args: object) ->
         safe_template = _safe_log_argument(template)
         safe_args = tuple(_safe_log_argument(arg) for arg in args)
         safe_error = _safe_log_argument(error)
-        logger.error(
+        logger.log(
+            logging.WARNING if isinstance(error, ClientVisibleError) else logging.ERROR,
             "Malformed client-facing log template %r with args=%r; original error: %s",
             safe_template,
             safe_args,
             safe_error,
-            exc_info=not isinstance(error, ClientVisibleError),
+            exc_info=None if isinstance(error, ClientVisibleError) else True,
         )
         return
     if isinstance(error, ClientVisibleError):
@@ -453,9 +454,12 @@ def log_client_facing_failure(error: Exception, template: str, *args: object) ->
 
 
 def _safe_log_argument(value: object) -> object:
+    """Snapshot malformed-log values without trusting hostile string methods."""
+    # Exact types preserve builtin logging representations without admitting subclasses.
     if type(value) in (str, int, float, bytes):
         return value
     try:
+        # The unbound call strips any surviving ``str``-subclass overrides.
         return str.__str__(str(value))
     except Exception as rendering_error:
         return f"<unprintable {type(value).__name__}: {type(rendering_error).__name__}>"

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -6,6 +6,7 @@ import ast
 import asyncio
 import json
 import logging
+from enum import IntEnum
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Iterator, NamedTuple
@@ -554,6 +555,151 @@ def test_log_level_follows_the_marker_not_the_call_site(
     assert record.levelno == expected_level
     assert (record.exc_info is not None) is expects_traceback
     assert "task 7" in record.getMessage()
+
+
+@pytest.mark.parametrize(
+    ("template", "args"),
+    [
+        ("Pause command rejected", ()),
+        ("Task %s failed: %s", ()),
+        ("Task %d failed: %s", ()),
+        ("Task %(task_id)s failed: %s", ()),
+    ],
+    ids=[
+        "missing-placeholder",
+        "count-mismatch",
+        "integer-placeholder",
+        "mapping-placeholder",
+    ],
+)
+def test_log_helper_rejects_every_malformed_percent_template(
+    caplog: pytest.LogCaptureFixture,
+    template: str,
+    args: tuple[object, ...],
+) -> None:
+    with caplog.at_level(logging.ERROR, logger=WEBSOCKET_LOGGER):
+        websocket_api.log_client_facing_failure(
+            ValueError("operator detail"), template, *args
+        )
+
+    records = [record for record in caplog.records if record.name == WEBSOCKET_LOGGER]
+    assert len(records) == 1
+    assert "malformed client-facing log template" in records[0].getMessage().lower()
+    assert "operator detail" in records[0].getMessage()
+
+
+def test_log_helper_accepts_int_enum_for_native_integer_placeholder(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class TaskNumber(IntEnum):
+        FIRST = 7
+
+    with caplog.at_level(logging.ERROR, logger=WEBSOCKET_LOGGER):
+        websocket_api.log_client_facing_failure(
+            ValueError("operator detail"),
+            "Task %d failed: %s",
+            TaskNumber.FIRST,
+        )
+
+    records = [record for record in caplog.records if record.name == WEBSOCKET_LOGGER]
+    assert len(records) == 1
+    assert records[0].getMessage() == "Task 7 failed: operator detail"
+    assert "malformed client-facing log template" not in records[0].getMessage().lower()
+
+
+def test_log_helper_does_not_raise_for_unprintable_values(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class BrokenText:
+        def __str__(self) -> str:
+            raise RuntimeError("broken text")
+
+    class BrokenStr(str):
+        __str__ = BrokenText.__str__
+
+        def __repr__(self) -> str:
+            raise RuntimeError("broken repr")
+
+    class BadFallback(str):
+        def __str__(self) -> str:
+            return self
+
+        def __repr__(self) -> str:
+            raise RuntimeError("bad repr")
+
+    class StatefulText(str):
+        calls = 0
+
+        def __str__(self) -> str:
+            type(self).calls += 1
+            if type(self).calls >= 3:
+                raise RuntimeError("rendered repeatedly")
+            return self
+
+    with caplog.at_level(logging.ERROR, logger=WEBSOCKET_LOGGER):
+        websocket_api.log_client_facing_failure(
+            ValueError(BrokenText()), "Data validation error: %s"
+        )
+        websocket_api.log_client_facing_failure(
+            ValueError("operator detail"), "Task %s failed: %s", BrokenStr("x")
+        )
+        websocket_api.log_client_facing_failure(
+            ValueError("operator detail"), "Malformed template", BadFallback("x")
+        )
+        websocket_api.log_client_facing_failure(
+            ValueError("operator detail"),
+            "Task %s failed: %s",
+            StatefulText("stable"),
+        )
+
+    records = [record for record in caplog.records if record.name == WEBSOCKET_LOGGER]
+    assert len(records) == 4
+    assert "unprintable ValueError" in records[0].getMessage()
+    assert "unprintable BrokenStr" in records[1].getMessage()
+    assert "malformed client-facing log template" in records[2].getMessage().lower()
+    assert "Task stable failed" in records[3].getMessage()
+
+
+def test_client_visible_error_is_a_subclass_only_marker() -> None:
+    """The marker base cannot escape handlers that catch its typed subclasses."""
+    with pytest.raises(TypeError, match="must be subclassed"):
+        websocket_api.ClientVisibleError("bare marker")
+
+    assert str(websocket_api.ClientVisibleValidationError("curated")) == "curated"
+
+
+@pytest.mark.parametrize("message", ["", "   ", "\t\n"])
+def test_empty_client_visible_message_falls_back_to_the_generic_text(
+    message: str,
+) -> None:
+    error = websocket_api.ClientVisibleValidationError(message)
+
+    assert (
+        websocket_api.client_safe_error_message(error)
+        == websocket_api.CLIENT_SAFE_VALIDATION_ERROR
+    )
+
+
+def test_client_visible_message_preserves_non_ascii_text() -> None:
+    message = "请求无效：缺少步骤标识"
+
+    assert (
+        websocket_api.client_safe_error_message(
+            websocket_api.ClientVisibleValidationError(message)
+        )
+        == message
+    )
+
+
+def test_empty_client_visible_outer_error_does_not_expose_its_cause() -> None:
+    cause = RuntimeError(SECRET)
+    error = websocket_api.ClientVisibleValidationError("")
+    error.__cause__ = cause
+
+    rendered = websocket_api.client_safe_error_message(error)
+
+    assert rendered == websocket_api.CLIENT_SAFE_VALIDATION_ERROR
+    assert SECRET not in rendered
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -557,6 +557,19 @@ def test_log_level_follows_the_marker_not_the_call_site(
     assert "task 7" in record.getMessage()
 
 
+def test_malformed_curated_failure_remains_a_warning_without_traceback(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    websocket_api.log_client_facing_failure(
+        websocket_api.ClientVisibleValidationError("Authentication required"),
+        "Pause command rejected",
+    )
+
+    (record,) = [r for r in caplog.records if r.name == WEBSOCKET_LOGGER]
+    assert (record.levelno, record.exc_info) == (logging.WARNING, None)
+    assert "malformed client-facing log template" in record.getMessage().lower()
+
+
 @pytest.mark.parametrize(
     ("template", "args"),
     [
@@ -564,12 +577,14 @@ def test_log_level_follows_the_marker_not_the_call_site(
         ("Task %s failed: %s", ()),
         ("Task %d failed: %s", ()),
         ("Task %(task_id)s failed: %s", ()),
+        ("%%s", ()),
     ],
     ids=[
         "missing-placeholder",
         "count-mismatch",
         "integer-placeholder",
         "mapping-placeholder",
+        "terminal-escaped-percent-s",
     ],
 )
 def test_log_helper_rejects_every_malformed_percent_template(
@@ -577,13 +592,17 @@ def test_log_helper_rejects_every_malformed_percent_template(
     template: str,
     args: tuple[object, ...],
 ) -> None:
-    with caplog.at_level(logging.ERROR, logger=WEBSOCKET_LOGGER):
-        websocket_api.log_client_facing_failure(
-            ValueError("operator detail"), template, *args
-        )
+    try:
+        raise ValueError("operator detail")
+    except ValueError as error:
+        with caplog.at_level(logging.ERROR, logger=WEBSOCKET_LOGGER):
+            websocket_api.log_client_facing_failure(error, template, *args)
 
     records = [record for record in caplog.records if record.name == WEBSOCKET_LOGGER]
     assert len(records) == 1
+    assert records[0].levelno == logging.ERROR
+    assert records[0].exc_info is not None
+    assert records[0].exc_info[0] is ValueError
     assert "malformed client-facing log template" in records[0].getMessage().lower()
     assert "operator detail" in records[0].getMessage()
 
@@ -605,6 +624,26 @@ def test_log_helper_accepts_int_enum_for_native_integer_placeholder(
     assert len(records) == 1
     assert records[0].getMessage() == "Task 7 failed: operator detail"
     assert "malformed client-facing log template" not in records[0].getMessage().lower()
+
+
+@pytest.mark.parametrize(
+    ("template", "args", "expected_message"),
+    [
+        ("V=%r: %s", (SimpleNamespace(x="é"),), "V=namespace(x='é'): e"),
+        ("V=%a: %s", (SimpleNamespace(x="é"),), "V=namespace(x='\\xe9'): e"),
+        ("100%%: %s", (), "100%: e"),
+    ],
+)
+def test_log_helper_preserves_native_percent_formatting(
+    caplog: pytest.LogCaptureFixture,
+    template: str,
+    args: tuple[object, ...],
+    expected_message: str,
+) -> None:
+    websocket_api.log_client_facing_failure(ValueError("e"), template, *args)
+
+    (record,) = [r for r in caplog.records if r.name == WEBSOCKET_LOGGER]
+    assert record.getMessage() == expected_message
 
 
 def test_log_helper_does_not_raise_for_unprintable_values(


### PR DESCRIPTION
## Summary

- make `ClientVisibleError` a subclass-only marker
- fall back to generic client text for blank or whitespace-only curated messages
- validate the complete native percent-format contract before logging
- render a valid log message exactly once while preserving native `%d`, `%r`, and `%a` semantics
- keep malformed-template fallback logging non-throwing for hostile or unprintable values
- preserve the existing WARNING/ERROR and traceback split

This is the runtime half of #1708, split from the test-only AST analysis so the production behavior change stays small and independently revertible. Its AST companion is #1734; together they supersede #1708.

## Review coverage

This replacement fixes Roger's malformed log-template finding on #1708. The subclass-only marker and blank-client fallback complete the deferred runtime requirements recorded in #1720.

## Testing

- `uv run pytest -q tests/web/api/test_websocket_client_safe_errors.py`
  - passed with 3 expected xfails tracked by #1497
- `uv run ruff check src/xagent/web/api/websocket.py tests/web/api/test_websocket_client_safe_errors.py`
- `uv run ruff format --check src/xagent/web/api/websocket.py tests/web/api/test_websocket_client_safe_errors.py`
- `git diff --check origin/main...2e739324`

Preflight reviewed the exact `origin/main...2e739324` range along both repository-standards and issue-spec axes; no blocking findings remain.

## Out of scope

- client-safe AST analysis: #1547
- stable egress identity and audience tracking: #1716
- blank-marker cause/traceback policy: #1717
- broader producer shapes outside the AST guard's recognized grammar: #1497

Closes #1720
