### PR TITLE
fix(interactions): drop whitespace-only ask_user options and normalize BOM field names

### DIFF
--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -662,6 +662,14 @@ describe("ClarificationForm delivery failures", () => {
 })
 
 describe("ClarificationForm blank option filtering", () => {
+  beforeEach(() => {
+    appContextMock.dispatch.mockReset()
+    appContextMock.filesDisabled = false
+    appContextMock.providerAvailable = true
+    appContextMock.sendMessage.mockReset()
+    toastErrorMock.mockReset()
+  })
+
   afterEach(() => {
     cleanup()
   })
@@ -697,7 +705,13 @@ describe("ClarificationForm blank option filtering", () => {
     expect(screen.getByText("common.noOptions")).toBeInTheDocument()
   })
 
-  it("a select_one interaction keeps a good option and drops a blank one", () => {
+  it("a select_one interaction drops an option whose label alone is blank", () => {
+    // label and value are independent halves of the same filter
+    // (opt.value.trim() !== "" && opt.label.trim() !== ""); a blank value
+    // makes this option non-blank in isolation, so a regression that only
+    // reverted the label half back to a truthiness check would let this
+    // option survive even though a case that leaves both halves blank at
+    // once would still be dropped by the (unregressed) value half alone.
     const interactions = [
       {
         type: "select_one" as const,
@@ -705,7 +719,7 @@ describe("ClarificationForm blank option filtering", () => {
         label: "Choice",
         options: [
           { label: "Import", value: "import" },
-          { label: "   ", value: "   " },
+          { label: "   ", value: "blank-label-only" },
         ],
       },
     ]
@@ -717,6 +731,32 @@ describe("ClarificationForm blank option filtering", () => {
 
     expect(screen.getByText("Import")).toBeInTheDocument()
     expect(blankOptionSpans(container)).toHaveLength(0)
+  })
+
+  it("a select_one interaction drops an option whose value alone is blank", () => {
+    // Mirrors the case above for the other half of the same filter: a
+    // non-blank label makes this option non-blank in isolation, so a
+    // regression that only reverted the value half back to a truthiness
+    // check would let this option survive.
+    const interactions = [
+      {
+        type: "select_one" as const,
+        field: "choice",
+        label: "Choice",
+        options: [
+          { label: "Import", value: "import" },
+          { label: "Blank value only", value: "   " },
+        ],
+      },
+    ]
+    const { container } = render(
+      <ClarificationForm interactions={interactions} onSend={vi.fn()} />,
+    )
+
+    fireEvent.click(screen.getByText("chatPage.clarification.selectOption"))
+
+    expect(screen.getByText("Import")).toBeInTheDocument()
+    expect(screen.queryByText("Blank value only")).not.toBeInTheDocument()
   })
 
   it("an action_cards interaction keeps a good option and drops a blank one", () => {

--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -681,7 +681,7 @@ describe("ClarificationForm blank option filtering", () => {
       (el) => el.textContent !== "" && el.textContent?.trim() === "",
     )
 
-  it("F-1: a select_one interaction whose only option is blank shows no options", () => {
+  it("a select_one interaction whose only option is blank shows no options", () => {
     const interactions = [
       {
         type: "select_one" as const,
@@ -697,7 +697,7 @@ describe("ClarificationForm blank option filtering", () => {
     expect(screen.getByText("common.noOptions")).toBeInTheDocument()
   })
 
-  it("F-2: a select_one interaction keeps a good option and drops a blank one", () => {
+  it("a select_one interaction keeps a good option and drops a blank one", () => {
     const interactions = [
       {
         type: "select_one" as const,
@@ -719,7 +719,7 @@ describe("ClarificationForm blank option filtering", () => {
     expect(blankOptionSpans(container)).toHaveLength(0)
   })
 
-  it("F-3: an action_cards interaction keeps a good option and drops a blank one", () => {
+  it("an action_cards interaction keeps a good option and drops a blank one", () => {
     // Mirrors the shape the agent-builder skill instructs the model to use
     // for this interaction type: a mix of a real choice and, in the failure
     // case this fix targets, a blank one.

--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -743,4 +743,31 @@ describe("ClarificationForm blank option filtering", () => {
     expect(screen.getByText("Import")).toBeInTheDocument()
     expect(blankOptionSpans(container)).toHaveLength(0)
   })
+
+  it("renders options from a legacy message that still carries actions", () => {
+    // The backend normalizer now strips a well-formed interaction down to
+    // one options carrier and never emits actions, but that only applies to
+    // new payloads. Rows persisted before that change, and anything from
+    // Agent Builder's self-parsed chat response (which never reaches the
+    // backend normalizer at all), can still carry only actions with no
+    // options key -- this component's own fallback (rawOptions above) is
+    // the sole thing still rendering those.
+    const interactions = [
+      {
+        type: "action_cards" as const,
+        field: "source",
+        label: "Source",
+        actions: [
+          { label: "Import", value: "import" },
+          { label: "   ", value: "   " },
+        ],
+      },
+    ]
+    const { container } = render(
+      <ClarificationForm interactions={interactions} onSend={vi.fn()} />,
+    )
+
+    expect(screen.getByText("Import")).toBeInTheDocument()
+    expect(blankOptionSpans(container)).toHaveLength(0)
+  })
 })

--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -660,3 +660,87 @@ describe("ClarificationForm delivery failures", () => {
     expect(screen.queryByRole("alert")).toBeNull()
   })
 })
+
+describe("ClarificationForm blank option filtering", () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  // The option label is rendered into a <span> on both branches this suite
+  // covers: select_one's dropdown option (ui/select.tsx, "font-medium
+  // truncate") and action_cards' card (clarification-form.tsx, "font-medium
+  // text-sm text-foreground"). action_cards renders each card as a <div
+  // onClick>, not a <button> -- getAllByRole("button") returns an empty
+  // array for it regardless of whether the blank-option filter is
+  // trim-aware, so it cannot be used to detect a blank card here. No other
+  // <span> in this component's default render (no files staged, no
+  // description set on any option) is ever blank, so a <span> with blank
+  // text content can only be a surviving blank option.
+  const blankOptionSpans = (container: HTMLElement) =>
+    Array.from(container.querySelectorAll("span")).filter(
+      (el) => el.textContent !== "" && el.textContent?.trim() === "",
+    )
+
+  it("F-1: a select_one interaction whose only option is blank shows no options", () => {
+    const interactions = [
+      {
+        type: "select_one" as const,
+        field: "choice",
+        label: "Choice",
+        options: [{ label: "   ", value: "   " }],
+      },
+    ]
+    render(<ClarificationForm interactions={interactions} onSend={vi.fn()} />)
+
+    fireEvent.click(screen.getByText("chatPage.clarification.selectOption"))
+
+    expect(screen.getByText("common.noOptions")).toBeInTheDocument()
+  })
+
+  it("F-2: a select_one interaction keeps a good option and drops a blank one", () => {
+    const interactions = [
+      {
+        type: "select_one" as const,
+        field: "choice",
+        label: "Choice",
+        options: [
+          { label: "Import", value: "import" },
+          { label: "   ", value: "   " },
+        ],
+      },
+    ]
+    const { container } = render(
+      <ClarificationForm interactions={interactions} onSend={vi.fn()} />,
+    )
+
+    fireEvent.click(screen.getByText("chatPage.clarification.selectOption"))
+
+    expect(screen.getByText("Import")).toBeInTheDocument()
+    expect(blankOptionSpans(container)).toHaveLength(0)
+  })
+
+  it("F-3: an action_cards interaction keeps a good option and drops a blank one", () => {
+    // Mirrors the shape the agent-builder skill instructs the model to use
+    // for this interaction type: a mix of a real choice and, in the failure
+    // case this fix targets, a blank one.
+    const interactions = [
+      {
+        type: "action_cards" as const,
+        field: "source",
+        label: "Source",
+        options: [
+          { label: "Import", value: "import" },
+          { label: "   ", value: "   " },
+        ],
+      },
+    ]
+    const { container } = render(
+      <ClarificationForm interactions={interactions} onSend={vi.fn()} />,
+    )
+
+    // No dropdown to open: action_cards renders its cards directly inside
+    // CollapsibleContent, which is open by default (active defaults to true).
+    expect(screen.getByText("Import")).toBeInTheDocument()
+    expect(blankOptionSpans(container)).toHaveLength(0)
+  })
+})

--- a/frontend/src/components/chat/clarification-form.tsx
+++ b/frontend/src/components/chat/clarification-form.tsx
@@ -208,7 +208,7 @@ export function ClarificationForm({
           description: typeof opt?.description === "string" ? opt.description : undefined,
           action_type: typeof opt?.action_type === "string" ? opt.action_type : undefined,
         }))
-        .filter((opt: { value: string; label: string }) => opt.value && opt.label)
+        .filter((opt: { value: string; label: string }) => opt.value.trim() !== "" && opt.label.trim() !== "")
       return {
         ...interaction,
         type,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -259,10 +259,6 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
     site (``_pause_for_tool_results``) runs its own deduplication across all
     tools' interactions after calling this function once per tool.
 
-    Today those two call sites are the only callers in the repository; there
-    is no mechanical guard against a third call site being added without
-    also being covered by this contract.
-
     The output never carries an ``actions`` key: ``actions`` is a model
     alias for ``options`` (consumed above whenever ``options`` itself is
     missing or not a list, and ``actions`` is itself a list), and leaving
@@ -280,9 +276,10 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
 
         item = dict(interaction)
         field = item.get("field") or item.get("id") or item.get("name")
-        if not isinstance(field, str) or not _normalize_interaction_text(field):
-            field = f"response_{index}"
-        item["field"] = _normalize_interaction_text(field)
+        normalized_field = (
+            _normalize_interaction_text(field) if isinstance(field, str) else ""
+        )
+        item["field"] = normalized_field or f"response_{index}"
 
         # Widened from "options" not in item: an interaction can carry both
         # a malformed options (present but not a list) and a well-formed

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -259,6 +259,12 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
     As of commit 95fada70f, those two call sites are the only callers in the
     repository; there is no mechanical guard against a third call site being
     added without also being covered by this contract.
+
+    The output never carries an ``actions`` key: ``actions`` is a model
+    alias for ``options`` (consumed above whenever ``options`` itself is
+    missing or not a list), and leaving the raw, unfiltered alias in the
+    output would give the persisted row a second, never-filtered carrier of
+    the same option list.
     """
 
     if not isinstance(interactions, list):
@@ -275,7 +281,16 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
             field = f"response_{index}"
         item["field"] = _normalize_interaction_text(field)
 
-        if "options" not in item and isinstance(item.get("actions"), list):
+        # Widened from "options" not in item: an interaction can carry both
+        # a malformed options (present but not a list) and a well-formed
+        # actions alias, and the alias is the only place the real data
+        # lives in that shape -- narrower than "not in item" would leave
+        # the alias unconsumed and drop every option for that interaction
+        # (verified: the malformed-options-plus-actions case loses all its
+        # options under the narrower condition).
+        if not isinstance(item.get("options"), list) and isinstance(
+            item.get("actions"), list
+        ):
             item["options"] = item["actions"]
 
         options = item.get("options")
@@ -315,6 +330,32 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
                     },
                 )
             item["options"] = filtered_options
+        elif "options" in item:
+            # options is present but neither a list nor rescued by the
+            # actions alias above -- a malformed shape this function has
+            # always left untouched, but silently: nothing signaled that
+            # it happened. Same untrusted-input logging rule as the other
+            # two warnings in this function: bounded, integer-only.
+            logger.warning(
+                "ask_user_question interaction %d has a non-list options value",
+                index,
+                extra={"interaction_index": index},
+            )
+
+        # Leave only one carrier of the option list in the output. The
+        # alias branch above has already consumed actions into options
+        # wherever it had anything useful to contribute; what is left is
+        # either a duplicate of options (already-filtered content) or,
+        # when options was itself a list, content actions never fed into
+        # the filter at all. Either way, actions in the output is a second,
+        # unfiltered copy of the same data that gets persisted verbatim
+        # into task_chat_messages.interactions and replayed unchanged.
+        # Unconditional so this holds regardless of whether options ended
+        # up a list -- must run after the alias branch above, not before:
+        # popping actions first would delete the only place a malformed
+        # options's real data lives before the alias branch can consume it,
+        # dropping every option for that interaction.
+        item.pop("actions", None)
 
         normalized.append(item)
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -168,8 +168,98 @@ class ToolCallRecord:
         )
 
 
+# Every code point that Python's str.strip() or JavaScript's
+# String.prototype.trim() treats as trimmable: ECMA-262 WhiteSpace (TAB VT FF
+# ZWNBSP + Unicode Zs) and LineTerminator (LF CR LS PS), unioned with the five
+# extra code points CPython's str.strip() treats as whitespace (U+001C-U+001F,
+# U+0085).
+#
+# The table is frozen as a literal instead of derived from CPython's
+# whitespace table for two reasons: (1) this invariant runs in the direction
+# "whatever JavaScript trims, we must also trim", and CPython's whitespace
+# table shifts with the Unicode version bundled in each interpreter release;
+# (2) the normalized value is written back into item["field"], and the
+# frontend's own trim() must be a no-op on the result -- that only holds
+# while this table is a superset of the JavaScript table, which the coverage
+# test in tests/core/agent/test_react.py pins down.
+#
+# Every code point is written as an escape, never a literal: several of them
+# (U+2028/U+2029 in particular) are silently rewritten by some editors and
+# transports when they appear as literal bytes.
+_INTERACTION_TRIM_CHARS = (
+    "\t\n\v\f\r\x1c\x1d\x1e\x1f\x20\x85\xa0"
+    "\u1680\u2000\u2001\u2002\u2003\u2004\u2005"
+    "\u2006\u2007\u2008\u2009\u200a"
+    "\u2028\u2029\u202f\u205f\u3000\ufeff"
+)  # 30 code points
+
+
+def _normalize_interaction_text(value: str) -> str:
+    """Strip every code point either Python or JavaScript treats as trimmable.
+
+    One pass over one union table, deliberately -- not ``value.strip()``
+    followed by a second pass over the JavaScript-only characters.
+
+    One pass is a fixed point by construction: ``str.strip(chars)`` deletes
+    from both ends up to the first character not in ``chars``, so the
+    returned value's first and last characters are, by definition, not in
+    ``chars``; stripping the same ``chars`` again is the identity. That is
+    what lets the caller write the result back into ``item["field"]`` and
+    rely on the frontend's own ``trim()`` being a no-op on it.
+
+    Two passes over two different tables would not be a fixed point: each
+    pass stops at a character its own table does not contain, and that
+    stopping point says nothing about the other table -- e.g. a value
+    starting with U+FEFF then U+001C would have the first pass halt
+    immediately on U+FEFF (Python does not treat it as space), then a second
+    pass over the JavaScript-only characters would remove U+FEFF and halt on
+    U+001C (JavaScript does not trim it), leaving U+001C behind. Do not
+    "optimize" this back into two passes.
+    """
+    return value.strip(_INTERACTION_TRIM_CHARS)
+
+
+def _is_non_blank_str(value: Any) -> bool:
+    """True when value is a string that stays non-empty after
+    _normalize_interaction_text -- the blankness judgment shared by option
+    label/value filtering and field-name fallback. Takes Any (not str) so
+    the isinstance check and the trim happen together, on the same value:
+    calling _normalize_interaction_text directly on a fresh dict.get(...)
+    expression defeats type-narrowing across the two calls.
+    """
+    return isinstance(value, str) and bool(_normalize_interaction_text(value))
+
+
 def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
-    """Normalize common model variants into the frontend interaction contract."""
+    """Normalize common model variants into the frontend interaction contract.
+
+    A label or value that is blank after ``_normalize_interaction_text`` is
+    treated the same as missing: the option is dropped. A field name that is
+    blank after normalization falls back to ``response_{index}``; a
+    well-formed field name is normalized and written back so the frontend's
+    own ``trim()`` is a no-op on it. Survivors are otherwise kept verbatim --
+    only blankness is judged here, not content.
+
+    The alias chain ``field or id or name`` intentionally keeps its raw
+    truthiness check; it is not normalization-aware. The frontend's own
+    alias chains (clarification-form.tsx, app-context-chat.tsx) make the
+    same raw-truthiness choice, and because this function always writes its
+    result back into ``item["field"]``, the frontend never evaluates its own
+    ``id``/``name`` fallback for a field this function has already resolved
+    -- so this stays consistent with the frontend regardless of which one
+    changes first.
+
+    This function does not deduplicate field names within a single call; a
+    batch with colliding normalized fields is returned unchanged, and a
+    warning is logged. The single-tool call site (``ask_user_question`` in
+    ``_handle_control_tool``) sends the result on as-is. The multi-tool call
+    site (``_pause_for_tool_results``) runs its own deduplication across all
+    tools' interactions after calling this function once per tool.
+
+    As of commit 95fada70f, those two call sites are the only callers in the
+    repository; there is no mechanical guard against a third call site being
+    added without also being covered by this contract.
+    """
 
     if not isinstance(interactions, list):
         return []
@@ -181,16 +271,16 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
 
         item = dict(interaction)
         field = item.get("field") or item.get("id") or item.get("name")
-        if not isinstance(field, str) or not field.strip():
+        if not isinstance(field, str) or not _normalize_interaction_text(field):
             field = f"response_{index}"
-        item["field"] = field.strip()
+        item["field"] = _normalize_interaction_text(field)
 
         if "options" not in item and isinstance(item.get("actions"), list):
             item["options"] = item["actions"]
 
         options = item.get("options")
         if isinstance(options, list):
-            item["options"] = [
+            filtered_options = [
                 {
                     key: value
                     for key, value in {
@@ -203,13 +293,47 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
                 }
                 for option in options
                 if isinstance(option, dict)
-                and isinstance(option.get("label"), str)
-                and option.get("label")
-                and isinstance(option.get("value"), str)
-                and option.get("value")
+                and _is_non_blank_str(option.get("label"))
+                and _is_non_blank_str(option.get("value"))
             ]
+            if options and not filtered_options:
+                # All options for this interaction were blank. The
+                # interaction is still emitted (the question still goes
+                # out), so this is the only signal that it happened. Bounded
+                # to integer counts, never the model-controlled field name:
+                # this module's logging never carries untrusted-input text
+                # (see STRIP_LOG_MAX_TOOL_NAMES above for the same rule
+                # applied to tool names).
+                logger.warning(
+                    "ask_user_question dropped all %d option(s) for interaction %d",
+                    len(options),
+                    index,
+                    extra={
+                        "dropped": len(options),
+                        "total": len(options),
+                        "interaction_index": index,
+                    },
+                )
+            item["options"] = filtered_options
 
         normalized.append(item)
+
+    field_counts: dict[str, int] = {}
+    for item in normalized:
+        field_counts[item["field"]] = field_counts.get(item["field"], 0) + 1
+    colliding_field_count = sum(1 for count in field_counts.values() if count > 1)
+    if colliding_field_count:
+        # Same untrusted-input logging rule as above: integer counts only,
+        # never the colliding field name itself.
+        logger.warning(
+            "ask_user_question interactions have %d colliding field name(s) out of %d",
+            colliding_field_count,
+            len(normalized),
+            extra={
+                "colliding_field_count": colliding_field_count,
+                "total": len(normalized),
+            },
+        )
 
     return normalized
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -256,9 +256,9 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
     site (``_pause_for_tool_results``) runs its own deduplication across all
     tools' interactions after calling this function once per tool.
 
-    As of commit 95fada70f, those two call sites are the only callers in the
-    repository; there is no mechanical guard against a third call site being
-    added without also being covered by this contract.
+    Today those two call sites are the only callers in the repository; there
+    is no mechanical guard against a third call site being added without
+    also being covered by this contract.
 
     The output never carries an ``actions`` key: ``actions`` is a model
     alias for ``options`` (consumed above whenever ``options`` itself is
@@ -314,11 +314,13 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
             if options and not filtered_options:
                 # All options for this interaction were blank. The
                 # interaction is still emitted (the question still goes
-                # out), so this is the only signal that it happened. Bounded
-                # to integer counts, never the model-controlled field name:
-                # this module's logging never carries untrusted-input text
-                # (see STRIP_LOG_MAX_TOOL_NAMES above for the same rule
-                # applied to tool names).
+                # out), so this is the only signal that it happened. This
+                # warning's payload is bounded to integer counts, never the
+                # model-controlled field name -- the same discipline
+                # STRIP_LOG_MAX_TOOL_NAMES above applies to tool names, but
+                # that is this warning's own choice, not a blanket rule for
+                # every log call in this module (several elsewhere put raw
+                # tool names or argument keys straight into the message).
                 logger.warning(
                     "ask_user_question dropped all %d option(s) for interaction %d",
                     len(options),
@@ -334,22 +336,26 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
             # options is present but neither a list nor rescued by the
             # actions alias above -- a malformed shape this function has
             # always left untouched, but silently: nothing signaled that
-            # it happened. Same untrusted-input logging rule as the other
-            # two warnings in this function: bounded, integer-only.
+            # it happened. Same payload discipline as the other two
+            # warnings in this function: bounded, integer-only.
             logger.warning(
                 "ask_user_question interaction %d has a non-list options value",
                 index,
                 extra={"interaction_index": index},
             )
 
-        # Leave only one carrier of the option list in the output. The
-        # alias branch above has already consumed actions into options
-        # wherever it had anything useful to contribute; what is left is
-        # either a duplicate of options (already-filtered content) or,
-        # when options was itself a list, content actions never fed into
-        # the filter at all. Either way, actions in the output is a second,
-        # unfiltered copy of the same data that gets persisted verbatim
-        # into task_chat_messages.interactions and replayed unchanged.
+        # Leave only one carrier of the option list in the output. Whether
+        # or not the alias branch above used actions to seed options,
+        # item["actions"] itself is never touched by the filter step above
+        # (that step reassigns item["options"] to a new, filtered list and
+        # leaves the actions key exactly as the model gave it) -- so
+        # whatever is left under item["actions"] is always the original,
+        # unfiltered list: either the same content options was seeded
+        # from, pre-filter, or, when options was itself already a list, a
+        # completely unrelated list the filter never saw. Either way,
+        # leaving it in the output gives the persisted row a second,
+        # unfiltered carrier of option data that gets stored verbatim into
+        # task_chat_messages.interactions and replayed unchanged.
         # Unconditional so this holds regardless of whether options ended
         # up a list -- must run after the alias branch above, not before:
         # popping actions first would delete the only place a malformed
@@ -364,8 +370,8 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
         field_counts[item["field"]] = field_counts.get(item["field"], 0) + 1
     colliding_field_count = sum(1 for count in field_counts.values() if count > 1)
     if colliding_field_count:
-        # Same untrusted-input logging rule as above: integer counts only,
-        # never the colliding field name itself.
+        # Same payload discipline as the other warnings in this function:
+        # integer counts only, never the colliding field name itself.
         logger.warning(
             "ask_user_question interactions have %d colliding field name(s) out of %d",
             colliding_field_count,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -249,9 +249,12 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
     -- so this stays consistent with the frontend regardless of which one
     changes first.
 
-    This function does not deduplicate field names within a single call; a
-    batch with colliding normalized fields is returned unchanged, and a
-    warning is logged. The single-tool call site (``ask_user_question`` in
+    This function does not deduplicate field names within a single call: it
+    keeps every colliding entry as its own interaction rather than dropping
+    or renaming one. Each one still goes through every other step above --
+    its field is trimmed, its options are filtered, ``actions`` is stripped
+    -- only the name collision itself is left as-is, and a warning is
+    logged. The single-tool call site (``ask_user_question`` in
     ``_handle_control_tool``) sends the result on as-is. The multi-tool call
     site (``_pause_for_tool_results``) runs its own deduplication across all
     tools' interactions after calling this function once per tool.
@@ -262,9 +265,9 @@ def _normalize_ask_user_interactions(interactions: Any) -> list[dict[str, Any]]:
 
     The output never carries an ``actions`` key: ``actions`` is a model
     alias for ``options`` (consumed above whenever ``options`` itself is
-    missing or not a list), and leaving the raw, unfiltered alias in the
-    output would give the persisted row a second, never-filtered carrier of
-    the same option list.
+    missing or not a list, and ``actions`` is itself a list), and leaving
+    the raw, unfiltered alias in the output would give the persisted row a
+    second, never-filtered carrier of the same option list.
     """
 
     if not isinstance(interactions, list):

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1079,14 +1079,19 @@ def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
             raise ValueError(f"{where} is a {interaction.type} carrying options")
         # Either half blank, not both: an option the user can see but not
         # submit, and one they can submit but not see, are both unusable.
-        # The renderer's own filter (clarification-form.tsx) and the
-        # model-facing producer (``_normalize_ask_user_interactions``,
-        # react.py) both keep an option only when value and label are
-        # still non-blank after trimming against a table covering every
-        # code point either Python's ``str.strip()`` or JavaScript's
-        # ``trim()`` treats as whitespace, so an option that survives
-        # either of them has already cleared that bar. This check does
-        # not rely on that, though: it is falsy, not trim-aware, and
+        # The renderer's own filter (clarification-form.tsx) keeps an
+        # option only when value and label are non-blank under
+        # JavaScript's own ``trim()``. The model-facing producer
+        # (``_normalize_ask_user_interactions``, react.py) keeps an option
+        # only when both are non-blank under a wider table -- every code
+        # point either Python's ``str.strip()`` or JavaScript's ``trim()``
+        # treats as whitespace, a strict superset of what the renderer
+        # checks. The two are not equivalent: a value like a single
+        # ``"\x1c"`` (a control code point Python treats as whitespace but
+        # JavaScript's ``trim()`` does not) survives the renderer's filter
+        # but is dropped by the producer, so the producer is the stricter
+        # of the two, not the looser one. This check here does not rely on
+        # either of them: it is falsy, not trim-aware, and
         # ``InteractionOption.label``/``value`` (ask_user_tool.py) are
         # required ``str`` with no ``min_length`` or whitespace
         # constraint, so a whitespace-only label or value -- not just the

--- a/src/xagent/web/services/task_interaction_service.py
+++ b/src/xagent/web/services/task_interaction_service.py
@@ -1039,10 +1039,19 @@ def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
         # #1368 as a blank one. Stripped here only to test, not to
         # normalize what gets stored: the model-facing producer
         # (``_normalize_ask_user_interactions``, ``react.py``) already
-        # trims a field and substitutes for a blank one before it ever
-        # reaches this validator, so a well-formed field arrives here
-        # pre-trimmed and this pair of checks costs that producer nothing;
-        # they exist for whatever reaches this write side some other way.
+        # trims a field -- against a table covering every code point
+        # either Python's ``str.strip()`` or JavaScript's ``trim()``
+        # treats as whitespace, including a leading BOM (U+FEFF), which
+        # ``str.strip()`` alone does not -- and substitutes for a blank
+        # one before it ever reaches this validator, so a well-formed
+        # field arrives here pre-trimmed and this pair of checks costs
+        # that producer nothing. These two checks themselves use plain
+        # ``str.strip()``, though, not that table: they exist for
+        # whatever reaches this write side some other way, and for a
+        # field that does, a leading or trailing BOM would pass both of
+        # them unnoticed even though it would not survive the producer's
+        # own trim. Narrowing these two checks to match would mean
+        # importing that same table here.
         #
         # Both react.py paths run that normalizer, so both arrive
         # pre-trimmed, and there the resemblance stops -- whoever wires the
@@ -1069,17 +1078,28 @@ def validate_v1_write_payload(parsed: AskUserQuestionArgs) -> None:
         if interaction.type in _V1_TYPES_REJECTING_OPTIONS and interaction.options:
             raise ValueError(f"{where} is a {interaction.type} carrying options")
         # Either half blank, not both: an option the user can see but not
-        # submit, and one they can submit but not see, are both unusable,
-        # and the renderer already treats them the same way -- its own
-        # filter keeps an option only when value and label are both
-        # truthy (clarification-form.tsx). An option dropped there leaves
-        # a select the user cannot complete, or, if it was the only one, a
-        # form with an empty control; refusing the write is the only place
-        # that outcome can still be prevented. Falsy, not stripped: the
-        # two fields are required ``str`` on ``InteractionOption``
-        # (ask_user_tool.py), so a payload that got this far can only be
-        # blank by being the empty string, and stripping would start
-        # rejecting a whitespace label the renderer does display.
+        # submit, and one they can submit but not see, are both unusable.
+        # The renderer's own filter (clarification-form.tsx) and the
+        # model-facing producer (``_normalize_ask_user_interactions``,
+        # react.py) both keep an option only when value and label are
+        # still non-blank after trimming against a table covering every
+        # code point either Python's ``str.strip()`` or JavaScript's
+        # ``trim()`` treats as whitespace, so an option that survives
+        # either of them has already cleared that bar. This check does
+        # not rely on that, though: it is falsy, not trim-aware, and
+        # ``InteractionOption.label``/``value`` (ask_user_tool.py) are
+        # required ``str`` with no ``min_length`` or whitespace
+        # constraint, so a whitespace-only label or value -- not just the
+        # empty string -- reaches this line, and this line lets it
+        # through. A payload that reaches this validator some way other
+        # than the react.py producer could still carry one past it;
+        # catching that here too would mean checking against the same
+        # trim table the producer uses, which this validator does not
+        # import today. An option dropped by the renderer's own filter
+        # leaves a select the user cannot complete, or, if it was the
+        # only one, a form with an empty control; refusing the write is
+        # the only place that outcome can still be prevented for whatever
+        # this check does catch.
         for option_index, option in enumerate(interaction.options or ()):
             if not option.label or not option.value:
                 raise ValueError(

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -4499,16 +4499,19 @@ async def test_react_pattern_ask_user_question_drops_invalid_options() -> None:
     ]
 
 
+# Independent reference for JavaScript's String.prototype.trim() semantics,
+# derived from unicodedata rather than the production _INTERACTION_TRIM_CHARS
+# constant -- reusing that constant here would make every assertion below
+# self-proving instead of an independent check. Built once at module scope
+# and reused, instead of being rebuilt inline in each function that needs it.
+_JS_TRIM = {chr(c) for c in range(0x110000) if unicodedata.category(chr(c)) == "Zs"}
+_JS_TRIM |= {"\t", "\n", "\v", "\f", "\r", "\ufeff", "\u2028", "\u2029"}
+
+
 def _js_trim_equivalent(value: str) -> str:
-    """Reference JavaScript String.prototype.trim() semantics, derived from
-    unicodedata rather than the production _INTERACTION_TRIM_CHARS constant
-    -- reusing that constant here would make every assertion below
-    self-proving instead of an independent check."""
-    js_trim_chars = {
-        chr(c) for c in range(0x110000) if unicodedata.category(chr(c)) == "Zs"
-    }
-    js_trim_chars |= {"\t", "\n", "\v", "\f", "\r", "\ufeff", "\u2028", "\u2029"}
-    return value.strip("".join(js_trim_chars))
+    """Reference JavaScript String.prototype.trim(), via the independent
+    _JS_TRIM set above."""
+    return value.strip("".join(_JS_TRIM))
 
 
 def test_trim_table_covers_every_javascript_trimmed_code_point() -> None:
@@ -4516,11 +4519,7 @@ def test_trim_table_covers_every_javascript_trimmed_code_point() -> None:
     every code point JavaScript's trim() removes, or writing the normalized
     field back into item["field"] and relying on the frontend's own trim()
     being a no-op on it stops holding."""
-    js_trimmed = {
-        chr(c) for c in range(0x110000) if unicodedata.category(chr(c)) == "Zs"
-    }
-    js_trimmed |= {"\t", "\n", "\v", "\f", "\r", "\ufeff", "\u2028", "\u2029"}
-    assert js_trimmed <= set(_INTERACTION_TRIM_CHARS)
+    assert _JS_TRIM <= set(_INTERACTION_TRIM_CHARS)
 
 
 def test_trim_table_python_only_difference_is_exactly_five_code_points() -> None:
@@ -4529,17 +4528,26 @@ def test_trim_table_python_only_difference_is_exactly_five_code_points() -> None
     of these five were mistyped (e.g. U+001C typoed into U+001B), since a
     typo like that only shrinks the Python-only difference by one member and
     stays within a superset of the JavaScript table."""
-    js_trimmed = {
-        chr(c) for c in range(0x110000) if unicodedata.category(chr(c)) == "Zs"
-    }
-    js_trimmed |= {"\t", "\n", "\v", "\f", "\r", "\ufeff", "\u2028", "\u2029"}
-    assert set(_INTERACTION_TRIM_CHARS) - js_trimmed == {
+    assert set(_INTERACTION_TRIM_CHARS) - _JS_TRIM == {
         "\x1c",
         "\x1d",
         "\x1e",
         "\x1f",
         "\x85",
     }
+
+
+def test_python_whitespace_set_is_a_subset_of_the_frozen_trim_table() -> None:
+    """task_interaction_service.py's write-side field/option checks use
+    plain str.strip() rather than importing _INTERACTION_TRIM_CHARS -- that
+    is only safe to reason about at all if every code point Python's own
+    str.isspace() treats as whitespace is already inside the frozen table.
+    Computed independently (via isspace(), not by re-deriving from
+    _INTERACTION_TRIM_CHARS or from _JS_TRIM), so a typo that dropped one of
+    the five Python-only code points from the frozen table would be caught
+    here even if it happened to still pass the two JS-side checks above."""
+    python_whitespace = {chr(c) for c in range(0x110000) if chr(c).isspace()}
+    assert python_whitespace <= set(_INTERACTION_TRIM_CHARS)
 
 
 def test_normalize_keeps_well_formed_options_and_fields() -> None:
@@ -4594,6 +4602,7 @@ _BLANK_TEXT_CASES = [
     ("v5_bom_only", "\ufeff"),
     ("v8_python_only_control", "\x1c"),
     ("v9_js_line_separator", "\u2028"),
+    ("v10_nbsp", "\xa0"),
 ]
 
 
@@ -4745,6 +4754,11 @@ def test_normalize_logs_when_all_options_are_dropped(
     assert extra_keys == {"dropped", "total", "interaction_index"}
     assert all(isinstance(record.__dict__[k], int) for k in extra_keys)
     assert record.args is None or all(isinstance(a, int) for a in record.args)
+    # Both options in this interaction were blank, so dropped == total == 2,
+    # not just "some int" -- pins the actual count, not merely its type.
+    assert record.__dict__["dropped"] == 2
+    assert record.__dict__["total"] == 2
+    assert record.__dict__["interaction_index"] == 0
 
 
 def test_normalize_keeps_surviving_option_text_verbatim() -> None:

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -4512,7 +4512,7 @@ def _js_trim_equivalent(value: str) -> str:
 
 
 def test_trim_table_covers_every_javascript_trimmed_code_point() -> None:
-    """I-5 coverage, superset half: _INTERACTION_TRIM_CHARS must contain
+    """Coverage check, superset half: _INTERACTION_TRIM_CHARS must contain
     every code point JavaScript's trim() removes, or writing the normalized
     field back into item["field"] and relying on the frontend's own trim()
     being a no-op on it stops holding."""
@@ -4524,7 +4524,7 @@ def test_trim_table_covers_every_javascript_trimmed_code_point() -> None:
 
 
 def test_trim_table_python_only_difference_is_exactly_five_code_points() -> None:
-    """I-5 coverage, differential half: pins the five Python-only code
+    """Coverage check, differential half: pins the five Python-only code
     points exactly. The superset check above alone would still pass if one
     of these five were mistyped (e.g. U+001C typoed into U+001B), since a
     typo like that only shrinks the Python-only difference by one member and
@@ -4543,7 +4543,7 @@ def test_trim_table_python_only_difference_is_exactly_five_code_points() -> None
 
 
 def test_normalize_keeps_well_formed_options_and_fields() -> None:
-    """I-1: a normal option and a normal field pass through unchanged."""
+    """A normal option and a normal field pass through unchanged."""
     normalized = _normalize_ask_user_interactions(
         [
             {
@@ -4554,6 +4554,35 @@ def test_normalize_keeps_well_formed_options_and_fields() -> None:
         ]
     )
     assert normalized[0]["options"] == [{"label": "A", "value": "a"}]
+    assert normalized[0]["field"] == "choice"
+
+
+def test_normalize_returns_empty_list_for_non_list_interactions() -> None:
+    """A top-level interactions value that is not a list -- the model
+    sending a dict or a string instead of an array, say -- is rejected
+    outright rather than partially processed."""
+    assert _normalize_ask_user_interactions("not-a-list") == []
+    assert _normalize_ask_user_interactions({"field": "choice"}) == []
+    assert _normalize_ask_user_interactions(None) == []
+
+
+def test_normalize_skips_non_dict_elements_within_the_list() -> None:
+    """A non-dict element inside an otherwise well-formed interactions list
+    is dropped, and the well-formed interactions around it are still
+    normalized -- one malformed element does not fail the whole batch."""
+    normalized = _normalize_ask_user_interactions(
+        [
+            "not-a-dict",
+            {
+                "type": "select_one",
+                "field": "choice",
+                "options": [{"label": "A", "value": "a"}],
+            },
+            42,
+            None,
+        ]
+    )
+    assert len(normalized) == 1
     assert normalized[0]["field"] == "choice"
 
 
@@ -4570,10 +4599,11 @@ _BLANK_TEXT_CASES = [
 
 @pytest.mark.parametrize("case_id,value", _BLANK_TEXT_CASES)
 def test_normalize_drops_blank_options(case_id: str, value: str) -> None:
-    """I-3: an option whose label or value is blank under
+    """An option whose label or value is blank under
     _INTERACTION_TRIM_CHARS is dropped -- the same treatment the existing
-    empty-string-label case already gets (I-2's regression test above),
-    widened from "the empty string" to "blank under the trim table"."""
+    empty-string-label case already gets (see the regression test above
+    for missing/empty label or value), widened from "the empty string" to
+    "blank under the trim table"."""
     normalized = _normalize_ask_user_interactions(
         [
             {
@@ -4592,12 +4622,26 @@ def test_normalize_drops_blank_options(case_id: str, value: str) -> None:
 
 @pytest.mark.parametrize("case_id,value", _BLANK_TEXT_CASES)
 def test_normalize_substitutes_blank_field(case_id: str, value: str) -> None:
-    """I-4: a field name blank under _INTERACTION_TRIM_CHARS falls back to
+    """A field name blank under _INTERACTION_TRIM_CHARS falls back to
     response_{index}."""
     normalized = _normalize_ask_user_interactions(
         [{"type": "select_one", "field": value, "label": "Choice"}]
     )
     assert normalized[0]["field"] == "response_0"
+
+
+def test_normalize_substitutes_blank_field_using_its_own_index() -> None:
+    """The fallback is f"response_{index}" for the interaction's own
+    position, not a fixed "response_0" -- a well-formed interaction ahead
+    of the blank one must not shift what the blank one falls back to."""
+    normalized = _normalize_ask_user_interactions(
+        [
+            {"type": "select_one", "field": "choice", "label": "Choice"},
+            {"type": "select_one", "field": "   ", "label": "Other"},
+        ]
+    )
+    assert normalized[0]["field"] == "choice"
+    assert normalized[1]["field"] == "response_1"
 
 
 @pytest.mark.parametrize(
@@ -4610,7 +4654,7 @@ def test_normalize_substitutes_blank_field(case_id: str, value: str) -> None:
 def test_normalize_field_bom_normalizes_to_frontend_equivalent(
     case_id: str, value: str, expected: str
 ) -> None:
-    """I-4/I-5: a field wrapped in a BOM (with or without interior spacing)
+    """A field wrapped in a BOM (with or without interior spacing)
     normalizes to the same string the frontend's own trim() produces. The
     same normalization applies when the value arrives through the field/id/
     name alias chain rather than "field" directly."""
@@ -4642,7 +4686,7 @@ def test_normalize_field_bom_normalizes_to_frontend_equivalent(
 def test_normalized_field_is_stable_under_javascript_trim(
     case_id: str, value: str
 ) -> None:
-    """I-5: whatever field the normalizer produces must already be a fixed
+    """Whatever field the normalizer produces must already be a fixed
     point of the frontend's own trim(). If it were not, writing the result
     back into item["field"] and trusting the frontend to leave it alone
     would silently stop being true for that input."""
@@ -4656,7 +4700,7 @@ def test_normalized_field_is_stable_under_javascript_trim(
 def test_normalize_logs_when_all_options_are_dropped(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """I-6/I-9: an interaction whose options are all blank keeps the
+    """An interaction whose options are all blank keeps the
     interaction (the question still goes out) and logs exactly one warning.
     The warning's extra keys are exactly {dropped, total, interaction_index},
     all ints, and its message format args are also all ints -- no
@@ -4704,7 +4748,7 @@ def test_normalize_logs_when_all_options_are_dropped(
 
 
 def test_normalize_keeps_surviving_option_text_verbatim() -> None:
-    """I-10: an option that survives the blank filter keeps its label and
+    """An option that survives the blank filter keeps its label and
     value exactly as given -- normalization only judges blankness, it never
     rewrites content. A BOM-wrapped value is the only kind of input that can
     tell "judge blank" apart from "judge blank and also rewrite": a purely
@@ -4720,7 +4764,7 @@ def test_normalize_keeps_surviving_option_text_verbatim() -> None:
 def test_normalize_keeps_colliding_fields_at_single_tool_callsite(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
-    """I-11: within one ask_user_question call, a BOM-wrapped field name and
+    """Within one ask_user_question call, a BOM-wrapped field name and
     its plain counterpart now normalize to the same field. This function
     does not deduplicate -- both interactions are kept unchanged, and the
     single-tool call site sends the result on as-is (the multi-tool call
@@ -4763,7 +4807,7 @@ def test_normalize_keeps_colliding_fields_at_single_tool_callsite(
 
 
 def test_normalize_blank_alias_does_not_fall_through_to_next_key() -> None:
-    """S-4 (decided): the field/id/name alias chain keeps its raw truthiness
+    """The field/id/name alias chain keeps its raw truthiness
     check on purpose. A BOM-only field is truthy before normalization, so it
     wins the alias chain and is only normalized away to blank afterward --
     id="ok" is never reached. Widening the blankness judgment to include BOM
@@ -4822,7 +4866,7 @@ def test_normalize_blank_alias_does_not_fall_through_to_next_key() -> None:
     ],
 )
 def test_normalize_strips_actions_alias_from_output(case_id: str, raw: dict) -> None:
-    """I-12: the output never carries an actions key, unconditionally --
+    """The output never carries an actions key, unconditionally --
     whether options was missing, a well-formed list, or a malformed
     non-list value, and whether actions itself was a list or not. Case 1
     additionally asserts the alias survived into options: without that
@@ -4838,15 +4882,16 @@ def test_normalize_strips_actions_alias_from_output(case_id: str, raw: dict) -> 
 
 
 def test_normalize_aliases_actions_when_options_is_not_a_list() -> None:
-    """I-13: when options is present but not a list, the alias branch --
+    """When options is present but not a list, the alias branch --
     widened from "options" not in item to "options is not a list" -- still
     rescues actions into options, and the usual blank-option filter still
     runs on what it rescued. This is the test that would catch the pop
     running before the alias branch: with the pop moved earlier, actions
     would already be gone by the time the alias branch runs, options would
-    stay "auto", and this assertion would fail even though every I-12 case
-    would still pass (I-12 only checks that actions is gone, not that its
-    data went anywhere)."""
+    stay "auto", and this assertion would fail even though every case in
+    test_normalize_strips_actions_alias_from_output would still pass (that
+    test only checks that actions is gone, not that its data went
+    anywhere)."""
     normalized = _normalize_ask_user_interactions(
         [
             {
@@ -4871,8 +4916,9 @@ def test_normalize_logs_when_options_is_not_a_list(
     is a malformed shape the model produced; today it silently renders as
     no available options (the renderer falls back to interaction.options ||
     []), and this warning is the only signal that it happened. Same
-    integer-only payload discipline as the I-6 and I-11 warnings in this
-    same function."""
+    integer-only payload discipline as the other two warnings in this
+    same function (the all-options-blank warning and the colliding-field-
+    name warning)."""
     with caplog.at_level(
         logging.WARNING, logger="xagent.core.agent.pattern.react.react"
     ):
@@ -4904,7 +4950,7 @@ def test_normalize_logs_when_options_is_not_a_list(
 
 @pytest.mark.asyncio
 async def test_pause_for_tool_results_deduplicates_normalized_fields() -> None:
-    """I-8: _pause_for_tool_results runs its own field-name dedup after
+    """_pause_for_tool_results runs its own field-name dedup after
     calling the normalizer for each tool. Two tools whose fields now
     normalize (via the BOM fix) to the same string still end up with
     distinct field names in the published interactions -- narrowing the

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -5,6 +5,7 @@ import inspect
 import json
 import logging
 import re
+import unicodedata
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
@@ -22,6 +23,10 @@ from xagent.core.agent import (
     ToolCallRecord,
 )
 from xagent.core.agent.context.execution import CLOCK_TIMEZONE_METADATA_KEY
+from xagent.core.agent.pattern.react.react import (
+    _INTERACTION_TRIM_CHARS,
+    _normalize_ask_user_interactions,
+)
 from xagent.core.agent.result import tool_result_succeeded
 from xagent.core.file_ref import WORKSPACE_OUTPUT_FILES_TOOL_NAME
 from xagent.core.model.chat.basic.router import RouterLLM
@@ -4491,6 +4496,328 @@ async def test_react_pattern_ask_user_question_drops_invalid_options() -> None:
     assert result["interactions"][0]["options"] == [
         {"label": "A", "value": "a"},
         {"label": "B", "value": "b", "description": "Bee"},
+    ]
+
+
+def _js_trim_equivalent(value: str) -> str:
+    """Reference JavaScript String.prototype.trim() semantics, derived from
+    unicodedata rather than the production _INTERACTION_TRIM_CHARS constant
+    -- reusing that constant here would make every assertion below
+    self-proving instead of an independent check."""
+    js_trim_chars = {
+        chr(c) for c in range(0x110000) if unicodedata.category(chr(c)) == "Zs"
+    }
+    js_trim_chars |= {"\t", "\n", "\v", "\f", "\r", "\ufeff", "\u2028", "\u2029"}
+    return value.strip("".join(js_trim_chars))
+
+
+def test_trim_table_covers_every_javascript_trimmed_code_point() -> None:
+    """I-5 coverage, superset half: _INTERACTION_TRIM_CHARS must contain
+    every code point JavaScript's trim() removes, or writing the normalized
+    field back into item["field"] and relying on the frontend's own trim()
+    being a no-op on it stops holding."""
+    js_trimmed = {
+        chr(c) for c in range(0x110000) if unicodedata.category(chr(c)) == "Zs"
+    }
+    js_trimmed |= {"\t", "\n", "\v", "\f", "\r", "\ufeff", "\u2028", "\u2029"}
+    assert js_trimmed <= set(_INTERACTION_TRIM_CHARS)
+
+
+def test_trim_table_python_only_difference_is_exactly_five_code_points() -> None:
+    """I-5 coverage, differential half: pins the five Python-only code
+    points exactly. The superset check above alone would still pass if one
+    of these five were mistyped (e.g. U+001C typoed into U+001B), since a
+    typo like that only shrinks the Python-only difference by one member and
+    stays within a superset of the JavaScript table."""
+    js_trimmed = {
+        chr(c) for c in range(0x110000) if unicodedata.category(chr(c)) == "Zs"
+    }
+    js_trimmed |= {"\t", "\n", "\v", "\f", "\r", "\ufeff", "\u2028", "\u2029"}
+    assert set(_INTERACTION_TRIM_CHARS) - js_trimmed == {
+        "\x1c",
+        "\x1d",
+        "\x1e",
+        "\x1f",
+        "\x85",
+    }
+
+
+def test_normalize_keeps_well_formed_options_and_fields() -> None:
+    """I-1: a normal option and a normal field pass through unchanged."""
+    normalized = _normalize_ask_user_interactions(
+        [
+            {
+                "type": "select_one",
+                "field": "choice",
+                "options": [{"label": "A", "value": "a"}],
+            }
+        ]
+    )
+    assert normalized[0]["options"] == [{"label": "A", "value": "a"}]
+    assert normalized[0]["field"] == "choice"
+
+
+_BLANK_TEXT_CASES = [
+    ("v1_empty", ""),
+    ("v2_ascii_spaces", "   "),
+    ("v3_mixed_whitespace", "\t\n "),
+    ("v4_fullwidth_space", "\u3000"),
+    ("v5_bom_only", "\ufeff"),
+    ("v8_python_only_control", "\x1c"),
+    ("v9_js_line_separator", "\u2028"),
+]
+
+
+@pytest.mark.parametrize("case_id,value", _BLANK_TEXT_CASES)
+def test_normalize_drops_blank_options(case_id: str, value: str) -> None:
+    """I-3: an option whose label or value is blank under
+    _INTERACTION_TRIM_CHARS is dropped -- the same treatment the existing
+    empty-string-label case already gets (I-2's regression test above),
+    widened from "the empty string" to "blank under the trim table"."""
+    normalized = _normalize_ask_user_interactions(
+        [
+            {
+                "type": "select_one",
+                "field": "choice",
+                "options": [
+                    {"label": value, "value": "kept-value"},
+                    {"label": "kept-label", "value": value},
+                    {"label": "A", "value": "a"},
+                ],
+            }
+        ]
+    )
+    assert normalized[0]["options"] == [{"label": "A", "value": "a"}]
+
+
+@pytest.mark.parametrize("case_id,value", _BLANK_TEXT_CASES)
+def test_normalize_substitutes_blank_field(case_id: str, value: str) -> None:
+    """I-4: a field name blank under _INTERACTION_TRIM_CHARS falls back to
+    response_{index}."""
+    normalized = _normalize_ask_user_interactions(
+        [{"type": "select_one", "field": value, "label": "Choice"}]
+    )
+    assert normalized[0]["field"] == "response_0"
+
+
+@pytest.mark.parametrize(
+    "case_id,value,expected",
+    [
+        ("v6_bom_prefix", "\ufeffabc", "abc"),
+        ("v7_bom_and_space_both_ends", "\ufeff abc\ufeff", "abc"),
+    ],
+)
+def test_normalize_field_bom_normalizes_to_frontend_equivalent(
+    case_id: str, value: str, expected: str
+) -> None:
+    """I-4/I-5: a field wrapped in a BOM (with or without interior spacing)
+    normalizes to the same string the frontend's own trim() produces. The
+    same normalization applies when the value arrives through the field/id/
+    name alias chain rather than "field" directly."""
+    normalized = _normalize_ask_user_interactions(
+        [{"type": "select_one", "field": value, "label": "Choice"}]
+    )
+    assert normalized[0]["field"] == expected
+
+    normalized_via_alias = _normalize_ask_user_interactions(
+        [{"type": "select_one", "id": value, "label": "Choice"}]
+    )
+    assert normalized_via_alias[0]["field"] == expected
+
+
+@pytest.mark.parametrize(
+    "case_id,value",
+    [
+        ("v1_empty", ""),
+        ("v2_ascii_spaces", "   "),
+        ("v3_mixed_whitespace", "\t\n "),
+        ("v4_fullwidth_space", "\u3000"),
+        ("v5_bom_only", "\ufeff"),
+        ("v6_bom_prefix", "\ufeffabc"),
+        ("v7_bom_and_space_both_ends", "\ufeff abc\ufeff"),
+        ("v8_python_only_control", "\x1c"),
+        ("v9_js_line_separator", "\u2028"),
+    ],
+)
+def test_normalized_field_is_stable_under_javascript_trim(
+    case_id: str, value: str
+) -> None:
+    """I-5: whatever field the normalizer produces must already be a fixed
+    point of the frontend's own trim(). If it were not, writing the result
+    back into item["field"] and trusting the frontend to leave it alone
+    would silently stop being true for that input."""
+    normalized = _normalize_ask_user_interactions(
+        [{"type": "select_one", "field": value, "label": "Choice"}]
+    )
+    field = normalized[0]["field"]
+    assert _js_trim_equivalent(field) == field
+
+
+def test_normalize_logs_when_all_options_are_dropped(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """I-6/I-9: an interaction whose options are all blank keeps the
+    interaction (the question still goes out) and logs exactly one warning.
+    The warning's extra keys are exactly {dropped, total, interaction_index},
+    all ints, and its message format args are also all ints -- no
+    model-controlled string (the field name, a label, a value) is allowed
+    into either half of this log line."""
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.agent.pattern.react.react"
+    ):
+        normalized = _normalize_ask_user_interactions(
+            [
+                {
+                    "type": "select_one",
+                    "field": "choice",
+                    "options": [
+                        {"label": "   ", "value": "   "},
+                        {"label": "\ufeff", "value": "\ufeff"},
+                    ],
+                }
+            ]
+        )
+
+    assert len(normalized) == 1
+    assert normalized[0]["options"] == []
+
+    dropped_records = [r for r in caplog.records if "dropped all" in r.getMessage()]
+    assert len(dropped_records) == 1
+    record = dropped_records[0]
+
+    baseline_attrs = set(
+        logging.LogRecord("n", logging.WARNING, "p", 1, "m", None, None).__dict__
+    )
+    # "taskName" is a LogRecord attribute added in 3.12. "message" and
+    # (when some other test module's logging setup is still attached to the
+    # root logger) "asctime" are added by a Formatter.format() pass -- set
+    # record.message / record.asctime as a side effect of formatting, not by
+    # this log call's own extra= payload. All three are excluded so this
+    # comparison is stable regardless of Python version, test runner, or
+    # which other test modules ran earlier in the same process.
+    extra_keys = (
+        set(record.__dict__) - baseline_attrs - {"taskName", "message", "asctime"}
+    )
+    assert extra_keys == {"dropped", "total", "interaction_index"}
+    assert all(isinstance(record.__dict__[k], int) for k in extra_keys)
+    assert record.args is None or all(isinstance(a, int) for a in record.args)
+
+
+def test_normalize_keeps_surviving_option_text_verbatim() -> None:
+    """I-10: an option that survives the blank filter keeps its label and
+    value exactly as given -- normalization only judges blankness, it never
+    rewrites content. A BOM-wrapped value is the only kind of input that can
+    tell "judge blank" apart from "judge blank and also rewrite": a purely
+    blank value would be dropped under either implementation, so it would
+    not catch a rewrite regression."""
+    raw = {"label": "\ufeffImport", "value": "\ufeffimport"}
+    normalized = _normalize_ask_user_interactions(
+        [{"type": "select_one", "field": "choice", "options": [raw]}]
+    )
+    assert normalized[0]["options"] == [raw]
+
+
+def test_normalize_keeps_colliding_fields_at_single_tool_callsite(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """I-11: within one ask_user_question call, a BOM-wrapped field name and
+    its plain counterpart now normalize to the same field. This function
+    does not deduplicate -- both interactions are kept unchanged, and the
+    single-tool call site sends the result on as-is (the multi-tool call
+    site has its own dedup, covered separately below). One warning is
+    logged, with an integer-only extra/message-args payload."""
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.agent.pattern.react.react"
+    ):
+        normalized = _normalize_ask_user_interactions(
+            [
+                {"type": "select_one", "field": "\ufeffchoice"},
+                {"type": "select_one", "field": "choice"},
+            ]
+        )
+
+    assert [item["field"] for item in normalized] == ["choice", "choice"]
+
+    collision_records = [
+        r for r in caplog.records if "colliding field name" in r.getMessage()
+    ]
+    assert len(collision_records) == 1
+    record = collision_records[0]
+
+    baseline_attrs = set(
+        logging.LogRecord("n", logging.WARNING, "p", 1, "m", None, None).__dict__
+    )
+    # "taskName" is a LogRecord attribute added in 3.12. "message" and
+    # (when some other test module's logging setup is still attached to the
+    # root logger) "asctime" are added by a Formatter.format() pass -- set
+    # record.message / record.asctime as a side effect of formatting, not by
+    # this log call's own extra= payload. All three are excluded so this
+    # comparison is stable regardless of Python version, test runner, or
+    # which other test modules ran earlier in the same process.
+    extra_keys = (
+        set(record.__dict__) - baseline_attrs - {"taskName", "message", "asctime"}
+    )
+    assert extra_keys == {"colliding_field_count", "total"}
+    assert all(isinstance(record.__dict__[k], int) for k in extra_keys)
+    assert record.args is None or all(isinstance(a, int) for a in record.args)
+
+
+def test_normalize_blank_alias_does_not_fall_through_to_next_key() -> None:
+    """S-4 (decided): the field/id/name alias chain keeps its raw truthiness
+    check on purpose. A BOM-only field is truthy before normalization, so it
+    wins the alias chain and is only normalized away to blank afterward --
+    id="ok" is never reached. Widening the blankness judgment to include BOM
+    does not create a new alias-chain outcome, it only adds a new way to
+    reach the one a plain whitespace field already produced (the second
+    case below, pinned as a regression)."""
+    normalized_bom = _normalize_ask_user_interactions(
+        [{"type": "select_one", "field": "\ufeff", "id": "ok"}]
+    )
+    assert normalized_bom[0]["field"] == "response_0"
+
+    normalized_whitespace = _normalize_ask_user_interactions(
+        [{"type": "select_one", "field": "   ", "id": "ok"}]
+    )
+    assert normalized_whitespace[0]["field"] == "response_0"
+
+
+@pytest.mark.asyncio
+async def test_pause_for_tool_results_deduplicates_normalized_fields() -> None:
+    """I-8: _pause_for_tool_results runs its own field-name dedup after
+    calling the normalizer for each tool. Two tools whose fields now
+    normalize (via the BOM fix) to the same string still end up with
+    distinct field names in the published interactions -- narrowing the
+    normalizer's output domain does not break the existing dedup loop."""
+    pattern = ReActPattern(max_iterations=2)
+    runtime = PatternRuntime(execution_id="exec-1")
+    context = ExecutionContext()
+    context.add_user_message("Ask")
+
+    tool_call_a = {"id": "call_a", "name": "tool_a"}
+    tool_call_b = {"id": "call_b", "name": "tool_b"}
+    result_a = {
+        "status": "waiting_for_user",
+        "message": "Pick one",
+        "message_type": "question",
+        "interactions": [{"type": "select_one", "field": "\ufeffchoice"}],
+    }
+    result_b = {
+        "status": "waiting_for_user",
+        "message": "Pick another",
+        "message_type": "question",
+        "interactions": [{"type": "select_one", "field": "choice"}],
+    }
+
+    outcome = await pattern._pause_for_tool_results(
+        waiting_pairs=[(tool_call_a, result_a), (tool_call_b, result_b)],
+        context=context,
+        runtime=runtime,
+    )
+
+    assert outcome["status"] == "waiting_for_user"
+    assert [item["field"] for item in outcome["interactions"]] == [
+        "choice",
+        "choice_2",
     ]
 
 

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -4781,6 +4781,127 @@ def test_normalize_blank_alias_does_not_fall_through_to_next_key() -> None:
     assert normalized_whitespace[0]["field"] == "response_0"
 
 
+@pytest.mark.parametrize(
+    "case_id,raw",
+    [
+        (
+            "case1_alias_only",
+            {
+                "type": "select_one",
+                "field": "f",
+                "actions": [{"label": "A", "value": "a"}],
+            },
+        ),
+        (
+            "case2_options_and_unrelated_actions",
+            {
+                "type": "select_one",
+                "field": "f",
+                "options": [{"label": "A", "value": "a"}],
+                "actions": [{"label": "X", "value": "x"}],
+            },
+        ),
+        (
+            "case3_options_not_a_list",
+            {
+                "type": "select_one",
+                "field": "f",
+                "options": "auto",
+                "actions": [{"label": "B", "value": "b"}],
+            },
+        ),
+        (
+            "case4_actions_not_a_list",
+            {
+                "type": "select_one",
+                "field": "f",
+                "options": "auto",
+                "actions": "bad",
+            },
+        ),
+    ],
+)
+def test_normalize_strips_actions_alias_from_output(case_id: str, raw: dict) -> None:
+    """I-12: the output never carries an actions key, unconditionally --
+    whether options was missing, a well-formed list, or a malformed
+    non-list value, and whether actions itself was a list or not. Case 1
+    additionally asserts the alias survived into options: without that
+    second assertion, moving the pop above the alias branch would still
+    pass this case (actions is gone either way, just for the wrong reason)
+    while silently losing the alias's only copy of the data -- a gap only
+    test_normalize_aliases_actions_when_options_is_not_a_list below would
+    otherwise catch alone."""
+    normalized = _normalize_ask_user_interactions([raw])
+    assert "actions" not in normalized[0]
+    if case_id == "case1_alias_only":
+        assert normalized[0]["options"] == [{"label": "A", "value": "a"}]
+
+
+def test_normalize_aliases_actions_when_options_is_not_a_list() -> None:
+    """I-13: when options is present but not a list, the alias branch --
+    widened from "options" not in item to "options is not a list" -- still
+    rescues actions into options, and the usual blank-option filter still
+    runs on what it rescued. This is the test that would catch the pop
+    running before the alias branch: with the pop moved earlier, actions
+    would already be gone by the time the alias branch runs, options would
+    stay "auto", and this assertion would fail even though every I-12 case
+    would still pass (I-12 only checks that actions is gone, not that its
+    data went anywhere)."""
+    normalized = _normalize_ask_user_interactions(
+        [
+            {
+                "type": "select_one",
+                "field": "f",
+                "options": "auto",
+                "actions": [
+                    {"label": "   ", "value": "   "},
+                    {"label": "B", "value": "b"},
+                ],
+            }
+        ]
+    )
+    assert normalized[0]["options"] == [{"label": "B", "value": "b"}]
+    assert "actions" not in normalized[0]
+
+
+def test_normalize_logs_when_options_is_not_a_list(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """options present but neither a list nor rescued by an actions alias
+    is a malformed shape the model produced; today it silently renders as
+    no available options (the renderer falls back to interaction.options ||
+    []), and this warning is the only signal that it happened. Same
+    integer-only payload discipline as the I-6 and I-11 warnings in this
+    same function."""
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.agent.pattern.react.react"
+    ):
+        normalized = _normalize_ask_user_interactions(
+            [{"type": "select_one", "field": "choice", "options": "auto"}]
+        )
+
+    assert normalized[0]["options"] == "auto"
+    assert "actions" not in normalized[0]
+
+    records = [r for r in caplog.records if "non-list options" in r.getMessage()]
+    assert len(records) == 1
+    record = records[0]
+
+    baseline_attrs = set(
+        logging.LogRecord("n", logging.WARNING, "p", 1, "m", None, None).__dict__
+    )
+    # Same three attributes excluded for the same reasons as the other two
+    # warning tests in this module: "taskName" (3.12+ LogRecord attribute),
+    # "message" and "asctime" (added by a Formatter.format() pass, not by
+    # this call's own extra= payload).
+    extra_keys = (
+        set(record.__dict__) - baseline_attrs - {"taskName", "message", "asctime"}
+    )
+    assert extra_keys == {"interaction_index"}
+    assert all(isinstance(record.__dict__[k], int) for k in extra_keys)
+    assert record.args is None or all(isinstance(a, int) for a in record.args)
+
+
 @pytest.mark.asyncio
 async def test_pause_for_tool_results_deduplicates_normalized_fields() -> None:
     """I-8: _pause_for_tool_results runs its own field-name dedup after


### PR DESCRIPTION
## Summary

The live ask_user pipeline accepts two payload shapes that later break for the
end user (#1737):

- Whitespace-only option label/value: the producer-side truthiness filter
  admits them, the frontend renders a blank option row, and a selected
  whitespace-only value is trimmed to empty on submit — the question then
  counts as unanswered and submission is rejected.
- Field names carrying U+FEFF: Python str.strip() keeps the BOM while the
  frontend's String.trim() removes it, so the produced answer key and the
  frontend answer key diverge.

## Changes

- `_normalize_ask_user_interactions` (react.py) now normalizes against a frozen
  30-codepoint table — the union of Python's `str.split()` whitespace set and
  JavaScript's `trim()` set — applied as a single-pass strip (single-pass is a
  fixed point by construction; two chained strips are not). Whitespace-only
  options are dropped with a bounded warning that never carries
  model-controlled text.
- The legacy `actions` alias is promoted to `options` when `options` is missing
  or not a list (previously such payloads lost their only data), then stripped
  from the normalized payload so persisted interactions carry a single source
  of truth.
- Colliding field names after normalization pass through unchanged with a
  warning; deduplication policy belongs to the write-admission gate.
- clarification-form.tsx: the option filter is now trim-aware (one line).
  This also covers payloads that bypass the backend normalizer (Agent Builder
  direct output, replayed legacy rows).
- task_interaction_service.py: two stale comment blocks corrected to match
  today's behavior (comment-only, no logic change).

## Verification

- Backend: 188 tests in test_react.py (42 new) and 193 in
  test_task_interaction_service.py — all green.
- Frontend: 26 tests in clarification-form.test.tsx (4 new) — all green.
- Every new invariant was mutation-checked: break the guarded behavior,
  confirm the pinned test fails.
- pre-commit: all 11 hooks pass.

Fixes #1737.
