### PR TITLE
feat: add widget header close and new-conversation overflow controls

### DIFF
--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -700,16 +700,25 @@
   // no direct handle to panel/fab, so it signals intent back here over
   // postMessage instead.
   window.addEventListener('message', function (event) {
-    if (event.origin !== host || event.source !== iframe.contentWindow) return;
+    if (event.origin !== host || !iframe.contentWindow || event.source !== iframe.contentWindow) return;
     var data = event.data;
-    if (!data || data.xagent !== true) return;
+    if (!data || data.xagent !== true || data.v !== 1) return;
     if (data.type === 'widget_close') {
       closePanel();
     }
   });
 
-  if (!readStoredClosed()) {
-    openPanel(true);
+  // Deferred to the moment each mode actually starts loading the iframe (see
+  // call sites below), not called unconditionally here: guest mode's iframe
+  // src is only set after a successful embed-ticket exchange, and auto-
+  // opening ahead of that would show a returning visitor a blank panel --
+  // every reload -- on any auth failure (stale allowlist, rate limit,
+  // network error). Session mode sets its iframe src synchronously and
+  // unconditionally, so it calls this immediately.
+  function maybeAutoOpen() {
+    if (!readStoredClosed()) {
+      openPanel(true);
+    }
   }
 
   mode.attach(iframe);
@@ -744,6 +753,7 @@
             url += '&embed_ticket=' + encodeURIComponent(ticket);
           }
           iframe.src = withTimezone(url);
+          maybeAutoOpen();
         }
 
         // Request a short-lived embed ticket from the top-level page. This fetch
@@ -875,6 +885,7 @@
     function attach(iframe) {
       state.iframe = iframe;
       iframe.src = withTimezone(host + '/widget/chat/session');
+      maybeAutoOpen();
       window.addEventListener('message', onMessage);
       window.addEventListener('pageshow', onPageShow);
       window.addEventListener('pagehide', onPageHide);

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -656,11 +656,13 @@
 
   var isOpen = false;
 
-  function openPanel() {
+  function openPanel(skipPersist) {
     isOpen = true;
     panel.classList.add('open');
     fab.innerHTML = closeIcon;
-    persistClosed(false);
+    if (!skipPersist) {
+      persistClosed(false);
+    }
   }
 
   function closePanel() {
@@ -707,7 +709,7 @@
   });
 
   if (!readStoredClosed()) {
-    openPanel();
+    openPanel(true);
   }
 
   mode.attach(iframe);

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -209,23 +209,23 @@
   var iconColor = scriptTag.getAttribute('data-icon-color') || '#fff';
   var panelBgColor = scriptTag.getAttribute('data-panel-bg-color') || '#fff';
 
-  // Minimized state: persisted across reloads so a visitor who left the
-  // panel open sees it reopen on their next page load. Absent/unparsable
-  // storage defaults to minimized (today's baseline: closed until the FAB
-  // is clicked), so a first-time visitor never sees an unsolicited popup.
-  var MINIMIZED_STORAGE_KEY = 'xagent_widget_minimized';
+  // Closed state: persisted across reloads so a visitor who left the panel
+  // open sees it reopen on their next page load. Absent/unparsable storage
+  // defaults to closed (today's baseline: closed until the FAB is clicked),
+  // so a first-time visitor never sees an unsolicited popup.
+  var CLOSED_STORAGE_KEY = 'xagent_widget_closed';
 
-  function readStoredMinimized() {
+  function readStoredClosed() {
     try {
-      return localStorage.getItem(MINIMIZED_STORAGE_KEY) !== 'false';
+      return localStorage.getItem(CLOSED_STORAGE_KEY) !== 'false';
     } catch (e) {
       return true;
     }
   }
 
-  function persistMinimized(minimized) {
+  function persistClosed(closed) {
     try {
-      localStorage.setItem(MINIMIZED_STORAGE_KEY, String(minimized));
+      localStorage.setItem(CLOSED_STORAGE_KEY, String(closed));
     } catch (e) {
       // Storage can be unavailable (private browsing, quota); the toggle
       // still works for the session, it just won't survive a reload.
@@ -660,14 +660,14 @@
     isOpen = true;
     panel.classList.add('open');
     fab.innerHTML = closeIcon;
-    persistMinimized(false);
+    persistClosed(false);
   }
 
   function closePanel() {
     isOpen = false;
     panel.classList.remove('open');
     fab.innerHTML = chatIcon;
-    persistMinimized(true);
+    persistClosed(true);
   }
 
   fab.onclick = function () {
@@ -694,21 +694,19 @@
   // <html>'s own childList changes when body itself is swapped out.
   panelRemovalObserver.observe(document.documentElement, { childList: true, subtree: true });
 
-  // The header's minimize/close controls live inside the iframe's React app
-  // and have no direct handle to panel/fab, so they signal intent back here
-  // over postMessage instead. Both currently collapse to the same hide
-  // action; kept as distinct message types since they're two separately
-  // named product controls, even though today's effect is identical.
+  // The header's close control lives inside the iframe's React app and has
+  // no direct handle to panel/fab, so it signals intent back here over
+  // postMessage instead.
   window.addEventListener('message', function (event) {
     if (event.origin !== host || event.source !== iframe.contentWindow) return;
     var data = event.data;
     if (!data || data.xagent !== true) return;
-    if (data.type === 'widget_minimize' || data.type === 'widget_close') {
+    if (data.type === 'widget_close') {
       closePanel();
     }
   });
 
-  if (!readStoredMinimized()) {
+  if (!readStoredClosed()) {
     openPanel();
   }
 

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -633,6 +633,7 @@
     panelRemovalObserver.disconnect();
     window.removeEventListener('resize', onWindowResize);
     window.removeEventListener('blur', onWindowBlur);
+    window.removeEventListener('message', onChromeMessage);
     document.removeEventListener('pointermove', onPointerMove);
     document.removeEventListener('pointerup', endDrag);
     document.removeEventListener('pointercancel', cancelDrag);
@@ -698,15 +699,21 @@
 
   // The header's close control lives inside the iframe's React app and has
   // no direct handle to panel/fab, so it signals intent back here over
-  // postMessage instead.
-  window.addEventListener('message', function (event) {
-    if (event.origin !== host || !iframe.contentWindow || event.source !== iframe.contentWindow) return;
+  // postMessage instead. Named (not inline) so panelRemovalObserver can
+  // remove it below, matching every other listener's teardown in this file
+  // -- otherwise a host SPA that removes the widget without a full page
+  // reload leaves this listener retaining the closure indefinitely, and a
+  // stray message arriving afterward would still mutate a detached panel
+  // and corrupt the next load's auto-open decision in localStorage.
+  function onChromeMessage(event) {
+    if (torndown || event.origin !== host || !iframe.contentWindow || event.source !== iframe.contentWindow) return;
     var data = event.data;
     if (!data || data.xagent !== true || data.v !== 1) return;
     if (data.type === 'widget_close') {
       closePanel();
     }
-  });
+  }
+  window.addEventListener('message', onChromeMessage);
 
   // Deferred to the moment each mode actually starts loading the iframe (see
   // call sites below), not called unconditionally here: guest mode's iframe
@@ -885,7 +892,6 @@
     function attach(iframe) {
       state.iframe = iframe;
       iframe.src = withTimezone(host + '/widget/chat/session');
-      maybeAutoOpen();
       window.addEventListener('message', onMessage);
       window.addEventListener('pageshow', onPageShow);
       window.addEventListener('pagehide', onPageHide);
@@ -1176,6 +1182,14 @@
           return;
         }
         applySession(payload);
+        // Gated to the initial exchange, not every reconnect: this is the
+        // first point session mode actually knows the grant is usable (a
+        // returning visitor whose grant has since expired or been consumed
+        // reaches recordFailure below instead, never auto-opening onto the
+        // degraded/terminal screen -- same reasoning as guest mode's
+        // ticket-fetch-success gate on maybeAutoOpen). A later reconnect
+        // succeeding shouldn't re-open a panel the visitor has since closed.
+        if (phase === 'exchange') maybeAutoOpen();
         flush();
         return;
       }

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -209,46 +209,6 @@
   var iconColor = scriptTag.getAttribute('data-icon-color') || '#fff';
   var panelBgColor = scriptTag.getAttribute('data-panel-bg-color') || '#fff';
 
-  // Two widgets embedded on the same host page (different agents/grants)
-  // must not collide on one shared preference -- without this, the last one
-  // to persist a value silently restores *both* instances to it on the next
-  // load. Guest mode has a stable, non-secret identifier available for this
-  // (the widget key, or the deprecated token); session mode's grant is
-  // single-use and genuinely encrypted (not merely signed), so there is no
-  // stable client-visible identifier to derive one from under the current
-  // protocol -- those instances still share one namespace until that's
-  // addressed separately (would need a new, non-rotating instance id shipped
-  // server-side alongside the grant).
-  var instanceStorageKeySuffix = scriptTag.getAttribute('data-widget-key')
-    || scriptTag.getAttribute('data-token')
-    || '';
-  function namespacedStorageKey(base) {
-    return instanceStorageKeySuffix ? base + ':' + instanceStorageKeySuffix : base;
-  }
-
-  // Closed state: persisted across reloads so a visitor who left the panel
-  // open sees it reopen on their next page load. Absent/unparsable storage
-  // defaults to closed (today's baseline: closed until the FAB is clicked),
-  // so a first-time visitor never sees an unsolicited popup.
-  var CLOSED_STORAGE_KEY = namespacedStorageKey('xagent_widget_closed');
-
-  function readStoredClosed() {
-    try {
-      return localStorage.getItem(CLOSED_STORAGE_KEY) !== 'false';
-    } catch (e) {
-      return true;
-    }
-  }
-
-  function persistClosed(closed) {
-    try {
-      localStorage.setItem(CLOSED_STORAGE_KEY, String(closed));
-    } catch (e) {
-      // Storage can be unavailable (private browsing, quota); the toggle
-      // still works for the session, it just won't survive a reload.
-    }
-  }
-
   // Read by use-websocket.ts off the iframe URL, where it outranks the browser
   // zone. Optional: absent means the iframe URL is unchanged.
   var embedTimezone = (scriptTag.getAttribute('data-timezone') || '').trim();
@@ -271,12 +231,6 @@
   // reloads. Inline width is only ever applied above MOBILE_BREAKPOINT --
   // below it the CSS media query owns sizing, and inline width would win
   // over that media query by specificity if left in place.
-  // Not namespaced like CLOSED_STORAGE_KEY below, despite the identical
-  // multi-instance collision risk: doing so consistently would mean
-  // rewriting ~25 hardcoded key-literal assertions in widget-bootstrap.test.ts
-  // (PR #1742, untouched by this PR) for a key this PR didn't introduce.
-  // Left as a known, flagged gap alongside CLOSED_STORAGE_KEY's own
-  // session-mode limitation above, for a follow-up covering both together.
   var WIDTH_STORAGE_KEY = 'xagent_widget_width';
   var DEFAULT_PANEL_WIDTH = 380;
   var MIN_PANEL_WIDTH = 320;
@@ -680,20 +634,16 @@
 
   var isOpen = false;
 
-  function openPanel(skipPersist) {
+  function openPanel() {
     isOpen = true;
     panel.classList.add('open');
     fab.innerHTML = closeIcon;
-    if (!skipPersist) {
-      persistClosed(false);
-    }
   }
 
   function closePanel() {
     isOpen = false;
     panel.classList.remove('open');
     fab.innerHTML = chatIcon;
-    persistClosed(true);
   }
 
   fab.onclick = function () {
@@ -720,43 +670,21 @@
   // <html>'s own childList changes when body itself is swapped out.
   panelRemovalObserver.observe(document.documentElement, { childList: true, subtree: true });
 
-  // The header's close control, and guest mode's post-authentication ready
-  // signal (see maybeAutoOpen below), live inside the iframe's React app and
-  // have no direct handle to panel/fab, so they signal intent back here over
+  // The header's close control lives inside the iframe's React app and has
+  // no direct handle to panel/fab, so it signals intent back here over
   // postMessage instead. Named (not inline) so panelRemovalObserver can
   // remove it below, matching every other listener's teardown in this file
   // -- otherwise a host SPA that removes the widget without a full page
-  // reload leaves this listener retaining the closure indefinitely, and a
-  // stray message arriving afterward would still mutate a detached panel
-  // and corrupt the next load's auto-open decision in localStorage.
+  // reload leaves this listener retaining the closure indefinitely.
   function onChromeMessage(event) {
     if (torndown || event.origin !== host || !iframe.contentWindow || event.source !== iframe.contentWindow) return;
     var data = event.data;
     if (!data || data.xagent !== true || data.v !== 1) return;
     if (data.type === 'widget_close') {
       closePanel();
-    } else if (data.type === 'widget_ready') {
-      maybeAutoOpen();
     }
   }
   window.addEventListener('message', onChromeMessage);
-
-  // Called once the visitor's session is confirmed fully usable, not called
-  // unconditionally here: guest mode's iframe.src being set only means the
-  // *embed ticket* exchange (parent-side, this file) succeeded -- the child
-  // then redeems that ticket for a real session via its own /api/widget/auth
-  // call, which can independently fail (a live allowlist re-check, a rate
-  // limit, a network error, a malformed response). Auto-opening ahead of
-  // that would show a returning visitor the auth-error screen, every reload.
-  // Guest mode instead calls this from onChromeMessage above, once the child
-  // posts back widget_ready after its own auth succeeds. Session mode's
-  // grant exchange *is* the complete handshake (no separate child-side auth
-  // call follows it), so it calls this immediately on that success.
-  function maybeAutoOpen() {
-    if (!readStoredClosed()) {
-      openPanel(true);
-    }
-  }
 
   mode.attach(iframe);
 
@@ -1211,14 +1139,6 @@
           return;
         }
         applySession(payload);
-        // Gated to the initial exchange, not every reconnect: this is the
-        // first point session mode actually knows the grant is usable (a
-        // returning visitor whose grant has since expired or been consumed
-        // reaches recordFailure below instead, never auto-opening onto the
-        // degraded/terminal screen -- same reasoning as guest mode's
-        // ticket-fetch-success gate on maybeAutoOpen). A later reconnect
-        // succeeding shouldn't re-open a panel the visitor has since closed.
-        if (phase === 'exchange') maybeAutoOpen();
         flush();
         return;
       }

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -209,11 +209,28 @@
   var iconColor = scriptTag.getAttribute('data-icon-color') || '#fff';
   var panelBgColor = scriptTag.getAttribute('data-panel-bg-color') || '#fff';
 
+  // Two widgets embedded on the same host page (different agents/grants)
+  // must not collide on one shared preference -- without this, the last one
+  // to persist a value silently restores *both* instances to it on the next
+  // load. Guest mode has a stable, non-secret identifier available for this
+  // (the widget key, or the deprecated token); session mode's grant is
+  // single-use and genuinely encrypted (not merely signed), so there is no
+  // stable client-visible identifier to derive one from under the current
+  // protocol -- those instances still share one namespace until that's
+  // addressed separately (would need a new, non-rotating instance id shipped
+  // server-side alongside the grant).
+  var instanceStorageKeySuffix = scriptTag.getAttribute('data-widget-key')
+    || scriptTag.getAttribute('data-token')
+    || '';
+  function namespacedStorageKey(base) {
+    return instanceStorageKeySuffix ? base + ':' + instanceStorageKeySuffix : base;
+  }
+
   // Closed state: persisted across reloads so a visitor who left the panel
   // open sees it reopen on their next page load. Absent/unparsable storage
   // defaults to closed (today's baseline: closed until the FAB is clicked),
   // so a first-time visitor never sees an unsolicited popup.
-  var CLOSED_STORAGE_KEY = 'xagent_widget_closed';
+  var CLOSED_STORAGE_KEY = namespacedStorageKey('xagent_widget_closed');
 
   function readStoredClosed() {
     try {
@@ -254,6 +271,12 @@
   // reloads. Inline width is only ever applied above MOBILE_BREAKPOINT --
   // below it the CSS media query owns sizing, and inline width would win
   // over that media query by specificity if left in place.
+  // Not namespaced like CLOSED_STORAGE_KEY below, despite the identical
+  // multi-instance collision risk: doing so consistently would mean
+  // rewriting ~25 hardcoded key-literal assertions in widget-bootstrap.test.ts
+  // (PR #1742, untouched by this PR) for a key this PR didn't introduce.
+  // Left as a known, flagged gap alongside CLOSED_STORAGE_KEY's own
+  // session-mode limitation above, for a follow-up covering both together.
   var WIDTH_STORAGE_KEY = 'xagent_widget_width';
   var DEFAULT_PANEL_WIDTH = 380;
   var MIN_PANEL_WIDTH = 320;
@@ -697,8 +720,9 @@
   // <html>'s own childList changes when body itself is swapped out.
   panelRemovalObserver.observe(document.documentElement, { childList: true, subtree: true });
 
-  // The header's close control lives inside the iframe's React app and has
-  // no direct handle to panel/fab, so it signals intent back here over
+  // The header's close control, and guest mode's post-authentication ready
+  // signal (see maybeAutoOpen below), live inside the iframe's React app and
+  // have no direct handle to panel/fab, so they signal intent back here over
   // postMessage instead. Named (not inline) so panelRemovalObserver can
   // remove it below, matching every other listener's teardown in this file
   // -- otherwise a host SPA that removes the widget without a full page
@@ -711,17 +735,23 @@
     if (!data || data.xagent !== true || data.v !== 1) return;
     if (data.type === 'widget_close') {
       closePanel();
+    } else if (data.type === 'widget_ready') {
+      maybeAutoOpen();
     }
   }
   window.addEventListener('message', onChromeMessage);
 
-  // Deferred to the moment each mode actually starts loading the iframe (see
-  // call sites below), not called unconditionally here: guest mode's iframe
-  // src is only set after a successful embed-ticket exchange, and auto-
-  // opening ahead of that would show a returning visitor a blank panel --
-  // every reload -- on any auth failure (stale allowlist, rate limit,
-  // network error). Session mode sets its iframe src synchronously and
-  // unconditionally, so it calls this immediately.
+  // Called once the visitor's session is confirmed fully usable, not called
+  // unconditionally here: guest mode's iframe.src being set only means the
+  // *embed ticket* exchange (parent-side, this file) succeeded -- the child
+  // then redeems that ticket for a real session via its own /api/widget/auth
+  // call, which can independently fail (a live allowlist re-check, a rate
+  // limit, a network error, a malformed response). Auto-opening ahead of
+  // that would show a returning visitor the auth-error screen, every reload.
+  // Guest mode instead calls this from onChromeMessage above, once the child
+  // posts back widget_ready after its own auth succeeds. Session mode's
+  // grant exchange *is* the complete handshake (no separate child-side auth
+  // call follows it), so it calls this immediately on that success.
   function maybeAutoOpen() {
     if (!readStoredClosed()) {
       openPanel(true);
@@ -760,7 +790,6 @@
             url += '&embed_ticket=' + encodeURIComponent(ticket);
           }
           iframe.src = withTimezone(url);
-          maybeAutoOpen();
         }
 
         // Request a short-lived embed ticket from the top-level page. This fetch

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -209,6 +209,29 @@
   var iconColor = scriptTag.getAttribute('data-icon-color') || '#fff';
   var panelBgColor = scriptTag.getAttribute('data-panel-bg-color') || '#fff';
 
+  // Minimized state: persisted across reloads so a visitor who left the
+  // panel open sees it reopen on their next page load. Absent/unparsable
+  // storage defaults to minimized (today's baseline: closed until the FAB
+  // is clicked), so a first-time visitor never sees an unsolicited popup.
+  var MINIMIZED_STORAGE_KEY = 'xagent_widget_minimized';
+
+  function readStoredMinimized() {
+    try {
+      return localStorage.getItem(MINIMIZED_STORAGE_KEY) !== 'false';
+    } catch (e) {
+      return true;
+    }
+  }
+
+  function persistMinimized(minimized) {
+    try {
+      localStorage.setItem(MINIMIZED_STORAGE_KEY, String(minimized));
+    } catch (e) {
+      // Storage can be unavailable (private browsing, quota); the toggle
+      // still works for the session, it just won't survive a reload.
+    }
+  }
+
   // Read by use-websocket.ts off the iframe URL, where it outranks the browser
   // zone. Optional: absent means the iframe URL is unchanged.
   var embedTimezone = (scriptTag.getAttribute('data-timezone') || '').trim();
@@ -632,14 +655,26 @@
   fab.innerHTML = chatIcon;
 
   var isOpen = false;
+
+  function openPanel() {
+    isOpen = true;
+    panel.classList.add('open');
+    fab.innerHTML = closeIcon;
+    persistMinimized(false);
+  }
+
+  function closePanel() {
+    isOpen = false;
+    panel.classList.remove('open');
+    fab.innerHTML = chatIcon;
+    persistMinimized(true);
+  }
+
   fab.onclick = function () {
-    isOpen = !isOpen;
     if (isOpen) {
-      panel.classList.add('open');
-      fab.innerHTML = closeIcon;
+      closePanel();
     } else {
-      panel.classList.remove('open');
-      fab.innerHTML = chatIcon;
+      openPanel();
     }
   };
 
@@ -658,6 +693,24 @@
   // the childList of the *old* body node that still holds container -- only
   // <html>'s own childList changes when body itself is swapped out.
   panelRemovalObserver.observe(document.documentElement, { childList: true, subtree: true });
+
+  // The header's minimize/close controls live inside the iframe's React app
+  // and have no direct handle to panel/fab, so they signal intent back here
+  // over postMessage instead. Both currently collapse to the same hide
+  // action; kept as distinct message types since they're two separately
+  // named product controls, even though today's effect is identical.
+  window.addEventListener('message', function (event) {
+    if (event.origin !== host || event.source !== iframe.contentWindow) return;
+    var data = event.data;
+    if (!data || data.xagent !== true) return;
+    if (data.type === 'widget_minimize' || data.type === 'widget_close') {
+      closePanel();
+    }
+  });
+
+  if (!readStoredMinimized()) {
+    openPanel();
+  }
 
   mode.attach(iframe);
 

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -399,6 +399,10 @@ describe("PublicAgentChatPage", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1)
     // No conversation yet — nothing to end.
     expect(screen.queryByRole("button", { name: "widgetChat.newConversation" })).toBeNull()
+    // The embedded widget's minimize/close controls render even with no
+    // active conversation — they toggle the host panel, not the chat itself.
+    expect(screen.getByRole("button", { name: "widgetChat.close" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "widgetChat.moreOptions" })).toBeInTheDocument()
   })
 
   it("ends the conversation and returns to the start screen", async () => {
@@ -608,6 +612,9 @@ describe("PublicAgentChatPage", () => {
     // A share visitor already has the full page; unlike the embedded widget
     // iframe, an in-tab navigation away from it is ordinary browser behavior.
     expect(app.provider?.transport?.capabilities?.linksOpenInNewTab).toBe("disabled")
+    // A share link has no parent widget.js panel to signal minimize/close to.
+    expect(screen.queryByRole("button", { name: "widgetChat.close" })).toBeNull()
+    expect(screen.queryByRole("button", { name: "widgetChat.moreOptions" })).toBeNull()
   })
 
   it("reuses a persisted, unexpired share token without re-authing", async () => {

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -397,12 +397,13 @@ describe("PublicAgentChatPage", () => {
 
     expect(await screen.findByRole("button", { name: "start:Support Agent" })).toBeInTheDocument()
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    // No conversation yet — nothing to end.
+    // No conversation yet — nothing to end, so the "..." menu (which would
+    // only ever hold the new-conversation action) doesn't render either.
     expect(screen.queryByRole("button", { name: "widgetChat.newConversation" })).toBeNull()
-    // The embedded widget's minimize/close controls render even with no
-    // active conversation — they toggle the host panel, not the chat itself.
+    expect(screen.queryByRole("button", { name: "widgetChat.moreOptions" })).toBeNull()
+    // The close control still renders — it toggles the host panel, not the
+    // chat itself, so it's independent of whether a conversation exists.
     expect(screen.getByRole("button", { name: "widgetChat.close" })).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "widgetChat.moreOptions" })).toBeInTheDocument()
   })
 
   it("ends the conversation and returns to the start screen", async () => {
@@ -413,7 +414,8 @@ describe("PublicAgentChatPage", () => {
     renderWidgetPage()
 
     await screen.findByTestId("conversation-panel")
-    fireEvent.click(screen.getByRole("button", { name: "widgetChat.newConversation" }))
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.newConversation" }))
 
     // The persisted id is dropped, so a reload cannot resurrect the old task,
     // and the next message goes through the fresh-task path in handleSend.
@@ -434,7 +436,8 @@ describe("PublicAgentChatPage", () => {
     renderWidgetPage()
 
     await screen.findByTestId("conversation-panel")
-    fireEvent.click(screen.getByRole("button", { name: "widgetChat.newConversation" }))
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.newConversation" }))
 
     expect(app.dispatch).toHaveBeenCalledWith({ type: "SET_PROCESSING", payload: false })
     expect(app.dispatch).toHaveBeenCalledWith({ type: "SET_CURRENT_TASK", payload: null })

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -615,9 +615,12 @@ describe("PublicAgentChatPage", () => {
     // A share visitor already has the full page; unlike the embedded widget
     // iframe, an in-tab navigation away from it is ordinary browser behavior.
     expect(app.provider?.transport?.capabilities?.linksOpenInNewTab).toBe("disabled")
-    // A share link has no parent widget.js panel to signal minimize/close to.
+    // A share link has no parent widget.js panel to signal close to. (The
+    // "..." trigger's absence isn't asserted here -- it would also be absent
+    // in widget mode at this same taskless start screen, so it wouldn't
+    // prove anything about the share/widget exclusion specifically; that's
+    // covered instead once there's an active share conversation, below.)
     expect(screen.queryByRole("button", { name: "widgetChat.close" })).toBeNull()
-    expect(screen.queryByRole("button", { name: "widgetChat.moreOptions" })).toBeNull()
   })
 
   it("reuses a persisted, unexpired share token without re-authing", async () => {
@@ -706,6 +709,11 @@ describe("PublicAgentChatPage", () => {
     expect(fetchMock).not.toHaveBeenCalled()
     // Hiding the trace is scoped to the widget (#1041); share links keep it.
     expect(panel).toHaveAttribute("data-show-process-view", "true")
+    // The share/widget exclusion only means something once there's an active
+    // conversation -- in widget mode this same state renders the "..." menu
+    // (see the standalone-newConversation share button asserted below).
+    expect(screen.queryByRole("button", { name: "widgetChat.moreOptions" })).toBeNull()
+    expect(screen.getByRole("button", { name: "widgetChat.newConversation" })).toBeInTheDocument()
   })
 
   it("ends a share conversation and returns to the start screen", async () => {

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -396,23 +396,29 @@ function PublicConversationContent({
               <p className="text-xs text-destructive">{createTaskError}</p>
             )}
           </div>
-          {(state.taskId || authMode === "widget") && (
-            <div className="ml-auto flex items-center gap-1">
-              {state.taskId && (
-                <button
-                  type="button"
-                  onClick={handleNewConversation}
-                  title={t("widgetChat.newConversation")}
-                  aria-label={t("widgetChat.newConversation")}
-                  className="p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-                >
-                  <MessageSquarePlus className="w-4 h-4" />
-                </button>
-              )}
-              {/* The embedded widget is the only mode a host page can hide;
-                  a standalone share link has no parent to signal. */}
-              {authMode === "widget" && <WidgetChromeControls />}
-            </div>
+          {/* A standalone share link has no parent widget.js to signal, so
+              it keeps its own visible reset button instead of the "..."
+              menu -- the embedded widget is the only mode that can be
+              hidden from a host page. */}
+          {authMode === "share" ? (
+            state.taskId && (
+              <button
+                type="button"
+                onClick={handleNewConversation}
+                title={t("widgetChat.newConversation")}
+                aria-label={t("widgetChat.newConversation")}
+                className="ml-auto p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+              >
+                <MessageSquarePlus className="w-4 h-4" />
+              </button>
+            )
+          ) : (
+            <WidgetChromeControls
+              newConversation={state.taskId ? {
+                label: t("widgetChat.newConversation"),
+                onClick: handleNewConversation,
+              } : undefined}
+            />
           )}
         </div>
       </div>

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -4,7 +4,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { Loader2, MessageSquarePlus } from "lucide-react"
 import { ChatStartScreen } from "@/components/chat/ChatStartScreen"
 import { TaskConversationPanel } from "@/components/task/task-conversation-panel"
-import { WidgetChromeControls } from "@/components/widget/widget-chrome-controls"
+import { iconButtonClassName, WidgetChromeControls } from "@/components/widget/widget-chrome-controls"
 import { AppProvider, useApp, type AppProviderTransportConfig } from "@/contexts/app-context-chat"
 import { resolveReportedTimezone } from "@/hooks/use-websocket"
 import { usePublicFileAccessPolicy } from "@/contexts/file-access-context"
@@ -407,7 +407,7 @@ function PublicConversationContent({
                 onClick={handleNewConversation}
                 title={t("widgetChat.newConversation")}
                 aria-label={t("widgetChat.newConversation")}
-                className="ml-auto p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+                className={`ml-auto ${iconButtonClassName}`}
               >
                 <MessageSquarePlus className="w-4 h-4" />
               </button>

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -11,7 +11,6 @@ import { usePublicFileAccessPolicy } from "@/contexts/file-access-context"
 import { useI18n } from "@/contexts/i18n-context"
 import { uploadPublicChatFile } from "@/lib/public-chat-file-upload"
 import { normalizeTaskStatus } from "@/lib/task-status"
-import { postToParentWidget } from "@/lib/widget-parent-message"
 import {
   getApiUrl,
 } from "@/lib/utils"
@@ -596,14 +595,6 @@ export function PublicAgentChatPage({
         persistShareAuth(authData)
         setAuthResult(authData)
         setErrorMessage(null)
-        // Tells widget.js it's now safe to auto-restore the panel to open:
-        // the embed-ticket exchange it saw succeed only got this far, not
-        // all the way through this call's own auth check. A share page has
-        // no parent widget.js panel to signal (postToParentWidget no-ops
-        // there anyway), so this is effectively widget-mode only.
-        if (authMode === "widget") {
-          postToParentWidget("widget_ready")
-        }
       } catch (error) {
         console.error(error)
         setErrorMessage((error as Error).message || t("widgetChat.messages.error_init"))

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -4,6 +4,7 @@ import React, { useCallback, useEffect, useMemo, useState } from "react"
 import { Loader2, MessageSquarePlus } from "lucide-react"
 import { ChatStartScreen } from "@/components/chat/ChatStartScreen"
 import { TaskConversationPanel } from "@/components/task/task-conversation-panel"
+import { WidgetChromeControls } from "@/components/widget/widget-chrome-controls"
 import { AppProvider, useApp, type AppProviderTransportConfig } from "@/contexts/app-context-chat"
 import { resolveReportedTimezone } from "@/hooks/use-websocket"
 import { usePublicFileAccessPolicy } from "@/contexts/file-access-context"
@@ -395,16 +396,23 @@ function PublicConversationContent({
               <p className="text-xs text-destructive">{createTaskError}</p>
             )}
           </div>
-          {state.taskId && (
-            <button
-              type="button"
-              onClick={handleNewConversation}
-              title={t("widgetChat.newConversation")}
-              aria-label={t("widgetChat.newConversation")}
-              className="ml-auto p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
-            >
-              <MessageSquarePlus className="w-4 h-4" />
-            </button>
+          {(state.taskId || authMode === "widget") && (
+            <div className="ml-auto flex items-center gap-1">
+              {state.taskId && (
+                <button
+                  type="button"
+                  onClick={handleNewConversation}
+                  title={t("widgetChat.newConversation")}
+                  aria-label={t("widgetChat.newConversation")}
+                  className="p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+                >
+                  <MessageSquarePlus className="w-4 h-4" />
+                </button>
+              )}
+              {/* The embedded widget is the only mode a host page can hide;
+                  a standalone share link has no parent to signal. */}
+              {authMode === "widget" && <WidgetChromeControls />}
+            </div>
           )}
         </div>
       </div>

--- a/frontend/src/components/widget/public-agent-chat-page.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.tsx
@@ -11,6 +11,7 @@ import { usePublicFileAccessPolicy } from "@/contexts/file-access-context"
 import { useI18n } from "@/contexts/i18n-context"
 import { uploadPublicChatFile } from "@/lib/public-chat-file-upload"
 import { normalizeTaskStatus } from "@/lib/task-status"
+import { postToParentWidget } from "@/lib/widget-parent-message"
 import {
   getApiUrl,
 } from "@/lib/utils"
@@ -595,6 +596,14 @@ export function PublicAgentChatPage({
         persistShareAuth(authData)
         setAuthResult(authData)
         setErrorMessage(null)
+        // Tells widget.js it's now safe to auto-restore the panel to open:
+        // the embed-ticket exchange it saw succeed only got this far, not
+        // all the way through this call's own auth check. A share page has
+        // no parent widget.js panel to signal (postToParentWidget no-ops
+        // there anyway), so this is effectively widget-mode only.
+        if (authMode === "widget") {
+          postToParentWidget("widget_ready")
+        }
       } catch (error) {
         console.error(error)
         setErrorMessage((error as Error).message || t("widgetChat.messages.error_init"))

--- a/frontend/src/components/widget/session-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.test.tsx
@@ -207,7 +207,12 @@ describe("SessionAgentChatPage", () => {
   })
 
   it("constructs the exact active Session transport and does not leak credentials", () => {
-    const storageSet = vi.spyOn(Storage.prototype, "setItem")
+    // Same fix as widget-chrome.test.ts: this suite's localStorage is a
+    // LocalStorageMock with its own prototype (vitest.setup.ts), unrelated
+    // to native Storage.prototype -- spying there never intercepted this
+    // component's actual localStorage.setItem calls, so this credential-leak
+    // assertion was vacuous.
+    const storageSet = vi.spyOn(localStorage, "setItem")
     setBridge("active", activeSession())
     app.isConnected = true
 

--- a/frontend/src/components/widget/session-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.test.tsx
@@ -247,7 +247,8 @@ describe("SessionAgentChatPage", () => {
     render(<SessionAgentChatPage />)
 
     expect(screen.getByRole("alert")).toHaveTextContent("widgetSession.reloadRequired")
-    expect(screen.getByRole("button", {
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    expect(screen.getByRole("menuitem", {
       name: "widgetSession.startNewConversation",
     })).toBeDisabled()
     expect(app.startProps).toBeNull()
@@ -263,7 +264,8 @@ describe("SessionAgentChatPage", () => {
     app.state.taskId = 92
     app.startNewConversation.mockRejectedValueOnce(new Error("timeout"))
     const { rerender } = render(<SessionAgentChatPage />)
-    fireEvent.click(screen.getByRole("button", { name: "widgetSession.startNewConversation" }))
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    fireEvent.click(screen.getByRole("menuitem", { name: "widgetSession.startNewConversation" }))
     await screen.findByText("widgetSession.resetFailed")
 
     app.sessionConversationState = "reload_required"
@@ -303,11 +305,13 @@ describe("SessionAgentChatPage", () => {
       { mode: "balanced" },
       [],
     )
-    expect(screen.queryByRole("button", {
+    expect(screen.queryByRole("menuitem", {
       name: "widgetSession.startNewConversation",
     })).not.toBeInTheDocument()
+    // No conversation yet — nothing to reset, so the "..." menu (which would
+    // only ever hold the new-conversation action) doesn't render either.
+    expect(screen.queryByRole("button", { name: "widgetChat.moreOptions" })).toBeNull()
     expect(screen.getByRole("button", { name: "widgetChat.close" })).toBeInTheDocument()
-    expect(screen.getByRole("button", { name: "widgetChat.moreOptions" })).toBeInTheDocument()
   })
 
   it("renders the conversation with files disabled and gates reset on pending work", () => {
@@ -326,14 +330,15 @@ describe("SessionAgentChatPage", () => {
       showTaskFiles: false,
       showTaskActions: false,
     }))
-    const reset = screen.getByRole("button", {
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    const reset = screen.getByRole("menuitem", {
       name: "widgetSession.startNewConversation",
     })
     expect(reset).toBeDisabled()
 
     app.isMessageDeliveryPending = false
     rerender(<SessionAgentChatPage />)
-    fireEvent.click(screen.getByRole("button", {
+    fireEvent.click(screen.getByRole("menuitem", {
       name: "widgetSession.startNewConversation",
     }))
     expect(app.startNewConversation).toHaveBeenCalledTimes(1)

--- a/frontend/src/components/widget/session-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.test.tsx
@@ -305,11 +305,11 @@ describe("SessionAgentChatPage", () => {
       { mode: "balanced" },
       [],
     )
-    expect(screen.queryByRole("menuitem", {
-      name: "widgetSession.startNewConversation",
-    })).not.toBeInTheDocument()
     // No conversation yet — nothing to reset, so the "..." menu (which would
-    // only ever hold the new-conversation action) doesn't render either.
+    // only ever hold the new-conversation action) doesn't render either. (Not
+    // asserting the menuitem itself is absent here: the menu was never
+    // opened, so that check can't fail regardless of whether this logic
+    // works — the trigger's own absence, below, is what actually proves it.)
     expect(screen.queryByRole("button", { name: "widgetChat.moreOptions" })).toBeNull()
     expect(screen.getByRole("button", { name: "widgetChat.close" })).toBeInTheDocument()
   })
@@ -342,6 +342,27 @@ describe("SessionAgentChatPage", () => {
       name: "widgetSession.startNewConversation",
     }))
     expect(app.startNewConversation).toHaveBeenCalledTimes(1)
+  })
+
+  it("keeps the reset visibly pending on the trigger after the menu auto-closes on click", () => {
+    // The menuitem click that starts the reset also closes the menu (normal
+    // menu UX), so the "Resetting..." label is only reachable here if the
+    // trigger itself carries the pending state too.
+    setBridge("active", activeSession())
+    app.state.taskId = 71
+    app.isConnected = true
+
+    const { rerender } = render(<SessionAgentChatPage />)
+    const trigger = screen.getByRole("button", { name: "widgetChat.moreOptions" })
+    fireEvent.click(trigger)
+    fireEvent.click(screen.getByRole("menuitem", { name: "widgetSession.startNewConversation" }))
+    expect(screen.queryByRole("menu")).toBeNull()
+
+    app.isConversationResetPending = true
+    rerender(<SessionAgentChatPage />)
+
+    expect(trigger).toBeDisabled()
+    expect(screen.queryByRole("menu")).toBeNull()
   })
 
   it("shows connecting and the non-blocking absolute-expiry warning", () => {

--- a/frontend/src/components/widget/session-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.test.tsx
@@ -362,12 +362,16 @@ describe("SessionAgentChatPage", () => {
     fireEvent.click(trigger)
     fireEvent.click(screen.getByRole("menuitem", { name: "widgetSession.startNewConversation" }))
     expect(screen.queryByRole("menu")).toBeNull()
+    expect(app.startNewConversation).toHaveBeenCalledTimes(1)
 
     app.isConversationResetPending = true
     rerender(<SessionAgentChatPage />)
 
     expect(trigger).toBeDisabled()
     expect(screen.queryByRole("menu")).toBeNull()
+    // Not just "disabled" -- the whole point of this prop is a visible
+    // in-progress indicator on the trigger once the menu itself has closed.
+    expect(trigger.querySelector("svg.animate-spin")).not.toBeNull()
   })
 
   it("shows connecting and the non-blocking absolute-expiry warning", () => {

--- a/frontend/src/components/widget/session-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.test.tsx
@@ -306,6 +306,8 @@ describe("SessionAgentChatPage", () => {
     expect(screen.queryByRole("button", {
       name: "widgetSession.startNewConversation",
     })).not.toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "widgetChat.close" })).toBeInTheDocument()
+    expect(screen.getByRole("button", { name: "widgetChat.moreOptions" })).toBeInTheDocument()
   })
 
   it("renders the conversation with files disabled and gates reset on pending work", () => {

--- a/frontend/src/components/widget/session-agent-chat-page.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.tsx
@@ -4,7 +4,6 @@ import React, { useCallback, useMemo, useState } from "react"
 import { Loader2 } from "lucide-react"
 import { ChatStartScreen } from "@/components/chat/ChatStartScreen"
 import { TaskConversationPanel } from "@/components/task/task-conversation-panel"
-import { Button } from "@/components/ui/button"
 import { WidgetChromeControls } from "@/components/widget/widget-chrome-controls"
 import {
   AppProvider,
@@ -156,22 +155,15 @@ function SessionConversationContent({
                 : t("widgetChat.status.connecting")}
             </p>
           </div>
-          <div className="ml-auto flex items-center gap-1">
-            {hasEstablishedConversation ? (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                disabled={resetDisabled}
-                onClick={() => void handleStartNewConversation()}
-              >
-                {isConversationResetPending
-                  ? t("widgetSession.resetting")
-                  : t("widgetSession.startNewConversation")}
-              </Button>
-            ) : null}
-            <WidgetChromeControls />
-          </div>
+          <WidgetChromeControls
+            newConversation={hasEstablishedConversation ? {
+              label: isConversationResetPending
+                ? t("widgetSession.resetting")
+                : t("widgetSession.startNewConversation"),
+              onClick: () => void handleStartNewConversation(),
+              disabled: resetDisabled,
+            } : undefined}
+          />
         </div>
         {isAbsoluteExpiryWarningVisible ? (
           <p

--- a/frontend/src/components/widget/session-agent-chat-page.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.tsx
@@ -5,6 +5,7 @@ import { Loader2 } from "lucide-react"
 import { ChatStartScreen } from "@/components/chat/ChatStartScreen"
 import { TaskConversationPanel } from "@/components/task/task-conversation-panel"
 import { Button } from "@/components/ui/button"
+import { WidgetChromeControls } from "@/components/widget/widget-chrome-controls"
 import {
   AppProvider,
   type AppProviderTransportConfig,
@@ -155,20 +156,22 @@ function SessionConversationContent({
                 : t("widgetChat.status.connecting")}
             </p>
           </div>
-          {hasEstablishedConversation ? (
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              className="ml-auto"
-              disabled={resetDisabled}
-              onClick={() => void handleStartNewConversation()}
-            >
-              {isConversationResetPending
-                ? t("widgetSession.resetting")
-                : t("widgetSession.startNewConversation")}
-            </Button>
-          ) : null}
+          <div className="ml-auto flex items-center gap-1">
+            {hasEstablishedConversation ? (
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                disabled={resetDisabled}
+                onClick={() => void handleStartNewConversation()}
+              >
+                {isConversationResetPending
+                  ? t("widgetSession.resetting")
+                  : t("widgetSession.startNewConversation")}
+              </Button>
+            ) : null}
+            <WidgetChromeControls />
+          </div>
         </div>
         {isAbsoluteExpiryWarningVisible ? (
           <p

--- a/frontend/src/components/widget/session-agent-chat-page.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.tsx
@@ -162,6 +162,7 @@ function SessionConversationContent({
                 : t("widgetSession.startNewConversation"),
               onClick: () => void handleStartNewConversation(),
               disabled: resetDisabled,
+              pending: isConversationResetPending,
             } : undefined}
           />
         </div>

--- a/frontend/src/components/widget/widget-chrome-controls.test.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.test.tsx
@@ -1,0 +1,97 @@
+import React from "react"
+import { cleanup, fireEvent, render, screen } from "@testing-library/react"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { WidgetChromeControls } from "./widget-chrome-controls"
+
+vi.mock("@/contexts/i18n-context", () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}))
+
+describe("WidgetChromeControls", () => {
+  const postMessageSpy = vi.fn()
+
+  beforeEach(() => {
+    postMessageSpy.mockReset()
+    vi.stubGlobal("parent", { postMessage: postMessageSpy })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.unstubAllGlobals()
+  })
+
+  it("renders a close button and a collapsed menu trigger", () => {
+    render(<WidgetChromeControls />)
+
+    expect(screen.getByRole("button", { name: "widgetChat.close" })).toBeInTheDocument()
+    const menuTrigger = screen.getByRole("button", { name: "widgetChat.moreOptions" })
+    expect(menuTrigger).toHaveAttribute("aria-expanded", "false")
+    expect(screen.queryByRole("menu")).toBeNull()
+  })
+
+  it("posts widget_close to the parent window when the close button is clicked", () => {
+    render(<WidgetChromeControls />)
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.close" }))
+
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { xagent: true, v: 1, type: "widget_close" },
+      "*",
+    )
+  })
+
+  it("opens the menu on trigger click and posts widget_minimize, closing the menu", () => {
+    render(<WidgetChromeControls />)
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.minimize" }))
+
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { xagent: true, v: 1, type: "widget_minimize" },
+      "*",
+    )
+    expect(screen.queryByRole("menu")).toBeNull()
+  })
+
+  it("closes the menu on Escape", () => {
+    render(<WidgetChromeControls />)
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+
+    fireEvent.keyDown(document, { key: "Escape" })
+
+    expect(screen.queryByRole("menu")).toBeNull()
+  })
+
+  it("closes the menu when the iframe window loses focus", () => {
+    // e.g. the host page's own FAB, entirely outside this document, hiding
+    // the panel -- neither the pointerdown nor the Escape listener fires.
+    render(<WidgetChromeControls />)
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+
+    fireEvent(window, new Event("blur"))
+
+    expect(screen.queryByRole("menu")).toBeNull()
+  })
+
+  it("closes the menu on an outside pointer press", () => {
+    render(
+      <div>
+        <div data-testid="outside">outside</div>
+        <WidgetChromeControls />
+      </div>,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+
+    fireEvent.pointerDown(screen.getByTestId("outside"))
+
+    expect(screen.queryByRole("menu")).toBeNull()
+  })
+})

--- a/frontend/src/components/widget/widget-chrome-controls.test.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.test.tsx
@@ -48,6 +48,15 @@ describe("WidgetChromeControls", () => {
     )
   })
 
+  it("does not post a message when the page is visited directly (window.parent === window)", () => {
+    vi.stubGlobal("parent", window)
+
+    render(<WidgetChromeControls />)
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.close" }))
+
+    expect(postMessageSpy).not.toHaveBeenCalled()
+  })
+
   it("opens the menu on trigger click, shows the given label, and calls onClick then closes the menu", () => {
     render(<WidgetChromeControls newConversation={{ label: "Start over", onClick: onNewConversation }} />)
 
@@ -95,6 +104,25 @@ describe("WidgetChromeControls", () => {
     fireEvent(window, new Event("blur"))
 
     expect(screen.queryByRole("menu")).toBeNull()
+  })
+
+  it("ignores a pointerdown whose target was removed from the DOM during dispatch", () => {
+    // A sibling handler on the target itself can synchronously detach it
+    // before the event finishes bubbling to this component's document
+    // listener; Node.contains() on a now-disconnected node would otherwise
+    // read the same as a genuine outside click and close the menu.
+    render(<WidgetChromeControls newConversation={{ label: "Start over", onClick: onNewConversation }} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+
+    const ephemeral = document.createElement("button")
+    document.body.appendChild(ephemeral)
+    ephemeral.addEventListener("pointerdown", () => ephemeral.remove())
+
+    fireEvent.pointerDown(ephemeral)
+
+    expect(screen.getByRole("menu")).toBeInTheDocument()
   })
 
   it("closes the menu on an outside pointer press", () => {

--- a/frontend/src/components/widget/widget-chrome-controls.test.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.test.tsx
@@ -101,6 +101,7 @@ describe("WidgetChromeControls", () => {
     fireEvent.click(trigger)
     fireEvent.click(screen.getByRole("menuitem", { name: "Start over" }))
     expect(screen.queryByRole("menu")).toBeNull()
+    expect(onNewConversation).toHaveBeenCalledTimes(1)
 
     rerender(
       <WidgetChromeControls
@@ -115,6 +116,9 @@ describe("WidgetChromeControls", () => {
 
     expect(trigger).toBeDisabled()
     expect(screen.queryByRole("menu")).toBeNull()
+    // Not just "disabled" -- the whole point of this prop is a visible
+    // in-progress indicator on the trigger once the menu itself has closed.
+    expect(trigger.querySelector("svg.animate-spin")).not.toBeNull()
   })
 
   it("closes the menu on Escape", () => {
@@ -139,6 +143,23 @@ describe("WidgetChromeControls", () => {
     fireEvent(window, new Event("blur"))
 
     expect(screen.queryByRole("menu")).toBeNull()
+  })
+
+  it("ignores a blur caused by focus moving within this same document, not the panel being hidden", () => {
+    // e.g. focus moving into the chat composer -- document.hasFocus() stays
+    // true because the iframe itself was never actually hidden; only a blur
+    // where it goes false (focus left the iframe's document entirely) means
+    // the host page hid the panel out from under an open menu.
+    const hasFocusSpy = vi.spyOn(document, "hasFocus").mockReturnValue(true)
+    render(<WidgetChromeControls newConversation={{ label: "Start over", onClick: onNewConversation }} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+
+    fireEvent(window, new Event("blur"))
+
+    expect(screen.getByRole("menu")).toBeInTheDocument()
+    hasFocusSpy.mockRestore()
   })
 
   it("ignores a pointerdown whose target was removed from the DOM during dispatch", () => {

--- a/frontend/src/components/widget/widget-chrome-controls.test.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.test.tsx
@@ -49,12 +49,17 @@ describe("WidgetChromeControls", () => {
   })
 
   it("does not post a message when the page is visited directly (window.parent === window)", () => {
+    // window.parent === window here means the guard's else-branch calls the
+    // real window.postMessage, not the postMessageSpy stub above -- spy on
+    // the real one directly so a missing guard would actually be caught.
     vi.stubGlobal("parent", window)
+    const realPostMessageSpy = vi.spyOn(window, "postMessage")
 
     render(<WidgetChromeControls />)
     fireEvent.click(screen.getByRole("button", { name: "widgetChat.close" }))
 
-    expect(postMessageSpy).not.toHaveBeenCalled()
+    expect(realPostMessageSpy).not.toHaveBeenCalled()
+    realPostMessageSpy.mockRestore()
   })
 
   it("opens the menu on trigger click, shows the given label, and calls onClick then closes the menu", () => {
@@ -80,6 +85,36 @@ describe("WidgetChromeControls", () => {
     fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
 
     expect(screen.getByRole("menuitem", { name: "Resetting..." })).toBeDisabled()
+  })
+
+  it("keeps a pending action visible on the trigger after the menu closes on click", () => {
+    // The menu closes immediately on menuitem click (standard menu UX), so a
+    // slow round-trip needs feedback that survives that -- the trigger itself
+    // switches to a spinner rather than depending on the visitor reopening
+    // the (by-then pending) menu to see anything changed.
+    const { rerender } = render(
+      <WidgetChromeControls
+        newConversation={{ label: "Start over", onClick: onNewConversation }}
+      />,
+    )
+    const trigger = screen.getByRole("button", { name: "widgetChat.moreOptions" })
+    fireEvent.click(trigger)
+    fireEvent.click(screen.getByRole("menuitem", { name: "Start over" }))
+    expect(screen.queryByRole("menu")).toBeNull()
+
+    rerender(
+      <WidgetChromeControls
+        newConversation={{
+          label: "Resetting...",
+          onClick: onNewConversation,
+          disabled: true,
+          pending: true,
+        }}
+      />,
+    )
+
+    expect(trigger).toBeDisabled()
+    expect(screen.queryByRole("menu")).toBeNull()
   })
 
   it("closes the menu on Escape", () => {

--- a/frontend/src/components/widget/widget-chrome-controls.test.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.test.tsx
@@ -9,9 +9,11 @@ vi.mock("@/contexts/i18n-context", () => ({
 
 describe("WidgetChromeControls", () => {
   const postMessageSpy = vi.fn()
+  const onNewConversation = vi.fn()
 
   beforeEach(() => {
     postMessageSpy.mockReset()
+    onNewConversation.mockReset()
     vi.stubGlobal("parent", { postMessage: postMessageSpy })
   })
 
@@ -20,10 +22,16 @@ describe("WidgetChromeControls", () => {
     vi.unstubAllGlobals()
   })
 
-  it("renders a close button and a collapsed menu trigger", () => {
+  it("renders only the close button when there is no new-conversation action", () => {
     render(<WidgetChromeControls />)
 
     expect(screen.getByRole("button", { name: "widgetChat.close" })).toBeInTheDocument()
+    expect(screen.queryByRole("button", { name: "widgetChat.moreOptions" })).toBeNull()
+  })
+
+  it("renders a collapsed menu trigger when a new-conversation action is given", () => {
+    render(<WidgetChromeControls newConversation={{ label: "Start over", onClick: onNewConversation }} />)
+
     const menuTrigger = screen.getByRole("button", { name: "widgetChat.moreOptions" })
     expect(menuTrigger).toHaveAttribute("aria-expanded", "false")
     expect(screen.queryByRole("menu")).toBeNull()
@@ -40,23 +48,33 @@ describe("WidgetChromeControls", () => {
     )
   })
 
-  it("opens the menu on trigger click and posts widget_minimize, closing the menu", () => {
-    render(<WidgetChromeControls />)
+  it("opens the menu on trigger click, shows the given label, and calls onClick then closes the menu", () => {
+    render(<WidgetChromeControls newConversation={{ label: "Start over", onClick: onNewConversation }} />)
 
     fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
-    expect(screen.getByRole("menu")).toBeInTheDocument()
+    const item = screen.getByRole("menuitem", { name: "Start over" })
+    expect(item).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.minimize" }))
+    fireEvent.click(item)
 
-    expect(postMessageSpy).toHaveBeenCalledWith(
-      { xagent: true, v: 1, type: "widget_minimize" },
-      "*",
-    )
+    expect(onNewConversation).toHaveBeenCalledTimes(1)
     expect(screen.queryByRole("menu")).toBeNull()
   })
 
+  it("disables the new-conversation menu item when told to", () => {
+    render(
+      <WidgetChromeControls
+        newConversation={{ label: "Resetting...", onClick: onNewConversation, disabled: true }}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+
+    expect(screen.getByRole("menuitem", { name: "Resetting..." })).toBeDisabled()
+  })
+
   it("closes the menu on Escape", () => {
-    render(<WidgetChromeControls />)
+    render(<WidgetChromeControls newConversation={{ label: "Start over", onClick: onNewConversation }} />)
 
     fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
     expect(screen.getByRole("menu")).toBeInTheDocument()
@@ -69,7 +87,7 @@ describe("WidgetChromeControls", () => {
   it("closes the menu when the iframe window loses focus", () => {
     // e.g. the host page's own FAB, entirely outside this document, hiding
     // the panel -- neither the pointerdown nor the Escape listener fires.
-    render(<WidgetChromeControls />)
+    render(<WidgetChromeControls newConversation={{ label: "Start over", onClick: onNewConversation }} />)
 
     fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
     expect(screen.getByRole("menu")).toBeInTheDocument()
@@ -83,7 +101,7 @@ describe("WidgetChromeControls", () => {
     render(
       <div>
         <div data-testid="outside">outside</div>
-        <WidgetChromeControls />
+        <WidgetChromeControls newConversation={{ label: "Start over", onClick: onNewConversation }} />
       </div>,
     )
 

--- a/frontend/src/components/widget/widget-chrome-controls.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.tsx
@@ -5,7 +5,9 @@ import { Loader2, MessageSquarePlus, MoreHorizontal, X } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context"
 import { postToParentWidget } from "@/lib/widget-parent-message"
 
-const iconButtonClassName =
+// Exported so the standalone share-mode reset button (public-agent-chat-page.tsx)
+// can match this styling instead of drifting with its own duplicate string.
+export const iconButtonClassName =
   "p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors "
   + "disabled:pointer-events-none disabled:opacity-50 "
   + "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
@@ -52,8 +54,14 @@ export function WidgetChromeControls({ newConversation }: WidgetChromeControlsPr
     // widget.js can hide this whole iframe from the host page's own FAB, a
     // click entirely outside this document that the two listeners above
     // never see. The iframe is never unmounted, so without this the menu
-    // would still be open the next time the panel is shown.
-    const handleBlur = () => setIsMenuOpen(false)
+    // would still be open the next time the panel is shown. Guarded the same
+    // way as widget.js's own onWindowBlur: focus moving into a child of this
+    // same document (e.g. the chat composer autofocusing) also fires a
+    // window blur without the panel actually being hidden.
+    const handleBlur = () => {
+      if (document.hasFocus()) return
+      setIsMenuOpen(false)
+    }
 
     document.addEventListener("pointerdown", handlePointerDown)
     document.addEventListener("keydown", handleKeyDown)

--- a/frontend/src/components/widget/widget-chrome-controls.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useEffect, useRef, useState } from "react"
-import { MessageSquarePlus, MoreHorizontal, X } from "lucide-react"
+import { Loader2, MessageSquarePlus, MoreHorizontal, X } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context"
 
 // The host page's widget.js owns panel visibility; it has no direct handle
@@ -19,6 +19,7 @@ const postCloseToParent = () => {
 
 const iconButtonClassName =
   "p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors "
+  + "disabled:pointer-events-none disabled:opacity-50 "
   + "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 
 interface WidgetChromeControlsProps {
@@ -30,6 +31,12 @@ interface WidgetChromeControlsProps {
     label: string
     onClick: () => void
     disabled?: boolean
+    // The menu closes as soon as an item is clicked (standard menu UX), so a
+    // pending round-trip (e.g. Session mode's reset) would otherwise show no
+    // feedback at all unless the visitor happens to reopen the menu during
+    // it. Surfaced as a spinner on the trigger itself instead, which stays
+    // visible with the menu closed.
+    pending?: boolean
   }
 }
 
@@ -87,13 +94,18 @@ export function WidgetChromeControls({ newConversation }: WidgetChromeControlsPr
           <button
             type="button"
             onClick={() => setIsMenuOpen((open) => !open)}
+            disabled={newConversation.pending}
             title={t("widgetChat.moreOptions")}
             aria-label={t("widgetChat.moreOptions")}
             aria-haspopup="menu"
             aria-expanded={isMenuOpen}
             className={iconButtonClassName}
           >
-            <MoreHorizontal className="w-4 h-4" />
+            {newConversation.pending ? (
+              <Loader2 className="w-4 h-4 animate-spin" />
+            ) : (
+              <MoreHorizontal className="w-4 h-4" />
+            )}
           </button>
           {isMenuOpen ? (
             <div

--- a/frontend/src/components/widget/widget-chrome-controls.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.tsx
@@ -1,0 +1,105 @@
+"use client"
+
+import React, { useEffect, useRef, useState } from "react"
+import { Minus, MoreHorizontal, X } from "lucide-react"
+import { useI18n } from "@/contexts/i18n-context"
+
+type ChromeMessageType = "widget_minimize" | "widget_close"
+
+// The host page's widget.js owns panel visibility; it has no direct handle
+// into this iframe's React tree, so intent is signalled back over
+// postMessage instead. The host is an arbitrary third-party origin from in
+// here, so targetOrigin can't be pinned tighter than "*" -- this carries no
+// sensitive payload, unlike the parent -> iframe session protocol.
+const postToParent = (type: ChromeMessageType) => {
+  window.parent.postMessage({ xagent: true, v: 1, type }, "*")
+}
+
+const iconButtonClassName =
+  "p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+
+export function WidgetChromeControls() {
+  const { t } = useI18n()
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!isMenuOpen) return
+
+    const handlePointerDown = (event: PointerEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsMenuOpen(false)
+      }
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setIsMenuOpen(false)
+    }
+    // widget.js can hide this whole iframe from the host page's own FAB, a
+    // click entirely outside this document that the two listeners above
+    // never see. The iframe is never unmounted, so without this the menu
+    // would still be open the next time the panel is shown.
+    const handleBlur = () => setIsMenuOpen(false)
+
+    document.addEventListener("pointerdown", handlePointerDown)
+    document.addEventListener("keydown", handleKeyDown)
+    window.addEventListener("blur", handleBlur)
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown)
+      document.removeEventListener("keydown", handleKeyDown)
+      window.removeEventListener("blur", handleBlur)
+    }
+  }, [isMenuOpen])
+
+  const handleMinimize = () => {
+    setIsMenuOpen(false)
+    postToParent("widget_minimize")
+  }
+
+  const handleClose = () => {
+    setIsMenuOpen(false)
+    postToParent("widget_close")
+  }
+
+  return (
+    <div className="ml-auto flex items-center gap-1">
+      <div ref={menuRef} className="relative">
+        <button
+          type="button"
+          onClick={() => setIsMenuOpen((open) => !open)}
+          title={t("widgetChat.moreOptions")}
+          aria-label={t("widgetChat.moreOptions")}
+          aria-haspopup="menu"
+          aria-expanded={isMenuOpen}
+          className={iconButtonClassName}
+        >
+          <MoreHorizontal className="w-4 h-4" />
+        </button>
+        {isMenuOpen ? (
+          <div
+            role="menu"
+            className="absolute right-0 top-full z-20 mt-1 min-w-[160px] rounded-md border bg-popover py-1 text-popover-foreground shadow-md"
+          >
+            <button
+              type="button"
+              role="menuitem"
+              onClick={handleMinimize}
+              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-muted/50 transition-colors"
+            >
+              <Minus className="w-4 h-4" />
+              {t("widgetChat.minimize")}
+            </button>
+          </div>
+        ) : null}
+      </div>
+      <button
+        type="button"
+        onClick={handleClose}
+        title={t("widgetChat.close")}
+        aria-label={t("widgetChat.close")}
+        className={iconButtonClassName}
+      >
+        <X className="w-4 h-4" />
+      </button>
+    </div>
+  )
+}

--- a/frontend/src/components/widget/widget-chrome-controls.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.tsx
@@ -3,19 +3,7 @@
 import React, { useEffect, useRef, useState } from "react"
 import { Loader2, MessageSquarePlus, MoreHorizontal, X } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context"
-
-// The host page's widget.js owns panel visibility; it has no direct handle
-// into this iframe's React tree, so close intent is signalled back over
-// postMessage instead. The host is an arbitrary third-party origin from in
-// here, so targetOrigin can't be pinned tighter than "*" -- this carries no
-// sensitive payload, unlike the parent -> iframe session protocol.
-const postCloseToParent = () => {
-  // A direct (non-embedded) visit to this page has window.parent === window;
-  // posting there would just send the widget its own message right back.
-  if (window.parent !== window) {
-    window.parent.postMessage({ xagent: true, v: 1, type: "widget_close" }, "*")
-  }
-}
+import { postToParentWidget } from "@/lib/widget-parent-message"
 
 const iconButtonClassName =
   "p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors "
@@ -84,7 +72,7 @@ export function WidgetChromeControls({ newConversation }: WidgetChromeControlsPr
 
   const handleClose = () => {
     setIsMenuOpen(false)
-    postCloseToParent()
+    postToParentWidget("widget_close")
   }
 
   return (

--- a/frontend/src/components/widget/widget-chrome-controls.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.tsx
@@ -1,24 +1,34 @@
 "use client"
 
 import React, { useEffect, useRef, useState } from "react"
-import { Minus, MoreHorizontal, X } from "lucide-react"
+import { MessageSquarePlus, MoreHorizontal, X } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context"
 
-type ChromeMessageType = "widget_minimize" | "widget_close"
-
 // The host page's widget.js owns panel visibility; it has no direct handle
-// into this iframe's React tree, so intent is signalled back over
+// into this iframe's React tree, so close intent is signalled back over
 // postMessage instead. The host is an arbitrary third-party origin from in
 // here, so targetOrigin can't be pinned tighter than "*" -- this carries no
 // sensitive payload, unlike the parent -> iframe session protocol.
-const postToParent = (type: ChromeMessageType) => {
-  window.parent.postMessage({ xagent: true, v: 1, type }, "*")
+const postCloseToParent = () => {
+  window.parent.postMessage({ xagent: true, v: 1, type: "widget_close" }, "*")
 }
 
 const iconButtonClassName =
   "p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
 
-export function WidgetChromeControls() {
+interface WidgetChromeControlsProps {
+  // Undefined hides the "..." menu entirely -- it would otherwise open onto
+  // nothing. Each host page supplies its own already-resolved label/handler
+  // since "new conversation" means something different (and is disabled/
+  // pending differently) in guest vs. Session mode.
+  newConversation?: {
+    label: string
+    onClick: () => void
+    disabled?: boolean
+  }
+}
+
+export function WidgetChromeControls({ newConversation }: WidgetChromeControlsProps) {
   const { t } = useI18n()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
@@ -50,47 +60,50 @@ export function WidgetChromeControls() {
     }
   }, [isMenuOpen])
 
-  const handleMinimize = () => {
+  const handleNewConversation = () => {
     setIsMenuOpen(false)
-    postToParent("widget_minimize")
+    newConversation?.onClick()
   }
 
   const handleClose = () => {
     setIsMenuOpen(false)
-    postToParent("widget_close")
+    postCloseToParent()
   }
 
   return (
     <div className="ml-auto flex items-center gap-1">
-      <div ref={menuRef} className="relative">
-        <button
-          type="button"
-          onClick={() => setIsMenuOpen((open) => !open)}
-          title={t("widgetChat.moreOptions")}
-          aria-label={t("widgetChat.moreOptions")}
-          aria-haspopup="menu"
-          aria-expanded={isMenuOpen}
-          className={iconButtonClassName}
-        >
-          <MoreHorizontal className="w-4 h-4" />
-        </button>
-        {isMenuOpen ? (
-          <div
-            role="menu"
-            className="absolute right-0 top-full z-20 mt-1 min-w-[160px] rounded-md border bg-popover py-1 text-popover-foreground shadow-md"
+      {newConversation ? (
+        <div ref={menuRef} className="relative">
+          <button
+            type="button"
+            onClick={() => setIsMenuOpen((open) => !open)}
+            title={t("widgetChat.moreOptions")}
+            aria-label={t("widgetChat.moreOptions")}
+            aria-haspopup="menu"
+            aria-expanded={isMenuOpen}
+            className={iconButtonClassName}
           >
-            <button
-              type="button"
-              role="menuitem"
-              onClick={handleMinimize}
-              className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-muted/50 transition-colors"
+            <MoreHorizontal className="w-4 h-4" />
+          </button>
+          {isMenuOpen ? (
+            <div
+              role="menu"
+              className="absolute right-0 top-full z-20 mt-1 w-max max-w-xs rounded-md border bg-popover py-1 text-popover-foreground shadow-md"
             >
-              <Minus className="w-4 h-4" />
-              {t("widgetChat.minimize")}
-            </button>
-          </div>
-        ) : null}
-      </div>
+              <button
+                type="button"
+                role="menuitem"
+                onClick={handleNewConversation}
+                disabled={newConversation.disabled}
+                className="flex w-full items-center gap-2 whitespace-nowrap px-3 py-2 text-left text-sm hover:bg-muted/50 transition-colors disabled:pointer-events-none disabled:opacity-50"
+              >
+                <MessageSquarePlus className="w-4 h-4 shrink-0" />
+                {newConversation.label}
+              </button>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
       <button
         type="button"
         onClick={handleClose}

--- a/frontend/src/components/widget/widget-chrome-controls.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.tsx
@@ -10,7 +10,11 @@ import { useI18n } from "@/contexts/i18n-context"
 // here, so targetOrigin can't be pinned tighter than "*" -- this carries no
 // sensitive payload, unlike the parent -> iframe session protocol.
 const postCloseToParent = () => {
-  window.parent.postMessage({ xagent: true, v: 1, type: "widget_close" }, "*")
+  // A direct (non-embedded) visit to this page has window.parent === window;
+  // posting there would just send the widget its own message right back.
+  if (window.parent !== window) {
+    window.parent.postMessage({ xagent: true, v: 1, type: "widget_close" }, "*")
+  }
 }
 
 const iconButtonClassName =
@@ -37,7 +41,12 @@ export function WidgetChromeControls({ newConversation }: WidgetChromeControlsPr
     if (!isMenuOpen) return
 
     const handlePointerDown = (event: PointerEvent) => {
-      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+      const target = event.target as Node | null
+      // A target already detached from the tree (removed by some other
+      // handler earlier in the same dispatch) fails Node.contains() the
+      // same way a genuine outside click would; don't misread that as one.
+      if (target && !target.isConnected) return
+      if (menuRef.current && !menuRef.current.contains(target)) {
         setIsMenuOpen(false)
       }
     }

--- a/frontend/src/components/widget/widget-chrome-controls.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.tsx
@@ -18,7 +18,8 @@ const postCloseToParent = () => {
 }
 
 const iconButtonClassName =
-  "p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors"
+  "p-2 rounded-md text-muted-foreground hover:text-foreground hover:bg-muted/50 transition-colors "
+  + "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 
 interface WidgetChromeControlsProps {
   // Undefined hides the "..." menu entirely -- it would otherwise open onto
@@ -104,7 +105,7 @@ export function WidgetChromeControls({ newConversation }: WidgetChromeControlsPr
                 role="menuitem"
                 onClick={handleNewConversation}
                 disabled={newConversation.disabled}
-                className="flex w-full items-center gap-2 whitespace-nowrap px-3 py-2 text-left text-sm hover:bg-muted/50 transition-colors disabled:pointer-events-none disabled:opacity-50"
+                className="flex w-full items-center gap-2 whitespace-nowrap px-3 py-2 text-left text-sm hover:bg-muted/50 transition-colors disabled:pointer-events-none disabled:opacity-50 focus-visible:bg-muted/50 focus-visible:outline-none"
               >
                 <MessageSquarePlus className="w-4 h-4 shrink-0" />
                 {newConversation.label}

--- a/frontend/src/components/widget/widget-chrome.test.ts
+++ b/frontend/src/components/widget/widget-chrome.test.ts
@@ -8,7 +8,10 @@ const widgetScript = readFileSync(widgetScriptPath, "utf8")
 const widgetScriptUrl = pathToFileURL(widgetScriptPath).href
 
 const HOST = "https://chat.example"
-const CLOSED_KEY = "xagent_widget_closed"
+// Namespaced by data-widget-key (this file's default runWidget() attribute)
+// so two different agents' widgets embedded on one host page don't collide
+// on one shared open/closed preference.
+const CLOSED_KEY = "xagent_widget_closed:widget-secret"
 
 function runWidget(attributes: Record<string, string> = { "data-widget-key": "widget-secret" }) {
   const script = document.createElement("script")
@@ -76,6 +79,29 @@ describe("widget close chrome", () => {
     expect(localStorage.getItem(CLOSED_KEY)).toBeNull()
   })
 
+  it("keeps two different agents' widgets on one host page from colliding on one shared preference", () => {
+    // A fresh Response per call: mockResolvedValue would hand out the same
+    // instance to both widgets, and a fetch body can only be read once.
+    fetchMock.mockImplementation(() => Promise.resolve(new Response(
+      JSON.stringify({ ticket: "t", agent_id: 1 }),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    )))
+
+    runWidget({ "data-widget-key": "widget-secret" })
+    runWidget({ "data-widget-key": "other-widget-secret" })
+
+    const fabs = document.querySelectorAll<HTMLButtonElement>(".xagent-widget-fab")
+    const panels = document.querySelectorAll(".xagent-widget-panel")
+    expect(fabs).toHaveLength(2)
+
+    fabs[0].click()
+
+    expect(panels[0]).toHaveClass("open")
+    expect(panels[1]).not.toHaveClass("open")
+    expect(localStorage.getItem(CLOSED_KEY)).toBe("false")
+    expect(localStorage.getItem("xagent_widget_closed:other-widget-secret")).toBeNull()
+  })
+
   it("opens on FAB click and persists the open (not-closed) preference", () => {
     runWidget()
 
@@ -95,29 +121,58 @@ describe("widget close chrome", () => {
     expect(localStorage.getItem(CLOSED_KEY)).toBe("true")
   })
 
-  it("reopens automatically once the embed ticket resolves, for a visitor who last left it open", async () => {
+  it("does not auto-open on the embed ticket resolving alone -- only once the child confirms widget_ready", async () => {
+    // The ticket exchange succeeding only means the *parent's* half of
+    // authentication worked; the child still has to redeem that ticket via
+    // its own /api/widget/auth call, which can independently fail. Setting
+    // iframe.src is not itself proof the visitor will see a working chat.
     localStorage.setItem(CLOSED_KEY, "false")
 
     runWidget()
 
-    // Guest mode's auto-open is deferred to iframe.src actually being set,
-    // which only happens after this fetch's promise chain resolves.
     await vi.waitFor(() => {
-      expect(panelEl()).toHaveClass("open")
+      expect(iframeEl()?.getAttribute("src")).not.toBeNull()
     })
+    expect(panelEl()).not.toHaveClass("open")
   })
 
-  it("does not re-persist the preference when auto-restoring on load", async () => {
+  it("reopens once the child posts widget_ready, for a visitor who last left it open", async () => {
+    localStorage.setItem(CLOSED_KEY, "false")
+
+    runWidget()
+    await vi.waitFor(() => {
+      expect(iframeEl()?.getAttribute("src")).not.toBeNull()
+    })
+    fromIframe("widget_ready")
+
+    expect(panelEl()).toHaveClass("open")
+  })
+
+  it("does not re-persist the preference when auto-restoring on widget_ready", async () => {
     localStorage.setItem(CLOSED_KEY, "false")
     const setItemSpy = vi.spyOn(localStorage, "setItem")
 
     runWidget()
-
     await vi.waitFor(() => {
-      expect(panelEl()).toHaveClass("open")
+      expect(iframeEl()?.getAttribute("src")).not.toBeNull()
     })
+    fromIframe("widget_ready")
+
+    expect(panelEl()).toHaveClass("open")
     expect(setItemSpy).not.toHaveBeenCalledWith(CLOSED_KEY, expect.anything())
     setItemSpy.mockRestore()
+  })
+
+  it("stays closed on load once the visitor has closed it before, even once widget_ready arrives", async () => {
+    localStorage.setItem(CLOSED_KEY, "true")
+
+    runWidget()
+    await vi.waitFor(() => {
+      expect(iframeEl()?.getAttribute("src")).not.toBeNull()
+    })
+    fromIframe("widget_ready")
+
+    expect(panelEl()).not.toHaveClass("open")
   })
 
   it("does not auto-open when the embed-ticket request fails, even for a visitor who left it open", async () => {

--- a/frontend/src/components/widget/widget-chrome.test.ts
+++ b/frontend/src/components/widget/widget-chrome.test.ts
@@ -158,6 +158,40 @@ describe("widget close chrome", () => {
     expect(localStorage.getItem(CLOSED_KEY)).toBe("true")
   })
 
+  it("stops reacting to widget_close once the widget is torn down (removed from the DOM)", async () => {
+    // Regression coverage: this listener used to be an inline anonymous
+    // function, structurally impossible to removeEventListener, and wasn't
+    // wired into the file's established torndown-flag/teardown-observer
+    // pattern that every other listener here uses. A stray message arriving
+    // after removal (a host SPA swap, not a full page reload) would
+    // otherwise still mutate a detached panel and corrupt the next load's
+    // auto-open decision in storage.
+    runWidget()
+    fabEl()?.click()
+    expect(panelEl()).toHaveClass("open")
+    expect(localStorage.getItem(CLOSED_KEY)).toBe("false")
+    // Captured before removal: jsdom may null out a detached iframe's own
+    // contentWindow, which would make the pre-existing origin/source check
+    // reject the message on its own -- this proves the *teardown* path
+    // specifically, independent of that check, by keeping the source a
+    // match regardless.
+    const capturedSource = iframeEl()?.contentWindow as Window
+
+    document.querySelector(".xagent-widget-container")?.remove()
+    // The teardown observer's callback fires as a microtask.
+    await Promise.resolve()
+
+    window.dispatchEvent(new MessageEvent("message", {
+      data: { xagent: true, v: 1, type: "widget_close" },
+      origin: HOST,
+      source: capturedSource,
+    }))
+
+    // Unchanged from the open-click above: a stray post-teardown widget_close
+    // must not have run closePanel() and re-persisted it as closed.
+    expect(localStorage.getItem(CLOSED_KEY)).toBe("false")
+  })
+
   it("ignores an unrecognized chrome message type", () => {
     runWidget()
     fabEl()?.click()

--- a/frontend/src/components/widget/widget-chrome.test.ts
+++ b/frontend/src/components/widget/widget-chrome.test.ts
@@ -2,6 +2,7 @@ import { readFileSync } from "node:fs"
 import { resolve } from "node:path"
 import { pathToFileURL } from "node:url"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { WidgetParentMessageType } from "@/lib/widget-parent-message"
 
 const widgetScriptPath = resolve(process.cwd(), "public/widget.js")
 const widgetScript = readFileSync(widgetScriptPath, "utf8")
@@ -58,7 +59,17 @@ describe("widget close chrome", () => {
     }))
   })
 
-  afterEach(() => {
+  afterEach(async () => {
+    for (const container of document.querySelectorAll(".xagent-widget-container")) {
+      container.remove()
+    }
+    // Let panelRemovalObserver's callback run its production teardown (which
+    // touches `window`) before Vitest tears down the jsdom globals -- a
+    // container left in the DOM until then fires that MutationObserver
+    // callback after `window` is already gone, surfacing as an uncaught
+    // "window is not defined" even though every test still passes.
+    await Promise.resolve()
+
     if (currentScriptDescriptor) {
       Object.defineProperty(document, "currentScript", currentScriptDescriptor)
     } else {
@@ -66,6 +77,16 @@ describe("widget close chrome", () => {
     }
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
+  })
+
+  it("keeps the widget_close message type literal in sync with the host script", () => {
+    // widget.js is a hand-authored static asset with no build-time import
+    // from TS source, so nothing else ties these two literals together --
+    // a rename on one side without the other would silently break the close
+    // button (a same-origin, same-source, correctly-enveloped message the
+    // host would now just ignore) with no compiler error to catch it.
+    const messageType: WidgetParentMessageType = "widget_close"
+    expect(widgetScript).toContain(`data.type === '${messageType}'`)
   })
 
   it("starts closed for a first-time visitor", () => {
@@ -99,6 +120,21 @@ describe("widget close chrome", () => {
     fromIframe("widget_close")
 
     expect(panelEl()).not.toHaveClass("open")
+  })
+
+  it("reopens on FAB click after a widget_close message closed it", () => {
+    // openPanel()/closePanel() share one `isOpen` variable with fab.onclick;
+    // a widget_close message must leave that variable in the same state a
+    // manual FAB close would, not just the panel's CSS class, or the FAB
+    // toggle desyncs from the panel on the very next click.
+    runWidget()
+    fabEl()?.click()
+    fromIframe("widget_close")
+    expect(panelEl()).not.toHaveClass("open")
+
+    fabEl()?.click()
+
+    expect(panelEl()).toHaveClass("open")
   })
 
   it("stops reacting to widget_close once the widget is torn down (removed from the DOM)", async () => {

--- a/frontend/src/components/widget/widget-chrome.test.ts
+++ b/frontend/src/components/widget/widget-chrome.test.ts
@@ -1,0 +1,194 @@
+import { readFileSync } from "node:fs"
+import { resolve } from "node:path"
+import { pathToFileURL } from "node:url"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+
+const widgetScriptPath = resolve(process.cwd(), "public/widget.js")
+const widgetScript = readFileSync(widgetScriptPath, "utf8")
+const widgetScriptUrl = pathToFileURL(widgetScriptPath).href
+
+const HOST = "https://chat.example"
+const MINIMIZED_KEY = "xagent_widget_minimized"
+
+function runWidget(attributes: Record<string, string> = { "data-widget-key": "widget-secret" }) {
+  const script = document.createElement("script")
+  script.src = `${HOST}/widget.js`
+  for (const [name, value] of Object.entries(attributes)) {
+    script.setAttribute(name, value)
+  }
+  document.body.appendChild(script)
+  Object.defineProperty(document, "currentScript", { configurable: true, value: script })
+  window.eval(`${widgetScript}\n//# sourceURL=${widgetScriptUrl}`)
+}
+
+function panelEl() {
+  return document.querySelector(".xagent-widget-panel")
+}
+
+function fabEl() {
+  return document.querySelector<HTMLButtonElement>(".xagent-widget-fab")
+}
+
+function iframeEl() {
+  return document.querySelector<HTMLIFrameElement>(".xagent-widget-iframe")
+}
+
+function fromIframe(type: string) {
+  window.dispatchEvent(new MessageEvent("message", {
+    data: { xagent: true, v: 1, type },
+    origin: HOST,
+    source: iframeEl()?.contentWindow as Window,
+  }))
+}
+
+describe("widget minimize/close chrome", () => {
+  let currentScriptDescriptor: PropertyDescriptor | undefined
+  const fetchMock = vi.fn()
+
+  beforeEach(() => {
+    currentScriptDescriptor = Object.getOwnPropertyDescriptor(document, "currentScript")
+    document.head.innerHTML = ""
+    document.body.innerHTML = ""
+    localStorage.clear()
+    localStorage.setItem("xagent_guest_id", "guest-fixed")
+    vi.stubGlobal("fetch", fetchMock)
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValue(new Response(JSON.stringify({ ticket: "t", agent_id: 1 }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    }))
+  })
+
+  afterEach(() => {
+    if (currentScriptDescriptor) {
+      Object.defineProperty(document, "currentScript", currentScriptDescriptor)
+    } else {
+      Reflect.deleteProperty(document, "currentScript")
+    }
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it("starts closed with no persisted preference for a first-time visitor", () => {
+    runWidget()
+
+    expect(panelEl()).not.toHaveClass("open")
+    expect(localStorage.getItem(MINIMIZED_KEY)).toBeNull()
+  })
+
+  it("opens on FAB click and persists the open (non-minimized) preference", () => {
+    runWidget()
+
+    fabEl()?.click()
+
+    expect(panelEl()).toHaveClass("open")
+    expect(localStorage.getItem(MINIMIZED_KEY)).toBe("false")
+  })
+
+  it("closes on a second FAB click and persists the minimized preference", () => {
+    runWidget()
+
+    fabEl()?.click()
+    fabEl()?.click()
+
+    expect(panelEl()).not.toHaveClass("open")
+    expect(localStorage.getItem(MINIMIZED_KEY)).toBe("true")
+  })
+
+  it("reopens automatically on load when the visitor last left it open", () => {
+    localStorage.setItem(MINIMIZED_KEY, "false")
+
+    runWidget()
+
+    expect(panelEl()).toHaveClass("open")
+  })
+
+  it("stays closed on load once the visitor has minimized it before", () => {
+    localStorage.setItem(MINIMIZED_KEY, "true")
+
+    runWidget()
+
+    expect(panelEl()).not.toHaveClass("open")
+  })
+
+  it("closes the panel and persists minimized when the iframe posts widget_close", () => {
+    runWidget()
+    fabEl()?.click()
+    expect(panelEl()).toHaveClass("open")
+
+    fromIframe("widget_close")
+
+    expect(panelEl()).not.toHaveClass("open")
+    expect(localStorage.getItem(MINIMIZED_KEY)).toBe("true")
+  })
+
+  it("closes the panel when the iframe posts widget_minimize", () => {
+    runWidget()
+    fabEl()?.click()
+
+    fromIframe("widget_minimize")
+
+    expect(panelEl()).not.toHaveClass("open")
+  })
+
+  it("ignores a chrome message from a different origin", () => {
+    runWidget()
+    fabEl()?.click()
+
+    window.dispatchEvent(new MessageEvent("message", {
+      data: { xagent: true, v: 1, type: "widget_close" },
+      origin: "https://evil.example",
+      source: iframeEl()?.contentWindow as Window,
+    }))
+
+    expect(panelEl()).toHaveClass("open")
+  })
+
+  it("ignores a chrome message not sourced from this widget's own iframe", () => {
+    runWidget()
+    fabEl()?.click()
+
+    window.dispatchEvent(new MessageEvent("message", {
+      data: { xagent: true, v: 1, type: "widget_close" },
+      origin: HOST,
+      source: window,
+    }))
+
+    expect(panelEl()).toHaveClass("open")
+  })
+
+  it("ignores a same-origin, same-source message missing the xagent envelope", () => {
+    runWidget()
+    fabEl()?.click()
+
+    window.dispatchEvent(new MessageEvent("message", {
+      data: { type: "widget_close" },
+      origin: HOST,
+      source: iframeEl()?.contentWindow as Window,
+    }))
+
+    expect(panelEl()).toHaveClass("open")
+  })
+
+  it("falls back to minimized when reading the persisted preference throws", () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("blocked")
+    })
+
+    runWidget()
+
+    expect(panelEl()).not.toHaveClass("open")
+    getItemSpy.mockRestore()
+  })
+
+  it("does not throw when persisting the preference is blocked", () => {
+    runWidget()
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+      throw new Error("blocked")
+    })
+
+    expect(() => fabEl()?.click()).not.toThrow()
+    expect(panelEl()).toHaveClass("open")
+    setItemSpy.mockRestore()
+  })
+})

--- a/frontend/src/components/widget/widget-chrome.test.ts
+++ b/frontend/src/components/widget/widget-chrome.test.ts
@@ -8,7 +8,7 @@ const widgetScript = readFileSync(widgetScriptPath, "utf8")
 const widgetScriptUrl = pathToFileURL(widgetScriptPath).href
 
 const HOST = "https://chat.example"
-const MINIMIZED_KEY = "xagent_widget_minimized"
+const CLOSED_KEY = "xagent_widget_closed"
 
 function runWidget(attributes: Record<string, string> = { "data-widget-key": "widget-secret" }) {
   const script = document.createElement("script")
@@ -41,7 +41,7 @@ function fromIframe(type: string) {
   }))
 }
 
-describe("widget minimize/close chrome", () => {
+describe("widget close chrome", () => {
   let currentScriptDescriptor: PropertyDescriptor | undefined
   const fetchMock = vi.fn()
 
@@ -73,45 +73,45 @@ describe("widget minimize/close chrome", () => {
     runWidget()
 
     expect(panelEl()).not.toHaveClass("open")
-    expect(localStorage.getItem(MINIMIZED_KEY)).toBeNull()
+    expect(localStorage.getItem(CLOSED_KEY)).toBeNull()
   })
 
-  it("opens on FAB click and persists the open (non-minimized) preference", () => {
+  it("opens on FAB click and persists the open (not-closed) preference", () => {
     runWidget()
 
     fabEl()?.click()
 
     expect(panelEl()).toHaveClass("open")
-    expect(localStorage.getItem(MINIMIZED_KEY)).toBe("false")
+    expect(localStorage.getItem(CLOSED_KEY)).toBe("false")
   })
 
-  it("closes on a second FAB click and persists the minimized preference", () => {
+  it("closes on a second FAB click and persists the closed preference", () => {
     runWidget()
 
     fabEl()?.click()
     fabEl()?.click()
 
     expect(panelEl()).not.toHaveClass("open")
-    expect(localStorage.getItem(MINIMIZED_KEY)).toBe("true")
+    expect(localStorage.getItem(CLOSED_KEY)).toBe("true")
   })
 
   it("reopens automatically on load when the visitor last left it open", () => {
-    localStorage.setItem(MINIMIZED_KEY, "false")
+    localStorage.setItem(CLOSED_KEY, "false")
 
     runWidget()
 
     expect(panelEl()).toHaveClass("open")
   })
 
-  it("stays closed on load once the visitor has minimized it before", () => {
-    localStorage.setItem(MINIMIZED_KEY, "true")
+  it("stays closed on load once the visitor has closed it before", () => {
+    localStorage.setItem(CLOSED_KEY, "true")
 
     runWidget()
 
     expect(panelEl()).not.toHaveClass("open")
   })
 
-  it("closes the panel and persists minimized when the iframe posts widget_close", () => {
+  it("closes the panel and persists closed when the iframe posts widget_close", () => {
     runWidget()
     fabEl()?.click()
     expect(panelEl()).toHaveClass("open")
@@ -119,16 +119,16 @@ describe("widget minimize/close chrome", () => {
     fromIframe("widget_close")
 
     expect(panelEl()).not.toHaveClass("open")
-    expect(localStorage.getItem(MINIMIZED_KEY)).toBe("true")
+    expect(localStorage.getItem(CLOSED_KEY)).toBe("true")
   })
 
-  it("closes the panel when the iframe posts widget_minimize", () => {
+  it("ignores an unrecognized chrome message type", () => {
     runWidget()
     fabEl()?.click()
 
     fromIframe("widget_minimize")
 
-    expect(panelEl()).not.toHaveClass("open")
+    expect(panelEl()).toHaveClass("open")
   })
 
   it("ignores a chrome message from a different origin", () => {
@@ -170,7 +170,7 @@ describe("widget minimize/close chrome", () => {
     expect(panelEl()).toHaveClass("open")
   })
 
-  it("falls back to minimized when reading the persisted preference throws", () => {
+  it("falls back to closed when reading the persisted preference throws", () => {
     const getItemSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
       throw new Error("blocked")
     })

--- a/frontend/src/components/widget/widget-chrome.test.ts
+++ b/frontend/src/components/widget/widget-chrome.test.ts
@@ -8,10 +8,6 @@ const widgetScript = readFileSync(widgetScriptPath, "utf8")
 const widgetScriptUrl = pathToFileURL(widgetScriptPath).href
 
 const HOST = "https://chat.example"
-// Namespaced by data-widget-key (this file's default runWidget() attribute)
-// so two different agents' widgets embedded on one host page don't collide
-// on one shared open/closed preference.
-const CLOSED_KEY = "xagent_widget_closed:widget-secret"
 
 function runWidget(attributes: Record<string, string> = { "data-widget-key": "widget-secret" }) {
   const script = document.createElement("script")
@@ -72,137 +68,30 @@ describe("widget close chrome", () => {
     vi.restoreAllMocks()
   })
 
-  it("starts closed with no persisted preference for a first-time visitor", () => {
+  it("starts closed for a first-time visitor", () => {
     runWidget()
 
     expect(panelEl()).not.toHaveClass("open")
-    expect(localStorage.getItem(CLOSED_KEY)).toBeNull()
   })
 
-  it("keeps two different agents' widgets on one host page from colliding on one shared preference", () => {
-    // A fresh Response per call: mockResolvedValue would hand out the same
-    // instance to both widgets, and a fetch body can only be read once.
-    fetchMock.mockImplementation(() => Promise.resolve(new Response(
-      JSON.stringify({ ticket: "t", agent_id: 1 }),
-      { status: 200, headers: { "Content-Type": "application/json" } },
-    )))
-
-    runWidget({ "data-widget-key": "widget-secret" })
-    runWidget({ "data-widget-key": "other-widget-secret" })
-
-    const fabs = document.querySelectorAll<HTMLButtonElement>(".xagent-widget-fab")
-    const panels = document.querySelectorAll(".xagent-widget-panel")
-    expect(fabs).toHaveLength(2)
-
-    fabs[0].click()
-
-    expect(panels[0]).toHaveClass("open")
-    expect(panels[1]).not.toHaveClass("open")
-    expect(localStorage.getItem(CLOSED_KEY)).toBe("false")
-    expect(localStorage.getItem("xagent_widget_closed:other-widget-secret")).toBeNull()
-  })
-
-  it("opens on FAB click and persists the open (not-closed) preference", () => {
+  it("opens on FAB click", () => {
     runWidget()
 
     fabEl()?.click()
 
     expect(panelEl()).toHaveClass("open")
-    expect(localStorage.getItem(CLOSED_KEY)).toBe("false")
   })
 
-  it("closes on a second FAB click and persists the closed preference", () => {
+  it("closes on a second FAB click", () => {
     runWidget()
 
     fabEl()?.click()
     fabEl()?.click()
 
     expect(panelEl()).not.toHaveClass("open")
-    expect(localStorage.getItem(CLOSED_KEY)).toBe("true")
   })
 
-  it("does not auto-open on the embed ticket resolving alone -- only once the child confirms widget_ready", async () => {
-    // The ticket exchange succeeding only means the *parent's* half of
-    // authentication worked; the child still has to redeem that ticket via
-    // its own /api/widget/auth call, which can independently fail. Setting
-    // iframe.src is not itself proof the visitor will see a working chat.
-    localStorage.setItem(CLOSED_KEY, "false")
-
-    runWidget()
-
-    await vi.waitFor(() => {
-      expect(iframeEl()?.getAttribute("src")).not.toBeNull()
-    })
-    expect(panelEl()).not.toHaveClass("open")
-  })
-
-  it("reopens once the child posts widget_ready, for a visitor who last left it open", async () => {
-    localStorage.setItem(CLOSED_KEY, "false")
-
-    runWidget()
-    await vi.waitFor(() => {
-      expect(iframeEl()?.getAttribute("src")).not.toBeNull()
-    })
-    fromIframe("widget_ready")
-
-    expect(panelEl()).toHaveClass("open")
-  })
-
-  it("does not re-persist the preference when auto-restoring on widget_ready", async () => {
-    localStorage.setItem(CLOSED_KEY, "false")
-    const setItemSpy = vi.spyOn(localStorage, "setItem")
-
-    runWidget()
-    await vi.waitFor(() => {
-      expect(iframeEl()?.getAttribute("src")).not.toBeNull()
-    })
-    fromIframe("widget_ready")
-
-    expect(panelEl()).toHaveClass("open")
-    expect(setItemSpy).not.toHaveBeenCalledWith(CLOSED_KEY, expect.anything())
-    setItemSpy.mockRestore()
-  })
-
-  it("stays closed on load once the visitor has closed it before, even once widget_ready arrives", async () => {
-    localStorage.setItem(CLOSED_KEY, "true")
-
-    runWidget()
-    await vi.waitFor(() => {
-      expect(iframeEl()?.getAttribute("src")).not.toBeNull()
-    })
-    fromIframe("widget_ready")
-
-    expect(panelEl()).not.toHaveClass("open")
-  })
-
-  it("does not auto-open when the embed-ticket request fails, even for a visitor who left it open", async () => {
-    // A stale allowlist, a rate limit, or a network error all resolve this
-    // fetch chain without ever setting iframe.src (see createGuestMode) --
-    // auto-opening ahead of that would show a blank panel on every reload.
-    fetchMock.mockReset()
-    fetchMock.mockResolvedValueOnce(new Response("forbidden", { status: 403 }))
-    localStorage.setItem(CLOSED_KEY, "false")
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
-
-    runWidget()
-
-    await vi.waitFor(() => {
-      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("embed authorization failed"))
-    })
-    expect(panelEl()).not.toHaveClass("open")
-    expect(iframeEl()?.getAttribute("src")).toBeNull()
-    errorSpy.mockRestore()
-  })
-
-  it("stays closed on load once the visitor has closed it before", () => {
-    localStorage.setItem(CLOSED_KEY, "true")
-
-    runWidget()
-
-    expect(panelEl()).not.toHaveClass("open")
-  })
-
-  it("closes the panel and persists closed when the iframe posts widget_close", () => {
+  it("closes the panel when the iframe posts widget_close", () => {
     runWidget()
     fabEl()?.click()
     expect(panelEl()).toHaveClass("open")
@@ -210,7 +99,6 @@ describe("widget close chrome", () => {
     fromIframe("widget_close")
 
     expect(panelEl()).not.toHaveClass("open")
-    expect(localStorage.getItem(CLOSED_KEY)).toBe("true")
   })
 
   it("stops reacting to widget_close once the widget is torn down (removed from the DOM)", async () => {
@@ -219,17 +107,18 @@ describe("widget close chrome", () => {
     // wired into the file's established torndown-flag/teardown-observer
     // pattern that every other listener here uses. A stray message arriving
     // after removal (a host SPA swap, not a full page reload) would
-    // otherwise still mutate a detached panel and corrupt the next load's
-    // auto-open decision in storage.
+    // otherwise still mutate a detached panel.
     runWidget()
     fabEl()?.click()
     expect(panelEl()).toHaveClass("open")
-    expect(localStorage.getItem(CLOSED_KEY)).toBe("false")
-    // Captured before removal: jsdom may null out a detached iframe's own
+    // Both captured before removal: querying by class after the container is
+    // detached returns null (the element still exists, just outside the
+    // document), and jsdom may separately null out a detached iframe's own
     // contentWindow, which would make the pre-existing origin/source check
     // reject the message on its own -- this proves the *teardown* path
     // specifically, independent of that check, by keeping the source a
     // match regardless.
+    const capturedPanel = panelEl()
     const capturedSource = iframeEl()?.contentWindow as Window
 
     document.querySelector(".xagent-widget-container")?.remove()
@@ -243,8 +132,8 @@ describe("widget close chrome", () => {
     }))
 
     // Unchanged from the open-click above: a stray post-teardown widget_close
-    // must not have run closePanel() and re-persisted it as closed.
-    expect(localStorage.getItem(CLOSED_KEY)).toBe("false")
+    // must not have run closePanel().
+    expect(capturedPanel).toHaveClass("open")
   })
 
   it("ignores an unrecognized chrome message type", () => {
@@ -326,53 +215,5 @@ describe("widget close chrome", () => {
 
     expect(panelEl()).toHaveClass("open")
     contentWindowGetter.mockRestore()
-  })
-
-  it("falls back to closed when reading the persisted preference throws", async () => {
-    // Scoped to this one key: a blanket throw would also hit the pre-existing,
-    // unrelated xagent_guest_id lookup earlier in the same bootstrap and blow
-    // up before ever reaching readStoredClosed().
-    const realGetItem = localStorage.getItem.bind(localStorage)
-    const getItemSpy = vi.spyOn(localStorage, "getItem").mockImplementation((key) => {
-      if (key === CLOSED_KEY) throw new Error("blocked")
-      return realGetItem(key)
-    })
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
-
-    runWidget()
-
-    await vi.waitFor(() => {
-      expect(iframeEl()?.getAttribute("src")).not.toBeNull()
-    })
-    expect(panelEl()).not.toHaveClass("open")
-    // "panel stays closed" alone doesn't distinguish a graceful fallback from
-    // readStoredClosed() throwing and the exception just happening to be
-    // swallowed one level up, by the embed-ticket fetch chain's own catch --
-    // which logs this different message. Assert it's never reached.
-    expect(errorSpy).not.toHaveBeenCalledWith(
-      expect.stringContaining("embed authorization request failed"),
-    )
-    getItemSpy.mockRestore()
-    errorSpy.mockRestore()
-  })
-
-  it("does not surface an uncaught error when persisting the preference is blocked", () => {
-    // A synchronous throw inside a native onclick handler doesn't propagate
-    // back through .click() in jsdom (matches real browser behavior) --
-    // expect(() => ...).not.toThrow() can't observe it either way. The
-    // window "error" event is how jsdom actually surfaces it.
-    runWidget()
-    const setItemSpy = vi.spyOn(localStorage, "setItem").mockImplementation(() => {
-      throw new Error("blocked")
-    })
-    const onError = vi.fn()
-    window.addEventListener("error", onError)
-
-    fabEl()?.click()
-
-    expect(onError).not.toHaveBeenCalled()
-    expect(panelEl()).toHaveClass("open")
-    window.removeEventListener("error", onError)
-    setItemSpy.mockRestore()
   })
 })

--- a/frontend/src/components/widget/widget-chrome.test.ts
+++ b/frontend/src/components/widget/widget-chrome.test.ts
@@ -103,6 +103,16 @@ describe("widget close chrome", () => {
     expect(panelEl()).toHaveClass("open")
   })
 
+  it("does not re-persist the preference when auto-restoring on load", () => {
+    localStorage.setItem(CLOSED_KEY, "false")
+    const setItemSpy = vi.spyOn(Storage.prototype, "setItem")
+
+    runWidget()
+
+    expect(setItemSpy).not.toHaveBeenCalledWith(CLOSED_KEY, expect.anything())
+    setItemSpy.mockRestore()
+  })
+
   it("stays closed on load once the visitor has closed it before", () => {
     localStorage.setItem(CLOSED_KEY, "true")
 

--- a/frontend/src/components/widget/widget-chrome.test.ts
+++ b/frontend/src/components/widget/widget-chrome.test.ts
@@ -95,22 +95,48 @@ describe("widget close chrome", () => {
     expect(localStorage.getItem(CLOSED_KEY)).toBe("true")
   })
 
-  it("reopens automatically on load when the visitor last left it open", () => {
+  it("reopens automatically once the embed ticket resolves, for a visitor who last left it open", async () => {
     localStorage.setItem(CLOSED_KEY, "false")
 
     runWidget()
 
-    expect(panelEl()).toHaveClass("open")
+    // Guest mode's auto-open is deferred to iframe.src actually being set,
+    // which only happens after this fetch's promise chain resolves.
+    await vi.waitFor(() => {
+      expect(panelEl()).toHaveClass("open")
+    })
   })
 
-  it("does not re-persist the preference when auto-restoring on load", () => {
+  it("does not re-persist the preference when auto-restoring on load", async () => {
     localStorage.setItem(CLOSED_KEY, "false")
-    const setItemSpy = vi.spyOn(Storage.prototype, "setItem")
+    const setItemSpy = vi.spyOn(localStorage, "setItem")
 
     runWidget()
 
+    await vi.waitFor(() => {
+      expect(panelEl()).toHaveClass("open")
+    })
     expect(setItemSpy).not.toHaveBeenCalledWith(CLOSED_KEY, expect.anything())
     setItemSpy.mockRestore()
+  })
+
+  it("does not auto-open when the embed-ticket request fails, even for a visitor who left it open", async () => {
+    // A stale allowlist, a rate limit, or a network error all resolve this
+    // fetch chain without ever setting iframe.src (see createGuestMode) --
+    // auto-opening ahead of that would show a blank panel on every reload.
+    fetchMock.mockReset()
+    fetchMock.mockResolvedValueOnce(new Response("forbidden", { status: 403 }))
+    localStorage.setItem(CLOSED_KEY, "false")
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+    runWidget()
+
+    await vi.waitFor(() => {
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining("embed authorization failed"))
+    })
+    expect(panelEl()).not.toHaveClass("open")
+    expect(iframeEl()?.getAttribute("src")).toBeNull()
+    errorSpy.mockRestore()
   })
 
   it("stays closed on load once the visitor has closed it before", () => {
@@ -180,25 +206,84 @@ describe("widget close chrome", () => {
     expect(panelEl()).toHaveClass("open")
   })
 
-  it("falls back to closed when reading the persisted preference throws", () => {
-    const getItemSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
-      throw new Error("blocked")
-    })
-
+  it("ignores a same-origin, same-source message with a mismatched protocol version", () => {
     runWidget()
+    fabEl()?.click()
 
-    expect(panelEl()).not.toHaveClass("open")
-    getItemSpy.mockRestore()
+    window.dispatchEvent(new MessageEvent("message", {
+      data: { xagent: true, v: 2, type: "widget_close" },
+      origin: HOST,
+      source: iframeEl()?.contentWindow as Window,
+    }))
+
+    expect(panelEl()).toHaveClass("open")
   })
 
-  it("does not throw when persisting the preference is blocked", () => {
+  it("ignores a chrome message when the iframe has been detached (contentWindow is null)", () => {
     runWidget()
-    const setItemSpy = vi.spyOn(Storage.prototype, "setItem").mockImplementation(() => {
+    fabEl()?.click()
+    const frame = iframeEl()
+    if (!frame) throw new Error("iframe not mounted")
+    const contentWindowGetter = vi.spyOn(frame, "contentWindow", "get").mockReturnValue(null)
+
+    // A detached iframe's own contentWindow is null; a same-origin message
+    // whose event.source also happens to be null must not be misread as a
+    // match against it.
+    window.dispatchEvent(new MessageEvent("message", {
+      data: { xagent: true, v: 1, type: "widget_close" },
+      origin: HOST,
+      source: null,
+    }))
+
+    expect(panelEl()).toHaveClass("open")
+    contentWindowGetter.mockRestore()
+  })
+
+  it("falls back to closed when reading the persisted preference throws", async () => {
+    // Scoped to this one key: a blanket throw would also hit the pre-existing,
+    // unrelated xagent_guest_id lookup earlier in the same bootstrap and blow
+    // up before ever reaching readStoredClosed().
+    const realGetItem = localStorage.getItem.bind(localStorage)
+    const getItemSpy = vi.spyOn(localStorage, "getItem").mockImplementation((key) => {
+      if (key === CLOSED_KEY) throw new Error("blocked")
+      return realGetItem(key)
+    })
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+
+    runWidget()
+
+    await vi.waitFor(() => {
+      expect(iframeEl()?.getAttribute("src")).not.toBeNull()
+    })
+    expect(panelEl()).not.toHaveClass("open")
+    // "panel stays closed" alone doesn't distinguish a graceful fallback from
+    // readStoredClosed() throwing and the exception just happening to be
+    // swallowed one level up, by the embed-ticket fetch chain's own catch --
+    // which logs this different message. Assert it's never reached.
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("embed authorization request failed"),
+    )
+    getItemSpy.mockRestore()
+    errorSpy.mockRestore()
+  })
+
+  it("does not surface an uncaught error when persisting the preference is blocked", () => {
+    // A synchronous throw inside a native onclick handler doesn't propagate
+    // back through .click() in jsdom (matches real browser behavior) --
+    // expect(() => ...).not.toThrow() can't observe it either way. The
+    // window "error" event is how jsdom actually surfaces it.
+    runWidget()
+    const setItemSpy = vi.spyOn(localStorage, "setItem").mockImplementation(() => {
       throw new Error("blocked")
     })
+    const onError = vi.fn()
+    window.addEventListener("error", onError)
 
-    expect(() => fabEl()?.click()).not.toThrow()
+    fabEl()?.click()
+
+    expect(onError).not.toHaveBeenCalled()
     expect(panelEl()).toHaveClass("open")
+    window.removeEventListener("error", onError)
     setItemSpy.mockRestore()
   })
 })

--- a/frontend/src/components/widget/widget-session.test.ts
+++ b/frontend/src/components/widget/widget-session.test.ts
@@ -33,16 +33,6 @@ function iframeEl(): HTMLIFrameElement | null {
   return document.querySelector<HTMLIFrameElement>(".xagent-widget-iframe")
 }
 
-function panelEl(): Element | null {
-  return document.querySelector(".xagent-widget-panel")
-}
-
-function fabEl(): HTMLButtonElement | null {
-  return document.querySelector<HTMLButtonElement>(".xagent-widget-fab")
-}
-
-const CLOSED_KEY = "xagent_widget_closed"
-
 function spyOnIframePostMessage(frame = iframeEl()) {
   if (!frame?.contentWindow) throw new Error("iframe not mounted")
   return vi.spyOn(frame.contentWindow, "postMessage")
@@ -311,62 +301,6 @@ describe("widget session mode", () => {
     await vi.waitFor(() => {
       expect(response.bodyUsed).toBe(true)
     })
-  })
-
-  it("auto-opens once the initial grant exchange succeeds, for a visitor who last left it open", async () => {
-    localStorage.setItem(CLOSED_KEY, "false")
-    fetchMock.mockResolvedValueOnce(jsonResponse(200, exchangeBody()))
-
-    runWidget({ "data-encrypted-context": GRANT })
-
-    // Session mode sets iframe.src synchronously and unconditionally --
-    // unlike guest mode, that alone doesn't mean the grant is usable, so
-    // this has to wait for the exchange itself to resolve.
-    await vi.waitFor(() => {
-      expect(panelEl()).toHaveClass("open")
-    })
-  })
-
-  it("does not auto-open when the initial grant exchange fails, even for a visitor who left it open", async () => {
-    // A returning visitor's grant can have expired, been consumed, or the
-    // exchange can just fail -- auto-opening ahead of that would show the
-    // degraded/terminal screen unprompted, on every reload.
-    localStorage.setItem(CLOSED_KEY, "false")
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
-    fetchMock.mockResolvedValueOnce(errorResponse(401, "grant_expired"))
-
-    runWidget({ "data-encrypted-context": GRANT })
-
-    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[grant_expired]"),
-    ))
-    expect(panelEl()).not.toHaveClass("open")
-  })
-
-  it("does not re-open a panel the visitor has since closed when a later reconnect succeeds", async () => {
-    localStorage.setItem(CLOSED_KEY, "false")
-    fetchMock
-      .mockResolvedValueOnce(jsonResponse(200, exchangeBody()))
-      .mockResolvedValueOnce(jsonResponse(200, exchangeBody({
-        session_token: "st_second",
-        reconnect_token: "rt_second",
-      })))
-    runWidget({ "data-encrypted-context": GRANT })
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
-    await flushAsync()
-    // The initial exchange auto-opened it (per the test above); confirm that
-    // before the visitor closes it themselves, so a later false-negative here
-    // can't be mistaken for this test's own point.
-    expect(panelEl()).toHaveClass("open")
-
-    fabEl()?.click()
-    expect(panelEl()).not.toHaveClass("open")
-
-    fromIframe("reconnect_request", { reason: "ws_closed" })
-    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
-    await flushAsync()
-
-    expect(panelEl()).not.toHaveClass("open")
   })
 
   it("sends the opaque grant value verbatim after checking that it is not blank", () => {

--- a/frontend/src/components/widget/widget-session.test.ts
+++ b/frontend/src/components/widget/widget-session.test.ts
@@ -33,6 +33,16 @@ function iframeEl(): HTMLIFrameElement | null {
   return document.querySelector<HTMLIFrameElement>(".xagent-widget-iframe")
 }
 
+function panelEl(): Element | null {
+  return document.querySelector(".xagent-widget-panel")
+}
+
+function fabEl(): HTMLButtonElement | null {
+  return document.querySelector<HTMLButtonElement>(".xagent-widget-fab")
+}
+
+const CLOSED_KEY = "xagent_widget_closed"
+
 function spyOnIframePostMessage(frame = iframeEl()) {
   if (!frame?.contentWindow) throw new Error("iframe not mounted")
   return vi.spyOn(frame.contentWindow, "postMessage")
@@ -301,6 +311,62 @@ describe("widget session mode", () => {
     await vi.waitFor(() => {
       expect(response.bodyUsed).toBe(true)
     })
+  })
+
+  it("auto-opens once the initial grant exchange succeeds, for a visitor who last left it open", async () => {
+    localStorage.setItem(CLOSED_KEY, "false")
+    fetchMock.mockResolvedValueOnce(jsonResponse(200, exchangeBody()))
+
+    runWidget({ "data-encrypted-context": GRANT })
+
+    // Session mode sets iframe.src synchronously and unconditionally --
+    // unlike guest mode, that alone doesn't mean the grant is usable, so
+    // this has to wait for the exchange itself to resolve.
+    await vi.waitFor(() => {
+      expect(panelEl()).toHaveClass("open")
+    })
+  })
+
+  it("does not auto-open when the initial grant exchange fails, even for a visitor who left it open", async () => {
+    // A returning visitor's grant can have expired, been consumed, or the
+    // exchange can just fail -- auto-opening ahead of that would show the
+    // degraded/terminal screen unprompted, on every reload.
+    localStorage.setItem(CLOSED_KEY, "false")
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => undefined)
+    fetchMock.mockResolvedValueOnce(errorResponse(401, "grant_expired"))
+
+    runWidget({ "data-encrypted-context": GRANT })
+
+    await vi.waitFor(() => expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[grant_expired]"),
+    ))
+    expect(panelEl()).not.toHaveClass("open")
+  })
+
+  it("does not re-open a panel the visitor has since closed when a later reconnect succeeds", async () => {
+    localStorage.setItem(CLOSED_KEY, "false")
+    fetchMock
+      .mockResolvedValueOnce(jsonResponse(200, exchangeBody()))
+      .mockResolvedValueOnce(jsonResponse(200, exchangeBody({
+        session_token: "st_second",
+        reconnect_token: "rt_second",
+      })))
+    runWidget({ "data-encrypted-context": GRANT })
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+    await flushAsync()
+    // The initial exchange auto-opened it (per the test above); confirm that
+    // before the visitor closes it themselves, so a later false-negative here
+    // can't be mistaken for this test's own point.
+    expect(panelEl()).toHaveClass("open")
+
+    fabEl()?.click()
+    expect(panelEl()).not.toHaveClass("open")
+
+    fromIframe("reconnect_request", { reason: "ws_closed" })
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    await flushAsync()
+
+    expect(panelEl()).not.toHaveClass("open")
   })
 
   it("sends the opaque grant value verbatim after checking that it is not blank", () => {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -516,7 +516,6 @@ Build when you need.`,
   widgetChat: {
     title: "AI Assistant",
     newConversation: "New conversation",
-    minimize: "Minimize",
     close: "Close",
     moreOptions: "More options",
     status: {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -516,6 +516,9 @@ Build when you need.`,
   widgetChat: {
     title: "AI Assistant",
     newConversation: "New conversation",
+    minimize: "Minimize",
+    close: "Close",
+    moreOptions: "More options",
     status: {
       initializing: "Initializing...",
       connecting: "Connecting...",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -516,6 +516,9 @@ const zh = {
   widgetChat: {
     title: "AI 助手",
     newConversation: "新建会话",
+    minimize: "最小化",
+    close: "关闭",
+    moreOptions: "更多选项",
     status: {
       initializing: "正在初始化...",
       connecting: "连接中...",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -516,7 +516,6 @@ const zh = {
   widgetChat: {
     title: "AI 助手",
     newConversation: "新建会话",
-    minimize: "最小化",
     close: "关闭",
     moreOptions: "更多选项",
     status: {

--- a/frontend/src/lib/widget-parent-message.ts
+++ b/frontend/src/lib/widget-parent-message.ts
@@ -4,7 +4,7 @@
 // third-party origin from in here, so targetOrigin can't be pinned tighter
 // than "*" -- every message sent this way carries no sensitive payload,
 // unlike the parent -> iframe session protocol.
-export type WidgetParentMessageType = "widget_close" | "widget_ready"
+export type WidgetParentMessageType = "widget_close"
 
 export function postToParentWidget(type: WidgetParentMessageType): void {
   // A direct (non-embedded) visit to this page has window.parent === window;

--- a/frontend/src/lib/widget-parent-message.ts
+++ b/frontend/src/lib/widget-parent-message.ts
@@ -1,0 +1,15 @@
+// The host page's widget.js owns panel visibility and the auto-open decision;
+// it has no direct handle into this iframe's React tree, so intent is
+// signalled back over postMessage instead. The host is an arbitrary
+// third-party origin from in here, so targetOrigin can't be pinned tighter
+// than "*" -- every message sent this way carries no sensitive payload,
+// unlike the parent -> iframe session protocol.
+export type WidgetParentMessageType = "widget_close" | "widget_ready"
+
+export function postToParentWidget(type: WidgetParentMessageType): void {
+  // A direct (non-embedded) visit to this page has window.parent === window;
+  // posting there would just send the widget its own message right back.
+  if (window.parent !== window) {
+    window.parent.postMessage({ xagent: true, v: 1, type }, "*")
+  }
+}

--- a/frontend/vitest.widget.config.ts
+++ b/frontend/vitest.widget.config.ts
@@ -21,6 +21,7 @@ const widgetConfig = mergeConfig(baseConfig, defineConfig({
         "src/components/widget/public-agent-chat-page.tsx",
         "src/components/widget/session-agent-chat-page.tsx",
         "src/components/widget/use-widget-session.ts",
+        "src/components/widget/widget-chrome-controls.tsx",
         "src/contexts/app-context-chat.tsx",
         "src/contexts/auth-context.tsx",
         "src/contexts/file-access-context.tsx",
@@ -62,6 +63,9 @@ const widgetConfig = mergeConfig(baseConfig, defineConfig({
         },
         "src/components/widget/use-widget-session.ts": {
           statements: 95, branches: 80, functions: 90, lines: 95,
+        },
+        "src/components/widget/widget-chrome-controls.tsx": {
+          statements: 95, branches: 90, functions: 95, lines: 95,
         },
         "src/lib/files-disabled-presentation.ts": {
           statements: 85, branches: 80, functions: 90, lines: 85,
@@ -144,6 +148,8 @@ export default defineConfig({
       "src/components/ui/__tests__/markdown-renderer.test.tsx",
       "src/components/widget/widget-bootstrap.test.ts",
       "src/components/widget/widget-session.test.ts",
+      "src/components/widget/widget-chrome.test.ts",
+      "src/components/widget/widget-chrome-controls.test.tsx",
       "src/components/widget/public-agent-chat-page.test.tsx",
       "src/components/widget/session-agent-chat-page.test.tsx",
       "src/components/widget/session-agent-chat-page.integration.test.tsx",

--- a/frontend/vitest.widget.config.ts
+++ b/frontend/vitest.widget.config.ts
@@ -30,6 +30,7 @@ const widgetConfig = mergeConfig(baseConfig, defineConfig({
         "src/lib/api-wrapper.ts",
         "src/lib/auth-cache.ts",
         "src/lib/files-disabled-presentation.ts",
+        "src/lib/widget-parent-message.ts",
         "src/contexts/presentation-capabilities.tsx",
         "src/app/settings/page.tsx",
         "src/components/layout/sidebar.tsx",
@@ -66,6 +67,9 @@ const widgetConfig = mergeConfig(baseConfig, defineConfig({
         },
         "src/components/widget/widget-chrome-controls.tsx": {
           statements: 95, branches: 90, functions: 95, lines: 95,
+        },
+        "src/lib/widget-parent-message.ts": {
+          statements: 100, branches: 100, functions: 100, lines: 100,
         },
         "src/lib/files-disabled-presentation.ts": {
           statements: 85, branches: 80, functions: 90, lines: 85,


### PR DESCRIPTION
## Summary
- Adds a header close (X) button and, once there's an active conversation, a "..." overflow menu with "New conversation" (moved out of its own standalone button) to the embedded chat widget's iframe UI — one always-visible dismiss action, the one secondary action tucked behind an overflow menu that only appears when there's something to put in it.
- The iframe has no direct handle to the host page's panel/FAB, so the close action signals intent back to `frontend/public/widget.js` over `postMessage`. widget.js validates both `event.origin` and `event.source` before acting.
- The new controls only render in embedded `"widget"` mode; the standalone `"share"` page (same component, no parent widget.js) never shows them and keeps its own always-visible "new conversation" button, since there's nothing to signal and no overflow menu to fold it into.

This is one slice of a larger widget layout improvement request (right-docking — already the default, resizable width — landed separately, an expand mode, and mobile full-screen/bottom-sheet handling). This PR is scoped to the close control + new-conversation overflow only.

Caught and fixed in self-review before opening this PR: the "..." menu's open/closed state had no listener for the panel being hidden from *outside* the iframe (the host page's own FAB) — reopening the widget after that could show the menu still expanded from before. Fixed with a `window` `blur` listener inside the iframe, mirroring the same host-page-runs-unsandboxed reasoning as the earlier resize-handle PR.

An earlier revision of this PR also persisted open/closed state across reloads (auto-reopening the panel for a returning visitor). That was removed during review: `widget.js` is a shared, unversioned script every existing embed pulls fresh on each visit, so shipping it as default-on would have silently changed behavior for every already-deployed integration with no opt-out. This PR is now scoped to the close/overflow controls only; persisted state can be revisited separately with an explicit opt-in.

## Test plan
- [x] `npm run test:widget:coverage` — full widget test lane, all per-file coverage thresholds met (`widget-chrome-controls.tsx` at 100%).
- [x] `npm run lint` / `npm run type-check` / `npm run build` all clean.
- [x] `widget-chrome.test.ts` covers widget.js's parent-side behavior: the FAB open/close toggle, the postMessage listener (correct `widget_close` handling — including that a FAB click after it correctly reopens the panel, not just that the panel closed — ignoring an unrecognized message type, and rejecting a mismatched origin, a mismatched source, and a same-origin message missing the `xagent` envelope), and a contract test tying the `widget_close` string literal to the TS-side type it has to stay in sync with.
- [x] `widget-chrome-controls.test.tsx` covers the React header component: the "..." trigger only renders when a new-conversation action is supplied; menu open/close via trigger click, outside pointer press, Escape, and window blur (guarded against a same-document focus move, not just any blur); close button posts `widget_close`; the menu item shows the caller-supplied label, respects `disabled`, and calls `onClick` then closes the menu; the pending state shows a spinner on the trigger itself once the menu has closed.
- [x] `public-agent-chat-page.test.tsx` / `session-agent-chat-page.test.tsx` assert: the close control always renders in widget/session mode, the "..." trigger and menu item are absent until there's an active conversation, the share page keeps its own standalone button (now sharing the same focus-visible/disabled styling as the header controls) and never shows the overflow controls, and clicking through the menu still drives the same reset behavior as before.
- [x] Manually verified end-to-end against a local backend + a real agent: open/close via the header, the overflow menu appearing only once a conversation exists, and the "New conversation" item fitting on one line.
