### PR TITLE
feat: make widget panel width resizable and persist it

### DIFF
--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -227,6 +227,48 @@
     return url + (url.indexOf('?') === -1 ? '?' : '&') + 'timezone=' + encoded;
   }
 
+  // Panel width: resizable via the left-edge drag handle, persisted across
+  // reloads. Inline width is only ever applied above MOBILE_BREAKPOINT --
+  // below it the CSS media query owns sizing, and inline width would win
+  // over that media query by specificity if left in place.
+  var WIDTH_STORAGE_KEY = 'xagent_widget_width';
+  var DEFAULT_PANEL_WIDTH = 380;
+  var MIN_PANEL_WIDTH = 320;
+  var MAX_PANEL_WIDTH = 720;
+  var MOBILE_BREAKPOINT = 480;
+  var HORIZONTAL_VIEWPORT_MARGIN = 40;
+
+  function isMobileViewport() {
+    return window.innerWidth <= MOBILE_BREAKPOINT;
+  }
+
+  function clampPanelWidth(width) {
+    var viewportMax = window.innerWidth - HORIZONTAL_VIEWPORT_MARGIN;
+    return Math.min(Math.max(width, MIN_PANEL_WIDTH), Math.min(MAX_PANEL_WIDTH, viewportMax));
+  }
+
+  function readStoredWidth() {
+    var raw;
+    try {
+      raw = localStorage.getItem(WIDTH_STORAGE_KEY);
+    } catch (e) {
+      return DEFAULT_PANEL_WIDTH;
+    }
+    var parsed = raw ? parseInt(raw, 10) : NaN;
+    return isNaN(parsed) ? DEFAULT_PANEL_WIDTH : parsed;
+  }
+
+  function persistWidth(width) {
+    try {
+      localStorage.setItem(WIDTH_STORAGE_KEY, String(width));
+    } catch (e) {
+      // Storage can be unavailable (private browsing, quota); resizing still
+      // works for the session, it just won't survive a reload.
+    }
+  }
+
+  var panelWidth = clampPanelWidth(readStoredWidth());
+
   // Styles
   var style = document.createElement('style');
   style.innerHTML = `
@@ -297,10 +339,30 @@
       background: transparent;
     }
 
-    @media (max-width: 480px) {
+    .xagent-widget-resize-handle {
+      position: absolute;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      width: 6px;
+      cursor: ew-resize;
+      z-index: 2;
+      touch-action: none;
+    }
+
+    .xagent-widget-resize-handle:hover,
+    .xagent-widget-resize-handle:active {
+      background: rgba(0, 0, 0, 0.15);
+    }
+
+    @media (max-width: ${MOBILE_BREAKPOINT}px) {
       .xagent-widget-panel {
-        width: calc(100vw - 40px);
+        width: calc(100vw - ${HORIZONTAL_VIEWPORT_MARGIN}px);
         height: calc(100vh - 120px);
+      }
+
+      .xagent-widget-resize-handle {
+        display: none;
       }
     }
   `;
@@ -318,6 +380,60 @@
   var iframe = document.createElement('iframe');
   iframe.className = 'xagent-widget-iframe';
   panel.appendChild(iframe);
+
+  // Left-edge resize handle
+  var resizeHandle = document.createElement('div');
+  resizeHandle.className = 'xagent-widget-resize-handle';
+  panel.appendChild(resizeHandle);
+
+  function applyPanelWidth() {
+    panel.style.width = isMobileViewport() ? '' : panelWidth + 'px';
+  }
+  applyPanelWidth();
+  window.addEventListener('resize', function () {
+    panelWidth = clampPanelWidth(panelWidth);
+    applyPanelWidth();
+  });
+
+  var dragState = null;
+
+  resizeHandle.addEventListener('pointerdown', function (event) {
+    // Ignore a second simultaneous pointer (e.g. a touchscreen device) so it
+    // can't hijack dragState mid-drag and strand the first pointer's cleanup.
+    if (isMobileViewport() || dragState) return;
+    dragState = {
+      pointerId: event.pointerId,
+      startX: event.clientX,
+      startWidth: panel.getBoundingClientRect().width
+    };
+    resizeHandle.setPointerCapture(event.pointerId);
+    document.body.style.userSelect = 'none';
+    event.preventDefault();
+  });
+
+  resizeHandle.addEventListener('pointermove', function (event) {
+    if (!dragState || event.pointerId !== dragState.pointerId) return;
+    // Panel is right-anchored, so dragging the left edge left (clientX
+    // decreasing) should grow the panel.
+    var delta = dragState.startX - event.clientX;
+    panelWidth = clampPanelWidth(dragState.startWidth + delta);
+    panel.style.width = panelWidth + 'px';
+  });
+
+  function endDrag(event) {
+    if (!dragState || (event && event.pointerId !== dragState.pointerId)) return;
+    dragState = null;
+    document.body.style.userSelect = '';
+    persistWidth(panelWidth);
+  }
+  resizeHandle.addEventListener('pointerup', endDrag);
+  resizeHandle.addEventListener('pointercancel', endDrag);
+  // A drag released off-window (e.g. Alt+Tab away mid-drag) never delivers
+  // pointerup/pointercancel to the handle, which would otherwise strand
+  // userSelect: 'none' on the host page indefinitely.
+  window.addEventListener('blur', function () {
+    endDrag(null);
+  });
 
   // FAB
   var fab = document.createElement('button');

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -326,7 +326,7 @@
       position: absolute;
       bottom: calc(${buttonSize} + 20px);
       right: 0;
-      width: 380px;
+      width: ${DEFAULT_PANEL_WIDTH}px;
       height: 600px;
       max-height: calc(100vh - 100px);
       background: ${panelBgColor};
@@ -367,6 +367,15 @@
     .xagent-widget-resize-handle:hover,
     .xagent-widget-resize-handle:active {
       background: rgba(0, 0, 0, 0.15);
+    }
+
+    /* visibility transitions to a closed panel keep it hit-testable for the
+       duration of the transition (per spec, as long as either end of the
+       transition is 'visible') -- without this, the handle stays draggable
+       and cursor-hinting during that window even though the panel is
+       already fading out. */
+    .xagent-widget-panel:not(.open) .xagent-widget-resize-handle {
+      display: none;
     }
 
     @media (max-width: ${MOBILE_BREAKPOINT}px) {
@@ -433,22 +442,19 @@
       // box-sizing: border-box is in effect -- computed style avoids that
       // mismatch (a jump by the border width on every drag start) even if
       // something on the host page ends up overriding our own box-sizing rule.
-      // This is the *rendered* width, which is <= the user's raw preference
-      // whenever the viewport is currently clamping it down (previewWidth
-      // below) -- pointermove needs both to avoid re-corrupting the
-      // preference on a drag that never escapes that clamp.
       startWidth: parseInt(window.getComputedStyle(panel).width, 10) || DEFAULT_PANEL_WIDTH,
       // The drag's live candidate. panelWidth itself is never written until
-      // a real release commits it (see endDrag) -- cancelling a drag (blur,
-      // a mid-drag viewport change, pointercancel, DOM removal) then needs
-      // no rollback of anything, since the committed preference was never
-      // touched in the first place.
-      previewWidth: panelWidth,
-      // Sticky for the rest of this drag: once the user visibly shrinks past
-      // the starting render, later pointermove events adopt the live value
-      // outright (see onPointerMove) instead of continuing to protect a
-      // preference the user has already demonstrated they're moving away from.
-      shrunkPastStart: false,
+      // a real release commits it (see finishDrag) -- cancelling a drag
+      // (blur, a mid-drag viewport change, pointercancel, DOM removal) then
+      // needs no rollback of anything, since the committed preference was
+      // never touched in the first place.
+      lastWidth: null,
+      // Whether this drag ever visibly rendered a width other than
+      // startWidth -- a release with this still false is a no-op (a plain
+      // click, or a drag fully absorbed by the viewport ceiling) and must
+      // leave the existing preference alone rather than re-commit whatever
+      // startWidth happened to be.
+      moved: false,
       originalCursor: document.body.style.cursor,
       originalUserSelect: document.body.style.userSelect
     };
@@ -476,15 +482,15 @@
     var delta = dragState.startX - event.clientX;
     var candidate = clampPanelWidth(dragState.startWidth + delta);
     panel.style.width = candidate + 'px';
-    if (candidate < dragState.startWidth) dragState.shrunkPastStart = true;
-    // If the drag started already pinned to the viewport ceiling (the raw
-    // preference is wider than what currently fits) and never visibly shrinks
-    // past that ceiling, keep the wider preference intact instead of silently
-    // replacing it with the ceiling value -- once the user does demonstrate a
-    // real shrink, adopt the live value for the rest of the drag, including a
-    // later move back up to exactly the ceiling (that's now a real choice,
-    // not an unmoved starting position).
-    dragState.previewWidth = dragState.shrunkPastStart ? candidate : Math.max(candidate, dragState.previewWidth);
+    dragState.lastWidth = candidate;
+    // A drag that started already pinned to the viewport ceiling (the raw
+    // preference is wider than what currently fits) and never visibly moves
+    // the render away from that ceiling hasn't expressed a new choice --
+    // leave the existing preference alone rather than re-committing the
+    // ceiling value on release. Always tracking the *latest* candidate here
+    // (not a running min/max across the drag) is what makes an overshoot
+    // that gets corrected back commit the corrected value, not the peak.
+    if (candidate !== dragState.startWidth) dragState.moved = true;
   }
 
   function restoreDragSideEffects() {
@@ -509,40 +515,42 @@
     } catch (e) {}
   }
 
-  function endDrag(event) {
+  // A real release (pointerup/pointercancel... see below) commits whatever
+  // was last rendered; any other way a drag ends only cancels. Both share
+  // this one path so the guard, cleanup, and re-render can't drift apart
+  // between the two the way they did across earlier rounds.
+  function finishDrag(commit, event) {
     if (!dragState || (event && event.pointerId !== dragState.pointerId)) return;
     restoreDragSideEffects();
-    // Skip committing once the panel has left the DOM: this same cleanup
-    // runs from the teardown observer below on removal, by which point any
-    // width here reflects a stale, no-longer-visible instance rather than a
-    // choice the user can still see or reconsider.
-    if (panel.isConnected) {
-      panelWidth = dragState.previewWidth;
+    // dragState.moved false means this release never actually rendered a
+    // different width (a plain click, or a drag fully absorbed by the
+    // viewport ceiling) -- leave the existing preference untouched rather
+    // than re-committing startWidth as if it were a real choice. Skip
+    // committing entirely once the panel has left the DOM: any width here
+    // reflects a stale, no-longer-visible instance rather than a choice the
+    // user can still see or reconsider.
+    if (commit && dragState.moved && panel.isConnected) {
+      panelWidth = dragState.lastWidth;
       persistWidth(panelWidth);
     }
     dragState = null;
+    applyPanelWidth();
+  }
+  function endDrag(event) {
+    finishDrag(true, event);
+  }
+  // Cancels rather than commits: window blur, a viewport change invalidating
+  // this drag's frozen geometry, DOM removal, and pointercancel (an
+  // involuntary interruption -- a touch gesture reinterpreted as a scroll,
+  // an OS-level interrupt, capture lost to another element -- rather than
+  // the user confirming a release) are none of them the user releasing the
+  // handle, so none of them persist a width.
+  function cancelDrag(event) {
+    finishDrag(false, event);
   }
   document.addEventListener('pointermove', onPointerMove);
   document.addEventListener('pointerup', endDrag);
-  // pointercancel is an involuntary interruption (a touch gesture
-  // reinterpreted as a scroll, an OS-level interrupt, capture lost to
-  // another element) rather than the user confirming a release, so it goes
-  // through cancelDrag (below) like blur/resize, not endDrag.
   document.addEventListener('pointercancel', cancelDrag);
-
-  // Cancels rather than commits: an interruption -- window blur, a viewport
-  // change invalidating this drag's frozen geometry, pointercancel, DOM
-  // removal -- is not the user confirming a width via release, so it must
-  // not persist one. Unlike endDrag, this never touches the committed
-  // panelWidth at all (only dragState.previewWidth, which is simply
-  // discarded) -- so there's nothing to roll back, and no risk of an
-  // abandoned draft surviving to be picked up by a later, unrelated drag.
-  function cancelDrag(event) {
-    if (!dragState || (event && event.pointerId !== dragState.pointerId)) return;
-    restoreDragSideEffects();
-    dragState = null;
-    applyPanelWidth();
-  }
 
   function onWindowBlur() {
     // Focus moving into this widget's own iframe (e.g. the chat composer
@@ -587,6 +595,11 @@
     document.removeEventListener('pointerup', endDrag);
     document.removeEventListener('pointercancel', cancelDrag);
     cancelDrag();
+    // Belt-and-suspenders for a host SPA that re-inserts this same node
+    // later (torndown permanently blocks a new drag regardless, but without
+    // this the handle would still show its ew-resize cursor and hover
+    // highlight, looking interactive while doing nothing).
+    resizeHandle.style.display = 'none';
   });
 
   // FAB
@@ -621,7 +634,11 @@
   // container directly, or wiping a wrapper it added around container)
   // would otherwise mutate a node this observer never inspects, and the
   // callback would simply never fire.
-  panelRemovalObserver.observe(document.body, { childList: true, subtree: true });
+  // documentElement, not body: a host framework that replaces <body> wholesale
+  // on navigation (e.g. Turbo Drive, htmx boosted navigation) never mutates
+  // the childList of the *old* body node that still holds container -- only
+  // <html>'s own childList changes when body itself is swapped out.
+  panelRemovalObserver.observe(document.documentElement, { childList: true, subtree: true });
 
   mode.attach(iframe);
 
@@ -790,7 +807,10 @@
       window.addEventListener('pageshow', onPageShow);
       window.addEventListener('pagehide', onPageHide);
       state.observer = new MutationObserver(onDomMutation);
-      state.observer.observe(document.body, { childList: true, subtree: true });
+      // documentElement, not body: see panelRemovalObserver's identical
+      // reasoning above -- a full <body> replacement never mutates the old
+      // body's own childList.
+      state.observer.observe(document.documentElement, { childList: true, subtree: true });
       runLoadFlow();
     }
 

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -309,6 +309,10 @@
     }
 
     .xagent-widget-panel {
+      /* Pin the box model so the resize drag's width math (which reads
+         computed CSS width) can't drift from the host page's own
+         box-sizing default. */
+      box-sizing: border-box;
       position: absolute;
       bottom: calc(${buttonSize} + 20px);
       right: 0;
@@ -393,7 +397,17 @@
     panel.style.width = isMobileViewport() ? '' : clampPanelWidth(panelWidth) + 'px';
   }
   applyPanelWidth();
-  window.addEventListener('resize', applyPanelWidth);
+  // Self-unsubscribes once the panel leaves the DOM (e.g. a host SPA removing
+  // the widget without a full page reload) -- otherwise this window-level
+  // listener is a GC root keeping the whole closure, panel included, alive
+  // indefinitely.
+  window.addEventListener('resize', function onWindowResize() {
+    if (!panel.isConnected) {
+      window.removeEventListener('resize', onWindowResize);
+      return;
+    }
+    applyPanelWidth();
+  });
 
   var dragState = null;
 
@@ -404,7 +418,12 @@
     dragState = {
       pointerId: event.pointerId,
       startX: event.clientX,
-      startWidth: panel.getBoundingClientRect().width,
+      // getBoundingClientRect().width is always border-box regardless of
+      // box-sizing, but panel.style.width sets content-box width unless
+      // box-sizing: border-box is in effect -- computed style avoids that
+      // mismatch (a jump by the border width on every drag start) even if
+      // something on the host page ends up overriding our own box-sizing rule.
+      startWidth: parseInt(window.getComputedStyle(panel).width, 10) || DEFAULT_PANEL_WIDTH,
       originalUserSelect: document.body.style.userSelect
     };
     // Older browsers without Pointer Capture still get a working drag via
@@ -439,8 +458,13 @@
   resizeHandle.addEventListener('pointercancel', endDrag);
   // A drag released off-window (e.g. Alt+Tab away mid-drag) never delivers
   // pointerup/pointercancel to the handle, which would otherwise strand
-  // userSelect: 'none' on the host page indefinitely.
-  window.addEventListener('blur', function () {
+  // userSelect: 'none' on the host page indefinitely. Self-unsubscribes once
+  // the panel leaves the DOM, for the same reason as the resize listener above.
+  window.addEventListener('blur', function onWindowBlur() {
+    if (!panel.isConnected) {
+      window.removeEventListener('blur', onWindowBlur);
+      return;
+    }
     endDrag(null);
   });
 

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -255,7 +255,13 @@
       return DEFAULT_PANEL_WIDTH;
     }
     var parsed = raw ? parseInt(raw, 10) : NaN;
-    return isNaN(parsed) ? DEFAULT_PANEL_WIDTH : parsed;
+    // Bounds-check against the static MIN/MAX only (never the viewport --
+    // that's applyPanelWidth's job) so a corrupted or stale-schema stored
+    // value self-heals on the next load instead of being echoed back forever.
+    if (isNaN(parsed) || parsed < MIN_PANEL_WIDTH || parsed > MAX_PANEL_WIDTH) {
+      return DEFAULT_PANEL_WIDTH;
+    }
+    return parsed;
   }
 
   function persistWidth(width) {
@@ -401,17 +407,7 @@
     panel.style.width = isMobileViewport() ? '' : clampPanelWidth(panelWidth) + 'px';
   }
   applyPanelWidth();
-  // Self-unsubscribes once the panel leaves the DOM (e.g. a host SPA removing
-  // the widget without a full page reload) -- otherwise this window-level
-  // listener is a GC root keeping the whole closure, panel included, alive
-  // indefinitely.
-  window.addEventListener('resize', function onWindowResize() {
-    if (!panel.isConnected) {
-      window.removeEventListener('resize', onWindowResize);
-      return;
-    }
-    applyPanelWidth();
-  });
+  window.addEventListener('resize', applyPanelWidth);
 
   var dragState = null;
 
@@ -427,57 +423,98 @@
       // box-sizing: border-box is in effect -- computed style avoids that
       // mismatch (a jump by the border width on every drag start) even if
       // something on the host page ends up overriding our own box-sizing rule.
+      // This is the *rendered* width, which is <= the user's raw preference
+      // whenever the viewport is currently clamping it down (startPanelWidth
+      // below) -- pointermove needs both to avoid re-corrupting the
+      // preference on a drag that never escapes that clamp.
       startWidth: parseInt(window.getComputedStyle(panel).width, 10) || DEFAULT_PANEL_WIDTH,
+      startPanelWidth: panelWidth,
       originalUserSelect: document.body.style.userSelect
     };
-    // pointermove/pointerup are bound only to this 6px handle, so once the
-    // cursor leaves it the drag lives entirely on this capture -- it has
-    // near-universal support in browsers this widget runs in, but guard the
-    // call anyway since it's not essential to starting the drag itself.
+    // Optimization, not the drag's only path: pointermove/pointerup/
+    // pointercancel are bound to `document` below specifically so the drag
+    // still works if this capture silently fails.
     try {
       resizeHandle.setPointerCapture(event.pointerId);
     } catch (e) {}
     document.body.style.userSelect = 'none';
     // Without this, the iframe (a sibling of the handle, not an ancestor)
     // would intercept pointer events once the cursor moves over it mid-drag;
-    // disabling its pointer-events lets those events fall through to the
-    // captured handle instead of stalling on the iframe.
+    // disabling its pointer-events lets those events fall through to panel
+    // and bubble to the document-level listeners below instead of stalling
+    // on the iframe.
     iframe.style.pointerEvents = 'none';
     event.preventDefault();
   });
 
-  resizeHandle.addEventListener('pointermove', function (event) {
+  function onPointerMove(event) {
     if (!dragState || event.pointerId !== dragState.pointerId) return;
     // Panel is right-anchored, so dragging the left edge left (clientX
     // decreasing) should grow the panel.
     var delta = dragState.startX - event.clientX;
-    panelWidth = clampPanelWidth(dragState.startWidth + delta);
-    panel.style.width = panelWidth + 'px';
-  });
+    var candidate = clampPanelWidth(dragState.startWidth + delta);
+    panel.style.width = candidate + 'px';
+    // If the drag started already pinned to the viewport ceiling (the raw
+    // preference is wider than what currently fits) and the cursor never
+    // actually moves the rendered width below that ceiling, keep the wider
+    // preference intact rather than silently replacing it with the ceiling
+    // value -- only a drag that visibly shrinks the panel below where it
+    // started counts as the user choosing a new, smaller width.
+    panelWidth = candidate < dragState.startWidth
+      ? candidate
+      : Math.max(candidate, dragState.startPanelWidth);
+  }
 
   function endDrag(event) {
     if (!dragState || (event && event.pointerId !== dragState.pointerId)) return;
-    document.body.style.userSelect = dragState.originalUserSelect;
+    // Only restore if nothing else changed it in the meantime -- a host page
+    // that set its own userSelect after this drag started (e.g. while
+    // rebuilding its own UI mid-drag) must not have that value clobbered by
+    // a stale snapshot from before it ran.
+    if (document.body.style.userSelect === 'none') {
+      document.body.style.userSelect = dragState.originalUserSelect;
+    }
     iframe.style.pointerEvents = '';
     dragState = null;
-    persistWidth(panelWidth);
+    // Skip persisting once the panel has left the DOM: this same cleanup
+    // runs from the teardown observer below on removal, by which point any
+    // width here reflects a stale, no-longer-visible instance rather than a
+    // choice the user can still see or reconsider.
+    if (panel.isConnected) persistWidth(panelWidth);
   }
-  resizeHandle.addEventListener('pointerup', endDrag);
-  resizeHandle.addEventListener('pointercancel', endDrag);
-  // A drag released off-window (e.g. Alt+Tab away mid-drag, or a host SPA
-  // removing the widget mid-drag) never delivers pointerup/pointercancel to
-  // the handle, which would otherwise strand userSelect: 'none' on the host
-  // page indefinitely -- including past the panel's own removal, since that
-  // removal doesn't touch document.body. So endDrag must run unconditionally
-  // here, before the isConnected self-unsubscribe (added for the same reason
-  // as the resize listener above): unlike that listener, this one has a
-  // cleanup obligation that self-unsubscribing must not skip.
-  window.addEventListener('blur', function onWindowBlur() {
+  document.addEventListener('pointermove', onPointerMove);
+  document.addEventListener('pointerup', endDrag);
+  document.addEventListener('pointercancel', endDrag);
+
+  function onWindowBlur() {
+    // A drag released off-window (e.g. Alt+Tab away mid-drag) never delivers
+    // pointerup/pointercancel, which would otherwise strand userSelect:
+    // 'none' on the host page indefinitely. A no-op when no drag is active.
     endDrag(null);
-    if (!panel.isConnected) {
-      window.removeEventListener('blur', onWindowBlur);
-    }
+  }
+  window.addEventListener('blur', onWindowBlur);
+
+  // Immediate, synchronous teardown the instant the panel leaves the DOM --
+  // covers both leak prevention (the listeners above are otherwise GC roots
+  // keeping this whole closure, panel included, alive indefinitely) and the
+  // drag-interrupted-by-removal case (blur alone doesn't fire just because a
+  // host SPA removes the widget, so waiting for it would leave userSelect
+  // stranded on the host page until an unrelated future blur happens to
+  // occur, if ever). Matches the isConnected-driven detection this file
+  // already uses for the session controller's own listeners, just scoped to
+  // the panel and triggered synchronously rather than via a MutationObserver
+  // dedicated to iframe connectivity.
+  var panelRemovalObserver = new MutationObserver(function () {
+    if (panel.isConnected) return;
+    panelRemovalObserver.disconnect();
+    window.removeEventListener('resize', applyPanelWidth);
+    window.removeEventListener('blur', onWindowBlur);
+    document.removeEventListener('pointermove', onPointerMove);
+    document.removeEventListener('pointerup', endDrag);
+    document.removeEventListener('pointercancel', endDrag);
+    endDrag(null);
   });
+  panelRemovalObserver.observe(document.body, { childList: true, subtree: true });
 
   // FAB
   var fab = document.createElement('button');

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -407,14 +407,19 @@
     panel.style.width = isMobileViewport() ? '' : clampPanelWidth(panelWidth) + 'px';
   }
   applyPanelWidth();
-  window.addEventListener('resize', applyPanelWidth);
 
   var dragState = null;
+  // Set once this instance is torn down (panelRemovalObserver below) so a
+  // stray pointerdown can never start a new, permanently uncleanable drag --
+  // e.g. if a host SPA re-inserts this same panel node into the DOM after
+  // removing it, which flips panel.isConnected back to true but does not
+  // re-arm the (already-disconnected) observer or any removed listener.
+  var torndown = false;
 
   resizeHandle.addEventListener('pointerdown', function (event) {
     // Ignore a second simultaneous pointer (e.g. a touchscreen device) so it
     // can't hijack dragState mid-drag and strand the first pointer's cleanup.
-    if (isMobileViewport() || dragState) return;
+    if (torndown || isMobileViewport() || dragState) return;
     dragState = {
       pointerId: event.pointerId,
       startX: event.clientX,
@@ -429,6 +434,11 @@
       // preference on a drag that never escapes that clamp.
       startWidth: parseInt(window.getComputedStyle(panel).width, 10) || DEFAULT_PANEL_WIDTH,
       startPanelWidth: panelWidth,
+      // Sticky for the rest of this drag: once the user visibly shrinks past
+      // the starting render, later pointermove events adopt the live value
+      // outright (see onPointerMove) instead of continuing to protect a
+      // preference the user has already demonstrated they're moving away from.
+      shrunkPastStart: false,
       originalUserSelect: document.body.style.userSelect
     };
     // Optimization, not the drag's only path: pointermove/pointerup/
@@ -437,6 +447,7 @@
     try {
       resizeHandle.setPointerCapture(event.pointerId);
     } catch (e) {}
+    document.body.style.cursor = 'ew-resize';
     document.body.style.userSelect = 'none';
     // Without this, the iframe (a sibling of the handle, not an ancestor)
     // would intercept pointer events once the cursor moves over it mid-drag;
@@ -454,19 +465,18 @@
     var delta = dragState.startX - event.clientX;
     var candidate = clampPanelWidth(dragState.startWidth + delta);
     panel.style.width = candidate + 'px';
+    if (candidate < dragState.startWidth) dragState.shrunkPastStart = true;
     // If the drag started already pinned to the viewport ceiling (the raw
-    // preference is wider than what currently fits) and the cursor never
-    // actually moves the rendered width below that ceiling, keep the wider
-    // preference intact rather than silently replacing it with the ceiling
-    // value -- only a drag that visibly shrinks the panel below where it
-    // started counts as the user choosing a new, smaller width.
-    panelWidth = candidate < dragState.startWidth
-      ? candidate
-      : Math.max(candidate, dragState.startPanelWidth);
+    // preference is wider than what currently fits) and never visibly shrinks
+    // past that ceiling, keep the wider preference intact instead of silently
+    // replacing it with the ceiling value -- once the user does demonstrate a
+    // real shrink, adopt the live value for the rest of the drag, including a
+    // later move back up to exactly the ceiling (that's now a real choice,
+    // not an unmoved starting position).
+    panelWidth = dragState.shrunkPastStart ? candidate : Math.max(candidate, dragState.startPanelWidth);
   }
 
-  function endDrag(event) {
-    if (!dragState || (event && event.pointerId !== dragState.pointerId)) return;
+  function restoreDragSideEffects() {
     // Only restore if nothing else changed it in the meantime -- a host page
     // that set its own userSelect after this drag started (e.g. while
     // rebuilding its own UI mid-drag) must not have that value clobbered by
@@ -474,7 +484,13 @@
     if (document.body.style.userSelect === 'none') {
       document.body.style.userSelect = dragState.originalUserSelect;
     }
+    document.body.style.cursor = '';
     iframe.style.pointerEvents = '';
+  }
+
+  function endDrag(event) {
+    if (!dragState || (event && event.pointerId !== dragState.pointerId)) return;
+    restoreDragSideEffects();
     dragState = null;
     // Skip persisting once the panel has left the DOM: this same cleanup
     // runs from the teardown observer below on removal, by which point any
@@ -486,35 +502,64 @@
   document.addEventListener('pointerup', endDrag);
   document.addEventListener('pointercancel', endDrag);
 
+  // Cancels rather than commits: an interruption -- window blur, a viewport
+  // change invalidating this drag's frozen geometry, DOM removal -- is not
+  // the user confirming a width via release, so it must not persist one
+  // (and, for blur/resize, must not go on computing candidates against a
+  // stale dragState.startX/startWidth after this point either).
+  function cancelDrag() {
+    if (!dragState) return;
+    restoreDragSideEffects();
+    dragState = null;
+  }
+
   function onWindowBlur() {
+    // Focus moving into this widget's own iframe (e.g. the chat composer
+    // autofocusing) also fires a parent-window blur; the window itself
+    // hasn't actually lost focus, so this isn't the interruption below
+    // exists for.
+    if (document.hasFocus()) return;
     // A drag released off-window (e.g. Alt+Tab away mid-drag) never delivers
     // pointerup/pointercancel, which would otherwise strand userSelect:
     // 'none' on the host page indefinitely. A no-op when no drag is active.
-    endDrag(null);
+    cancelDrag();
   }
   window.addEventListener('blur', onWindowBlur);
 
-  // Immediate, synchronous teardown the instant the panel leaves the DOM --
-  // covers both leak prevention (the listeners above are otherwise GC roots
-  // keeping this whole closure, panel included, alive indefinitely) and the
-  // drag-interrupted-by-removal case (blur alone doesn't fire just because a
-  // host SPA removes the widget, so waiting for it would leave userSelect
-  // stranded on the host page until an unrelated future blur happens to
-  // occur, if ever). Matches the isConnected-driven detection this file
-  // already uses for the session controller's own listeners, just scoped to
-  // the panel and triggered synchronously rather than via a MutationObserver
-  // dedicated to iframe connectivity.
+  function onWindowResize() {
+    applyPanelWidth();
+    // A viewport change mid-drag invalidates this drag's frozen startX/
+    // startWidth anchors -- rather than let a later pointermove misread the
+    // viewport's own movement as the user shrinking the panel (and persist
+    // that on release), end the drag cleanly here. The user can just grab
+    // the handle again if they still want to resize.
+    cancelDrag();
+  }
+  window.addEventListener('resize', onWindowResize);
+
+  // Teardown the instant the panel leaves the DOM (a microtask later, per
+  // MutationObserver) -- covers both leak prevention (the listeners above
+  // are otherwise GC roots keeping this whole closure, panel included, alive
+  // indefinitely) and the drag-interrupted-by-removal case (blur alone
+  // doesn't fire just because a host SPA removes the widget, so waiting for
+  // it would leave userSelect stranded on the host page until an unrelated
+  // future blur happens to occur, if ever). Matches the isConnected-driven
+  // detection this file already uses for the session controller's own
+  // listeners. `container` (observed here via its parent, document.body) is
+  // never reparented after the initial append below, so watching only direct
+  // children is enough -- no need for `subtree`.
   var panelRemovalObserver = new MutationObserver(function () {
     if (panel.isConnected) return;
+    torndown = true;
     panelRemovalObserver.disconnect();
-    window.removeEventListener('resize', applyPanelWidth);
+    window.removeEventListener('resize', onWindowResize);
     window.removeEventListener('blur', onWindowBlur);
     document.removeEventListener('pointermove', onPointerMove);
     document.removeEventListener('pointerup', endDrag);
     document.removeEventListener('pointercancel', endDrag);
-    endDrag(null);
+    cancelDrag();
   });
-  panelRemovalObserver.observe(document.body, { childList: true, subtree: true });
+  panelRemovalObserver.observe(document.body, { childList: true });
 
   // FAB
   var fab = document.createElement('button');

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -386,14 +386,14 @@
   resizeHandle.className = 'xagent-widget-resize-handle';
   panel.appendChild(resizeHandle);
 
+  // Clamp on render rather than mutating panelWidth here: a temporary narrow
+  // viewport (a shrunk window, a rotated device) must not permanently shrink
+  // the user's stored preference once the viewport widens again.
   function applyPanelWidth() {
-    panel.style.width = isMobileViewport() ? '' : panelWidth + 'px';
+    panel.style.width = isMobileViewport() ? '' : clampPanelWidth(panelWidth) + 'px';
   }
   applyPanelWidth();
-  window.addEventListener('resize', function () {
-    panelWidth = clampPanelWidth(panelWidth);
-    applyPanelWidth();
-  });
+  window.addEventListener('resize', applyPanelWidth);
 
   var dragState = null;
 
@@ -404,10 +404,18 @@
     dragState = {
       pointerId: event.pointerId,
       startX: event.clientX,
-      startWidth: panel.getBoundingClientRect().width
+      startWidth: panel.getBoundingClientRect().width,
+      originalUserSelect: document.body.style.userSelect
     };
-    resizeHandle.setPointerCapture(event.pointerId);
+    // Older browsers without Pointer Capture still get a working drag via
+    // iframe.style.pointerEvents below; this call is a nice-to-have.
+    try {
+      resizeHandle.setPointerCapture(event.pointerId);
+    } catch (e) {}
     document.body.style.userSelect = 'none';
+    // The iframe would otherwise intercept pointer events once the cursor
+    // moves over it mid-drag, stalling the resize.
+    iframe.style.pointerEvents = 'none';
     event.preventDefault();
   });
 
@@ -422,8 +430,9 @@
 
   function endDrag(event) {
     if (!dragState || (event && event.pointerId !== dragState.pointerId)) return;
+    document.body.style.userSelect = dragState.originalUserSelect;
+    iframe.style.pointerEvents = '';
     dragState = null;
-    document.body.style.userSelect = '';
     persistWidth(panelWidth);
   }
   resizeHandle.addEventListener('pointerup', endDrag);

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -570,9 +570,23 @@
   }
   window.addEventListener('blur', onWindowBlur);
 
+  var lastViewportWidth = window.innerWidth;
   function onWindowResize() {
+    var currentViewportWidth = window.innerWidth;
+    var widthChanged = currentViewportWidth !== lastViewportWidth;
+    lastViewportWidth = currentViewportWidth;
+    // Only a horizontal change affects anything here -- isMobileViewport()/
+    // clampPanelWidth() and a drag's frozen startX/startWidth anchors all
+    // depend solely on innerWidth. A resize event with an unchanged
+    // innerWidth (e.g. a mobile on-screen keyboard opening, which only moves
+    // innerHeight) must be a complete no-op: applyPanelWidth() would just
+    // re-render the same value when idle, but during an active drag it would
+    // clobber the live preview (it always renders from the last *committed*
+    // width, not dragState's in-progress one) without actually cancelling
+    // the drag -- worse than doing nothing.
+    if (!widthChanged) return;
     applyPanelWidth();
-    // A viewport change mid-drag invalidates this drag's frozen startX/
+    // A genuine width change mid-drag invalidates this drag's frozen startX/
     // startWidth anchors -- rather than let a later pointermove misread the
     // viewport's own movement as the user shrinking the panel (and persist
     // that on release), end the drag cleanly here. The user can just grab

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -433,7 +433,12 @@
     // way: only a real, explicit non-primary button should block the drag.
     // Ignore a second simultaneous pointer (e.g. a touchscreen device) so it
     // can't hijack dragState mid-drag and strand the first pointer's cleanup.
-    if (torndown || isMobileViewport() || dragState || (event.button || 0) !== 0) return;
+    // The injected stylesheet already hides the handle while the panel is
+    // closed (see .xagent-widget-panel:not(.open) above), but a host page
+    // whose CSP blocks that inline <style> would leave it visually
+    // draggable with no CSS backing it up -- check the open class directly
+    // too, as defense in depth that doesn't depend on the stylesheet loading.
+    if (torndown || isMobileViewport() || dragState || (event.button || 0) !== 0 || !panel.classList.contains('open')) return;
     dragState = {
       pointerId: event.pointerId,
       startX: event.clientX,

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -417,9 +417,12 @@
   var torndown = false;
 
   resizeHandle.addEventListener('pointerdown', function (event) {
+    // event.button is 0 for touch/pen contact and the primary mouse button;
+    // a nonzero value here is a right-click, middle-click, or pen barrel
+    // button, none of which should start a resize.
     // Ignore a second simultaneous pointer (e.g. a touchscreen device) so it
     // can't hijack dragState mid-drag and strand the first pointer's cleanup.
-    if (torndown || isMobileViewport() || dragState) return;
+    if (torndown || isMobileViewport() || dragState || event.button !== 0) return;
     dragState = {
       pointerId: event.pointerId,
       startX: event.clientX,
@@ -439,6 +442,7 @@
       // outright (see onPointerMove) instead of continuing to protect a
       // preference the user has already demonstrated they're moving away from.
       shrunkPastStart: false,
+      originalCursor: document.body.style.cursor,
       originalUserSelect: document.body.style.userSelect
     };
     // Optimization, not the drag's only path: pointermove/pointerup/
@@ -478,13 +482,15 @@
 
   function restoreDragSideEffects() {
     // Only restore if nothing else changed it in the meantime -- a host page
-    // that set its own userSelect after this drag started (e.g. while
+    // that set its own userSelect/cursor after this drag started (e.g. while
     // rebuilding its own UI mid-drag) must not have that value clobbered by
     // a stale snapshot from before it ran.
     if (document.body.style.userSelect === 'none') {
       document.body.style.userSelect = dragState.originalUserSelect;
     }
-    document.body.style.cursor = '';
+    if (document.body.style.cursor === 'ew-resize') {
+      document.body.style.cursor = dragState.originalCursor;
+    }
     iframe.style.pointerEvents = '';
   }
 
@@ -500,16 +506,25 @@
   }
   document.addEventListener('pointermove', onPointerMove);
   document.addEventListener('pointerup', endDrag);
-  document.addEventListener('pointercancel', endDrag);
+  // pointercancel is an involuntary interruption (a touch gesture
+  // reinterpreted as a scroll, an OS-level interrupt, capture lost to
+  // another element) rather than the user confirming a release, so it goes
+  // through cancelDrag (below) like blur/resize, not endDrag.
+  document.addEventListener('pointercancel', cancelDrag);
 
   // Cancels rather than commits: an interruption -- window blur, a viewport
-  // change invalidating this drag's frozen geometry, DOM removal -- is not
-  // the user confirming a width via release, so it must not persist one
-  // (and, for blur/resize, must not go on computing candidates against a
-  // stale dragState.startX/startWidth after this point either).
-  function cancelDrag() {
-    if (!dragState) return;
+  // change invalidating this drag's frozen geometry, pointercancel, DOM
+  // removal -- is not the user confirming a width via release, so it must
+  // not persist one. Also rolls panelWidth and the render back to this
+  // drag's starting point rather than just clearing dragState: otherwise the
+  // abandoned in-progress width survives as the module's current value, and
+  // a later, unrelated zero-movement drag could commit it via
+  // endDrag/persistWidth as if the user had confirmed it.
+  function cancelDrag(event) {
+    if (!dragState || (event && event.pointerId !== dragState.pointerId)) return;
     restoreDragSideEffects();
+    panelWidth = dragState.startPanelWidth;
+    applyPanelWidth();
     dragState = null;
   }
 
@@ -556,10 +571,15 @@
     window.removeEventListener('blur', onWindowBlur);
     document.removeEventListener('pointermove', onPointerMove);
     document.removeEventListener('pointerup', endDrag);
-    document.removeEventListener('pointercancel', endDrag);
+    document.removeEventListener('pointercancel', cancelDrag);
     cancelDrag();
   });
-  panelRemovalObserver.observe(document.body, { childList: true });
+  // subtree: true because "direct child of body" only catches container's
+  // own removal -- a host page reaching further in (removing panel from
+  // container directly, or wiping a wrapper it added around container)
+  // would otherwise mutate a node this observer never inspects, and the
+  // callback would simply never fire.
+  panelRemovalObserver.observe(document.body, { childList: true, subtree: true });
 
   // FAB
   var fab = document.createElement('button');

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -419,10 +419,12 @@
   resizeHandle.addEventListener('pointerdown', function (event) {
     // event.button is 0 for touch/pen contact and the primary mouse button;
     // a nonzero value here is a right-click, middle-click, or pen barrel
-    // button, none of which should start a resize.
+    // button, none of which should start a resize. Guard against a
+    // non-numeric value (a synthetic event with no button field) the same
+    // way: only a real, explicit non-primary button should block the drag.
     // Ignore a second simultaneous pointer (e.g. a touchscreen device) so it
     // can't hijack dragState mid-drag and strand the first pointer's cleanup.
-    if (torndown || isMobileViewport() || dragState || event.button !== 0) return;
+    if (torndown || isMobileViewport() || dragState || (event.button || 0) !== 0) return;
     dragState = {
       pointerId: event.pointerId,
       startX: event.clientX,
@@ -432,11 +434,16 @@
       // mismatch (a jump by the border width on every drag start) even if
       // something on the host page ends up overriding our own box-sizing rule.
       // This is the *rendered* width, which is <= the user's raw preference
-      // whenever the viewport is currently clamping it down (startPanelWidth
+      // whenever the viewport is currently clamping it down (previewWidth
       // below) -- pointermove needs both to avoid re-corrupting the
       // preference on a drag that never escapes that clamp.
       startWidth: parseInt(window.getComputedStyle(panel).width, 10) || DEFAULT_PANEL_WIDTH,
-      startPanelWidth: panelWidth,
+      // The drag's live candidate. panelWidth itself is never written until
+      // a real release commits it (see endDrag) -- cancelling a drag (blur,
+      // a mid-drag viewport change, pointercancel, DOM removal) then needs
+      // no rollback of anything, since the committed preference was never
+      // touched in the first place.
+      previewWidth: panelWidth,
       // Sticky for the rest of this drag: once the user visibly shrinks past
       // the starting render, later pointermove events adopt the live value
       // outright (see onPointerMove) instead of continuing to protect a
@@ -477,7 +484,7 @@
     // real shrink, adopt the live value for the rest of the drag, including a
     // later move back up to exactly the ceiling (that's now a real choice,
     // not an unmoved starting position).
-    panelWidth = dragState.shrunkPastStart ? candidate : Math.max(candidate, dragState.startPanelWidth);
+    dragState.previewWidth = dragState.shrunkPastStart ? candidate : Math.max(candidate, dragState.previewWidth);
   }
 
   function restoreDragSideEffects() {
@@ -492,17 +499,28 @@
       document.body.style.cursor = dragState.originalCursor;
     }
     iframe.style.pointerEvents = '';
+    // The browser normally releases capture implicitly on pointerup/
+    // pointercancel, but not on blur or a plain resize event -- release
+    // explicitly so a drag ended that way can't keep this pointer's future
+    // events (and thus other elements on the host page) captured to the
+    // handle until an eventual real pointerup arrives.
+    try {
+      resizeHandle.releasePointerCapture(dragState.pointerId);
+    } catch (e) {}
   }
 
   function endDrag(event) {
     if (!dragState || (event && event.pointerId !== dragState.pointerId)) return;
     restoreDragSideEffects();
-    dragState = null;
-    // Skip persisting once the panel has left the DOM: this same cleanup
+    // Skip committing once the panel has left the DOM: this same cleanup
     // runs from the teardown observer below on removal, by which point any
     // width here reflects a stale, no-longer-visible instance rather than a
     // choice the user can still see or reconsider.
-    if (panel.isConnected) persistWidth(panelWidth);
+    if (panel.isConnected) {
+      panelWidth = dragState.previewWidth;
+      persistWidth(panelWidth);
+    }
+    dragState = null;
   }
   document.addEventListener('pointermove', onPointerMove);
   document.addEventListener('pointerup', endDrag);
@@ -515,17 +533,15 @@
   // Cancels rather than commits: an interruption -- window blur, a viewport
   // change invalidating this drag's frozen geometry, pointercancel, DOM
   // removal -- is not the user confirming a width via release, so it must
-  // not persist one. Also rolls panelWidth and the render back to this
-  // drag's starting point rather than just clearing dragState: otherwise the
-  // abandoned in-progress width survives as the module's current value, and
-  // a later, unrelated zero-movement drag could commit it via
-  // endDrag/persistWidth as if the user had confirmed it.
+  // not persist one. Unlike endDrag, this never touches the committed
+  // panelWidth at all (only dragState.previewWidth, which is simply
+  // discarded) -- so there's nothing to roll back, and no risk of an
+  // abandoned draft surviving to be picked up by a later, unrelated drag.
   function cancelDrag(event) {
     if (!dragState || (event && event.pointerId !== dragState.pointerId)) return;
     restoreDragSideEffects();
-    panelWidth = dragState.startPanelWidth;
-    applyPanelWidth();
     dragState = null;
+    applyPanelWidth();
   }
 
   function onWindowBlur() {
@@ -560,9 +576,7 @@
   // it would leave userSelect stranded on the host page until an unrelated
   // future blur happens to occur, if ever). Matches the isConnected-driven
   // detection this file already uses for the session controller's own
-  // listeners. `container` (observed here via its parent, document.body) is
-  // never reparented after the initial append below, so watching only direct
-  // children is enough -- no need for `subtree`.
+  // listeners.
   var panelRemovalObserver = new MutationObserver(function () {
     if (panel.isConnected) return;
     torndown = true;
@@ -574,12 +588,6 @@
     document.removeEventListener('pointercancel', cancelDrag);
     cancelDrag();
   });
-  // subtree: true because "direct child of body" only catches container's
-  // own removal -- a host page reaching further in (removing panel from
-  // container directly, or wiping a wrapper it added around container)
-  // would otherwise mutate a node this observer never inspects, and the
-  // callback would simply never fire.
-  panelRemovalObserver.observe(document.body, { childList: true, subtree: true });
 
   // FAB
   var fab = document.createElement('button');
@@ -606,6 +614,14 @@
   container.appendChild(panel);
   container.appendChild(fab);
   document.body.appendChild(container);
+
+  // Armed only after container is actually in the tree: subtree: true is
+  // needed because "direct child of body" alone only catches container's
+  // own removal -- a host page reaching further in (removing panel from
+  // container directly, or wiping a wrapper it added around container)
+  // would otherwise mutate a node this observer never inspects, and the
+  // callback would simply never fire.
+  panelRemovalObserver.observe(document.body, { childList: true, subtree: true });
 
   mode.attach(iframe);
 

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -267,7 +267,11 @@
     }
   }
 
-  var panelWidth = clampPanelWidth(readStoredWidth());
+  // Raw preferred width, deliberately NOT clamped here: applyPanelWidth below
+  // clamps only for rendering, without writing the clamped value back here,
+  // so a viewport narrower than the stored preference at load never
+  // overwrites it (e.g. via a later, otherwise-unmoved drag release).
+  var panelWidth = readStoredWidth();
 
   // Styles
   var style = document.createElement('style');
@@ -426,14 +430,18 @@
       startWidth: parseInt(window.getComputedStyle(panel).width, 10) || DEFAULT_PANEL_WIDTH,
       originalUserSelect: document.body.style.userSelect
     };
-    // Older browsers without Pointer Capture still get a working drag via
-    // iframe.style.pointerEvents below; this call is a nice-to-have.
+    // pointermove/pointerup are bound only to this 6px handle, so once the
+    // cursor leaves it the drag lives entirely on this capture -- it has
+    // near-universal support in browsers this widget runs in, but guard the
+    // call anyway since it's not essential to starting the drag itself.
     try {
       resizeHandle.setPointerCapture(event.pointerId);
     } catch (e) {}
     document.body.style.userSelect = 'none';
-    // The iframe would otherwise intercept pointer events once the cursor
-    // moves over it mid-drag, stalling the resize.
+    // Without this, the iframe (a sibling of the handle, not an ancestor)
+    // would intercept pointer events once the cursor moves over it mid-drag;
+    // disabling its pointer-events lets those events fall through to the
+    // captured handle instead of stalling on the iframe.
     iframe.style.pointerEvents = 'none';
     event.preventDefault();
   });
@@ -456,16 +464,19 @@
   }
   resizeHandle.addEventListener('pointerup', endDrag);
   resizeHandle.addEventListener('pointercancel', endDrag);
-  // A drag released off-window (e.g. Alt+Tab away mid-drag) never delivers
-  // pointerup/pointercancel to the handle, which would otherwise strand
-  // userSelect: 'none' on the host page indefinitely. Self-unsubscribes once
-  // the panel leaves the DOM, for the same reason as the resize listener above.
+  // A drag released off-window (e.g. Alt+Tab away mid-drag, or a host SPA
+  // removing the widget mid-drag) never delivers pointerup/pointercancel to
+  // the handle, which would otherwise strand userSelect: 'none' on the host
+  // page indefinitely -- including past the panel's own removal, since that
+  // removal doesn't touch document.body. So endDrag must run unconditionally
+  // here, before the isConnected self-unsubscribe (added for the same reason
+  // as the resize listener above): unlike that listener, this one has a
+  // cleanup obligation that self-unsubscribing must not skip.
   window.addEventListener('blur', function onWindowBlur() {
+    endDrag(null);
     if (!panel.isConnected) {
       window.removeEventListener('blur', onWindowBlur);
-      return;
     }
-    endDrag(null);
   });
 
   // FAB

--- a/frontend/src/components/widget/widget-bootstrap.test.ts
+++ b/frontend/src/components/widget/widget-bootstrap.test.ts
@@ -154,6 +154,7 @@ describe("widget bootstrap", () => {
       // innerHTML resets don't touch inline styles on body itself, and it's
       // shared across every test in this file.
       document.body.style.userSelect = ""
+      document.body.style.cursor = ""
       fetchMock.mockResolvedValue(new Response(JSON.stringify({
         ticket: "ticket/one",
         agent_id: 17,
@@ -186,11 +187,16 @@ describe("widget bootstrap", () => {
     function firePointerEvent(
       target: EventTarget,
       type: string,
-      init: { pointerId: number; clientX: number },
+      init: { pointerId: number; clientX: number; button?: number },
     ) {
       // jsdom has no PointerEvent constructor; a plain Event with the fields
       // the widget reads is enough since addEventListener matches by type.
-      const event = new MouseEvent(type, { bubbles: true, cancelable: true, clientX: init.clientX })
+      const event = new MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        clientX: init.clientX,
+        button: init.button ?? 0,
+      })
       Object.defineProperty(event, "pointerId", { value: init.pointerId })
       target.dispatchEvent(event)
     }
@@ -310,6 +316,20 @@ describe("widget bootstrap", () => {
       expect(panel().style.width).toBe("380px")
     })
 
+    it("declares the mobile media rule that actually hides the resize handle", () => {
+      // jsdom doesn't evaluate CSS, so the inline-width behavior above can't
+      // prove the stylesheet itself still hides the handle below the
+      // breakpoint -- assert the injected rule text directly, so weakening
+      // or dropping that declaration fails here even though it wouldn't
+      // change any inline style the other tests observe.
+      runWidget({ "data-widget-key": "widget-secret" })
+      const css = document.head.querySelector("style")!.textContent!
+
+      expect(css).toMatch(/@media\s*\(max-width:\s*480px\)/)
+      const mobileBlock = css.slice(css.indexOf("@media"))
+      expect(mobileBlock).toMatch(/\.xagent-widget-resize-handle\s*{[^}]*display:\s*none/)
+    })
+
     it("ignores a drag start below the mobile breakpoint", () => {
       setInnerWidth(400)
       runWidget({ "data-widget-key": "widget-secret" })
@@ -342,11 +362,58 @@ describe("widget bootstrap", () => {
       expect(localStorage.getItem("xagent_widget_width")).toBe("500")
     })
 
-    it("ends the drag on pointercancel", () => {
+    it("cancels rather than commits on pointercancel, reverting the in-progress width", () => {
+      // pointercancel is an involuntary interruption (a touch gesture
+      // reinterpreted as a scroll, an OS-level interrupt), not the user
+      // confirming a release -- it must not persist wherever the drag had
+      // gotten to.
       runWidget({ "data-widget-key": "widget-secret" })
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 2, clientX: 300 })
-      firePointerEvent(handle(), "pointercancel", { pointerId: 2, clientX: 300 })
+      firePointerEvent(handle(), "pointermove", { pointerId: 2, clientX: 250 }) // mid-drag, unconfirmed
+      expect(panel().style.width).toBe("430px")
+
+      firePointerEvent(handle(), "pointercancel", { pointerId: 2, clientX: 250 })
+
+      expect(document.body.style.userSelect).toBe("")
+      expect(widgetIframe().style.pointerEvents).toBe("")
+      expect(panel().style.width).toBe("380px") // reverted, not left at the abandoned 430px
+      expect(localStorage.getItem("xagent_widget_width")).toBeNull()
+    })
+
+    it("does not let a cancelled drag's abandoned width survive to be committed by a later no-op drag", () => {
+      // A drag that gets cancelled must roll panelWidth itself back, not
+      // just skip persisting once -- otherwise the abandoned in-progress
+      // value stays the module's current width, and an unrelated
+      // zero-movement drag later on would commit it via a normal release.
+      runWidget({ "data-widget-key": "widget-secret" })
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 21, clientX: 300 })
+      firePointerEvent(handle(), "pointermove", { pointerId: 21, clientX: 250 }) // -> 430px, abandoned below
+      window.dispatchEvent(new Event("blur")) // cancels; must revert to 380px, not just skip persisting
+
+      // An unrelated click-and-release with zero movement.
+      firePointerEvent(handle(), "pointerdown", { pointerId: 22, clientX: 300 })
+      firePointerEvent(handle(), "pointerup", { pointerId: 22, clientX: 300 })
+
+      expect(localStorage.getItem("xagent_widget_width")).toBe("380") // not the abandoned 430
+    })
+
+    it("restores the host page's own cursor rather than clearing it", () => {
+      runWidget({ "data-widget-key": "widget-secret" })
+      document.body.style.cursor = "help"
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 23, clientX: 300 })
+      expect(document.body.style.cursor).toBe("ew-resize")
+
+      firePointerEvent(handle(), "pointerup", { pointerId: 23, clientX: 300 })
+      expect(document.body.style.cursor).toBe("help")
+    })
+
+    it("ignores a non-primary pointer button", () => {
+      runWidget({ "data-widget-key": "widget-secret" })
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 24, clientX: 300, button: 2 })
 
       expect(document.body.style.userSelect).toBe("")
       expect(widgetIframe().style.pointerEvents).toBe("")
@@ -386,11 +453,13 @@ describe("widget bootstrap", () => {
       // A blur interruption is not the user confirming a width via release --
       // nothing was ever persisted in this test.
       expect(localStorage.getItem("xagent_widget_width")).toBeNull()
+      // Reverted, not left at the abandoned 430px (380 + 50 from the move above).
+      expect(panel().style.width).toBe("380px")
 
       // The cancelled drag is really over: further movement on the same
       // pointer does nothing, regardless of where it goes.
       firePointerEvent(handle(), "pointermove", { pointerId: 3, clientX: 100 })
-      expect(panel().style.width).toBe("430px") // unchanged from the last real move (380 + 50)
+      expect(panel().style.width).toBe("380px")
     })
 
     it("ignores a blur caused by focus moving into the widget's own iframe", () => {
@@ -425,9 +494,11 @@ describe("widget bootstrap", () => {
       expect(document.body.style.userSelect).toBe("")
       expect(widgetIframe().style.pointerEvents).toBe("")
       expect(localStorage.getItem("xagent_widget_width")).toBeNull()
+      // Reverted, not left at the abandoned 430px (380 + 50 from the move above).
+      expect(panel().style.width).toBe("380px")
 
       firePointerEvent(handle(), "pointermove", { pointerId: 18, clientX: 100 })
-      expect(panel().style.width).toBe("430px") // unchanged from the last real move (380 + 50): the drag is over
+      expect(panel().style.width).toBe("380px") // still unaffected: the drag is over
     })
 
     it("keeps a wider preference across a drag that shrinks past the ceiling and returns to it", () => {
@@ -537,19 +608,46 @@ describe("widget bootstrap", () => {
     })
 
     it("stops reacting to window/document listeners once the panel leaves the DOM", async () => {
+      // Spy without mockImplementation so these still call through -- we
+      // want the real listeners attached, just also recorded.
+      const winAddSpy = vi.spyOn(window, "addEventListener")
+      const docAddSpy = vi.spyOn(document, "addEventListener")
       const winRemoveSpy = vi.spyOn(window, "removeEventListener")
       const docRemoveSpy = vi.spyOn(document, "removeEventListener")
       runWidget({ "data-widget-key": "widget-secret" })
       const detachedHandle = handle()
+      const detachedPanel = panel()
+
+      function addedListener(spy: typeof winAddSpy, type: string) {
+        return spy.mock.calls.find(([calledType]) => calledType === type)?.[1]
+      }
+      // Captured before removal so removeEventListener can be checked
+      // against the *exact* function reference that was added -- not just
+      // "any function", which would also pass if the wrong handler (or a
+      // fresh unrelated one) were removed instead.
+      const resizeListener = addedListener(winAddSpy, "resize")
+      const blurListener = addedListener(winAddSpy, "blur")
+      const pointermoveListener = addedListener(docAddSpy, "pointermove")
+      const pointerupListener = addedListener(docAddSpy, "pointerup")
+      const pointercancelListener = addedListener(docAddSpy, "pointercancel")
 
       document.querySelector(".xagent-widget-container")?.remove()
       await Promise.resolve()
 
-      expect(winRemoveSpy).toHaveBeenCalledWith("resize", expect.any(Function))
-      expect(winRemoveSpy).toHaveBeenCalledWith("blur", expect.any(Function))
-      expect(docRemoveSpy).toHaveBeenCalledWith("pointermove", expect.any(Function))
-      expect(docRemoveSpy).toHaveBeenCalledWith("pointerup", expect.any(Function))
-      expect(docRemoveSpy).toHaveBeenCalledWith("pointercancel", expect.any(Function))
+      expect(winRemoveSpy).toHaveBeenCalledWith("resize", resizeListener)
+      expect(winRemoveSpy).toHaveBeenCalledWith("blur", blurListener)
+      expect(docRemoveSpy).toHaveBeenCalledWith("pointermove", pointermoveListener)
+      expect(docRemoveSpy).toHaveBeenCalledWith("pointerup", pointerupListener)
+      expect(docRemoveSpy).toHaveBeenCalledWith("pointercancel", pointercancelListener)
+
+      // Behavioral proof for the resize listener specifically: below the
+      // mobile breakpoint this would normally clear the inline width, so an
+      // unchanged value after dispatch proves the listener is truly gone,
+      // not just idle.
+      const widthBeforeResize = detachedPanel.style.width
+      setInnerWidth(400)
+      window.dispatchEvent(new Event("resize"))
+      expect(detachedPanel.style.width).toBe(widthBeforeResize)
 
       // Functional proof, not just a spy check that could pass even if the
       // handler removed were the wrong one: the torndown flag permanently

--- a/frontend/src/components/widget/widget-bootstrap.test.ts
+++ b/frontend/src/components/widget/widget-bootstrap.test.ts
@@ -145,4 +145,192 @@ describe("widget bootstrap", () => {
       "https://chat.example/widget/chat/legacy-token?guest_id=guest-fixed",
     )
   })
+
+  describe("panel resize", () => {
+    let originalInnerWidth: number
+
+    beforeEach(() => {
+      originalInnerWidth = window.innerWidth
+      // innerHTML resets don't touch inline styles on body itself, and it's
+      // shared across every test in this file.
+      document.body.style.userSelect = ""
+      fetchMock.mockResolvedValue(new Response(JSON.stringify({
+        ticket: "ticket/one",
+        agent_id: 17,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }))
+    })
+
+    afterEach(() => {
+      setInnerWidth(originalInnerWidth)
+    })
+
+    function setInnerWidth(value: number) {
+      Object.defineProperty(window, "innerWidth", { configurable: true, value })
+    }
+
+    function panel() {
+      return document.querySelector<HTMLDivElement>(".xagent-widget-panel")!
+    }
+
+    function handle() {
+      return document.querySelector<HTMLDivElement>(".xagent-widget-resize-handle")!
+    }
+
+    function widgetIframe() {
+      return document.querySelector<HTMLIFrameElement>(".xagent-widget-iframe")!
+    }
+
+    function firePointerEvent(
+      target: EventTarget,
+      type: string,
+      init: { pointerId: number; clientX: number },
+    ) {
+      // jsdom has no PointerEvent constructor; a plain Event with the fields
+      // the widget reads is enough since addEventListener matches by type.
+      const event = new MouseEvent(type, { bubbles: true, cancelable: true, clientX: init.clientX })
+      Object.defineProperty(event, "pointerId", { value: init.pointerId })
+      target.dispatchEvent(event)
+    }
+
+    it("applies the default width on a fresh visit", () => {
+      runWidget({ "data-widget-key": "widget-secret" })
+      expect(panel().style.width).toBe("380px")
+    })
+
+    it("applies a persisted width from localStorage", () => {
+      localStorage.setItem("xagent_widget_width", "500")
+      runWidget({ "data-widget-key": "widget-secret" })
+      expect(panel().style.width).toBe("500px")
+    })
+
+    it("falls back to the default width for a corrupt stored value", () => {
+      localStorage.setItem("xagent_widget_width", "not-a-number")
+      runWidget({ "data-widget-key": "widget-secret" })
+      expect(panel().style.width).toBe("380px")
+    })
+
+    it("falls back to the default width when reading storage throws", () => {
+      const realGetItem = window.localStorage.getItem.bind(window.localStorage)
+      vi.spyOn(window.localStorage, "getItem").mockImplementation((key) => {
+        if (key === "xagent_widget_width") throw new Error("blocked")
+        return realGetItem(key)
+      })
+      runWidget({ "data-widget-key": "widget-secret" })
+      expect(panel().style.width).toBe("380px")
+    })
+
+    it("re-clamps to the viewport on resize without losing the stored preference", () => {
+      localStorage.setItem("xagent_widget_width", "600")
+      runWidget({ "data-widget-key": "widget-secret" })
+      expect(panel().style.width).toBe("600px")
+
+      setInnerWidth(500)
+      window.dispatchEvent(new Event("resize"))
+      expect(panel().style.width).toBe("460px")
+
+      setInnerWidth(1024)
+      window.dispatchEvent(new Event("resize"))
+      expect(panel().style.width).toBe("600px")
+    })
+
+    it("hides the inline width below the mobile breakpoint and restores it above", () => {
+      runWidget({ "data-widget-key": "widget-secret" })
+
+      setInnerWidth(400)
+      window.dispatchEvent(new Event("resize"))
+      expect(panel().style.width).toBe("")
+
+      setInnerWidth(1024)
+      window.dispatchEvent(new Event("resize"))
+      expect(panel().style.width).toBe("380px")
+    })
+
+    it("ignores a drag start below the mobile breakpoint", () => {
+      setInnerWidth(400)
+      runWidget({ "data-widget-key": "widget-secret" })
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 1, clientX: 100 })
+
+      expect(document.body.style.userSelect).toBe("")
+      expect(widgetIframe().style.pointerEvents).toBe("")
+    })
+
+    it("resizes the panel while dragging and persists the final width on release", () => {
+      runWidget({ "data-widget-key": "widget-secret" })
+      document.body.style.userSelect = "text"
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 7, clientX: 300 })
+      expect(document.body.style.userSelect).toBe("none")
+      expect(widgetIframe().style.pointerEvents).toBe("none")
+
+      // getBoundingClientRect().width is always 0 in jsdom, so startWidth is
+      // 0 and the resulting width is driven entirely by clientX delta.
+      firePointerEvent(handle(), "pointermove", { pointerId: 7, clientX: 250 })
+      expect(panel().style.width).toBe("320px") // clamped to MIN_PANEL_WIDTH
+
+      firePointerEvent(handle(), "pointermove", { pointerId: 7, clientX: -50 })
+      expect(panel().style.width).toBe("350px") // within bounds, no clamping
+
+      firePointerEvent(handle(), "pointerup", { pointerId: 7, clientX: -50 })
+      expect(document.body.style.userSelect).toBe("text")
+      expect(widgetIframe().style.pointerEvents).toBe("")
+      expect(localStorage.getItem("xagent_widget_width")).toBe("350")
+    })
+
+    it("ends the drag on pointercancel", () => {
+      runWidget({ "data-widget-key": "widget-secret" })
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 2, clientX: 300 })
+      firePointerEvent(handle(), "pointercancel", { pointerId: 2, clientX: 300 })
+
+      expect(document.body.style.userSelect).toBe("")
+      expect(widgetIframe().style.pointerEvents).toBe("")
+    })
+
+    it("ignores a second concurrent pointer without disrupting the first pointer's drag", () => {
+      runWidget({ "data-widget-key": "widget-secret" })
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 1, clientX: 300 })
+      firePointerEvent(handle(), "pointerdown", { pointerId: 2, clientX: 100 })
+      firePointerEvent(handle(), "pointermove", { pointerId: 2, clientX: 0 })
+      expect(panel().style.width).toBe("380px") // untouched: pointer 2 was never tracked
+
+      firePointerEvent(handle(), "pointerup", { pointerId: 2, clientX: 0 })
+      expect(document.body.style.userSelect).toBe("none") // pointer 1's drag is still active
+
+      firePointerEvent(handle(), "pointermove", { pointerId: 1, clientX: 250 })
+      expect(panel().style.width).toBe("320px")
+
+      firePointerEvent(handle(), "pointerup", { pointerId: 1, clientX: 250 })
+      expect(document.body.style.userSelect).toBe("")
+      expect(localStorage.getItem("xagent_widget_width")).toBe("320")
+    })
+
+    it("cleans up an interrupted drag on window blur", () => {
+      runWidget({ "data-widget-key": "widget-secret" })
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 3, clientX: 300 })
+      expect(document.body.style.userSelect).toBe("none")
+
+      window.dispatchEvent(new Event("blur"))
+
+      expect(document.body.style.userSelect).toBe("")
+      expect(widgetIframe().style.pointerEvents).toBe("")
+      expect(localStorage.getItem("xagent_widget_width")).toBe("380")
+    })
+
+    it("does not throw when persisting the width fails", () => {
+      runWidget({ "data-widget-key": "widget-secret" })
+      vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+        throw new Error("quota exceeded")
+      })
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 4, clientX: 300 })
+      expect(() => firePointerEvent(handle(), "pointerup", { pointerId: 4, clientX: 300 }))
+        .not.toThrow()
+    })
+  })
 })

--- a/frontend/src/components/widget/widget-bootstrap.test.ts
+++ b/frontend/src/components/widget/widget-bootstrap.test.ts
@@ -371,17 +371,84 @@ describe("widget bootstrap", () => {
       expect(localStorage.getItem("xagent_widget_width")).toBe("430")
     })
 
-    it("cleans up an interrupted drag on window blur", () => {
+    it("cancels (without persisting) an interrupted drag on window blur", () => {
       runWidget({ "data-widget-key": "widget-secret" })
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 3, clientX: 300 })
-      expect(document.body.style.userSelect).toBe("none")
+      firePointerEvent(handle(), "pointermove", { pointerId: 3, clientX: 250 }) // mid-drag, unconfirmed
+      expect(document.body.style.cursor).toBe("ew-resize")
 
       window.dispatchEvent(new Event("blur"))
 
       expect(document.body.style.userSelect).toBe("")
+      expect(document.body.style.cursor).toBe("")
       expect(widgetIframe().style.pointerEvents).toBe("")
-      expect(localStorage.getItem("xagent_widget_width")).toBe("380")
+      // A blur interruption is not the user confirming a width via release --
+      // nothing was ever persisted in this test.
+      expect(localStorage.getItem("xagent_widget_width")).toBeNull()
+
+      // The cancelled drag is really over: further movement on the same
+      // pointer does nothing, regardless of where it goes.
+      firePointerEvent(handle(), "pointermove", { pointerId: 3, clientX: 100 })
+      expect(panel().style.width).toBe("430px") // unchanged from the last real move (380 + 50)
+    })
+
+    it("ignores a blur caused by focus moving into the widget's own iframe", () => {
+      runWidget({ "data-widget-key": "widget-secret" })
+      vi.spyOn(document, "hasFocus").mockReturnValue(true)
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 17, clientX: 300 })
+      expect(document.body.style.userSelect).toBe("none")
+
+      window.dispatchEvent(new Event("blur"))
+
+      // document.hasFocus() still true means the window itself never lost
+      // focus -- this blur doesn't interrupt the drag.
+      expect(document.body.style.userSelect).toBe("none")
+
+      firePointerEvent(handle(), "pointerup", { pointerId: 17, clientX: 300 })
+      expect(document.body.style.userSelect).toBe("")
+    })
+
+    it("cancels (without persisting) an active drag on window resize", () => {
+      runWidget({ "data-widget-key": "widget-secret" })
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 18, clientX: 300 })
+      firePointerEvent(handle(), "pointermove", { pointerId: 18, clientX: 250 }) // mid-drag, unconfirmed
+      expect(document.body.style.userSelect).toBe("none")
+
+      // A viewport change invalidates this drag's frozen startX/startWidth --
+      // rather than let the next pointermove misread it as a shrink, the
+      // drag is cancelled outright.
+      window.dispatchEvent(new Event("resize"))
+
+      expect(document.body.style.userSelect).toBe("")
+      expect(widgetIframe().style.pointerEvents).toBe("")
+      expect(localStorage.getItem("xagent_widget_width")).toBeNull()
+
+      firePointerEvent(handle(), "pointermove", { pointerId: 18, clientX: 100 })
+      expect(panel().style.width).toBe("430px") // unchanged from the last real move (380 + 50): the drag is over
+    })
+
+    it("keeps a wider preference across a drag that shrinks past the ceiling and returns to it", () => {
+      localStorage.setItem("xagent_widget_width", "700")
+      setInnerWidth(600) // viewportMax = 560
+      runWidget({ "data-widget-key": "widget-secret" })
+      expect(panel().style.width).toBe("560px")
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 19, clientX: 300 })
+      // Genuinely shrink past the ceiling first...
+      firePointerEvent(handle(), "pointermove", { pointerId: 19, clientX: 350 })
+      expect(panel().style.width).toBe("510px")
+      // ...then drag back up to exactly the ceiling value. Since this drag
+      // already demonstrated a real shrink, this is now a deliberate choice
+      // of 560, not an unmoved starting position -- it must NOT snap back to
+      // the untouched 700px preference.
+      firePointerEvent(handle(), "pointermove", { pointerId: 19, clientX: 300 })
+      expect(panel().style.width).toBe("560px")
+      firePointerEvent(handle(), "pointerup", { pointerId: 19, clientX: 300 })
+
+      expect(localStorage.getItem("xagent_widget_width")).toBe("560")
     })
 
     it("does not restore userSelect if the host page changed it since drag start", () => {
@@ -449,6 +516,26 @@ describe("widget bootstrap", () => {
       expect(localStorage.getItem("xagent_widget_width")).toBeNull()
     })
 
+    it("never starts a new drag if the same panel node is later re-inserted into the DOM", async () => {
+      runWidget({ "data-widget-key": "widget-secret" })
+      const container = document.querySelector(".xagent-widget-container")!
+      const detachedHandle = handle()
+
+      container.remove()
+      await Promise.resolve() // teardown observer fires and disconnects
+
+      // Re-inserting the SAME node (e.g. a host SPA's portal/keep-alive
+      // remounting it) flips isConnected back to true without re-arming the
+      // (already-disconnected) observer or any removed listener.
+      document.body.appendChild(container)
+      expect(container.isConnected).toBe(true)
+
+      document.body.style.userSelect = "text"
+      firePointerEvent(detachedHandle, "pointerdown", { pointerId: 20, clientX: 300 })
+      // The torndown flag blocks this permanently, regardless of isConnected.
+      expect(document.body.style.userSelect).toBe("text")
+    })
+
     it("stops reacting to window/document listeners once the panel leaves the DOM", async () => {
       const winRemoveSpy = vi.spyOn(window, "removeEventListener")
       const docRemoveSpy = vi.spyOn(document, "removeEventListener")
@@ -465,17 +552,17 @@ describe("widget bootstrap", () => {
       expect(docRemoveSpy).toHaveBeenCalledWith("pointercancel", expect.any(Function))
 
       // Functional proof, not just a spy check that could pass even if the
-      // handler removed were the wrong one: pointerdown is bound directly to
-      // the handle element itself (not torn down, since it isn't a GC-root
-      // concern), so a fresh drag still starts even though the panel is
-      // detached -- but with the blur listener actually gone, nothing
-      // restores userSelect afterward.
+      // handler removed were the wrong one: the torndown flag permanently
+      // blocks pointerdown on this instance's handle -- covering a host SPA
+      // re-inserting this same panel node later, which flips
+      // panel.isConnected back to true without re-arming anything -- so a
+      // fresh drag never starts and userSelect is never touched at all.
       document.body.style.userSelect = "text"
       firePointerEvent(detachedHandle, "pointerdown", { pointerId: 16, clientX: 300 })
-      expect(document.body.style.userSelect).toBe("none")
+      expect(document.body.style.userSelect).toBe("text")
 
       window.dispatchEvent(new Event("blur"))
-      expect(document.body.style.userSelect).toBe("none")
+      expect(document.body.style.userSelect).toBe("text")
     })
   })
 })

--- a/frontend/src/components/widget/widget-bootstrap.test.ts
+++ b/frontend/src/components/widget/widget-bootstrap.test.ts
@@ -707,6 +707,30 @@ describe("widget bootstrap", () => {
       expect(panel().style.width).toBe("") // still unaffected: the drag is over
     })
 
+    it("does not cancel an active drag on a resize event that leaves the viewport width unchanged", () => {
+      // Mobile browsers fire a bare `resize` event when the on-screen
+      // keyboard opens/closes (innerHeight changes, innerWidth doesn't) --
+      // startX/startWidth depend only on innerWidth, so this must not abort
+      // an in-progress drag the way the genuine-width-change test above does.
+      runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 26, clientX: 300 })
+      firePointerEvent(handle(), "pointermove", { pointerId: 26, clientX: 250 })
+      expect(panel().style.width).toBe("430px")
+      expect(document.body.style.userSelect).toBe("none")
+
+      window.dispatchEvent(new Event("resize")) // innerWidth unchanged
+
+      expect(document.body.style.userSelect).toBe("none") // drag still active
+      expect(panel().style.width).toBe("430px")
+
+      firePointerEvent(handle(), "pointermove", { pointerId: 26, clientX: 200 })
+      expect(panel().style.width).toBe("480px")
+      firePointerEvent(handle(), "pointerup", { pointerId: 26, clientX: 200 })
+      expect(localStorage.getItem("xagent_widget_width")).toBe("480")
+    })
+
     it("keeps a wider preference across a drag that shrinks past the ceiling and returns to it", () => {
       localStorage.setItem("xagent_widget_width", "700")
       setInnerWidth(600) // viewportMax = 560

--- a/frontend/src/components/widget/widget-bootstrap.test.ts
+++ b/frontend/src/components/widget/widget-bootstrap.test.ts
@@ -236,6 +236,25 @@ describe("widget bootstrap", () => {
       expect(panel().style.width).toBe("600px")
     })
 
+    it("does not corrupt a stored preference wider than the load-time viewport", () => {
+      localStorage.setItem("xagent_widget_width", "700")
+      setInnerWidth(600) // viewportMax = 560, so the initial render clamps the display
+      runWidget({ "data-widget-key": "widget-secret" })
+      expect(panel().style.width).toBe("560px")
+
+      // A click-and-release with no movement must not persist the render
+      // clamp over the raw stored preference.
+      firePointerEvent(handle(), "pointerdown", { pointerId: 6, clientX: 300 })
+      firePointerEvent(handle(), "pointerup", { pointerId: 6, clientX: 300 })
+      expect(localStorage.getItem("xagent_widget_width")).toBe("700")
+
+      // Widening the viewport back must recover the full preference, not the
+      // narrower value that was ever rendered.
+      setInnerWidth(1024)
+      window.dispatchEvent(new Event("resize"))
+      expect(panel().style.width).toBe("700px")
+    })
+
     it("hides the inline width below the mobile breakpoint and restores it above", () => {
       runWidget({ "data-widget-key": "widget-secret" })
 
@@ -362,9 +381,10 @@ describe("widget bootstrap", () => {
       expect(removeSpy).toHaveBeenCalledWith("resize", expect.any(Function))
     })
 
-    it("stops reacting to window blur once the panel leaves the DOM", () => {
+    it("still cleans up an interrupted drag on blur after the panel leaves the DOM", () => {
       const removeSpy = vi.spyOn(window, "removeEventListener")
       runWidget({ "data-widget-key": "widget-secret" })
+      document.body.style.userSelect = "text"
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 9, clientX: 300 })
       expect(document.body.style.userSelect).toBe("none")
@@ -372,11 +392,17 @@ describe("widget bootstrap", () => {
       document.querySelector(".xagent-widget-container")?.remove()
       window.dispatchEvent(new Event("blur"))
 
-      // userSelect is still stuck at the drag's 'none': endDrag never ran,
-      // proving the (now-detached) panel's blur listener self-removed
-      // instead of firing.
-      expect(document.body.style.userSelect).toBe("none")
+      // The drag's cleanup obligation (restoring the host page's userSelect)
+      // must run even though the panel is no longer connected -- unlike the
+      // resize listener, self-unsubscribing here must not skip it.
+      expect(document.body.style.userSelect).toBe("text")
       expect(removeSpy).toHaveBeenCalledWith("blur", expect.any(Function))
+
+      // And the listener is now actually gone: a second blur is a no-op,
+      // not just a repeat no-drag-active early return.
+      document.body.style.userSelect = "text"
+      window.dispatchEvent(new Event("blur"))
+      expect(document.body.style.userSelect).toBe("text")
     })
   })
 })

--- a/frontend/src/components/widget/widget-bootstrap.test.ts
+++ b/frontend/src/components/widget/widget-bootstrap.test.ts
@@ -183,6 +183,14 @@ describe("widget bootstrap", () => {
       return document.querySelector<HTMLDivElement>(".xagent-widget-resize-handle")!
     }
 
+    function openPanel() {
+      // The handle is only draggable while the panel carries the 'open'
+      // class (see the pointerdown guard in widget.js) -- click the FAB,
+      // the same real-world path a user takes, rather than poking the class
+      // directly.
+      document.querySelector<HTMLButtonElement>(".xagent-widget-fab")!.click()
+    }
+
     function widgetIframe() {
       return document.querySelector<HTMLIFrameElement>(".xagent-widget-iframe")!
     }
@@ -236,6 +244,22 @@ describe("widget bootstrap", () => {
       expect(panel().style.width).toBe("380px")
     })
 
+    it("accepts a stored value at exactly the minimum boundary", () => {
+      // readStoredWidth rejects strictly below MIN_PANEL_WIDTH (320) -- pin
+      // that the boundary value itself is accepted, not folded into the
+      // rejected range by an off-by-one.
+      localStorage.setItem("xagent_widget_width", "320")
+      runWidget({ "data-widget-key": "widget-secret" })
+      expect(panel().style.width).toBe("320px")
+    })
+
+    it("accepts a stored value at exactly the maximum boundary", () => {
+      // Same as above for the upper MAX_PANEL_WIDTH (720) boundary.
+      localStorage.setItem("xagent_widget_width", "720")
+      runWidget({ "data-widget-key": "widget-secret" })
+      expect(panel().style.width).toBe("720px")
+    })
+
     it("falls back to the default width when reading storage throws", () => {
       const realGetItem = window.localStorage.getItem.bind(window.localStorage)
       vi.spyOn(window.localStorage, "getItem").mockImplementation((key) => {
@@ -244,6 +268,38 @@ describe("widget bootstrap", () => {
       })
       runWidget({ "data-widget-key": "widget-secret" })
       expect(panel().style.width).toBe("380px")
+    })
+
+    it("round-trips a dragged width through storage into a fresh load", () => {
+      // Every other persistence test either seeds storage directly or checks
+      // it after a drag -- neither proves a value a drag itself wrote is
+      // actually what the *next* page load reads back. Simulate that next
+      // load by tearing down this instance's DOM and re-running the
+      // bootstrap script, the same way a real page refresh would.
+      // The describe-level mock resolves every call with the same Response
+      // instance, whose body a single fetch already consumes -- this test
+      // fetches twice (once per runWidget), so it needs a fresh Response per
+      // call instead.
+      fetchMock.mockImplementation(() => Promise.resolve(new Response(JSON.stringify({
+        ticket: "ticket/one",
+        agent_id: 17,
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      })))
+      runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 10, clientX: 300 })
+      firePointerEvent(handle(), "pointermove", { pointerId: 10, clientX: 200 })
+      expect(panel().style.width).toBe("480px")
+      firePointerEvent(handle(), "pointerup", { pointerId: 10, clientX: 200 })
+      expect(localStorage.getItem("xagent_widget_width")).toBe("480")
+
+      document.head.innerHTML = ""
+      document.body.innerHTML = ""
+      runWidget({ "data-widget-key": "widget-secret" })
+      expect(panel().style.width).toBe("480px")
     })
 
     it("re-clamps to the viewport on resize without losing the stored preference", () => {
@@ -268,6 +324,7 @@ describe("widget bootstrap", () => {
 
       // A click-and-release with no movement must not persist the render
       // clamp over the raw stored preference.
+      openPanel()
       firePointerEvent(handle(), "pointerdown", { pointerId: 6, clientX: 300 })
       firePointerEvent(handle(), "pointerup", { pointerId: 6, clientX: 300 })
       expect(localStorage.getItem("xagent_widget_width")).toBe("700")
@@ -288,6 +345,7 @@ describe("widget bootstrap", () => {
       // A 1px nudge attempting to widen further is fully absorbed by the
       // ceiling -- the rendered width never actually changes, unlike a true
       // zero-movement release.
+      openPanel()
       firePointerEvent(handle(), "pointerdown", { pointerId: 11, clientX: 300 })
       firePointerEvent(handle(), "pointermove", { pointerId: 11, clientX: 299 })
       expect(panel().style.width).toBe("560px")
@@ -308,6 +366,7 @@ describe("widget bootstrap", () => {
 
       // Drag right (shrink) past the ceiling: a real, visible size change,
       // as opposed to the previous test's absorbed widening attempt.
+      openPanel()
       firePointerEvent(handle(), "pointerdown", { pointerId: 12, clientX: 300 })
       firePointerEvent(handle(), "pointermove", { pointerId: 12, clientX: 350 })
       expect(panel().style.width).toBe("510px") // 560 - 50, a real shrink
@@ -342,10 +401,27 @@ describe("widget bootstrap", () => {
       expect(mobileBlock).toMatch(/\.xagent-widget-resize-handle\s*{[^}]*display:\s*none/)
     })
 
+    it("declares the closed-panel rule that hides the resize handle without JS", () => {
+      // Same rationale as the mobile-rule test above: the JS-level
+      // panel.classList.contains('open') check in the pointerdown guard is
+      // defense in depth, not the primary mechanism -- this stylesheet rule
+      // is what actually keeps the handle un-hit-testable while the panel is
+      // closed on a real page.
+      runWidget({ "data-widget-key": "widget-secret" })
+      const css = document.head.querySelector("style")!.textContent!
+
+      expect(css).toMatch(
+        /\.xagent-widget-panel:not\(\.open\)\s*\.xagent-widget-resize-handle\s*{[^}]*display:\s*none/,
+      )
+    })
+
     it("ignores a drag start below the mobile breakpoint", () => {
       setInnerWidth(400)
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
 
+      // Isolate the mobile-viewport guard specifically: with the panel open,
+      // only isMobileViewport() can be blocking this pointerdown.
       firePointerEvent(handle(), "pointerdown", { pointerId: 1, clientX: 100 })
 
       expect(document.body.style.userSelect).toBe("")
@@ -374,6 +450,7 @@ describe("widget bootstrap", () => {
 
     it("resizes the panel while dragging and persists the final width on release", () => {
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
       document.body.style.userSelect = "text"
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 7, clientX: 300 })
@@ -394,12 +471,29 @@ describe("widget bootstrap", () => {
       expect(localStorage.getItem("xagent_widget_width")).toBe("500")
     })
 
+    it("clamps a drag to the static MAX_PANEL_WIDTH, not just the viewport ceiling", () => {
+      // The other ceiling-clamp tests all clamp against a narrowed viewport
+      // (viewportMax below 720) -- this one keeps the default wide viewport
+      // (viewportMax = 984) so the static 720px cap itself is what stops the
+      // drag, not window width.
+      runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 9, clientX: 300 })
+      firePointerEvent(handle(), "pointermove", { pointerId: 9, clientX: -100 }) // 380 + 400 = 780, capped to 720
+      expect(panel().style.width).toBe("720px")
+
+      firePointerEvent(handle(), "pointerup", { pointerId: 9, clientX: -100 })
+      expect(localStorage.getItem("xagent_widget_width")).toBe("720")
+    })
+
     it("commits the width the drag actually ends at, not the widest point it passed through", () => {
       // A very ordinary gesture: overshoot while dragging, then correct back
       // -- while still wider than the start, i.e. never triggering the old
       // "shrunk past the ceiling" escape hatch. The committed width must
       // match what's actually rendered when the pointer is released.
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 8, clientX: 300 })
       firePointerEvent(handle(), "pointermove", { pointerId: 8, clientX: 180 }) // overshoot to 500px
@@ -422,6 +516,7 @@ describe("widget bootstrap", () => {
       // dispatching where an event would actually land if capture were
       // unavailable and the cursor were, say, over the iframe.
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 27, clientX: 300 })
       firePointerEvent(document, "pointermove", { pointerId: 27, clientX: 200 })
@@ -439,6 +534,7 @@ describe("widget bootstrap", () => {
       // observe the call (production code already guards the call in a
       // try/catch for exactly this kind of absence).
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
       const releaseSpy = vi.fn()
       handle().releasePointerCapture = releaseSpy
 
@@ -454,6 +550,7 @@ describe("widget bootstrap", () => {
       // confirming a release -- it must not persist wherever the drag had
       // gotten to.
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 2, clientX: 300 })
       firePointerEvent(handle(), "pointermove", { pointerId: 2, clientX: 250 }) // mid-drag, unconfirmed
@@ -473,6 +570,7 @@ describe("widget bootstrap", () => {
       // the module's current width, and an unrelated zero-movement drag
       // later on would commit it via a normal release.
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 21, clientX: 300 })
       firePointerEvent(handle(), "pointermove", { pointerId: 21, clientX: 250 }) // -> 430px, abandoned below
@@ -490,6 +588,7 @@ describe("widget bootstrap", () => {
 
     it("restores the host page's own cursor rather than clearing it", () => {
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
       document.body.style.cursor = "help"
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 23, clientX: 300 })
@@ -501,7 +600,10 @@ describe("widget bootstrap", () => {
 
     it("ignores a non-primary pointer button", () => {
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
 
+      // Isolate the button guard: with the panel open, only a non-primary
+      // button can be blocking this pointerdown.
       firePointerEvent(handle(), "pointerdown", { pointerId: 24, clientX: 300, button: 2 })
 
       expect(document.body.style.userSelect).toBe("")
@@ -517,6 +619,7 @@ describe("widget bootstrap", () => {
 
     it("ignores a second concurrent pointer without disrupting the first pointer's drag", () => {
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 1, clientX: 300 })
       firePointerEvent(handle(), "pointerdown", { pointerId: 2, clientX: 100 })
@@ -536,6 +639,7 @@ describe("widget bootstrap", () => {
 
     it("cancels (without persisting) an interrupted drag on window blur", () => {
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 3, clientX: 300 })
       firePointerEvent(handle(), "pointermove", { pointerId: 3, clientX: 250 }) // mid-drag, unconfirmed
@@ -560,6 +664,7 @@ describe("widget bootstrap", () => {
 
     it("ignores a blur caused by focus moving into the widget's own iframe", () => {
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
       vi.spyOn(document, "hasFocus").mockReturnValue(true)
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 17, clientX: 300 })
@@ -577,6 +682,7 @@ describe("widget bootstrap", () => {
 
     it("cancels an active drag on a genuine viewport change and re-renders for the new viewport", () => {
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 18, clientX: 300 })
       firePointerEvent(handle(), "pointermove", { pointerId: 18, clientX: 100 }) // -> 580px, abandoned below
@@ -605,6 +711,7 @@ describe("widget bootstrap", () => {
       localStorage.setItem("xagent_widget_width", "700")
       setInnerWidth(600) // viewportMax = 560
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
       expect(panel().style.width).toBe("560px")
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 19, clientX: 300 })
@@ -624,6 +731,7 @@ describe("widget bootstrap", () => {
 
     it("does not restore userSelect if the host page changed it since drag start", () => {
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 13, clientX: 300 })
       expect(document.body.style.userSelect).toBe("none")
@@ -641,6 +749,7 @@ describe("widget bootstrap", () => {
       // has two symmetric checks and this one had no dedicated negative-space
       // coverage of its own.
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 14, clientX: 300 })
       expect(document.body.style.cursor).toBe("ew-resize")
@@ -653,6 +762,7 @@ describe("widget bootstrap", () => {
 
     it("does not throw when persisting the width fails", () => {
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
       vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
         throw new Error("quota exceeded")
       })
@@ -664,6 +774,7 @@ describe("widget bootstrap", () => {
 
     it("falls back to the default width if computed style is unreadable", () => {
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
       vi.spyOn(window, "getComputedStyle").mockReturnValue({ width: "auto" } as CSSStyleDeclaration)
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 5, clientX: 300 })
@@ -674,6 +785,7 @@ describe("widget bootstrap", () => {
 
     it("tears down cleanup immediately on DOM removal, even mid-drag, without waiting for blur", async () => {
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
       document.body.style.userSelect = "text"
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 14, clientX: 300 })
@@ -689,6 +801,7 @@ describe("widget bootstrap", () => {
 
     it("skips persisting the width for a drag interrupted by DOM removal", async () => {
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 15, clientX: 300 })
       firePointerEvent(handle(), "pointermove", { pointerId: 15, clientX: 200 }) // mid-drag, unconfirmed
@@ -711,6 +824,7 @@ describe("widget bootstrap", () => {
       // only shows up as a *subtree* mutation of document.body -- this is
       // the one scenario that actually distinguishes the two.
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
       document.body.style.userSelect = "text"
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 25, clientX: 300 })
@@ -724,6 +838,7 @@ describe("widget bootstrap", () => {
 
     it("never starts a new drag if the same panel node is later re-inserted into the DOM", async () => {
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
       const container = document.querySelector(".xagent-widget-container")!
       const detachedHandle = handle()
 
@@ -738,7 +853,9 @@ describe("widget bootstrap", () => {
 
       document.body.style.userSelect = "text"
       firePointerEvent(detachedHandle, "pointerdown", { pointerId: 20, clientX: 300 })
-      // The torndown flag blocks this permanently, regardless of isConnected.
+      // The torndown flag blocks this permanently, regardless of isConnected
+      // -- the panel was opened above, so the open-state guard can't be
+      // masking this as the actual reason.
       expect(document.body.style.userSelect).toBe("text")
     })
 
@@ -750,6 +867,7 @@ describe("widget bootstrap", () => {
       const winRemoveSpy = vi.spyOn(window, "removeEventListener")
       const docRemoveSpy = vi.spyOn(document, "removeEventListener")
       runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
       const detachedHandle = handle()
       const detachedPanel = panel()
 

--- a/frontend/src/components/widget/widget-bootstrap.test.ts
+++ b/frontend/src/components/widget/widget-bootstrap.test.ts
@@ -266,18 +266,18 @@ describe("widget bootstrap", () => {
       expect(document.body.style.userSelect).toBe("none")
       expect(widgetIframe().style.pointerEvents).toBe("none")
 
-      // getBoundingClientRect().width is always 0 in jsdom, so startWidth is
-      // 0 and the resulting width is driven entirely by clientX delta.
-      firePointerEvent(handle(), "pointermove", { pointerId: 7, clientX: 250 })
-      expect(panel().style.width).toBe("320px") // clamped to MIN_PANEL_WIDTH
+      // startWidth is read from computed style, which reflects the panel's
+      // width at drag start (380px, the default applied on load).
+      firePointerEvent(handle(), "pointermove", { pointerId: 7, clientX: 400 })
+      expect(panel().style.width).toBe("320px") // 380 - 100 = 280, clamped to MIN_PANEL_WIDTH
 
-      firePointerEvent(handle(), "pointermove", { pointerId: 7, clientX: -50 })
-      expect(panel().style.width).toBe("350px") // within bounds, no clamping
+      firePointerEvent(handle(), "pointermove", { pointerId: 7, clientX: 180 })
+      expect(panel().style.width).toBe("500px") // 380 + 120 = 500, within bounds
 
-      firePointerEvent(handle(), "pointerup", { pointerId: 7, clientX: -50 })
+      firePointerEvent(handle(), "pointerup", { pointerId: 7, clientX: 180 })
       expect(document.body.style.userSelect).toBe("text")
       expect(widgetIframe().style.pointerEvents).toBe("")
-      expect(localStorage.getItem("xagent_widget_width")).toBe("350")
+      expect(localStorage.getItem("xagent_widget_width")).toBe("500")
     })
 
     it("ends the drag on pointercancel", () => {
@@ -302,11 +302,11 @@ describe("widget bootstrap", () => {
       expect(document.body.style.userSelect).toBe("none") // pointer 1's drag is still active
 
       firePointerEvent(handle(), "pointermove", { pointerId: 1, clientX: 250 })
-      expect(panel().style.width).toBe("320px")
+      expect(panel().style.width).toBe("430px") // 380 + 50, from pointer 1's own startWidth
 
       firePointerEvent(handle(), "pointerup", { pointerId: 1, clientX: 250 })
       expect(document.body.style.userSelect).toBe("")
-      expect(localStorage.getItem("xagent_widget_width")).toBe("320")
+      expect(localStorage.getItem("xagent_widget_width")).toBe("430")
     })
 
     it("cleans up an interrupted drag on window blur", () => {
@@ -331,6 +331,52 @@ describe("widget bootstrap", () => {
       firePointerEvent(handle(), "pointerdown", { pointerId: 4, clientX: 300 })
       expect(() => firePointerEvent(handle(), "pointerup", { pointerId: 4, clientX: 300 }))
         .not.toThrow()
+    })
+
+    it("falls back to the default width if computed style is unreadable", () => {
+      runWidget({ "data-widget-key": "widget-secret" })
+      vi.spyOn(window, "getComputedStyle").mockReturnValue({ width: "auto" } as CSSStyleDeclaration)
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 5, clientX: 300 })
+      firePointerEvent(handle(), "pointermove", { pointerId: 5, clientX: 250 })
+
+      expect(panel().style.width).toBe("430px") // DEFAULT_PANEL_WIDTH (380) + 50
+    })
+
+    it("stops reacting to window resize once the panel leaves the DOM", () => {
+      const removeSpy = vi.spyOn(window, "removeEventListener")
+      localStorage.setItem("xagent_widget_width", "600")
+      runWidget({ "data-widget-key": "widget-secret" })
+      const panelEl = panel()
+      expect(panelEl.style.width).toBe("600px")
+
+      document.querySelector(".xagent-widget-container")?.remove()
+
+      // Below the mobile breakpoint would normally clear the inline width;
+      // an unchanged value proves the listener self-removed instead of
+      // reapplying the clamp to a detached panel.
+      setInnerWidth(400)
+      window.dispatchEvent(new Event("resize"))
+
+      expect(panelEl.style.width).toBe("600px")
+      expect(removeSpy).toHaveBeenCalledWith("resize", expect.any(Function))
+    })
+
+    it("stops reacting to window blur once the panel leaves the DOM", () => {
+      const removeSpy = vi.spyOn(window, "removeEventListener")
+      runWidget({ "data-widget-key": "widget-secret" })
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 9, clientX: 300 })
+      expect(document.body.style.userSelect).toBe("none")
+
+      document.querySelector(".xagent-widget-container")?.remove()
+      window.dispatchEvent(new Event("blur"))
+
+      // userSelect is still stuck at the drag's 'none': endDrag never ran,
+      // proving the (now-detached) panel's blur listener self-removed
+      // instead of firing.
+      expect(document.body.style.userSelect).toBe("none")
+      expect(removeSpy).toHaveBeenCalledWith("blur", expect.any(Function))
     })
   })
 })

--- a/frontend/src/components/widget/widget-bootstrap.test.ts
+++ b/frontend/src/components/widget/widget-bootstrap.test.ts
@@ -212,6 +212,12 @@ describe("widget bootstrap", () => {
       expect(panel().style.width).toBe("380px")
     })
 
+    it("falls back to the default width for an out-of-range stored value", () => {
+      localStorage.setItem("xagent_widget_width", "99999")
+      runWidget({ "data-widget-key": "widget-secret" })
+      expect(panel().style.width).toBe("380px")
+    })
+
     it("falls back to the default width when reading storage throws", () => {
       const realGetItem = window.localStorage.getItem.bind(window.localStorage)
       vi.spyOn(window.localStorage, "getItem").mockImplementation((key) => {
@@ -253,6 +259,43 @@ describe("widget bootstrap", () => {
       setInnerWidth(1024)
       window.dispatchEvent(new Event("resize"))
       expect(panel().style.width).toBe("700px")
+    })
+
+    it("does not lose a wider preference to a drag that never escapes the viewport ceiling", () => {
+      localStorage.setItem("xagent_widget_width", "700")
+      setInnerWidth(600) // viewportMax = 560
+      runWidget({ "data-widget-key": "widget-secret" })
+      expect(panel().style.width).toBe("560px")
+
+      // A 1px nudge attempting to widen further is fully absorbed by the
+      // ceiling -- the rendered width never actually changes, unlike a true
+      // zero-movement release.
+      firePointerEvent(handle(), "pointerdown", { pointerId: 11, clientX: 300 })
+      firePointerEvent(handle(), "pointermove", { pointerId: 11, clientX: 299 })
+      expect(panel().style.width).toBe("560px")
+      firePointerEvent(handle(), "pointerup", { pointerId: 11, clientX: 299 })
+
+      // The 700px preference must survive this drag, not get silently
+      // replaced by the 560px ceiling it never actually moved past.
+      expect(localStorage.getItem("xagent_widget_width")).toBe("700")
+      setInnerWidth(1024)
+      window.dispatchEvent(new Event("resize"))
+      expect(panel().style.width).toBe("700px")
+    })
+
+    it("does adopt a genuinely smaller width when a drag visibly shrinks past the ceiling", () => {
+      localStorage.setItem("xagent_widget_width", "700")
+      setInnerWidth(600) // viewportMax = 560
+      runWidget({ "data-widget-key": "widget-secret" })
+
+      // Drag right (shrink) past the ceiling: a real, visible size change,
+      // as opposed to the previous test's absorbed widening attempt.
+      firePointerEvent(handle(), "pointerdown", { pointerId: 12, clientX: 300 })
+      firePointerEvent(handle(), "pointermove", { pointerId: 12, clientX: 350 })
+      expect(panel().style.width).toBe("510px") // 560 - 50, a real shrink
+      firePointerEvent(handle(), "pointerup", { pointerId: 12, clientX: 350 })
+
+      expect(localStorage.getItem("xagent_widget_width")).toBe("510")
     })
 
     it("hides the inline width below the mobile breakpoint and restores it above", () => {
@@ -341,6 +384,20 @@ describe("widget bootstrap", () => {
       expect(localStorage.getItem("xagent_widget_width")).toBe("380")
     })
 
+    it("does not restore userSelect if the host page changed it since drag start", () => {
+      runWidget({ "data-widget-key": "widget-secret" })
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 13, clientX: 300 })
+      expect(document.body.style.userSelect).toBe("none")
+
+      // Host page sets its own value mid-drag, e.g. while rebuilding its own UI.
+      document.body.style.userSelect = "all"
+
+      firePointerEvent(handle(), "pointerup", { pointerId: 13, clientX: 300 })
+      // Must NOT be clobbered back to the pre-drag snapshot.
+      expect(document.body.style.userSelect).toBe("all")
+    })
+
     it("does not throw when persisting the width fails", () => {
       runWidget({ "data-widget-key": "widget-secret" })
       vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
@@ -362,47 +419,63 @@ describe("widget bootstrap", () => {
       expect(panel().style.width).toBe("430px") // DEFAULT_PANEL_WIDTH (380) + 50
     })
 
-    it("stops reacting to window resize once the panel leaves the DOM", () => {
-      const removeSpy = vi.spyOn(window, "removeEventListener")
-      localStorage.setItem("xagent_widget_width", "600")
-      runWidget({ "data-widget-key": "widget-secret" })
-      const panelEl = panel()
-      expect(panelEl.style.width).toBe("600px")
-
-      document.querySelector(".xagent-widget-container")?.remove()
-
-      // Below the mobile breakpoint would normally clear the inline width;
-      // an unchanged value proves the listener self-removed instead of
-      // reapplying the clamp to a detached panel.
-      setInnerWidth(400)
-      window.dispatchEvent(new Event("resize"))
-
-      expect(panelEl.style.width).toBe("600px")
-      expect(removeSpy).toHaveBeenCalledWith("resize", expect.any(Function))
-    })
-
-    it("still cleans up an interrupted drag on blur after the panel leaves the DOM", () => {
-      const removeSpy = vi.spyOn(window, "removeEventListener")
+    it("tears down cleanup immediately on DOM removal, even mid-drag, without waiting for blur", async () => {
       runWidget({ "data-widget-key": "widget-secret" })
       document.body.style.userSelect = "text"
 
-      firePointerEvent(handle(), "pointerdown", { pointerId: 9, clientX: 300 })
+      firePointerEvent(handle(), "pointerdown", { pointerId: 14, clientX: 300 })
       expect(document.body.style.userSelect).toBe("none")
 
       document.querySelector(".xagent-widget-container")?.remove()
-      window.dispatchEvent(new Event("blur"))
+      // The teardown observer's callback fires as a microtask.
+      await Promise.resolve()
 
-      // The drag's cleanup obligation (restoring the host page's userSelect)
-      // must run even though the panel is no longer connected -- unlike the
-      // resize listener, self-unsubscribing here must not skip it.
+      // Cleanup already ran on removal itself -- no blur or resize needed.
       expect(document.body.style.userSelect).toBe("text")
-      expect(removeSpy).toHaveBeenCalledWith("blur", expect.any(Function))
+    })
 
-      // And the listener is now actually gone: a second blur is a no-op,
-      // not just a repeat no-drag-active early return.
+    it("skips persisting the width for a drag interrupted by DOM removal", async () => {
+      runWidget({ "data-widget-key": "widget-secret" })
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 15, clientX: 300 })
+      firePointerEvent(handle(), "pointermove", { pointerId: 15, clientX: 200 }) // mid-drag, unconfirmed
+      expect(panel().style.width).not.toBe("380px")
+
+      document.querySelector(".xagent-widget-container")?.remove()
+      await Promise.resolve()
+
+      // The unconfirmed mid-drag width must not have been written to
+      // storage -- nothing was ever persisted in this test at all.
+      expect(localStorage.getItem("xagent_widget_width")).toBeNull()
+    })
+
+    it("stops reacting to window/document listeners once the panel leaves the DOM", async () => {
+      const winRemoveSpy = vi.spyOn(window, "removeEventListener")
+      const docRemoveSpy = vi.spyOn(document, "removeEventListener")
+      runWidget({ "data-widget-key": "widget-secret" })
+      const detachedHandle = handle()
+
+      document.querySelector(".xagent-widget-container")?.remove()
+      await Promise.resolve()
+
+      expect(winRemoveSpy).toHaveBeenCalledWith("resize", expect.any(Function))
+      expect(winRemoveSpy).toHaveBeenCalledWith("blur", expect.any(Function))
+      expect(docRemoveSpy).toHaveBeenCalledWith("pointermove", expect.any(Function))
+      expect(docRemoveSpy).toHaveBeenCalledWith("pointerup", expect.any(Function))
+      expect(docRemoveSpy).toHaveBeenCalledWith("pointercancel", expect.any(Function))
+
+      // Functional proof, not just a spy check that could pass even if the
+      // handler removed were the wrong one: pointerdown is bound directly to
+      // the handle element itself (not torn down, since it isn't a GC-root
+      // concern), so a fresh drag still starts even though the panel is
+      // detached -- but with the blur listener actually gone, nothing
+      // restores userSelect afterward.
       document.body.style.userSelect = "text"
+      firePointerEvent(detachedHandle, "pointerdown", { pointerId: 16, clientX: 300 })
+      expect(document.body.style.userSelect).toBe("none")
+
       window.dispatchEvent(new Event("blur"))
-      expect(document.body.style.userSelect).toBe("text")
+      expect(document.body.style.userSelect).toBe("none")
     })
   })
 })

--- a/frontend/src/components/widget/widget-bootstrap.test.ts
+++ b/frontend/src/components/widget/widget-bootstrap.test.ts
@@ -33,6 +33,12 @@ describe("widget bootstrap", () => {
     currentScriptDescriptor = Object.getOwnPropertyDescriptor(document, "currentScript")
     document.head.innerHTML = ""
     document.body.innerHTML = ""
+    // innerHTML resets don't touch inline styles on body itself, and it's
+    // shared across every test in this file (not just the panel-resize
+    // describe below) -- reset here, not just in a nested beforeEach, so any
+    // test anywhere in the file that touches these can't leak into another.
+    document.body.style.userSelect = ""
+    document.body.style.cursor = ""
     localStorage.setItem("xagent_guest_id", "guest-fixed")
     vi.stubGlobal("fetch", fetchMock)
     fetchMock.mockReset()
@@ -151,10 +157,7 @@ describe("widget bootstrap", () => {
 
     beforeEach(() => {
       originalInnerWidth = window.innerWidth
-      // innerHTML resets don't touch inline styles on body itself, and it's
-      // shared across every test in this file.
-      document.body.style.userSelect = ""
-      document.body.style.cursor = ""
+      // userSelect/cursor are reset in the outer beforeEach above.
       fetchMock.mockResolvedValue(new Response(JSON.stringify({
         ticket: "ticket/one",
         agent_id: 17,
@@ -416,7 +419,14 @@ describe("widget bootstrap", () => {
       firePointerEvent(handle(), "pointerdown", { pointerId: 24, clientX: 300, button: 2 })
 
       expect(document.body.style.userSelect).toBe("")
+      expect(document.body.style.cursor).toBe("")
       expect(widgetIframe().style.pointerEvents).toBe("")
+      // Proves dragState itself was never created, not just that these three
+      // particular side effects happen to be unset: if the button guard were
+      // moved after dragState's assignment, this assertion alone wouldn't
+      // catch it, but a subsequent move actually changing the width would.
+      firePointerEvent(handle(), "pointermove", { pointerId: 24, clientX: 100 })
+      expect(panel().style.width).toBe("380px")
     })
 
     it("ignores a second concurrent pointer without disrupting the first pointer's drag", () => {
@@ -587,6 +597,26 @@ describe("widget bootstrap", () => {
       expect(localStorage.getItem("xagent_widget_width")).toBeNull()
     })
 
+    it("tears down when the panel is removed directly, without container itself leaving the DOM", async () => {
+      // Regression coverage for subtree: true. A remove() on .xagent-widget-
+      // container (used by every other teardown test in this file) is
+      // already a direct childList change on document.body, so it would
+      // pass even with the narrower { childList: true } this diff replaced.
+      // Removing panel out from under container, while container stays put,
+      // only shows up as a *subtree* mutation of document.body -- this is
+      // the one scenario that actually distinguishes the two.
+      runWidget({ "data-widget-key": "widget-secret" })
+      document.body.style.userSelect = "text"
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 25, clientX: 300 })
+      expect(document.body.style.userSelect).toBe("none")
+
+      panel().remove()
+      await Promise.resolve()
+
+      expect(document.body.style.userSelect).toBe("text")
+    })
+
     it("never starts a new drag if the same panel node is later re-inserted into the DOM", async () => {
       runWidget({ "data-widget-key": "widget-secret" })
       const container = document.querySelector(".xagent-widget-container")!
@@ -619,7 +649,12 @@ describe("widget bootstrap", () => {
       const detachedPanel = panel()
 
       function addedListener(spy: typeof winAddSpy, type: string) {
-        return spy.mock.calls.find(([calledType]) => calledType === type)?.[1]
+        const matches = spy.mock.calls.filter(([calledType]) => calledType === type)
+        // Fail loudly on zero or multiple matches rather than silently
+        // returning undefined (a legal, if useless, arg to
+        // toHaveBeenCalledWith) or picking an arbitrary one of several.
+        expect(matches).toHaveLength(1)
+        return matches[0][1]
       }
       // Captured before removal so removeEventListener can be checked
       // against the *exact* function reference that was added -- not just

--- a/frontend/src/components/widget/widget-bootstrap.test.ts
+++ b/frontend/src/components/widget/widget-bootstrap.test.ts
@@ -202,6 +202,7 @@ describe("widget bootstrap", () => {
       })
       Object.defineProperty(event, "pointerId", { value: init.pointerId })
       target.dispatchEvent(event)
+      return event
     }
 
     it("applies the default width on a fresh visit", () => {
@@ -223,6 +224,14 @@ describe("widget bootstrap", () => {
 
     it("falls back to the default width for an out-of-range stored value", () => {
       localStorage.setItem("xagent_widget_width", "99999")
+      runWidget({ "data-widget-key": "widget-secret" })
+      expect(panel().style.width).toBe("380px")
+    })
+
+    it("falls back to the default width for a stored value below the minimum", () => {
+      // Only the upper bound was covered above; MIN_PANEL_WIDTH is a
+      // separate comparison in the same guard.
+      localStorage.setItem("xagent_widget_width", "100")
       runWidget({ "data-widget-key": "widget-secret" })
       expect(panel().style.width).toBe("380px")
     })
@@ -340,7 +349,27 @@ describe("widget bootstrap", () => {
       firePointerEvent(handle(), "pointerdown", { pointerId: 1, clientX: 100 })
 
       expect(document.body.style.userSelect).toBe("")
+      expect(document.body.style.cursor).toBe("")
       expect(widgetIframe().style.pointerEvents).toBe("")
+      // Proves dragState was never created, not just that these three
+      // particular side effects happen to be unset.
+      firePointerEvent(handle(), "pointermove", { pointerId: 1, clientX: 250 })
+      expect(panel().style.width).toBe("")
+    })
+
+    it("boundary: applies the mobile CSS at exactly the breakpoint width, not just below it", () => {
+      // isMobileViewport() uses <=, matching the CSS media query's own
+      // max-width: 480px (also <= in CSS terms) -- off by one here would
+      // mean inline width wins over the media query by specificity right at
+      // this exact width, which is the one case the whole mobile branch
+      // exists to prevent (see the comment above applyPanelWidth). 480 is
+      // MOBILE_BREAKPOINT's value, not importable from widget.js's IIFE
+      // closure -- the CSS-rule-content test above already pins that the
+      // constant itself is 480, so hardcoding it here is safe.
+      setInnerWidth(480)
+      runWidget({ "data-widget-key": "widget-secret" })
+
+      expect(panel().style.width).toBe("")
     })
 
     it("resizes the panel while dragging and persists the final width on release", () => {
@@ -365,6 +394,60 @@ describe("widget bootstrap", () => {
       expect(localStorage.getItem("xagent_widget_width")).toBe("500")
     })
 
+    it("commits the width the drag actually ends at, not the widest point it passed through", () => {
+      // A very ordinary gesture: overshoot while dragging, then correct back
+      // -- while still wider than the start, i.e. never triggering the old
+      // "shrunk past the ceiling" escape hatch. The committed width must
+      // match what's actually rendered when the pointer is released.
+      runWidget({ "data-widget-key": "widget-secret" })
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 8, clientX: 300 })
+      firePointerEvent(handle(), "pointermove", { pointerId: 8, clientX: 180 }) // overshoot to 500px
+      expect(panel().style.width).toBe("500px")
+      firePointerEvent(handle(), "pointermove", { pointerId: 8, clientX: 280 }) // correct back to 400px
+      expect(panel().style.width).toBe("400px")
+
+      firePointerEvent(handle(), "pointerup", { pointerId: 8, clientX: 280 })
+      expect(panel().style.width).toBe("400px") // unchanged by the commit itself
+      expect(localStorage.getItem("xagent_widget_width")).toBe("400") // not the passed-through 500
+    })
+
+    it("continues tracking the drag when pointermove/pointerup arrive on document rather than the handle", () => {
+      // jsdom has no PointerEvent/setPointerCapture at all, so every other
+      // test in this file dispatching pointermove/pointerup directly on
+      // handle() can't distinguish "capture is retargeting these events"
+      // from "these listeners just happen to live on the same element".
+      // Real Pointer Capture would retarget events to the handle
+      // regardless of what's under the cursor; bypass that entirely here by
+      // dispatching where an event would actually land if capture were
+      // unavailable and the cursor were, say, over the iframe.
+      runWidget({ "data-widget-key": "widget-secret" })
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 27, clientX: 300 })
+      firePointerEvent(document, "pointermove", { pointerId: 27, clientX: 200 })
+      expect(panel().style.width).toBe("480px")
+
+      firePointerEvent(document, "pointerup", { pointerId: 27, clientX: 200 })
+      expect(localStorage.getItem("xagent_widget_width")).toBe("480")
+    })
+
+    it("releases pointer capture when a drag is cancelled, not just on a real release", () => {
+      // Browsers auto-release capture on pointerup/pointercancel, but not on
+      // blur or a plain resize -- restoreDragSideEffects releases it
+      // explicitly for those paths. jsdom doesn't implement (release)
+      // PointerCapture at all, so stub it directly on the handle instance to
+      // observe the call (production code already guards the call in a
+      // try/catch for exactly this kind of absence).
+      runWidget({ "data-widget-key": "widget-secret" })
+      const releaseSpy = vi.fn()
+      handle().releasePointerCapture = releaseSpy
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 28, clientX: 300 })
+      window.dispatchEvent(new Event("blur")) // cancels, no pointerup/pointercancel ever fires
+
+      expect(releaseSpy).toHaveBeenCalledWith(28)
+    })
+
     it("cancels rather than commits on pointercancel, reverting the in-progress width", () => {
       // pointercancel is an involuntary interruption (a touch gesture
       // reinterpreted as a scroll, an OS-level interrupt), not the user
@@ -385,21 +468,24 @@ describe("widget bootstrap", () => {
     })
 
     it("does not let a cancelled drag's abandoned width survive to be committed by a later no-op drag", () => {
-      // A drag that gets cancelled must roll panelWidth itself back, not
-      // just skip persisting once -- otherwise the abandoned in-progress
-      // value stays the module's current width, and an unrelated
-      // zero-movement drag later on would commit it via a normal release.
+      // A cancelled drag must never have touched the committed panelWidth in
+      // the first place -- otherwise the abandoned in-progress value stays
+      // the module's current width, and an unrelated zero-movement drag
+      // later on would commit it via a normal release.
       runWidget({ "data-widget-key": "widget-secret" })
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 21, clientX: 300 })
       firePointerEvent(handle(), "pointermove", { pointerId: 21, clientX: 250 }) // -> 430px, abandoned below
-      window.dispatchEvent(new Event("blur")) // cancels; must revert to 380px, not just skip persisting
+      window.dispatchEvent(new Event("blur")) // cancels: 430 must never reach panelWidth
+      expect(panel().style.width).toBe("380px")
 
-      // An unrelated click-and-release with zero movement.
+      // An unrelated click-and-release with zero movement -- a true no-op,
+      // so it persists nothing at all rather than re-affirming 380.
       firePointerEvent(handle(), "pointerdown", { pointerId: 22, clientX: 300 })
       firePointerEvent(handle(), "pointerup", { pointerId: 22, clientX: 300 })
 
-      expect(localStorage.getItem("xagent_widget_width")).toBe("380") // not the abandoned 430
+      expect(localStorage.getItem("xagent_widget_width")).not.toBe("430")
+      expect(localStorage.getItem("xagent_widget_width")).toBeNull()
     })
 
     it("restores the host page's own cursor rather than clearing it", () => {
@@ -489,26 +575,30 @@ describe("widget bootstrap", () => {
       expect(document.body.style.userSelect).toBe("")
     })
 
-    it("cancels (without persisting) an active drag on window resize", () => {
+    it("cancels an active drag on a genuine viewport change and re-renders for the new viewport", () => {
       runWidget({ "data-widget-key": "widget-secret" })
 
       firePointerEvent(handle(), "pointerdown", { pointerId: 18, clientX: 300 })
-      firePointerEvent(handle(), "pointermove", { pointerId: 18, clientX: 250 }) // mid-drag, unconfirmed
+      firePointerEvent(handle(), "pointermove", { pointerId: 18, clientX: 100 }) // -> 580px, abandoned below
+      expect(panel().style.width).toBe("580px")
       expect(document.body.style.userSelect).toBe("none")
 
-      // A viewport change invalidates this drag's frozen startX/startWidth --
-      // rather than let the next pointermove misread it as a shrink, the
-      // drag is cancelled outright.
+      // A real viewport change (not just a bare resize event) invalidates
+      // this drag's frozen startX/startWidth anchors -- rather than let the
+      // next pointermove misread the viewport's own movement as the user
+      // shrinking the panel, the drag is cancelled outright, and the panel
+      // re-renders for the *new* viewport off the untouched preference
+      // (380), not a stale snapshot of the old render or the abandoned 580.
+      setInnerWidth(350) // now below the mobile breakpoint
       window.dispatchEvent(new Event("resize"))
 
       expect(document.body.style.userSelect).toBe("")
       expect(widgetIframe().style.pointerEvents).toBe("")
       expect(localStorage.getItem("xagent_widget_width")).toBeNull()
-      // Reverted, not left at the abandoned 430px (380 + 50 from the move above).
-      expect(panel().style.width).toBe("380px")
+      expect(panel().style.width).toBe("") // mobile now: inline width cleared, not "380px" or "580px"
 
-      firePointerEvent(handle(), "pointermove", { pointerId: 18, clientX: 100 })
-      expect(panel().style.width).toBe("380px") // still unaffected: the drag is over
+      firePointerEvent(handle(), "pointermove", { pointerId: 18, clientX: 50 })
+      expect(panel().style.width).toBe("") // still unaffected: the drag is over
     })
 
     it("keeps a wider preference across a drag that shrinks past the ceiling and returns to it", () => {
@@ -544,6 +634,21 @@ describe("widget bootstrap", () => {
       firePointerEvent(handle(), "pointerup", { pointerId: 13, clientX: 300 })
       // Must NOT be clobbered back to the pre-drag snapshot.
       expect(document.body.style.userSelect).toBe("all")
+    })
+
+    it("does not restore cursor if the host page changed it since drag start", () => {
+      // Same guard as userSelect above, applied to cursor -- restoreDragSideEffects
+      // has two symmetric checks and this one had no dedicated negative-space
+      // coverage of its own.
+      runWidget({ "data-widget-key": "widget-secret" })
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 14, clientX: 300 })
+      expect(document.body.style.cursor).toBe("ew-resize")
+
+      document.body.style.cursor = "wait"
+
+      firePointerEvent(handle(), "pointerup", { pointerId: 14, clientX: 300 })
+      expect(document.body.style.cursor).toBe("wait")
     })
 
     it("does not throw when persisting the width fails", () => {

--- a/frontend/src/components/widget/widget-session.test.ts
+++ b/frontend/src/components/widget/widget-session.test.ts
@@ -268,7 +268,19 @@ describe("widget session mode", () => {
     runWidget({ "data-encrypted-context": GRANT })
 
     expect(iframeEl()?.src).toBe(`${HOST}/widget/chat/session`)
-    expect(observeSpy).toHaveBeenCalledWith(document.body, { childList: true, subtree: true })
+    // Two MutationObservers now exist in session mode: the widget's own
+    // panel-removal teardown (armed before mode.attach runs) and this
+    // controller's iframe-connectivity one, both on document.body with the
+    // same options -- so "was called with these args" alone no longer pins
+    // this controller's own observer specifically. Assert every observe()
+    // call has the expected target/options, so a regression in either one
+    // (e.g. this controller's own observer losing `subtree`) still fails
+    // here instead of being masked by the other happening to be correct.
+    expect(observeSpy).toHaveBeenCalledTimes(2)
+    observeSpy.mock.calls.forEach(([target, options]) => {
+      expect(target).toBe(document.body)
+      expect(options).toEqual({ childList: true, subtree: true })
+    })
     expect(fetchMock).toHaveBeenCalledTimes(1)
     expect(fetchMock).toHaveBeenCalledWith(EXCHANGE_URL, expect.objectContaining({
       method: "POST",

--- a/frontend/src/components/widget/widget-session.test.ts
+++ b/frontend/src/components/widget/widget-session.test.ts
@@ -270,15 +270,17 @@ describe("widget session mode", () => {
     expect(iframeEl()?.src).toBe(`${HOST}/widget/chat/session`)
     // Two MutationObservers now exist in session mode: the widget's own
     // panel-removal teardown (armed before mode.attach runs) and this
-    // controller's iframe-connectivity one, both on document.body with the
-    // same options -- so "was called with these args" alone no longer pins
-    // this controller's own observer specifically. Assert every observe()
-    // call has the expected target/options, so a regression in either one
-    // (e.g. this controller's own observer losing `subtree`) still fails
-    // here instead of being masked by the other happening to be correct.
+    // controller's iframe-connectivity one, both on document.documentElement
+    // with the same options -- so "was called with these args" alone no
+    // longer pins this controller's own observer specifically. Assert every
+    // observe() call has the expected target/options, so a regression in
+    // either one (e.g. this controller's own observer losing `subtree`, or
+    // reverting to document.body -- which misses a host framework replacing
+    // <body> wholesale on navigation) still fails here instead of being
+    // masked by the other happening to be correct.
     expect(observeSpy).toHaveBeenCalledTimes(2)
     observeSpy.mock.calls.forEach(([target, options]) => {
-      expect(target).toBe(document.body)
+      expect(target).toBe(document.documentElement)
       expect(options).toEqual({ childList: true, subtree: true })
     })
     expect(fetchMock).toHaveBeenCalledTimes(1)


### PR DESCRIPTION
## Summary
- Adds a left-edge drag handle to the embedded chat widget panel (`frontend/public/widget.js`), so visitors can resize it between 320px and 720px (clamped to the viewport).
- Persists the chosen width in `localStorage` so it survives page reloads.
- Desktop-only by design: below the existing 480px mobile breakpoint the handle is hidden and the CSS media query keeps sizing the panel, since an inline width would otherwise win over that media query by specificity.
- Guards against two edge cases in the drag implementation: a `window` `blur` fallback so an interrupted drag (e.g. Alt+Tab mid-drag) can't strand `userSelect: none` on the *host* page, and ignoring a second simultaneous pointer so a touchscreen device can't hijack an in-progress drag.

This is one slice of a larger widget layout improvement request (right-docking, minimize/close controls, an expand mode, and mobile full-screen/bottom-sheet handling); this PR is scoped to resizing + persistence only.

## Test plan
- [x] Manually verified via a local host page embedding `widget.js`: dragging the left edge resizes the panel, the width persists across reload, and the resize handle is hidden below the mobile breakpoint.
- [x] Verified the interrupted-drag fallback: dispatching a `blur` event mid-drag correctly clears `userSelect` and persists the in-progress width.
- [x] Verified a second concurrent pointer during an active drag is ignored and does not disrupt the first pointer's drag or its cleanup.