### PR TITLE
- Normalize KB search filters into a shared `FilterExpression` path.

### DIFF
--- a/src/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
+++ b/src/src/xagent/core/tools/core/RAG_tools/kb/collection_handle.py
@@ -1,0 +1,4637 @@
+"""Collection-scoped KB backend handle.
+
+``KBCollectionHandle`` is the collection-scoped backend boundary that owns
+backend-specific data-plane mechanics (the document-row lifecycle in #508 and
+the parse/chunk lifecycle in #509). ``LanceDBCollectionHandle`` is the first
+implementation and delegates to the current LanceDB tables via the bound
+vector index store.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import numbers
+import os
+import uuid
+from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator, Sequence
+from dataclasses import dataclass
+from datetime import timezone
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Iterable, List, Optional, Set, cast
+
+if TYPE_CHECKING:
+    from .models import KBVectorStorageCleanupResult
+
+import pandas as pd
+
+try:
+    import pyarrow as pa  # type: ignore
+    from pyarrow import Table as PyArrowTable
+except ImportError:  # pragma: no cover - pyarrow is an optional runtime dep
+    pa = None
+    PyArrowTable = Any
+
+from ..core.config import (
+    DEFAULT_LANCEDB_BATCH_SIZE,
+)
+from ..core.exceptions import (
+    ConfigurationError,
+    DatabaseOperationError,
+    DocumentValidationError,
+    HashComputationError,
+    MainPointerError,
+    VectorValidationError,
+)
+from ..core.schemas import (
+    ChunkEmbeddingData,
+    ChunkForEmbedding,
+    ChunkRecordSnapshot,
+    DenseSearchResponse,
+    DocumentRecordDetail,
+    DocumentRecordListResult,
+    EmbeddingReadResponse,
+    EmbeddingRecordSnapshot,
+    EmbeddingWriteResponse,
+    FusionConfig,
+    FusionStrategy,
+    HybridSearchResponse,
+    IndexOperation,
+    IndexStatus,
+    ParsedParagraph,
+    ParseRecordDetail,
+    RegisterDocumentRequest,
+    RegisterDocumentResponse,
+    SearchFallbackAction,
+    SearchResult,
+    SearchWarning,
+    SparseSearchResponse,
+)
+from ..LanceDB.model_tag_utils import to_model_tag
+from ..LanceDB.schema_manager import _safe_close_table
+from ..retrieval.search_hybrid import _linear_fusion, _rrf_fusion
+from ..storage.contracts import (
+    FilterCondition,
+    FilterExpression,
+    FilterOperator,
+    IngestionStatusStore,
+    MainPointerStore,
+    MetadataStore,
+    VectorIndexStore,
+)
+from ..utils import check_file_type, compute_file_hash
+from ..utils.filter_utils import parse_legacy_filters, validate_filter_depth
+from ..utils.hash_utils import compute_chunk_hash
+from ..utils.metadata_utils import deserialize_metadata, serialize_metadata
+from ..utils.string_utils import generate_deterministic_doc_id
+from .models import KBBackendCapabilities, KBCollectionContext, KBStorageBackend
+from .version_compatibility import (
+    KBMainPointerSnapshot,
+    KBVersionCandidateCleanupSnapshot,
+    KBVersionCandidateRollbackResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _safe_int_value(value: Any, default: int = 0) -> int:
+    """Coerce a row value to ``int``, mapping ``None``/NaN to ``default``."""
+    if value is None:
+        return default
+    try:
+        if value != value:  # NaN is never equal to itself.  # noqa: PLR0124
+            return default
+    except Exception:  # noqa: BLE001 - non-comparable values fall through
+        pass
+    try:
+        return int(value)
+    except (ValueError, TypeError):
+        return default
+
+
+def _int_env(name: str, default: int) -> int:
+    """Read an integer environment variable, falling back to ``default``.
+
+    A missing variable, or one set to a non-numeric value, yields ``default``
+    instead of raising, so a malformed operator override cannot crash an
+    embedding write.
+    """
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except (ValueError, TypeError):
+        return default
+
+
+def _safe_optional_str(value: Any) -> str | None:
+    """Return the string value or ``None`` for ``None``/NaN sentinels."""
+    if value is None:
+        return None
+    try:
+        if value != value:  # NaN  # noqa: PLR0124
+            return None
+    except Exception:  # noqa: BLE001
+        pass
+    return str(value)
+
+
+def validate_query_vector_format(query_vector: list[float]) -> None:
+    """Validate a query vector's format and content (collection-independent).
+
+    Pure check shared by the collection handle and the vector-storage facade
+    (the facade's validate path has no collection to bind a handle). Raises
+    ``VectorValidationError`` for non-list, empty, non-numeric, or NaN/inf
+    vectors; numpy scalar types are admitted via ``numbers.Number``.
+    """
+    if not isinstance(query_vector, list):
+        raise VectorValidationError("query_vector must be a list")
+
+    if len(query_vector) == 0:
+        raise VectorValidationError("query_vector cannot be empty")
+
+    if not all(isinstance(x, numbers.Number) for x in query_vector):
+        raise VectorValidationError("query_vector must contain only numbers")
+
+    for x in query_vector:
+        if not isinstance(x, numbers.Real):
+            continue  # Skip non-real numbers (e.g. complex).
+        float_val = float(x)
+        if float_val != float_val or abs(float_val) == float("inf"):
+            raise VectorValidationError(
+                "query_vector contains invalid values (NaN or infinity)"
+            )
+
+
+def _normalize_filter_expression(filters: Any) -> FilterExpression | None:
+    """Normalize public search filters into one abstract filter expression."""
+
+    if filters is None:
+        return None
+    if isinstance(filters, dict):
+        return parse_legacy_filters(filters)
+    if isinstance(filters, (tuple, list)):
+        return filters if filters else None
+    return filters
+
+
+def _build_search_filter_expression(
+    collection: str,
+    filters: Any,
+) -> FilterExpression | None:
+    """Combine the mandatory collection filter with caller-provided filters."""
+
+    conditions: list[FilterExpression] = []
+    if collection:
+        conditions.append(
+            FilterCondition(
+                field="collection",
+                operator=FilterOperator.EQ,
+                value=collection,
+            )
+        )
+
+    normalized_filters = _normalize_filter_expression(filters)
+    if normalized_filters is not None:
+        conditions.append(normalized_filters)
+
+    if not conditions:
+        return None
+    if len(conditions) == 1:
+        return conditions[0]
+    return tuple(conditions)
+
+
+def _filter_expression_fields(expr: FilterExpression | None) -> set[str]:
+    """Return the field names referenced by one filter expression."""
+
+    if expr is None:
+        return set()
+    if isinstance(expr, FilterCondition):
+        return {expr.field}
+    if isinstance(expr, tuple) or isinstance(expr, list):
+        fields: set[str] = set()
+        for item in expr:
+            fields.update(_filter_expression_fields(item))
+        return fields
+    return set()
+
+
+def _evaluate_filter_expression(
+    batch_df: pd.DataFrame,
+    expr: FilterExpression | None,
+) -> pd.Series:
+    """Evaluate one abstract filter expression against a pandas batch."""
+
+    if expr is None:
+        return pd.Series(True, index=batch_df.index, dtype=bool)
+
+    if isinstance(expr, FilterCondition):
+        if expr.field not in batch_df.columns:
+            return pd.Series(False, index=batch_df.index, dtype=bool)
+
+        series = batch_df[expr.field]
+        operator = expr.operator
+        value = expr.value
+
+        if operator == FilterOperator.EQ:
+            return series == value
+        if operator == FilterOperator.NE:
+            return series != value
+        if operator == FilterOperator.GT:
+            return series > value
+        if operator == FilterOperator.GTE:
+            return series >= value
+        if operator == FilterOperator.LT:
+            return series < value
+        if operator == FilterOperator.LTE:
+            return series <= value
+        if operator == FilterOperator.IN:
+            if isinstance(value, (list, tuple, set)):
+                return series.isin(list(value))
+            return series.isin([value])
+        if operator == FilterOperator.CONTAINS:
+            return series.astype(str).str.contains(
+                str(value), na=False, regex=False
+            )
+        if operator == FilterOperator.IS_NULL:
+            return series.isna()
+        if operator == FilterOperator.IS_NOT_NULL:
+            return ~series.isna()
+        raise ValueError(f"Unsupported filter operator: {operator}")
+
+    if isinstance(expr, tuple):
+        mask = pd.Series(True, index=batch_df.index, dtype=bool)
+        for item in expr:
+            mask &= _evaluate_filter_expression(batch_df, item)
+        return mask
+
+    if isinstance(expr, list):
+        mask = pd.Series(False, index=batch_df.index, dtype=bool)
+        for item in expr:
+            mask |= _evaluate_filter_expression(batch_df, item)
+        return mask
+
+    raise TypeError(f"Unsupported filter expression: {type(expr).__name__}")
+
+
+class KBHandleProvider:
+    """Open collection-scoped handles for resolved KB contexts."""
+
+    def open(self, context: KBCollectionContext) -> LanceDBCollectionHandle:
+        """Return a backend-specific handle for the resolved collection context."""
+        if context.backend is KBStorageBackend.LANCEDB:
+            return LanceDBCollectionHandle(context)
+        raise ValueError(
+            f"KB storage backend {context.backend.value!r} is not supported by "
+            "KBHandleProvider"
+        )
+
+    def reset_for_tests(self) -> None:
+        """Clear provider-owned caches for test reset.
+
+        The current provider is stateless, but the hook keeps the coordinator
+        reset path ready for backend handle caches.
+        """
+
+
+class KBCollectionHandle(ABC):
+    """Collection-scoped backend handle for KB data-plane operations.
+
+    Phase 2 moves backend-specific, collection-local data-plane mechanics here.
+    The first family (#508) is the document-row lifecycle. The coordinator owns
+    context resolution, access policy, and orchestration; the handle owns the
+    backend mechanics for a single collection.
+    """
+
+    @abstractmethod
+    def register_document(
+        self, request: RegisterDocumentRequest
+    ) -> RegisterDocumentResponse:
+        """Idempotently register (upsert) a document row for this collection.
+
+        Preserves deterministic doc_id generation, content-hash calculation,
+        file-type detection, and the exact persisted field set.
+        """
+
+    @abstractmethod
+    def load_document(
+        self, doc_id: str, *, user_id: int | None = None, is_admin: bool = False
+    ) -> DocumentRecordDetail | None:
+        """Load a single document row by id within the given scope.
+
+        Returns ``None`` when the row is absent or not visible to the scope.
+        """
+
+    @abstractmethod
+    def list_documents(
+        self, *, user_id: int | None = None, is_admin: bool = False, limit: int = 100
+    ) -> DocumentRecordListResult:
+        """List document rows for this collection as a semantic result."""
+
+    @abstractmethod
+    def delete_document_record(
+        self, doc_id: str, *, user_id: int | None = None, is_admin: bool = False
+    ) -> int:
+        """Delete only this document's row (no cascade).
+
+        Idempotent; returns the number of rows deleted. Parse/chunk/embedding
+        cleanup is intentionally out of scope here.
+        """
+
+    # --- Rollback compensation (document plane only) ---
+
+    @abstractmethod
+    def snapshot_document(
+        self, doc_id: str, *, user_id: int | None = None, is_admin: bool = False
+    ) -> DocumentRecordDetail | None:
+        """Capture the current document row for later restore (None if absent)."""
+
+    @abstractmethod
+    def restore_document(self, snapshot: DocumentRecordDetail) -> None:
+        """Restore a previously snapshotted document row, preserving all fields."""
+
+    @abstractmethod
+    def delete_created_document(
+        self, doc_id: str, *, user_id: int | None = None, is_admin: bool = False
+    ) -> int:
+        """Idempotently delete a newly created document row (compensation)."""
+
+    # --- Parse data-plane (#509) ---
+
+    @abstractmethod
+    def parse_exists(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> bool:
+        """Return whether a parse row exists for ``(doc_id, parse_hash)``."""
+
+    @abstractmethod
+    def read_parse_paragraphs(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> list[ParsedParagraph]:
+        """Return the reuse-hit parsed paragraphs for ``(doc_id, parse_hash)``.
+
+        Empty list when no visible parse row exists.
+        """
+
+    @abstractmethod
+    def write_parse(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        parse_method: Any,
+        params: dict[str, Any],
+        paragraphs: list[ParsedParagraph],
+        *,
+        user_id: int | None = None,
+    ) -> bool:
+        """Persist a parse row for this collection (idempotent upsert)."""
+
+    @abstractmethod
+    def read_latest_parse_record(
+        self,
+        doc_id: str,
+        parse_hash: str | None = None,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> ParseRecordDetail | None:
+        """Return the latest parse row (by ``created_at``) for display.
+
+        When ``parse_hash`` is given only that version is considered. Returns
+        ``None`` when no visible parse row exists; the display layer maps that
+        to the appropriate ``DocumentNotFoundError``.
+        """
+
+    # --- Chunk data-plane (#509) ---
+
+    @abstractmethod
+    def chunk_exists(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        config_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> bool:
+        """Return whether chunk rows exist for ``(doc_id, parse_hash, config_hash)``."""
+
+    @abstractmethod
+    def read_existing_chunks(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        config_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Return the reuse-hit chunk dicts (metadata deserialized).
+
+        Empty list when no visible chunk rows exist.
+        """
+
+    @abstractmethod
+    def read_parse_paragraph_dicts(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Return parsed paragraphs as ``{text, metadata}`` dicts for chunking."""
+
+    @abstractmethod
+    def write_chunks(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        config_hash: str,
+        params: dict[str, Any],
+        chunks: list[dict[str, Any]],
+        *,
+        user_id: int | None = None,
+    ) -> bool:
+        """Persist chunk rows for this collection (idempotent upsert).
+
+        Returns ``False`` when there are no chunks to write.
+        """
+
+    # --- Embedding data-plane (#510) ---
+
+    @abstractmethod
+    def validate_query_vector(
+        self,
+        query_vector: list[float],
+        *,
+        model_tag: str | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> None:
+        """Validate a query vector's format/content (no store access).
+
+        Raises ``VectorValidationError`` for non-list, empty, non-numeric, or
+        NaN/inf vectors. ``model_tag``/``user_id``/``is_admin`` are accepted for
+        signature parity and logging only.
+        """
+
+    @abstractmethod
+    def read_chunks_needing_embedding(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        model: str,
+        *,
+        filters: dict[str, Any] | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> EmbeddingReadResponse:
+        """Return chunks that still need an embedding for ``model``.
+
+        Reads the chunks table for ``(doc_id, parse_hash)`` and excludes
+        ``chunk_id``s already present in the ``embeddings_{model_tag}`` table.
+        """
+
+    @abstractmethod
+    def write_embeddings(
+        self,
+        embeddings: list[ChunkEmbeddingData],
+        *,
+        create_index: bool = True,
+        user_id: int | None = None,
+    ) -> EmbeddingWriteResponse:
+        """Write embedding vectors for this collection (idempotent upsert).
+
+        Groups by model, validates per-model dimension consistency, routes each
+        model to its ``embeddings_{model_tag}`` table, upserts in batches (with
+        spill-retry), and optionally creates the index. Stale deletion is a
+        no-op (``deleted_stale_count`` is always 0; merge handles overwrites).
+        """
+
+    @abstractmethod
+    def delete_embedding_records(
+        self,
+        doc_id: str,
+        *,
+        parse_hash: str | None = None,
+        chunk_ids: list[str] | None = None,
+        model_tag: str | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> int:
+        """Delete embedding rows for a document across per-model tables.
+
+        Row-only (no cascade); ``model_tag`` narrows to one model's table,
+        ``None`` spans all. Idempotent; returns the total rows deleted.
+        """
+
+    # --- Embedding rollback compensation (methods only; wiring in #514) ---
+
+    @abstractmethod
+    def snapshot_embeddings(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        *,
+        chunk_ids: list[str] | None = None,
+        model_tag: str | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> EmbeddingRecordSnapshot | None:
+        """Capture embedding rows across matching model tables (None if absent)."""
+
+    @abstractmethod
+    def restore_embeddings(self, snapshot: EmbeddingRecordSnapshot) -> None:
+        """Restore snapshotted embedding rows, grouped per model tag.
+
+        Refuses rows from another collection (collection-guard); idempotent.
+        """
+
+    @abstractmethod
+    def delete_created_embeddings(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        *,
+        chunk_ids: list[str] | None = None,
+        model_tag: str | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> int:
+        """Idempotently delete newly created embedding rows (compensation)."""
+
+    # --- Search data-plane (#511) ---
+
+    @abstractmethod
+    def search_dense(
+        self,
+        model_tag: str,
+        query_vector: list[float],
+        *,
+        top_k: int = 10,
+        filters: Any = None,
+        readonly: bool = False,
+        nprobes: int | None = None,
+        refine_factor: int | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> DenseSearchResponse:
+        """Execute dense vector search for this collection."""
+
+    @abstractmethod
+    async def search_dense_async(
+        self,
+        model_tag: str,
+        query_vector: list[float],
+        *,
+        top_k: int = 10,
+        filters: Any = None,
+        readonly: bool = False,
+        nprobes: int | None = None,
+        refine_factor: int | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> DenseSearchResponse:
+        """Async dense vector search for this collection."""
+
+    @abstractmethod
+    def search_sparse(
+        self,
+        model_tag: str,
+        query_text: str,
+        *,
+        top_k: int,
+        filters: Any = None,
+        readonly: bool = False,
+        nprobes: int | None = None,
+        refine_factor: int | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> SparseSearchResponse:
+        """Execute sparse (FTS) search for this collection."""
+
+    @abstractmethod
+    async def search_sparse_async(
+        self,
+        model_tag: str,
+        query_text: str,
+        *,
+        top_k: int,
+        filters: Any = None,
+        readonly: bool = False,
+        nprobes: int | None = None,
+        refine_factor: int | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> SparseSearchResponse:
+        """Async sparse (FTS) search for this collection."""
+
+    @abstractmethod
+    def search_hybrid(
+        self,
+        model_tag: str,
+        query_text: str,
+        query_vector: list[float],
+        *,
+        top_k: int = 10,
+        filters: Any = None,
+        fusion_config: FusionConfig | None = None,
+        readonly: bool = False,
+        nprobes: int | None = None,
+        refine_factor: int | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> HybridSearchResponse:
+        """Execute hybrid (dense + sparse) search with fusion for this collection."""
+
+    @abstractmethod
+    async def search_hybrid_async(
+        self,
+        model_tag: str,
+        query_text: str,
+        query_vector: list[float],
+        *,
+        top_k: int = 10,
+        filters: Any = None,
+        fusion_config: FusionConfig | None = None,
+        readonly: bool = False,
+        nprobes: int | None = None,
+        refine_factor: int | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> HybridSearchResponse:
+        """Async hybrid (dense + sparse) search with fusion for this collection."""
+
+    # --- Parse/chunk cleanup (row only, collection scoped) (#509) ---
+
+    @abstractmethod
+    def delete_parse_records(
+        self,
+        doc_id: str,
+        *,
+        parse_hash: str | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> int:
+        """Delete parse rows for a document (optionally one parse_hash).
+
+        Row-only (no cascade into chunks/embeddings); idempotent.
+        """
+
+    @abstractmethod
+    def delete_chunk_records(
+        self,
+        doc_id: str,
+        *,
+        parse_hash: str | None = None,
+        config_hash: str | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> int:
+        """Delete chunk rows for a document (optionally narrowed).
+
+        Row-only (no cascade into embeddings); idempotent.
+        """
+
+    # --- Parse/chunk rollback compensation (methods only; wiring in #514) ---
+
+    @abstractmethod
+    def snapshot_parse(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> ParseRecordDetail | None:
+        """Capture a parse row for later restore (None if absent)."""
+
+    @abstractmethod
+    def restore_parse(self, snapshot: ParseRecordDetail) -> None:
+        """Restore a snapshotted parse row, preserving every field."""
+
+    @abstractmethod
+    def delete_created_parse(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> int:
+        """Idempotently delete a newly created parse row (compensation)."""
+
+    @abstractmethod
+    def snapshot_chunks(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        config_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> ChunkRecordSnapshot | None:
+        """Capture all chunk rows for a config for later restore (None if absent)."""
+
+    @abstractmethod
+    def restore_chunks(self, snapshot: ChunkRecordSnapshot) -> None:
+        """Restore snapshotted chunk rows, preserving every field."""
+
+    @abstractmethod
+    def delete_created_chunks(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        config_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> int:
+        """Idempotently delete newly created chunk rows (compensation)."""
+
+    @abstractmethod
+    def cleanup_cascade(
+        self,
+        doc_id: str,
+        scope: str,
+        *,
+        new_parse_hash: Optional[str] = None,
+        old_parse_hash: Optional[str] = None,
+        model_tag: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: Optional[bool] = None,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> Dict[str, int]:
+        """Version cascade cleanup for a document by scope (policy layer)."""
+
+    @abstractmethod
+    def cleanup_document_cascade(
+        self,
+        doc_id: str,
+        *,
+        model_tag: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = True,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> Dict[str, int]:
+        """Cascade cleanup for all data of a document."""
+
+    @abstractmethod
+    def cleanup_parse_cascade(
+        self,
+        doc_id: str,
+        *,
+        old_parse_hash: Optional[str] = None,
+        new_parse_hash: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = True,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> Dict[str, int]:
+        """Cascade cleanup when promoting a parse version."""
+
+    @abstractmethod
+    def cleanup_chunk_cascade(
+        self,
+        doc_id: str,
+        *,
+        old_parse_hash: Optional[str] = None,
+        new_parse_hash: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = True,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> Dict[str, int]:
+        """Cascade cleanup when promoting a chunk version."""
+
+    @abstractmethod
+    def cleanup_embed_cascade(
+        self,
+        doc_id: str,
+        *,
+        model_tag: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = True,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> Dict[str, int]:
+        """Cascade cleanup when promoting an embeddings version."""
+
+    # --- Collection-level rename primitives (#H05 Phase 2) ---
+
+    @abstractmethod
+    def rename_collection_data(
+        self,
+        new_name: str,
+        user_id: int | None,
+        is_admin: bool,
+        warnings_out: list[str] | None = None,
+    ) -> list[str]:
+        """Rename the collection field across all vector-side data tables.
+
+        Updates the ``collection`` column from ``self.context.collection`` to
+        ``new_name`` in the documents, parses, chunks, and all embeddings_*
+        tables.  Uses the same multi-tenancy filter semantics as other store
+        writes.
+
+        Args:
+            new_name: Target collection name.
+            user_id: User ID for tenant-scoped rename; ``None`` treated as 0
+                for non-admin callers.
+            is_admin: When ``True`` renames all matching rows regardless of
+                ``user_id``.
+            warnings_out: Optional list to accumulate per-table warning
+                messages (best-effort updates).
+
+        Returns:
+            List of warning messages generated during best-effort updates
+            (empty on full success).
+        """
+
+    @abstractmethod
+    def rename_collection_status(
+        self,
+        new_name: str,
+        user_id: int | None,
+        is_admin: bool,
+    ) -> list[str]:
+        """Rename ingestion status rows from this collection's name to ``new_name``.
+
+        Updates the ``collection`` column in the ``ingestion_runs`` table from
+        ``self.context.collection`` to ``new_name``.
+
+        Args:
+            new_name: Target collection name.
+            user_id: User ID for tenant-scoped rename.
+            is_admin: When ``True`` renames all matching rows regardless of
+                ``user_id``.
+
+        Returns:
+            List of warning messages on partial failure (empty on success).
+        """
+
+    @abstractmethod
+    async def rename_collection_metadata(
+        self,
+        new_name: str,
+        user_id: int | None,
+        is_admin: bool,
+    ) -> None:
+        """Rename control-plane metadata from this collection's name to ``new_name``.
+
+        Async – this is the **only** async method on ``KBCollectionHandle``.
+        Wraps ``await metadata_store.rename_collection(...)`` to update the
+        ``collection_config`` and ``collection_metadata`` rows.
+
+        Args:
+            new_name: Target collection name.
+            user_id: User ID for tenant-scoped rename.
+            is_admin: When ``True`` renames across all tenants.
+        """
+
+    # --- Collection-level cascade delete (#H05) ---
+
+    @abstractmethod
+    def delete_collection_data(
+        self,
+        *,
+        user_id: int | None,
+        is_admin: bool,
+        warnings_out: list[str] | None = None,
+    ) -> dict[str, int]:
+        """Delete all data for this collection (cascade across all vector-side tables).
+
+        Uses ``self.context.collection`` as the collection name; no external
+        ``collection_name`` argument is accepted (the handle is already scoped).
+
+        Returns a ``dict[str, int]`` mapping table names to deleted row counts.
+        Raises ``DatabaseOperationError`` on failure.
+        """
+
+    @abstractmethod
+    def delete_documents_data(
+        self,
+        doc_ids: list[str],
+        *,
+        user_id: int | None,
+        is_admin: bool,
+        warnings_out: list[str] | None = None,
+    ) -> dict[str, int]:
+        """Delete vector-side data for specific document IDs in this collection.
+
+        Batches deletes internally.  On partial failure raises
+        ``DatabaseOperationError`` with ``details`` containing:
+            ``{"deleted_counts": dict, "deleted_doc_ids": list, "failed_batch_index": int}``
+        This exact shape is the downstream contract for
+        ``CollectionOperationResult.partial_success``.
+
+        Returns a ``dict[str, int]`` mapping table names to total deleted row
+        counts across all successfully processed batches.
+        """
+
+    # --- Collection-level rollback config primitives (#H05 Phase 4) ---
+
+    @abstractmethod
+    async def delete_collection_config(self, *, tenant_only: bool = False) -> int:
+        """Delete the collection_config row(s) for this collection.
+
+        When ``tenant_only`` is ``False`` (default) all tenant rows for this
+        collection are removed (admin scope – use only when the collection is
+        completely empty across all tenants).  When ``tenant_only`` is ``True``
+        only the row belonging to the handle's bound user scope is deleted,
+        leaving other tenants' rows intact.
+
+        Idempotent – returns the number of rows deleted (0 when no row
+        existed, which is not an error).
+        """
+
+    @abstractmethod
+    def cleanup_collection_data_after_rollback(
+        self,
+        *,
+        user_id: int | None,
+        is_admin: bool,
+    ) -> dict[str, int]:
+        """Remove all vector-side data for this collection (rollback compensation).
+
+        Composes the Phase 1 :meth:`delete_collection_data` primitive to clean
+        up a failed new-collection ingestion.  Does **not** touch the
+        filesystem; physical file cleanup is the caller's responsibility.
+
+        Returns a ``dict[str, int]`` mapping table names to deleted row counts.
+        """
+
+    @abstractmethod
+    def cleanup_embeddings_for_operation(
+        self,
+        *,
+        doc_id: Optional[str] = None,
+        parse_hash: Optional[str] = None,
+        chunk_ids: Optional[Sequence[str]] = None,
+        model_tag: Optional[str] = None,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> "KBVectorStorageCleanupResult":
+        """Delete or preview embedding rows created by a failed operation.
+
+        The cleanup scope is bound to this handle's collection + user scope;
+        rollback callers pass the operation's known document/parse/chunk/
+        model-tag identity. Per-table failures never raise - they are folded
+        into the result (``status="incomplete"``,
+        ``side_effects_may_remain=True``). ``status="skipped"`` on an empty
+        filter set; ``"planned"`` for previews; ``"complete"`` after deletes.
+        """
+
+    # --- Collection-level statistics (#H05 Phase 3) ---
+
+    @abstractmethod
+    def count_documents(self, user_id: int | None, is_admin: bool) -> int:
+        """Count documents visible to the given user in this collection.
+
+        When ``is_admin`` is ``True`` all rows are counted regardless of
+        ``user_id``.  Otherwise only rows owned by ``user_id`` are counted.
+
+        Returns:
+            Number of document rows visible to the caller.
+        """
+
+    @abstractmethod
+    def collection_stats(self, user_id: int | None, is_admin: bool) -> dict[str, int]:
+        """Return aggregate statistics for this collection.
+
+        Counts rows across the documents, chunks, and all embeddings_* tables
+        that are visible to the caller under the given user/admin scope.
+
+        Returns:
+            A ``dict`` with at least these keys:
+            - ``"documents"`` – count of document rows
+            - ``"chunks"``    – count of chunk rows
+            - ``"embeddings"``– total count of embedding rows across all model
+              tables
+        """
+
+    @abstractmethod
+    def list_collection_documents(
+        self,
+        user_id: int | None,
+        is_admin: bool,
+        max_results: int = 1_000_000,
+    ) -> list[str]:
+        """List document IDs visible to the given user in this collection.
+
+        Returns a sorted list of unique doc_id strings for documents visible
+        to the caller under the given user/admin scope.  Used by the coordinator
+        before deletion to populate ``affected_documents`` and to collect
+        tenant-owned doc_ids when the caller has not pre-computed them.
+
+        Args:
+            user_id: Owner filter; ``None`` treated as 0 for non-admin callers.
+            is_admin: When ``True`` lists all documents regardless of user_id.
+            max_results: Upper bound on the number of document IDs returned.
+
+        Returns:
+            Sorted list of unique doc_id strings.
+        """
+
+
+@dataclass(frozen=True)
+class LanceDBCollectionHandle(KBCollectionHandle):
+    """LanceDB-backed collection handle.
+
+    The initial delegate is the current LanceDB documents-table implementation,
+    reached through the bound vector index store.
+    """
+
+    context: KBCollectionContext
+
+    @property
+    def metadata_store(self) -> MetadataStore:
+        """Return the metadata store bound to this collection context."""
+        return self.context.metadata_store
+
+    @property
+    def vector_index_store(self) -> VectorIndexStore:
+        """Return the vector index store bound to this collection context."""
+        return self.context.vector_index_store
+
+    @property
+    def ingestion_status_store(self) -> IngestionStatusStore:
+        """Return the ingestion status store bound to this collection context."""
+        return self.context.ingestion_status_store
+
+    @property
+    def main_pointer_store(self) -> MainPointerStore:
+        """Return the main pointer store bound to this collection context."""
+        return self.context.main_pointer_store
+
+    @property
+    def backend(self) -> KBStorageBackend:
+        """Return the collection storage backend."""
+        return self.context.backend
+
+    @property
+    def capabilities(self) -> KBBackendCapabilities:
+        """Return backend capabilities for this collection."""
+        return self.context.capabilities
+
+    def register_document(
+        self, request: RegisterDocumentRequest
+    ) -> RegisterDocumentResponse:
+        """Register a document row in this collection's documents table.
+
+        Behavior mirrors the legacy ``_register_document`` helper: input
+        validation, file-type detection, deterministic doc_id (with UUID
+        fallback), SHA256 content hash, an admin-scoped existence check for the
+        ``created`` flag, and an idempotent upsert of the full row.
+        """
+        # The handle is collection-scoped: persist into the bound context
+        # collection rather than trusting request.collection, so a reused handle
+        # can never write outside its resolved collection. Through the
+        # coordinator the two already match (context.collection is the
+        # normalized form of request.collection).
+        collection = self.context.collection
+        file_id = request.file_id
+        source_path = request.source_path
+        metadata_source_path = request.metadata_source_path or source_path
+        file_type = request.file_type
+        doc_id = request.doc_id
+        uploaded_at = request.uploaded_at
+
+        if not collection:
+            raise DocumentValidationError("Collection name cannot be empty")
+
+        if not source_path or not Path(source_path).exists():
+            raise DocumentValidationError(f"Source path does not exist: {source_path}")
+
+        # Auto-detect file type if not provided.
+        if not file_type:
+            try:
+                file_type = check_file_type(source_path)
+            except DocumentValidationError as e:
+                raise DocumentValidationError(f"File type detection failed: {e}") from e
+
+        # Deterministic doc_id from (collection, file_id/source_path) for
+        # idempotent registration; fall back to a UUID if generation fails.
+        if not doc_id:
+            try:
+                stable_key = file_id or metadata_source_path
+                doc_id = generate_deterministic_doc_id(collection, stable_key)
+            except Exception as e:  # noqa: BLE001 - fallback keeps registration working
+                logger.debug(
+                    "Deterministic doc_id generation failed (%s), falling back to UUID",
+                    e,
+                )
+                doc_id = str(uuid.uuid4())
+
+        if not uploaded_at:
+            uploaded_at = pd.Timestamp.now(tz="UTC")
+        elif uploaded_at.tzinfo is None:
+            uploaded_at = uploaded_at.replace(tzinfo=timezone.utc)
+
+        try:
+            content_hash = compute_file_hash(source_path)
+        except Exception as e:
+            raise HashComputationError(f"Failed to compute content hash: {e}") from e
+
+        try:
+            vector_store = self.vector_index_store
+
+            # Existence check uses admin mode to see all records (incl. legacy).
+            exists = (
+                vector_store.count_rows_or_zero(
+                    "documents",
+                    filters={"collection": collection, "doc_id": doc_id},
+                    user_id=request.user_id,
+                    is_admin=True,
+                )
+                > 0
+            )
+
+            doc_record = {
+                "collection": collection,
+                "doc_id": doc_id,
+                "file_id": file_id,
+                "source_path": metadata_source_path,
+                "file_type": file_type,
+                "content_hash": content_hash,
+                "uploaded_at": uploaded_at,
+                "title": None,
+                "language": None,
+                "user_id": request.user_id,
+            }
+
+            vector_store.upsert_documents([doc_record])
+            created = not exists
+        except ConfigurationError:
+            raise
+        except Exception as e:
+            raise DatabaseOperationError(
+                f"Failed to register document in database: {e}"
+            ) from e
+
+        return RegisterDocumentResponse(
+            doc_id=doc_id,
+            created=created,
+            content_hash=content_hash,
+        )
+
+    def load_document(
+        self, doc_id: str, *, user_id: int | None = None, is_admin: bool = False
+    ) -> DocumentRecordDetail | None:
+        """Load a document row by id within this collection's scope.
+
+        Streams the single matching row via ``iter_batches``. Returns ``None``
+        when the row is absent or not visible to the given scope.
+        """
+        vector_store = self.vector_index_store
+        query_filters = {"collection": self.context.collection, "doc_id": doc_id}
+        try:
+            # iter_batches yields only non-empty batches under the same scope
+            # filter, so an absent or out-of-scope row yields nothing and we fall
+            # through to None -- a separate existence count would be redundant.
+            for batch in vector_store.iter_batches(
+                table_name="documents",
+                filters=query_filters,
+                user_id=user_id,
+                is_admin=is_admin,
+            ):
+                # to_pylist() converts the Arrow batch directly to native Python
+                # objects in C++, avoiding Pandas' int->float upcasting on null
+                # columns (the reason from_row still normalizes defensively).
+                for row_dict in batch.to_pylist():
+                    return DocumentRecordDetail.from_row(row_dict)
+            return None
+        except Exception as e:
+            raise DatabaseOperationError(f"Failed to retrieve document: {e}") from e
+
+    def list_documents(
+        self, *, user_id: int | None = None, is_admin: bool = False, limit: int = 100
+    ) -> DocumentRecordListResult:
+        """List document rows for this collection.
+
+        Mirrors the legacy file-level ``_list_documents_impl``: a batch scan of
+        the documents table filtered by collection, honoring ``limit``.
+        """
+        vector_store = self.vector_index_store
+        query_filters = {"collection": self.context.collection}
+        records: list[DocumentRecordDetail] = []
+        try:
+            for batch in vector_store.iter_batches(
+                table_name="documents",
+                filters=query_filters,
+                user_id=user_id,
+                is_admin=is_admin,
+            ):
+                # to_pylist() bypasses Pandas (see load_document) when materializing
+                # rows; from_row still normalizes any residual null sentinels.
+                for row_dict in batch.to_pylist():
+                    records.append(DocumentRecordDetail.from_row(row_dict))
+                    if len(records) >= limit:
+                        break
+                if len(records) >= limit:
+                    break
+        except Exception as e:
+            raise DatabaseOperationError(f"Failed to list documents: {e}") from e
+        return DocumentRecordListResult(documents=records, total_count=len(records))
+
+    def delete_document_record(
+        self, doc_id: str, *, user_id: int | None = None, is_admin: bool = False
+    ) -> int:
+        """Delete only this document's row via the bound store (no cascade)."""
+        return self.vector_index_store.delete_document_record(
+            collection_name=self.context.collection,
+            doc_id=doc_id,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    def snapshot_document(
+        self, doc_id: str, *, user_id: int | None = None, is_admin: bool = False
+    ) -> DocumentRecordDetail | None:
+        """Capture the current document row before a destructive operation.
+
+        Returns ``None`` when there is no existing row to snapshot. Note that
+        these compensation methods are added for #514 to wire into the live
+        rollback path; #508 only provides the mechanics.
+        """
+        return self.load_document(doc_id, user_id=user_id, is_admin=is_admin)
+
+    def restore_document(self, snapshot: DocumentRecordDetail) -> None:
+        """Restore a snapshotted document row, preserving every field.
+
+        Re-upserts the full row (keyed by collection + doc_id), so ``file_id``,
+        ``user_id``, collection, metadata, content hash, and file type are all
+        restored exactly. Refuses snapshots from another collection so the
+        collection-scoped boundary holds even on direct handle reuse.
+        """
+        if snapshot.collection != self.context.collection:
+            raise DocumentValidationError(
+                f"Handle bound to collection {self.context.collection!r} "
+                f"cannot restore a snapshot from {snapshot.collection!r}"
+            )
+        self.vector_index_store.upsert_documents([snapshot.to_legacy_dict()])
+
+    def delete_created_document(
+        self, doc_id: str, *, user_id: int | None = None, is_admin: bool = False
+    ) -> int:
+        """Idempotently delete a newly created document row (row-only)."""
+        return self.delete_document_record(doc_id, user_id=user_id, is_admin=is_admin)
+
+    # --- Parse data-plane (#509) ---
+
+    def parse_exists(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> bool:
+        """Return whether a parse row exists for ``(doc_id, parse_hash)``."""
+        try:
+            return bool(
+                self.vector_index_store.count_rows_or_zero(
+                    "parses",
+                    filters={
+                        "collection": self.context.collection,
+                        "doc_id": doc_id,
+                        "parse_hash": parse_hash,
+                    },
+                    user_id=user_id,
+                    is_admin=is_admin,
+                )
+                > 0
+            )
+        except Exception as e:
+            raise DatabaseOperationError(f"Database query failed: {e}") from e
+
+    def read_parse_paragraphs(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> list[ParsedParagraph]:
+        """Return the reuse-hit parsed paragraphs for ``(doc_id, parse_hash)``."""
+        vector_store = self.vector_index_store
+        query_filters = {
+            "collection": self.context.collection,
+            "doc_id": doc_id,
+            "parse_hash": parse_hash,
+        }
+        try:
+            if (
+                vector_store.count_rows_or_zero(
+                    "parses", filters=query_filters, user_id=user_id, is_admin=is_admin
+                )
+                == 0
+            ):
+                return []
+            for batch in vector_store.iter_batches(
+                table_name="parses",
+                filters=query_filters,
+                user_id=user_id,
+                is_admin=is_admin,
+            ):
+                for record in batch.to_pylist():
+                    parsed_content = record.get("parsed_content")
+                    if not parsed_content:
+                        continue
+                    data = json.loads(parsed_content)
+                    return [
+                        ParsedParagraph(
+                            text=item.get("text", ""),
+                            metadata=item.get("metadata", {}),
+                        )
+                        for item in data
+                    ]
+            return []
+        except Exception as e:
+            logger.error("Failed to read parse content: %s", e)
+            raise DatabaseOperationError(f"Failed reading parse content: {e}") from e
+
+    def write_parse(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        parse_method: Any,
+        params: dict[str, Any],
+        paragraphs: list[ParsedParagraph],
+        *,
+        user_id: int | None = None,
+    ) -> bool:
+        """Persist a parse row into this collection (idempotent upsert)."""
+        try:
+            parsed_content = json.dumps(
+                [para.model_dump() for para in paragraphs], ensure_ascii=False
+            )
+            parse_record = {
+                "collection": self.context.collection,
+                "doc_id": doc_id,
+                "parse_hash": parse_hash,
+                "parser": f"local:{parse_method}@v1.0.0",
+                "created_at": pd.Timestamp.now(tz="UTC"),
+                "params_json": json.dumps(params, ensure_ascii=False),
+                "parsed_content": parsed_content,
+                "user_id": user_id,
+            }
+            self.vector_index_store.upsert_parses([parse_record])
+            return True
+        except Exception as e:
+            raise DatabaseOperationError(f"Database write failed: {e}") from e
+
+    def read_latest_parse_record(
+        self,
+        doc_id: str,
+        parse_hash: str | None = None,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> ParseRecordDetail | None:
+        """Return the latest parse row (by ``created_at``) for display."""
+        vector_store = self.vector_index_store
+        query_filters: dict[str, Any] = {
+            "collection": self.context.collection,
+            "doc_id": doc_id,
+        }
+        if parse_hash:
+            query_filters["parse_hash"] = parse_hash
+        try:
+            if (
+                vector_store.count_rows_or_zero(
+                    "parses", filters=query_filters, user_id=user_id, is_admin=is_admin
+                )
+                == 0
+            ):
+                return None
+            records: list[dict[str, Any]] = []
+            for batch in vector_store.iter_batches(
+                table_name="parses",
+                filters=query_filters,
+                user_id=user_id,
+                is_admin=is_admin,
+            ):
+                records.extend(batch.to_pylist())
+            if not records:
+                return None
+
+            # Latest by created_at desc; (t is not None, t) sorts None rows last.
+            def _created_at_key(record: dict[str, Any]) -> Any:
+                created_at = record.get("created_at")
+                return (created_at is not None, created_at)
+
+            records_sorted = sorted(records, key=_created_at_key, reverse=True)
+            return ParseRecordDetail.from_row(records_sorted[0])
+        except Exception as e:
+            logger.error("Failed to read latest parse record: %s", e)
+            raise DatabaseOperationError(f"Failed to read parse result: {e}") from e
+
+    # --- Chunk data-plane (#509) ---
+
+    def chunk_exists(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        config_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> bool:
+        """Return whether chunk rows exist for the given config."""
+        try:
+            return bool(
+                self.vector_index_store.count_rows_or_zero(
+                    "chunks",
+                    filters={
+                        "collection": self.context.collection,
+                        "doc_id": doc_id,
+                        "parse_hash": parse_hash,
+                        "config_hash": config_hash,
+                    },
+                    user_id=user_id,
+                    is_admin=is_admin,
+                )
+                > 0
+            )
+        except Exception as e:
+            raise DatabaseOperationError(f"Database query failed: {e}") from e
+
+    def read_existing_chunks(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        config_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Return the reuse-hit chunk dicts (metadata deserialized)."""
+        vector_store = self.vector_index_store
+        query_filters = {
+            "collection": self.context.collection,
+            "doc_id": doc_id,
+            "parse_hash": parse_hash,
+            "config_hash": config_hash,
+        }
+        try:
+            if (
+                vector_store.count_rows_or_zero(
+                    "chunks", filters=query_filters, user_id=user_id, is_admin=is_admin
+                )
+                == 0
+            ):
+                return []
+
+            chunks: list[dict[str, Any]] = []
+            for batch in vector_store.iter_batches(
+                table_name="chunks",
+                filters=query_filters,
+                user_id=user_id,
+                is_admin=is_admin,
+            ):
+                for row in batch.to_pylist():
+                    index_value = row.get("index")
+                    chunks.append(
+                        {
+                            "chunk_id": row["chunk_id"],
+                            "index": int(index_value) if index_value is not None else 0,
+                            "text": row["text"],
+                            "page_number": row.get("page_number"),
+                            "section": row.get("section"),
+                            "anchor": row.get("anchor"),
+                            "json_path": row.get("json_path"),
+                            "created_at": row["created_at"],
+                            "metadata": deserialize_metadata(row.get("metadata")),
+                        }
+                    )
+            # LanceDB does not guarantee scan order; sort by index so reused
+            # chunks come back deterministically (mirrors snapshot_chunks).
+            chunks.sort(key=lambda chunk: chunk["index"])
+            return chunks
+        except Exception as e:
+            logger.error("Failed to get existing chunks: %s", e)
+            raise DatabaseOperationError(f"Database query failed: {e}") from e
+
+    def read_parse_paragraph_dicts(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Return parsed paragraphs as ``{text, metadata}`` dicts for chunking."""
+        vector_store = self.vector_index_store
+        query_filters = {
+            "collection": self.context.collection,
+            "doc_id": doc_id,
+            "parse_hash": parse_hash,
+        }
+        try:
+            if (
+                vector_store.count_rows_or_zero(
+                    "parses", filters=query_filters, user_id=user_id, is_admin=is_admin
+                )
+                == 0
+            ):
+                return []
+
+            records: list[dict[str, Any]] = []
+            for batch in vector_store.iter_batches(
+                table_name="parses",
+                filters=query_filters,
+                user_id=user_id,
+                is_admin=is_admin,
+            ):
+                records.extend(batch.to_pylist())
+
+            if not records:
+                return []
+            parsed_content = records[0].get("parsed_content")
+            if not parsed_content:
+                return []
+            data = json.loads(parsed_content)
+            return [
+                {"text": item.get("text", ""), "metadata": item.get("metadata", {})}
+                for item in data
+            ]
+        except Exception as e:
+            logger.error("Failed to read parses: %s", e)
+            raise DatabaseOperationError(f"Failed reading parses: {e}") from e
+
+    def write_chunks(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        config_hash: str,
+        params: dict[str, Any],
+        chunks: list[dict[str, Any]],
+        *,
+        user_id: int | None = None,
+    ) -> bool:
+        """Persist chunk rows into this collection (idempotent upsert)."""
+        try:
+            rows = []
+            for chunk in chunks:
+                text = chunk["text"]
+                rows.append(
+                    {
+                        "collection": self.context.collection,
+                        "doc_id": doc_id,
+                        "parse_hash": parse_hash,
+                        "chunk_id": chunk["chunk_id"],
+                        "index": int(chunk["index"]),
+                        "text": text,
+                        "page_number": chunk.get("page_number"),
+                        "section": chunk.get("section"),
+                        "anchor": chunk.get("anchor"),
+                        "json_path": chunk.get("json_path"),
+                        "chunk_hash": compute_chunk_hash(text, params),
+                        "config_hash": config_hash,
+                        "created_at": chunk["created_at"],
+                        "metadata": serialize_metadata(chunk.get("metadata")),
+                        "user_id": user_id,
+                    }
+                )
+
+            if not rows:
+                return False
+
+            self.vector_index_store.upsert_chunks(rows)
+            return True
+        except Exception as e:
+            logger.error("Failed to write chunk records: %s", e)
+            raise DatabaseOperationError(f"Database write failed: {e}") from e
+
+    # --- Embedding data-plane (#510) ---
+
+    def validate_query_vector(
+        self,
+        query_vector: list[float],
+        *,
+        model_tag: str | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> None:
+        """Validate a query vector's format and content (no store access)."""
+        validate_query_vector_format(query_vector)
+
+    def read_chunks_needing_embedding(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        model: str,
+        *,
+        filters: dict[str, Any] | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> EmbeddingReadResponse:
+        """Return chunks that still need an embedding for ``model``."""
+        collection = self.context.collection
+        try:
+            if not collection or not doc_id or not parse_hash or not model:
+                raise DocumentValidationError(
+                    "Collection, doc_id, parse_hash, and model are required"
+                )
+
+            vector_store = self.vector_index_store
+            query_filters: dict[str, Any] = {
+                "collection": collection,
+                "doc_id": doc_id,
+                "parse_hash": parse_hash,
+            }
+            if filters:
+                query_filters.update(filters)
+
+            total_count = vector_store.count_rows_or_zero(
+                table_name="chunks",
+                filters=query_filters,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+            if total_count == 0:
+                return EmbeddingReadResponse(chunks=[], total_count=0, pending_count=0)
+
+            chunks_data: list[dict[str, Any]] = []
+            for batch in vector_store.iter_batches(
+                table_name="chunks",
+                columns=None,
+                batch_size=1000,
+                filters=query_filters,
+                user_id=user_id,
+                is_admin=is_admin,
+            ):
+                chunks_data.extend(batch.to_pylist())
+                if len(chunks_data) >= total_count:
+                    break
+
+            # Chunks already embedded for this model tag are excluded by
+            # chunk_id presence in the per-model embeddings table.
+            embedded_chunk_ids: set[str] = set()
+            model_tag = to_model_tag(model)
+            embeddings_table_name = f"embeddings_{model_tag}"
+            try:
+                embedding_filters: dict[str, Any] = {
+                    "collection": collection,
+                    "doc_id": doc_id,
+                    "parse_hash": parse_hash,
+                }
+                embedding_count = vector_store.count_rows_or_zero(
+                    table_name=embeddings_table_name,
+                    filters=embedding_filters,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                )
+                if embedding_count > 0:
+                    for batch in vector_store.iter_batches(
+                        table_name=embeddings_table_name,
+                        columns=["chunk_id"],
+                        filters=embedding_filters,
+                        user_id=user_id,
+                        is_admin=is_admin,
+                    ):
+                        for row in batch.to_pylist():
+                            chunk_id = row.get("chunk_id")
+                            if chunk_id is not None:
+                                embedded_chunk_ids.add(chunk_id)
+            except Exception as e:  # noqa: BLE001 - missing/absent table = none embedded
+                logger.warning(
+                    "Failed to query existing embeddings for model %s "
+                    "(assuming none exist): %s",
+                    model,
+                    e,
+                )
+                embedded_chunk_ids = set()
+
+            pending_chunks: list[ChunkForEmbedding] = []
+            for chunk_dict in chunks_data:
+                chunk_id = chunk_dict["chunk_id"]
+                if chunk_id in embedded_chunk_ids:
+                    continue
+                metadata = deserialize_metadata(chunk_dict.get("metadata"))
+                index = _safe_int_value(chunk_dict.get("index"), default=0)
+
+                page_number_value = chunk_dict.get("page_number")
+                # A missing page number can arrive as None or as a pandas/LanceDB
+                # NaN sentinel (NaN != NaN); both mean "no page", not page 1.
+                if (
+                    page_number_value is not None
+                    and page_number_value == page_number_value
+                ):
+                    page_num = _safe_int_value(page_number_value, default=1)
+                    page_number = page_num if page_num > 0 else None
+                else:
+                    page_number = None
+
+                pending_chunks.append(
+                    ChunkForEmbedding(
+                        doc_id=chunk_dict["doc_id"],
+                        chunk_id=chunk_id,
+                        parse_hash=chunk_dict["parse_hash"],
+                        index=index,
+                        text=chunk_dict["text"],
+                        chunk_hash=chunk_dict["chunk_hash"],
+                        page_number=page_number,
+                        section=_safe_optional_str(chunk_dict.get("section")),
+                        anchor=_safe_optional_str(chunk_dict.get("anchor")),
+                        json_path=_safe_optional_str(chunk_dict.get("json_path")),
+                        metadata=metadata,
+                    )
+                )
+
+            return EmbeddingReadResponse(
+                chunks=pending_chunks,
+                total_count=total_count,
+                pending_count=len(pending_chunks),
+            )
+        except Exception as e:
+            if isinstance(
+                e,
+                (
+                    DocumentValidationError,
+                    DatabaseOperationError,
+                    ConfigurationError,
+                    VectorValidationError,
+                ),
+            ):
+                raise
+            logger.error("Failed to read chunks for embedding: %s", e)
+            raise DatabaseOperationError(
+                f"Failed to read chunks for embedding: {e}"
+            ) from e
+
+    def write_embeddings(
+        self,
+        embeddings: list[ChunkEmbeddingData],
+        *,
+        create_index: bool = True,
+        user_id: int | None = None,
+    ) -> EmbeddingWriteResponse:
+        """Write embedding vectors for this collection (idempotent upsert)."""
+        if not embeddings:
+            return EmbeddingWriteResponse(
+                upsert_count=0,
+                deleted_stale_count=0,
+                index_status=IndexOperation.SKIPPED.value,
+            )
+
+        collection = self.context.collection
+        try:
+            if not collection:
+                raise DocumentValidationError("Collection name is required")
+
+            embeddings_by_model: dict[str, list[ChunkEmbeddingData]] = {}
+            for embedding in embeddings:
+                embeddings_by_model.setdefault(embedding.model, []).append(embedding)
+
+            total_upserted = 0
+            index_statuses: list[str] = []
+            for model, model_embeddings in embeddings_by_model.items():
+                upserted, idx_status = self._process_model_embeddings(
+                    model, model_embeddings, create_index, user_id
+                )
+                total_upserted += upserted
+                index_statuses.append(idx_status)
+
+            # Map create_index result strings onto IndexOperation.
+            if "index_building" in index_statuses:
+                overall = IndexOperation.CREATED
+            elif "index_ready" in index_statuses:
+                overall = IndexOperation.READY
+            elif "failed" in index_statuses or "index_corrupted" in index_statuses:
+                overall = IndexOperation.FAILED
+            elif "below_threshold" in index_statuses:
+                overall = IndexOperation.SKIPPED_THRESHOLD
+            else:
+                overall = IndexOperation.SKIPPED
+
+            return EmbeddingWriteResponse(
+                upsert_count=total_upserted,
+                deleted_stale_count=0,  # merge_insert handles updates automatically
+                index_status=overall.value,
+            )
+        except Exception as e:
+            if isinstance(
+                e,
+                (
+                    DocumentValidationError,
+                    DatabaseOperationError,
+                    ConfigurationError,
+                    VectorValidationError,
+                ),
+            ):
+                raise
+            logger.error("Failed to write embeddings to database: %s", e)
+            raise DatabaseOperationError(
+                f"Failed to write embeddings to database: {e}"
+            ) from e
+
+    def _process_model_embeddings(
+        self,
+        model: str,
+        model_embeddings: list[ChunkEmbeddingData],
+        create_index: bool,
+        user_id: int | None,
+    ) -> tuple[int, str]:
+        """Upsert one model's embeddings via the bound store (batched)."""
+        model_tag = to_model_tag(model)
+        vector_store = self.vector_index_store
+
+        first_dim = len(model_embeddings[0].vector)
+        unique_dims = {len(item.vector) for item in model_embeddings}
+        if len(unique_dims) > 1:
+            raise VectorValidationError(
+                f"Multiple vector dimensions found for model {model}: {unique_dims}"
+            )
+
+        original_batch_size = _int_env("LANCEDB_BATCH_SIZE", DEFAULT_LANCEDB_BATCH_SIZE)
+        batch_size = original_batch_size
+        batch_timestamp = pd.Timestamp.now(tz="UTC")
+        max_spill_retries = _int_env("LANCEDB_MAX_SPILL_RETRIES", 3)
+        spill_retry_count = 0
+
+        upserted_count = 0
+        current_idx = 0
+        total_embeddings = len(model_embeddings)
+
+        while current_idx < total_embeddings:
+            end_idx = min(current_idx + batch_size, total_embeddings)
+            batch_embeddings = model_embeddings[current_idx:end_idx]
+
+            records_to_merge = [
+                {
+                    "collection": self.context.collection,
+                    "doc_id": embedding.doc_id,
+                    "chunk_id": embedding.chunk_id,
+                    "parse_hash": embedding.parse_hash,
+                    "model": model,
+                    "vector": embedding.vector,
+                    "text": embedding.text,
+                    "chunk_hash": embedding.chunk_hash,
+                    "created_at": batch_timestamp,
+                    "vector_dimension": first_dim,
+                    "metadata": serialize_metadata(embedding.metadata),
+                    "user_id": user_id,
+                }
+                for embedding in batch_embeddings
+            ]
+
+            try:
+                vector_store.upsert_embeddings(model_tag, records_to_merge)
+                upserted_count += len(records_to_merge)
+                current_idx = end_idx
+                spill_retry_count = 0
+            except Exception as batch_error:  # noqa: BLE001 - spill-retry then re-raise
+                # TODO: brittle string match; replace with a typed lancedb spill
+                # exception if/when one is exposed (cf. is_non_recoverable_merge_error).
+                if "Spill has sent an error" in str(batch_error):
+                    spill_retry_count += 1
+                    if spill_retry_count <= max_spill_retries:
+                        if batch_size > 50:
+                            batch_size = max(50, batch_size // 2)
+                            logger.info(
+                                "Reducing batch size to %d and retrying "
+                                "(spill retry %d/%d)",
+                                batch_size,
+                                spill_retry_count,
+                                max_spill_retries,
+                            )
+                        continue
+                raise
+
+        index_status: str = IndexOperation.SKIPPED.value
+        if create_index:
+            try:
+                index_status = vector_store.create_index(
+                    model_tag, readonly=False
+                ).status
+            except Exception as index_error:  # noqa: BLE001 - index failure is non-fatal
+                logger.warning(
+                    "Failed to create index for embeddings_%s: %s",
+                    model_tag,
+                    index_error,
+                )
+                index_status = IndexOperation.FAILED.value
+
+        return upserted_count, index_status
+
+    def delete_embedding_records(
+        self,
+        doc_id: str,
+        *,
+        parse_hash: str | None = None,
+        chunk_ids: list[str] | None = None,
+        model_tag: str | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> int:
+        """Delete embedding rows for a document via the bound store (no cascade)."""
+        return self.vector_index_store.delete_embedding_records(
+            self.context.collection,
+            doc_id,
+            parse_hash=parse_hash,
+            chunk_ids=chunk_ids,
+            model_tag=model_tag,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    # --- Embedding rollback compensation (methods only; wiring in #514) ---
+
+    def _embedding_table_names(self, model_tag: str | None) -> list[str]:
+        """List bound embedding tables, optionally scoped to one model tag."""
+        tables = [
+            name
+            for name in self.vector_index_store.list_table_names()
+            if name.startswith("embeddings_")
+        ]
+        if model_tag is None:
+            return tables
+        candidates = {
+            f"embeddings_{model_tag}",
+            f"embeddings_{to_model_tag(model_tag)}",
+        }
+        return [name for name in tables if name in candidates]
+
+    def snapshot_embeddings(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        *,
+        chunk_ids: list[str] | None = None,
+        model_tag: str | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> EmbeddingRecordSnapshot | None:
+        """Capture embedding rows across matching model tables (None if absent)."""
+        vector_store = self.vector_index_store
+        query_filters = {
+            "collection": self.context.collection,
+            "doc_id": doc_id,
+            "parse_hash": parse_hash,
+        }
+        chunk_id_set = set(chunk_ids) if chunk_ids else None
+        rows: list[dict[str, Any]] = []
+        try:
+            for table_name in self._embedding_table_names(model_tag):
+                if (
+                    vector_store.count_rows_or_zero(
+                        table_name,
+                        filters=query_filters,
+                        user_id=user_id,
+                        is_admin=is_admin,
+                    )
+                    == 0
+                ):
+                    continue
+                for batch in vector_store.iter_batches(
+                    table_name=table_name,
+                    filters=query_filters,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                ):
+                    for row in batch.to_pylist():
+                        if chunk_id_set is not None and row.get("chunk_id") not in (
+                            chunk_id_set
+                        ):
+                            continue
+                        rows.append(row)
+        except Exception as e:
+            logger.error("Failed to snapshot embeddings: %s", e)
+            raise DatabaseOperationError(f"Failed to snapshot embeddings: {e}") from e
+
+        if not rows:
+            return None
+        # Deterministic order across tables for a faithful restore/round trip.
+        rows.sort(key=lambda row: (row.get("model") or "", row.get("chunk_id") or ""))
+        return EmbeddingRecordSnapshot.from_rows(rows)
+
+    def restore_embeddings(self, snapshot: EmbeddingRecordSnapshot) -> None:
+        """Restore snapshotted embedding rows, grouped per model tag."""
+        if not snapshot.records:
+            return
+        for record in snapshot.records:
+            if record.collection != self.context.collection:
+                raise DocumentValidationError(
+                    f"Handle bound to collection {self.context.collection!r} "
+                    f"cannot restore an embedding snapshot from "
+                    f"{record.collection!r}"
+                )
+        for model_tag, rows in snapshot.group_by_model_tag().items():
+            self.vector_index_store.upsert_embeddings(model_tag, rows)
+
+    def delete_created_embeddings(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        *,
+        chunk_ids: list[str] | None = None,
+        model_tag: str | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> int:
+        """Idempotently delete newly created embedding rows (compensation)."""
+        return self.delete_embedding_records(
+            doc_id,
+            parse_hash=parse_hash,
+            chunk_ids=chunk_ids,
+            model_tag=model_tag,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    # --- Search data-plane (#511) ---
+
+    def _dense_unsupported(self, model_tag: str) -> DenseSearchResponse:
+        return DenseSearchResponse(
+            results=[],
+            total_count=0,
+            status="failed",
+            warnings=[
+                SearchWarning(
+                    code="SEARCH_NOT_SUPPORTED",
+                    message="This backend does not support search.",
+                    fallback_action=SearchFallbackAction.PARTIAL_RESULTS,
+                    affected_models=[model_tag],
+                )
+            ],
+            index_status=IndexStatus.NO_INDEX,
+            index_advice=None,
+            idempotency_key=None,
+            fallback_info=None,
+            nprobes=None,
+            refine_factor=None,
+        )
+
+    @staticmethod
+    def _map_index_status(index_status: str) -> IndexStatus:
+        return {
+            "index_building": IndexStatus.INDEX_BUILDING,
+            "no_index": IndexStatus.NO_INDEX,
+            "index_corrupted": IndexStatus.INDEX_CORRUPTED,
+            "readonly": IndexStatus.READONLY,
+            "below_threshold": IndexStatus.BELOW_THRESHOLD,
+        }.get(index_status, IndexStatus.INDEX_READY)
+
+    def _dense_engine(
+        self,
+        collection: str,
+        model_tag: str,
+        query_vector: list[float],
+        *,
+        top_k: int,
+        filters: Any,
+        readonly: bool,
+        nprobes: int | None,
+        refine_factor: int | None,
+        user_id: int | None,
+        is_admin: bool,
+    ) -> tuple[list[SearchResult], str, str | None]:
+        try:
+            vector_store = self.vector_index_store
+            index_result_obj = vector_store.create_index(model_tag, readonly)
+            index_status = index_result_obj.status
+            index_advice = index_result_obj.advice
+            filter_expr = _build_search_filter_expression(collection, filters)
+            if filter_expr is not None:
+                validate_filter_depth(filter_expr)
+            raw_results = vector_store.search_vectors_by_model(
+                model_tag=model_tag,
+                query_vector=query_vector,
+                top_k=top_k,
+                filters=filter_expr,
+                vector_column_name="vector",
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+            search_results = []
+            for row in raw_results:
+                distance_value = row.get("_distance")
+                distance = float(distance_value) if distance_value is not None else 0.0
+                score = 1.0 / (1.0 + max(0.0, distance))
+                metadata = deserialize_metadata(row.get("metadata"))
+                search_results.append(
+                    SearchResult(
+                        doc_id=row["doc_id"],
+                        chunk_id=row["chunk_id"],
+                        text=row["text"],
+                        score=score,
+                        parse_hash=row.get("parse_hash"),
+                        model_tag=model_tag,
+                        created_at=row.get("created_at"),
+                        metadata=metadata,
+                    )
+                )
+            return search_results, index_status, index_advice
+        except Exception as e:
+            logger.error("Failed to execute dense search: %s", str(e))
+            raise
+
+    async def _dense_engine_async(
+        self,
+        collection: str,
+        model_tag: str,
+        query_vector: list[float],
+        *,
+        top_k: int,
+        filters: Any,
+        readonly: bool,
+        nprobes: int | None,
+        refine_factor: int | None,
+        user_id: int | None,
+        is_admin: bool,
+    ) -> tuple[list[SearchResult], str, str | None]:
+        try:
+            vector_store = self.vector_index_store
+            index_result_obj = vector_store.create_index(model_tag, readonly)
+            index_status = index_result_obj.status
+            index_advice = index_result_obj.advice
+            filter_expr = _build_search_filter_expression(collection, filters)
+            if filter_expr is not None:
+                validate_filter_depth(filter_expr)
+            raw_results = await vector_store.search_vectors_by_model_async(
+                model_tag=model_tag,
+                query_vector=query_vector,
+                top_k=top_k,
+                filters=filter_expr,
+                vector_column_name="vector",
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+            search_results = []
+            for row in raw_results:
+                distance_value = row.get("_distance")
+                distance = float(distance_value) if distance_value is not None else 0.0
+                score = 1.0 / (1.0 + max(0.0, distance))
+                metadata = deserialize_metadata(row.get("metadata"))
+                search_results.append(
+                    SearchResult(
+                        doc_id=row["doc_id"],
+                        chunk_id=row["chunk_id"],
+                        text=row["text"],
+                        score=score,
+                        parse_hash=row.get("parse_hash"),
+                        model_tag=model_tag,
+                        created_at=row.get("created_at"),
+                        metadata=metadata,
+                    )
+                )
+            return search_results, index_status, index_advice
+        except Exception as e:
+            logger.error("Failed to execute async dense search: %s", str(e))
+            raise
+
+    def search_dense(
+        self,
+        model_tag: str,
+        query_vector: list[float],
+        *,
+        top_k: int = 10,
+        filters: Any = None,
+        readonly: bool = False,
+        nprobes: int | None = None,
+        refine_factor: int | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> DenseSearchResponse:
+        if not self.capabilities.supports_search:
+            return self._dense_unsupported(model_tag)
+        collection = self.context.collection
+        try:
+            results, index_status, index_advice = self._dense_engine(
+                collection,
+                model_tag,
+                query_vector,
+                top_k=top_k,
+                filters=filters,
+                readonly=readonly,
+                nprobes=nprobes,
+                refine_factor=refine_factor,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+            return DenseSearchResponse(
+                results=results,
+                total_count=len(results),
+                status="success",
+                warnings=[],
+                index_status=self._map_index_status(index_status),
+                index_advice=index_advice,
+                idempotency_key=None,
+                fallback_info=None,
+                nprobes=nprobes,
+                refine_factor=refine_factor,
+            )
+        except Exception as e:  # noqa: BLE001 - search returns failed response, never raises
+            logger.error(
+                "Dense search failed for %s in collection '%s': %s",
+                model_tag,
+                collection,
+                e,
+            )
+            return DenseSearchResponse(
+                results=[],
+                total_count=0,
+                status="failed",
+                warnings=[
+                    SearchWarning(
+                        code="DENSE_SEARCH_FAILED",
+                        message=f"An unexpected error occurred during dense search: {e}",
+                        fallback_action=SearchFallbackAction.PARTIAL_RESULTS,
+                        affected_models=[model_tag],
+                    )
+                ],
+                index_status=IndexStatus.NO_INDEX,
+                index_advice=None,
+                idempotency_key=None,
+                fallback_info=None,
+                nprobes=nprobes,
+                refine_factor=refine_factor,
+            )
+
+    async def search_dense_async(
+        self,
+        model_tag: str,
+        query_vector: list[float],
+        *,
+        top_k: int = 10,
+        filters: Any = None,
+        readonly: bool = False,
+        nprobes: int | None = None,
+        refine_factor: int | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> DenseSearchResponse:
+        if not self.capabilities.supports_search:
+            return self._dense_unsupported(model_tag)
+        collection = self.context.collection
+        try:
+            results, index_status, index_advice = await self._dense_engine_async(
+                collection,
+                model_tag,
+                query_vector,
+                top_k=top_k,
+                filters=filters,
+                readonly=readonly,
+                nprobes=nprobes,
+                refine_factor=refine_factor,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+            return DenseSearchResponse(
+                results=results,
+                total_count=len(results),
+                status="success",
+                warnings=[],
+                index_status=self._map_index_status(index_status),
+                index_advice=index_advice,
+                idempotency_key=None,
+                fallback_info=None,
+                nprobes=nprobes,
+                refine_factor=refine_factor,
+            )
+        except Exception as e:  # noqa: BLE001 - search returns failed response, never raises
+            logger.error(
+                "Dense search failed (async) for %s in collection '%s': %s",
+                model_tag,
+                collection,
+                e,
+            )
+            return DenseSearchResponse(
+                results=[],
+                total_count=0,
+                status="failed",
+                warnings=[
+                    SearchWarning(
+                        code="DENSE_SEARCH_FAILED",
+                        message=f"An unexpected error occurred during dense search: {e}",
+                        fallback_action=SearchFallbackAction.PARTIAL_RESULTS,
+                        affected_models=[model_tag],
+                    )
+                ],
+                index_status=IndexStatus.NO_INDEX,
+                index_advice=None,
+                idempotency_key=None,
+                fallback_info=None,
+                nprobes=nprobes,
+                refine_factor=refine_factor,
+            )
+
+    def _sparse_unsupported(
+        self, model_tag: str, query_text: str
+    ) -> SparseSearchResponse:
+        return SparseSearchResponse(
+            results=[],
+            total_count=0,
+            status="failed",
+            warnings=[
+                SearchWarning(
+                    code="SEARCH_NOT_SUPPORTED",
+                    message="This backend does not support search.",
+                    fallback_action=SearchFallbackAction.PARTIAL_RESULTS,
+                    affected_models=[model_tag],
+                )
+            ],
+            fts_enabled=False,
+            query_text=query_text,
+        )
+
+    @staticmethod
+    def _build_sparse_response(
+        *,
+        results: List[SearchResult],
+        warnings: List[SearchWarning],
+        fts_enabled: bool,
+        query_text: str,
+        status: str = "success",
+    ) -> SparseSearchResponse:
+        """Helper to assemble `SparseSearchResponse`. Allows fallback reuse."""
+        return SparseSearchResponse(
+            results=results,
+            total_count=len(results),
+            status=status,
+            warnings=warnings,
+            fts_enabled=fts_enabled,
+            query_text=query_text,
+        )
+
+    def _substring_fallback(
+        self,
+        *,
+        table: Any,
+        collection: str,
+        query_text: str,
+        model_tag: str,
+        top_k: int,
+        current_warnings: List[SearchWarning],
+        batch_size: int = 2048,
+        filter_expr: FilterExpression | None = None,
+    ) -> List[SearchResult]:
+        """Perform a memory-friendly substring scan across the table when FTS misses."""
+
+        if filter_expr is None and collection:
+            filter_expr = FilterCondition(
+                field="collection",
+                operator=FilterOperator.EQ,
+                value=collection,
+            )
+
+        desired_columns: Set[str] = {
+            "collection",
+            "doc_id",
+            "chunk_id",
+            "text",
+            "parse_hash",
+            "created_at",
+            "metadata",
+        }
+        if filter_expr is not None:
+            desired_columns.update(_filter_expression_fields(filter_expr))
+
+        results: List[SearchResult] = []
+
+        try:
+            if hasattr(table, "to_batches"):
+                batch_iter: Iterable[Any] = table.to_batches(
+                    columns=list(desired_columns), batch_size=batch_size
+                )
+            else:
+                if pa is None:  # pragma: no cover - Safety guard when pyarrow missing
+                    raise ImportError(
+                        "pyarrow is required for substring fallback when LanceDB table does not expose to_batches()."
+                    )
+                arrow_table: PyArrowTable = table.to_arrow()  # type: ignore
+                arrow_table = arrow_table.select(list(desired_columns))
+                batch_iter = arrow_table.to_batches(max_chunksize=batch_size)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Substring fallback failed to read batches: %s", exc)
+            return results
+
+        for batch in batch_iter:
+            batch_df = batch.to_pandas()
+
+            mask = _evaluate_filter_expression(batch_df, filter_expr)
+
+            if not mask.any():
+                continue
+
+            text_mask = (
+                batch_df["text"]
+                .astype(str)
+                .str.contains(query_text, na=False, regex=False)
+            )
+            mask &= text_mask
+
+            if not mask.any():
+                continue
+
+            for _, row in batch_df.loc[mask].iterrows():
+                # Deserialize metadata from JSON string to dictionary
+                metadata = deserialize_metadata(row.get("metadata"))
+                results.append(
+                    SearchResult(
+                        doc_id=row["doc_id"],
+                        chunk_id=row["chunk_id"],
+                        text=row["text"],
+                        score=1.0,
+                        parse_hash=row["parse_hash"],
+                        model_tag=model_tag,
+                        created_at=row["created_at"],
+                        metadata=metadata,
+                    )
+                )
+                if len(results) >= top_k:
+                    break
+
+            if len(results) >= top_k:
+                break
+
+        if results:
+            current_warnings.append(
+                SearchWarning(
+                    code="FTS_FALLBACK",
+                    message=(
+                        "Full-text index returned no matches; used substring search fallback. "
+                        "Check FTS tokenizer configuration or update LanceDB to ensure proper tokenisation for query language."
+                    ),
+                    fallback_action=SearchFallbackAction.BRUTE_FORCE,
+                    affected_models=[model_tag],
+                )
+            )
+
+        return results
+
+    async def _substring_fallback_async(
+        self,
+        *,
+        model_tag: str,
+        collection: str,
+        query_text: str,
+        top_k: int,
+        current_warnings: List[SearchWarning],
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+        batch_size: int = 2048,
+        filter_expr: FilterExpression | None = None,
+    ) -> List[SearchResult]:
+        """Perform async substring scan using iter_batches_async when FTS misses."""
+
+        vector_store = self.vector_index_store
+        results: List[SearchResult] = []
+
+        if filter_expr is None and collection:
+            filter_expr = FilterCondition(
+                field="collection",
+                operator=FilterOperator.EQ,
+                value=collection,
+            )
+
+        desired_columns: Set[str] = {
+            "doc_id",
+            "chunk_id",
+            "text",
+            "parse_hash",
+            "created_at",
+            "metadata",
+        }
+        if filter_expr is not None:
+            desired_columns.update(_filter_expression_fields(filter_expr))
+
+        _table = None
+        try:
+            # Open embeddings table with legacy fallback
+            _table, table_name = vector_store.open_embeddings_table(model_tag)
+
+            # Use async batch iteration for memory-efficient scanning
+            # Specify only required columns to minimize memory usage
+            async for batch in cast(
+                AsyncIterator[Any],
+                vector_store.iter_batches_async(
+                    table_name=table_name,
+                    columns=list(desired_columns),
+                    batch_size=batch_size,
+                    filters={"collection": collection},
+                    user_id=user_id,
+                    is_admin=is_admin,
+                ),
+            ):
+                batch_df = batch.to_pandas()
+
+                mask = _evaluate_filter_expression(batch_df, filter_expr)
+                if not mask.any():
+                    continue
+
+                text_mask = (
+                    batch_df["text"]
+                    .astype(str)
+                    .str.contains(query_text, na=False, regex=False)
+                )
+                matching_rows = batch_df[mask & text_mask]
+
+                # Early exit: stop processing if we already have enough results
+                if len(results) >= top_k:
+                    break
+
+                for _, row in matching_rows.iterrows():
+                    metadata = deserialize_metadata(row.get("metadata"))
+                    results.append(
+                        SearchResult(
+                            doc_id=row["doc_id"],
+                            chunk_id=row["chunk_id"],
+                            text=row["text"],
+                            score=1.0,
+                            parse_hash=row["parse_hash"],
+                            model_tag=model_tag,
+                            created_at=row["created_at"],
+                            metadata=metadata,
+                        )
+                    )
+
+                    # Early exit: stop as soon as we have enough results
+                    if len(results) >= top_k:
+                        break
+
+                if len(results) >= top_k:
+                    break
+
+            if results:
+                current_warnings.append(
+                    SearchWarning(
+                        code="FTS_FALLBACK",
+                        message=(
+                            "Full-text index returned no matches; used async substring search fallback. "
+                            "Check FTS tokenizer configuration or update LanceDB to ensure proper tokenisation for query language."
+                        ),
+                        fallback_action=SearchFallbackAction.BRUTE_FORCE,
+                        affected_models=[model_tag],
+                    )
+                )
+
+        except Exception as exc:
+            logger.error("Async substring fallback failed: %s", exc)
+        finally:
+            _safe_close_table(_table)
+
+        return results
+
+    def search_sparse(
+        self,
+        model_tag: str,
+        query_text: str,
+        *,
+        top_k: int,
+        filters: Any = None,
+        readonly: bool = False,
+        nprobes: Optional[int] = None,
+        refine_factor: Optional[int] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> SparseSearchResponse:
+        """Execute sparse (FTS) search for this collection."""
+        if not self.capabilities.supports_search:
+            return self._sparse_unsupported(model_tag, query_text)
+
+        collection = self.context.collection
+        _fts_enabled = False
+        current_warnings: List[SearchWarning] = []
+
+        if readonly:
+            current_warnings.append(
+                SearchWarning(
+                    code="READONLY_MODE",
+                    message=f"Readonly mode enabled for sparse search on {model_tag}. No FTS index operations will be performed.",
+                    fallback_action=SearchFallbackAction.REBUILD_INDEX,
+                    affected_models=[model_tag],
+                )
+            )
+
+        table = None
+        try:
+            vector_store = self.vector_index_store
+
+            # Open embeddings table with legacy fallback (handled by abstraction layer)
+            # open_embeddings_table will handle adding the "embeddings_" prefix
+            table, actual_table_name = vector_store.open_embeddings_table(model_tag)
+
+            # Use storage abstraction for index management
+            index_result_obj = vector_store.create_index(model_tag, readonly)
+
+            # Use FTS enabled status from index result
+            _fts_enabled = index_result_obj.fts_enabled
+
+            if not _fts_enabled:
+                current_warnings.append(
+                    SearchWarning(
+                        code="FTS_INDEX_MISSING",
+                        message=f"FTS index not found on 'text' column for {model_tag}. Sparse search performance may be degraded.",
+                        fallback_action=SearchFallbackAction.REBUILD_INDEX,
+                        affected_models=[model_tag],
+                    )
+                )
+
+            search_query = table.search(query_text, query_type="fts").limit(top_k)
+
+            filter_expr = _build_search_filter_expression(collection, filters)
+
+            # Validate filter expression depth to prevent DoS
+            if filter_expr is not None:
+                validate_filter_depth(filter_expr)
+
+            # Use abstract filter builder to get backend-specific syntax
+            if filter_expr:
+                backend_filter = vector_store.build_filter_expression(
+                    filters=filter_expr,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                )
+                if backend_filter:
+                    search_query = search_query.where(backend_filter)
+
+            # LanceDB's search().to_pandas() returns Any due to missing type stubs
+            raw_results_df = pd.DataFrame(search_query.to_pandas())
+
+            if not raw_results_df.empty:
+                search_results: List[SearchResult] = []
+                for _, row in raw_results_df.iterrows():
+                    # LanceDB FTS returns TF-IDF score (higher is better),
+                    # normalize to similarity score (0-1) similar to dense search
+                    # Using score/(1+score) formula to convert TF-IDF to normalized similarity
+                    raw_score_value = row.get("_score")
+                    raw_score = (
+                        float(raw_score_value) if pd.notna(raw_score_value) else 0.0
+                    )
+                    # Normalize TF-IDF score to [0, 1) range using x/(1+x) formula
+                    score = raw_score / (1.0 + raw_score)
+                    # Deserialize metadata from JSON string to dictionary
+                    metadata = deserialize_metadata(row.get("metadata"))
+                    search_results.append(
+                        SearchResult(
+                            doc_id=row["doc_id"],
+                            chunk_id=row["chunk_id"],
+                            text=row["text"],
+                            score=score,
+                            parse_hash=row["parse_hash"],
+                            model_tag=model_tag,
+                            created_at=row["created_at"],
+                            metadata=metadata,
+                        )
+                    )
+
+                return self._build_sparse_response(
+                    results=search_results,
+                    warnings=current_warnings,
+                    fts_enabled=_fts_enabled,
+                    query_text=query_text,
+                )
+
+            logger.warning(
+                "FTS lookup returned no rows for query '%s'; falling back to substring match",
+                query_text,
+            )
+            fallback_results = self._substring_fallback(
+                table=table,
+                collection=collection,
+                query_text=query_text,
+                model_tag=model_tag,
+                top_k=top_k,
+                current_warnings=current_warnings,
+                filter_expr=filter_expr,
+            )
+
+            return self._build_sparse_response(
+                results=fallback_results,
+                warnings=current_warnings,
+                fts_enabled=_fts_enabled,
+                query_text=query_text,
+            )
+
+        except Exception as e:
+            logger.error(
+                "Sparse search failed for %s with query '%s': %s",
+                model_tag,
+                query_text,
+                e,
+            )
+            error_warnings = current_warnings + [
+                SearchWarning(
+                    code="FTS_SEARCH_FAILED",
+                    message=f"An unexpected error occurred during sparse search: {str(e)}",
+                    fallback_action=SearchFallbackAction.PARTIAL_RESULTS,
+                    affected_models=[model_tag],
+                )
+            ]
+            return self._build_sparse_response(
+                results=[],
+                warnings=error_warnings,
+                fts_enabled=_fts_enabled,
+                query_text=query_text,
+                status="failed",
+            )
+        finally:
+            _safe_close_table(table)
+
+    async def search_sparse_async(
+        self,
+        model_tag: str,
+        query_text: str,
+        *,
+        top_k: int,
+        filters: Any = None,
+        readonly: bool = False,
+        nprobes: Optional[int] = None,
+        refine_factor: Optional[int] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = False,
+    ) -> SparseSearchResponse:
+        """Async sparse (FTS) search for this collection."""
+        if not self.capabilities.supports_search:
+            return self._sparse_unsupported(model_tag, query_text)
+
+        collection = self.context.collection
+        vector_store = self.vector_index_store
+
+        _fts_enabled = False
+        current_warnings: List[SearchWarning] = []
+
+        if readonly:
+            current_warnings.append(
+                SearchWarning(
+                    code="READONLY_MODE",
+                    message=f"Readonly mode enabled for sparse search on {model_tag}. No FTS index operations will be performed.",
+                    fallback_action=SearchFallbackAction.REBUILD_INDEX,
+                    affected_models=[model_tag],
+                )
+            )
+
+        try:
+            # Check and create FTS index if needed (using storage abstraction layer)
+            if not readonly:
+                index_result_obj = vector_store.create_index(model_tag, readonly=False)
+                _fts_enabled = index_result_obj.fts_enabled
+
+            if not _fts_enabled:
+                current_warnings.append(
+                    SearchWarning(
+                        code="FTS_INDEX_MISSING",
+                        message=f"FTS index may not be enabled on 'text' column for {model_tag}. Sparse search performance may be degraded.",
+                        fallback_action=SearchFallbackAction.REBUILD_INDEX,
+                        affected_models=[model_tag],
+                    )
+                )
+
+            filter_expr = _build_search_filter_expression(collection, filters)
+
+            # Validate filter expression depth to prevent DoS
+            if filter_expr is not None:
+                validate_filter_depth(filter_expr)
+
+            # Execute async FTS search using abstraction layer (by model_tag)
+            raw_results = await vector_store.search_fts_by_model_async(
+                model_tag=model_tag,
+                query_text=query_text,
+                top_k=top_k,
+                filters=filter_expr,
+                text_column_name="text",
+            )
+
+            if not raw_results:
+                logger.warning(
+                    "FTS lookup returned no results for query '%s'; falling back to substring match",
+                    query_text,
+                )
+                # Use async iter_batches for fallback
+                fallback_results = await self._substring_fallback_async(
+                    model_tag=model_tag,
+                    collection=collection,
+                    query_text=query_text,
+                    top_k=top_k,
+                    current_warnings=current_warnings,
+                    user_id=user_id,
+                    is_admin=is_admin,
+                    filter_expr=filter_expr,
+                )
+
+                return self._build_sparse_response(
+                    results=fallback_results,
+                    warnings=current_warnings,
+                    fts_enabled=_fts_enabled,
+                    query_text=query_text,
+                )
+
+            # Convert raw results to SearchResult objects
+            search_results: List[SearchResult] = []
+            for row in raw_results:
+                # LanceDB FTS returns TF-IDF score (higher is better)
+                raw_score_value = row.get("_score")
+                raw_score = (
+                    float(raw_score_value) if raw_score_value is not None else 0.0
+                )
+                # Normalize TF-IDF score to [0, 1) range
+                score = raw_score / (1.0 + raw_score)
+
+                # Deserialize metadata
+                metadata = deserialize_metadata(row.get("metadata"))
+
+                search_results.append(
+                    SearchResult(
+                        doc_id=row["doc_id"],
+                        chunk_id=row["chunk_id"],
+                        text=row["text"],
+                        score=score,
+                        parse_hash=row.get("parse_hash"),
+                        model_tag=model_tag,
+                        created_at=row.get("created_at"),
+                        metadata=metadata,
+                    )
+                )
+
+            return self._build_sparse_response(
+                results=search_results,
+                warnings=current_warnings,
+                fts_enabled=_fts_enabled,
+                query_text=query_text,
+            )
+
+        except Exception as e:
+            logger.error(
+                "Async sparse search failed for %s with query '%s': %s",
+                model_tag,
+                query_text,
+                e,
+            )
+            error_warnings = current_warnings + [
+                SearchWarning(
+                    code="FTS_SEARCH_FAILED",
+                    message=f"An unexpected error occurred during sparse search: {str(e)}",
+                    fallback_action=SearchFallbackAction.PARTIAL_RESULTS,
+                    affected_models=[model_tag],
+                )
+            ]
+            return self._build_sparse_response(
+                results=[],
+                warnings=error_warnings,
+                fts_enabled=_fts_enabled,
+                query_text=query_text,
+                status="failed",
+            )
+
+    def _hybrid_unsupported(
+        self, model_tag: str, fusion_config: FusionConfig | None
+    ) -> HybridSearchResponse:
+        return HybridSearchResponse(
+            results=[],
+            total_count=0,
+            status="failed",
+            warnings=[
+                SearchWarning(
+                    code="SEARCH_NOT_SUPPORTED",
+                    message="This backend does not support search.",
+                    fallback_action=SearchFallbackAction.PARTIAL_RESULTS,
+                    affected_models=[model_tag],
+                )
+            ],
+            fusion_config=fusion_config or FusionConfig(),
+            dense_count=0,
+            sparse_count=0,
+            index_status=IndexStatus.NO_INDEX,
+            index_advice=None,
+        )
+
+    def search_hybrid(
+        self,
+        model_tag: str,
+        query_text: str,
+        query_vector: list[float],
+        *,
+        top_k: int = 10,
+        filters: Any = None,
+        fusion_config: FusionConfig | None = None,
+        readonly: bool = False,
+        nprobes: int | None = None,
+        refine_factor: int | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> HybridSearchResponse:
+        """Execute hybrid (dense + sparse) search with fusion for this collection."""
+        if not self.capabilities.supports_search:
+            return self._hybrid_unsupported(model_tag, fusion_config)
+
+        if fusion_config is None:
+            fusion_config = FusionConfig()
+
+        # 1. Execute Dense Search
+        logger.info("Executing dense search for model %s...", model_tag)
+        dense_response = self.search_dense(
+            model_tag,
+            query_vector,
+            top_k=top_k * 2,
+            filters=filters,
+            readonly=readonly,
+            nprobes=nprobes,
+            refine_factor=refine_factor,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+        # 2. Execute Sparse Search
+        logger.info("Executing sparse search for model %s...", model_tag)
+        sparse_response = self.search_sparse(
+            model_tag,
+            query_text,
+            top_k=top_k * 2,
+            filters=filters,
+            readonly=readonly,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+        # 3-6. Fuse and build the response (shared sync logic).
+        return self._fuse_hybrid(
+            model_tag,
+            query_text,
+            dense_response,
+            sparse_response,
+            top_k=top_k,
+            fusion_config=fusion_config,
+        )
+
+    def _fuse_hybrid(
+        self,
+        model_tag: str,
+        query_text: str,
+        dense_response: DenseSearchResponse,
+        sparse_response: SparseSearchResponse,
+        *,
+        top_k: int,
+        fusion_config: FusionConfig,
+    ) -> HybridSearchResponse:
+        """Fuse already-fetched dense/sparse responses into a hybrid response.
+
+        Holds every step that runs after the dense/sparse calls in both the sync
+        and async hybrid paths. It consumes already-fetched response objects, so
+        it is purely synchronous and shared by ``search_hybrid`` and
+        ``search_hybrid_async``.
+        """
+        all_warnings: List[SearchWarning] = []
+
+        dense_results = dense_response.results
+        all_warnings.extend(dense_response.warnings)
+
+        sparse_results = sparse_response.results
+        all_warnings.extend(sparse_response.warnings)
+
+        # Get index status and advice from dense search (primary source for index info)
+        index_status = dense_response.index_status
+        index_advice = dense_response.index_advice
+
+        # 3. Preserve original scores and ranks before fusion
+        dense_rank_map: Dict[str, int] = {}
+        sparse_rank_map: Dict[str, int] = {}
+        dense_score_map: Dict[str, float] = {}
+        sparse_score_map: Dict[str, float] = {}
+
+        for rank, result in enumerate(dense_results, start=1):
+            unique_id = f"{result.doc_id}-{result.chunk_id}-{result.parse_hash}-{result.model_tag}"
+            dense_rank_map[unique_id] = rank
+            dense_score_map[unique_id] = result.score
+
+        for rank, result in enumerate(sparse_results, start=1):
+            unique_id = f"{result.doc_id}-{result.chunk_id}-{result.parse_hash}-{result.model_tag}"
+            sparse_rank_map[unique_id] = rank
+            sparse_score_map[unique_id] = result.score
+
+        # 4. Fuse Results
+        logger.info("Fusing results using strategy: %s", fusion_config.strategy.value)
+        fused_results: List[SearchResult] = []
+        if fusion_config.strategy == FusionStrategy.RRF:
+            fused_results = _rrf_fusion(
+                [dense_results, sparse_results], k=fusion_config.rrf_k
+            )
+        elif fusion_config.strategy == FusionStrategy.LINEAR:
+            fused_results = _linear_fusion(
+                dense_results=dense_results,
+                sparse_results=sparse_results,
+                dense_weight=fusion_config.dense_weight,
+                sparse_weight=fusion_config.sparse_weight,
+                normalize_scores=fusion_config.normalize_scores,
+            )
+        else:
+            logger.warning(
+                "Unknown fusion strategy: %s. Defaulting to dense results.",
+                fusion_config.strategy,
+            )
+            fused_results = dense_results
+
+        # 5. Attach original scores and ranks to fused results
+        updated_fused_results: List[SearchResult] = []
+        for result in fused_results:
+            unique_id = f"{result.doc_id}-{result.chunk_id}-{result.parse_hash}-{result.model_tag}"
+            updated_fused_results.append(
+                result.model_copy(
+                    update={
+                        "vector_score": dense_score_map.get(unique_id),
+                        "fts_score": sparse_score_map.get(unique_id),
+                        "vector_rank": dense_rank_map.get(unique_id),
+                        "fts_rank": sparse_rank_map.get(unique_id),
+                    }
+                )
+            )
+        fused_results = updated_fused_results
+
+        # Limit to top_k after fusion
+        final_results = fused_results[:top_k]
+
+        # 6. Build Response
+        return HybridSearchResponse(
+            results=final_results,
+            total_count=len(final_results),
+            status="success" if not all_warnings else "partial_success",
+            warnings=all_warnings,
+            fusion_config=fusion_config,
+            dense_count=len(dense_results),
+            sparse_count=len(sparse_results),
+            index_status=index_status,
+            index_advice=index_advice,
+        )
+
+    async def search_hybrid_async(
+        self,
+        model_tag: str,
+        query_text: str,
+        query_vector: list[float],
+        *,
+        top_k: int = 10,
+        filters: Any = None,
+        fusion_config: FusionConfig | None = None,
+        readonly: bool = False,
+        nprobes: int | None = None,
+        refine_factor: int | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> HybridSearchResponse:
+        """Async hybrid (dense + sparse) search with fusion for this collection."""
+        if not self.capabilities.supports_search:
+            return self._hybrid_unsupported(model_tag, fusion_config)
+
+        if fusion_config is None:
+            fusion_config = FusionConfig()
+
+        # 1. Execute Dense Search (async)
+        logger.info("Executing async dense search for model %s...", model_tag)
+        dense_response = await self.search_dense_async(
+            model_tag,
+            query_vector,
+            top_k=top_k * 2,
+            filters=filters,
+            readonly=readonly,
+            nprobes=nprobes,
+            refine_factor=refine_factor,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+        # 2. Execute Sparse Search (async)
+        logger.info("Executing async sparse search for model %s...", model_tag)
+        sparse_response = await self.search_sparse_async(
+            model_tag,
+            query_text,
+            top_k=top_k * 2,
+            filters=filters,
+            readonly=readonly,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+        # 3-6. Fuse and build the response (shared sync logic).
+        return self._fuse_hybrid(
+            model_tag,
+            query_text,
+            dense_response,
+            sparse_response,
+            top_k=top_k,
+            fusion_config=fusion_config,
+        )
+
+    # --- Parse/chunk cleanup (row only, collection scoped) (#509) ---
+
+    def delete_parse_records(
+        self,
+        doc_id: str,
+        *,
+        parse_hash: str | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> int:
+        """Delete parse rows for a document via the bound store (no cascade)."""
+        return self.vector_index_store.delete_parse_records(
+            collection_name=self.context.collection,
+            doc_id=doc_id,
+            parse_hash=parse_hash,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    def delete_chunk_records(
+        self,
+        doc_id: str,
+        *,
+        parse_hash: str | None = None,
+        config_hash: str | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> int:
+        """Delete chunk rows for a document via the bound store (no cascade)."""
+        return self.vector_index_store.delete_chunk_records(
+            collection_name=self.context.collection,
+            doc_id=doc_id,
+            parse_hash=parse_hash,
+            config_hash=config_hash,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    # --- Parse/chunk rollback compensation (methods only; wiring in #514) ---
+
+    def snapshot_parse(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> ParseRecordDetail | None:
+        """Capture a parse row before a destructive operation (None if absent)."""
+        return self.read_latest_parse_record(
+            doc_id, parse_hash=parse_hash, user_id=user_id, is_admin=is_admin
+        )
+
+    def restore_parse(self, snapshot: ParseRecordDetail) -> None:
+        """Restore a snapshotted parse row, preserving every field.
+
+        Refuses snapshots from another collection so the collection-scoped
+        boundary holds even on direct handle reuse.
+        """
+        if snapshot.collection != self.context.collection:
+            raise DocumentValidationError(
+                f"Handle bound to collection {self.context.collection!r} "
+                f"cannot restore a parse snapshot from {snapshot.collection!r}"
+            )
+        self.vector_index_store.upsert_parses([snapshot.to_legacy_dict()])
+
+    def delete_created_parse(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> int:
+        """Idempotently delete a newly created parse row (compensation)."""
+        return self.delete_parse_records(
+            doc_id, parse_hash=parse_hash, user_id=user_id, is_admin=is_admin
+        )
+
+    def snapshot_chunks(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        config_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> ChunkRecordSnapshot | None:
+        """Capture all chunk rows for a config (None if none exist)."""
+        vector_store = self.vector_index_store
+        query_filters = {
+            "collection": self.context.collection,
+            "doc_id": doc_id,
+            "parse_hash": parse_hash,
+            "config_hash": config_hash,
+        }
+        try:
+            if (
+                vector_store.count_rows_or_zero(
+                    "chunks", filters=query_filters, user_id=user_id, is_admin=is_admin
+                )
+                == 0
+            ):
+                return None
+            rows: list[dict[str, Any]] = []
+            for batch in vector_store.iter_batches(
+                table_name="chunks",
+                filters=query_filters,
+                user_id=user_id,
+                is_admin=is_admin,
+            ):
+                rows.extend(batch.to_pylist())
+            if not rows:
+                return None
+            # Preserve original chunk order for a faithful restore.
+            rows.sort(key=lambda row: row.get("index") or 0)
+            return ChunkRecordSnapshot.from_rows(rows)
+        except Exception as e:
+            logger.error("Failed to snapshot chunks: %s", e)
+            raise DatabaseOperationError(f"Failed to snapshot chunks: {e}") from e
+
+    def restore_chunks(self, snapshot: ChunkRecordSnapshot) -> None:
+        """Restore snapshotted chunk rows, preserving every field.
+
+        Refuses snapshots whose rows belong to another collection so the
+        collection-scoped boundary holds even on direct handle reuse.
+        """
+        rows = snapshot.to_legacy_dicts()
+        if not rows:
+            return
+        for chunk in snapshot.chunks:
+            if chunk.collection != self.context.collection:
+                raise DocumentValidationError(
+                    f"Handle bound to collection {self.context.collection!r} "
+                    f"cannot restore a chunk snapshot from {chunk.collection!r}"
+                )
+        self.vector_index_store.upsert_chunks(rows)
+
+    def delete_created_chunks(
+        self,
+        doc_id: str,
+        parse_hash: str,
+        config_hash: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> int:
+        """Idempotently delete newly created chunk rows (compensation)."""
+        return self.delete_chunk_records(
+            doc_id,
+            parse_hash=parse_hash,
+            config_hash=config_hash,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    # --- Version cascade cleanup (Task 5) ---
+
+    def cleanup_cascade(
+        self,
+        doc_id: str,
+        scope: str,
+        *,
+        new_parse_hash: Optional[str] = None,
+        old_parse_hash: Optional[str] = None,
+        model_tag: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: Optional[bool] = None,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> Dict[str, int]:
+        """Policy layer: is_admin=None → True, then delegate to store."""
+        from ..utils.user_scope import resolve_user_scope
+
+        if is_admin is None:
+            is_admin = True
+        user_scope = resolve_user_scope(user_id=user_id, is_admin=is_admin)
+        return self.vector_index_store.cleanup_cascade_by_scope(
+            collection=self.context.collection,
+            doc_id=doc_id,
+            scope=scope,
+            new_parse_hash=new_parse_hash,
+            old_parse_hash=old_parse_hash,
+            model_tag=model_tag,
+            user_id=user_scope.user_id,
+            is_admin=user_scope.is_admin,
+            preview_only=preview_only,
+            confirm=confirm,
+        )
+
+    def cleanup_document_cascade(
+        self,
+        doc_id: str,
+        *,
+        model_tag: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = True,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> Dict[str, int]:
+        from ..core.exceptions import CascadeCleanupError
+
+        try:
+            return self.cleanup_cascade(
+                doc_id,
+                "document",
+                model_tag=model_tag,
+                user_id=user_id,
+                is_admin=is_admin,
+                preview_only=preview_only,
+                confirm=confirm,
+            )
+        except Exception as e:
+            raise CascadeCleanupError(f"Failed to cleanup document cascade: {e}") from e
+
+    def cleanup_parse_cascade(
+        self,
+        doc_id: str,
+        *,
+        old_parse_hash: Optional[str] = None,
+        new_parse_hash: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = True,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> Dict[str, int]:
+        from ..core.exceptions import CascadeCleanupError
+
+        try:
+            return self.cleanup_cascade(
+                doc_id,
+                "parse",
+                old_parse_hash=old_parse_hash,
+                new_parse_hash=new_parse_hash,
+                user_id=user_id,
+                is_admin=is_admin,
+                preview_only=preview_only,
+                confirm=confirm,
+            )
+        except Exception as e:
+            raise CascadeCleanupError(f"Failed to cleanup parse cascade: {e}") from e
+
+    def cleanup_chunk_cascade(
+        self,
+        doc_id: str,
+        *,
+        old_parse_hash: Optional[str] = None,
+        new_parse_hash: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = True,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> Dict[str, int]:
+        from ..core.exceptions import CascadeCleanupError
+
+        try:
+            return self.cleanup_cascade(
+                doc_id,
+                "chunk",
+                old_parse_hash=old_parse_hash,
+                new_parse_hash=new_parse_hash,
+                user_id=user_id,
+                is_admin=is_admin,
+                preview_only=preview_only,
+                confirm=confirm,
+            )
+        except Exception as e:
+            raise CascadeCleanupError(f"Failed to cleanup chunk cascade: {e}") from e
+
+    def cleanup_embed_cascade(
+        self,
+        doc_id: str,
+        *,
+        model_tag: Optional[str] = None,
+        user_id: Optional[int] = None,
+        is_admin: bool = True,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> Dict[str, int]:
+        from ..core.exceptions import CascadeCleanupError
+
+        try:
+            return self.cleanup_cascade(
+                doc_id,
+                "embeddings",
+                model_tag=model_tag,
+                user_id=user_id,
+                is_admin=is_admin,
+                preview_only=preview_only,
+                confirm=confirm,
+            )
+        except Exception as e:
+            raise CascadeCleanupError(f"Failed to cleanup embed cascade: {e}") from e
+
+    # --- Ingestion-status data-plane (#513) ---
+
+    def write_ingestion_status(
+        self,
+        doc_id: str,
+        *,
+        status: str,
+        message: str | None = None,
+        parse_hash: str | None = None,
+        user_id: int | None = None,
+    ) -> None:
+        """Write ingestion status for a document in this collection (sync)."""
+        self.ingestion_status_store.write_ingestion_status(
+            collection=self.context.collection,
+            doc_id=doc_id,
+            status=status,
+            message=message,
+            parse_hash=parse_hash,
+            user_id=user_id,
+        )
+
+    def load_ingestion_status(
+        self,
+        *,
+        doc_id: str | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Load ingestion status rows for this collection (sync)."""
+        return self.ingestion_status_store.load_ingestion_status(
+            collection=self.context.collection,
+            doc_id=doc_id,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    def clear_ingestion_status(
+        self,
+        doc_id: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> None:
+        """Remove ingestion status row for a document in this collection (sync)."""
+        self.ingestion_status_store.clear_ingestion_status(
+            collection=self.context.collection,
+            doc_id=doc_id,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    # --- Collection-level cascade delete (#H05) ---
+
+    def delete_collection_data(
+        self,
+        *,
+        user_id: int | None,
+        is_admin: bool,
+        warnings_out: list[str] | None = None,
+    ) -> dict[str, int]:
+        """Delete all data for this collection from vector-side tables.
+
+        Delegates to the bound vector index store's ``delete_collection_data``,
+        passing ``self.context.collection`` so the handle boundary is respected.
+        Subsequent reads will not observe stale cached table handles because the
+        store invalidates its table cache internally.
+        """
+        return self.vector_index_store.delete_collection_data(
+            collection_name=self.context.collection,
+            user_id=user_id,
+            is_admin=is_admin,
+            warnings_out=warnings_out,
+        )
+
+    def delete_documents_data(
+        self,
+        doc_ids: list[str],
+        *,
+        user_id: int | None,
+        is_admin: bool,
+        warnings_out: list[str] | None = None,
+    ) -> dict[str, int]:
+        """Delete vector-side data for specific document IDs in this collection.
+
+        Delegates to the bound vector index store's ``delete_documents_data``.
+        On partial failure the store raises ``DatabaseOperationError`` with
+        ``details={"deleted_counts": ..., "deleted_doc_ids": ..., "failed_batch_index": ...}``
+        which is the downstream contract for ``CollectionOperationResult.partial_success``.
+        That exception propagates unchanged so callers receive the exact details dict.
+        """
+        return self.vector_index_store.delete_documents_data(
+            collection_name=self.context.collection,
+            doc_ids=doc_ids,
+            user_id=user_id,
+            is_admin=is_admin,
+            warnings_out=warnings_out,
+        )
+
+    # --- Collection-level rename primitives (#H05 Phase 2) ---
+
+    def rename_collection_data(
+        self,
+        new_name: str,
+        user_id: int | None,
+        is_admin: bool,
+        warnings_out: list[str] | None = None,
+    ) -> list[str]:
+        """Rename the collection field across all vector-side data tables.
+
+        Delegates to the bound vector index store's ``rename_collection_data``,
+        passing ``self.context.collection`` as the old name.  The coordinator
+        should call this via ``asyncio.to_thread`` when running in an async
+        context.
+
+        The table cache is invalidated after the rename so that subsequent
+        ``count_rows`` / ``iter_batches`` calls see the updated rows (matching
+        the behaviour of ``delete_collection_data``).
+
+        Returns:
+            List of per-table warning messages (empty on full success).
+        """
+        store = self.vector_index_store
+        warnings = store.rename_collection_data(
+            collection_name=self.context.collection,
+            new_name=new_name,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+        # Invalidate the table cache so subsequent reads observe the renamed rows.
+        if hasattr(store, "invalidate_table_cache"):
+            store.invalidate_table_cache()
+        if warnings_out is not None:
+            warnings_out.extend(warnings)
+        return warnings
+
+    def rename_collection_status(
+        self,
+        new_name: str,
+        user_id: int | None,
+        is_admin: bool,
+    ) -> list[str]:
+        """Rename ingestion status rows from this collection to ``new_name``.
+
+        Best-effort: never raises; returns a list of warning strings on
+        partial failures.
+        """
+        try:
+            return self.ingestion_status_store.rename_collection_status(
+                old_name=self.context.collection,
+                new_name=new_name,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "rename_collection_status(%r -> %r) failed: %s",
+                self.context.collection,
+                new_name,
+                exc,
+            )
+            return [str(exc)]
+
+    async def rename_collection_status_async(
+        self,
+        new_name: str,
+        user_id: int | None,
+        is_admin: bool,
+    ) -> List[str]:
+        """Rename ingestion status rows from this collection to ``new_name`` (async).
+
+        Best-effort: never raises; returns a list of warning strings on
+        partial failures.
+        """
+        try:
+            return await self.ingestion_status_store.rename_collection_status_async(
+                old_name=self.context.collection,
+                new_name=new_name,
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "rename_collection_status_async(%r -> %r) failed: %s",
+                self.context.collection,
+                new_name,
+                exc,
+            )
+            return [str(exc)]
+
+    async def rename_collection_metadata(
+        self,
+        new_name: str,
+        user_id: int | None,
+        is_admin: bool,
+    ) -> None:
+        """Rename control-plane metadata rows to ``new_name``.
+
+        This is the **only** async method on ``KBCollectionHandle``.  It wraps
+        ``await metadata_store.rename_collection(...)`` which updates the
+        ``collection_config`` and ``collection_metadata`` rows.  The coordinator
+        calls this directly with ``await`` (no ``asyncio.to_thread`` wrapper
+        needed, unlike the two sync rename primitives above).
+
+        Args:
+            new_name: Target collection name.
+            user_id: User ID for tenant-scoped rename.
+            is_admin: When ``True`` renames across all tenants.
+        """
+        await self.metadata_store.rename_collection(
+            old_name=self.context.collection,
+            new_name=new_name,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    # --- Collection-level statistics (#H05 Phase 3) ---
+
+    def collection_stats(self, user_id: int | None, is_admin: bool) -> dict[str, int]:
+        """Return aggregate statistics for this collection.
+
+        Counts document rows, chunk rows, and all embedding rows (summed across
+        all ``embeddings_*`` tables) that are visible to the caller under the
+        given user/admin scope.
+
+        Returns:
+            A ``dict`` with keys ``"documents"``, ``"chunks"``, and
+            ``"embeddings"``.
+        """
+        collection = self.context.collection
+        store = self.vector_index_store
+
+        documents = store.count_rows_or_zero(
+            "documents",
+            filters={"collection": collection},
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+        chunks = store.count_rows_or_zero(
+            "chunks",
+            filters={"collection": collection},
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+        embeddings = sum(
+            store.count_rows_or_zero(
+                table_name,
+                filters={"collection": collection},
+                user_id=user_id,
+                is_admin=is_admin,
+            )
+            for table_name in store.list_table_names()
+            if table_name.startswith("embeddings_")
+        )
+        return {
+            "documents": documents,
+            "chunks": chunks,
+            "embeddings": embeddings,
+        }
+
+    def count_documents(self, user_id: int | None, is_admin: bool) -> int:
+        """Count documents visible to the given user in this collection.
+
+        When ``is_admin`` is ``True`` all rows are counted regardless of
+        ``user_id``.  Otherwise only rows owned by ``user_id`` are counted.
+        """
+        return self.vector_index_store.count_rows_or_zero(
+            "documents",
+            filters={"collection": self.context.collection},
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    def list_collection_documents(
+        self,
+        user_id: int | None,
+        is_admin: bool,
+        max_results: int = 1_000_000,
+    ) -> list[str]:
+        """List document IDs for this collection.
+
+        Delegates to the bound vector index store's ``list_document_records`` and
+        returns a sorted list of unique doc_id strings.  The coordinator uses this
+        before deletion to collect tenant-owned doc_ids (when the caller has not
+        pre-computed them) and to populate ``affected_documents`` in the result.
+        """
+        store = self.vector_index_store
+        records = store.list_document_records(
+            collection_name=self.context.collection,
+            user_id=user_id,
+            is_admin=is_admin,
+            max_results=max_results,
+        )
+        return sorted({r.doc_id for r in records})
+
+    # --- Collection-level rollback config primitives (#H05 Phase 4) ---
+
+    async def delete_collection_config(self, *, tenant_only: bool = False) -> int:
+        """Delete the collection_config row(s) for this collection (idempotent).
+
+        When ``tenant_only`` is ``False`` (default) delegates with
+        ``is_admin=True`` so all tenant rows for this collection are removed.
+        When ``tenant_only`` is ``True`` uses the handle's bound user scope so
+        only that tenant's config row is removed, leaving other tenants' rows
+        intact.  Returns the number of config rows deleted (0 when none
+        existed).
+
+        ``delete_orphaned_metadata=True`` lets the metadata store drop the
+        collection_metadata record once removing this tenant's config row
+        leaves the collection with zero config rows (a true orphan).  This is
+        scope-safe: it only ever deletes the current tenant's own config row
+        and the shared metadata record when nothing remains — it never touches
+        another tenant's config row.
+        """
+        if tenant_only:
+            user_id = self.context.user_scope.user_id
+            is_admin = self.context.user_scope.is_admin
+        else:
+            user_id = None
+            is_admin = True
+        result = await self.metadata_store.delete_collection_metadata(
+            collection_name=self.context.collection,
+            user_id=user_id,
+            is_admin=is_admin,
+            delete_orphaned_metadata=True,
+        )
+        return result.get("config_rows", 0)
+
+    def cleanup_collection_data_after_rollback(
+        self,
+        *,
+        user_id: int | None,
+        is_admin: bool,
+    ) -> dict[str, int]:
+        """Remove all vector-side data for this collection (rollback compensation).
+
+        Composes the Phase 1 :meth:`delete_collection_data` primitive.  Does
+        **not** access the filesystem; physical file cleanup is the caller's
+        responsibility.
+
+        Returns a ``dict[str, int]`` mapping table names to deleted row counts.
+        """
+        return self.delete_collection_data(user_id=user_id, is_admin=is_admin)
+
+    def cleanup_embeddings_for_operation(
+        self,
+        *,
+        doc_id: Optional[str] = None,
+        parse_hash: Optional[str] = None,
+        chunk_ids: Optional[Sequence[str]] = None,
+        model_tag: Optional[str] = None,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> "KBVectorStorageCleanupResult":
+        """Delete or preview embedding rows for a failed operation (#515).
+
+        Ports the former facade ``_cleanup_vectors_for_operation_impl``: builds
+        per-table predicates via ``kb/cleanup_filters`` (relocation tracked in
+        #821), counts/deletes through this handle's raw store connection, and
+        derives status / side_effects_may_remain exactly as before.
+        """
+        from ..utils.lancedb_query_utils import _safe_count_rows
+        from .cleanup_filters import KBCleanupScope, build_embedding_cleanup_filters
+        from .models import KBVectorStorageCleanupResult
+
+        scope = KBCleanupScope(
+            collection=self.context.collection,
+            user_id=self.context.user_scope.user_id,
+            is_admin=self.context.user_scope.is_admin,
+            doc_id=doc_id,
+            parse_hash=parse_hash,
+            chunk_ids=tuple(chunk_ids or ()),
+            model_tag=model_tag,
+        )
+        conn = self.vector_index_store.get_raw_connection()
+
+        table_counts: dict[str, int] = {}
+        warnings: list[str] = []
+        side_effects_may_remain = False
+        should_delete = bool(confirm and not preview_only)
+        table_filters = build_embedding_cleanup_filters(conn, scope)
+
+        if not table_filters:
+            return KBVectorStorageCleanupResult(
+                collection=scope.collection,
+                status="skipped",
+                deleted_count=0,
+                table_counts={},
+                model_tag=scope.model_tag,
+                preview_only=preview_only,
+            )
+
+        for table_name, filter_exprs in table_filters.items():
+            table = None
+            try:
+                table = conn.open_table(table_name)
+                count = 0
+                for filter_expr in filter_exprs:
+                    matched = _safe_count_rows(table, filter_expr, on_error="raise")
+                    if should_delete and matched > 0:
+                        table.delete(filter_expr)
+                    count += matched
+                table_counts[table_name] = count
+            except Exception as exc:  # noqa: BLE001 - report rollback cleanup state
+                side_effects_may_remain = True
+                message = f"{table_name}: {exc}"
+                warnings.append(message)
+                logger.warning("Vector cleanup failed for %s: %s", table_name, exc)
+            finally:
+                _safe_close_table(table)
+
+        deleted_count = sum(table_counts.values())
+        if warnings:
+            status = "incomplete"
+        elif should_delete:
+            status = "complete"
+        else:
+            status = "planned"
+
+        return KBVectorStorageCleanupResult(
+            collection=scope.collection,
+            status=status,
+            deleted_count=deleted_count,
+            table_counts=table_counts,
+            model_tag=scope.model_tag,
+            preview_only=preview_only,
+            warnings=tuple(warnings),
+            side_effects_may_remain=side_effects_may_remain,
+        )
+
+    # --- Rollback snapshot/restore/clear primitives (#513 Task 7) ---
+
+    def capture_status_snapshot(
+        self,
+        doc_id: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = True,
+    ) -> List[Dict[str, Any]]:
+        """Capture the current ingestion-status rows for ``doc_id`` (snapshot).
+
+        Returns the list of status rows as returned by ``load_ingestion_status``.
+        An empty list means no status row exists (snapshot of absence).
+        """
+        return self.load_ingestion_status(
+            doc_id=doc_id, user_id=user_id, is_admin=is_admin
+        )
+
+    def restore_status_snapshot(
+        self,
+        doc_id: str,
+        snapshot: List[Dict[str, Any]],
+        *,
+        user_id: int | None = None,
+    ) -> None:
+        """Restore an ingestion-status snapshot captured by ``capture_status_snapshot``.
+
+        If ``snapshot`` is empty the status row is cleared (restoring absence).
+        If ``snapshot`` contains a row it is re-written (restoring the prior state).
+        """
+        if not snapshot:
+            self.clear_ingestion_status(doc_id, user_id=user_id, is_admin=True)
+            return
+        for row in snapshot:
+            self.write_ingestion_status(
+                doc_id,
+                status=row.get("status", ""),
+                message=row.get("message"),
+                parse_hash=row.get("parse_hash"),
+                user_id=row.get("user_id"),
+            )
+
+    def clear_status_snapshot(
+        self,
+        doc_id: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = True,
+    ) -> None:
+        """Clear the ingestion-status row for ``doc_id`` (post-rollback cleanup).
+
+        Thin wrapper over ``clear_ingestion_status`` for the rollback path.
+        """
+        self.clear_ingestion_status(doc_id, user_id=user_id, is_admin=is_admin)
+
+    def capture_main_pointer_snapshot(
+        self,
+        doc_id: str,
+        step_type: str,
+        model_tag: str | None = None,
+    ) -> "KBMainPointerSnapshot":
+        """Capture the current main-pointer row as a snapshot before mutation.
+
+        Returns a :class:`KBMainPointerSnapshot`; ``pointer`` is ``None`` when
+        no pointer exists (snapshot of absence).
+        """
+        return KBMainPointerSnapshot(
+            collection=self.context.collection,
+            doc_id=doc_id,
+            step_type=step_type,
+            model_tag=model_tag,
+            pointer=self.get_main_pointer(doc_id, step_type, model_tag),
+        )
+
+    def restore_main_pointer_snapshot(
+        self,
+        snapshot: "KBMainPointerSnapshot",
+        *,
+        operator: str | None = None,
+    ) -> bool:
+        """Restore the main pointer to the state recorded in ``snapshot``.
+
+        If ``snapshot.pointer`` is ``None`` the pointer is deleted (restoring
+        absence).  Returns ``True`` on success, ``False`` when the snapshot
+        pointer is incomplete (missing ``semantic_id`` or ``technical_id``).
+        """
+        if snapshot.pointer is None:
+            self.delete_main_pointer(
+                snapshot.doc_id, snapshot.step_type, snapshot.model_tag
+            )
+            return True
+
+        semantic_id = snapshot.pointer.get("semantic_id")
+        technical_id = snapshot.pointer.get("technical_id")
+        if not semantic_id or not technical_id:
+            logger.warning(
+                "Failed to restore main pointer snapshot for %s/%s/%s: "
+                "missing semantic_id or technical_id",
+                snapshot.collection,
+                snapshot.doc_id,
+                snapshot.step_type,
+            )
+            return False
+
+        self.set_main_pointer(
+            snapshot.doc_id,
+            snapshot.step_type,
+            semantic_id,
+            technical_id,
+            model_tag=snapshot.model_tag,
+            operator=operator,
+        )
+        return True
+
+    def capture_candidate_cleanup_snapshot(
+        self,
+        doc_id: str,
+        scope: str,
+        *,
+        new_parse_hash: str | None = None,
+        old_parse_hash: str | None = None,
+        model_tag: str | None = None,
+        user_id: int | None = None,
+        is_admin: bool | None = None,
+    ) -> "KBVersionCandidateCleanupSnapshot":
+        """Capture a preview of what candidate cleanup would delete (preview_only=True).
+
+        The preview counts are stored in the snapshot; no rows are actually
+        deleted.  The snapshot can later be passed to
+        ``restore_candidate_cleanup_snapshot`` to determine rollback feasibility.
+        """
+        cleanup_counts = self.cleanup_cascade(
+            doc_id,
+            scope,
+            new_parse_hash=new_parse_hash,
+            old_parse_hash=old_parse_hash,
+            model_tag=model_tag,
+            user_id=user_id,
+            is_admin=is_admin,
+            preview_only=True,
+            confirm=False,
+        )
+        return KBVersionCandidateCleanupSnapshot(
+            collection=self.context.collection,
+            doc_id=doc_id,
+            scope=scope,
+            cleanup_counts=cleanup_counts,
+            new_parse_hash=new_parse_hash,
+            old_parse_hash=old_parse_hash,
+            model_tag=model_tag,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    def restore_candidate_cleanup_snapshot(
+        self,
+        snapshot: "KBVersionCandidateCleanupSnapshot",
+        *,
+        cleanup_executed: bool = False,
+    ) -> "KBVersionCandidateRollbackResult":
+        """Assess rollback feasibility for a candidate-cleanup snapshot.
+
+        When ``cleanup_executed=True`` and the snapshot recorded side effects,
+        returns a result with ``status="incomplete"``, ``restorable=False``,
+        and ``side_effects_may_remain=True`` — the inspectable-incomplete
+        invariant.  Never issues further deletes; the state is left inspectable.
+        """
+        cleanup_counts = dict(snapshot.cleanup_counts)
+        has_candidate_side_effects = any(
+            int(count) > 0 for count in cleanup_counts.values()
+        )
+        if not cleanup_executed or not has_candidate_side_effects:
+            return KBVersionCandidateRollbackResult(
+                collection=snapshot.collection,
+                doc_id=snapshot.doc_id,
+                status="not_needed",
+                restorable=True,
+                cleanup_counts=cleanup_counts,
+            )
+
+        return KBVersionCandidateRollbackResult(
+            collection=snapshot.collection,
+            doc_id=snapshot.doc_id,
+            status="incomplete",
+            skipped=True,
+            restorable=False,
+            reason="candidate_cleanup_not_restorable",
+            cleanup_counts=cleanup_counts,
+            warnings=(
+                "Version candidate cleanup cannot be restored from the handle; "
+                "preserve visible rollback state and report remaining side effects.",
+            ),
+            side_effects_may_remain=True,
+        )
+
+    async def write_ingestion_status_async(
+        self,
+        doc_id: str,
+        *,
+        status: str,
+        message: str | None = None,
+        parse_hash: str | None = None,
+        user_id: int | None = None,
+    ) -> None:
+        """Write ingestion status for a document in this collection (async)."""
+        await self.ingestion_status_store.write_ingestion_status_async(
+            collection=self.context.collection,
+            doc_id=doc_id,
+            status=status,
+            message=message,
+            parse_hash=parse_hash,
+            user_id=user_id,
+        )
+
+    async def load_ingestion_status_async(
+        self,
+        *,
+        doc_id: str | None = None,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> List[Dict[str, Any]]:
+        """Load ingestion status rows for this collection (async)."""
+        return await self.ingestion_status_store.load_ingestion_status_async(
+            collection=self.context.collection,
+            doc_id=doc_id,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    async def clear_ingestion_status_async(
+        self,
+        doc_id: str,
+        *,
+        user_id: int | None = None,
+        is_admin: bool = False,
+    ) -> None:
+        """Remove ingestion status row for a document in this collection (async)."""
+        await self.ingestion_status_store.clear_ingestion_status_async(
+            collection=self.context.collection,
+            doc_id=doc_id,
+            user_id=user_id,
+            is_admin=is_admin,
+        )
+
+    # --- Main-pointer data-plane (#513) ---
+
+    def get_main_pointer(
+        self,
+        doc_id: str,
+        step_type: str,
+        model_tag: str | None = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Get the main pointer for a document stage in this collection (sync)."""
+        try:
+            return self.main_pointer_store.get_main_pointer(
+                collection=self.context.collection,
+                doc_id=doc_id,
+                step_type=step_type,
+                model_tag=model_tag,
+                user_id=None,
+            )
+        except Exception as e:
+            raise MainPointerError(f"Failed to get main pointer: {e}") from e
+
+    def set_main_pointer(
+        self,
+        doc_id: str,
+        step_type: str,
+        semantic_id: str,
+        technical_id: str,
+        model_tag: str | None = None,
+        operator: str | None = None,
+    ) -> None:
+        """Set or update the main pointer for a document stage in this collection (sync)."""
+        try:
+            self.main_pointer_store.set_main_pointer(
+                collection=self.context.collection,
+                doc_id=doc_id,
+                step_type=step_type,
+                semantic_id=semantic_id,
+                technical_id=technical_id,
+                model_tag=model_tag,
+                operator=operator,
+                user_id=None,
+            )
+        except Exception as e:
+            raise MainPointerError(f"Failed to set main pointer: {e}") from e
+
+    def list_main_pointers(
+        self,
+        doc_id: str | None = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        """List main pointers for this collection (sync)."""
+        try:
+            return self.main_pointer_store.list_main_pointers(
+                collection=self.context.collection,
+                doc_id=doc_id,
+                user_id=None,
+                limit=limit,
+            )
+        except Exception as e:
+            raise MainPointerError(f"Failed to list main pointers: {e}") from e
+
+    def delete_main_pointer(
+        self,
+        doc_id: str,
+        step_type: str,
+        model_tag: str | None = None,
+    ) -> bool:
+        """Delete the main pointer for a document stage in this collection (sync)."""
+        try:
+            return self.main_pointer_store.delete_main_pointer(
+                collection=self.context.collection,
+                doc_id=doc_id,
+                step_type=step_type,
+                model_tag=model_tag,
+                user_id=None,
+            )
+        except Exception as e:
+            raise MainPointerError(f"Failed to delete main pointer: {e}") from e
+
+    async def get_main_pointer_async(
+        self,
+        doc_id: str,
+        step_type: str,
+        model_tag: str | None = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Get the main pointer for a document stage in this collection (async)."""
+        try:
+            return await self.main_pointer_store.get_main_pointer_async(
+                collection=self.context.collection,
+                doc_id=doc_id,
+                step_type=step_type,
+                model_tag=model_tag,
+                user_id=None,
+            )
+        except Exception as e:
+            raise MainPointerError(f"Failed to get main pointer: {e}") from e
+
+    async def set_main_pointer_async(
+        self,
+        doc_id: str,
+        step_type: str,
+        semantic_id: str,
+        technical_id: str,
+        model_tag: str | None = None,
+        operator: str | None = None,
+    ) -> None:
+        """Set or update the main pointer for a document stage in this collection (async)."""
+        try:
+            await self.main_pointer_store.set_main_pointer_async(
+                collection=self.context.collection,
+                doc_id=doc_id,
+                step_type=step_type,
+                semantic_id=semantic_id,
+                technical_id=technical_id,
+                model_tag=model_tag,
+                operator=operator,
+                user_id=None,
+            )
+        except Exception as e:
+            raise MainPointerError(f"Failed to set main pointer: {e}") from e
+
+    async def list_main_pointers_async(
+        self,
+        doc_id: str | None = None,
+        limit: int = 100,
+    ) -> List[Dict[str, Any]]:
+        """List main pointers for this collection (async)."""
+        try:
+            return await self.main_pointer_store.list_main_pointers_async(
+                collection=self.context.collection,
+                doc_id=doc_id,
+                user_id=None,
+                limit=limit,
+            )
+        except Exception as e:
+            raise MainPointerError(f"Failed to list main pointers: {e}") from e
+
+    async def delete_main_pointer_async(
+        self,
+        doc_id: str,
+        step_type: str,
+        model_tag: str | None = None,
+    ) -> bool:
+        """Delete the main pointer for a document stage in this collection (async)."""
+        try:
+            return await self.main_pointer_store.delete_main_pointer_async(
+                collection=self.context.collection,
+                doc_id=doc_id,
+                step_type=step_type,
+                model_tag=model_tag,
+                user_id=None,
+            )
+        except Exception as e:
+            raise MainPointerError(f"Failed to delete main pointer: {e}") from e
+
+    # --- Version candidate listing (#513 Task 4) ---
+
+    def list_candidates(
+        self,
+        doc_id: str,
+        step_type: "Any",
+        model_tag: Optional[str] = None,
+        state: Optional[str] = None,
+        limit: int = 50,
+        order_by: str = "created_at desc",
+    ) -> Dict[str, Any]:
+        """List version candidates for a document/stage within this collection.
+
+        Resolves ``step_type``, calls the vector index store's semantic method,
+        then applies state-filter / total-count capture / sort / limit /
+        result-dict assembly (the orchestration from ``_list_candidates_impl``).
+
+        Args:
+            doc_id: Document ID.
+            step_type: Processing stage as :class:`StepType` enum or string.
+            model_tag: Required for ``embed`` step.
+            state: Optional state filter (``"candidate"``, ``"main"``, etc.).
+            limit: Maximum candidates to return (default 50).
+            order_by: Sort order (``"created_at desc"`` or ``"created_at asc"``).
+
+        Returns:
+            Result dict with keys ``candidates``, ``total_count``,
+            ``returned_count``, ``step_type``, ``model_tag``, ``filters``.
+        """
+        from ..core.exceptions import DatabaseOperationError, VersionManagementError
+        from ..core.schemas import StepType as _StepType
+
+        def _resolve(st: Any) -> "_StepType":
+            if isinstance(st, _StepType):
+                return st
+            elif isinstance(st, str):
+                try:
+                    return _StepType(st)
+                except ValueError:
+                    raise VersionManagementError(
+                        f"Invalid step_type string: '{st}'. Expected one of: "
+                        + ", ".join(["'" + s.value + "'" for s in _StepType])
+                    )
+            else:
+                raise VersionManagementError(
+                    f"Unsupported step_type type: {type(st)}. Expected StepType or str."
+                )
+
+        try:
+            resolved = _resolve(step_type)
+
+            candidates = self.vector_index_store.list_version_candidate_rows(
+                self.context.collection,
+                doc_id,
+                resolved.value,
+                model_tag,
+            )
+
+            # Apply state filter if specified
+            if state is not None:
+                candidates = [c for c in candidates if c["state"] == state]
+
+            # Record total count before limit (after state filter, matching _list_candidates_impl)
+            total_count = len(candidates)
+
+            # Sort by order_by (must happen before limit)
+            if order_by == "created_at desc":
+                candidates.sort(key=lambda x: x["created_at"], reverse=True)
+            elif order_by == "created_at asc":
+                candidates.sort(key=lambda x: x["created_at"], reverse=False)
+
+            # Apply limit after sorting
+            if limit > 0:
+                candidates = candidates[:limit]
+
+            return {
+                "candidates": candidates,
+                "total_count": total_count,
+                "returned_count": len(candidates),
+                "step_type": resolved.value,
+                "model_tag": model_tag,
+                "filters": {"state": state, "limit": limit, "order_by": order_by},
+            }
+
+        except (DatabaseOperationError, VersionManagementError):
+            raise
+        except Exception as e:
+            raise VersionManagementError(f"Failed to list candidates: {e}") from e
+
+    # --- Version promotion orchestration (#513 Task 6) ---
+
+    def _call_cleanup_cascade_for_step(
+        self,
+        doc_id: str,
+        step_type: Any,
+        technical_id: str,
+        old_technical_id: Optional[str] = None,
+        model_tag: Optional[str] = None,
+        preview_only: bool = True,
+        confirm: bool = False,
+    ) -> Dict[str, int]:
+        """Scope-mapping helper: route step_type → cleanup_cascade scope."""
+        from ..core.exceptions import VersionManagementError
+        from ..core.schemas import StepType as _StepType
+
+        if step_type == _StepType.PARSE:
+            return self.cleanup_cascade(
+                doc_id,
+                "parse",
+                new_parse_hash=technical_id,
+                old_parse_hash=old_technical_id,
+                preview_only=preview_only,
+                confirm=confirm,
+            )
+        elif step_type == _StepType.CHUNK:
+            return self.cleanup_cascade(
+                doc_id,
+                "chunk",
+                new_parse_hash=technical_id,
+                old_parse_hash=old_technical_id,
+                preview_only=preview_only,
+                confirm=confirm,
+            )
+        elif step_type == _StepType.EMBED:
+            if not model_tag:
+                raise VersionManagementError("model_tag is required for embed step")
+            return self.cleanup_cascade(
+                doc_id,
+                "embeddings",
+                model_tag=model_tag,
+                preview_only=preview_only,
+                confirm=confirm,
+            )
+        else:
+            step_type_str = (
+                step_type.value if isinstance(step_type, _StepType) else str(step_type)
+            )
+            raise VersionManagementError(f"Invalid step_type: {step_type_str}")
+
+    def _resolve_selected_id_from_candidates(
+        self,
+        doc_id: str,
+        step_type: Any,
+        selected_id: str,
+        model_tag: Optional[str] = None,
+    ) -> tuple:
+        """Resolve selected_id → (technical_id, semantic_id) via list_candidates."""
+        from ..core.exceptions import VersionManagementError
+
+        try:
+            candidates_result = self.list_candidates(
+                doc_id,
+                step_type,
+                model_tag=model_tag,
+            )
+            candidates = candidates_result.get("candidates", [])
+
+            if not candidates:
+                raise VersionManagementError(f"No candidates found for {step_type}")
+
+            for candidate in candidates:
+                if candidate["technical_id"] == selected_id:
+                    return candidate["technical_id"], candidate["semantic_id"]
+
+            for candidate in candidates:
+                if candidate["semantic_id"] == selected_id:
+                    return candidate["technical_id"], candidate["semantic_id"]
+
+            available_ids = [c["semantic_id"] for c in candidates]
+            raise VersionManagementError(
+                f"Selected ID '{selected_id}' not found. Available IDs: {available_ids}"
+            )
+
+        except Exception as e:
+            if isinstance(e, VersionManagementError):
+                raise
+            raise VersionManagementError(f"Failed to resolve selected_id: {e}")
+
+    def _calculate_cleanup_plan_for_step(
+        self,
+        doc_id: str,
+        step_type: Any,
+        technical_id: str,
+        model_tag: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Calculate cleanup plan for a version promotion (preview_only=True)."""
+        from ..core.exceptions import VersionManagementError
+        from ..core.schemas import StepType as _StepType
+
+        try:
+            current_pointer = self.get_main_pointer(doc_id, step_type.value, model_tag)
+            old_technical_id = None
+            if current_pointer:
+                old_technical_id = current_pointer["technical_id"]
+
+            deleted_counts = self._call_cleanup_cascade_for_step(
+                doc_id,
+                step_type,
+                technical_id,
+                old_technical_id=old_technical_id,
+                model_tag=model_tag,
+                preview_only=True,
+                confirm=False,
+            )
+
+            notes = []
+            if step_type == _StepType.PARSE and deleted_counts.get("chunks", 0) > 0:
+                notes.append("Requires re-chunk/embed")
+            elif (
+                step_type == _StepType.CHUNK and deleted_counts.get("embeddings", 0) > 0
+            ):
+                notes.append("Requires re-embed")
+
+            return {
+                "deleted_counts": deleted_counts,
+                "notes": notes,
+                "current_pointer": current_pointer,
+                "new_technical_id": technical_id,
+            }
+
+        except Exception as e:
+            raise VersionManagementError(f"Failed to calculate cleanup plan: {e}")
+
+    def promote_version_main(
+        self,
+        doc_id: str,
+        step_type: "Any",
+        selected_id: str,
+        operator: Optional[str] = None,
+        preview_only: bool = False,
+        confirm: bool = False,
+        model_tag: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Promote a candidate version to main for a document stage (pure orchestration).
+
+        Relocates ``_promote_version_main_impl`` body to the handle, calling
+        handle primitives (``list_candidates``, ``get_main_pointer``,
+        ``cleanup_cascade``, ``set_main_pointer``) instead of module-level fns.
+        The ``lancedb_dir`` resolution is dropped (no longer needed by the handle).
+
+        Args:
+            doc_id: Document ID.
+            step_type: Processing step type (:class:`StepType` or string).
+            selected_id: Technical or semantic ID of the candidate to promote.
+            operator: Operator name (default: ``$USER`` env var or ``"unknown"``).
+            preview_only: If True, only return preview without executing.
+            confirm: If True, execute the promotion.
+            model_tag: Required for embed step.
+
+        Returns:
+            Result dict with keys ``promoted``, ``preview``, ``main_pointer``,
+            ``deleted_counts``, ``notes``, and optionally ``message``/``operator``.
+
+        Raises:
+            VersionManagementError: Any error during the promotion flow.
+        """
+        from ..core.exceptions import VersionManagementError
+        from ..core.schemas import StepType as _StepType
+
+        def _resolve(st: "Any") -> "_StepType":
+            if isinstance(st, _StepType):
+                return st
+            elif isinstance(st, str):
+                try:
+                    return _StepType(st)
+                except ValueError:
+                    raise VersionManagementError(
+                        f"Invalid step_type string: '{st}'. Expected one of: "
+                        + ", ".join(["'" + s.value + "'" for s in _StepType])
+                    )
+            else:
+                raise VersionManagementError(
+                    f"Unsupported step_type type: {type(st)}. Expected StepType or str."
+                )
+
+        resolved_step_type = _resolve(step_type)
+
+        # Validate and set operator
+        if not operator:
+            operator = os.environ.get("USER", "unknown")
+        if len(operator) > 32:
+            raise VersionManagementError("Operator name too long (max 32 characters)")
+
+        try:
+            # Resolve selected_id to technical_id and semantic_id
+            technical_id, semantic_id = self._resolve_selected_id_from_candidates(
+                doc_id, resolved_step_type, selected_id, model_tag
+            )
+
+            # Calculate cleanup plan
+            cleanup_plan = self._calculate_cleanup_plan_for_step(
+                doc_id, resolved_step_type, technical_id, model_tag
+            )
+
+            if preview_only or not confirm:
+                message = (
+                    "Preview of promotion to be applied."
+                    if preview_only
+                    else "Set confirm=True to execute the promotion."
+                )
+                return {
+                    "promoted": False,
+                    "preview": True,
+                    "message": message,
+                    "main_pointer": {
+                        "step_type": resolved_step_type.value,
+                        "semantic_id": semantic_id,
+                        "technical_id": technical_id,
+                        "model_tag": model_tag,
+                    },
+                    "deleted_counts": cleanup_plan["deleted_counts"],
+                    "notes": cleanup_plan["notes"],
+                }
+
+            # Perform cascade cleanup
+            old_technical_id = None
+            if cleanup_plan["current_pointer"]:
+                old_technical_id = cleanup_plan["current_pointer"]["technical_id"]
+
+            deleted_counts = self._call_cleanup_cascade_for_step(
+                doc_id,
+                resolved_step_type,
+                technical_id,
+                old_technical_id=old_technical_id,
+                model_tag=model_tag,
+                preview_only=False,
+                confirm=True,
+            )
+
+            if not deleted_counts:
+                raise VersionManagementError(
+                    f"[Promotion] No records deleted for "
+                    f"{self.context.collection}/{doc_id}/{resolved_step_type.value}"
+                )
+
+            # Update main pointer
+            self.set_main_pointer(
+                doc_id,
+                resolved_step_type.value,
+                semantic_id,
+                technical_id,
+                model_tag,
+                operator,
+            )
+
+            # Generate notes
+            notes = []
+            if (
+                resolved_step_type == _StepType.PARSE
+                and deleted_counts.get("chunks", 0) > 0
+            ):
+                notes.append("Requires re-chunk/embed")
+            elif (
+                resolved_step_type == _StepType.CHUNK
+                and deleted_counts.get("embeddings", 0) > 0
+            ):
+                notes.append("Requires re-embed")
+
+            logger.info(
+                "Promoted version for %s/%s/%s to %s (operator: %s)",
+                self.context.collection,
+                doc_id,
+                resolved_step_type.value,
+                technical_id,
+                operator,
+            )
+
+            return {
+                "promoted": True,
+                "preview": False,
+                "main_pointer": {
+                    "step_type": resolved_step_type.value,
+                    "semantic_id": semantic_id,
+                    "technical_id": technical_id,
+                    "model_tag": model_tag,
+                },
+                "deleted_counts": deleted_counts,
+                "notes": notes,
+                "operator": operator,
+            }
+
+        except Exception as e:
+            if isinstance(e, VersionManagementError):
+                raise
+            raise VersionManagementError(f"Failed to promote version main: {e}") from e

--- a/src/src/xagent/core/tools/core/RAG_tools/retrieval/search_dense.py
+++ b/src/src/xagent/core/tools/core/RAG_tools/retrieval/search_dense.py
@@ -1,0 +1,119 @@
+"""
+Dense vector search implementation for RAG retrieval.
+
+This module provides the main entry point for dense vector search operations,
+handling input validation and delegating to the KB coordinator facade.
+
+Phase 1A Option C: Provides both sync and async search functions.
+"""
+
+import logging
+from typing import TYPE_CHECKING, Any, List, Optional
+
+from ..core.exceptions import DocumentValidationError
+from ..core.schemas import DenseSearchResponse
+from ..vector_storage.vector_manager import validate_query_vector
+
+if TYPE_CHECKING:
+    from ..kb import KBLegacyStepCompatibilityFacade
+
+logger = logging.getLogger(__name__)
+
+
+def _get_legacy_step_compatibility_facade() -> "KBLegacyStepCompatibilityFacade":
+    """Return the coordinator-owned legacy step compatibility facade."""
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().legacy_step_compatibility
+
+
+def _validate_dense_inputs(
+    collection: str, model_tag: str, top_k: int, query_vector: List[float]
+) -> None:
+    """Validate dense-search inputs at the public boundary.
+
+    Raises:
+        DocumentValidationError: If collection/model_tag/top_k are invalid.
+        VectorValidationError: If query-vector validation fails.
+    """
+    if not collection or not isinstance(collection, str):
+        raise DocumentValidationError("Collection must be a non-empty string")
+    if not model_tag or not isinstance(model_tag, str):
+        raise DocumentValidationError("model_tag must be a non-empty string")
+    if top_k <= 0 or top_k > 1000:
+        raise DocumentValidationError("top_k must be between 1 and 1000")
+    validate_query_vector(query_vector)
+
+
+def search_dense(
+    collection: str,
+    model_tag: str,
+    query_vector: List[float],
+    *,
+    top_k: int = 10,
+    filters: Any = None,
+    readonly: bool = False,
+    nprobes: Optional[int] = None,
+    refine_factor: Optional[int] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> DenseSearchResponse:
+    """Execute dense vector search for RAG retrieval.
+
+    Raises:
+        DocumentValidationError: If input validation fails.
+        VectorValidationError: If query-vector validation fails.
+    """
+    # Input validation at the public boundary.
+    _validate_dense_inputs(collection, model_tag, top_k, query_vector)
+
+    return _get_legacy_step_compatibility_facade().search_dense(
+        collection=collection,
+        model_tag=model_tag,
+        query_vector=query_vector,
+        top_k=top_k,
+        filters=filters,
+        readonly=readonly,
+        nprobes=nprobes,
+        refine_factor=refine_factor,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+# --- Async variant (Phase 1A Option C) ---
+
+
+async def search_dense_async(
+    collection: str,
+    model_tag: str,
+    query_vector: List[float],
+    *,
+    top_k: int = 10,
+    filters: Any = None,
+    readonly: bool = False,
+    nprobes: Optional[int] = None,
+    refine_factor: Optional[int] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> DenseSearchResponse:
+    """Execute dense vector search using async vector store abstraction.
+
+    Raises:
+        DocumentValidationError: If input validation fails.
+        VectorValidationError: If query-vector validation fails.
+    """
+    # Input validation at the public boundary (shared with the sync path).
+    _validate_dense_inputs(collection, model_tag, top_k, query_vector)
+    return await _get_legacy_step_compatibility_facade().search_dense_async(
+        collection=collection,
+        model_tag=model_tag,
+        query_vector=query_vector,
+        top_k=top_k,
+        filters=filters,
+        readonly=readonly,
+        nprobes=nprobes,
+        refine_factor=refine_factor,
+        user_id=user_id,
+        is_admin=is_admin,
+    )

--- a/src/src/xagent/core/tools/core/RAG_tools/retrieval/search_hybrid.py
+++ b/src/src/xagent/core/tools/core/RAG_tools/retrieval/search_hybrid.py
@@ -1,0 +1,227 @@
+"""Hybrid search implementation combining dense and sparse retrieval.
+
+This module provides fusion strategies for combining vector search and
+full-text search results using RRF or linear weighted combination.
+"""
+
+import logging
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+from ..core.exceptions import DocumentValidationError
+from ..core.schemas import (
+    FusionConfig,
+    HybridSearchResponse,
+    SearchResult,
+)
+from ..vector_storage.vector_manager import validate_query_vector
+
+if TYPE_CHECKING:
+    from ..kb import KBLegacyStepCompatibilityFacade
+
+logger = logging.getLogger(__name__)
+
+
+def _rrf_fusion(
+    rank_lists: List[List[SearchResult]], k: int = 60
+) -> List[SearchResult]:
+    """Performs Reciprocal Rank Fusion (RRF) on multiple lists of SearchResult.
+
+    Args:
+        rank_lists: A list of ranked lists, where each inner list contains SearchResult objects.
+        k: A constant that determines the impact of lower ranks. Higher k means smoother curve.
+
+    Returns:
+        A single list of SearchResult objects, fused and re-ranked by RRF score.
+    """
+    fused_scores: Dict[str, float] = {}
+    # Track original search results by a unique identifier to preserve full data
+    result_map: Dict[str, SearchResult] = {}
+
+    for rank_list in rank_lists:
+        for rank, result in enumerate(rank_list, start=1):
+            # Create a unique key for each search result (doc_id + chunk_id + model_tag is a good candidate)
+            unique_id = f"{result.doc_id}-{result.chunk_id}-{result.parse_hash}-{result.model_tag}"
+            fused_scores[unique_id] = fused_scores.get(unique_id, 0.0) + (
+                1.0 / (k + rank)
+            )
+            if unique_id not in result_map:
+                result_map[unique_id] = result.model_copy()  # Store a copy
+
+    # Sort results by fused RRF score in descending order
+    sorted_unique_ids = sorted(
+        fused_scores.keys(), key=lambda uid: fused_scores[uid], reverse=True
+    )
+    fused_results = []
+    for uid in sorted_unique_ids:
+        original_result = result_map[uid]
+        new_score = fused_scores[uid]
+        fused_results.append(
+            original_result.model_copy(update={"score": new_score})
+        )  # Create new instance with updated score
+
+    return fused_results
+
+
+def _linear_fusion(
+    dense_results: List[SearchResult],
+    sparse_results: List[SearchResult],
+    dense_weight: float,
+    sparse_weight: float,
+    normalize_scores: bool,
+) -> List[SearchResult]:
+    """Performs linear weighted fusion on dense and sparse search results.
+
+    Args:
+        dense_results: List of SearchResult objects from dense search.
+        sparse_results: List of SearchResult objects from sparse search.
+        dense_weight: Weight for dense results in linear fusion (0-1).
+        sparse_weight: Weight for sparse results in linear fusion (0-1).
+        normalize_scores: Whether to normalize scores (Min-Max) before fusion.
+
+    Returns:
+        A single list of SearchResult objects, fused and re-ranked.
+    """
+    combined_results: Dict[str, SearchResult] = {}
+
+    def normalize(scores: List[float]) -> List[float]:
+        if not scores or not normalize_scores:
+            return scores
+        min_score = min(scores)
+        max_score = max(scores)
+        if max_score == min_score:
+            logger.debug(
+                "Score normalization skipped: all scores are equal (%f). Returning zeros.",
+                max_score,
+            )
+            return [0.0 for _ in scores]
+        return [(s - min_score) / (max_score - min_score) for s in scores]
+
+    # Extract scores for normalization if needed
+    dense_scores = [r.score for r in dense_results]
+    sparse_scores = [r.score for r in sparse_results]
+
+    normalized_dense_scores = normalize(dense_scores)
+    normalized_sparse_scores = normalize(sparse_scores)
+
+    # Map normalized scores back to results for processing
+    for i, result in enumerate(dense_results):
+        unique_id = (
+            f"{result.doc_id}-{result.chunk_id}-{result.parse_hash}-{result.model_tag}"
+        )
+        current_score = normalized_dense_scores[i] * dense_weight
+        if unique_id not in combined_results:
+            combined_results[unique_id] = result.model_copy(
+                update={"score": current_score}
+            )
+        else:
+            # Create a new SearchResult with updated score
+            existing_result = combined_results[unique_id]
+            updated_score = existing_result.score + current_score
+            combined_results[unique_id] = existing_result.model_copy(
+                update={"score": updated_score}
+            )
+
+    for i, result in enumerate(sparse_results):
+        unique_id = (
+            f"{result.doc_id}-{result.chunk_id}-{result.parse_hash}-{result.model_tag}"
+        )
+        current_score = normalized_sparse_scores[i] * sparse_weight
+        if unique_id not in combined_results:
+            combined_results[unique_id] = result.model_copy(
+                update={"score": current_score}
+            )
+        else:
+            # Create a new SearchResult with updated score
+            existing_result = combined_results[unique_id]
+            updated_score = existing_result.score + current_score
+            combined_results[unique_id] = existing_result.model_copy(
+                update={"score": updated_score}
+            )
+
+    # Extract combined results
+    fused_results = list(combined_results.values())
+
+    # Normalize final scores to [0, 1] range to ensure consistency
+    if fused_results:
+        scores = [r.score for r in fused_results]
+        min_score = min(scores)
+        max_score = max(scores)
+
+        if max_score > min_score:
+            # Min-Max normalization to [0, 1] range
+            fused_results = [
+                r.model_copy(
+                    update={"score": (r.score - min_score) / (max_score - min_score)}
+                )
+                for r in fused_results
+            ]
+        elif max_score == min_score and max_score > 0:
+            # All scores are equal and non-zero, normalize to 1.0
+            fused_results = [r.model_copy(update={"score": 1.0}) for r in fused_results]
+        else:
+            # All scores are zero or negative, set to 0.0
+            fused_results = [r.model_copy(update={"score": 0.0}) for r in fused_results]
+
+    # Sort results by normalized fused score in descending order
+    fused_results.sort(key=lambda r: r.score, reverse=True)
+    return fused_results
+
+
+def _get_legacy_step_compatibility_facade() -> "KBLegacyStepCompatibilityFacade":
+    """Return the coordinator-owned legacy step compatibility facade."""
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().legacy_step_compatibility
+
+
+def _validate_hybrid_inputs(
+    collection: str,
+    model_tag: str,
+    top_k: int,
+    query_text: str,
+    query_vector: List[float],
+) -> None:
+    """Validate hybrid-search inputs at the public boundary."""
+
+    if not collection or not isinstance(collection, str):
+        raise DocumentValidationError("Collection must be a non-empty string")
+    if not model_tag or not isinstance(model_tag, str):
+        raise DocumentValidationError("model_tag must be a non-empty string")
+    if not query_text or not isinstance(query_text, str):
+        raise DocumentValidationError("query_text must be a non-empty string")
+    if top_k <= 0 or top_k > 1000:
+        raise DocumentValidationError("top_k must be between 1 and 1000")
+    validate_query_vector(query_vector)
+
+
+def search_hybrid(
+    collection: str,
+    model_tag: str,
+    query_text: str,
+    query_vector: List[float],
+    *,
+    top_k: int = 10,
+    filters: Any = None,
+    fusion_config: Optional[FusionConfig] = None,
+    readonly: bool = False,
+    nprobes: Optional[int] = None,
+    refine_factor: Optional[int] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> HybridSearchResponse:
+    """Performs hybrid search, combining dense and sparse retrieval."""
+    _validate_hybrid_inputs(collection, model_tag, top_k, query_text, query_vector)
+    return _get_legacy_step_compatibility_facade().search_hybrid(
+        collection=collection,
+        model_tag=model_tag,
+        query_text=query_text,
+        query_vector=query_vector,
+        top_k=top_k,
+        filters=filters,
+        fusion_config=fusion_config,
+        readonly=readonly,
+        nprobes=nprobes,
+        refine_factor=refine_factor,
+        user_id=user_id,
+        is_admin=is_admin,
+    )

--- a/src/src/xagent/core/tools/core/RAG_tools/retrieval/search_sparse.py
+++ b/src/src/xagent/core/tools/core/RAG_tools/retrieval/search_sparse.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Optional
+
+from ..core.exceptions import DocumentValidationError
+from ..core.schemas import (
+    SparseSearchResponse,
+)
+
+if TYPE_CHECKING:
+    from ..kb import KBLegacyStepCompatibilityFacade
+
+logger = logging.getLogger(__name__)
+
+
+def _get_legacy_step_compatibility_facade() -> "KBLegacyStepCompatibilityFacade":
+    """Return the coordinator-owned legacy step compatibility facade."""
+    from ..kb import get_kb_coordinator
+
+    return get_kb_coordinator().legacy_step_compatibility
+
+
+def _validate_sparse_inputs(
+    collection: str,
+    model_tag: str,
+    top_k: int,
+    query_text: str,
+) -> None:
+    """Validate sparse-search inputs at the public boundary."""
+
+    if not collection or not isinstance(collection, str):
+        raise DocumentValidationError("Collection must be a non-empty string")
+    if not model_tag or not isinstance(model_tag, str):
+        raise DocumentValidationError("model_tag must be a non-empty string")
+    if not query_text or not isinstance(query_text, str):
+        raise DocumentValidationError("query_text must be a non-empty string")
+    if top_k <= 0 or top_k > 1000:
+        raise DocumentValidationError("top_k must be between 1 and 1000")
+
+
+def search_sparse(
+    collection: str,
+    model_tag: str,
+    query_text: str,
+    *,
+    top_k: int,
+    filters: Any = None,
+    readonly: bool = False,
+    nprobes: Optional[int] = None,
+    refine_factor: Optional[int] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> SparseSearchResponse:
+    """Performs sparse (Full-Text Search) retrieval on the specified collection."""
+    _validate_sparse_inputs(collection, model_tag, top_k, query_text)
+    return _get_legacy_step_compatibility_facade().search_sparse(
+        collection=collection,
+        model_tag=model_tag,
+        query_text=query_text,
+        top_k=top_k,
+        filters=filters,
+        readonly=readonly,
+        nprobes=nprobes,
+        refine_factor=refine_factor,
+        user_id=user_id,
+        is_admin=is_admin,
+    )
+
+
+# --- Async variant (Phase 1A Option C) ---
+
+
+async def search_sparse_async(
+    collection: str,
+    model_tag: str,
+    query_text: str,
+    *,
+    top_k: int,
+    filters: Any = None,
+    readonly: bool = False,
+    nprobes: Optional[int] = None,
+    refine_factor: Optional[int] = None,
+    user_id: Optional[int] = None,
+    is_admin: bool = False,
+) -> SparseSearchResponse:
+    """Perform sparse retrieval using async vector store abstraction."""
+    _validate_sparse_inputs(collection, model_tag, top_k, query_text)
+    return await _get_legacy_step_compatibility_facade().search_sparse_async(
+        collection=collection,
+        model_tag=model_tag,
+        query_text=query_text,
+        top_k=top_k,
+        filters=filters,
+        readonly=readonly,
+        nprobes=nprobes,
+        refine_factor=refine_factor,
+        user_id=user_id,
+        is_admin=is_admin,
+    )

--- a/tests/tests/core/tools/core/RAG_tools/kb/test_collection_handle_search.py
+++ b/tests/tests/core/tools/core/RAG_tools/kb/test_collection_handle_search.py
@@ -1,0 +1,861 @@
+"""Tests for the collection handle dense search lifecycle (#511).
+
+The handle owns collection-scoped dense search mechanics: capability guard,
+index creation, filter building, score conversion, and result assembly.
+Search provider calls (vector store) are mocked.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    DenseSearchResponse,
+    IndexStatus,
+    SparseSearchResponse,
+)
+from xagent.core.tools.core.RAG_tools.kb.collection_handle import (
+    LanceDBCollectionHandle,
+)
+from xagent.core.tools.core.RAG_tools.storage.contracts import (
+    FilterCondition,
+    FilterOperator,
+)
+
+
+def _make_handle(*, supports_search: bool = True):
+    """Create a LanceDBCollectionHandle with mocked context/store/capabilities.
+
+    LanceDBCollectionHandle is a frozen dataclass, so we use object.__setattr__
+    to inject mocks into the underlying ``context`` field.
+    """
+    handle = LanceDBCollectionHandle.__new__(LanceDBCollectionHandle)
+    ctx = MagicMock()
+    ctx.collection = "col1"
+    # frozen dataclass — must use object.__setattr__
+    object.__setattr__(handle, "context", ctx)
+
+    store = MagicMock()
+    ctx.vector_index_store = store
+
+    caps = MagicMock()
+    caps.supports_search = supports_search
+    ctx.capabilities = caps
+
+    return handle, ctx, store, caps
+
+
+def _index_result(status="index_ready", advice=None):
+    obj = MagicMock()
+    obj.status = status
+    obj.advice = advice
+    obj.fts_enabled = True
+    return obj
+
+
+def test_search_dense_success_score_and_filters():
+    handle, ctx, store, _ = _make_handle()
+    store.create_index.return_value = _index_result()
+    store.search_vectors_by_model.return_value = [
+        {
+            "doc_id": "d1",
+            "chunk_id": "c1",
+            "text": "t",
+            "parse_hash": "h",
+            "created_at": "2026-01-01",
+            "metadata": None,
+            "_distance": 1.0,
+        },
+    ]
+    resp = handle.search_dense(
+        "model-x", [0.1, 0.2], top_k=5, user_id=7, is_admin=False
+    )
+    assert isinstance(resp, DenseSearchResponse)
+    assert resp.status == "success"
+    assert resp.total_count == 1
+    assert resp.results[0].score == pytest.approx(0.5)  # 1/(1+1.0)
+    # collection filter + user scope reached the store
+    kwargs = store.search_vectors_by_model.call_args.kwargs
+    assert kwargs["model_tag"] == "model-x"
+    assert kwargs["user_id"] == 7 and kwargs["is_admin"] is False
+
+
+def test_search_dense_preserves_prebuilt_filter_expression():
+    handle, _, store, _ = _make_handle()
+    store.create_index.return_value = _index_result()
+    store.search_vectors_by_model.return_value = [
+        {
+            "doc_id": "d1",
+            "chunk_id": "c1",
+            "text": "t",
+            "parse_hash": "h",
+            "created_at": "2026-01-01",
+            "metadata": None,
+            "_distance": 0.0,
+        },
+    ]
+
+    custom_filter = (
+        FilterCondition(
+            field="doc_id",
+            operator=FilterOperator.EQ,
+            value="d1",
+        ),
+        FilterCondition(
+            field="chunk_id",
+            operator=FilterOperator.EQ,
+            value="c1",
+        ),
+    )
+
+    resp = handle.search_dense(
+        "model-x",
+        [0.1, 0.2],
+        top_k=5,
+        filters=custom_filter,
+        user_id=7,
+        is_admin=False,
+    )
+
+    assert isinstance(resp, DenseSearchResponse)
+    assert resp.status == "success"
+    passed_filters = store.search_vectors_by_model.call_args.kwargs["filters"]
+    assert isinstance(passed_filters, tuple)
+    assert len(passed_filters) == 2
+    assert passed_filters[1] == custom_filter
+
+
+@pytest.mark.parametrize(
+    "custom_filter",
+    [
+        FilterCondition(
+            field="doc_id",
+            operator=FilterOperator.EQ,
+            value="d1",
+        ),
+        [
+            FilterCondition(
+                field="doc_id",
+                operator=FilterOperator.EQ,
+                value="d1",
+            ),
+            FilterCondition(
+                field="chunk_id",
+                operator=FilterOperator.EQ,
+                value="c1",
+            ),
+        ],
+    ],
+)
+def test_search_dense_preserves_single_and_list_filter_expressions(custom_filter):
+    handle, _, store, _ = _make_handle()
+    store.create_index.return_value = _index_result()
+    store.search_vectors_by_model.return_value = [
+        {
+            "doc_id": "d1",
+            "chunk_id": "c1",
+            "text": "t",
+            "parse_hash": "h",
+            "created_at": "2026-01-01",
+            "metadata": None,
+            "_distance": 0.0,
+        },
+    ]
+
+    resp = handle.search_dense(
+        "model-x",
+        [0.1, 0.2],
+        top_k=5,
+        filters=custom_filter,
+        user_id=7,
+        is_admin=False,
+    )
+
+    assert resp.status == "success"
+    passed_filters = store.search_vectors_by_model.call_args.kwargs["filters"]
+    assert isinstance(passed_filters, tuple)
+    assert len(passed_filters) == 2
+    assert passed_filters[1] == custom_filter
+
+
+def test_search_dense_failure_returns_failed_response():
+    handle, _, store, _ = _make_handle()
+    store.create_index.side_effect = RuntimeError("boom")
+    resp = handle.search_dense("model-x", [0.1])
+    assert resp.status == "failed"
+    assert resp.results == [] and resp.total_count == 0
+    assert resp.index_status == IndexStatus.NO_INDEX
+    assert any(w.code == "DENSE_SEARCH_FAILED" for w in resp.warnings)
+
+
+def test_search_dense_capability_unsupported():
+    handle, _, store, _ = _make_handle(supports_search=False)
+    resp = handle.search_dense("model-x", [0.1])
+    assert resp.status == "failed"
+    assert any(w.code == "SEARCH_NOT_SUPPORTED" for w in resp.warnings)
+    store.create_index.assert_not_called()  # guard is before any store access
+
+
+@pytest.mark.asyncio
+async def test_search_dense_async_capability_unsupported():
+    handle, _, store, _ = _make_handle(supports_search=False)
+    resp = await handle.search_dense_async("model-x", [0.1])
+    assert resp.status == "failed"
+    assert any(w.code == "SEARCH_NOT_SUPPORTED" for w in resp.warnings)
+
+
+@pytest.mark.asyncio
+async def test_search_dense_async_success():
+    handle, ctx, store, _ = _make_handle()
+    store.create_index.return_value = _index_result()
+    store.search_vectors_by_model_async = AsyncMock(
+        return_value=[
+            {
+                "doc_id": "d1",
+                "chunk_id": "c1",
+                "text": "t",
+                "parse_hash": "h",
+                "created_at": "2026-01-01",
+                "metadata": None,
+                "_distance": 1.0,
+            },
+        ]
+    )
+    resp = await handle.search_dense_async(
+        "model-x", [0.1, 0.2], top_k=5, user_id=7, is_admin=False
+    )
+    assert isinstance(resp, DenseSearchResponse)
+    assert resp.status == "success"
+    assert resp.total_count == 1
+    assert resp.results[0].score == pytest.approx(0.5)  # 1/(1+1.0)
+    kwargs = store.search_vectors_by_model_async.call_args.kwargs
+    assert kwargs["model_tag"] == "model-x"
+    assert kwargs["user_id"] == 7 and kwargs["is_admin"] is False
+
+
+def test_search_sparse_substring_fallback_honors_operator_filters():
+    from xagent.core.tools.core.RAG_tools.core.schemas import IndexResult
+
+    handle, ctx, mock_vector_store, _ = _make_handle()
+    ctx.collection = "test_col"
+
+    mock_table = MagicMock()
+    mock_table.list_indices.return_value = [MagicMock(index_type="FTS", columns=["text"])]
+
+    mock_vector_store.create_index.return_value = IndexResult(
+        status="index_ready", advice=None, fts_enabled=True
+    )
+    mock_vector_store.build_filter_expression.return_value = "collection == 'test_col'"
+    mock_vector_store.open_embeddings_table.return_value = (
+        mock_table,
+        "embeddings_test_model",
+    )
+
+    mock_search = MagicMock()
+    mock_limit = MagicMock()
+    mock_where = MagicMock()
+    mock_table.search.return_value = mock_search
+    mock_search.limit.return_value = mock_limit
+    mock_limit.where.return_value = mock_where
+    mock_where.to_pandas.return_value = pd.DataFrame()
+
+    batch_df = pd.DataFrame(
+        [
+            {
+                "collection": "test_col",
+                "doc_id": "doc1",
+                "chunk_id": "chunk1",
+                "text": "hello world",
+                "parse_hash": "hash1",
+                "created_at": "2026-01-01",
+                "metadata": None,
+                "page_number": 1,
+            },
+            {
+                "collection": "test_col",
+                "doc_id": "doc2",
+                "chunk_id": "chunk2",
+                "text": "hello again",
+                "parse_hash": "hash2",
+                "created_at": "2026-01-02",
+                "metadata": None,
+                "page_number": 3,
+            },
+        ]
+    )
+    mock_batch = MagicMock()
+    mock_batch.to_pandas.return_value = batch_df
+    mock_table.to_batches.return_value = [mock_batch]
+
+    filters = {"page_number": {"operator": "gte", "value": 2}}
+
+    response = handle.search_sparse(
+        "test_model",
+        "hello",
+        top_k=5,
+        filters=filters,
+        user_id=None,
+        is_admin=True,
+    )
+
+    assert response.status == "success"
+    assert len(response.results) == 1
+    assert response.results[0].doc_id == "doc2"
+
+
+@pytest.mark.asyncio
+async def test_search_sparse_async_substring_fallback_honors_operator_filters():
+    handle, ctx, mock_vector_store, _ = _make_handle()
+    ctx.collection = "test_col"
+
+    mock_vector_store.create_index.return_value = _index_result()
+    mock_vector_store.search_fts_by_model_async = AsyncMock(return_value=[])
+    mock_vector_store.open_embeddings_table.return_value = (
+        MagicMock(),
+        "embeddings_test_model",
+    )
+
+    batch_df = pd.DataFrame(
+        [
+            {
+                "collection": "test_col",
+                "doc_id": "doc1",
+                "chunk_id": "chunk1",
+                "text": "hello world",
+                "parse_hash": "hash1",
+                "created_at": "2026-01-01",
+                "metadata": None,
+                "page_number": 1,
+            },
+            {
+                "collection": "test_col",
+                "doc_id": "doc2",
+                "chunk_id": "chunk2",
+                "text": "hello again",
+                "parse_hash": "hash2",
+                "created_at": "2026-01-02",
+                "metadata": None,
+                "page_number": 3,
+            },
+        ]
+    )
+    mock_batch = MagicMock()
+    mock_batch.to_pandas.return_value = batch_df
+
+    async def iter_batches_async(**kwargs):
+        yield mock_batch
+
+    mock_vector_store.iter_batches_async = iter_batches_async
+
+    with patch(
+        "xagent.core.tools.core.RAG_tools.kb.collection_handle._safe_close_table"
+    ):
+        response = await handle.search_sparse_async(
+            "test_model",
+            "hello",
+            top_k=5,
+            filters={"page_number": {"operator": "gte", "value": 2}},
+            user_id=None,
+            is_admin=True,
+        )
+
+    assert response.status == "success"
+    assert len(response.results) == 1
+    assert response.results[0].doc_id == "doc2"
+
+
+# ---------------------------------------------------------------------------
+# Sparse search tests
+# ---------------------------------------------------------------------------
+
+
+def test_search_sparse_capability_unsupported():
+    handle, _, store, _ = _make_handle(supports_search=False)
+    resp = handle.search_sparse("model-x", "hello", top_k=3)
+    assert isinstance(resp, SparseSearchResponse)
+    assert resp.status == "failed"
+    assert any(w.code == "SEARCH_NOT_SUPPORTED" for w in resp.warnings)
+    store.open_embeddings_table.assert_not_called()
+
+
+def test_search_sparse_fts_hit_scores_normalized():
+    handle, _, store, _ = _make_handle()
+    store.open_embeddings_table.return_value = (MagicMock(), "embeddings_model-x")
+    store.create_index.return_value = _index_result()
+    # Return None from build_filter_expression so the .where() branch is skipped
+    # and the FTS result chain is: search().limit().to_pandas()
+    store.build_filter_expression.return_value = None
+    fts_table = store.open_embeddings_table.return_value[0]
+    rows = pd.DataFrame(
+        [
+            {
+                "doc_id": "d1",
+                "chunk_id": "c1",
+                "text": "hello",
+                "parse_hash": "h",
+                "created_at": "2026",
+                "metadata": None,
+                "_score": 3.0,
+            }
+        ]
+    )
+    fts_table.search.return_value.limit.return_value.to_pandas.return_value = rows
+    resp = handle.search_sparse("model-x", "hello", top_k=3)
+    assert resp.status == "success"
+    assert resp.fts_enabled is True
+    assert resp.results[0].score == pytest.approx(0.75)  # 3/(1+3)
+
+
+# ---------------------------------------------------------------------------
+# Hybrid search tests
+# ---------------------------------------------------------------------------
+
+
+def test_search_hybrid_capability_unsupported():
+    from xagent.core.tools.core.RAG_tools.core.schemas import HybridSearchResponse
+
+    handle, _, _, _ = _make_handle(supports_search=False)
+    resp = handle.search_hybrid("model-x", "q", [0.1], top_k=5)
+    assert isinstance(resp, HybridSearchResponse)
+    assert resp.status == "failed"
+    assert any(w.code == "SEARCH_NOT_SUPPORTED" for w in resp.warnings)
+    assert resp.dense_count == 0 and resp.sparse_count == 0
+
+
+def test_search_hybrid_fetches_double_top_k_and_fuses(monkeypatch):
+    from xagent.core.tools.core.RAG_tools.core.schemas import (
+        DenseSearchResponse,
+        IndexStatus,
+        SearchResult,
+        SparseSearchResponse,
+    )
+
+    handle, _, _, _ = _make_handle()
+    dense = DenseSearchResponse(
+        results=[
+            SearchResult(
+                doc_id="d",
+                chunk_id="c",
+                text="t",
+                score=0.9,
+                parse_hash="h",
+                model_tag="model-x",
+                created_at="2026",
+                metadata=None,
+            )
+        ],
+        total_count=1,
+        status="success",
+        warnings=[],
+        index_status=IndexStatus.INDEX_READY,
+        index_advice=None,
+        idempotency_key=None,
+        fallback_info=None,
+        nprobes=None,
+        refine_factor=None,
+    )
+    sparse = SparseSearchResponse(
+        results=[],
+        total_count=0,
+        status="success",
+        warnings=[],
+        fts_enabled=True,
+        query_text="q",
+    )
+    captured = {}
+
+    def fake_dense(self, model_tag, query_vector, *, top_k, **kw):
+        captured["dense_top_k"] = top_k
+        return dense
+
+    def fake_sparse(self, model_tag, query_text, *, top_k, **kw):
+        captured["sparse_top_k"] = top_k
+        return sparse
+
+    monkeypatch.setattr(type(handle), "search_dense", fake_dense)
+    monkeypatch.setattr(type(handle), "search_sparse", fake_sparse)
+    resp = handle.search_hybrid("model-x", "q", [0.1], top_k=5)
+    assert captured["dense_top_k"] == 10 and captured["sparse_top_k"] == 10  # top_k*2
+    assert resp.status in ("success", "partial_success")
+    assert resp.dense_count == 1 and resp.sparse_count == 0
+    # The fused output contains the dense result with the original score/rank
+    # attached: vector_* from dense, fts_* unset because sparse missed.
+    assert len(resp.results) == 1
+    fused = resp.results[0]
+    assert fused.doc_id == "d" and fused.chunk_id == "c"
+    assert fused.vector_score == pytest.approx(0.9)  # dense original score
+    assert fused.vector_rank == 1
+    assert fused.fts_score is None and fused.fts_rank is None
+
+
+def test_search_hybrid_linear_fusion_attaches_scores(monkeypatch):
+    from xagent.core.tools.core.RAG_tools.core.schemas import (
+        DenseSearchResponse,
+        FusionConfig,
+        FusionStrategy,
+        IndexStatus,
+        SearchResult,
+        SparseSearchResponse,
+    )
+
+    handle, _, _, _ = _make_handle()
+    dense = DenseSearchResponse(
+        results=[
+            SearchResult(
+                doc_id="d",
+                chunk_id="c",
+                text="t",
+                score=0.9,
+                parse_hash="h",
+                model_tag="model-x",
+                created_at="2026",
+                metadata=None,
+            )
+        ],
+        total_count=1,
+        status="success",
+        warnings=[],
+        index_status=IndexStatus.INDEX_READY,
+        index_advice=None,
+        idempotency_key=None,
+        fallback_info=None,
+        nprobes=None,
+        refine_factor=None,
+    )
+    sparse = SparseSearchResponse(
+        results=[
+            SearchResult(
+                doc_id="d2",
+                chunk_id="c2",
+                text="t2",
+                score=0.7,
+                parse_hash="h",
+                model_tag="model-x",
+                created_at="2026",
+                metadata=None,
+            )
+        ],
+        total_count=1,
+        status="success",
+        warnings=[],
+        fts_enabled=True,
+        query_text="q",
+    )
+
+    def fake_dense(self, model_tag, query_vector, *, top_k, **kw):
+        return dense
+
+    def fake_sparse(self, model_tag, query_text, *, top_k, **kw):
+        return sparse
+
+    monkeypatch.setattr(type(handle), "search_dense", fake_dense)
+    monkeypatch.setattr(type(handle), "search_sparse", fake_sparse)
+    cfg = FusionConfig(
+        strategy=FusionStrategy.LINEAR,
+        dense_weight=0.6,
+        sparse_weight=0.4,
+        normalize_scores=True,
+    )
+    resp = handle.search_hybrid("model-x", "q", [0.1], top_k=5, fusion_config=cfg)
+    assert resp.status in ("success", "partial_success")
+    assert resp.dense_count == 1 and resp.sparse_count == 1
+    assert resp.fusion_config.strategy == FusionStrategy.LINEAR
+    # Linear fusion combines both lists; both unique results survive.
+    assert len(resp.results) == 2
+    by_doc = {r.doc_id: r for r in resp.results}
+    # Dense-only doc carries its dense score/rank, no fts attachment.
+    assert by_doc["d"].vector_score == pytest.approx(0.9)
+    assert by_doc["d"].vector_rank == 1
+    assert by_doc["d"].fts_score is None and by_doc["d"].fts_rank is None
+    # Sparse-only doc carries its fts score/rank, no vector attachment.
+    assert by_doc["d2"].fts_score == pytest.approx(0.7)
+    assert by_doc["d2"].fts_rank == 1
+    assert by_doc["d2"].vector_score is None and by_doc["d2"].vector_rank is None
+
+
+@pytest.mark.asyncio
+async def test_search_hybrid_async_capability_unsupported():
+    from xagent.core.tools.core.RAG_tools.core.schemas import HybridSearchResponse
+
+    handle, _, _, _ = _make_handle(supports_search=False)
+    resp = await handle.search_hybrid_async("model-x", "q", [0.1], top_k=5)
+    assert isinstance(resp, HybridSearchResponse)
+    assert resp.status == "failed"
+    assert any(w.code == "SEARCH_NOT_SUPPORTED" for w in resp.warnings)
+    assert resp.dense_count == 0 and resp.sparse_count == 0
+
+
+@pytest.mark.asyncio
+async def test_search_hybrid_async_fetches_double_top_k_and_fuses(monkeypatch):
+    from xagent.core.tools.core.RAG_tools.core.schemas import (
+        DenseSearchResponse,
+        IndexStatus,
+        SearchResult,
+        SparseSearchResponse,
+    )
+
+    handle, _, _, _ = _make_handle()
+    dense = DenseSearchResponse(
+        results=[
+            SearchResult(
+                doc_id="d",
+                chunk_id="c",
+                text="t",
+                score=0.9,
+                parse_hash="h",
+                model_tag="model-x",
+                created_at="2026",
+                metadata=None,
+            )
+        ],
+        total_count=1,
+        status="success",
+        warnings=[],
+        index_status=IndexStatus.INDEX_READY,
+        index_advice=None,
+        idempotency_key=None,
+        fallback_info=None,
+        nprobes=None,
+        refine_factor=None,
+    )
+    sparse = SparseSearchResponse(
+        results=[],
+        total_count=0,
+        status="success",
+        warnings=[],
+        fts_enabled=True,
+        query_text="q",
+    )
+    captured = {}
+
+    async def fake_dense_async(self, model_tag, query_vector, *, top_k, **kw):
+        captured["dense_top_k"] = top_k
+        return dense
+
+    async def fake_sparse_async(self, model_tag, query_text, *, top_k, **kw):
+        captured["sparse_top_k"] = top_k
+        return sparse
+
+    monkeypatch.setattr(type(handle), "search_dense_async", fake_dense_async)
+    monkeypatch.setattr(type(handle), "search_sparse_async", fake_sparse_async)
+    resp = await handle.search_hybrid_async("model-x", "q", [0.1], top_k=5)
+    assert captured["dense_top_k"] == 10 and captured["sparse_top_k"] == 10  # top_k*2
+    assert resp.status in ("success", "partial_success")
+    assert resp.dense_count == 1 and resp.sparse_count == 0
+    # _fuse_hybrid is shared; verify it attaches vector_score/rank via the async path too.
+    assert len(resp.results) == 1
+    fused = resp.results[0]
+    assert fused.doc_id == "d" and fused.vector_score == pytest.approx(0.9)
+    assert fused.vector_rank == 1
+    assert fused.fts_score is None and fused.fts_rank is None
+
+
+# ---------------------------------------------------------------------------
+# Cross-mode capability-degradation tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "call",
+    [
+        lambda h: h.search_dense("m", [0.1], top_k=3),
+        lambda h: h.search_sparse("m", "q", top_k=3),
+        lambda h: h.search_hybrid("m", "q", [0.1], top_k=3),
+    ],
+)
+def test_all_modes_degrade_when_search_unsupported(call):
+    handle, _, _, _ = _make_handle(supports_search=False)
+    resp = call(handle)
+    assert resp.status == "failed"
+    assert any(w.code == "SEARCH_NOT_SUPPORTED" for w in resp.warnings)
+
+
+# ---------------------------------------------------------------------------
+# Rollback-scope filter test
+# ---------------------------------------------------------------------------
+
+
+def test_dense_passes_collection_and_user_scope_to_store():
+    # Rollback-incomplete remnants must still be filtered: assert the store call
+    # always carries the collection filter + user scope so a stray row in another
+    # collection / another user cannot leak.
+    handle, ctx, store, _ = _make_handle()
+    store.create_index.return_value = _index_result()
+    store.search_vectors_by_model.return_value = []
+    handle.search_dense("m", [0.1], top_k=3, user_id=42, is_admin=False)
+    kwargs = store.search_vectors_by_model.call_args.kwargs
+    assert kwargs["user_id"] == 42 and kwargs["is_admin"] is False
+    # collection filter present in the FilterExpression
+    assert kwargs["filters"] is not None
+
+
+@pytest.mark.asyncio
+async def test_search_hybrid_async_linear_fusion(monkeypatch):
+    """LINEAR fusion path exercised via the async hybrid method."""
+    from xagent.core.tools.core.RAG_tools.core.schemas import (
+        DenseSearchResponse,
+        FusionConfig,
+        FusionStrategy,
+        IndexStatus,
+        SearchResult,
+        SparseSearchResponse,
+    )
+
+    handle, _, _, _ = _make_handle()
+    dense = DenseSearchResponse(
+        results=[
+            SearchResult(
+                doc_id="da",
+                chunk_id="ca",
+                text="ta",
+                score=0.8,
+                parse_hash="ha",
+                model_tag="model-x",
+                created_at="2026",
+                metadata=None,
+            )
+        ],
+        total_count=1,
+        status="success",
+        warnings=[],
+        index_status=IndexStatus.INDEX_READY,
+        index_advice=None,
+        idempotency_key=None,
+        fallback_info=None,
+        nprobes=None,
+        refine_factor=None,
+    )
+    sparse = SparseSearchResponse(
+        results=[
+            SearchResult(
+                doc_id="db",
+                chunk_id="cb",
+                text="tb",
+                score=0.6,
+                parse_hash="hb",
+                model_tag="model-x",
+                created_at="2026",
+                metadata=None,
+            )
+        ],
+        total_count=1,
+        status="success",
+        warnings=[],
+        fts_enabled=True,
+        query_text="q",
+    )
+
+    async def fake_dense_async(self, model_tag, query_vector, *, top_k, **kw):
+        return dense
+
+    async def fake_sparse_async(self, model_tag, query_text, *, top_k, **kw):
+        return sparse
+
+    monkeypatch.setattr(type(handle), "search_dense_async", fake_dense_async)
+    monkeypatch.setattr(type(handle), "search_sparse_async", fake_sparse_async)
+    cfg = FusionConfig(
+        strategy=FusionStrategy.LINEAR,
+        dense_weight=0.5,
+        sparse_weight=0.5,
+        normalize_scores=True,
+    )
+    resp = await handle.search_hybrid_async(
+        "model-x", "q", [0.1], top_k=5, fusion_config=cfg
+    )
+    assert resp.status in ("success", "partial_success")
+    assert resp.fusion_config.strategy == FusionStrategy.LINEAR
+    assert resp.dense_count == 1 and resp.sparse_count == 1
+    assert len(resp.results) == 2
+    by_doc = {r.doc_id: r for r in resp.results}
+    assert by_doc["da"].vector_rank == 1 and by_doc["da"].fts_score is None
+    assert by_doc["db"].fts_rank == 1 and by_doc["db"].vector_score is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #72: Ported from test_retrieval_helper_compatibility.py
+# Exact collection-filter equality assertions moved from facade engine tests.
+# ---------------------------------------------------------------------------
+
+
+def _filter_conditions(expr):
+    """Extract (field, operator, value) triples from a FilterExpression tree."""
+    if expr is None:
+        return []
+    if isinstance(expr, (tuple, list)):
+        conditions = []
+        for item in expr:
+            conditions.extend(_filter_conditions(item))
+        return conditions
+    operator = getattr(expr, "operator", None)
+    return [
+        (
+            getattr(expr, "field"),
+            getattr(operator, "value", operator),
+            getattr(expr, "value"),
+        )
+    ]
+
+
+def test_dense_collection_filter_equality_issue_72():
+    """search_dense always applies an exact-match collection filter (Issue #72).
+
+    Ported from test_retrieval_facade_preserves_sync_tuple_filter_scope_and_conversion.
+    The handle must build FilterCondition(field="collection", operator=EQ, value=collection)
+    and pass it to store.search_vectors_by_model — not just any non-None filter.
+    """
+    handle, ctx, store, _ = _make_handle()
+    ctx.collection = "docs"
+    store.create_index.return_value = _index_result()
+    store.search_vectors_by_model.return_value = []
+    handle.search_dense("model-a", [0.5, 0.25], top_k=5, user_id=7, is_admin=False)
+    kwargs = store.search_vectors_by_model.call_args.kwargs
+    conditions = _filter_conditions(kwargs["filters"])
+    # The first condition MUST be the collection equality filter for Issue #72.
+    assert ("collection", "eq", "docs") in conditions, (
+        "Issue #72: collection equality filter missing from store call"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dense_async_collection_filter_equality_issue_72():
+    """search_dense_async always applies an exact-match collection filter (Issue #72)."""
+    from unittest.mock import AsyncMock
+
+    handle, ctx, store, _ = _make_handle()
+    ctx.collection = "docs"
+    store.create_index.return_value = _index_result()
+    store.search_vectors_by_model_async = AsyncMock(return_value=[])
+    await handle.search_dense_async(
+        "model-a", [0.5], top_k=3, user_id=None, is_admin=True
+    )
+    kwargs = store.search_vectors_by_model_async.call_args.kwargs
+    conditions = _filter_conditions(kwargs["filters"])
+    assert ("collection", "eq", "docs") in conditions, (
+        "Issue #72: collection equality filter missing from async store call"
+    )
+
+
+def test_dense_invalid_filter_returns_failed_response():
+    """search_dense returns a failed response for unknown filter operators.
+
+    Ported from test_retrieval_facade_preserves_invalid_legacy_filter_errors.
+    The handle catches parse errors and returns a structured failed response.
+    """
+    handle, ctx, store, _ = _make_handle()
+    ctx.collection = "docs"
+    store.create_index.return_value = _index_result()
+    # Unknown operator causes parse failure; handle returns failed response
+    resp = handle.search_dense(
+        "model-a",
+        [0.5],
+        top_k=5,
+        filters={"page_number": {"operator": "between", "value": [1, 3]}},
+        user_id=7,
+        is_admin=False,
+    )
+    assert resp.status == "failed"
+    assert any(w.code == "DENSE_SEARCH_FAILED" for w in resp.warnings)
+    assert any("between" in w.message for w in resp.warnings)

--- a/tests/tests/core/tools/core/RAG_tools/retrieval/test_search_hybrid.py
+++ b/tests/tests/core/tools/core/RAG_tools/retrieval/test_search_hybrid.py
@@ -1,0 +1,1020 @@
+import datetime
+from typing import Generator, Tuple
+from unittest.mock import Mock
+
+import pytest
+
+from xagent.core.tools.core.RAG_tools.core.exceptions import DocumentValidationError
+from xagent.core.tools.core.RAG_tools.core.exceptions import VectorValidationError
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    DenseSearchResponse,
+    FusionConfig,
+    FusionStrategy,
+    HybridSearchResponse,
+    IndexStatus,
+    SearchFallbackAction,
+    SearchResult,
+    SearchWarning,
+    SparseSearchResponse,
+)
+from xagent.core.tools.core.RAG_tools.retrieval.search_hybrid import (
+    _linear_fusion,
+    _rrf_fusion,
+    search_hybrid,
+)
+
+
+class TestFusionFunctions:
+    """Tests for internal fusion helper functions."""
+
+    def test_rrf_fusion_basic(self) -> None:
+        """Test RRF fusion with basic scenario."""
+        # Setup sample data
+        results1 = [
+            SearchResult(
+                doc_id="d1",
+                chunk_id="c1",
+                text="t1",
+                score=0.9,
+                parse_hash="p1",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+            SearchResult(
+                doc_id="d2",
+                chunk_id="c2",
+                text="t2",
+                score=0.8,
+                parse_hash="p2",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+        ]
+        results2 = [
+            SearchResult(
+                doc_id="d2",
+                chunk_id="c2",
+                text="t2",
+                score=0.95,
+                parse_hash="p2",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+            SearchResult(
+                doc_id="d3",
+                chunk_id="c3",
+                text="t3",
+                score=0.7,
+                parse_hash="p3",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+        ]
+
+        rank_lists = [results1, results2]
+        fused = _rrf_fusion(rank_lists, k=1)  # Using k=1 for simpler score calculation
+
+        # Expected RRF scores:
+        # d1-c1: 1/(1+1) = 0.5 (from results1)
+        # d2-c2: 1/(1+2) + 1/(1+1) = 0.333 + 0.5 = 0.833 (from results1 & results2)
+        # d3-c3: 1/(1+2) = 0.333 (from results2)
+
+        assert len(fused) == 3
+        # d2-c2 should be highest ranked
+        assert fused[0].doc_id == "d2"
+        assert abs(fused[0].score - 0.833) < 0.001
+        # d1-c1 next
+        assert fused[1].doc_id == "d1"
+        assert abs(fused[1].score - 0.5) < 0.001
+        # d3-c3 last
+        assert fused[2].doc_id == "d3"
+        assert abs(fused[2].score - 0.333) < 0.001
+
+    def test_rrf_fusion_empty_lists(self) -> None:
+        """Test RRF fusion with empty input lists."""
+        fused = _rrf_fusion([], k=10)
+        assert len(fused) == 0
+
+        fused = _rrf_fusion([[]], k=10)
+        assert len(fused) == 0
+
+        fused = _rrf_fusion([[], []], k=10)
+        assert len(fused) == 0
+
+    def test_linear_fusion_basic(self) -> None:
+        """Test linear fusion with basic scenario and no normalization."""
+        dense_results = [
+            SearchResult(
+                doc_id="d1",
+                chunk_id="c1",
+                text="t1",
+                score=0.8,
+                parse_hash="p1",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+            SearchResult(
+                doc_id="d2",
+                chunk_id="c2",
+                text="t2",
+                score=0.6,
+                parse_hash="p2",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+        ]
+        sparse_results = [
+            SearchResult(
+                doc_id="d2",
+                chunk_id="c2",
+                text="t2",
+                score=0.7,
+                parse_hash="p2",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+            SearchResult(
+                doc_id="d3",
+                chunk_id="c3",
+                text="t3",
+                score=0.5,
+                parse_hash="p3",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+        ]
+
+        fused = _linear_fusion(
+            dense_results,
+            sparse_results,
+            dense_weight=0.5,
+            sparse_weight=0.5,
+            normalize_scores=False,
+        )
+
+        # Expected scores before final normalization:
+        # d1-c1: 0.8 * 0.5 = 0.4
+        # d2-c2: (0.6 * 0.5) + (0.7 * 0.5) = 0.3 + 0.35 = 0.65
+        # d3-c3: 0.5 * 0.5 = 0.25
+        # After final normalization (Min-Max to [0,1]):
+        # min_score = 0.25, max_score = 0.65, range = 0.4
+        # d2-c2: (0.65 - 0.25) / 0.4 = 1.0
+        # d1-c1: (0.4 - 0.25) / 0.4 = 0.375
+        # d3-c3: (0.25 - 0.25) / 0.4 = 0.0
+
+        assert len(fused) == 3
+        assert fused[0].doc_id == "d2"
+        assert abs(fused[0].score - 1.0) < 0.001
+        assert fused[1].doc_id == "d1"
+        assert abs(fused[1].score - 0.375) < 0.001
+        assert fused[2].doc_id == "d3"
+        assert abs(fused[2].score - 0.0) < 0.001
+
+    def test_linear_fusion_with_normalization(self) -> None:
+        """Test linear fusion with Min-Max normalization."""
+        dense_results = [
+            SearchResult(
+                doc_id="d1",
+                chunk_id="c1",
+                text="t1",
+                score=0.8,
+                parse_hash="p1",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+            SearchResult(
+                doc_id="d2",
+                chunk_id="c2",
+                text="t2",
+                score=0.6,
+                parse_hash="p2",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+        ]
+        sparse_results = [
+            SearchResult(
+                doc_id="d2",
+                chunk_id="c2",
+                text="t2",
+                score=0.7,
+                parse_hash="p2",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+            SearchResult(
+                doc_id="d3",
+                chunk_id="c3",
+                text="t3",
+                score=0.5,
+                parse_hash="p3",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+        ]
+
+        # Normalized dense scores: [ (0.8-0.6)/(0.8-0.6)=1.0, (0.6-0.6)/(0.8-0.6)=0.0 ] -> [1.0, 0.0]
+        # Normalized sparse scores: [ (0.7-0.5)/(0.7-0.5)=1.0, (0.5-0.5)/(0.7-0.5)=0.0 ] -> [1.0, 0.0]
+
+        fused = _linear_fusion(
+            dense_results,
+            sparse_results,
+            dense_weight=0.5,
+            sparse_weight=0.5,
+            normalize_scores=True,
+        )
+
+        # Expected scores before final normalization:
+        # d1-c1: 1.0 * 0.5 = 0.5
+        # d2-c2: (0.0 * 0.5) + (1.0 * 0.5) = 0.0 + 0.5 = 0.5
+        # d3-c3: 0.0 * 0.5 = 0.0
+        # After final normalization (Min-Max to [0,1]):
+        # d1-c1 and d2-c2: 0.5/0.5 = 1.0 (both have same score)
+        # d3-c3: 0.0/0.5 = 0.0
+
+        assert len(fused) == 3
+        # d1 and d2 have the same score (both 1.0 after normalization)
+        doc_ids = [fused[0].doc_id, fused[1].doc_id]
+        assert set(doc_ids) == {"d1", "d2"}
+        assert abs(fused[0].score - 1.0) < 0.001
+        assert abs(fused[1].score - 1.0) < 0.001
+        assert fused[2].doc_id == "d3"
+        assert abs(fused[2].score - 0.0) < 0.001
+
+    def test_linear_fusion_empty_lists(self) -> None:
+        """Test linear fusion with empty input lists."""
+        fused = _linear_fusion(
+            [], [], dense_weight=0.5, sparse_weight=0.5, normalize_scores=True
+        )
+        assert len(fused) == 0
+
+        fused = _linear_fusion(
+            [
+                SearchResult(
+                    doc_id="d1",
+                    chunk_id="c1",
+                    text="t1",
+                    score=0.8,
+                    parse_hash="p1",
+                    model_tag="m1",
+                    created_at=datetime.datetime.now(),
+                )
+            ],
+            [],
+            dense_weight=0.5,
+            sparse_weight=0.5,
+            normalize_scores=True,
+        )
+        assert len(fused) == 1
+        assert fused[0].doc_id == "d1"
+
+
+class TestSearchHybrid:
+    """Tests for search_hybrid main function."""
+
+    def _patch_search_hybrid_module(self):
+        """Helper method to import and patch search_hybrid module.
+
+        Resolves ambiguity when module name and function name are the same.
+        """
+        import importlib
+
+        search_hybrid_module = importlib.import_module(
+            "xagent.core.tools.core.RAG_tools.retrieval.search_hybrid"
+        )
+        return search_hybrid_module
+
+    def _create_mock_search_results(self, count: int, base_id: str = "d") -> list:
+        """Helper to create mock search results for testing.
+
+        Args:
+            count: Number of results to create
+            base_id: Base identifier for doc_id, chunk_id, etc.
+
+        Returns:
+            List of SearchResult objects
+        """
+        results = []
+        for i in range(count):
+            results.append(
+                SearchResult(
+                    doc_id=f"{base_id}{i + 1}",
+                    chunk_id=f"c{i + 1}",
+                    text=f"t{i + 1}",
+                    score=0.9 - i * 0.01,
+                    parse_hash=f"p{i + 1}",
+                    model_tag="m1",
+                    created_at=datetime.datetime.now(),
+                )
+            )
+        return results
+
+    @pytest.mark.parametrize(
+        "collection,model_tag,top_k,query_text,query_vector",
+        [
+            ("", "model", 1, "hello", [0.1]),
+            ("collection", "", 1, "hello", [0.1]),
+            ("collection", "model", 0, "hello", [0.1]),
+            ("collection", "model", 2000, "hello", [0.1]),
+            ("collection", "model", 1, "", [0.1]),
+        ],
+    )
+    def test_search_hybrid_input_validation(
+        self,
+        collection: str,
+        model_tag: str,
+        top_k: int,
+        query_text: str,
+        query_vector: list[float],
+    ) -> None:
+        with pytest.raises(DocumentValidationError):
+            search_hybrid(
+                collection=collection,
+                model_tag=model_tag,
+                query_text=query_text,
+                query_vector=query_vector,
+                top_k=top_k,
+            )
+
+    def test_search_hybrid_query_vector_validation(self) -> None:
+        with pytest.raises(VectorValidationError):
+            search_hybrid(
+                collection="collection",
+                model_tag="model",
+                query_text="hello",
+                query_vector=[],
+                top_k=1,
+            )
+
+    @pytest.fixture
+    def mock_sub_searches(
+        self, make_handle, routed_facade
+    ) -> Generator[Tuple[Mock, Mock], None, None]:
+        """Mock the handle's dense/sparse sub-searches and route the public call.
+
+        Re-pointed (#511): the public ``search_hybrid`` now runs the real handle
+        ``search_hybrid`` (fusion logic identical to before — it reuses the same
+        ``_rrf_fusion``/``_linear_fusion`` free functions), which calls
+        ``handle.search_dense``/``handle.search_sparse``. We patch those handle
+        methods and route the public function to that handle. The handle invokes
+        them positionally ``(model_tag, query_vector|query_text, top_k=..., ...)``
+        with NO ``collection`` kwarg (the handle owns its collection).
+        """
+        search_hybrid_module = self._patch_search_hybrid_module()
+        handle, _store, _ = make_handle(collection="test_col")
+
+        mock_dense = Mock()
+        mock_sparse = Mock()
+        # Bind through the instance so calls drop the implicit ``self``.
+        object.__setattr__(handle, "search_dense", mock_dense)
+        object.__setattr__(handle, "search_sparse", mock_sparse)
+
+        with routed_facade(search_hybrid_module, handle):
+            yield mock_dense, mock_sparse
+
+    def test_hybrid_search_rrf_strategy(
+        self, mock_sub_searches: Tuple[Mock, Mock]
+    ) -> None:
+        """Test hybrid search with RRF fusion strategy."""
+        mock_dense, mock_sparse = mock_sub_searches
+
+        # Mock dense search response
+        dense_results = [
+            SearchResult(
+                doc_id="d1",
+                chunk_id="c1",
+                text="t1",
+                score=0.9,
+                parse_hash="p1",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+            SearchResult(
+                doc_id="d2",
+                chunk_id="c2",
+                text="t2",
+                score=0.8,
+                parse_hash="p2",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+        ]
+        mock_dense.return_value = DenseSearchResponse(
+            results=dense_results,
+            total_count=len(dense_results),
+            index_status=IndexStatus.INDEX_READY,
+            index_advice="Ready",
+            warnings=[],
+        )
+
+        # Mock sparse search response
+        sparse_results = [
+            SearchResult(
+                doc_id="d2",
+                chunk_id="c2",
+                text="t2",
+                score=0.7,
+                parse_hash="p2",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+            SearchResult(
+                doc_id="d3",
+                chunk_id="c3",
+                text="t3",
+                score=0.6,
+                parse_hash="p3",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+        ]
+        mock_sparse.return_value = SparseSearchResponse(
+            results=sparse_results,
+            total_count=len(sparse_results),
+            fts_enabled=True,
+            query_text="query",
+            warnings=[],
+        )
+
+        fusion_config = FusionConfig(strategy=FusionStrategy.RRF, rrf_k=1)
+
+        response = search_hybrid(
+            collection="test_col",
+            model_tag="test_model",
+            query_text="hybrid query",
+            query_vector=[0.1, 0.2, 0.3],
+            top_k=2,
+            fusion_config=fusion_config,
+        )
+
+        assert isinstance(response, HybridSearchResponse)
+        assert response.status == "success"
+        assert len(response.results) == 2
+        assert response.total_count == 2
+        assert response.fusion_config.strategy == FusionStrategy.RRF
+        assert response.index_status == IndexStatus.INDEX_READY
+        assert response.index_advice is not None
+        assert "Ready" in response.index_advice
+
+        # Verify RRF logic (same as _rrf_fusion_basic test)
+        assert response.results[0].doc_id == "d2"
+        assert abs(response.results[0].score - 0.833) < 0.001
+        assert response.results[1].doc_id == "d1"
+        assert abs(response.results[1].score - 0.5) < 0.001
+
+        mock_dense.assert_called_once_with(
+            "test_model",
+            [0.1, 0.2, 0.3],
+            top_k=4,  # top_k * 2
+            filters=None,
+            readonly=False,
+            nprobes=None,
+            refine_factor=None,
+            user_id=None,
+            is_admin=False,
+        )
+        mock_sparse.assert_called_once_with(
+            "test_model",
+            "hybrid query",
+            top_k=4,  # top_k * 2
+            filters=None,
+            readonly=False,
+            user_id=None,
+            is_admin=False,
+        )
+
+    def test_hybrid_search_linear_strategy(
+        self, mock_sub_searches: Tuple[Mock, Mock]
+    ) -> None:
+        """Test hybrid search with linear fusion strategy."""
+        mock_dense, mock_sparse = mock_sub_searches
+
+        # Mock dense search response
+        dense_results = [
+            SearchResult(
+                doc_id="d1",
+                chunk_id="c1",
+                text="t1",
+                score=0.8,
+                parse_hash="p1",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+            SearchResult(
+                doc_id="d2",
+                chunk_id="c2",
+                text="t2",
+                score=0.6,
+                parse_hash="p2",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+        ]
+        mock_dense.return_value = DenseSearchResponse(
+            results=dense_results,
+            total_count=len(dense_results),
+            index_status=IndexStatus.INDEX_READY,
+            index_advice="Ready",
+            warnings=[],
+        )
+
+        # Mock sparse search response
+        sparse_results = [
+            SearchResult(
+                doc_id="d2",
+                chunk_id="c2",
+                text="t2",
+                score=0.7,
+                parse_hash="p2",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+            SearchResult(
+                doc_id="d3",
+                chunk_id="c3",
+                text="t3",
+                score=0.5,
+                parse_hash="p3",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            ),
+        ]
+        mock_sparse.return_value = SparseSearchResponse(
+            results=sparse_results,
+            total_count=len(sparse_results),
+            fts_enabled=True,
+            query_text="query",
+            warnings=[],
+        )
+
+        fusion_config = FusionConfig(
+            strategy=FusionStrategy.LINEAR,
+            dense_weight=0.6,
+            sparse_weight=0.4,
+            normalize_scores=False,
+        )
+
+        response = search_hybrid(
+            collection="test_col",
+            model_tag="test_model",
+            query_text="hybrid query",
+            query_vector=[0.1, 0.2, 0.3],
+            top_k=3,
+            fusion_config=fusion_config,
+        )
+
+        assert isinstance(response, HybridSearchResponse)
+        assert response.status == "success"
+        assert len(response.results) == 3
+        assert response.total_count == 3
+        assert response.fusion_config.strategy == FusionStrategy.LINEAR
+
+        # Verify linear fusion logic with final normalization
+        # Before final normalization:
+        # d1-c1: 0.8 * 0.6 = 0.48
+        # d2-c2: (0.6 * 0.6) + (0.7 * 0.4) = 0.36 + 0.28 = 0.64
+        # d3-c3: 0.5 * 0.4 = 0.2
+        # After final normalization (Min-Max to [0,1]):
+        # min_score = 0.2, max_score = 0.64, range = 0.44
+        # d2-c2: (0.64 - 0.2) / 0.44 = 1.0
+        # d1-c1: (0.48 - 0.2) / 0.44 ≈ 0.636
+        # d3-c3: (0.2 - 0.2) / 0.44 = 0.0
+
+        assert response.results[0].doc_id == "d2"
+        assert abs(response.results[0].score - 1.0) < 0.001
+        assert response.results[1].doc_id == "d1"
+        assert abs(response.results[1].score - ((0.48 - 0.2) / (0.64 - 0.2))) < 0.001
+        assert response.results[2].doc_id == "d3"
+        assert abs(response.results[2].score - 0.0) < 0.001
+
+    def test_hybrid_search_with_filters_and_warnings(
+        self, mock_sub_searches: Tuple[Mock, Mock]
+    ) -> None:
+        """Test hybrid search with filters and warning propagation."""
+        mock_dense, mock_sparse = mock_sub_searches
+
+        dense_warning = SearchWarning(
+            code="DENSE_WARN",
+            message="Dense degraded",
+            fallback_action=SearchFallbackAction.PARTIAL_RESULTS,
+            affected_models=["m1"],
+        )
+        sparse_warning = SearchWarning(
+            code="SPARSE_WARN",
+            message="Sparse degraded",
+            fallback_action=SearchFallbackAction.PARTIAL_RESULTS,
+            affected_models=["m1"],
+        )
+
+        dense_results = [
+            SearchResult(
+                doc_id="d1",
+                chunk_id="c1",
+                text="t1",
+                score=0.9,
+                parse_hash="p1",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            )
+        ]
+        sparse_results = [
+            SearchResult(
+                doc_id="d2",
+                chunk_id="c2",
+                text="t2",
+                score=0.8,
+                parse_hash="p2",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            )
+        ]
+
+        mock_dense.return_value = DenseSearchResponse(
+            results=dense_results,
+            total_count=len(dense_results),
+            index_status=IndexStatus.NO_INDEX,
+            index_advice="Build index",
+            warnings=[dense_warning],
+        )
+        mock_sparse.return_value = SparseSearchResponse(
+            results=sparse_results,
+            total_count=len(sparse_results),
+            fts_enabled=False,
+            query_text="query",
+            warnings=[sparse_warning],
+        )
+
+        filters = {"collection": "filtered_col"}
+        fusion_config = FusionConfig(strategy=FusionStrategy.RRF)
+
+        response = search_hybrid(
+            collection="test_col",
+            model_tag="test_model",
+            query_text="filtered query",
+            query_vector=[0.1, 0.2, 0.3],
+            top_k=1,
+            filters=filters,
+            fusion_config=fusion_config,
+        )
+
+        assert response.status == "partial_success"
+        assert len(response.warnings) == 2
+        assert any(w.code == "DENSE_WARN" for w in response.warnings)
+        assert any(w.code == "SPARSE_WARN" for w in response.warnings)
+        assert response.index_status == IndexStatus.NO_INDEX
+        assert response.index_advice is not None
+        assert "Build index" in response.index_advice
+
+        mock_dense.assert_called_once_with(
+            "test_model",
+            [0.1, 0.2, 0.3],
+            top_k=2,  # top_k * 2
+            filters=filters,
+            readonly=False,
+            nprobes=None,
+            refine_factor=None,
+            user_id=None,
+            is_admin=False,
+        )
+        mock_sparse.assert_called_once_with(
+            "test_model",
+            "filtered query",
+            top_k=2,  # top_k * 2
+            filters=filters,
+            readonly=False,
+            user_id=None,
+            is_admin=False,
+        )
+
+    def test_hybrid_search_empty_results(
+        self, mock_sub_searches: Tuple[Mock, Mock]
+    ) -> None:
+        """Test hybrid search when sub-searches return empty results."""
+        mock_dense, mock_sparse = mock_sub_searches
+
+        mock_dense.return_value = DenseSearchResponse(
+            results=[],
+            total_count=0,
+            index_status=IndexStatus.NO_INDEX,
+            index_advice="No index",
+            warnings=[],
+        )
+        mock_sparse.return_value = SparseSearchResponse(
+            results=[],
+            total_count=0,
+            fts_enabled=False,
+            query_text="empty",
+            warnings=[],
+        )
+
+        response = search_hybrid(
+            collection="test_col",
+            model_tag="test_model",
+            query_text="empty query",
+            query_vector=[0.1, 0.2, 0.3],
+            top_k=5,
+        )
+
+        assert response.status == "success"
+        assert len(response.results) == 0
+        assert response.total_count == 0
+        assert not response.warnings
+
+    def test_hybrid_search_default_fusion_config(
+        self, mock_sub_searches: Tuple[Mock, Mock]
+    ) -> None:
+        """Test hybrid search uses default FusionConfig when none is provided."""
+        mock_dense, mock_sparse = mock_sub_searches
+
+        dense_results = [
+            SearchResult(
+                doc_id="d1",
+                chunk_id="c1",
+                text="t1",
+                score=0.9,
+                parse_hash="p1",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            )
+        ]
+        sparse_results = [
+            SearchResult(
+                doc_id="d2",
+                chunk_id="c2",
+                text="t2",
+                score=0.8,
+                parse_hash="p2",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            )
+        ]
+
+        mock_dense.return_value = DenseSearchResponse(
+            results=dense_results,
+            total_count=len(dense_results),
+            index_status=IndexStatus.INDEX_READY,
+            index_advice="Ready",
+            warnings=[],
+        )
+        mock_sparse.return_value = SparseSearchResponse(
+            results=sparse_results,
+            total_count=len(sparse_results),
+            fts_enabled=True,
+            query_text="query",
+            warnings=[],
+        )
+
+        response = search_hybrid(
+            collection="test_col",
+            model_tag="test_model",
+            query_text="default config",
+            query_vector=[0.1, 0.2, 0.3],
+            top_k=1,
+        )
+
+        assert response.fusion_config.strategy == FusionStrategy.RRF
+        assert response.fusion_config.rrf_k == 60  # Default RRF k value
+        assert response.status == "success"  # No warnings, so success
+        assert len(response.results) == 1
+        assert response.total_count == 1
+        assert response.index_status == IndexStatus.INDEX_READY
+
+    def test_hybrid_search_readonly_mode(
+        self, mock_sub_searches: Tuple[Mock, Mock]
+    ) -> None:
+        """Test readonly mode propagation in hybrid search."""
+        mock_dense, mock_sparse = mock_sub_searches
+
+        dense_results = [
+            SearchResult(
+                doc_id="d1",
+                chunk_id="c1",
+                text="t1",
+                score=0.9,
+                parse_hash="p1",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            )
+        ]
+        sparse_results = [
+            SearchResult(
+                doc_id="d2",
+                chunk_id="c2",
+                text="t2",
+                score=0.8,
+                parse_hash="p2",
+                model_tag="m1",
+                created_at=datetime.datetime.now(),
+            )
+        ]
+
+        mock_dense.return_value = DenseSearchResponse(
+            results=dense_results,
+            total_count=len(dense_results),
+            index_status=IndexStatus.READONLY,
+            index_advice="Readonly mode enabled",
+            warnings=[
+                SearchWarning(
+                    code="READONLY_MODE",
+                    message="RO",
+                    fallback_action=SearchFallbackAction.REBUILD_INDEX,
+                    affected_models=["m1"],
+                )
+            ],
+        )
+        mock_sparse.return_value = SparseSearchResponse(
+            results=sparse_results,
+            total_count=len(sparse_results),
+            fts_enabled=True,
+            query_text="query",
+            warnings=[
+                SearchWarning(
+                    code="READONLY_MODE",
+                    message="RO",
+                    fallback_action=SearchFallbackAction.REBUILD_INDEX,
+                    affected_models=["m1"],
+                )
+            ],
+        )
+
+        response = search_hybrid(
+            collection="test_col",
+            model_tag="test_model",
+            query_text="readonly query",
+            query_vector=[0.1, 0.2, 0.3],
+            top_k=1,
+            readonly=True,
+        )
+
+        assert response.status == "partial_success"
+        assert response.index_status == IndexStatus.READONLY
+        assert any(w.code == "READONLY_MODE" for w in response.warnings)
+
+        mock_dense.assert_called_once_with(
+            "test_model",
+            [0.1, 0.2, 0.3],
+            top_k=2,
+            filters=None,
+            readonly=True,  # Verify readonly is propagated
+            nprobes=None,
+            refine_factor=None,
+            user_id=None,
+            is_admin=False,
+        )
+        mock_sparse.assert_called_once_with(
+            "test_model",
+            "readonly query",
+            top_k=2,
+            filters=None,
+            readonly=True,  # Verify readonly is propagated
+            user_id=None,
+            is_admin=False,
+        )
+
+    def test_hybrid_search_top_k_limit(
+        self, mock_sub_searches: Tuple[Mock, Mock]
+    ) -> None:
+        """Test top_k limit is applied after fusion."""
+        mock_dense, mock_sparse = mock_sub_searches
+
+        # Create dense results with decreasing scores
+        dense_results = []
+        for i in range(5):
+            dense_results.append(
+                SearchResult(
+                    doc_id=f"d{i}",
+                    chunk_id=f"c{i}",
+                    text=f"t{i}",
+                    score=0.9 - i * 0.01,
+                    parse_hash="p1",
+                    model_tag="m1",
+                    created_at=datetime.datetime.now(),
+                )
+            )
+
+        # Create sparse results with different doc_ids
+        sparse_results = []
+        for i in range(5):
+            sparse_results.append(
+                SearchResult(
+                    doc_id=f"d{i + 5}",
+                    chunk_id=f"c{i + 5}",
+                    text=f"t{i + 5}",
+                    score=0.8 - i * 0.01,
+                    parse_hash="p2",
+                    model_tag="m1",
+                    created_at=datetime.datetime.now(),
+                )
+            )
+
+        mock_dense.return_value = DenseSearchResponse(
+            results=dense_results,
+            total_count=len(dense_results),
+            index_status=IndexStatus.INDEX_READY,
+            index_advice="Ready",
+            warnings=[],
+        )
+        mock_sparse.return_value = SparseSearchResponse(
+            results=sparse_results,
+            total_count=len(sparse_results),
+            fts_enabled=True,
+            query_text="query",
+            warnings=[],
+        )
+
+        response = search_hybrid(
+            collection="test_col",
+            model_tag="test_model",
+            query_text="top_k test",
+            query_vector=[0.1, 0.2, 0.3],
+            top_k=3,  # Request only 3 results
+        )
+
+        assert response.total_count == 3
+        assert len(response.results) == 3
+        # Ensure results are sorted by score and truncated
+        assert response.results[0].score >= response.results[1].score
+        assert response.results[1].score >= response.results[2].score
+
+    # Removed test_hybrid_search_unsupported_strategy_fallback:
+    # Pydantic V2's strict enum validation prevents creating FusionConfig with invalid strategy.
+    # This is the desired behavior - invalid strategies are caught at input validation layer.
+
+    def test_linear_fusion_score_normalization(self) -> None:
+        """Test that linear fusion normalizes final scores to [0, 1] range."""
+        from xagent.core.tools.core.RAG_tools.retrieval.search_hybrid import (
+            _linear_fusion,
+        )
+
+        # Create test data that would result in scores > 1.0 before normalization
+        dense_results = [
+            SearchResult(
+                doc_id="doc1",
+                chunk_id="chunk1",
+                text="dense content 1",
+                score=0.9,
+                parse_hash="hash1",
+                model_tag="model1",
+                created_at=datetime.datetime.now(),
+            ),
+            SearchResult(
+                doc_id="doc2",
+                chunk_id="chunk2",
+                text="dense content 2",
+                score=0.6,
+                parse_hash="hash2",
+                model_tag="model1",
+                created_at=datetime.datetime.now(),
+            ),
+        ]
+
+        sparse_results = [
+            SearchResult(
+                doc_id="doc1",  # Same doc as in dense - should get combined score
+                chunk_id="chunk1",
+                text="sparse content 1",
+                score=0.8,
+                parse_hash="hash1",
+                model_tag="model1",
+                created_at=datetime.datetime.now(),
+            ),
+            SearchResult(
+                doc_id="doc3",
+                chunk_id="chunk3",
+                text="sparse content 3",
+                score=0.5,
+                parse_hash="hash3",
+                model_tag="model1",
+                created_at=datetime.datetime.now(),
+            ),
+        ]
+
+        # Use weights that would cause combined scores > 1.0
+        # doc1: 0.7 * 0.9 + 0.8 * 0.8 = 0.63 + 0.64 = 1.27
+        # doc2: 0.7 * 0.6 = 0.42
+        # doc3: 0.8 * 0.5 = 0.4
+        fused_results = _linear_fusion(
+            dense_results=dense_results,
+            sparse_results=sparse_results,
+            dense_weight=0.7,
+            sparse_weight=0.8,
+            normalize_scores=True,
+        )
+
+        # Verify that all scores are in [0, 1] range after normalization
+        for result in fused_results:
+            assert 0.0 <= result.score <= 1.0, (
+                f"Score {result.score} is not in [0, 1] range"
+            )
+
+        # Verify that the highest score is 1.0 (after normalization)
+        max_score = max(r.score for r in fused_results)
+        assert abs(max_score - 1.0) < 0.001, (
+            f"Max score should be 1.0 after normalization, got {max_score}"
+        )
+
+        # Verify results are sorted by score in descending order
+        scores = [r.score for r in fused_results]
+        assert scores == sorted(scores, reverse=True), (
+            "Results should be sorted by score descending"
+        )

--- a/tests/tests/core/tools/core/RAG_tools/retrieval/test_search_sparse.py
+++ b/tests/tests/core/tools/core/RAG_tools/retrieval/test_search_sparse.py
@@ -1,0 +1,675 @@
+"""Tests for search_sparse functionality.
+
+This module tests the sparse (FTS) search implementation:
+- search_sparse main function
+- Integration with LanceDB and index management
+"""
+
+import importlib
+from typing import List
+from unittest.mock import Mock, patch
+
+import pandas as pd
+import pytest
+
+from xagent.core.tools.core.RAG_tools.core.exceptions import DocumentValidationError
+from xagent.core.tools.core.RAG_tools.core.schemas import (
+    SearchFallbackAction,
+    SearchResult,
+    SearchWarning,
+    SparseSearchResponse,
+)
+
+search_sparse_module = importlib.import_module(
+    "xagent.core.tools.core.RAG_tools.retrieval.search_sparse"
+)
+
+
+@pytest.mark.parametrize(
+    "collection,model_tag,top_k,query_text",
+    [
+        ("", "model", 1, "hello"),
+        ("collection", "", 1, "hello"),
+        ("collection", "model", 0, "hello"),
+        ("collection", "model", 1, ""),
+    ],
+)
+def test_search_sparse_input_validation(
+    collection: str,
+    model_tag: str,
+    top_k: int,
+    query_text: str,
+) -> None:
+    with pytest.raises(DocumentValidationError):
+        search_sparse_module.search_sparse(
+            collection=collection,
+            model_tag=model_tag,
+            query_text=query_text,
+            top_k=top_k,
+            user_id=None,
+            is_admin=True,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "collection,model_tag,top_k,query_text",
+    [
+        ("", "model", 1, "hello"),
+        ("collection", "", 1, "hello"),
+        ("collection", "model", 0, "hello"),
+        ("collection", "model", 1, ""),
+    ],
+)
+async def test_search_sparse_async_input_validation(
+    collection: str,
+    model_tag: str,
+    top_k: int,
+    query_text: str,
+) -> None:
+    with pytest.raises(DocumentValidationError):
+        await search_sparse_module.search_sparse_async(
+            collection=collection,
+            model_tag=model_tag,
+            query_text=query_text,
+            top_k=top_k,
+            user_id=None,
+            is_admin=True,
+        )
+
+
+class TestSearchSparse:
+    """Test search_sparse main function."""
+
+    def test_search_sparse_success_no_filters(self, make_handle, routed_facade) -> None:
+        """Test successful sparse search with collection filter only (KB isolation).
+
+        Re-pointed (#511): the public ``search_sparse`` runs the real handle FTS
+        logic against a mock ``vector_index_store``. The store-call chain
+        (open_embeddings_table -> create_index -> table.search(..fts).limit().where()
+        -> to_pandas) is identical to the legacy free-function path, so the
+        behavioral assertions are unchanged.
+        """
+        from xagent.core.tools.core.RAG_tools.core.schemas import IndexResult
+
+        handle, mock_vector_store, _ = make_handle(collection="test_col")
+
+        mock_table = Mock()
+        mock_table.name = "embeddings_test_model"
+        mock_table.list_indices.return_value = [
+            Mock(index_type="FTS", columns=["text"])
+        ]
+
+        mock_vector_store.create_index.return_value = IndexResult(
+            status="index_ready", advice=None, fts_enabled=True
+        )
+        mock_vector_store.build_filter_expression.return_value = (
+            "collection == 'test_col'"
+        )
+        mock_vector_store.open_embeddings_table.return_value = (
+            mock_table,
+            "embeddings_test_model",
+        )
+
+        mock_results_df = pd.DataFrame(
+            [
+                {
+                    "doc_id": "doc1",
+                    "chunk_id": "chunk1",
+                    "text": "test content one",
+                    "_score": 0.9,
+                    "parse_hash": "hash1",
+                    "created_at": pd.Timestamp.now(),
+                }
+            ]
+        )
+        mock_search = Mock()
+        mock_limit = Mock()
+        mock_where = Mock()
+        mock_table.search.return_value = mock_search
+        mock_search.limit.return_value = mock_limit
+        mock_limit.where.return_value = mock_where
+        mock_where.to_pandas.return_value = mock_results_df
+
+        with routed_facade(search_sparse_module, handle):
+            response = search_sparse_module.search_sparse(
+                collection="test_col",
+                model_tag="test_model",
+                query_text="content",
+                top_k=1,
+                user_id=None,
+                is_admin=True,
+            )
+
+        assert isinstance(response, SparseSearchResponse)
+        assert response.status == "success"
+        assert response.total_count == 1
+        assert response.fts_enabled is True
+        assert len(response.results) == 1
+        assert response.results[0].doc_id == "doc1"
+        assert response.results[0].text == "test content one"
+        # Score is normalized from TF-IDF to similarity score (0-1 range)
+        assert abs(response.results[0].score - 0.4736842105263158) < 1e-10
+        assert not response.warnings
+
+        # Verify calls: collection filter must be applied for KB isolation
+        mock_vector_store.open_embeddings_table.assert_called_once_with("test_model")
+        mock_vector_store.build_filter_expression.assert_called_once()
+        mock_table.search.assert_called_once_with("content", query_type="fts")
+        mock_search.limit.assert_called_once_with(1)
+        mock_limit.where.assert_called_once()
+        where_arg = mock_limit.where.call_args[0][0]
+        assert "collection" in where_arg.lower() or "test_col" in where_arg
+
+    def test_search_sparse_with_filters(self, make_handle, routed_facade) -> None:
+        """Test sparse search with filters."""
+        from xagent.core.tools.core.RAG_tools.core.schemas import IndexResult
+        from xagent.core.tools.core.RAG_tools.kb.collection_handle import (
+            LanceDBCollectionHandle,
+        )
+
+        handle, mock_vector_store, _ = make_handle(collection="test_col")
+
+        mock_table = Mock()
+        mock_table.name = "embeddings_test_model"
+        mock_table.list_indices.return_value = [
+            Mock(index_type="FTS", columns=["text"])
+        ]
+
+        mock_vector_store.create_index.return_value = IndexResult(
+            status="index_ready", advice=None, fts_enabled=True
+        )
+        mock_vector_store.build_filter_expression.return_value = (
+            "doc_id = 'filtered_doc' AND collection = 'test_col'"
+        )
+        mock_vector_store.open_embeddings_table.return_value = (
+            mock_table,
+            "embeddings_test_model",
+        )
+
+        mock_results_df = pd.DataFrame([])
+        mock_search = Mock()
+        mock_limit = Mock()
+        mock_where = Mock()
+        mock_table.search.return_value = mock_search
+        mock_search.limit.return_value = mock_limit
+        mock_limit.where.return_value = mock_where
+        mock_where.to_pandas.return_value = mock_results_df
+
+        filters = {"doc_id": "filtered_doc", "collection": "test_col"}
+
+        with patch.object(
+            LanceDBCollectionHandle, "_substring_fallback", return_value=[]
+        ) as mock_fallback:
+            with routed_facade(search_sparse_module, handle):
+                response = search_sparse_module.search_sparse(
+                    collection="test_col",
+                    model_tag="test_model",
+                    query_text="filtered content",
+                    top_k=5,
+                    filters=filters,
+                    user_id=None,
+                    is_admin=True,
+                )
+
+        assert response.status == "success"
+        assert response.total_count == 0
+        assert len(response.results) == 0
+        assert response.warnings == []
+
+        mock_fallback.assert_called_once()
+        mock_vector_store.open_embeddings_table.assert_called_once_with("test_model")
+        mock_vector_store.build_filter_expression.assert_called()
+        mock_table.search.assert_called_once_with("filtered content", query_type="fts")
+        mock_search.limit.assert_called_once_with(5)
+        mock_limit.where.assert_called_once()
+        mock_where.to_pandas.assert_called_once()
+
+    def test_search_sparse_applies_collection_filter(
+        self, make_handle, routed_facade
+    ) -> None:
+        """Test that search_sparse always applies collection filter for KB isolation (Issue #72)."""
+        from xagent.core.tools.core.RAG_tools.core.schemas import IndexResult
+        from xagent.core.tools.core.RAG_tools.kb.collection_handle import (
+            LanceDBCollectionHandle,
+        )
+
+        handle, mock_vector_store, _ = make_handle(collection="my_kb")
+
+        mock_table = Mock()
+        mock_table.list_indices.return_value = [
+            Mock(index_type="FTS", columns=["text"])
+        ]
+
+        mock_vector_store.create_index.return_value = IndexResult(
+            status="index_ready", advice=None, fts_enabled=True
+        )
+        mock_vector_store.build_filter_expression.return_value = "collection == 'my_kb'"
+        mock_vector_store.open_embeddings_table.return_value = (
+            mock_table,
+            "embeddings_test_model",
+        )
+
+        mock_search = Mock()
+        mock_limit = Mock()
+        mock_where = Mock()
+        mock_table.search.return_value = mock_search
+        mock_search.limit.return_value = mock_limit
+        mock_limit.where.return_value = mock_where
+        mock_where.to_pandas.return_value = pd.DataFrame()
+
+        with patch.object(
+            LanceDBCollectionHandle, "_substring_fallback", return_value=[]
+        ):
+            with routed_facade(search_sparse_module, handle):
+                search_sparse_module.search_sparse(
+                    collection="my_kb",
+                    model_tag="test_model",
+                    query_text="query",
+                    top_k=5,
+                    user_id=None,
+                    is_admin=True,
+                )
+
+        mock_vector_store.build_filter_expression.assert_called_once()
+        mock_limit.where.assert_called_once()
+
+    def test_search_sparse_fts_index_missing(self, make_handle, routed_facade) -> None:
+        """Test sparse search when FTS index is missing."""
+        from xagent.core.tools.core.RAG_tools.core.schemas import IndexResult
+        from xagent.core.tools.core.RAG_tools.kb.collection_handle import (
+            LanceDBCollectionHandle,
+        )
+
+        handle, mock_vector_store, _ = make_handle(collection="test_col")
+
+        mock_table = Mock()
+        mock_table.list_indices.return_value = []
+
+        mock_vector_store.create_index.return_value = IndexResult(
+            status="index_ready",
+            advice=None,
+            fts_enabled=False,  # FTS not enabled
+        )
+        mock_vector_store.build_filter_expression.return_value = (
+            "collection == 'test_col'"
+        )
+        mock_vector_store.open_embeddings_table.return_value = (
+            mock_table,
+            "embeddings_test_model",
+        )
+
+        mock_search = Mock()
+        mock_limit = Mock()
+        mock_where = Mock()
+        mock_table.search.return_value = mock_search
+        mock_search.limit.return_value = mock_limit
+        mock_limit.where.return_value = mock_where
+        mock_where.to_pandas.return_value = pd.DataFrame()
+
+        with patch.object(
+            LanceDBCollectionHandle, "_substring_fallback", return_value=[]
+        ):
+            with routed_facade(search_sparse_module, handle):
+                response = search_sparse_module.search_sparse(
+                    collection="test_col",
+                    model_tag="test_model",
+                    query_text="query",
+                    top_k=1,
+                    user_id=None,
+                    is_admin=True,
+                )
+
+        assert response.status == "success"
+        assert response.fts_enabled is False
+        assert any(w.code == "FTS_INDEX_MISSING" for w in response.warnings)
+
+        mock_vector_store.open_embeddings_table.assert_called_once_with("test_model")
+        mock_table.search.assert_called_once_with("query", query_type="fts")
+        mock_search.limit.assert_called_once_with(1)
+
+    def test_search_sparse_readonly_mode(self, make_handle, routed_facade) -> None:
+        """Test sparse search in readonly mode."""
+        from xagent.core.tools.core.RAG_tools.core.schemas import IndexResult
+        from xagent.core.tools.core.RAG_tools.kb.collection_handle import (
+            LanceDBCollectionHandle,
+        )
+
+        handle, mock_vector_store, _ = make_handle(collection="test_col")
+
+        mock_table = Mock()
+        mock_table.list_indices.return_value = [
+            Mock(index_type="FTS", columns=["text"])
+        ]
+
+        mock_vector_store.create_index.return_value = IndexResult(
+            status="index_ready", advice=None, fts_enabled=True
+        )
+        mock_vector_store.build_filter_expression.return_value = (
+            "collection == 'test_col'"
+        )
+        mock_vector_store.open_embeddings_table.return_value = (
+            mock_table,
+            "embeddings_test_model",
+        )
+
+        mock_search = Mock()
+        mock_limit = Mock()
+        mock_where = Mock()
+        mock_table.search.return_value = mock_search
+        mock_search.limit.return_value = mock_limit
+        mock_limit.where.return_value = mock_where
+        mock_where.to_pandas.return_value = pd.DataFrame()
+
+        with patch.object(
+            LanceDBCollectionHandle, "_substring_fallback", return_value=[]
+        ):
+            with routed_facade(search_sparse_module, handle):
+                response = search_sparse_module.search_sparse(
+                    collection="test_col",
+                    model_tag="test_model",
+                    query_text="query",
+                    top_k=1,
+                    readonly=True,
+                    user_id=None,
+                    is_admin=True,
+                )
+
+        assert response.status == "success"
+        # FTS should be enabled since the table has the index
+        assert response.fts_enabled is True
+        assert any(w.code == "READONLY_MODE" for w in response.warnings)
+
+        mock_vector_store.open_embeddings_table.assert_called_once_with("test_model")
+        mock_table.search.assert_called_once_with("query", query_type="fts")
+        mock_search.limit.assert_called_once_with(1)
+
+    @patch(
+        "xagent.core.tools.core.RAG_tools.utils.model_resolver.resolve_embedding_adapter"
+    )
+    def test_search_sparse_database_error(
+        self, mock_resolve: Mock, make_handle, routed_facade
+    ) -> None:
+        """Test error handling during database operation."""
+        handle, mock_vector_store, _ = make_handle(collection="test_col")
+        db_exception_message = "DB connection failed"
+        mock_vector_store.open_embeddings_table.side_effect = Exception(
+            db_exception_message
+        )
+
+        mock_cfg = Mock()
+        mock_cfg.model_name = "legacy_model"
+        mock_resolve.return_value = (mock_cfg, object())
+
+        with routed_facade(search_sparse_module, handle):
+            response = search_sparse_module.search_sparse(
+                collection="test_col",
+                model_tag="test_model",
+                query_text="query",
+                top_k=1,
+            )
+
+        assert response.status == "failed"
+        assert response.total_count == 0
+        assert len(response.results) == 0
+        assert len(response.warnings) == 1
+        assert response.warnings[0].code == "FTS_SEARCH_FAILED"
+        # Check for the wrapped error message
+        assert (
+            f"An unexpected error occurred during sparse search: {db_exception_message}"
+            in response.warnings[0].message
+        )
+
+        # Verify calls - open_embeddings_table is called once (handles fallback internally)
+        assert mock_vector_store.open_embeddings_table.call_count == 1
+        mock_vector_store.open_embeddings_table.assert_called_once_with("test_model")
+
+    def test_search_sparse_empty_results(self, make_handle, routed_facade) -> None:
+        """Test sparse search returning no results."""
+        from xagent.core.tools.core.RAG_tools.core.schemas import IndexResult
+        from xagent.core.tools.core.RAG_tools.kb.collection_handle import (
+            LanceDBCollectionHandle,
+        )
+
+        handle, mock_vector_store, _ = make_handle(collection="test_col")
+
+        mock_table = Mock()
+        mock_table.list_indices.return_value = [
+            Mock(index_type="FTS", columns=["text"])
+        ]
+
+        mock_vector_store.create_index.return_value = IndexResult(
+            status="index_ready", advice=None, fts_enabled=True
+        )
+        mock_vector_store.build_filter_expression.return_value = (
+            "collection == 'test_col'"
+        )
+        mock_vector_store.open_embeddings_table.return_value = (
+            mock_table,
+            "embeddings_test_model",
+        )
+
+        mock_search = Mock()
+        mock_limit = Mock()
+        mock_where = Mock()
+        mock_table.search.return_value = mock_search
+        mock_search.limit.return_value = mock_limit
+        mock_limit.where.return_value = mock_where
+        mock_where.to_pandas.return_value = pd.DataFrame()
+
+        with patch.object(
+            LanceDBCollectionHandle, "_substring_fallback", return_value=[]
+        ):
+            with routed_facade(search_sparse_module, handle):
+                response = search_sparse_module.search_sparse(
+                    collection="test_col",
+                    model_tag="test_model",
+                    query_text="no matches",
+                    top_k=5,
+                    user_id=None,
+                    is_admin=True,
+                )
+
+        assert response.status == "success"
+        assert response.total_count == 0
+        assert len(response.results) == 0
+        assert response.warnings == []
+
+        mock_vector_store.open_embeddings_table.assert_called_once_with("test_model")
+        mock_table.search.assert_called_once_with("no matches", query_type="fts")
+        mock_search.limit.assert_called_once_with(5)
+
+    def test_search_sparse_triggers_fallback_with_results(
+        self, make_handle, routed_facade
+    ) -> None:
+        """Ensure fallback populates results and emits an FTS warning."""
+        from xagent.core.tools.core.RAG_tools.core.schemas import IndexResult
+        from xagent.core.tools.core.RAG_tools.kb.collection_handle import (
+            LanceDBCollectionHandle,
+        )
+
+        def _fake_fallback(self, **kwargs: object) -> List[SearchResult]:
+            current_warnings: List[SearchWarning] = kwargs["current_warnings"]  # type: ignore[assignment]
+            current_warnings.append(
+                SearchWarning(
+                    code="FTS_FALLBACK",
+                    message="Fallback executed",
+                    fallback_action=SearchFallbackAction.PARTIAL_RESULTS,
+                    affected_models=["test_model"],
+                )
+            )
+            return [
+                SearchResult(
+                    doc_id="doc-fallback",
+                    chunk_id="chunk-fallback",
+                    text="matched text",
+                    score=1.0,
+                    parse_hash="hash",
+                    model_tag="test_model",
+                    created_at=pd.Timestamp.now(),
+                )
+            ]
+
+        handle, mock_vector_store, _ = make_handle(collection="test_col")
+
+        mock_table = Mock()
+        mock_table.list_indices.return_value = [
+            Mock(index_type="FTS", columns=["text"])
+        ]
+
+        mock_vector_store.create_index.return_value = IndexResult(
+            status="index_ready", advice=None, fts_enabled=True
+        )
+        mock_vector_store.build_filter_expression.return_value = (
+            "collection == 'test_col'"
+        )
+        mock_vector_store.open_embeddings_table.return_value = (
+            mock_table,
+            "embeddings_test_model",
+        )
+
+        mock_search = Mock()
+        mock_limit = Mock()
+        mock_where = Mock()
+        mock_table.search.return_value = mock_search
+        mock_search.limit.return_value = mock_limit
+        mock_limit.where.return_value = mock_where
+        mock_where.to_pandas.return_value = pd.DataFrame()
+
+        with patch.object(
+            LanceDBCollectionHandle,
+            "_substring_fallback",
+            autospec=True,
+            side_effect=_fake_fallback,
+        ):
+            with routed_facade(search_sparse_module, handle):
+                response = search_sparse_module.search_sparse(
+                    collection="test_col",
+                    model_tag="test_model",
+                    query_text="fallback",
+                    top_k=3,
+                    user_id=None,
+                    is_admin=True,
+                )
+
+        assert response.status == "success"
+        assert response.total_count == 1
+        assert response.results[0].doc_id == "doc-fallback"
+        assert any(w.code == "FTS_FALLBACK" for w in response.warnings)
+
+    def test_search_sparse_score_clamping(self, make_handle, routed_facade) -> None:
+        """Test that sparse search scores are properly clamped to [0, 1] range."""
+        from xagent.core.tools.core.RAG_tools.core.schemas import IndexResult
+
+        handle, mock_vector_store, _ = make_handle(collection="test_col")
+
+        mock_table = Mock()
+        mock_table.list_indices.return_value = [
+            Mock(index_type="FTS", columns=["text"])
+        ]
+
+        mock_vector_store.create_index.return_value = IndexResult(
+            status="index_ready", advice=None, fts_enabled=True
+        )
+        mock_vector_store.build_filter_expression.return_value = (
+            "collection == 'test_col'"
+        )
+        mock_vector_store.open_embeddings_table.return_value = (
+            mock_table,
+            "embeddings_test_model",
+        )
+
+        mock_search = Mock()
+        mock_limit = Mock()
+        mock_where = Mock()
+        mock_table.search.return_value = mock_search
+        mock_search.limit.return_value = mock_limit
+        mock_limit.where.return_value = mock_where
+
+        # Create test data with a very high _score that would result in score > 1
+        test_data = pd.DataFrame(
+            {
+                "doc_id": ["doc1"],
+                "chunk_id": ["chunk1"],
+                "text": ["test text"],
+                "parse_hash": ["hash1"],
+                "created_at": [pd.Timestamp.now()],
+                "metadata": ['{"key": "value"}'],
+                "_score": [100.0],  # score = 100/101 ≈ 0.99
+            }
+        )
+        mock_where.to_pandas.return_value = test_data
+
+        with routed_facade(search_sparse_module, handle):
+            response = search_sparse_module.search_sparse(
+                collection="test_col",
+                model_tag="test_model",
+                query_text="test",
+                top_k=10,
+                user_id=None,
+                is_admin=True,
+            )
+
+        assert response.status == "success"
+        assert len(response.results) == 1
+        # Verify score is properly clamped and within [0, 1]
+        assert 0.0 <= response.results[0].score <= 1.0
+        # For _score = 100, expected score = 100 / (1 + 100) = 100/101 ≈ 0.9901
+        expected_score = 100.0 / (1.0 + 100.0)
+        assert abs(response.results[0].score - expected_score) < 0.0001
+
+    def test_search_sparse_fts_fallback_warning_content(self) -> None:
+        """Test that FTS_FALLBACK warning has correct content and fallback_action.
+
+        The _substring_fallback logic now lives on LanceDBCollectionHandle.
+        Call it via the handle instance to verify warning message content.
+        """
+        from xagent.core.tools.core.RAG_tools.core.schemas import SearchWarning
+        from xagent.core.tools.core.RAG_tools.kb.collection_handle import (
+            LanceDBCollectionHandle,
+        )
+
+        warnings: List[SearchWarning] = []
+
+        # Mock table with some matching results to trigger the warning
+        mock_table = Mock()
+        mock_batch = Mock()
+        mock_batch.to_pandas.return_value = pd.DataFrame(
+            {
+                "collection": ["test_col"],
+                "doc_id": ["doc1"],
+                "chunk_id": ["chunk1"],
+                "text": ["test query content"],
+                "parse_hash": ["hash1"],
+                "created_at": [pd.Timestamp.now()],
+                "metadata": ['{"key": "value"}'],
+            }
+        )
+        mock_table.to_batches.return_value = [mock_batch]
+
+        # Create a handle instance to call the method
+        handle = LanceDBCollectionHandle.__new__(LanceDBCollectionHandle)
+        results = handle._substring_fallback(
+            table=mock_table,
+            collection="test_col",
+            query_text="test query",
+            model_tag="test_model",
+            top_k=5,
+            filter_expr=None,
+            current_warnings=warnings,
+        )
+
+        # Verify results were found and warning was added
+        assert len(results) > 0
+        assert len(warnings) == 1
+        warning = warnings[0]
+
+        assert warning.code == "FTS_FALLBACK"
+        assert warning.fallback_action == SearchFallbackAction.BRUTE_FORCE
+        assert warning.affected_models == ["test_model"]
+
+        # Verify detailed message content
+        assert "Full-text index returned no matches" in warning.message
+        assert "used substring search fallback" in warning.message
+        assert "Check FTS tokenizer configuration" in warning.message
+        assert "update LanceDB to ensure proper tokenisation" in warning.message


### PR DESCRIPTION
- Preserve prebuilt `FilterCondition`, tuple, and list filters for dense search.
- Apply legacy operator filters in substring fallback instead of comparing raw operator dicts.
- Add public input validation for sparse and hybrid search to match dense search behavior.
- Add regression coverage for dense non-dict filters, substring legacy operators, and sparse/hybrid validation @rogercloud 