### PR TITLE
feat(mcp): share the mcp_oauth reconnect validator with the connect path

### DIFF
--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -15,7 +15,18 @@ import shlex
 from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Annotated, Any, Callable, Dict, List, Literal, Optional, Union, cast
+from typing import (
+    Annotated,
+    Any,
+    Callable,
+    Dict,
+    List,
+    Literal,
+    NoReturn,
+    Optional,
+    Union,
+    cast,
+)
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 import httpx
@@ -35,6 +46,14 @@ from ...core.tools.core.mcp.model import MASKED_SECRET_VALUE, SENSITIVE_AUTH_FIE
 from ...core.utils.encryption import decrypt_value, encrypt_value
 from ..auth_dependencies import get_current_user, is_admin_user
 from ..mcp_apps import (
+    MCP_OAUTH_RECONNECT_REFUSAL_APP_HIDDEN,
+    MCP_OAUTH_RECONNECT_REFUSAL_APP_MISSING,
+    MCP_OAUTH_RECONNECT_REFUSAL_INVALID_AUTH_CONFIG,
+    MCP_OAUTH_RECONNECT_REFUSAL_INVALID_SERVER_CONFIG,
+    MCP_OAUTH_RECONNECT_REFUSAL_NOT_MCP_OAUTH,
+    MCP_OAUTH_RECONNECT_REFUSAL_SERVER_CONFIG_DRIFT,
+    MCP_OAUTH_RECONNECT_REFUSAL_USER_OWNED_SQUAT,
+    explain_mcp_oauth_reconnect_refusal,
     get_all_mcp_apps,
     get_app_by_name,
     restrict_to_app_scoped_oauth_grant,
@@ -56,6 +75,7 @@ from ..services.mcp_oauth import (
     MCP_OAUTH_PERSISTED_VALUE_MAX_LENGTH,
     MCP_OAUTH_RESOURCE_OWNER_KEY_MAX_LENGTH,
     MCP_OAUTH_TOKEN_ENDPOINT_AUTH_METHOD_MAX_LENGTH,
+    MCP_OAUTH_TOKEN_ENDPOINT_AUTH_METHODS,
     MCP_OAUTH_TOKEN_TYPE_MAX_LENGTH,
     MCPOAuthDiscoveryError,
     _same_url,
@@ -92,9 +112,6 @@ MCP_OAUTH_FLOW_STATE_RETENTION = timedelta(days=1)
 # Most stale rows the sweep in connect_mcp_oauth removes per request, so a
 # first-deploy backlog cannot turn one connect into a long transaction.
 MCP_OAUTH_FLOW_STATE_SWEEP_BATCH = 1000
-MCP_OAUTH_TOKEN_ENDPOINT_AUTH_METHODS = frozenset(
-    {"none", "client_secret_post", "client_secret_basic"}
-)
 
 
 # Pydantic models for API
@@ -2807,6 +2824,57 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
     return server, app_info
 
 
+# Each pre-flight refusal re-raised as exactly the response the connect path's
+# own gate would have produced, so moving the checks earlier changes when a
+# caller is refused but never what they see. Kept as a table beside the
+# validator's reason codes: a new code with no entry here raises KeyError in
+# tests rather than silently degrading to a generic 400 in production.
+_MCP_OAUTH_RECONNECT_REFUSAL_RESPONSES: dict[str, tuple[int, Any]] = {
+    # _reject_hidden_catalog_app deliberately mirrors the missing-app 404 so a
+    # hidden app is indistinguishable from a nonexistent one.
+    MCP_OAUTH_RECONNECT_REFUSAL_APP_MISSING: (
+        status.HTTP_404_NOT_FOUND,
+        "MCP app not found",
+    ),
+    MCP_OAUTH_RECONNECT_REFUSAL_APP_HIDDEN: (
+        status.HTTP_404_NOT_FOUND,
+        "MCP app not found",
+    ),
+    MCP_OAUTH_RECONNECT_REFUSAL_NOT_MCP_OAUTH: (
+        status.HTTP_400_BAD_REQUEST,
+        "This app is not a remote-OAuth connector",
+    ),
+    MCP_OAUTH_RECONNECT_REFUSAL_SERVER_CONFIG_DRIFT: (
+        status.HTTP_409_CONFLICT,
+        "A server with this name already exists with a different configuration",
+    ),
+    MCP_OAUTH_RECONNECT_REFUSAL_USER_OWNED_SQUAT: (
+        status.HTTP_409_CONFLICT,
+        "A user-owned server already exists under this catalog id",
+    ),
+    MCP_OAUTH_RECONNECT_REFUSAL_INVALID_SERVER_CONFIG: (
+        status.HTTP_400_BAD_REQUEST,
+        "Invalid app configuration",
+    ),
+    # connect_mcp_oauth reports its auth-config bounds with this structured
+    # detail; the message is intentionally generic because the offending field
+    # is an admin authoring fault, not something the caller can act on.
+    MCP_OAUTH_RECONNECT_REFUSAL_INVALID_AUTH_CONFIG: (
+        status.HTTP_400_BAD_REQUEST,
+        {
+            "code": "unsupported_auth_server",
+            "message": "This connector's OAuth configuration is not usable",
+        },
+    ),
+}
+
+
+def _raise_mcp_oauth_reconnect_refusal(refusal: str) -> NoReturn:
+    """Turn a pre-flight refusal code into the connect path's own response."""
+    status_code, detail = _MCP_OAUTH_RECONNECT_REFUSAL_RESPONSES[refusal]
+    raise HTTPException(status_code=status_code, detail=detail)
+
+
 def _ensure_catalog_mcp_oauth_server(
     db: Session, app_id: str
 ) -> tuple[MCPServer, dict]:
@@ -3041,6 +3109,20 @@ async def connect_mcp_oauth_app(
     server; only the server row's origin (catalog vs. a user-typed URL)
     differs.
     """
+    # Pre-flight the deterministic refusals *before* provisioning anything.
+    # This route used to commit the shared server row and this user's
+    # association first and only reach connect_mcp_oauth's auth-config
+    # validation afterwards, so a mis-authored catalog entry left the user in a
+    # one-way door: disconnect succeeded, and every reconnect re-created the
+    # association and then 400'd. Sharing the check with the pre-flight helper
+    # also keeps a consumer that asks "would a reconnect work?" from having to
+    # re-derive these rules into a copy that goes stale.
+    refusal = explain_mcp_oauth_reconnect_refusal(
+        db, app_id, cast(int, current_user.id)
+    )
+    if refusal is not None:
+        _raise_mcp_oauth_reconnect_refusal(refusal)
+
     server, app_info = _ensure_catalog_mcp_oauth_server(db, app_id)
 
     assoc: Any = (

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -11,7 +11,20 @@ from typing import Any, Dict, List
 from sqlalchemy.orm import Session
 
 from .builtin_mcp_registry import get_builtin_execution_fields_and_optional_scopes
+from .models.mcp import MCPServer, UserMCPServer
 from .models.public_mcp import PublicMCPApp
+
+# Reasons explain_mcp_oauth_reconnect_refusal can return. Stable identifiers:
+# a consumer (e.g. a "may I tear this connection down?" gate) branches on them,
+# so they are part of this function's contract and must not be reworded to
+# track an upstream error message.
+MCP_OAUTH_RECONNECT_REFUSAL_APP_MISSING = "app_missing"
+MCP_OAUTH_RECONNECT_REFUSAL_APP_HIDDEN = "app_hidden"
+MCP_OAUTH_RECONNECT_REFUSAL_NOT_MCP_OAUTH = "not_mcp_oauth"
+MCP_OAUTH_RECONNECT_REFUSAL_SERVER_CONFIG_DRIFT = "server_config_drift"
+MCP_OAUTH_RECONNECT_REFUSAL_USER_OWNED_SQUAT = "user_owned_squat"
+MCP_OAUTH_RECONNECT_REFUSAL_INVALID_SERVER_CONFIG = "invalid_server_config"
+MCP_OAUTH_RECONNECT_REFUSAL_INVALID_AUTH_CONFIG = "invalid_auth_config"
 
 # Apps that must not be satisfied by a bare provider-level OAuth grant (one
 # created via the app_id-less connect flow, e.g. UserOAuth.provider == "meta").
@@ -211,3 +224,164 @@ def get_app_for_mcp_server(db: Session, server: Any) -> Dict[str, Any] | None:
             return None
         return get_app_by_id(db, app_id)
     return get_app_by_name(db, str(getattr(server, "name", "")))
+
+
+def _bounded_auth_value_refusal(auth: Mapping[str, Any]) -> str | None:
+    """Reject auth config that connect_mcp_oauth would 400 on deterministically.
+
+    Only the statically decidable half of connect_mcp_oauth's validation. The
+    ``issuer`` and ``resource`` bounds it also enforces are deliberately out of
+    scope: those values come from runtime discovery against the remote server,
+    so no amount of reading the catalog row can predict them.
+
+    ``token_endpoint_auth_method`` is checked only on the static-``client_id``
+    branch, mirroring connect_mcp_oauth exactly. Without a client_id the flow
+    takes the Dynamic Client Registration branch, where the method is whatever
+    the authorization server hands back at registration time — not this row's.
+    """
+    from .services.mcp_oauth import (
+        MCP_OAUTH_PERSISTED_VALUE_MAX_LENGTH,
+        MCP_OAUTH_TOKEN_ENDPOINT_AUTH_METHOD_MAX_LENGTH,
+        MCP_OAUTH_TOKEN_ENDPOINT_AUTH_METHODS,
+    )
+
+    def _configured(key: str) -> str | None:
+        # Matches _configured_mcp_oauth_value: strip, and treat falsy as absent.
+        value = auth.get(key)
+        return str(value).strip() if value else None
+
+    # redirect_uri is bounded whether or not it is configured -- an absent one
+    # falls back to a default that is itself bounded, and a default we generate
+    # is never over the limit, so only a configured value can refuse here.
+    redirect_uri = _configured("redirect_uri")
+    if redirect_uri and len(redirect_uri) > MCP_OAUTH_PERSISTED_VALUE_MAX_LENGTH:
+        return MCP_OAUTH_RECONNECT_REFUSAL_INVALID_AUTH_CONFIG
+
+    client_id = _configured("client_id")
+    if not client_id:
+        return None
+    if len(client_id) > MCP_OAUTH_PERSISTED_VALUE_MAX_LENGTH:
+        return MCP_OAUTH_RECONNECT_REFUSAL_INVALID_AUTH_CONFIG
+
+    # Same default as connect_mcp_oauth: an unset method means "post" when a
+    # secret is configured and "none" when it is not, and both defaults are
+    # members of the allowlist -- so only an explicit value can refuse.
+    method = str(
+        auth.get("token_endpoint_auth_method")
+        or ("client_secret_post" if _configured("client_secret") else "none")
+    )
+    if len(method) > MCP_OAUTH_TOKEN_ENDPOINT_AUTH_METHOD_MAX_LENGTH:
+        return MCP_OAUTH_RECONNECT_REFUSAL_INVALID_AUTH_CONFIG
+    if method not in MCP_OAUTH_TOKEN_ENDPOINT_AUTH_METHODS:
+        return MCP_OAUTH_RECONNECT_REFUSAL_INVALID_AUTH_CONFIG
+    return None
+
+
+def explain_mcp_oauth_reconnect_refusal(
+    db: Session, app_id: str, user_id: int
+) -> str | None:
+    """Why an mcp_oauth reconnect for ``app_id`` would fail now, or None.
+
+    Answers "if this user were to POST /api/mcp/apps/{app_id}/oauth/connect
+    right now, would it be refused before any authorization redirect?" -- None
+    means the deterministic gates all pass. A non-None result is one of the
+    ``MCP_OAUTH_RECONNECT_REFUSAL_*`` codes.
+
+    Single source of truth in the same spirit as classify_app_auth:
+    connect_mcp_oauth_app calls this itself before it touches the database, so
+    a consumer asking the question ahead of time and the connect path answering
+    it for real cannot drift apart. A caller that only predicted the outcome by
+    re-deriving these rules would be a second copy, silently going stale on the
+    next hardening fix here.
+
+    Only *deterministic* refusals are covered -- those decidable from the
+    catalog row, the shared server row and this user's associations. Anything
+    that depends on reaching the remote server (OAuth metadata discovery, DCR,
+    the authorization server's own errors) is out of scope and may still fail
+    after this returns None.
+
+    Ordering note: calling this before the connect path mutates anything also
+    fixes a pre-existing one-way door. connect_mcp_oauth_app used to commit the
+    shared server row and this user's association *first* and only then call
+    connect_mcp_oauth, which is where the auth-config bounds are enforced -- so
+    a mis-authored catalog entry produced a connection that disconnected fine
+    but whose every reconnect attempt created an association and then 400'd.
+
+    Not covered on purpose: whether a *shared* server row could be created at
+    all when none exists yet. That path (_add_catalog_server_with_race_recovery)
+    can fail on infrastructure grounds, which is not statically decidable; the
+    schema-level half of it -- a catalog transport MCPServerConfig would reject
+    -- is checked here.
+
+    ``user_id`` is deliberately part of the signature even though no refusal
+    reads it today: every gate the connect path applies before the redirect
+    happens to be user-independent. The owned-row check is the near miss --
+    it rejects a row *any* user owns, the caller included, so it is not a
+    per-user rule either. Asking the question per user is still the honest
+    contract (whether *this* user can reconnect), and it means a future
+    user-scoped gate -- a per-user block, a quota, an association in a state
+    that cannot be revived -- lands here rather than forcing every consumer to
+    change signature.
+    """
+    app_info = get_app_by_id(db, app_id)
+    if not app_info:
+        return MCP_OAUTH_RECONNECT_REFUSAL_APP_MISSING
+    # Mirrors _reject_hidden_catalog_app: hiding an app is used as a release
+    # gate and blocks reconnect for already-connected users too, not just
+    # fresh connects.
+    if not app_info.get("is_visible_in_connector", True):
+        return MCP_OAUTH_RECONNECT_REFUSAL_APP_HIDDEN
+    if app_info.get("auth_type") != "mcp_oauth":
+        return MCP_OAUTH_RECONNECT_REFUSAL_NOT_MCP_OAUTH
+
+    launch = app_info.get("launch_config") or {}
+    url = launch.get("url")
+    auth = launch.get("auth")
+    auth = auth if isinstance(auth, Mapping) else {}
+    transport = str(app_info["transport"])
+    server_name = str(app_info["id"])
+
+    # The auth bounds are a property of the catalog entry alone, so they refuse
+    # identically on the reuse and the create path. Checked before either so a
+    # mis-authored entry reports the authoring fault rather than whichever
+    # row-shaped symptom it happens to hit first.
+    auth_refusal = _bounded_auth_value_refusal(auth)
+    if auth_refusal is not None:
+        return auth_refusal
+
+    server = db.query(MCPServer).filter(MCPServer.name == server_name).first()
+    if server is None:
+        # Create path: the catalog's own transport must survive
+        # MCPServerConfig's validator, which matches exact case -- while
+        # classify_app_auth lowercases before testing HTTP_MCP_TRANSPORTS. An
+        # entry authored as "Streamable_HTTP" therefore classifies as
+        # mcp_oauth and then cannot be persisted at all.
+        from ..core.tools.core.mcp.data_config import MCPServerConfig
+
+        try:
+            MCPServerConfig(
+                name=server_name,
+                transport=transport,
+                url=url,
+                managed="external",
+            )
+        except ValueError:
+            return MCP_OAUTH_RECONNECT_REFUSAL_INVALID_SERVER_CONFIG
+        return None
+
+    # Reuse path: the existing shared row must still match the catalog, or
+    # _ensure_catalog_mcp_oauth_server 409s rather than adopting a possible
+    # hijack. Transport compared case-insensitively, exactly as there.
+    if str(server.transport or "").lower() != transport.lower() or server.url != url:
+        return MCP_OAUTH_RECONNECT_REFUSAL_SERVER_CONFIG_DRIFT
+    owned = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.mcpserver_id == server.id,
+            UserMCPServer.is_owner.is_(True),
+        )
+        .first()
+    )
+    if owned is not None:
+        return MCP_OAUTH_RECONNECT_REFUSAL_USER_OWNED_SQUAT
+    return None

--- a/src/xagent/web/services/mcp_oauth.py
+++ b/src/xagent/web/services/mcp_oauth.py
@@ -30,6 +30,13 @@ MCP_OAUTH_PERSISTED_VALUE_MAX_LENGTH = 1000
 MCP_OAUTH_SCOPE_MAX_LENGTH = 1000
 MCP_OAUTH_RESOURCE_OWNER_KEY_MAX_LENGTH = 512
 MCP_OAUTH_TOKEN_ENDPOINT_AUTH_METHOD_MAX_LENGTH = 100
+# Token endpoint auth methods we can actually perform. Lives here beside its
+# length bound rather than in the API layer so both the connect route and
+# mcp_apps' pre-flight reconnect validator test the same set -- an allowlist
+# that exists twice is one that eventually disagrees with itself.
+MCP_OAUTH_TOKEN_ENDPOINT_AUTH_METHODS = frozenset(
+    {"none", "client_secret_post", "client_secret_basic"}
+)
 MCP_OAUTH_TOKEN_TYPE_MAX_LENGTH = 50
 MCP_OAUTH_CLIENT_REGISTRATION_MAX_RESPONSE_BYTES = 64 * 1024
 OAUTH_ERROR_MESSAGE_MAX_LENGTH = 500

--- a/tests/web/api/test_mcp_oauth_reconnect_validator.py
+++ b/tests/web/api/test_mcp_oauth_reconnect_validator.py
@@ -1,0 +1,620 @@
+"""Tests for the shared mcp_oauth reconnect pre-flight validator.
+
+``explain_mcp_oauth_reconnect_refusal`` answers "would an mcp_oauth connect for
+this app succeed past its deterministic gates right now?". It exists so a
+consumer asking that question ahead of time and the connect route answering it
+for real share one implementation instead of two that drift; every test here
+therefore pins both halves -- the predicted refusal *and* the connect route
+refusing the same way.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.web.api import mcp as mcp_api
+from xagent.web.api.mcp import MCPOAuthConnectRequest, connect_mcp_oauth_app
+from xagent.web.mcp_apps import (
+    MCP_OAUTH_RECONNECT_REFUSAL_APP_HIDDEN,
+    MCP_OAUTH_RECONNECT_REFUSAL_APP_MISSING,
+    MCP_OAUTH_RECONNECT_REFUSAL_INVALID_AUTH_CONFIG,
+    MCP_OAUTH_RECONNECT_REFUSAL_INVALID_SERVER_CONFIG,
+    MCP_OAUTH_RECONNECT_REFUSAL_NOT_MCP_OAUTH,
+    MCP_OAUTH_RECONNECT_REFUSAL_SERVER_CONFIG_DRIFT,
+    MCP_OAUTH_RECONNECT_REFUSAL_USER_OWNED_SQUAT,
+    explain_mcp_oauth_reconnect_refusal,
+)
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.services import mcp_oauth as mcp_oauth_service
+from xagent.web.services.mcp_oauth import (
+    MCP_OAUTH_PERSISTED_VALUE_MAX_LENGTH,
+    MCP_OAUTH_TOKEN_ENDPOINT_AUTH_METHOD_MAX_LENGTH,
+)
+
+APP_ID = "remote-notes"
+APP_URL = "https://mcp.example.com/mcp"
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'reconnect.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(engine)
+    db = sessionmaker(bind=engine, autoflush=False, autocommit=False)()
+
+    user = User(username="alice", password_hash="x", is_admin=False)
+    other = User(username="bob", password_hash="x", is_admin=False)
+    db.add_all([user, other])
+    db.commit()
+    db.refresh(user)
+    db.refresh(other)
+
+    yield db, user, other
+    db.close()
+    engine.dispose()
+
+
+def _add_app(
+    db,
+    *,
+    app_id: str = APP_ID,
+    transport: str = "streamable_http",
+    url: str | None = APP_URL,
+    auth: dict | None = None,
+    is_visible: bool = True,
+) -> PublicMCPApp:
+    """A catalog row shaped like a real remote-MCP-OAuth connector.
+
+    The app_id must not match a real builtin registry entry: the builtin
+    execution overlay replaces a DB row's execution fields with the canonical
+    registry values for matching app_ids, which would override this fixture.
+    """
+    app = PublicMCPApp(
+        app_id=app_id,
+        name=app_id.title(),
+        transport=transport,
+        launch_config={
+            "url": url,
+            "auth": {"type": "mcp_oauth"} if auth is None else auth,
+        },
+        is_visible_in_connector=is_visible,
+    )
+    db.add(app)
+    db.commit()
+    return app
+
+
+def _add_shared_server(
+    db, *, name: str = APP_ID, transport: str = "streamable_http", url: str = APP_URL
+) -> MCPServer:
+    """The legitimate shared catalog row: no association, so no owner."""
+    server = MCPServer.from_config(
+        {
+            "name": name,
+            "managed": "external",
+            "transport": transport,
+            "url": url,
+            "auth": {"type": "mcp_oauth"},
+        }
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    return server
+
+
+def _discovery() -> SimpleNamespace:
+    return SimpleNamespace(
+        resource=APP_URL,
+        scopes=("notes.read",),
+        protected_resource=SimpleNamespace(
+            authorization_servers=("https://auth.example.com",),
+        ),
+        authorization_server=SimpleNamespace(
+            issuer="https://auth.example.com",
+            authorization_endpoint="https://auth.example.com/authorize",
+            token_endpoint="https://auth.example.com/token",
+            registration_endpoint="https://auth.example.com/register",
+            client_id_metadata_document_supported=True,
+            raw={"issuer": "https://auth.example.com"},
+        ),
+    )
+
+
+def _stub_discovery(monkeypatch) -> None:
+    """Let the happy path reach the authorization redirect without a network.
+
+    Only used by the accepts-case and by the association-ordering test, which
+    must prove the refusal fires *before* provisioning rather than because
+    discovery was unreachable.
+    """
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+
+
+async def _connect(db, user, *, app_id: str = APP_ID):
+    return await connect_mcp_oauth_app(
+        app_id, MCPOAuthConnectRequest(redirect_after="/settings/mcp"), user, db
+    )
+
+
+def _assocs(db, user_id: int) -> list[UserMCPServer]:
+    return db.query(UserMCPServer).filter(UserMCPServer.user_id == user_id).all()
+
+
+# --------------------------------------------------------------------------
+# Accepting case: nothing deterministic refuses a well-formed catalog entry.
+# --------------------------------------------------------------------------
+
+
+def test_returns_none_for_a_well_formed_app(db_session):
+    db, user, _ = db_session
+    _add_app(db)
+    assert explain_mcp_oauth_reconnect_refusal(db, APP_ID, user.id) is None
+
+
+def test_returns_none_when_the_shared_row_already_matches(db_session):
+    """The reuse path: an existing unowned row matching the catalog is fine."""
+    db, user, _ = db_session
+    _add_app(db)
+    _add_shared_server(db)
+    assert explain_mcp_oauth_reconnect_refusal(db, APP_ID, user.id) is None
+
+
+@pytest.mark.asyncio
+async def test_accepted_app_still_reaches_the_authorization_redirect(
+    db_session, monkeypatch
+):
+    """The pre-flight must not refuse what the connect path would have allowed.
+
+    Without this, a validator that returned a code unconditionally would pass
+    every refusal test below while breaking the feature outright.
+    """
+    db, user, _ = db_session
+    _add_app(
+        db,
+        auth={
+            "type": "mcp_oauth",
+            "client_id": "static-client",
+            "token_endpoint_auth_method": "none",
+        },
+    )
+    monkeypatch.setenv("XAGENT_PUBLIC_API_BASE_URL", "https://api.xagent.test/")
+    _stub_discovery(monkeypatch)
+
+    response = await _connect(db, user)
+
+    assert response.status_code == 303
+    assert "https://auth.example.com/authorize" in response.headers["location"]
+    assert len(_assocs(db, user.id)) == 1
+
+
+# --------------------------------------------------------------------------
+# Catalog-level refusals.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_app(db_session):
+    db, user, _ = db_session
+    assert (
+        explain_mcp_oauth_reconnect_refusal(db, "no-such-app", user.id)
+        == MCP_OAUTH_RECONNECT_REFUSAL_APP_MISSING
+    )
+    with pytest.raises(mcp_api.HTTPException) as exc:
+        await _connect(db, user, app_id="no-such-app")
+    assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_hidden_app(db_session):
+    db, user, _ = db_session
+    _add_app(db, is_visible=False)
+    assert (
+        explain_mcp_oauth_reconnect_refusal(db, APP_ID, user.id)
+        == MCP_OAUTH_RECONNECT_REFUSAL_APP_HIDDEN
+    )
+    with pytest.raises(mcp_api.HTTPException) as exc:
+        await _connect(db, user)
+    # 404, not 403: a hidden app is indistinguishable from a missing one.
+    assert exc.value.status_code == 404
+    assert exc.value.detail == "MCP app not found"
+
+
+@pytest.mark.asyncio
+async def test_app_that_is_not_an_mcp_oauth_connector(db_session):
+    """An api_key catalog app: classify_app_auth gives it a non-mcp_oauth type."""
+    db, user, _ = db_session
+    db.add(
+        PublicMCPApp(
+            app_id="maps",
+            name="Maps",
+            transport="stdio",
+            launch_config={"command": "npx", "required_env": ["MAPS_KEY"]},
+        )
+    )
+    db.commit()
+
+    assert (
+        explain_mcp_oauth_reconnect_refusal(db, "maps", user.id)
+        == MCP_OAUTH_RECONNECT_REFUSAL_NOT_MCP_OAUTH
+    )
+    with pytest.raises(mcp_api.HTTPException) as exc:
+        await _connect(db, user, app_id="maps")
+    assert exc.value.status_code == 400
+
+
+# --------------------------------------------------------------------------
+# Auth-config refusals -- the class of bug this validator was written for.
+# These were previously only caught *after* the association was committed.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "auth",
+    [
+        pytest.param(
+            {
+                "type": "mcp_oauth",
+                "client_id": "c" * (MCP_OAUTH_PERSISTED_VALUE_MAX_LENGTH + 1),
+            },
+            id="client_id_too_long",
+        ),
+        pytest.param(
+            {
+                "type": "mcp_oauth",
+                "redirect_uri": "https://x.example.com/"
+                + "p" * MCP_OAUTH_PERSISTED_VALUE_MAX_LENGTH,
+            },
+            id="redirect_uri_too_long",
+        ),
+        pytest.param(
+            {
+                "type": "mcp_oauth",
+                "client_id": "static-client",
+                "token_endpoint_auth_method": "private_key_jwt",
+            },
+            id="unsupported_auth_method",
+        ),
+    ],
+)
+def test_invalid_auth_config_is_refused(db_session, auth):
+    db, user, _ = db_session
+    _add_app(db, auth=auth)
+    assert (
+        explain_mcp_oauth_reconnect_refusal(db, APP_ID, user.id)
+        == MCP_OAUTH_RECONNECT_REFUSAL_INVALID_AUTH_CONFIG
+    )
+
+
+def test_overlong_auth_method_is_refused_on_the_length_bound(db_session, monkeypatch):
+    """The length bound must be checked *before* the allowlist, as upstream does.
+
+    An overlong method is necessarily also outside the three-member allowlist,
+    so a plain refusal assertion cannot tell the two branches apart and would
+    pass with the length check deleted. Widening the allowlist to admit the
+    overlong value isolates the bound: it is the only thing left that can
+    refuse, so the refusal proves the bound is checked and is checked first.
+    """
+    db, user, _ = db_session
+    overlong = "m" * (MCP_OAUTH_TOKEN_ENDPOINT_AUTH_METHOD_MAX_LENGTH + 1)
+    _add_app(
+        db,
+        auth={
+            "type": "mcp_oauth",
+            "client_id": "static-client",
+            "token_endpoint_auth_method": overlong,
+        },
+    )
+    monkeypatch.setattr(
+        mcp_oauth_service,
+        "MCP_OAUTH_TOKEN_ENDPOINT_AUTH_METHODS",
+        frozenset({overlong}),
+    )
+
+    assert (
+        explain_mcp_oauth_reconnect_refusal(db, APP_ID, user.id)
+        == MCP_OAUTH_RECONNECT_REFUSAL_INVALID_AUTH_CONFIG
+    )
+
+
+@pytest.mark.parametrize(
+    "auth",
+    [
+        pytest.param(
+            {"type": "mcp_oauth", "token_endpoint_auth_method": "private_key_jwt"},
+            id="unsupported_method_without_client_id",
+        ),
+        pytest.param(
+            {
+                "type": "mcp_oauth",
+                "token_endpoint_auth_method": "m"
+                * (MCP_OAUTH_TOKEN_ENDPOINT_AUTH_METHOD_MAX_LENGTH + 1),
+            },
+            id="overlong_method_without_client_id",
+        ),
+    ],
+)
+def test_auth_method_is_only_checked_on_the_static_client_id_branch(db_session, auth):
+    """Without a client_id the flow registers dynamically.
+
+    connect_mcp_oauth then takes its method from the *registered* client, never
+    from this row -- so refusing here would block a connect that actually works.
+    Pinned because over-mirroring is as wrong as under-mirroring.
+    """
+    db, user, _ = db_session
+    _add_app(db, auth=auth)
+    assert explain_mcp_oauth_reconnect_refusal(db, APP_ID, user.id) is None
+
+
+@pytest.mark.parametrize(
+    ("auth", "case"),
+    [
+        pytest.param(
+            {"type": "mcp_oauth", "client_id": "static-client"},
+            "none",
+            id="defaults_to_none_without_secret",
+        ),
+        pytest.param(
+            {
+                "type": "mcp_oauth",
+                "client_id": "static-client",
+                "client_secret": "shh",
+            },
+            "client_secret_post",
+            id="defaults_to_post_with_secret",
+        ),
+    ],
+)
+def test_default_auth_method_is_accepted(db_session, auth, case):
+    """An unset method resolves to an allowlisted default, either way."""
+    db, user, _ = db_session
+    _add_app(db, auth=auth)
+    assert explain_mcp_oauth_reconnect_refusal(db, APP_ID, user.id) is None
+
+
+# --------------------------------------------------------------------------
+# Server-row refusals.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("server_transport", "server_url"),
+    [
+        pytest.param("sse", APP_URL, id="transport_drift"),
+        pytest.param("streamable_http", "https://evil.example.com/mcp", id="url_drift"),
+    ],
+)
+async def test_shared_row_drifted_from_the_catalog(
+    db_session, server_transport, server_url
+):
+    db, user, _ = db_session
+    _add_app(db)
+    _add_shared_server(db, transport=server_transport, url=server_url)
+
+    assert (
+        explain_mcp_oauth_reconnect_refusal(db, APP_ID, user.id)
+        == MCP_OAUTH_RECONNECT_REFUSAL_SERVER_CONFIG_DRIFT
+    )
+    with pytest.raises(mcp_api.HTTPException) as exc:
+        await _connect(db, user)
+    assert exc.value.status_code == 409
+
+
+def test_transport_drift_is_compared_case_insensitively(db_session):
+    """_ensure_catalog_mcp_oauth_server lowercases both sides; so must this.
+
+    An admin PATCH can store a mixed-case transport, and the two halves of
+    this feature must not disagree about the same row.
+    """
+    db, user, _ = db_session
+    _add_app(db)
+    server = _add_shared_server(db)
+    server.transport = "Streamable_HTTP"
+    db.commit()
+
+    assert explain_mcp_oauth_reconnect_refusal(db, APP_ID, user.id) is None
+
+
+@pytest.mark.asyncio
+async def test_user_owned_row_squatting_the_catalog_id(db_session):
+    """A row someone owns could later have a foreign URL swapped in."""
+    db, user, other = db_session
+    _add_app(db)
+    server = _add_shared_server(db)
+    db.add(
+        UserMCPServer(
+            user_id=other.id,
+            mcpserver_id=server.id,
+            is_active=True,
+            is_owner=True,
+            can_edit=True,
+            can_delete=True,
+        )
+    )
+    db.commit()
+
+    assert (
+        explain_mcp_oauth_reconnect_refusal(db, APP_ID, user.id)
+        == MCP_OAUTH_RECONNECT_REFUSAL_USER_OWNED_SQUAT
+    )
+    with pytest.raises(mcp_api.HTTPException) as exc:
+        await _connect(db, user)
+    assert exc.value.status_code == 409
+
+
+def test_the_owner_themselves_is_also_refused(db_session):
+    """The squat gate rejects a row *any* user owns, the caller included.
+
+    Pins the claim the docstring makes about user_id: this is not a per-user
+    rule, so the owner does not get a pass. Upstream refuses them for the same
+    reason it refuses everyone else -- an owner keeps edit rights and could
+    later swap in a foreign URL that every connected user then runs.
+    """
+    db, user, _ = db_session
+    _add_app(db)
+    server = _add_shared_server(db)
+    db.add(
+        UserMCPServer(
+            user_id=user.id,
+            mcpserver_id=server.id,
+            is_active=True,
+            is_owner=True,
+            can_edit=True,
+            can_delete=True,
+        )
+    )
+    db.commit()
+
+    assert (
+        explain_mcp_oauth_reconnect_refusal(db, APP_ID, user.id)
+        == MCP_OAUTH_RECONNECT_REFUSAL_USER_OWNED_SQUAT
+    )
+
+
+def test_a_non_owning_association_is_not_a_squat(db_session):
+    """Connect users get is_owner=False rows; those must not refuse a reconnect."""
+    db, user, other = db_session
+    _add_app(db)
+    server = _add_shared_server(db)
+    db.add(
+        UserMCPServer(
+            user_id=other.id,
+            mcpserver_id=server.id,
+            is_active=True,
+            is_owner=False,
+            can_edit=False,
+            can_delete=True,
+        )
+    )
+    db.commit()
+
+    assert explain_mcp_oauth_reconnect_refusal(db, APP_ID, user.id) is None
+
+
+@pytest.mark.asyncio
+async def test_catalog_transport_the_server_schema_would_reject(db_session):
+    """classify_app_auth lowercases before testing HTTP_MCP_TRANSPORTS, but
+    MCPServerConfig's validator matches exact case -- so an entry authored as
+    "Streamable_HTTP" classifies as mcp_oauth and then cannot be persisted at
+    all. Only reachable while no shared row exists yet (the create path).
+    """
+    db, user, _ = db_session
+    _add_app(db, transport="Streamable_HTTP")
+
+    assert (
+        explain_mcp_oauth_reconnect_refusal(db, APP_ID, user.id)
+        == MCP_OAUTH_RECONNECT_REFUSAL_INVALID_SERVER_CONFIG
+    )
+    with pytest.raises(mcp_api.HTTPException) as exc:
+        await _connect(db, user)
+    assert exc.value.status_code == 400
+
+
+def test_non_string_catalog_url_the_server_schema_would_reject(db_session):
+    """classify_app_auth only tests that ``url`` is truthy, so a mis-authored
+    non-string url (an admin PATCH can store any JSON) still classifies as
+    mcp_oauth and then fails MCPServerConfig. Caught here because the raw value
+    is handed to the schema rather than coerced first -- pydantic's
+    ValidationError is a ValueError, so the create-path guard sees it.
+    """
+    db, user, _ = db_session
+    _add_app(db, url={"href": APP_URL})
+
+    assert (
+        explain_mcp_oauth_reconnect_refusal(db, APP_ID, user.id)
+        == MCP_OAUTH_RECONNECT_REFUSAL_INVALID_SERVER_CONFIG
+    )
+
+
+# --------------------------------------------------------------------------
+# The core guarantee: the connect path calls the validator itself, before it
+# provisions anything. This is what stops the validator from becoming a
+# second, drifting copy -- and it closes the pre-existing one-way door.
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connect_refuses_before_creating_any_association(db_session, monkeypatch):
+    """A mis-authored auth config must fail with the database untouched.
+
+    Previously connect_mcp_oauth_app committed the shared server row and this
+    user's association first and only reached the auth-config bounds inside
+    connect_mcp_oauth -- so disconnect worked while every reconnect created an
+    association and then 400'd, a one-way door. Discovery is stubbed so a
+    surviving association could not be blamed on an unreachable network.
+    """
+    db, user, _ = db_session
+    _add_app(
+        db,
+        auth={
+            "type": "mcp_oauth",
+            "client_id": "static-client",
+            "token_endpoint_auth_method": "private_key_jwt",
+        },
+    )
+    _stub_discovery(monkeypatch)
+
+    with pytest.raises(mcp_api.HTTPException) as exc:
+        await _connect(db, user)
+
+    assert exc.value.status_code == 400
+    assert _assocs(db, user.id) == []
+    assert db.query(MCPServer).filter(MCPServer.name == APP_ID).first() is None
+
+
+@pytest.mark.asyncio
+async def test_connect_consults_the_shared_validator(db_session, monkeypatch):
+    """Pins the wiring itself, not just an agreeing outcome.
+
+    Both halves refusing identically is also what a duplicated rule set looks
+    like right up until it drifts. Forcing the shared validator to report a
+    refusal it could not have derived from this well-formed app proves the
+    route reads that one function rather than re-deriving the rules.
+    """
+    db, user, _ = db_session
+    _add_app(db)
+    calls: list[tuple[str, int]] = []
+
+    def fake_explain(_db, app_id, user_id):
+        calls.append((app_id, user_id))
+        return MCP_OAUTH_RECONNECT_REFUSAL_USER_OWNED_SQUAT
+
+    monkeypatch.setattr(mcp_api, "explain_mcp_oauth_reconnect_refusal", fake_explain)
+
+    with pytest.raises(mcp_api.HTTPException) as exc:
+        await _connect(db, user)
+
+    assert calls == [(APP_ID, user.id)]
+    assert exc.value.status_code == 409
+    assert _assocs(db, user.id) == []
+
+
+@pytest.mark.asyncio
+async def test_every_refusal_code_maps_to_a_response(db_session):
+    """No reason code may fall through to a KeyError at request time."""
+    for refusal in (
+        MCP_OAUTH_RECONNECT_REFUSAL_APP_MISSING,
+        MCP_OAUTH_RECONNECT_REFUSAL_APP_HIDDEN,
+        MCP_OAUTH_RECONNECT_REFUSAL_NOT_MCP_OAUTH,
+        MCP_OAUTH_RECONNECT_REFUSAL_SERVER_CONFIG_DRIFT,
+        MCP_OAUTH_RECONNECT_REFUSAL_USER_OWNED_SQUAT,
+        MCP_OAUTH_RECONNECT_REFUSAL_INVALID_SERVER_CONFIG,
+        MCP_OAUTH_RECONNECT_REFUSAL_INVALID_AUTH_CONFIG,
+    ):
+        with pytest.raises(mcp_api.HTTPException) as exc:
+            mcp_api._raise_mcp_oauth_reconnect_refusal(refusal)
+        assert exc.value.status_code in (400, 404, 409)


### PR DESCRIPTION
## Why

The `mcp_oauth` reconnect rules currently live only inside the connect path, spread across `_ensure_catalog_mcp_oauth_server`, `_reject_hidden_catalog_app`, `_reject_user_owned_catalog_squat` and `connect_mcp_oauth`. A consumer that needs to know *in advance* whether a reconnect would succeed has no way to ask, so xagent-saas PR #720's disconnect gate mirrors these private rules instead — it must not tear a connection down if the user could then neither use the tools nor get back.

That mirror has taken five review rounds without converging, each one finding another rule it had failed to copy: the auth-config bounds, the fail-closed handling of an invalid `auth.app_id` stamp, and the ambiguity of `get_app_by_name`'s unordered `.first()` when two apps share a display name. The durable fix is for upstream to expose the check rather than have consumers re-derive it, so once this lands the downstream gate calls it directly and deletes its mirror.

## What

`explain_mcp_oauth_reconnect_refusal(db, app_id, user_id) -> str | None` in `mcp_apps.py`. `None` means the deterministic gates all pass; otherwise it returns one of the stable `MCP_OAUTH_RECONNECT_REFUSAL_*` codes.

**`connect_mcp_oauth_app` calls it itself, before it provisions anything.** This is the part that makes it a single source of truth rather than a second copy that goes stale — the same pattern, and for the same stated reason, as `classify_app_auth`. Each refusal is re-raised as exactly the status and detail the route's own gate produced, so this changes *when* a caller is refused, never *what they see*.

Refusals collected: missing or hidden catalog app, a non-`mcp_oauth` auth type, transport/url drift on an existing shared row, a user-owned row squatting the catalog id, a catalog transport or url `MCPServerConfig` would reject, and the statically decidable auth bounds (`client_id`/`redirect_uri` length, `token_endpoint_auth_method` length and allowlist).

Out of scope on purpose, because they are not statically decidable: the `issuer` and `resource` bounds, whose values come from runtime discovery against the remote server, and `token_endpoint_auth_method` on the Dynamic Client Registration branch, where it comes from the registered client rather than the catalog row. Over-mirroring is a bug too — a test pins that the DCR branch is *not* checked.

## Second benefit: a one-way door closes

`connect_mcp_oauth_app` committed the shared server row and the user's association *first*, and only then called `connect_mcp_oauth`, which is where the auth-config bounds are enforced. A mis-authored catalog entry therefore produced a connector that disconnected cleanly but whose every reconnect attempt created an association and then 400'd — the exact "no tools and no way back" state the downstream gate exists to prevent. Pre-flighting the same checks fixes the ordering as a side effect.

## Notes

`MCP_OAUTH_TOKEN_ENDPOINT_AUTH_METHODS` moves from `api/mcp.py` to `services/mcp_oauth.py`, beside the length bound it pairs with, so both call sites test one allowlist. It is still importable from `api/mcp.py`.

`user_id` is in the signature although no refusal reads it today — every gate the route applies before the redirect happens to be user-independent, including the owned-row check, which rejects a row *any* user owns (a test pins that the owner gets no pass, verified against the route's own 409). Asking per user is the honest contract, and it means a future user-scoped gate lands here instead of changing every consumer's signature.

## Testing

25 tests in `tests/web/api/test_mcp_oauth_reconnect_validator.py`. Every refusal is asserted twice — the predicted code *and* the route refusing the same way — plus an accepting case that reaches the authorization redirect, so a validator that refused unconditionally could not pass.

Two tests pin the wiring itself rather than an agreeing outcome, since two implementations agreeing is also what a duplicated rule set looks like right before it drifts:
- the route is forced to see a refusal it could not have derived from a well-formed app, proving it reads the shared function;
- a mis-authored auth config leaves **no** `UserMCPServer` row and no server row, with discovery stubbed so a surviving association could not be blamed on an unreachable network.

All 15 mutants of the validation branches were verified to turn the corresponding test red — including two the first pass caught as ineffective: an overlong `token_endpoint_auth_method` is necessarily also outside the allowlist, so that case now widens the allowlist to isolate the length bound and pin its ordering; and the non-string-url case fails if the value is coerced to `str` before the schema sees it.

Related suites (`test_mcp_oauth_flow`, `test_mcp_apps_connect`, `test_mcp_apps_attachability`, `test_mcp_apps_catalog_dedupe`, `test_mcp_apps_team_visibility`) pass unchanged: 198 total. `ruff check`, `ruff format --check`, `mypy` and `codespell` clean on the changed files.
