### PR TITLE
feat(v1): replay known steps on mid-run attach and stage live frames until handoff

### DIFF
--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -2792,8 +2792,13 @@ async def _generate(
         # single end event can only close the second, later id. That step
         # is left stuck at ``status="running"`` for the rest of the
         # connection -- the same symptom this warm-up replay exists to
-        # eliminate, reintroduced in this one residual window. A task
-        # deleted in the gap
+        # eliminate, reintroduced in this one residual window.
+        # Tracked as #1776: removing this window needs the broadcast
+        # producer to carry the originating trace event's persisted
+        # identity onto live frames, which is a change in
+        # ``api/websocket.py`` and visible to every consumer of that
+        # broadcast, not just this stream.
+        # A task deleted in the gap
         # between attach and this read closes the stream the same way
         # the watchdog would for the same race, instead of raising out of
         # the generator. Any other failure here -- a transient DB error,

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -2576,12 +2576,13 @@ def _build_warm_up_frames(
 
       - The byte budget keeps a *prefix* of the count-capped window (see
         ``_snapshot_steps_within_wire_budget``), so a window too heavy
-        for the budget loses its newest steps, not its oldest. Nothing
-        about those steps is lost to the client's live view: the
-        projector below is warmed from the *whole* history regardless of
-        what this batch admitted, so a still-running step trimmed here
-        still pairs correctly and still gets its ``step.completed``
-        live.
+        for the budget loses its newest steps, not its oldest. The
+        projector below is still warmed from the *whole* history
+        regardless of what this batch admitted, so a still-running step
+        trimmed here still gets its ``step.completed`` live -- but this
+        stream never sent that step's ``step.started``, so on this
+        stream that end arrives with no start to pair with. See the
+        endpoint's fifth best-effort delivery reason in ``tasks.py``.
       - The budget cutting the batch to zero steps is a legal outcome,
         not an error: the stream simply goes live with no replay. There
         is no marker frame for it and no ``stream.error``. Which steps a

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -2544,16 +2544,8 @@ def _event_row_id(event: Any) -> int:
     exposed to clients as part of a public step's derived id) --
     ``id`` is ``TraceEvent.id``, the same column
     ``_load_task_steps_version_snapshot``'s ``SELECT max(...)`` reads.
-    Duck-typed the same way ``_step_mapping.py``'s own accessors are,
-    so this works against both a real ``_TraceEventSnapshot`` (attribute
-    access) and a dict-shaped test double (mapping access).
     """
-    value = getattr(event, "id", None)
-    if value is None and isinstance(event, dict):
-        value = event.get("id")
-    if value is None:
-        raise TypeError(f"event has no 'id' to filter by: {event!r}")
-    return int(value)
+    return int(event.id)
 
 
 def _build_warm_up_frames(
@@ -2943,7 +2935,7 @@ async def _generate(
                 # queue, same as it always did. See ``enqueue_close`` and
                 # ``abortive_close`` for which reasons set it.
                 for frame_text in warm_up_frames:
-                    if sink.closing and sink.abortive_close:
+                    if sink.abortive_close:
                         break
                     if monotonic() >= deadline:
                         # No close of our own needed here: the main loop

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -13,24 +13,32 @@ client without polling. Four more events are lifecycle-only and
 carry no step/message content of their own -- ``task.status``,
 ``task.completed``, ``task.input_required``, and ``stream.error``.
 
-Each connection gets its own projector, and that projector is fed only
-the frames broadcast after the connection registered. A step that was
-already running at that moment therefore has no matching start in it,
-so the step's eventual end event folds in as an orphan and is dropped:
-that step never appears on this stream at all, since its start was
-broadcast before this connection existed.
-Clients attaching mid-task reconcile against
-``GET /v1/chat/tasks/{task_id}/steps``, which reads the database and
-so is unaffected by when the stream was opened. The two attach-time
-fast paths are the exception to all of this: an attach that finds the
-task already terminal, or already waiting on user input, closes without
-ever registering a projector, and sends a bounded one-shot snapshot of
-the task's steps between ``task.status`` and its conclusion frame (see
-``_fast_path_step_snapshot``) instead of projecting anything live.
+Attaching mid-task -- after a step has already started -- doesn't drop
+that step's eventual end event: ``_generate`` replays trace history into
+a fresh projector before entering its main loop, yields the resulting
+steps directly (same as the initial ``task.status`` frame), then hands
+that pre-warmed projector to the sink (``V1EventStreamSink.finish_warm_up``).
+Anything broadcast between registration and that hand-off is staged,
+not fed to an empty projector, and replayed through the warm one in
+arrival order once it's ready -- see ``V1EventStreamSink._warm`` /
+``_staged_messages`` for why an empty projector would otherwise fold a
+step's end event in as an orphan and silently drop it. That replay is
+bounded (``REPLAY_MAX_STEPS`` steps and ``MAX_SNAPSHOT_WIRE_BYTES`` of
+serialized frames, see ``_build_warm_up_frames``), so a client that
+needs a task's complete history reconciles against
+``GET /v1/chat/tasks/{task_id}/steps``, which reads the database and so
+is unaffected by when the stream was opened or by what this stream's
+bounds admitted. The two attach-time fast paths are the exception to
+all of this: an attach that finds the task already terminal, or already
+waiting on user input, closes without ever registering a projector, and
+sends a bounded one-shot snapshot of the task's steps between
+``task.status`` and its conclusion frame (see
+``_fast_path_step_snapshot``) instead of replaying or projecting
+anything live.
 
 No ``task.status`` frame is
 ever guaranteed to be fresh or in order, at any point in the stream's
-life: ``ConnectionManager.broadcast_to_task``
+life, independent of the above: ``ConnectionManager.broadcast_to_task``
 stamps each event with whatever ``run_id`` / ``state_version`` tuple
 its producer captured, falling back to a fresh read of the task row
 (status included) when the producer didn't capture one, and this sink
@@ -86,18 +94,36 @@ values it deliberately leaves unbounded, in one place:
     inside ordinary backlog territory, so 4 MiB is the tightest value
     that leaves ordinary traffic alone -- against the ~16 MiB a full
     element-capped queue of maximum frames would otherwise hold.
-  - One attach-time fast-path step snapshot: ``REPLAY_MAX_STEPS`` (512
-    steps) *and* ``MAX_SNAPSHOT_WIRE_BYTES`` (4 MiB of serialized frame
-    text). Whichever binds first cuts the snapshot short: the step cap
-    binds on a long history of ordinary steps, the byte budget on a
-    short history of large ones -- 512 steps each carrying a ``data``
-    sub-object right at the 64 KiB cap is ~32 MiB generated into one
-    response, and these paths are exempt from the concurrency caps
-    below, so nothing else bounds how many such responses run at once.
-    The step cap keeps the most recent steps (in ``started_at`` order);
-    the byte budget then admits that window from its oldest end, so the
-    snapshot stays a contiguous run in wire order. Either way the
-    conclusion frame (``task.completed`` / ``task.input_required``)
+  - One sink's warm-up staging buffer
+    (``V1EventStreamSink._staged_messages``, held only between
+    registration and ``finish_warm_up`` draining it): ``OUTBOUND_QUEUE_MAX_SIZE``
+    (256 messages -- the same count cap the outbound queue above reuses)
+    *and* ``STAGED_MESSAGES_MAX_TEXT_CHARS`` (4 MiB, summed across staged
+    messages). Overflowing either closes the connection for
+    ``resync_required`` the same way the outbound queue's own overflow
+    does. Sized off the same 4 MiB factor as the queue's byte budget and
+    the snapshot budget below, but counted on a different unit: this
+    total is the *raw* broadcast text a staged message arrived in, before
+    projection, not serialized wire bytes -- a staged message is not a
+    frame yet.
+  - One attach-time batch of steps -- the two fast-path snapshots
+    (``_fast_path_step_snapshot``) and the normal streaming path's
+    warm-up replay (``_build_warm_up_frames``) alike:
+    ``REPLAY_MAX_STEPS`` (512 steps) *and* ``MAX_SNAPSHOT_WIRE_BYTES``
+    (4 MiB of serialized frame text), the same two caps applied through
+    the same ``_snapshot_steps_within_wire_budget`` in all three places.
+    The two are applied in series, step cap first: the step cap binds
+    on a long history of ordinary steps, the byte budget (applied to
+    that already-capped window) on a short history of large ones -- 512
+    steps each carrying a ``data`` sub-object right
+    at the 64 KiB cap is ~32 MiB generated into one response, and these
+    paths are exempt from the concurrency caps below, so nothing else
+    bounds how many such responses run at once. The step cap keeps the
+    most recent steps (in ``started_at`` order); the byte budget then
+    admits that window from its oldest end, so the batch stays a
+    contiguous run in wire order. The two fast paths and the warm-up
+    replay part ways on how a cut batch is reported, though: the fast
+    paths' conclusion frame (``task.completed`` / ``task.input_required``)
     carries ``snapshot_truncated`` (``true``) and ``snapshot_total_steps``
     (the task's full public step count), so the client can tell a bounded
     snapshot from a complete one and knows how much of it is missing --
@@ -105,15 +131,33 @@ values it deliberately leaves unbounded, in one place:
     carries it, not a ``step.*`` frame, because the conclusion is the one
     frame every exit of these paths emits: a snapshot the byte budget cut
     to zero steps still has to be reportable, and a ``step.*`` frame that
-    does not exist cannot report it. ``MAX_SNAPSHOT_WIRE_BYTES`` measures
-    only the step frames' own wire bytes -- the marker riding the
-    conclusion is not part of what it bounds. These bound how much one
-    response may hold, not how much backlog may accumulate: the fast
-    paths ``yield`` their frames straight from the generator, so no sink
-    and no outbound queue exist
-    on those paths and neither queue bound above applies to them. Each
-    of those frames is still subject to the 64 KiB per-step ``data``
-    cap, which is applied per frame wherever the frame is built.
+    does not exist cannot report it. The warm-up replay has no conclusion
+    frame at attach time to carry an equivalent marker, and reports
+    nothing: its bounds are part of the endpoint's documented contract
+    instead of a per-attach signal, with ``GET .../steps`` as the
+    client's reconciliation path either way. ``MAX_SNAPSHOT_WIRE_BYTES``
+    measures only the step frames' own wire bytes -- the marker riding
+    the fast paths' conclusion is not part of what it bounds. These bound
+    how much one response may hold, not how much backlog may accumulate:
+    the fast paths ``yield`` their frames straight from the generator, so
+    no sink and no outbound queue exist on those paths and neither queue
+    bound above applies to them; the warm-up replay yields its frames the
+    same way, before the sink starts feeding live frames from its own
+    queue. Each of those frames is still subject to the 64 KiB per-step
+    ``data`` cap, which is applied per frame wherever the frame is built.
+    Deliberately uncapped: the *read* that feeds the warm-up replay
+    (``TaskStepsReader`` / ``tasks.py``'s ``_load_task_steps_snapshot``)
+    is a plain ``.all()`` over every one of the task's trace rows, no
+    ``LIMIT`` -- the same unbounded read ``GET .../steps`` itself does.
+    ``REPLAY_MAX_STEPS`` / ``MAX_SNAPSHOT_WIRE_BYTES`` bound only the
+    batch of already-folded steps this endpoint *sends*, after that full
+    read and fold have already happened; they do not bound how many rows
+    get read or folded to produce it. This read also bypasses the
+    fast paths' ``max_event_id``-keyed cache on purpose, not as an
+    oversight: the cache holds already-folded ``PublicStep`` objects,
+    while the warm-up replay needs the raw trace rows themselves to
+    build a projector that keeps folding live events afterward (see
+    ``TaskStepsReader``'s own comment above for the same distinction).
   - Concurrent streams: ``PER_TASK_STREAM_CAP`` (2) and
     ``PER_PRINCIPAL_STREAM_CAP`` (32), both rejected with 429 at
     attach, before any sink exists.
@@ -248,25 +292,51 @@ MAX_QUEUED_WIRE_BYTES = 64 * MAX_FRAME_CONTENT_BYTES
 # delay the completion signal to the watchdog's next cycle instead of
 # firing it immediately.
 MAX_RAW_FRAME_TEXT_CHARS = 4 * MAX_FRAME_CONTENT_BYTES
-# Upper bound on how many steps either attach-time fast path
-# (already-terminal / already-waiting-for-user) puts on the wire in its
-# one-shot response. Those paths emit their whole step snapshot in a
-# single burst and then close, so they have no admission / deadline /
-# heartbeat loop and no per-attach outbound queue of their own to
-# otherwise bound how much one response can hold. Exceeding it keeps
-# only the most recent ``REPLAY_MAX_STEPS`` steps (in ``started_at``
-# order, same as everywhere else) and marks the response's conclusion
-# frame as truncated -- see ``_fast_path_step_snapshot``. Bounds the
-# count only; ``MAX_SNAPSHOT_WIRE_BYTES`` below bounds the size.
+# Cumulative cap on the text length of every message held in
+# ``V1EventStreamSink._staged_messages`` at once, on top of that list's
+# existing count cap (``OUTBOUND_QUEUE_MAX_SIZE``). The staging buffer is
+# the warm-up window's analogue of the outbound queue -- both hold one
+# connection's frames while something else is busy -- so it is sized from
+# the same factor as ``MAX_QUEUED_WIRE_BYTES`` and
+# ``MAX_SNAPSHOT_WIRE_BYTES`` below, and carries the same magnitude:
+# giving one connection a 4 MiB queue budget and a larger staging budget
+# would be two different answers to the same question. The unit differs
+# and that is deliberate -- this counts the *raw* broadcast text a staged
+# message arrived in, before projection, because a staged message is not
+# a frame yet, whereas the other two count wire bytes. Without this,
+# worst case under the raw pre-check alone is ``OUTBOUND_QUEUE_MAX_SIZE``
+# staged messages each just under ``MAX_RAW_FRAME_TEXT_CHARS``, so a
+# warm-up window full of near-cap (rather than over-cap) staged frames
+# could hold far more than the connection's own queue ever may.
+STAGED_MESSAGES_MAX_TEXT_CHARS = 64 * MAX_FRAME_CONTENT_BYTES
+# Upper bound on how many steps one attach puts on the wire in a single
+# burst, shared by the three producers that emit a batch of steps with
+# no pacing of their own: the two attach-time fast paths
+# (already-terminal / already-waiting-for-user), which emit their whole
+# step snapshot and then close, and the normal streaming path's warm-up
+# replay (``_build_warm_up_frames``), which emits the task's known steps
+# before going live. None of them passes through the admission /
+# deadline / heartbeat loop or the per-attach outbound queue that bounds
+# everything else this module sends. Exceeding it keeps only the most
+# recent ``REPLAY_MAX_STEPS`` steps (in ``started_at`` order, same as
+# everywhere else). Bounds the count only; ``MAX_SNAPSHOT_WIRE_BYTES``
+# below bounds the size. The fast paths report a cut snapshot on their
+# conclusion frame (see ``_snapshot_marker_fields``); the replay path has
+# no conclusion frame at attach time and reports nothing -- its bounds
+# are part of the endpoint's documented contract instead, with
+# ``GET .../steps`` as the client's reconciliation path.
 REPLAY_MAX_STEPS = 512
-# The attach-time snapshot's second bound, on the total wire bytes one
-# response may hold rather than on its step count -- the fast paths'
+# The second bound on one attach's batch of steps, on the total wire
+# bytes it may hold rather than on its step count -- the batch paths'
 # analogue of the queue's ``MAX_QUEUED_WIRE_BYTES``, sized the same way
-# and measured the same way. Why this value, and why the step-count cap
-# alone leaves the response unbounded, is argued once in the module
-# docstring's size-bounds section, not repeated here. Strictly over the
-# budget stops the snapshot, exactly on it does not -- the same boundary
-# rule the queue budget and ``MAX_RAW_FRAME_TEXT_CHARS`` use.
+# and measured the same way. Applied by
+# ``_snapshot_steps_within_wire_budget``, which both the fast paths and
+# the warm-up replay call so the two share one rule rather than each
+# bounding itself. Why this value, and why the step-count cap alone
+# leaves a batch unbounded, is argued once in the module docstring's
+# size-bounds section, not repeated here. Strictly over the budget stops
+# the batch, exactly on it does not -- the same boundary rule the queue
+# budget and ``MAX_RAW_FRAME_TEXT_CHARS`` use.
 MAX_SNAPSHOT_WIRE_BYTES = 64 * MAX_FRAME_CONTENT_BYTES
 # Floor for the final wait when the 1-hour deadline is close: keeps the
 # queue wait from being called with a near-zero timeout, which would spin
@@ -315,6 +385,17 @@ def _stream_close_reason(status: TaskStatus, control_state: str | None) -> str |
 # -- never called directly.
 TaskSnapshotReader = Callable[[int, "ApiKeyPrincipal"], Any]
 
+# A sync callable: (task_id, principal) -> ``_TaskStepsSnapshot``-shaped
+# object (duck-typed: ``.events``, an ordered sequence of
+# ``_TraceEventSnapshot``-shaped rows, oldest first -- exactly what
+# ``PublicStepProjector.from_history`` expects), raising the same
+# ``V1ApiError(TASK_NOT_FOUND, 404)`` on a deleted/unowned task. This is
+# an *uncached*, full read -- unlike ``TaskStepsResponseReader`` below,
+# the normal streaming path needs raw trace rows to build a projector
+# that keeps folding live events afterward, not an already-finalized
+# step list. Always run through ``run_db_io_cancellation_safe``.
+TaskStepsReader = Callable[[int, "ApiKeyPrincipal"], Any]
+
 # A sync callable: (task_id, principal) -> ``StepsResponse``-shaped
 # object (duck-typed: ``.steps``, a list of already-validated
 # ``PublicStep``), backed by the *same cache* the polling
@@ -331,12 +412,29 @@ TaskStepsResponseReader = Callable[[int, "ApiKeyPrincipal"], Any]
 # shaped object (duck-typed: ``.task_id`` / ``.agent_id`` /
 # ``.max_event_id``) -- the same cheap ``max(TraceEvent.id)`` read
 # ``tasks.py``'s ``_load_task_steps_version_snapshot`` runs for the
-# ``GET .../steps`` cache key. Distinct from ``TaskSnapshotReader``
-# because the two readers return different shapes: this one carries
-# ``max_event_id``, not ``run_id``/``state_version``. Used only by the
-# attach-time fast paths' steps-cursor fence (see
-# ``_fast_path_steps_cursor_changed``) to catch a trace row landing
-# between the steps read and the fence's recheck.
+# ``GET .../steps`` cache key, raising ``V1ApiError(TASK_NOT_FOUND, 404)``
+# on a deleted/unowned task. Distinct from ``TaskSnapshotReader`` because
+# the two readers return different shapes: this one carries
+# ``max_event_id``, not ``run_id``/``state_version``. Two consumers, both
+# needing that cursor and nothing else:
+#
+#   - the attach-time fast paths' steps-cursor fence (see
+#     ``_fast_path_steps_cursor_changed``), to catch a trace row landing
+#     between the steps read and the fence's recheck;
+#   - the normal streaming path, read once per attach immediately after
+#     ``register_connection``, to bound the warm-up replay to events
+#     committed at or before that point (see ``_generate``'s
+#     ``replay_watermark`` and ``_build_warm_up_frames``).
+#
+# The second is a distinct read from ``TaskStepsReader`` above because it
+# only needs ``SELECT max(TraceEvent.id)``, not the full row set, and has
+# to run as close to registration as possible rather than being folded
+# into the (potentially much slower) full trace read. Required, not
+# optional, at both public entry points (``build_event_stream_response``
+# and ``_generate``): without a cursor there is no bound on which rows
+# the replay folds in, and an attach that silently replayed the whole
+# history would contradict this module's own rule that a *failed*
+# watermark read closes the stream rather than replaying unbounded.
 TaskStepsVersionReader = Callable[[int, "ApiKeyPrincipal"], Any]
 
 # A callable of one argument -- ``snapshot_total_steps`` -- returning the
@@ -482,10 +580,10 @@ def error_frame(code: str, *, message: str | None = None) -> str:
 
 # The broadcast ``type`` values that can ever produce a content frame --
 # shared between ``project_content_frames``'s own dispatch and the sink's
-# live routing decision (``send_text``) so the two can't drift: the set
-# ``send_text`` hands to the projector must be exactly the set this
-# dispatch acts on, or a type present in one but absent from the other
-# silently drops content on one side.
+# warm-up staging decision (``send_text``) so the two can't drift: a
+# frame type staging would hold onto during warm-up must be exactly the
+# set this dispatch actually acts on, or a type absent from one but
+# present in the other silently drops content on one side.
 _CONTENT_FRAME_TYPES = ("trace_event", "final_answer_delta", "final_answer_end")
 
 
@@ -669,6 +767,15 @@ def _snapshot_marker_fields(snapshot_total_steps: int | None) -> dict[str, Any]:
     every exit of these paths emits -- a snapshot the byte budget cut to
     zero steps still has to be reportable, and a ``step.*`` frame that
     does not exist cannot report it.
+
+    Scoped to the two attach-time fast paths, and only they call it. The
+    normal streaming path's warm-up replay is bounded by the same two
+    caps but emits no marker at all: it has no conclusion frame at attach
+    time to carry one, and hanging the marker on the first replayed
+    ``step.*`` frame instead would put it on a frame that a replay cut to
+    zero steps never emits -- reporting the mild case and staying silent
+    on the severe one. Its bounds are documented on the endpoint instead,
+    with ``GET .../steps`` as the reconciliation path.
     """
     if snapshot_total_steps is None:
         return {}
@@ -709,15 +816,18 @@ def _step_wire_frame(step: "PublicStep") -> str:
     event name from its status.
 
     This is the only place step content is normalized for this stream.
-    Both producers route through here -- live folding
-    (``_step_content_frame``, below) and the attach-time fast paths'
-    cached snapshot (``_fast_path_step_snapshot``, consumed frame-by-frame
-    in each fast path's own yield loop) -- so there is one
-    ``model_dump(mode="json")`` call site, one size cap, and one status ->
-    event-name rule, rather than a copy per producer that could drift
-    apart. Taking the model rather than an already-dumped dict is what
-    makes that structural: a caller cannot supply un-normalized values
-    without going around the type.
+    Three producers route through here -- live folding
+    (``_step_content_frame``, below), the attach-time fast paths' cached
+    snapshot (``_fast_path_step_snapshot``, consumed frame-by-frame in
+    each fast path's own yield loop), and the normal streaming path's
+    warm-up replay (``_build_warm_up_frames``, which serializes its
+    admitted steps with this function directly, having already validated
+    them to ``PublicStep`` so the shared byte budget could measure them)
+    -- so there is one ``model_dump(mode="json")`` call site, one size
+    cap, and one status -> event-name rule, rather than a copy per
+    producer that could drift apart. Taking the model rather than an
+    already-dumped dict is what makes that structural: a caller cannot
+    supply un-normalized values without going around the type.
     """
     public_step_json = step.model_dump(mode="json")
     capped = {**public_step_json, "data": _capped_step_data(public_step_json["data"])}
@@ -742,9 +852,10 @@ def _step_content_frame(step: dict[str, Any]) -> str:
     same public step-type list, zero second copy of either. The JSON
     coercion that goes with it (``started_at``/``completed_at`` in
     particular) happens one level down, in ``_step_wire_frame``, which
-    both producers of step content share; this function's own job is
+    every producer of step content shares; this function's own job is
     the raw-dict-to-model validation that only the live path needs,
-    because the fast paths read ``PublicStep`` objects already.
+    because the fast paths read ``PublicStep`` objects already and the
+    warm-up replay validates its own batch up front.
     """
     return _step_wire_frame(PublicStep(**step))
 
@@ -795,14 +906,15 @@ def _feed_trace_event(
     token-by-token via ``message.delta``/``message.completed`` -- is
     deliberately NOT filtered here: it folds into a ``message`` step
     the same way any other ``ai_message`` does, exactly matching what
-    ``steps()`` already shows for the same persisted row. A client that
-    already rendered the delta/completed sequence sees this step as a
-    duplicate of content it has, not as new information -- duplication,
-    not loss, is the accepted trade-off. The alternative -- dropping it
-    here -- has no persisted counterpart: ``steps()`` surfaces this same
-    row as a ``message`` step regardless, so filtering it only on the
-    live path would make the stream disagree with ``steps()`` about
-    whether the step exists.
+    ``steps()`` and warm-up replay already show for the same persisted
+    row. A client that already rendered the delta/completed sequence
+    sees this step as a duplicate of content it has, not as new
+    information -- duplication, not loss, is the accepted trade-off.
+    The alternative -- dropping it on the live path -- has no persisted
+    counterpart: ``steps()`` and a fresh attach's warm-up replay both
+    surface this same row as a ``message`` step regardless, so filtering
+    it only here would make an already-running attach disagree with
+    those two about whether the step exists.
     """
     data = message.get("data")
     if not isinstance(data, dict):
@@ -994,24 +1106,63 @@ class V1EventStreamSink:
             maxsize=OUTBOUND_QUEUE_MAX_SIZE
         )
         self._closing = False
+        # Set by ``enqueue_close(abortive=True)``. Distinguishes *why* the
+        # sink is closing for callers that must react before the close
+        # frame itself is dequeued -- right now that's exactly one place,
+        # ``_generate``'s warm-up replay loop (see its own comment): a
+        # revoked key or a deleted task must stop that loop from handing
+        # out any more history, while every other close reason (a normal
+        # terminal/input-required conclusion, a resync signal) is exactly
+        # the case that loop exists to finish serving first. See
+        # ``enqueue_close`` for which reasons set this.
+        self._abortive_close = False
         self._last_status = initial_status
         # One incremental folding state machine per connection (never
         # shared across sinks -- see ``PublicStepProjector``'s own
-        # preconditions). Starts empty, and every content-bearing frame
-        # broadcast from then on is fed straight into it by ``send_text``.
-        # Because it starts empty, a step already running at attach time
-        # has no matching start here, so that step's end event folds in
-        # as an orphan and is dropped -- see the module docstring.
-        # ``retain_finished=False``: this sink acts on each ``feed()``
-        # result immediately (``_step_content_frame`` serializes it on
-        # the spot) and never calls ``materialized_steps()``, so
-        # retaining every finalized step would hold each one's
-        # untruncated ``data`` -- tool args and results, delegation
-        # input/output, message content -- for as long as the connection
-        # lives (up to ``STREAM_MAX_DURATION_SECONDS``) in a list nothing
-        # on this path reads. The pending table the pairing rules need is
-        # kept either way.
+        # preconditions). Starts empty and *unwarmed*: nothing is fed
+        # into it directly until ``finish_warm_up`` swaps in a projector
+        # pre-warmed by replaying trace history (wired in ``_generate``).
+        # Content-bearing frames that arrive before that point are
+        # staged, not fed -- see ``_warm`` / ``_staged_messages`` below.
+        # ``retain_finished=False`` on both this placeholder and the
+        # warmed replacement (``finish_warm_up`` requires it of what it
+        # is handed): this sink acts on each ``feed()`` result
+        # immediately (``_step_content_frame`` serializes it on the spot)
+        # and never calls ``materialized_steps()``, so retaining every
+        # finalized step would hold each one's untruncated ``data`` --
+        # tool args and results, delegation input/output, message content
+        # -- for as long as the connection lives (up to
+        # ``STREAM_MAX_DURATION_SECONDS``) in a list nothing on this path
+        # reads. The pending table the pairing rules need is kept either
+        # way.
         self._projector = PublicStepProjector(retain_finished=False)
+        # Becomes True exactly once, when ``finish_warm_up`` runs. While
+        # False, ``send_text`` diverts every content-bearing frame (see
+        # ``_CONTENT_FRAME_TYPES``) into ``_staged_messages`` instead of
+        # feeding ``_projector`` directly -- feeding a live *end* event
+        # into a projector that hasn't seen the matching *start* (because
+        # that start is only in trace history, not yet replayed) would
+        # fold it in as a plain orphan end and silently drop that
+        # step.completed for this stream. Lifecycle handling elsewhere in
+        # ``send_text`` (task.status, the completion hint) doesn't use
+        # the projector at all and runs unconditionally regardless of
+        # this flag.
+        self._warm = False
+        # Raw broadcast dicts held during the unwarmed window above, in
+        # arrival order, until ``finish_warm_up`` drains them through the
+        # projector it just warmed. Bounded the same way the outbound
+        # queue is bounded, and for the same reason: an attach can't be
+        # allowed to accumulate unbounded memory for a slow warm-up read
+        # under a burst of live traffic. Reuses ``_put_or_overflow``'s
+        # overflow policy (``resync_required`` then close) rather than a
+        # second one -- see ``_stage_content_message``.
+        self._staged_messages: list[dict[str, Any]] = []
+        # Cumulative text length (``len(text)``, the same O(1) proxy the
+        # raw-frame pre-check in ``send_text`` uses) of everything
+        # currently in ``_staged_messages``, kept in lockstep with that
+        # list rather than recomputed by re-serializing it -- see
+        # ``STAGED_MESSAGES_MAX_TEXT_CHARS``.
+        self._staged_text_chars = 0
         # Recorded at construction time (always inside the endpoint's own
         # request coroutine) so later state-mutating calls -- however they
         # got here -- can be asserted to run on the same loop.
@@ -1038,6 +1189,26 @@ class V1EventStreamSink:
         """Total wire bytes of the frames currently queued."""
         return self._queued_bytes
 
+    @property
+    def warm(self) -> bool:
+        return self._warm
+
+    @property
+    def abortive_close(self) -> bool:
+        """True once any ``enqueue_close(..., abortive=True)`` has run,
+        including one that arrived after a non-abortive close had
+        already claimed the close frame. This is a data-suppression
+        switch, not a record of which caller won: a close that lost
+        that race still revoked the client's standing to see the rest
+        of the buffered history. Meaningless (always False) while
+        ``closing`` is itself False -- check both, not this alone; see
+        ``enqueue_close``."""
+        return self._abortive_close
+
+    @property
+    def staged_message_count(self) -> int:
+        return len(self._staged_messages)
+
     def _assert_owner_loop(self) -> None:
         if asyncio.get_running_loop() is not self._owner_loop:
             raise RuntimeError("v1 SSE sink touched from a foreign event loop")
@@ -1050,7 +1221,7 @@ class V1EventStreamSink:
         self._last_status = status
         self._put_or_overflow(status_frame(status))
 
-    def enqueue_close(self, frame_text: str) -> bool:
+    def enqueue_close(self, frame_text: str, *, abortive: bool = False) -> bool:
         """Close exactly once; the first caller wins.
 
         Drains any queued backlog before inserting the close frame so
@@ -1059,8 +1230,33 @@ class V1EventStreamSink:
         intentional: every close reason tells the client to resync
         (``steps()`` + re-attach) rather than trust the tail of the
         stream.
+
+        ``abortive`` (default False) records *why* on ``abortive_close``,
+        for the one caller that needs to react before this close frame
+        is even dequeued -- ``_generate``'s warm-up replay loop, which
+        checks it between each already-built history frame it yields.
+        An abortive close means the client has lost the right to see
+        *any* further data, including history that predates the close:
+        today that's the watchdog's ``unauthorized`` (key
+        revoked/paused) and ``task_deleted`` (row gone) reasons. A
+        non-abortive reason -- a normal terminal/input-required
+        conclusion, ``resync_required``, ``stream_expired`` -- never
+        sets it, so on its own the replay loop keeps handing out the
+        history it already read; those close the stream, but they don't
+        retroactively revoke the client's standing to see what already
+        happened.
+
+        ``abortive`` is latched before the already-closing early return,
+        so an abortive close still suppresses the rest of the replay
+        even when a non-abortive close got here first. Only the close
+        *frame* is first-caller-wins; the revocation is not. A client
+        whose key was revoked mid-replay therefore reads the earlier
+        reason on the wire and re-attaches, and that re-attach is
+        refused at authentication.
         """
         self._assert_owner_loop()
+        if abortive:
+            self._abortive_close = True
         if self._closing:
             return False
         self._closing = True
@@ -1128,6 +1324,101 @@ class V1EventStreamSink:
         except asyncio.QueueFull:
             self.enqueue_close(error_frame("resync_required"))
 
+    def _stage_content_message(self, message: dict[str, Any], text_chars: int) -> None:
+        """Hold one content-bearing broadcast frame's raw dict until
+        ``finish_warm_up`` can feed it through a projector that actually
+        has the pairing state to fold it correctly.
+
+        Deliberately the same cap and the same overflow policy as
+        ``_put_or_overflow`` -- ``OUTBOUND_QUEUE_MAX_SIZE``, then
+        ``resync_required`` -- rather than a second, differently-sized
+        backlog with its own failure mode. In practice this list only
+        ever holds what arrives during one warm-up read plus however
+        many replay frames get yielded afterward, both bounded by how
+        long that takes; hitting the cap here means the same thing
+        hitting it on the outbound queue means -- the client can't keep
+        up (or something is broadcasting far faster than normal) and
+        needs to resync. A second, cumulative bound on top of the count
+        cap: ``text_chars`` (the raw frame's own ``len(text)``, already
+        computed once by ``send_text``'s pre-check -- never
+        re-serialized here) is tracked against
+        ``STAGED_MESSAGES_MAX_TEXT_CHARS`` so a run of large-but-under-
+        the-single-frame-cap messages during a slow warm-up read can't
+        hold unbounded memory just because it stayed under the count
+        cap.
+        """
+        if self._closing:
+            return
+        if (
+            len(self._staged_messages) >= OUTBOUND_QUEUE_MAX_SIZE
+            or self._staged_text_chars + text_chars > STAGED_MESSAGES_MAX_TEXT_CHARS
+        ):
+            self.enqueue_close(
+                error_frame(
+                    "resync_required",
+                    message=(
+                        "The warm-up staging buffer overflowed; call "
+                        "steps() to resync, then re-attach."
+                    ),
+                )
+            )
+            return
+        self._staged_messages.append(message)
+        self._staged_text_chars += text_chars
+
+    def finish_warm_up(self, projector: "PublicStepProjector") -> None:
+        """Switch from staging content-bearing frames to feeding them
+        live, now that ``projector``'s pairing state reflects a full
+        replay of trace history.
+
+        Adopts ``projector`` in place of this sink's original empty one
+        (nothing was ever fed into that one -- see ``_warm``), then
+        drains every frame staged since registration through the exact
+        same classification a live frame gets, in the order it actually
+        arrived, and queues the result. This is what rescues a step
+        whose start event is only in history but whose end event
+        happened to arrive during the warm-up window: replayed here
+        against a projector that already has the start pending, instead
+        of being fed to an empty one and dropped as an orphan end.
+        Called at most once per connection, synchronously, with no
+        ``await`` in between reassigning ``_projector`` and draining --
+        so no frame arriving after this call starts can be staged
+        instead of fed live, and no frame staged before it is missed.
+
+        Each staged message is projected through ``_project_and_queue``,
+        so one bad staged message (a malformed field the projector can't
+        fold) only drops that one frame and bumps ``dropped_frame_count``
+        -- it doesn't abort the rest of the drain or close the stream.
+        Closing the stream over a warm-up failure is reserved for a
+        failure that corrupts the whole replayed baseline instead --
+        the trace-history *read* failing before this method is even
+        called (see the read-failure test), not one staged frame among
+        many failing to project.
+
+        ``projector`` must already have released its finished-step
+        retention (``PublicStepProjector.take_materialized_steps``, which
+        is how ``_build_warm_up_frames`` reads the history out). This
+        sink never calls ``materialized_steps()``, so a retaining
+        projector adopted here would hold every step's untruncated
+        ``data`` for the connection's whole life in a list nothing reads
+        -- the same defect ``retain_finished=False`` exists to prevent,
+        reintroduced through the back door. Asserted rather than
+        documented because the leak is invisible at the call site: the
+        stream behaves correctly either way, it just grows.
+        """
+        self._assert_owner_loop()
+        if projector.retains_finished:
+            raise RuntimeError(
+                "v1 SSE sink was handed a projector that still retains "
+                "finished steps; warm-up must release retention first"
+            )
+        self._projector = projector
+        self._warm = True
+        staged, self._staged_messages = self._staged_messages, []
+        self._staged_text_chars = 0
+        for staged_message in staged:
+            self._project_and_queue(staged_message)
+
     def _project_and_queue(self, message: dict[str, Any]) -> None:
         """Project one content frame and enqueue its output. Never raises --
         a frame that fails to project is dropped and counted, exactly like a
@@ -1168,14 +1459,18 @@ class V1EventStreamSink:
         it -- ``project_content_frames`` returns an empty list for every
         frame shape this method already handles on its own
         (``task_completed``, the versioned lifecycle types, ``task_info``),
-        so the two never fight over the same frame. A content frame is
-        projected and queued via ``_project_and_queue``, which always
-        routes successfully-projected output through ``_put_or_overflow``
-        like any other queued frame -- never a direct
-        ``queue.put_nowait`` -- so it gets the same closed guard and the
-        same overflow-to-``resync_required`` handling status frames
-        already get, on both of the queue's bounds: its element count
-        and its total queued wire bytes.
+        so the two never fight over the same frame. Until this sink is
+        warm (see ``_warm``), a content-bearing frame is staged rather
+        than projected immediately -- ``finish_warm_up`` replays staged
+        frames through the projector it just warmed. Once warm, a live
+        content frame is projected and queued via the same
+        ``_project_and_queue`` helper ``finish_warm_up`` uses for its
+        replay, which always routes successfully-projected output
+        through ``_put_or_overflow`` like any other queued frame --
+        never a direct ``queue.put_nowait`` -- so it gets the same
+        closed guard and the same overflow-to-``resync_required``
+        handling status frames already get, on both of the queue's
+        bounds: its element count and its total queued wire bytes.
 
         The raw-size check itself runs after ``json.loads`` and the
         lifecycle handling above, guarding only the call into
@@ -1269,6 +1564,7 @@ class V1EventStreamSink:
                         self.completion_hint.set()
             if str(message.get("type") or "") in _CONTENT_FRAME_TYPES:
                 frame = message
+                measured_chars = len(text)
                 if message.get("event_type") != "task_info":
                     measured_chars, frame = _measured_content_frame(text, message)
                     if measured_chars > MAX_RAW_FRAME_TEXT_CHARS:
@@ -1282,7 +1578,20 @@ class V1EventStreamSink:
                             self.task_id,
                         )
                         return
-                self._project_and_queue(frame)
+                # The raw-size check runs before the warm/staged split, so
+                # a frame too large to project is dropped whether this
+                # sink is warm or not -- staging an oversized frame would
+                # only defer the same drop to ``finish_warm_up`` while
+                # holding its bytes in the meantime. What gets staged is
+                # the same measured frame the warm path projects, counted
+                # in the same unit the check above used (characters
+                # excluding the task-description stamp), so the staging
+                # budget and the raw-frame cap measure one thing rather
+                # than two.
+                if self._warm:
+                    self._project_and_queue(frame)
+                else:
+                    self._stage_content_message(frame, measured_chars)
         except Exception:
             self.dropped_frame_count += 1
             logger.exception(
@@ -1381,7 +1690,11 @@ async def watchdog_check_once(
         lambda: _is_runtime_key_active(sink.principal_key_prefix)
     )
     if not key_active:
-        return sink.enqueue_close(error_frame("unauthorized"))
+        # Abortive: the key that authorized this attach no longer does,
+        # so any history still queued up for direct replay (see
+        # ``_generate``'s warm-up loop) must stop going out too, not
+        # just future live frames.
+        return sink.enqueue_close(error_frame("unauthorized"), abortive=True)
 
     try:
         snapshot = await run_db_io_cancellation_safe(
@@ -1389,7 +1702,10 @@ async def watchdog_check_once(
         )
     except V1ApiError as exc:
         if exc.code is V1ErrorCode.TASK_NOT_FOUND:
-            return sink.enqueue_close(error_frame("task_deleted"))
+            # Abortive for the same reason: the task row this stream is
+            # replaying history for is gone, so that history shouldn't
+            # keep going out either.
+            return sink.enqueue_close(error_frame("task_deleted"), abortive=True)
         raise
 
     status = snapshot.status
@@ -1498,17 +1814,34 @@ def _snapshot_steps_within_wire_budget(
     A prefix, not a suffix, even though ``REPLAY_MAX_STEPS`` keeps the
     most recent steps: a step whose ``data`` cannot be serialized cannot
     be measured either, and admitting it here is what keeps the emit loop
-    reaching it and reporting it through
-    ``_fast_path_step_serialize_error_frame`` -- with the steps before it
-    already on the wire, which is the behavior
-    ``GET /v1/chat/tasks/{task_id}/events`` documents. Dropping from the
-    oldest end instead would put an unserializable step at the head of
-    the window, where it suppresses every good step behind it, or force
-    the failure to be folded into "snapshot truncated" and never
-    reported. The budget only binds on a window averaging more than 8 KiB
-    per step, and a client whose snapshot was cut is told so by the
-    conclusion frame's ``snapshot_truncated`` and sent to
-    ``GET .../steps`` either way.
+    reaching it. Dropping from the oldest end instead would put an
+    unserializable step at the head of the window, where it suppresses
+    every good step behind it. The budget only binds on a window
+    averaging more than 8 KiB per step.
+
+    The two callers do not fail the same way once an admitted-but-
+    unserializable step is actually reached, and that asymmetry is not
+    this function's concern -- it only decides which steps to admit:
+
+      - On the two attach-time fast paths, the emit loop reaches the bad
+        step with every step before it already on the wire, reports it
+        through ``_fast_path_step_serialize_error_frame``, and a client
+        whose snapshot was cut this way is told so by the conclusion
+        frame's ``snapshot_truncated`` -- the behavior
+        ``GET /v1/chat/tasks/{task_id}/events`` documents. Folding the
+        failure into "snapshot truncated" instead, with no error frame,
+        would silently misreport a serialize failure as an ordinary size
+        cut.
+      - On the normal streaming path's warm-up replay
+        (``_build_warm_up_frames``), there is no per-step emit loop and no
+        conclusion frame to carry a marker: the bad step's serialization
+        raises out of the one call that builds the whole batch, so the
+        entire replayed history for that attach is discarded and the
+        connection closes for resync (see ``_generate``'s handling around
+        its call to ``_build_warm_up_frames``) rather than sending the
+        steps that came before it. There is no marker frame for this
+        either way; a client reconciles against ``GET .../steps``, same
+        as any other bounded or empty replay batch.
     """
     budget_remaining = MAX_SNAPSHOT_WIRE_BYTES
     admitted = 0
@@ -1538,9 +1871,13 @@ async def _fast_path_step_snapshot(
     burst of fast-path attaches on one task collapses into a cache hit
     instead of each one re-reading and re-projecting independently.
 
-    Bounded by two caps, whichever binds first: ``REPLAY_MAX_STEPS``
-    (step count) and ``MAX_SNAPSHOT_WIRE_BYTES`` (serialized size, via
-    ``_snapshot_steps_within_wire_budget``). Without them, a fast-path
+    Bounded by two caps applied in series: ``REPLAY_MAX_STEPS`` (step
+    count) first, then ``MAX_SNAPSHOT_WIRE_BYTES`` (serialized size, via
+    ``_snapshot_steps_within_wire_budget``) over that already-capped
+    window -- the same two caps, in the same order, through the same
+    function, that bound the normal streaming path's warm-up replay
+    (see ``_build_warm_up_frames``).
+    Without them, a fast-path
     attach to a task with an unusually long or heavy step history
     returned every step from this cached list in one shot, with no
     admission / deadline / heartbeat loop to pace it, unlike everything
@@ -1549,12 +1886,14 @@ async def _fast_path_step_snapshot(
     documents (``schemas/v1.py``'s ``StepsResponse``: "Steps are
     returned in monotonic started_at order") and
     ``map_trace_events_to_public_steps`` enforces with an explicit final
-    sort (``_step_mapping.py:640-643``), not a property its projection's
-    own fold order already guarantees on its own -- that sort is exactly
-    why it's needed. ``steps[-REPLAY_MAX_STEPS:]`` keeps the most recent
-    steps and drops the oldest; the byte budget is then applied to that
-    window from its oldest end (see ``_snapshot_steps_within_wire_budget`` for why a
-    prefix, not a suffix, is what it keeps). Returns the validated
+    sort (``_step_mapping.py``'s ``output.sort(key=lambda s:
+    s["started_at"])``, right before it returns), not a property its
+    projection's own fold order already guarantees on its own -- that
+    sort is exactly why it's needed. ``steps[-REPLAY_MAX_STEPS:]`` keeps
+    the most recent steps and drops the oldest; the byte budget is then
+    applied to that window from its oldest end (see
+    ``_snapshot_steps_within_wire_budget`` for why a prefix, not a
+    suffix, is what it keeps). Returns the validated
     ``PublicStep`` objects themselves, not their serialized frame text
     -- serialization happens one frame at a time in each fast path's own
     yield loop below instead, so a large step list is never fully
@@ -1595,15 +1934,15 @@ def _fast_path_steps_read_error_frame(
     ``TaskStepsVersionReader``) after ``build_event_stream_response``
     already resolved it once to pick this fast path -- a task deleted in
     that gap surfaces here as ``V1ApiError(TASK_NOT_FOUND)`` from
-    whichever one ran, same as it does to the watchdog (which already
-    emits ``task_deleted`` for it, not ``resync_required``): the task is
-    gone, not merely unreadable, so ``steps()`` + reattach would just
-    404 instead of resyncing anything. Only that specific shape gets
-    ``task_deleted``; every other failure (a transient DB error, a bug
-    in projection) keeps the existing ``resync_required`` handling and
-    is logged -- ``task_deleted`` isn't logged here for the same reason
-    the watchdog path doesn't log it: a deleted task racing the attach
-    isn't a bug in this stream.
+    whichever one ran, same as it does to the warm-up read and the
+    watchdog (both already emit ``task_deleted`` for it, not
+    ``resync_required``): the task is gone, not merely unreadable, so
+    ``steps()`` + reattach would just 404 instead of resyncing anything.
+    Only that specific shape gets ``task_deleted``; every other failure
+    (a transient DB error, a bug in projection) keeps the existing
+    ``resync_required`` handling and is logged -- ``task_deleted`` isn't
+    logged here for the same reason the warm-up and watchdog paths don't
+    log it: a deleted task racing the attach isn't a bug in this stream.
 
     Must be called from inside the ``except`` block it serves -- the
     ``logger.exception`` call below relies on the caller's still-active
@@ -1853,8 +2192,11 @@ async def _fast_path_snapshot_stream(
 
     ``task.status`` is emitted first, then the steps read runs inside a
     ``try``/``except`` that also covers the cursor baseline capture
-    below -- both reads have to succeed before any step content is trusted,
-    so a failure in either is handled identically. A bare exception here
+    below -- both reads have to succeed before any step content is
+    trusted, so a failure in either is handled identically. That is the
+    same order and the same failure handling ``_generate`` uses around
+    its own warm-up read (see that function's docstring). A bare
+    exception here
     would not produce a different HTTP status: ``StreamingResponse``
     sends the response start (200, headers) before ever pulling a chunk
     from this generator, so letting the read's exception propagate
@@ -2091,6 +2433,117 @@ def _input_required_snapshot_stream(
     )
 
 
+def _event_row_id(event: Any) -> int:
+    """The trace row's numeric primary key, for watermark filtering.
+
+    Distinct from ``event_id`` (the row's own string identifier,
+    exposed to clients as part of a public step's derived id) --
+    ``id`` is ``TraceEvent.id``, the same column
+    ``_load_task_steps_version_snapshot``'s ``SELECT max(...)`` reads.
+    Duck-typed the same way ``_step_mapping.py``'s own accessors are,
+    so this works against both a real ``_TraceEventSnapshot`` (attribute
+    access) and a dict-shaped test double (mapping access).
+    """
+    value = getattr(event, "id", None)
+    if value is None and isinstance(event, dict):
+        value = event.get("id")
+    if value is None:
+        raise TypeError(f"event has no 'id' to filter by: {event!r}")
+    return int(value)
+
+
+def _build_warm_up_frames(
+    task_id: int,
+    principal: "ApiKeyPrincipal",
+    read_task_steps: TaskStepsReader,
+    replay_watermark: int,
+) -> "tuple[PublicStepProjector, list[str]]":
+    """Read trace history and fold + serialize it to SSE frame text, all
+    synchronously, so the whole warm-up read runs in one worker thread
+    (via ``run_db_io_cancellation_safe``). Folding and JSON
+    serialization stay off the event loop together with the DB read:
+    a long trace history projected on the loop would stall every other
+    stream this process is serving, not just this one attach.
+
+    ``replay_watermark`` (see ``TaskStepsVersionReader``, and
+    ``_generate``'s call site) bounds which rows this replay folds in:
+    any row with ``id > replay_watermark`` is excluded here -- it was
+    committed after the watermark was captured, so it's exclusively
+    covered by staging + ``finish_warm_up``'s drain instead. Without
+    this bound, a row committed in the gap between registration and this
+    read would be folded in twice: once here (this read sees it, since
+    it's already committed) and once more via the staged drain (its
+    broadcast reached the still-cold sink in that same gap) -- a
+    duplicate ``step.started``/``step.completed`` for the same step.
+    Required, not optional: an attach with no watermark to bound itself
+    to is exactly the unbounded replay ``_generate`` refuses to fall back
+    to when the watermark read *fails*.
+
+    The materialized steps are sorted by ``started_at`` (stable, so
+    same-timestamp ties keep resolve order) to match ``steps()``'s own
+    ordering -- ``PublicStepProjector``'s own output is in resolve order,
+    which can differ from started_at order when a later-started step
+    finishes first.
+
+    That sorted list is then bounded by the same two caps, applied by the
+    same function, that bound the attach-time fast paths' one-shot
+    snapshot: ``REPLAY_MAX_STEPS`` keeps the most recent steps, and
+    ``_snapshot_steps_within_wire_budget`` then trims that window to
+    ``MAX_SNAPSHOT_WIRE_BYTES`` of serialized frames. Sharing the
+    function is the point -- both paths emit a batch of steps with no
+    pacing of their own, so they get one rule rather than each inventing
+    its own. Two consequences follow from that shared rule and are
+    deliberate:
+
+      - The byte budget keeps a *prefix* of the count-capped window (see
+        ``_snapshot_steps_within_wire_budget``), so a window too heavy
+        for the budget loses its newest steps, not its oldest. Nothing
+        about those steps is lost to the client's live view: the
+        projector below is warmed from the *whole* history regardless of
+        what this batch admitted, so a still-running step trimmed here
+        still pairs correctly and still gets its ``step.completed``
+        live.
+      - The budget cutting the batch to zero steps is a legal outcome,
+        not an error: the stream simply goes live with no replay. There
+        is no marker frame for it and no ``stream.error``. Which steps a
+        replay contains is bounded by contract, and a client that needs
+        the task's full history reconciles against ``GET .../steps`` --
+        see the endpoint docstring in ``tasks.py``.
+
+    Validating to ``PublicStep`` up front is what lets the shared budget
+    measure these steps at all (it takes the model, not a raw dict), and
+    it means the admitted steps are serialized here by ``_step_wire_frame``
+    directly rather than through ``_step_content_frame``'s
+    validate-then-serialize wrapper.
+
+    Serializing each step here rather than deferring it (see
+    ``_step_content_frame``'s own docstring on why that ordering
+    matters in general) is still safe: this projector is exclusively
+    owned by this function's caller at this point -- nothing feeds it
+    live events until ``finish_warm_up`` runs, back on the event loop,
+    strictly after this returns.
+
+    The projector returned here has already released its finished-step
+    retention (``take_materialized_steps``), so the sink that keeps
+    feeding it for the rest of the connection's life does not accumulate
+    a timeline nothing reads -- see ``PublicStepProjector``'s class
+    docstring on the two retention modes.
+    """
+    steps_snapshot = read_task_steps(task_id, principal)
+    events = [
+        event
+        for event in steps_snapshot.events
+        if _event_row_id(event) <= replay_watermark
+    ]
+    warmed_projector = PublicStepProjector.from_history(events)
+    steps = warmed_projector.take_materialized_steps()
+    steps.sort(key=lambda step: step["started_at"])
+    admitted = _snapshot_steps_within_wire_budget(
+        [PublicStep(**step) for step in steps[-REPLAY_MAX_STEPS:]]
+    )
+    return warmed_projector, [_step_wire_frame(step) for step in admitted]
+
+
 async def _generate(
     task_id: int,
     principal: ApiKeyPrincipal,
@@ -2098,6 +2551,8 @@ async def _generate(
     key_prefix: str,
     initial_status: str,
     read_task_snapshot: TaskSnapshotReader,
+    read_task_steps: TaskStepsReader,
+    read_task_steps_version: TaskStepsVersionReader,
     watchdog_interval_seconds: float,
     stream_max_duration_seconds: float,
     heartbeat_interval_seconds: float,
@@ -2121,6 +2576,14 @@ async def _generate(
     ``build_event_stream_response`` (read-only, no mutation) -- so a
     rejected attach still fails before any stream bytes are sent; only
     the actual counter mutation and registration move here.
+
+    ``read_task_steps_version`` is read once right after registration to
+    capture the watermark the warm-up replay bounds itself to (see
+    ``_build_warm_up_frames``). It is required: a failed read of that
+    watermark closes the stream for resync rather than replaying the
+    task's history unbounded, and an absent *reader* would produce that
+    same unbounded replay silently, which is the one outcome this path
+    refuses.
     """
     deadline = monotonic() + stream_max_duration_seconds
     sink = V1EventStreamSink(
@@ -2156,6 +2619,64 @@ async def _generate(
                 key_prefix,
             )
         manager.register_connection(cast(WebSocket, sink), task_id)
+        # Capture the replay watermark as close to registration as this
+        # generator can manage -- see ``TaskStepsVersionReader`` and
+        # ``_build_warm_up_frames``'s docstring for what it bounds and
+        # why. A failure here (a transient DB error, or the task
+        # deleted in the instant after registration) closes the stream
+        # for resync instead of falling back to an unbounded replay.
+        # The watermark is what bounds the warm-up replay's duplicate
+        # window to "registration to this one ``max(id)`` query" (see
+        # ``_build_warm_up_frames``'s docstring); falling back to an
+        # unbounded replay on a failed read removes that bound
+        # entirely, widening the same duplicate window to
+        # "registration to the end of reading the task's entire trace
+        # history" -- worse in proportion to how much history the task
+        # has. ``sink.enqueue_close`` here just queues the frame --
+        # the sink isn't warm yet and nothing has been yielded from
+        # its queue at this point, so the frame is actually delivered
+        # once the ``while True`` loop below reaches it, after the
+        # warm-up build below is skipped. ``replay_watermark`` staying
+        # ``None`` is exactly that skip signal, and the only way it can
+        # stay ``None``: the reader itself is a required argument, so
+        # "no watermark" always means "the read failed", never "nobody
+        # wired one up".
+        replay_watermark: int | None = None
+        try:
+            version_snapshot = await run_db_io_cancellation_safe(
+                lambda: read_task_steps_version(task_id, principal)
+            )
+            # Converted here rather than in an ``else`` clause: a
+            # reader handing back a ``max_event_id`` that is not an
+            # integer is a failed read like any other, and the comment
+            # above promises every failure at this step closes the
+            # stream for resync rather than propagating out of this
+            # generator. In an ``else`` the conversion sits outside
+            # that promise.
+            replay_watermark = int(version_snapshot.max_event_id)
+            # Nothing else in this generator reads ``version_snapshot`` --
+            # the one field it carries is already copied into
+            # ``replay_watermark`` above. Same reasoning as releasing
+            # ``warm_up_frames`` below: don't leave it pinned in this
+            # frame's locals for the rest of a connection that can live
+            # an hour.
+            del version_snapshot
+        except Exception:
+            logger.exception(
+                "v1 SSE replay watermark read failed for task %s; "
+                "closing for resync instead of falling back to an "
+                "unbounded warm-up replay",
+                task_id,
+            )
+            sink.enqueue_close(
+                error_frame(
+                    "resync_required",
+                    message=(
+                        "Reading the replay watermark failed; call "
+                        "steps() to resync, then re-attach."
+                    ),
+                )
+            )
         watchdog_task = asyncio.create_task(
             _watchdog_loop(
                 sink,
@@ -2169,6 +2690,140 @@ async def _generate(
         # closed (``aclose()``, e.g. on client disconnect) while suspended
         # here still has to unregister the sink and cancel the watchdog.
         yield status_frame(initial_status)
+        # Warm-up: replay trace history into a fresh projector, yield its
+        # materialized steps directly (bypassing the outbound queue, same
+        # as the initial status frame above), then hand that projector to
+        # the sink so it starts feeding live frames instead of staging
+        # them. Registration (above) already happened before this read,
+        # so nothing broadcast between then and now is lost -- it's
+        # either already staged (``sink.staged_message_count``) or, for
+        # ``task.status``, already queued (that path doesn't go through
+        # the projector or staging at all). Bounding this replay to
+        # ``replay_watermark`` (captured just above) narrows the window
+        # in which a row can be folded in *twice*: a row committed after
+        # the watermark is excluded from this read and reaches the
+        # client exactly once, through staging + the drain
+        # ``finish_warm_up`` runs below -- without that bound, every row
+        # committed between registration and the end of this read would
+        # be replayed here AND drained from staging, producing a duplicate
+        # ``step.started``/``step.completed``. The residual window is the
+        # gap between registration and the watermark read (one
+        # ``SELECT max(id)``): a row committed inside it is both at or
+        # below the watermark and already staged, so it is delivered
+        # twice. That ordering is deliberate -- reading the watermark
+        # before registering would turn the same gap into a *lost* row
+        # (excluded from replay, broadcast before the sink existed), and
+        # this transport prefers a duplicate over a loss; clients dedupe
+        # by step id for the step families keyed by a persisted execution
+        # id (``tool_call``/``agent_delegation``, and the ``action``/``step``
+        # phases of ``thinking``, keyed by ``tool_call_id``/``step_id`` --
+        # stable across replay and live delivery of the same row). Two
+        # families are not covered by that dedupe, for two different
+        # reasons. A ``message`` step's id is minted fresh per broadcast
+        # (``create_stream_event``'s ``event_id``, a new uuid4 every call --
+        # see this module's docstring and
+        # ``test_known_divergence_message_step_id_differs_between_the_two_paths``),
+        # so a message step delivered twice in this residual window
+        # reaches the client as two differently-id'd steps, not one a
+        # step-id dedup collapses -- but harmlessly, since each copy is
+        # itself a complete, terminal step. The ``planning`` phase of
+        # ``thinking`` (``dag_plan_*``/``dag_execution``, see
+        # ``_step_mapping.py``'s ``feed``) has no persisted-key id at all --
+        # it pairs on an in-memory replan counter -- so a row folded in
+        # twice in this window (once by the replay, once by the staged
+        # drain) advances that counter twice and synthesizes two different
+        # step ids from the one row: the first reaches the client as
+        # ``step.started`` and is never finalized, because the row's
+        # single end event can only close the second, later id. That step
+        # is left stuck at ``status="running"`` for the rest of the
+        # connection -- the same symptom this warm-up replay exists to
+        # eliminate, reintroduced in this one residual window. A task
+        # deleted in the gap
+        # between attach and this read closes the stream the same way
+        # the watchdog would for the same race, instead of raising out of
+        # the generator. Any other failure here -- a transient DB error,
+        # a bug in the projector fold -- gets the same ``resync_required``
+        # close every other overload/backlog condition in this module
+        # gets, instead of letting the exception propagate out of the
+        # generator and leave the client with a response that just stops,
+        # no close frame at all: that would break this module's own
+        # invariant that a close frame is always how a client tells "the
+        # task ended" apart from "the stream ended".
+        # Skipped when the watermark read above already failed and closed
+        # for resync: there is no watermark to bound this read to, and
+        # the close frame it queued is what the loop below will deliver.
+        if replay_watermark is not None:
+            watermark = replay_watermark
+            try:
+                warmed_projector, warm_up_frames = await run_db_io_cancellation_safe(
+                    lambda: _build_warm_up_frames(
+                        task_id, principal, read_task_steps, watermark
+                    )
+                )
+            except Exception as exc:
+                if (
+                    isinstance(exc, V1ApiError)
+                    and exc.code is V1ErrorCode.TASK_NOT_FOUND
+                ):
+                    sink.enqueue_close(error_frame("task_deleted"))
+                else:
+                    logger.exception(
+                        "v1 SSE warm-up failed for task %s; closing for resync "
+                        "instead of leaving the client with a truncated stream "
+                        "and no close frame",
+                        task_id,
+                    )
+                    sink.enqueue_close(
+                        error_frame(
+                            "resync_required",
+                            message=(
+                                "Reading trace history failed; call steps() "
+                                "to resync, then re-attach."
+                            ),
+                        )
+                    )
+            else:
+                # ``warm_up_frames`` is already fully read and serialized
+                # by this point (see ``_build_warm_up_frames``); this loop
+                # only yields it, one frame at a time, on the event loop.
+                # The watchdog runs concurrently (``watchdog_task``,
+                # created above) and can call ``sink.enqueue_close`` while
+                # this loop is still mid-yield -- most closes should let
+                # this loop finish handing out history it already read
+                # before the close frame follows behind it in the queue,
+                # since that history describes the task's own past and
+                # doesn't become invalid just because the stream is now
+                # ending (a normal terminal/input-required conclusion, a
+                # resync signal). An *abortive* close is different: it
+                # means the client's standing to see this task's content
+                # at all was just revoked (key deauthorized) or the task
+                # itself is gone (row deleted) -- continuing to hand out
+                # buffered history after that would leak content the
+                # client is no longer authorized to see, or content for a
+                # task that no longer exists. So only an abortive close
+                # breaks this loop early; every other close reason is
+                # left to arrive after replay finishes, via the queue,
+                # same as it always did. See ``enqueue_close`` and
+                # ``abortive_close`` for which reasons set it.
+                for frame_text in warm_up_frames:
+                    if sink.closing and sink.abortive_close:
+                        break
+                    yield frame_text
+                # Every frame this batch holds has now either been handed
+                # off or abandoned by the abortive-close break above --
+                # either way nothing in this generator reads
+                # ``warm_up_frames`` again, but the name stays bound in
+                # this frame's locals for as long as the generator itself
+                # is suspended, which for an idle stream is up to
+                # ``stream_max_duration_seconds`` (an hour in production).
+                # Left alone, a large replay batch would sit there for the
+                # rest of the connection's life pinning memory nothing
+                # will ever look at again. Same "don't hold what nothing
+                # reads" reasoning as ``PublicStepProjector.
+                # take_materialized_steps`` releasing ``_finished`` once
+                # the warm-up replay that needed it is over.
+                del warm_up_frames
+                sink.finish_warm_up(warmed_projector)
         while True:
             remaining = deadline - monotonic()
             if remaining <= 0:
@@ -2241,6 +2896,7 @@ async def build_event_stream_response(
     principal: ApiKeyPrincipal,
     initial_snapshot: "_TaskInfoSnapshot",
     read_task_snapshot: TaskSnapshotReader,
+    read_task_steps: TaskStepsReader,
     read_task_steps_response: TaskStepsResponseReader,
     read_task_steps_version: TaskStepsVersionReader,
     watchdog_interval_seconds: float = WATCHDOG_INTERVAL_SECONDS,
@@ -2256,21 +2912,29 @@ async def build_event_stream_response(
     per-principal reservation) ever exists, so a rejected attach never
     touches ``manager`` or the per-principal counter. Both fast paths
     below read their step content through ``read_task_steps_response``
-    (see ``TaskStepsResponseReader``), a cache-backed read of the
-    task's current step list -- they're one-shot and don't need a
-    live-foldable projector. They also take ``read_task_snapshot``
-    directly, the same reader that authorized ``initial_snapshot``, to
-    reread the task row once their own steps read returns non-empty
-    content and confirm nothing restarted the task in between (see
-    ``_fast_path_generation_changed``), and ``read_task_steps_version``
-    to reread the steps cursor (``max_event_id``) the same way -- a
-    trace row can land in that same window, and even the commits that
-    write the task row itself (a checkpoint-pointer ``UPDATE``, see
-    ``_fast_path_steps_cursor_changed``) never touch ``run_id`` or
-    ``state_version``, so the run_id/state_version reread alone cannot
-    see it either way. ``read_task_steps_version`` is required rather
-    than defaulted: a caller with no way to check the cursor would have
-    no way to catch a row landing in that window.
+    instead of the normal streaming path's ``read_task_steps`` (see
+    ``TaskStepsResponseReader``) -- a different, cache-backed shape,
+    since they're one-shot and don't need a live-foldable projector,
+    only the task's current step list. They also take
+    ``read_task_snapshot`` directly, the same reader that authorized
+    ``initial_snapshot``, to reread the task row once their own steps
+    read returns non-empty content and confirm nothing restarted the
+    task in between (see ``_fast_path_generation_changed``).
+
+    ``read_task_steps_version`` serves both shapes of attach, which is
+    why it is required here rather than defaulted: the fast paths use it
+    to reread the steps cursor (``max_event_id``) the same way they
+    reread the task row -- a trace row can land in that same window, and
+    even the commits that write the task row itself (a checkpoint-pointer
+    ``UPDATE``, see ``_fast_path_steps_cursor_changed``) never touch
+    ``run_id`` or ``state_version``, so the run_id/state_version reread
+    alone cannot see it either way -- while the normal streaming path
+    reads it once at registration to bound its warm-up replay (see
+    ``_generate``). The reader is required rather than defaulted:
+    without a watermark the replay would fold the task's whole history,
+    which contradicts this module's own rule that a *failed* watermark
+    read closes the stream rather than replaying unbounded. A caller
+    that cannot supply the reader fails at the call.
     """
     close_reason = _stream_close_reason(
         initial_snapshot.status, initial_snapshot.control_state
@@ -2311,6 +2975,8 @@ async def build_event_stream_response(
             key_prefix=key_prefix,
             initial_status=initial_snapshot.status.value,
             read_task_snapshot=read_task_snapshot,
+            read_task_steps=read_task_steps,
+            read_task_steps_version=read_task_steps_version,
             watchdog_interval_seconds=watchdog_interval_seconds,
             stream_max_duration_seconds=stream_max_duration_seconds,
             heartbeat_interval_seconds=heartbeat_interval_seconds,

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -111,12 +111,13 @@ values it deliberately leaves unbounded, in one place:
     (``_fast_path_step_snapshot``) and the normal streaming path's
     warm-up replay (``_build_warm_up_frames``) alike:
     ``REPLAY_MAX_STEPS`` (512 steps) *and* ``MAX_SNAPSHOT_WIRE_BYTES``
-    (4 MiB of serialized frame text), the same two caps applied through
-    the same ``_snapshot_steps_within_wire_budget`` in all three places.
-    The two are applied in series, step cap first: the step cap binds
-    on a long history of ordinary steps, the byte budget (applied to
-    that already-capped window) on a short history of large ones -- 512
-    steps each carrying a ``data`` sub-object right
+    (4 MiB of serialized frame text). The step cap is written inline
+    at each of the three call sites; ``_snapshot_steps_within_wire_budget``
+    applies the byte cap alone, to whichever window the step cap
+    already produced. The two are applied in series, step cap first:
+    the step cap binds on a long history of ordinary steps, the byte
+    budget (applied to that already-capped window) on a short history
+    of large ones -- 512 steps each carrying a ``data`` sub-object right
     at the 64 KiB cap is ~32 MiB generated into one response, and these
     paths are exempt from the concurrency caps below, so nothing else
     bounds how many such responses run at once. The step cap keeps the
@@ -1370,10 +1371,13 @@ class V1EventStreamSink:
         ``finish_warm_up`` can feed it through a projector that actually
         has the pairing state to fold it correctly.
 
-        Deliberately the same cap and the same overflow policy as
-        ``_put_or_overflow`` -- ``OUTBOUND_QUEUE_MAX_SIZE``, then
-        ``resync_required`` -- rather than a second, differently-sized
-        backlog with its own failure mode. In practice this list only
+        Reuses ``_put_or_overflow``'s own count cap and overflow policy
+        -- ``OUTBOUND_QUEUE_MAX_SIZE``, then ``resync_required`` -- for
+        the constant and the rationale, not the implementation: this
+        list is a plain Python list with its own check here, not a
+        call into ``_put_or_overflow`` (which enforces the outbound
+        queue's own separate ``MAX_QUEUED_WIRE_BYTES`` bound, not this
+        one). In practice this list only
         ever holds what arrives during one warm-up read plus however
         many replay frames get yielded afterward, both bounded by how
         long that takes; hitting the cap here means the same thing
@@ -1976,11 +1980,12 @@ async def _fast_path_step_snapshot(
     instead of each one re-reading and re-projecting independently.
 
     Bounded by two caps applied in series: ``REPLAY_MAX_STEPS`` (step
-    count) first, then ``MAX_SNAPSHOT_WIRE_BYTES`` (serialized size, via
-    ``_snapshot_steps_within_wire_budget``) over that already-capped
-    window -- the same two caps, in the same order, through the same
-    function, that bound the normal streaming path's warm-up replay
-    (see ``_build_warm_up_frames``).
+    count) first, written inline here the same way the normal
+    streaming path's warm-up replay writes it (see
+    ``_build_warm_up_frames``); then ``MAX_SNAPSHOT_WIRE_BYTES``
+    (serialized size) over that already-capped window, applied by the
+    same ``_snapshot_steps_within_wire_budget`` that replay path
+    shares too.
     Without them, a fast-path
     attach to a task with an unusually long or heavy step history
     returned every step from this cached list in one shot, with no
@@ -2581,15 +2586,16 @@ def _build_warm_up_frames(
     which can differ from started_at order when a later-started step
     finishes first.
 
-    That sorted list is then bounded by the same two caps, applied by the
-    same function, that bound the attach-time fast paths' one-shot
-    snapshot: ``REPLAY_MAX_STEPS`` keeps the most recent steps, and
-    ``_snapshot_steps_within_wire_budget`` then trims that window to
-    ``MAX_SNAPSHOT_WIRE_BYTES`` of serialized frames. Sharing the
-    function is the point -- both paths emit a batch of steps with no
-    pacing of their own, so they get one rule rather than each inventing
-    its own. Two consequences follow from that shared rule and are
-    deliberate:
+    That sorted list is then bounded by the same two caps that bound
+    the attach-time fast paths' one-shot snapshot, in the same order:
+    ``REPLAY_MAX_STEPS`` keeps the most recent steps, written inline
+    here just as it is at the fast path's own call site; then
+    ``_snapshot_steps_within_wire_budget`` -- the one function both
+    paths share -- trims that window to ``MAX_SNAPSHOT_WIRE_BYTES`` of
+    serialized frames. Sharing that function is the point -- both
+    paths emit a batch of steps with no pacing of their own, so the
+    byte cap gets one rule rather than each inventing its own. Two
+    consequences follow from that shared rule and are deliberate:
 
       - The byte budget keeps a *prefix* of the count-capped window (see
         ``_snapshot_steps_within_wire_budget``), so a window too heavy
@@ -2632,6 +2638,11 @@ def _build_warm_up_frames(
         for event in steps_snapshot.events
         if _event_row_id(event) <= replay_watermark
     ]
+    # ``from_history`` feeds every event straight into a fresh
+    # projector with none of ``_feed_trace_event``'s three guards (the
+    # delegated-child-agent source check, the ``task_info``
+    # short-circuit, the audit-only-data drop) -- the same
+    # live-vs-batch equivalence gap already tracked as #1405.
     warmed_projector = PublicStepProjector.from_history(events)
     steps = warmed_projector.take_materialized_steps()
     steps.sort(key=lambda step: step["started_at"])

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -76,7 +76,8 @@ values it deliberately leaves unbounded, in one place:
     string to cut (see ``_capped_step_data``).
   - One inbound broadcast frame, before it is projected at all:
     ``MAX_RAW_FRAME_TEXT_CHARS`` (256 KiB), measured excluding the
-    ``task_description`` stamp every converted trace event carries (see
+    task's own description column, which every converted trace event
+    and every ``task_info`` frame carries under one of two keys (see
     ``_measured_content_frame``). Over the cap is a silent drop --
     counted and logged, never a close, and never applied to a
     lifecycle frame.
@@ -272,8 +273,9 @@ MAX_FRAME_CONTENT_BYTES = 64 * 1024
 # is ~10 KiB against a 4 MiB budget.
 MAX_QUEUED_WIRE_BYTES = 64 * MAX_FRAME_CONTENT_BYTES
 # Check on a raw broadcast frame's text length -- measured excluding
-# the internal task-description stamp broadcast frames carry (see
-# ``_measured_content_frame``) -- run after ``json.loads`` parses it,
+# the task's own description column, which arrives under one of two
+# keys depending on the frame family (see ``_measured_content_frame``)
+# -- run after ``json.loads`` parses it,
 # gating only the call into the projection pass -- ``MAX_FRAME_CONTENT_BYTES`` only bounds the *projected*
 # content that ends up on the wire, so without this a multi-megabyte raw
 # frame still pays for a full ``serialize_trace_data`` walk + projection
@@ -301,14 +303,23 @@ MAX_RAW_FRAME_TEXT_CHARS = 4 * MAX_FRAME_CONTENT_BYTES
 # ``MAX_SNAPSHOT_WIRE_BYTES`` below, and carries the same magnitude:
 # giving one connection a 4 MiB queue budget and a larger staging budget
 # would be two different answers to the same question. The unit differs
-# and that is deliberate -- this counts the *raw* broadcast text a staged
-# message arrived in, before projection, because a staged message is not
+# and that is deliberate -- this counts the description-free measure of
+# a staged message, before projection, because a staged message is not
 # a frame yet, whereas the other two count wire bytes. Without this,
 # worst case under the raw pre-check alone is ``OUTBOUND_QUEUE_MAX_SIZE``
 # staged messages each just under ``MAX_RAW_FRAME_TEXT_CHARS``, so a
 # warm-up window full of near-cap (rather than over-cap) staged frames
 # could hold far more than the connection's own queue ever may.
 STAGED_MESSAGES_MAX_TEXT_CHARS = 64 * MAX_FRAME_CONTENT_BYTES
+# The two keys a task's own ``description`` column arrives under, per
+# frame family -- see ``_measured_content_frame``, which strips them
+# before this module measures or projects anything. Kept as two tuples
+# rather than one union so a content frame that legitimately carries a
+# ``data["description"]`` of its own keeps it: only ``task_info``, whose
+# projection output is empty by construction, has that key overwritten
+# by the task column.
+_TRACE_DESCRIPTION_STAMPS = ("task_description",)
+_TASK_INFO_DESCRIPTION_STAMPS = ("task_description", "description")
 # Upper bound on how many steps one attach puts on the wire in a single
 # burst, shared by the three producers that emit a batch of steps with
 # no pacing of their own: the two attach-time fast paths
@@ -1006,55 +1017,72 @@ def project_content_frames(
 def _measured_content_frame(
     text: str, message: dict[str, Any]
 ) -> tuple[int, dict[str, Any]]:
-    """Return ``(chars, frame)`` -- the length the drop check below
-    compares against the cap, and the frame projection should consume.
+    """Return ``(chars, frame)`` -- the frame's length with the task's
+    own description stamp removed, and the frame every consumer past
+    this point should use in place of the raw one.
 
+    The task's ``description`` column reaches a broadcast frame under
+    two different keys, from two different producers, and is unbounded
+    in both (``Column(Text)``, filled from the task's first user
+    message, which has no ``max_length`` of its own):
     ``ws_trace_handlers.py``'s ``_convert_trace_event_to_stream_event``
-    copies the task's ``description`` column onto
-    ``data["task_description"]`` for *every* trace event it converts,
-    with no event-type gate. That column has no length bound
-    (``Column(Text)``, filled from the task's first user message, which
-    has no ``max_length`` of its own), and it is re-stamped on each
-    frame -- so counting it would let one long description push every
-    subsequent ``step.*`` frame of that task past
-    ``MAX_RAW_FRAME_TEXT_CHARS`` and drop the task's whole content
-    stream for the life of the connection.
+    stamps it as ``data["task_description"]`` on *every* trace event it
+    converts, with no event-type gate, and every ``task_info`` producer
+    in ``websocket.py`` puts the same column on ``data["description"]``.
+    Both are re-stamped per frame, so counting either one would let one
+    long description spend a budget on a field that cannot reach the
+    wire -- pushing frames past ``MAX_RAW_FRAME_TEXT_CHARS`` (a silent
+    content drop for the life of the connection) or past
+    ``STAGED_MESSAGES_MAX_TEXT_CHARS`` (a ``resync_required`` close that
+    re-fails identically on every re-attach, since the trigger is a
+    property of the task rather than the load on it).
 
-    Excluding it costs the client nothing, because no content this
-    module puts on the wire can contain it: each of the four producers
-    builds its ``data`` from explicitly named keys (``_step_mapping``'s
-    ``_build_thinking_start`` / ``_build_tool_start`` /
-    ``_build_message_step`` and the ``extra_data_fn`` patches, then
-    ``message_delta_frame`` / ``message_completed_frame``), so the
-    description was consuming a budget it could never spend.
+    Excluding both costs the client nothing, because no content this
+    module puts on the wire can contain either: each of the four
+    producers builds its ``data`` from explicitly named keys
+    (``_step_mapping``'s ``_build_thinking_start`` /
+    ``_build_tool_start`` / ``_build_message_step`` and the
+    ``extra_data_fn`` patches, then ``message_delta_frame`` /
+    ``message_completed_frame``), and ``_feed_trace_event`` returns
+    ``[]`` for ``task_info`` outright.
 
-    An under-cap frame is returned unchanged, description and all --
-    the walk that projection pays over it is already bounded by the
-    cap. An over-cap frame carrying a description is pruned *before*
-    both measuring and projecting, not just before measuring: the raw
-    frame check was this field's only per-frame CPU bound (a
-    synchronous, unbounded ``clean_string`` walk during projection), so
-    a frame that survives the check must not still be paying for the
-    field the check just excused it from. Measured by re-serializing
-    the parsed frame without that one field rather than by subtracting
-    an estimate of the field's serialized length: an estimate would
-    have to reproduce the producer's separators and escaping, while a
-    re-dump is exact in the same character domain ``len(text)`` is
-    measured in (``broadcast_to_task`` serializes with a default
-    ``json.dumps``, and so does this). It runs only for a frame that is
-    both over the cap and carrying a description -- the frame that
-    would otherwise be dropped outright -- so an ordinary frame still
-    costs one ``len()``, and the re-dump's own cost scales with the
-    frame *without* the description, not with the description.
-    ``json.dumps`` cannot fail here: ``message`` came out of
-    ``json.loads`` in the caller.
+    Pruning is unconditional -- not, as it once was, only for a frame
+    already over the raw cap. Both of this value's consumers need the
+    description gone, not just the drop check: the staging buffer
+    accumulates it across frames. The drop check's own decision is
+    unaffected by the change (pruning can only lower the number, and a
+    frame already under the cap stays under it), so the boundary it
+    enforces is exactly the one it enforced before. Removing the field
+    before projection rather than after is what keeps a surviving
+    frame from paying the synchronous, unbounded ``clean_string`` walk
+    ``serialize_trace_data`` would otherwise run over it. That is a
+    clear saving when the description is the bulk of the frame; when
+    the payload is the bulk and the description is small, the extra
+    ``json.dumps`` this function adds costs on the order of 0.2 ms on a
+    200 KiB frame more than skipping it would. Accepted because one
+    number has to serve both the drop check and the staging budget
+    below, and the alternative -- two numbers kept in step by hand --
+    is the class of failure this function exists to close. Measured by
+    re-serializing the parsed frame without those keys rather than by
+    subtracting an estimate of their serialized length: an estimate
+    would have to reproduce the producer's separators and escaping,
+    while a re-dump is exact in the same character domain ``len(text)``
+    is measured in (``broadcast_to_task`` serializes with a default
+    ``json.dumps``, and so does this). ``json.dumps`` cannot fail here:
+    ``message`` came out of ``json.loads`` in the caller.
     """
-    if len(text) <= MAX_RAW_FRAME_TEXT_CHARS:
-        return len(text), message
     data = message.get("data")
-    if not isinstance(data, dict) or "task_description" not in data:
+    if not isinstance(data, dict):
         return len(text), message
-    pruned = {key: value for key, value in data.items() if key != "task_description"}
+    stamps = (
+        _TASK_INFO_DESCRIPTION_STAMPS
+        if message.get("event_type") == "task_info"
+        else _TRACE_DESCRIPTION_STAMPS
+    )
+    present = [key for key in stamps if key in data]
+    if not present:
+        return len(text), message
+    pruned = {key: value for key, value in data.items() if key not in present}
     frame = {**message, "data": pruned}
     return len(json.dumps(frame)), frame
 
@@ -1342,13 +1370,17 @@ class V1EventStreamSink:
         hitting it on the outbound queue means -- the client can't keep
         up (or something is broadcasting far faster than normal) and
         needs to resync. A second, cumulative bound on top of the count
-        cap: ``text_chars`` (the raw frame's own ``len(text)``, already
-        computed once by ``send_text``'s pre-check -- never
-        re-serialized here) is tracked against
+        cap: ``text_chars`` (the frame's length with the task's own
+        description stamp removed, already computed once by
+        ``send_text``'s pre-check via ``_measured_content_frame`` --
+        never re-serialized here) is tracked against
         ``STAGED_MESSAGES_MAX_TEXT_CHARS`` so a run of large-but-under-
         the-single-frame-cap messages during a slow warm-up read can't
         hold unbounded memory just because it stayed under the count
-        cap.
+        cap. Charging the description here instead would make this
+        overflow a property of the task rather than of the load on it:
+        one long description, re-stamped per frame, crosses the budget
+        on its own and closes every attach to that task identically.
         """
         if self._closing:
             return
@@ -1482,11 +1514,12 @@ class V1EventStreamSink:
         ``type`` is in ``_CONTENT_FRAME_TYPES``; dispatch into the
         projector is unchanged for that whole set regardless. What it
         compares against ``MAX_RAW_FRAME_TEXT_CHARS`` (256 KiB) is the
-        frame's own character count minus the ``task_description``
-        field the broadcast conversion stamps onto every trace event --
-        see ``_measured_content_frame`` for why that subtraction exists
-        and why it costs nothing on the ordinary path. Strictly greater
-        than the cap is a drop, exactly equal is kept. On a drop,
+        frame's own character count minus whichever key the task's own
+        description column arrived under -- see
+        ``_measured_content_frame`` for the two keys, why that
+        subtraction exists, and why it lowers rather than raises this
+        method's per-frame cost. Strictly greater than the cap is a
+        drop, exactly equal is kept. On a drop,
         ``dropped_frame_count`` is incremented, one ``logger.warning``
         fires, and the method returns -- no queued frame, no close, no
         ``stream.error``: a dropped frame is invisible to the client.
@@ -1515,23 +1548,29 @@ class V1EventStreamSink:
             an oversized ``task_info`` increments
             ``dropped_frame_count`` and logs a drop warning. It is not
             what protects ``task.status``/``completion_hint``
-            delivery. It is there because such a frame carries the
-            task description with no size bound of its own, so
-            counting it as a dropped content frame would be counting a
-            drop that had no content to lose.
+            delivery. It is there because ``_feed_trace_event`` returns
+            ``[]`` for ``task_info``: counting it as a dropped content
+            frame would be counting a drop that had no content to lose.
 
         The parse is not extra cost on the fan-out path:
         ``ConnectionManager.broadcast_to_task`` serializes the frame
         with ``json.dumps`` once per connection, inside its own send
-        loop, before this method is called at all. What happens to the
-        expensive half here -- ``serialize_trace_data`` plus the
-        projection fold -- depends on where the frame lands: a frame
-        under the cap pays it in full; a frame over the cap only
-        because of its task description is pruned by
-        ``_measured_content_frame`` before projection runs, not just
-        before the comparison, so it pays that cost against the frame
-        without the description instead; and a frame still over the
-        cap after pruning is dropped outright and pays none of it.
+        loop, before this method is called at all. Pruning is now
+        unconditional rather than only for a frame over the cap, so
+        the expensive half here -- ``serialize_trace_data`` plus the
+        projection fold -- never runs over the description at all, for
+        every frame this method admits. That is a clear net saving
+        when the description is the bulk of the frame (about −0.11 ms
+        at a 64 KiB description, −0.34 ms at 200 KiB); when the
+        payload is the bulk and the description is small, the extra
+        ``json.dumps`` ``_measured_content_frame`` now always pays
+        costs up to about +0.21 ms per frame on a 200 KiB frame,
+        roughly +38% of that frame's processing. Accepted because it
+        is what lets one number serve both the drop check and the
+        staging budget below; the alternative -- two numbers kept in
+        step by hand -- is the failure mode this fix exists to close.
+        A frame still over the cap after pruning is dropped outright
+        and pays none of it.
         """
         try:
             self._assert_owner_loop()
@@ -1566,21 +1605,21 @@ class V1EventStreamSink:
                         # read wouldn't have closed anyway.
                         self.completion_hint.set()
             if str(message.get("type") or "") in _CONTENT_FRAME_TYPES:
-                frame = message
-                measured_chars = len(text)
-                if message.get("event_type") != "task_info":
-                    measured_chars, frame = _measured_content_frame(text, message)
-                    if measured_chars > MAX_RAW_FRAME_TEXT_CHARS:
-                        self.dropped_frame_count += 1
-                        logger.warning(
-                            "v1 SSE sink dropped an oversized broadcast frame "
-                            "(%d chars, %d excluding the task description) for "
-                            "task %s before projecting it",
-                            len(text),
-                            measured_chars,
-                            self.task_id,
-                        )
-                        return
+                measured_chars, frame = _measured_content_frame(text, message)
+                if (
+                    message.get("event_type") != "task_info"
+                    and measured_chars > MAX_RAW_FRAME_TEXT_CHARS
+                ):
+                    self.dropped_frame_count += 1
+                    logger.warning(
+                        "v1 SSE sink dropped an oversized broadcast frame "
+                        "(%d chars, %d excluding the task description) for "
+                        "task %s before projecting it",
+                        len(text),
+                        measured_chars,
+                        self.task_id,
+                    )
+                    return
                 # The raw-size check runs before the warm/staged split, so
                 # a frame too large to project is dropped whether this
                 # sink is warm or not -- staging an oversized frame would

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -1405,6 +1405,21 @@ class V1EventStreamSink:
         overflow a property of the task rather than of the load on it:
         one long description, re-stamped per frame, crosses the budget
         on its own and closes every attach to that task identically.
+
+        The count cap is exactly ``OUTBOUND_QUEUE_MAX_SIZE``, not one
+        less, which leaves the hand-off no margin: lifecycle frames
+        (``task.status``) skip staging and go straight into the
+        outbound queue while this sink is still cold, so a staging list
+        at its cap plus one such frame is one item more than the queue
+        can hold, and ``finish_warm_up``'s drain overflows into the same
+        ``resync_required`` close an over-full queue always takes. That
+        overflow is the documented outcome for this case, not an
+        unhandled edge. Reserving a slot here instead would buy one
+        frame of headroom against a backlog that is already at the
+        "this client cannot keep up" threshold, at the cost of a
+        second, differently-sized cap to keep in step with the first.
+        Pinned by
+        ``test_a_cold_status_frame_leaves_the_staging_drain_no_margin``.
         """
         if self._closing:
             return
@@ -2776,6 +2791,19 @@ async def _generate(
                 key_prefix,
             )
         manager.register_connection(cast(WebSocket, sink), task_id)
+        # Registering before the watermark read below is deliberate, and
+        # it leans on an ordering this file cannot enforce on its own: a
+        # trace row is committed by ``DatabaseTraceHandler`` before
+        # ``WebSocketTraceHandler`` broadcasts it, because
+        # ``create_task_tracer`` (``web/tracing.py``) lists them in that
+        # order and the tracer awaits each handler in turn rather than
+        # dispatching them concurrently (``Tracer``'s notify loop in
+        # ``core/agent/trace.py``). That is what makes "already
+        # committed" imply "its broadcast has not gone out yet, or went
+        # out to a sink that was already registered" -- so registering
+        # first costs at most a duplicate frame, never a lost one.
+        # Handler order has its own test; the sequential dispatch does
+        # not, and lives outside this module.
         # Capture the replay watermark as close to registration as this
         # generator can manage -- see ``TaskStepsVersionReader`` and
         # ``_build_warm_up_frames``'s docstring for what it bounds and

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -2620,10 +2620,11 @@ async def _generate(
     ``read_task_steps_version`` is read once right after registration to
     capture the watermark the warm-up replay bounds itself to (see
     ``_build_warm_up_frames``). It is required: a failed read of that
-    watermark closes the stream for resync rather than replaying the
-    task's history unbounded, and an absent *reader* would produce that
-    same unbounded replay silently, which is the one outcome this path
-    refuses.
+    watermark closes the stream -- with ``resync_required``, or with
+    ``task_deleted`` when the failure is the task itself being gone --
+    rather than replaying the task's history unbounded, and an absent
+    *reader* would produce that same unbounded replay silently, which
+    is the one outcome this path refuses.
     """
     deadline = monotonic() + stream_max_duration_seconds
     sink = V1EventStreamSink(
@@ -2662,9 +2663,12 @@ async def _generate(
         # Capture the replay watermark as close to registration as this
         # generator can manage -- see ``TaskStepsVersionReader`` and
         # ``_build_warm_up_frames``'s docstring for what it bounds and
-        # why. A failure here (a transient DB error, or the task
-        # deleted in the instant after registration) closes the stream
-        # for resync instead of falling back to an unbounded replay.
+        # why. A failure here never falls back to an unbounded
+        # replay; it closes the stream, and the close reason splits
+        # by cause: a transient DB error gets ``resync_required``,
+        # while a task deleted in the instant after registration gets
+        # ``task_deleted`` (see the handler below for why those are
+        # not the same recovery for a client).
         # The watermark is what bounds the warm-up replay's duplicate
         # window to "registration to this one ``max(id)`` query" (see
         # ``_build_warm_up_frames``'s docstring); falling back to an
@@ -2690,9 +2694,10 @@ async def _generate(
             # reader handing back a ``max_event_id`` that is not an
             # integer is a failed read like any other, and the comment
             # above promises every failure at this step closes the
-            # stream for resync rather than propagating out of this
-            # generator. In an ``else`` the conversion sits outside
-            # that promise.
+            # stream rather than propagating out of this generator --
+            # with ``resync_required`` for exactly this kind of
+            # failure, since the task itself is fine. In an ``else``
+            # the conversion sits outside that promise.
             replay_watermark = int(version_snapshot.max_event_id)
             # Nothing else in this generator reads ``version_snapshot`` --
             # the one field it carries is already copied into
@@ -2701,22 +2706,32 @@ async def _generate(
             # frame's locals for the rest of a connection that can live
             # an hour.
             del version_snapshot
-        except Exception:
-            logger.exception(
-                "v1 SSE replay watermark read failed for task %s; "
-                "closing for resync instead of falling back to an "
-                "unbounded warm-up replay",
-                task_id,
-            )
-            sink.enqueue_close(
-                error_frame(
-                    "resync_required",
-                    message=(
-                        "Reading the replay watermark failed; call "
-                        "steps() to resync, then re-attach."
-                    ),
+        except Exception as exc:
+            if isinstance(exc, V1ApiError) and exc.code is V1ErrorCode.TASK_NOT_FOUND:
+                # Same split, and the same reason, as the history-read
+                # branch below: the task is gone, not merely unreadable,
+                # so telling the client to call steps() and re-attach
+                # would send it to a 404. Not logged, for the same
+                # reason that branch and the watchdog don't log it -- a
+                # task deleted while an attach is in flight is a race,
+                # not a bug in this stream.
+                sink.enqueue_close(error_frame("task_deleted"))
+            else:
+                logger.exception(
+                    "v1 SSE replay watermark read failed for task %s; "
+                    "closing for resync instead of falling back to an "
+                    "unbounded warm-up replay",
+                    task_id,
                 )
-            )
+                sink.enqueue_close(
+                    error_frame(
+                        "resync_required",
+                        message=(
+                            "Reading the replay watermark failed; call "
+                            "steps() to resync, then re-attach."
+                        ),
+                    )
+                )
         watchdog_task = asyncio.create_task(
             _watchdog_loop(
                 sink,
@@ -2789,9 +2804,10 @@ async def _generate(
         # no close frame at all: that would break this module's own
         # invariant that a close frame is always how a client tells "the
         # task ended" apart from "the stream ended".
-        # Skipped when the watermark read above already failed and closed
-        # for resync: there is no watermark to bound this read to, and
-        # the close frame it queued is what the loop below will deliver.
+        # Skipped when the watermark read above already failed and
+        # closed the stream (for resync, or as ``task_deleted``):
+        # there is no watermark to bound this read to, and the close
+        # frame it queued is what the loop below will deliver.
         if replay_watermark is not None:
             watermark = replay_watermark
             try:

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -2798,17 +2798,17 @@ async def _generate(
         # identity onto live frames, which is a change in
         # ``api/websocket.py`` and visible to every consumer of that
         # broadcast, not just this stream.
-        # A task deleted in the gap
-        # between attach and this read closes the stream the same way
-        # the watchdog would for the same race, instead of raising out of
-        # the generator. Any other failure here -- a transient DB error,
-        # a bug in the projector fold -- gets the same ``resync_required``
-        # close every other overload/backlog condition in this module
-        # gets, instead of letting the exception propagate out of the
-        # generator and leave the client with a response that just stops,
-        # no close frame at all: that would break this module's own
-        # invariant that a close frame is always how a client tells "the
-        # task ended" apart from "the stream ended".
+        # A task deleted in the gap between attach and this read closes
+        # the stream the same way the watchdog would for the same race,
+        # instead of raising out of the generator. Any other failure
+        # here -- a transient DB error, a bug in the projector fold --
+        # gets the same ``resync_required`` close every other
+        # overload/backlog condition in this module gets, instead of
+        # letting the exception propagate out of the generator and
+        # leave the client with a response that just stops, no close
+        # frame at all: that would break this module's own invariant
+        # that a close frame is always how a client tells "the task
+        # ended" apart from "the stream ended".
         # Skipped when the watermark read above already failed and
         # closed the stream (for resync, or as ``task_deleted``):
         # there is no watermark to bound this read to, and the close

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -1202,7 +1202,8 @@ class V1EventStreamSink:
         that race still revoked the client's standing to see the rest
         of the buffered history. Meaningless (always False) while
         ``closing`` is itself False -- check both, not this alone; see
-        ``enqueue_close``."""
+        ``enqueue_close``. Also decides how long the watchdog keeps
+        checking; see ``_watchdog_coverage_done``."""
         return self._abortive_close
 
     @property
@@ -1232,9 +1233,11 @@ class V1EventStreamSink:
         stream.
 
         ``abortive`` (default False) records *why* on ``abortive_close``,
-        for the one caller that needs to react before this close frame
-        is even dequeued -- ``_generate``'s warm-up replay loop, which
-        checks it between each already-built history frame it yields.
+        for the two readers that need it before this close frame is
+        even dequeued: ``_generate``'s warm-up replay loop, which
+        checks it between each already-built history frame it yields,
+        and ``_watchdog_coverage_done``, which uses it to decide
+        whether this stream still needs an authorization check at all.
         An abortive close means the client has lost the right to see
         *any* further data, including history that predates the close:
         today that's the watchdog's ``unauthorized`` (key
@@ -1732,10 +1735,29 @@ async def watchdog_check_once(
         # so they only measure how long ago the pause happened, not
         # whether anyone is still managing it. Closing on that signal
         # would kill legitimately paused streams too. The 1-hour absolute
-        # cap is what actually bounds an orphaned paused stream's lifetime.
+        # cap is what actually bounds an orphaned paused stream's
+        # lifetime while a client is still reading it -- it closes
+        # non-abortively (``stream_expired``), so it does not bound this
+        # watchdog's own lifetime; see ``_watchdog_coverage_done``.
         sink.enqueue_status(status.value)
         return False
     return False  # pending/running: keep streaming
+
+
+def _watchdog_coverage_done(sink: V1EventStreamSink) -> bool:
+    """Whether this watchdog has anything left to protect.
+
+    A close on its own is not enough. ``_generate`` hands the initial
+    status frame and every warm-up replay frame straight to the client,
+    bypassing ``_put_or_overflow``'s closing guard, so an ordinary close
+    -- a staging overflow's ``resync_required``, a terminal
+    ``task.completed`` -- stops nothing on that path. Only
+    ``abortive_close`` stops it, and this loop is the only thing that
+    ever sets it (see ``watchdog_check_once``). Coverage therefore ends
+    when the revocation is already latched; otherwise it ends with the
+    connection, when ``_generate``'s ``finally`` cancels this task.
+    """
+    return sink.closing and sink.abortive_close
 
 
 async def _watchdog_loop(
@@ -1754,10 +1776,23 @@ async def _watchdog_loop(
     watchdog coverage for the rest of the stream's lifetime -- that
     would leave an orphaned stream open until the 1-hour absolute cap
     with nobody watching it. So every per-cycle check is wrapped and
-    logged; only cancellation (this loop's own teardown, not a check
-    failure) ends the loop early.
+    logged and the loop keeps going.
+
+    The exit rule is coverage, not closing: this loop only returns once
+    ``_watchdog_coverage_done`` is true -- the revocation is already
+    latched -- or it is cancelled during ``_generate``'s teardown. A
+    close by itself does not end the loop, because ``_generate``'s
+    warm-up replay yields its frames directly to the client, bypassing
+    the outbound queue's closing guard; an ordinary close (a staging
+    overflow, a terminal state this loop itself just found) leaves that
+    direct path free to keep emitting, so this loop has to stay alive to
+    catch a revocation that lands afterward. A consumer that stops
+    reading gives this loop no way to observe that closing ever
+    happened, so it keeps polling on its normal cadence until the
+    generator's teardown cancels it -- there is no time bound on that
+    other than the connection's own.
     """
-    while not sink.closing:
+    while not _watchdog_coverage_done(sink):
         try:
             await asyncio.wait_for(
                 sink.completion_hint.wait(), timeout=interval_seconds
@@ -1766,13 +1801,18 @@ async def _watchdog_loop(
             pass
         else:
             sink.completion_hint.clear()
-        if sink.closing:
+        if _watchdog_coverage_done(sink):
             return
         try:
-            if await watchdog_check_once(
+            # The return value is deliberately not an exit condition. A
+            # check that closes the stream non-abortively -- a terminal
+            # task found while the warm-up read is still in flight --
+            # leaves the direct replay free to keep emitting, so this
+            # loop must stay alive to observe a revocation that lands
+            # after it. Only the condition above ends it.
+            await watchdog_check_once(
                 sink, task_id, principal, read_task_snapshot=read_task_snapshot
-            ):
-                return
+            )
         except Exception:
             logger.exception(
                 "v1 SSE watchdog check failed for task %s; retrying next cycle",

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -104,9 +104,9 @@ values it deliberately leaves unbounded, in one place:
     ``resync_required`` the same way the outbound queue's own overflow
     does. Sized off the same 4 MiB factor as the queue's byte budget and
     the snapshot budget below, but counted on a different unit: this
-    total is the *raw* broadcast text a staged message arrived in, before
-    projection, not serialized wire bytes -- a staged message is not a
-    frame yet.
+    total is the description-free measure of a staged message (see
+    ``_measured_content_frame``), before projection, not serialized wire
+    bytes -- a staged message is not a frame yet.
   - One attach-time batch of steps -- the two fast-path snapshots
     (``_fast_path_step_snapshot``) and the normal streaming path's
     warm-up replay (``_build_warm_up_frames``) alike:
@@ -1189,11 +1189,16 @@ class V1EventStreamSink:
         # overflow policy (``resync_required`` then close) rather than a
         # second one -- see ``_stage_content_message``.
         self._staged_messages: list[dict[str, Any]] = []
-        # Cumulative text length (``len(text)``, the same O(1) proxy the
-        # raw-frame pre-check in ``send_text`` uses) of everything
-        # currently in ``_staged_messages``, kept in lockstep with that
-        # list rather than recomputed by re-serializing it -- see
-        # ``STAGED_MESSAGES_MAX_TEXT_CHARS``.
+        # Cumulative text length of everything currently in
+        # ``_staged_messages`` -- the description-free measure
+        # ``_measured_content_frame`` returns, not a raw ``len(text)``,
+        # and the same value ``send_text``'s pre-check already
+        # computed, so nothing here is re-serialized a second time.
+        # Kept in lockstep with that list rather than recomputed -- see
+        # ``STAGED_MESSAGES_MAX_TEXT_CHARS``. Cheap (an O(1) ``len()``)
+        # only for a frame with no description key to prune; one that
+        # does carry one pays a ``json.dumps`` there, whose cost scales
+        # with the frame's own size.
         self._staged_text_chars = 0
         # Recorded at construction time (always inside the endpoint's own
         # request coroutine) so later state-mutating calls -- however they
@@ -1574,8 +1579,8 @@ class V1EventStreamSink:
         the expensive half here -- ``serialize_trace_data`` plus the
         projection fold -- never runs over the description at all, for
         every frame this method admits. That is a clear net saving
-        when the description is the bulk of the frame (about −0.11 ms
-        at a 64 KiB description, −0.34 ms at 200 KiB); when the
+        when the description is the bulk of the frame (about -0.11 ms
+        at a 64 KiB description, -0.34 ms at 200 KiB); when the
         payload is the bulk and the description is small, the extra
         ``json.dumps`` ``_measured_content_frame`` now always pays
         costs up to about +0.21 ms per frame on a 200 KiB frame,
@@ -1640,10 +1645,11 @@ class V1EventStreamSink:
                 # only defer the same drop to ``finish_warm_up`` while
                 # holding its bytes in the meantime. What gets staged is
                 # the same measured frame the warm path projects, counted
-                # in the same unit the check above used (characters
-                # excluding the task-description stamp), so the staging
-                # budget and the raw-frame cap measure one thing rather
-                # than two.
+                # in the same unit the check above used (the task's own
+                # description column excluded, whichever of the two keys
+                # it arrived under -- see ``_measured_content_frame``), so
+                # the staging budget and the raw-frame cap measure one
+                # thing rather than two.
                 if self._warm:
                     self._project_and_queue(frame)
                 else:

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -2936,17 +2936,23 @@ async def _generate(
                 # itself is gone (row deleted) -- continuing to hand out
                 # buffered history after that would leak content the
                 # client is no longer authorized to see, or content for a
-                # task that no longer exists. So only an abortive close
-                # breaks this loop early; every other close reason is
-                # left to arrive after replay finishes, via the queue,
-                # same as it always did. See ``enqueue_close`` and
+                # task that no longer exists. An abortive close and the
+                # connection's absolute deadline are the two conditions
+                # that break this loop early; every *other* close reason
+                # is still left to arrive after replay finishes, via the
+                # queue, same as it always did. See ``enqueue_close`` and
                 # ``abortive_close`` for which reasons set it.
                 for frame_text in warm_up_frames:
                     if sink.closing and sink.abortive_close:
                         break
+                    if monotonic() >= deadline:
+                        # No close of our own needed here: the main loop
+                        # below re-evaluates the deadline on its very
+                        # first pass and enqueues ``stream_expired`` then.
+                        break
                     yield frame_text
                 # Every frame this batch holds has now either been handed
-                # off or abandoned by the abortive-close break above --
+                # off or abandoned by one of the two breaks above --
                 # either way nothing in this generator reads
                 # ``warm_up_frames`` again, but the name stays bound in
                 # this frame's locals for as long as the generator itself

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -24,11 +24,16 @@ arrival order once it's ready -- see ``V1EventStreamSink._warm`` /
 ``_staged_messages`` for why an empty projector would otherwise fold a
 step's end event in as an orphan and silently drop it. That replay is
 bounded (``REPLAY_MAX_STEPS`` steps and ``MAX_SNAPSHOT_WIRE_BYTES`` of
-serialized frames, see ``_build_warm_up_frames``), so a client that
+serialized frames, see ``_build_warm_up_frames``), and it also ends
+early at a step whose ``data`` cannot be serialized, so a client that
 needs a task's complete history reconciles against
-``GET /v1/chat/tasks/{task_id}/steps``, which reads the database and so
-is unaffected by when the stream was opened or by what this stream's
-bounds admitted. The two attach-time fast paths are the exception to
+``GET /v1/chat/tasks/{task_id}/steps``, which reads the database rather
+than this stream's batch. That read does not depend on when the stream
+was opened or on what this stream's bounds admitted; it is not, however,
+an unconditional fallback -- see the endpoint docstring's best-effort
+delivery reasons in ``tasks.py`` for the full list of ways a replay can
+come up short, and for the one case where the reconciling read can fail
+on the same data. The two attach-time fast paths are the exception to
 all of this: an attach that finds the task already terminal, or already
 waiting on user input, closes without ever registering a projector, and
 sends a bounded one-shot snapshot of the task's steps between
@@ -1927,8 +1932,10 @@ def _snapshot_steps_within_wire_budget(
 
     A prefix, not a suffix, even though ``REPLAY_MAX_STEPS`` keeps the
     most recent steps: a step whose ``data`` cannot be serialized cannot
-    be measured either, and admitting it here is what keeps the emit loop
-    reaching it. Dropping from the oldest end instead would put an
+    be measured either, and admitting it here is what leaves the
+    decision with each caller -- the fast paths' emit loop reaches it
+    and reports it, the warm-up replay ends its batch at it. Dropping
+    from the oldest end instead would put an
     unserializable step at the head of the window, where it suppresses
     every good step behind it. The budget only binds on a window
     averaging more than 8 KiB per step.
@@ -1947,15 +1954,17 @@ def _snapshot_steps_within_wire_budget(
         would silently misreport a serialize failure as an ordinary size
         cut.
       - On the normal streaming path's warm-up replay
-        (``_build_warm_up_frames``), there is no per-step emit loop and no
-        conclusion frame to carry a marker: the bad step's serialization
-        raises out of the one call that builds the whole batch, so the
-        entire replayed history for that attach is discarded and the
-        connection closes for resync (see ``_generate``'s handling around
-        its call to ``_build_warm_up_frames``) rather than sending the
-        steps that came before it. There is no marker frame for this
-        either way; a client reconciles against ``GET .../steps``, same
-        as any other bounded or empty replay batch.
+        (``_build_warm_up_frames``), there is no per-step emit loop and
+        no conclusion frame to carry a marker. That caller serializes
+        the admitted steps one at a time and stops at the first one
+        that raises, so every step ahead of it is still replayed and
+        the connection still goes live -- the bad step, and whatever
+        the measuring pass stopped short of, are simply not in the
+        batch. There is no marker frame for this either way; a client
+        reconciles against ``GET .../steps``, same as any other bounded
+        or empty replay batch, and the endpoint's sixth best-effort
+        delivery reason in ``tasks.py`` states what that endpoint can
+        and cannot do for this particular case.
     """
     budget_remaining = MAX_SNAPSHOT_WIRE_BYTES
     admitted = 0
@@ -1963,8 +1972,10 @@ def _snapshot_steps_within_wire_budget(
         try:
             frame_bytes = len(_step_wire_frame(step))
         except Exception:
-            # Unmeasurable: admit it so the emit loop fails on it -- see
-            # the docstring above.
+            # Unmeasurable: admit it so the caller decides what to do
+            # about it -- the fast paths' emit loop reports it, the
+            # warm-up replay ends its batch there. See the docstring
+            # above.
             admitted += 1
             break
         if frame_bytes > budget_remaining:
@@ -2618,6 +2629,15 @@ def _build_warm_up_frames(
         replay contains is bounded by contract, and a client that needs
         the task's full history reconciles against ``GET .../steps`` --
         see the endpoint docstring in ``tasks.py``.
+      - A step whose serialization raises ends the batch at that step
+        rather than failing the whole attach: the frames already built
+        are returned, the stream goes live, and nothing on the wire
+        marks the cut. The shared budget admits such a step on purpose
+        -- it cannot be measured, so it cannot be budgeted -- which
+        makes it always the *last* admitted step, so "stop here" and
+        "skip it" produce the same batch today; stopping is what
+        matches the prefix the byte budget already produces. See the
+        endpoint's sixth best-effort delivery reason in ``tasks.py``.
 
     Validating to ``PublicStep`` up front is what lets the shared budget
     measure these steps at all (it takes the model, not a raw dict), and
@@ -2655,7 +2675,29 @@ def _build_warm_up_frames(
     admitted = _snapshot_steps_within_wire_budget(
         [PublicStep(**step) for step in steps[-REPLAY_MAX_STEPS:]]
     )
-    return warmed_projector, [_step_wire_frame(step) for step in admitted]
+    frames: list[str] = []
+    for step in admitted:
+        try:
+            frames.append(_step_wire_frame(step))
+        except Exception:
+            # One step whose ``data`` cannot be serialized ends this
+            # batch instead of taking the whole attach down with it:
+            # every step already serialized is still replayed and the
+            # stream still goes live. The shared budget admits such a
+            # step on purpose (unmeasurable, so unbudgetable) -- this
+            # loop is what keeps that decision from costing this attach
+            # the steps ahead of it. See the endpoint's sixth
+            # best-effort delivery reason in ``tasks.py``.
+            logger.exception(
+                "v1 SSE warm-up replay stopped at an unserializable step "
+                "for task %s; replaying the %d step(s) before it and "
+                "dropping %d admitted step(s)",
+                task_id,
+                len(frames),
+                len(admitted) - len(frames),
+            )
+            break
+    return warmed_projector, frames
 
 
 async def _generate(

--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -1134,15 +1134,18 @@ class V1EventStreamSink:
             maxsize=OUTBOUND_QUEUE_MAX_SIZE
         )
         self._closing = False
-        # Set by ``enqueue_close(abortive=True)``. Distinguishes *why* the
-        # sink is closing for callers that must react before the close
-        # frame itself is dequeued -- right now that's exactly one place,
-        # ``_generate``'s warm-up replay loop (see its own comment): a
-        # revoked key or a deleted task must stop that loop from handing
-        # out any more history, while every other close reason (a normal
-        # terminal/input-required conclusion, a resync signal) is exactly
-        # the case that loop exists to finish serving first. See
-        # ``enqueue_close`` for which reasons set this.
+        # Set by ``enqueue_close(abortive=True)``. Distinguishes *why*
+        # the sink is closing for callers that must react before the
+        # close frame itself is dequeued -- two places read it that way
+        # today: ``_generate``'s warm-up replay loop (see its own
+        # comment), where a revoked key or a deleted task must stop
+        # that loop from handing out any more history, while every
+        # other close reason (a normal terminal/input-required
+        # conclusion, a resync signal) is exactly the case that loop
+        # exists to finish serving first; and ``_watchdog_coverage_done``,
+        # which uses it to keep the watchdog alive past an ordinary
+        # close on a sink that never became warm. See ``enqueue_close``
+        # for which reasons set this.
         self._abortive_close = False
         self._last_status = initial_status
         # One incremental folding state machine per connection (never
@@ -1228,10 +1231,13 @@ class V1EventStreamSink:
         already claimed the close frame. This is a data-suppression
         switch, not a record of which caller won: a close that lost
         that race still revoked the client's standing to see the rest
-        of the buffered history. Meaningless (always False) while
-        ``closing`` is itself False -- check both, not this alone; see
-        ``enqueue_close``. Also decides how long the watchdog keeps
-        checking; see ``_watchdog_coverage_done``."""
+        of the buffered history. Implies ``closing`` -- ``enqueue_close``
+        latches this before its already-closing early return -- so a
+        check that only cares about revocation can read this alone; a
+        check that also cares about an ordinary close still needs
+        ``closing`` too, since this alone says nothing about whether a
+        close happened at all; see ``_watchdog_coverage_done``. Also
+        decides how long the watchdog keeps checking."""
         return self._abortive_close
 
     @property
@@ -1269,7 +1275,11 @@ class V1EventStreamSink:
         An abortive close means the client has lost the right to see
         *any* further data, including history that predates the close:
         today that's the watchdog's ``unauthorized`` (key
-        revoked/paused) and ``task_deleted`` (row gone) reasons. A
+        revoked/paused) and ``task_deleted`` (row gone) reasons, plus
+        the same ``task_deleted`` reason from ``_generate``'s own two
+        pre-loop reads (the replay watermark and the warm-up history),
+        each of which abandons the warm-up on a deleted task before it
+        can ever set ``sink.warm``. A
         non-abortive reason -- a normal terminal/input-required
         conclusion, ``resync_required``, ``stream_expired`` -- never
         sets it, so on its own the replay loop keeps handing out the
@@ -1776,8 +1786,11 @@ async def watchdog_check_once(
         # would kill legitimately paused streams too. The 1-hour absolute
         # cap is what actually bounds an orphaned paused stream's
         # lifetime while a client is still reading it -- it closes
-        # non-abortively (``stream_expired``), so it does not bound this
-        # watchdog's own lifetime; see ``_watchdog_coverage_done``.
+        # non-abortively (``stream_expired``), so it ends this
+        # watchdog's own coverage only once the warm-up handoff has
+        # completed (``sink.warm``); on a stream whose warm-up read
+        # never got that far, this watchdog runs on to the connection's
+        # own teardown as before. See ``_watchdog_coverage_done``.
         sink.enqueue_status(status.value)
         return False
     return False  # pending/running: keep streaming
@@ -1786,17 +1799,24 @@ async def watchdog_check_once(
 def _watchdog_coverage_done(sink: V1EventStreamSink) -> bool:
     """Whether this watchdog has anything left to protect.
 
-    A close on its own is not enough. ``_generate`` hands the initial
-    status frame and every warm-up replay frame straight to the client,
-    bypassing ``_put_or_overflow``'s closing guard, so an ordinary close
-    -- a staging overflow's ``resync_required``, a terminal
-    ``task.completed`` -- stops nothing on that path. Only
-    ``abortive_close`` stops it, and this loop is the only thing that
-    ever sets it (see ``watchdog_check_once``). Coverage therefore ends
-    when the revocation is already latched; otherwise it ends with the
-    connection, when ``_generate``'s ``finally`` cancels this task.
+    A close on its own is not enough while the sink is still cold.
+    ``_generate`` hands the initial status frame and every warm-up
+    replay frame straight to the client, bypassing
+    ``_put_or_overflow``'s closing guard, so on a cold sink an ordinary
+    close -- a staging overflow's ``resync_required``, a terminal
+    ``task.completed`` -- stops nothing on that path. Coverage
+    therefore ends on either of two conditions: the warm-up handoff is
+    over (``sink.warm``), after which every emission goes through
+    ``_put_or_overflow``'s closing guard and an ordinary close really
+    does stop the stream; or a revocation is already latched
+    (``sink.abortive_close``), set both by this loop's own
+    ``watchdog_check_once`` and by the two read failures in
+    ``_generate`` that abandon the warm-up on a deleted task before it
+    can ever set ``warm`` (see ``enqueue_close``). Otherwise coverage
+    ends with the connection, when ``_generate``'s ``finally`` cancels
+    this task.
     """
-    return sink.closing and sink.abortive_close
+    return sink.closing and (sink.warm or sink.abortive_close)
 
 
 async def _watchdog_loop(
@@ -1819,17 +1839,21 @@ async def _watchdog_loop(
 
     The exit rule is coverage, not closing: this loop only returns once
     ``_watchdog_coverage_done`` is true -- the revocation is already
-    latched -- or it is cancelled during ``_generate``'s teardown. A
-    close by itself does not end the loop, because ``_generate``'s
-    warm-up replay yields its frames directly to the client, bypassing
-    the outbound queue's closing guard; an ordinary close (a staging
+    latched, or the warm-up handoff is over -- or it is cancelled
+    during ``_generate``'s teardown. A close by itself does not end the
+    loop on a sink that is still cold, because ``_generate``'s warm-up
+    replay yields its frames directly to the client, bypassing the
+    outbound queue's closing guard; an ordinary close (a staging
     overflow, a terminal state this loop itself just found) leaves that
-    direct path free to keep emitting, so this loop has to stay alive to
-    catch a revocation that lands afterward. A consumer that stops
-    reading gives this loop no way to observe that closing ever
-    happened, so it keeps polling on its normal cadence until the
-    generator's teardown cancels it -- there is no time bound on that
-    other than the connection's own.
+    direct path free to keep emitting until the handoff completes, so
+    this loop has to stay alive to catch a revocation that lands before
+    then. Once the handoff is over, every emission goes through
+    ``_put_or_overflow``'s closing guard instead, and an ordinary close
+    really does stop the stream. A consumer that stops reading gives
+    this loop no way to observe that closing ever happened, so it keeps
+    polling on its normal cadence until the generator's teardown
+    cancels it -- there is no time bound on that other than the
+    connection's own.
     """
     while not _watchdog_coverage_done(sink):
         try:
@@ -1845,10 +1869,11 @@ async def _watchdog_loop(
         try:
             # The return value is deliberately not an exit condition. A
             # check that closes the stream non-abortively -- a terminal
-            # task found while the warm-up read is still in flight --
-            # leaves the direct replay free to keep emitting, so this
-            # loop must stay alive to observe a revocation that lands
-            # after it. Only the condition above ends it.
+            # task found while the warm-up read is still in flight,
+            # sink still cold -- leaves the direct replay free to keep
+            # emitting, so this loop must stay alive to observe a
+            # revocation that lands after it. Only the condition above
+            # ends it.
             await watchdog_check_once(
                 sink, task_id, principal, read_task_snapshot=read_task_snapshot
             )
@@ -2754,8 +2779,13 @@ async def _generate(
                 # would send it to a 404. Not logged, for the same
                 # reason that branch and the watchdog don't log it -- a
                 # task deleted while an attach is in flight is a race,
-                # not a bug in this stream.
-                sink.enqueue_close(error_frame("task_deleted"))
+                # not a bug in this stream. ``abortive=True`` for the
+                # same reason ``watchdog_check_once`` sets it on this
+                # same task_deleted reason: the row is gone, and this
+                # read fails before the warm-up handoff can ever set
+                # ``sink.warm``, so it's also what ends watchdog
+                # coverage on this path.
+                sink.enqueue_close(error_frame("task_deleted"), abortive=True)
             else:
                 logger.exception(
                     "v1 SSE replay watermark read failed for task %s; "
@@ -2866,7 +2896,12 @@ async def _generate(
                     isinstance(exc, V1ApiError)
                     and exc.code is V1ErrorCode.TASK_NOT_FOUND
                 ):
-                    sink.enqueue_close(error_frame("task_deleted"))
+                    # abortive=True for the same reason as the
+                    # watermark-read branch above: the row is gone, and
+                    # this read fails before the warm-up handoff can
+                    # ever set ``sink.warm``, so it's also what ends
+                    # watchdog coverage on this path.
+                    sink.enqueue_close(error_frame("task_deleted"), abortive=True)
                 else:
                     logger.exception(
                         "v1 SSE warm-up failed for task %s; closing for resync "

--- a/src/xagent/web/api/v1/_step_mapping.py
+++ b/src/xagent/web/api/v1/_step_mapping.py
@@ -201,14 +201,26 @@ class PublicStepProjector:
         nothing reads. :meth:`materialized_steps` raises in this mode
         rather than returning a silently partial timeline.
 
+    A consumer that needs both in sequence -- the whole timeline once,
+    and then a projector that keeps folding live events without
+    retaining any of them -- cannot express that as a construction-time
+    flag, because each mode breaks one half of it. :meth:`take_materialized_steps`
+    is that transition: it returns the timeline and drops retention in
+    the same call, leaving an instance indistinguishable from one built
+    with ``retain_finished=False``. It exists so the pre-warm caller
+    never has to reach into the projector's own list to do it.
+
     ``feed``'s return value is identical in both modes; the mode only
     decides whether the projector also keeps the step afterwards. The
     pending table is kept either way -- the pairing rules need it.
 
     :meth:`materialized_steps` never sorts by ``started_at``. That global
-    resort is a batch-only concern (see ``map_trace_events_to_public_steps``):
-    a live consumer wants steps in the order they actually resolved, not
-    resorted on every event.
+    resort is left to the two callers that need public, ``started_at``-
+    ordered output: ``map_trace_events_to_public_steps`` (the batch
+    driver behind ``GET .../steps``) and ``_events_stream.py``'s
+    ``_build_warm_up_frames`` (the attach-time replay), each sorting the
+    snapshot it takes for its own purpose. A live consumer wants steps in
+    the order they actually resolved, not resorted on every event.
 
     Preconditions for the incremental path: one instance per task, fed
     in event order, from one thread/task at a time. ``feed`` mutates
@@ -263,14 +275,26 @@ class PublicStepProjector:
             projector.feed(event)
         return projector
 
+    @property
+    def retains_finished(self) -> bool:
+        """Whether this projector still keeps finished steps.
+
+        The retention mode as a readable fact rather than an inference
+        from whether :meth:`materialized_steps` happens to raise, so a
+        consumer whose correctness depends on being handed a
+        *non*-retaining projector can check for it directly.
+        """
+        return self._finished is not None
+
     def materialized_steps(self) -> List[Dict[str, Any]]:
         """Return every step currently known, finished or still running.
 
         Order: finished steps in the order they resolved, then any
         still-``pending`` (``running``) steps in the order they started.
-        Callers that need the public started_at-sorted order (currently
-        only the ``map_trace_events_to_public_steps`` batch driver) sort
-        this themselves.
+        Callers that need the public started_at-sorted order --
+        ``map_trace_events_to_public_steps`` (the batch driver) and
+        ``_events_stream.py``'s ``_build_warm_up_frames`` (the attach-time
+        replay) -- sort this themselves.
 
         The list itself is a fresh snapshot, but the step dicts inside
         it are the projector's live objects: a still-``running`` step
@@ -278,17 +302,49 @@ class PublicStepProjector:
         :meth:`feed`). Treat them as read-only views -- a caller that
         needs a stable picture must copy before storing.
 
-        Raises ``RuntimeError`` on a projector built with
-        ``retain_finished=False``: the finished steps it would need were
-        never kept, so there is no partial answer worth returning.
+        Raises ``RuntimeError`` on a projector that is not retaining --
+        one built with ``retain_finished=False``, or one that has since
+        released retention through :meth:`take_materialized_steps`. The
+        finished steps it would need were never kept (or are already
+        gone), so there is no partial answer worth returning.
         """
         if self._finished is None:
             raise RuntimeError(
                 "materialized_steps() needs the finished-step history; this "
-                "projector was built with retain_finished=False"
+                "projector is not retaining finished steps"
             )
         steps = list(self._finished)
         steps.extend(self._pending.values())
+        return steps
+
+    def take_materialized_steps(self) -> List[Dict[str, Any]]:
+        """Return every step known so far, then stop retaining finished ones.
+
+        The pre-warm exit. A caller that replays a task's history to
+        build pairing state, reads that history out exactly once, and
+        then keeps feeding the same instance live events needs both
+        halves of the retention question answered differently over time:
+        retention on while the history is being folded and read, off
+        afterwards. The v1 SSE warm-up replay is that caller -- it hands
+        the projector to a sink that serializes each ``feed`` result
+        immediately and never asks for the timeline again, over a
+        connection that can live an hour.
+
+        Returns exactly what :meth:`materialized_steps` would have
+        returned, with the same live-object caveat. Afterwards this
+        instance behaves as if it had been built with
+        ``retain_finished=False``: :meth:`feed` still returns every step
+        it changes, :meth:`materialized_steps` raises, and nothing
+        accumulates. Releasing retention here rather than letting the
+        caller clear the projector's own list is what keeps that
+        invariant checkable in one place.
+
+        Raises ``RuntimeError`` on a projector that is already not
+        retaining, for the same reason :meth:`materialized_steps` does:
+        there is no timeline to hand back.
+        """
+        steps = self.materialized_steps()
+        self._finished = None
         return steps
 
     def feed(self, event: Any) -> List[Dict[str, Any]]:
@@ -311,7 +367,6 @@ class PublicStepProjector:
         event_type = _safe_get(event, "event_type")
         if not event_type:
             return []
-
         # ===== messages: one event per message, no pairing =====
         if event_type == "user_message":
             step = _build_message_step(event, role="user")

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1423,8 +1423,9 @@ async def stream_chat_task_events(
       ``message.delta``/``message.completed`` carries the shortened text
       itself plus ``truncated: true`` and no ``original_bytes``. A raw
       broadcast frame that runs past 256 KiB -- measured without the
-      internal task-description stamp such frames carry -- is dropped
-      whole instead of truncated (see Behavior below): no marker, no
+      task's own description column, which such frames carry under one
+      of two keys depending on the frame family -- is dropped whole
+      instead of truncated (see Behavior below): no marker, no
       content.
       This cap is specific to this stream -- ``GET .../steps`` applies
       no such cap and always returns a step's full, untruncated
@@ -1483,11 +1484,12 @@ async def stream_chat_task_events(
         so its content never reaches the per-field truncation cap
         described above and leaves no ``"truncated": true`` marker --
         this is a full drop, not a truncation. The size measured
-        excludes the task description that the broadcast conversion
-        stamps onto every trace event, so a task's description alone
-        can no longer blank out its step stream this way -- a frame is
-        only dropped here when its content, apart from that field, is
-        still over the cap. (4) a planning step can be left unresolved:
+        excludes the task's own description column -- which arrives
+        under one of two keys depending on the frame family -- so a
+        task's description alone can no longer blank out its step
+        stream this way -- a frame is only dropped here when its
+        content, apart from that column, is still over the cap. (4) a
+        planning step can be left unresolved:
         when a planning round ends without emitting its own terminal
         event (a plan-generation error escaping before it), the next
         round clears the pairing key that step was waiting on, so the

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -733,8 +733,18 @@ class _TaskStepsVersionSnapshot:
 
 @dataclass(frozen=True)
 class _TraceEventSnapshot:
-    """Trace fields consumed by the pure public-step mapper."""
+    """Trace fields consumed by the pure public-step mapper.
 
+    ``id`` is the row's numeric primary key (``TraceEvent.id``) --
+    distinct from ``event_id`` below (the row's own string identifier,
+    exposed to SDK clients as part of a public step's derived id).
+    Kept here specifically so ``v1/_events_stream.py``'s warm-up replay
+    can bound itself to a watermark (``id <= some max_event_id``,
+    the same column ``_load_task_steps_version_snapshot`` reads) without
+    a second, id-only read of the same rows.
+    """
+
+    id: int
     task_id: int
     event_id: str
     event_type: str
@@ -886,6 +896,7 @@ def _load_task_steps_snapshot(
         )
         events = tuple(
             _TraceEventSnapshot(
+                id=int(row.id),
                 task_id=int(row.task_id),
                 event_id=str(row.event_id),
                 event_type=str(row.event_type),
@@ -1290,16 +1301,28 @@ async def stream_chat_task_events(
       - ``step.started``: ``{step}``, a running ``PublicStep``.
       - ``step.completed``: ``{step}``, the same step once its end event
         (or failure) resolves it -- ``status`` is ``"completed"`` or
-        ``"failed"``. On the two attach-time fast paths below (the task
-        is already finished, or already waiting on user input), these
-        frames are that attach's one-shot step snapshot: in
-        ``started_at`` order, drawn from the task's most recent steps
-        up to a step-count cap (512) and a total-wire-bytes budget over the
-        snapshot's serialized frames. When the byte budget is what binds,
-        it keeps that window's oldest contiguous run, so the very latest
-        steps may be the ones missing. Whether the snapshot was cut short
-        is reported on the conclusion frame, not on these -- ``GET
-        .../steps`` is the authoritative full history either way.
+        ``"failed"``. Every attach opens with a batch of these frames
+        describing the steps the task already has, in ``started_at``
+        order: a replay of the task's history on the normal path, and a
+        one-shot snapshot on the two attach-time fast paths below (the
+        task is already finished, or already waiting on user input).
+        Both batches are drawn from the task's most recent steps and are
+        bounded by two caps applied in series, not whichever binds first:
+        a step-count cap (512) keeps the most recent steps, then a
+        total-wire-bytes budget (4 MiB) over that window's serialized
+        frames trims it further. Either cap can be the one that actually
+        removes something, and both can fire on the same batch. When the
+        byte budget is what trims, it keeps that window's oldest
+        contiguous run, so the very latest steps may be the ones missing;
+        a batch can also come out empty. Whether the batch was cut short
+        is reported on the conclusion frame on the fast paths, and is not
+        reported at all on the normal path, which has no conclusion frame
+        at attach time -- these ``step.*`` frames carry no **batch-level**
+        truncation field of their own on either path (a step's own
+        ``data`` can still carry its own ``truncated: true`` when that
+        step's content overflows the per-frame cap -- see below). ``GET
+        .../steps`` is the authoritative full history either way, and is
+        where a client that needs every step reconciles.
       - ``message.delta``: ``{message_id, text}``, one chunk of a
         streamed final answer as the agent generates it.
       - ``message.completed``: ``{message_id, content}``, that same
@@ -1313,26 +1336,49 @@ async def stream_chat_task_events(
         over them: prefer the accumulated deltas, or ``steps()`` for the
         full persisted text.
       A ``message`` ``PublicStep``'s ``id`` cannot be correlated between
-      this stream and ``GET .../steps``: the live frame mints a fresh id
-      per broadcast, while ``steps()`` returns the persisted trace
-      event's own id as that step's id.
+      this stream and ``GET .../steps`` for a step this connection
+      projects *live*: the live frame mints a fresh id per broadcast,
+      while ``steps()`` returns the persisted trace event's own id as
+      that step's id. This does not hold for the attach-time replay
+      batch above: a replayed step is folded from the same persisted
+      ``TraceEvent`` rows ``steps()`` reads, through the same
+      ``PublicStepProjector`` fold, so its id is that same row's own id
+      and matches ``steps()`` exactly.
       A ``thinking`` step whose id begins with ``thinking:plan:`` or
-      ``thinking:planning:`` cannot be correlated either, and is the one
-      case where trying to actively corrupts client state. Both ids end
-      in a count of the planning cycles the projection has seen, and
-      this stream's projection starts empty at attach: it numbers the
-      first planning cycle it observes ``:1`` however many already
-      happened, while ``steps()`` counts from the start of the task's
-      persisted history. A client attaching during a task's second
-      planning cycle is therefore sent ``thinking:plan:{task_id}:1`` for
-      a step ``steps()`` calls ``thinking:plan:{task_id}:2`` -- and
-      ``thinking:plan:{task_id}:1`` already exists in ``steps()`` as the
-      first cycle, a different step. Merging the two surfaces by id
-      overwrites one with the other. These ids are stable within one
-      connection and nowhere else: a re-attach after ``stream_expired``
-      (the 1-hour cap) or ``resync_required`` (queue overflow) opens a
-      new connection whose count starts over. Reconcile planning steps
-      against ``steps()`` by ``started_at`` and content, not by id.
+      ``thinking:planning:`` is correlated the same way: the replay
+      batch's ids match ``steps()`` exactly, because the projector that
+      builds that batch is warmed by replaying the task's full
+      persisted history rather than starting empty, so the planning-
+      cycle count it lands on is the same one ``steps()`` computes from
+      the same rows.
+      A client library may carry a stricter rule than this contract. The
+      Python SDK's ``events()`` guidance tells callers to reconcile a
+      planning step by ``started_at`` plus content, "never by id", with
+      no exception for a replayed step -- wording that predates the
+      attach-time replay batch. A caller that follows it is safe rather
+      than wrong: it forgoes a correlation this endpoint does offer for
+      replayed steps instead of making one this endpoint does not
+      support. Narrowing that guidance to the live-projected case is
+      SDK-side work, not a difference in what this endpoint sends.
+      The gap that remains is narrower than the replay batch, and is
+      real in two cases. First, a ``thinking:plan:``/``thinking:planning:``
+      id minted for a live frame *after* the replay batch: its count
+      continues from whatever this connection's own projector had
+      observed by then, and a client must not assume that always equals
+      ``steps()``'s own count. Second, the narrow race window between
+      this connection's registration with the broadcast manager and the
+      watermark read that bounds the replay (see ``_build_warm_up_frames``):
+      a row landing inside that window is folded in twice -- once by the
+      replay, and once more as a live broadcast that carries no
+      persisted id to dedupe it against -- which can push a live
+      planning-cycle count out of step with ``steps()`` from that point
+      on. Trying to actively correlate a step id across either of these
+      two live cases corrupts client state rather than merely missing a
+      match. These live ids are stable within one connection and nowhere
+      else: a re-attach after ``stream_expired`` (the 1-hour cap) or
+      ``resync_required`` (queue overflow) opens a new connection whose
+      count starts over. Reconcile a live planning step against
+      ``steps()`` by ``started_at`` and content, not by id.
       Every other public step type -- ``tool_call``,
       ``agent_delegation``, and ``thinking`` steps whose id carries the
       originating step id rather than a count -- keeps the same id
@@ -1348,11 +1394,11 @@ async def stream_chat_task_events(
       this stream: once as its ``message.delta``/``message.completed``
       sequence, and again as a ``message``-type ``step.completed`` once
       the underlying ``ai_message`` trace event folds in -- the same
-      step ``steps()`` already shows for that row. This is duplication,
-      not loss: a client that already rendered the delta/completed
-      sequence can ignore the matching step, or use it as the
-      authoritative record instead, but should not expect the two to be
-      mutually exclusive.
+      step ``steps()`` and a fresh attach's replay already show for
+      that row. This is duplication, not loss: a client that already
+      rendered the delta/completed sequence can ignore the matching
+      step, or use it as the authoritative record instead, but should
+      not expect the two to be mutually exclusive.
       A ``step.*``/``message.*`` frame whose content-bearing field would
       exceed a per-frame byte cap has that field truncated (or, for a
       step's structured ``data``, replaced) and flagged with
@@ -1378,28 +1424,36 @@ async def stream_chat_task_events(
 
     Behavior:
       - Normal attach: opens the stream, emits ``task.status`` for the
-        task's current state, then goes live -- a status update each
-        time the task's status changes (consecutive duplicates are
-        suppressed), ``step.*``/``message.*`` frames as new trace
-        events and streamed answer chunks arrive, and
-        ``task.completed`` when the task finishes. A ``: ping`` comment
-        line is sent whenever 15s pass without any other frame going
-        out, to keep the connection alive -- not on a fixed 15s
-        cadence regardless of activity.
-      - A stream that goes live carries only what happens after the
-        connection opens; it never resends the steps that already
-        happened. (The two attach-time fast paths below are the
-        exception: they send a one-shot snapshot of the task's steps
-        and close, rather than going live at all.) That has one
-        consequence a client must handle: a step that was already
-        running at attach time does not appear on this stream at all.
-        Its ``step.started`` was broadcast before this connection
-        existed, and its end event arrives here with no matching
-        start, so that end is dropped rather than sent -- the client
-        sees neither half of the step. ``GET .../steps`` reads the
-        database and is unaffected by when the stream was opened, so a
-        client attaching to an already-running task reconciles there
-        rather than expecting this stream to fill the gap.
+        task's current state, then replays the task's already-known
+        steps as ``step.started``/``step.completed`` frames in
+        ``started_at`` order -- the same order ``steps()`` returns them
+        in -- then goes live: a status update each time the task's
+        status changes (consecutive duplicates are suppressed), further
+        ``step.*``/``message.*`` frames as new trace events and streamed
+        answer chunks arrive, and ``task.completed`` when the task
+        finishes. A ``: ping`` comment line is sent whenever 15s pass
+        without any other frame going out, to keep the connection
+        alive -- not on a fixed 15s cadence regardless of activity.
+      - The replay is what lets a client attach to a task that is
+        already running and still see that task's in-flight steps
+        resolve: a step whose ``step.started`` was broadcast before the
+        connection existed is replayed here, so its end event arriving
+        later has a start to pair with and reaches the client as
+        ``step.completed`` rather than being dropped as an orphan.
+      - The replay is bounded, and a client must not treat it as the
+        task's complete history. It is capped in series: at most 512
+        steps, then at most 4 MiB of serialized step frames over that
+        window (the same two bounds the fast paths' snapshot uses,
+        applied in the same order; see ``step.started``/``step.completed``
+        above for which end of the window each one drops). A task with
+        more history than that gets a partial replay, with no marker
+        frame saying so, and a replay can legitimately be empty. This is
+        a bound, not a failure:
+        nothing about it closes the stream or emits ``stream.error``.
+        ``GET .../steps`` reads the database, is unaffected by when the
+        stream was opened or by what the replay admitted, and is the
+        authoritative full history -- a client that needs every step
+        reconciles there.
       - Frame sequence into ``task.completed``: a task that fails emits
         ``task.status`` (``"failed"``) from the failure broadcast first,
         then the watchdog's authoritative ``task.completed`` close
@@ -1442,7 +1496,13 @@ async def stream_chat_task_events(
         presence or absence proves nothing about whether a content frame
         was lost this way: a ``stream.error`` does not mean content was
         dropped, and its absence does not mean nothing was. Only
-        reconciling against ``steps()`` answers that. No failure
+        reconciling against ``steps()`` answers that. A related but
+        separate mechanism is the warm-up staging buffer (used only
+        during a fresh attach's replay window, before this sink goes
+        live): if it overflows, the still-unfed staged messages are
+        dropped and the stream closes with ``resync_required`` for that
+        specific reason -- a bound on that buffer, not the outbound
+        queue (1) describes. No failure
         information is lost when a status frame is dropped this way --
         ``task.completed`` still carries ``status: "failed"`` and a
         populated ``error`` -- but a dropped content frame has no such
@@ -1512,9 +1572,13 @@ async def stream_chat_task_events(
       - No ``task.status`` frame is guaranteed to be fresh or in order,
         at any point in the stream's life, not only at attach: this
         endpoint never buffers or reconciles ``task.status`` frame
-        order against anything. Accepted because only the three close
-        frames above are treated as authoritative; each comes from a
-        direct read of the task row, never from frame ordering.
+        order against anything (``step.*``/``message.*`` frames are a
+        separate story -- attaching mid-task replays known steps before
+        going live specifically so a step's end event isn't misread as
+        an orphan; that ordering guarantee doesn't extend to
+        ``task.status``). Accepted because only the three close frames
+        above are treated as authoritative; each comes from a direct
+        read of the task row, never from frame ordering.
 
     Args:
         task_id: Path parameter; the target task's primary key.
@@ -1546,10 +1610,11 @@ async def stream_chat_task_events(
             registers a sink at all, so it never counts toward either
             cap -- its step snapshot read goes through the same
             ``max_event_id``-keyed cache ``GET .../steps`` uses. That
-            snapshot is bounded by a step-count cap and a
-            total-wire-bytes budget; a snapshot cut short by either
-            carries the ``snapshot_truncated``/``snapshot_total_steps``
-            marker on its conclusion frame as described above. When a
+            snapshot is bounded by the same step-count cap and
+            total-wire-bytes budget the normal streaming path's own
+            history replay is; a snapshot cut short by either carries
+            the ``snapshot_truncated``/``snapshot_total_steps`` marker
+            on its conclusion frame as described above. When a
             shared cache backend is configured (Redis; see
             ``hot_path_cache.get_cache_backend``), a burst of fast-path
             attaches on one task (or repeated attaches after it's
@@ -1568,11 +1633,12 @@ async def stream_chat_task_events(
             watchdog's 30s database poll picks it up, not via broadcast.
             That poll only ever reads task status, though, never step
             content: an attach routed to a different worker than the one
-            executing the task still gets the authoritative close frame
-            (the watchdog reads the task row), but receives none of the
-            live ``step.*``/``message.*`` frames produced in between --
-            there is no equivalent fallback delivery for content the way
-            there is for a status transition, so such an attach
+            executing the task still gets a correct history replay (it
+            reads the database) and the authoritative close frame (the
+            watchdog reads the task row), but receives none of the live
+            ``step.*``/``message.*`` frames produced in between -- there
+            is no equivalent fallback delivery for content the way there
+            is for a status transition, so such an attach's live portion
             degrades to the lifecycle-only shape. Some transitions --
             lease-expiry recovery among them -- never broadcast at all,
             in any deployment shape, so the watchdog poll is their only
@@ -1586,6 +1652,7 @@ async def stream_chat_task_events(
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=_load_task_info_snapshot,
+        read_task_steps=_load_task_steps_snapshot,
         read_task_steps_response=_get_chat_task_steps_sync,
         read_task_steps_version=_load_task_steps_version_snapshot,
     )

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1372,7 +1372,11 @@ async def stream_chat_task_events(
       replay, and once more as a live broadcast that carries no
       persisted id to dedupe it against -- which can push a live
       planning-cycle count out of step with ``steps()`` from that point
-      on. Trying to actively correlate a step id across either of these
+      on. A planning step opened inside that window can also be left at
+      ``status: "running"`` for the rest of the connection: the row is
+      folded twice, so it produces two public step ids, and the row's
+      single end event closes only the later one. Tracked as #1776.
+      Trying to actively correlate a step id across either of these
       two live cases corrupts client state rather than merely missing a
       match. These live ids are stable within one connection and nowhere
       else: a re-attach after ``stream_expired`` (the 1-hour cap) or
@@ -1441,11 +1445,10 @@ async def stream_chat_task_events(
         later has a start to pair with and reaches the client as
         ``step.completed`` rather than being dropped as an orphan.
       - The replay is bounded, and a client must not treat it as the
-        task's complete history. It is capped in series: at most 512
-        steps, then at most 4 MiB of serialized step frames over that
-        window (the same two bounds the fast paths' snapshot uses,
-        applied in the same order; see ``step.started``/``step.completed``
-        above for which end of the window each one drops). A task with
+        task's complete history. It carries the same two caps, applied
+        in the same order, that ``step.started``/``step.completed``
+        above states for every attach-time batch, including which end
+        of the window each one drops. A task with
         more history than that gets a partial replay, with no marker
         frame saying so, and a replay can legitimately be empty. This is
         a bound, not a failure:

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1443,7 +1443,9 @@ async def stream_chat_task_events(
         resolve: a step whose ``step.started`` was broadcast before the
         connection existed is replayed here, so its end event arriving
         later has a start to pair with and reaches the client as
-        ``step.completed`` rather than being dropped as an orphan.
+        ``step.completed`` rather than being dropped as an orphan --
+        unless the replay's byte budget trimmed that step out of the
+        batch, which is reason (5) below.
       - The replay is bounded, and a client must not treat it as the
         task's complete history. It carries the same two caps, applied
         in the same order, that ``step.started``/``step.completed``
@@ -1461,7 +1463,7 @@ async def stream_chat_task_events(
         ``task.status`` (``"failed"``) from the failure broadcast first,
         then the watchdog's authoritative ``task.completed`` close
         frame. Delivery of every ``step.*``/``message.*`` content frame
-        on this stream is best-effort, not guaranteed, for four
+        on this stream is best-effort, not guaranteed, for five
         separate reasons: (1) closing a stream for any reason drains its
         queued backlog before inserting the close frame, so any
         already-queued frame -- a ``task.status``, a ``step.*``, a
@@ -1489,7 +1491,17 @@ async def stream_chat_task_events(
         stream's life (``_step_mapping.py``'s ``dag_execute_start``
         branch). This one is not a stream-only artifact: ``GET
         .../steps`` folds the same events and shows that step the same
-        way. (2), (3) and (4) are silent: none of them ever produces a
+        way. (5) the replay's byte budget can trim a still-running step
+        out of the batch it sends at attach time: the projector that
+        feeds the live view is still warmed from the task's whole
+        history regardless, so that step's ``step.completed`` still
+        arrives once it resolves, but this stream never sent the
+        ``step.started`` the replay would otherwise have given it, so
+        the end arrives with no start on this stream to pair with. This
+        one is a stream-only artifact, unlike (4): ``GET .../steps``
+        reads the task's full history directly and is unaffected by
+        what one stream attach's replay admitted. (2), (3), (4) and (5)
+        are silent: none of them ever produces a
         ``stream.error`` frame or any other signal on the wire. (1) is
         not silent in the same way -- the
         close frame that follows a queue-drain is often itself a
@@ -1578,8 +1590,10 @@ async def stream_chat_task_events(
         order against anything (``step.*``/``message.*`` frames are a
         separate story -- attaching mid-task replays known steps before
         going live specifically so a step's end event isn't misread as
-        an orphan; that ordering guarantee doesn't extend to
-        ``task.status``). Accepted because only the three close frames
+        an orphan, unless the replay's byte budget trimmed that step
+        out of the batch, which is reason (5) below; that ordering
+        guarantee doesn't extend to ``task.status``). Accepted because
+        only the three close frames
         above are treated as authoritative; each comes from a direct
         read of the task row, never from frame ordering.
 

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1451,7 +1451,8 @@ async def stream_chat_task_events(
         later has a start to pair with and reaches the client as
         ``step.completed`` rather than being dropped as an orphan --
         unless the replay's byte budget trimmed that step out of the
-        batch, which is reason (5) below.
+        batch, or the batch ended early at a step this stream could not
+        serialize -- reasons (5) and (6) below.
       - The replay is bounded, and a client must not treat it as the
         task's complete history. It carries the same two caps, applied
         in the same order, that ``step.started``/``step.completed``
@@ -1461,15 +1462,21 @@ async def stream_chat_task_events(
         frame saying so, and a replay can legitimately be empty. This is
         a bound, not a failure:
         nothing about it closes the stream or emits ``stream.error``.
+        A step whose data this stream
+        cannot serialize ends the batch at that step, which shortens the
+        replay the same way without closing the stream either; that one
+        is reason (6) below.
         ``GET .../steps`` reads the database, is unaffected by when the
         stream was opened or by what the replay admitted, and is the
         authoritative full history -- a client that needs every step
-        reconciles there.
+        reconciles there. That is true of a replay shortened by either
+        cap. It is not unconditionally true of a replay shortened by a
+        step it could not serialize: reason (6) below says why.
       - Frame sequence into ``task.completed``: a task that fails emits
         ``task.status`` (``"failed"``) from the failure broadcast first,
         then the watchdog's authoritative ``task.completed`` close
         frame. Delivery of every ``step.*``/``message.*`` content frame
-        on this stream is best-effort, not guaranteed, for five
+        on this stream is best-effort, not guaranteed, for six
         separate reasons: (1) closing a stream for any reason drains its
         queued backlog before inserting the close frame, so any
         already-queued frame -- a ``task.status``, a ``step.*``, a
@@ -1507,8 +1514,18 @@ async def stream_chat_task_events(
         the end arrives with no start on this stream to pair with. This
         one is a stream-only artifact, unlike (4): ``GET .../steps``
         reads the task's full history directly and is unaffected by
-        what one stream attach's replay admitted. (2), (3), (4) and (5)
-        are silent: none of them ever produces a
+        what one stream attach's replay admitted. (6) a step whose data
+        cannot be turned into JSON ends the replay batch at that step:
+        the steps serialized before it still go out and the stream
+        still goes live, but that step and anything the batch had not
+        reached are missing from the replay, leaving the same
+        start-without-end shape reason (5) describes. Reconciling this
+        one against ``GET .../steps`` is not guaranteed to work the way
+        it does for (5): that endpoint serializes the same step data on
+        its own read path, so data that defeats the replay can make
+        that read fail as well. That is a property of the data, not of
+        this stream, and it is tracked separately. (2), (3), (4), (5)
+        and (6) are silent: none of them ever produces a
         ``stream.error`` frame or any other signal on the wire. (1) is
         not silent in the same way -- the
         close frame that follows a queue-drain is often itself a
@@ -1598,7 +1615,9 @@ async def stream_chat_task_events(
         separate story -- attaching mid-task replays known steps before
         going live specifically so a step's end event isn't misread as
         an orphan, unless the replay's byte budget trimmed that step
-        out of the batch, which is reason (5) below; that ordering
+        out of the batch, or the batch ended early at a step this
+        stream could not serialize -- reasons (5) and (6) below; that
+        ordering
         guarantee doesn't extend to ``task.status``). Accepted because
         only the three close frames
         above are treated as authoritative; each comes from a direct

--- a/src/xagent/web/api/v1/tasks.py
+++ b/src/xagent/web/api/v1/tasks.py
@@ -1376,6 +1376,8 @@ async def stream_chat_task_events(
       ``status: "running"`` for the rest of the connection: the row is
       folded twice, so it produces two public step ids, and the row's
       single end event closes only the later one. Tracked as #1776.
+      This is a defect, unlike the final-answer duplication described
+      below, which is deliberate.
       Trying to actively correlate a step id across either of these
       two live cases corrupts client state rather than merely missing a
       match. These live ids are stable within one connection and nowhere
@@ -1402,7 +1404,10 @@ async def stream_chat_task_events(
       that row. This is duplication, not loss: a client that already
       rendered the delta/completed sequence can ignore the matching
       step, or use it as the authoritative record instead, but should
-      not expect the two to be mutually exclusive.
+      not expect the two to be mutually exclusive. Unlike the
+      race-window duplication described above (tracked as #1776),
+      this one is by design on every attach, not a narrow-window
+      defect.
       A ``step.*``/``message.*`` frame whose content-bearing field would
       exceed a per-frame byte cap has that field truncated (or, for a
       step's structured ``data``, replaced) and flagged with

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -3212,6 +3212,43 @@ async def test_staged_messages_byte_budget_overflow_closes_with_resync_required(
     assert "resync_required" in frame_text
 
 
+async def test_a_cold_status_frame_leaves_the_staging_drain_no_margin():
+    """The staging list and the outbound queue are capped by the *same*
+    constant, so a lifecycle frame that bypassed staging while the sink
+    was cold makes the warm-up drain one frame too big for the queue.
+
+    Pins that zero margin so the two caps cannot drift apart silently:
+    with the staging cap one lower, the drain would fit and this test's
+    overflow would not happen. What the overflow must not become is a
+    silent truncation -- the client is told to resync, which is the same
+    answer every other over-full queue gets.
+    """
+    sink = _make_sink(task_id=97, warm=False)
+    # A lifecycle frame goes straight into the outbound queue even
+    # though the sink is cold -- it never touches staging.
+    sink.enqueue_status("paused")
+    assert sink.queue.qsize() == 1
+
+    for i in range(es.OUTBOUND_QUEUE_MAX_SIZE):
+        await sink.send_text(
+            _trace_event_frame(
+                "tool_execution_start",
+                task_id=97,
+                data={"tool_call_id": f"call-{i}", "tool_name": "x", "tool_args": {}},
+            )
+        )
+    assert sink.staged_message_count == es.OUTBOUND_QUEUE_MAX_SIZE
+    assert sink.closing is False
+
+    sink.finish_warm_up(es.PublicStepProjector(retain_finished=False))
+
+    # 1 lifecycle frame + 256 drained frames > 256 slots.
+    assert sink.closing is True
+    frame_text, is_close = sink.queue.get_nowait()
+    assert is_close is True
+    assert "resync_required" in frame_text
+
+
 async def test_one_task_info_frame_cannot_overflow_the_staging_budget():
     """A ``task_info`` frame carries the task's ``description`` column
     under ``data["description"]``, and that column is unbounded
@@ -3541,6 +3578,107 @@ async def test_warm_up_replay_is_sorted_by_started_at_not_resolve_order():
     )
     polled_ids = [step["id"] for step in steps_resp.json()["steps"]]
     assert polled_ids == ids_in_order
+
+
+# ===== a step whose serialization raises ends the replay batch there,
+# instead of failing the whole attach =====
+
+
+async def test_warm_up_replay_keeps_the_prefix_before_an_unserializable_step():
+    """``_build_warm_up_frames`` serializes its admitted steps one at a
+    time and stops at the first one that raises, so a persisted step
+    whose ``data`` cannot be turned into JSON costs the client that step
+    and whatever came after it -- not the whole attach.
+
+    The shared budget (``_snapshot_steps_within_wire_budget``) admits
+    such a step on purpose: it cannot be measured, so it cannot be
+    budgeted, and each caller decides what to do when the emit reaches
+    it. The two attach-time fast paths report it and close; this path
+    has no per-step emit loop and no conclusion frame to carry a marker,
+    so it ends the batch quietly and goes live -- reason (6) in the
+    endpoint's best-effort delivery list.
+
+    Three things are asserted, because a fix that only delivers the
+    prefix and then closes anyway would satisfy the first alone: the
+    good step reaches the client, no ``stream.error`` follows it, and a
+    frame broadcast afterwards is delivered -- which is only true if the
+    sink actually finished warm-up and went live.
+    """
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    class _Unserializable:
+        pass
+
+    good_row = v1_tasks._TraceEventSnapshot(
+        id=1,
+        task_id=task_id,
+        event_id="good",
+        event_type="ai_message",
+        timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC),
+        step_id=None,
+        data={"content": "this step serializes fine"},
+    )
+    bad_row = v1_tasks._TraceEventSnapshot(
+        id=2,
+        task_id=task_id,
+        event_id="bad",
+        event_type="ai_message",
+        timestamp=datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC),
+        step_id=None,
+        data={"content": _Unserializable()},
+    )
+
+    def _poisoned_read_task_steps(task_id_, principal_):
+        return SimpleNamespace(events=[good_row, bad_row])
+
+    def _version_reader(task_id_, principal_):
+        return v1_tasks._TaskStepsVersionSnapshot(
+            task_id=task_id, agent_id=agent_id, max_event_id=2
+        )
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=_poisoned_read_task_steps,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=_version_reader,
+        **_long_intervals(),
+    )
+    try:
+        first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert "event: task.status" in first
+
+        # The prefix really is delivered -- the step ordered before the
+        # unserializable one is not collateral damage.
+        second = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert second.startswith("event: step.completed\n")
+        assert "this step serializes fine" in second
+
+        # The stream is live, not closing: a frame broadcast now is
+        # projected and delivered, which only happens after
+        # ``finish_warm_up`` has run.
+        await es.manager.broadcast_to_task(
+            {
+                "type": "final_answer_delta",
+                "message_id": "after_warm_up",
+                "task_id": task_id,
+                "delta": "live",
+            },
+            task_id,
+        )
+        third = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert third.startswith("event: message.delta\n")
+        assert json.loads(third.split("data: ", 1)[1]) == {
+            "message_id": "after_warm_up",
+            "text": "live",
+        }
+    finally:
+        await resp.body_iterator.aclose()
 
 
 # ===== the replay's second bound: the same wire-byte budget the

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -3398,6 +3398,45 @@ async def test_generate_wires_read_task_steps_version_into_the_watermark(monkeyp
         await resp.body_iterator.aclose()
 
 
+async def test_a_task_deleted_during_the_watermark_read_closes_with_task_deleted():
+    """The watermark read re-resolves the task in its own session, so a
+    delete landing while it is in flight raises ``TASK_NOT_FOUND`` into
+    this generator's handler -- before the watchdog exists, so nothing
+    later can correct the code. The client must be told the task is
+    gone, not told to call ``steps()`` and re-attach, which can only
+    404 for a row that no longer exists."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    def _deleting_version_reader(task_id_, principal_):
+        db = _direct_db_session()
+        try:
+            db.query(Task).filter(Task.id == task_id_).delete()
+            db.commit()
+        finally:
+            db.close()
+        return v1_tasks._load_task_steps_version_snapshot(task_id_, principal_)
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=_deleting_version_reader,
+        **_long_intervals(),
+    )
+    frames = []
+    async for chunk in resp.body_iterator:
+        frames.append(chunk)
+    body = "".join(frames)
+    assert _parse_error_frame(body)["code"] == "task_deleted"
+    assert "event: step.started" not in body
+
+
 def test_fast_paths_without_a_steps_version_reader_is_a_call_error():
     """``read_task_steps_version`` is a required argument on all three
     attach-time fast-path entry points -- ``_terminal_snapshot_stream``,

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -2816,6 +2816,7 @@ async def test_orphan_end_during_warm_up_is_rescued_by_staging():
     # What a real warm-up read would have produced: a projector that has
     # already replayed the matching start event from history.
     history_start_event = {
+        "id": 1,
         "task_id": 41,
         "event_id": "hist-1",
         "event_type": "tool_execution_start",
@@ -3832,7 +3833,7 @@ async def test_the_watermark_read_splits_task_deleted_from_every_other_failure(
     whose code is not ``TASK_NOT_FOUND``.
 
     ``_long_intervals()`` keeps the watchdog asleep for the whole test,
-    so the close frame either leg observes can only be the one this
+    so the close frame any leg observes can only be the one this
     handler queued -- not the watchdog independently discovering the
     same deleted row. Either way the warm-up block is skipped
     (``replay_watermark`` stays ``None``), so no history reaches the
@@ -4045,8 +4046,9 @@ def test_fast_path_step_snapshot_hits_the_steps_cache(monkeypatch):
 async def test_fast_path_step_read_failure_closes_with_resync_required_not_a_bare_disconnect():
     """Both attach-time fast paths now catch a snapshot-read failure and
     close with ``stream.error {resync_required}``, matching the
-    invariant ``_generate`` already enforces around its own warm-up read
-    (see ``test_warm_up_read_failure_closes_with_resync_required_not_a_bare_disconnect``)
+    invariant ``_generate`` already enforces around its own watermark
+    read (see
+    ``test_the_watermark_read_splits_task_deleted_from_every_other_failure``)
     -- not a bare exception out of the generator. That distinction
     matters here specifically because ``StreamingResponse`` sends the
     HTTP response start (200, headers) before ever pulling a chunk from

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -1510,6 +1510,38 @@ async def _three_step_task() -> tuple[int, ApiKeyPrincipal]:
     return task_id, principal
 
 
+def _revoke_key_for(principal: ApiKeyPrincipal) -> None:
+    """Revoke the API key this principal authenticated with -- the same
+    row edit ``test_watchdog_closes_within_one_cycle_on_key_invalidation``
+    makes, reachable from a principal alone."""
+    db = _direct_db_session()
+    try:
+        key_row = (
+            db.query(AgentApiKey)
+            .filter(AgentApiKey.key_prefix == principal.key.key_prefix)
+            .one()
+        )
+        key_row.revoked_at = datetime.now(UTC)
+        db.commit()
+    finally:
+        db.close()
+
+
+async def _poll_until(predicate) -> None:
+    """Wait for a state the watchdog reaches on its own cadence.
+
+    Bounded and re-checked rather than one sleep sized to a guessed
+    number of cycles: each cycle does two real database reads through
+    the shared thread pool, so a fixed sleep is a timing bet that gets
+    thinner the more loaded the machine is.
+    """
+    for _ in range(200):
+        if predicate():
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError("the watchdog did not reach the expected state in 4s")
+
+
 async def test_abortive_close_during_replay_stops_further_history_frames():
     """An abortive close landing between two replayed history frames
     must stop the replay right there -- the client must never see
@@ -1616,6 +1648,80 @@ async def test_abortive_close_after_a_non_abortive_one_still_stops_the_replay():
         assert "event: step.completed" not in remaining_body
         assert remaining_body.count("event: stream.error") == 1
         assert "resync_required" in remaining_body
+    finally:
+        await resp.body_iterator.aclose()
+
+
+@pytest.mark.parametrize(
+    ("close_claimed_by_watchdog", "expected_close_event"),
+    [
+        pytest.param(False, "event: stream.error", id="close-claimed-elsewhere"),
+        pytest.param(True, "event: task.completed", id="close-claimed-by-the-watchdog"),
+    ],
+)
+async def test_watchdog_keeps_checking_authorization_across_an_ordinary_close(
+    close_claimed_by_watchdog, expected_close_event
+):
+    """An ordinary close must not end authorization coverage.
+
+    The warm-up replay hands its frames to the client directly, bypassing
+    the outbound queue's closing guard, so a close that is not abortive
+    stops nothing on that path -- only ``abortive_close`` does, and only
+    ``watchdog_check_once`` ever sets it. A watchdog that stops at a
+    close therefore never observes a key revoked afterwards, and the
+    replay hands that key the task's persisted history.
+
+    The two legs differ in one variable, who claims the close, because
+    the loop had two separate exits that both ended coverage: one on
+    seeing ``closing`` before running a check, and one on a check of its
+    own having closed the stream. A terminal task found while the
+    warm-up read is still in flight reaches the second one without any
+    staging overflow at all.
+    """
+    task_id, principal = await _three_step_task()
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
+        watchdog_interval_seconds=0.05,
+        stream_max_duration_seconds=600.0,
+        heartbeat_interval_seconds=600.0,
+    )
+    try:
+        status = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert "event: task.status" in status
+        # Suspended on the initial status yield, which runs before the
+        # warm-up read: the sink is registered and still cold, the
+        # watchdog is running, and no history has been read or handed
+        # out yet.
+        sink = next(
+            c
+            for c in es.manager.connections_for_task(task_id)
+            if isinstance(c, es.V1EventStreamSink)
+        )
+        assert sink.warm is False
+
+        if close_claimed_by_watchdog:
+            _set_task_status(task_id, TaskStatus.COMPLETED, output="done")
+            await _poll_until(lambda: sink.closing)
+        else:
+            assert sink.enqueue_close(es.error_frame("resync_required")) is True
+        assert sink.abortive_close is False
+
+        _revoke_key_for(principal)
+        await _poll_until(lambda: sink.abortive_close)
+
+        frames = []
+        async for chunk in resp.body_iterator:
+            frames.append(chunk)
+        body = "".join(frames)
+        assert "event: step.started" not in body
+        assert frames[-1].startswith(expected_close_event)
     finally:
         await resp.body_iterator.aclose()
 

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -3479,26 +3479,103 @@ async def test_generate_wires_read_task_steps_version_into_the_watermark(monkeyp
         await resp.body_iterator.aclose()
 
 
-async def test_a_task_deleted_during_the_watermark_read_closes_with_task_deleted():
-    """The watermark read re-resolves the task in its own session, so a
-    delete landing while it is in flight raises ``TASK_NOT_FOUND`` into
-    this generator's handler -- before the watchdog exists, so nothing
-    later can correct the code. The client must be told the task is
-    gone, not told to call ``steps()`` and re-attach, which can only
-    404 for a row that no longer exists."""
+def _delete_the_task_then_read_the_watermark(task_id_, principal_):
+    """The race this split exists for: a supported DELETE removes the
+    row while this read is in flight, so the production reader's own
+    ``_resolve_task_or_404`` raises ``V1ApiError(TASK_NOT_FOUND)``. The
+    delete is real and the reader is the production one -- nothing
+    about the ``TASK_NOT_FOUND`` reaching the handler is synthesized."""
+    db = _direct_db_session()
+    try:
+        db.query(Task).filter(Task.id == task_id_).delete()
+        db.commit()
+    finally:
+        db.close()
+    return v1_tasks._load_task_steps_version_snapshot(task_id_, principal_)
+
+
+def _fail_the_watermark_read_transiently(task_id_, principal_):
+    """A failure that is not the task being gone.
+
+    A bare ``RuntimeError`` rather than a ``V1ApiError`` carrying some
+    other code, deliberately. The guard being pinned is
+    ``isinstance(exc, V1ApiError) and exc.code is TASK_NOT_FOUND``, and
+    this exercises the ``isinstance`` half: it is the shape a
+    driver-level or connection-level database failure actually reaches
+    this handler as, and the shape the comment above the handler names
+    when it says "a transient DB error". The task row is untouched and
+    still readable, which is exactly why ``resync_required`` -- call
+    ``steps()``, re-attach -- is the recovery that works here and
+    ``task_deleted`` is not."""
+    raise RuntimeError("transient database failure")
+
+
+def _fail_the_watermark_read_with_a_different_v1_api_error(task_id_, principal_):
+    """A ``V1ApiError`` that is not ``TASK_NOT_FOUND``.
+
+    Pins the other half of the guard: ``isinstance(exc, V1ApiError) and
+    exc.code is TASK_NOT_FOUND``. The two legs above only exercise the
+    ``isinstance`` half -- a bare ``RuntimeError`` is never a
+    ``V1ApiError`` in the first place, so a guard loosened to just
+    ``isinstance(exc, V1ApiError)`` would still pass both of them. This
+    leg is the one that would catch that: a rate-limited read is a real
+    ``V1ApiError``, but its code is not ``TASK_NOT_FOUND``, so this
+    close must still be ``resync_required`` -- the task itself is fine,
+    only this one read was throttled."""
+    raise V1ApiError(V1ErrorCode.RATE_LIMITED, 429)
+
+
+@pytest.mark.parametrize(
+    ("read_task_steps_version", "expected_code"),
+    [
+        pytest.param(
+            _delete_the_task_then_read_the_watermark,
+            "task_deleted",
+            id="task-deleted",
+        ),
+        pytest.param(
+            _fail_the_watermark_read_transiently,
+            "resync_required",
+            id="transient-read-failure",
+        ),
+        pytest.param(
+            _fail_the_watermark_read_with_a_different_v1_api_error,
+            "resync_required",
+            id="other-v1-api-error",
+        ),
+    ],
+)
+async def test_the_watermark_read_splits_task_deleted_from_every_other_failure(
+    read_task_steps_version, expected_code
+):
+    """The watermark read's handler classifies by cause, and every half
+    of that split is load-bearing.
+
+    This read re-resolves the task in its own session, so a delete
+    landing while it is in flight raises ``TASK_NOT_FOUND`` into the
+    handler. That close is claimed before the watchdog exists, so
+    nothing later can correct the code, and a client told to call
+    ``steps()`` and re-attach for a row that no longer exists only gets
+    a 404 back.
+
+    The other two legs matter just as much, and are the ones a
+    collapsed or loosened guard breaks silently: a failure that is not
+    the task being gone must still close with ``resync_required``,
+    because the task is there and resynchronizing does work -- whether
+    that failure is not a ``V1ApiError`` at all, or is a ``V1ApiError``
+    whose code is not ``TASK_NOT_FOUND``.
+
+    ``_long_intervals()`` keeps the watchdog asleep for the whole test,
+    so the close frame either leg observes can only be the one this
+    handler queued -- not the watchdog independently discovering the
+    same deleted row. Either way the warm-up block is skipped
+    (``replay_watermark`` stays ``None``), so no history reaches the
+    client from this attach; that is what the ``step.started``
+    assertion pins."""
     agent_id, full_key = _create_agent_with_key()
     task_id = _create_task(full_key, agent_id)
     principal = _principal_for(full_key)
     snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
-
-    def _deleting_version_reader(task_id_, principal_):
-        db = _direct_db_session()
-        try:
-            db.query(Task).filter(Task.id == task_id_).delete()
-            db.commit()
-        finally:
-            db.close()
-        return v1_tasks._load_task_steps_version_snapshot(task_id_, principal_)
 
     resp = await es.build_event_stream_response(
         task_id=task_id,
@@ -3507,14 +3584,15 @@ async def test_a_task_deleted_during_the_watermark_read_closes_with_task_deleted
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
         read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
-        read_task_steps_version=_deleting_version_reader,
+        read_task_steps_version=read_task_steps_version,
         **_long_intervals(),
     )
     frames = []
-    async for chunk in resp.body_iterator:
+    async for chunk in asyncio_timeout_iter(resp.body_iterator, timeout=2):
         frames.append(chunk)
     body = "".join(frames)
-    assert _parse_error_frame(body)["code"] == "task_deleted"
+    assert "event: task.status" in body
+    assert _parse_error_frame(body)["code"] == expected_code
     assert "event: step.started" not in body
 
 

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -4276,7 +4276,7 @@ async def test_fast_path_task_not_found_closes_with_task_deleted_not_resync_requ
     this fast path, so a task deleted in that exact gap surfaces here as
     ``V1ApiError(TASK_NOT_FOUND)`` -- the same condition the warm-up read
     and the watchdog already report as ``task_deleted`` (see
-    ``test_warm_up_read_task_not_found_closes_with_task_deleted_not_resync_required``),
+    ``test_generates_own_task_not_found_reads_are_abortive_and_end_watchdog_coverage``),
     not ``resync_required``. Asking a client to ``steps()`` and reattach
     for a task that's gone would just 404 instead of resyncing anything.
 

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -3075,13 +3075,214 @@ async def test_oversized_non_dict_json_frame_is_ignored_without_counting():
     assert sink.queue.empty()
 
 
-# ===== staged messages are also bounded by cumulative text size, not
-# just count =====
+# ===== the warm-up staging buffer's two bounds, and the one quantity
+# that must never enter either: the task's own description stamp =====
 
 
-# ===== a frame that fails to project is dropped, not fatal -- neither
-# during finish_warm_up's replay nor on the live path, and never
-# double-counted between the two (see _project_and_queue) =====
+async def test_staged_messages_overflow_closes_with_resync_required():
+    """The staging list reuses the outbound queue's own count cap and
+    overflow policy (``resync_required`` then close) instead of a second
+    one -- this pins that reuse rather than assuming it."""
+    sink = _make_sink(task_id=43, warm=False)
+    for i in range(es.OUTBOUND_QUEUE_MAX_SIZE):
+        await sink.send_text(
+            _trace_event_frame(
+                "tool_execution_start",
+                task_id=43,
+                data={"tool_call_id": f"call-{i}", "tool_name": "x", "tool_args": {}},
+            )
+        )
+    assert sink.staged_message_count == es.OUTBOUND_QUEUE_MAX_SIZE
+    assert sink.closing is False
+
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_start",
+            task_id=43,
+            data={"tool_call_id": "overflow", "tool_name": "x", "tool_args": {}},
+        )
+    )
+
+    assert sink.closing is True
+    frame_text, is_close = sink.queue.get_nowait()
+    assert is_close is True
+    assert "resync_required" in frame_text
+
+
+async def test_staged_messages_byte_budget_overflow_closes_with_resync_required():
+    """``_staged_messages`` is bounded by cumulative character count on
+    top of its count cap -- a run of large-but-individually-legal
+    messages (each under ``MAX_RAW_FRAME_TEXT_CHARS``, so none is dropped
+    by the pre-check) can still overflow the cumulative budget well
+    before the count cap binds. Uses a payload just under the per-frame
+    raw-size limit so few enough messages are needed to keep the test
+    fast, and asserts the count cap did not bind instead."""
+    sink = _make_sink(task_id=95, warm=False)
+    near_cap_delta = "x" * (es.MAX_RAW_FRAME_TEXT_CHARS - 200)
+    messages_needed = (es.STAGED_MESSAGES_MAX_TEXT_CHARS // len(near_cap_delta)) + 2
+    assert messages_needed < es.OUTBOUND_QUEUE_MAX_SIZE, (
+        "fixture assumption: the byte budget must overflow before the "
+        "count cap does, or this test would re-pin the count cap instead"
+    )
+
+    for i in range(messages_needed):
+        await sink.send_text(
+            json.dumps(
+                {
+                    "type": "final_answer_delta",
+                    "message_id": f"final_answer_{i}",
+                    "task_id": 95,
+                    "delta": near_cap_delta,
+                }
+            )
+        )
+        if sink.closing:
+            break
+
+    assert sink.closing is True
+    assert sink.staged_message_count < es.OUTBOUND_QUEUE_MAX_SIZE
+    frame_text, is_close = sink.queue.get_nowait()
+    assert is_close is True
+    assert "resync_required" in frame_text
+
+
+async def test_one_task_info_frame_cannot_overflow_the_staging_budget():
+    """A ``task_info`` frame carries the task's ``description`` column
+    under ``data["description"]``, and that column is unbounded
+    (``Column(Text)``). Charged raw, one such frame crosses
+    ``STAGED_MESSAGES_MAX_TEXT_CHARS`` by itself and closes the attach
+    with ``resync_required`` -- and because the trigger is a property of
+    the task rather than the load on it, the re-attach the close asks for
+    fails at exactly the same frame, forever. The description is
+    therefore excluded from the charge, which leaves this frame costing
+    the few hundred characters its actual lifecycle fields occupy.
+
+    ``task_info`` is also the family with nothing to lose by it:
+    ``_feed_trace_event`` returns ``[]`` for it, so the description is
+    charged against a budget it could never spend.
+
+    The sink starts at ``status="pending"`` rather than the frame's own
+    ``"running"``: ``enqueue_status`` no-ops when a status repeats the
+    sink's last one, and a ``task_info`` frame's ``status`` would
+    otherwise be deduped away, leaving nothing to assert on the
+    lifecycle half below. ``"running"`` is not in
+    ``_EARLY_WAKE_STATUS_VALUES`` either way, so nothing about the
+    content half's handling changes."""
+    sink = _make_sink(task_id=105, status="pending", warm=False)
+    huge_description = "d" * (es.STAGED_MESSAGES_MAX_TEXT_CHARS + 1000)
+    raw = json.dumps(
+        {
+            "type": "trace_event",
+            "event_id": "ev-105",
+            "event_type": "task_info",
+            "task_id": 105,
+            "timestamp": 0,
+            "status": "running",
+            "data": {
+                "id": 105,
+                "title": "t",
+                "description": huge_description,
+                "status": "running",
+            },
+        }
+    )
+    assert len(raw) > es.STAGED_MESSAGES_MAX_TEXT_CHARS
+
+    await sink.send_text(raw)
+
+    assert sink.closing is False
+    assert sink.dropped_frame_count == 0
+    assert sink.staged_message_count == 1
+    assert sink._staged_text_chars < 1000
+    assert "description" not in sink._staged_messages[0]["data"]
+    # The lifecycle half still went out: task_info is a versioned task
+    # event, and its status is enqueued before the content branch runs.
+    frame_text, _ = sink.queue.get_nowait()
+    assert frame_text.startswith("event: task.status\n")
+
+
+async def test_a_long_task_description_cannot_overflow_the_staging_budget():
+    """The same defect on the ordinary path, which is the half a
+    ``task_info``-only fix does not reach.
+    ``ws_trace_handlers.py``'s converter stamps the same unbounded column
+    onto *every* trace event as ``data["task_description"]``, and a frame
+    at or under ``MAX_RAW_FRAME_TEXT_CHARS`` used to be charged its full
+    ``len(text)``. A description a little under that per-frame cap
+    therefore crossed the 4 MiB staging budget after ~17 frames of a
+    warm-up window, again identically on every re-attach.
+
+    Sends more frames than the old code survived and asserts the stream
+    is still open, then asserts the accumulated charge is the frames'
+    own content rather than the description repeated per frame."""
+    sink = _make_sink(task_id=106, status="running", warm=False)
+    description = "d" * (200 * 1024)
+    frames = 40
+
+    for i in range(frames):
+        await sink.send_text(
+            _trace_event_frame(
+                "tool_execution_start",
+                task_id=106,
+                step_id=f"step-{i}",
+                data={
+                    "tool_call_id": f"call-{i}",
+                    "tool_name": "search",
+                    "tool_args": {},
+                    "task_description": description,
+                },
+            )
+        )
+
+    assert sink.closing is False
+    assert sink.dropped_frame_count == 0
+    assert sink.staged_message_count == frames
+    assert sink._staged_text_chars < frames * 1000
+    assert all(
+        "task_description" not in staged["data"] for staged in sink._staged_messages
+    )
+
+
+async def test_the_raw_frame_drop_boundary_is_unchanged_by_the_description_exclusion():
+    """Excluding the description from the *measure* must not move the
+    per-frame drop boundary, which is a settled contract with tests on
+    both sides of it: pruning can only lower a frame's measured length,
+    and a frame already at or under the cap stays under it.
+
+    Near-duplicate of ``test_a_frame_still_over_the_cap_without_its_description_is_dropped``
+    (above): that test already pins the end-to-end drop for a frame
+    whose own content -- not its description -- is what pushes it over
+    the cap. What this test adds is a direct call into
+    ``_measured_content_frame`` that pins the *ordering* inside it --
+    prune, then compare -- rather than only the ``send_text``-level
+    outcome. The complementary mutation (the drop check reading the
+    *unpruned* length instead of the pruned one) is not caught here:
+    this frame is over the cap on its own tool arguments regardless of
+    pruning, so that mutation leaves this test green. It is caught by
+    the existing
+    ``test_a_huge_task_description_does_not_drop_a_small_content_frame``,
+    whose frame is under the cap without its description and over it
+    with -- the only shape that can tell the two checks apart."""
+    sink = _make_sink(task_id=107)
+    filler = "y" * (es.MAX_RAW_FRAME_TEXT_CHARS + 1000)
+    raw = _trace_event_frame(
+        "tool_execution_start",
+        task_id=107,
+        step_id="step-1",
+        data={
+            "tool_call_id": "call-1",
+            "tool_name": "search",
+            "tool_args": {"query": filler},
+            "task_description": "d" * (200 * 1024),
+        },
+    )
+    measured, pruned = es._measured_content_frame(raw, json.loads(raw))
+    assert "task_description" not in pruned["data"]
+    assert measured > es.MAX_RAW_FRAME_TEXT_CHARS
+
+    await sink.send_text(raw)
+
+    assert sink.dropped_frame_count == 1
+    assert sink.queue.empty()
 
 
 # ===== a frame that fails to project is dropped, not fatal, and never

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -3,8 +3,8 @@
 Covers registration, the sink's frame filter and exception discipline,
 the watchdog, the 1-hour cap, concurrency caps, and the ``step.*`` /
 ``message.*`` content projection layered on top of that transport
-(classification, filtering, and the fast paths' cached step
-snapshot). Tests either drive ``_events_stream`` directly (fast,
+(classification, filtering, warm-up replay, and the fast paths' cached
+step snapshot). Tests either drive ``_events_stream`` directly (fast,
 deterministic -- used whenever a test needs injected short intervals or
 precise control over the race between the watchdog and the deadline) or
 go through the real HTTP endpoint (used for the 401/404/429/terminal-
@@ -182,10 +182,38 @@ def _key_prefix_for_agent(agent_id: int) -> str:
         db.close()
 
 
-def _make_sink(task_id: int = 1, status: str = "running") -> es.V1EventStreamSink:
-    return es.V1EventStreamSink(
+def _current_watermark(task_id: int, principal: ApiKeyPrincipal) -> int:
+    """The replay watermark a real attach captures right after
+    registration, read the same way ``_generate`` reads it.
+
+    ``_build_warm_up_frames`` requires one -- there is no "replay
+    everything" mode -- so a test that wants the task's whole history
+    admitted asks for the current cursor rather than inventing a
+    sentinel that could drift from what the endpoint would have used.
+    """
+    return int(
+        v1_tasks._load_task_steps_version_snapshot(task_id, principal).max_event_id
+    )
+
+
+def _make_sink(
+    task_id: int = 1, status: str = "running", *, warm: bool = True
+) -> es.V1EventStreamSink:
+    """``warm=True`` (the default) finishes warm-up immediately with an
+    empty projector, so a bare ``send_text`` call projects content
+    frames right away instead of staging them -- what every content-
+    projection test here wants except the ones that specifically test
+    staging/warm-up itself (``warm=False``, see the warm-up section).
+
+    ``retain_finished=False`` because ``finish_warm_up`` requires it --
+    a live sink never reads a timeline back, so a retaining projector is
+    rejected rather than left to accumulate one (see that method)."""
+    sink = es.V1EventStreamSink(
         task_id=task_id, principal_key_prefix="pfx-test", initial_status=status
     )
+    if warm:
+        sink.finish_warm_up(es.PublicStepProjector(retain_finished=False))
+    return sink
 
 
 def _insert_trace_event(
@@ -493,6 +521,7 @@ async def test_events_paused_attach_does_not_take_a_fast_path():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
@@ -535,6 +564,7 @@ async def test_sse_responses_disable_proxy_buffering(task_state):
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
@@ -592,6 +622,7 @@ async def test_fast_path_failure_sends_the_response_start_before_its_close_frame
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=_unreachable_read_task_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=_broken_read_task_steps_response,
         read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
     )
@@ -734,6 +765,7 @@ async def test_generator_read_path_keeps_queued_wire_bytes_at_zero_between_frame
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
@@ -783,6 +815,7 @@ async def test_watchdog_closes_within_one_cycle_on_key_invalidation(field):
     )
     assert closed is True
     assert sink.closing is True
+    assert sink.abortive_close is True
     assert sink.queue.get_nowait() == (es.error_frame("unauthorized"), True)
 
 
@@ -916,6 +949,7 @@ async def test_watchdog_terminal_task_row_closes_with_completed():
         sink, task_id, principal, read_task_snapshot=v1_tasks._load_task_info_snapshot
     )
     assert closed is True
+    assert sink.abortive_close is False
     assert sink.queue.get_nowait() == (
         es.completed_frame(status="failed", output=None, error="boom"),
         True,
@@ -944,6 +978,7 @@ async def test_watchdog_missing_task_row_closes_with_task_deleted():
         sink, task_id, principal, read_task_snapshot=v1_tasks._load_task_info_snapshot
     )
     assert closed is True
+    assert sink.abortive_close is True
     assert sink.queue.get_nowait() == (es.error_frame("task_deleted"), True)
 
 
@@ -963,6 +998,7 @@ async def test_real_delete_route_closes_stream_with_task_deleted():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(watchdog_interval_seconds=0.01),
@@ -1017,6 +1053,7 @@ async def test_watchdog_survives_transient_check_failure_and_still_closes():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=flaky_reader,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(watchdog_interval_seconds=0.01),
@@ -1106,6 +1143,7 @@ async def test_sink_unregistered_after_generator_teardown():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
@@ -1145,6 +1183,7 @@ async def test_unstarted_generator_leaves_no_registration_or_reservation():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
@@ -1202,6 +1241,7 @@ async def test_principal_slot_released_after_real_stream_teardown():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
@@ -1249,6 +1289,8 @@ async def test_generate_serves_stream_when_reservation_race_lost(caplog):
             key_prefix=key_prefix,
             initial_status=snapshot.status.value,
             read_task_snapshot=v1_tasks._load_task_info_snapshot,
+            read_task_steps=v1_tasks._load_task_steps_snapshot,
+            read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
             **_long_intervals(),
         )
         first = await agen.__anext__()
@@ -1290,6 +1332,7 @@ async def test_absolute_deadline_emits_expired_then_closes():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(
@@ -1325,6 +1368,7 @@ async def test_deadline_wait_budget_shrinks_below_the_heartbeat():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(
@@ -1370,6 +1414,21 @@ async def test_close_frame_delivered_when_enqueued_between_two_yields():
     async def _never_read(task_id, principal):  # pragma: no cover
         raise AssertionError("watchdog must not run in this test")
 
+    def _empty_steps(task_id, principal):
+        # Real, working (unlike ``_never_read`` above) -- the warm-up
+        # read in ``_generate`` always runs, unconditionally, right
+        # after the first yield. No history for this sentinel task_id,
+        # so warm-up completes with zero replay frames and the test's
+        # hand-driven ``asend`` sequence below still lands on the next
+        # ``yield`` being the while loop's first dequeue, as before.
+        return SimpleNamespace(events=())
+
+    def _steps_cursor(task_id, principal):
+        # Also real and working, for the same reason: the watermark read
+        # runs unconditionally at registration, and a failure there would
+        # close the stream for resync before the sequence below starts.
+        return SimpleNamespace(max_event_id=0)
+
     task_id = 987_654_321  # sentinel, not a real DB row -- unused by this test
     gen = es._generate(
         task_id,
@@ -1377,6 +1436,8 @@ async def test_close_frame_delivered_when_enqueued_between_two_yields():
         key_prefix="pfx-close-frame-race-test",
         initial_status="running",
         read_task_snapshot=_never_read,
+        read_task_steps=_empty_steps,
+        read_task_steps_version=_steps_cursor,
         watchdog_interval_seconds=10_000,
         stream_max_duration_seconds=10_000,
         heartbeat_interval_seconds=10_000,
@@ -1419,6 +1480,200 @@ async def test_close_frame_delivered_when_enqueued_between_two_yields():
         await gen.aclose()
 
 
+# ===== an abortive close (unauthorized / task_deleted) cuts the warm-up
+# replay short; every other close reason lets it finish first =====
+
+
+async def _three_step_task() -> tuple[int, ApiKeyPrincipal]:
+    """A real task with three independent, still-``running`` steps (no
+    end event for any of them), so ``_build_warm_up_frames`` replays
+    exactly three ``step.started`` frames in a deterministic
+    ``started_at`` order -- enough to inject a close after the first one
+    and still have at least one more that must (or must not) follow it."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    for index in range(3):
+        _insert_trace_event(
+            task_id=task_id,
+            event_type="tool_execution_start",
+            event_id=f"hist-{index}",
+            timestamp=base.replace(second=index),
+            step_id=f"step-{index}",
+            data={
+                "tool_call_id": f"call-{index}",
+                "tool_name": "search",
+                "tool_args": {},
+            },
+        )
+    return task_id, principal
+
+
+async def test_abortive_close_during_replay_stops_further_history_frames():
+    """An abortive close landing between two replayed history frames
+    must stop the replay right there -- the client must never see
+    history frames queued up after the point its authorization was
+    revoked. This drives the close directly via ``sink.enqueue_close(...,
+    abortive=True)`` -- the same frame shape (``unauthorized``) the
+    watchdog would enqueue, but not through ``watchdog_check_once``
+    itself; that production call site is covered separately by
+    ``test_watchdog_closes_within_one_cycle_on_key_invalidation``'s own
+    ``sink.abortive_close is True`` assertion. Driven by hand via
+    ``__anext__`` so the close can be injected deterministically after
+    exactly one history frame, the same technique
+    ``test_close_frame_delivered_when_enqueued_between_two_yields`` uses
+    for the non-replay case."""
+    task_id, principal = await _three_step_task()
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
+        **_long_intervals(),
+    )
+    try:
+        status = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert "event: task.status" in status
+
+        first_step = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert first_step.startswith("event: step.started\n")
+
+        sink = next(
+            c
+            for c in es.manager.connections_for_task(task_id)
+            if isinstance(c, es.V1EventStreamSink)
+        )
+        won = sink.enqueue_close(es.error_frame("unauthorized"), abortive=True)
+        assert won is True
+
+        remaining_frames = []
+        async for chunk in resp.body_iterator:
+            remaining_frames.append(chunk)
+        remaining_body = "".join(remaining_frames)
+        assert "event: step.started" not in remaining_body
+        assert remaining_body.count("event: stream.error") == 1
+        assert "unauthorized" in remaining_body
+    finally:
+        await resp.body_iterator.aclose()
+
+
+async def test_abortive_close_after_a_non_abortive_one_still_stops_the_replay():
+    """The revocation an abortive close carries is not first-caller-wins,
+    even though the close frame is.
+
+    A non-abortive close (here ``resync_required``, the reason a staging
+    overflow enqueues) can land during the replay and claim the close
+    frame. If a watchdog ``unauthorized`` close then arrives, its early
+    return must not swallow the suppression: the client just lost the
+    right to see this task's content, and the frames still queued behind
+    the replay cursor are exactly the content that revocation covers.
+
+    The client reads the earlier close reason on the wire -- that part
+    stays first-caller-wins -- and re-attaches, where authentication
+    refuses it. What it must not read is the rest of the history."""
+    task_id, principal = await _three_step_task()
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
+        **_long_intervals(),
+    )
+    try:
+        status = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert "event: task.status" in status
+
+        first_step = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert first_step.startswith("event: step.started\n")
+
+        sink = next(
+            c
+            for c in es.manager.connections_for_task(task_id)
+            if isinstance(c, es.V1EventStreamSink)
+        )
+        first_won = sink.enqueue_close(es.error_frame("resync_required"))
+        assert first_won is True
+        assert sink.abortive_close is False
+
+        second_won = sink.enqueue_close(es.error_frame("unauthorized"), abortive=True)
+        assert second_won is False
+        assert sink.abortive_close is True
+
+        remaining_frames = []
+        async for chunk in resp.body_iterator:
+            remaining_frames.append(chunk)
+        remaining_body = "".join(remaining_frames)
+        assert "event: step.started" not in remaining_body
+        assert "event: step.completed" not in remaining_body
+        assert remaining_body.count("event: stream.error") == 1
+        assert "resync_required" in remaining_body
+    finally:
+        await resp.body_iterator.aclose()
+
+
+async def test_normal_terminal_close_during_replay_lets_replay_finish_first():
+    """A non-abortive close landing between two replayed history frames
+    must NOT cut the replay short -- that history describes the task's
+    own past and stays valid even though the stream is about to end;
+    only the close frame itself is deferred to arrive after it, via the
+    normal queue path. Drives the close directly via
+    ``sink.enqueue_close`` with the same frame shape
+    (``task.completed``) the watchdog would enqueue for a terminal task
+    -- not through ``watchdog_check_once`` itself; that production call
+    site is covered separately by
+    ``test_watchdog_terminal_task_row_closes_with_completed``'s own
+    ``sink.abortive_close is False`` assertion. Same injection point as
+    the abortive test above, opposite close reason."""
+    task_id, principal = await _three_step_task()
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
+        **_long_intervals(),
+    )
+    try:
+        status = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert "event: task.status" in status
+
+        first_step = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert first_step.startswith("event: step.started\n")
+
+        sink = next(
+            c
+            for c in es.manager.connections_for_task(task_id)
+            if isinstance(c, es.V1EventStreamSink)
+        )
+        won = sink.enqueue_close(
+            es.completed_frame(status="completed", output="done", error=None)
+        )
+        assert won is True
+
+        remaining_frames = []
+        async for chunk in resp.body_iterator:
+            remaining_frames.append(chunk)
+        remaining_body = "".join(remaining_frames)
+        assert remaining_body.count("event: step.started") == 2  # the other two
+        assert remaining_body.count("event: task.completed") == 1
+        # The close frame is the very last thing delivered.
+        assert remaining_frames[-1].startswith("event: task.completed\n")
+    finally:
+        await resp.body_iterator.aclose()
+
+
 async def test_close_exactly_once_under_watchdog_deadline_race():
     agent_id, full_key = _create_agent_with_key()
     task_id = _create_task(full_key, agent_id)  # non-terminal at attach
@@ -1430,6 +1685,7 @@ async def test_close_exactly_once_under_watchdog_deadline_race():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         watchdog_interval_seconds=0.001,
@@ -1468,6 +1724,7 @@ async def test_events_per_task_cap_third_stream_429():
             principal=principal,
             initial_snapshot=snapshot,
             read_task_snapshot=v1_tasks._load_task_info_snapshot,
+            read_task_steps=v1_tasks._load_task_steps_snapshot,
             read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
             read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
             **_long_intervals(),
@@ -1485,6 +1742,7 @@ async def test_events_per_task_cap_third_stream_429():
             principal=principal,
             initial_snapshot=snapshot,
             read_task_snapshot=v1_tasks._load_task_info_snapshot,
+            read_task_steps=v1_tasks._load_task_steps_snapshot,
             read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
             read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         )
@@ -1520,9 +1778,14 @@ async def test_fast_path_attach_exempt_from_both_caps(fast_path_status, closing_
     there is no way to fill that cap through it. Only after both caps
     are full does the task row flip to the fast-path status under test.
 
-    Also asserts one step frame goes out, so a regression that dropped
-    the snapshot could not hide behind the frame counts this test is
-    really about.
+    Also covers two properties of the fast path's step snapshot that a
+    frame-count-only assertion would miss entirely: it actually emits a
+    ``step.*`` frame for pre-existing history (not just the two
+    lifecycle frames alone -- a regression here would have
+    left ``PER_TASK_STREAM_CAP``-saturating cap coverage green while
+    silently dropping the snapshot), and a second fast-path attach on
+    the same task reuses the ``steps()`` cache instead of repeating the
+    full trace read.
     """
     set_cache_backend_for_testing(InMemoryTTLCache())
     try:
@@ -1557,6 +1820,7 @@ async def test_fast_path_attach_exempt_from_both_caps(fast_path_status, closing_
                 principal=principal,
                 initial_snapshot=running_snapshot,
                 read_task_snapshot=v1_tasks._load_task_info_snapshot,
+                read_task_steps=v1_tasks._load_task_steps_snapshot,
                 read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
                 read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
                 **_long_intervals(),
@@ -1678,6 +1942,7 @@ async def test_heartbeat_actually_sent_when_idle():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(heartbeat_interval_seconds=0.01),
@@ -1732,6 +1997,7 @@ async def test_broadcast_frame_reaches_generator_output_as_task_status():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
@@ -1787,6 +2053,7 @@ async def test_broadcast_content_frames_reach_generator_output_as_step_and_messa
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
@@ -1934,6 +2201,7 @@ async def test_completion_hint_wakes_watchdog_before_its_next_periodic_tick():
         principal=principal,
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
         read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
@@ -2106,10 +2374,11 @@ async def test_trace_event_ai_message_projects_a_completed_message_step(
     stream already delivered live as ``message.delta`` /
     ``message.completed``, so folding it too duplicates that content as a
     second delivery rather than losing it. Dropping it here -- the old
-    behavior -- had no persisted counterpart: ``steps()`` shows this exact
-    row as a ``message`` step regardless, so filtering only the live path
-    made an already-attached stream disagree with ``steps()`` about whether
-    the step exists. See
+    behavior -- had no persisted counterpart: ``steps()`` and a fresh
+    attach's warm-up replay both show this exact row as a ``message``
+    step regardless, so filtering only the live path made an
+    already-attached stream disagree with those two about whether the
+    step exists. See
     ``test_live_projection_matches_steps_for_a_streamed_final_answer``
     below for the two-path parity this restores.
     """
@@ -2346,8 +2615,64 @@ async def test_step_started_frame_text_is_unaffected_by_the_step_s_later_complet
     assert json.loads(started_text.split("data: ", 1)[1])["step"]["status"] == "running"
 
 
+# ===== warm-up staging: a step whose start is only in history and whose
+# end arrives during the warm-up window still resolves on this stream =====
+
+
+async def test_orphan_end_during_warm_up_is_rescued_by_staging():
+    """The scenario ``finish_warm_up`` exists for: a step's *start* event
+    is only in trace history (it happened before this connection
+    attached), and its *end* event happens to broadcast live while the
+    sink is still cold (registered, but the history read/replay hasn't
+    finished). Fed straight to an empty projector, that end event would
+    be a plain orphan end and get silently dropped -- there'd never be a
+    ``step.completed`` for it on this stream. Staging it and replaying
+    it through the *warmed* projector instead (which has the start
+    pending, from history) rescues it."""
+    sink = _make_sink(task_id=41, warm=False)
+
+    # Arrives while the sink is still cold -- gets staged, not projected.
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_end",
+            task_id=41,
+            data={"tool_call_id": "call-1", "success": True, "result": "sunny"},
+        )
+    )
+    assert sink.staged_message_count == 1
+    assert sink.queue.empty()
+
+    # What a real warm-up read would have produced: a projector that has
+    # already replayed the matching start event from history.
+    history_start_event = {
+        "task_id": 41,
+        "event_id": "hist-1",
+        "event_type": "tool_execution_start",
+        "timestamp": 0,
+        "step_id": "step-1",
+        "data": {"tool_call_id": "call-1", "tool_name": "search", "tool_args": {}},
+    }
+    warmed = es.PublicStepProjector.from_history([history_start_event])
+    # The same two calls, in the same order, that ``_build_warm_up_frames``
+    # makes: read the replayed timeline out, which is also what releases
+    # retention, then hand the projector over.
+    warmed.take_materialized_steps()
+
+    sink.finish_warm_up(warmed)
+
+    assert sink.warm is True
+    assert sink.staged_message_count == 0
+    frame_text, is_close = sink.queue.get_nowait()
+    assert is_close is False
+    assert frame_text.startswith("event: step.completed\n")
+    step = json.loads(frame_text.split("data: ", 1)[1])["step"]
+    assert step["id"] == "tool_call:call-1"
+    assert step["status"] == "completed"
+    assert step["data"]["result"] == "sunny"
+
+
 # ===== raw-frame size pre-check: an oversized content frame is dropped
-# before it's projected =====
+# before it's projected, on both the warm and the staging path =====
 
 
 def _sized_content_frame(task_id: int, total_chars: int) -> str:
@@ -2644,6 +2969,15 @@ async def test_oversized_non_dict_json_frame_is_ignored_without_counting():
     assert sink.queue.empty()
 
 
+# ===== staged messages are also bounded by cumulative text size, not
+# just count =====
+
+
+# ===== a frame that fails to project is dropped, not fatal -- neither
+# during finish_warm_up's replay nor on the live path, and never
+# double-counted between the two (see _project_and_queue) =====
+
+
 # ===== a frame that fails to project is dropped, not fatal, and never
 # double-counted between the sink's two except layers
 # (see _project_and_queue) =====
@@ -2652,11 +2986,11 @@ async def test_oversized_non_dict_json_frame_is_ignored_without_counting():
 async def test_poisoned_live_frame_increments_dropped_frame_count_only_once(
     monkeypatch,
 ):
-    """A projection failure on the live path is
+    """A projection failure on the live path (sink already warm) is
     caught inside ``_project_and_queue`` and never re-raises -- if it
     did, ``send_text``'s own outer ``except`` would catch it too and
     count the same dropped frame twice."""
-    sink = _make_sink(task_id=73)
+    sink = _make_sink(task_id=73)  # warm=True default -- the live path
 
     def _boom(message, projector):
         raise RuntimeError("boom live")
@@ -2673,6 +3007,378 @@ async def test_poisoned_live_frame_increments_dropped_frame_count_only_once(
 
     assert sink.dropped_frame_count == 1
     assert sink.queue.empty()
+
+
+async def test_warm_up_hands_the_sink_a_projector_that_stops_retaining():
+    """The live sink must never be handed a retaining projector.
+
+    ``_build_warm_up_frames`` reads the replayed timeline out with
+    ``take_materialized_steps``, which is also what releases retention,
+    so the projector it returns keeps nothing from that point on. This
+    pins the property on the real builder's real output rather than on a
+    hand-built projector, because the release lives in the builder, not
+    in the projector's constructor.
+
+    ``finish_warm_up`` then rejects a retaining projector outright. Both
+    are asserted here: what the builder produces, and what the sink
+    refuses. Without the release the stream still behaves correctly --
+    it just accumulates every finished step's untruncated ``data`` for
+    up to an hour in a list nothing reads, which is invisible to every
+    other assertion in this file."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="ai_message",
+        event_id="message-0",
+        timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC),
+        data={"content": "already finished"},
+    )
+
+    warmed, warm_up_frames = es._build_warm_up_frames(
+        task_id,
+        principal,
+        v1_tasks._load_task_steps_snapshot,
+        _current_watermark(task_id, principal),
+    )
+
+    # The history really was read out -- otherwise "retains nothing"
+    # would be trivially true of a projector that folded nothing.
+    assert len(warm_up_frames) == 1
+    assert warmed.retains_finished is False
+    with pytest.raises(RuntimeError):
+        warmed.materialized_steps()
+
+    sink = _make_sink(task_id=task_id, warm=False)
+    sink.finish_warm_up(warmed)
+    assert sink.warm is True
+
+    with pytest.raises(RuntimeError):
+        _make_sink(task_id=task_id, warm=False).finish_warm_up(
+            es.PublicStepProjector(retain_finished=True)
+        )
+
+
+async def test_attach_replays_history_before_live_frames():
+    """End-to-end warm-up through the real generator: a step that
+    started before attach is replayed as a ``step.started`` frame,
+    directly after the initial ``task.status`` and before anything else
+    -- the two frames a real client sees first, in order."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="tool_execution_start",
+        event_id="hist-1",
+        timestamp=base,
+        step_id="step-1",
+        data={"tool_call_id": "call-1", "tool_name": "search", "tool_args": {}},
+    )
+
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
+        **_long_intervals(),
+    )
+    try:
+        first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert "event: task.status" in first
+        second = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert second.startswith("event: step.started\n")
+        step = json.loads(second.split("data: ", 1)[1])["step"]
+        assert step["id"] == "tool_call:call-1"
+        assert step["status"] == "running"
+    finally:
+        await resp.body_iterator.aclose()
+
+
+async def test_warm_up_replay_is_sorted_by_started_at_not_resolve_order():
+    """``_build_warm_up_frames`` sorts its replay by ``started_at`` to
+    match ``steps()``'s own ordering -- ``PublicStepProjector.
+    materialized_steps()`` on its own returns *resolve* order, which
+    diverges when a later-started step finishes before an earlier one.
+    Step A starts first (t0) but finishes last (t3); step B starts
+    second (t1) but finishes first (t2) -- resolve order is [B, A],
+    started_at order is [A, B]. This pins the replay uses the latter."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    t0 = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    t1 = datetime(2026, 1, 1, 12, 0, 1, tzinfo=UTC)
+    t2 = datetime(2026, 1, 1, 12, 0, 2, tzinfo=UTC)
+    t3 = datetime(2026, 1, 1, 12, 0, 3, tzinfo=UTC)
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="tool_execution_start",
+        event_id="a-start",
+        timestamp=t0,
+        step_id="step-a",
+        data={"tool_call_id": "call-a", "tool_name": "x", "tool_args": {}},
+    )
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="tool_execution_start",
+        event_id="b-start",
+        timestamp=t1,
+        step_id="step-b",
+        data={"tool_call_id": "call-b", "tool_name": "x", "tool_args": {}},
+    )
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="tool_execution_end",
+        event_id="b-end",
+        timestamp=t2,
+        step_id="step-b",
+        data={"tool_call_id": "call-b", "success": True, "result": "b done"},
+    )
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="tool_execution_end",
+        event_id="a-end",
+        timestamp=t3,
+        step_id="step-a",
+        data={"tool_call_id": "call-a", "success": True, "result": "a done"},
+    )
+
+    _, warm_up_frames = es._build_warm_up_frames(
+        task_id,
+        principal,
+        v1_tasks._load_task_steps_snapshot,
+        _current_watermark(task_id, principal),
+    )
+    ids_in_order = [
+        json.loads(frame.split("data: ", 1)[1])["step"]["id"]
+        for frame in warm_up_frames
+    ]
+    assert ids_in_order == ["tool_call:call-a", "tool_call:call-b"]
+
+    # And this is what steps() itself returns for the same history --
+    # the replay now agrees with it instead of the resolve-order [B, A].
+    steps_resp = client.get(
+        f"/v1/chat/tasks/{task_id}/steps", headers=_bearer(full_key)
+    )
+    polled_ids = [step["id"] for step in steps_resp.json()["steps"]]
+    assert polled_ids == ids_in_order
+
+
+# ===== the replay's second bound: the same wire-byte budget the
+# attach-time fast paths' snapshot uses =====
+
+
+# ===== registration watermark: an event that lands in the gap between
+# `register_connection` and the warm-up read must not be folded into
+# the projector twice (once via replay, once via staged-drain) =====
+
+
+async def test_replay_watermark_excludes_a_row_committed_after_registration():
+    """Direct pin on ``_build_warm_up_frames``'s ``replay_watermark``
+    parameter, at the same sink level ``test_orphan_end_during_warm_up_is_rescued_by_staging``
+    uses for the cold-sink staging window: a trace row committed (and
+    broadcast) *after* the watermark was captured -- exactly the
+    registration-to-warm-up-read gap ``_generate`` now bounds replay to
+    -- must be excluded from this replay entirely, since it's already
+    covered by staging + ``finish_warm_up``'s drain. Without the bound
+    (``replay_watermark=None``, pinned by the mutation note below), the
+    same row would be replayed here AND drained from staging, producing
+    two ``step.started`` frames for the same step id instead of one."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+
+    # What ``_generate`` would have captured immediately after
+    # ``register_connection``, before any of this task's history exists.
+    watermark_at_registration = v1_tasks._load_task_steps_version_snapshot(
+        task_id, principal
+    ).max_event_id
+
+    # Lands *after* that watermark -- the gap-window event -- and its
+    # broadcast reaches the still-cold sink in the same window, so it's
+    # staged rather than fed to a live projector.
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="tool_execution_start",
+        event_id="gap-event",
+        timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC),
+        step_id="step-1",
+        data={"tool_call_id": "call-1", "tool_name": "search", "tool_args": {}},
+    )
+    sink = _make_sink(task_id=task_id, warm=False)
+    await sink.send_text(
+        _trace_event_frame(
+            "tool_execution_start",
+            task_id=task_id,
+            step_id="step-1",
+            data={"tool_call_id": "call-1", "tool_name": "search", "tool_args": {}},
+        )
+    )
+    assert sink.staged_message_count == 1
+
+    warmed_projector, warm_up_frames = es._build_warm_up_frames(
+        task_id,
+        principal,
+        v1_tasks._load_task_steps_snapshot,
+        watermark_at_registration,
+    )
+    # The gap event's row id is > the watermark -- excluded from this
+    # replay entirely, nothing to replay for a task with no history
+    # before the watermark.
+    assert warm_up_frames == []
+
+    sink.finish_warm_up(warmed_projector)
+    # The staged broadcast is the only source of this step's frame.
+    frame_text, is_close = sink.queue.get_nowait()
+    assert is_close is False
+    assert frame_text.startswith("event: step.started\n")
+    step = json.loads(frame_text.split("data: ", 1)[1])["step"]
+    assert step["id"] == "tool_call:call-1"
+    assert sink.queue.empty()  # exactly once -- no duplicate from replay
+
+
+async def test_generate_wires_read_task_steps_version_into_the_watermark(monkeypatch):
+    """Wiring smoke test through the real generator (not just the
+    ``_build_warm_up_frames`` unit above): ``read_task_steps_version``
+    passed into ``_generate`` is actually called once, right after
+    registration, and its result reaches ``_build_warm_up_frames`` as
+    ``replay_watermark`` -- catches a signature/plumbing regression the
+    sink-level test above wouldn't (it calls ``_build_warm_up_frames``
+    directly, bypassing ``_generate`` entirely)."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="tool_execution_start",
+        event_id="hist-1",
+        timestamp=base,
+        step_id="step-1",
+        data={"tool_call_id": "call-1", "tool_name": "search", "tool_args": {}},
+    )
+
+    calls: list[int] = []
+    original = v1_tasks._load_task_steps_version_snapshot
+
+    def _tracking_version_reader(task_id_, principal_):
+        calls.append(1)
+        return original(task_id_, principal_)
+
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=_tracking_version_reader,
+        **_long_intervals(),
+    )
+    try:
+        first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert "event: task.status" in first
+        second = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert second.startswith("event: step.started\n")
+        assert calls == [1]  # the version reader ran exactly once
+    finally:
+        await resp.body_iterator.aclose()
+
+
+def test_fast_paths_without_a_steps_version_reader_is_a_call_error():
+    """``read_task_steps_version`` is a required argument on all three
+    attach-time fast-path entry points -- ``_terminal_snapshot_stream``,
+    ``_input_required_snapshot_stream``, and the
+    ``_fast_path_snapshot_stream`` body they share -- not one carrying a
+    default.
+
+    ``build_event_stream_response`` always forwards its own reader into
+    whichever of the three it picks, so no caller inside this module can
+    reach one of them without a reader in hand. Requiredness is what
+    keeps that true for a caller outside it: the cursor baseline read
+    and its recheck are the only signal that catches a trace row landing
+    between the steps read and the fence, and a reader-less call would
+    otherwise run the fast path with that signal silently absent. This
+    pins the call itself as the failure point -- a ``TypeError`` naming
+    the argument, raised before any reader runs.
+
+    ``build_event_stream_response`` is pinned the same way. It is the
+    only entry point a caller outside this module reaches, so a default
+    restored there would accept reader-less attaches even with all three
+    inner entry points still required. Its own missing-argument
+    ``TypeError`` is raised at the call, not at the await: binding
+    happens before the coroutine object exists, so nothing is left
+    un-awaited by the assertion below."""
+
+    def _unused(task_id_, principal_):
+        raise AssertionError("must not run before the missing-argument TypeError")
+
+    terminal_snapshot = SimpleNamespace(
+        task_id=1, agent_id=1, status=TaskStatus.COMPLETED, output="done", error=None
+    )
+    with pytest.raises(TypeError, match="read_task_steps_version"):
+        es._terminal_snapshot_stream(
+            terminal_snapshot,
+            principal=None,
+            read_task_steps_response=_unused,
+            read_task_snapshot=_unused,
+        )
+
+    waiting_snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=TaskStatus.WAITING_FOR_USER,
+        pending_question="what next?",
+    )
+    with pytest.raises(TypeError, match="read_task_steps_version"):
+        es._input_required_snapshot_stream(
+            waiting_snapshot,
+            principal=None,
+            read_task_steps_response=_unused,
+            read_task_snapshot=_unused,
+        )
+
+    with pytest.raises(TypeError, match="read_task_steps_version"):
+        es._fast_path_snapshot_stream(
+            terminal_snapshot,
+            principal=None,
+            read_task_steps_response=_unused,
+            read_task_snapshot=_unused,
+            build_conclusion=lambda snapshot_total_steps: "",
+            path_name="terminal",
+        )
+
+    with pytest.raises(TypeError, match="read_task_steps_version"):
+        es.build_event_stream_response(
+            task_id=1,
+            principal=None,
+            initial_snapshot=terminal_snapshot,
+            read_task_snapshot=_unused,
+            read_task_steps_response=_unused,
+        )
+
+
+async def asyncio_timeout_iter(aiter, *, timeout: float):
+    """Drive an async iterator to exhaustion with a per-item timeout, so
+    a regression that makes the generator hang instead of closing fails
+    this test outright rather than stalling the whole suite."""
+    while True:
+        try:
+            item = await asyncio.wait_for(aiter.__anext__(), timeout=timeout)
+        except StopAsyncIteration:
+            return
+        yield item
+
+
+# ===== a staged frame that fails to project during warm-up doesn't
+# turn an otherwise-normal stream close into a resync_required one =====
 
 
 def test_fast_path_terminal_attach_includes_current_steps():
@@ -2768,7 +3474,9 @@ def test_fast_path_step_snapshot_hits_the_steps_cache(monkeypatch):
 
 async def test_fast_path_step_read_failure_closes_with_resync_required_not_a_bare_disconnect():
     """Both attach-time fast paths now catch a snapshot-read failure and
-    close with ``stream.error {resync_required}``
+    close with ``stream.error {resync_required}``, matching the
+    invariant ``_generate`` already enforces around its own warm-up read
+    (see ``test_warm_up_read_failure_closes_with_resync_required_not_a_bare_disconnect``)
     -- not a bare exception out of the generator. That distinction
     matters here specifically because ``StreamingResponse`` sends the
     HTTP response start (200, headers) before ever pulling a chunk from
@@ -2776,10 +3484,11 @@ async def test_fast_path_step_read_failure_closes_with_resync_required_not_a_bar
     HTTP status, it just ends an already-started 200 response with no
     bytes and no close frame, indistinguishable from the client's side
     from the connection merely dropping. ``task.status`` is emitted
-    first either way.
+    first either way, the same order ``_generate`` uses around its own
+    warm-up failure.
 
-    A step-read failure on either fast path does not cancel that path's
-    own lifecycle conclusion: the snapshot
+    Unlike the warm-up path, a step-read failure on either fast path
+    does not cancel that path's own lifecycle conclusion: the snapshot
     that picked the fast path was already read, successfully, before
     either generator started, so ``task.completed``/``task.input_required``
     is known-good independent of the steps read below it. Both bodies
@@ -2872,9 +3581,10 @@ async def test_fast_path_task_not_found_closes_with_task_deleted_not_resync_requ
     the task (see ``TaskStepsResponseReader``) after
     ``build_event_stream_response`` already resolved it once to pick
     this fast path, so a task deleted in that exact gap surfaces here as
-    ``V1ApiError(TASK_NOT_FOUND)`` -- the same condition the watchdog
-    already reports as ``task_deleted``, not ``resync_required``.
-    Asking a client to ``steps()`` and reattach
+    ``V1ApiError(TASK_NOT_FOUND)`` -- the same condition the warm-up read
+    and the watchdog already report as ``task_deleted`` (see
+    ``test_warm_up_read_task_not_found_closes_with_task_deleted_not_resync_required``),
+    not ``resync_required``. Asking a client to ``steps()`` and reattach
     for a task that's gone would just 404 instead of resyncing anything.
 
     The conclusion frame still goes out first in this case too: the
@@ -2882,8 +3592,8 @@ async def test_fast_path_task_not_found_closes_with_task_deleted_not_resync_requ
     it's already in hand and does not depend on the re-resolve that
     just 404ed.
 
-    ``principal`` is ``None`` here too -- see the companion read-failure
-    test above for why the key check is patched to succeed."""
+    ``principal`` is ``None`` here too, the same as the companion
+    read-failure test above."""
 
     def _deleted_read_task_steps_response(task_id_, principal_):
         raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404)
@@ -2940,17 +3650,30 @@ async def test_fast_path_task_not_found_closes_with_task_deleted_not_resync_requ
     )
 
 
-def test_fast_path_snapshot_bounds_match_the_documented_endpoint_contract():
-    """Pins the two literal values the attach-time snapshot is bounded
-    by. These aren't free internal tuning: ``tasks.py``'s endpoint
-    docstring documents ``REPLAY_MAX_STEPS`` as the literal number 512
-    (not a symbolic reference to this module) for API consumers reading
-    the ``GET /v1/chat/tasks/{task_id}/events`` contract, so a change to
-    either constant here has to be paired with updating that docstring
-    -- this test exists so such a change doesn't slip through silently.
+def test_attach_step_batch_bounds_match_the_documented_endpoint_contract():
+    """Pins the two literal values every attach-time batch of steps is
+    bounded by -- the fast paths' one-shot snapshot and the normal
+    path's history replay alike. These aren't free internal tuning:
+    ``tasks.py``'s ``stream_chat_task_events`` endpoint docstring
+    documents them as the literal numbers 512 and 4 MiB (not symbolic
+    references to this module) for API consumers reading the ``GET
+    /v1/chat/tasks/{task_id}/events`` contract, so a change to either
+    constant here has to be paired with updating that docstring -- this
+    test exists so such a change doesn't slip through silently.
+
+    Pinning the two module constants alone does not do that: a constant
+    can drift out of sync with the docstring's own hardcoded numbers
+    without either assertion below ever noticing, since neither reads
+    the docstring. The two assertions on ``__doc__`` close that gap by
+    checking the actual literal text the endpoint's real docstring
+    still carries, not just this module's own copies of the numbers.
     """
     assert es.REPLAY_MAX_STEPS == 512
     assert es.MAX_SNAPSHOT_WIRE_BYTES == 4 * 1024 * 1024
+
+    endpoint_doc = v1_tasks.stream_chat_task_events.__doc__ or ""
+    assert "512" in endpoint_doc
+    assert "4 MiB" in endpoint_doc
 
 
 @pytest.mark.parametrize(
@@ -3184,7 +3907,7 @@ async def test_fast_path_step_snapshot_replay_max_steps_boundary(
     literal 512/513 so this test keeps pinning the boundary itself even
     if the constant's value ever changes -- that value is pinned
     separately, by
-    ``test_fast_path_snapshot_bounds_match_the_documented_endpoint_contract``.
+    ``test_attach_step_batch_bounds_match_the_documented_endpoint_contract``.
     """
     base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
     steps = [
@@ -4597,79 +5320,6 @@ async def test_fast_path_unserializable_step_concludes_then_closes_for_resync(
     assert "moved to a new run" not in body
 
 
-def test_fast_paths_without_a_steps_version_reader_is_a_call_error():
-    """``read_task_steps_version`` is a required argument on all three
-    attach-time fast-path entry points -- ``_terminal_snapshot_stream``,
-    ``_input_required_snapshot_stream``, and the
-    ``_fast_path_snapshot_stream`` body they share -- not one carrying a
-    default.
-
-    ``build_event_stream_response`` always forwards its own reader into
-    whichever of the three it picks, so no caller inside this module can
-    reach one of them without a reader in hand. Requiredness is what
-    keeps that true for a caller outside it: the cursor baseline read
-    and its recheck are the only signal that catches a trace row landing
-    between the steps read and the fence, and a reader-less call would
-    otherwise run the fast path with that signal silently absent. This
-    pins the call itself as the failure point -- a ``TypeError`` naming
-    the argument, raised before any reader runs.
-
-    ``build_event_stream_response`` is pinned the same way. It is the
-    only entry point a caller outside this module reaches, so a default
-    restored there would accept reader-less attaches even with all three
-    inner entry points still required. Its own missing-argument
-    ``TypeError`` is raised at the call, not at the await: binding
-    happens before the coroutine object exists, so nothing is left
-    un-awaited by the assertion below."""
-
-    def _unused(task_id_, principal_):
-        raise AssertionError("must not run before the missing-argument TypeError")
-
-    terminal_snapshot = SimpleNamespace(
-        task_id=1, agent_id=1, status=TaskStatus.COMPLETED, output="done", error=None
-    )
-    with pytest.raises(TypeError, match="read_task_steps_version"):
-        es._terminal_snapshot_stream(
-            terminal_snapshot,
-            principal=None,
-            read_task_steps_response=_unused,
-            read_task_snapshot=_unused,
-        )
-
-    waiting_snapshot = SimpleNamespace(
-        task_id=1,
-        agent_id=1,
-        status=TaskStatus.WAITING_FOR_USER,
-        pending_question="what next?",
-    )
-    with pytest.raises(TypeError, match="read_task_steps_version"):
-        es._input_required_snapshot_stream(
-            waiting_snapshot,
-            principal=None,
-            read_task_steps_response=_unused,
-            read_task_snapshot=_unused,
-        )
-
-    with pytest.raises(TypeError, match="read_task_steps_version"):
-        es._fast_path_snapshot_stream(
-            terminal_snapshot,
-            principal=None,
-            read_task_steps_response=_unused,
-            read_task_snapshot=_unused,
-            build_conclusion=lambda snapshot_total_steps: "",
-            path_name="terminal",
-        )
-
-    with pytest.raises(TypeError, match="read_task_steps_version"):
-        es.build_event_stream_response(
-            task_id=1,
-            principal=None,
-            initial_snapshot=terminal_snapshot,
-            read_task_snapshot=_unused,
-            read_task_steps_response=_unused,
-        )
-
-
 # ===== single-frame content byte cap =====
 
 
@@ -5041,9 +5691,11 @@ async def test_nonfinite_step_data_values_are_normalized_to_null_on_the_wire():
     ``NaN``/``Infinity``/``-Infinity``, which a strict ``JSON.parse``
     client rejects outright.
 
-    Both producers of a ``step.*`` frame -- live projection
-    (``_step_content_frame``) and the attach-time fast paths' cached
-    snapshot -- funnel through ``_step_wire_frame``, and that function
+    All three producers of a ``step.*`` frame -- live projection
+    (``_step_content_frame``), the attach-time fast paths' cached
+    snapshot, and the normal path's history replay
+    (``_build_warm_up_frames``) -- funnel through
+    ``_step_wire_frame``, and that function
     is where the single ``model_dump(mode="json")`` runs: it takes the
     ``PublicStep`` model, not an already-dumped dict, so neither
     producer can reach a frame builder with un-normalized values.
@@ -5059,9 +5711,10 @@ async def test_nonfinite_step_data_values_are_normalized_to_null_on_the_wire():
     produces it; normalizing it in test setup first would have left the
     assertions green even if the normalization regressed to passing the
     raw dict straight through. Because that normalization sits in
-    ``_step_wire_frame``, which both producers must go through to build
-    a frame at all, this one assertion covers the fast paths too. It
-    changes no production code -- if that regression ever happens, this
+    ``_step_wire_frame``, which every producer must go through to build
+    a frame at all, this one assertion covers the fast paths and the
+    replay too. It changes no production code -- if that regression
+    ever happens, this
     test is the tripwire.
     """
     nested_nonfinite_data = {

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -1666,10 +1666,11 @@ async def test_watchdog_keeps_checking_authorization_across_an_ordinary_close(
 
     The warm-up replay hands its frames to the client directly, bypassing
     the outbound queue's closing guard, so a close that is not abortive
-    stops nothing on that path -- only ``abortive_close`` does, and only
-    ``watchdog_check_once`` ever sets it. A watchdog that stops at a
-    close therefore never observes a key revoked afterwards, and the
-    replay hands that key the task's persisted history.
+    stops nothing on that path -- only ``abortive_close`` does, set here
+    by ``watchdog_check_once`` (and, on a different path, by
+    ``_generate``'s own two pre-loop read failures). A watchdog that
+    stops at a close therefore never observes a key revoked afterwards,
+    and the replay hands that key the task's persisted history.
 
     The two legs differ in one variable, who claims the close, because
     the loop had two separate exits that both ended coverage: one on
@@ -1722,6 +1723,70 @@ async def test_watchdog_keeps_checking_authorization_across_an_ordinary_close(
         body = "".join(frames)
         assert "event: step.started" not in body
         assert frames[-1].startswith(expected_close_event)
+    finally:
+        await resp.body_iterator.aclose()
+
+
+async def test_watchdog_stops_once_the_warm_up_handoff_is_over():
+    """The warm-side mirror of the test above: once the warm-up handoff
+    is over, an ordinary close really does end watchdog coverage,
+    because every emission from that point on goes through
+    ``_put_or_overflow``'s closing guard -- there is no longer a direct
+    replay path left for the watchdog to keep guarding against.
+
+    Pulls frames until ``sink.warm`` is True. ``sink.warm`` flips inside
+    the generator, between the last replayed frame and whatever it
+    yields next, so the pull that observes it can block briefly on the
+    generator's own wait loop -- a short ``heartbeat_interval_seconds``
+    bounds that to one ``: ping`` cycle instead of the fixture's usual
+    minutes-long interval.
+
+    Then closes non-abortively and asserts the watchdog loop's actual
+    exit, not only the predicate flipping: ``_watchdog_coverage_done``
+    reading True proves nothing about whether the loop's own ``while``
+    re-checked it, so this awaits the watchdog task itself with a
+    timeout too -- a predicate that goes true without the task
+    finishing would still fail this test."""
+    task_id, principal = await _three_step_task()
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
+        watchdog_interval_seconds=0.05,
+        stream_max_duration_seconds=600.0,
+        heartbeat_interval_seconds=0.05,
+    )
+    try:
+        status = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert "event: task.status" in status
+        sink = next(
+            c
+            for c in es.manager.connections_for_task(task_id)
+            if isinstance(c, es.V1EventStreamSink)
+        )
+        assert sink.warm is False
+
+        watchdog_task = next(
+            t
+            for t in asyncio.all_tasks()
+            if t.get_coro().cr_code.co_name == "_watchdog_loop"
+        )
+
+        for _ in range(10):
+            if sink.warm:
+                break
+            await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert sink.warm is True
+
+        assert sink.enqueue_close(es.error_frame("resync_required")) is True
+        await _poll_until(lambda: es._watchdog_coverage_done(sink))
+        await asyncio.wait_for(watchdog_task, timeout=2)
+        assert watchdog_task.done()
     finally:
         await resp.body_iterator.aclose()
 

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -3863,6 +3863,127 @@ async def test_the_watermark_read_splits_task_deleted_from_every_other_failure(
     assert "event: step.started" not in body
 
 
+async def test_absolute_deadline_stops_the_warm_up_replay_early():
+    """The warm-up replay loop re-checks the connection's own absolute
+    deadline before every yield, not only the main loop below it.
+
+    ``stream_max_duration_seconds`` is negative, so the deadline bound
+    at generator start (``monotonic() + stream_max_duration_seconds``)
+    is already in the past by the time the replay loop reaches its
+    first frame, regardless of how long the watermark read and the
+    history read themselves took. The task has three known steps
+    (``_three_step_task``), so a replay that ran to completion would
+    yield three ``step.started`` frames; this pins that none of them
+    make it out, and that the stream instead closes with
+    ``stream_expired`` once the main loop's own deadline check runs on
+    its very next pass -- the deadline break needs no close of its
+    own."""
+    task_id, principal = await _three_step_task()
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=v1_tasks._load_task_steps_snapshot,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
+        **_long_intervals(stream_max_duration_seconds=-1.0),
+    )
+    try:
+        frames = []
+        async for chunk in asyncio_timeout_iter(resp.body_iterator, timeout=2):
+            frames.append(chunk)
+        body = "".join(frames)
+        assert "event: task.status" in body
+        assert "event: step.started" not in body
+        assert _parse_error_frame(body)["code"] == "stream_expired"
+        assert frames[-1].startswith("event: stream.error")
+    finally:
+        await resp.body_iterator.aclose()
+
+
+def _fail_the_history_read_because_the_task_is_gone(task_id_, principal_):
+    """The second, narrower ``TASK_NOT_FOUND`` race window
+    ``_build_warm_up_frames``'s own read covers -- the task is deleted
+    after the watermark read already succeeded, but before this read
+    runs. Distinct from ``_delete_the_task_then_read_the_watermark``
+    above, which covers the watermark read's own race instead."""
+    raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404)
+
+
+@pytest.mark.parametrize(
+    ("read_task_steps_version", "read_task_steps"),
+    [
+        pytest.param(
+            _delete_the_task_then_read_the_watermark,
+            v1_tasks._load_task_steps_snapshot,
+            id="watermark-read",
+        ),
+        pytest.param(
+            v1_tasks._load_task_steps_version_snapshot,
+            _fail_the_history_read_because_the_task_is_gone,
+            id="history-read",
+        ),
+    ],
+)
+async def test_generates_own_task_not_found_reads_are_abortive_and_end_watchdog_coverage(
+    read_task_steps_version, read_task_steps
+):
+    """Both of ``_generate``'s own pre-loop reads -- the replay
+    watermark and the warm-up history -- close ``task_deleted`` the
+    same way ``watchdog_check_once`` does when the task row is gone,
+    and on neither leg does the warm-up handoff ever run
+    (``sink.warm`` stays ``False``), so only ``abortive_close`` can end
+    the watchdog's own coverage on this path (see
+    ``_watchdog_coverage_done``). Pins the wire-level close code, pins
+    ``sink.abortive_close`` directly, and confirms the watchdog loop
+    actually exits on its own -- not just that the predicate flips --
+    by awaiting the watchdog task itself with a timeout. A short
+    ``watchdog_interval_seconds`` is what lets that task notice and
+    exit within the timeout, independent of the generator's own
+    teardown (which would cancel it regardless, masking a broken
+    ``abortive=True``)."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+    snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
+
+    resp = await es.build_event_stream_response(
+        task_id=task_id,
+        principal=principal,
+        initial_snapshot=snapshot,
+        read_task_snapshot=v1_tasks._load_task_info_snapshot,
+        read_task_steps=read_task_steps,
+        read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=read_task_steps_version,
+        **_long_intervals(watchdog_interval_seconds=0.05),
+    )
+    try:
+        first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert "event: task.status" in first
+        sink = next(
+            c
+            for c in es.manager.connections_for_task(task_id)
+            if isinstance(c, es.V1EventStreamSink)
+        )
+        watchdog_task = next(
+            t
+            for t in asyncio.all_tasks()
+            if t.get_coro().cr_code.co_name == "_watchdog_loop"
+        )
+
+        second = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
+        assert _parse_error_frame(second)["code"] == "task_deleted"
+        assert sink.abortive_close is True
+        assert sink.warm is False
+
+        await asyncio.wait_for(watchdog_task, timeout=2)
+        assert watchdog_task.done()
+    finally:
+        await resp.body_iterator.aclose()
+
+
 def test_fast_paths_without_a_steps_version_reader_is_a_call_error():
     """``read_task_steps_version`` is a required argument on all three
     attach-time fast-path entry points -- ``_terminal_snapshot_stream``,

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -3349,11 +3349,78 @@ async def test_replay_watermark_excludes_a_row_committed_after_registration():
     assert sink.queue.empty()  # exactly once -- no duplicate from replay
 
 
+async def test_a_planning_row_folded_twice_in_the_residual_window_leaves_one_step_running():
+    """Pins the accepted residual of registering before reading the
+    watermark, so it cannot drift silently. Tracked as #1776.
+
+    A row that commits inside the registration-to-watermark gap is both
+    at or below the watermark (so the replay folds it) and already
+    staged (so ``finish_warm_up``'s drain folds it again). This test
+    builds that same end state directly: insert the row, capture a
+    watermark above it, then hand the sink the row's broadcast while it
+    is still cold.
+
+    The planning family is the one that cannot absorb it. Its public
+    step id comes from an in-memory counter rather than from a key the
+    event carries, so two folds mint two different ids, and the row's
+    single end event -- arriving live, after the handoff -- closes only
+    the later one. The earlier step stays ``running`` for the rest of
+    the connection.
+
+    Asserting the duplicate is deliberate. Exactly one start with its
+    matching completion is the acceptance test for #1776, and it
+    belongs with the fix that carries a persisted identity onto
+    broadcast frames.
+    """
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_task(full_key, agent_id)
+    principal = _principal_for(full_key)
+
+    _insert_trace_event(
+        task_id=task_id,
+        event_type="dag_plan_start",
+        event_id="gap-plan",
+        timestamp=datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC),
+        data={},
+    )
+    watermark = v1_tasks._load_task_steps_version_snapshot(
+        task_id, principal
+    ).max_event_id
+
+    sink = _make_sink(task_id=task_id, warm=False)
+    await sink.send_text(_trace_event_frame("dag_plan_start", task_id=task_id, data={}))
+    assert sink.staged_message_count == 1
+
+    warmed_projector, warm_up_frames = es._build_warm_up_frames(
+        task_id, principal, v1_tasks._load_task_steps_snapshot, watermark
+    )
+    replayed = json.loads(warm_up_frames[0].split("data: ", 1)[1])["step"]
+
+    sink.finish_warm_up(warmed_projector)
+    drained_text, _ = sink.queue.get_nowait()
+    drained = json.loads(drained_text.split("data: ", 1)[1])["step"]
+
+    # One row, two public ids: the counter advanced on each fold.
+    assert drained["id"] != replayed["id"]
+    assert drained["status"] == "running"
+
+    await sink.send_text(_trace_event_frame("dag_plan_end", task_id=task_id, data={}))
+    completed_text, _ = sink.queue.get_nowait()
+    completed = json.loads(completed_text.split("data: ", 1)[1])["step"]
+    # The single end event closes only the later id; the replayed one is
+    # never finalized.
+    assert completed["id"] == drained["id"]
+    assert completed["status"] == "completed"
+    assert sink.queue.empty()
+
+
 async def test_generate_wires_read_task_steps_version_into_the_watermark(monkeypatch):
     """Wiring smoke test through the real generator (not just the
     ``_build_warm_up_frames`` unit above): ``read_task_steps_version``
-    passed into ``_generate`` is actually called once, right after
-    registration, and its result reaches ``_build_warm_up_frames`` as
+    passed into ``_generate`` is actually called exactly once, and by
+    the time it runs the sink is already visible in ``manager`` --
+    proof that registration happened first, not just that the reader
+    ran once -- and its result reaches ``_build_warm_up_frames`` as
     ``replay_watermark`` -- catches a signature/plumbing regression the
     sink-level test above wouldn't (it calls ``_build_warm_up_frames``
     directly, bypassing ``_generate`` entirely)."""
@@ -3370,11 +3437,25 @@ async def test_generate_wires_read_task_steps_version_into_the_watermark(monkeyp
         data={"tool_call_id": "call-1", "tool_name": "search", "tool_args": {}},
     )
 
-    calls: list[int] = []
+    calls: list[str] = []
     original = v1_tasks._load_task_steps_version_snapshot
 
     def _tracking_version_reader(task_id_, principal_):
-        calls.append(1)
+        # Ordering-sensitive on purpose: the sink only becomes visible
+        # in the manager once ``register_connection`` has run, so a
+        # reader moved ahead of registration records "unregistered"
+        # here and fails the assertion below. A count alone cannot see
+        # that, and the order is load-bearing -- registering second
+        # turns the gap this reader bounds from a duplicated row into a
+        # lost one.
+        calls.append(
+            "registered"
+            if any(
+                isinstance(c, es.V1EventStreamSink)
+                for c in es.manager.connections_for_task(task_id_)
+            )
+            else "unregistered"
+        )
         return original(task_id_, principal_)
 
     snapshot = v1_tasks._load_task_info_snapshot(task_id, principal)
@@ -3393,7 +3474,7 @@ async def test_generate_wires_read_task_steps_version_into_the_watermark(monkeyp
         assert "event: task.status" in first
         second = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
         assert second.startswith("event: step.started\n")
-        assert calls == [1]  # the version reader ran exactly once
+        assert calls == ["registered"]  # ran exactly once, and after registration
     finally:
         await resp.body_iterator.aclose()
 
@@ -3809,16 +3890,23 @@ def test_attach_step_batch_bounds_match_the_documented_endpoint_contract():
     Pinning the two module constants alone does not do that: a constant
     can drift out of sync with the docstring's own hardcoded numbers
     without either assertion below ever noticing, since neither reads
-    the docstring. The two assertions on ``__doc__`` close that gap by
-    checking the actual literal text the endpoint's real docstring
-    still carries, not just this module's own copies of the numbers.
+    the docstring. The assertions on ``__doc__`` close that gap by
+    pinning the authoritative passage's exact wording and requiring
+    each number to appear exactly once across the whole docstring, so a
+    second copy reappearing elsewhere -- the failure mode a bare
+    membership check cannot see -- fails the count.
     """
     assert es.REPLAY_MAX_STEPS == 512
     assert es.MAX_SNAPSHOT_WIRE_BYTES == 4 * 1024 * 1024
 
     endpoint_doc = v1_tasks.stream_chat_task_events.__doc__ or ""
-    assert "512" in endpoint_doc
-    assert "4 MiB" in endpoint_doc
+    assert "a step-count cap (512) keeps the most recent steps" in endpoint_doc
+    assert "total-wire-bytes budget (4 MiB)" in endpoint_doc
+    # Exactly one passage carries each number. A second copy is what
+    # lets one of them drift while the other stays right, so the count
+    # is part of the contract this test pins, not incidental.
+    assert endpoint_doc.count("512") == 1
+    assert endpoint_doc.count("4 MiB") == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/web/api/v1/test_steps_mapping.py
+++ b/tests/web/api/v1/test_steps_mapping.py
@@ -1842,3 +1842,61 @@ def test_two_full_rounds_interrupted_then_failed_close_independently():
     assert round_one_step["completed_at"] is None
     assert round_two_step["status"] == "failed"
     assert round_two_step["completed_at"] is not None
+
+
+def test_take_materialized_steps_returns_the_timeline_and_stops_retaining():
+    """The pre-warm exit, pinned in both halves.
+
+    A caller that replays history to build pairing state reads the
+    resulting timeline out exactly once and then keeps feeding the same
+    instance live events -- so it needs retention on for the read and
+    off forever after. This asserts the read returns the full timeline,
+    and that the same instance is afterwards indistinguishable from one
+    built with ``retain_finished=False``: ``materialized_steps()``
+    raises, ``feed()`` still returns what it changed, and nothing
+    accumulates.
+
+    Without the release, this projector would hold every finished
+    step's untruncated ``data`` for as long as its consumer lives.
+    """
+    projector = PublicStepProjector.from_history(
+        [
+            _ev("react_action_start", step_id="s1"),
+            _ev("react_action_end", step_id="s1", data={"success": True}),
+        ]
+    )
+    assert projector.retains_finished is True
+
+    taken = projector.take_materialized_steps()
+
+    assert [step["status"] for step in taken] == ["completed"]
+    assert projector.retains_finished is False
+    with pytest.raises(RuntimeError):
+        projector.materialized_steps()
+
+    # Still a working projector: it folds and reports, it just keeps
+    # nothing. Both halves matter -- an implementation that released
+    # retention by breaking ``feed`` would pass the assertions above.
+    changed = projector.feed(_ev("react_action_start", step_id="s2"))
+    assert len(changed) == 1
+    assert changed[0]["status"] == "running"
+    resolved = projector.feed(
+        _ev("react_action_end", step_id="s2", data={"success": True})
+    )
+    assert len(resolved) == 1
+    assert resolved[0]["status"] == "completed"
+    with pytest.raises(RuntimeError):
+        projector.materialized_steps()
+
+
+def test_take_materialized_steps_raises_on_an_already_released_projector():
+    """Calling it twice is a caller bug, not a silent empty answer: the
+    timeline it would return is gone, exactly the case
+    ``materialized_steps()`` already refuses to answer partially."""
+    projector = PublicStepProjector.from_history(
+        [_ev("react_action_start", step_id="s1")]
+    )
+    projector.take_materialized_steps()
+
+    with pytest.raises(RuntimeError):
+        projector.take_materialized_steps()


### PR DESCRIPTION
## What this changes

`GET /v1/chat/tasks/{task_id}/events` used to start a client's view of a task at
the moment it attached. Everything the task had already done was invisible on
this stream, and worse than invisible: a step whose `step.started` was broadcast
before the connection existed had its end event arrive here with no matching
start, so the projector dropped that end as an orphan. The client saw neither
half of the step, or -- once the step was later shown by some other path -- a
step stuck at `status="running"` for the rest of the connection.

After this change a fresh attach replays the task's already-known steps first,
then goes live. Live frames that arrive while that replay is being prepared are
held and released afterwards in arrival order, so no step is split across the
boundary between the two.

On the wire an attach now looks like: the initial `task.status` frame, then a
batch of `step.started` / `step.completed` frames in `started_at` order for
history, then live frames. The replay batch is bounded by contract and can
legitimately be empty; a client that needs guaranteed-complete history still
reconciles against `GET /v1/chat/tasks/{task_id}/steps`.

## The five pieces, and why each one is required

### 1. A watermark bounds which rows the replay may fold

`_generate` reads `read_task_steps_version(...).max_event_id` immediately after
`manager.register_connection(...)` and passes it to `_build_warm_up_frames`,
which excludes every row with `_event_row_id(event) > replay_watermark`.

The bound is needed because registration happens *before* the history read. A row
committed between those two points is visible to the read and was also broadcast
to the already-registered connection. Unbounded, it would be folded in twice and
the client would receive a duplicate `step.started` / `step.completed` pair. With
the bound, rows above the watermark are excluded from the replay and reach the
client only through the staging path below.

Registering before reading the watermark is deliberate. The opposite order turns
the same gap from a duplicate into a *lost* row -- excluded from the replay,
broadcast before the connection existed -- and this transport prefers a duplicate
to a loss. The residual duplicate window is one `SELECT max(id)` wide. The call
site records which step families dedupe by a persisted id (`tool_call`,
`agent_delegation`, and the action/step phases of `thinking`) and which two do
not, including why the planning phase of `thinking` is the one case where a
duplicate in that window would reintroduce the stuck-running symptom.

A failed watermark read does not fall back to an unbounded replay. It queues a
`resync_required` close frame and skips the warm-up entirely; the whole warm-up
block is gated on `replay_watermark is not None`. Because the reader is a
required argument, `None` can only ever mean "the read failed", never "no caller
wired one up".

### 2. A staging buffer covers the attach window

Between `register_connection` and `finish_warm_up` the sink is cold
(`self._warm is False`). In that window `send_text` routes content-bearing frames
to `_stage_content_message` instead of projecting them. `finish_warm_up` then
adopts the warmed projector and drains the staged list through
`_project_and_queue` in arrival order, with no `await` between the two, so no
frame can interleave and be classified against the wrong half of the switch.

Without staging, this sequence loses a step permanently:

```
t0  register_connection                      sink cold, empty projector
t1  read max(id) -> watermark = 2
t2  broadcast tool_execution_start (row 5, tool_execution_id "txC")
      -> fed straight to the empty projector; nothing pending pairs with it
t3  warm-up read returns rows id <= 2, so row 5 is correctly excluded
t4  finish_warm_up: warmed projector adopted, sink goes live
t5  broadcast tool_execution_end   (tool_execution_id "txC")
      -> the projector has no pending start for "txC"; dropped as an orphan
```

The client is left with a step that started and never completes. With staging,
the frame at t2 is held, t4 replays it into the warmed projector so the start is
pending, and t5 emits `step.completed` normally.

The buffer reuses the outbound queue's own count cap and overflow policy --
`OUTBOUND_QUEUE_MAX_SIZE` entries, then `resync_required` -- for the constant
and the rationale, not the implementation: it is a separate list with its own
check here, not a call into the queue's own overflow path. Its second,
cumulative bound is its own: `STAGED_MESSAGES_MAX_TEXT_CHARS` of
description-free text (the task's own description column excluded, whichever
of the two keys it arrived under -- see `_measured_content_frame`), tracked on
top of the count cap so a run of large-but-under-cap messages during a slow
warm-up read can't hold unbounded memory just because it stayed under the
count cap. That is a different constant from the outbound queue's own
cumulative bound (`MAX_QUEUED_WIRE_BYTES`, counted in serialized wire bytes
rather than in this character-count, description-free measure) -- the two buffers share
the count cap and the failure mode, not the byte-level bound. The character
count is the one `_measured_content_frame` hands to `send_text`'s oversize
pre-check -- a frame that carries a description key is serialized once more
after that key is pruned, so the count never includes the description, and the
same number feeds both the drop check and the staging budget. The oversize
check runs *ahead* of the warm/staged split so a frame too large to project is
dropped rather than staged and dropped later.

### 3. Two caps bound the replay batch

`_build_warm_up_frames` applies `REPLAY_MAX_STEPS` (keep the most recent steps,
written inline at the call site) and then `_snapshot_steps_within_wire_budget`
(`MAX_SNAPSHOT_WIRE_BYTES` of serialized frames) over that already-capped
window. The byte cap is applied by the same function that already bounds the
attach-time fast paths' one-shot snapshot; the step cap itself is written
inline at each of the three call sites rather than inside that shared
function. Sharing the byte-cap function is the point: all three paths emit a
batch with no admission or pacing loop of their own, so they get one rule
instead of each inventing its own.

Trimming the batch keeps the newest steps' start events off the wire, not their
end events. The projector is warmed from the *whole* history regardless of what
the batch admitted, so a still-running step cut from the batch still gets its
`step.completed` live once it resolves -- but this stream never sent that
step's `step.started`, so the end arrives with no start to pair with on this
stream. This is disclosed as the endpoint's fifth documented best-effort
delivery reason (`GET .../steps` is unaffected: it reads the task's full
history directly rather than through this batch's trim). The budget cutting
the batch to zero is a legal outcome: the stream simply goes live with no
replay, no marker frame and no `stream.error`.

A third thing can shorten the batch: a step whose data cannot be serialized. The
admitted steps are serialized one at a time, and the first one that raises ends
the batch there -- the steps ahead of it are still replayed and the stream still
goes live. This is the endpoint's sixth documented best-effort delivery reason,
and unlike the fifth it does not promise `GET .../steps` as a fallback: data
that defeats the replay's serialization can make that read fail too, which is a
pre-existing property of the public step surface, tracked separately as
`https://github.com/xorbitsai/xagent/issues/2161`.

### 4. An abortive close stops the replay immediately

The replay loop yields already-serialized frames one at a time on the event loop
while the watchdog runs concurrently and can close the stream mid-yield. Most
close reasons should let that loop finish -- the history describes the task's own
past and does not become invalid just because the stream is now ending.

Two reasons are different. `watchdog_check_once` calls
`enqueue_close(..., abortive=True)` when the API key that authorized the attach
is no longer active (`unauthorized`), and when the task row itself is gone
(`task_deleted`); `_generate`'s own two pre-loop reads (the replay watermark and
the warm-up history) do the same on the same `task_deleted` reason, since both
abandon the warm-up before it can ever mark the sink warm. At that instant the
loop may still be holding most of the batch:

```
t0  replay batch built: 400 step frames, 12 of them yielded so far
t1  watchdog: key deauthorized -> enqueue_close("unauthorized", abortive=True)
t2  without the check: frames 13..400 are still yielded to the client
      -> task content delivered after the client lost the right to see it
```

So the loop tests `sink.abortive_close` and the connection's own absolute
deadline before every yield and breaks out on either. Every non-abortive close
is still left to arrive behind the finished replay, through the queue, exactly
as before; the deadline break needs no close of its own, since the main loop
right below re-evaluates the deadline on its first pass and enqueues
`stream_expired` then. The watchdog itself also stops polling once the warm-up
handoff is over (`sink.warm`), rather than continuing to check the task row and
the auth key for the rest of the connection's life after an ordinary close that
already stopped every emission on the (now warm) outbound-queue path.

### 5. The batch and the retained timeline are released once delivered

`_generate` does `del warm_up_frames` right after the loop, and
`_build_warm_up_frames` returns a projector on which `take_materialized_steps()`
has already released finished-step retention (`self._finished = None`).
`finish_warm_up` refuses a projector that still retains, raising rather than
documenting the requirement.

Both matter because of lifetime, not size alone. This generator stays suspended
for up to `STREAM_MAX_DURATION_SECONDS` -- an hour in production. A local left
bound in its frame, or a projector accumulating every step's untruncated `data`
for a sink that never calls `materialized_steps()`, pins memory for the whole
connection with nothing ever reading it again. The retention check raises because
the leak is invisible at the call site: the stream behaves correctly either way,
it just grows.

## Relationship to #1934

#1934 is merged, so the requirement it introduced -- the steps-version reader is a
required argument on the attach fast paths -- is on `main` and no longer shows up in
this diff. Piece 1 above depends on that requirement directly: it is what makes
`replay_watermark is None` mean "the read failed" and nothing else, rather than "no
reader was supplied".

## Test coverage, and what lands separately

The tests in this pull request cover the attach behavior itself: replay before
live frames, `started_at` ordering, the orphan-end rescue through staging, the
watermark excluding a row committed after registration, abortive versus normal
close during replay, reader wiring, the projector's retention release, the
staging buffer's own two bounds (count and cumulative byte size), the task's
description column excluded from every frame budget it could otherwise
overflow -- both for a single `task_info` frame and for the ordinary per-frame
case -- with the per-frame drop boundary pinned unchanged by that exclusion,
and the watchdog ending its coverage once the warm-up handoff is over instead
of polling for the rest of the connection's life.

The bound coverage for this same path lands in a follow-up pull request that
adds tests only, with no production changes: the step cap and the wire budget at
their exact boundaries, a budget that cuts the batch to zero, the order in which
the two caps apply, a failed history read, a non-integer watermark, and the
release of the frame batch once it is fully delivered. Splitting them that way
keeps each diff reviewable. One item that list used to carry -- a step whose
serialization fails mid-batch -- is no longer deferred: review found a real
defect on that path, and both the fix and its test are in this pull request.

## Verification

Run on this branch:

- `pytest tests/web/api/v1/test_events_stream.py tests/web/api/v1/test_steps_mapping.py`
  -- 313 passed.
- `pre-commit run --all-files` -- the Python hooks all pass on the full tree:
  ruff check, ruff format, mypy, isort, codespell, alembic-check, end-of-file
  fixer, trailing-whitespace. The two npm hooks (eslint, tsc) could not run in
  this environment; this change touches no frontend files.
- The t0..t5 sequence in piece 2 above was reproduced directly against this
  branch: the step opened inside the attach window now reaches the client as
  `step.started` followed by `step.completed`, and a planning step opened inside
  that window no longer reuses a public step id the replayed history already
  emitted.

