### PR TITLE
fix: stamp provider usage on chat() responses and converge text unwrapping

### DIFF
--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -719,8 +719,14 @@ class ExecutionContext:
         input_tokens: int,
         output_tokens: int,
         prompt_message_count: int | None = None,
+        synthetic_purpose: str | None = None,
     ) -> None:
-        """Record provider usage for an LLM call without appending a message."""
+        """Record provider usage for an LLM call without appending a message.
+
+        ``synthetic_purpose`` marks internal non-conversational calls (e.g.
+        ``"context_compaction"``) whose prompt token count must not serve as
+        the context-freshness baseline.
+        """
 
         if input_tokens <= 0 and output_tokens <= 0:
             return
@@ -738,6 +744,7 @@ class ExecutionContext:
                 prompt_content_chars=self._message_content_chars(
                     self.messages[:prompt_message_count]
                 ),
+                synthetic_purpose=synthetic_purpose,
             )
         )
 
@@ -855,6 +862,7 @@ class ExecutionContext:
                         prompt_message_count=call.prompt_message_count,
                         prompt_content_chars=call.prompt_content_chars,
                         timestamp=call.timestamp,
+                        synthetic_purpose=call.synthetic_purpose,
                     )
                 )
         self.llm_calls = merged_calls
@@ -926,6 +934,7 @@ class ExecutionContext:
                     "prompt_message_count": call.prompt_message_count,
                     "prompt_content_chars": call.prompt_content_chars,
                     "timestamp": call.timestamp.isoformat(),
+                    "synthetic_purpose": call.synthetic_purpose,
                 }
                 for call in self.llm_calls
             ],
@@ -969,6 +978,9 @@ class ExecutionContext:
                 prompt_message_count=call.get("prompt_message_count"),
                 prompt_content_chars=call.get("prompt_content_chars"),
                 timestamp=datetime.fromisoformat(call["timestamp"]),
+                # Older checkpoints predate the field; absence means a real
+                # conversational call, i.e. eligible as freshness baseline.
+                synthetic_purpose=call.get("synthetic_purpose"),
             )
             for call in data.get("llm_calls", [])
         ]
@@ -1428,25 +1440,39 @@ class ExecutionContext:
         return self._get_total_tokens()
 
     def _get_total_tokens(self) -> int:
-        if self.llm_calls:
-            latest_call = self.llm_calls[-1]
-            if latest_call.input_tokens > 0:
-                prompt_message_count = latest_call.prompt_message_count
-                prompt_content_chars = latest_call.prompt_content_chars
-                if (
-                    prompt_message_count is not None
-                    and prompt_content_chars is not None
-                    and 0 <= prompt_message_count <= len(self.messages)
-                    and self._message_content_chars(
-                        self.messages[:prompt_message_count]
-                    )
-                    == prompt_content_chars
-                ):
-                    delta_chars = self._message_content_chars(
-                        self.messages[prompt_message_count:]
-                    )
-                    return latest_call.input_tokens + max(0, delta_chars // 4)
+        baseline_call = self._latest_freshness_baseline_call()
+        if baseline_call is not None and baseline_call.input_tokens > 0:
+            prompt_message_count = baseline_call.prompt_message_count
+            prompt_content_chars = baseline_call.prompt_content_chars
+            if (
+                prompt_message_count is not None
+                and prompt_content_chars is not None
+                and 0 <= prompt_message_count <= len(self.messages)
+                and self._message_content_chars(self.messages[:prompt_message_count])
+                == prompt_content_chars
+            ):
+                delta_chars = self._message_content_chars(
+                    self.messages[prompt_message_count:]
+                )
+                return baseline_call.input_tokens + max(0, delta_chars // 4)
         return self._estimate_message_tokens(self.messages)
+
+    def _latest_freshness_baseline_call(self) -> LLMCallRecord | None:
+        """Most recent usage record eligible as the context-size baseline.
+
+        Synthetic records (internal calls such as context compaction) are
+        skipped: their prompt is not the live conversation, so their token
+        count says nothing about the current context size. When a synthetic
+        call did not rewrite the messages (e.g. a declined LLM compaction),
+        its fingerprint still matches -- without this skip, a small
+        compact-prompt count would be mistaken for the live context size
+        and suppress the truncation fallback.
+        """
+        for call in reversed(self.llm_calls):
+            if call.synthetic_purpose:
+                continue
+            return call
+        return None
 
     def _estimate_message_tokens(self, messages: list[Message]) -> int:
         return sum(

--- a/src/xagent/core/agent/context/message.py
+++ b/src/xagent/core/agent/context/message.py
@@ -104,7 +104,14 @@ class Message:
 
 @dataclass
 class LLMCallRecord:
-    """Tracks token usage for a single LLM call."""
+    """Tracks token usage for a single LLM call.
+
+    ``synthetic_purpose`` marks records of internal, non-conversational
+    calls (currently only ``"context_compaction"``): their prompt is not
+    the live conversation, so they are skipped when the context-size
+    estimate picks its freshness baseline (see
+    ``ExecutionContext._get_total_tokens``).
+    """
 
     input_tokens: int
     output_tokens: int
@@ -113,3 +120,4 @@ class LLMCallRecord:
     prompt_message_count: int | None = None
     prompt_content_chars: int | None = None
     timestamp: datetime = field(default_factory=_utcnow)
+    synthetic_purpose: str | None = None

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -67,6 +67,7 @@ from ....file_ref import (
     final_deliverable_file_reference_instructions,
 )
 from ....model.chat.exceptions import LLMToolProtocolError
+from ....model.chat.response_shape import classify_chat_response
 from ....model.chat.tool_protocol import get_tool_protocol_error
 from ....tools.adapters.vibe.interaction_types import INTERACTION_TYPES
 from ....tools.user_interaction import (
@@ -944,10 +945,18 @@ class ReActPattern(AgentPattern):
 
             await runtime.checkpoint("after_llm", context=context, pattern=self)
             if normalized.get("done", True):
+                # Fall back to the raw response's usable *text*, never the
+                # raw value itself: for envelope adapters the raw is the
+                # whole envelope dict, and stringifying it downstream would
+                # leak an internal repr into the user-visible transcript.
+                response = assistant_content
+                if not response:
+                    raw_shape = classify_chat_response(normalized.get("raw"))
+                    response = raw_shape.text if raw_shape.kind == "text" else ""
                 return await self._finalize_success(
                     context=context,
                     runtime=runtime,
-                    response=assistant_content or normalized.get("raw"),
+                    response=response,
                 )
 
         self.status = "max_iterations"

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -1049,33 +1049,51 @@ class PatternRuntime:
             },
         )
 
-    def _extract_token_usage(self, response: Any) -> tuple[int, int] | None:
-        usage = self._get_value(response, "usage")
-        if usage is not None:
-            input_tokens = self._first_int(
-                usage, ("prompt_tokens", "input_tokens", "prompt_token_count")
-            )
-            output_tokens = self._first_int(
-                usage,
-                (
-                    "completion_tokens",
-                    "output_tokens",
-                    "candidates_token_count",
-                    "completion_token_count",
-                ),
-            )
-            if input_tokens > 0 or output_tokens > 0:
-                return input_tokens, output_tokens
+    def _resolve_usage_payload(self, response: Any) -> list[tuple[str, Any]]:
+        """Candidate usage payloads of a chat response, most preferred first.
 
-        usage_metadata = self._get_value(response, "usage_metadata")
-        if usage_metadata is not None:
-            input_tokens = self._first_int(
-                usage_metadata, ("prompt_token_count", "prompt_tokens", "input_tokens")
-            )
-            output_tokens = self._first_int(
-                usage_metadata,
-                ("candidates_token_count", "completion_tokens", "output_tokens"),
-            )
+        Looks at the top-level ``usage``/``usage_metadata`` keys first (the
+        adapter stamp and legacy shapes), then one level down inside ``raw``
+        for envelopes that embed the raw provider payload without a stamp.
+        Unknown shapes yield no candidates -- callers fail open to None/0
+        rather than raising.
+        """
+        candidates: list[tuple[str, Any]] = []
+        for key in ("usage", "usage_metadata"):
+            value = self._get_value(response, key)
+            if value is not None:
+                candidates.append((key, value))
+        raw = self._get_value(response, "raw")
+        if raw is not None:
+            for key in ("usage", "usage_metadata"):
+                value = self._get_value(raw, key)
+                if value is not None:
+                    candidates.append((key, value))
+        return candidates
+
+    def _extract_token_usage(self, response: Any) -> tuple[int, int] | None:
+        for key, usage in self._resolve_usage_payload(response):
+            if key == "usage":
+                input_tokens = self._first_int(
+                    usage, ("prompt_tokens", "input_tokens", "prompt_token_count")
+                )
+                output_tokens = self._first_int(
+                    usage,
+                    (
+                        "completion_tokens",
+                        "output_tokens",
+                        "candidates_token_count",
+                        "completion_token_count",
+                    ),
+                )
+            else:
+                input_tokens = self._first_int(
+                    usage, ("prompt_token_count", "prompt_tokens", "input_tokens")
+                )
+                output_tokens = self._first_int(
+                    usage,
+                    ("candidates_token_count", "completion_tokens", "output_tokens"),
+                )
             if input_tokens > 0 or output_tokens > 0:
                 return input_tokens, output_tokens
 
@@ -1083,15 +1101,18 @@ class PatternRuntime:
 
     def _extract_cached_tokens(self, response: Any) -> int:
         """Prompt-cache-hit tokens from a response's usage payload, 0 if absent."""
-        usage = self._get_value(response, "usage")
-        if usage is None:
-            return 0
-        direct = self._first_int(
-            usage, ("cached_input_tokens", "cache_read_input_tokens")
-        )
-        if direct > 0:
-            return direct
-        return extract_cached_input_tokens(usage)
+        for key, usage in self._resolve_usage_payload(response):
+            if key != "usage":
+                continue
+            direct = self._first_int(
+                usage, ("cached_input_tokens", "cache_read_input_tokens")
+            )
+            if direct > 0:
+                return direct
+            cached = extract_cached_input_tokens(usage)
+            if cached:
+                return cached
+        return 0
 
     def _first_int(self, source: Any, keys: tuple[str, ...]) -> int:
         for key in keys:

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -1022,17 +1022,17 @@ class PatternRuntime:
     ) -> None:
         event_metadata = metadata or {}
         usage = self._extract_token_usage(response)
-        attempt_pairs = self._extract_usage_attempt_pairs(response)
+        attempt_rows = self._extract_attempt_rows(response)
         # Internal calls (currently only "context_compaction") carry a
         # purpose marker; their prompt is not the live conversation, so the
         # records must not become the freshness baseline.
         purpose = event_metadata.get("purpose")
         if callable(getattr(context, "record_llm_usage", None)):
-            if attempt_pairs is not None:
+            if attempt_rows:
                 # Multi-attempt call: book every billed attempt in order --
                 # the final attempt lands last, so llm_calls[-1] stays the
                 # freshness baseline.
-                for input_tokens, output_tokens in attempt_pairs:
+                for (input_tokens, output_tokens), _payload in attempt_rows:
                     context.record_llm_usage(
                         input_tokens=input_tokens,
                         output_tokens=output_tokens,
@@ -1046,7 +1046,14 @@ class PatternRuntime:
                     prompt_message_count=len(getattr(context, "messages", [])),
                     synthetic_purpose=purpose,
                 )
-        cached_tokens = self._extract_cached_tokens(response)
+        # Cache metrics use the same aggregate scope as the token totals:
+        # summed over every billed attempt when there are several.
+        if attempt_rows:
+            cached_tokens = sum(
+                self._cached_from_payload(payload) for _pair, payload in attempt_rows
+            )
+        else:
+            cached_tokens = self._extract_cached_tokens(response)
         await self._emit_trace_event(
             TraceEventType(TraceScope.ACTION, TraceAction.END, TraceCategory.LLM),
             task_id=str(event_metadata.get("task_id") or self._task_id(context)),
@@ -1054,7 +1061,10 @@ class PatternRuntime:
             data={
                 "response": self._short_response(response),
                 "success": True,
-                **self._trace_token_fields(usage, attempt_pairs),
+                **self._trace_token_fields(
+                    None if attempt_rows else usage,
+                    [pair for pair, _payload in attempt_rows] or None,
+                ),
                 **({"cached_input_tokens": cached_tokens} if cached_tokens else {}),
                 **event_metadata,
             },
@@ -1115,28 +1125,26 @@ class PatternRuntime:
             )
         return input_tokens, output_tokens
 
-    def _extract_usage_attempt_pairs(
-        self, response: Any
-    ) -> list[tuple[int, int]] | None:
-        """(input, output) pairs of a multi-attempt envelope, or None.
+    def _extract_attempt_rows(self, carrier: Any) -> list[tuple[tuple[int, int], Any]]:
+        """Usable billed-attempt rows of a multi-attempt carrier.
 
-        Reads the ``usage_attempts`` contract key (every billed attempt of
-        one logical call, final attempt last). Each payload is extracted
-        with the same alias table as a top-level ``usage`` stamp.
+        ``carrier`` may be a response envelope (``usage_attempts`` key) or an
+        exception (``usage_attempts`` attribute). Each row is
+        ``((input, output), payload)`` for attempts whose counters coerce to
+        something usable. Wholly unusable rows are dropped so the trace
+        attempt count stays in lockstep with the records actually booked;
+        an empty result means "no usable attempts", letting callers fall
+        back to the top-level ``usage`` shape.
         """
-        attempts = self._get_value(response, "usage_attempts")
+        attempts = self._get_value(carrier, "usage_attempts")
         if not isinstance(attempts, list) or not attempts:
-            return None
-        return [self._usage_pair("usage", attempt) for attempt in attempts]
-
-    def _extract_exception_attempt_pairs(
-        self, error: Exception
-    ) -> list[tuple[int, int]] | None:
-        """(input, output) pairs carried by a failed call's exception."""
-        attempts = getattr(error, "usage_attempts", None)
-        if not isinstance(attempts, list) or not attempts:
-            return None
-        return [self._usage_pair("usage", attempt) for attempt in attempts]
+            return []
+        rows: list[tuple[tuple[int, int], Any]] = []
+        for payload in attempts:
+            pair = self._usage_pair("usage", payload)
+            if pair[0] > 0 or pair[1] > 0:
+                rows.append((pair, payload))
+        return rows
 
     @staticmethod
     def _trace_token_fields(
@@ -1150,7 +1158,7 @@ class PatternRuntime:
         across end events, so the event must match the per-attempt ledger)
         plus the attempt count and the final attempt's own numbers.
         """
-        if attempt_pairs is not None:
+        if attempt_pairs:
             total_input = sum(pair[0] for pair in attempt_pairs)
             total_output = sum(pair[1] for pair in attempt_pairs)
             return {
@@ -1174,14 +1182,33 @@ class PatternRuntime:
         for key, usage in self._resolve_usage_payload(response):
             if key != "usage":
                 continue
-            direct = self._first_int(
-                usage, ("cached_input_tokens", "cache_read_input_tokens")
-            )
-            if direct > 0:
-                return direct
-            cached = extract_cached_input_tokens(usage)
+            cached = self._cached_from_payload(usage)
             if cached:
                 return cached
+        return 0
+
+    def _cached_from_payload(self, usage: Any) -> int:
+        """Strictly-coerced cache-hit tokens from one usage payload.
+
+        Same alias table as the ledger-side ``extract_cached_input_tokens``,
+        but through ``_coerce_usage_int``: malformed values (bools, strings,
+        non-finite or non-integral numbers, negatives) are rejected rather
+        than truncated, and an invalid or zero alias never shadows the
+        nested ``prompt_tokens_details.cached_tokens`` fallback.
+        """
+        direct = self._first_int(
+            usage, ("cached_input_tokens", "cache_read_input_tokens")
+        )
+        if direct > 0:
+            return direct
+        hit = self._coerce_usage_int(self._get_value(usage, "prompt_cache_hit_tokens"))
+        if hit:
+            return hit
+        details = self._get_value(usage, "prompt_tokens_details")
+        if details is not None:
+            nested = self._coerce_usage_int(self._get_value(details, "cached_tokens"))
+            if nested:
+                return nested
         return 0
 
     def _first_int(self, source: Any, keys: tuple[str, ...]) -> int:
@@ -1237,16 +1264,22 @@ class PatternRuntime:
         # A call that failed after billing one or more attempts carries the
         # attempt payloads on the exception: book them (final last) so the
         # execution context and the error trace reflect the billed tokens.
-        attempt_pairs = self._extract_exception_attempt_pairs(error)
-        if attempt_pairs and callable(getattr(context, "record_llm_usage", None)):
+        attempt_rows = self._extract_attempt_rows(error)
+        if attempt_rows and callable(getattr(context, "record_llm_usage", None)):
             purpose = event_metadata.get("purpose")
-            for input_tokens, output_tokens in attempt_pairs:
+            for (input_tokens, output_tokens), _payload in attempt_rows:
                 context.record_llm_usage(
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     prompt_message_count=len(getattr(context, "messages", [])),
                     synthetic_purpose=purpose,
                 )
+        # Cache metrics use the same aggregate scope as the token totals.
+        attempt_cached = (
+            sum(self._cached_from_payload(payload) for _pair, payload in attempt_rows)
+            if attempt_rows
+            else 0
+        )
         await self._emit_trace_event(
             TraceEventType(TraceScope.ACTION, TraceAction.ERROR, TraceCategory.LLM),
             task_id=str(event_metadata.get("task_id") or self._task_id(context)),
@@ -1257,10 +1290,13 @@ class PatternRuntime:
                 "error_message": str(error),
                 "success": False,
                 **(
-                    self._trace_token_fields(None, attempt_pairs)
-                    if attempt_pairs
+                    self._trace_token_fields(
+                        None, [pair for pair, _payload in attempt_rows]
+                    )
+                    if attempt_rows
                     else {}
                 ),
+                **({"cached_input_tokens": attempt_cached} if attempt_cached else {}),
                 **protocol_metadata,
                 **event_metadata,
             },

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import inspect
 import logging
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Callable
@@ -1021,12 +1022,30 @@ class PatternRuntime:
     ) -> None:
         event_metadata = metadata or {}
         usage = self._extract_token_usage(response)
-        if usage is not None and callable(getattr(context, "record_llm_usage", None)):
-            context.record_llm_usage(
-                input_tokens=usage[0],
-                output_tokens=usage[1],
-                prompt_message_count=len(getattr(context, "messages", [])),
-            )
+        attempt_pairs = self._extract_usage_attempt_pairs(response)
+        # Internal calls (currently only "context_compaction") carry a
+        # purpose marker; their prompt is not the live conversation, so the
+        # records must not become the freshness baseline.
+        purpose = event_metadata.get("purpose")
+        if callable(getattr(context, "record_llm_usage", None)):
+            if attempt_pairs is not None:
+                # Multi-attempt call: book every billed attempt in order --
+                # the final attempt lands last, so llm_calls[-1] stays the
+                # freshness baseline.
+                for input_tokens, output_tokens in attempt_pairs:
+                    context.record_llm_usage(
+                        input_tokens=input_tokens,
+                        output_tokens=output_tokens,
+                        prompt_message_count=len(getattr(context, "messages", [])),
+                        synthetic_purpose=purpose,
+                    )
+            elif usage is not None:
+                context.record_llm_usage(
+                    input_tokens=usage[0],
+                    output_tokens=usage[1],
+                    prompt_message_count=len(getattr(context, "messages", [])),
+                    synthetic_purpose=purpose,
+                )
         cached_tokens = self._extract_cached_tokens(response)
         await self._emit_trace_event(
             TraceEventType(TraceScope.ACTION, TraceAction.END, TraceCategory.LLM),
@@ -1035,15 +1054,7 @@ class PatternRuntime:
             data={
                 "response": self._short_response(response),
                 "success": True,
-                **(
-                    {
-                        "input_tokens": usage[0],
-                        "output_tokens": usage[1],
-                        "total_tokens": usage[0] + usage[1],
-                    }
-                    if usage is not None
-                    else {}
-                ),
+                **self._trace_token_fields(usage, attempt_pairs),
                 **({"cached_input_tokens": cached_tokens} if cached_tokens else {}),
                 **event_metadata,
             },
@@ -1073,31 +1084,90 @@ class PatternRuntime:
 
     def _extract_token_usage(self, response: Any) -> tuple[int, int] | None:
         for key, usage in self._resolve_usage_payload(response):
-            if key == "usage":
-                input_tokens = self._first_int(
-                    usage, ("prompt_tokens", "input_tokens", "prompt_token_count")
-                )
-                output_tokens = self._first_int(
-                    usage,
-                    (
-                        "completion_tokens",
-                        "output_tokens",
-                        "candidates_token_count",
-                        "completion_token_count",
-                    ),
-                )
-            else:
-                input_tokens = self._first_int(
-                    usage, ("prompt_token_count", "prompt_tokens", "input_tokens")
-                )
-                output_tokens = self._first_int(
-                    usage,
-                    ("candidates_token_count", "completion_tokens", "output_tokens"),
-                )
+            input_tokens, output_tokens = self._usage_pair(key, usage)
             if input_tokens > 0 or output_tokens > 0:
                 return input_tokens, output_tokens
 
         return None
+
+    def _usage_pair(self, key: str, usage: Any) -> tuple[int, int]:
+        """(input, output) tokens of one usage payload by candidate kind."""
+        if key == "usage":
+            input_tokens = self._first_int(
+                usage, ("prompt_tokens", "input_tokens", "prompt_token_count")
+            )
+            output_tokens = self._first_int(
+                usage,
+                (
+                    "completion_tokens",
+                    "output_tokens",
+                    "candidates_token_count",
+                    "completion_token_count",
+                ),
+            )
+        else:
+            input_tokens = self._first_int(
+                usage, ("prompt_token_count", "prompt_tokens", "input_tokens")
+            )
+            output_tokens = self._first_int(
+                usage,
+                ("candidates_token_count", "completion_tokens", "output_tokens"),
+            )
+        return input_tokens, output_tokens
+
+    def _extract_usage_attempt_pairs(
+        self, response: Any
+    ) -> list[tuple[int, int]] | None:
+        """(input, output) pairs of a multi-attempt envelope, or None.
+
+        Reads the ``usage_attempts`` contract key (every billed attempt of
+        one logical call, final attempt last). Each payload is extracted
+        with the same alias table as a top-level ``usage`` stamp.
+        """
+        attempts = self._get_value(response, "usage_attempts")
+        if not isinstance(attempts, list) or not attempts:
+            return None
+        return [self._usage_pair("usage", attempt) for attempt in attempts]
+
+    def _extract_exception_attempt_pairs(
+        self, error: Exception
+    ) -> list[tuple[int, int]] | None:
+        """(input, output) pairs carried by a failed call's exception."""
+        attempts = getattr(error, "usage_attempts", None)
+        if not isinstance(attempts, list) or not attempts:
+            return None
+        return [self._usage_pair("usage", attempt) for attempt in attempts]
+
+    @staticmethod
+    def _trace_token_fields(
+        usage: tuple[int, int] | None,
+        attempt_pairs: list[tuple[int, int]] | None,
+    ) -> dict[str, Any]:
+        """Token fields of an LLM end/error trace event.
+
+        Single-attempt events keep the historical shape. Multi-attempt
+        events report billing totals (the monitor sums ``total_tokens``
+        across end events, so the event must match the per-attempt ledger)
+        plus the attempt count and the final attempt's own numbers.
+        """
+        if attempt_pairs is not None:
+            total_input = sum(pair[0] for pair in attempt_pairs)
+            total_output = sum(pair[1] for pair in attempt_pairs)
+            return {
+                "input_tokens": total_input,
+                "output_tokens": total_output,
+                "total_tokens": total_input + total_output,
+                "llm_attempt_count": len(attempt_pairs),
+                "final_prompt_tokens": attempt_pairs[-1][0],
+                "final_output_tokens": attempt_pairs[-1][1],
+            }
+        if usage is not None:
+            return {
+                "input_tokens": usage[0],
+                "output_tokens": usage[1],
+                "total_tokens": usage[0] + usage[1],
+            }
+        return {}
 
     def _extract_cached_tokens(self, response: Any) -> int:
         """Prompt-cache-hit tokens from a response's usage payload, 0 if absent."""
@@ -1116,12 +1186,32 @@ class PatternRuntime:
 
     def _first_int(self, source: Any, keys: tuple[str, ...]) -> int:
         for key in keys:
-            value = self._get_value(source, key)
-            if isinstance(value, int):
-                return value
-            if isinstance(value, float):
-                return int(value)
+            coerced = self._coerce_usage_int(self._get_value(source, key))
+            if coerced is not None:
+                return coerced
         return 0
+
+    @staticmethod
+    def _coerce_usage_int(value: Any) -> int | None:
+        """Coerce a usage counter to a non-negative int, or return None.
+
+        Usage numbers feed billing and context-freshness decisions, so the
+        coercion is strict: bools (an int subclass), non-finite floats
+        (NaN/inf, which ``int()`` would raise on), negatives, and
+        non-integral floats are all rejected instead of being truncated or
+        crashing the extractor. Integral floats (``10.0``) coerce. A None
+        result means "not a usable counter" -- callers skip to the next
+        alias/candidate rather than treating it as a measurement.
+        """
+        if isinstance(value, bool):
+            return None
+        if isinstance(value, int):
+            return value if value >= 0 else None
+        if isinstance(value, float):
+            if not math.isfinite(value) or value < 0 or not value.is_integer():
+                return None
+            return int(value)
+        return None
 
     def _get_value(self, source: Any, key: str) -> Any:
         if isinstance(source, dict):
@@ -1144,6 +1234,19 @@ class PatternRuntime:
             }
             if error.details:
                 protocol_metadata["protocol_details"] = error.details
+        # A call that failed after billing one or more attempts carries the
+        # attempt payloads on the exception: book them (final last) so the
+        # execution context and the error trace reflect the billed tokens.
+        attempt_pairs = self._extract_exception_attempt_pairs(error)
+        if attempt_pairs and callable(getattr(context, "record_llm_usage", None)):
+            purpose = event_metadata.get("purpose")
+            for input_tokens, output_tokens in attempt_pairs:
+                context.record_llm_usage(
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    prompt_message_count=len(getattr(context, "messages", [])),
+                    synthetic_purpose=purpose,
+                )
         await self._emit_trace_event(
             TraceEventType(TraceScope.ACTION, TraceAction.ERROR, TraceCategory.LLM),
             task_id=str(event_metadata.get("task_id") or self._task_id(context)),
@@ -1153,6 +1256,11 @@ class PatternRuntime:
                 "error": str(error),
                 "error_message": str(error),
                 "success": False,
+                **(
+                    self._trace_token_fields(None, attempt_pairs)
+                    if attempt_pairs
+                    else {}
+                ),
                 **protocol_metadata,
                 **event_metadata,
             },

--- a/src/xagent/core/agent/utils/context_builder.py
+++ b/src/xagent/core/agent/utils/context_builder.py
@@ -11,6 +11,7 @@ from ...file_ref import FILE_REF_MODEL_INSTRUCTIONS, FILE_REF_OUTPUT_INSTRUCTION
 from ...model.chat.basic.base import BaseLLM
 from ..trace import Tracer, trace_compact_end, trace_compact_start
 from .compact import CompactConfig, CompactUtils
+from .llm_utils import unwrap_chat_text
 
 logger = logging.getLogger(__name__)
 
@@ -396,13 +397,11 @@ class ContextBuilder:
                 },
             ]
 
-            # Get compacted response
+            # Get compacted response. ``unwrap_chat_text`` raises on a
+            # tool_call envelope instead of repr()ing it (#1714); the
+            # surrounding except falls back to truncation.
             response = await self.compact_llm.chat(messages=compact_prompt)
-            content = (
-                response
-                if isinstance(response, str)
-                else response.get("content", str(response))
-            )
+            content = unwrap_chat_text(response)
 
             # Parse back to messages format
             compacted_messages = CompactUtils.parse_compact_response(content)
@@ -489,13 +488,11 @@ class ContextBuilder:
                 },
             ]
 
-            # Get compacted response
+            # Get compacted response. ``unwrap_chat_text`` raises on a
+            # tool_call envelope instead of repr()ing it (#1714); the
+            # surrounding except falls back to truncation.
             response = await self.compact_llm.chat(messages=compact_prompt)
-            content = (
-                response
-                if isinstance(response, str)
-                else response.get("content", str(response))
-            )
+            content = unwrap_chat_text(response)
 
             # Parse back to messages format
             compacted_messages = CompactUtils.parse_compact_response(content)

--- a/src/xagent/core/agent/utils/llm_utils.py
+++ b/src/xagent/core/agent/utils/llm_utils.py
@@ -5,7 +5,7 @@ import logging
 import re
 from typing import Any, Dict, List
 
-from ...model.chat.exceptions import LLMNoTextContentError
+from ...model.chat.exceptions import LLMEmptyContentError, LLMNoTextContentError
 
 logger = logging.getLogger(__name__)
 
@@ -25,15 +25,20 @@ def unwrap_chat_text(response: Any) -> str:
         a dict envelope carrying a usable non-empty string.
 
     Raises:
+        LLMEmptyContentError: The envelope carries string content that is
+            empty or whitespace-only (same transient class the adapters raise
+            for an empty generation).
         LLMNoTextContentError: The response is a tool_call envelope, carries
-            empty/non-string content, or has an unrecognized shape.
+            non-string content, or has an unrecognized shape.
     """
     if isinstance(response, str):
         return response
     if isinstance(response, dict):
         content = response.get("content")
-        if isinstance(content, str) and content.strip():
-            return content
+        if isinstance(content, str):
+            if content.strip():
+                return content
+            raise LLMEmptyContentError("Chat response content is empty")
         raise LLMNoTextContentError(
             "Chat response has no usable text content "
             f"(type={response.get('type')!r}, keys={sorted(response.keys())})"

--- a/src/xagent/core/agent/utils/llm_utils.py
+++ b/src/xagent/core/agent/utils/llm_utils.py
@@ -6,6 +6,7 @@ import re
 from typing import Any, Dict, List
 
 from ...model.chat.exceptions import LLMEmptyContentError, LLMNoTextContentError
+from ...model.chat.response_shape import classify_chat_response
 
 logger = logging.getLogger(__name__)
 
@@ -18,27 +19,28 @@ def unwrap_chat_text(response: Any) -> str:
     ``{"type": "tool_call", ...}``. Callers that need the text must never
     fall back to ``str(response)``: on a tool_call envelope that yields the
     dict's repr, which then leaks into compacted context or API responses as
-    if it were model output (#1714).
+    if it were model output (#1714). Shape reading delegates to
+    ``classify_chat_response`` so every consumer shares one structural
+    source of truth.
 
     Returns:
         The response itself for plain-string replies, or the ``content`` of
         a dict envelope carrying a usable non-empty string.
 
     Raises:
-        LLMEmptyContentError: The envelope carries string content that is
+        LLMEmptyContentError: The response carries string content that is
             empty or whitespace-only (same transient class the adapters raise
-            for an empty generation).
+            for an empty generation) -- envelope or legacy plain string.
         LLMNoTextContentError: The response is a tool_call envelope, carries
             non-string content, or has an unrecognized shape.
     """
-    if isinstance(response, str):
-        return response
+    shape = classify_chat_response(response)
+    if shape.kind == "text":
+        assert shape.text is not None  # classifier invariant
+        return shape.text
+    if shape.kind == "empty":
+        raise LLMEmptyContentError("Chat response content is empty")
     if isinstance(response, dict):
-        content = response.get("content")
-        if isinstance(content, str):
-            if content.strip():
-                return content
-            raise LLMEmptyContentError("Chat response content is empty")
         raise LLMNoTextContentError(
             "Chat response has no usable text content "
             f"(type={response.get('type')!r}, keys={sorted(response.keys())})"

--- a/src/xagent/core/agent/utils/llm_utils.py
+++ b/src/xagent/core/agent/utils/llm_utils.py
@@ -5,7 +5,43 @@ import logging
 import re
 from typing import Any, Dict, List
 
+from ...model.chat.exceptions import LLMNoTextContentError
+
 logger = logging.getLogger(__name__)
+
+
+def unwrap_chat_text(response: Any) -> str:
+    """Extract the text content of a ``chat()`` response, or raise.
+
+    Adapters return either a plain string (legacy shape) or an envelope dict
+    such as ``{"type": "text", "content": ...}`` /
+    ``{"type": "tool_call", ...}``. Callers that need the text must never
+    fall back to ``str(response)``: on a tool_call envelope that yields the
+    dict's repr, which then leaks into compacted context or API responses as
+    if it were model output (#1714).
+
+    Returns:
+        The response itself for plain-string replies, or the ``content`` of
+        a dict envelope carrying a usable non-empty string.
+
+    Raises:
+        LLMNoTextContentError: The response is a tool_call envelope, carries
+            empty/non-string content, or has an unrecognized shape.
+    """
+    if isinstance(response, str):
+        return response
+    if isinstance(response, dict):
+        content = response.get("content")
+        if isinstance(content, str) and content.strip():
+            return content
+        raise LLMNoTextContentError(
+            "Chat response has no usable text content "
+            f"(type={response.get('type')!r}, keys={sorted(response.keys())})"
+        )
+    raise LLMNoTextContentError(
+        "Chat response has no usable text content "
+        f"(response type={type(response).__name__})"
+    )
 
 
 def clean_llm_content(content: str) -> str:

--- a/src/xagent/core/model/chat/basic/base.py
+++ b/src/xagent/core/model/chat/basic/base.py
@@ -4,6 +4,7 @@ import re
 from abc import ABC, abstractmethod
 from typing import Any, AsyncIterator, List
 
+from ..response_shape import classify_chat_response
 from ..types import ChunkType, StreamChunk
 
 
@@ -224,25 +225,27 @@ class BaseLLM(ABC):
             **kwargs: Additional parameters specific to the underlying model (e.g. top_p, user, stop).
 
         Returns:
-            The return type is a union; the concrete shape depends on the
-            implementation:
-                -> str: some implementations (e.g. Zhipu, Claude, Gemini)
-                   return the assistant reply content as a bare string.
-                -> dict: other implementations (e.g. the OpenAI family --
-                   OpenAI, OpenRouter, DashScope -- and Xinference) wrap
-                   the reply in an envelope instead:
-                     - {"type": "text", "content": <str>, ...} for a
-                       natural language response
-                     - {"type": "tool_call", "tool_calls": [...], ...} for a
-                       tool call
-                   A "raw" key carrying the provider's full response is
-                   present on some implementations' envelopes and absent on
-                   others, so callers must not require it. Neither list is
-                   exhaustive, and an implementation listed above as
-                   returning a bare string for ordinary replies can still
-                   return a tool-call envelope -- Gemini does exactly that.
-                   Callers that must accept more than one implementation need
-                   to branch on the shape rather than assume a bare string.
+            If the model returns a natural language response:
+                -> dict envelope with fields:
+                    - "type": "text"
+                    - "content": the assistant reply content
+                    - "usage": top-level provider usage stamp, when the provider
+                      reported one (e.g. {"prompt_tokens": ..., "completion_tokens": ...})
+                    - "raw": the provider's full response payload. Present on
+                      some implementations' envelopes and absent on others,
+                      so callers must not require it.
+                (Legacy adapters may still return a plain string reply.)
+
+            If the model triggers a tool call:
+                -> dict envelope with fields:
+                    - "type": "tool_call"
+                    - "tool_calls": list of tool call objects
+                    - "raw": the full response JSON
+                    - "usage": top-level provider usage stamp, when reported
+
+            Consumers needing the reply text must classify the envelope
+            structurally (``classify_chat_response`` / ``unwrap_chat_text``)
+            rather than stringifying it.
 
         Raises:
             RuntimeError if the model call fails or returns an unexpected format.
@@ -279,25 +282,13 @@ class BaseLLM(ABC):
             **kwargs: Additional parameters specific to the underlying model.
 
         Returns:
-            The return type is a union; the concrete shape depends on the
-            implementation:
-                -> str: some implementations (e.g. Zhipu, Claude, Gemini)
-                   return the assistant reply content as a bare string.
-                -> dict: other implementations (e.g. the OpenAI family --
-                   OpenAI, OpenRouter, DashScope -- and Xinference) wrap
-                   the reply in an envelope instead:
-                     - {"type": "text", "content": <str>, ...} for a
-                       natural language response
-                     - {"type": "tool_call", "tool_calls": [...], ...} for a
-                       tool call
-                   A "raw" key carrying the provider's full response is
-                   present on some implementations' envelopes and absent on
-                   others, so callers must not require it. Neither list is
-                   exhaustive, and an implementation listed above as
-                   returning a bare string for ordinary replies can still
-                   return a tool-call envelope -- Gemini does exactly that.
-                   Callers that must accept more than one implementation need
-                   to branch on the shape rather than assume a bare string.
+            Same envelope contract as ``chat()``: a text envelope
+            (``{"type": "text", "content": ...}``, optionally with ``usage``
+            and ``raw``) for a natural language response, a tool_call
+            envelope (``{"type": "tool_call", "tool_calls": [...]}``) when
+            the model triggers a tool call, or -- for legacy adapters -- a
+            plain string reply. Never stringify the envelope to get the
+            text; use ``classify_chat_response`` / ``unwrap_chat_text``.
 
         Raises:
             RuntimeError if the model doesn't support vision or the call fails.
@@ -379,16 +370,32 @@ class BaseLLM(ABC):
                 type=ChunkType.ERROR,
                 content="LLM returned None response",
             )
-        elif isinstance(result, str):
+            return
+
+        # Shape-discriminate via the shared classifier: a text envelope or
+        # legacy plain string is a token chunk, a tool_call envelope is a
+        # tool-call chunk, and anything else is an explicit error -- never a
+        # silent empty TOOL_CALL chunk (the pre-contract fallback treated
+        # every non-string as a tool call).
+        shape = classify_chat_response(result)
+        if shape.kind == "text":
+            assert shape.text is not None  # classifier invariant
             yield StreamChunk(
                 type=ChunkType.TOKEN,
-                content=result,
-                delta=result,
+                content=shape.text,
+                delta=shape.text,
             )
-        else:
-            # tool_call format
+        elif shape.kind == "tool_call":
             yield StreamChunk(
                 type=ChunkType.TOOL_CALL,
                 tool_calls=result.get("tool_calls", []),
                 raw=result,
+            )
+        else:
+            yield StreamChunk(
+                type=ChunkType.ERROR,
+                content=(
+                    "LLM returned an unusable chat response shape "
+                    f"({shape.kind}); expected a text or tool_call envelope"
+                ),
             )

--- a/src/xagent/core/model/chat/basic/base.py
+++ b/src/xagent/core/model/chat/basic/base.py
@@ -404,6 +404,7 @@ class BaseLLM(ABC):
                     "LLM returned an unusable chat response shape "
                     f"({shape.kind}); expected a text or tool_call envelope"
                 ),
+                raw=result,
             )
             return
 

--- a/src/xagent/core/model/chat/basic/base.py
+++ b/src/xagent/core/model/chat/basic/base.py
@@ -240,7 +240,9 @@ class BaseLLM(ABC):
                 -> dict envelope with fields:
                     - "type": "tool_call"
                     - "tool_calls": list of tool call objects
-                    - "raw": the full response JSON
+                    - "raw": the provider's full response payload -- optional,
+                      provider-dependent (e.g. Gemini's envelope omits it);
+                      callers must not require it
                     - "usage": top-level provider usage stamp, when reported
 
             Consumers needing the reply text must classify the envelope
@@ -376,16 +378,20 @@ class BaseLLM(ABC):
         # legacy plain string is a token chunk, a tool_call envelope is a
         # tool-call chunk, and anything else is an explicit error -- never a
         # silent empty TOOL_CALL chunk (the pre-contract fallback treated
-        # every non-string as a tool call).
+        # every non-string as a tool call). Usage-bearing envelopes also
+        # emit a USAGE chunk so the chat-to-stream adaptation keeps the
+        # billing metadata the runtime reads from streams.
         shape = classify_chat_response(result)
+        usage_payload = result.get("usage") if isinstance(result, dict) else None
         if shape.kind == "text":
             assert shape.text is not None  # classifier invariant
             yield StreamChunk(
                 type=ChunkType.TOKEN,
                 content=shape.text,
                 delta=shape.text,
+                raw=result,
             )
-        elif shape.kind == "tool_call":
+        elif shape.kind == "tool_call" and isinstance(result, dict):
             yield StreamChunk(
                 type=ChunkType.TOOL_CALL,
                 tool_calls=result.get("tool_calls", []),
@@ -398,4 +404,12 @@ class BaseLLM(ABC):
                     "LLM returned an unusable chat response shape "
                     f"({shape.kind}); expected a text or tool_call envelope"
                 ),
+            )
+            return
+
+        if isinstance(usage_payload, dict) and usage_payload:
+            yield StreamChunk(
+                type=ChunkType.USAGE,
+                usage=dict(usage_payload),
+                raw=result,
             )

--- a/src/xagent/core/model/chat/basic/claude.py
+++ b/src/xagent/core/model/chat/basic/claude.py
@@ -531,7 +531,8 @@ class ClaudeLLM(BaseLLM):
             **kwargs: Additional parameters to pass to the Anthropic API
 
         Returns:
-            - If normal text reply: return string
+            - If normal text reply: return dict with type "text" and content
+              (plus a top-level "usage" payload when the provider reported one)
             - If tool call triggered: return dict with type "tool_call" and tool_calls list
 
         Raises:
@@ -656,11 +657,17 @@ class ClaudeLLM(BaseLLM):
             # Make the API call
             response = await self._client.messages.create(**completion_params)
 
-            # Record token usage
+            # Record token usage; snapshot it as an OpenAI-style payload so the
+            # result envelopes below can carry a top-level ``usage`` stamp.
+            usage_payload: Optional[Dict[str, Any]] = None
             if hasattr(response, "usage"):
                 usage = response.usage
                 input_tokens, cache_read, cache_write = _anthropic_input_usage(usage)
                 output_tokens = getattr(usage, "output_tokens", 0)
+                usage_payload = {
+                    "prompt_tokens": input_tokens,
+                    "completion_tokens": output_tokens,
+                }
                 add_token_usage(
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
@@ -691,13 +698,16 @@ class ClaudeLLM(BaseLLM):
                         )
 
                 if tool_calls:
-                    return {
+                    result: Dict[str, Any] = {
                         "type": "tool_call",
                         "tool_calls": tool_calls,
                         "raw": response.model_dump()
                         if hasattr(response, "model_dump")
                         else str(response),
                     }
+                    if usage_payload is not None:
+                        result["usage"] = usage_payload
+                    return result
 
             # Extract text content
             text_content = []
@@ -706,6 +716,12 @@ class ClaudeLLM(BaseLLM):
                     text_content.append(block.text)
 
             content = "".join(text_content).strip()
+
+            def _text_result(text: str) -> Dict[str, Any]:
+                result: Dict[str, Any] = {"type": "text", "content": text}
+                if usage_payload is not None:
+                    result["usage"] = usage_payload
+                return result
 
             if not content:
                 # Empty response should trigger retry
@@ -716,10 +732,12 @@ class ClaudeLLM(BaseLLM):
                 try:
                     # Try to repair the JSON first
                     repaired_content = repair_loads(content, logging=False)
-                    # If repair succeeded, return the repaired JSON as string
-                    # to maintain consistency with normal text response
+                    # If repair succeeded, return the repaired JSON as the text
+                    # envelope's content, consistent with normal text responses
                     logger.info("JSON repair succeeded, returning repaired content")
-                    return json.dumps(repaired_content, ensure_ascii=False)
+                    return _text_result(
+                        json.dumps(repaired_content, ensure_ascii=False)
+                    )
                 except Exception as repair_error:
                     # JSON repair failed - raise retryable error to trigger retry
                     logger.warning(
@@ -736,9 +754,9 @@ class ClaudeLLM(BaseLLM):
                     # When using json_schema, the response is already validated JSON
                     # Return as-is since it's guaranteed to be valid
                     logger.info("Returning JSON schema validated response")
-                    return content
+                    return _text_result(content)
 
-            return content
+            return _text_result(content)
 
         except Exception as e:
             logger.error(f"Claude API error: {str(e)}")
@@ -1197,7 +1215,8 @@ class ClaudeLLM(BaseLLM):
             **kwargs: Additional parameters to pass to the Claude API
 
         Returns:
-            - If normal text reply: return string
+            - If normal text reply: return dict with type "text" and content
+              (plus a top-level "usage" payload when the provider reported one)
             - If tool call triggered: return dict with type "tool_call" and tool_calls list
 
         Raises:

--- a/src/xagent/core/model/chat/basic/claude.py
+++ b/src/xagent/core/model/chat/basic/claude.py
@@ -731,7 +731,14 @@ class ClaudeLLM(BaseLLM):
 
             if not content:
                 # Empty response should trigger retry
-                raise LLMRetryableError("LLM returned empty content and no tool calls")
+                error = LLMRetryableError(
+                    "LLM returned empty content and no tool calls"
+                )
+                # Usage was already booked above: carry this attempt's
+                # payload so the retry layer can merge the billed tokens.
+                if usage_payload is not None:
+                    error.usage_attempts = [usage_payload]
+                raise error
 
             # If JSON format was requested, try to repair and validate JSON
             if response_format and response_format.get("type") == "json_object":
@@ -749,9 +756,14 @@ class ClaudeLLM(BaseLLM):
                     logger.warning(
                         f"JSON repair failed, retrying LLM call: {repair_error}"
                     )
-                    raise LLMRetryableError(
+                    error = LLMRetryableError(
                         "LLM returned unrepairable JSON when response_format=json_object was requested"
                     )
+                    # Usage was already booked above: carry this attempt's
+                    # payload so the retry layer can merge the billed tokens.
+                    if usage_payload is not None:
+                        error.usage_attempts = [usage_payload]
+                    raise error
 
             # Handle output_config with json_schema - content should already be valid JSON
             if output_config is not None:

--- a/src/xagent/core/model/chat/basic/claude.py
+++ b/src/xagent/core/model/chat/basic/claude.py
@@ -16,7 +16,7 @@ else:
         Anthropic = None  # type: ignore
         AsyncAnthropic = None  # type: ignore
 
-from ..exceptions import LLMRetryableError, LLMTimeoutError
+from ..exceptions import LLMRetryableError, LLMTimeoutError, attach_usage_attempts
 from ..timeout_config import TimeoutConfig
 from ..token_context import add_token_usage
 from ..types import ChunkType, StreamChunk
@@ -798,7 +798,11 @@ class ClaudeLLM(BaseLLM):
                 if isinstance(e, APIStatusError):
                     raise LLMRetryableError(str(e)) from e
 
-            raise RuntimeError(f"Claude API error: {str(e)}") from e
+            wrapped = RuntimeError(f"Claude API error: {str(e)}")
+            # Preserve any billed-attempt payload carried by the cause so the
+            # wrap does not lose it from error-path accounting.
+            attach_usage_attempts(wrapped, getattr(e, "usage_attempts", None) or [])
+            raise wrapped from e
 
     async def stream_chat(
         self,

--- a/src/xagent/core/model/chat/basic/claude.py
+++ b/src/xagent/core/model/chat/basic/claude.py
@@ -668,6 +668,12 @@ class ClaudeLLM(BaseLLM):
                     "prompt_tokens": input_tokens,
                     "completion_tokens": output_tokens,
                 }
+                # Only stamp cache metrics when non-zero so a default 0 never
+                # shadows fallback fields in downstream extraction.
+                if cache_read > 0:
+                    usage_payload["cached_input_tokens"] = cache_read
+                if cache_write > 0:
+                    usage_payload["cache_write_input_tokens"] = cache_write
                 add_token_usage(
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,

--- a/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
+++ b/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
@@ -54,10 +54,14 @@ def normalize_deepseek_response(
         return response
     raw = response.get("raw") if isinstance(response, dict) else None
     error_response = tool_protocol_error_response(violation, raw=raw)
-    # Preserve the top-level usage stamp the adapter put on the original
-    # envelope so token accounting survives the error rebuild.
-    if isinstance(response, dict) and response.get("usage") is not None:
-        error_response["usage"] = response["usage"]
+    # Preserve the accounting metadata the adapter put on the original
+    # envelope -- the top-level usage stamp *and* the ordered billed-attempt
+    # list -- so token accounting survives the error rebuild intact.
+    if isinstance(response, dict):
+        if response.get("usage") is not None:
+            error_response["usage"] = response["usage"]
+        if response.get("usage_attempts") is not None:
+            error_response["usage_attempts"] = response["usage_attempts"]
     return error_response
 
 

--- a/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
+++ b/src/xagent/core/model/chat/basic/deepseek_tool_protocol.py
@@ -53,7 +53,12 @@ def normalize_deepseek_response(
     if violation is None:
         return response
     raw = response.get("raw") if isinstance(response, dict) else None
-    return tool_protocol_error_response(violation, raw=raw)
+    error_response = tool_protocol_error_response(violation, raw=raw)
+    # Preserve the top-level usage stamp the adapter put on the original
+    # envelope so token accounting survives the error rebuild.
+    if isinstance(response, dict) and response.get("usage") is not None:
+        error_response["usage"] = response["usage"]
+    return error_response
 
 
 async def adapt_deepseek_stream(

--- a/src/xagent/core/model/chat/basic/gemini.py
+++ b/src/xagent/core/model/chat/basic/gemini.py
@@ -607,23 +607,32 @@ class GeminiLLM(BaseLLM):
 
             # Extract response content
             if not response.candidates or len(response.candidates) == 0:
-                raise LLMInvalidResponseError("No candidates in Gemini SDK response")
+                error = LLMInvalidResponseError("No candidates in Gemini SDK response")
+                if usage_payload is not None:
+                    error.usage_attempts = [usage_payload]
+                raise error
 
             candidate = response.candidates[0]
 
             # Check if candidate.content exists
             if not hasattr(candidate, "content") or candidate.content is None:
-                raise LLMInvalidResponseError(
+                error = LLMInvalidResponseError(
                     "Candidate content is None in Gemini SDK response"
                 )
+                if usage_payload is not None:
+                    error.usage_attempts = [usage_payload]
+                raise error
 
             content_parts = candidate.content.parts
 
             # Check if content_parts is None
             if content_parts is None:
-                raise LLMInvalidResponseError(
+                error = LLMInvalidResponseError(
                     "Content parts is None in Gemini SDK response"
                 )
+                if usage_payload is not None:
+                    error.usage_attempts = [usage_payload]
+                raise error
 
             tool_calls = []
             text_parts = []
@@ -659,9 +668,14 @@ class GeminiLLM(BaseLLM):
             content = "".join(text_parts).strip()
 
             if not content:
-                raise LLMEmptyContentError(
+                error = LLMEmptyContentError(
                     "LLM returned empty content and no tool calls"
                 )
+                # Usage was already booked above: carry this attempt's
+                # payload so the retry layer can merge the billed tokens.
+                if usage_payload is not None:
+                    error.usage_attempts = [usage_payload]
+                raise error
 
             text_result: Dict[str, Any] = {"type": "text", "content": content}
             if usage_payload is not None:
@@ -695,7 +709,15 @@ class GeminiLLM(BaseLLM):
             if "rate limit" in str(e).lower() or "quota" in str(e).lower():
                 raise LLMRetryableError(str(e)) from e
 
-            raise RuntimeError(f"Gemini SDK API error: {str(e)}") from e
+            # Billed attempts attached by the raise sites above must survive
+            # the RuntimeError wrap: the retry wrapper reads them off the
+            # surfaced exception (its ``retry_on`` already looks through
+            # ``__cause__`` for the retry decision itself).
+            wrapped = RuntimeError(f"Gemini SDK API error: {str(e)}")
+            attempts = getattr(e, "usage_attempts", None)
+            if attempts:
+                wrapped.usage_attempts = attempts
+            raise wrapped from e
 
     async def stream_chat(
         self,

--- a/src/xagent/core/model/chat/basic/gemini.py
+++ b/src/xagent/core/model/chat/basic/gemini.py
@@ -574,7 +574,9 @@ class GeminiLLM(BaseLLM):
 
             response = await self._client.aio.models.generate_content(**api_params)
 
-            # Extract token usage
+            # Extract token usage; snapshot it as an OpenAI-style payload so
+            # the result envelopes below can carry a top-level ``usage`` stamp.
+            usage_payload: Optional[Dict[str, Any]] = None
             if hasattr(response, "usage_metadata") and response.usage_metadata:
                 usage_metadata = response.usage_metadata
                 input_tokens = getattr(usage_metadata, "prompt_token_count", 0)
@@ -584,6 +586,10 @@ class GeminiLLM(BaseLLM):
                 )
 
                 if input_tokens > 0 or output_tokens > 0:
+                    usage_payload = {
+                        "prompt_tokens": input_tokens,
+                        "completion_tokens": output_tokens,
+                    }
                     add_token_usage(
                         input_tokens=input_tokens,
                         output_tokens=output_tokens,
@@ -638,10 +644,13 @@ class GeminiLLM(BaseLLM):
                     text_parts.append(part.text)
 
             if tool_calls:
-                return {
+                tool_result: Dict[str, Any] = {
                     "type": "tool_call",
                     "tool_calls": tool_calls,
                 }
+                if usage_payload is not None:
+                    tool_result["usage"] = usage_payload
+                return tool_result
 
             content = "".join(text_parts).strip()
 
@@ -650,7 +659,10 @@ class GeminiLLM(BaseLLM):
                     "LLM returned empty content and no tool calls"
                 )
 
-            return content
+            text_result: Dict[str, Any] = {"type": "text", "content": content}
+            if usage_payload is not None:
+                text_result["usage"] = usage_payload
+            return text_result
 
         except Exception as e:
             logger.error("Gemini SDK API error: %s", redact_sensitive_text(str(e)))

--- a/src/xagent/core/model/chat/basic/gemini.py
+++ b/src/xagent/core/model/chat/basic/gemini.py
@@ -15,6 +15,7 @@ from ..exceptions import (
     LLMInvalidResponseError,
     LLMRetryableError,
     LLMTimeoutError,
+    attach_usage_attempts,
 )
 from ..timeout_config import TimeoutConfig
 from ..token_context import add_token_usage
@@ -668,14 +669,14 @@ class GeminiLLM(BaseLLM):
             content = "".join(text_parts).strip()
 
             if not content:
-                error = LLMEmptyContentError(
+                empty_error = LLMEmptyContentError(
                     "LLM returned empty content and no tool calls"
                 )
                 # Usage was already booked above: carry this attempt's
                 # payload so the retry layer can merge the billed tokens.
                 if usage_payload is not None:
-                    error.usage_attempts = [usage_payload]
-                raise error
+                    empty_error.usage_attempts = [usage_payload]
+                raise empty_error
 
             text_result: Dict[str, Any] = {"type": "text", "content": content}
             if usage_payload is not None:
@@ -714,9 +715,7 @@ class GeminiLLM(BaseLLM):
             # surfaced exception (its ``retry_on`` already looks through
             # ``__cause__`` for the retry decision itself).
             wrapped = RuntimeError(f"Gemini SDK API error: {str(e)}")
-            attempts = getattr(e, "usage_attempts", None)
-            if attempts:
-                wrapped.usage_attempts = attempts
+            attach_usage_attempts(wrapped, getattr(e, "usage_attempts", None) or [])
             raise wrapped from e
 
     async def stream_chat(

--- a/src/xagent/core/model/chat/basic/gemini.py
+++ b/src/xagent/core/model/chat/basic/gemini.py
@@ -686,6 +686,12 @@ class GeminiLLM(BaseLLM):
         except Exception as e:
             logger.error("Gemini SDK API error: %s", redact_sensitive_text(str(e)))
 
+            # Re-raise retryable errors as-is (same contract as claude.py):
+            # wrapping them into a plain RuntimeError would lose their type
+            # fidelity for any caller that catches the specific class.
+            if isinstance(e, LLMRetryableError):
+                raise
+
             error_text = str(e)
             error_text_lower = error_text.lower()
 

--- a/src/xagent/core/model/chat/basic/gemini.py
+++ b/src/xagent/core/model/chat/basic/gemini.py
@@ -590,6 +590,10 @@ class GeminiLLM(BaseLLM):
                         "prompt_tokens": input_tokens,
                         "completion_tokens": output_tokens,
                     }
+                    # Guard the comparison: real SDKs report int/None here,
+                    # but token accounting must never raise out of chat().
+                    if isinstance(cached_tokens, (int, float)) and cached_tokens > 0:
+                        usage_payload["cached_input_tokens"] = cached_tokens
                     add_token_usage(
                         input_tokens=input_tokens,
                         output_tokens=output_tokens,

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -21,6 +21,22 @@ logger = logging.getLogger(__name__)
 # transport module keep working unchanged.
 
 
+def _response_usage_payload(response: Any) -> Any:
+    """Return the provider usage payload of a raw SDK response, or None.
+
+    Stamped onto every chat/vision result envelope as a top-level ``usage``
+    key so consumers (notably ``PatternRuntime._extract_token_usage``) can
+    read usage without reaching into ``raw``. Read-only: the contextvar
+    ledger write stays with the adapter's single ``add_token_usage`` call.
+    """
+    usage = getattr(response, "usage", None)
+    if usage is None:
+        return None
+    if hasattr(usage, "model_dump"):
+        return usage.model_dump()
+    return usage
+
+
 def _truncate_error_detail(value: Any, limit: int = 4000) -> str:
     text = (
         value
@@ -386,6 +402,7 @@ class OpenAICompatibleLLM(BaseLLM):
 
         Returns:
             - If normal text reply: return dict with type "text" and content
+              (plus a top-level "usage" payload when the provider reported one)
             - If tool call triggered: return dict with type "tool_call" and tool_calls list
 
         Raises:
@@ -476,6 +493,10 @@ class OpenAICompatibleLLM(BaseLLM):
             choice = resp.choices[0]
             message = choice.message
 
+            # Snapshot usage once; every result envelope below is stamped with
+            # it so downstream consumers never need to dig through ``raw``.
+            usage_payload = _response_usage_payload(resp)
+
             # Record token usage to context
             if hasattr(resp, "usage") and resp.usage:
                 add_token_usage(
@@ -515,6 +536,8 @@ class OpenAICompatibleLLM(BaseLLM):
                     "tool_calls": tool_calls,
                     "raw": resp.model_dump(),
                 }
+                if usage_payload is not None:
+                    result["usage"] = usage_payload
                 has_reasoning_content, reasoning_content = _message_reasoning_content(
                     message
                 )
@@ -562,13 +585,16 @@ class OpenAICompatibleLLM(BaseLLM):
                     and reasoning_content
                     and reasoning_content.strip()
                 ):
-                    return {
+                    result = {
                         "type": "text",
                         "content": reasoning_content,
                         "reasoning_content": reasoning_content,
                         "reasoning": reasoning_content,
                         "raw": resp.model_dump(),
                     }
+                    if usage_payload is not None:
+                        result["usage"] = usage_payload
+                    return result
                 # If there are no tool calls and no content, this is an error
                 raise LLMEmptyContentError(
                     f"LLM returned {'empty' if content == '' else 'None'} content and no tool calls"
@@ -579,6 +605,8 @@ class OpenAICompatibleLLM(BaseLLM):
                 "content": content,
                 "raw": resp.model_dump(),
             }
+            if usage_payload is not None:
+                result["usage"] = usage_payload
             if has_reasoning_content:
                 result["reasoning_content"] = reasoning_content
                 result["reasoning"] = reasoning_content
@@ -750,6 +778,7 @@ class OpenAICompatibleLLM(BaseLLM):
 
         Returns:
             - If normal text reply: return dict with type "text" and content
+              (plus a top-level "usage" payload when the provider reported one)
             - If tool call triggered: return dict with type "tool_call" and tool_calls list
 
         Raises:
@@ -844,6 +873,10 @@ class OpenAICompatibleLLM(BaseLLM):
             choice = response.choices[0]
             message = choice.message
 
+            # Snapshot usage once; every result envelope below is stamped with
+            # it so downstream consumers never need to dig through ``raw``.
+            usage_payload = _response_usage_payload(response)
+
             # Record token usage to context
             if hasattr(response, "usage") and response.usage:
                 add_token_usage(
@@ -883,6 +916,8 @@ class OpenAICompatibleLLM(BaseLLM):
                     "tool_calls": tool_calls,
                     "raw": response.model_dump(),
                 }
+                if usage_payload is not None:
+                    result["usage"] = usage_payload
                 has_reasoning_content, reasoning_content = _message_reasoning_content(
                     message
                 )
@@ -920,13 +955,16 @@ class OpenAICompatibleLLM(BaseLLM):
                     and reasoning_content
                     and reasoning_content.strip()
                 ):
-                    return {
+                    result = {
                         "type": "text",
                         "content": reasoning_content,
                         "reasoning_content": reasoning_content,
                         "reasoning": reasoning_content,
                         "raw": response.model_dump(),
                     }
+                    if usage_payload is not None:
+                        result["usage"] = usage_payload
+                    return result
                 # If there are no tool calls and no content, this is an error
                 raise LLMEmptyContentError(
                     f"LLM returned {'empty' if content == '' else 'None'} content and no tool calls"
@@ -937,6 +975,8 @@ class OpenAICompatibleLLM(BaseLLM):
                 "content": content,
                 "raw": response.model_dump(),
             }
+            if usage_payload is not None:
+                text_result["usage"] = usage_payload
             if has_reasoning_content:
                 text_result["reasoning_content"] = reasoning_content
                 text_result["reasoning"] = reasoning_content

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -8,7 +8,13 @@ import openai
 from openai import AsyncOpenAI
 
 from ....utils.security import redact_sensitive_text
-from ..exceptions import LLMEmptyContentError, LLMRetryableError, LLMTimeoutError
+from ..exceptions import (
+    LLMEmptyContentError,
+    LLMRetryableError,
+    LLMTimeoutError,
+    attach_usage_attempts,
+    merge_usage_attempts_into_result,
+)
 from ..timeout_config import TimeoutConfig
 from ..token_context import add_token_usage, extract_cached_input_tokens
 from ..types import PROVIDER_STATE_METADATA_KEY, ChunkType, StreamChunk
@@ -710,15 +716,10 @@ class OpenAICompatibleLLM(BaseLLM):
 
             if superseded_attempts:
                 # ``usage`` stays the final attempt (freshness baseline);
-                # ``usage_attempts`` lists every billed attempt, final
-                # included, and is set only when more than one was billed.
-                final_attempts = result.get("usage_attempts")
-                if final_attempts is None:
-                    final_usage = result.get("usage")
-                    final_attempts = [final_usage] if final_usage is not None else []
-                attempts = superseded_attempts + list(final_attempts)
-                if len(attempts) > 1:
-                    result["usage_attempts"] = attempts
+                # ``usage_attempts`` lists every known billed attempt, final
+                # included. A known billed attempt is never suppressed, even
+                # when the final success is unmetered.
+                merge_usage_attempts_into_result(superseded_attempts, result)
 
             return result
 
@@ -730,27 +731,39 @@ class OpenAICompatibleLLM(BaseLLM):
         except openai.BadRequestError as e:
             # Handle bad request errors, including a response_format resend
             # that failed again (see the nested try/except above).
-            raise RuntimeError(_format_openai_error("OpenAI bad request", e)) from e
+            error = RuntimeError(_format_openai_error("OpenAI bad request", e))
+            attach_usage_attempts(error, superseded_attempts)
+            raise error from e
 
         except openai.APITimeoutError as e:
             # Handle timeout errors
-            raise RuntimeError(f"OpenAI API timeout: {str(e)}") from e
+            error = RuntimeError(f"OpenAI API timeout: {str(e)}")
+            attach_usage_attempts(error, superseded_attempts)
+            raise error from e
 
         except openai.RateLimitError as e:
             # Handle rate limit errors
-            raise RuntimeError(f"OpenAI rate limit exceeded: {e.message}") from e
+            error = RuntimeError(f"OpenAI rate limit exceeded: {e.message}")
+            attach_usage_attempts(error, superseded_attempts)
+            raise error from e
 
         except openai.AuthenticationError as e:
             # Handle authentication errors
-            raise RuntimeError(f"OpenAI authentication failed: {e.message}") from e
+            error = RuntimeError(f"OpenAI authentication failed: {e.message}")
+            attach_usage_attempts(error, superseded_attempts)
+            raise error from e
 
         except openai.APIError as e:
             # Handle OpenAI API errors
-            raise RuntimeError(_format_openai_error("OpenAI API error", e)) from e
+            error = RuntimeError(_format_openai_error("OpenAI API error", e))
+            attach_usage_attempts(error, superseded_attempts)
+            raise error from e
 
         except Exception as e:
             # Handle any other unexpected errors
-            raise RuntimeError(f"LLM chat failed: {str(e)}") from e
+            error = RuntimeError(f"LLM chat failed: {str(e)}")
+            attach_usage_attempts(error, superseded_attempts)
+            raise error from e
 
     @property
     def supports_thinking_mode(self) -> bool:

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -596,9 +596,15 @@ class OpenAICompatibleLLM(BaseLLM):
                         result["usage"] = usage_payload
                     return result
                 # If there are no tool calls and no content, this is an error
-                raise LLMEmptyContentError(
+                error = LLMEmptyContentError(
                     f"LLM returned {'empty' if content == '' else 'None'} content and no tool calls"
                 )
+                # Usage was already booked above: carry this attempt's
+                # payload so the retry layer can merge it instead of losing
+                # the billed tokens.
+                if usage_payload is not None:
+                    error.usage_attempts = [usage_payload]
+                raise error
 
             result = {
                 "type": "text",
@@ -613,6 +619,14 @@ class OpenAICompatibleLLM(BaseLLM):
             return result
 
         try:
+            # Billed usage payloads of superseded attempts inside this one
+            # logical call (currently only the thinking-disabled structured
+            # -output retry), oldest first. Assembled into the returned
+            # envelope as ``usage_attempts`` -- or prepended to a propagated
+            # retryable error -- so outer retry layers merge rather than
+            # lose the billed tokens.
+            superseded_attempts: List[Any] = []
+
             # Make the API call
             try:
                 response = await _make_api_call()
@@ -667,6 +681,12 @@ class OpenAICompatibleLLM(BaseLLM):
                             "Model returned non-JSON content with response_format while thinking was enabled. "
                             "Retrying with thinking disabled."
                         )
+                        # The first attempt was already billed: supersede it
+                        # so the envelope (or a propagated error) carries the
+                        # full ordered attempt list.
+                        first_attempt_usage = result.get("usage")
+                        if first_attempt_usage is not None:
+                            superseded_attempts.append(first_attempt_usage)
                         # One variable for both halves: what this retry
                         # sends, and what the response hook is told it
                         # sent. Two literals here would drift apart.
@@ -688,9 +708,23 @@ class OpenAICompatibleLLM(BaseLLM):
                             response, request_thinking=retry_thinking
                         )
 
+            if superseded_attempts:
+                # ``usage`` stays the final attempt (freshness baseline);
+                # ``usage_attempts`` lists every billed attempt, final
+                # included, and is set only when more than one was billed.
+                final_attempts = result.get("usage_attempts")
+                if final_attempts is None:
+                    final_usage = result.get("usage")
+                    final_attempts = [final_usage] if final_usage is not None else []
+                attempts = superseded_attempts + list(final_attempts)
+                if len(attempts) > 1:
+                    result["usage_attempts"] = attempts
+
             return result
 
-        except LLMRetryableError:
+        except LLMRetryableError as e:
+            if superseded_attempts:
+                e.usage_attempts = superseded_attempts + list(e.usage_attempts or [])
             raise
 
         except openai.BadRequestError as e:
@@ -966,9 +1000,15 @@ class OpenAICompatibleLLM(BaseLLM):
                         result["usage"] = usage_payload
                     return result
                 # If there are no tool calls and no content, this is an error
-                raise LLMEmptyContentError(
+                error = LLMEmptyContentError(
                     f"LLM returned {'empty' if content == '' else 'None'} content and no tool calls"
                 )
+                # Usage was already booked above: carry this attempt's
+                # payload so the retry layer can merge it instead of losing
+                # the billed tokens.
+                if usage_payload is not None:
+                    error.usage_attempts = [usage_payload]
+                raise error
 
             text_result: Dict[str, Any] = {
                 "type": "text",

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -5,7 +5,12 @@ import openai
 
 from .....config import get_openrouter_official_providers_only
 from ..error import retry_on
-from ..exceptions import LLMRetryableError, LLMToolProtocolError
+from ..exceptions import (
+    LLMRetryableError,
+    LLMToolProtocolError,
+    attach_usage_attempts,
+    merge_usage_attempts_into_result,
+)
 from ..timeout_config import TimeoutConfig
 from ..tool_protocol import TOOL_PROTOCOL_ERROR_KEY, get_tool_protocol_error
 from ..types import PROVIDER_STATE_METADATA_KEY, StreamChunk
@@ -592,6 +597,7 @@ class OpenRouterLLM(OpenAILLM):
         the already-sanitized messages instead of re-triggering this same
         prefix rejection on every iteration.
         """
+        collected_attempts: List[Any] = []
         try:
             response = await super().chat(
                 messages=messages,
@@ -605,6 +611,9 @@ class OpenRouterLLM(OpenAILLM):
                 **kwargs,
             )
         except RuntimeError as exc:
+            # The rejected attempt may already be billed: keep its payload so
+            # the retry's success envelope (or a terminal error) carries it.
+            collected_attempts.extend(getattr(exc, "usage_attempts", None) or [])
             sanitized_messages = self._deepseek_function_prefix_retry_messages(
                 exc, messages
             )
@@ -618,17 +627,26 @@ class OpenRouterLLM(OpenAILLM):
                 "OpenRouter DeepSeek rejected function-call history with an "
                 "assistant prefix; retrying once without tool-call prefixes"
             )
-            response = await super().chat(
-                messages=sanitized_messages,
-                temperature=temperature,
-                max_tokens=max_tokens,
-                tools=tools,
-                tool_choice=tool_choice,
-                response_format=response_format,
-                thinking=thinking,
-                output_config=output_config,
-                **kwargs,
-            )
+            try:
+                response = await super().chat(
+                    messages=sanitized_messages,
+                    temperature=temperature,
+                    max_tokens=max_tokens,
+                    tools=tools,
+                    tool_choice=tool_choice,
+                    response_format=response_format,
+                    thinking=thinking,
+                    output_config=output_config,
+                    **kwargs,
+                )
+            except RuntimeError as final_exc:
+                attach_usage_attempts(
+                    final_exc,
+                    collected_attempts
+                    + list(getattr(final_exc, "usage_attempts", None) or []),
+                )
+                raise
+            merge_usage_attempts_into_result(collected_attempts, response)
 
         return response
 
@@ -724,6 +742,7 @@ class OpenRouterLLM(OpenAILLM):
                 is_streaming=False,
             )
 
+        collected_attempts: List[Any] = []
         while True:
             sanitized_out: List[List[Dict[str, Any]]] = []
             call_kwargs: Dict[str, Any] = dict(
@@ -739,11 +758,23 @@ class OpenRouterLLM(OpenAILLM):
             if sanitize_messages:
                 call_kwargs["sanitized_out"] = sanitized_out
             try:
-                return await call(current_messages, **call_kwargs)
-            except LLMRetryableError:
+                result = await call(current_messages, **call_kwargs)
+            except LLMRetryableError as exc:
+                # Carries its own attempts; earlier compat-superseded billed
+                # attempts must ride along too.
+                if collected_attempts:
+                    attach_usage_attempts(
+                        exc,
+                        collected_attempts + list(exc.usage_attempts or []),
+                    )
                 raise
             except _COMPAT_RETRYABLE_ERRORS as exc:
+                # Every superseded iteration may already be billed: collect its
+                # payload before deciding to adjust, re-raise, or continue.
+                exc_attempts = list(getattr(exc, "usage_attempts", None) or [])
                 if retry_on(exc):
+                    if collected_attempts or exc_attempts:
+                        attach_usage_attempts(exc, collected_attempts + exc_attempts)
                     raise
 
                 adjustment = _next_compat_adjustment(
@@ -755,8 +786,11 @@ class OpenRouterLLM(OpenAILLM):
                     render=render,
                 )
                 if adjustment is None:
+                    if collected_attempts or exc_attempts:
+                        attach_usage_attempts(exc, collected_attempts + exc_attempts)
                     raise
 
+                collected_attempts.extend(exc_attempts)
                 current_tool_choice, current_thinking, log_message, action_key = (
                     adjustment
                 )
@@ -764,6 +798,10 @@ class OpenRouterLLM(OpenAILLM):
                 if sanitized_out:
                     current_messages = sanitized_out[-1]
                 logger.info(log_message)
+            else:
+                if collected_attempts:
+                    merge_usage_attempts_into_result(collected_attempts, result)
+                return result
 
     async def _stream_chat_with_prefix_retry(
         self,

--- a/src/xagent/core/model/chat/basic/xinference.py
+++ b/src/xagent/core/model/chat/basic/xinference.py
@@ -311,7 +311,9 @@ class XinferenceLLM(BaseLLM):
         # Xinference returns a dict-like object with various fields
         response_dict = dict(response) if not isinstance(response, dict) else response
 
-        # Record token usage if available
+        # Record token usage if available; the same payload is also stamped
+        # onto the returned envelope (the adapter-boundary usage contract, so
+        # consumers never need to dig through ``raw``).
         usage = response_dict.get("usage", {})
         if usage:
             add_token_usage(
@@ -342,6 +344,8 @@ class XinferenceLLM(BaseLLM):
                 if reasoning_content:
                     result["reasoning_content"] = reasoning_content
                     result["reasoning"] = reasoning_content
+                if usage:
+                    result["usage"] = usage
                 return result
 
             # Handle text content
@@ -355,6 +359,8 @@ class XinferenceLLM(BaseLLM):
                 if reasoning_content:
                     result["reasoning_content"] = reasoning_content
                     result["reasoning"] = reasoning_content
+                if usage:
+                    result["usage"] = usage
                 return result
 
             # Reasoning models (e.g. qwen3-thinking, deepseek-r1) may emit
@@ -375,22 +381,28 @@ class XinferenceLLM(BaseLLM):
                 and reasoning_content
                 and reasoning_content.strip()
             ):
-                return {
+                result = {
                     "type": "text",
                     "content": reasoning_content,
                     "reasoning_content": reasoning_content,
                     "reasoning": reasoning_content,
                     "raw": response_dict,
                 }
+                if usage:
+                    result["usage"] = usage
+                return result
 
         # Fallback: try to get content directly from response
         content = response_dict.get("content", "")
         if content:
-            return {
+            result = {
                 "type": "text",
                 "content": content,
                 "raw": response_dict,
             }
+            if usage:
+                result["usage"] = usage
+            return result
 
         raise RuntimeError(f"Invalid Xinference response: {response_dict}")
 

--- a/src/xagent/core/model/chat/basic/zhipu.py
+++ b/src/xagent/core/model/chat/basic/zhipu.py
@@ -160,7 +160,8 @@ class ZhipuLLM(BaseLLM):
             **kwargs: Additional parameters to pass to the Zhipu API
 
         Returns:
-            - If normal text reply: return string
+            - If normal text reply: return dict with type "text" and content
+              (plus a top-level "usage" payload when the provider reported one)
             - If tool call triggered: return dict with type "tool_call" and tool_calls list
 
         Raises:
@@ -247,7 +248,9 @@ class ZhipuLLM(BaseLLM):
                 logger.error(f"Zhipu API response missing choices: {response}")
                 raise RuntimeError("Zhipu API response missing choices")
 
-            # Record token usage
+            # Record token usage; snapshot it as an OpenAI-style payload so the
+            # result envelopes below can carry a top-level ``usage`` stamp.
+            usage_payload: Optional[Dict[str, Any]] = None
             if hasattr(response, "usage"):
                 usage = response.usage
                 input_tokens = getattr(usage, "prompt_tokens", 0) or getattr(
@@ -256,6 +259,10 @@ class ZhipuLLM(BaseLLM):
                 output_tokens = getattr(usage, "completion_tokens", 0) or getattr(
                     usage, "output_tokens", 0
                 )
+                usage_payload = {
+                    "prompt_tokens": input_tokens,
+                    "completion_tokens": output_tokens,
+                }
                 add_token_usage(
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
@@ -346,7 +353,7 @@ class ZhipuLLM(BaseLLM):
                         args = {}
 
                     # Return ReAct-compatible tool call format
-                    return {
+                    result: Dict[str, Any] = {
                         "type": "tool_call",
                         "tool_calls": [
                             {
@@ -364,6 +371,9 @@ class ZhipuLLM(BaseLLM):
                         if hasattr(response, "model_dump")
                         else str(response),
                     }
+                    if usage_payload is not None:
+                        result["usage"] = usage_payload
+                    return result
 
             # Handle text content
             content = message.content
@@ -390,7 +400,10 @@ class ZhipuLLM(BaseLLM):
                         "None/empty content but tool calls present, this is expected behavior"
                     )
 
-            return content
+            text_result: Dict[str, Any] = {"type": "text", "content": content}
+            if usage_payload is not None:
+                text_result["usage"] = usage_payload
+            return text_result
 
         except Exception as e:
             # Handle any errors
@@ -803,7 +816,8 @@ class ZhipuLLM(BaseLLM):
             **kwargs: Additional parameters to pass to the Zhipu API
 
         Returns:
-            - If normal text reply: return string
+            - If normal text reply: return dict with type "text" and content
+              (plus a top-level "usage" payload when the provider reported one)
             - If tool call triggered: return dict with type "tool_call" and tool_calls list
 
         Raises:
@@ -891,7 +905,9 @@ class ZhipuLLM(BaseLLM):
                 logger.error(f"Zhipu Vision API response missing choices: {response}")
                 raise RuntimeError("Zhipu Vision API response missing choices")
 
-            # Record token usage
+            # Record token usage; snapshot it as an OpenAI-style payload so the
+            # result envelopes below can carry a top-level ``usage`` stamp.
+            usage_payload: Optional[Dict[str, Any]] = None
             if hasattr(response, "usage"):
                 usage = response.usage
                 input_tokens = getattr(usage, "prompt_tokens", 0) or getattr(
@@ -900,6 +916,10 @@ class ZhipuLLM(BaseLLM):
                 output_tokens = getattr(usage, "completion_tokens", 0) or getattr(
                     usage, "output_tokens", 0
                 )
+                usage_payload = {
+                    "prompt_tokens": input_tokens,
+                    "completion_tokens": output_tokens,
+                }
                 add_token_usage(
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
@@ -990,7 +1010,7 @@ class ZhipuLLM(BaseLLM):
                         args = {}
 
                     # Return ReAct-compatible tool call format
-                    return {
+                    result: Dict[str, Any] = {
                         "type": "tool_call",
                         "tool_calls": [
                             {
@@ -1008,6 +1028,9 @@ class ZhipuLLM(BaseLLM):
                         if hasattr(response, "model_dump")
                         else str(response),
                     }
+                    if usage_payload is not None:
+                        result["usage"] = usage_payload
+                    return result
 
             # Handle text content
             content = message.content
@@ -1030,13 +1053,19 @@ class ZhipuLLM(BaseLLM):
                     logger.warning(
                         "No tool calls and None content, returning empty string"
                     )
-                    return ""
+                    empty_result: Dict[str, Any] = {"type": "text", "content": ""}
+                    if usage_payload is not None:
+                        empty_result["usage"] = usage_payload
+                    return empty_result
                 else:
                     logger.info(
                         "None content but tool calls present, this is expected behavior"
                     )
 
-            return content
+            vision_result: Dict[str, Any] = {"type": "text", "content": content}
+            if usage_payload is not None:
+                vision_result["usage"] = usage_payload
+            return vision_result
 
         except Exception as e:
             # Handle any errors

--- a/src/xagent/core/model/chat/basic/zhipu.py
+++ b/src/xagent/core/model/chat/basic/zhipu.py
@@ -259,17 +259,20 @@ class ZhipuLLM(BaseLLM):
                 output_tokens = getattr(usage, "completion_tokens", 0) or getattr(
                     usage, "output_tokens", 0
                 )
+                cached_tokens = extract_cached_input_tokens(usage)
                 usage_payload = {
                     "prompt_tokens": input_tokens,
                     "completion_tokens": output_tokens,
                 }
+                if cached_tokens > 0:
+                    usage_payload["cached_input_tokens"] = cached_tokens
                 add_token_usage(
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     model=self._model_name,
                     model_id=self.model_id,
                     call_type="chat",
-                    cached_input_tokens=extract_cached_input_tokens(usage),
+                    cached_input_tokens=cached_tokens,
                 )
 
             # Extract the choice
@@ -916,17 +919,20 @@ class ZhipuLLM(BaseLLM):
                 output_tokens = getattr(usage, "completion_tokens", 0) or getattr(
                     usage, "output_tokens", 0
                 )
+                cached_tokens = extract_cached_input_tokens(usage)
                 usage_payload = {
                     "prompt_tokens": input_tokens,
                     "completion_tokens": output_tokens,
                 }
+                if cached_tokens > 0:
+                    usage_payload["cached_input_tokens"] = cached_tokens
                 add_token_usage(
                     input_tokens=input_tokens,
                     output_tokens=output_tokens,
                     model=self._model_name,
                     model_id=self.model_id,
                     call_type="vision_chat",
-                    cached_input_tokens=extract_cached_input_tokens(usage),
+                    cached_input_tokens=cached_tokens,
                 )
 
             # Extract the choice

--- a/src/xagent/core/model/chat/basic/zhipu.py
+++ b/src/xagent/core/model/chat/basic/zhipu.py
@@ -12,7 +12,7 @@ except ImportError:
     # Fallback for when zai SDK is not available
     ZhipuAiClient = None
 
-from ..exceptions import LLMRetryableError, LLMTimeoutError
+from ..exceptions import LLMRetryableError, LLMTimeoutError, attach_usage_attempts
 from ..timeout_config import TimeoutConfig
 from ..token_context import add_token_usage, extract_cached_input_tokens
 from ..types import ChunkType, StreamChunk
@@ -395,9 +395,17 @@ class ZhipuLLM(BaseLLM):
 
                 # If there are no tool calls and no content, this is an error
                 if not tool_calls:
-                    raise RuntimeError(
+                    error = RuntimeError(
                         f"LLM returned {'empty' if content == '' else 'None'} content and no tool calls"
                     )
+                    # Billing is independent of retryability: this path stays
+                    # a non-retryable RuntimeError (#1714 problem 2), but the
+                    # already-booked usage payload must ride the exception so
+                    # ``on_llm_error`` can account for it.
+                    attach_usage_attempts(
+                        error, [usage_payload] if usage_payload is not None else []
+                    )
+                    raise error
                 else:
                     logger.info(
                         "None/empty content but tool calls present, this is expected behavior"
@@ -414,7 +422,11 @@ class ZhipuLLM(BaseLLM):
             logger.error(f"  - Exception type: {type(e).__name__}")
             logger.error(f"  - Exception message: {str(e)}")
             logger.error(f"  - Exception args: {e.args}")
-            raise RuntimeError(f"Zhipu API error: {str(e)}") from e
+            wrapped = RuntimeError(f"Zhipu API error: {str(e)}")
+            # Preserve any billed-attempt payload carried by the cause so the
+            # wrap does not lose it from error-path accounting.
+            attach_usage_attempts(wrapped, getattr(e, "usage_attempts", None) or [])
+            raise wrapped from e
 
     async def stream_chat(
         self,

--- a/src/xagent/core/model/chat/exceptions.py
+++ b/src/xagent/core/model/chat/exceptions.py
@@ -78,6 +78,20 @@ class LLMInvalidResponseError(LLMRetryableError):
     pass
 
 
+class LLMNoTextContentError(LLMInvalidResponseError):
+    """Raised when a chat response carries no usable text content.
+
+    Distinct from ``LLMEmptyContentError`` (the provider answered with an
+    empty string): this means the response has a non-text shape -- a
+    tool_call envelope or an unrecognized payload -- where the caller
+    required text. Stringifying such a response would leak an internal
+    dict repr into compacted context or API responses as if it were model
+    output (#1714), so consumers must fail explicitly instead.
+    """
+
+    pass
+
+
 class LLMTimeoutError(LLMRetryableError):
     """Raised when LLM request times out.
 

--- a/src/xagent/core/model/chat/exceptions.py
+++ b/src/xagent/core/model/chat/exceptions.py
@@ -33,6 +33,40 @@ class LLMRetryableError(RuntimeError):
         self.usage_attempts: list[Any] | None = None
 
 
+def attach_usage_attempts(error: BaseException, attempts: list[Any]) -> None:
+    """Attach ordered billed-usage payloads to a surfaced exception.
+
+    This is the accounting carrier for a call that fails after the adapter
+    already booked tokens: the retry wrapper merges it into an eventual
+    success envelope, and ``PatternRuntime.on_llm_error`` books it when every
+    attempt fails. Assignment goes through ``setattr`` because only
+    ``LLMRetryableError`` declares the attribute statically.
+    """
+    if attempts:
+        setattr(error, "usage_attempts", list(attempts))
+
+
+def merge_usage_attempts_into_result(history: list[Any], result: Any) -> None:
+    """Fold billed attempts from superseded/failed retries into a success envelope.
+
+    ``usage`` stays the final attempt (the context-freshness baseline);
+    ``usage_attempts`` becomes the ordered list of every known billed
+    attempt, final included. Written whenever ``history`` is non-empty: a
+    known billed attempt is never suppressed just because the final success
+    is unmetered or because a single attempt ended up known. A call with no
+    prior billed history keeps the single-attempt shape (no key).
+    """
+    if not history or not isinstance(result, dict):
+        return
+    final_attempts = result.get("usage_attempts")
+    if final_attempts is None:
+        final_usage = result.get("usage")
+        final_attempts = [final_usage] if final_usage is not None else []
+    merged = list(history) + list(final_attempts)
+    if merged:
+        result["usage_attempts"] = merged
+
+
 class LLMToolProtocolError(LLMRetryableError):
     """Structured provider tool-protocol failure.
 

--- a/src/xagent/core/model/chat/exceptions.py
+++ b/src/xagent/core/model/chat/exceptions.py
@@ -15,9 +15,22 @@ class LLMRetryableError(RuntimeError):
     - Server errors (5xx)
 
     Subclass this exception for specific retryable error types.
+
+    Attributes:
+        usage_attempts: Billed provider usage payloads of attempts made
+            before this error was raised, oldest first. Adapters attach
+            them when usage was already booked (``add_token_usage``) before
+            the failure; the retry wrapper merges them into the eventual
+            response envelope's ``usage_attempts`` (or onto the final
+            exception when every attempt fails) so billed tokens are never
+            lost from the execution context and trace. ``None`` means no
+            billed attempts were recorded. Always ``None`` at construction;
+            assigned by the adapter/wrapper afterwards.
     """
 
-    pass
+    def __init__(self, *args: Any) -> None:
+        super().__init__(*args)
+        self.usage_attempts: list[Any] | None = None
 
 
 class LLMToolProtocolError(LLMRetryableError):

--- a/src/xagent/core/model/chat/response_shape.py
+++ b/src/xagent/core/model/chat/response_shape.py
@@ -1,0 +1,62 @@
+"""Structural classification of ``chat()``/``vision_chat()`` response shapes.
+
+Adapters return a small union from the non-streaming chat methods:
+
+- a legacy plain string (the assistant reply),
+- a text envelope ``{"type": "text", "content": ...}`` (optionally with a
+  top-level ``usage`` stamp and a ``raw`` provider payload),
+- a tool-call envelope ``{"type": "tool_call", "tool_calls": [...]}``.
+
+This module is the single, dependency-neutral source of truth for telling
+those shapes apart. Consumers that need the text (``unwrap_chat_text`` in
+the agent layer, ``VisionCore`` in the tools layer, the default
+``stream_chat`` in this package) classify here instead of re-implementing
+isinstance chains -- and none of them ever falls back to ``str(response)``,
+which would leak an internal dict repr as if it were model output (#1714).
+"""
+
+from typing import Any, Literal, NamedTuple
+
+
+class ChatResponseShape(NamedTuple):
+    """Structural reading of a chat response.
+
+    ``kind`` is one of:
+
+    - ``"text"``: usable text is present; ``text`` carries it.
+    - ``"empty"``: a text-bearing shape with no usable text (empty or
+      whitespace-only) -- the same transient condition adapters raise
+      ``LLMEmptyContentError`` for.
+    - ``"tool_call"``: a tool-call envelope; there is no text by design.
+    - ``"unknown"``: any other payload (unrecognized dict, non-string
+      content, non-dict/non-string value).
+    """
+
+    kind: Literal["text", "empty", "tool_call", "unknown"]
+    text: str | None
+
+
+def classify_chat_response(response: Any) -> ChatResponseShape:
+    """Classify a ``chat()``/``vision_chat()`` response by structure.
+
+    Classification is purely structural and never raises: a legacy plain
+    string is text (or empty when whitespace-only); a dict tagged
+    ``type == "tool_call"`` is a tool call; any other dict with string
+    ``content`` is text (or empty when whitespace-only) regardless of its
+    ``type`` tag, matching the duck-typed acceptance ``unwrap_chat_text``
+    has always had; everything else is unknown.
+    """
+    if isinstance(response, str):
+        if response.strip():
+            return ChatResponseShape("text", response)
+        return ChatResponseShape("empty", None)
+    if isinstance(response, dict):
+        if response.get("type") == "tool_call":
+            return ChatResponseShape("tool_call", None)
+        content = response.get("content")
+        if isinstance(content, str):
+            if content.strip():
+                return ChatResponseShape("text", content)
+            return ChatResponseShape("empty", None)
+        return ChatResponseShape("unknown", None)
+    return ChatResponseShape("unknown", None)

--- a/src/xagent/core/retry/wrapper.py
+++ b/src/xagent/core/retry/wrapper.py
@@ -16,6 +16,12 @@ from typing import (
 
 from .strategy import ExponentialBackoff, RetryStrategy
 
+# NOTE: the usage-attempt carrier helpers live in ``model.chat.exceptions``,
+# but this module is imported *by* the model package's own adapters
+# (embedding/image/rerank/...), so a top-level import would create a cycle
+# (model/__init__ -> adapter -> retry.wrapper -> model.chat.exceptions).
+# They are imported lazily at the call sites instead.
+
 logger = logging.getLogger(__name__)
 
 
@@ -28,25 +34,6 @@ def _collect_usage_attempts(error: Exception, collected: list[Any]) -> None:
     attempts = getattr(error, "usage_attempts", None)
     if attempts:
         collected.extend(attempts)
-
-
-def _merge_usage_attempts(collected: list[Any], result: Any) -> None:
-    """Fold billed attempts from failed retries into a successful result.
-
-    ``usage`` stays the final attempt (the freshness baseline);
-    ``usage_attempts`` becomes the ordered list of every billed attempt,
-    final included, and is written only when more than one attempt was
-    billed -- a single-attempt envelope never carries the key.
-    """
-    if not collected or not isinstance(result, dict):
-        return
-    final_attempts = result.get("usage_attempts")
-    if final_attempts is None:
-        final_usage = result.get("usage")
-        final_attempts = [final_usage] if final_usage is not None else []
-    merged = collected + list(final_attempts)
-    if len(merged) > 1:
-        result["usage_attempts"] = merged
 
 
 @runtime_checkable
@@ -89,7 +76,9 @@ class RetryWrapper(Retryable):
                     )
                     time.sleep(delay)
             else:
-                _merge_usage_attempts(collected_attempts, result)
+                from ..model.chat.exceptions import merge_usage_attempts_into_result
+
+                merge_usage_attempts_into_result(collected_attempts, result)
                 return result
 
         if last_exception:
@@ -97,7 +86,9 @@ class RetryWrapper(Retryable):
             # final exception's own attempts (gathered when it was caught),
             # so it is the full ordered attempt history.
             if collected_attempts:
-                last_exception.usage_attempts = collected_attempts
+                from ..model.chat.exceptions import attach_usage_attempts
+
+                attach_usage_attempts(last_exception, collected_attempts)
             raise last_exception
         raise RuntimeError("Retry failed with no exception")
 
@@ -121,12 +112,16 @@ class RetryWrapper(Retryable):
                     )
                     await asyncio.sleep(delay)
             else:
-                _merge_usage_attempts(collected_attempts, result)
+                from ..model.chat.exceptions import merge_usage_attempts_into_result
+
+                merge_usage_attempts_into_result(collected_attempts, result)
                 return result
 
         if last_exception:
             if collected_attempts:
-                last_exception.usage_attempts = collected_attempts
+                from ..model.chat.exceptions import attach_usage_attempts
+
+                attach_usage_attempts(last_exception, collected_attempts)
             raise last_exception
         raise RuntimeError("Retry failed with no exception")
 

--- a/src/xagent/core/retry/wrapper.py
+++ b/src/xagent/core/retry/wrapper.py
@@ -19,6 +19,36 @@ from .strategy import ExponentialBackoff, RetryStrategy
 logger = logging.getLogger(__name__)
 
 
+def _collect_usage_attempts(error: Exception, collected: list[Any]) -> None:
+    """Append billed usage attempts carried by a retryable error.
+
+    Adapters attach ``usage_attempts`` to errors they raise *after* booking
+    the attempt's tokens, so a retry must not silently drop them.
+    """
+    attempts = getattr(error, "usage_attempts", None)
+    if attempts:
+        collected.extend(attempts)
+
+
+def _merge_usage_attempts(collected: list[Any], result: Any) -> None:
+    """Fold billed attempts from failed retries into a successful result.
+
+    ``usage`` stays the final attempt (the freshness baseline);
+    ``usage_attempts`` becomes the ordered list of every billed attempt,
+    final included, and is written only when more than one attempt was
+    billed -- a single-attempt envelope never carries the key.
+    """
+    if not collected or not isinstance(result, dict):
+        return
+    final_attempts = result.get("usage_attempts")
+    if final_attempts is None:
+        final_usage = result.get("usage")
+        final_attempts = [final_usage] if final_usage is not None else []
+    merged = collected + list(final_attempts)
+    if len(merged) > 1:
+        result["usage_attempts"] = merged
+
+
 @runtime_checkable
 class Retryable(Protocol):
     def invoke(self, *args: Any, **kwargs: Any) -> Any: ...
@@ -41,14 +71,16 @@ class RetryWrapper(Retryable):
 
     def invoke(self, *args: Any, **kwargs: Any) -> Any:
         last_exception: Optional[Exception] = None
+        collected_attempts: list[Any] = []
 
         for attempt in range(self.max_retries):
             try:
-                return self.target.invoke(*args, **kwargs)
+                result = self.target.invoke(*args, **kwargs)
             except Exception as e:
                 if not self.retry_on(e):
                     raise
 
+                _collect_usage_attempts(e, collected_attempts)
                 last_exception = e
                 if attempt < self.max_retries - 1:
                     delay = self.strategy.get_delay(attempt) / 1000.0
@@ -56,21 +88,31 @@ class RetryWrapper(Retryable):
                         f"Attempt {attempt + 1} failed: {e}. Retrying in {delay:.2f}s..."
                     )
                     time.sleep(delay)
+            else:
+                _merge_usage_attempts(collected_attempts, result)
+                return result
 
         if last_exception:
+            # Every attempt failed: the collected list already includes the
+            # final exception's own attempts (gathered when it was caught),
+            # so it is the full ordered attempt history.
+            if collected_attempts:
+                last_exception.usage_attempts = collected_attempts
             raise last_exception
         raise RuntimeError("Retry failed with no exception")
 
     async def ainvoke(self, *args: Any, **kwargs: Any) -> Any:
         last_exception: Optional[Exception] = None
+        collected_attempts: list[Any] = []
 
         for attempt in range(self.max_retries):
             try:
-                return await self.target.ainvoke(*args, **kwargs)
+                result = await self.target.ainvoke(*args, **kwargs)
             except Exception as e:
                 if not self.retry_on(e):
                     raise
 
+                _collect_usage_attempts(e, collected_attempts)
                 last_exception = e
                 if attempt < self.max_retries - 1:
                     delay = self.strategy.get_delay(attempt) / 1000.0
@@ -78,8 +120,13 @@ class RetryWrapper(Retryable):
                         f"Attempt {attempt + 1} failed: {e}. Retrying in {delay:.2f}s..."
                     )
                     await asyncio.sleep(delay)
+            else:
+                _merge_usage_attempts(collected_attempts, result)
+                return result
 
         if last_exception:
+            if collected_attempts:
+                last_exception.usage_attempts = collected_attempts
             raise last_exception
         raise RuntimeError("Retry failed with no exception")
 

--- a/src/xagent/core/retry/wrapper.py
+++ b/src/xagent/core/retry/wrapper.py
@@ -65,6 +65,17 @@ class RetryWrapper(Retryable):
                 result = self.target.invoke(*args, **kwargs)
             except Exception as e:
                 if not self.retry_on(e):
+                    # A terminal non-retryable error must still carry the
+                    # history collected from earlier billed attempts; its own
+                    # payload (if any) stays last.
+                    if collected_attempts:
+                        from ..model.chat.exceptions import attach_usage_attempts
+
+                        attach_usage_attempts(
+                            e,
+                            collected_attempts
+                            + list(getattr(e, "usage_attempts", None) or []),
+                        )
                     raise
 
                 _collect_usage_attempts(e, collected_attempts)
@@ -101,6 +112,17 @@ class RetryWrapper(Retryable):
                 result = await self.target.ainvoke(*args, **kwargs)
             except Exception as e:
                 if not self.retry_on(e):
+                    # A terminal non-retryable error must still carry the
+                    # history collected from earlier billed attempts; its own
+                    # payload (if any) stays last.
+                    if collected_attempts:
+                        from ..model.chat.exceptions import attach_usage_attempts
+
+                        attach_usage_attempts(
+                            e,
+                            collected_attempts
+                            + list(getattr(e, "usage_attempts", None) or []),
+                        )
                     raise
 
                 _collect_usage_attempts(e, collected_attempts)

--- a/src/xagent/core/tools/core/vision_tool.py
+++ b/src/xagent/core/tools/core/vision_tool.py
@@ -14,13 +14,14 @@ import shutil
 import subprocess
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, NamedTuple, Optional, Union
+from typing import Any, Dict, List, Optional, Union
 from urllib.parse import unquote_to_bytes, urlsplit
 
 import httpx
 from pydantic import BaseModel, Field
 
 from ...model.chat.basic.base import BaseLLM
+from ...model.chat.response_shape import classify_chat_response
 from ...utils.security import fetch_public_http_bytes
 from ...utils.svg import MAX_SVG_BYTES, rasterize_svg_bytes, validate_svg_bytes
 from .web_content import get_trusted_proxy_url
@@ -37,145 +38,21 @@ logger = logging.getLogger(__name__)
 _MAX_INLINE_VIDEO_BYTES = 64 * 1024 * 1024
 _MAX_INLINE_SVG_SOURCE_CHARS = 32_000
 
-_VISION_RAW_DISPLAY_TRUNCATION_LIMIT = 4000
 
+def _unusable_chat_response_error(kind: str) -> str:
+    """Failure message for a vision-model response with no usable text.
 
-def _truncate_vision_raw_display(
-    value: str, limit: int = _VISION_RAW_DISPLAY_TRUNCATION_LIMIT
-) -> str:
-    """Bound a diagnostic string so a provider payload cannot balloon a tool result.
-
-    ``limit`` is a prefix limit, not a total-length limit. An oversized value
-    keeps its first ``limit`` characters and then carries the marker
-    ``...<truncated N chars>``, so the returned string is
-    ``limit + 21 + len(str(N))`` characters long -- 4025 for a 9000-character
-    value at the default limit of 4000. A caller that needs a hard total
-    budget has to add that marker allowance itself.
-
-    Mirrors the truncation shape already used for chat error bodies
-    (``openai.py``'s ``_truncate_error_detail``) so vision diagnostics look
-    the same as the rest of the model layer's truncated output. This bounds
-    length only; it performs no key-level redaction of provider-internal
-    fields (e.g. ``system_fingerprint``) that may happen to fall within the
-    limit.
+    Deliberately carries no response payload: stringifying the response
+    would leak an internal envelope repr as if it were model output (#1714).
     """
-    if len(value) <= limit:
-        return value
-    return f"{value[:limit]}...<truncated {len(value) - limit} chars>"
-
-
-class _NormalizedVisionResponse(NamedTuple):
-    """One of four shapes a ``chat``/``vision_chat`` return value reduces to.
-
-    ``kind`` is one of ``"text"``, ``"empty"``, ``"tool_call"``, ``"unknown"``.
-    ``text`` is a ``str`` when ``kind`` is ``"text"`` or ``"empty"``, and
-    ``None`` for ``"tool_call"``/``"unknown"``. ``tool_calls`` is populated
-    only for ``"tool_call"`` and is otherwise an empty list. ``raw_display``
-    is a length-bounded string meant for logging and diagnostic fields: an
-    oversized value keeps a fixed-length prefix and carries a truncation
-    marker past it, so it is bounded rather than capped at an exact total.
-    It must never be surfaced as a user-visible answer.
-    """
-
-    kind: str
-    text: Optional[str]
-    tool_calls: List[Any]
-    raw_display: str
-
-
-def _normalize_vision_response(result: Any) -> _NormalizedVisionResponse:
-    """Reduce a ``vision_chat`` return value to a text/empty/tool_call/unknown shape.
-
-    ``vision_chat`` is typed ``str | dict[str, Any]``: OpenAI-family
-    providers wrap a reply in an envelope (``{"type": "text", "content":
-    ..., "raw": ...}`` or a tool-call envelope), while other providers
-    return a bare string. This function is a pure classifier: it does not
-    raise for the shapes providers actually return -- bare strings, ``None``,
-    and dicts of plain JSON data -- and it never decides whether a shape
-    counts as a failure; callers own that decision because only they know
-    what they need from the response. Diagnostic rendering for any other
-    input goes through ``str(result)``, so an object with a raising
-    ``__str__`` (or a raising ``__repr__`` on a value nested inside a dict)
-    propagates that exception to the caller's own exception handling.
-    An exception raised by ``vision_chat`` itself never reaches this
-    function; it is handled by the caller's own exception handling
-    before a return value exists to classify.
-    """
-    if isinstance(result, str):
-        if not result.strip():
-            return _NormalizedVisionResponse(
-                kind="empty",
-                text=result,
-                tool_calls=[],
-                raw_display=_truncate_vision_raw_display(result),
-            )
-        return _NormalizedVisionResponse(
-            kind="text",
-            text=result,
-            tool_calls=[],
-            raw_display=_truncate_vision_raw_display(result),
+    if kind == "tool_call":
+        return (
+            "Vision model returned a tool_call envelope instead of a text "
+            "answer; tool calls are not supported in this vision flow"
         )
-
-    if result is None:
-        return _NormalizedVisionResponse(
-            kind="unknown", text=None, tool_calls=[], raw_display="None"
-        )
-
-    if isinstance(result, dict):
-        response_type = result.get("type")
-
-        if response_type == "text":
-            content = result.get("content")
-            if isinstance(content, str):
-                if not content.strip():
-                    # xinference's text exit gates on bare truthiness, so
-                    # whitespace-only content is not rejected there; openai
-                    # rejects it via .strip().
-                    return _NormalizedVisionResponse(
-                        kind="empty",
-                        text=content,
-                        tool_calls=[],
-                        raw_display=_truncate_vision_raw_display(content),
-                    )
-                return _NormalizedVisionResponse(
-                    kind="text",
-                    text=content,
-                    tool_calls=[],
-                    raw_display=_truncate_vision_raw_display(content),
-                )
-            # A "text" envelope whose content is not a string carries no
-            # usable text payload, so it is classified as unknown rather
-            # than text.
-            return _NormalizedVisionResponse(
-                kind="unknown",
-                text=None,
-                tool_calls=[],
-                raw_display=_truncate_vision_raw_display(str(result)),
-            )
-
-        if response_type == "tool_call":
-            return _NormalizedVisionResponse(
-                kind="tool_call",
-                text=None,
-                tool_calls=result.get("tool_calls", []),
-                raw_display=_truncate_vision_raw_display(str(result)),
-            )
-
-        # Unrecognized envelope shape: unknown or missing "type" key.
-        return _NormalizedVisionResponse(
-            kind="unknown",
-            text=None,
-            tool_calls=[],
-            raw_display=_truncate_vision_raw_display(str(result)),
-        )
-
-    # Any other type (int, list, custom object, ...).
-    return _NormalizedVisionResponse(
-        kind="unknown",
-        text=None,
-        tool_calls=[],
-        raw_display=_truncate_vision_raw_display(str(result)),
-    )
+    if kind == "empty":
+        return "Vision model returned an empty answer"
+    return "Vision model returned an unrecognized response shape (no usable text)"
 
 
 class UnderstandMediaResult(BaseModel):
@@ -890,34 +767,18 @@ class VisionCore:
                 max_tokens=max_tokens,
             )
 
-            # Process the result
-            normalized = _normalize_vision_response(result)
-
-            if normalized.kind == "unknown":
-                logger.warning(
-                    "Media understanding received an unsupported response shape"
-                )
+            # Process the result. Shape classification is the shared
+            # structural source of truth (``classify_chat_response``);
+            # text-less shapes fail explicitly -- stringifying them would
+            # leak the envelope repr as if it were the model's answer.
+            shape = classify_chat_response(result)
+            if shape.kind != "text":
                 return UnderstandMediaResult(
                     success=False,
-                    error="Vision model returned an unsupported response shape",
                     warnings=warnings,
+                    error=_unusable_chat_response_error(shape.kind),
                 )
-
-            if normalized.kind == "empty":
-                logger.warning("Media understanding received an empty response")
-                return UnderstandMediaResult(
-                    success=False,
-                    error="Vision model returned an empty response",
-                    warnings=warnings,
-                )
-
-            if normalized.kind == "tool_call":
-                answer = (
-                    "Model triggered tool call instead of answering: "
-                    f"{normalized.tool_calls}"
-                )
-            else:
-                answer = normalized.text
+            answer = shape.text
 
             return UnderstandMediaResult(
                 success=True,
@@ -1117,56 +978,24 @@ class VisionCore:
             )
 
             # Parse the result
-            normalized = _normalize_vision_response(raw_result)
-
-            if normalized.kind == "tool_call":
-                logger.warning(
-                    "Object detection received a tool-call response instead of a"
-                    " detection payload"
-                )
-                return DetectObjectsResult(
-                    success=False,
-                    error=(
-                        "Vision model returned a tool call instead of a"
-                        " detection payload"
-                    ),
-                    parsing_method="tool_call_response",
-                    raw_response=normalized.raw_display,
-                    confidence_threshold=confidence_threshold,
-                    prompt_sent=prompt,
-                )
-
-            if normalized.kind == "unknown":
-                logger.warning(
-                    "Object detection received an unsupported response shape"
-                )
-                return DetectObjectsResult(
-                    success=False,
-                    error="Vision model returned an unsupported response shape",
-                    parsing_method="unknown_type",
-                    raw_response=normalized.raw_display,
-                    confidence_threshold=confidence_threshold,
-                    prompt_sent=prompt,
-                )
-
-            if normalized.kind == "empty":
-                logger.warning("Object detection received an empty response")
-                return DetectObjectsResult(
-                    success=False,
-                    error="Vision model returned an empty response",
-                    parsing_method="empty_response",
-                    raw_response=normalized.raw_display,
-                    confidence_threshold=confidence_threshold,
-                    prompt_sent=prompt,
-                )
-
-            # Every non-text kind has returned above, so normalized.kind is
-            # "text" here and normalized.text is a non-blank str.
-            assert normalized.text is not None
-            raw_response = normalized.text
             detections = []
             parsing_method = "unknown"
             parsing_error = None
+
+            # Unwrap via the shared structural classifier: without this the
+            # dict branches below stringified whole envelopes -- the model's
+            # JSON answer was lost to a repr, and a tool_call envelope became
+            # "success with zero detections" (#1714-class). Any non-text
+            # shape is an explicit tool-side failure instead.
+            shape = classify_chat_response(raw_result)
+            if shape.kind != "text":
+                return DetectObjectsResult(
+                    success=False,
+                    error=_unusable_chat_response_error(shape.kind),
+                    confidence_threshold=confidence_threshold,
+                    prompt_sent=prompt,
+                )
+            raw_response = shape.text or ""
 
             try:
                 detections = self._extract_detections_from_text(raw_response)
@@ -1235,7 +1064,7 @@ class VisionCore:
                 "confidence_threshold": confidence_threshold,
                 "prompt_sent": prompt,
                 "box_color": box_color if mark_objects else None,
-                "raw_response": normalized.raw_display,
+                "raw_response": raw_response,
                 "parsing_method": parsing_method,
             }
 

--- a/src/xagent/core/tools/core/vision_tool.py
+++ b/src/xagent/core/tools/core/vision_tool.py
@@ -14,14 +14,13 @@ import shutil
 import subprocess
 import uuid
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, NamedTuple, Optional, Union
 from urllib.parse import unquote_to_bytes, urlsplit
 
 import httpx
 from pydantic import BaseModel, Field
 
 from ...model.chat.basic.base import BaseLLM
-from ...model.chat.response_shape import classify_chat_response
 from ...utils.security import fetch_public_http_bytes
 from ...utils.svg import MAX_SVG_BYTES, rasterize_svg_bytes, validate_svg_bytes
 from .web_content import get_trusted_proxy_url
@@ -38,21 +37,145 @@ logger = logging.getLogger(__name__)
 _MAX_INLINE_VIDEO_BYTES = 64 * 1024 * 1024
 _MAX_INLINE_SVG_SOURCE_CHARS = 32_000
 
+_VISION_RAW_DISPLAY_TRUNCATION_LIMIT = 4000
 
-def _unusable_chat_response_error(kind: str) -> str:
-    """Failure message for a vision-model response with no usable text.
 
-    Deliberately carries no response payload: stringifying the response
-    would leak an internal envelope repr as if it were model output (#1714).
+def _truncate_vision_raw_display(
+    value: str, limit: int = _VISION_RAW_DISPLAY_TRUNCATION_LIMIT
+) -> str:
+    """Bound a diagnostic string so a provider payload cannot balloon a tool result.
+
+    ``limit`` is a prefix limit, not a total-length limit. An oversized value
+    keeps its first ``limit`` characters and then carries the marker
+    ``...<truncated N chars>``, so the returned string is
+    ``limit + 21 + len(str(N))`` characters long -- 4025 for a 9000-character
+    value at the default limit of 4000. A caller that needs a hard total
+    budget has to add that marker allowance itself.
+
+    Mirrors the truncation shape already used for chat error bodies
+    (``openai.py``'s ``_truncate_error_detail``) so vision diagnostics look
+    the same as the rest of the model layer's truncated output. This bounds
+    length only; it performs no key-level redaction of provider-internal
+    fields (e.g. ``system_fingerprint``) that may happen to fall within the
+    limit.
     """
-    if kind == "tool_call":
-        return (
-            "Vision model returned a tool_call envelope instead of a text "
-            "answer; tool calls are not supported in this vision flow"
+    if len(value) <= limit:
+        return value
+    return f"{value[:limit]}...<truncated {len(value) - limit} chars>"
+
+
+class _NormalizedVisionResponse(NamedTuple):
+    """One of four shapes a ``chat``/``vision_chat`` return value reduces to.
+
+    ``kind`` is one of ``"text"``, ``"empty"``, ``"tool_call"``, ``"unknown"``.
+    ``text`` is a ``str`` when ``kind`` is ``"text"`` or ``"empty"``, and
+    ``None`` for ``"tool_call"``/``"unknown"``. ``tool_calls`` is populated
+    only for ``"tool_call"`` and is otherwise an empty list. ``raw_display``
+    is a length-bounded string meant for logging and diagnostic fields: an
+    oversized value keeps a fixed-length prefix and carries a truncation
+    marker past it, so it is bounded rather than capped at an exact total.
+    It must never be surfaced as a user-visible answer.
+    """
+
+    kind: str
+    text: Optional[str]
+    tool_calls: List[Any]
+    raw_display: str
+
+
+def _normalize_vision_response(result: Any) -> _NormalizedVisionResponse:
+    """Reduce a ``vision_chat`` return value to a text/empty/tool_call/unknown shape.
+
+    ``vision_chat`` is typed ``str | dict[str, Any]``: OpenAI-family
+    providers wrap a reply in an envelope (``{"type": "text", "content":
+    ..., "raw": ...}`` or a tool-call envelope), while other providers
+    return a bare string. This function is a pure classifier: it does not
+    raise for the shapes providers actually return -- bare strings, ``None``,
+    and dicts of plain JSON data -- and it never decides whether a shape
+    counts as a failure; callers own that decision because only they know
+    what they need from the response. Diagnostic rendering for any other
+    input goes through ``str(result)``, so an object with a raising
+    ``__str__`` (or a raising ``__repr__`` on a value nested inside a dict)
+    propagates that exception to the caller's own exception handling.
+    An exception raised by ``vision_chat`` itself never reaches this
+    function; it is handled by the caller's own exception handling
+    before a return value exists to classify.
+    """
+    if isinstance(result, str):
+        if not result.strip():
+            return _NormalizedVisionResponse(
+                kind="empty",
+                text=result,
+                tool_calls=[],
+                raw_display=_truncate_vision_raw_display(result),
+            )
+        return _NormalizedVisionResponse(
+            kind="text",
+            text=result,
+            tool_calls=[],
+            raw_display=_truncate_vision_raw_display(result),
         )
-    if kind == "empty":
-        return "Vision model returned an empty answer"
-    return "Vision model returned an unrecognized response shape (no usable text)"
+
+    if result is None:
+        return _NormalizedVisionResponse(
+            kind="unknown", text=None, tool_calls=[], raw_display="None"
+        )
+
+    if isinstance(result, dict):
+        response_type = result.get("type")
+
+        if response_type == "text":
+            content = result.get("content")
+            if isinstance(content, str):
+                if not content.strip():
+                    # xinference's text exit gates on bare truthiness, so
+                    # whitespace-only content is not rejected there; openai
+                    # rejects it via .strip().
+                    return _NormalizedVisionResponse(
+                        kind="empty",
+                        text=content,
+                        tool_calls=[],
+                        raw_display=_truncate_vision_raw_display(content),
+                    )
+                return _NormalizedVisionResponse(
+                    kind="text",
+                    text=content,
+                    tool_calls=[],
+                    raw_display=_truncate_vision_raw_display(content),
+                )
+            # A "text" envelope whose content is not a string carries no
+            # usable text payload, so it is classified as unknown rather
+            # than text.
+            return _NormalizedVisionResponse(
+                kind="unknown",
+                text=None,
+                tool_calls=[],
+                raw_display=_truncate_vision_raw_display(str(result)),
+            )
+
+        if response_type == "tool_call":
+            return _NormalizedVisionResponse(
+                kind="tool_call",
+                text=None,
+                tool_calls=result.get("tool_calls", []),
+                raw_display=_truncate_vision_raw_display(str(result)),
+            )
+
+        # Unrecognized envelope shape: unknown or missing "type" key.
+        return _NormalizedVisionResponse(
+            kind="unknown",
+            text=None,
+            tool_calls=[],
+            raw_display=_truncate_vision_raw_display(str(result)),
+        )
+
+    # Any other type (int, list, custom object, ...).
+    return _NormalizedVisionResponse(
+        kind="unknown",
+        text=None,
+        tool_calls=[],
+        raw_display=_truncate_vision_raw_display(str(result)),
+    )
 
 
 class UnderstandMediaResult(BaseModel):
@@ -767,18 +890,41 @@ class VisionCore:
                 max_tokens=max_tokens,
             )
 
-            # Process the result. Shape classification is the shared
-            # structural source of truth (``classify_chat_response``);
-            # text-less shapes fail explicitly -- stringifying them would
-            # leak the envelope repr as if it were the model's answer.
-            shape = classify_chat_response(result)
-            if shape.kind != "text":
+            # Process the result
+            normalized = _normalize_vision_response(result)
+
+            if normalized.kind == "unknown":
+                logger.warning(
+                    "Media understanding received an unsupported response shape"
+                )
                 return UnderstandMediaResult(
                     success=False,
+                    error="Vision model returned an unsupported response shape",
                     warnings=warnings,
-                    error=_unusable_chat_response_error(shape.kind),
                 )
-            answer = shape.text
+
+            if normalized.kind == "empty":
+                logger.warning("Media understanding received an empty response")
+                return UnderstandMediaResult(
+                    success=False,
+                    error="Vision model returned an empty response",
+                    warnings=warnings,
+                )
+
+            if normalized.kind == "tool_call":
+                # A tool-call envelope is not an answer: report an explicit
+                # tool-side failure rather than a successful explanatory
+                # answer (PR #1787 review finding N5).
+                logger.warning(
+                    "Media understanding received a tool-call response instead of an answer"
+                )
+                return UnderstandMediaResult(
+                    success=False,
+                    error="Vision model returned a tool call instead of an answer",
+                    warnings=warnings,
+                )
+
+            answer = normalized.text
 
             return UnderstandMediaResult(
                 success=True,
@@ -978,24 +1124,56 @@ class VisionCore:
             )
 
             # Parse the result
-            detections = []
-            parsing_method = "unknown"
-            parsing_error = None
+            normalized = _normalize_vision_response(raw_result)
 
-            # Unwrap via the shared structural classifier: without this the
-            # dict branches below stringified whole envelopes -- the model's
-            # JSON answer was lost to a repr, and a tool_call envelope became
-            # "success with zero detections" (#1714-class). Any non-text
-            # shape is an explicit tool-side failure instead.
-            shape = classify_chat_response(raw_result)
-            if shape.kind != "text":
+            if normalized.kind == "tool_call":
+                logger.warning(
+                    "Object detection received a tool-call response instead of a"
+                    " detection payload"
+                )
                 return DetectObjectsResult(
                     success=False,
-                    error=_unusable_chat_response_error(shape.kind),
+                    error=(
+                        "Vision model returned a tool call instead of a"
+                        " detection payload"
+                    ),
+                    parsing_method="tool_call_response",
+                    raw_response=normalized.raw_display,
                     confidence_threshold=confidence_threshold,
                     prompt_sent=prompt,
                 )
-            raw_response = shape.text or ""
+
+            if normalized.kind == "unknown":
+                logger.warning(
+                    "Object detection received an unsupported response shape"
+                )
+                return DetectObjectsResult(
+                    success=False,
+                    error="Vision model returned an unsupported response shape",
+                    parsing_method="unknown_type",
+                    raw_response=normalized.raw_display,
+                    confidence_threshold=confidence_threshold,
+                    prompt_sent=prompt,
+                )
+
+            if normalized.kind == "empty":
+                logger.warning("Object detection received an empty response")
+                return DetectObjectsResult(
+                    success=False,
+                    error="Vision model returned an empty response",
+                    parsing_method="empty_response",
+                    raw_response=normalized.raw_display,
+                    confidence_threshold=confidence_threshold,
+                    prompt_sent=prompt,
+                )
+
+            # Every non-text kind has returned above, so normalized.kind is
+            # "text" here and normalized.text is a non-blank str.
+            assert normalized.text is not None
+            raw_response = normalized.text
+            detections = []
+            parsing_method = "unknown"
+            parsing_error = None
 
             try:
                 detections = self._extract_detections_from_text(raw_response)
@@ -1064,7 +1242,7 @@ class VisionCore:
                 "confidence_threshold": confidence_threshold,
                 "prompt_sent": prompt,
                 "box_color": box_color if mark_objects else None,
-                "raw_response": raw_response,
+                "raw_response": normalized.raw_display,
                 "parsing_method": parsing_method,
             }
 

--- a/src/xagent/core/tools/core/vision_tool.py
+++ b/src/xagent/core/tools/core/vision_tool.py
@@ -21,6 +21,7 @@ import httpx
 from pydantic import BaseModel, Field
 
 from ...model.chat.basic.base import BaseLLM
+from ...model.chat.response_shape import classify_chat_response
 from ...utils.security import fetch_public_http_bytes
 from ...utils.svg import MAX_SVG_BYTES, rasterize_svg_bytes, validate_svg_bytes
 from .web_content import get_trusted_proxy_url
@@ -86,95 +87,47 @@ class _NormalizedVisionResponse(NamedTuple):
 def _normalize_vision_response(result: Any) -> _NormalizedVisionResponse:
     """Reduce a ``vision_chat`` return value to a text/empty/tool_call/unknown shape.
 
-    ``vision_chat`` is typed ``str | dict[str, Any]``: OpenAI-family
-    providers wrap a reply in an envelope (``{"type": "text", "content":
-    ..., "raw": ...}`` or a tool-call envelope), while other providers
-    return a bare string. This function is a pure classifier: it does not
-    raise for the shapes providers actually return -- bare strings, ``None``,
-    and dicts of plain JSON data -- and it never decides whether a shape
-    counts as a failure; callers own that decision because only they know
-    what they need from the response. Diagnostic rendering for any other
-    input goes through ``str(result)``, so an object with a raising
-    ``__str__`` (or a raising ``__repr__`` on a value nested inside a dict)
-    propagates that exception to the caller's own exception handling.
-    An exception raised by ``vision_chat`` itself never reaches this
-    function; it is handled by the caller's own exception handling
-    before a return value exists to classify.
+    Structural kind/text decoding delegates to ``classify_chat_response`` --
+    the shared model/chat-layer classifier -- so every consumer reads the
+    same response union the same way (including content-only or
+    unknown-tag dicts that carry usable string content). This wrapper keeps
+    only VisionCore-specific policy: the ``tool_calls`` payload extraction
+    and the length-bounded ``raw_display`` diagnostic, which must never be
+    surfaced as a user-visible answer. ``str(result)`` is only rendered for
+    non-text shapes, so an object with a raising ``__str__`` (or a raising
+    ``__repr__`` nested inside a dict) propagates that exception to the
+    caller's own exception handling, as before. An exception raised by
+    ``vision_chat`` itself never reaches this function.
     """
-    if isinstance(result, str):
-        if not result.strip():
-            return _NormalizedVisionResponse(
-                kind="empty",
-                text=result,
-                tool_calls=[],
-                raw_display=_truncate_vision_raw_display(result),
-            )
-        return _NormalizedVisionResponse(
-            kind="text",
-            text=result,
-            tool_calls=[],
-            raw_display=_truncate_vision_raw_display(result),
-        )
+    shape = classify_chat_response(result)
+    kind = shape.kind
 
-    if result is None:
-        return _NormalizedVisionResponse(
-            kind="unknown", text=None, tool_calls=[], raw_display="None"
-        )
-
-    if isinstance(result, dict):
-        response_type = result.get("type")
-
-        if response_type == "text":
+    text: Optional[str] = shape.text
+    if kind == "empty":
+        # The shared classifier normalizes empty text away; this contract
+        # carries the original string alongside the kind, so recover it.
+        if isinstance(result, str):
+            text = result
+        elif isinstance(result, dict):
             content = result.get("content")
-            if isinstance(content, str):
-                if not content.strip():
-                    # xinference's text exit gates on bare truthiness, so
-                    # whitespace-only content is not rejected there; openai
-                    # rejects it via .strip().
-                    return _NormalizedVisionResponse(
-                        kind="empty",
-                        text=content,
-                        tool_calls=[],
-                        raw_display=_truncate_vision_raw_display(content),
-                    )
-                return _NormalizedVisionResponse(
-                    kind="text",
-                    text=content,
-                    tool_calls=[],
-                    raw_display=_truncate_vision_raw_display(content),
-                )
-            # A "text" envelope whose content is not a string carries no
-            # usable text payload, so it is classified as unknown rather
-            # than text.
-            return _NormalizedVisionResponse(
-                kind="unknown",
-                text=None,
-                tool_calls=[],
-                raw_display=_truncate_vision_raw_display(str(result)),
-            )
+            text = content if isinstance(content, str) else None
 
-        if response_type == "tool_call":
-            return _NormalizedVisionResponse(
-                kind="tool_call",
-                text=None,
-                tool_calls=result.get("tool_calls", []),
-                raw_display=_truncate_vision_raw_display(str(result)),
-            )
+    tool_calls: List[Any] = []
+    if kind == "tool_call" and isinstance(result, dict):
+        raw_tool_calls = result.get("tool_calls")
+        if isinstance(raw_tool_calls, list):
+            tool_calls = raw_tool_calls
 
-        # Unrecognized envelope shape: unknown or missing "type" key.
-        return _NormalizedVisionResponse(
-            kind="unknown",
-            text=None,
-            tool_calls=[],
-            raw_display=_truncate_vision_raw_display(str(result)),
-        )
+    raw_display: str
+    if result is None:
+        raw_display = "None"
+    elif kind in ("text", "empty") and text is not None:
+        raw_display = _truncate_vision_raw_display(text)
+    else:
+        raw_display = _truncate_vision_raw_display(str(result))
 
-    # Any other type (int, list, custom object, ...).
     return _NormalizedVisionResponse(
-        kind="unknown",
-        text=None,
-        tool_calls=[],
-        raw_display=_truncate_vision_raw_display(str(result)),
+        kind=kind, text=text, tool_calls=tool_calls, raw_display=raw_display
     )
 
 

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -17,6 +17,7 @@ from ...core.agent.language import (
     response_language_rules,
 )
 from ...core.agent.service import AgentService
+from ...core.agent.utils.llm_utils import unwrap_chat_text
 from ...core.agent.voice_policy import _VOICE_INSTRUCTIONS as _core_voice_instructions
 from ...core.agent.voice_policy import apply_output_voice, voice_from_preferences
 from ...core.memory.in_memory import InMemoryMemoryStore
@@ -575,10 +576,10 @@ async def optimize_instructions(
             ]
         )
 
-        if isinstance(response, dict) and "content" in response:
-            content = str(response["content"])
-        else:
-            content = response if isinstance(response, str) else str(response)
+        # Raises LLMNoTextContentError on a tool_call envelope or any other
+        # text-less shape rather than repr()ing it into a 200 response
+        # (#1714); the outer except turns that into a clear 500.
+        content = unwrap_chat_text(response)
 
         mismatch = detect_prose_script_mismatch(request.instructions, content)
         if mismatch is not None:

--- a/tests/core/agent/test_compact_llm_usage_contract.py
+++ b/tests/core/agent/test_compact_llm_usage_contract.py
@@ -610,6 +610,68 @@ class TestResolveUsagePayload:
         assert self.runtime._extract_cached_tokens("plain string") == 0
 
 
+class TestStrictUsageIntCoercion:
+    """Usage counters are billing inputs, so coercion must be strict:
+    bools, NaN/inf, negatives, non-integral floats, and numeric strings are
+    rejected rather than silently truncated or crashed on, and an invalid
+    earlier alias must not shadow a valid later candidate."""
+
+    def setup_method(self) -> None:
+        self.runtime = PatternRuntime()
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            float("nan"),
+            float("inf"),
+            float("-inf"),
+            True,
+            False,
+            -5,
+            10.5,
+            "10",
+            None,
+        ],
+    )
+    def test_first_int_rejects_invalid_values(self, bad: Any) -> None:
+        assert self.runtime._first_int({"prompt_tokens": bad}, ("prompt_tokens",)) == 0
+
+    @pytest.mark.parametrize(
+        ("good", "expected"),
+        [(10, 10), (0, 0), (10.0, 10), (2**40, 2**40)],
+    )
+    def test_first_int_accepts_valid_values(self, good: Any, expected: int) -> None:
+        assert (
+            self.runtime._first_int({"prompt_tokens": good}, ("prompt_tokens",))
+            == expected
+        )
+
+    def test_invalid_first_alias_falls_through_to_valid_candidate(self) -> None:
+        usage = {
+            "prompt_tokens": float("nan"),
+            "input_tokens": 7,
+            "completion_tokens": 3,
+        }
+        response = {"type": "text", "content": "x", "usage": usage}
+        assert self.runtime._extract_token_usage(response) == (7, 3)
+
+    def test_extract_token_usage_rejects_bool_and_negative(self) -> None:
+        response = {
+            "type": "text",
+            "content": "x",
+            "usage": {"prompt_tokens": True, "completion_tokens": -5},
+        }
+        assert self.runtime._extract_token_usage(response) is None
+
+    def test_extract_cached_tokens_rejects_non_finite(self) -> None:
+        response = {
+            "type": "text",
+            "content": "x",
+            "usage": {"cached_input_tokens": float("inf")},
+        }
+        assert self.runtime._extract_cached_tokens(response) == 0
+
+
 class TestUsageStampCachedTokens:
     """The stamp must carry cache metrics so ``_extract_cached_tokens`` sees
     prompt-cache hits on non-streaming calls (review findings on PR #1787).
@@ -690,6 +752,13 @@ class TestUnwrapChatText:
         with pytest.raises(LLMNoTextContentError):
             unwrap_chat_text(42)
 
+    def test_empty_plain_string_raises_empty_content(self) -> None:
+        """An empty legacy plain string is the same transient "no content"
+        as an empty envelope -- ``classify_chat_response`` is the single
+        source for that distinction."""
+        with pytest.raises(LLMEmptyContentError):
+            unwrap_chat_text("")
+
 
 @pytest.mark.asyncio
 async def test_openai_compact_cached_tokens_flow_to_trace_event(mocker) -> None:
@@ -728,6 +797,203 @@ async def test_openai_compact_cached_tokens_flow_to_trace_event(mocker) -> None:
     assert context.get_total_token_usage()["total"] == (
         PROMPT_TOKENS + COMPLETION_TOKENS
     )
+
+
+class TestSyntheticUsageFreshnessBaseline:
+    """A synthetic (context-compaction) usage record must never become the
+    freshness baseline of ``_get_total_tokens``: when an LLM compaction
+    declines (e.g. the compact model returns a tool_call envelope) the
+    messages are unchanged, so the record's fingerprint still matches and a
+    small compact-prompt token count would otherwise be mistaken for the
+    live context size -- suppressing the truncation fallback and letting
+    oversized history flow to the main model."""
+
+    def test_synthetic_record_does_not_hijack_freshness_baseline(self) -> None:
+        context = ExecutionContext()
+        context.compact_config.threshold = 100
+        context.add_user_message("u" * 2000)  # ~500 est tokens, over threshold
+        context.record_llm_usage(
+            input_tokens=10,
+            output_tokens=5,
+            synthetic_purpose="context_compaction",
+        )
+        # The fingerprint matches (messages unchanged) and 10 < threshold,
+        # but the record is synthetic: fall back to the char estimate.
+        assert context.estimate_context_tokens() > 100
+
+    def test_real_record_still_serves_as_freshness_baseline(self) -> None:
+        context = ExecutionContext()
+        context.add_user_message("u" * 2000)
+        context.record_llm_usage(input_tokens=42, output_tokens=5)
+        assert context.estimate_context_tokens() == 42
+
+    def test_synthetic_record_after_real_record_keeps_real_baseline(self) -> None:
+        context = ExecutionContext()
+        context.add_user_message("u" * 2000)
+        context.record_llm_usage(input_tokens=42, output_tokens=5)
+        context.record_llm_usage(
+            input_tokens=10,
+            output_tokens=5,
+            synthetic_purpose="context_compaction",
+        )
+        assert context.estimate_context_tokens() == 42
+
+    def test_synthetic_purpose_survives_checkpoint_roundtrip(self) -> None:
+        context = ExecutionContext()
+        context.add_user_message("hi")
+        context.record_llm_usage(
+            input_tokens=10,
+            output_tokens=5,
+            synthetic_purpose="context_compaction",
+        )
+        context.record_llm_usage(input_tokens=7, output_tokens=3)
+
+        restored = ExecutionContext.from_dict(context.to_dict())
+
+        assert [call.synthetic_purpose for call in restored.llm_calls] == [
+            "context_compaction",
+            None,
+        ]
+
+    def test_old_checkpoint_without_synthetic_purpose_defaults_none(self) -> None:
+        context = ExecutionContext()
+        context.add_user_message("hi")
+        context.record_llm_usage(input_tokens=10, output_tokens=5)
+        data = context.to_dict()
+        for call in data["llm_calls"]:
+            call.pop("synthetic_purpose", None)
+
+        restored = ExecutionContext.from_dict(data)
+
+        assert [call.synthetic_purpose for call in restored.llm_calls] == [None]
+
+    @pytest.mark.asyncio
+    async def test_failed_llm_compaction_still_truncates_oversized_history(
+        self,
+    ) -> None:
+        """Reviewer scenario: oversized history (chars/4 > threshold) and a
+        compact model returning a *stamped* tool_call envelope whose
+        prompt_tokens < threshold. LLM compaction declines, and the
+        truncation fallback must really truncate; the compact usage is
+        recorded exactly once and must not feed the freshness estimate."""
+        tracer = TraceEventRecorder()
+        context = ExecutionContext(execution_id="compact-freshness-contract")
+        context.compact_config.threshold = 100
+        context.compact_config.max_messages = 1
+        context.add_user_message("current request")
+        context.add_assistant_message(
+            "",
+            tool_calls=[
+                {"id": "call-1", "type": "function", "function": {"name": "read_file"}}
+            ],
+        )
+        context.add_tool_result(
+            "read_file", {"output": "x" * 2000}, tool_call_id="call-1"
+        )
+        assert context.estimate_context_tokens() > 100
+
+        compact_llm = FakeLLM(
+            [
+                {
+                    "type": "tool_call",
+                    "tool_calls": [
+                        {
+                            "id": "call_9",
+                            "type": "function",
+                            "function": {"name": "read_file", "arguments": "{}"},
+                        }
+                    ],
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+                }
+            ]
+        )
+
+        result = await ReActPattern(max_iterations=1).run(
+            context=context,
+            tools=[],
+            llm=FakeLLM([{"content": "done"}]),
+            compact_llm=compact_llm,
+            runtime=PatternRuntime(tracer=tracer),
+        )
+
+        assert result["success"] is True
+        # Truncation really happened: the declined LLM compaction left the
+        # messages untouched, so only the fallback's compact event proves the
+        # small compact-prompt count did not hijack the estimate. (Message
+        # counts alone cannot show it: the pattern appends afterwards.)
+        compact_end = next(
+            (
+                event
+                for event in tracer.events
+                if event["event_type"] == "action_end_compact"
+            ),
+            None,
+        )
+        assert compact_end is not None, "truncation fallback did not fire"
+        assert compact_end["data"]["strategy"] == "truncate"
+        assert compact_end["data"]["removed_count"] >= 1
+        # The compact call is billed exactly once, marked synthetic.
+        assert context.get_total_token_usage() == {
+            "total": 15,
+            "input": 10,
+            "output": 5,
+            "call_count": 1,
+        }
+        assert context.llm_calls[-1].synthetic_purpose == "context_compaction"
+
+    @pytest.mark.asyncio
+    async def test_failed_llm_compaction_empty_envelope_still_truncates(self) -> None:
+        """Empty-text-envelope variant of the freshness scenario: the empty
+        summary declines the LLM compaction and the fallback must truncate
+        regardless of the small stamped usage."""
+        tracer = TraceEventRecorder()
+        context = ExecutionContext(execution_id="compact-freshness-empty")
+        context.compact_config.threshold = 100
+        context.compact_config.max_messages = 1
+        context.add_user_message("current request")
+        context.add_assistant_message(
+            "",
+            tool_calls=[
+                {"id": "call-1", "type": "function", "function": {"name": "read_file"}}
+            ],
+        )
+        context.add_tool_result(
+            "read_file", {"output": "x" * 2000}, tool_call_id="call-1"
+        )
+        assert context.estimate_context_tokens() > 100
+
+        compact_llm = FakeLLM(
+            [
+                {
+                    "type": "text",
+                    "content": "",
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+                }
+            ]
+        )
+
+        result = await ReActPattern(max_iterations=1).run(
+            context=context,
+            tools=[],
+            llm=FakeLLM([{"content": "done"}]),
+            compact_llm=compact_llm,
+            runtime=PatternRuntime(tracer=tracer),
+        )
+
+        assert result["success"] is True
+        compact_end = next(
+            (
+                event
+                for event in tracer.events
+                if event["event_type"] == "action_end_compact"
+            ),
+            None,
+        )
+        assert compact_end is not None, "truncation fallback did not fire"
+        assert compact_end["data"]["strategy"] == "truncate"
+        assert compact_end["data"]["removed_count"] >= 1
+        assert context.get_total_token_usage()["call_count"] == 1
+        assert context.llm_calls[-1].synthetic_purpose == "context_compaction"
 
 
 class TestVisionChatUsageStamp:

--- a/tests/core/agent/test_compact_llm_usage_contract.py
+++ b/tests/core/agent/test_compact_llm_usage_contract.py
@@ -29,10 +29,15 @@ from openai.types.completion_usage import CompletionUsage
 
 from xagent.core.agent import ExecutionContext, PatternRuntime, ReActPattern
 from xagent.core.agent.utils.context_builder import ContextBuilder, StepExecutionResult
+from xagent.core.agent.utils.llm_utils import unwrap_chat_text
 from xagent.core.model.chat.basic.deepseek import DeepSeekLLM
 from xagent.core.model.chat.basic.gemini import GeminiLLM
 from xagent.core.model.chat.basic.openai import OpenAILLM
 from xagent.core.model.chat.basic.zhipu import ZhipuLLM
+from xagent.core.model.chat.exceptions import (
+    LLMEmptyContentError,
+    LLMNoTextContentError,
+)
 from xagent.core.model.chat.token_context import get_token_usage, reset_token_usage
 
 PROMPT_TOKENS = 10
@@ -553,3 +558,84 @@ class TestResolveUsagePayload:
         }
         assert self.runtime._extract_cached_tokens(response) == 6
         assert self.runtime._extract_cached_tokens("plain string") == 0
+
+
+class TestUsageStampCachedTokens:
+    """The stamp must carry cache metrics so ``_extract_cached_tokens`` sees
+    prompt-cache hits on non-streaming calls (review findings on PR #1787).
+    Cached keys are stamped only when non-zero, so a default 0 never shadows
+    fallback fields downstream."""
+
+    @pytest.mark.asyncio
+    async def test_zhipu_chat_stamp_includes_cached_tokens(self) -> None:
+        reset_token_usage()
+        llm = ZhipuLLM(model_name="glm-4.5", api_key="test-key")
+        response = _zhipu_response("cached reply")
+        response.usage.prompt_tokens_details = SimpleNamespace(cached_tokens=4)
+        llm._client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **kwargs: response)
+            )
+        )
+
+        result = await llm.chat(messages=[{"role": "user", "content": "hi"}])
+
+        assert result["usage"]["cached_input_tokens"] == 4
+
+    @pytest.mark.asyncio
+    async def test_zhipu_chat_stamp_omits_zero_cached_tokens(self) -> None:
+        reset_token_usage()
+        llm = ZhipuLLM(model_name="glm-4.5", api_key="test-key")
+        llm._client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(
+                    create=lambda **kwargs: _zhipu_response("plain reply")
+                )
+            )
+        )
+
+        result = await llm.chat(messages=[{"role": "user", "content": "hi"}])
+
+        assert "cached_input_tokens" not in result["usage"]
+
+    @pytest.mark.asyncio
+    async def test_gemini_chat_stamp_includes_cached_tokens(self) -> None:
+        reset_token_usage()
+        llm = GeminiLLM(model_name="gemini-2.5-flash", api_key="test-key")
+        response = _gemini_response("cached reply")
+        response.usage_metadata.cached_content_token_count = 4
+        llm._client = SimpleNamespace(
+            aio=SimpleNamespace(
+                models=SimpleNamespace(
+                    generate_content=AsyncMock(return_value=response)
+                )
+            )
+        )
+
+        result = await llm.chat(messages=[{"role": "user", "content": "hi"}])
+
+        assert result["usage"]["cached_input_tokens"] == 4
+
+
+class TestUnwrapChatText:
+    """``unwrap_chat_text`` distinguishes "no text shape" from "empty text"
+    so retry/fallback semantics stay aligned with the adapters' own classes."""
+
+    def test_plain_string_passthrough(self) -> None:
+        assert unwrap_chat_text("hello") == "hello"
+
+    def test_envelope_content(self) -> None:
+        assert unwrap_chat_text({"type": "text", "content": "hi"}) == "hi"
+
+    @pytest.mark.parametrize("content", ["", "   \n\t"])
+    def test_empty_envelope_content_raises_empty_content(self, content: str) -> None:
+        with pytest.raises(LLMEmptyContentError):
+            unwrap_chat_text({"type": "text", "content": content})
+
+    def test_tool_call_envelope_raises_no_text_content(self) -> None:
+        with pytest.raises(LLMNoTextContentError):
+            unwrap_chat_text({"type": "tool_call", "tool_calls": []})
+
+    def test_unrecognized_shape_raises_no_text_content(self) -> None:
+        with pytest.raises(LLMNoTextContentError):
+            unwrap_chat_text(42)

--- a/tests/core/agent/test_compact_llm_usage_contract.py
+++ b/tests/core/agent/test_compact_llm_usage_contract.py
@@ -1249,3 +1249,54 @@ async def test_compact_dependency_falls_back_when_compact_llm_returns_empty_cont
     assert "'content': ''" not in rendered
     # The explicit truncation fallback keeps real history rather than a repr.
     assert any("a" * 100 in m["content"] for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_zhipu_tool_call_envelope_uses_model_dump_raw() -> None:
+    """D8: the real zai-sdk response is a pydantic model, so the production
+    ``raw`` always goes through ``response.model_dump()`` -- the stand-in
+    must exercise that branch, not the ``str(response)`` fallback."""
+
+    class _ZaiLikeResponse(SimpleNamespace):
+        def model_dump(self) -> dict[str, Any]:
+            return {"id": "zai-1", "object": "chat.completion"}
+
+    tool_call = SimpleNamespace(
+        id="call_1",
+        type="function",
+        function=SimpleNamespace(name="calculator", arguments='{"expression": "2+2"}'),
+    )
+    response = _ZaiLikeResponse(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=None, tool_calls=[tool_call]),
+                finish_reason="tool_calls",
+            )
+        ],
+        usage=SimpleNamespace(prompt_tokens=PROMPT_TOKENS, completion_tokens=5),
+    )
+    reset_token_usage()
+    llm = ZhipuLLM(model_name="glm-4.5", api_key="test-key")
+    llm._client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(create=lambda **kwargs: response)
+        )
+    )
+
+    result = await llm.chat(
+        [{"role": "user", "content": "2+2?"}],
+        tools=[
+            {
+                "type": "function",
+                "function": {
+                    "name": "calculator",
+                    "description": "calc",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            }
+        ],
+    )
+
+    assert result["type"] == "tool_call"
+    assert result["raw"] == {"id": "zai-1", "object": "chat.completion"}
+    assert result["usage"]["prompt_tokens"] == PROMPT_TOKENS

--- a/tests/core/agent/test_compact_llm_usage_contract.py
+++ b/tests/core/agent/test_compact_llm_usage_contract.py
@@ -1,0 +1,555 @@
+"""Contract tests for compact-path token usage accounting (#520) and
+text-extraction of chat envelopes (#1714).
+
+Mock-boundary philosophy: the adapter under test runs its real code end to
+end; only the provider SDK's transport object is replaced (``AsyncOpenAI``
+for the OpenAI family, a duck-typed attribute stub for Zhipu/Gemini whose
+adapters read attributes rather than construct SDK types). Everything from
+the SDK response object inward -- envelope construction, the top-level
+``usage`` stamp, the runtime extractor, the context ledger and the
+contextvar ledger -- is production code, so a regression anywhere in that
+chain fails these tests. This mirrors test_vector_index_contract.py: the
+rest of the adapter suites mock the adapter's own return value, which is
+exactly why usage buried in ``raw.usage`` (#520) and repr()ed tool_call
+envelopes (#1714) survived unnoticed.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_message import ChatCompletionMessage
+from openai.types.completion_usage import CompletionUsage
+
+from xagent.core.agent import ExecutionContext, PatternRuntime, ReActPattern
+from xagent.core.agent.utils.context_builder import ContextBuilder, StepExecutionResult
+from xagent.core.model.chat.basic.deepseek import DeepSeekLLM
+from xagent.core.model.chat.basic.gemini import GeminiLLM
+from xagent.core.model.chat.basic.openai import OpenAILLM
+from xagent.core.model.chat.basic.zhipu import ZhipuLLM
+from xagent.core.model.chat.token_context import get_token_usage, reset_token_usage
+
+PROMPT_TOKENS = 10
+COMPLETION_TOKENS = 5
+COMPACT_SUMMARY = "summarized tool result"
+
+
+class FakeLLM:
+    """Queue-based fake for the main-pattern LLM (no usage accounting)."""
+
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = responses
+        self.calls: list[dict[str, Any]] = []
+
+    model_name = "fake-model"
+
+    async def chat(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        return self.responses.pop(0)
+
+
+class TraceEventRecorder:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    async def trace_event(
+        self,
+        event_type: Any,
+        *,
+        task_id: str | None = None,
+        step_id: str | None = None,
+        data: dict[str, Any] | None = None,
+        **_: Any,
+    ) -> str:
+        self.events.append(
+            {
+                "event_type": getattr(event_type, "value", str(event_type)),
+                "task_id": task_id,
+                "step_id": step_id,
+                "data": data or {},
+            }
+        )
+        return str(len(self.events))
+
+
+def _snapshot_ledger() -> tuple[int, int, int]:
+    """Value snapshot of the contextvar ledger (the object itself is live)."""
+    ledger = get_token_usage()
+    return ledger.llm_calls, ledger.input_tokens, ledger.output_tokens
+
+
+def _openai_completion(content: str) -> ChatCompletion:
+    """A real SDK response carrying real ``CompletionUsage``."""
+    return ChatCompletion(
+        id="compact-contract-completion",
+        choices=[
+            Choice(
+                finish_reason="stop",
+                index=0,
+                message=ChatCompletionMessage(
+                    content=content,
+                    role="assistant",
+                    tool_calls=None,
+                ),
+            )
+        ],
+        created=1234567890,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        usage=CompletionUsage(
+            prompt_tokens=PROMPT_TOKENS,
+            completion_tokens=COMPLETION_TOKENS,
+            total_tokens=PROMPT_TOKENS + COMPLETION_TOKENS,
+        ),
+    )
+
+
+def _zhipu_response(content: str) -> SimpleNamespace:
+    """Duck-typed stand-in for the zai-sdk response: the adapter only reads
+    attributes (``choices[0].message.content``, ``usage.prompt_tokens`` ...),
+    so a namespace at the transport boundary exercises the real adapter code."""
+    return SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(content=content, tool_calls=None),
+                finish_reason="stop",
+            )
+        ],
+        usage=SimpleNamespace(
+            prompt_tokens=PROMPT_TOKENS,
+            completion_tokens=COMPLETION_TOKENS,
+        ),
+    )
+
+
+def _gemini_response(content: str) -> SimpleNamespace:
+    """Duck-typed stand-in for the google-genai response, same reasoning as
+    the Zhipu stub: attribute reads only (``usage_metadata``,
+    ``candidates[0].content.parts[*].text``)."""
+    return SimpleNamespace(
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=PROMPT_TOKENS,
+            candidates_token_count=COMPLETION_TOKENS,
+            cached_content_token_count=0,
+        ),
+        candidates=[
+            SimpleNamespace(
+                content=SimpleNamespace(
+                    parts=[SimpleNamespace(text=content, function_call=None)]
+                )
+            )
+        ],
+    )
+
+
+def _react_compact_scenario() -> tuple[TraceEventRecorder, ExecutionContext]:
+    """threshold=1 context that forces one LLM compaction on the first turn."""
+    tracer = TraceEventRecorder()
+    context = ExecutionContext(execution_id="compact-usage-contract")
+    context.compact_config.threshold = 1
+    context.add_user_message("current request")
+    context.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "type": "function", "function": {"name": "read_file"}}
+        ],
+    )
+    context.add_tool_result("read_file", {"output": "x" * 200}, tool_call_id="call-1")
+    return tracer, context
+
+
+async def _run_compact_with(compact_llm: Any) -> tuple[TraceEventRecorder, Any]:
+    tracer, context = _react_compact_scenario()
+    runtime = PatternRuntime(tracer=tracer)
+    result = await ReActPattern(max_iterations=1).run(
+        context=context,
+        tools=[],
+        llm=FakeLLM([{"content": "done"}]),
+        compact_llm=compact_llm,
+        runtime=runtime,
+    )
+    assert result["success"] is True
+    return tracer, context
+
+
+def _assert_compact_usage_accounted(
+    tracer: TraceEventRecorder, context: Any, ledger_before: tuple[int, int, int]
+) -> None:
+    """One compact call must surface exactly once in every accounting view."""
+    compact_llm_events = [
+        event
+        for event in tracer.events
+        if event["event_type"] in {"action_start_llm", "action_end_llm"}
+        and event["data"].get("purpose") == "context_compaction"
+    ]
+    assert [event["event_type"] for event in compact_llm_events] == [
+        "action_start_llm",
+        "action_end_llm",
+    ]
+    end_data = compact_llm_events[1]["data"]
+    assert end_data["input_tokens"] == PROMPT_TOKENS
+    assert end_data["output_tokens"] == COMPLETION_TOKENS
+
+    # The execution-context ledger sees exactly one call with exact numbers.
+    assert context.get_total_token_usage() == {
+        "total": PROMPT_TOKENS + COMPLETION_TOKENS,
+        "input": PROMPT_TOKENS,
+        "output": COMPLETION_TOKENS,
+        "call_count": 1,
+    }
+
+    # The contextvar ledger also records exactly one call -- the adapter's own
+    # ``add_token_usage`` write; the stamp/extractor path must not double it.
+    calls_before, input_before, output_before = ledger_before
+    ledger = get_token_usage()
+    assert ledger.llm_calls - calls_before == 1
+    assert ledger.input_tokens - input_before == PROMPT_TOKENS
+    assert ledger.output_tokens - output_before == COMPLETION_TOKENS
+
+
+@pytest.mark.asyncio
+async def test_openai_chat_stamps_top_level_usage(mocker) -> None:
+    """The adapter envelope itself carries the stamp, not just the trace:
+    this is what lets consumers read usage without opening ``raw``."""
+    reset_token_usage()
+    llm = OpenAILLM(model_name="gpt-4o-mini", api_key="test-key")
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = _openai_completion(
+        COMPACT_SUMMARY
+    )
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+
+    response = await llm.chat([{"role": "user", "content": "hi"}])
+
+    assert response["type"] == "text"
+    assert response["usage"]["prompt_tokens"] == PROMPT_TOKENS
+    assert response["usage"]["completion_tokens"] == COMPLETION_TOKENS
+    assert response["usage"]["total_tokens"] == PROMPT_TOKENS + COMPLETION_TOKENS
+
+
+@pytest.mark.asyncio
+async def test_openai_tool_call_envelope_stamps_top_level_usage(mocker) -> None:
+    reset_token_usage()
+    llm = OpenAILLM(model_name="gpt-4o-mini", api_key="test-key")
+    mock_client = mocker.AsyncMock()
+    completion = ChatCompletion(
+        id="compact-contract-tool-call",
+        choices=[
+            Choice(
+                finish_reason="tool_calls",
+                index=0,
+                message=ChatCompletionMessage(
+                    content=None,
+                    role="assistant",
+                    tool_calls=[
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {
+                                "name": "read_file",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
+                ),
+            )
+        ],
+        created=1234567890,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        usage=CompletionUsage(
+            prompt_tokens=PROMPT_TOKENS,
+            completion_tokens=COMPLETION_TOKENS,
+            total_tokens=PROMPT_TOKENS + COMPLETION_TOKENS,
+        ),
+    )
+    mock_client.chat.completions.create.return_value = completion
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+
+    response = await llm.chat([{"role": "user", "content": "hi"}])
+
+    assert response["type"] == "tool_call"
+    assert response["usage"]["prompt_tokens"] == PROMPT_TOKENS
+    assert response["usage"]["completion_tokens"] == COMPLETION_TOKENS
+
+
+@pytest.mark.asyncio
+async def test_openai_compact_usage_flows_to_trace_and_context(mocker) -> None:
+    reset_token_usage()
+    ledger_before = _snapshot_ledger()
+    llm = OpenAILLM(model_name="gpt-4o-mini", api_key="test-key")
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = _openai_completion(
+        COMPACT_SUMMARY
+    )
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+
+    tracer, context = await _run_compact_with(llm)
+
+    assert any(
+        COMPACT_SUMMARY in (message.content or "") for message in context.messages
+    )
+    _assert_compact_usage_accounted(tracer, context, ledger_before)
+
+
+@pytest.mark.asyncio
+async def test_deepseek_compact_usage_flows_to_trace_and_context(mocker) -> None:
+    reset_token_usage()
+    ledger_before = _snapshot_ledger()
+    llm = DeepSeekLLM(model_name="deepseek-v4-flash", api_key="test-key")
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = _openai_completion(
+        COMPACT_SUMMARY
+    )
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+
+    tracer, context = await _run_compact_with(llm)
+
+    assert any(
+        COMPACT_SUMMARY in (message.content or "") for message in context.messages
+    )
+    _assert_compact_usage_accounted(tracer, context, ledger_before)
+
+
+@pytest.mark.asyncio
+async def test_zhipu_compact_usage_flows_to_trace_and_context() -> None:
+    reset_token_usage()
+    ledger_before = _snapshot_ledger()
+    llm = ZhipuLLM(model_name="glm-4.5", api_key="test-key")
+    llm._client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=lambda **kwargs: _zhipu_response(COMPACT_SUMMARY)
+            )
+        )
+    )
+
+    tracer, context = await _run_compact_with(llm)
+
+    assert any(
+        COMPACT_SUMMARY in (message.content or "") for message in context.messages
+    )
+    _assert_compact_usage_accounted(tracer, context, ledger_before)
+
+
+@pytest.mark.asyncio
+async def test_gemini_compact_usage_flows_to_trace_and_context() -> None:
+    reset_token_usage()
+    ledger_before = _snapshot_ledger()
+    llm = GeminiLLM(model_name="gemini-2.5-flash", api_key="test-key")
+    llm._client = SimpleNamespace(
+        aio=SimpleNamespace(
+            models=SimpleNamespace(
+                generate_content=AsyncMock(
+                    return_value=_gemini_response(COMPACT_SUMMARY)
+                )
+            )
+        )
+    )
+
+    tracer, context = await _run_compact_with(llm)
+
+    assert any(
+        COMPACT_SUMMARY in (message.content or "") for message in context.messages
+    )
+    _assert_compact_usage_accounted(tracer, context, ledger_before)
+
+
+@pytest.mark.asyncio
+async def test_compact_dependency_falls_back_when_compact_llm_returns_tool_call_envelope() -> (
+    None
+):
+    """#1714: a tool_call envelope from the compact model must never be
+    repr()ed into the rebuilt context; compaction fails explicitly and the
+    existing truncation/error fallbacks engage instead."""
+    tool_call_envelope = {
+        "type": "tool_call",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }
+        ],
+    }
+    compact_llm = FakeLLM([tool_call_envelope, tool_call_envelope])
+    builder = ContextBuilder(
+        llm=FakeLLM([]), compact_threshold=1, compact_llm=compact_llm
+    )
+    dep_result = StepExecutionResult(
+        step_id="dep-1",
+        messages=[
+            {"role": "user", "content": "u" * 100},
+            {"role": "assistant", "content": "a" * 100},
+        ],
+        final_result={},
+        agent_name="dep-agent",
+    )
+
+    messages = await builder.build_context_for_step(
+        step_name="target",
+        step_description="do something with the dependency output",
+        dependencies=["dep-1"],
+        dependency_results={"dep-1": dep_result},
+    )
+
+    # Both the individual and the whole-context compaction consulted the
+    # compact model and both had to fall back.
+    assert len(compact_llm.calls) == 2
+    rendered = json.dumps(messages, ensure_ascii=False)
+    assert "tool_calls" not in rendered
+    # The explicit truncation fallback keeps real history rather than a repr.
+    assert any("a" * 100 in m["content"] for m in messages)
+
+
+@pytest.mark.asyncio
+async def test_execution_context_compact_tolerates_tool_call_envelope() -> None:
+    """#1714 on the runtime path: a text-less envelope yields an empty summary,
+    so the LLM-summary strategy declines and truncation takes over."""
+    tracer, context = _react_compact_scenario()
+    runtime = PatternRuntime(tracer=tracer)
+    compact_llm = FakeLLM(
+        [
+            {
+                "type": "tool_call",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            }
+        ]
+    )
+
+    result = await ReActPattern(max_iterations=1).run(
+        context=context,
+        tools=[],
+        llm=FakeLLM([{"content": "done"}]),
+        compact_llm=compact_llm,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    rendered = json.dumps(
+        [m.content for m in context.messages], ensure_ascii=False, default=str
+    )
+    assert "'tool_calls'" not in rendered
+    assert '"tool_calls"' not in rendered
+
+
+def test_deepseek_violation_rebuild_preserves_usage_stamp() -> None:
+    """normalize_deepseek_response rebuilds the envelope on a protocol
+    violation; the adapter's top-level usage stamp must survive the rebuild."""
+    from xagent.core.model.chat.basic.deepseek_tool_protocol import (
+        normalize_deepseek_response,
+    )
+
+    usage = {"prompt_tokens": PROMPT_TOKENS, "completion_tokens": COMPLETION_TOKENS}
+    response = {
+        "type": "text",
+        "content": "Sure: <｜｜DSML｜｜tool_calls>",
+        "usage": usage,
+    }
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "final_answer",
+            "description": "Call final_answer.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+    normalized = normalize_deepseek_response(response, tools=[tool])
+
+    assert normalized["type"] == "tool_protocol_error"
+    assert normalized["usage"] == usage
+
+
+class TestResolveUsagePayload:
+    """The runtime extractor reads top-level stamps first, then ``raw``."""
+
+    def setup_method(self) -> None:
+        self.runtime = PatternRuntime()
+
+    @pytest.mark.parametrize(
+        ("response", "expected"),
+        [
+            # OpenAI-family envelope without a stamp: usage lives in raw.
+            (
+                {
+                    "type": "text",
+                    "content": "x",
+                    "raw": {"usage": {"prompt_tokens": 10, "completion_tokens": 5}},
+                },
+                (10, 5),
+            ),
+            # Legacy plain-string response: fail open.
+            ("plain string", None),
+            # Explicitly null usage in raw: fail open, never raise.
+            (
+                {"type": "text", "content": "x", "raw": {"usage": None}},
+                None,
+            ),
+            # Top-level stamp (backwards compatible, and preferred over raw).
+            (
+                {
+                    "type": "text",
+                    "content": "x",
+                    "usage": {"prompt_tokens": 3, "completion_tokens": 2},
+                    "raw": {"usage": {"prompt_tokens": 10, "completion_tokens": 5}},
+                },
+                (3, 2),
+            ),
+            # Gemini-style usage_metadata one level down in raw.
+            (
+                {
+                    "type": "text",
+                    "content": "x",
+                    "raw": {
+                        "usage_metadata": {
+                            "prompt_token_count": 7,
+                            "candidates_token_count": 4,
+                        }
+                    },
+                },
+                (7, 4),
+            ),
+        ],
+    )
+    def test_extract_token_usage_shapes(self, response: Any, expected: Any) -> None:
+        assert self.runtime._extract_token_usage(response) == expected
+
+    def test_extract_cached_tokens_reads_raw_usage(self) -> None:
+        response = {
+            "type": "text",
+            "content": "x",
+            "raw": {
+                "usage": {
+                    "prompt_tokens": 10,
+                    "completion_tokens": 5,
+                    "prompt_tokens_details": {"cached_tokens": 6},
+                }
+            },
+        }
+        assert self.runtime._extract_cached_tokens(response) == 6
+        assert self.runtime._extract_cached_tokens("plain string") == 0

--- a/tests/core/agent/test_compact_llm_usage_contract.py
+++ b/tests/core/agent/test_compact_llm_usage_contract.py
@@ -42,6 +42,7 @@ from xagent.core.model.chat.token_context import get_token_usage, reset_token_us
 
 PROMPT_TOKENS = 10
 COMPLETION_TOKENS = 5
+CACHED_TOKENS = 6
 COMPACT_SUMMARY = "summarized tool result"
 
 
@@ -539,10 +540,59 @@ class TestResolveUsagePayload:
                 },
                 (7, 4),
             ),
+            # Zhipu tool_call fallback shape: raw is a plain stringified
+            # response -- fail open, never raise or probe the string.
+            (
+                {
+                    "type": "tool_call",
+                    "tool_calls": [],
+                    "raw": "ChatCompletion(choices=[...])",
+                },
+                None,
+            ),
+            # Top-level usage_metadata (legacy Gemini-style attribute shape
+            # preserved as-is on the response): the original key order applies.
+            (
+                {
+                    "type": "text",
+                    "content": "x",
+                    "usage_metadata": {
+                        "prompt_token_count": 8,
+                        "candidates_token_count": 3,
+                    },
+                },
+                (8, 3),
+            ),
+            # Usage present but all-zero: not a measurement, fail open.
+            (
+                {
+                    "type": "text",
+                    "content": "x",
+                    "usage": {"prompt_tokens": 0, "completion_tokens": 0},
+                },
+                None,
+            ),
+            # All-zero usage in raw behaves the same one level down.
+            (
+                {
+                    "type": "text",
+                    "content": "x",
+                    "raw": {"usage": {"prompt_tokens": 0, "completion_tokens": 0}},
+                },
+                None,
+            ),
         ],
     )
     def test_extract_token_usage_shapes(self, response: Any, expected: Any) -> None:
         assert self.runtime._extract_token_usage(response) == expected
+
+    def test_extract_cached_tokens_fails_open_on_string_raw(self) -> None:
+        response = {
+            "type": "tool_call",
+            "tool_calls": [],
+            "raw": "ChatCompletion(choices=[...])",
+        }
+        assert self.runtime._extract_cached_tokens(response) == 0
 
     def test_extract_cached_tokens_reads_raw_usage(self) -> None:
         response = {
@@ -639,3 +689,297 @@ class TestUnwrapChatText:
     def test_unrecognized_shape_raises_no_text_content(self) -> None:
         with pytest.raises(LLMNoTextContentError):
             unwrap_chat_text(42)
+
+
+@pytest.mark.asyncio
+async def test_openai_compact_cached_tokens_flow_to_trace_event(mocker) -> None:
+    """End-to-end cache loop: a real CompletionUsage carrying
+    ``prompt_tokens_details.cached_tokens`` must surface as
+    ``cached_input_tokens`` on the compact trace event -- the stamp alone is
+    not enough, the extractor must read it back."""
+    from openai.types.completion_usage import PromptTokensDetails
+
+    reset_token_usage()
+    llm = OpenAILLM(model_name="gpt-4o-mini", api_key="test-key")
+    completion = _openai_completion(COMPACT_SUMMARY)
+    completion.usage = CompletionUsage(
+        prompt_tokens=PROMPT_TOKENS,
+        completion_tokens=COMPLETION_TOKENS,
+        total_tokens=PROMPT_TOKENS + COMPLETION_TOKENS,
+        prompt_tokens_details=PromptTokensDetails(cached_tokens=CACHED_TOKENS),
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = completion
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+
+    tracer, context = await _run_compact_with(llm)
+
+    compact_end = next(
+        event
+        for event in tracer.events
+        if event["event_type"] == "action_end_llm"
+        and event["data"].get("purpose") == "context_compaction"
+    )
+    assert compact_end["data"]["cached_input_tokens"] == CACHED_TOKENS
+    assert compact_end["data"]["input_tokens"] == PROMPT_TOKENS
+    assert context.get_total_token_usage()["total"] == (
+        PROMPT_TOKENS + COMPLETION_TOKENS
+    )
+
+
+class TestVisionChatUsageStamp:
+    """``vision_chat`` envelopes carry the same top-level usage stamp as
+    ``chat()`` -- image inputs account tokens identically (#520)."""
+
+    @pytest.mark.asyncio
+    async def test_openai_vision_chat_stamps_top_level_usage(self, mocker) -> None:
+        llm = OpenAILLM(
+            model_name="gpt-4o-mini",
+            api_key="test-key",
+            abilities=["chat", "vision"],
+        )
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.return_value = _openai_completion(
+            "A diagram on a whiteboard."
+        )
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image."},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/jpeg;base64,ZmFrZV9pbWFnZV9kYXRh"
+                        },
+                    },
+                ],
+            }
+        ]
+
+        response = await llm.vision_chat(messages)
+
+        assert response["type"] == "text"
+        assert response["content"] == "A diagram on a whiteboard."
+        assert response["usage"]["prompt_tokens"] == PROMPT_TOKENS
+        assert response["usage"]["completion_tokens"] == COMPLETION_TOKENS
+
+    @pytest.mark.asyncio
+    async def test_zhipu_vision_chat_stamps_usage_with_cached_tokens(self) -> None:
+        llm = ZhipuLLM(model_name="glm-4.5v", api_key="test-key")
+        response = _zhipu_response("A flowchart with three boxes.")
+        response.usage.prompt_tokens_details = SimpleNamespace(
+            cached_tokens=CACHED_TOKENS
+        )
+        llm._client = SimpleNamespace(
+            chat=SimpleNamespace(
+                completions=SimpleNamespace(create=lambda **kwargs: response)
+            )
+        )
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "Describe this image."},
+                    {
+                        "type": "image_url",
+                        "image_url": {
+                            "url": "data:image/jpeg;base64,ZmFrZV9pbWFnZV9kYXRh"
+                        },
+                    },
+                ],
+            }
+        ]
+
+        result = await llm.vision_chat(messages=messages)
+
+        assert result["type"] == "text"
+        assert result["content"] == "A flowchart with three boxes."
+        assert result["usage"] == {
+            "prompt_tokens": PROMPT_TOKENS,
+            "completion_tokens": COMPLETION_TOKENS,
+            "cached_input_tokens": CACHED_TOKENS,
+        }
+
+
+@pytest.mark.asyncio
+async def test_openai_reasoning_truncation_branch_stamps_usage(mocker) -> None:
+    """The reasoning-content early return (content empty, finish_reason
+    "length") is a separate result-construction branch; its envelope must
+    carry the stamp too."""
+    llm = OpenAILLM(model_name="gpt-4o-mini", api_key="test-key")
+    completion = ChatCompletion(
+        id="compact-contract-reasoning",
+        choices=[
+            Choice(
+                finish_reason="length",
+                index=0,
+                message=ChatCompletionMessage(
+                    content="",
+                    role="assistant",
+                    tool_calls=None,
+                    reasoning_content="partial reasoning trace",  # type: ignore[call-arg]
+                ),
+            )
+        ],
+        created=1234567890,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        usage=CompletionUsage(
+            prompt_tokens=PROMPT_TOKENS,
+            completion_tokens=COMPLETION_TOKENS,
+            total_tokens=PROMPT_TOKENS + COMPLETION_TOKENS,
+        ),
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = completion
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+
+    response = await llm.chat([{"role": "user", "content": "hi"}])
+
+    assert response["type"] == "text"
+    assert response["content"] == "partial reasoning trace"
+    assert response["usage"]["prompt_tokens"] == PROMPT_TOKENS
+    assert response["usage"]["completion_tokens"] == COMPLETION_TOKENS
+
+
+@pytest.mark.asyncio
+async def test_compact_usage_survives_checkpoint_roundtrip(mocker) -> None:
+    """Invariant I5: usage recorded during compaction must survive
+    ``to_dict``/``from_dict`` unchanged -- checkpoints are how executions
+    resume, and a lossy roundtrip would silently drop billed tokens."""
+    reset_token_usage()
+    llm = OpenAILLM(model_name="gpt-4o-mini", api_key="test-key")
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = _openai_completion(
+        COMPACT_SUMMARY
+    )
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+
+    _, context = await _run_compact_with(llm)
+
+    expected = {
+        "total": PROMPT_TOKENS + COMPLETION_TOKENS,
+        "input": PROMPT_TOKENS,
+        "output": COMPLETION_TOKENS,
+        "call_count": 1,
+    }
+    assert context.get_total_token_usage() == expected
+
+    restored = ExecutionContext.from_dict(context.to_dict())
+
+    assert restored.get_total_token_usage() == expected
+
+
+@pytest.mark.asyncio
+async def test_compact_estimate_reflects_current_messages_not_stale_record(
+    mocker,
+) -> None:
+    """Invariant I4 + the implicit ordering contract in
+    ``PatternRuntime.compact_context_if_needed``: ``on_llm_end`` (which calls
+    ``record_llm_usage``) runs *before* ``compact_with_llm_response`` rewrites
+    ``context.messages``. If someone swaps them, the record's
+    ``prompt_message_count``/``prompt_content_chars`` describe the *rewritten*
+    message list, the staleness check in ``_get_total_tokens`` then passes,
+    and ``estimate_context_tokens`` silently reports the compact call's
+    prompt tokens (~10) instead of estimating the summary text (~hundreds).
+    """
+    reset_token_usage()
+    llm = OpenAILLM(model_name="gpt-4o-mini", api_key="test-key")
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = _openai_completion(
+        COMPACT_SUMMARY
+    )
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+
+    tracer = TraceEventRecorder()
+    context = ExecutionContext(execution_id="compact-estimate-contract")
+    context.compact_config.threshold = 1
+    context.add_user_message("current request")
+    context.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "type": "function", "function": {"name": "read_file"}}
+        ],
+    )
+    # Large enough that the summary is genuinely smaller than the original.
+    context.add_tool_result("read_file", {"output": "x" * 4000}, tool_call_id="call-1")
+    estimate_before = context.estimate_context_tokens()
+    message_count_before = len(context.messages)
+
+    result = await ReActPattern(max_iterations=1).run(
+        context=context,
+        tools=[],
+        llm=FakeLLM([{"content": "done"}]),
+        compact_llm=llm,
+        runtime=PatternRuntime(tracer=tracer),
+    )
+
+    assert result["success"] is True
+    # Compaction really shrank the message list.
+    compact_end = next(
+        event for event in tracer.events if event["event_type"] == "action_end_compact"
+    )
+    assert compact_end["data"]["original_count"] == message_count_before
+    assert compact_end["data"]["final_count"] < message_count_before
+
+    # The post-compaction estimate is a live estimate of the current
+    # messages: smaller than before, positive, and far above the compact
+    # call's own prompt-token count (which a swapped record would leak).
+    estimate_after = context.estimate_context_tokens()
+    assert 0 < estimate_after < estimate_before
+    assert estimate_after > 3 * PROMPT_TOKENS
+
+
+@pytest.mark.asyncio
+async def test_compact_dependency_falls_back_when_compact_llm_returns_empty_content() -> (
+    None
+):
+    """#1714 empty-content path: an empty text envelope now raises
+    ``LLMEmptyContentError`` from ``unwrap_chat_text``; compaction must fail
+    explicitly and engage the truncation fallback, with no residue of the
+    envelope in the rebuilt context."""
+    empty_envelope = {"type": "text", "content": ""}
+    compact_llm = FakeLLM([empty_envelope, empty_envelope])
+    builder = ContextBuilder(
+        llm=FakeLLM([]), compact_threshold=1, compact_llm=compact_llm
+    )
+    dep_result = StepExecutionResult(
+        step_id="dep-1",
+        messages=[
+            {"role": "user", "content": "u" * 100},
+            {"role": "assistant", "content": "a" * 100},
+        ],
+        final_result={},
+        agent_name="dep-agent",
+    )
+
+    messages = await builder.build_context_for_step(
+        step_name="target",
+        step_description="do something with the dependency output",
+        dependencies=["dep-1"],
+        dependency_results={"dep-1": dep_result},
+    )
+
+    # Both compaction levels consulted the compact model and both fell back.
+    assert len(compact_llm.calls) == 2
+    rendered = json.dumps(messages, ensure_ascii=False)
+    assert "'content': ''" not in rendered
+    # The explicit truncation fallback keeps real history rather than a repr.
+    assert any("a" * 100 in m["content"] for m in messages)

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -7712,3 +7712,33 @@ def test_tool_call_date_line_uses_the_caller_timezone() -> None:
 
 def test_tool_call_date_line_degrades_to_utc_for_an_unusable_timezone() -> None:
     assert _date_instruction(_react_clock_prompt("Not/AZone")) == UTC_DATE_INSTRUCTION
+
+
+@pytest.mark.asyncio
+async def test_react_finalize_fallback_never_leaks_envelope_repr() -> None:
+    """C3: when the model's text unwraps to an empty final answer, the
+    finalize fallback must surface the envelope's *text* -- never the whole
+    envelope, whose repr would land in the user-visible transcript."""
+    context = ExecutionContext(execution_id="react-envelope-fallback")
+    context.add_user_message("hi")
+    runtime = PatternRuntime(tracer=TraceEventRecorder())
+    json_text = '{"action": "final_answer", "action_input": ""}'
+
+    result = await ReActPattern(max_iterations=1).run(
+        context=context,
+        tools=[],
+        llm=FakeLLM(
+            [
+                {
+                    "type": "text",
+                    "content": json_text,
+                    "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+                }
+            ]
+        ),
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert result["output"] == json_text
+    assert "'type': 'text'" not in str(result)

--- a/tests/core/agent/test_usage_attempts_contract.py
+++ b/tests/core/agent/test_usage_attempts_contract.py
@@ -1,0 +1,439 @@
+"""Contract tests for billed-attempt propagation (``usage_attempts``).
+
+Contract (review N2 on PR #1787):
+
+- ``usage`` on a chat() envelope is the *last* attempt's payload -- it is
+  the context-freshness baseline and its semantics do not change.
+- ``usage_attempts`` is the ordered list of *all billed* attempts of one
+  logical call (including the last), set only when more than one attempt
+  was billed. A single-attempt envelope never carries the key.
+- Attempts billed before a retryable failure travel on the exception
+  (``LLMRetryableError.usage_attempts``); the retry wrapper merges them
+  into the eventual envelope, or onto the final exception when every
+  attempt fails. Nothing is ever derived by diffing the shared task
+  ledger -- the ledger stays the adapter's own ``add_token_usage`` writes,
+  so the trace totals and the ledger must agree exactly.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock
+
+import pytest
+from openai.types.chat import ChatCompletion
+from openai.types.chat.chat_completion import Choice
+from openai.types.chat.chat_completion_message import ChatCompletionMessage
+from openai.types.completion_usage import CompletionUsage
+
+from xagent.core.agent import ExecutionContext, PatternRuntime
+from xagent.core.model.chat.basic.base import BaseLLM
+from xagent.core.model.chat.basic.claude import ClaudeLLM
+from xagent.core.model.chat.basic.gemini import GeminiLLM
+from xagent.core.model.chat.basic.openai import OpenAILLM
+from xagent.core.model.chat.error import retry_on
+from xagent.core.model.chat.exceptions import LLMEmptyContentError
+from xagent.core.model.chat.token_context import get_token_usage, reset_token_usage
+from xagent.core.retry import create_retry_wrapper
+from xagent.core.retry.strategy import ExponentialBackoff
+
+# Distinct per-attempt usages: the first (failed) attempt and the final one.
+P1, C1 = 10, 5
+P2, C2 = 20, 7
+
+U1 = {"prompt_tokens": P1, "completion_tokens": C1, "total_tokens": P1 + C1}
+U2 = {"prompt_tokens": P2, "completion_tokens": C2, "total_tokens": P2 + C2}
+
+
+class TraceEventRecorder:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    async def trace_event(
+        self,
+        event_type: Any,
+        *,
+        task_id: str | None = None,
+        step_id: str | None = None,
+        data: dict[str, Any] | None = None,
+        **_: Any,
+    ) -> str:
+        self.events.append(
+            {
+                "event_type": getattr(event_type, "value", str(event_type)),
+                "task_id": task_id,
+                "step_id": step_id,
+                "data": data or {},
+            }
+        )
+        return str(len(self.events))
+
+
+def _wrapped(llm: Any, max_retries: int = 3) -> Any:
+    """The production retry boundary, with zero-delay backoff for tests."""
+    return create_retry_wrapper(
+        llm,
+        BaseLLM,
+        retry_methods={"chat"},
+        max_retries=max_retries,
+        retry_on=retry_on,
+        strategy=ExponentialBackoff(base_delay_ms=0),
+    )
+
+
+def _openai_completion(
+    content: str | None,
+    prompt_tokens: int,
+    completion_tokens: int,
+    *,
+    finish_reason: str = "stop",
+    reasoning_content: str | None = None,
+) -> ChatCompletion:
+    kwargs: dict[str, Any] = {}
+    if reasoning_content is not None:
+        kwargs["reasoning_content"] = reasoning_content
+    return ChatCompletion(
+        id="usage-attempts-completion",
+        choices=[
+            Choice(
+                finish_reason=finish_reason,  # type: ignore[arg-type]
+                index=0,
+                message=ChatCompletionMessage(
+                    content=content,
+                    role="assistant",
+                    tool_calls=None,
+                    **kwargs,  # type: ignore[arg-type]
+                ),
+            )
+        ],
+        created=1234567890,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        usage=CompletionUsage(
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            total_tokens=prompt_tokens + completion_tokens,
+        ),
+    )
+
+
+def _openai_llm(mocker: Any, side_effects: list[Any]) -> OpenAILLM:
+    llm = OpenAILLM(
+        model_name="gpt-4o-mini",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "thinking_mode"],
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = side_effects
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    return llm
+
+
+def _attempt_prompts(response: dict[str, Any]) -> list[int]:
+    return [attempt["prompt_tokens"] for attempt in response["usage_attempts"]]
+
+
+@pytest.mark.asyncio
+async def test_openai_outer_retry_merges_usage_attempts(mocker: Any) -> None:
+    """First attempt bills (empty content -> retryable), second succeeds:
+    the envelope keeps the final attempt in ``usage`` and lists both in
+    ``usage_attempts``; the task ledger must equal the attempt sum."""
+    reset_token_usage()
+    llm = _openai_llm(
+        mocker,
+        [
+            _openai_completion("", P1, C1),
+            _openai_completion("recovered", P2, C2),
+        ],
+    )
+
+    response = await _wrapped(llm).chat([{"role": "user", "content": "hi"}])
+
+    assert response["type"] == "text"
+    assert response["usage"]["prompt_tokens"] == P2
+    assert response["usage"]["completion_tokens"] == C2
+    assert _attempt_prompts(response) == [P1, P2]
+    ledger = get_token_usage()
+    assert ledger.llm_calls == 2
+    assert ledger.input_tokens == P1 + P2
+    assert ledger.output_tokens == C1 + C2
+
+
+@pytest.mark.asyncio
+async def test_openai_single_attempt_envelope_has_no_usage_attempts(
+    mocker: Any,
+) -> None:
+    reset_token_usage()
+    llm = _openai_llm(mocker, [_openai_completion("clean", P2, C2)])
+
+    response = await _wrapped(llm).chat([{"role": "user", "content": "hi"}])
+
+    assert response["usage"]["prompt_tokens"] == P2
+    assert "usage_attempts" not in response
+
+
+@pytest.mark.asyncio
+async def test_openai_structured_output_second_request_collects_attempts(
+    mocker: Any,
+) -> None:
+    """The thinking-disabled JSON retry is a second billed request inside
+    one chat() call: both attempts must surface on the envelope without any
+    outer retry wrapper being involved."""
+    reset_token_usage()
+    llm = _openai_llm(
+        mocker,
+        [
+            # Thinking active + non-JSON content triggers the degrade retry.
+            _openai_completion(
+                "not json at all{",
+                P1,
+                C1,
+                reasoning_content="some reasoning trace",
+            ),
+            _openai_completion('{"ok": true}', P2, C2),
+        ],
+    )
+
+    response = await llm.chat(
+        [{"role": "user", "content": "hi"}],
+        response_format={"type": "json_object"},
+    )
+
+    assert response["type"] == "text"
+    assert response["usage"]["prompt_tokens"] == P2
+    assert _attempt_prompts(response) == [P1, P2]
+    ledger = get_token_usage()
+    assert ledger.llm_calls == 2
+    assert ledger.input_tokens == P1 + P2
+
+
+@pytest.mark.asyncio
+async def test_openai_all_attempts_failed_exception_carries_attempts(
+    mocker: Any,
+) -> None:
+    """Every attempt fails: the final exception must carry the full ordered
+    attempt list so the runtime can still book the billed tokens."""
+    reset_token_usage()
+    llm = _openai_llm(
+        mocker,
+        [
+            _openai_completion("", P1, C1),
+            _openai_completion("", P2, C2),
+        ],
+    )
+
+    with pytest.raises(LLMEmptyContentError) as exc_info:
+        await _wrapped(llm, max_retries=2).chat([{"role": "user", "content": "hi"}])
+
+    attempts = exc_info.value.usage_attempts
+    assert [attempt["prompt_tokens"] for attempt in attempts] == [P1, P2]
+    ledger = get_token_usage()
+    assert ledger.llm_calls == 2
+    assert ledger.input_tokens == P1 + P2
+
+
+def _claude_response(
+    text: str | None, input_tokens: int, output_tokens: int
+) -> SimpleNamespace:
+    content = [SimpleNamespace(type="text", text=text)] if text is not None else []
+    return SimpleNamespace(
+        stop_reason="end_turn",
+        content=content,
+        usage=SimpleNamespace(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_input_tokens=0,
+            cache_creation_input_tokens=0,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_claude_outer_retry_merges_usage_attempts() -> None:
+    reset_token_usage()
+    llm = ClaudeLLM(model_name="claude-3-5-sonnet-20241022", api_key="test-key")
+    llm._client = SimpleNamespace(
+        messages=SimpleNamespace(
+            create=AsyncMock(
+                side_effect=[
+                    _claude_response(None, P1, C1),
+                    _claude_response("recovered", P2, C2),
+                ]
+            )
+        )
+    )
+
+    response = await _wrapped(llm).chat([{"role": "user", "content": "hi"}])
+
+    assert response["type"] == "text"
+    assert response["usage"]["prompt_tokens"] == P2
+    assert _attempt_prompts(response) == [P1, P2]
+    ledger = get_token_usage()
+    assert ledger.llm_calls == 2
+    assert ledger.input_tokens == P1 + P2
+
+
+def _gemini_response(
+    text: str | None, prompt_tokens: int, completion_tokens: int
+) -> SimpleNamespace:
+    parts = [SimpleNamespace(text=text, function_call=None)] if text is not None else []
+    return SimpleNamespace(
+        usage_metadata=SimpleNamespace(
+            prompt_token_count=prompt_tokens,
+            candidates_token_count=completion_tokens,
+            cached_content_token_count=0,
+        ),
+        candidates=[SimpleNamespace(content=SimpleNamespace(parts=parts))],
+    )
+
+
+@pytest.mark.asyncio
+async def test_gemini_outer_retry_merges_usage_attempts() -> None:
+    """Gemini wraps its retryable errors into RuntimeError (``from e``);
+    the billed attempts must survive that wrap onto the surfaced exception."""
+    reset_token_usage()
+    llm = GeminiLLM(model_name="gemini-2.5-flash", api_key="test-key")
+    llm._client = SimpleNamespace(
+        aio=SimpleNamespace(
+            models=SimpleNamespace(
+                generate_content=AsyncMock(
+                    side_effect=[
+                        _gemini_response(None, P1, C1),
+                        _gemini_response("recovered", P2, C2),
+                    ]
+                )
+            )
+        )
+    )
+
+    response = await _wrapped(llm).chat([{"role": "user", "content": "hi"}])
+
+    assert response["type"] == "text"
+    assert response["usage"]["prompt_tokens"] == P2
+    assert _attempt_prompts(response) == [P1, P2]
+    ledger = get_token_usage()
+    assert ledger.llm_calls == 2
+    assert ledger.input_tokens == P1 + P2
+
+
+class TestRuntimeAttemptRecording:
+    """The runtime books every billed attempt (final last, so the freshness
+    baseline stays the final attempt) and reports billing totals on the
+    trace -- the same totals the monitor aggregates from end events."""
+
+    def setup_method(self) -> None:
+        self.tracer = TraceEventRecorder()
+        self.runtime = PatternRuntime(tracer=self.tracer)
+        self.context = ExecutionContext(execution_id="usage-attempts-runtime")
+        self.context.add_user_message("hi")
+
+    def _end_event(self) -> dict[str, Any]:
+        return next(
+            event
+            for event in self.tracer.events
+            if event["event_type"] == "action_end_llm"
+        )
+
+    @pytest.mark.asyncio
+    async def test_on_llm_end_records_each_attempt_and_trace_totals(self) -> None:
+        envelope = {
+            "type": "text",
+            "content": "ok",
+            "usage": U2,
+            "usage_attempts": [U1, U2],
+        }
+
+        await self.runtime.on_llm_end(context=self.context, response=envelope)
+
+        records = self.context.llm_calls
+        assert [(r.input_tokens, r.output_tokens) for r in records] == [
+            (P1, C1),
+            (P2, C2),
+        ]
+        # The final attempt sits at the tail: freshness-baseline safe.
+        assert records[-1].input_tokens == P2
+        data = self._end_event()["data"]
+        assert data["input_tokens"] == P1 + P2
+        assert data["output_tokens"] == C1 + C2
+        assert data["total_tokens"] == P1 + P2 + C1 + C2
+        assert data["llm_attempt_count"] == 2
+        assert data["final_prompt_tokens"] == P2
+        assert data["final_output_tokens"] == C2
+
+    @pytest.mark.asyncio
+    async def test_on_llm_end_single_attempt_shape_unchanged(self) -> None:
+        envelope = {"type": "text", "content": "ok", "usage": U2}
+
+        await self.runtime.on_llm_end(context=self.context, response=envelope)
+
+        assert len(self.context.llm_calls) == 1
+        data = self._end_event()["data"]
+        assert data["input_tokens"] == P2
+        assert data["output_tokens"] == C2
+        assert data["total_tokens"] == P2 + C2
+        assert "llm_attempt_count" not in data
+        assert "final_prompt_tokens" not in data
+
+    @pytest.mark.asyncio
+    async def test_on_llm_end_marks_all_attempt_records_synthetic(self) -> None:
+        envelope = {
+            "type": "text",
+            "content": "ok",
+            "usage": U2,
+            "usage_attempts": [U1, U2],
+        }
+
+        await self.runtime.on_llm_end(
+            context=self.context,
+            response=envelope,
+            metadata={"purpose": "context_compaction"},
+        )
+
+        assert [record.synthetic_purpose for record in self.context.llm_calls] == [
+            "context_compaction",
+            "context_compaction",
+        ]
+
+    @pytest.mark.asyncio
+    async def test_on_llm_error_records_attempts_and_trace_tokens(self) -> None:
+        error = LLMEmptyContentError("all attempts failed")
+        error.usage_attempts = [U1, U2]
+
+        await self.runtime.on_llm_error(context=self.context, error=error)
+
+        records = self.context.llm_calls
+        assert [(r.input_tokens, r.output_tokens) for r in records] == [
+            (P1, C1),
+            (P2, C2),
+        ]
+        error_event = next(
+            event
+            for event in self.tracer.events
+            if event["event_type"] == "action_error_llm"
+        )
+        data = error_event["data"]
+        assert data["input_tokens"] == P1 + P2
+        assert data["output_tokens"] == C1 + C2
+        assert data["total_tokens"] == P1 + P2 + C1 + C2
+        assert data["llm_attempt_count"] == 2
+        assert data["final_prompt_tokens"] == P2
+        assert data["final_output_tokens"] == C2
+
+    @pytest.mark.asyncio
+    async def test_on_llm_error_without_attempts_keeps_current_shape(self) -> None:
+        await self.runtime.on_llm_error(
+            context=self.context, error=RuntimeError("plain failure")
+        )
+
+        assert self.context.llm_calls == []
+        error_event = next(
+            event
+            for event in self.tracer.events
+            if event["event_type"] == "action_error_llm"
+        )
+        assert "input_tokens" not in error_event["data"]
+        assert "llm_attempt_count" not in error_event["data"]

--- a/tests/core/agent/test_usage_attempts_contract.py
+++ b/tests/core/agent/test_usage_attempts_contract.py
@@ -32,6 +32,7 @@ from xagent.core.model.chat.basic.base import BaseLLM
 from xagent.core.model.chat.basic.claude import ClaudeLLM
 from xagent.core.model.chat.basic.gemini import GeminiLLM
 from xagent.core.model.chat.basic.openai import OpenAILLM
+from xagent.core.model.chat.basic.zhipu import ZhipuLLM
 from xagent.core.model.chat.error import retry_on
 from xagent.core.model.chat.exceptions import LLMEmptyContentError
 from xagent.core.model.chat.token_context import get_token_usage, reset_token_usage
@@ -437,3 +438,334 @@ class TestRuntimeAttemptRecording:
         )
         assert "input_tokens" not in error_event["data"]
         assert "llm_attempt_count" not in error_event["data"]
+
+
+# ---------------------------------------------------------------------------
+# Round-2 regressions (review R1-xx on PR #1787)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_openai_generic_error_after_internal_retry_carries_attempts(
+    mocker: Any,
+) -> None:
+    """R1-01: the first (billed, superseded) attempt is followed by a
+    thinking-disabled resend that raises BadRequestError. The surfaced
+    RuntimeError wraps the SDK error -- it must still carry the known billed
+    attempt so error-path accounting does not lose it."""
+    import httpx
+    import openai as openai_pkg
+
+    reset_token_usage()
+    llm = _openai_llm(
+        mocker,
+        [
+            _openai_completion(
+                "not json at all{",
+                P1,
+                C1,
+                reasoning_content="some reasoning trace",
+            ),
+            openai_pkg.BadRequestError(
+                "second request rejected",
+                response=httpx.Response(
+                    400, request=httpx.Request("POST", "https://api.openai.com/x")
+                ),
+                body=None,
+            ),
+        ],
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await llm.chat(
+            [{"role": "user", "content": "hi"}],
+            response_format={"type": "json_object"},
+        )
+
+    attempts = getattr(exc_info.value, "usage_attempts", None)
+    assert attempts is not None
+    assert [attempt["prompt_tokens"] for attempt in attempts] == [P1]
+    # The ledger booked the first attempt; the error carrier must agree.
+    assert get_token_usage().input_tokens == P1
+
+    # And the runtime books it through on_llm_error.
+    tracer = TraceEventRecorder()
+    runtime = PatternRuntime(tracer=tracer)
+    context = ExecutionContext(execution_id="r1-01")
+    context.add_user_message("hi")
+    await runtime.on_llm_error(context=context, error=exc_info.value)
+
+    assert context.get_total_token_usage() == {
+        "total": P1 + C1,
+        "input": P1,
+        "output": C1,
+        "call_count": 1,
+    }
+    error_event = next(
+        event for event in tracer.events if event["event_type"] == "action_error_llm"
+    )
+    assert error_event["data"]["input_tokens"] == P1
+
+
+@pytest.mark.asyncio
+async def test_retry_wrapper_preserves_singleton_history_when_final_unmetered() -> None:
+    """R1-02: one collected billed failure followed by an unmetered success
+    must still surface the known attempt -- a one-element history is not
+    suppressed, and nothing is promoted into ``usage``."""
+
+    class _FlakyLLM:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def chat(self, *args: Any, **kwargs: Any) -> Any:
+            self.calls += 1
+            if self.calls == 1:
+                error = LLMEmptyContentError("empty first attempt")
+                error.usage_attempts = [U1]
+                raise error
+            return {"type": "text", "content": "ok"}  # deliberately unmetered
+
+    response = await _wrapped(_FlakyLLM()).chat([{"role": "user", "content": "hi"}])
+
+    assert response.get("usage") is None
+    assert response["usage_attempts"] == [U1]
+
+    # And the runtime books that single known attempt from the envelope.
+    tracer = TraceEventRecorder()
+    runtime = PatternRuntime(tracer=tracer)
+    context = ExecutionContext(execution_id="r1-02")
+    context.add_user_message("hi")
+    await runtime.on_llm_end(context=context, response=response)
+
+    assert context.get_total_token_usage() == {
+        "total": P1 + C1,
+        "input": P1,
+        "output": C1,
+        "call_count": 1,
+    }
+    end_event = next(
+        event for event in tracer.events if event["event_type"] == "action_end_llm"
+    )
+    assert end_event["data"]["llm_attempt_count"] == 1
+    assert end_event["data"]["input_tokens"] == P1
+
+
+def test_deepseek_violation_rebuild_preserves_usage_attempts() -> None:
+    """R1-03: the protocol-error rebuild is a response transformation, not a
+    new provider request -- it must carry the full ordered attempt list, not
+    just the final usage stamp."""
+    from xagent.core.model.chat.basic.deepseek_tool_protocol import (
+        normalize_deepseek_response,
+    )
+
+    response = {
+        "type": "text",
+        "content": "Sure: <｜｜DSML｜｜tool_calls>",
+        "usage": U2,
+        "usage_attempts": [U1, U2],
+    }
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "final_answer",
+            "description": "Call final_answer.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+    normalized = normalize_deepseek_response(response, tools=[tool])
+
+    assert normalized["type"] == "tool_protocol_error"
+    assert normalized["usage"] == U2
+    assert normalized["usage_attempts"] == [U1, U2]
+
+
+@pytest.mark.asyncio
+async def test_deepseek_rebuild_attempts_booked_through_on_llm_end() -> None:
+    """R1-03 end-to-end: the rebuilt error envelope books both attempts."""
+    from xagent.core.model.chat.basic.deepseek_tool_protocol import (
+        normalize_deepseek_response,
+    )
+
+    response = {
+        "type": "text",
+        "content": "Sure: <｜｜DSML｜｜tool_calls>",
+        "usage": U2,
+        "usage_attempts": [U1, U2],
+    }
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "final_answer",
+            "description": "Call final_answer.",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+    rebuilt = normalize_deepseek_response(response, tools=[tool])
+
+    tracer = TraceEventRecorder()
+    runtime = PatternRuntime(tracer=tracer)
+    context = ExecutionContext(execution_id="r1-03")
+    context.add_user_message("hi")
+    await runtime.on_llm_end(context=context, response=rebuilt)
+
+    assert [
+        (record.input_tokens, record.output_tokens) for record in context.llm_calls
+    ] == [(P1, C1), (P2, C2)]
+    end_event = next(
+        event for event in tracer.events if event["event_type"] == "action_end_llm"
+    )
+    assert end_event["data"]["llm_attempt_count"] == 2
+    assert end_event["data"]["input_tokens"] == P1 + P2
+
+
+@pytest.mark.asyncio
+async def test_zhipu_blank_response_error_carries_booked_usage() -> None:
+    """R1-05: billing is independent of retryability -- the non-retryable
+    blank-response RuntimeError must carry the usage the adapter booked."""
+    reset_token_usage()
+    llm = ZhipuLLM(model_name="glm-4.5", api_key="test-key")
+    llm._client = SimpleNamespace(
+        chat=SimpleNamespace(
+            completions=SimpleNamespace(
+                create=lambda **kwargs: SimpleNamespace(
+                    choices=[
+                        SimpleNamespace(
+                            message=SimpleNamespace(content=None, tool_calls=None),
+                            finish_reason="stop",
+                        )
+                    ],
+                    usage=SimpleNamespace(
+                        prompt_tokens=P1,
+                        completion_tokens=C1,
+                    ),
+                )
+            )
+        )
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await llm.chat([{"role": "user", "content": "hi"}])
+
+    # The surfaced error is the outer "Zhipu API error" wrap; the payload
+    # must survive both the raise and the wrap.
+    attempts = getattr(exc_info.value, "usage_attempts", None)
+    assert attempts is not None
+    assert [attempt["prompt_tokens"] for attempt in attempts] == [P1]
+    assert get_token_usage().input_tokens == P1
+
+    tracer = TraceEventRecorder()
+    runtime = PatternRuntime(tracer=tracer)
+    context = ExecutionContext(execution_id="r1-05")
+    context.add_user_message("hi")
+    await runtime.on_llm_error(context=context, error=exc_info.value)
+
+    assert context.get_total_token_usage()["total"] == P1 + C1
+    error_event = next(
+        event for event in tracer.events if event["event_type"] == "action_error_llm"
+    )
+    assert error_event["data"]["input_tokens"] == P1
+
+
+class TestAttemptCacheScope:
+    """R1-04: cache metrics share the aggregate scope of the token totals --
+    summed over every billed attempt on success, and extracted on the
+    all-failed error path too."""
+
+    def setup_method(self) -> None:
+        self.tracer = TraceEventRecorder()
+        self.runtime = PatternRuntime(tracer=self.tracer)
+        self.context = ExecutionContext(execution_id="attempt-cache-scope")
+        self.context.add_user_message("hi")
+
+    @pytest.mark.asyncio
+    async def test_end_trace_sums_cache_over_attempts(self) -> None:
+        u1 = {**U1, "cached_input_tokens": 6}
+        u2 = {**U2, "prompt_tokens_details": {"cached_tokens": 2}}
+        envelope = {
+            "type": "text",
+            "content": "ok",
+            "usage": u2,
+            "usage_attempts": [u1, u2],
+        }
+
+        await self.runtime.on_llm_end(context=self.context, response=envelope)
+
+        end_event = next(
+            event
+            for event in self.tracer.events
+            if event["event_type"] == "action_end_llm"
+        )
+        assert end_event["data"]["cached_input_tokens"] == 8
+        assert end_event["data"]["llm_attempt_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_error_trace_extracts_cache_from_attempts(self) -> None:
+        error = LLMEmptyContentError("all attempts failed")
+        error.usage_attempts = [{**U1, "cached_input_tokens": 6}, U2]
+
+        await self.runtime.on_llm_error(context=self.context, error=error)
+
+        error_event = next(
+            event
+            for event in self.tracer.events
+            if event["event_type"] == "action_error_llm"
+        )
+        assert error_event["data"]["cached_input_tokens"] == 6
+
+
+class TestMalformedAttemptRows:
+    """N3 residual: unusable attempt rows are dropped so the trace attempt
+    count stays in lockstep with the booked records, and a wholly unusable
+    list falls back to the valid top-level usage."""
+
+    def setup_method(self) -> None:
+        self.tracer = TraceEventRecorder()
+        self.runtime = PatternRuntime(tracer=self.tracer)
+        self.context = ExecutionContext(execution_id="malformed-attempts")
+        self.context.add_user_message("hi")
+
+    @pytest.mark.asyncio
+    async def test_malformed_row_dropped_everywhere(self) -> None:
+        envelope = {
+            "type": "text",
+            "content": "ok",
+            "usage": U2,
+            "usage_attempts": [
+                {"prompt_tokens": True, "completion_tokens": float("nan")},
+                U2,
+            ],
+        }
+
+        await self.runtime.on_llm_end(context=self.context, response=envelope)
+
+        # Exactly one record booked, and the trace counts exactly one attempt.
+        assert len(self.context.llm_calls) == 1
+        end_event = next(
+            event
+            for event in self.tracer.events
+            if event["event_type"] == "action_end_llm"
+        )
+        assert end_event["data"]["llm_attempt_count"] == 1
+        assert end_event["data"]["input_tokens"] == P2
+
+    @pytest.mark.asyncio
+    async def test_all_invalid_attempts_fall_back_to_top_level_usage(self) -> None:
+        envelope = {
+            "type": "text",
+            "content": "ok",
+            "usage": U2,
+            "usage_attempts": [{"prompt_tokens": "ten", "completion_tokens": None}],
+        }
+
+        await self.runtime.on_llm_end(context=self.context, response=envelope)
+
+        assert self.context.get_total_token_usage()["total"] == P2 + C2
+        end_event = next(
+            event
+            for event in self.tracer.events
+            if event["event_type"] == "action_end_llm"
+        )
+        # Single-attempt historical shape restored: no attempt fields.
+        assert "llm_attempt_count" not in end_event["data"]
+        assert end_event["data"]["input_tokens"] == P2

--- a/tests/core/agent/test_usage_attempts_contract.py
+++ b/tests/core/agent/test_usage_attempts_contract.py
@@ -769,3 +769,43 @@ class TestMalformedAttemptRows:
         # Single-attempt historical shape restored: no attempt fields.
         assert "llm_attempt_count" not in end_event["data"]
         assert end_event["data"]["input_tokens"] == P2
+
+
+@pytest.mark.asyncio
+async def test_retry_wrapper_non_retryable_terminal_carries_collected_attempts() -> (
+    None
+):
+    """C1: a non-retryable error after a billed retryable one must carry the
+    collected history out of the wrapper -- the ``not retry_on: raise``
+    short-circuit is a terminal carrier too."""
+
+    class _FlakyLLM:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def chat(self, *args: Any, **kwargs: Any) -> Any:
+            self.calls += 1
+            if self.calls == 1:
+                error = LLMEmptyContentError("empty first attempt")
+                error.usage_attempts = [U1]
+                raise error
+            raise RuntimeError("second attempt fails non-retryably")
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await _wrapped(_FlakyLLM()).chat([{"role": "user", "content": "hi"}])
+
+    assert not isinstance(exc_info.value, LLMEmptyContentError)
+    assert exc_info.value.usage_attempts == [U1]
+
+    # And the runtime books the carried attempt through on_llm_error.
+    tracer = TraceEventRecorder()
+    runtime = PatternRuntime(tracer=tracer)
+    context = ExecutionContext(execution_id="c1-terminal")
+    context.add_user_message("hi")
+    await runtime.on_llm_error(context=context, error=exc_info.value)
+
+    assert context.get_total_token_usage()["total"] == P1 + C1
+    error_event = next(
+        event for event in tracer.events if event["event_type"] == "action_error_llm"
+    )
+    assert error_event["data"]["input_tokens"] == P1

--- a/tests/core/model/chat/basic/test_base_stream_contract.py
+++ b/tests/core/model/chat/basic/test_base_stream_contract.py
@@ -103,3 +103,61 @@ async def test_none_result_yields_error_chunk() -> None:
     chunks = await _collect(None)
     assert len(chunks) == 1
     assert chunks[0].type == ChunkType.ERROR
+
+
+@pytest.mark.asyncio
+async def test_usage_bearing_text_envelope_emits_usage_chunk() -> None:
+    """R1-06: the chat-to-stream adaptation must keep the billing metadata
+    the envelope carries -- raw on the content chunk and a USAGE chunk."""
+    envelope = {
+        "type": "text",
+        "content": "hi",
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15},
+    }
+    chunks = await _collect(envelope)
+    assert [chunk.type for chunk in chunks] == [ChunkType.TOKEN, ChunkType.USAGE]
+    assert chunks[0].raw is envelope
+    assert chunks[1].usage == {
+        "prompt_tokens": 10,
+        "completion_tokens": 5,
+        "total_tokens": 15,
+    }
+    assert chunks[1].raw is envelope
+
+
+@pytest.mark.asyncio
+async def test_usage_bearing_tool_call_envelope_emits_usage_chunk() -> None:
+    envelope = {
+        "type": "tool_call",
+        "tool_calls": [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }
+        ],
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+    }
+    chunks = await _collect(envelope)
+    assert [chunk.type for chunk in chunks] == [ChunkType.TOOL_CALL, ChunkType.USAGE]
+    assert chunks[1].usage == {"prompt_tokens": 10, "completion_tokens": 5}
+
+
+@pytest.mark.asyncio
+async def test_usage_chunk_feeds_runtime_extraction() -> None:
+    """R1-06 through the runtime's own chunk reader: the USAGE chunk the
+    default emits is what ``_chunk_usage``/reconstruction consumes."""
+    from xagent.core.agent import PatternRuntime
+
+    envelope = {
+        "type": "text",
+        "content": "hi",
+        "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+    }
+    chunks = await _collect(envelope)
+    runtime = PatternRuntime()
+    usage_payload: dict[str, Any] = {}
+    for chunk in chunks:
+        usage_payload.update(runtime._chunk_usage(chunk))
+    assert usage_payload["prompt_tokens"] == 10
+    assert usage_payload["completion_tokens"] == 5

--- a/tests/core/model/chat/basic/test_base_stream_contract.py
+++ b/tests/core/model/chat/basic/test_base_stream_contract.py
@@ -1,0 +1,105 @@
+"""Contract tests for ``BaseLLM.stream_chat``'s default shape handling.
+
+The default (non-streaming) implementation maps the ``chat()`` response
+union onto a single chunk. It must distinguish a text envelope from a
+tool-call envelope from a legacy plain string, and must fail explicitly --
+never silently emit an empty TOOL_CALL chunk -- on shapes it does not
+recognize. Concrete adapters all override ``stream_chat``; this pins the
+inherited default via a minimal subclass.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xagent.core.model.chat.basic.base import BaseLLM
+from xagent.core.model.chat.types import ChunkType, StreamChunk
+
+
+class _MinimalLLM(BaseLLM):
+    """Smallest concrete BaseLLM: inherits the default ``stream_chat``."""
+
+    def __init__(self, result: Any) -> None:
+        self._result = result
+
+    @property
+    def abilities(self) -> list[str]:
+        return ["chat"]
+
+    @property
+    def model_name(self) -> str:
+        return "minimal-model"
+
+    @property
+    def supports_thinking_mode(self) -> bool:
+        return False
+
+    async def chat(self, messages: Any, **kwargs: Any) -> Any:
+        return self._result
+
+
+async def _collect(result: Any) -> list[StreamChunk]:
+    llm = _MinimalLLM(result)
+    return [
+        chunk async for chunk in llm.stream_chat([{"role": "user", "content": "hi"}])
+    ]
+
+
+@pytest.mark.asyncio
+async def test_text_envelope_yields_token_chunk() -> None:
+    chunks = await _collect({"type": "text", "content": "hi", "usage": {}})
+    assert len(chunks) == 1
+    assert chunks[0].type == ChunkType.TOKEN
+    assert chunks[0].content == "hi"
+    assert chunks[0].delta == "hi"
+
+
+@pytest.mark.asyncio
+async def test_legacy_plain_string_yields_token_chunk() -> None:
+    chunks = await _collect("plain reply")
+    assert len(chunks) == 1
+    assert chunks[0].type == ChunkType.TOKEN
+    assert chunks[0].content == "plain reply"
+
+
+@pytest.mark.asyncio
+async def test_tool_call_envelope_yields_tool_call_chunk() -> None:
+    tool_calls = [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "read_file", "arguments": "{}"},
+        }
+    ]
+    envelope = {"type": "tool_call", "tool_calls": tool_calls}
+    chunks = await _collect(envelope)
+    assert len(chunks) == 1
+    assert chunks[0].type == ChunkType.TOOL_CALL
+    assert chunks[0].tool_calls == tool_calls
+    assert chunks[0].raw is envelope
+
+
+@pytest.mark.asyncio
+async def test_unknown_dict_shape_yields_error_chunk_not_empty_tool_call() -> None:
+    chunks = await _collect({"unexpected": "shape"})
+    assert len(chunks) == 1
+    assert chunks[0].type == ChunkType.ERROR
+    assert chunks[0].content
+    # The pre-contract behavior emitted a TOOL_CALL chunk with no tool calls.
+    assert not (chunks[0].type == ChunkType.TOOL_CALL and not chunks[0].tool_calls)
+
+
+@pytest.mark.asyncio
+async def test_empty_envelope_yields_error_chunk() -> None:
+    chunks = await _collect({"type": "text", "content": ""})
+    assert len(chunks) == 1
+    assert chunks[0].type == ChunkType.ERROR
+
+
+@pytest.mark.asyncio
+async def test_none_result_yields_error_chunk() -> None:
+    chunks = await _collect(None)
+    assert len(chunks) == 1
+    assert chunks[0].type == ChunkType.ERROR

--- a/tests/core/model/chat/basic/test_claude.py
+++ b/tests/core/model/chat/basic/test_claude.py
@@ -177,6 +177,43 @@ class TestClaudeLLM:
         assert call_args.kwargs["temperature"] == 0.7
 
     @pytest.mark.asyncio
+    async def test_usage_stamp_includes_cache_metrics(self, llm, mocker):
+        """Cache read/write tokens ride the usage stamp so PatternRuntime's
+        _extract_cached_tokens sees prompt-cache hits on non-streaming calls."""
+        mock_client = mocker.AsyncMock()
+
+        mock_text_block = mocker.Mock()
+        mock_text_block.type = "text"
+        mock_text_block.text = "Cached"
+
+        mock_usage = mocker.Mock()
+        mock_usage.input_tokens = 10
+        mock_usage.output_tokens = 5
+        mock_usage.cache_read_input_tokens = 4
+        mock_usage.cache_creation_input_tokens = 2
+
+        mock_response = mocker.Mock()
+        mock_response.stop_reason = "stop"
+        mock_response.content = [mock_text_block]
+        mock_response.usage = mock_usage
+
+        mock_client.messages.create.return_value = mock_response
+        mocker.patch(
+            "xagent.core.model.chat.basic.claude.AsyncAnthropic",
+            return_value=mock_client,
+        )
+
+        response = await llm.chat([{"role": "user", "content": "hi"}])
+
+        # _anthropic_input_usage re-adds cache tokens into the input total.
+        assert response["usage"] == {
+            "prompt_tokens": 16,
+            "completion_tokens": 5,
+            "cached_input_tokens": 4,
+            "cache_write_input_tokens": 2,
+        }
+
+    @pytest.mark.asyncio
     async def test_tool_calling(self, llm, mocker):
         """Test tool calling functionality."""
         # Setup mock

--- a/tests/core/model/chat/basic/test_claude.py
+++ b/tests/core/model/chat/basic/test_claude.py
@@ -163,9 +163,10 @@ class TestClaudeLLM:
 
         response = await llm.chat(messages)
 
-        # Verify response is a non-empty string
-        assert isinstance(response, str)
-        assert response == "Hello World"
+        # Verify response is a text envelope carrying the usage stamp
+        assert response["type"] == "text"
+        assert response["content"] == "Hello World"
+        assert response["usage"] == {"prompt_tokens": 10, "completion_tokens": 5}
         print(f"Basic chat response: {response}")
 
         # Verify the API was called with correct parameters
@@ -235,6 +236,8 @@ class TestClaudeLLM:
         assert isinstance(response, dict)
         assert response.get("type") == "tool_call"
         assert "tool_calls" in response
+        # The usage stamp rides on tool_call envelopes too.
+        assert response["usage"] == {"prompt_tokens": 20, "completion_tokens": 10}
 
         tool_calls = response["tool_calls"]
         assert len(tool_calls) > 0
@@ -387,8 +390,8 @@ class TestClaudeLLM:
             messages = [{"role": "user", "content": "Say 'test'"}]
             response = await ctx_llm.chat(messages)
 
-            assert isinstance(response, str)
-            assert response == "test"
+            assert response["type"] == "text"
+            assert response["content"] == "test"
             print(f"Context manager response: {response}")
 
         # Verify the client was properly closed
@@ -466,8 +469,8 @@ class TestClaudeLLM:
             max_tokens=50,  # Limit response length
         )
 
-        assert isinstance(response, str)
-        assert response == "Test response"
+        assert response["type"] == "text"
+        assert response["content"] == "Test response"
         print(f"Custom parameters response: {response}")
 
         # Verify custom parameters were passed
@@ -565,7 +568,7 @@ class TestClaudeLLM:
             messages, thinking={"type": "enabled", "budget_tokens": 20480}
         )
 
-        assert isinstance(response, str)
+        assert response["type"] == "text"
 
         # Verify thinking mode was passed
         call_args = mock_client.messages.create.call_args
@@ -604,7 +607,7 @@ class TestClaudeLLM:
         # Test with thinking mode explicitly disabled
         response = await llm.chat(messages, thinking={"type": "disabled"})
 
-        assert isinstance(response, str)
+        assert response["type"] == "text"
 
         # Verify thinking mode was set to disabled
         call_args = mock_client.messages.create.call_args
@@ -654,8 +657,8 @@ class TestClaudeLLM:
 
         response = await llm.vision_chat(messages)
 
-        assert isinstance(response, str)
-        assert response == "I see an image"
+        assert response["type"] == "text"
+        assert response["content"] == "I see an image"
         print(f"Vision chat response: {response}")
 
     @pytest.mark.asyncio
@@ -1012,10 +1015,10 @@ class TestClaudeLLM:
 
         response = await llm.chat(messages, output_config=output_config)
 
-        assert isinstance(response, str)
-        # Verify the response contains the expected JSON
-        assert "joke" in response
-        assert "punchline" in response
+        assert response["type"] == "text"
+        # Verify the response content contains the expected JSON
+        assert "joke" in response["content"]
+        assert "punchline" in response["content"]
 
         # Verify the API was called with output_config
         mock_client.messages.create.assert_called_once()

--- a/tests/core/model/chat/basic/test_gemini_sdk.py
+++ b/tests/core/model/chat/basic/test_gemini_sdk.py
@@ -806,3 +806,38 @@ class TestGeminiPromptCacheUsage:
 
         usage_payloads = [c.usage for c in chunks if c.is_usage()]
         assert usage_payloads and usage_payloads[0]["cached_input_tokens"] == 60
+
+
+@pytest.mark.asyncio
+async def test_empty_content_error_keeps_retryable_type_fidelity(
+    mocker: pytest_mock.MockerFixture,
+) -> None:
+    """D7: an empty generation surfaces as ``LLMEmptyContentError`` itself,
+    not re-wrapped into a plain ``RuntimeError`` (same contract as claude.py)."""
+    from xagent.core.model.chat.exceptions import LLMEmptyContentError
+
+    llm = GeminiLLM(model_name="gemini-2.5-flash", api_key="test-key")
+
+    mock_sdk_client = MagicMock()
+    mock_response = MagicMock()
+    mock_candidate = MagicMock()
+    mock_content = MagicMock()
+    mock_part = MagicMock()
+    mock_part.text = ""
+    mock_part.function_call = None
+    mock_content.parts = [mock_part]
+    mock_candidate.content = mock_content
+    mock_response.candidates = [mock_candidate]
+    mock_response.usage_metadata.prompt_token_count = 10
+    mock_response.usage_metadata.candidates_token_count = 0
+    mock_response.usage_metadata.cached_content_token_count = 0
+
+    mocker.patch("google.genai.Client", return_value=mock_sdk_client)
+
+    async def mock_generate_content(*args, **kwargs):
+        return mock_response
+
+    mock_sdk_client.aio.models.generate_content = mock_generate_content
+
+    with pytest.raises(LLMEmptyContentError):
+        await llm.chat([{"role": "user", "content": "hi"}])

--- a/tests/core/model/chat/basic/test_gemini_sdk.py
+++ b/tests/core/model/chat/basic/test_gemini_sdk.py
@@ -90,9 +90,10 @@ class TestGeminiLLMSDK:
 
         response = await llm.chat(messages)
 
-        # Verify response
-        assert isinstance(response, str)
-        assert response == "Hello World"
+        # Verify response: a text envelope carrying the usage stamp
+        assert response["type"] == "text"
+        assert response["content"] == "Hello World"
+        assert response["usage"] == {"prompt_tokens": 10, "completion_tokens": 5}
         print(f"Basic chat response: {response}")
 
     @pytest.mark.asyncio
@@ -286,6 +287,8 @@ class TestGeminiLLMSDK:
         assert isinstance(response, dict)
         assert response.get("type") == "tool_call"
         assert "tool_calls" in response
+        # The usage stamp rides on tool_call envelopes too (no ``raw`` here).
+        assert response["usage"] == {"prompt_tokens": 15, "completion_tokens": 10}
 
         tool_calls = response["tool_calls"]
         assert len(tool_calls) > 0
@@ -454,10 +457,11 @@ class TestGeminiLLMSDK:
 
         response = await llm.chat(messages, response_format={"type": "json_object"})
 
-        # Verify JSON response
-        assert isinstance(response, str)
-        assert "greeting" in response
-        assert "count" in response
+        # Verify JSON response: text envelope, JSON in its content
+        assert response["type"] == "text"
+        assert "greeting" in response["content"]
+        assert "count" in response["content"]
+        assert response["usage"] == {"prompt_tokens": 14, "completion_tokens": 20}
         print(f"JSON mode response: {response}")
 
     @pytest.mark.asyncio

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -12,7 +12,7 @@ from xagent.core.model.chat.basic.deepseek_tool_protocol import (
     DEEPSEEK_PROVIDER_STATE_NAMESPACE,
     DEEPSEEK_REASONING_CONTENT_STATE_KEY,
 )
-from xagent.core.model.chat.basic.openai import OpenAILLM
+from xagent.core.model.chat.basic.openai import OpenAICompatibleLLM, OpenAILLM
 from xagent.core.model.chat.basic.openrouter import OpenRouterLLM
 from xagent.core.model.chat.error import retry_on
 from xagent.core.model.chat.exceptions import (
@@ -3847,3 +3847,87 @@ async def test_openrouter_deepseek_response_format_resend_stays_silent(mocker, c
     ]
     for record in caplog.records:
         assert "SECRET-THOUGHT" not in record.getMessage()
+
+
+@pytest.mark.asyncio
+async def test_openrouter_prefix_retry_preserves_billed_attempts(mocker, monkeypatch):
+    """C2: the prefix retry must fold the rejected attempt's billed usage
+    into the eventual envelope instead of discarding it."""
+    monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
+    billed = {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    prefix_failure = RuntimeError(
+        "Provider returned error: function call should not be used with prefix"
+    )
+    prefix_failure.usage_attempts = [billed]
+    success = {"type": "text", "content": "Hello World"}
+
+    mocker.patch.object(
+        OpenAICompatibleLLM,
+        "chat",
+        new=mocker.AsyncMock(side_effect=[prefix_failure, success]),
+    )
+    llm = OpenRouterLLM(model_name="deepseek/deepseek-v4-flash", api_key="test-key")
+
+    result = await llm.chat(_tool_call_history())
+
+    assert result["content"] == "Hello World"
+    assert result["usage_attempts"] == [billed]
+
+
+@pytest.mark.asyncio
+async def test_openrouter_compat_loop_preserves_billed_attempts(mocker):
+    """C2: a superseded compat iteration's billed usage must merge into the
+    eventual envelope rather than vanish with the caught exception."""
+    billed = {"prompt_tokens": 10, "completion_tokens": 5, "total_tokens": 15}
+    compat_failure = RuntimeError(_OPENROUTER_TOOL_CHOICE_ERROR)
+    compat_failure.usage_attempts = [billed]
+    final_usage = {"prompt_tokens": 20, "completion_tokens": 7, "total_tokens": 27}
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+    mocker.patch.object(
+        llm,
+        "_chat_with_prefix_retry",
+        side_effect=[
+            compat_failure,
+            {"type": "text", "content": "Hello World", "usage": final_usage},
+        ],
+    )
+
+    result = await llm.chat(
+        [{"role": "user", "content": "score?"}],
+        tools=_two_tool_schema(),
+        tool_choice="required",
+    )
+
+    assert result["content"] == "Hello World"
+    assert result["usage"] == final_usage
+    assert result["usage_attempts"] == [billed, final_usage]
+
+
+@pytest.mark.asyncio
+async def test_openrouter_compat_loop_terminal_error_carries_billed_attempts(
+    mocker,
+):
+    """C2: when no adjustment remains, the surfaced error must carry the
+    compat-superseded billed attempts collected so far."""
+    first_billed = {"prompt_tokens": 10, "completion_tokens": 5}
+    second_billed = {"prompt_tokens": 20, "completion_tokens": 7}
+    first_failure = RuntimeError(_OPENROUTER_TOOL_CHOICE_ERROR)
+    first_failure.usage_attempts = [first_billed]
+    terminal_failure = RuntimeError("an unadjustable provider error")
+    terminal_failure.usage_attempts = [second_billed]
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+    mocker.patch.object(
+        llm,
+        "_chat_with_prefix_retry",
+        side_effect=[first_failure, terminal_failure],
+    )
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await llm.chat(
+            [{"role": "user", "content": "score?"}],
+            tools=_two_tool_schema(),
+            tool_choice="required",
+        )
+
+    assert exc_info.value is terminal_failure
+    assert exc_info.value.usage_attempts == [first_billed, second_billed]

--- a/tests/core/model/chat/basic/test_xinference.py
+++ b/tests/core/model/chat/basic/test_xinference.py
@@ -1022,3 +1022,45 @@ class TestXinferencePromptCacheUsage:
         assert usage.input_tokens == 100
         inp = next(d for d in usage.details if d["type"] == "input")
         assert inp["cached_tokens"] == 60
+
+
+class TestXinferenceUsageStamp:
+    """D2: ``_process_chat_response`` stamps the provider usage onto every
+    envelope branch, so consumers never need to dig through ``raw``."""
+
+    def _payload(self) -> dict:
+        return {
+            "choices": [
+                {
+                    "message": {"role": "assistant", "content": "ok"},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {"prompt_tokens": 10, "completion_tokens": 5},
+        }
+
+    def test_text_envelope_stamps_usage(self) -> None:
+        llm = XinferenceLLM(model_name="qwen3.8")
+        result = llm._process_chat_response(self._payload())
+        assert result["usage"] == {"prompt_tokens": 10, "completion_tokens": 5}
+
+    def test_tool_call_envelope_stamps_usage(self) -> None:
+        llm = XinferenceLLM(model_name="qwen3.8")
+        payload = self._payload()
+        payload["choices"][0]["message"]["tool_calls"] = [
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": "search", "arguments": "{}"},
+            }
+        ]
+        result = llm._process_chat_response(payload)
+        assert result["type"] == "tool_call"
+        assert result["usage"] == {"prompt_tokens": 10, "completion_tokens": 5}
+
+    def test_no_usage_no_stamp(self) -> None:
+        llm = XinferenceLLM(model_name="qwen3.8")
+        payload = self._payload()
+        del payload["usage"]
+        result = llm._process_chat_response(payload)
+        assert "usage" not in result

--- a/tests/core/model/chat/basic/test_zhipu.py
+++ b/tests/core/model/chat/basic/test_zhipu.py
@@ -137,6 +137,10 @@ class TestZhipuLLM:
         mock_response.choices = [mock_choice]
         mock_response.usage.prompt_tokens = 12
         mock_response.usage.completion_tokens = 4
+        # Declare "no cache" explicitly: MagicMock auto-attrs would otherwise
+        # coerce to phantom cache tokens (int(MagicMock()) == 1).
+        mock_response.usage.prompt_cache_hit_tokens = 0
+        mock_response.usage.prompt_tokens_details = None
 
         mock_zhipu_client.chat.completions.create.return_value = mock_response
 

--- a/tests/core/model/chat/basic/test_zhipu.py
+++ b/tests/core/model/chat/basic/test_zhipu.py
@@ -70,7 +70,8 @@ class TestZhipuLLM:
 
         result = await zhipu_llm.chat([{"role": "user", "content": "Hello"}])
 
-        assert result == "Hello, world!"
+        assert result["type"] == "text"
+        assert result["content"] == "Hello, world!"
 
     @pytest.mark.asyncio
     async def test_none_content_response(self, zhipu_llm, mock_zhipu_client):
@@ -134,6 +135,8 @@ class TestZhipuLLM:
 
         mock_response = MagicMock()
         mock_response.choices = [mock_choice]
+        mock_response.usage.prompt_tokens = 12
+        mock_response.usage.completion_tokens = 4
 
         mock_zhipu_client.chat.completions.create.return_value = mock_response
 
@@ -158,6 +161,8 @@ class TestZhipuLLM:
         assert result["type"] == "tool_call"
         assert len(result["tool_calls"]) == 1
         assert result["tool_calls"][0]["function"]["name"] == "calculator"
+        # The usage stamp rides on tool_call envelopes too.
+        assert result["usage"] == {"prompt_tokens": 12, "completion_tokens": 4}
 
     @pytest.mark.asyncio
     async def test_stream_chat_yields_tool_call_argument_deltas(
@@ -292,7 +297,8 @@ class TestZhipuLLM:
         assert "thinking" in call_args.kwargs
         assert call_args.kwargs["thinking"]["type"] == "disabled"
 
-        assert result == "Response with thinking disabled"
+        assert result["type"] == "text"
+        assert result["content"] == "Response with thinking disabled"
 
     @pytest.mark.asyncio
     async def test_empty_string_api_key_fallback(self, monkeypatch):

--- a/tests/core/model/chat/test_response_shape.py
+++ b/tests/core/model/chat/test_response_shape.py
@@ -1,0 +1,185 @@
+"""Shape-matrix tests for ``classify_chat_response`` (#1714-class).
+
+The classifier is the single structural source of truth for the
+chat()/vision_chat() response union; ``unwrap_chat_text`` (agent layer),
+``VisionCore`` (tools layer), and the default ``stream_chat`` all delegate
+to it. The matrix pins every shape so no consumer ever falls back to
+``str(response)`` (repr leak) or reports success on a text-less result.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from xagent.core.model.chat.basic.base import BaseLLM
+from xagent.core.model.chat.response_shape import (
+    ChatResponseShape,
+    classify_chat_response,
+)
+from xagent.core.tools.core.vision_tool import VisionCore
+
+
+class TestClassifyChatResponseMatrix:
+    @pytest.mark.parametrize(
+        ("response", "kind", "text"),
+        [
+            # Legacy plain-string reply.
+            ("hello", "text", "hello"),
+            # Typed text envelope from the adapter contract.
+            ({"type": "text", "content": "hi"}, "text", "hi"),
+            # Content-only dict without a type tag (duck-typed text).
+            ({"content": "hi"}, "text", "hi"),
+            # Text envelope with extra keys (usage stamp, raw payload).
+            (
+                {
+                    "type": "text",
+                    "content": "hi",
+                    "usage": {"prompt_tokens": 1},
+                    "raw": {},
+                },
+                "text",
+                "hi",
+            ),
+            # Empty text shapes: empty string content, whitespace-only,
+            # and a legacy empty plain string.
+            ({"type": "text", "content": ""}, "empty", None),
+            ({"type": "text", "content": "  \n\t"}, "empty", None),
+            ({"content": ""}, "empty", None),
+            ("", "empty", None),
+            ("   ", "empty", None),
+            # Tool-call envelope (with and without arguments).
+            (
+                {
+                    "type": "tool_call",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "read_file", "arguments": "{}"},
+                        }
+                    ],
+                },
+                "tool_call",
+                None,
+            ),
+            ({"type": "tool_call", "tool_calls": []}, "tool_call", None),
+            # Unknown shapes: unrecognized dict, non-string content,
+            # non-dict/non-str payloads.
+            ({"foo": 1}, "unknown", None),
+            ({"type": "text", "content": 123}, "unknown", None),
+            ({"type": "text", "content": ["a", "b"]}, "unknown", None),
+            ({"type": "text"}, "unknown", None),
+            # An unrecognized type tag does not disqualify usable string
+            # content: classification is structural (duck-typed), matching
+            # the long-standing unwrap_chat_text acceptance.
+            ({"type": "mystery", "content": "hi"}, "text", "hi"),
+            (None, "unknown", None),
+            (42, "unknown", None),
+            (["a", "b"], "unknown", None),
+        ],
+    )
+    def test_shape_matrix(self, response: Any, kind: str, text: str | None) -> None:
+        shape = classify_chat_response(response)
+        assert shape.kind == kind
+        assert shape.text == text
+
+    def test_result_is_named_tuple(self) -> None:
+        shape = classify_chat_response("x")
+        assert isinstance(shape, ChatResponseShape)
+        assert tuple(shape) == ("text", "x")
+
+
+_MEDIA = "data:image/jpeg;base64,ZmFrZV9pbWFnZV9kYXRh"
+_TOOL_CALL_ENVELOPE = {
+    "type": "tool_call",
+    "tool_calls": [
+        {
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "read_file", "arguments": "{}"},
+        }
+    ],
+}
+
+
+def _vision_core(tmp_path: Any, response: Any) -> VisionCore:
+    model = Mock(spec=BaseLLM)
+    model.vision_chat = AsyncMock(return_value=response)
+    model.has_ability = Mock(return_value=True)
+    model.supports_native_video_input = False
+    return VisionCore(model, output_directory=str(tmp_path))
+
+
+class TestVisionCoreResponseShapes:
+    """VisionCore consumes the classifier: text-less shapes fail explicitly
+    -- never a repr leak, never "success with zero results"."""
+
+    @pytest.mark.asyncio
+    async def test_understand_media_tool_call_envelope_fails_without_repr(
+        self, tmp_path: Any
+    ) -> None:
+        core = _vision_core(tmp_path, _TOOL_CALL_ENVELOPE)
+        result = await core.understand_media(_MEDIA, "What is shown?")
+        assert result.success is False
+        assert result.error is not None
+        assert "'tool_calls'" not in result.error
+        assert "'type': 'tool_call'" not in result.error
+
+    @pytest.mark.asyncio
+    async def test_understand_media_unknown_shape_fails_without_repr(
+        self, tmp_path: Any
+    ) -> None:
+        core = _vision_core(tmp_path, {"unexpected": {"nested": 1}})
+        result = await core.understand_media(_MEDIA, "What is shown?")
+        assert result.success is False
+        assert result.error is not None
+        assert "'nested'" not in result.error
+
+    @pytest.mark.asyncio
+    async def test_understand_media_empty_envelope_fails(self, tmp_path: Any) -> None:
+        core = _vision_core(tmp_path, {"type": "text", "content": "  "})
+        result = await core.understand_media(_MEDIA, "What is shown?")
+        assert result.success is False
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_understand_media_text_envelope_succeeds(self, tmp_path: Any) -> None:
+        core = _vision_core(
+            tmp_path,
+            {
+                "type": "text",
+                "content": "A labelled diagram.",
+                "usage": {"prompt_tokens": 3},
+            },
+        )
+        result = await core.understand_media(_MEDIA, "What is shown?")
+        assert result.success is True
+        assert result.answer == "A labelled diagram."
+
+    @pytest.mark.asyncio
+    async def test_detect_objects_tool_call_envelope_fails_without_zero_success(
+        self, tmp_path: Any
+    ) -> None:
+        core = _vision_core(tmp_path, _TOOL_CALL_ENVELOPE)
+        result = await core.detect_objects(_MEDIA, task="Find things")
+        assert result.success is False
+        assert result.error is not None
+        assert "'tool_calls'" not in result.error
+        assert result.total_detections == 0
+
+    @pytest.mark.asyncio
+    async def test_detect_objects_unknown_shape_fails(self, tmp_path: Any) -> None:
+        core = _vision_core(tmp_path, {"unexpected": "shape"})
+        result = await core.detect_objects(_MEDIA, task="Find things")
+        assert result.success is False
+        assert result.error is not None
+
+    @pytest.mark.asyncio
+    async def test_detect_objects_empty_envelope_fails(self, tmp_path: Any) -> None:
+        core = _vision_core(tmp_path, {"type": "text", "content": ""})
+        result = await core.detect_objects(_MEDIA, task="Find things")
+        assert result.success is False
+        assert result.error is not None

--- a/tests/core/tools/test_vision_tool.py
+++ b/tests/core/tools/test_vision_tool.py
@@ -248,6 +248,26 @@ _VISION_RESPONSE_SHAPE_MATRIX = [
         [],
         str([1, 2, 3]),
     ),
+    # Content-bearing dicts without a recognized type tag are text: the
+    # normalizer delegates structural decoding to the shared
+    # ``classify_chat_response`` (PR #1787 review finding R0-D4), so vision
+    # consumers accept the same duck-typed shapes as chat consumers.
+    (
+        "content_only_dict",
+        {"content": "usable text without a type tag"},
+        "text",
+        "usable text without a type tag",
+        [],
+        "usable text without a type tag",
+    ),
+    (
+        "unknown_tag_str_content",
+        {"type": "mystery", "content": "usable text on an unknown tag"},
+        "text",
+        "usable text on an unknown tag",
+        [],
+        "usable text on an unknown tag",
+    ),
 ]
 
 

--- a/tests/core/tools/test_vision_tool.py
+++ b/tests/core/tools/test_vision_tool.py
@@ -1278,11 +1278,13 @@ class TestVisionToolUnderstandMediaEnvelope:
         assert result.error == expected_error
 
     @pytest.mark.asyncio
-    async def test_understand_media_tool_call_message_unchanged(
+    async def test_understand_media_tool_call_fails_explicitly(
         self, vision_tool_without_workspace, mock_vision_model
     ):
-        """The existing tool-call message text is not part of this fix and
-        must survive the rewrite unchanged."""
+        """A tool-call envelope is not an answer: understand_media reports an
+        explicit tool-side failure rather than a successful explanatory
+        answer (PR #1787 review finding N5, superseding the message text
+        #1721 deliberately preserved)."""
         mock_vision_model.vision_chat.return_value = {
             "type": "tool_call",
             "tool_calls": [{"id": "c1", "type": "function"}],
@@ -1293,11 +1295,9 @@ class TestVisionToolUnderstandMediaEnvelope:
             "data:image/jpeg;base64,ZmFrZV9pbWFnZV9kYXRh", "Describe this."
         )
 
-        assert result.success is True
-        assert result.answer == (
-            "Model triggered tool call instead of answering: "
-            "[{'id': 'c1', 'type': 'function'}]"
-        )
+        assert result.success is False
+        assert result.answer is None
+        assert result.error == "Vision model returned a tool call instead of an answer"
 
     @pytest.mark.asyncio
     @pytest.mark.parametrize(

--- a/tests/core/tools/test_vision_tool.py
+++ b/tests/core/tools/test_vision_tool.py
@@ -2379,3 +2379,56 @@ class TestDrawBoundingBoxes:
             finally:
                 if os.path.exists(temp_image_path):
                     os.unlink(temp_image_path)
+
+
+class TestVisionToolChatEnvelope:
+    """Regression tests for the chat-envelope contract (#520/#1714 class).
+
+    Adapters now return ``{"type": "text", "content": ...}`` envelopes from
+    ``vision_chat``; the tool must read ``content``, never repr the envelope.
+    """
+
+    @pytest.mark.asyncio
+    async def test_understand_images_unwraps_text_envelope(self) -> None:
+        model = Mock(spec=BaseLLM)
+        model.vision_chat = AsyncMock(
+            return_value={
+                "type": "text",
+                "content": "A cat sitting on a keyboard.",
+                "usage": {"prompt_tokens": 12, "completion_tokens": 4},
+            }
+        )
+        model.has_ability = Mock(return_value=True)
+
+        result = await VisionTool(model).understand_images(
+            "data:image/jpeg;base64,ZmFrZV9pbWFnZV9kYXRh",
+            "What is in this image?",
+        )
+
+        assert result.success is True
+        assert result.answer == "A cat sitting on a keyboard."
+        assert "'type': 'text'" not in result.answer
+
+    @pytest.mark.asyncio
+    async def test_detect_objects_parses_text_envelope_content(self) -> None:
+        model = Mock(spec=BaseLLM)
+        model.vision_chat = AsyncMock(
+            return_value={
+                "type": "text",
+                "content": (
+                    '{"detections": [{"class": "person", "confidence": 0.95, '
+                    '"bbox": [0.1, 0.1, 0.6, 0.8]}]}'
+                ),
+                "usage": {"prompt_tokens": 12, "completion_tokens": 4},
+            }
+        )
+        model.has_ability = Mock(return_value=True)
+
+        result = await VisionTool(model).detect_objects(
+            "data:image/jpeg;base64,ZmFrZV9pbWFnZV9kYXRh",
+            task="Find all objects in the image",
+        )
+
+        assert result.success is True
+        assert len(result.detections) == 1
+        assert result.detections[0]["class"] == "person"

--- a/tests/web/api/test_agents_optimize_instructions.py
+++ b/tests/web/api/test_agents_optimize_instructions.py
@@ -80,3 +80,40 @@ async def test_optimize_instructions_falls_back_on_wrong_language_output(
     )
 
     assert result == {"optimized_instructions": draft}
+
+
+@pytest.mark.asyncio
+async def test_optimize_instructions_rejects_tool_call_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """#1714: a tool_call envelope from the LLM must surface as an explicit
+    500, never a 200 carrying the envelope's repr as "optimized" text."""
+
+    class _ToolCallLLM:
+        async def chat(self, **kwargs: Any) -> dict[str, Any]:
+            return {
+                "type": "tool_call",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": "{}"},
+                    }
+                ],
+            }
+
+    monkeypatch.setattr(
+        agents_api,
+        "UserAwareModelStorage",
+        lambda db: _FakeModelStorage(_ToolCallLLM()),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(agents_api.HTTPException) as exc_info:
+        await agents_api.optimize_instructions(
+            agents_api.OptimizeInstructionsRequest(instructions="请用中文回答。"),
+            SimpleNamespace(id=7),
+            object(),
+        )
+
+    assert exc_info.value.status_code == 500
+    assert "no usable text content" in exc_info.value.detail

--- a/tests/web/api/test_agents_optimize_instructions.py
+++ b/tests/web/api/test_agents_optimize_instructions.py
@@ -117,3 +117,32 @@ async def test_optimize_instructions_rejects_tool_call_envelope(
 
     assert exc_info.value.status_code == 500
     assert "no usable text content" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_optimize_instructions_rejects_empty_content_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An empty text envelope raises ``LLMEmptyContentError`` from
+    ``unwrap_chat_text`` and must surface as an explicit 500, not a 200 with
+    an empty "optimization"."""
+
+    class _EmptyContentLLM:
+        async def chat(self, **kwargs: Any) -> dict[str, Any]:
+            return {"type": "text", "content": ""}
+
+    monkeypatch.setattr(
+        agents_api,
+        "UserAwareModelStorage",
+        lambda db: _FakeModelStorage(_EmptyContentLLM()),  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(agents_api.HTTPException) as exc_info:
+        await agents_api.optimize_instructions(
+            agents_api.OptimizeInstructionsRequest(instructions="请用中文回答。"),
+            SimpleNamespace(id=7),
+            object(),
+        )
+
+    assert exc_info.value.status_code == 500
+    assert "empty" in exc_info.value.detail


### PR DESCRIPTION
Fixes #520. Refs #1714 (problem 1 only).

## Summary

`chat()` has no normalized response contract, and every consumer hand-parses its own subset. This PR stamps provider usage at the adapter boundary so `PatternRuntime`'s token extraction works for real adapter shapes, teaches the usage extractors to fall back one level under `raw`, and converges the three hand-written text-unwrapping call sites onto one helper that never `repr()`s a tool_call envelope.

## Root cause

`on_llm_end` → `_extract_token_usage` → `record_llm_usage` is the only path populating `ExecutionContext.llm_calls`, and the extractor only recognized top-level `usage`/`usage_metadata`. Today that shape is produced solely by the streaming reconstruction in `run_streaming_llm_call` — and by the FakeLLM test double, which is why the gap stayed invisible. Real non-streaming responses differ: OpenAI/DeepSeek nest usage under `raw`; Zhipu/Gemini/Claude text paths return bare strings whose usage only reaches the contextvar ledger. The same missing contract causes #1714 problem 1 from the consumer side: callers keying on `content` turn a tool_call envelope into its `repr()`, and the compaction path reports that as a successful compaction.

## What changed

- **Adapters**: a `_response_usage_payload()` snapshot in `OpenAICompatibleLLM` stamps top-level `usage` on all six chat/vision return sites (inherited by DeepSeek/DashScope/OpenRouter/Azure); Zhipu/Gemini/Claude text paths return the `{type, content, usage}` envelope the streaming path already emits; tool_call envelopes are stamped too (including Gemini's, which carries no `raw`); `normalize_deepseek_response`'s rebuild path preserves the stamp. `add_token_usage` call sites are untouched — the contextvar ledger is still written exactly once per call, by the adapter; the runtime stays read-only against it.
- **Runtime**: `_resolve_usage_payload()` shared by `_extract_token_usage` and `_extract_cached_tokens` (same top-level-only gap) — top level first, then one level under `raw`, fail-open on unknown shapes.
- **Unwrap**: new `unwrap_chat_text()` (`agent/utils/llm_utils.py`) raises instead of `str(response)`: `LLMNoTextContentError` (new, `model/chat/exceptions.py`) for non-text shapes, `LLMEmptyContentError` for empty/whitespace envelope content — matching the adapters' own empty-generation class. `ContextBuilder._compact_individual_dependency` / `_compact_dependency_messages` and `optimize_instructions` migrated onto it. Compaction now falls back to truncation explicitly; the endpoint returns an error instead of 200 + repr.
- **Cache metrics**: the Claude/Gemini/Zhipu stamps carry `cached_input_tokens` (and `cache_write_input_tokens` for Claude) when non-zero, so `_extract_cached_tokens` sees prompt-cache hits on non-streaming calls; comparisons are type-guarded so an unexpected provider value can never raise out of `chat()`. (Review findings, fixed in d2f0f16.)
- **vision_tool repr leaks (pre-existing, same class as #1714)**: `understand_media` did `str(result)` on non-str results and `detect_objects` stringified the envelope before parsing, dropping the detections. The envelope change widened this existing landmine (Zhipu vision now returns envelopes too), so both are fixed here with red-first regression tests. (7efc2a2)
- **Compaction freshness isolation (review N1)**: usage records of internal calls carry `synthetic_purpose` and are excluded from the context-freshness baseline (`_latest_freshness_baseline_call`), so a failed LLM compaction can no longer suppress the truncation fallback; the field round-trips through checkpoints.
- **First-class billed attempts (review N2)**: `usage` stays the final attempt (freshness baseline); `usage_attempts` lists every billed attempt of a logical call, set only when >1. Adapters attach booked payloads to retryable errors and collect superseded internal retries; `RetryWrapper` merges across outer retries; `on_llm_end` books each attempt in order (final last) and traces billing totals + `llm_attempt_count` + final-attempt numbers; `on_llm_error` covers the all-failed path.
- **Strict usage coercion (review N3)**: `_coerce_usage_int` rejects bools, non-finite/negative/non-integral values and falls through to later aliases/candidates.
- **BaseLLM contract + default stream boundary (review N4)**: docs describe the envelope contract; the default `stream_chat` discriminates text/tool_call/legacy-string/unknown via the shared classifier (unknown → explicit ERROR chunk).
- **Shared structural classifier (review N5)**: `model/chat/response_shape.classify_chat_response` is the single shape source for `unwrap_chat_text` and the default `stream_chat`. Reconciled with #1721's vision normalizer on rebase: `detect_objects` already failed explicitly there; `understand_media` now also fails explicitly on tool_call envelopes (94b3be9; flips a test #1721 deliberately preserved — flagged in the review thread).

## Intentional contract change

Zhipu/Gemini/Claude `chat()` text paths now return envelope dicts instead of bare strings. Consumer audit (`grep -rn "\.chat(" src/`): `_normalize_llm_response`, `_response_content`, `_short_response`, `_compact_response_text`, and DAG/Auto via ReAct normalization all already duck-type `str | dict`. The affected adapter tests were updated to the new contract.

## Test plan

- `tests/core/agent/test_compact_llm_usage_contract.py` (36 tests): per adapter family the response is built with real SDK types (e.g. `ChatCompletion` with a populated `CompletionUsage`), only the SDK client is patched, and the real adapter is driven through the real compact path — asserting the `action_end_llm` (`purpose=context_compaction`) token fields, `get_total_token_usage()`, and the trace `cached_input_tokens` end to end. Includes a no-double-counting guard (contextvar ledger and `llm_calls` each record exactly once), vision/reasoning-branch stamp coverage, extractor edge shapes (string `raw`, top-level `usage_metadata`, all-zero usage), the checkpoint round-trip of `llm_calls`, the record-before-rewrite ordering contract behind `estimate_context_tokens()`, and #1714 regressions (tool_call or empty-content envelope fed to compaction → explicit truncation fallback, no repr anywhere).
- Local runs (after rebase onto `d1e2ca1`): **1705 passed, 0 failed** across agent / model.chat / retry / vision / web suites (2 pre-existing environment failures in `test_executor.py` / `test_browser_tools.py`, red on a clean main checkout too — they need browser/workspace env). `ruff check` / `ruff format --check` clean on touched files.
- Mutation-verified: every change was reverted line-by-line and the expected test went red (extractor `raw` fallback, each adapter stamp incl. vision/reasoning branches, cache-metric stamping, both exception branches of `unwrap_chat_text`, the record/rewrite ordering — swapping `on_llm_end` after `compact_with_llm_response` reds the estimate test — and both `vision_tool` fixes, which were red before the fix by construction).

## Known boundaries / out of scope

- Pre-existing, deliberately not fixed here: `BaseLLM`'s default `stream_chat` treats any dict as a tool_call envelope; no current adapter triggers it. Worth its own issue — happy to file.
- Zhipu/Gemini contract fixtures use field-accurate stand-ins rather than real SDK types (offline construction of zai-sdk / google-genai responses is unreliable); noted in the test module docstring.
- #1714 problem 2 (whitespace-only content / exception-type divergence across providers) is not addressed here. Evaluated and deliberately left alone: Zhipu `vision_chat`'s empty-content early return is now an empty-text envelope — behavior-parity with the old `""` for its consumers, and raising would lose the retryable classification inside that method's `except Exception → RuntimeError` wrapper.
- Considered and set aside: a full response-envelope migration (disproportionate); measuring usage via a contextvar-ledger diff (a naive before/after misattributes tokens under concurrent DAG steps; the scoped-rebind variant adds more mechanism than this needs).
- Happy to split the unwrap-helper commits into a stacked PR if you'd rather keep this one observability-only.

cc @rogercloud
