### PR TITLE
fix: make client-safe AST analysis fail closed

### DIFF
--- a/tests/web/api/client_safe_ast_guard.py
+++ b/tests/web/api/client_safe_ast_guard.py
@@ -1,4 +1,9 @@
-"""Fail-closed AST analysis for client-visible WebSocket messages."""
+"""Fail-closed AST analysis for recognized client-visible WebSocket shapes.
+
+This models the direct producers and literal payload grammar declared below,
+not general Python control flow or every possible egress. Unsupported producer
+shapes remain explicit regression xfails tracked outside this module.
+"""
 
 from __future__ import annotations
 
@@ -7,6 +12,7 @@ from typing import Iterator, NamedTuple
 
 FUNCTION_NODES = (ast.FunctionDef, ast.AsyncFunctionDef)
 TRY_NODES = (ast.Try, ast.TryStar)
+LOOP_NODES = (ast.For, ast.AsyncFor, ast.While)
 COMPREHENSION_NODES = (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)
 
 # arg name -> positional index of the client-visible message
@@ -206,7 +212,7 @@ def _resolved_assignments(
                     assignments = [
                         value
                         for value in all_assignments
-                        if _precedes(value, reference)
+                        if _can_reach_reference(value, reference, parents)
                     ]
                     if not assignments:
                         return [_incoming_parameter()]
@@ -217,7 +223,9 @@ def _resolved_assignments(
         all_assignments = _local_assignments([scope], name)
         if all_assignments:
             assignments = [
-                value for value in all_assignments if _precedes(value, reference)
+                value
+                for value in all_assignments
+                if _can_reach_reference(value, reference, parents)
             ]
             if not assignments:
                 return [_incoming_parameter()]
@@ -277,6 +285,38 @@ def _precedes(value: ast.expr, reference: ast.AST) -> bool:
     return value_position < reference_position
 
 
+def _can_reach_reference(
+    value: ast.expr, reference: ast.AST, parents: dict[ast.AST, ast.AST]
+) -> bool:
+    """Whether a binding can reach a reference directly or on a loop back-edge."""
+    return _precedes(value, reference) or _reaches_on_loop_backedge(
+        value, reference, parents
+    )
+
+
+def _reaches_on_loop_backedge(
+    value: ast.expr, reference: ast.AST, parents: dict[ast.AST, ast.AST]
+) -> bool:
+    """A later binding in a repeated loop region reaches the next iteration."""
+    if _precedes(value, reference):
+        return False
+    binding_node: ast.AST = getattr(value, "_binding_node", value)
+    current: ast.AST | None = binding_node
+    while current is not None:
+        parent = parents.get(current)
+        if isinstance(parent, LOOP_NODES):
+            binding_branch = _descendant_control_branch(binding_node, parent, parents)
+            reference_branch = _descendant_control_branch(reference, parent, parents)
+            if (binding_branch == "body" and reference_branch == "body") or (
+                isinstance(parent, ast.While)
+                and binding_branch in {"body", "test"}
+                and reference_branch == "test"
+            ):
+                return True
+        current = parent
+    return False
+
+
 def _is_conditional_before_reference(
     value: ast.expr,
     reference: ast.AST,
@@ -284,6 +324,9 @@ def _is_conditional_before_reference(
     parents: dict[ast.AST, ast.AST],
 ) -> bool:
     """Whether an assignment can be skipped on the path to ``reference``."""
+    if _reaches_on_loop_backedge(value, reference, parents):
+        # The binding is unavailable on the first iteration.
+        return True
     current: ast.AST | None = value
     while current is not None and current is not scope:
         parent = parents.get(current)
@@ -476,18 +519,16 @@ def _local_assignments(scopes: list[ast.AST], name: str) -> list[ast.expr]:
                 values.extend(_target_values(node.target, node.value, name))
             elif isinstance(node, ast.AugAssign):
                 if _target_contains_name(node.target, name):
-                    values.append(
-                        ast.copy_location(
-                            ast.Call(
-                                func=ast.Name(
-                                    id="_augmented_assignment", ctx=ast.Load()
-                                ),
-                                args=[node.value],
-                                keywords=[],
-                            ),
-                            node,
-                        )
+                    binding = ast.copy_location(
+                        ast.Call(
+                            func=ast.Name(id="_augmented_assignment", ctx=ast.Load()),
+                            args=[node.value],
+                            keywords=[],
+                        ),
+                        node,
                     )
+                    binding._binding_node = node  # type: ignore[attr-defined]
+                    values.append(binding)
             elif isinstance(node, ast.NamedExpr):
                 values.extend(_target_values(node.target, node.value, name))
             elif isinstance(node, (ast.For, ast.AsyncFor)):
@@ -573,7 +614,9 @@ def _reaching_alias_assignments(
     assignments = _local_assignments([scope], name)
     if not deferred:
         assignments = [
-            assignment for assignment in assignments if _precedes(assignment, reference)
+            assignment
+            for assignment in assignments
+            if _can_reach_reference(assignment, reference, parents)
         ]
     direct = [
         assignment
@@ -630,6 +673,11 @@ def _resolve_alias_values(
     parents: dict[ast.AST, ast.AST],
     visited: frozenset[str],
 ) -> str:
+    """Resolve direct single-name aliases, leaving ambiguous shapes unresolved.
+
+    This is deliberately not a general alias engine: ambiguous or non-name
+    values keep the original name and may remain outside the recognized grammar.
+    """
     resolved: list[str] = []
     for assignment in assignments:
         if not isinstance(assignment, ast.Name) or assignment.id == name:

--- a/tests/web/api/client_safe_ast_guard.py
+++ b/tests/web/api/client_safe_ast_guard.py
@@ -1,0 +1,914 @@
+"""Fail-closed AST analysis for client-visible WebSocket messages."""
+
+from __future__ import annotations
+
+import ast
+from typing import Iterator, NamedTuple
+
+FUNCTION_NODES = (ast.FunctionDef, ast.AsyncFunctionDef)
+TRY_NODES = (ast.Try, ast.TryStar)
+COMPREHENSION_NODES = (ast.ListComp, ast.SetComp, ast.DictComp, ast.GeneratorExp)
+
+# arg name -> positional index of the client-visible message
+PRODUCERS: dict[str, int | None] = {
+    "finish_delivery_failure": 0,
+    "finish_delivery": 1,
+    "send_message_delivery": None,  # keyword-only
+}
+
+# The one deliberate exception: agent RuntimeError text is passed through to
+# the INITIATING SENDER - the rejection ack and the personal error bubble.
+# Narrowing that wording is the product decision tracked in #1479.
+#
+# The broadcast half of the passthrough is closed (maintainer scope ruling on
+# #1514): the task-wide broadcast reaches every connection under the task_id,
+# anonymous widget and share visitors included, and DurableStorageOperation-
+# Error subclasses RuntimeError with tenant-scope text in its message, so
+# broadcasts carry CLIENT_SAFE_TASK_FAILURE instead - pinned by the two
+# audience-boundary tests at the end of this file. Still #1479: whether the
+# sender copy should also be narrowed when the initiator is an anonymous
+# public connection.
+#
+# Anchored to the function and the exception handler that owns the expression.
+# The raw wording is the deliberate #1479 RuntimeError contract; the same text
+# in a validation or generic-exception branch is not curated and must fail.
+
+
+class _RawMessageAllowance(NamedTuple):
+    function: str
+    handler: str
+    expression: str
+
+
+ALLOWED_RAW_MESSAGES = {
+    _RawMessageAllowance(
+        "_handle_chat_message_unserialized",
+        "RuntimeError",
+        "f'Runtime error: {str(e)}'",
+    ),
+    _RawMessageAllowance(
+        "handle_execute_task", "RuntimeError", "f'Runtime error: {str(e)}'"
+    ),
+    _RawMessageAllowance(
+        "handle_intervention", "RuntimeError", "f'Runtime error: {str(e)}'"
+    ),
+    _RawMessageAllowance(
+        "_handle_pause_task_unserialized",
+        "RuntimeError",
+        "f'Runtime error: {str(e)}'",
+    ),
+    _RawMessageAllowance(
+        "_handle_resume_task_unserialized",
+        "RuntimeError",
+        "f'Runtime error: {str(e)}'",
+    ),
+}
+
+
+def _parents(tree: ast.Module) -> dict[ast.AST, ast.AST]:
+    parents: dict[ast.AST, ast.AST] = {}
+    for node in ast.walk(tree):
+        for child in ast.iter_child_nodes(node):
+            parents[child] = node
+    return parents
+
+
+def _enclosing_functions(
+    node: ast.AST, parents: dict[ast.AST, ast.AST]
+) -> list[ast.AST]:
+    """Innermost-first chain of functions a node can read locals from."""
+    chain: list[ast.AST] = []
+    current = parents.get(node)
+    while current is not None:
+        if isinstance(current, FUNCTION_NODES):
+            chain.append(current)
+        current = parents.get(current)
+    return chain
+
+
+def _message_expression(node: ast.Call, index: int | None) -> ast.expr | None:
+    for keyword in node.keywords:
+        if keyword.arg == "message":
+            return keyword.value
+    if index is not None and len(node.args) > index:
+        return node.args[index]
+    return None
+
+
+# ``send_text`` takes a serialized payload, so the dict sits one call deeper.
+ERROR_PAYLOAD_SINKS = {"send_personal_message", "broadcast_to_task", "send_text"}
+
+# Both render in the client's conversation, so both are the same disclosure
+# surface. ``agent_error`` was missing until review found a producer using it.
+ERROR_PAYLOAD_TYPES = {"error", "agent_error"}
+
+# The only functions allowed to mint client-visible text from an exception.
+SAFE_MESSAGE_BUILDERS = {
+    "client_safe_error_message",
+    "client_safe_task_command_failure",
+}
+
+
+def _unwrap_serializer(expr: ast.expr, parents: dict[ast.AST, ast.AST]) -> ast.expr:
+    """``json.dumps(payload)`` -> ``payload``; anything else unchanged."""
+    if (
+        isinstance(expr, ast.Call)
+        and _called_name(expr, parents) == "dumps"
+        and expr.args
+    ):
+        return expr.args[0]
+    return expr
+
+
+def _error_payload_message(
+    node: ast.Call, parents: dict[ast.AST, ast.AST]
+) -> ast.expr | None:
+    """The message of an ``{"type": "error", ...}`` payload, if this is one."""
+    if _called_name(node, parents) not in ERROR_PAYLOAD_SINKS:
+        return None
+    for raw in (*node.args, *(kw.value for kw in node.keywords)):
+        argument = _unwrap_serializer(raw, parents)
+        if not isinstance(argument, ast.Dict):
+            continue
+        keys = {
+            key.value: value
+            for key, value in zip(argument.keys, argument.values)
+            if isinstance(key, ast.Constant)
+        }
+        kind = keys.get("type")
+        if isinstance(kind, ast.Constant) and kind.value in ERROR_PAYLOAD_TYPES:
+            return keys.get("message")
+    return None
+
+
+ATTRIBUTE_CALL_RECEIVERS = {
+    "broadcast_to_task": {"manager"},
+    "dumps": {"json"},
+    "send_personal_message": {"manager"},
+    "send_text": {"connection", "self.ws", "websocket"},
+}
+
+
+def _attribute_path(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        owner = _attribute_path(node.value)
+        if owner is not None:
+            return f"{owner}.{node.attr}"
+    return None
+
+
+def _called_name(
+    node: ast.Call, parents: dict[ast.AST, ast.AST] | None = None
+) -> str | None:
+    if isinstance(node.func, ast.Name):
+        if parents is None:
+            return node.func.id
+        return _single_name_alias(node.func.id, node, parents)
+    if isinstance(node.func, ast.Attribute):
+        receivers = ATTRIBUTE_CALL_RECEIVERS.get(node.func.attr)
+        if receivers is not None and _attribute_path(node.func.value) in receivers:
+            return node.func.attr
+    return None
+
+
+def _is_parameter(scopes: list[ast.AST], name: str) -> bool:
+    """A forwarded parameter is vetted at the wrapper's own call sites."""
+    for scope in scopes:
+        if not isinstance(scope, FUNCTION_NODES):
+            continue
+        arguments = scope.args
+        for argument in (
+            *arguments.posonlyargs,
+            *arguments.args,
+            *arguments.kwonlyargs,
+            *(argument for argument in (arguments.vararg, arguments.kwarg) if argument),
+        ):
+            if argument.arg == name:
+                return True
+    return False
+
+
+def _resolved_assignments(
+    scopes: list[ast.AST],
+    name: str,
+    reference: ast.AST,
+    parents: dict[ast.AST, ast.AST],
+) -> list[ast.expr]:
+    """Prefer the active control branch, then the nearest lexical binding."""
+    for scope in scopes:
+        current = parents.get(reference)
+        while current is not None and current is not scope:
+            if isinstance(current, (ast.ExceptHandler, ast.If)):
+                all_assignments = _local_assignments([current], name)
+                if all_assignments:
+                    assignments = [
+                        value
+                        for value in all_assignments
+                        if _precedes(value, reference)
+                    ]
+                    if not assignments:
+                        return [_incoming_parameter()]
+                    return _include_unassigned_parameter_path(
+                        assignments, scopes, name, reference, current, parents
+                    )
+            current = parents.get(current)
+        all_assignments = _local_assignments([scope], name)
+        if all_assignments:
+            assignments = [
+                value for value in all_assignments if _precedes(value, reference)
+            ]
+            if not assignments:
+                return [_incoming_parameter()]
+            return _include_unassigned_parameter_path(
+                assignments, scopes, name, reference, scope, parents
+            )
+        if _is_parameter([scope], name):
+            return []
+    return []
+
+
+def _include_unassigned_parameter_path(
+    assignments: list[ast.expr],
+    scopes: list[ast.AST],
+    name: str,
+    reference: ast.AST,
+    binding_scope: ast.AST,
+    parents: dict[ast.AST, ast.AST],
+) -> list[ast.expr]:
+    """Keep the incoming binding when every local assignment is conditional."""
+    if not all(
+        _is_conditional_before_reference(value, reference, binding_scope, parents)
+        for value in assignments
+    ):
+        return assignments
+    return [*assignments, _incoming_parameter()]
+
+
+def _incoming_parameter() -> ast.Call:
+    return ast.Call(
+        func=ast.Name(id="_incoming_parameter", ctx=ast.Load()),
+        args=[],
+        keywords=[],
+    )
+
+
+def _unknown_binding(node: ast.AST) -> ast.Call:
+    binding = ast.copy_location(
+        ast.Call(
+            func=ast.Name(id="_unknown_binding", ctx=ast.Load()),
+            args=[],
+            keywords=[],
+        ),
+        node,
+    )
+    binding._binding_node = node  # type: ignore[attr-defined]
+    return binding
+
+
+def _precedes(value: ast.expr, reference: ast.AST) -> bool:
+    """Only bindings evaluated before the client-facing sink can reach it."""
+    value_position = (getattr(value, "lineno", -1), getattr(value, "col_offset", -1))
+    reference_position = (
+        getattr(reference, "lineno", -1),
+        getattr(reference, "col_offset", -1),
+    )
+    return value_position < reference_position
+
+
+def _is_conditional_before_reference(
+    value: ast.expr,
+    reference: ast.AST,
+    scope: ast.AST,
+    parents: dict[ast.AST, ast.AST],
+) -> bool:
+    """Whether an assignment can be skipped on the path to ``reference``."""
+    current: ast.AST | None = value
+    while current is not None and current is not scope:
+        parent = parents.get(current)
+        if isinstance(parent, (ast.If, ast.For, ast.AsyncFor, ast.While)):
+            value_branch = _control_branch(current, parent)
+            reference_branch = _descendant_control_branch(reference, parent, parents)
+            if value_branch in {"body", "orelse"} and value_branch != reference_branch:
+                return True
+        elif isinstance(parent, ast.match_case):
+            if not _is_descendant(reference, parent, parents):
+                return True
+        elif isinstance(parent, ast.BoolOp):
+            if current is not parent.values[0] and not _is_descendant(
+                reference, current, parents
+            ):
+                return True
+        elif isinstance(parent, TRY_NODES):
+            value_region = _try_region(current, parent, parents)
+            reference_region = _try_region(reference, parent, parents)
+            if isinstance(value_region, ast.ExceptHandler):
+                if value_region is not reference_region:
+                    return True
+            elif value_region == "body":
+                if isinstance(reference_region, ast.ExceptHandler) or (
+                    reference_region == "finalbody"
+                ):
+                    return True
+                if reference_region is None and parent.handlers:
+                    return True
+            elif value_region == "orelse" and reference_region != "orelse":
+                return True
+        elif isinstance(parent, ast.IfExp):
+            if current in (parent.body, parent.orelse) and not _is_descendant(
+                reference, current, parents
+            ):
+                return True
+        current = parent
+    return False
+
+
+def _control_branch(
+    node: ast.AST, conditional: ast.If | ast.For | ast.AsyncFor | ast.While
+) -> str:
+    if node in conditional.body:
+        return "body"
+    if node in conditional.orelse:
+        return "orelse"
+    return "test"
+
+
+def _descendant_control_branch(
+    node: ast.AST,
+    conditional: ast.If | ast.For | ast.AsyncFor | ast.While,
+    parents: dict[ast.AST, ast.AST],
+) -> str | None:
+    current = node
+    while current is not conditional:
+        parent = parents.get(current)
+        if parent is conditional:
+            return _control_branch(current, conditional)
+        if parent is None:
+            return None
+        current = parent
+    return None
+
+
+def _try_region(
+    node: ast.AST,
+    conditional: ast.Try | ast.TryStar,
+    parents: dict[ast.AST, ast.AST],
+) -> str | ast.ExceptHandler | None:
+    current = node
+    while current is not conditional:
+        parent = parents.get(current)
+        if parent is conditional:
+            if current in conditional.body:
+                return "body"
+            if current in conditional.orelse:
+                return "orelse"
+            if current in conditional.finalbody:
+                return "finalbody"
+            if isinstance(current, ast.ExceptHandler):
+                return current
+            return None
+        if parent is None:
+            return None
+        current = parent
+    return None
+
+
+def _is_descendant(
+    node: ast.AST, ancestor: ast.AST, parents: dict[ast.AST, ast.AST]
+) -> bool:
+    current: ast.AST | None = node
+    while current is not None:
+        if current is ancestor:
+            return True
+        current = parents.get(current)
+    return False
+
+
+def _scope_nodes(scope: ast.AST) -> Iterator[ast.AST]:
+    """Walk one lexical scope without borrowing bindings from its closures."""
+    if isinstance(scope, (ast.Module, ast.ClassDef) + FUNCTION_NODES):
+        children: Iterator[ast.AST] = iter(scope.body)
+    else:
+        children = ast.iter_child_nodes(scope)
+    for child in children:
+        yield from _scope_node(child)
+
+
+def _scope_node(node: ast.AST) -> Iterator[ast.AST]:
+    """Walk a node, entering only the outer-evaluated parts of new scopes."""
+    if isinstance(node, ast.Lambda):
+        for expression in _definition_time_expressions(node):
+            yield from _scope_node(expression)
+        return
+    yield node
+    if isinstance(node, FUNCTION_NODES + (ast.ClassDef,)):
+        for expression in _definition_time_expressions(node):
+            yield from _scope_node(expression)
+        return
+    for child in ast.iter_child_nodes(node):
+        yield from _scope_node(child)
+
+
+def _definition_time_expressions(node: ast.AST) -> Iterator[ast.expr]:
+    if isinstance(node, FUNCTION_NODES + (ast.Lambda,)):
+        if isinstance(node, FUNCTION_NODES):
+            yield from node.decorator_list
+        arguments = node.args
+        yield from arguments.defaults
+        yield from (default for default in arguments.kw_defaults if default is not None)
+        if isinstance(node, FUNCTION_NODES):
+            for argument in (
+                *arguments.posonlyargs,
+                *arguments.args,
+                *arguments.kwonlyargs,
+                *(arg for arg in (arguments.vararg, arguments.kwarg) if arg),
+            ):
+                if argument.annotation is not None:
+                    yield argument.annotation
+            if node.returns is not None:
+                yield node.returns
+    elif isinstance(node, ast.ClassDef):
+        yield from node.decorator_list
+        yield from node.bases
+        yield from (keyword.value for keyword in node.keywords)
+
+
+def _target_values(target: ast.expr, value: ast.expr, name: str) -> list[ast.expr]:
+    if isinstance(target, ast.Name):
+        return [value] if target.id == name else []
+    if isinstance(target, (ast.List, ast.Tuple)):
+        if isinstance(value, (ast.List, ast.Tuple)) and len(target.elts) == len(
+            value.elts
+        ):
+            values: list[ast.expr] = []
+            for child_target, child_value in zip(target.elts, value.elts):
+                values.extend(_target_values(child_target, child_value, name))
+            return values
+        if any(_target_contains_name(child, name) for child in target.elts):
+            return [value]
+    if isinstance(target, ast.Starred) and _target_contains_name(target.value, name):
+        return [value]
+    return []
+
+
+def _target_contains_name(target: ast.expr, name: str) -> bool:
+    if isinstance(target, ast.Name):
+        return target.id == name
+    if isinstance(target, ast.Starred):
+        return _target_contains_name(target.value, name)
+    if isinstance(target, (ast.List, ast.Tuple)):
+        return any(_target_contains_name(child, name) for child in target.elts)
+    return False
+
+
+def _local_assignments(scopes: list[ast.AST], name: str) -> list[ast.expr]:
+    """Values bound to ``name`` in the given lexical scopes."""
+    values: list[ast.expr] = []
+    for scope in scopes:
+        if isinstance(scope, ast.ExceptHandler) and scope.name == name:
+            values.append(_unknown_binding(scope))
+        for node in _scope_nodes(scope):
+            if isinstance(node, ast.Assign):
+                for target in node.targets:
+                    values.extend(_target_values(target, node.value, name))
+            elif isinstance(node, ast.AnnAssign) and node.value is not None:
+                values.extend(_target_values(node.target, node.value, name))
+            elif isinstance(node, ast.AugAssign):
+                if _target_contains_name(node.target, name):
+                    values.append(
+                        ast.copy_location(
+                            ast.Call(
+                                func=ast.Name(
+                                    id="_augmented_assignment", ctx=ast.Load()
+                                ),
+                                args=[node.value],
+                                keywords=[],
+                            ),
+                            node,
+                        )
+                    )
+            elif isinstance(node, ast.NamedExpr):
+                values.extend(_target_values(node.target, node.value, name))
+            elif isinstance(node, (ast.For, ast.AsyncFor)):
+                if _target_contains_name(node.target, name):
+                    values.append(_unknown_binding(node.target))
+            elif isinstance(node, (ast.MatchAs, ast.MatchStar)):
+                if node.name == name:
+                    values.append(_unknown_binding(node))
+            elif isinstance(node, ast.MatchMapping) and node.rest == name:
+                values.append(_unknown_binding(node))
+            elif (
+                isinstance(node, ast.withitem)
+                and node.optional_vars is not None
+                and _target_contains_name(node.optional_vars, name)
+            ):
+                values.append(_unknown_binding(node.optional_vars))
+            elif isinstance(node, ast.ExceptHandler) and node.name == name:
+                values.append(_unknown_binding(node))
+            elif isinstance(node, FUNCTION_NODES + (ast.ClassDef,)):
+                if node.name == name:
+                    values.append(_unknown_binding(node))
+            elif isinstance(node, (ast.Import, ast.ImportFrom)):
+                if any(
+                    alias.name == "*"
+                    or (alias.asname or alias.name.split(".")[0]) == name
+                    for alias in node.names
+                ):
+                    values.append(_unknown_binding(node))
+    return values
+
+
+def _single_name_alias(
+    name: str,
+    node: ast.AST,
+    parents: dict[ast.AST, ast.AST],
+    visited: frozenset[str] = frozenset(),
+) -> str:
+    """Resolve recursive aliases from definitions that can reach the call."""
+    if name in visited:
+        return name
+    visited = visited | {name}
+    scopes = _enclosing_functions(node, parents)
+    for index, scope in enumerate(scopes):
+        assignments = _reaching_alias_assignments(
+            scope,
+            name,
+            node,
+            parents,
+            deferred=index > 0,
+            prune_overwritten=index == 0,
+        )
+        if not assignments:
+            if _is_parameter([scope], name):
+                return name
+            continue
+        return _resolve_alias_values(name, assignments, parents, visited)
+    current: ast.AST | None = node
+    while current is not None and not isinstance(current, ast.Module):
+        current = parents.get(current)
+    if isinstance(current, ast.Module):
+        assignments = _reaching_alias_assignments(
+            current,
+            name,
+            node,
+            parents,
+            deferred=bool(scopes),
+            prune_overwritten=True,
+        )
+        if assignments:
+            return _resolve_alias_values(name, assignments, parents, visited)
+    return name
+
+
+def _reaching_alias_assignments(
+    scope: ast.AST,
+    name: str,
+    reference: ast.AST,
+    parents: dict[ast.AST, ast.AST],
+    *,
+    deferred: bool,
+    prune_overwritten: bool,
+) -> list[ast.expr]:
+    assignments = _local_assignments([scope], name)
+    if not deferred:
+        assignments = [
+            assignment for assignment in assignments if _precedes(assignment, reference)
+        ]
+    direct = [
+        assignment
+        for assignment in assignments
+        if _is_direct_scope_binding(assignment, scope, parents)
+    ]
+    direct_overwrites = [
+        assignment
+        for assignment in direct
+        if not (isinstance(assignment, ast.Name) and assignment.id == name)
+    ]
+    if direct_overwrites and prune_overwritten:
+        last_direct = max(
+            direct_overwrites,
+            key=lambda assignment: (
+                getattr(assignment, "lineno", -1),
+                getattr(assignment, "col_offset", -1),
+            ),
+        )
+        assignments = [
+            assignment
+            for assignment in assignments
+            if assignment is last_direct or _precedes(last_direct, assignment)
+        ]
+    return assignments
+
+
+def _is_direct_scope_binding(
+    binding: ast.expr,
+    scope: ast.AST,
+    parents: dict[ast.AST, ast.AST],
+) -> bool:
+    current: ast.AST = getattr(binding, "_binding_node", binding)
+    while current in parents and parents[current] is not scope:
+        current = parents[current]
+    return parents.get(current) is scope and isinstance(
+        current,
+        (
+            ast.Assign,
+            ast.AnnAssign,
+            ast.AugAssign,
+            ast.Expr,
+            ast.Import,
+            ast.ImportFrom,
+            ast.ClassDef,
+        )
+        + FUNCTION_NODES,
+    )
+
+
+def _resolve_alias_values(
+    name: str,
+    assignments: list[ast.expr],
+    parents: dict[ast.AST, ast.AST],
+    visited: frozenset[str],
+) -> str:
+    resolved: list[str] = []
+    for assignment in assignments:
+        if not isinstance(assignment, ast.Name) or assignment.id == name:
+            continue
+        alias = _single_name_alias(assignment.id, assignment, parents, visited)
+        if alias in PRODUCERS:
+            return alias
+        resolved.append(alias)
+    if len(assignments) == 1 and len(resolved) == 1:
+        return resolved[0]
+    return name
+
+
+def _module_bindings(module: ast.Module, name: str) -> list[ast.AST]:
+    bindings: list[ast.AST] = []
+    for node in _scope_nodes(module):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                bindings.extend(_target_values(target, node.value, name))
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            bindings.extend(_target_values(node.target, node.value, name))
+        elif isinstance(node, ast.AugAssign) and _target_contains_name(
+            node.target, name
+        ):
+            bindings.append(_unknown_binding(node))
+        elif isinstance(node, ast.NamedExpr):
+            bindings.extend(_target_values(node.target, node.value, name))
+        elif isinstance(node, (ast.For, ast.AsyncFor)) and _target_contains_name(
+            node.target, name
+        ):
+            bindings.append(_unknown_binding(node.target))
+        elif isinstance(node, (ast.MatchAs, ast.MatchStar)) and node.name == name:
+            bindings.append(_unknown_binding(node))
+        elif isinstance(node, ast.MatchMapping) and node.rest == name:
+            bindings.append(_unknown_binding(node))
+        elif (
+            isinstance(node, ast.withitem)
+            and node.optional_vars is not None
+            and _target_contains_name(node.optional_vars, name)
+        ):
+            bindings.append(_unknown_binding(node.optional_vars))
+        elif isinstance(node, ast.ExceptHandler) and node.name == name:
+            bindings.append(_unknown_binding(node))
+        elif isinstance(node, FUNCTION_NODES + (ast.ClassDef,)) and node.name == name:
+            bindings.append(node)
+        elif isinstance(node, (ast.Import, ast.ImportFrom)) and any(
+            alias.name == "*" or (alias.asname or alias.name.split(".")[0]) == name
+            for alias in node.names
+        ):
+            bindings.append(node)
+    return bindings
+
+
+def _is_unshadowed_module_name(
+    node: ast.Name,
+    parents: dict[ast.AST, ast.AST],
+    expected: type[ast.AST],
+) -> bool:
+    scopes = _enclosing_functions(node, parents)
+    if (
+        _is_comprehension_binding(node, node.id, parents)
+        or _is_parameter(scopes, node.id)
+        or any(_local_assignments([scope], node.id) for scope in scopes)
+    ):
+        return False
+    module: ast.AST = node
+    while module in parents:
+        module = parents[module]
+    bindings = (
+        _module_bindings(module, node.id) if isinstance(module, ast.Module) else []
+    )
+    if not bindings:
+        return True
+    if (
+        len(bindings) != 1
+        or not isinstance(bindings[0], expected)
+        or not _is_direct_module_binding(bindings[0], module, parents)
+    ):
+        return False
+    if expected is ast.Dict:
+        table = bindings[0]
+        assert isinstance(table, ast.Dict)
+        return all(
+            isinstance(key, ast.Constant)
+            and isinstance(key.value, str)
+            and isinstance(value, ast.Constant)
+            and isinstance(value.value, str)
+            for key, value in zip(table.keys, table.values)
+        )
+    return True
+
+
+def _is_direct_module_binding(
+    binding: ast.AST,
+    module: ast.Module,
+    parents: dict[ast.AST, ast.AST],
+) -> bool:
+    if isinstance(binding, FUNCTION_NODES + (ast.ClassDef,)):
+        return parents.get(binding) is module
+    statement = parents.get(binding)
+    return isinstance(statement, (ast.Assign, ast.AnnAssign)) and (
+        parents.get(statement) is module
+    )
+
+
+def _is_comprehension_binding(
+    node: ast.AST, name: str, parents: dict[ast.AST, ast.AST]
+) -> bool:
+    current: ast.AST | None = node
+    while current is not None:
+        if isinstance(current, COMPREHENSION_NODES) and any(
+            _target_contains_name(generator.target, name)
+            for generator in current.generators
+        ):
+            return True
+        current = parents.get(current)
+    return False
+
+
+def _is_client_safe(expr: ast.expr, parents: dict[ast.AST, ast.AST]) -> bool:
+    if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
+        return True
+    if isinstance(expr, ast.Call) and isinstance(expr.func, ast.Name):
+        if expr.func.id == "client_safe_error_message" and _is_unshadowed_module_name(
+            expr.func, parents, ast.FunctionDef
+        ):
+            return True
+        if expr.func.id == "client_safe_task_command_failure" and (
+            _is_unshadowed_module_name(expr.func, parents, ast.FunctionDef)
+        ):
+            # The prefix argument must be attribute access on server state
+            # (``command.kind``), never a literal or a bare name a caller
+            # could point at untrusted text.
+            return bool(expr.args) and isinstance(expr.args[0], ast.Attribute)
+        return False
+    # `_TURN_REJECTION_MESSAGES.get(reason, "<literal>")` - a curated table.
+    if isinstance(expr, ast.Call) and isinstance(expr.func, ast.Attribute):
+        return (
+            expr.func.attr == "get"
+            and isinstance(expr.func.value, ast.Name)
+            and expr.func.value.id == "_TURN_REJECTION_MESSAGES"
+            and _is_unshadowed_module_name(expr.func.value, parents, ast.Dict)
+            and len(expr.args) == 2
+            and not expr.keywords
+            and isinstance(expr.args[1], ast.Constant)
+            and isinstance(expr.args[1].value, str)
+        )
+    if isinstance(expr, ast.BoolOp):
+        return all(_is_client_safe(value, parents) for value in expr.values)
+    return False
+
+
+class _ScanResult(NamedTuple):
+    offenders: list[str]
+    producers: int
+    error_payloads: int
+    used_allowlist: set[_RawMessageAllowance]
+
+
+def _allowlist_key(
+    candidate: ast.expr,
+    sink: ast.Call,
+    parents: dict[ast.AST, ast.AST],
+) -> _RawMessageAllowance:
+    functions = _enclosing_functions(candidate, parents)
+    qualname = ".".join(
+        reversed(
+            [scope.name for scope in functions if isinstance(scope, FUNCTION_NODES)]
+        )
+    )
+    candidate_handler = _enclosing_exception_handler(candidate, parents)
+    sink_handler = _enclosing_exception_handler(sink, parents)
+    handler_name = "<mismatched-except>"
+    if candidate_handler is sink_handler and candidate_handler is not None:
+        handler_name = (
+            ast.unparse(candidate_handler.type)
+            if candidate_handler.type is not None
+            else "BaseException"
+        )
+        if not _handler_target_is_used(candidate_handler, candidate):
+            handler_name = "<unbound-except>"
+    return _RawMessageAllowance(
+        qualname or "<module>", handler_name, ast.unparse(candidate)
+    )
+
+
+def _enclosing_exception_handler(
+    node: ast.AST, parents: dict[ast.AST, ast.AST]
+) -> ast.ExceptHandler | None:
+    current = parents.get(node)
+    while current is not None:
+        if isinstance(current, ast.ExceptHandler):
+            return current
+        current = parents.get(current)
+    return None
+
+
+def _handler_target_is_used(handler: ast.ExceptHandler, candidate: ast.expr) -> bool:
+    return isinstance(handler.name, str) and any(
+        isinstance(node, ast.Name)
+        and isinstance(node.ctx, ast.Load)
+        and node.id == handler.name
+        for node in ast.walk(candidate)
+    )
+
+
+def _inside_unsupported_scope(node: ast.AST, parents: dict[ast.AST, ast.AST]) -> bool:
+    current = parents.get(node)
+    while current is not None:
+        if isinstance(current, (ast.Lambda, ast.ClassDef)):
+            return True
+        if isinstance(current, FUNCTION_NODES):
+            return False
+        current = parents.get(current)
+    return False
+
+
+def _scan(tree: ast.Module) -> _ScanResult:
+    """The one copy of the sweep's recognition logic.
+
+    Both the production sweep and the snippet-based regression tests run
+    this same function, so a change to the analysis cannot pass the snippet
+    tests while silently not applying to the real module (or vice versa).
+    """
+    parents = _parents(tree)
+    producers = 0
+    error_payloads = 0
+    offenders: list[str] = []
+    used_allowlist: set[_RawMessageAllowance] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _called_name(node, parents)
+        is_producer = name in PRODUCERS
+        if is_producer:
+            expr = _message_expression(node, PRODUCERS[name])
+        else:
+            # The error bubble renders in the same conversation as the
+            # rejection ack, so it is the same disclosure surface.
+            expr = _error_payload_message(node, parents)
+            name = f"{name}(error payload)"
+        if expr is None:
+            continue
+        if is_producer:
+            producers += 1
+        else:
+            error_payloads += 1
+        if _inside_unsupported_scope(node, parents):
+            offenders.append(f"{name}:{node.lineno} is inside an unsupported scope")
+            continue
+        scopes = _enclosing_functions(node, parents)
+        if isinstance(expr, ast.Name):
+            candidates = (
+                [_unknown_binding(expr)]
+                if _is_comprehension_binding(expr, expr.id, parents)
+                else _resolved_assignments(scopes, expr.id, node, parents)
+            )
+        else:
+            candidates = [expr]
+        if not candidates:
+            # Only a name nothing rebinds is a genuinely forwarded parameter,
+            # vetted at the wrapper's own call sites. Every supported rebinding
+            # form lands in candidates instead of taking this short-circuit.
+            if isinstance(expr, ast.Name) and _is_parameter(scopes, expr.id):
+                continue
+            offenders.append(f"{name}:{node.lineno} passes an unresolvable name")
+            continue
+        for candidate in candidates:
+            if _is_client_safe(candidate, parents):
+                continue
+            key = _allowlist_key(candidate, node, parents)
+            if key in ALLOWED_RAW_MESSAGES:
+                used_allowlist.add(key)
+                continue
+            offenders.append(
+                f"{name}:{node.lineno} may send {ast.unparse(candidate)!r}"
+            )
+    return _ScanResult(offenders, producers, error_payloads, used_allowlist)
+
+
+def guard_offenders(source: str) -> list[str]:
+    return _scan(ast.parse(source)).offenders

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -9,7 +9,7 @@ import logging
 from enum import IntEnum
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Iterator, NamedTuple
+from typing import Iterator
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -19,6 +19,12 @@ from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
 from xagent.web.services.task_orchestrator import TaskTurnOrchestrator
 
+from .client_safe_ast_guard import (
+    ALLOWED_RAW_MESSAGES,
+    SAFE_MESSAGE_BUILDERS,
+    _scan,
+)
+from .client_safe_ast_guard import guard_offenders as _guard_offenders
 from .conftest import _direct_db_session
 
 SECRET = "/srv/xagent/secrets/prod.key"
@@ -146,247 +152,6 @@ async def test_execute_task_keeps_a_message_written_for_the_sender(
     )
 
 
-FUNCTION_NODES = (ast.FunctionDef, ast.AsyncFunctionDef)
-
-# arg name -> positional index of the client-visible message
-PRODUCERS: dict[str, int | None] = {
-    "finish_delivery_failure": 0,
-    "finish_delivery": 1,
-    "send_message_delivery": None,  # keyword-only
-}
-
-# The one deliberate exception: agent RuntimeError text is passed through to
-# the INITIATING SENDER - the rejection ack and the personal error bubble.
-# Narrowing that wording is the product decision tracked in #1479.
-#
-# The broadcast half of the passthrough is closed (maintainer scope ruling on
-# #1514): the task-wide broadcast reaches every connection under the task_id,
-# anonymous widget and share visitors included, and DurableStorageOperation-
-# Error subclasses RuntimeError with tenant-scope text in its message, so
-# broadcasts carry CLIENT_SAFE_TASK_FAILURE instead - pinned by the two
-# audience-boundary tests at the end of this file. Still #1479: whether the
-# sender copy should also be narrowed when the initiator is an anonymous
-# public connection.
-#
-# Anchored to (enclosing function, expression) rather than to the expression
-# alone, which blessed the string in every function it appeared in. This stops
-# reuse in a *different* function only: `_local_assignments` unions every
-# assignment in the enclosing function regardless of branch, so moving the
-# string between branches of an allowlisted function is NOT caught. #1547.
-ALLOWED_RAW_MESSAGES = {
-    ("_handle_chat_message_unserialized", "f'Runtime error: {str(e)}'"),
-    # The same #1479 flow seen through the closure scope chain: the outer
-    # function's runtime-error string reaches these closures' ``message``
-    # parameter at their call sites. Surfaced when the parameter short-circuit
-    # stopped hiding rebound names; not a new leak.
-    ("finish_delivery", "f'Runtime error: {str(e)}'"),
-    ("finish_delivery_failure", "f'Runtime error: {str(e)}'"),
-    ("handle_execute_task", "f'Runtime error: {str(e)}'"),
-    ("handle_intervention", "f'Runtime error: {str(e)}'"),
-    ("_handle_pause_task_unserialized", "f'Runtime error: {str(e)}'"),
-    ("_handle_resume_task_unserialized", "f'Runtime error: {str(e)}'"),
-}
-
-
-def _parents(tree: ast.Module) -> dict[ast.AST, ast.AST]:
-    parents: dict[ast.AST, ast.AST] = {}
-    for node in ast.walk(tree):
-        for child in ast.iter_child_nodes(node):
-            parents[child] = node
-    return parents
-
-
-def _enclosing_functions(
-    node: ast.AST, parents: dict[ast.AST, ast.AST]
-) -> list[ast.AST]:
-    """Innermost-first chain of functions a node can read locals from."""
-    chain: list[ast.AST] = []
-    current = parents.get(node)
-    while current is not None:
-        if isinstance(current, FUNCTION_NODES):
-            chain.append(current)
-        current = parents.get(current)
-    return chain
-
-
-def _message_expression(node: ast.Call, index: int | None) -> ast.expr | None:
-    for keyword in node.keywords:
-        if keyword.arg == "message":
-            return keyword.value
-    if index is not None and len(node.args) > index:
-        return node.args[index]
-    return None
-
-
-# ``send_text`` takes a serialized payload, so the dict sits one call deeper.
-ERROR_PAYLOAD_SINKS = {"send_personal_message", "broadcast_to_task", "send_text"}
-
-# Both render in the client's conversation, so both are the same disclosure
-# surface. ``agent_error`` was missing until review found a producer using it.
-ERROR_PAYLOAD_TYPES = {"error", "agent_error"}
-
-# The only functions allowed to mint client-visible text from an exception.
-SAFE_MESSAGE_BUILDERS = {
-    "client_safe_error_message",
-    "client_safe_task_command_failure",
-}
-
-
-def _unwrap_serializer(expr: ast.expr) -> ast.expr:
-    """``json.dumps(payload)`` -> ``payload``; anything else unchanged."""
-    if isinstance(expr, ast.Call) and _called_name(expr) == "dumps" and expr.args:
-        return expr.args[0]
-    return expr
-
-
-def _error_payload_message(node: ast.Call) -> ast.expr | None:
-    """The message of an ``{"type": "error", ...}`` payload, if this is one."""
-    if _called_name(node) not in ERROR_PAYLOAD_SINKS:
-        return None
-    for raw in (*node.args, *(kw.value for kw in node.keywords)):
-        argument = _unwrap_serializer(raw)
-        if not isinstance(argument, ast.Dict):
-            continue
-        keys = {
-            key.value: value
-            for key, value in zip(argument.keys, argument.values)
-            if isinstance(key, ast.Constant)
-        }
-        kind = keys.get("type")
-        if isinstance(kind, ast.Constant) and kind.value in ERROR_PAYLOAD_TYPES:
-            return keys.get("message")
-    return None
-
-
-def _called_name(node: ast.Call) -> str | None:
-    if isinstance(node.func, ast.Name):
-        return node.func.id
-    if isinstance(node.func, ast.Attribute):
-        return node.func.attr
-    return None
-
-
-def _is_parameter(scopes: list[ast.AST], name: str) -> bool:
-    """A forwarded parameter is vetted at the wrapper's own call sites."""
-    for scope in scopes:
-        if not isinstance(scope, FUNCTION_NODES):
-            continue
-        arguments = scope.args
-        for argument in (
-            *arguments.posonlyargs,
-            *arguments.args,
-            *arguments.kwonlyargs,
-        ):
-            if argument.arg == name:
-                return True
-    return False
-
-
-def _local_assignments(scopes: list[ast.AST], name: str) -> list[ast.expr]:
-    """Values assigned to `name` inside the given scopes only."""
-    values: list[ast.expr] = []
-    for scope in scopes:
-        for node in ast.walk(scope):
-            if isinstance(node, ast.Assign):
-                for target in node.targets:
-                    if isinstance(target, ast.Name) and target.id == name:
-                        values.append(node.value)
-    return values
-
-
-def _is_client_safe(expr: ast.expr) -> bool:
-    if isinstance(expr, ast.Constant) and isinstance(expr.value, str):
-        return True
-    if isinstance(expr, ast.Call) and isinstance(expr.func, ast.Name):
-        if expr.func.id == "client_safe_error_message":
-            return True
-        if expr.func.id == "client_safe_task_command_failure":
-            # The prefix argument must be attribute access on server state
-            # (``command.kind``), never a literal or a bare name a caller
-            # could point at untrusted text.
-            return bool(expr.args) and isinstance(expr.args[0], ast.Attribute)
-        return False
-    # `_TURN_REJECTION_MESSAGES.get(reason, "<literal>")` - a curated table.
-    if isinstance(expr, ast.Call) and isinstance(expr.func, ast.Attribute):
-        return expr.func.attr == "get" and all(
-            isinstance(arg, ast.Constant) or isinstance(arg, ast.Attribute)
-            for arg in expr.args[1:]
-        )
-    if isinstance(expr, ast.BoolOp):
-        return all(_is_client_safe(value) for value in expr.values)
-    return False
-
-
-class _ScanResult(NamedTuple):
-    offenders: list[str]
-    producers: int
-    error_payloads: int
-    used_allowlist: set[tuple[str, str]]
-
-
-def _scan(tree: ast.Module) -> _ScanResult:
-    """The one copy of the sweep's recognition logic.
-
-    Both the production sweep and the snippet-based regression tests run
-    this same function, so a change to the analysis cannot pass the snippet
-    tests while silently not applying to the real module (or vice versa).
-    """
-    parents = _parents(tree)
-    producers = 0
-    error_payloads = 0
-    offenders: list[str] = []
-    used_allowlist: set[tuple[str, str]] = set()
-    for node in ast.walk(tree):
-        if not isinstance(node, ast.Call):
-            continue
-        name = _called_name(node)
-        is_producer = name in PRODUCERS
-        if is_producer:
-            expr = _message_expression(node, PRODUCERS[name])
-        else:
-            # The error bubble renders in the same conversation as the
-            # rejection ack, so it is the same disclosure surface.
-            expr = _error_payload_message(node)
-            name = f"{name}(error payload)"
-        if expr is None:
-            continue
-        if is_producer:
-            producers += 1
-        else:
-            error_payloads += 1
-        scopes = _enclosing_functions(node, parents)
-        candidates = (
-            _local_assignments(scopes, expr.id)
-            if isinstance(expr, ast.Name)
-            else [expr]
-        )
-        if not candidates:
-            # Only a name nothing rebinds is a genuinely forwarded parameter,
-            # vetted at the wrapper's own call sites. A parameter rebound by a
-            # plain assignment lands in the candidates instead; rebinding via
-            # AnnAssign/AugAssign/walrus/tuple targets is still invisible to
-            # ``_local_assignments`` and tracked in #1547.
-            if isinstance(expr, ast.Name) and _is_parameter(scopes, expr.id):
-                continue
-            offenders.append(f"{name}:{node.lineno} passes an unresolvable name")
-            continue
-        enclosing = next(
-            (scope.name for scope in scopes if isinstance(scope, FUNCTION_NODES)),
-            "<module>",
-        )
-        for candidate in candidates:
-            if _is_client_safe(candidate):
-                continue
-            key = (enclosing, ast.unparse(candidate))
-            if key in ALLOWED_RAW_MESSAGES:
-                used_allowlist.add(key)
-                continue
-            offenders.append(
-                f"{name}:{node.lineno} may send {ast.unparse(candidate)!r}"
-            )
-    return _ScanResult(offenders, producers, error_payloads, used_allowlist)
-
-
 def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
     """Exception text may not reach a client through the *recognized* shapes.
 
@@ -414,14 +179,15 @@ def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
             f"SAFE_MESSAGE_BUILDERS blesses {builder!r}, which does not exist"
         )
 
-    # Actual counts at the time of writing: 23 producers, 30 error payloads.
-    # These floors sit below that, so a minority of sites can still vanish
-    # silently; tightening them to exact equality is tracked in #1547.
-    assert result.producers >= 21, (
-        f"the producers moved; only {result.producers} matched"
+    # These are deliberate exact baselines. If a producer is added or removed,
+    # inspect the changed site and bump the corresponding count in this test.
+    assert result.producers == 23, (
+        f"expected exactly 23 producers, matched {result.producers}; "
+        "review the changed sites and bump deliberately"
     )
-    assert result.error_payloads >= 21, (
-        f"the error payloads moved; only {result.error_payloads} matched"
+    assert result.error_payloads == 32, (
+        f"expected exactly 32 error payloads, matched {result.error_payloads}; "
+        "review the changed sites and bump deliberately"
     )
     # Every allowlist entry must be earned by a live call site: a stale entry
     # is a standing exemption nothing uses, and an unused closure entry is
@@ -920,11 +686,6 @@ async def leak(websocket):
 # dependency is written down rather than left implicit.
 
 
-def _guard_offenders(source: str) -> list[str]:
-    """Run the one sweep implementation over an arbitrary module source."""
-    return _scan(ast.parse(source)).offenders
-
-
 @pytest.mark.xfail(
     strict=True,
     reason="Known guard blind spots, all tracked in #1497. When one is closed "
@@ -1025,6 +786,78 @@ async def outer(websocket, message):
 """,
         id="nested-shadow",
     ),
+    pytest.param(
+        """
+async def leak(websocket, message):
+    try:
+        pass
+    except Exception as e:
+        message: str = str(e)
+        await send_message_delivery(
+            websocket,
+            client_message_id="c",
+            turn_id="t",
+            accepted=False,
+            message=message,
+            rejection_outcome="not_accepted",
+        )
+""",
+        id="annotated-rebind",
+    ),
+    pytest.param(
+        """
+async def leak(websocket, message):
+    try:
+        pass
+    except Exception as e:
+        message += str(e)
+        await send_message_delivery(
+            websocket,
+            client_message_id="c",
+            turn_id="t",
+            accepted=False,
+            message=message,
+            rejection_outcome="not_accepted",
+        )
+""",
+        id="augmented-rebind",
+    ),
+    pytest.param(
+        """
+async def leak(websocket, message):
+    try:
+        pass
+    except Exception as e:
+        (message := str(e))
+        await send_message_delivery(
+            websocket,
+            client_message_id="c",
+            turn_id="t",
+            accepted=False,
+            message=message,
+            rejection_outcome="not_accepted",
+        )
+""",
+        id="walrus-rebind",
+    ),
+    pytest.param(
+        """
+async def leak(websocket, message):
+    try:
+        pass
+    except Exception as e:
+        message, ignored = str(e), None
+        await send_message_delivery(
+            websocket,
+            client_message_id="c",
+            turn_id="t",
+            accepted=False,
+            message=message,
+            rejection_outcome="not_accepted",
+        )
+""",
+        id="tuple-rebind",
+    ),
 ]
 
 
@@ -1055,12 +888,663 @@ async def forward(websocket, message):
     assert not _guard_offenders(source)
 
 
+def test_allowlist_is_scoped_to_the_runtime_error_handler() -> None:
+    source = """
+async def handle_intervention(websocket):
+    try:
+        pass
+    except ValueError as e:
+        await manager.send_personal_message(
+            {"type": "error", "message": f"Runtime error: {str(e)}"},
+            websocket,
+        )
+"""
+
+    assert _guard_offenders(source), "a validation branch cannot reuse the carve-out"
+
+
+def test_allowlist_cannot_flow_from_runtime_into_a_validation_handler() -> None:
+    source = """
+async def handle_intervention(websocket):
+    try:
+        pass
+    except RuntimeError as e:
+        message = f"Runtime error: {str(e)}"
+
+    try:
+        pass
+    except ValueError:
+        await manager.send_personal_message(
+            {"type": "error", "message": message},
+            websocket,
+        )
+"""
+
+    assert _guard_offenders(source), "the carve-out cannot cross except handlers"
+
+
+def test_allowlist_cannot_flow_into_a_nested_runtime_error_handler() -> None:
+    source = """
+async def handle_intervention(websocket):
+    try: first_operation()
+    except RuntimeError as e:
+        message = f"Runtime error: {str(e)}"
+        try: second_operation()
+        except RuntimeError as other:
+            await manager.send_personal_message({"type": "error", "message": message})
+"""
+
+    assert _guard_offenders(source), "a nested handler cannot borrow the carve-out"
+
+
+def test_conditional_allowlisted_assignment_keeps_the_incoming_parameter() -> None:
+    source = """
+async def handle_intervention(websocket, message, flag):
+    try:
+        pass
+    except RuntimeError as e:
+        if flag:
+            message = f"Runtime error: {str(e)}"
+        await manager.send_personal_message(
+            {"type": "error", "message": message},
+            websocket,
+        )
+"""
+
+    assert _guard_offenders(source), "the false branch still forwards raw input"
+
+
+def test_conditional_assignment_keeps_the_outer_local_definition() -> None:
+    source = """
+async def handle_intervention(websocket, error, flag):
+    message = str(error)
+    try: pass
+    except RuntimeError as e:
+        if flag: message = f"Runtime error: {str(e)}"
+        else:
+            await manager.send_personal_message({"type": "error", "message": message})
+"""
+
+    assert _guard_offenders(source), "the else branch still uses the outer local"
+
+
+def test_allowlisted_assignment_after_sink_cannot_rewrite_history() -> None:
+    source = """
+async def handle_intervention(websocket, message):
+    try:
+        pass
+    except RuntimeError as e:
+        await manager.send_personal_message(
+            {"type": "error", "message": message},
+            websocket,
+        )
+        message = f"Runtime error: {str(e)}"
+"""
+
+    assert _guard_offenders(source), "a later binding cannot sanitize an earlier send"
+
+
+@pytest.mark.parametrize(
+    "control_flow",
+    [
+        'for item in items:\n            message = f"Runtime error: {str(e)}"',
+        'async for item in items:\n            message = f"Runtime error: {str(e)}"',
+        'while items:\n            message = f"Runtime error: {str(e)}"\n            break',
+        'match items:\n            case [item]:\n                message = f"Runtime error: {str(e)}"',
+    ],
+    ids=["for", "async-for", "while", "match"],
+)
+def test_conditional_control_flow_keeps_the_incoming_parameter(
+    control_flow: str,
+) -> None:
+    source = f"""
+async def handle_intervention(websocket, message, items):
+    try:
+        pass
+    except RuntimeError as e:
+        {control_flow}
+        await manager.send_personal_message(
+            {{"type": "error", "message": message}},
+            websocket,
+        )
+"""
+
+    assert _guard_offenders(source), "the control flow can skip the safe binding"
+
+
+def test_short_circuit_walrus_keeps_the_incoming_parameter() -> None:
+    source = """
+async def handle_intervention(websocket, message, flag):
+    try:
+        pass
+    except RuntimeError as e:
+        flag and (message := f"Runtime error: {str(e)}")
+        await manager.send_personal_message(
+            {"type": "error", "message": message},
+            websocket,
+        )
+"""
+
+    assert _guard_offenders(source), "the short-circuited walrus may never bind"
+
+
+@pytest.mark.parametrize(
+    "tail",
+    [
+        "except Exception: await send_message_delivery(message=message)",
+        "except* Exception: await send_message_delivery(message=message)",
+        "finally: await send_message_delivery(message=message)",
+        "except Exception: pass\n    await send_message_delivery(message=message)",
+    ],
+    ids=["handler", "exception-group-handler", "finally", "after-handled-try"],
+)
+def test_try_reaching_definitions_keep_the_skipped_value(tail: str) -> None:
+    source = f"""
+async def leak(message):
+    try: may_raise(); message = "safe"
+    {tail}
+"""
+    assert _guard_offenders(source)
+
+
+def test_try_assignment_reaches_a_later_sink_in_the_same_body() -> None:
+    source = """
+async def reject(message):
+    try: message = "safe"; await send_message_delivery(message=message)
+    except Exception: pass
+"""
+    assert not _guard_offenders(source)
+
+
+def test_lambda_bindings_do_not_reach_the_enclosing_scope() -> None:
+    source = """
+async def leak(websocket, error):
+    message = "safe"; build_detail = lambda: (message := error.detail)
+    await send_message_delivery(message=message)
+"""
+
+    assert not _guard_offenders(source), "the lambda has its own lexical scope"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        """async def outer(message, raw):
+    maker = lambda message: send_message_delivery(message=message)
+    await maker(raw)""",
+        """async def outer(message, raw):
+    class Pending:
+        message = raw
+        delivery = send_message_delivery(message=message)
+    await Pending.delivery""",
+    ],
+    ids=["lambda", "class"],
+)
+def test_guard_rejects_sinks_inside_unsupported_scopes(source: str) -> None:
+    assert _guard_offenders(source)
+
+
+def test_conditional_expression_assignment_keeps_the_incoming_value() -> None:
+    source = """
+async def leak(message, flag):
+    "safe" if flag else (message := "safe")
+    await send_message_delivery(message=message)
+"""
+    assert _guard_offenders(source)
+
+
+def test_guard_catches_augassign_that_keeps_a_forwarded_parameter() -> None:
+    source = """
+async def leak(websocket, message):
+    message += "!"
+    await send_message_delivery(
+        websocket,
+        client_message_id="c",
+        turn_id="t",
+        accepted=False,
+        message=message,
+        rejection_outcome="not_accepted",
+    )
+"""
+
+    assert _guard_offenders(source)
+
+
+def test_guard_catches_a_nested_unpack_rebinding() -> None:
+    source = """
+async def leak(websocket, message, source):
+    ((message, other), final) = source
+    await send_message_delivery(
+        websocket,
+        client_message_id="c",
+        turn_id="t",
+        accepted=False,
+        message=message,
+        rejection_outcome="not_accepted",
+    )
+"""
+
+    assert _guard_offenders(source)
+
+
+@pytest.mark.parametrize(
+    "body",
+    [
+        "for message in items: await send_message_delivery(message=message)",
+        "await gather(*(send_message_delivery(message=message) for message in items))",
+        """match items:
+        case {"raw": message}: await send_message_delivery(message=message)""",
+        "with resource as message: await send_message_delivery(message=message)",
+        """try: pass
+    except Exception as message: await send_message_delivery(message=message)""",
+    ],
+    ids=["loop", "comprehension", "match", "with", "except"],
+)
+def test_guard_catches_non_assignment_rebindings(body: str) -> None:
+    source = f"async def leak(message, items, resource):\n    {body}\n"
+    assert _guard_offenders(source), "the binding is not a forwarded parameter"
+
+
+@pytest.mark.parametrize(
+    "expression",
+    [
+        'message_data.get("error", "fallback")',
+        'message_data.get("error")',
+        'error.__dict__.get("detail", "fallback")',
+    ],
+)
+def test_guard_rejects_get_calls_from_untrusted_receivers(expression: str) -> None:
+    source = f"""
+async def leak(websocket, message_data, error):
+    await send_message_delivery(
+        websocket,
+        client_message_id="c",
+        turn_id="t",
+        accepted=False,
+        message={expression},
+        rejection_outcome="not_accepted",
+    )
+"""
+
+    assert _guard_offenders(source)
+
+
+def test_guard_accepts_the_curated_rejection_table_lookup() -> None:
+    source = """
+async def reject(websocket, reason):
+    await send_message_delivery(
+        websocket,
+        client_message_id="c",
+        turn_id="t",
+        accepted=False,
+        message=_TURN_REJECTION_MESSAGES.get(reason, "Task is busy"),
+        rejection_outcome="not_accepted",
+    )
+"""
+
+    assert not _guard_offenders(source)
+
+
+@pytest.mark.parametrize(
+    ("parameters", "binding", "fallback"),
+    [
+        ("reason, error", "", "error.detail"),
+        ("_TURN_REJECTION_MESSAGES, reason", "", '"Task is busy"'),
+        ("reason, **_TURN_REJECTION_MESSAGES", "", '"fallback"'),
+        ("reason", "from evil import _TURN_REJECTION_MESSAGES", '"fallback"'),
+        ("reason", "class _TURN_REJECTION_MESSAGES: get = evil_get", '"fallback"'),
+    ],
+    ids=["nonliteral-fallback", "parameter", "kwargs", "import", "class"],
+)
+def test_guard_rejects_unsafe_curated_lookups(
+    parameters: str, binding: str, fallback: str
+) -> None:
+    source = f"""
+async def leak({parameters}):
+    {binding}
+    await send_message_delivery(message=_TURN_REJECTION_MESSAGES.get(reason, {fallback}))
+"""
+    assert _guard_offenders(source)
+
+
+def test_guard_rejects_a_rebound_module_curated_table() -> None:
+    source = """
+_TURN_REJECTION_MESSAGES = attacker_controlled
+async def leak(reason):
+    await send_message_delivery(message=_TURN_REJECTION_MESSAGES.get(reason, "fallback"))
+"""
+    assert _guard_offenders(source)
+
+
+def test_guard_rejects_a_conditionally_rebound_module_curated_table() -> None:
+    source = """
+_TURN_REJECTION_MESSAGES = {"busy": "safe"}
+if flag:
+    _TURN_REJECTION_MESSAGES = attacker_controlled
+async def leak(reason):
+    await send_message_delivery(message=_TURN_REJECTION_MESSAGES.get(reason, "fallback"))
+"""
+    assert _guard_offenders(source)
+
+
+@pytest.mark.parametrize(
+    "binding",
+    [
+        """def configure(value=(_TURN_REJECTION_MESSAGES := attacker_controlled)):
+    pass""",
+        "configure = lambda value=(_TURN_REJECTION_MESSAGES := attacker_controlled): value",
+        """class Configure((_TURN_REJECTION_MESSAGES := attacker_controlled)):
+    pass""",
+    ],
+    ids=["function-default", "lambda-default", "class-base"],
+)
+def test_guard_rejects_a_curated_table_rebound_during_definition(
+    binding: str,
+) -> None:
+    source = f"""
+_TURN_REJECTION_MESSAGES = {{"busy": "safe"}}
+{binding}
+async def leak(reason):
+    await send_message_delivery(message=_TURN_REJECTION_MESSAGES.get(reason, "fallback"))
+"""
+    assert _guard_offenders(source)
+
+
+def test_guard_rejects_curated_table_comprehension_and_star_import_shadows() -> None:
+    source = """
+_TURN_REJECTION_MESSAGES = {"busy": "safe"}
+from evil import *
+async def leak(reason, tables):
+    await gather(*(send_message_delivery(
+        message=_TURN_REJECTION_MESSAGES.get(reason, "fallback")
+    ) for _TURN_REJECTION_MESSAGES in tables))
+"""
+    assert _guard_offenders(source)
+
+
+def test_guard_resolves_a_single_name_producer_alias() -> None:
+    source = """
+async def leak(websocket):
+    producer = send_message_delivery
+    try:
+        pass
+    except Exception as error:
+        await producer(
+            websocket,
+            client_message_id="c",
+            turn_id="t",
+            accepted=False,
+            message=f"leaked: {str(error)}",
+            rejection_outcome="not_accepted",
+        )
+"""
+
+    assert _guard_offenders(source)
+
+
+def test_guard_resolves_a_module_level_producer_alias() -> None:
+    source = """
+producer = send_message_delivery
+
+async def leak(websocket, error):
+    await producer(
+        websocket,
+        client_message_id="c",
+        turn_id="t",
+        accepted=False,
+        message=str(error),
+        rejection_outcome="not_accepted",
+    )
+"""
+
+    assert _guard_offenders(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        """async def leak(error, flag):
+    if flag:
+        producer = send_message_delivery
+    else:
+        producer = audit
+    await producer(message=str(error))""",
+        """producer = send_message_delivery
+producer = send_message_delivery
+async def leak(error):
+    await producer(message=str(error))""",
+    ],
+    ids=["conditional-local", "duplicate-module"],
+)
+def test_guard_treats_any_preceding_producer_alias_as_egress(source: str) -> None:
+    assert _guard_offenders(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        """async def leak(error):
+    await producer(message=str(error))
+producer = send_message_delivery""",
+        """async def leak(error):
+    await producer(message=str(error))
+if flag:
+    producer = send_message_delivery
+else:
+    producer = audit""",
+        """async def leak(error):
+    first = send_message_delivery
+    producer = first
+    await producer(message=str(error))""",
+        """first = send_message_delivery
+producer = first
+async def leak(error):
+    await producer(message=str(error))""",
+        """async def outer(error):
+    async def leak():
+        await producer(message=str(error))
+    producer = send_message_delivery
+    return leak""",
+    ],
+    ids=[
+        "module-binding-after-function",
+        "conditional-module-binding-after-function",
+        "chained-local",
+        "chained-module",
+        "outer-closure-binding-after-function",
+    ],
+)
+def test_guard_resolves_deferred_and_chained_producer_aliases(source: str) -> None:
+    assert _guard_offenders(source)
+
+
+def test_guard_uses_the_last_unconditional_producer_alias_binding() -> None:
+    source = """
+producer = send_message_delivery
+producer = audit
+async def record(error):
+    await producer(message=str(error))
+"""
+    assert not _guard_offenders(source)
+
+
+def test_guard_does_not_treat_a_short_circuit_rebind_as_a_direct_alias() -> None:
+    source = """
+async def record(error):
+    producer = send_message_delivery
+    producer = producer and audit
+    await producer(message=str(error))
+"""
+    assert not _guard_offenders(source)
+
+
+@pytest.mark.parametrize(
+    ("source", "is_egress"),
+    [
+        (
+            """async def leak(error):
+    first = send_message_delivery
+    producer = first
+    first = audit
+    await producer(message=str(error))""",
+            True,
+        ),
+        (
+            """first = send_message_delivery
+producer = first
+first = audit
+async def leak(error):
+    await producer(message=str(error))""",
+            True,
+        ),
+        (
+            """async def record(error):
+    first = audit
+    producer = first
+    first = send_message_delivery
+    await producer(message=str(error))""",
+            False,
+        ),
+        (
+            """first = audit
+producer = first
+first = send_message_delivery
+async def record(error):
+    await producer(message=str(error))""",
+            False,
+        ),
+    ],
+    ids=[
+        "local-captures-egress",
+        "module-captures-egress",
+        "local-captures-audit",
+        "module-captures-audit",
+    ],
+)
+def test_guard_resolves_chained_aliases_at_assignment_time(
+    source: str, is_egress: bool
+) -> None:
+    assert bool(_guard_offenders(source)) is is_egress
+
+
+def test_guard_keeps_outer_aliases_that_reach_an_early_nested_call() -> None:
+    source = """
+async def outer(error):
+    producer = send_message_delivery
+    async def leak():
+        await producer(message=str(error))
+    await leak()
+    producer = audit
+"""
+    assert _guard_offenders(source)
+
+
+@pytest.mark.parametrize(
+    ("seed", "is_egress"), [("send_message_delivery", True), ("audit", False)]
+)
+@pytest.mark.parametrize("scope", ["local", "module"])
+def test_guard_preserves_seeded_self_aliases(
+    seed: str, is_egress: bool, scope: str
+) -> None:
+    module_binding = (
+        f"producer = {seed}\nproducer = producer\n" if scope == "module" else ""
+    )
+    local_binding = (
+        "" if scope == "module" else f"    producer = {seed}\n    producer = producer\n"
+    )
+    source = f"""{module_binding}async def record(error):
+{local_binding}    await producer(message=str(error))
+"""
+    assert bool(_guard_offenders(source)) is is_egress
+
+
+@pytest.mark.parametrize("scope", ["local", "module"])
+def test_guard_resolves_a_producer_alias_rebound_after_the_sink(scope: str) -> None:
+    binding = "producer = send_message_delivery\n" if scope == "module" else ""
+    local_binding = (
+        "" if scope == "module" else "    producer = send_message_delivery\n"
+    )
+    source = f"""{binding}async def leak(error):
+{local_binding}    await producer(message=str(error))
+    producer = audit
+"""
+    assert _guard_offenders(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        """async def leak(client_safe_error_message, error):
+    await send_message_delivery(message=client_safe_error_message(error))""",
+        """async def leak(error):
+    client_safe_error_message = raw_message
+    await send_message_delivery(message=client_safe_error_message(error))""",
+        """async def leak(error, builders):
+    await gather(*(send_message_delivery(message=client_safe_error_message(error))
+        for client_safe_error_message in builders))""",
+    ],
+    ids=["parameter", "local", "comprehension"],
+)
+def test_guard_rejects_shadowed_safe_message_builders(source: str) -> None:
+    assert _guard_offenders(source)
+
+
+def test_guard_rejects_a_conditionally_rebound_safe_message_builder() -> None:
+    source = """
+def client_safe_error_message(error):
+    return "safe"
+if flag:
+    client_safe_error_message = raw_message
+async def leak(error):
+    await send_message_delivery(message=client_safe_error_message(error))
+"""
+    assert _guard_offenders(source)
+
+
+def test_guard_rejects_a_safe_builder_rebound_in_a_decorator() -> None:
+    source = """
+def client_safe_error_message(error):
+    return "safe"
+@(client_safe_error_message := attacker_controlled)
+def configure():
+    pass
+async def leak(error):
+    await send_message_delivery(message=client_safe_error_message(error))
+"""
+    assert _guard_offenders(source)
+
+
+def test_allowlist_does_not_apply_to_a_same_named_nested_handler() -> None:
+    source = """
+async def outer(websocket):
+    async def handle_intervention():
+        try:
+            pass
+        except RuntimeError as e:
+            await manager.send_personal_message(
+                {"type": "error", "message": f"Runtime error: {str(e)}"},
+                websocket,
+            )
+"""
+
+    assert _guard_offenders(source)
+
+
+def test_guard_ignores_a_same_named_method_on_an_unrelated_receiver() -> None:
+    source = """
+async def audit_failure(audit, error):
+    await audit.send_text(
+        json.dumps({"type": "error", "message": str(error)})
+    )
+"""
+
+    assert not _guard_offenders(source)
+
+
 # The concurrent-delete race (TaskCommandTaskMissing between lookup and
 # enqueue) is pinned in tests/web/services/test_task_command_transport.py:
 # recovery-allowed returns None, and the strict path converts to
 # ClientVisibleValidationError with "Task N not found" preserved.
-
-
 # --- Round 5: runtime payload contracts for the changed egresses ------------
 
 

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -14,17 +14,17 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.web.api.client_safe_ast_guard import (
+    ALLOWED_RAW_MESSAGES,
+    SAFE_MESSAGE_BUILDERS,
+    _scan,
+)
+from tests.web.api.client_safe_ast_guard import guard_offenders as _guard_offenders
 from xagent.web.api import websocket as websocket_api
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
 from xagent.web.services.task_orchestrator import TaskTurnOrchestrator
 
-from .client_safe_ast_guard import (
-    ALLOWED_RAW_MESSAGES,
-    SAFE_MESSAGE_BUILDERS,
-    _scan,
-)
-from .client_safe_ast_guard import guard_offenders as _guard_offenders
 from .conftest import _direct_db_session
 
 SECRET = "/srv/xagent/secrets/prod.key"
@@ -181,12 +181,12 @@ def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
 
     # These are deliberate exact baselines. If a producer is added or removed,
     # inspect the changed site and bump the corresponding count in this test.
-    assert result.producers == 23, (
-        f"expected exactly 23 producers, matched {result.producers}; "
+    assert result.producers == 26, (
+        f"expected exactly 26 producers, matched {result.producers}; "
         "review the changed sites and bump deliberately"
     )
-    assert result.error_payloads == 33, (
-        f"expected exactly 33 error payloads, matched {result.error_payloads}; "
+    assert result.error_payloads == 35, (
+        f"expected exactly 35 error payloads, matched {result.error_payloads}; "
         "review the changed sites and bump deliberately"
     )
     # Every allowlist entry must be earned by a live call site: a stale entry

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -185,8 +185,8 @@ def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
         f"expected exactly 23 producers, matched {result.producers}; "
         "review the changed sites and bump deliberately"
     )
-    assert result.error_payloads == 32, (
-        f"expected exactly 32 error payloads, matched {result.error_payloads}; "
+    assert result.error_payloads == 33, (
+        f"expected exactly 33 error payloads, matched {result.error_payloads}; "
         "review the changed sites and bump deliberately"
     )
     # Every allowlist entry must be earned by a live call site: a stale entry
@@ -985,6 +985,91 @@ async def handle_intervention(websocket, message):
 
 
 @pytest.mark.parametrize(
+    "loop_header",
+    ["for item in items:", "async for item in items:", "while items:"],
+    ids=["for", "async-for", "while"],
+)
+def test_loop_backedge_rebinding_reaches_an_earlier_sink(loop_header: str) -> None:
+    source = f"""
+async def leak(items, error):
+    message = "safe"
+    {loop_header}
+        await send_message_delivery(message=message)
+        message = str(error)
+"""
+
+    assert _guard_offenders(source), "the next iteration sends the rebound value"
+
+
+def test_loop_backedge_binding_is_unavailable_on_the_first_iteration() -> None:
+    source = """
+async def leak(items, message):
+    for item in items:
+        await send_message_delivery(message=message)
+        message = "safe"
+"""
+
+    assert _guard_offenders(source), "the first iteration still sends the input"
+
+
+def test_while_backedge_rebinding_reaches_the_next_condition() -> None:
+    source = """
+async def leak(error):
+    message = "safe"
+    while await send_message_delivery(message=message):
+        message = str(error)
+"""
+
+    assert _guard_offenders(source), "the next condition sees the rebound value"
+
+
+def test_while_condition_rebinding_reaches_the_next_condition() -> None:
+    source = """
+async def leak(error):
+    message = "safe"
+    while (await send_message_delivery(message=message)) or (message := str(error)):
+        pass
+"""
+
+    assert _guard_offenders(source), "the next condition sees the rebound value"
+
+
+def test_safe_while_condition_backedge_keeps_the_sink_clean() -> None:
+    source = """
+async def deliver():
+    message = "safe"
+    while (await send_message_delivery(message=message)) or (message := "still safe"):
+        pass
+"""
+
+    assert not _guard_offenders(source)
+
+
+def test_loop_backedge_augassign_reaches_an_earlier_sink() -> None:
+    source = """
+async def leak(items, error):
+    message = "safe"
+    for item in items:
+        await send_message_delivery(message=message)
+        message += str(error)
+"""
+
+    assert _guard_offenders(source), "the augmented value reaches iteration two"
+
+
+def test_safe_loop_backedge_keeps_the_sink_clean() -> None:
+    source = """
+async def deliver(items):
+    message = "safe"
+    for item in items:
+        await send_message_delivery(message=message)
+        message = "still safe"
+"""
+
+    assert not _guard_offenders(source)
+
+
+@pytest.mark.parametrize(
     "control_flow",
     [
         'for item in items:\n            message = f"Runtime error: {str(e)}"',
@@ -1469,6 +1554,18 @@ def test_guard_resolves_a_producer_alias_rebound_after_the_sink(scope: str) -> N
     producer = audit
 """
     assert _guard_offenders(source)
+
+
+def test_guard_resolves_a_producer_alias_on_the_next_loop_iteration() -> None:
+    source = """
+async def leak(items, error):
+    producer = audit
+    for item in items:
+        await producer(message=str(error))
+        producer = send_message_delivery
+"""
+
+    assert _guard_offenders(source), "the second iteration calls the producer"
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- move the client-safe AST analysis into a focused test helper
- make reaching-definition analysis conservative across branches, `try` paths, lexical scopes, Python binding forms, and loop back-edges
- bind the `RuntimeError` allowance to the originating handler and exception target
- require curated lookup receiver identity, supported arity, and a literal fallback
- resolve direct single-`Name` producer aliases and pin the production sweep to exactly 23 producers and 33 error payloads

This is the AST-analysis half of #1708, split so the large test-only guard change can be reviewed independently from runtime error/logging behavior. Its runtime companion is #1733; together they supersede #1708.

## Review coverage

This replacement accounts for Roger's six Major findings on #1708:

- branch reaching definitions
- `Try` path reachability
- missing binding forms
- `RuntimeError` allowlist provenance
- curated `.get()` receiver/fallback trust
- lambda lexical scope

The latest review fix also models loop back-edges for message values and direct producer aliases, including `For`/`AsyncFor` bodies and the repeated body/test regions of `While`.

## Testing

- `pytest -q tests/web/api/test_websocket_client_safe_errors.py`
  - 130 passed, 3 expected xfails tracked by #1497
- `pre-commit run --files tests/web/api/client_safe_ast_guard.py tests/web/api/test_websocket_client_safe_errors.py`
- `git diff --check 152f1bd10a0a199fa082d29d8c9a7c825e24c56c...fe5f39d4`

Preflight reviewed the exact `152f1bd10a0a199fa082d29d8c9a7c825e24c56c...fe5f39d4` fix-round range along both repository-standards and issue-spec axes; no blocking findings remain. The payload baseline includes the safe external-cancel notification added on `main` by #1719.

## Out of scope

- broader producer and payload shapes outside the guard's recognized grammar: #1497
- `nonlocal` and `global` message rebinding: #1745
- splatted producer arguments and payload keywords: #1746
- stable egress identity and audience tracking beyond aggregate counts: #1716
- blank-marker cause/traceback policy: #1717
- deduplicating local/module binder traversal: #1732
- runtime marker and logging behavior: #1720

Closes #1547
