### PR TITLE
enh(openrouter): allow thinking for DeepSeek-served models that declare it

### DIFF
--- a/src/xagent/core/model/chat/basic/deepseek.py
+++ b/src/xagent/core/model/chat/basic/deepseek.py
@@ -160,8 +160,9 @@ class DeepSeekLLM(OpenAICompatibleLLM):
         result: Dict[str, Any],
         *,
         thinking: Optional[Dict[str, Any]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
-        _ = thinking
+        _ = thinking, response_format
         return deepseek_reasoning_provider_state(
             result, fields=(DEEPSEEK_REASONING_CONTENT_STATE_KEY,)
         )

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -425,6 +425,13 @@ class OpenAICompatibleLLM(BaseLLM):
 
         self._apply_output_config(completion_params, output_config)
 
+        # The response_format degrade branch below (retry without
+        # response_format after a 400) resets the ``response_format``
+        # local to None so the structured-output degrade check further
+        # down still gates correctly. The capture sentinel further below
+        # needs to know what this particular request was actually built
+        # with, which can differ from that local on that narrow path, so
+        # it is tracked separately here.
         extra_body = self._prepare_provider_reasoning_extra_body(
             extra_body=extra_body,
             thinking=thinking,
@@ -433,6 +440,7 @@ class OpenAICompatibleLLM(BaseLLM):
             output_config=output_config,
             is_streaming=False,
         )
+        built_response_format = response_format
 
         # Helper function to process response
         async def _make_api_call() -> Any:
@@ -514,7 +522,9 @@ class OpenAICompatibleLLM(BaseLLM):
                     result["reasoning_content"] = reasoning_content
                     result["reasoning"] = reasoning_content
                 provider_state = self._response_provider_state(
-                    result, thinking=request_thinking, response_format=response_format
+                    result,
+                    thinking=request_thinking,
+                    response_format=built_response_format,
                 )
                 if provider_state:
                     result[PROVIDER_STATE_METADATA_KEY] = provider_state
@@ -644,6 +654,7 @@ class OpenAICompatibleLLM(BaseLLM):
                             output_config=output_config,
                             is_streaming=False,
                         )
+                        built_response_format = response_format
                         response = await _make_api_call()
                         result = _process_response(
                             response, request_thinking=retry_thinking

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -293,6 +293,7 @@ class OpenAICompatibleLLM(BaseLLM):
         self,
         *,
         thinking: Optional[Dict[str, Any]],
+        response_format: Optional[Dict[str, Any]],
         has_tool_calls: bool,
         has_reasoning_content: bool,
         observed_field_names: tuple[str, ...],
@@ -303,11 +304,18 @@ class OpenAICompatibleLLM(BaseLLM):
         the streaming path: called with the whole stream's outcome (whether
         any delta ever carried a recognized reasoning field, whether the
         response ended with tool calls, and every field name -- never a
-        value -- seen on any delta), so a subclass can warn when thinking
-        was requested but nothing recognized was ever captured. Default is a
+        value -- seen on any delta), so a subclass can decide whether this
+        request could have produced reasoning at all. ``response_format`` is
+        the value this request's extra_body was built from. Default is a
         no-op; only ``OpenRouterLLM`` currently overrides it.
         """
-        _ = thinking, has_tool_calls, has_reasoning_content, observed_field_names
+        _ = (
+            thinking,
+            response_format,
+            has_tool_calls,
+            has_reasoning_content,
+            observed_field_names,
+        )
 
     def _build_request_messages(
         self,
@@ -1134,8 +1142,14 @@ class OpenAICompatibleLLM(BaseLLM):
             # capture failure (thinking requested, tool calls in the
             # response, but no recognized reasoning field ever captured).
             # See ``_check_stream_reasoning_capture``'s docstring.
+            # ``response_format`` is passed as the value this request's
+            # extra_body was built from: the response_format pop-and-retry
+            # above drops it from completion_params only and reuses the
+            # already-built extra_body, so the local variable still
+            # describes what actually went on the wire.
             self._check_stream_reasoning_capture(
                 thinking=thinking,
+                response_format=response_format,
                 has_tool_calls=bool(accumulated_tool_calls),
                 has_reasoning_content=has_reasoning_content,
                 observed_field_names=tuple(sorted(observed_reasoning_field_names)),

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -271,15 +271,18 @@ class OpenAICompatibleLLM(BaseLLM):
         result: Dict[str, Any],
         *,
         thinking: Optional[Dict[str, Any]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Return opaque provider-owned message state for future LLM requests.
 
-        ``thinking`` is the request's thinking configuration, made available
-        so a subclass can decide whether this request could have produced
-        reasoning at all (e.g. to decide whether an empty capture is worth a
-        warning).
+        ``thinking`` and ``response_format`` are this request's own thinking
+        configuration and response format, made available so a subclass can
+        decide whether this request could have produced reasoning at all
+        (e.g. to decide whether an empty capture is worth a warning).
+        Mirrors ``_check_stream_reasoning_capture``'s parameters, for the
+        non-streaming path.
         """
-        _ = result, thinking
+        _ = result, thinking, response_format
         return {}
 
     def _delta_reasoning_content(self, delta: Any) -> tuple[bool, Any]:
@@ -511,7 +514,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     result["reasoning_content"] = reasoning_content
                     result["reasoning"] = reasoning_content
                 provider_state = self._response_provider_state(
-                    result, thinking=request_thinking
+                    result, thinking=request_thinking, response_format=response_format
                 )
                 if provider_state:
                     result[PROVIDER_STATE_METADATA_KEY] = provider_state
@@ -876,7 +879,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     result["reasoning_content"] = reasoning_content
                     result["reasoning"] = reasoning_content
                 provider_state = self._response_provider_state(
-                    result, thinking=thinking
+                    result, thinking=thinking, response_format=response_format
                 )
                 if provider_state:
                     result[PROVIDER_STATE_METADATA_KEY] = provider_state

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -275,8 +275,9 @@ class OpenAICompatibleLLM(BaseLLM):
         """Return opaque provider-owned message state for future LLM requests.
 
         ``thinking`` is the request's thinking configuration, made available
-        so a subclass can tell whether reasoning content was actually asked
-        for (e.g. to decide whether an empty capture is worth a warning).
+        so a subclass can decide whether this request could have produced
+        reasoning at all (e.g. to decide whether an empty capture is worth a
+        warning).
         """
         _ = result, thinking
         return {}
@@ -1139,9 +1140,10 @@ class OpenAICompatibleLLM(BaseLLM):
                     yield chunk
 
             # One-time hook for a subclass to detect a silent streaming
-            # capture failure (thinking requested, tool calls in the
-            # response, but no recognized reasoning field ever captured).
-            # See ``_check_stream_reasoning_capture``'s docstring.
+            # capture failure (the request did not go out with reasoning
+            # disabled, tool calls in the response, but no recognized
+            # reasoning field ever captured). See
+            # ``_check_stream_reasoning_capture``'s docstring.
             # ``response_format`` is passed as the value this request's
             # extra_body was built from: the response_format pop-and-retry
             # above drops it from completion_params only and reuses the

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -1021,6 +1021,56 @@ class OpenRouterLLM(OpenAILLM):
             },
         }
 
+    def _provider_reasoning_intent(
+        self,
+        thinking: Optional[Dict[str, Any]],
+        *,
+        response_format: Optional[Dict[str, Any]],
+        is_streaming: bool,
+    ) -> tuple[bool, bool]:
+        """Return ``(should_disable, should_enable)`` for one request.
+
+        Single source of truth for what this client asks the endpoint to do
+        about reasoning. The request builder below turns the pair into
+        extra_body keys; the two capture sentinels ask the same method
+        whether this request actually went out with thinking disabled.
+        Recomputing the branch separately in a sentinel would let the two
+        answers drift apart, and a sentinel that disagrees with the payload
+        is worse than no sentinel.
+        """
+        if thinking is not None:
+            should_enable = thinking.get("type") == "enabled" or thinking.get(
+                "enable", False
+            )
+            should_disable = not should_enable and (
+                thinking.get("type") == "disabled" or not thinking.get("enable", False)
+            )
+            return bool(should_disable), bool(should_enable)
+
+        if is_streaming and response_format:
+            # Provider reasoning can corrupt structured JSON on this
+            # transport, so a structured stream is disabled unconditionally
+            # -- the declared ability does not reach this branch.
+            return (
+                self.supports_thinking_mode or self._uses_deepseek_tool_protocol,
+                False,
+            )
+
+        # DeepSeek-served endpoints can default to thinking mode, and once a
+        # response carries reasoning_content they require it to be replayed
+        # verbatim on the next request of a tool-call chain. That replay is
+        # implemented (_prepare_messages_for_request, _response_provider_
+        # state, _attach_reasoning_content_to_raw below), so this is no
+        # longer the reason thinking stays off by default. It stays off
+        # here anyway, matching DeepSeekLLM's own default: turning
+        # thinking on changes token cost and response shape for every
+        # DeepSeek-authored slug on this client, which is a separate call
+        # from closing the replay gap and is left for a change that makes
+        # that call explicitly (#1537). This deliberately ignores
+        # supports_thinking_mode: a declared thinking_mode ability does
+        # not flip this default on its own.
+        return self._uses_deepseek_tool_protocol, False
+
     def _prepare_provider_reasoning_extra_body(
         self,
         *,
@@ -1033,35 +1083,9 @@ class OpenRouterLLM(OpenAILLM):
     ) -> Dict[str, Any]:
         _ = tools, output_config
         updated_extra_body = dict(extra_body)
-
-        if thinking is not None:
-            should_enable = thinking.get("type") == "enabled" or thinking.get(
-                "enable", False
-            )
-            should_disable = not should_enable and (
-                thinking.get("type") == "disabled" or not thinking.get("enable", False)
-            )
-        elif is_streaming and response_format:
-            should_disable = (
-                self.supports_thinking_mode or self._uses_deepseek_tool_protocol
-            )
-            should_enable = False
-        else:
-            # DeepSeek-served endpoints can default to thinking mode, and once a
-            # response carries reasoning_content they require it to be replayed
-            # verbatim on the next request of a tool-call chain. That replay is
-            # implemented (_prepare_messages_for_request, _response_provider_
-            # state, _attach_reasoning_content_to_raw below), so this is no
-            # longer the reason thinking stays off by default. It stays off
-            # here anyway, matching DeepSeekLLM's own default: turning
-            # thinking on changes token cost and response shape for every
-            # DeepSeek-authored slug on this client, which is a separate call
-            # from closing the replay gap and is left for a change that makes
-            # that call explicitly (#1537). This deliberately ignores
-            # supports_thinking_mode: a declared thinking_mode ability does
-            # not flip this default on its own.
-            should_disable = self._uses_deepseek_tool_protocol
-            should_enable = False
+        should_disable, should_enable = self._provider_reasoning_intent(
+            thinking, response_format=response_format, is_streaming=is_streaming
+        )
 
         if should_disable:
             updated_extra_body["reasoning"] = {"enabled": False}

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -382,12 +382,14 @@ class OpenRouterLLM(OpenAILLM):
             # back here. Log which reasoning-like keys (if any) showed up --
             # key names only, never their content.
             #
-            # ``response_format`` is this call's own value, handed down by
-            # the caller that built the request: structured requests
-            # disable reasoning on this path too, so a sentinel that
-            # assumed ``None`` would report a miss against a response it
-            # had itself made impossible. ``is_streaming`` stays a literal
-            # because both call sites of this hook are non-streaming.
+            # ``response_format`` is the value the caller building this
+            # particular request used to construct its extra_body, not
+            # necessarily whatever ``response_format`` was originally
+            # passed in: structured requests disable reasoning on this
+            # path too, so a sentinel that assumed ``None`` would report a
+            # miss against a response it had itself made impossible.
+            # ``is_streaming`` stays a literal because both call sites of
+            # this hook are non-streaming.
             logger.warning(
                 "OpenRouter deepseek model %s returned a tool call "
                 "without thinking disabled, but no reasoning content was "

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -361,6 +361,7 @@ class OpenRouterLLM(OpenAILLM):
         result: Dict[str, Any],
         *,
         thinking: Optional[Dict[str, Any]] = None,
+        response_format: Optional[Dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         if not self._uses_deepseek_tool_protocol:
             return {}
@@ -371,7 +372,7 @@ class OpenRouterLLM(OpenAILLM):
             not provider_state
             and result.get("tool_calls")
             and not self._provider_reasoning_intent(
-                thinking=thinking, response_format=None, is_streaming=False
+                thinking=thinking, response_format=response_format, is_streaming=False
             )[0]
         ):
             # This request did not go out with an explicit disable payload,
@@ -381,11 +382,12 @@ class OpenRouterLLM(OpenAILLM):
             # back here. Log which reasoning-like keys (if any) showed up --
             # key names only, never their content.
             #
-            # Both call sites of this hook are non-streaming request paths,
-            # and the only intent branch that reads ``response_format`` also
-            # requires streaming, so ``response_format=None`` here is exact
-            # rather than an approximation. A future streaming caller of
-            # this hook must pass that path's real ``response_format``.
+            # ``response_format`` is this call's own value, handed down by
+            # the caller that built the request: structured requests
+            # disable reasoning on this path too, so a sentinel that
+            # assumed ``None`` would report a miss against a response it
+            # had itself made impossible. ``is_streaming`` stays a literal
+            # because both call sites of this hook are non-streaming.
             logger.warning(
                 "OpenRouter deepseek model %s returned a tool call "
                 "without thinking disabled, but no reasoning content was "

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -371,7 +371,7 @@ class OpenRouterLLM(OpenAILLM):
             not provider_state
             and result.get("tool_calls")
             and not self._provider_reasoning_intent(
-                thinking, response_format=None, is_streaming=False
+                thinking=thinking, response_format=None, is_streaming=False
             )[0]
         ):
             # This request did not go out with an explicit disable payload,
@@ -457,7 +457,7 @@ class OpenRouterLLM(OpenAILLM):
             and has_tool_calls
             and not has_reasoning_content
             and not self._provider_reasoning_intent(
-                thinking, response_format=response_format, is_streaming=True
+                thinking=thinking, response_format=response_format, is_streaming=True
             )[0]
         ):
             logger.warning(
@@ -1034,8 +1034,8 @@ class OpenRouterLLM(OpenAILLM):
 
     def _provider_reasoning_intent(
         self,
-        thinking: Optional[Dict[str, Any]],
         *,
+        thinking: Optional[Dict[str, Any]],
         response_format: Optional[Dict[str, Any]],
         is_streaming: bool,
     ) -> tuple[bool, bool]:
@@ -1114,7 +1114,9 @@ class OpenRouterLLM(OpenAILLM):
         _ = tools, output_config
         updated_extra_body = dict(extra_body)
         should_disable, should_enable = self._provider_reasoning_intent(
-            thinking, response_format=response_format, is_streaming=is_streaming
+            thinking=thinking,
+            response_format=response_format,
+            is_streaming=is_streaming,
         )
 
         if should_disable:

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -370,20 +370,27 @@ class OpenRouterLLM(OpenAILLM):
         if (
             not provider_state
             and result.get("tool_calls")
-            and _thinking_requested(thinking)
+            and not self._provider_reasoning_intent(
+                thinking, response_format=None, is_streaming=False
+            )[0]
         ):
-            # Thinking was requested and the response is a tool call, but
-            # neither known reasoning field spelling was captured. This is
-            # the one silent-failure mode of the whole mechanism (see
-            # OPENROUTER_REASONING_FIELDS): the next request in this tool
-            # chain will 400 with no clue pointing back here, so log which
-            # reasoning-like keys (if any) actually showed up -- key names
-            # only, never their content.
+            # This request did not go out with an explicit disable payload,
+            # so the endpoint was free to produce reasoning content and its
+            # absence from a tool-call response is a real capture miss:
+            # the next request in this chain will 400 with no clue pointing
+            # back here. Log which reasoning-like keys (if any) showed up --
+            # key names only, never their content.
+            #
+            # Both call sites of this hook are non-streaming request paths,
+            # and the only intent branch that reads ``response_format`` also
+            # requires streaming, so ``response_format=None`` here is exact
+            # rather than an approximation. A future streaming caller of
+            # this hook must pass that path's real ``response_format``.
             logger.warning(
-                "OpenRouter deepseek model %s returned a tool call with "
-                "thinking requested, but no reasoning content was captured "
-                "under any known field spelling %s; observed reasoning-like "
-                "keys: %s",
+                "OpenRouter deepseek model %s returned a tool call "
+                "without thinking disabled, but no reasoning content was "
+                "captured under any known field spelling %s; observed "
+                "reasoning-like keys: %s",
                 self._model_name,
                 OPENROUTER_REASONING_FIELDS,
                 reasoning_field_names(result),
@@ -431,29 +438,33 @@ class OpenRouterLLM(OpenAILLM):
         self,
         *,
         thinking: Optional[Dict[str, Any]],
+        response_format: Optional[Dict[str, Any]],
         has_tool_calls: bool,
         has_reasoning_content: bool,
         observed_field_names: tuple[str, ...],
     ) -> None:
         """Streaming counterpart of the WARNING in ``_response_provider_state``.
 
-        Same silent-failure mode, same gate (deepseek slugs only, thinking
-        requested, response ended with tool calls), just checked over the
-        whole stream's outcome instead of one non-streaming response body:
-        if no delta ever carried a recognized reasoning field, the next
-        request in this tool chain will 400 with nothing pointing back here.
+        Same silent-failure mode, same gate (deepseek slugs only, this
+        request did not go out with thinking disabled, response ended with
+        tool calls), just checked over the whole stream's outcome instead of
+        one non-streaming response body: if no delta ever carried a
+        recognized reasoning field, the next request in this tool chain will
+        400 with nothing pointing back here.
         """
         if (
             self._uses_deepseek_tool_protocol
             and has_tool_calls
-            and _thinking_requested(thinking)
             and not has_reasoning_content
+            and not self._provider_reasoning_intent(
+                thinking, response_format=response_format, is_streaming=True
+            )[0]
         ):
             logger.warning(
-                "OpenRouter deepseek model %s streamed a tool call with "
-                "thinking requested, but no reasoning content was captured "
-                "under any known field spelling %s across the stream; "
-                "observed reasoning-like keys: %s",
+                "OpenRouter deepseek model %s streamed a tool call "
+                "without thinking disabled, but no reasoning content was "
+                "captured under any known field spelling %s across the "
+                "stream; observed reasoning-like keys: %s",
                 self._model_name,
                 OPENROUTER_REASONING_FIELDS,
                 observed_field_names,
@@ -1048,9 +1059,11 @@ class OpenRouterLLM(OpenAILLM):
             return bool(should_disable), bool(should_enable)
 
         if is_streaming and response_format:
-            # Provider reasoning can corrupt structured JSON on this
-            # transport, so a structured stream is disabled unconditionally
-            # -- the declared ability does not reach this branch.
+            # The caller said nothing about reasoning and this is a
+            # structured stream, where provider reasoning can corrupt the
+            # JSON. Disable it: the declared ability does not reach this
+            # branch. A caller that asked for reasoning explicitly is
+            # answered above and is not overridden here.
             return (
                 self.supports_thinking_mode or self._uses_deepseek_tool_protocol,
                 False,

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -1060,15 +1060,20 @@ class OpenRouterLLM(OpenAILLM):
             )
             return bool(should_disable), bool(should_enable)
 
-        if is_streaming and response_format:
-            # The caller said nothing about reasoning and this is a
-            # structured stream, where provider reasoning can corrupt the
-            # JSON. Disable it regardless of the declared ability, which
-            # does not open the default here. A caller that asked for
+        if response_format:
+            # The caller said nothing about reasoning and this request asks
+            # for structured output, where provider reasoning can corrupt
+            # the JSON. Disable it for every DeepSeek-served model, declared
+            # ability or not: the ability says the operator wants reasoning,
+            # it does not say they want it mixed into a JSON body. Models
+            # from other authors keep the streaming-only rule this client
+            # has always had -- widening that one would change requests for
+            # models this change is not about. A caller that asked for
             # reasoning explicitly is answered above and is not overridden
             # here.
             return (
-                self.supports_thinking_mode or self._uses_deepseek_tool_protocol,
+                self._uses_deepseek_tool_protocol
+                or (is_streaming and self.supports_thinking_mode),
                 False,
             )
 

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -1069,20 +1069,36 @@ class OpenRouterLLM(OpenAILLM):
                 False,
             )
 
-        # DeepSeek-served endpoints can default to thinking mode, and once a
-        # response carries reasoning_content they require it to be replayed
-        # verbatim on the next request of a tool-call chain. That replay is
-        # implemented (_prepare_messages_for_request, _response_provider_
-        # state, _attach_reasoning_content_to_raw below), so this is no
-        # longer the reason thinking stays off by default. It stays off
-        # here anyway, matching DeepSeekLLM's own default: turning
-        # thinking on changes token cost and response shape for every
-        # DeepSeek-authored slug on this client, which is a separate call
-        # from closing the replay gap and is left for a change that makes
-        # that call explicitly (#1537). This deliberately ignores
-        # supports_thinking_mode: a declared thinking_mode ability does
-        # not flip this default on its own.
-        return self._uses_deepseek_tool_protocol, False
+        # No caller-supplied thinking configuration. DeepSeek-served
+        # endpoints turn reasoning on by themselves, so the only question
+        # here is whether this client overrides that with an explicit
+        # disable payload. It does, unless the model record declares the
+        # ``thinking_mode`` ability.
+        #
+        # The ability is operator-set configuration read from the model
+        # record, while ``_uses_deepseek_tool_protocol`` is inferred from
+        # the model name. Gating on the explicit configuration keeps the
+        # decision with whoever configured the model: a record that asks
+        # for thinking gets the endpoint's reasoning, and a record that
+        # never asked for it keeps the cheaper non-reasoning shape it has
+        # always had. Reasoning produced this way is captured and replayed
+        # on the next request of a tool-call chain
+        # (``_prepare_messages_for_request``, ``_response_provider_state``,
+        # ``_attach_reasoning_content_to_raw``), which is what makes
+        # leaving it on safe.
+        #
+        # This is deliberately different from ``DeepSeekLLM``, which
+        # disables reasoning for every request that does not ask for it and
+        # never consults abilities. That client talks to one endpoint whose
+        # default it knows; this one routes the same author's models
+        # through endpoints whose defaults it does not control, so the
+        # declared ability is the only signal available about what the
+        # operator wants. Aligning the direct client is a separate decision
+        # about a different endpoint and is not made here.
+        return (
+            self._uses_deepseek_tool_protocol and not self.supports_thinking_mode,
+            False,
+        )
 
     def _prepare_provider_reasoning_extra_body(
         self,

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -1061,9 +1061,10 @@ class OpenRouterLLM(OpenAILLM):
         if is_streaming and response_format:
             # The caller said nothing about reasoning and this is a
             # structured stream, where provider reasoning can corrupt the
-            # JSON. Disable it: the declared ability does not reach this
-            # branch. A caller that asked for reasoning explicitly is
-            # answered above and is not overridden here.
+            # JSON. Disable it regardless of the declared ability, which
+            # does not open the default here. A caller that asked for
+            # reasoning explicitly is answered above and is not overridden
+            # here.
             return (
                 self.supports_thinking_mode or self._uses_deepseek_tool_protocol,
                 False,

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -2827,6 +2827,94 @@ async def test_openrouter_deepseek_stream_replays_reasoning_content(mocker):
 
 
 @pytest.mark.asyncio
+async def test_openrouter_deepseek_declared_thinking_stream_captures_and_replays_without_request_thinking(
+    mocker,
+):
+    """Streaming counterpart of the non-streaming capture-then-replay test.
+
+    Each half of this round trip is already pinned on its own -- streamed
+    capture, streamed replay, and the declared-ability default. What is only
+    covered here is the composition: one streamed tool-call turn captures
+    reasoning, and the next streamed turn sends it back, with neither call
+    passing ``thinking`` at all.
+    """
+
+    async def first_stream():
+        yield _reasoning_delta_chunk(reasoning_content="Use the search tool first")
+        yield _tool_call_delta_chunk(
+            call_id="call_1",
+            index=0,
+            name="search",
+            arguments='{"query":"xagent"}',
+            finish_reason="tool_calls",
+        )
+
+    async def second_stream():
+        yield _tool_call_delta_chunk(
+            call_id="call_2",
+            index=0,
+            name="search",
+            arguments='{"query":"xagent"}',
+            finish_reason="tool_calls",
+        )
+
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        first_stream(),
+        second_stream(),
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "thinking_mode"],
+    )
+
+    round1 = [
+        chunk
+        async for chunk in llm.stream_chat(
+            [{"role": "user", "content": "Search xagent"}],
+            tools=_single_tool_schema("search"),
+        )
+    ]
+    assert (
+        "extra_body" not in mock_client.chat.completions.create.call_args_list[0].kwargs
+    )
+    tool_chunks = [chunk for chunk in round1 if chunk.is_tool_call()]
+    assert tool_chunks, "expected at least one tool-call chunk"
+    captured = tool_chunks[-1].raw[PROVIDER_STATE_METADATA_KEY]
+    assert captured == _deepseek_provider_state("Use the search tool first")
+
+    messages = [
+        {"role": "user", "content": "Search xagent"},
+        {
+            "role": "assistant",
+            "content": "",
+            PROVIDER_STATE_METADATA_KEY: captured,
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+    ]
+    async for _chunk in llm.stream_chat(messages, tools=_single_tool_schema("search")):
+        pass
+
+    second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
+    assert "extra_body" not in second_call
+    sent = second_call["messages"]
+    assert sent[1]["reasoning_content"] == "Use the search tool first"
+    assert PROVIDER_STATE_METADATA_KEY not in sent[1]
+
+
+@pytest.mark.asyncio
 async def test_openrouter_deepseek_default_first_turn_request_is_byte_identical(
     mocker, mock_chat_completion
 ):

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -3786,3 +3786,64 @@ async def test_openrouter_deepseek_structured_stream_stays_disabled_and_silent(
         for record in caplog.records
         if "no reasoning content was captured" in record.message
     ]
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_response_format_resend_stays_silent(mocker, caplog):
+    """The capture sentinel must judge the resent request, not the caller's.
+
+    When the endpoint rejects ``response_format`` with a 400, ``OpenAILLM.chat``
+    drops it and resends -- but reuses the extra_body it already built while
+    ``response_format`` was still set, so the resend still goes out with
+    thinking disabled. The sentinel must recognize that: if it instead looked
+    at the now-cleared ``response_format`` local, it would conclude the resend
+    left thinking open and wrongly warn about a missing capture on this
+    tool-call response.
+    """
+    import logging
+
+    response = _openrouter_tool_call_response(
+        reasoning_content="unset",
+        raw_message_extra={
+            "reasoning_details": [{"type": "reasoning.text", "text": "SECRET-THOUGHT"}]
+        },
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        _bad_request_error(
+            "the model does not support response_format for this request"
+        ),
+        response,
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "thinking_mode"],
+    )
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.model.chat.basic.openrouter"
+    ):
+        await llm.chat(
+            [{"role": "user", "content": "Search xagent"}],
+            tools=_single_tool_schema("search"),
+            response_format={"type": "json_object"},
+        )
+
+    assert mock_client.chat.completions.create.await_count == 2
+    for call in mock_client.chat.completions.create.call_args_list:
+        assert call.kwargs["extra_body"] == {
+            "reasoning": {"enabled": False},
+            "thinking": {"type": "disabled"},
+        }
+    assert not [
+        record.message
+        for record in caplog.records
+        if "no reasoning content was captured" in record.message
+    ]
+    for record in caplog.records:
+        assert "SECRET-THOUGHT" not in record.getMessage()

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -1004,6 +1004,13 @@ def test_openrouter_reasoning_hook_enables_reasoning_payload(monkeypatch):
 def test_openrouter_deepseek_defaults_to_disabled_thinking(
     monkeypatch, model_name, is_streaming, response_format
 ):
+    """The undeclared-ability half of a declared/undeclared contrast pair.
+
+    This model record never declares ``thinking_mode``, so every request
+    shape here keeps the disabled default. See
+    ``test_openrouter_deepseek_declared_thinking_ability_leaves_default_open``
+    for the same shapes with the ability declared.
+    """
     monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
     llm = OpenRouterLLM(
         model_name=model_name,
@@ -1025,6 +1032,58 @@ def test_openrouter_deepseek_defaults_to_disabled_thinking(
         "reasoning": {"enabled": False},
         "thinking": {"type": "disabled"},
     }
+
+
+@pytest.mark.parametrize(
+    ("is_streaming", "response_format", "expected_extra"),
+    [
+        (False, None, {}),
+        (False, {"type": "json_object"}, {}),
+        (True, None, {}),
+        (
+            True,
+            {"type": "json_object"},
+            {"reasoning": {"enabled": False}, "thinking": {"type": "disabled"}},
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "model_name",
+    [
+        "deepseek/deepseek-v4-flash",
+        "openrouter/deepseek/deepseek-v4-flash",
+    ],
+)
+def test_openrouter_deepseek_declared_thinking_ability_leaves_default_open(
+    monkeypatch, model_name, is_streaming, response_format, expected_extra
+):
+    """The declared-ability half of a declared/undeclared contrast pair.
+
+    A model record that declares ``thinking_mode`` gets nothing sent for an
+    unspecified request, except on the structured-streaming shape, which
+    stays disabled unconditionally: that branch is only reached when the
+    caller specified no thinking configuration at all, and the declared
+    ability does not change that. See
+    ``test_openrouter_deepseek_defaults_to_disabled_thinking`` for the same
+    shapes without the ability declared.
+    """
+    monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
+    llm = OpenRouterLLM(
+        model_name=model_name,
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "thinking_mode"],
+    )
+
+    extra_body = llm._prepare_provider_reasoning_extra_body(
+        extra_body={"trace_id": "abc"},
+        thinking=None,
+        tools=None,
+        response_format=response_format,
+        output_config=None,
+        is_streaming=is_streaming,
+    )
+
+    assert extra_body == {"trace_id": "abc", **expected_extra}
 
 
 def test_openrouter_deepseek_structured_streaming_disables_thinking(monkeypatch):
@@ -1153,6 +1212,71 @@ async def test_structured_output_retry_disables_openrouter_reasoning(
     second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
     assert second_call["extra_body"]["reasoning"] == {"enabled": False}
     assert second_call["extra_body"]["thinking"] == {"type": "disabled"}
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_default_thinking_triggers_structured_degrade_resend(
+    mocker, monkeypatch
+):
+    """The structured-output degrade resend above is triggered by the
+    response's own reasoning_content and the declared ability, not by what
+    this call requested -- so it also fires when the caller passes no
+    ``thinking`` at all. What matters for PR-2 is what the *first* request
+    sent: with the ability declared and no thinking requested, it must
+    carry nothing, not a disable payload.
+    """
+    monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
+
+    first_message = SimpleNamespace(
+        content="not json",
+        tool_calls=None,
+        reasoning_content="reasoning here",
+    )
+    second_message = SimpleNamespace(
+        content='{"status": "ok"}',
+        tool_calls=None,
+        reasoning_content=None,
+    )
+    first_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=first_message)],
+        usage=None,
+        model_dump=lambda: {"id": "openrouter-default-first"},
+    )
+    second_response = SimpleNamespace(
+        choices=[SimpleNamespace(message=second_message)],
+        usage=None,
+        model_dump=lambda: {"id": "openrouter-default-second"},
+    )
+
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [first_response, second_response]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "thinking_mode"],
+    )
+
+    result = await llm.chat(
+        [{"role": "user", "content": "Return JSON"}],
+        response_format={"type": "json_object"},
+    )
+
+    assert result["content"] == '{"status": "ok"}'
+    assert mock_client.chat.completions.create.await_count == 2
+    assert (
+        "extra_body" not in mock_client.chat.completions.create.call_args_list[0].kwargs
+    )
+    assert mock_client.chat.completions.create.call_args_list[1].kwargs[
+        "extra_body"
+    ] == {
+        "reasoning": {"enabled": False},
+        "thinking": {"type": "disabled"},
+    }
 
 
 # ==========================================================================
@@ -1777,6 +1901,63 @@ async def test_openrouter_deepseek_no_op_thinking_retry_falls_through_to_next_ru
     assert second_call["extra_body"]["thinking"] == {"type": "enabled"}
 
 
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_declared_thinking_makes_disable_retry_a_real_fix(
+    mocker, monkeypatch
+):
+    """Mirror of the no-op test above: once the model record declares
+    ``thinking_mode``, DeepSeek's unspecified default no longer renders as
+    disabled, so the "disable thinking" rule (2) is a real change against
+    this same combined error and gets to fire instead of being skipped as a
+    no-op.
+    """
+    monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
+    combined_error = (
+        "Reasoning is mandatory for this endpoint and cannot be disabled, "
+        "and thinking conflicts with tool_choice here."
+    )
+    success_response = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="ok", tool_calls=None, reasoning_content=None
+                )
+            )
+        ],
+        usage=None,
+        model_dump=lambda: {"id": "openrouter-declared-noop"},
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        RuntimeError(combined_error),
+        success_response,
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "thinking_mode"],
+    )
+
+    result = await llm.chat(
+        [{"role": "user", "content": "score?"}],
+        tools=_two_tool_schema(),
+        tool_choice="required",
+    )
+
+    assert result["content"] == "ok"
+    assert mock_client.chat.completions.create.await_count == 2
+    assert (
+        "extra_body" not in mock_client.chat.completions.create.call_args_list[0].kwargs
+    )
+    second = mock_client.chat.completions.create.call_args_list[1].kwargs["extra_body"]
+    assert second["thinking"] == {"type": "disabled"}
+    assert second["reasoning"] == {"enabled": False}
+
+
 # ==========================================================================
 # Client-layer equivalents of the RouterLLM-level retry tests that used to
 # live in tests/core/model/test_router_provider_config.py (moved here because
@@ -2022,6 +2203,44 @@ async def test_openrouter_deepseek_stream_no_op_thinking_default_propagates(mock
     assert calls == 1
 
 
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_declared_thinking_stream_spends_disable_retry(
+    mocker, monkeypatch
+):
+    """Mirror of the no-op test above: once the model record declares
+    ``thinking_mode``, DeepSeek's unspecified default no longer renders as
+    disabled, so the disable-thinking retry (rule 2) is a real change and
+    actually spends its budget before the request fails for good.
+    """
+    monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
+    seen: list = []
+
+    async def rejects():
+        if False:
+            yield None
+        raise RuntimeError(_THINKING_TOOL_CHOICE_ERROR)
+
+    def fake_inner(*_args, **kwargs):
+        seen.append(kwargs.get("thinking"))
+        return rejects()
+
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "thinking_mode"],
+    )
+    mocker.patch.object(llm, "_stream_chat_inner", side_effect=fake_inner)
+
+    with pytest.raises(RuntimeError, match="Thinking mode does not support"):
+        async for _chunk in llm.stream_chat(
+            [{"role": "user", "content": "score?"}],
+            tool_choice="required",
+        ):
+            pass
+
+    assert seen == [None, openrouter_module._DISABLE_DOWNSTREAM_THINKING]
+
+
 # ---------------------------------------------------------------------------
 # DeepSeek reasoning-content replay on OpenRouter (issue #1537).
 #
@@ -2029,9 +2248,11 @@ async def test_openrouter_deepseek_stream_no_op_thinking_default_propagates(mock
 # OpenRouterLLM via ``deepseek_tool_protocol``'s shared functions. The
 # direct-DeepSeek side of that same mechanism keeps its own coverage in
 # test_deepseek.py, and test_openai.py holds the negative case pinning that
-# a plain OpenAI-compatible client captures nothing. Whether thinking should
-# default to enabled for deepseek slugs is a separate question and is not
-# decided by any test here.
+# a plain OpenAI-compatible client captures nothing. Whether a deepseek slug
+# is asked to disable reasoning when the caller says nothing is decided by
+# the model record's declared abilities; the request-payload tests around
+# ``test_openrouter_deepseek_defaults_to_disabled_thinking`` pin both rows
+# of that contrast.
 # ---------------------------------------------------------------------------
 
 
@@ -2155,6 +2376,73 @@ async def test_openrouter_deepseek_captures_reasoning_alias_from_raw(mocker):
     assert result[PROVIDER_STATE_METADATA_KEY] == _deepseek_provider_state(
         "alt-spelling-thinking"
     )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_declared_thinking_captures_and_replays_without_request_thinking(
+    mocker,
+):
+    """The path PR-2 opens: a model record that declares ``thinking_mode``
+    gets reasoning captured and replayed across a tool-call chain even when
+    neither request in the chain passes ``thinking`` at all.
+    """
+    first = _openrouter_tool_call_response(
+        reasoning_content="Use the search tool first"
+    )
+    second = SimpleNamespace(
+        choices=[
+            SimpleNamespace(
+                message=SimpleNamespace(
+                    content="done", tool_calls=None, reasoning_content=None
+                )
+            )
+        ],
+        usage=None,
+        model_dump=lambda: {"id": "openrouter-second-turn"},
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [first, second]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "thinking_mode"],
+    )
+
+    round1 = await llm.chat(
+        [{"role": "user", "content": "Search xagent"}],
+        tools=_single_tool_schema("search"),
+    )
+    assert (
+        "extra_body" not in mock_client.chat.completions.create.call_args_list[0].kwargs
+    )
+    assert round1[PROVIDER_STATE_METADATA_KEY] == _deepseek_provider_state(
+        "Use the search tool first"
+    )
+
+    messages = [
+        {"role": "user", "content": "Search xagent"},
+        {
+            "role": "assistant",
+            "content": "",
+            PROVIDER_STATE_METADATA_KEY: round1[PROVIDER_STATE_METADATA_KEY],
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "search", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "content": "result"},
+    ]
+    await llm.chat(messages, tools=_single_tool_schema("search"))
+    sent = mock_client.chat.completions.create.call_args_list[1].kwargs["messages"]
+    assert sent[1]["reasoning_content"] == "Use the search tool first"
+    assert PROVIDER_STATE_METADATA_KEY not in sent[1]
 
 
 @pytest.mark.asyncio
@@ -2898,12 +3186,13 @@ async def test_openrouter_deepseek_warns_when_capture_misses_all_known_spellings
 async def test_openrouter_deepseek_no_warning_when_thinking_not_requested(
     mocker, caplog
 ):
-    """The capture-miss WARNING stays silent when thinking was not requested.
+    """The capture-miss WARNING stays silent for a model record that never
+    declared ``thinking_mode``.
 
-    Thinking is off by default for every deepseek slug, so this is the
-    highest-traffic path today. An empty capture there is the expected
-    outcome rather than a sign that the provider renamed its reasoning
-    field, and warning about it would turn the signal into noise.
+    This model record's requests still go out with an explicit disable
+    payload, so an empty reasoning capture here is the expected outcome
+    rather than a sign that the provider renamed its reasoning field, and
+    warning about it would turn the signal into noise.
     """
     import logging
 
@@ -2928,6 +3217,55 @@ async def test_openrouter_deepseek_no_warning_when_thinking_not_requested(
         "no reasoning content was captured" in record.message
         for record in caplog.records
     )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_warns_when_declared_thinking_capture_misses(
+    mocker, caplog
+):
+    """The gate this change fixes: a model record that declares
+    ``thinking_mode`` gets nothing sent on an unspecified request, so a
+    tool-call response with no captured reasoning is a real capture miss
+    and must warn, even though the caller never asked for thinking either.
+    """
+    import logging
+
+    response = _openrouter_tool_call_response(
+        reasoning_content="unset",
+        raw_message_extra={
+            "reasoning_details": [{"type": "reasoning.text", "text": "SECRET-THOUGHT"}]
+        },
+    )
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "thinking_mode"],
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = response
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.model.chat.basic.openrouter"
+    ):
+        await llm.chat(
+            [{"role": "user", "content": "Search xagent"}],
+            tools=_single_tool_schema("search"),
+        )
+
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if "no reasoning content was captured" in record.message
+    ]
+    assert len(messages) == 1
+    assert "reasoning_details" in messages[0]
+    for record in caplog.records:
+        assert "SECRET-THOUGHT" not in record.getMessage()
+        assert "Search xagent" not in record.getMessage()
 
 
 @pytest.mark.asyncio
@@ -3061,16 +3399,78 @@ async def test_openrouter_deepseek_stream_warns_when_capture_misses_all_known_sp
 
 
 @pytest.mark.asyncio
+async def test_openrouter_deepseek_stream_warns_when_declared_thinking_capture_misses(
+    mocker, caplog
+):
+    """Streaming counterpart of
+    ``test_openrouter_deepseek_warns_when_declared_thinking_capture_misses``:
+    a model record that declares ``thinking_mode`` gets nothing sent on an
+    unspecified streaming request either, so a stream that ends with a tool
+    call and no captured reasoning is a real capture miss and must warn.
+    """
+    import logging
+
+    async def stream():
+        chunk = _tool_call_delta_chunk(
+            call_id="call_1",
+            index=0,
+            name="search",
+            arguments='{"query":"xagent"}',
+            finish_reason="tool_calls",
+        )
+        chunk.choices[0].delta.reasoning_details = [
+            {"type": "reasoning.text", "text": "SECRET-THOUGHT"}
+        ]
+        yield chunk
+
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = stream()
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "thinking_mode"],
+    )
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.model.chat.basic.openrouter"
+    ):
+        chunks = [
+            chunk
+            async for chunk in llm.stream_chat(
+                [{"role": "user", "content": "Search xagent"}],
+                tools=_single_tool_schema("search"),
+            )
+        ]
+
+    assert chunks
+    messages = [
+        record.getMessage()
+        for record in caplog.records
+        if "no reasoning content was captured" in record.message
+    ]
+    assert len(messages) == 1
+    assert "reasoning_details" in messages[0]
+    for record in caplog.records:
+        assert "SECRET-THOUGHT" not in record.getMessage()
+        assert "Search xagent" not in record.getMessage()
+
+
+@pytest.mark.asyncio
 async def test_openrouter_deepseek_stream_no_warning_when_thinking_not_requested(
     mocker, caplog
 ):
-    """The streaming capture-miss WARNING is silent without thinking too.
+    """The streaming capture-miss WARNING stays silent for a model record
+    that never declared ``thinking_mode``.
 
     Same rule as
-    ``test_openrouter_deepseek_no_warning_when_thinking_not_requested``: an
-    empty capture is the expected outcome, not a sign of a renamed provider
-    field, on the path where thinking was never requested -- off by default
-    for every deepseek slug, and the highest-traffic streaming path today.
+    ``test_openrouter_deepseek_no_warning_when_thinking_not_requested``: this
+    model record's requests still go out with an explicit disable payload,
+    so an empty capture here is the expected outcome, not a sign of a
+    renamed provider field.
     """
     import logging
 
@@ -3151,3 +3551,69 @@ async def test_openrouter_non_deepseek_stream_no_capture_warning(mocker, caplog)
         "no reasoning content was captured" in record.message
         for record in caplog.records
     )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_structured_stream_stays_disabled_and_silent(
+    mocker, caplog
+):
+    """A structured streaming request still disables thinking unconditionally
+    even for a model record that declares ``thinking_mode`` -- and the
+    streaming capture sentinel must agree, staying silent about a capture it
+    knows this request could not have produced.
+
+    The model record here declares the ability specifically so this test can
+    tell apart the two things the streaming sentinel could be looking at: if
+    it forgot to look at this call's own ``response_format`` and instead
+    reused the declared-ability default-open answer, it would wrongly treat
+    the missing capture as a real miss and warn.
+    """
+    import logging
+
+    async def stream():
+        chunk = _tool_call_delta_chunk(
+            call_id="call_1",
+            index=0,
+            name="search",
+            arguments='{"query":"xagent"}',
+            finish_reason="tool_calls",
+        )
+        chunk.choices[0].delta.reasoning_details = [
+            {"type": "reasoning.text", "text": "SECRET-THOUGHT"}
+        ]
+        yield chunk
+
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = stream()
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "thinking_mode"],
+    )
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.model.chat.basic.openrouter"
+    ):
+        chunks = [
+            chunk
+            async for chunk in llm.stream_chat(
+                [{"role": "user", "content": "Search xagent"}],
+                tools=_single_tool_schema("search"),
+                response_format={"type": "json_object"},
+            )
+        ]
+
+    assert chunks
+    assert mock_client.chat.completions.create.call_args.kwargs["extra_body"] == {
+        "reasoning": {"enabled": False},
+        "thinking": {"type": "disabled"},
+    }
+    assert not [
+        record.message
+        for record in caplog.records
+        if "no reasoning content was captured" in record.message
+    ]

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -1923,6 +1923,12 @@ async def test_openrouter_deepseek_declared_thinking_makes_disable_retry_a_real_
     disabled, so the "disable thinking" rule (2) is a real change against
     this same combined error and gets to fire instead of being skipped as a
     no-op.
+
+    The endpoint modelled here is the one the error text describes: it
+    refuses every request that does not ask for reasoning explicitly. So the
+    disable attempt this fallthrough now spends is rejected in turn, and
+    recovery costs three upstream requests -- the unspecified first attempt,
+    the disable attempt, and the enable attempt that finally succeeds.
     """
     monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
     combined_error = (
@@ -1943,6 +1949,7 @@ async def test_openrouter_deepseek_declared_thinking_makes_disable_retry_a_real_
     mock_client = mocker.AsyncMock()
     mock_client.chat.completions.create.side_effect = [
         RuntimeError(combined_error),
+        RuntimeError(combined_error),
         success_response,
     ]
     mocker.patch(
@@ -1962,13 +1969,17 @@ async def test_openrouter_deepseek_declared_thinking_makes_disable_retry_a_real_
     )
 
     assert result["content"] == "ok"
-    assert mock_client.chat.completions.create.await_count == 2
-    assert (
-        "extra_body" not in mock_client.chat.completions.create.call_args_list[0].kwargs
-    )
-    second = mock_client.chat.completions.create.call_args_list[1].kwargs["extra_body"]
-    assert second["thinking"] == {"type": "disabled"}
-    assert second["reasoning"] == {"enabled": False}
+    calls = mock_client.chat.completions.create.call_args_list
+    assert mock_client.chat.completions.create.await_count == 3
+    assert "extra_body" not in calls[0].kwargs
+    assert calls[1].kwargs["extra_body"] == {
+        "reasoning": {"enabled": False},
+        "thinking": {"type": "disabled"},
+    }
+    assert calls[2].kwargs["extra_body"] == {
+        "reasoning": {"enabled": True},
+        "thinking": {"type": "enabled"},
+    }
 
 
 # ==========================================================================

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -1038,7 +1038,11 @@ def test_openrouter_deepseek_defaults_to_disabled_thinking(
     ("is_streaming", "response_format", "expected_extra"),
     [
         (False, None, {}),
-        (False, {"type": "json_object"}, {}),
+        (
+            False,
+            {"type": "json_object"},
+            {"reasoning": {"enabled": False}, "thinking": {"type": "disabled"}},
+        ),
         (True, None, {}),
         (
             True,
@@ -1060,10 +1064,11 @@ def test_openrouter_deepseek_declared_thinking_ability_leaves_default_open(
     """The declared-ability half of a declared/undeclared contrast pair.
 
     A model record that declares ``thinking_mode`` gets nothing sent for an
-    unspecified request, except on the structured-streaming shape, which
-    stays disabled unconditionally: that branch is only reached when the
-    caller specified no thinking configuration at all, and the declared
-    ability does not change that. See
+    unspecified request, except when the request asks for structured
+    output -- streaming or not -- which stays disabled: that branch is only
+    reached when the caller specified no thinking configuration at all, and
+    the declared ability says the operator wants reasoning, not that they
+    want it mixed into a JSON body. See
     ``test_openrouter_deepseek_defaults_to_disabled_thinking`` for the same
     shapes without the ability declared.
     """
@@ -1219,11 +1224,13 @@ async def test_openrouter_deepseek_default_thinking_triggers_structured_degrade_
     mocker, monkeypatch
 ):
     """The structured-output degrade resend above is triggered by the
-    response's own reasoning_content and the declared ability, not by what
-    this call requested -- so it also fires when the caller passes no
-    ``thinking`` at all. What matters for PR-2 is what the *first* request
-    sent: with the ability declared and no thinking requested, it must
-    carry nothing, not a disable payload.
+    response's own reasoning_content, not by what this call requested -- so
+    it also fires when the caller passes no ``thinking`` at all. The
+    mandatory reasoning-disable for structured output does not depend on
+    whether this call's model record declares the thinking ability either,
+    so the first request already carries the disable payload; the degrade
+    resend exists because this endpoint reasoned anyway, ignoring that
+    payload, and it repeats the same disable ask on the resend.
     """
     monkeypatch.setenv("XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY", "false")
 
@@ -1268,15 +1275,21 @@ async def test_openrouter_deepseek_default_thinking_triggers_structured_degrade_
 
     assert result["content"] == '{"status": "ok"}'
     assert mock_client.chat.completions.create.await_count == 2
-    assert (
-        "extra_body" not in mock_client.chat.completions.create.call_args_list[0].kwargs
-    )
-    assert mock_client.chat.completions.create.call_args_list[1].kwargs[
-        "extra_body"
-    ] == {
+    disabled = {
         "reasoning": {"enabled": False},
         "thinking": {"type": "disabled"},
     }
+    # The structured-output rule already asked for no reasoning on the way
+    # out; this endpoint reasoned anyway. The degrade resend is the second
+    # line of defence for exactly that, and it repeats the same ask.
+    assert (
+        mock_client.chat.completions.create.call_args_list[0].kwargs["extra_body"]
+        == disabled
+    )
+    assert (
+        mock_client.chat.completions.create.call_args_list[1].kwargs["extra_body"]
+        == disabled
+    )
 
 
 # ==========================================================================
@@ -3551,6 +3564,63 @@ async def test_openrouter_non_deepseek_stream_no_capture_warning(mocker, caplog)
         "no reasoning content was captured" in record.message
         for record in caplog.records
     )
+
+
+@pytest.mark.asyncio
+async def test_openrouter_deepseek_structured_non_stream_stays_disabled_and_silent(
+    mocker, caplog
+):
+    """Non-streaming half of the structured-output rule, and of the sentinel
+    agreement the streaming test below pins.
+
+    A structured request disables thinking whatever the transport, and the
+    non-streaming capture sentinel must agree, staying silent about a
+    capture it knows this request could not have produced. The model record
+    declares the ability specifically so this test can tell apart the two
+    things the sentinel could be looking at: if it ignored this call's own
+    ``response_format`` and reused the declared-ability default-open
+    answer, it would treat the missing capture as a real miss and warn.
+    """
+    import logging
+
+    response = _openrouter_tool_call_response(
+        reasoning_content="unset",
+        raw_message_extra={
+            "reasoning_details": [{"type": "reasoning.text", "text": "SECRET-THOUGHT"}]
+        },
+    )
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.return_value = response
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(
+        model_name="deepseek/deepseek-v4-flash",
+        api_key="test-key",
+        abilities=["chat", "tool_calling", "thinking_mode"],
+    )
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.model.chat.basic.openrouter"
+    ):
+        await llm.chat(
+            [{"role": "user", "content": "Search xagent"}],
+            tools=_single_tool_schema("search"),
+            response_format={"type": "json_object"},
+        )
+
+    assert mock_client.chat.completions.create.call_args.kwargs["extra_body"] == {
+        "reasoning": {"enabled": False},
+        "thinking": {"type": "disabled"},
+    }
+    assert not [
+        record.message
+        for record in caplog.records
+        if "no reasoning content was captured" in record.message
+    ]
+    for record in caplog.records:
+        assert "SECRET-THOUGHT" not in record.getMessage()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #1537.

DeepSeek-authored models routed through OpenRouter had reasoning turned off on
every request that did not explicitly ask for it, regardless of how the model
was configured. A model record that declares the `thinking_mode` ability still
got a disable payload on the wire, so the ability had no effect. The reason it
stayed off was that reasoning content produced on a tool-call chain has to be
replayed verbatim on the next request, and that replay did not exist yet. It
does now, so this change lets the declared ability decide.

## Behavior

Every row but the last describes a DeepSeek-authored model routed through
OpenRouter.

| Request | Model declares `thinking_mode` | Before | After |
|---|---|---|---|
| No thinking configuration, non-streaming | no | disable payload sent | unchanged |
| No thinking configuration, non-streaming, no structured output | yes | disable payload sent | nothing sent; the endpoint's own default applies |
| No thinking configuration, streaming, no structured output | no | disable payload sent | unchanged |
| No thinking configuration, streaming, no structured output | yes | disable payload sent | nothing sent |
| No thinking configuration, any transport + `response_format` | either | disable payload sent | unchanged: still disabled, because provider reasoning can corrupt structured JSON whatever the transport |
| Thinking explicitly enabled or disabled by the caller | either | honored | unchanged |
| Model not authored by DeepSeek | either | no payload, apart from the structured-streaming rule above | unchanged |

A model that never declared the ability keeps its current request byte for
byte. Only records whose configuration asks for reasoning change.

Structured requests are the one shape where a declared ability does not open
the default. They keep the payload they had before this change on either
transport, so the JSON degrade-and-resend recovery in `chat` is not newly
relied on. Models from other authors keep the streaming-only form of that rule
they have always had.

## Deliberate divergence from the direct DeepSeek client

The direct DeepSeek client keeps disabling reasoning for every request that
does not ask for it, and does not consult abilities at all. That is intentional
and is stated in the code comment: it talks to a single endpoint whose default
it knows, while this client routes the same author's models through endpoints
whose defaults it does not control, and the declared ability is the only signal
available about what the operator wants. Aligning the two is a separate
decision about a different endpoint and is not made here.

## Capture-miss warning

The client already warns when a DeepSeek-served response comes back as a tool
call with no reasoning content under any recognized field name — the case where
the next request in the chain would fail with an unhelpful 400. That warning was
gated on "the caller asked for reasoning", which is exactly the condition this
change makes insufficient: the newly opened path never asks, the endpoint
reasons anyway, and the warning would never fire on the one path it now needs to
cover. The gate is now "this request did not go out with reasoning disabled",
computed from the same method that builds the request, so the warning and the
payload cannot disagree. Both hooks take the request's structured-output setting
for that reason: a structured request is disabled on either transport, so a
sentinel that assumed otherwise would report a miss against a response it had
itself made impossible. What each hook receives is the value the request it is
judging was built from, which on one degrade path differs from the value the
caller originally passed.

The rewritten gate agrees with the old one on every configuration that exists
before this change; what it adds is the one configuration this change creates.

Still not covered: an endpoint that ignores the disable payload, reasons anyway
and returns nothing under a recognized field name stays silent. That was true
before this change and is unchanged by it.

## Retry budget

One provider-compatibility retry rule replays the request with reasoning
disabled. For a model that declares the ability, that is now a real change to
the request rather than a no-op, so the rule fires where it used to be skipped
and spends one retry. Models that do not declare the ability are unaffected.
Covered by tests for both the non-streaming and the streaming path.

Against an endpoint that refuses every request not asking for reasoning
explicitly, recovery costs three upstream requests: the unspecified first
attempt, the disable attempt this rule now spends, and the enable attempt that
succeeds. The loop's four-request cap bounds it, and the test pins each
payload.

## Size and verification

| File | Added | Removed |
|---|---|---|
| `src/xagent/core/model/chat/basic/openrouter.py` | 115 | 50 |
| `src/xagent/core/model/chat/basic/openai.py` | 42 | 12 |
| `src/xagent/core/model/chat/basic/deepseek.py` | 2 | 1 |
| `tests/core/model/chat/basic/test_openrouter.py` | 736 | 40 |

- `pytest tests/core/model/chat/basic/` — 383 passed
- `pytest tests/core/model/chat/basic/test_openrouter.py` — 110 passed

Each added test was re-run against a build with the change deliberately undone,
to confirm it pins the new behavior rather than passing by accident:

- Dropping the ability check, so the default goes back to always-disabled: 12
  test cases fail, covering seven of the added tests once parameter
  combinations are counted.
- Narrowing the structured-output rule back to streaming only: four cases fail,
  all of them pinning the non-streaming structured shape.
- Widening that rule to models from other authors: the pre-existing test for a
  non-DeepSeek model asking for structured output fails, which is what keeps
  this change confined to DeepSeek-served models.
- Putting either capture-miss gate back on "the caller asked for reasoning":
  exactly one test fails, one per transport.
- Making either gate ignore the request's structured-output setting: exactly one
  test fails per transport, the ones pinning structured requests as disabled and
  silent.
- Handing the non-streaming gate the caller's original setting instead of the
  one its request was built from: the test covering the degrade-and-resend path
  fails on a warning about a capture that request had itself made impossible.

