### PR TITLE
fix(mcp): make MCP OAuth transport classification agree across the connect chain

### DIFF
--- a/src/xagent/migrations/versions/20260826_normalize_mcp_transport_case.py
+++ b/src/xagent/migrations/versions/20260826_normalize_mcp_transport_case.py
@@ -1,0 +1,72 @@
+"""Normalize stored MCP transport values to their canonical lowercase form
+
+Revision ID: 20260826_normalize_mcp_transport_case
+Revises: 20260825_add_slack_channels_join_scope
+Create Date: 2026-08-26
+
+`transport` is a free-form string on the MCP API models, so rows written
+before the write-time normalizing validators shipped may hold a mixed-case
+or padded value (e.g. "Streamable_HTTP"). Such a row is classified as
+connectable by the case-insensitive half of the MCP OAuth feature and
+rejected by the exact-matching half, and it never matches the transport
+dispatch in the core MCP session layer, so it can never actually connect.
+
+The application code now normalizes on every write, but a shared catalog row
+is only rewritten for its auth config, never its transport, so an
+un-migrated row would stay mixed-case indefinitely. Backfill the two web-layer
+tables once so the stored values agree with what every reader expects.
+
+Idempotent: LOWER(TRIM(...)) is a no-op on already-canonical values, and the
+WHERE clause skips rows that are already normalized.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260826_normalize_mcp_transport_case"
+down_revision = "20260825_add_slack_channels_join_scope"
+branch_labels = None
+depends_on = None
+
+_TABLES = ("mcp_servers", "public_mcp_apps")
+
+
+def _tables_with_transport() -> list[str]:
+    from alembic import context
+
+    bind = context.get_bind()
+    inspector = sa.inspect(bind)
+    existing = set(inspector.get_table_names())
+    present = []
+    for table in _TABLES:
+        if table not in existing:
+            continue
+        columns = {col["name"] for col in inspector.get_columns(table)}
+        if "transport" in columns:
+            present.append(table)
+    return present
+
+
+def upgrade() -> None:
+    for table in _tables_with_transport():
+        # LOWER/TRIM are ANSI SQL and behave identically on PostgreSQL and
+        # SQLite, so no dialect branch is needed here. NULL transports are left
+        # alone: the comparison below is NULL-safe (evaluates to NULL, not
+        # true), so those rows are skipped rather than rewritten to ''.
+        op.execute(
+            f"""
+            UPDATE {table}
+            SET transport = LOWER(TRIM(transport))
+            WHERE transport IS NOT NULL
+              AND transport <> LOWER(TRIM(transport))
+            """
+        )
+
+
+def downgrade() -> None:
+    # Deliberately not reversible: the original mixed-case/padded spellings are
+    # not recorded anywhere, and restoring them would reintroduce rows that the
+    # application cannot connect. Normalized values remain valid for every
+    # earlier revision, so leaving them in place is safe.
+    pass

--- a/src/xagent/web/api/admin_mcp.py
+++ b/src/xagent/web/api/admin_mcp.py
@@ -3,7 +3,13 @@ from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from pydantic import BaseModel, Field, ValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -90,9 +96,25 @@ class PublicMCPAppBase(BaseModel):
 
 
 class PublicMCPAppCreate(PublicMCPAppBase):
-    # Validator lives on the write model only, not PublicMCPAppBase — otherwise
-    # PublicMCPAppResponse would inherit it and re-run on response serialization,
-    # turning one legacy/partial DB row into a full-list 500 on read.
+    # Validators live on the write models only, not PublicMCPAppBase — otherwise
+    # PublicMCPAppResponse would inherit them and re-run on response serialization,
+    # turning one legacy/partial DB row into a full-list 500 on read (and, for
+    # the transport normalizer below, reporting a lowercased transport for a row
+    # that is still stored mixed-case).
+
+    # Canonicalize the stored transport: it is a free-form string, and an
+    # admin-authored mixed-case value ("Streamable_HTTP") passes the shape check
+    # below (classify_app_auth compares case-insensitively) yet produces a shared
+    # server row that the connect path's exact comparisons reject. Storing the
+    # lowercase form keeps the catalog and the connect path from disagreeing
+    # about the same app.
+    @field_validator("transport")
+    @classmethod
+    def _normalize_transport(cls, value: str) -> str:
+        from ..services.mcp_runtime import normalize_transport
+
+        return normalize_transport(value)
+
     @model_validator(mode="after")
     def _enforce_auth_classification(self) -> "PublicMCPAppCreate":
         # Reuse the single source of truth (classify_app_auth) rather than
@@ -145,6 +167,15 @@ class PublicMCPAppUpdate(BaseModel):
         default=None,
         description=_LAUNCH_CONFIG_DESCRIPTION,
     )
+
+    # Same canonicalization as PublicMCPAppCreate, so a PATCH that re-cases a
+    # transport can't reintroduce a mixed-case row.
+    @field_validator("transport")
+    @classmethod
+    def _normalize_transport(cls, value: Optional[str]) -> Optional[str]:
+        from ..services.mcp_runtime import normalize_transport
+
+        return None if value is None else normalize_transport(value)
 
 
 _PUBLIC_MCP_APP_FIELDS = tuple(PublicMCPAppBase.model_fields)

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -51,6 +51,7 @@ from ..oauth_provider_quirks import requires_json_accept_header
 from ..services import gmail_provisioning
 from ..services.auth_email import send_password_reset_email
 from ..services.db_runtime import await_task_settlement, propagate_deferred_cancellation
+from ..services.mcp_runtime import normalize_transport
 from ..services.user_oauth import delete_scoped_user_oauth_accounts
 from ..utils.graphql_errors import graphql_errors_message, truncate_error_text
 
@@ -1972,7 +1973,10 @@ def _ensure_user_mcp_server(
         return metadata
 
     def _ensure_server_matches_oauth_app(server: MCPServer) -> None:
-        if server.transport != "oauth":
+        # Normalized like every other transport check on this path: an exact
+        # comparison rejects a legacy mixed-case row as a conflicting custom
+        # server, blocking a legitimate reconnect to its own OAuth app.
+        if normalize_transport(server.transport) != "oauth":
             raise ValueError(
                 f"OAuth app '{app_info['name']}' conflicts with an existing MCP server "
                 f"using transport '{server.transport}'. Delete or rename that custom "

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -21,7 +21,7 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse, Response
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -71,7 +71,7 @@ from ..services.mcp_oauth import (
     select_mcp_oauth_grants,
     validate_mcp_oauth_persisted_value,
 )
-from ..services.mcp_runtime import HTTP_MCP_TRANSPORTS
+from ..services.mcp_runtime import HTTP_MCP_TRANSPORTS, normalize_transport
 from ..services.user_oauth import (
     delete_scoped_user_oauth_accounts,
     list_scoped_user_oauth_accounts,
@@ -121,6 +121,17 @@ class MCPServerCreate(BaseModel):
         False, description="Allow runtime Authorization header binding"
     )
 
+    # Canonicalize before anything reads it: transport is free-form here, and
+    # the value validated by TransportFieldValidator / stored on the row is the
+    # one every later comparison (exact and case-insensitive alike) must agree
+    # on. Also applies to the update endpoint, which rebuilds this model from
+    # the request and the stored row, so editing a legacy mixed-case server
+    # heals it.
+    @field_validator("transport")
+    @classmethod
+    def _normalize_transport(cls, value: str) -> str:
+        return normalize_transport(value)
+
 
 class MCPServerUpdate(BaseModel):
     """Request model for updating MCP server."""
@@ -144,6 +155,15 @@ class MCPServerUpdate(BaseModel):
     allow_delegated_authorization: Optional[bool] = Field(
         None, description="Allow runtime Authorization header binding"
     )
+
+    # Same canonicalization as MCPServerCreate, applied before
+    # _global_config_tampered compares the incoming transport with the stored
+    # one — otherwise a payload that only re-cases an unchanged transport would
+    # read as a global-config edit by a non-owner.
+    @field_validator("transport")
+    @classmethod
+    def _normalize_transport(cls, value: Optional[str]) -> Optional[str]:
+        return None if value is None else normalize_transport(value)
 
 
 class MCPAppConnectRequest(BaseModel):
@@ -609,7 +629,7 @@ def _get_mcp_oauth_config(server: MCPServer) -> dict[str, Any]:
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="MCP server is not configured for MCP OAuth",
         )
-    if server.transport not in HTTP_MCP_TRANSPORTS:
+    if normalize_transport(server.transport) not in HTTP_MCP_TRANSPORTS:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="MCP OAuth is only supported for HTTP MCP transports",

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -231,6 +231,14 @@ class MCPConnectionTest(BaseModel):
     transport: str = Field(..., description="Transport type")
     config: dict[str, Any] = Field(..., description="Connection configuration")
 
+    # Same canonicalization as the save path (MCPServerCreate): testing a
+    # connection must not accept a transport spelling that saving it would
+    # reject, or vice versa.
+    @field_validator("transport")
+    @classmethod
+    def _normalize_transport(cls, value: str) -> str:
+        return normalize_transport(value)
+
 
 class MCPConnectionTestResponse(BaseModel):
     """Response model for MCP connection test."""
@@ -1422,7 +1430,14 @@ def _global_config_tampered(server_data: MCPServerUpdate, server: MCPServer) -> 
     fields_set = server_data.model_fields_set
     if server_data.name is not None and server_data.name != server.name:
         return True
-    if server_data.transport is not None and server_data.transport != server.transport:
+    # Both sides normalized: server_data.transport has already been through the
+    # MCPServerUpdate validator, while server.transport is the raw stored value,
+    # which for a row written before that validator shipped may still be
+    # mixed-case or padded. Comparing normalized-vs-raw would flag a non-owner
+    # who merely echoes the row's own unchanged transport as tampering.
+    if server_data.transport is not None and normalize_transport(
+        server_data.transport
+    ) != normalize_transport(server.transport):
         return True
     if (
         server_data.description is not None
@@ -1935,7 +1950,7 @@ def _is_mcp_oauth_server(server: MCPServer) -> bool:
     whether the server counts as connected."""
     auth: dict[str, Any] = server.auth if isinstance(server.auth, dict) else {}
     return (
-        str(server.transport or "").lower() in HTTP_MCP_TRANSPORTS
+        normalize_transport(server.transport) in HTTP_MCP_TRANSPORTS
         and auth.get("type") == "mcp_oauth"
     )
 
@@ -2801,7 +2816,7 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
         if (
             server.command != command
             or (server.args or []) != (launch.get("args") or [])
-            or str(server.transport or "").lower() != "stdio"
+            or normalize_transport(server.transport) != "stdio"
         ):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -2861,7 +2876,7 @@ def _ensure_catalog_mcp_oauth_server(
     # URL), so only reuse it if it matches the official configuration.
     if server:
         if (
-            str(server.transport or "").lower() != transport.lower()
+            normalize_transport(server.transport) != normalize_transport(transport)
             or server.url != url
         ):
             raise HTTPException(

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -1528,7 +1528,10 @@ def _db_server_to_response(
         id=server.id,
         user_id=user_mcp.user_id,
         name=server.name,
-        transport=server.transport,
+        # Normalized on read too: the frontend compares this value exactly, so
+        # an un-migrated row must not report a spelling the API itself would no
+        # longer accept on write.
+        transport=normalize_transport(server.transport),
         description=server.description,
         config=config,
         is_active=user_mcp.is_active,
@@ -2379,7 +2382,7 @@ def list_mcp_apps(
                 "description": server.description or "Custom MCP Server",
                 "icon": "",
                 "users": "1",
-                "transport": server.transport,
+                "transport": normalize_transport(server.transport),
                 # F1: this loop's own membership check above (name-based)
                 # doesn't gate on a real grant, so a custom mcp_oauth
                 # server the user abandoned mid-consent must not be
@@ -3324,10 +3327,25 @@ def update_mcp_server(
 
         # Build update config - only include provided fields. Non-owners keep the
         # existing global config untouched.
+        # An explicitly-supplied transport must not fall back to the stored
+        # value just because it normalized to "". Before write-time
+        # normalization a blank/whitespace-only transport failed
+        # MCPServerConfig.validate_transport with a 400; the `or` fallback
+        # below would silently keep the old transport instead, turning a
+        # rejected edit into a no-op the caller never learns about.
+        if can_edit_global and server_data.transport is not None:
+            if not server_data.transport:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Transport must not be blank",
+                )
+            requested_transport = server_data.transport
+        else:
+            requested_transport = server.transport
+
         update_data = MCPServerCreate(
             name=(server_data.name if can_edit_global else None) or server.name,
-            transport=(server_data.transport if can_edit_global else None)
-            or server.transport,
+            transport=requested_transport,
             description=server_data.description
             if can_edit_global and server_data.description is not None
             else server.description,

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -231,9 +231,11 @@ class MCPConnectionTest(BaseModel):
     transport: str = Field(..., description="Transport type")
     config: dict[str, Any] = Field(..., description="Connection configuration")
 
-    # Same canonicalization as the save path (MCPServerCreate): testing a
-    # connection must not accept a transport spelling that saving it would
-    # reject, or vice versa.
+    # Same case/whitespace canonicalization as the save path
+    # (MCPServerCreate), so Test and Save agree on how a transport is spelled.
+    # This is spelling parity only: Test still does not validate against
+    # MCPServerConfig's allowed-value list, so an unknown transport is accepted
+    # here and fails at connect time, where Save rejects it up front.
     @field_validator("transport")
     @classmethod
     def _normalize_transport(cls, value: str) -> str:
@@ -1585,7 +1587,7 @@ def _enrich_oauth_server_info(
     Return (app_id, provider, connected_account) for an OAuth-based MCPServer.
     This encapsulates the logic of looking up app information in O(1) time.
     """
-    if server.transport != "oauth":
+    if normalize_transport(server.transport) != "oauth":
         return None, None, None
 
     app_info = get_app_by_name(db, str(server.name))
@@ -1703,7 +1705,12 @@ def _oauth_keys_for_app(app: dict) -> list[str]:
 
 
 def _is_oauth_server_for_app(server: MCPServer, app: dict) -> bool:
-    if server.transport != "oauth":
+    # Normalized to match _build_active_oauth_server_lookup and
+    # _server_catalog_keys, which admit a row into the lookup via
+    # _normalize_app_key. An exact check here rejects a row those two just
+    # accepted, so _lookup_oauth_server_for_app returns None and a connected
+    # OAuth app renders as disconnected.
+    if normalize_transport(server.transport) != "oauth":
         return False
 
     app_id = _normalize_app_key(app.get("id"))
@@ -3435,7 +3442,7 @@ def _catalog_server_has_platform_key(db: Session, server: MCPServer) -> bool:
     with no signal to the admin. A catalog row with no platform key is not
     special and cascades away as before.
     """
-    if str(getattr(server, "transport", "") or "").lower() == "oauth":
+    if normalize_transport(getattr(server, "transport", None)) == "oauth":
         return False
     env = getattr(server, "env", None)
     if not env:
@@ -3505,7 +3512,7 @@ async def delete_mcp_server(
             )
 
         # If it's an OAuth server, also delete the corresponding OAuth tokens
-        if server.transport == "oauth":
+        if normalize_transport(server.transport) == "oauth":
             from ..mcp_apps import get_app_by_name
 
             # Find the corresponding app_id and provider

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -1708,11 +1708,14 @@ def _oauth_keys_for_app(app: dict) -> list[str]:
 
 
 def _is_oauth_server_for_app(server: MCPServer, app: dict) -> bool:
-    # Normalized to match _build_active_oauth_server_lookup and
-    # _server_catalog_keys, which admit a row into the lookup via
-    # _normalize_app_key. An exact check here rejects a row those two just
-    # accepted, so _lookup_oauth_server_for_app returns None and a connected
-    # OAuth app renders as disconnected.
+    # Normalized so this agrees with _build_active_oauth_server_lookup and
+    # _server_catalog_keys, which admit a row into the lookup. Note those two
+    # use a *different* helper (_normalize_app_key); the two normalizers agree
+    # on every transport value (both strip and lowercase, and transports carry
+    # no internal whitespace for _normalize_app_key to hyphenate), which is
+    # what makes this safe. An exact check here would reject a row those two
+    # just accepted, so _lookup_oauth_server_for_app returns None and a
+    # connected OAuth app renders as disconnected.
     if normalize_transport(server.transport) != "oauth":
         return False
 

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -147,6 +147,8 @@ def classify_app_auth(transport: Any, launch_config: Any) -> str:
 
 
 def _app_to_dict(app: PublicMCPApp) -> Dict[str, Any]:
+    from .services.mcp_runtime import normalize_transport
+
     # One registry scan (not two - see the helper's own docstring) since
     # this runs per app on the connector-listing path.
     execution_fields, optional_oauth_scopes = (
@@ -155,7 +157,10 @@ def _app_to_dict(app: PublicMCPApp) -> Dict[str, Any]:
     if execution_fields is None:
         execution_fields = {
             "name": app.name,
-            "transport": app.transport,
+            # Normalized on read: the connector list is compared exactly by the
+            # frontend, and auth_type below is already derived from the
+            # normalized value -- the two must not disagree about one row.
+            "transport": normalize_transport(app.transport),
             "provider_name": app.provider_name,
             "oauth_scopes": deepcopy(app.oauth_scopes or []),
             "launch_config": deepcopy(app.launch_config or {}),

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -106,9 +106,10 @@ def classify_app_auth(transport: Any, launch_config: Any) -> str:
     """
     # Reuses the runtime's notion of which transports are remote ("oauth"
     # here instead means a static-provider redirect wrapping our own stdio
-    # module). Lowercased like the builtin_oauth check above: an admin PATCH
-    # can store a mixed-case transport, and the two halves of this feature
-    # must not disagree about the same row.
+    # module). Lowercased like the builtin_oauth check above: transport is
+    # normalized on write now, but rows stored before that may still be
+    # mixed-case, and the two halves of this feature must not disagree about
+    # the same row.
     from .services.mcp_runtime import HTTP_MCP_TRANSPORTS
 
     if str(transport or "").lower() == "oauth":

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -106,13 +106,16 @@ def classify_app_auth(transport: Any, launch_config: Any) -> str:
     """
     # Reuses the runtime's notion of which transports are remote ("oauth"
     # here instead means a static-provider redirect wrapping our own stdio
-    # module). Lowercased like the builtin_oauth check above: transport is
-    # normalized on write now, but rows stored before that may still be
-    # mixed-case, and the two halves of this feature must not disagree about
-    # the same row.
-    from .services.mcp_runtime import HTTP_MCP_TRANSPORTS
+    # module). Normalized through the same helper the write path uses:
+    # transport is canonicalized on write now, but rows stored before that may
+    # still be mixed-case or padded, and the two halves of this feature must
+    # not disagree about the same row. Going through the shared helper rather
+    # than a local .lower() keeps this from drifting out of step with it again.
+    from .services.mcp_runtime import HTTP_MCP_TRANSPORTS, normalize_transport
 
-    if str(transport or "").lower() == "oauth":
+    normalized_transport = normalize_transport(transport)
+
+    if normalized_transport == "oauth":
         return "builtin_oauth"
     launch = launch_config if isinstance(launch_config, dict) else {}
     if launch.get("required_env") and launch.get("command"):
@@ -126,7 +129,7 @@ def classify_app_auth(transport: Any, launch_config: Any) -> str:
     # keyless would offer a no-secrets Connect button for a server that fails
     # at tool-call time for a missing token.
     if (
-        str(transport or "").lower() == "stdio"
+        normalized_transport == "stdio"
         and launch.get("command")
         and not launch.get("required_env")
         and not launch.get("env_mapping")
@@ -134,7 +137,7 @@ def classify_app_auth(transport: Any, launch_config: Any) -> str:
         return "keyless"
     auth = launch.get("auth")
     if (
-        str(transport or "").lower() in HTTP_MCP_TRANSPORTS
+        normalized_transport in HTTP_MCP_TRANSPORTS
         and launch.get("url")
         and isinstance(auth, dict)
         and auth.get("type") == "mcp_oauth"

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -14,6 +14,20 @@ from .mcp_oauth import MCPOAuthRuntimeError, resolve_mcp_oauth_runtime_auth
 HTTP_MCP_TRANSPORTS = frozenset({"sse", "websocket", "streamable_http"})
 
 
+def normalize_transport(transport: Any) -> str:
+    """Canonicalize a transport identifier to its stored lowercase form.
+
+    Transport is a free-form string on the API models, so a mixed-case value
+    ("Streamable_HTTP") can be authored through the admin catalog or the
+    server create/update endpoints. Half of this feature compares it
+    case-insensitively and half compares it exactly, so an un-normalized row
+    is classified as connectable by one half and rejected by the other.
+    Normalizing at every write keeps the stored value in the one form all of
+    those comparisons agree on.
+    """
+    return str(transport or "").strip().lower()
+
+
 @dataclass(frozen=True)
 class MCPRuntimeConnectionBuild:
     """Executable MCP connection plus any runtime authorization diagnostic."""
@@ -573,8 +587,15 @@ def _is_mcp_oauth_http_server(server: Any, auth_config: Any) -> bool:
     # a different layer than the catalog auth_type (mcp_apps.classify_app_auth):
     # this also covers user-added custom HTTP servers that were never catalog
     # entries, so it stays independent by design.
+    #
+    # Compared case-insensitively for the same reason the rest of the feature
+    # is: transport is normalized on every write now, but a row stored before
+    # that may still be mixed-case, and a False here is not a rejection — the
+    # caller falls through and returns the connection unauthorized, skipping
+    # the per-user OAuth token exchange entirely. Matching the stored row
+    # loosely is strictly safer than silently serving it without a grant.
     return (
-        getattr(server, "transport", None) in HTTP_MCP_TRANSPORTS
+        normalize_transport(getattr(server, "transport", None)) in HTTP_MCP_TRANSPORTS
         and isinstance(auth_config, dict)
         and auth_config.get("type") == "mcp_oauth"
     )

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3478,8 +3478,15 @@ class WebToolConfig(BaseToolConfig):
         # Add transport-specific configuration
         transport_config: Dict[str, Any] = {}
 
-        # Handle OAuth credentials
-        if server.transport == "oauth":
+        # Handle OAuth credentials. Normalized like the rest of the transport
+        # chain: an exact comparison sends a legacy mixed-case row down the
+        # non-OAuth path, silently dropping its OAuth credential wiring.
+        from ...web.services.mcp_runtime import (
+            HTTP_MCP_TRANSPORTS,
+            normalize_transport,
+        )
+
+        if normalize_transport(server.transport) == "oauth":
             # Find corresponding OAuth account
             # The provider might be linkedin, google, etc. based on the app config
             from ...web.mcp_apps import get_app_for_mcp_server
@@ -3608,7 +3615,12 @@ class WebToolConfig(BaseToolConfig):
                     )
                 config["transport"] = "stdio"
 
-        if server.transport == "stdio":
+        # Normalized like the OAuth check above: a legacy mixed-case/padded row
+        # would otherwise match neither branch, leaving transport_config empty
+        # so the connection loses its command/env or its url/headers entirely.
+        normalized_server_transport = normalize_transport(server.transport)
+
+        if normalized_server_transport == "stdio":
             if server.command:
                 transport_config["command"] = server.command
             if server.args:
@@ -3629,7 +3641,7 @@ class WebToolConfig(BaseToolConfig):
             if server.cwd:
                 transport_config["cwd"] = server.cwd
 
-        elif server.transport in ["sse", "websocket", "streamable_http"]:
+        elif normalized_server_transport in HTTP_MCP_TRANSPORTS:
             from ...web.mcp_apps import get_app_for_mcp_server
             from ...web.services.mcp_runtime import (
                 build_mcp_runtime_connection,

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3458,10 +3458,20 @@ class WebToolConfig(BaseToolConfig):
             getattr(server, "allow_delegated_authorization", False)
         )
         runtime_values = self._get_connector_runtime_for("mcp", int(server.id))
+        from ...web.services.mcp_runtime import (
+            HTTP_MCP_TRANSPORTS,
+            normalize_transport,
+        )
+
+        # Normalized, not raw: this value is consumed downstream by the core
+        # session layer's exact-match transport dispatch (via ToolFactory), so
+        # a legacy mixed-case row would reach it as "Streamable_HTTP" and fail
+        # with `ValueError: Unsupported transport`. The branch selection below
+        # normalizes too; this is the value that actually leaves the function.
         config: Dict[str, Any] = {
             "id": int(server.id),
             "name": server.name,
-            "transport": server.transport,
+            "transport": normalize_transport(server.transport),
             "description": server.description,
             "runtime_input_schema": getattr(server, "runtime_input_schema", None),
             "runtime_bindings": runtime_bindings,
@@ -3481,11 +3491,6 @@ class WebToolConfig(BaseToolConfig):
         # Handle OAuth credentials. Normalized like the rest of the transport
         # chain: an exact comparison sends a legacy mixed-case row down the
         # non-OAuth path, silently dropping its OAuth credential wiring.
-        from ...web.services.mcp_runtime import (
-            HTTP_MCP_TRANSPORTS,
-            normalize_transport,
-        )
-
         if normalize_transport(server.transport) == "oauth":
             # Find corresponding OAuth account
             # The provider might be linkedin, google, etc. based on the app config

--- a/tests/migrations/test_20260826_normalize_mcp_transport_case.py
+++ b/tests/migrations/test_20260826_normalize_mcp_transport_case.py
@@ -1,0 +1,215 @@
+"""Tests for migration 20260826_normalize_mcp_transport_case.
+
+Covers the backfill that lowercases/trims stored MCP `transport` values:
+- mixed-case and padded rows are canonicalized in both affected tables
+- already-canonical rows are left byte-identical (idempotent)
+- NULL transports are preserved, not rewritten to ''
+- the migration tolerates a database where one of the tables is absent
+
+Following this repo's existing migration-test convention (see
+tests/migrations/test_custom_api_migration.py): rather than replaying the
+full alembic history, the minimal pre-migration schema is created directly
+with raw DDL, stamped to this migration's parent revision, and only the
+migration under test is run against it.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+PARENT_REVISION = "20260825_add_slack_channels_join_scope"
+TARGET_REVISION = "20260826_normalize_mcp_transport_case"
+
+_CREATE_MCP_SERVERS_TABLE = """
+CREATE TABLE mcp_servers (
+    id INTEGER PRIMARY KEY,
+    name VARCHAR(100) NOT NULL,
+    transport VARCHAR(50),
+    url VARCHAR(500)
+)
+"""
+
+_CREATE_PUBLIC_MCP_APPS_TABLE = """
+CREATE TABLE public_mcp_apps (
+    id INTEGER PRIMARY KEY,
+    app_id VARCHAR(100) NOT NULL,
+    name VARCHAR(100) NOT NULL,
+    transport VARCHAR(50)
+)
+"""
+
+
+@pytest.fixture
+def db_url(tmp_path: Path) -> str:
+    return f"sqlite:///{tmp_path / 'test.db'}"
+
+
+def _stamp_parent(db_url: str, *, create_tables: tuple[str, ...]) -> Config:
+    config = Config()
+    config.set_main_option("sqlalchemy.url", db_url)
+    config.set_main_option("script_location", "src/xagent/migrations")
+
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text("CREATE TABLE alembic_version (version_num VARCHAR(32) NOT NULL)")
+        )
+        conn.execute(
+            text(
+                "INSERT INTO alembic_version (version_num) "
+                f"VALUES ('{PARENT_REVISION}')"
+            )
+        )
+        for ddl in create_tables:
+            conn.execute(text(ddl))
+    engine.dispose()
+    return config
+
+
+@pytest.fixture
+def config_at_parent_revision(db_url: str) -> Config:
+    return _stamp_parent(
+        db_url,
+        create_tables=(_CREATE_MCP_SERVERS_TABLE, _CREATE_PUBLIC_MCP_APPS_TABLE),
+    )
+
+
+def test_backfill_normalizes_mcp_servers_transport(
+    db_url: str, config_at_parent_revision: Config
+) -> None:
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        for row_id, transport in enumerate(
+            ["Streamable_HTTP", " streamable_http ", "STDIO", "sse"], start=1
+        ):
+            conn.execute(
+                text(
+                    "INSERT INTO mcp_servers (id, name, transport) "
+                    "VALUES (:id, :name, :transport)"
+                ),
+                {"id": row_id, "name": f"s{row_id}", "transport": transport},
+            )
+    engine.dispose()
+
+    command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        stored = dict(conn.execute(text("SELECT id, transport FROM mcp_servers")).all())
+    engine.dispose()
+
+    assert stored == {
+        1: "streamable_http",
+        2: "streamable_http",
+        3: "stdio",
+        4: "sse",
+    }
+
+
+def test_backfill_normalizes_public_mcp_apps_transport(
+    db_url: str, config_at_parent_revision: Config
+) -> None:
+    """The catalog table matters most: a shared catalog row's transport is
+    never rewritten by the connect path, so without this backfill it would
+    stay mixed-case indefinitely."""
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO public_mcp_apps (id, app_id, name, transport) "
+                "VALUES (1, 'mixed', 'Mixed', 'Streamable_HTTP')"
+            )
+        )
+    engine.dispose()
+
+    command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        transport = conn.execute(
+            text("SELECT transport FROM public_mcp_apps WHERE id = 1")
+        ).scalar_one()
+    engine.dispose()
+
+    assert transport == "streamable_http"
+
+
+def test_backfill_preserves_null_transport(
+    db_url: str, config_at_parent_revision: Config
+) -> None:
+    """A NULL transport must stay NULL rather than become '' -- the WHERE
+    clause is NULL-safe, so those rows are skipped entirely."""
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text("INSERT INTO mcp_servers (id, name, transport) VALUES (1, 's1', NULL)")
+        )
+    engine.dispose()
+
+    command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        transport = conn.execute(
+            text("SELECT transport FROM mcp_servers WHERE id = 1")
+        ).scalar_one()
+    engine.dispose()
+
+    assert transport is None
+
+
+def test_backfill_is_idempotent_on_already_canonical_rows(
+    db_url: str, config_at_parent_revision: Config
+) -> None:
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO mcp_servers (id, name, transport) "
+                "VALUES (1, 's1', 'streamable_http')"
+            )
+        )
+    engine.dispose()
+
+    command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        transport = conn.execute(
+            text("SELECT transport FROM mcp_servers WHERE id = 1")
+        ).scalar_one()
+    engine.dispose()
+
+    assert transport == "streamable_http"
+
+
+def test_backfill_tolerates_missing_table(db_url: str) -> None:
+    """A database without one of the two tables (e.g. a partially initialized
+    deployment) must not crash the upgrade."""
+    config = _stamp_parent(db_url, create_tables=(_CREATE_MCP_SERVERS_TABLE,))
+
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO mcp_servers (id, name, transport) "
+                "VALUES (1, 's1', 'Streamable_HTTP')"
+            )
+        )
+    engine.dispose()
+
+    command.upgrade(config, TARGET_REVISION)
+
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        transport = conn.execute(
+            text("SELECT transport FROM mcp_servers WHERE id = 1")
+        ).scalar_one()
+    engine.dispose()
+
+    assert transport == "streamable_http"

--- a/tests/migrations/test_20260826_normalize_mcp_transport_case.py
+++ b/tests/migrations/test_20260826_normalize_mcp_transport_case.py
@@ -213,3 +213,134 @@ def test_backfill_tolerates_missing_table(db_url: str) -> None:
     engine.dispose()
 
     assert transport == "streamable_http"
+
+
+_CREATE_MCP_SERVERS_WITHOUT_TRANSPORT = """
+CREATE TABLE mcp_servers (
+    id INTEGER PRIMARY KEY,
+    name VARCHAR(100) NOT NULL
+)
+"""
+
+
+def test_backfill_tolerates_table_without_transport_column(db_url: str) -> None:
+    """The column-existence guard must actually fire.
+
+    Without a test, a typo in the table or column name would make the guard
+    skip every table and the backfill would silently no-op in production.
+    """
+    config = _stamp_parent(
+        db_url,
+        create_tables=(
+            _CREATE_MCP_SERVERS_WITHOUT_TRANSPORT,
+            _CREATE_PUBLIC_MCP_APPS_TABLE,
+        ),
+    )
+
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        conn.execute(text("INSERT INTO mcp_servers (id, name) VALUES (1, 's1')"))
+        conn.execute(
+            text(
+                "INSERT INTO public_mcp_apps (id, app_id, name, transport) "
+                "VALUES (1, 'mixed', 'Mixed', 'Streamable_HTTP')"
+            )
+        )
+    engine.dispose()
+
+    command.upgrade(config, TARGET_REVISION)
+
+    # The transport-less table was skipped, and the other one was still
+    # backfilled -- the guard is per-table, not all-or-nothing.
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        assert (
+            conn.execute(
+                text("SELECT transport FROM public_mcp_apps WHERE id = 1")
+            ).scalar_one()
+            == "streamable_http"
+        )
+    engine.dispose()
+
+
+def test_backfill_is_idempotent_across_repeated_runs(
+    db_url: str, config_at_parent_revision: Config
+) -> None:
+    """A true re-run, not just one upgrade over canonical data: stamp back to
+    the parent and upgrade again, which is what a re-applied migration does."""
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO mcp_servers (id, name, transport) "
+                "VALUES (1, 's1', ' Streamable_HTTP ')"
+            )
+        )
+    engine.dispose()
+
+    command.upgrade(config_at_parent_revision, TARGET_REVISION)
+    command.stamp(config_at_parent_revision, PARENT_REVISION)
+    command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        transport = conn.execute(
+            text("SELECT transport FROM mcp_servers WHERE id = 1")
+        ).scalar_one()
+    engine.dispose()
+
+    assert transport == "streamable_http"
+
+
+def test_backfill_normalizes_whitespace_only_transport_to_empty_string(
+    db_url: str, config_at_parent_revision: Config
+) -> None:
+    """A whitespace-only value trims to ''. It stays a non-connectable row
+    either way, but the stored form must be the canonical one so every
+    comparison agrees about it."""
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO mcp_servers (id, name, transport) "
+                "VALUES (1, 's1', '   '), (2, 's2', '')"
+            )
+        )
+    engine.dispose()
+
+    command.upgrade(config_at_parent_revision, TARGET_REVISION)
+
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        stored = dict(conn.execute(text("SELECT id, transport FROM mcp_servers")).all())
+    engine.dispose()
+
+    assert stored == {1: "", 2: ""}
+
+
+def test_downgrade_is_a_documented_no_op(
+    db_url: str, config_at_parent_revision: Config
+) -> None:
+    """downgrade() deliberately does not restore the original spellings; it
+    must at least run cleanly and leave the normalized data intact."""
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                "INSERT INTO mcp_servers (id, name, transport) "
+                "VALUES (1, 's1', 'Streamable_HTTP')"
+            )
+        )
+    engine.dispose()
+
+    command.upgrade(config_at_parent_revision, TARGET_REVISION)
+    command.downgrade(config_at_parent_revision, PARENT_REVISION)
+
+    engine = create_engine(db_url)
+    with engine.begin() as conn:
+        transport = conn.execute(
+            text("SELECT transport FROM mcp_servers WHERE id = 1")
+        ).scalar_one()
+    engine.dispose()
+
+    assert transport == "streamable_http"

--- a/tests/web/api/test_mcp_api.py
+++ b/tests/web/api/test_mcp_api.py
@@ -664,6 +664,28 @@ class TestMCPApiFunctions:
         # Changed top-level name -> tampered
         assert _global_config_tampered(MCPServerUpdate(name="other"), server)
 
+    def test_global_config_tampered_normalizes_both_sides_of_transport(self):
+        """MCPServerUpdate.transport is normalized by its validator, but the
+        stored value on a row written before that validator shipped is not.
+        Comparing normalized-vs-raw would flag a non-owner who merely echoes
+        the row's own unchanged transport as tampering (spurious 403)."""
+        server = MCPServer.from_config(
+            {
+                "name": "svc",
+                "managed": "external",
+                "transport": "streamable_http",
+                "url": "https://mcp.example.com/mcp",
+            }
+        )
+        # Simulate a legacy row stored before write-time normalization.
+        server.transport = "Streamable_HTTP"
+
+        echoed = MCPServerUpdate(transport="Streamable_HTTP")
+        assert _global_config_tampered(echoed, server) is False
+
+        # A genuinely different transport is still caught.
+        assert _global_config_tampered(MCPServerUpdate(transport="sse"), server)
+
     def test_auth_metadata_tampered(self):
         """Non-secret auth metadata is diffed; secrets/masked values are ignored."""
         current = {"type": "oauth2", "client_id": "abc", "client_secret": "enc"}

--- a/tests/web/api/test_mcp_api.py
+++ b/tests/web/api/test_mcp_api.py
@@ -3,7 +3,7 @@ Test MCP API endpoints and functions
 """
 
 from types import SimpleNamespace
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import ValidationError
@@ -960,3 +960,82 @@ class TestMcpOAuthServerTransportNormalization:
             managed="external",
         )
         assert _is_mcp_oauth_server(server) is False
+
+
+class TestTransportNormalizationOnRead:
+    """Stored transport must not be reported raw: the frontend compares these
+    values exactly, and `auth_type` on the same payload is already derived from
+    the normalized value."""
+
+    def test_server_response_reports_normalized_transport(self):
+        server = MCPServer(
+            id=1,
+            name="remote",
+            transport=" Streamable_HTTP ",
+            url="https://mcp.example.com/mcp",
+            managed="external",
+        )
+        user_mcp = MagicMock()
+        user_mcp.user_id = 1
+        user_mcp.is_active = True
+        user_mcp.is_default = False
+        user_mcp.is_owner = True
+        user_mcp.env = None
+        user_mcp.env_source = None
+
+        response = _db_server_to_response(
+            server=server,
+            user_mcp=user_mcp,
+            manager=MagicMock(),
+        )
+
+        assert response.transport == "streamable_http"
+
+
+class TestOAuthTransportNormalizationCoverage:
+    """Positive coverage for the gate the review flagged as fixed-but-untested:
+    a mixed-case "OAuth" row must pass it, not just a lowercase one.
+
+    These drive the real functions rather than re-asserting normalize_transport,
+    so they fail if the call site reverts to an exact comparison."""
+
+    @pytest.mark.parametrize(
+        "transport",
+        ["oauth", "OAuth", " oauth ", "OAUTH"],
+        ids=["canonical", "mixed-case", "padded", "upper"],
+    )
+    def test_mixed_case_oauth_server_is_enriched_as_an_oauth_server(
+        self, transport: str
+    ):
+        """_enrich_oauth_server_info returns (None, None, None) for a
+        non-OAuth transport, so a legacy "OAuth" row would lose its app_id,
+        provider and connected-account in the server listing."""
+        from xagent.web.api.mcp import _enrich_oauth_server_info
+
+        db = MagicMock()
+        db.query.return_value.filter.return_value.first.return_value = None
+        server = MCPServer(
+            id=1, name="no-such-app", transport=transport, managed="external"
+        )
+
+        # No catalog app matches, so it still returns (None, None, None) --
+        # but only after passing the transport gate. Patch the lookup to prove
+        # the gate was passed rather than short-circuited.
+        with patch(
+            "xagent.web.api.mcp.get_app_by_name",
+            return_value={"id": "slack", "provider": "slack"},
+        ):
+            app_id, provider, _ = _enrich_oauth_server_info(db, server, {})
+
+        assert (app_id, provider) == ("slack", "slack")
+
+    def test_non_oauth_transport_is_not_enriched(self):
+        """The gate must still exclude a genuinely non-OAuth row."""
+        from xagent.web.api.mcp import _enrich_oauth_server_info
+
+        server = MCPServer(id=1, name="local", transport="stdio", managed="external")
+        assert _enrich_oauth_server_info(MagicMock(), server, {}) == (
+            None,
+            None,
+            None,
+        )

--- a/tests/web/api/test_mcp_api.py
+++ b/tests/web/api/test_mcp_api.py
@@ -2,6 +2,7 @@
 Test MCP API endpoints and functions
 """
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -17,10 +18,13 @@ from xagent.web.api.mcp import (
     MCPServerCreate,
     MCPServerUpdate,
     _auth_metadata_tampered,
+    _build_active_oauth_server_lookup,
     _build_server_config,
     _check_mcp_permission,
     _db_server_to_response,
     _global_config_tampered,
+    _is_oauth_server_for_app,
+    _lookup_oauth_server_for_app,
     _mask_env,
     _merge_masked_env,
     get_mcp_servers,
@@ -877,3 +881,82 @@ class TestMCPApiModels:
         response = MCPConnectionTestResponse(**minimal_response)
         assert response.success is False
         assert response.details is None
+
+
+class TestOAuthServerLookupTransportNormalization:
+    """The lookup that decides whether a connected OAuth app renders as
+    connected spans three helpers. Two normalize transport via
+    _normalize_app_key; the confirmation check must agree with them, or a row
+    they admit is rejected downstream and the app shows as disconnected."""
+
+    @staticmethod
+    def _server(transport: str) -> MCPServer:
+        return MCPServer(
+            id=1,
+            name="slack",
+            transport=transport,
+            auth={"app_id": "slack", "provider": "slack"},
+            managed="external",
+        )
+
+    APP = {"id": "slack", "provider": "slack", "name": "Slack"}
+
+    @pytest.mark.parametrize(
+        "transport",
+        ["oauth", "OAuth", " oauth ", "OAUTH"],
+        ids=["canonical", "mixed-case", "padded", "upper"],
+    )
+    def test_connected_oauth_app_is_found_regardless_of_transport_spelling(
+        self, transport: str
+    ):
+        server = self._server(transport)
+        user_mcp = SimpleNamespace(is_active=True)
+
+        lookup = _build_active_oauth_server_lookup([(server, user_mcp)])
+        # The row is admitted into the lookup by the normalizing builder...
+        assert lookup, "row should be admitted by the normalizing lookup builder"
+        # ...so the confirmation check must not reject it.
+        assert _is_oauth_server_for_app(server, self.APP) is True
+        assert _lookup_oauth_server_for_app(self.APP, lookup) is server
+
+    def test_non_oauth_transport_is_still_excluded(self):
+        """Normalization must not pull a genuinely non-OAuth row into the
+        builtin_oauth branch."""
+        server = self._server("stdio")
+        assert _is_oauth_server_for_app(server, self.APP) is False
+
+
+class TestMcpOAuthServerTransportNormalization:
+    """`_is_mcp_oauth_server` backs both the connection-state gate and the
+    connector picker's auth_type hint, so it must classify a legacy row the
+    same way the rest of the chain does."""
+
+    @pytest.mark.parametrize(
+        "transport",
+        ["streamable_http", "Streamable_HTTP", " streamable_http ", "SSE"],
+        ids=["canonical", "mixed-case", "padded", "upper-sse"],
+    )
+    def test_mcp_oauth_server_detected_regardless_of_spelling(self, transport: str):
+        from xagent.web.api.mcp import _is_mcp_oauth_server
+
+        server = MCPServer(
+            id=1,
+            name="remote",
+            transport=transport,
+            url="https://mcp.example.com/mcp",
+            auth={"type": "mcp_oauth"},
+            managed="external",
+        )
+        assert _is_mcp_oauth_server(server) is True
+
+    def test_stdio_is_not_an_mcp_oauth_server(self):
+        from xagent.web.api.mcp import _is_mcp_oauth_server
+
+        server = MCPServer(
+            id=1,
+            name="local",
+            transport="STDIO",
+            auth={"type": "mcp_oauth"},
+            managed="external",
+        )
+        assert _is_mcp_oauth_server(server) is False

--- a/tests/web/api/test_mcp_api.py
+++ b/tests/web/api/test_mcp_api.py
@@ -919,10 +919,16 @@ class TestOAuthServerLookupTransportNormalization:
         assert _is_oauth_server_for_app(server, self.APP) is True
         assert _lookup_oauth_server_for_app(self.APP, lookup) is server
 
-    def test_non_oauth_transport_is_still_excluded(self):
-        """Normalization must not pull a genuinely non-OAuth row into the
-        builtin_oauth branch."""
-        server = self._server("stdio")
+    @pytest.mark.parametrize(
+        "transport",
+        ["stdio", "oauth2", "streamable_http", "custom_api", "auth", ""],
+        ids=["stdio", "oauth2", "http", "custom-api", "substring", "empty"],
+    )
+    def test_non_oauth_transport_is_still_excluded(self, transport: str):
+        """Normalization must not widen the set. `stdio` alone does not
+        discriminate; `oauth2` and `auth` would be admitted by a normalizer
+        that matched loosely instead of on the exact canonical value."""
+        server = self._server(transport)
         assert _is_oauth_server_for_app(server, self.APP) is False
 
 
@@ -949,13 +955,20 @@ class TestMcpOAuthServerTransportNormalization:
         )
         assert _is_mcp_oauth_server(server) is True
 
-    def test_stdio_is_not_an_mcp_oauth_server(self):
+    @pytest.mark.parametrize(
+        "transport",
+        ["STDIO", "oauth", "http", "streamable", "custom_api", ""],
+        ids=["stdio-upper", "oauth", "http", "prefix", "custom-api", "empty"],
+    )
+    def test_non_http_transport_is_not_an_mcp_oauth_server(self, transport: str):
+        """Includes values a loose normalizer would wrongly admit ("http" as a
+        substring of no canonical value, "streamable" as a prefix of one)."""
         from xagent.web.api.mcp import _is_mcp_oauth_server
 
         server = MCPServer(
             id=1,
             name="local",
-            transport="STDIO",
+            transport=transport,
             auth={"type": "mcp_oauth"},
             managed="external",
         )

--- a/tests/web/api/test_mcp_apps_connect.py
+++ b/tests/web/api/test_mcp_apps_connect.py
@@ -1237,3 +1237,36 @@ def test_connect_coerces_scalar_env_values(test_db):
     )
     assoc2 = test_db.query(UserMCPServer).filter(UserMCPServer.user_id == 2).first()
     assert assoc2.env is None
+
+
+def test_connect_reuses_shared_stdio_row_with_padded_transport(test_db):
+    """_ensure_catalog_app_server's stdio guard must normalize like the rest of
+    the chain.
+
+    A legacy shared row stored as " stdio " is the same stdio server; rejecting
+    it as a different configuration (409) would strand the catalog app for
+    every user until the row is hand-edited.
+    """
+    from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
+    from xagent.web.models.mcp import MCPServer
+
+    test_db.add(
+        MCPServer(
+            name="google-maps",
+            managed="external",
+            transport=" stdio ",
+            command="npx",
+            args=["-y", "@cablate/mcp-google-map", "--stdio"],
+        )
+    )
+    test_db.commit()
+
+    connect_mcp_app(
+        "google-maps",
+        MCPAppConnectRequest(env={"GOOGLE_MAPS_API_KEY": "alice-key"}),
+        current_user=_user(test_db, 1),
+        db=test_db,
+    )
+
+    # Reused, not duplicated or rejected.
+    assert test_db.query(MCPServer).filter(MCPServer.name == "google-maps").count() == 1

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -3384,3 +3384,44 @@ async def test_connect_app_reuses_shared_row_for_padded_catalog_transport(
 
     assert response.status_code == 303
     assert db.query(MCPServer).filter(MCPServer.name == "padded-notes").count() == 1
+
+
+def test_update_rejects_blank_transport_instead_of_silently_keeping_the_old_one(
+    db_session,
+):
+    """`normalize_transport("   ")` is `""`, which is falsy. The update path's
+    `or server.transport` fallback would therefore silently keep the stored
+    transport, turning an invalid edit into a no-op the caller never learns
+    about -- before write-time normalization this failed with a 400."""
+    db, user, _ = db_session
+    server = MCPServer(
+        name="editable",
+        managed="external",
+        transport="streamable_http",
+        url="https://mcp.example.com/mcp",
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    db.add(
+        UserMCPServer(
+            user_id=user.id,
+            mcpserver_id=server.id,
+            is_owner=True,
+            is_active=True,
+            can_edit=True,
+        )
+    )
+    db.commit()
+
+    with pytest.raises(mcp_api.HTTPException) as exc:
+        update_mcp_server(
+            server.id,
+            MCPServerUpdate(transport="   "),
+            user,
+            db,
+        )
+    assert exc.value.status_code == 400
+
+    db.refresh(server)
+    assert server.transport == "streamable_http"

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -3193,3 +3193,114 @@ async def test_status_reports_discovered_grant_without_configured_selectors(db_s
     status_response = await get_mcp_oauth_status(server.id, user, db)
 
     assert [item.id for item in status_response.grants] == [grant.id]
+
+
+@pytest.mark.asyncio
+async def test_connect_app_reuses_mixed_case_shared_row_without_pkce_rejection(
+    db_session, monkeypatch
+):
+    """A legacy shared row whose transport differs only in case must not be
+    admitted by the reuse check and then rejected by the PKCE start.
+
+    `transport` is a free-form string, so a row stored before write-time
+    normalization can hold "Streamable_HTTP". _ensure_catalog_mcp_oauth_server
+    compares it case-insensitively and reuses it, so the connect must go
+    through to discovery rather than 400 at _get_mcp_oauth_config.
+    """
+    db, user, _ = db_session
+    _add_remote_oauth_catalog_app(db)
+    monkeypatch.setenv("XAGENT_PUBLIC_API_BASE_URL", "https://api.xagent.test/")
+
+    # Written directly, the way a row predating normalization would exist.
+    db.add(
+        MCPServer(
+            name="remote-notes",
+            transport="Streamable_HTTP",
+            url="https://mcp.example.com/mcp",
+            auth={"type": "mcp_oauth"},
+            managed="external",
+        )
+    )
+    db.commit()
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    def registration_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            201,
+            json={
+                "client_id": "dynamic-client-123",
+                "token_endpoint_auth_method": "none",
+            },
+        )
+
+    registration_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(registration_handler)
+    )
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+    monkeypatch.setattr(
+        mcp_oauth_service,
+        "create_mcp_oauth_http_client",
+        lambda **kwargs: registration_client,
+    )
+
+    response = await connect_mcp_oauth_app(
+        "remote-notes",
+        MCPOAuthConnectRequest(redirect_after="/settings/mcp"),
+        user,
+        db,
+    )
+
+    # The reuse check admitted the row, so the PKCE start must too.
+    assert response.status_code == 303
+    query = parse_qs(urlparse(response.headers["location"]).query)
+    assert query["client_id"] == ["dynamic-client-123"]
+
+    # Reused, not duplicated.
+    assert db.query(MCPServer).filter(MCPServer.name == "remote-notes").count() == 1
+
+
+def test_get_mcp_oauth_config_accepts_mixed_case_http_transport():
+    """_get_mcp_oauth_config must classify transport the same way the reuse
+    check that admits the row does."""
+    server = MCPServer(
+        name="mixed-case",
+        transport="Streamable_HTTP",
+        url="https://mcp.example.com/mcp",
+        auth={"type": "mcp_oauth"},
+        managed="external",
+    )
+
+    assert mcp_api._get_mcp_oauth_config(server) == {"type": "mcp_oauth"}
+
+
+def test_get_mcp_oauth_config_still_rejects_non_http_transport():
+    """Normalizing case must not admit a genuinely non-HTTP transport."""
+    server = MCPServer(
+        name="stdio-server",
+        transport="STDIO",
+        url="https://mcp.example.com/mcp",
+        auth={"type": "mcp_oauth"},
+        managed="external",
+    )
+
+    with pytest.raises(HTTPException) as exc:
+        mcp_api._get_mcp_oauth_config(server)
+    assert exc.value.status_code == 400
+    assert "HTTP MCP transports" in str(exc.value.detail)
+
+
+def test_mcp_server_create_normalizes_transport():
+    """Write-time normalization is what keeps mixed-case rows from being
+    created in the first place."""
+    created = mcp_api.MCPServerCreate(
+        name="remote",
+        transport="  Streamable_HTTP ",
+        config={"url": "https://mcp.example.com/mcp"},
+    )
+    assert created.transport == "streamable_http"
+
+    updated = MCPServerUpdate(transport="SSE")
+    assert updated.transport == "sse"
+    assert MCPServerUpdate().transport is None

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -3304,3 +3304,83 @@ def test_mcp_server_create_normalizes_transport():
     updated = MCPServerUpdate(transport="SSE")
     assert updated.transport == "sse"
     assert MCPServerUpdate().transport is None
+
+    # The test-connection path must agree with the save path, so a transport
+    # spelling can't be accepted by one and rejected by the other.
+    tested = mcp_api.MCPConnectionTest(
+        name="remote",
+        transport=" Streamable_HTTP ",
+        config={"url": "https://mcp.example.com/mcp"},
+    )
+    assert tested.transport == "streamable_http"
+
+
+@pytest.mark.asyncio
+async def test_connect_app_reuses_shared_row_for_padded_catalog_transport(
+    db_session, monkeypatch
+):
+    """A padded legacy catalog transport must not 409 against a canonical
+    shared row.
+
+    classify_app_auth routes the app here by normalizing (strip + lower), so
+    the reuse check must normalize identically. A local .lower() there would
+    leave " streamable_http " != "streamable_http" and reject the row as a
+    different configuration -- admitted by one half of the chain, rejected by
+    the other, which is the very class of bug this feature guards against.
+    """
+    db, user, _ = db_session
+    monkeypatch.setenv("XAGENT_PUBLIC_API_BASE_URL", "https://api.xagent.test/")
+
+    db.add(
+        PublicMCPApp(
+            app_id="padded-notes",
+            name="PaddedNotes",
+            transport=" streamable_http ",
+            launch_config={
+                "url": "https://mcp.example.com/mcp",
+                "auth": {"type": "mcp_oauth"},
+            },
+        )
+    )
+    db.add(
+        MCPServer(
+            name="padded-notes",
+            transport="streamable_http",
+            url="https://mcp.example.com/mcp",
+            auth={"type": "mcp_oauth"},
+            managed="external",
+        )
+    )
+    db.commit()
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    def registration_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            201,
+            json={
+                "client_id": "dynamic-client-123",
+                "token_endpoint_auth_method": "none",
+            },
+        )
+
+    registration_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(registration_handler)
+    )
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+    monkeypatch.setattr(
+        mcp_oauth_service,
+        "create_mcp_oauth_http_client",
+        lambda **kwargs: registration_client,
+    )
+
+    response = await connect_mcp_oauth_app(
+        "padded-notes",
+        MCPOAuthConnectRequest(redirect_after="/settings/mcp"),
+        user,
+        db,
+    )
+
+    assert response.status_code == 303
+    assert db.query(MCPServer).filter(MCPServer.name == "padded-notes").count() == 1

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -2312,3 +2312,61 @@ def test_admin_custom_catalog_writes_record_before_after_audits() -> None:
             shutil.rmtree(temp_dir)
         except OSError:
             pass
+
+
+def test_admin_catalog_write_normalizes_transport_case() -> None:
+    """`transport` is a free-form string, and the shape check that guards these
+    writes (classify_app_auth) compares it case-insensitively — so a mixed-case
+    "Streamable_HTTP" is accepted here, while the connect path it feeds compares
+    exactly. Normalize on write so the stored row can't be classified
+    connectable by one half of the feature and rejected by the other."""
+    temp_dir = _setup_test_db()
+    try:
+        _setup_admin()
+        admin_headers = _login("admin", "admin123")
+
+        created = client.post(
+            "/api/admin/mcp/apps",
+            headers=admin_headers,
+            json={
+                "app_id": "remote-mixed",
+                "name": "RemoteMixed",
+                "transport": "Streamable_HTTP",
+                "launch_config": {
+                    "url": "https://mcp.example.com/mcp",
+                    "auth": {"type": "mcp_oauth"},
+                },
+            },
+        )
+        assert created.status_code == 200
+        app_pk = created.json()["id"]
+
+        db = next(get_db())
+        try:
+            stored = db.query(PublicMCPApp).filter(PublicMCPApp.id == app_pk).one()
+            assert stored.transport == "streamable_http"
+        finally:
+            db.close()
+
+        # A PATCH must not be able to reintroduce a mixed-case row either.
+        patched = client.patch(
+            f"/api/admin/mcp/apps/{app_pk}",
+            headers=admin_headers,
+            json={"transport": "SSE"},
+        )
+        assert patched.status_code == 200
+
+        db = next(get_db())
+        try:
+            stored = db.query(PublicMCPApp).filter(PublicMCPApp.id == app_pk).one()
+            assert stored.transport == "sse"
+        finally:
+            db.close()
+    finally:
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass

--- a/tests/web/services/test_mcp_shared_env_hook.py
+++ b/tests/web/services/test_mcp_shared_env_hook.py
@@ -2,6 +2,8 @@
 
 import asyncio
 
+import pytest
+
 from xagent.web.services import mcp_runtime
 
 
@@ -221,10 +223,17 @@ def test_mcp_oauth_http_classification_is_case_insensitive():
     )
 
 
-def test_mcp_oauth_http_classification_still_excludes_stdio():
-    """Case-insensitivity must not pull a non-HTTP transport into the
-    OAuth runtime path."""
-    server = _FakeHttpOAuthServer("stdio")
+@pytest.mark.parametrize(
+    "transport",
+    ["stdio", "oauth", "oauth2", "http", "streamable", "custom_api", ""],
+    ids=["stdio", "oauth", "oauth2", "http", "prefix", "custom-api", "empty"],
+)
+def test_mcp_oauth_http_classification_excludes_non_http_transports(transport):
+    """Normalizing case must not widen the set. `stdio` alone does not
+    discriminate -- it is excluded with or without normalization. These
+    include values that a sloppy normalizer (substring/prefix matching, or
+    treating "oauth" as HTTP) would wrongly admit."""
+    server = _FakeHttpOAuthServer(transport)
 
     assert (
         mcp_runtime._is_mcp_oauth_http_server(server, server._decrypt_auth_config(None))

--- a/tests/web/services/test_mcp_shared_env_hook.py
+++ b/tests/web/services/test_mcp_shared_env_hook.py
@@ -186,3 +186,68 @@ def test_build_mcp_runtime_connection_without_user_id_does_not_scrub_forged_over
     )
 
     assert build.connection["env"]["XAGENT_MCP_CALLER_ID"] == "spoofed"
+
+
+class _FakeHttpOAuthServer:
+    """Stand-in for an mcp_oauth-authorized HTTP MCPServer row."""
+
+    def __init__(self, transport, server_id=7):
+        self.id = server_id
+        self.name = "remote-notes"
+        self.transport = transport
+        self.url = "https://mcp.example.com/mcp"
+
+    def to_connection_dict(self):
+        return {
+            "transport": self.transport,
+            "url": self.url,
+            "auth": {"type": "mcp_oauth"},
+        }
+
+    def _decrypt_auth_config(self, auth):
+        return {"type": "mcp_oauth"}
+
+
+def test_mcp_oauth_http_classification_is_case_insensitive():
+    """A row stored before write-time transport normalization can hold
+    "Streamable_HTTP". A False here is not a rejection: the caller returns
+    the connection as-is, skipping the per-user OAuth token exchange, so the
+    server would be handed to the runtime without a grant."""
+    server = _FakeHttpOAuthServer("Streamable_HTTP")
+
+    assert (
+        mcp_runtime._is_mcp_oauth_http_server(server, server._decrypt_auth_config(None))
+        is True
+    )
+
+
+def test_mcp_oauth_http_classification_still_excludes_stdio():
+    """Case-insensitivity must not pull a non-HTTP transport into the
+    OAuth runtime path."""
+    server = _FakeHttpOAuthServer("stdio")
+
+    assert (
+        mcp_runtime._is_mcp_oauth_http_server(server, server._decrypt_auth_config(None))
+        is False
+    )
+
+
+def test_mixed_case_mcp_oauth_server_is_not_served_without_a_grant():
+    """The end-to-end consequence: build_mcp_runtime_connection must refuse a
+    mixed-case mcp_oauth row (no db/user context to resolve a grant) rather
+    than fall through and return it unauthorized."""
+    server = _FakeHttpOAuthServer("Streamable_HTTP")
+
+    build = asyncio.run(
+        mcp_runtime.build_mcp_runtime_connection(db=None, server=server, user_id=42)
+    )
+
+    assert build.connection is None
+    assert build.diagnostic is not None
+    assert build.diagnostic["code"] == "authorization_required"
+
+
+def test_normalize_transport_canonicalizes_case_and_padding():
+    assert mcp_runtime.normalize_transport("  Streamable_HTTP ") == "streamable_http"
+    assert mcp_runtime.normalize_transport("SSE") == "sse"
+    assert mcp_runtime.normalize_transport(None) == ""

--- a/tests/web/test_classify_app_auth.py
+++ b/tests/web/test_classify_app_auth.py
@@ -374,3 +374,28 @@ def test_classify_app_auth_normalizes_transport_for_keyless(transport: str):
 )
 def test_classify_app_auth_normalizes_transport_for_builtin_oauth(transport: str):
     assert classify_app_auth(transport, {"command": "npx"}) == "builtin_oauth"
+
+
+def test_catalog_listing_reports_normalized_transport(catalog_db):
+    """The connector listing's `transport` and `auth_type` come from the same
+    row; auth_type is derived from the normalized value, so transport must be
+    normalized too or the two disagree about one app."""
+    catalog_db.add(
+        PublicMCPApp(
+            app_id="padded-remote",
+            name="Padded Remote",
+            transport=" Streamable_HTTP ",
+            launch_config={
+                "url": "https://mcp.example.com/mcp",
+                "auth": {"type": "mcp_oauth"},
+            },
+        )
+    )
+    catalog_db.commit()
+
+    app = next(
+        a for a in mcp_apps.get_all_mcp_apps(catalog_db) if a["id"] == "padded-remote"
+    )
+
+    assert app["transport"] == "streamable_http"
+    assert app["auth_type"] == "mcp_oauth"

--- a/tests/web/test_classify_app_auth.py
+++ b/tests/web/test_classify_app_auth.py
@@ -332,3 +332,45 @@ def test_invalid_stable_app_id_does_not_fall_back_to_name(
     )
 
     assert app is None
+
+
+@pytest.mark.parametrize(
+    "transport",
+    [
+        "streamable_http",
+        "Streamable_HTTP",
+        " streamable_http ",
+        "  STREAMABLE_HTTP\t",
+    ],
+    ids=["canonical", "mixed-case", "padded", "padded-upper"],
+)
+def test_classify_app_auth_normalizes_transport_like_the_write_path(transport: str):
+    """This must agree with normalize_transport(), which the write-time
+    validators and the connect path both use. A local .lower() here would
+    still disagree about a padded legacy row, reintroducing the same class of
+    chain-disagreement bug via whitespace instead of case."""
+    assert (
+        classify_app_auth(
+            transport,
+            {"url": "https://mcp.example.com/mcp", "auth": {"type": "mcp_oauth"}},
+        )
+        == "mcp_oauth"
+    )
+
+
+@pytest.mark.parametrize(
+    "transport",
+    ["stdio", "STDIO", " stdio "],
+    ids=["canonical", "upper", "padded"],
+)
+def test_classify_app_auth_normalizes_transport_for_keyless(transport: str):
+    assert classify_app_auth(transport, {"command": "npx"}) == "keyless"
+
+
+@pytest.mark.parametrize(
+    "transport",
+    ["oauth", "OAuth", " oauth "],
+    ids=["canonical", "mixed-case", "padded"],
+)
+def test_classify_app_auth_normalizes_transport_for_builtin_oauth(transport: str):
+    assert classify_app_auth(transport, {"command": "npx"}) == "builtin_oauth"

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -2814,3 +2814,39 @@ async def test_mixed_case_http_transport_takes_the_http_dispatch_branch(
     await _tool_config(db, user).get_mcp_server_configs()
 
     assert [s.name for s in calls] == ["remote-notes"]
+
+
+@pytest.mark.asyncio
+async def test_built_config_reports_normalized_transport(db_session):
+    """The `transport` value in the returned config is consumed by the core
+    session layer's exact-match dispatch (via ToolFactory), so it must be the
+    canonical form -- not the raw stored value.
+
+    Selecting the right branch is not enough: a legacy row that takes the
+    correct branch but carries "Streamable_HTTP" downstream still dies with
+    `ValueError: Unsupported transport` at session creation.
+    """
+    db, user = db_session
+    server = MCPServer(
+        name="remote-raw-transport",
+        description="remote",
+        managed="external",
+        transport="Streamable_HTTP",
+        url="https://mcp.example.com/mcp",
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    db.add(
+        UserMCPServer(
+            user_id=user.id,
+            mcpserver_id=server.id,
+            is_owner=True,
+            is_active=True,
+        )
+    )
+    db.commit()
+
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "streamable_http"

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -21,6 +21,7 @@ from xagent.web.models.oauth_provider import OAuthProvider
 from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
 from xagent.web.models.user_oauth import UserOAuth
+from xagent.web.services import mcp_runtime as mcp_runtime_module
 from xagent.web.services.mcp_oauth import MCPAuthorizationChallenge
 from xagent.web.tools import config as web_tools_config
 from xagent.web.tools.config import (
@@ -2713,3 +2714,103 @@ async def test_remote_hook_refresh_classification_reaches_tool_failure_trace(
     public_output = repr(result) + repr(tracer.events) + caplog.text
     assert private_exception_text not in public_output
     assert "http-private-exception-secret" not in public_output
+
+
+@pytest.mark.asyncio
+async def test_mixed_case_oauth_transport_still_gets_oauth_credential_wiring(
+    db_session,
+):
+    """A legacy row stored as "OAuth" must still take the OAuth branch in
+    _build_mcp_server_config.
+
+    An exact `server.transport == "oauth"` check sends such a row down the
+    non-OAuth path, which silently drops its credential wiring -- the config is
+    built without the injected access token, so the connector fails at
+    tool-call time rather than reporting a credential problem.
+    """
+    server = _add_oauth_server(
+        db_session[0],
+        db_session[1],
+        name="Gmail Legacy Case",
+        app_id="gmail-legacy-case",
+        provider="google",
+        launch_config={
+            "command": "uv",
+            "args": ["run", "python", "-m", "xagent.web.tools.mcp.gmail"],
+            "env_mapping": {"GOOGLE_ACCESS_TOKEN": "access_token"},
+        },
+    )
+    db, user = db_session
+    # Simulate a row written before write-time transport normalization.
+    server.transport = "OAuth"
+    db.commit()
+
+    async def resolver(request: TokenRequest) -> ResolvedToken | None:
+        return ResolvedToken(
+            access_token="hook-token",
+            expires_at=datetime.now(timezone.utc) + timedelta(hours=1),
+        )
+
+    set_oauth_token_resolver_hook(resolver)
+
+    configs = await _tool_config(db, user).get_mcp_server_configs()
+
+    # The OAuth branch ran: the token was injected into the launch env.
+    assert configs[0]["config"]["env"]["GOOGLE_ACCESS_TOKEN"] == "hook-token"
+
+
+@pytest.mark.asyncio
+async def test_mixed_case_http_transport_takes_the_http_dispatch_branch(
+    db_session, monkeypatch
+):
+    """A legacy HTTP row stored as "Streamable_HTTP" must still match the HTTP
+    branch of _build_mcp_server_config's transport dispatch.
+
+    Matching neither branch leaves transport_config empty, so the row silently
+    loses the whole remote pipeline (runtime connection build, OAuth token
+    exchange, header wiring) instead of reporting a failure.
+
+    Note the assertion is on the connection-shaped keys this branch adds, not
+    on `url`: `url` comes from MCPServer.to_connection_dict() in the core MCP
+    layer, whose own exact-match comparison is deliberately outside this PR's
+    scope (a mixed-case row loses `url` there identically before and after this
+    branch). The backfill migration is what removes that input; this assertion
+    pins the part the web layer actually controls.
+    """
+    db, user = db_session
+    server = MCPServer(
+        name="remote-notes",
+        description="remote",
+        managed="external",
+        transport="Streamable_HTTP",
+        url="https://mcp.example.com/mcp",
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    db.add(
+        UserMCPServer(
+            user_id=user.id,
+            mcpserver_id=server.id,
+            is_owner=True,
+            is_active=True,
+        )
+    )
+    db.commit()
+
+    # The HTTP branch is the only caller of build_mcp_runtime_connection on
+    # this path, so observing that call is a direct signal that the dispatch
+    # matched. Under the old exact-match dispatch neither branch ran and it
+    # was never called.
+    calls: list = []
+    real_build = mcp_runtime_module.build_mcp_runtime_connection
+
+    async def spy(db_arg, server_arg, **kwargs):
+        calls.append(server_arg)
+        return await real_build(db_arg, server_arg, **kwargs)
+
+    monkeypatch.setattr(mcp_runtime_module, "build_mcp_runtime_connection", spy)
+
+    await _tool_config(db, user).get_mcp_server_configs()
+
+    assert [s.name for s in calls] == ["remote-notes"]


### PR DESCRIPTION
> **This PR is now an umbrella and is not for review.** After four rounds it became clear that its shape, not just its content, was the problem — 1396 lines spanning five separate concerns, forcing a full-diff context rebuild every round. It has been split into three independently reviewable PRs tracked in #1828.
>
> | Layer | Issue | Scope |
> | --- | --- | --- |
> | 1 | #1829 | Canonicalize on write — the shared helper and the five API write models |
> | 2 | #1830 | Normalize every web-layer read (depends on #1829) |
> | 3 | #1831 | Backfill migration (independent; lands last, only layer that mutates data) |
>
> The split follows where the blocking findings actually landed: they cluster by layer rather than crossing between them, and layer 3's open questions (offline SQL generation, whitespace semantics, rolling-writer convergence) are pure alembic/deployment concerns with no dependency on layers 1 and 2. Layers 1 and 2 are no-ops for already-canonical rows, so all data-mutating risk is isolated in the last PR.
>
> This PR will be closed once the sub-PRs are open. The findings from rounds 1–4 carry over to whichever layer owns them; nothing raised here is being dropped.

---

## Problem

`transport` is a free-form string on the MCP API models, so a mixed-case value such as `Streamable_HTTP` can be stored. The MCP OAuth feature then compares it two different ways along the same reconnect chain:

| Comparison | Site |
| --- | --- |
| Case-insensitive | `mcp_apps.classify_app_auth`, `mcp.py::_is_mcp_oauth_server` |
| Exact | `mcp.py::_get_mcp_oauth_config`, `mcp_runtime.py::_is_mcp_oauth_http_server` |

The two halves disagree about the same row:

1. `_ensure_catalog_mcp_oauth_server` reuses an existing shared row after a **case-insensitive** transport comparison, so a `Streamable_HTTP` row is admitted.
2. It then calls `connect_mcp_oauth` → `_get_mcp_oauth_config`, which compares **exactly** and raises `400 MCP OAuth is only supported for HTTP MCP transports`.
3. Meanwhile `classify_app_auth` still advertises that app as `mcp_oauth`, so the connector UI keeps offering a Connect button that deterministically fails at PKCE start.

This is reachable through the product, not just in theory: `PublicMCPAppCreate`'s write-time shape check delegates to the case-insensitive `classify_app_auth`, so admin create / PUT / PATCH accept a mixed-case transport today. Verified against this branch's parent:

```
1. admin write validation: ACCEPTED mixed-case transport
2. classify_app_auth -> mcp_oauth
3. connect: HTTP 400 -> MCP OAuth is only supported for HTTP MCP transports
```

## Strictness at the runtime layer was not a safety gate

It is tempting to read the exact comparison in `_is_mcp_oauth_http_server` as a deliberate guard, and to leave it alone so nothing extra reaches the runtime. It does not work that way. A `False` there is **not** a rejection — `build_mcp_runtime_connection` falls through and returns the connection as-is, skipping the per-user OAuth token exchange entirely.

And because `MCPServer.to_connection_dict()` compares transport exactly too, the connection that falls through matches neither the stdio branch nor the HTTP branch. Measured on the parent commit, for a mixed-case `mcp_oauth` row:

```
4. runtime _is_mcp_oauth_http_server -> False
5. to_connection_dict keys -> ['auth', 'concurrency_safe', 'concurrent_tools', 'name', 'transport']
   has url: False | leaks raw auth: True
```

So the "strict" path produces a connection with no `url` and with the decrypted auth config dumped into `connection["auth"]`, instead of taking the `mcp_oauth` branch that strips `Authorization`. Loosening that comparison is strictly safer than leaving it, because the alternative is serving the server without a grant.

## Fix

Fix it at the source rather than papering over the read sites:

- **Normalize on write.** A shared `normalize_transport()` helper canonicalizes transport to lowercase, applied in `MCPServerCreate` / `MCPServerUpdate` and `PublicMCPAppCreate` / `PublicMCPAppUpdate`. Mixed-case rows stop being created, and because the server update endpoint rebuilds `MCPServerCreate` from the request plus the stored row, editing a legacy server heals it.
- **Route every transport comparison on this chain through the same helper** — `_get_mcp_oauth_config`, `_is_mcp_oauth_http_server`, `_is_mcp_oauth_server`, both catalog reuse checks, `classify_app_auth`, and `_global_config_tampered` — so rows stored before this change are classified consistently instead of being admitted by one half of the feature and rejected by the other.
- **Backfill the stored values** with a migration (`20260826_normalize_mcp_transport_case`) that lowercases/trims `transport` in `mcp_servers` and `public_mcp_apps`. A shared catalog row's transport is never rewritten by the connect path, so an un-migrated row would otherwise stay mixed-case indefinitely.

The catalog normalizer deliberately lives on the **write models only**, not on `PublicMCPAppBase`. `PublicMCPAppResponse` inherits from that base, and a validator there would report a lowercased transport for a row that is still stored mixed-case — the same hazard the existing comment on `_enforce_auth_classification` already warns about. This was confirmed empirically before being moved.

After the fix, authoring the same app through the real write path is consistent end to end:

```
1. admin write model stores transport -> 'streamable_http'
3. connect: reached discovery (no contradiction)
5. runtime _is_mcp_oauth_http_server -> True
6. connection has url: True | leaks raw auth: False
```

### Side effects of normalizing on write

Two behavior changes follow from normalizing before validation, both deliberate:

1. **A validation hole closes.** The `TRANSPORT_REQUIRED_FIELDS` lookup in `_build_server_config` becomes case-correct. Previously `transport="STDIO"` returned an empty required-field set (the dict lookup missed), so a payload with no `command` was silently accepted; it is now rejected with `Transport 'stdio' requires field 'command'`.

2. **The API accepts spellings it used to reject.** `POST /api/mcp/servers` with `transport: "STDIO"` previously failed `MCPServerConfig.validate_transport`'s exact allowlist with a 400. The normalizing field validator now runs first, so it is accepted as `stdio`. This is a widening of the documented contract — intended as ergonomics, but worth stating explicitly rather than leaving as an undocumented side effect.

### Tradeoff: a later failure replaces an earlier one

Making `_get_mcp_oauth_config` and `_is_mcp_oauth_http_server` case-insensitive means a legacy mixed-case OAuth row that used to be rejected up front with a clear `400 "MCP OAuth is only supported for HTTP MCP transports"` now proceeds through the full PKCE flow before failing later. This is UX-only — the connection was never going to work either way — and the window is bounded by whether the backfill has run on a given row. Accepted deliberately: the alternative is keeping the chain internally inconsistent, which is the bug this PR exists to fix.

## Tests

Seven regression tests across three suites:

- `test_connect_app_reuses_mixed_case_shared_row_without_pkce_rejection` — the headline case: a legacy shared row differing only in case is reused **and** the PKCE start succeeds, instead of reuse passing and PKCE returning 400.
- `test_get_mcp_oauth_config_accepts_mixed_case_http_transport` and `test_get_mcp_oauth_config_still_rejects_non_http_transport` — the relaxation does not admit a genuinely non-HTTP transport.
- `test_mcp_oauth_http_classification_is_case_insensitive`, `test_mcp_oauth_http_classification_still_excludes_stdio`, and `test_mixed_case_mcp_oauth_server_is_not_served_without_a_grant` — the runtime layer, including the end-to-end consequence that such a row is refused rather than served unauthorized.
- `test_mcp_server_create_normalizes_transport`, `test_admin_catalog_write_normalizes_transport_case`, and `test_normalize_transport_canonicalizes_case_and_padding` — write-time normalization, including that a PATCH cannot reintroduce a mixed-case row.

All were mutation-verified: reverting the PKCE gate, the runtime check, and `normalize_transport` each turns the corresponding tests red (all 7 fail under the third mutation). The runtime mutation fails by showing the connection returned with `auth` still present and no grant resolved — the exact fall-through described above.

## Scope: what this does and does not fix

Narrowed per review. This PR covers the **web layer** — the API models, the catalog/connect path, and the OAuth runtime classification — plus a one-time backfill of the stored values.

It deliberately does **not** touch the core MCP layer (`core/tools/core/mcp/model.py::to_connection_dict`, `core/tools/core/mcp/sessions.py`'s transport dispatch), which still compares exactly. Two reasons:

1. **Nothing is relocated by this PR.** A legacy mixed-case row fails at `sessions.py` with `ValueError: Unsupported transport` *identically before and after* this branch — verified by driving the same connection dict through `create_session` under both the old and new runtime behavior:

   ```
   BEFORE PR (auth left in, no url): ValueError -> Unsupported transport: Streamable_HTTP
   AFTER  PR (auth popped,   no url): ValueError -> Unsupported transport: Streamable_HTTP
   ```

   Such a row could never connect. What changes is that it no longer leaks the decrypted auth config on the way to that failure.

2. **The backfill removes the input instead.** Once stored transports are canonical, the core dispatch never sees a mixed-case value, so relaxing it would be dead code. Keeping that layer strict preserves it as a genuine protocol-boundary check, and it has callers beyond this feature.

The read-side relaxations in the web layer are kept regardless of the backfill, because the app must still tolerate un-migrated rows during a rolling deploy.

## Downstream motivation

`xagent-saas`'s Toby disconnect path (xorbitsai/xagent-saas#720) has to predict whether a reconnect will fail, and currently mirrors **both** standards — one of its branches exists solely to model this inconsistency. Once this lands, that branch can be deleted. Surfaced during round 5 of that PR's review.

