### PR TITLE
feat: add python-docx to the sandbox image

### DIFF
--- a/docker/Dockerfile.sandbox
+++ b/docker/Dockerfile.sandbox
@@ -56,7 +56,7 @@ RUN --mount=type=cache,target=/root/.cache/uv \
         -r /tmp/sandbox-requirements.txt \
     && rm /tmp/sandbox-requirements.txt \
     && uvx --version \
-    && python -c "import cloudpickle, fsspec, matplotlib, mcp; import numpy, openpyxl, pandas, pydantic, pydantic_settings"
+    && python -c "import cloudpickle, docx, fsspec, matplotlib, mcp; import numpy, openpyxl, pandas, pydantic, pydantic_settings"
 
 # Allow pip install without --break-system-packages globally. Sandboxed tools
 # can install their explicitly declared runtime dependencies as an unprivileged

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -175,6 +175,7 @@ sandbox = [
   "numpy>=1.21.0",
   "matplotlib>=3.5.0",
   "openpyxl>=3.1.0",
+  "python-docx>=1.1.0",
   "fsspec>=2024.0.0",
 ]
 
@@ -226,6 +227,7 @@ test = [
   "copilotkit==0.1.69",
   "langgraph-prebuilt<1.0.9",
   "openpyxl>=3.1.5",
+  "python-docx>=1.1.0",
   "asyncssh>=2.14.0",
 ]
 

--- a/src/xagent/core/tools/adapters/vibe/python_executor.py
+++ b/src/xagent/core/tools/adapters/vibe/python_executor.py
@@ -141,6 +141,7 @@ class PythonExecutorTool(AbstractBaseTool):
         "numpy>=1.21.0",
         "matplotlib>=3.5.0",
         "openpyxl>=3.1.0",  # required by the xlsx-financial-report skill
+        "python-docx>=1.1.0",  # for .docx generation; skill lands in #1640
     ]
 )
 class PythonExecutorToolForBasic(PythonExecutorTool):

--- a/tests/test_docker_workflow_versions.py
+++ b/tests/test_docker_workflow_versions.py
@@ -24,6 +24,7 @@ SANDBOX_DISTRIBUTION_IMPORTS = {
     "numpy": "numpy",
     "matplotlib": "matplotlib",
     "openpyxl": "openpyxl",
+    "python-docx": "docx",
     "fsspec": "fsspec",
 }
 SANDBOX_DIRECT_REQUIREMENTS = {
@@ -35,6 +36,7 @@ SANDBOX_DIRECT_REQUIREMENTS = {
     "numpy": "numpy>=1.21.0",
     "matplotlib": "matplotlib>=3.5.0",
     "openpyxl": "openpyxl>=3.1.0",
+    "python-docx": "python-docx>=1.1.0",
     "fsspec": "fsspec>=2024.0.0",
 }
 

--- a/uv.lock
+++ b/uv.lock
@@ -4064,9 +4064,9 @@ name = "ocrmac"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click", marker = "sys_platform == 'darwin'" },
-    { name = "pillow", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-vision", marker = "sys_platform == 'darwin'" },
+    { name = "click" },
+    { name = "pillow" },
+    { name = "pyobjc-framework-vision" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/07/3e15ab404f75875c5e48c47163300eb90b7409044d8711fc3aaf52503f2e/ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9", size = 1454317, upload-time = "2026-01-08T16:44:26.412Z" }
 wheels = [
@@ -5404,7 +5404,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -5421,8 +5421,8 @@ name = "pyobjc-framework-coreml"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/2d/baa9ea02cbb1c200683cb7273b69b4bee5070e86f2060b77e6a27c2a9d7e/pyobjc_framework_coreml-12.1.tar.gz", hash = "sha256:0d1a4216891a18775c9e0170d908714c18e4f53f9dc79fb0f5263b2aa81609ba", size = 40465, upload-time = "2025-11-14T10:14:02.265Z" }
 wheels = [
@@ -5439,8 +5439,8 @@ name = "pyobjc-framework-quartz"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
 wheels = [
@@ -5457,10 +5457,10 @@ name = "pyobjc-framework-vision"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-coreml", marker = "sys_platform == 'darwin'" },
-    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-core" },
+    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-framework-coreml" },
+    { name = "pyobjc-framework-quartz" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/5a/08bb3e278f870443d226c141af14205ff41c0274da1e053b72b11dfc9fb2/pyobjc_framework_vision-12.1.tar.gz", hash = "sha256:a30959100e85dcede3a786c544e621ad6eb65ff6abf85721f805822b8c5fe9b0", size = 59538, upload-time = "2025-11-14T10:23:21.979Z" }
 wheels = [
@@ -6897,13 +6897,13 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform == 'darwin'" },
-    { name = "fsspec", marker = "sys_platform == 'darwin'" },
-    { name = "jinja2", marker = "sys_platform == 'darwin'" },
-    { name = "networkx", marker = "sys_platform == 'darwin'" },
-    { name = "setuptools", marker = "sys_platform == 'darwin'" },
-    { name = "sympy", marker = "sys_platform == 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:10802fd383bbfed646212e765a72c37d2185205d4f26eb197a254e8ac7ddcb25", upload-time = "2026-05-12T16:20:07Z" },
@@ -6931,13 +6931,13 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "filelock", marker = "sys_platform != 'darwin'" },
-    { name = "fsspec", marker = "sys_platform != 'darwin'" },
-    { name = "jinja2", marker = "sys_platform != 'darwin'" },
-    { name = "networkx", marker = "sys_platform != 'darwin'" },
-    { name = "setuptools", marker = "sys_platform != 'darwin'" },
-    { name = "sympy", marker = "sys_platform != 'darwin'" },
-    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
+    { name = "filelock" },
+    { name = "fsspec" },
+    { name = "jinja2" },
+    { name = "networkx" },
+    { name = "setuptools" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:aaa9c1f5e8c518d7be1e3c3e1b090ca7d63b6e353a1abd6cfdaf902405093467", upload-time = "2026-05-12T23:16:01Z" },
@@ -6981,9 +6981,9 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform == 'darwin'" },
-    { name = "pillow", marker = "sys_platform == 'darwin'" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:df0c166b6bdf7c47f88e81e8b43bc085451d5c50d0c5d1691bc474c1227d6fed", upload-time = "2026-05-12T16:20:37Z" },
@@ -7011,9 +7011,9 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "numpy", marker = "sys_platform != 'darwin'" },
-    { name = "pillow", marker = "sys_platform != 'darwin'" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
+    { name = "numpy" },
+    { name = "pillow" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" } },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:99d05d071ff34305334ee1854f5edf7c2767b96ba59fe92e76d84a1fa72c8e06", upload-time = "2026-05-12T16:20:36Z" },
@@ -7937,6 +7937,7 @@ dev = [
     { name = "pytest-socket" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
+    { name = "python-docx" },
     { name = "ruff" },
     { name = "types-docker" },
     { name = "types-openpyxl" },
@@ -7954,6 +7955,7 @@ sandbox = [
     { name = "pandas" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "python-docx" },
 ]
 static-type-check = [
     { name = "types-docker" },
@@ -7979,6 +7981,7 @@ test = [
     { name = "pytest-socket" },
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
+    { name = "python-docx" },
 ]
 
 [package.metadata]
@@ -8134,6 +8137,7 @@ dev = [
     { name = "pytest-socket", specifier = ">=0.7.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.0" },
+    { name = "python-docx", specifier = ">=1.1.0" },
     { name = "ruff", specifier = ">=0.12.3" },
     { name = "types-docker", specifier = ">=7.1.0.20251009" },
     { name = "types-openpyxl", specifier = ">=3.1.5" },
@@ -8151,6 +8155,7 @@ sandbox = [
     { name = "pandas", specifier = ">=1.3.0" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "pydantic-settings" },
+    { name = "python-docx", specifier = ">=1.1.0" },
 ]
 static-type-check = [
     { name = "types-docker", specifier = ">=7.1.0.20251009" },
@@ -8176,6 +8181,7 @@ test = [
     { name = "pytest-socket", specifier = ">=0.7.0" },
     { name = "pytest-timeout", specifier = ">=2.4.0" },
     { name = "pytest-xdist", specifier = ">=3.0" },
+    { name = "python-docx", specifier = ">=1.1.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

Adds `python-docx` to the sandbox image so untrusted code running through `execute_python_code` can generate Word documents. The sandbox ships `openpyxl` but not `python-docx`, so `import docx` fails there today.

Wired the same way `openpyxl` is, position for position:

| Where | Why it is needed |
| --- | --- |
| `pyproject.toml` `sandbox` group | What `Dockerfile.sandbox` exports to build the image |
| `pyproject.toml` `test` group | How `openpyxl` is declared for the tests that import it |
| `docker/Dockerfile.sandbox` | The runtime import smoke check, so a missing package fails the build rather than the first task that needs it |
| `python_executor.py` `@sandbox_config` | Provisions the package into sandbox leases served from images built **before** this change — the other two edits do not reach those |
| `tests/test_docker_workflow_versions.py` | The pinned maps that tie pyproject, the lock and the Dockerfile import line together |

## Why it is split out

Split from #1640, which pairs this with a new builtin skill for editorial `.docx` reports. That skill is still in review; this dependency is independent of it and is useful on its own — an agent can write `.docx` from `execute_python_code` without the skill, it just has no house style to follow.

Across four review rounds on #1640, none of the findings were against these lines. Landing them separately unblocks the capability while the skill's documentation is worked through.

## Verification

- `tests/test_docker_workflow_versions.py`: 22 passed. Mutation-checked — removing `python-docx` from the sandbox group fails 3 tests, dropping `docx` from the Dockerfile smoke check fails 1.
- Relocked. Compared the group exports against a pristine copy of the base commit: the `sandbox` group goes 45 → 47 and `test` 133 → 135, adding exactly `python-docx==1.2.0` and `lxml==6.0.2`. No package version changes anywhere in the lock; the rest of the `uv.lock` diff is marker re-emission.
- `python-docx` publishes a `py3-none-any` wheel, so there is no platform or Python-version risk for the image's 3.11.
- ruff check/format and codespell clean.
