### PR TITLE
fix(tools): fail closed when the runtime tool policy cannot be resolved

### DIFF
--- a/src/xagent/web/services/tool_credentials.py
+++ b/src/xagent/web/services/tool_credentials.py
@@ -77,7 +77,11 @@ def has_user_tool_policy_hooks() -> bool:
 # Only meaningful while ``has_user_tool_policy_hooks()`` is true. With no hook
 # registered there is no policy to lose, and standalone xagent keeps its
 # unrestricted default.
-TOOL_POLICY_UNAVAILABLE_ALLOWLIST: list[str] = []
+#
+# A tuple so the constant itself cannot be mutated in place: this is the value
+# that denies every tool, and a caller that appended to it would silently widen
+# what an unresolved policy grants.
+TOOL_POLICY_UNAVAILABLE_ALLOWLIST: tuple[str, ...] = ()
 
 
 def unresolved_tool_policy_allowlist() -> list[str] | None:
@@ -86,6 +90,9 @@ def unresolved_tool_policy_allowlist() -> list[str] | None:
     ``None`` (no filtering) when no application hook is registered, so the
     fail-closed behaviour is scoped to deployments that actually delegate
     authorization to the hooks.
+
+    Returns a fresh ``list`` because the allowlist contract consumers implement
+    is ``Optional[list]``; the immutable constant above is the source value.
     """
     if not has_user_tool_policy_hooks():
         return None

--- a/src/xagent/web/services/tool_credentials.py
+++ b/src/xagent/web/services/tool_credentials.py
@@ -66,6 +66,18 @@ def has_user_tool_policy_hooks() -> bool:
     )
 
 
+def has_user_tool_overrides_hook() -> bool:
+    """Return whether an application registered the overrides hook specifically.
+
+    A caller deciding that an overrides read was *unresolvable* needs this
+    rather than :func:`has_user_tool_policy_hooks`: with no overrides hook
+    registered, ``get_user_tool_overrides`` returns ``{}`` without consulting
+    ``user`` at all, so a missing runtime user resolves that input rather than
+    leaving it unresolved.
+    """
+    return _get_user_tool_overrides_hook is not None
+
+
 # The allowlist value that means "policy could not be resolved". A registering
 # application enforces authorization through the hooks above, so a failed or
 # missing runtime ``User`` reload must not be reported as "no policy

--- a/src/xagent/web/services/tool_credentials.py
+++ b/src/xagent/web/services/tool_credentials.py
@@ -66,6 +66,32 @@ def has_user_tool_policy_hooks() -> bool:
     )
 
 
+# The allowlist value that means "policy could not be resolved". A registering
+# application enforces authorization through the hooks above, so a failed or
+# missing runtime ``User`` reload must not be reported as "no policy
+# configured": that would build the globally available tool set and run the
+# turn unrestricted. Resolving to an empty allowlist reuses the hook's existing
+# "an empty list means no tools allowed" contract, so every consumer that
+# already honours a concrete allowlist fails closed with no new branch.
+#
+# Only meaningful while ``has_user_tool_policy_hooks()`` is true. With no hook
+# registered there is no policy to lose, and standalone xagent keeps its
+# unrestricted default.
+TOOL_POLICY_UNAVAILABLE_ALLOWLIST: list[str] = []
+
+
+def unresolved_tool_policy_allowlist() -> list[str] | None:
+    """Return the fail-closed allowlist for an unresolvable policy read.
+
+    ``None`` (no filtering) when no application hook is registered, so the
+    fail-closed behaviour is scoped to deployments that actually delegate
+    authorization to the hooks.
+    """
+    if not has_user_tool_policy_hooks():
+        return None
+    return list(TOOL_POLICY_UNAVAILABLE_ALLOWLIST)
+
+
 TOOL_CREDENTIAL_SPECS: dict[str, dict[str, ToolFieldSpec]] = {
     "exa_web_search": {
         "api_key": {

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -64,6 +64,7 @@ from ..services.tool_credentials import (
     get_user_tool_overrides,
     has_user_tool_policy_hooks,
     resolve_tool_credential,
+    unresolved_tool_policy_allowlist,
 )
 from ..services.user_oauth import (
     get_scoped_user_oauth_account,
@@ -1203,6 +1204,15 @@ def _load_tool_runtime_policy_snapshot(
 
     from ..models.user import User
 
+    # A registering application enforces authorization through the policy
+    # hooks, so "could not resolve the policy" must not be reported as "no
+    # policy configured". Both branches below reach the hooks not at all, so
+    # the application has nothing to intercept; the loader itself has to fail
+    # closed. Recorded per input and collapsed into a deny-all allowlist after
+    # every input has had its own isolated Session, so an unresolvable
+    # overrides read cannot skip the independent allowlist read.
+    unresolved: set[str] = set()
+
     def load_policy_input(
         input_name: str,
         loader: Callable[[Any, Any], Any],
@@ -1212,11 +1222,21 @@ def _load_tool_runtime_policy_snapshot(
             try:
                 user = db.query(User).filter(User.id == user_id).first()
                 if user is None:
+                    unresolved.add(input_name)
+                    logger.warning(
+                        "Tool policy %s unresolved: user %s could not be reloaded",
+                        input_name,
+                        user_id,
+                    )
                     return default
                 return loader(db, user)
             except Exception as exc:
+                # Pool timeouts keep propagating (the caller retries the turn),
+                # and CancelledError is a BaseException that is deliberately
+                # not caught here.
                 if is_database_pool_timeout(exc):
                     raise
+                unresolved.add(input_name)
                 logger.exception("Failed to get user tool %s", input_name)
                 return default
 
@@ -1233,6 +1253,16 @@ def _load_tool_runtime_policy_snapshot(
         lambda db, user: normalize_tool_allowlist(get_user_tool_allowlist(db, user)),
         None,
     )
+    if unresolved:
+        fail_closed = unresolved_tool_policy_allowlist()
+        if fail_closed is not None:
+            logger.error(
+                "Tool policy unresolved for user %s (%s); denying every tool "
+                "for this turn",
+                user_id,
+                ", ".join(sorted(unresolved)),
+            )
+            tool_allowlist = fail_closed
     return _ToolRuntimePolicySnapshot(
         tool_overrides=tool_overrides,
         tool_allowlist=tool_allowlist,
@@ -1399,6 +1429,13 @@ class WebToolConfig(BaseToolConfig):
         # separate flag tracks whether the hook has been consulted yet.
         self._cached_tool_allowlist: Optional[list] = None
         self._tool_allowlist_cached: bool = False
+        # Names the policy inputs whose read could not be resolved (the hook
+        # never ran). ``get_user_tool_allowlist`` turns a non-empty set into a
+        # deny-all allowlist so the execution layer fails closed instead of
+        # building every tool. Each accessor clears its own entry before
+        # re-reading, so a transient failure cannot latch deny-all onto a config
+        # that is reused across turns.
+        self._unresolved_tool_policy_inputs: set[str] = set()
 
         # Sandbox instance - only store reference, lifecycle managed by upper layer
         self._sandbox: Optional[Any] = sandbox
@@ -2115,6 +2152,37 @@ class WebToolConfig(BaseToolConfig):
         """See BaseToolConfig.get_voice's docstring."""
         return self._voice
 
+    def _note_unresolved_tool_policy(self, input_name: str, reason: str) -> None:
+        """Record that a policy input could not be resolved for this turn.
+
+        The registered hook never ran on these paths, so the application that
+        owns authorization has nothing to intercept and cannot repair the read.
+        ``get_user_tool_allowlist`` converts a recorded input into a deny-all
+        allowlist so the execution layer builds no tools instead of the full
+        default set. Entries live only as long as the cached read that produced
+        them: each accessor drops its own entry before consulting the hook
+        again, so a transient failure denies one turn rather than latching.
+        """
+        if not has_user_tool_policy_hooks():
+            # No application policy to lose: standalone xagent keeps its
+            # unrestricted default rather than denying every tool.
+            return
+        self._unresolved_tool_policy_inputs.add(input_name)
+        # Invalidate any allowlist already cached by an earlier read. The two
+        # inputs are read in either order, so a clean allowlist cached before
+        # this failure would otherwise keep reporting "no filtering" and hand
+        # the turn the full tool set. Re-deriving it applies the denial.
+        if input_name != "allowlist":
+            self._tool_allowlist_cached = False
+            self._cached_tool_allowlist = None
+        logger.error(
+            "Tool policy %s unresolved for user %s (%s); denying every tool "
+            "for this turn",
+            input_name,
+            self._user_id,
+            reason,
+        )
+
     def get_user_tool_overrides(self) -> dict:
         """Return per-user tool overrides from the registered hook.
 
@@ -2123,13 +2191,20 @@ class WebToolConfig(BaseToolConfig):
         """
         if self._cached_tool_overrides is not None:
             return self._cached_tool_overrides
+        # This read supersedes whatever the previous one concluded.
+        self._unresolved_tool_policy_inputs.discard("overrides")
         if self._user is None:
+            # No user to hand the hook: the policy is unresolved, not absent.
+            # The overrides mapping stays a dict (the tool-listing API indexes
+            # it); ``get_user_tool_allowlist`` carries the fail-closed signal.
+            self._note_unresolved_tool_policy("overrides", "no runtime user")
             self._cached_tool_overrides = {}
             return {}
         try:
             self._cached_tool_overrides = get_user_tool_overrides(self.db, self._user)
         except Exception:
             logger.exception("Failed to get user tool overrides")
+            self._note_unresolved_tool_policy("overrides", "hook read failed")
             self._cached_tool_overrides = {}
         return self._cached_tool_overrides
 
@@ -2204,6 +2279,10 @@ class WebToolConfig(BaseToolConfig):
         self._cached_tool_overrides = snapshot.tool_overrides
         self._cached_tool_allowlist = snapshot.tool_allowlist
         self._tool_allowlist_cached = True
+        # The worker resolved the policy itself and already folded any
+        # unresolvable input into ``snapshot.tool_allowlist``; stale entries from
+        # an earlier in-request read must not latch deny-all onto this snapshot.
+        self._unresolved_tool_policy_inputs.clear()
 
     async def prepare_factory_runtime(self) -> None:
         """Prefetch synchronous ToolFactory inputs without blocking its loop.
@@ -2348,6 +2427,10 @@ class WebToolConfig(BaseToolConfig):
                 self._cached_tool_overrides = None
                 self._tool_allowlist_cached = False
                 self._cached_tool_allowlist = None
+                # The accessors below each drop their own entry before
+                # re-reading, so nothing from a previous turn survives; clearing
+                # here keeps that explicit for the in-request branch.
+                self._unresolved_tool_policy_inputs.clear()
                 self.refresh_user_tool_overrides()
                 self.refresh_user_tool_allowlist()
                 return
@@ -2366,6 +2449,10 @@ class WebToolConfig(BaseToolConfig):
         self._cached_tool_overrides = policy_snapshot.tool_overrides
         self._cached_tool_allowlist = policy_snapshot.tool_allowlist
         self._tool_allowlist_cached = True
+        # This snapshot is authoritative for the turn (the loader already
+        # fail-closed any input it could not resolve), so drop entries left by
+        # an earlier read rather than denying every tool for the rest of the run.
+        self._unresolved_tool_policy_inputs.clear()
         self._pending_runtime_policy = policy_snapshot
 
     def refresh_user_tool_overrides(self) -> dict:
@@ -2381,16 +2468,38 @@ class WebToolConfig(BaseToolConfig):
         list means keep only those tool names (execution layer only). The
         allowlist is resolved from the active execution scope by the hook, so
         it can differ per turn even for the same user.
+
+        When a policy hook is registered but a policy input could not be
+        resolved, this returns the empty list ("no tools allowed") rather than
+        ``None``: the hook never ran, so the application enforcing
+        authorization has nothing to intercept, and reporting "no allowlist"
+        would build the globally available tool set. With no hook registered
+        there is no policy to lose and the unrestricted default is kept.
         """
         if self._tool_allowlist_cached:
             return self._cached_tool_allowlist
+        # This read supersedes whatever the previous one concluded. The
+        # overrides entry is left alone: an unresolved overrides read in this
+        # same turn must still deny below.
+        self._unresolved_tool_policy_inputs.discard("allowlist")
         try:
+            # ``self._user`` may legitimately be ``None`` here: the allowlist is
+            # resolved from the active execution scope, so the hook is consulted
+            # with whatever user the config holds rather than short-circuited.
             self._cached_tool_allowlist = normalize_tool_allowlist(
                 get_user_tool_allowlist(self.db, self._user)
             )
         except Exception:
             logger.exception("Failed to get user tool allowlist")
+            self._note_unresolved_tool_policy("allowlist", "hook read failed")
             self._cached_tool_allowlist = None
+        if self._unresolved_tool_policy_inputs:
+            # An unresolved read on either policy input denies every tool
+            # rather than reporting "no allowlist configured", which would
+            # skip the execution layer's positive filter entirely.
+            fail_closed = unresolved_tool_policy_allowlist()
+            if fail_closed is not None:
+                self._cached_tool_allowlist = fail_closed
         self._tool_allowlist_cached = True
         return self._cached_tool_allowlist
 
@@ -2398,6 +2507,10 @@ class WebToolConfig(BaseToolConfig):
         """Reload the positive tool allowlist from the registered hook."""
         # The active execution scope (hence the CA allowlist) can change while
         # an AgentService instance is reused across turns.
+        #
+        # ``get_user_tool_allowlist`` drops only its own unresolved entry before
+        # re-reading, so a fresh allowlist answer lifts the denial it caused
+        # while an unresolved overrides read from the same turn still denies.
         self._tool_allowlist_cached = False
         self._cached_tool_allowlist = None
         return self.get_user_tool_allowlist()

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -2189,6 +2189,8 @@ class WebToolConfig(BaseToolConfig):
         Both display layer and execution layer use this as the single
         source of truth for per-user tool policies.
         """
+        from ..services.db_runtime import is_database_pool_timeout
+
         if self._cached_tool_overrides is not None:
             return self._cached_tool_overrides
         # This read supersedes whatever the previous one concluded.
@@ -2202,7 +2204,14 @@ class WebToolConfig(BaseToolConfig):
             return {}
         try:
             self._cached_tool_overrides = get_user_tool_overrides(self.db, self._user)
-        except Exception:
+        except Exception as exc:
+            # A pool checkout timeout is not an unresolved policy: the very next
+            # step needs the same pool, so propagate it for the caller to retry
+            # rather than spending the turn with no tools. Matches
+            # ``_load_tool_runtime_policy_snapshot``. Nothing is cached and no
+            # input is recorded, so the retry re-reads from scratch.
+            if is_database_pool_timeout(exc):
+                raise
             logger.exception("Failed to get user tool overrides")
             self._note_unresolved_tool_policy("overrides", "hook read failed")
             self._cached_tool_overrides = {}
@@ -2476,6 +2485,8 @@ class WebToolConfig(BaseToolConfig):
         would build the globally available tool set. With no hook registered
         there is no policy to lose and the unrestricted default is kept.
         """
+        from ..services.db_runtime import is_database_pool_timeout
+
         if self._tool_allowlist_cached:
             return self._cached_tool_allowlist
         # This read supersedes whatever the previous one concluded. The
@@ -2489,7 +2500,12 @@ class WebToolConfig(BaseToolConfig):
             self._cached_tool_allowlist = normalize_tool_allowlist(
                 get_user_tool_allowlist(self.db, self._user)
             )
-        except Exception:
+        except Exception as exc:
+            # See get_user_tool_overrides: a pool timeout propagates for retry
+            # instead of being recorded as an unresolved policy. Left uncached
+            # so the retry re-reads, and no deny-all is applied on the way out.
+            if is_database_pool_timeout(exc):
+                raise
             logger.exception("Failed to get user tool allowlist")
             self._note_unresolved_tool_policy("allowlist", "hook read failed")
             self._cached_tool_allowlist = None

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -2187,8 +2187,13 @@ class WebToolConfig(BaseToolConfig):
     def get_user_tool_overrides(self) -> dict:
         """Return per-user tool overrides from the registered hook.
 
-        Both display layer and execution layer use this as the single
-        source of truth for per-user tool policies.
+        Both display layer and execution layer read per-user tool policy from
+        here, but this is no longer the whole picture: ``{}`` means either "no
+        overrides configured" or "the policy could not be resolved", and the
+        two are not distinguishable from the return value. The fail-closed
+        signal for an unresolved read is carried by
+        :meth:`get_user_tool_allowlist`, so the execution layer must consult
+        both.
         """
         from ..services.db_runtime import is_database_pool_timeout
 

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -62,6 +62,7 @@ from ..services.tool_credentials import (
     get_sql_connection_map,
     get_user_tool_allowlist,
     get_user_tool_overrides,
+    has_user_tool_overrides_hook,
     has_user_tool_policy_hooks,
     resolve_tool_credential,
     unresolved_tool_policy_allowlist,
@@ -2199,7 +2200,14 @@ class WebToolConfig(BaseToolConfig):
             # No user to hand the hook: the policy is unresolved, not absent.
             # The overrides mapping stays a dict (the tool-listing API indexes
             # it); ``get_user_tool_allowlist`` carries the fail-closed signal.
-            self._note_unresolved_tool_policy("overrides", "no runtime user")
+            #
+            # Gated on the overrides hook specifically, not on either hook:
+            # with no overrides hook registered ``get_user_tool_overrides``
+            # ignores ``user`` and returns ``{}`` regardless, so a missing user
+            # resolves this input. Recording it would deny an allowlist-only
+            # deployment whose allowlist hook answered successfully.
+            if has_user_tool_overrides_hook():
+                self._note_unresolved_tool_policy("overrides", "no runtime user")
             self._cached_tool_overrides = {}
             return {}
         try:

--- a/tests/web/api/test_tools_api.py
+++ b/tests/web/api/test_tools_api.py
@@ -1173,10 +1173,11 @@ class TestWebToolConfigUserOverride:
             set_user_tool_overrides_hook(None)
 
     @pytest.mark.asyncio
-    async def test_create_all_tools_skips_filter_when_no_user_at_all(self):
-        """When neither explicit user nor request.user is set,
-        get_user_tool_overrides() returns {} and ToolFactory filtering is skipped.
-        This is the safe fallback — no user means no per-user policy can apply."""
+    async def test_create_all_tools_denies_every_tool_when_no_user_at_all(self):
+        """When a policy hook is registered but neither explicit user nor
+        request.user is set, the hook never runs. That is "policy unavailable",
+        not "no policy": the turn must get no tools rather than the full set,
+        which would include the very tool the policy disables."""
         from unittest.mock import AsyncMock, MagicMock, patch
 
         from xagent.core.tools.adapters.vibe.factory import ToolFactory
@@ -1195,7 +1196,7 @@ class TestWebToolConfigUserOverride:
                 db=MagicMock(),
                 request=request_without_user,
                 user_id=42,
-                # No explicit user passed — this is the pre-fix bug path
+                # No explicit user passed — the unresolvable-policy path.
                 workspace_config={"base_dir": "/tmp", "task_id": "test"},
             )
 
@@ -1211,13 +1212,46 @@ class TestWebToolConfigUserOverride:
                 result = await ToolFactory.create_all_tools(cfg)
 
             tool_names = [t.name for t in result]
-            # Without explicit user, overrides are {} and filtering is skipped
-            assert "browser_navigate" in tool_names, (
-                "No filtering when no user (existing behavior)"
+            assert "browser_navigate" not in tool_names, (
+                "an unresolved policy must not hand back a tool the policy disables"
             )
-            assert "calculator" in tool_names
+            # Fail closed all the way: an unresolved policy cannot be narrowed
+            # to just the disabled names, because the hook never told us any.
+            assert tool_names == []
         finally:
             set_user_tool_overrides_hook(None)
+
+    @pytest.mark.asyncio
+    async def test_create_all_tools_keeps_every_tool_when_no_hook_registered(self):
+        """Standalone xagent registers no policy hook, so a config without a
+        runtime user has no policy to lose and keeps its unrestricted default."""
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from xagent.core.tools.adapters.vibe.factory import ToolFactory
+        from xagent.web.tools.config import WebToolConfig
+
+        request_without_user = MagicMock()
+        del request_without_user.user
+
+        cfg = WebToolConfig(
+            db=MagicMock(),
+            request=request_without_user,
+            user_id=42,
+            workspace_config={"base_dir": "/tmp", "task_id": "test"},
+        )
+
+        tool_browser = MagicMock()
+        tool_browser.name = "browser_navigate"
+        tool_calc = MagicMock()
+        tool_calc.name = "calculator"
+
+        with patch(
+            "xagent.core.tools.adapters.vibe.factory.ToolRegistry.create_registered_tools",
+            AsyncMock(return_value=[tool_browser, tool_calc]),
+        ):
+            result = await ToolFactory.create_all_tools(cfg)
+
+        assert sorted(t.name for t in result) == ["browser_navigate", "calculator"]
 
     @pytest.mark.asyncio
     async def test_create_all_tools_keeps_disabled_when_filter_false(self):

--- a/tests/web/tools/test_user_tool_allowlist.py
+++ b/tests/web/tools/test_user_tool_allowlist.py
@@ -124,6 +124,118 @@ def test_config_denies_when_an_allowlist_read_precedes_a_failed_overrides_read(
         set_user_tool_overrides_hook(None)
 
 
+@pytest.mark.parametrize("accessor", ["overrides", "allowlist"])
+def test_config_propagates_pool_timeouts_instead_of_denying(
+    clear_allowlist_hook, accessor
+):
+    """A pool checkout timeout is not an unresolved policy.
+
+    The next step in the turn needs the same pool, so the caller must get the
+    timeout and retry rather than spending the turn with no tools. This matches
+    ``_load_tool_runtime_policy_snapshot``, which already re-raises.
+    """
+    from unittest.mock import MagicMock
+
+    from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+
+    from xagent.web.services.tool_credentials import set_user_tool_overrides_hook
+
+    checkout_timeout = SQLAlchemyTimeoutError("pool checkout timed out")
+
+    def _timeout(db, user):
+        raise checkout_timeout
+
+    set_user_tool_allowlist_hook(_timeout)
+    set_user_tool_overrides_hook(_timeout)
+    try:
+        cfg = WebToolConfig(
+            db=MagicMock(), request=MagicMock(user=MagicMock(id=42)), user_id=42
+        )
+        read = (
+            cfg.get_user_tool_overrides
+            if accessor == "overrides"
+            else cfg.get_user_tool_allowlist
+        )
+
+        with pytest.raises(SQLAlchemyTimeoutError) as exc_info:
+            read()
+        assert exc_info.value is checkout_timeout
+
+        # Nothing recorded and nothing cached: the retry re-reads from scratch
+        # rather than inheriting a deny-all from the timed-out attempt.
+        assert cfg._unresolved_tool_policy_inputs == set()
+    finally:
+        set_user_tool_overrides_hook(None)
+
+
+def test_config_serves_real_policy_after_a_pool_timeout_retry(clear_allowlist_hook):
+    """The retry a propagated timeout invites must see the real policy."""
+    from unittest.mock import MagicMock
+
+    from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+
+    failing = {"value": True}
+
+    def _flaky(db, user):
+        if failing["value"]:
+            raise SQLAlchemyTimeoutError("pool checkout timed out")
+        return ["only_this"]
+
+    set_user_tool_allowlist_hook(_flaky)
+    cfg = WebToolConfig(
+        db=MagicMock(), request=MagicMock(user=MagicMock(id=42)), user_id=42
+    )
+
+    with pytest.raises(SQLAlchemyTimeoutError):
+        cfg.get_user_tool_allowlist()
+
+    failing["value"] = False
+    # No refresh call needed: the timed-out read cached nothing.
+    assert cfg.get_user_tool_allowlist() == ["only_this"]
+
+
+def test_config_keeps_denying_when_an_allowlist_timeout_follows_a_failed_overrides_read(
+    clear_allowlist_hook,
+):
+    """A propagated timeout must not discard an already-unresolved input.
+
+    The allowlist read clears only its own entry before consulting the hook, so
+    an overrides input that could not be resolved has to keep denying once the
+    retried allowlist read succeeds.
+    """
+    from unittest.mock import MagicMock
+
+    from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
+
+    from xagent.web.services.tool_credentials import set_user_tool_overrides_hook
+
+    failing = {"value": True}
+
+    def _flaky_allowlist(db, user):
+        if failing["value"]:
+            raise SQLAlchemyTimeoutError("pool checkout timed out")
+        return None  # the hook itself says "no allowlist configured"
+
+    set_user_tool_allowlist_hook(_flaky_allowlist)
+    set_user_tool_overrides_hook(lambda db, user: {"file": {"enabled": False}})
+    try:
+        request_without_user = MagicMock()
+        del request_without_user.user
+        cfg = WebToolConfig(db=MagicMock(), request=request_without_user, user_id=42)
+
+        # The overrides read cannot reach the hook (no runtime user).
+        assert cfg.get_user_tool_overrides() == {}
+        with pytest.raises(SQLAlchemyTimeoutError):
+            cfg.get_user_tool_allowlist()
+
+        failing["value"] = False
+        # The hook now answers "no allowlist", but the unresolved overrides read
+        # still denies: a resolved allowlist does not vouch for the other input.
+        assert cfg.get_user_tool_allowlist() == []
+    finally:
+        set_user_tool_overrides_hook(None)
+
+
 def test_config_recovers_after_a_transient_hook_failure(clear_allowlist_hook):
     calls = {"n": 0}
 

--- a/tests/web/tools/test_user_tool_allowlist.py
+++ b/tests/web/tools/test_user_tool_allowlist.py
@@ -236,6 +236,47 @@ def test_config_keeps_denying_when_an_allowlist_timeout_follows_a_failed_overrid
         set_user_tool_overrides_hook(None)
 
 
+def test_missing_user_does_not_deny_an_allowlist_only_deployment(clear_allowlist_hook):
+    """A missing runtime user must not deny when no overrides hook is registered.
+
+    With no overrides hook, ``get_user_tool_overrides`` ignores ``user`` and
+    returns ``{}`` regardless, so that input is resolved rather than unresolved.
+    Recording it would discard an allowlist the hook returned successfully.
+    """
+    from unittest.mock import MagicMock
+
+    set_user_tool_allowlist_hook(lambda db, user: ["shell", "file"])
+    request_without_user = MagicMock()
+    del request_without_user.user
+    cfg = WebToolConfig(db=MagicMock(), request=request_without_user, user_id=42)
+
+    # Read order matches the factory's (overrides at factory.py:632, then
+    # allowlist at :651) so the cross-input path is exercised.
+    assert cfg.get_user_tool_overrides() == {}
+    assert cfg.get_user_tool_allowlist() == ["shell", "file"]
+
+
+def test_missing_user_still_denies_when_the_overrides_hook_is_registered(
+    clear_allowlist_hook,
+):
+    """The narrower gate must not reopen the fail-open path it guards."""
+    from unittest.mock import MagicMock
+
+    from xagent.web.services.tool_credentials import set_user_tool_overrides_hook
+
+    set_user_tool_allowlist_hook(lambda db, user: ["shell"])
+    set_user_tool_overrides_hook(lambda db, user: {"file": {"enabled": False}})
+    try:
+        request_without_user = MagicMock()
+        del request_without_user.user
+        cfg = WebToolConfig(db=MagicMock(), request=request_without_user, user_id=42)
+
+        assert cfg.get_user_tool_overrides() == {}
+        assert cfg.get_user_tool_allowlist() == []
+    finally:
+        set_user_tool_overrides_hook(None)
+
+
 def test_config_recovers_after_a_transient_hook_failure(clear_allowlist_hook):
     calls = {"n": 0}
 

--- a/tests/web/tools/test_user_tool_allowlist.py
+++ b/tests/web/tools/test_user_tool_allowlist.py
@@ -75,14 +75,71 @@ def test_config_caches_none_result(clear_allowlist_hook):
     assert calls["n"] == 1
 
 
-def test_config_swallows_hook_errors(clear_allowlist_hook):
+def test_config_fails_closed_on_hook_errors(clear_allowlist_hook):
     def _boom(db, user):
         raise RuntimeError("hook failed")
 
     set_user_tool_allowlist_hook(_boom)
     cfg = _config()
-    # A failing hook must not break tool building; treated as "no allowlist".
-    assert cfg.get_user_tool_allowlist() is None
+    # A failing hook must not break tool building, but it must not be reported
+    # as "no allowlist configured" either: the application enforces
+    # authorization through this hook, so an unresolved read denies every tool
+    # instead of skipping the positive filter and building the full set.
+    assert cfg.get_user_tool_allowlist() == []
+
+
+def test_config_reports_no_allowlist_when_no_hook_registered(clear_allowlist_hook):
+    # Standalone xagent registers no policy hook, so there is no policy to
+    # lose: the accessor still means "no filtering", not "deny every tool".
+    assert _config().get_user_tool_allowlist() is None
+
+
+def test_config_denies_when_an_allowlist_read_precedes_a_failed_overrides_read(
+    clear_allowlist_hook,
+):
+    """The deny must not depend on which policy input is read first.
+
+    The allowlist read caches "no allowlist configured". If a later overrides
+    read cannot be resolved, that cached ``None`` must not keep reporting "no
+    filtering" — which is exactly the full-tool-set fail-open path.
+    """
+    from unittest.mock import MagicMock
+
+    from xagent.web.services.tool_credentials import set_user_tool_overrides_hook
+
+    set_user_tool_allowlist_hook(lambda db, user: None)
+    set_user_tool_overrides_hook(lambda db, user: {"file": {"enabled": False}})
+    try:
+        request_without_user = MagicMock()
+        del request_without_user.user
+        cfg = WebToolConfig(db=MagicMock(), request=request_without_user, user_id=42)
+
+        # Allowlist first: nothing has failed yet, so "no allowlist" is right.
+        assert cfg.get_user_tool_allowlist() is None
+        # The overrides read cannot reach the hook (no runtime user).
+        assert cfg.get_user_tool_overrides() == {}
+        # That failure has to invalidate the cached allowlist and deny.
+        assert cfg.get_user_tool_allowlist() == []
+    finally:
+        set_user_tool_overrides_hook(None)
+
+
+def test_config_recovers_after_a_transient_hook_failure(clear_allowlist_hook):
+    calls = {"n": 0}
+
+    def _flaky(db, user):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise RuntimeError("hook failed")
+        return ["only_this"]
+
+    set_user_tool_allowlist_hook(_flaky)
+    cfg = _config()
+
+    assert cfg.get_user_tool_allowlist() == []
+    # Fail closed must not latch: once the hook answers again the turn gets the
+    # real policy rather than staying denied for the life of the config.
+    assert cfg.refresh_user_tool_allowlist() == ["only_this"]
 
 
 @pytest.mark.parametrize(

--- a/tests/web/tools/test_web_tool_config_session_factory.py
+++ b/tests/web/tools/test_web_tool_config_session_factory.py
@@ -2445,6 +2445,208 @@ def test_runtime_policy_propagates_later_input_checkout_timeout():
         set_user_tool_allowlist_hook(None)
 
 
+# --------------------------------------------------------------------------- #
+# Fail-closed policy resolution (xagent #1739)
+#
+# The policy hooks are how a registering application enforces authorization. On
+# the two branches below the hook never runs, so the application has nothing to
+# intercept: reporting "no policy configured" would build the globally available
+# tool set and run the turn unrestricted.
+# --------------------------------------------------------------------------- #
+class _UserReloadSession:
+    """Session whose ``User`` reload misbehaves in a configurable way."""
+
+    def __init__(self, mode: str):
+        self._mode = mode
+        self.closed = False
+
+    def connection(self):
+        return object()
+
+    def query(self, *_args, **_kwargs):
+        if self._mode == "raise":
+            raise RuntimeError("user reload failed")
+        if self._mode == "cancel":
+            raise asyncio.CancelledError()
+        return _ListChain([] if self._mode == "missing" else [SimpleNamespace(id=1)])
+
+    def close(self):
+        self.closed = True
+
+
+def _policy_snapshot_for(mode: str, *, overrides=None, allowlist=None):
+    from xagent.web.tools.config import _load_tool_runtime_policy_snapshot
+
+    sessions: list[_UserReloadSession] = []
+
+    def session_factory() -> _UserReloadSession:
+        session = _UserReloadSession(mode)
+        sessions.append(session)
+        return session
+
+    set_user_tool_overrides_hook(overrides or (lambda _db, _user: {}))
+    set_user_tool_allowlist_hook(allowlist or (lambda _db, _user: None))
+    try:
+        return _load_tool_runtime_policy_snapshot(session_factory, 1), sessions
+    finally:
+        set_user_tool_overrides_hook(None)
+        set_user_tool_allowlist_hook(None)
+
+
+@pytest.mark.parametrize("mode", ["raise", "missing"])
+def test_runtime_policy_denies_every_tool_when_user_reload_fails(mode):
+    # ``raise`` is an ordinary loader failure; ``missing`` is a reload that
+    # returns None. Both used to yield overrides={} / allowlist=None, which the
+    # factory reads as "no disable set, no positive filter" — the full tool set.
+    snapshot, sessions = _policy_snapshot_for(
+        mode,
+        # A permissive-looking hook makes the point: even when the policy would
+        # have allowed something, an unresolved read grants nothing.
+        allowlist=lambda _db, _user: ["file", "shell"],
+    )
+
+    assert snapshot.tool_allowlist == []
+    # The overrides mapping stays a dict: the tool-listing API indexes it.
+    assert snapshot.tool_overrides == {}
+    assert all(session.closed for session in sessions)
+
+
+def test_runtime_policy_keeps_a_healthy_read_unrestricted():
+    # The guard above must be conditional, not a blanket deny: a resolvable
+    # policy is passed through untouched. Without this case, an implementation
+    # that denied every turn would satisfy the two tests above.
+    snapshot, _ = _policy_snapshot_for(
+        "ok",
+        overrides=lambda _db, _user: {"file": {"enabled": False}},
+        allowlist=lambda _db, _user: ["shell"],
+    )
+
+    assert snapshot.tool_allowlist == ["shell"]
+    assert snapshot.tool_overrides == {"file": {"enabled": False}}
+
+
+def test_runtime_policy_keeps_a_healthy_read_without_an_allowlist():
+    # "No allowlist configured" is a legitimate resolved answer and must stay
+    # ``None`` (no filtering) rather than collapsing into the deny-all value.
+    snapshot, _ = _policy_snapshot_for("ok")
+
+    assert snapshot.tool_allowlist is None
+    assert snapshot.tool_overrides == {}
+
+
+@pytest.mark.parametrize("mode", ["raise", "missing"])
+def test_runtime_policy_stays_open_without_a_registered_hook(mode):
+    """Standalone xagent must keep its unrestricted default."""
+    from xagent.web.tools.config import _load_tool_runtime_policy_snapshot
+
+    sessions: list[_UserReloadSession] = []
+
+    def session_factory() -> _UserReloadSession:
+        session = _UserReloadSession(mode)
+        sessions.append(session)
+        return session
+
+    set_user_tool_overrides_hook(None)
+    set_user_tool_allowlist_hook(None)
+    snapshot = _load_tool_runtime_policy_snapshot(session_factory, 1)
+
+    # No hook registered means no policy to lose: denying every tool here would
+    # break every deployment that never delegated authorization to a hook.
+    assert snapshot.tool_allowlist is None
+    assert snapshot.tool_overrides == {}
+    assert all(session.closed for session in sessions)
+
+
+def test_runtime_policy_still_propagates_pool_timeouts():
+    """A pool timeout is retried by the caller, not converted to deny-all."""
+    from xagent.web.tools.config import _load_tool_runtime_policy_snapshot
+
+    checkout_timeout = SQLAlchemyTimeoutError("overrides checkout timed out")
+    sessions: list[_PostgresAbortSession] = []
+
+    def session_factory() -> _PostgresAbortSession:
+        session = _PostgresAbortSession(checkout_error=checkout_timeout)
+        sessions.append(session)
+        return session
+
+    set_user_tool_overrides_hook(lambda _db, _user: {})
+    set_user_tool_allowlist_hook(lambda _db, _user: ["file"])
+    try:
+        with pytest.raises(SQLAlchemyTimeoutError) as exc_info:
+            _load_tool_runtime_policy_snapshot(session_factory, 1)
+
+        assert exc_info.value is checkout_timeout
+        assert all(session.closed for session in sessions)
+    finally:
+        set_user_tool_overrides_hook(None)
+        set_user_tool_allowlist_hook(None)
+
+
+def test_runtime_policy_still_propagates_cancellation():
+    """CancelledError is a BaseException and must not be swallowed."""
+    from xagent.web.tools.config import _load_tool_runtime_policy_snapshot
+
+    sessions: list[_UserReloadSession] = []
+
+    def session_factory() -> _UserReloadSession:
+        session = _UserReloadSession("cancel")
+        sessions.append(session)
+        return session
+
+    set_user_tool_overrides_hook(lambda _db, _user: {})
+    set_user_tool_allowlist_hook(lambda _db, _user: ["file"])
+    try:
+        with pytest.raises(asyncio.CancelledError):
+            _load_tool_runtime_policy_snapshot(session_factory, 1)
+
+        assert all(session.closed for session in sessions)
+    finally:
+        set_user_tool_overrides_hook(None)
+        set_user_tool_allowlist_hook(None)
+
+
+def test_runtime_policy_denies_when_only_the_overrides_read_fails():
+    """An unresolved overrides read must not be rescued by a healthy allowlist.
+
+    The two inputs load through independent Sessions, so one can succeed while
+    the other fails. The disable set the hook would have returned is unknown, so
+    the allowlist it did return cannot be trusted to be complete.
+    """
+    from xagent.web.tools.config import _load_tool_runtime_policy_snapshot
+
+    sessions: list[_PostgresAbortSession] = []
+
+    def session_factory() -> _PostgresAbortSession:
+        session = _PostgresAbortSession()
+        sessions.append(session)
+        return session
+
+    def load_overrides(db: _PostgresAbortSession, _user):
+        db.swallow_statement_failure()
+        raise RuntimeError("overrides read failed")
+
+    allowlist_hook_called = False
+
+    def load_allowlist(_db, _user):
+        nonlocal allowlist_hook_called
+        allowlist_hook_called = True
+        return ["file"]
+
+    set_user_tool_overrides_hook(load_overrides)
+    set_user_tool_allowlist_hook(load_allowlist)
+    try:
+        snapshot = _load_tool_runtime_policy_snapshot(session_factory, 1)
+
+        # The independent allowlist read still runs (its own Session is clean)…
+        assert allowlist_hook_called is True
+        # …but the unresolved overrides input still denies the turn.
+        assert snapshot.tool_allowlist == []
+        assert all(session.closed for session in sessions)
+    finally:
+        set_user_tool_overrides_hook(None)
+        set_user_tool_allowlist_hook(None)
+
+
 @pytest.mark.asyncio
 async def test_default_model_prefetch_returns_every_pool_checkout(
     monkeypatch,


### PR DESCRIPTION
Fixes #1739.

## Problem

`_load_tool_runtime_policy_snapshot` and `WebToolConfig`'s two policy accessors converted a failed or missing runtime `User` reload into "no policy configured" instead of "policy unavailable".

The defaults are `{}` for overrides and `None` for the allowlist. In `core/tools/adapters/vibe/factory.py`, `{}` is falsy so no disable set is computed, and `None` means "no allowlist" so no positive filter is applied — the net effect is the **globally available tool set**. An application that registers `set_user_tool_overrides_hook` / `set_user_tool_allowlist_hook` to enforce authorization lost that enforcement on exactly the branches where the hook never ran, so it had nothing to intercept and no way to repair the read.

Reproduced against the pre-fix tree with a stub session:

```
user is None    overrides={} allowlist=None
query raises    overrides={} allowlist=None
```

## Approach

Option 1 from the issue (sentinel snapshot). An unresolvable policy read now resolves to an **empty allowlist**, reusing the hook's documented "an empty list means no tools allowed" contract. Every consumer that already honours a concrete allowlist therefore fails closed with no new branch, and the turn stays alive with zero tools rather than aborting on a transient database error (option 2's trade-off).

## Scope: three call sites, not one

The issue names the snapshot loader, but the factory applies policy by reading the **accessors** (`getattr(config, "get_user_tool_overrides")()` / `get_user_tool_allowlist`, factory.py:632/651) — the snapshot only pre-populates their caches. Fixing the loader alone would leave the same fail-open reachable through `WebToolConfig.get_user_tool_overrides` (`except → {}`, and `self._user is None → {}`) and `get_user_tool_allowlist` (`except → None`), which is the path `refresh_runtime_policy` falls back to when there is no `db_factory`. All three are fixed together:

- **Snapshot loader** records each input it could not resolve and collapses them *after* every input has had its own isolated Session, so an unresolvable overrides read cannot skip the independent allowlist read.
- **`get_user_tool_overrides`** keeps returning a `dict` — the tool-listing API indexes it (`web/api/tools.py:438`) — and records the unresolved input instead.
- **`get_user_tool_allowlist`** carries the deny. Recording an unresolved input also invalidates any allowlist already cached, so the denial does not depend on which of the two inputs happens to be read first.

## Deliberately unchanged

- `is_database_pool_timeout` still propagates (the caller retries the turn).
- `CancelledError` is a `BaseException` and is still not swallowed.
- Gated on `has_user_tool_policy_hooks()`: with no hook registered there is no policy to lose, so **standalone xagent keeps its unrestricted default**.
- The denial is scoped per read rather than sticky, so a transient failure denies one turn instead of latching onto a config reused across turns.

## Tests

Two existing tests asserted the fail-open behaviour as intended and are rewritten to assert the fail-closed contract:

- `test_create_all_tools_skips_filter_when_no_user_at_all` → `..._denies_every_tool_when_no_user_at_all`. It documented the full tool set as "the safe fallback" while a hook was registered and `user_id` was present, so the turn received `browser_navigate` — the exact tool the policy disables.
- `test_config_swallows_hook_errors` → `test_config_fails_closed_on_hook_errors`.

New coverage:

| Case | Test |
| --- | --- |
| Ordinary exception / missing user → no tools | `test_runtime_policy_denies_every_tool_when_user_reload_fails[raise\|missing]` |
| Healthy read unaffected (no over-denial) | `test_runtime_policy_keeps_a_healthy_read_unrestricted`, `..._without_an_allowlist` |
| No hook registered → behaviour unchanged | `test_runtime_policy_stays_open_without_a_registered_hook`, `test_create_all_tools_keeps_every_tool_when_no_hook_registered`, `test_config_reports_no_allowlist_when_no_hook_registered` |
| Pool timeout still propagates | `test_runtime_policy_still_propagates_pool_timeouts` |
| Cancellation still not swallowed | `test_runtime_policy_still_propagates_cancellation` |
| One input fails, the other is healthy | `test_runtime_policy_denies_when_only_the_overrides_read_fails` |
| Deny does not latch | `test_config_recovers_after_a_transient_hook_failure` |
| Deny is read-order independent | `test_config_denies_when_an_allowlist_read_precedes_a_failed_overrides_read` |

Every new test was mutation-verified — reverting the fix (and, separately, making the deny unconditional, making it latch, and dropping the cache invalidation) turns the matching tests red. The healthy-read and no-hook cases are what stop a blanket deny-all from passing.

The read-ordering hole was found by self-review after the first implementation: the deny was a pull (applied only when the allowlist happened to be read) rather than a push, so an allowlist cached before a later overrides failure kept reporting "no filtering". Fixed and covered by the last test above.

`tests/web/tools/ tests/web/api/test_tools_api.py tests/core/agent/test_agent_service_tool_refresh.py`: 1419 passed, 0 failed (baseline 1406 passed; the identical 63 errors are a pre-existing local migration-path environment issue). ruff check/format, mypy, and codespell are clean on the changed files.

## Downstream

Unblocks xorbitsai/xagent-saas#792 (role-based tool permissions), whose review finding **G28** is this fail-open — a role-restricted turn could silently receive every tool. That PR is currently draft pending this merge, and will bump the submodule afterwards.

xorbitsai/xagent#1668 (agent API key gated by visibility rather than ownership) is a separate upstream issue and is intentionally not touched here.
