### PR TITLE
feat: carry question event identity through publication

### DIFF
--- a/src/xagent/core/agent/clarification.py
+++ b/src/xagent/core/agent/clarification.py
@@ -14,14 +14,13 @@ result dict verbatim into ``AutoPattern.last_result`` (see
 ``pattern/auto/auto.py``), and a waiting ReAct child's result carries the
 draft under ``result["clarification_draft"]``.
 
-``turn_marker`` is the only idempotency-relevant value this module produces,
-and it carries no persistence-format promise of its own: it is a stable,
-opaque string. Its idempotency scope is a single ``(task_id, run_id)``
-partition -- two different tasks or runs may legitimately produce equal
-markers, since neither identifier is a marker component. Deriving a storage
-key (length limits, character-set validation, or any other on-disk
-contract) is a web-layer concern that reads this string; this module does
-not know what that contract looks like.
+``event_id`` is the clarification's stable identity. The runtime allocates it
+before publishing the question and stores that same value in the waiting
+request, so a draft reconstructed after checkpoint restore still names the
+published question occurrence. ``turn_marker`` remains a deterministic,
+opaque description of the waiting turn, but it is not a second publication
+identity. Storage validation and on-disk key constraints remain web-layer
+concerns; this core module does not know what those contracts look like.
 """
 
 from __future__ import annotations
@@ -64,7 +63,9 @@ class ClarificationRequestItem:
 class ClarificationDraft:
     """A typed view over a waiting turn, common to all clarification sources.
 
-    ``requests`` carries one item per pending question: the single-source
+    ``event_id`` names the already-published question occurrence. It is empty
+    only for a draft restored from a checkpoint written before this field
+    existed. ``requests`` carries one item per pending question: the single-source
     waiting points (``send_message`` / ``ask_user_question``) contribute
     exactly one item, and the multi-tool waiting point contributes one item
     per waiting tool. A malformed or legacy waiting payload can yield an
@@ -98,6 +99,7 @@ class ClarificationDraft:
     origin_execution_id: str
     turn_message_count: int
     turn_marker: str
+    event_id: str = ""
 
     def with_origin_step(self, step_id: str) -> "ClarificationDraft":
         """Return a copy attributed to ``step_id``, with the marker redone.
@@ -141,6 +143,7 @@ class ClarificationDraft:
 
         return {
             "source": self.source,
+            "event_id": self.event_id,
             "message": self.message,
             "message_type": self.message_type,
             "interactions": list(self.interactions),
@@ -326,6 +329,7 @@ def draft_from_waiting_request(
 
     return ClarificationDraft(
         source=source,
+        event_id=str(request.get("event_id") or ""),
         message=message,
         message_type=message_type,
         interactions=interactions,

--- a/src/xagent/core/agent/clarification.py
+++ b/src/xagent/core/agent/clarification.py
@@ -29,6 +29,8 @@ import logging
 from dataclasses import dataclass, replace
 from typing import Any
 
+from pydantic import JsonValue
+
 logger = logging.getLogger(__name__)
 
 CLARIFICATION_SOURCES = frozenset({"send_message", "ask_user_question", "tool_waiting"})
@@ -63,9 +65,9 @@ class ClarificationRequestItem:
 class ClarificationDraft:
     """A typed view over a waiting turn, common to all clarification sources.
 
-    ``event_id`` names the already-published question occurrence. It is empty
-    only for a draft restored from a checkpoint written before this field
-    existed. ``requests`` carries one item per pending question: the single-source
+    ``event_id`` names the already-published question occurrence. Legacy
+    absence is empty; malformed restored values remain unchanged for web
+    validation. ``requests`` carries one item per pending question: the single-source
     waiting points (``send_message`` / ``ask_user_question``) contribute
     exactly one item, and the multi-tool waiting point contributes one item
     per waiting tool. A malformed or legacy waiting payload can yield an
@@ -99,7 +101,7 @@ class ClarificationDraft:
     origin_execution_id: str
     turn_message_count: int
     turn_marker: str
-    event_id: str = ""
+    event_id: JsonValue = ""
 
     def with_origin_step(self, step_id: str) -> "ClarificationDraft":
         """Return a copy attributed to ``step_id``, with the marker redone.
@@ -329,7 +331,7 @@ def draft_from_waiting_request(
 
     return ClarificationDraft(
         source=source,
-        event_id=str(request.get("event_id") or ""),
+        event_id=request.get("event_id", ""),
         message=message,
         message_type=message_type,
         interactions=interactions,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -2116,7 +2116,7 @@ class ReActPattern(AgentPattern):
             expect_response = bool(args.get("expect_response", False))
             message_type = str(args.get("message_type", "info"))
             visible = bool(args.get("visible", True))
-            await runtime.send_message(
+            outbound_message = await runtime.send_message(
                 message=message,
                 message_type=message_type,
                 expect_response=expect_response,
@@ -2143,6 +2143,7 @@ class ReActPattern(AgentPattern):
                     tool_call_id=tool_call.get("id"),
                 )
                 self.waiting_for_user_request = {
+                    "event_id": outbound_message["event_id"],
                     "tool_call_id": tool_call.get("id"),
                     "tool_name": name,
                     "message": message,
@@ -2180,7 +2181,7 @@ class ReActPattern(AgentPattern):
             interactions = _normalize_ask_user_interactions(
                 args.get("interactions", [])
             )
-            await runtime.send_message(
+            outbound_message = await runtime.send_message(
                 message=message,
                 message_type="question",
                 expect_response=True,
@@ -2208,6 +2209,7 @@ class ReActPattern(AgentPattern):
                 tool_call_id=tool_call.get("id"),
             )
             self.waiting_for_user_request = {
+                "event_id": outbound_message["event_id"],
                 "tool_call_id": tool_call.get("id"),
                 "tool_name": name,
                 "message": message,
@@ -2500,7 +2502,7 @@ class ReActPattern(AgentPattern):
             )
             message_type = "question"
 
-        await runtime.send_message(
+        outbound_message = await runtime.send_message(
             message=message,
             message_type=message_type,
             expect_response=True,
@@ -2509,6 +2511,7 @@ class ReActPattern(AgentPattern):
         )
         self.status = "waiting_for_user"
         self.waiting_for_user_request = {
+            "event_id": outbound_message["event_id"],
             "kind": "tool_waiting_for_user",
             "requests": requests,
             "message": message,

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -660,6 +660,8 @@ class PatternRuntime:
             "visible": visible,
             "metadata": outbound_metadata,
         }
+        if expect_response or message_type == "question":
+            payload["event_id"] = str(uuid4())
         if step_id:
             payload["step_id"] = str(step_id)
         self.outbound_messages.append(payload)

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -888,11 +888,16 @@ def create_stream_event(
     task_id: Union[int, str],
     data: Dict[str, Any],
     timestamp: Optional[Any] = None,
+    *,
+    event_id: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Create unified stream event format"""
+    """Create a stream event, preserving a producer-supplied event identity."""
+    resolved_event_id = (
+        event_id if isinstance(event_id, str) and event_id else str(uuid.uuid4())
+    )
     return {
         "type": "trace_event",
-        "event_id": str(uuid.uuid4()),
+        "event_id": resolved_event_id,
         "event_type": event_type,
         "task_id": task_id,
         "timestamp": _stream_timestamp(timestamp),
@@ -1075,6 +1080,7 @@ def make_agent_outbound_handler(task_id: int) -> Any:
                 "visible": bool(payload.get("visible", True)),
                 "metadata": payload.get("metadata") or {},
             },
+            event_id=payload.get("event_id"),
         )
         await asyncio.to_thread(_persist_agent_outbound_event, task_id, event)
         await manager.broadcast_to_task(event, task_id)
@@ -9191,6 +9197,7 @@ clarification questions as plain assistant text.
                             "visible": bool(payload.get("visible", True)),
                             "metadata": payload.get("metadata") or {},
                         },
+                        event_id=payload.get("event_id"),
                     )
                 )
             )

--- a/src/xagent/web/services/task_clarification_draft.py
+++ b/src/xagent/web/services/task_clarification_draft.py
@@ -17,12 +17,11 @@ row? The answer is one of three outcomes, never folded into a boolean:
   publishable payload (no resume anchor, or the payload could not be shaped
   within the size and character limits below). The caller's own settlement
   proceeds exactly as it would have before this module existed.
-* :class:`FailClosed` -- carries one of five reason strings that split into
-  two different consequences, not one. Two of them (from the guard that
-  pairs waiting status against draft presence) do not discard the round at
-  all: no structured row is written, but the finalizer's existing path for
-  that status proceeds unchanged. The other three (an unfenced lease, a
-  task row no longer owned by the lease that produced this result, or an
+* :class:`FailClosed` -- carries one of six reason strings that split into
+  two different consequences, not one. Three of them do not discard the
+  round at all: no structured row is written, but the finalizer's existing
+  path for that status proceeds unchanged. The other three (an unfenced
+  lease, a task row no longer owned by the lease that produced this result, or an
   attempt that is no longer current) do mean the caller must discard this
   round's settlement wholesale, the same way it already discards a late,
   no-longer-owned result. See :class:`FailClosed` itself for which reason
@@ -85,7 +84,6 @@ is the caller's obligation, not this module's.
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 from dataclasses import dataclass, field
@@ -202,6 +200,7 @@ NotApplicableReason = Literal["no_anchor", "payload_too_large", "empty_question"
 FailClosedReason = Literal[
     "missing_draft",
     "draft_status_mismatch",
+    "missing_event_id",
     "unfenced_lease",
     "ownership_changed",
     "attempt_mismatch",
@@ -241,12 +240,12 @@ class NotApplicable:
 class FailClosed:
     """No structured row is published this round. What the caller must do
     about the *round itself* depends on which guard produced ``reason`` --
-    the five values split into two different consequences, not one.
+    the six values split into two different consequences, not one.
 
-    ``"missing_draft"`` and ``"draft_status_mismatch"`` come from guard 1
-    (the waiting-status/draft-presence pairing) and do not discard the
-    round: no structured row is written and a stray draft is dropped, but
-    the finalizer's existing path for that status proceeds exactly as it
+    ``"missing_draft"``, ``"draft_status_mismatch"``, and
+    ``"missing_event_id"`` do not discard the round: no structured row is
+    written and a stray or unidentified draft is dropped, but the
+    finalizer's existing path for that status proceeds exactly as it
     already does today.
 
     ``"unfenced_lease"``, ``"ownership_changed"``, and ``"attempt_mismatch"``
@@ -267,18 +266,16 @@ ClarificationResolution = Publishable | NotApplicable | FailClosed
 
 
 def clarification_idempotency_key(draft: ClarificationDraft) -> str:
-    """Derive a ``stage()`` idempotency key from the draft's content.
+    """Reuse the question event identity as the ``stage()`` idempotency key.
 
-    Reads only ``turn_marker`` -- never ``message`` or ``interactions`` --
-    so that truncating or otherwise reshaping the payload in
-    :func:`build_clarification_payload` can never change the key a re-entrant
-    resume of the same turn produces. A key that moved with the payload
-    would turn a replay that should cost nothing (the active row already
-    matches) into a fresh request every time the payload's shape changed.
+    The runtime generates this identity before publishing the question and
+    carries it through the waiting checkpoint. Reusing it here makes the
+    outbound TraceEvent, checkpoint draft, and durable interaction row name
+    the same question occurrence. Payload truncation or reshaping cannot
+    move the key because none of the payload content participates in it.
     """
 
-    digest = hashlib.sha256(draft.turn_marker.encode("utf-8")).hexdigest()[:32]
-    return f"clarification.{digest}"
+    return draft.event_id
 
 
 def build_clarification_payload(draft: ClarificationDraft) -> dict[str, Any]:
@@ -364,6 +361,7 @@ def build_clarification_payload(draft: ClarificationDraft) -> dict[str, Any]:
         interactions_dropped = True
 
     payload: dict[str, Any] = {
+        "event_id": draft.event_id,
         "message": question,
         "interactions": interactions_payload,
         "message_type": _strip_control_characters(draft.message_type),
@@ -483,7 +481,11 @@ def resolve_publishable_clarification(
     5. ``anchor is not None`` -- no resume anchor means this run's most
        recent checkpoint was never one a structured interaction can resume
        against; this degrades, it does not fail the round.
-    5b. The payload built from the draft fits the character domain and size
+    6. ``draft.event_id`` is non-empty -- a question without the identity
+       allocated before publication cannot safely become a native interaction
+       row, because the row could not be tied back to the published question.
+       This fails closed for native publication without discarding the round.
+    7. The payload built from the draft fits the character domain and size
         limits in :func:`build_clarification_payload`; if it does not
         (empty after filtering, or reduced to only whitespace, or still
         oversized after truncation), that also degrades rather than fails.
@@ -572,6 +574,13 @@ def resolve_publishable_clarification(
 
     if anchor is None:
         return NotApplicable("no_anchor")
+
+    if not draft.event_id:
+        logger.warning(
+            "a clarification draft had no question event identity",
+            extra={"task_id": task.id, "run_id": lease.run_id},
+        )
+        return FailClosed("missing_event_id")
 
     payload = build_clarification_payload(draft)
 

--- a/src/xagent/web/services/task_clarification_draft.py
+++ b/src/xagent/web/services/task_clarification_draft.py
@@ -17,8 +17,8 @@ row? The answer is one of three outcomes, never folded into a boolean:
   publishable payload (no resume anchor, or the payload could not be shaped
   within the size and character limits below). The caller's own settlement
   proceeds exactly as it would have before this module existed.
-* :class:`FailClosed` -- carries one of six reason strings that split into
-  two different consequences, not one. Three of them do not discard the
+* :class:`FailClosed` -- carries one of seven reason strings that split into
+  two different consequences, not one. Four of them do not discard the
   round at all: no structured row is written, but the finalizer's existing
   path for that status proceeds unchanged. The other three (an unfenced
   lease, a task row no longer owned by the lease that produced this result, or an
@@ -63,6 +63,13 @@ unread today -- removing them now would trade the free "add an optional
 field" path above for a version bump later, to add back exactly what was
 just deleted.
 
+The payload's ``event_id`` is also intentionally outside the v1 question-shape
+readers. It is correlation metadata for the already-published question and the
+authoritative staging identity: the publication path passes the same value to
+``stage()`` separately as ``request_idempotency_key``. Neither
+:func:`parse_clarification_payload` nor the compatibility reader should add an
+``event_id`` field merely to consume metadata that staging already owns.
+
 An application-layer invariant worth stating plainly: a task can have at
 most one *active* interaction row at a time (the database enforces this
 with a unique constraint on the active slot). Nothing in this module
@@ -98,6 +105,7 @@ from .ops_signals import (
     clear_degradation,
     register_degradation,
 )
+from .task_command_transport import COMMAND_ID_PATTERN
 from .task_interaction_staging import InteractionAnchor
 from .task_lease_service import (
     TaskLease,
@@ -201,6 +209,7 @@ FailClosedReason = Literal[
     "missing_draft",
     "draft_status_mismatch",
     "missing_event_id",
+    "invalid_event_id",
     "unfenced_lease",
     "ownership_changed",
     "attempt_mismatch",
@@ -240,13 +249,13 @@ class NotApplicable:
 class FailClosed:
     """No structured row is published this round. What the caller must do
     about the *round itself* depends on which guard produced ``reason`` --
-    the six values split into two different consequences, not one.
+    the seven values split into two different consequences, not one.
 
     ``"missing_draft"``, ``"draft_status_mismatch"``, and
-    ``"missing_event_id"`` do not discard the round: no structured row is
-    written and a stray or unidentified draft is dropped, but the
-    finalizer's existing path for that status proceeds exactly as it
-    already does today.
+    the two event-identity failures (``"missing_event_id"`` and
+    ``"invalid_event_id"``) do not discard the round: no structured row is
+    written and a stray or unidentified draft is dropped, but the finalizer's
+    existing path for that status proceeds exactly as it already does today.
 
     ``"unfenced_lease"``, ``"ownership_changed"``, and ``"attempt_mismatch"``
     come from guards 2 through 4 and mean the opposite: this round's
@@ -275,6 +284,8 @@ def clarification_idempotency_key(draft: ClarificationDraft) -> str:
     move the key because none of the payload content participates in it.
     """
 
+    if not isinstance(draft.event_id, str):
+        raise TypeError("clarification event identity must be validated first")
     return draft.event_id
 
 
@@ -481,10 +492,11 @@ def resolve_publishable_clarification(
     5. ``anchor is not None`` -- no resume anchor means this run's most
        recent checkpoint was never one a structured interaction can resume
        against; this degrades, it does not fail the round.
-    6. ``draft.event_id`` is non-empty -- a question without the identity
-       allocated before publication cannot safely become a native interaction
-       row, because the row could not be tied back to the published question.
-       This fails closed for native publication without discarding the round.
+    6. ``draft.event_id`` is a non-empty string in the downstream command-ID
+       domain -- a question without the identity allocated before publication,
+       or with a restored identity that staging would normalize or reject,
+       cannot safely become a native interaction row. This fails closed for
+       native publication without discarding the round.
     7. The payload built from the draft fits the character domain and size
         limits in :func:`build_clarification_payload`; if it does not
         (empty after filtering, or reduced to only whitespace, or still
@@ -575,12 +587,18 @@ def resolve_publishable_clarification(
     if anchor is None:
         return NotApplicable("no_anchor")
 
-    if not draft.event_id:
+    if draft.event_id == "":
         logger.warning(
             "a clarification draft had no question event identity",
             extra={"task_id": task.id, "run_id": lease.run_id},
         )
         return FailClosed("missing_event_id")
+
+    if (
+        not isinstance(draft.event_id, str)
+        or COMMAND_ID_PATTERN.fullmatch(draft.event_id) is None
+    ):
+        return FailClosed("invalid_event_id")
 
     payload = build_clarification_payload(draft)
 

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -872,10 +872,12 @@ def _replay_or_raise_closed(
     snapshots of the same waiting turn, and the fields that could
     disagree cannot. The one key derivation that exists today,
     ``clarification_idempotency_key`` (``task_clarification_draft.py``),
-    honours this by hashing only ``ClarificationDraft.turn_marker``, which
-    is composed from the turn's message count, origin step and ordered
-    pending-request ids and from nothing else -- deliberately not from the
-    message text, so reshaping the payload cannot move the key.
+    honours this by reusing ``ClarificationDraft.event_id``. The runtime
+    allocates that identity before publishing the question and carries it
+    through the waiting checkpoint; ``turn_marker`` is descriptive checkpoint
+    state only. The request payload carries the same event id as correlation
+    metadata, but staging receives it separately as the idempotency key and
+    never extracts or normalizes identity from the payload.
 
     This is the obligation any future key derivation inherits. A key
     derived from anything that can change while the waiting turn stays the

--- a/tests/core/agent/concurrency_harness.py
+++ b/tests/core/agent/concurrency_harness.py
@@ -223,8 +223,17 @@ class FakeRuntime:
     async def should_interrupt(self) -> bool:
         return bool(self._interrupt)
 
-    async def send_message(self, **kwargs: Any) -> None:
-        self.events.append(("send_message", dict(kwargs)))
+    async def send_message(self, **kwargs: Any) -> dict[str, Any]:
+        payload = dict(kwargs)
+        if bool(payload.get("expect_response")) or payload.get("message_type") == (
+            "question"
+        ):
+            message_number = 1 + sum(
+                kind == "send_message" for kind, _payload in self.events
+            )
+            payload["event_id"] = f"fake-agent-message-{message_number}"
+        self.events.append(("send_message", payload))
+        return payload
 
     def request_interrupt(self, reason: str | None = None) -> None:
         self._interrupt = True

--- a/tests/core/agent/test_clarification_draft.py
+++ b/tests/core/agent/test_clarification_draft.py
@@ -139,6 +139,7 @@ def test_send_message_draft_classifies_and_shapes_requests() -> None:
     assert draft.requests[0].interaction_id == "call-send"
     assert draft.requests[0].tool_name == "send_message"
     assert draft.origin_execution_id == "exec-1"
+    assert draft.event_id == ""  # legacy checkpoints did not carry this field
     assert draft.interactions == ()
     assert draft.message == "Choose A or B"
 
@@ -284,6 +285,9 @@ async def test_checkpoint_snapshot_survives_real_trace_serializer() -> None:
     result = await pattern.run(context=context, tools=[], llm=llm)
     assert result["status"] == "waiting_for_user"
     waiting_request_before = dict(pattern.waiting_for_user_request or {})
+    question_event_id = waiting_request_before["event_id"]
+    assert question_event_id
+    assert result["clarification_draft"].event_id == question_event_id
 
     backend = RecordingTraceBackend()
     store = TraceCheckpointStore(backend)
@@ -304,6 +308,10 @@ async def test_checkpoint_snapshot_survives_real_trace_serializer() -> None:
     assert (
         out["snapshot"]["pattern_state"]["waiting_for_user_request"]
         == waiting_request_before
+    )
+    assert (
+        out["snapshot"]["pattern_state"]["waiting_for_user_request"]["event_id"]
+        == question_event_id
     )
     assert "_serialization_error" not in out
 
@@ -387,6 +395,7 @@ def test_compose_turn_marker_produces_a_fixed_literal_format() -> None:
 
 def _marker_draft(**overrides: Any) -> ClarificationDraft:
     values: dict[str, Any] = {
+        "event_id": "11111111-1111-4111-8111-111111111111",
         "source": "send_message",
         "message": "what is your favorite color?",
         "message_type": "info",
@@ -405,22 +414,18 @@ def _marker_draft(**overrides: Any) -> ClarificationDraft:
     return ClarificationDraft(turn_marker=turn_marker, **values)
 
 
-def test_idempotency_key_input_set_is_exactly_the_turn_marker_components() -> None:
-    """Completes the half of the replay contract
-    ``test_idempotency_key_ignores_message_content``
-    (``tests/web/services/test_task_clarification_draft.py``) leaves
-    uncovered: that test pins that ``message`` does not move the key. This
-    pins the other side -- ``message_type`` and ``interactions`` do not move
-    it either, since neither is a ``turn_marker`` component -- and that each
-    of the three components that do make up ``turn_marker``
-    (``turn_message_count``, ``origin_step_id``, ``requests``) changes the
-    key when it changes, one field at a time.
+def test_idempotency_key_input_is_exactly_the_question_event_id() -> None:
+    """Checkpoint-derived fields and payload content cannot rename a question.
+
+    The event identity is allocated before publication, so it is now the
+    complete idempotency input. The older turn marker remains useful for
+    describing the waiting turn, but it no longer creates a second identity.
     """
 
     base = _marker_draft()
     base_key = clarification_idempotency_key(base)
 
-    # Not turn_marker components: the key must not move.
+    # Neither payload content nor checkpoint-derived marker components move it.
     assert clarification_idempotency_key(
         _marker_draft(message="a different question")
     ) == (base_key)
@@ -432,19 +437,24 @@ def test_idempotency_key_input_set_is_exactly_the_turn_marker_components() -> No
         == base_key
     )
 
-    # turn_marker components: the key must move for each, independently.
     assert (
-        clarification_idempotency_key(_marker_draft(turn_message_count=4)) != base_key
+        clarification_idempotency_key(_marker_draft(turn_message_count=4)) == base_key
     )
     assert (
         clarification_idempotency_key(_marker_draft(origin_step_id="step-2"))
-        != base_key
+        == base_key
     )
     assert (
         clarification_idempotency_key(
             _marker_draft(
                 requests=(ClarificationRequestItem("respond", "call-2", "call-2"),)
             )
+        )
+        == base_key
+    )
+    assert (
+        clarification_idempotency_key(
+            _marker_draft(event_id="22222222-2222-4222-8222-222222222222")
         )
         != base_key
     )

--- a/tests/core/agent/test_clarification_draft.py
+++ b/tests/core/agent/test_clarification_draft.py
@@ -144,6 +144,16 @@ def test_send_message_draft_classifies_and_shapes_requests() -> None:
     assert draft.message == "Choose A or B"
 
 
+def test_restored_non_string_event_identity_is_preserved_for_web_validation() -> None:
+    request = _send_message_request()
+    request["event_id"] = 123
+
+    draft = draft_from_waiting_request(request, execution_id="exec-1", step_id=None)
+
+    assert draft is not None
+    assert draft.event_id == 123
+
+
 def test_ask_user_question_draft_classifies_and_matches_normalized_interactions() -> (
     None
 ):
@@ -370,19 +380,13 @@ def test_distinct_nonempty_tool_call_ids_produce_distinct_markers() -> None:
 
 
 def test_compose_turn_marker_produces_a_fixed_literal_format() -> None:
-    """The replay contract in ``_replay_or_raise_closed``
-    (``task_interaction_staging.py``) rests on ``clarification_idempotency_key``
-    hashing ``turn_marker`` and nothing else, and on ``turn_marker`` staying a
-    function of the waiting turn's own identity. Every existing marker test
-    compares two markers to each other, so this encoding's literal output
-    could change -- a different separator, a dropped length prefix -- without
-    any test here noticing.
+    """``turn_marker`` is descriptive checkpoint state, not publication identity.
 
-    This test failing does not mean the code is wrong: it means the encoding
-    changed, which is exactly the moment ``clarification_idempotency_key``'s
-    output for every already-published row also changes, silently. Whoever
-    causes this test to fail must audit whether that key shift is safe for
-    rows already on disk before touching the assertion below.
+    Every other marker test compares two generated markers, so the literal
+    encoding could change -- a different separator or a dropped length prefix
+    -- without those tests noticing. A change here requires checking marker
+    consumers and restore compatibility, but it cannot rename a published
+    interaction: that identity comes only from the question ``event_id``.
     """
 
     marker = _compose_turn_marker(

--- a/tests/core/agent/test_concurrency_harness.py
+++ b/tests/core/agent/test_concurrency_harness.py
@@ -113,6 +113,20 @@ async def test_fake_runtime_records_event_sequence() -> None:
     assert runtime.events_of("on_tool_start")[0]["tool_call_id"] == "cc-1"
 
 
+async def test_fake_runtime_returns_question_event_identity() -> None:
+    runtime = FakeRuntime()
+
+    outbound = await runtime.send_message(
+        message="which?",
+        message_type="question",
+        expect_response=True,
+        visible=True,
+    )
+
+    assert outbound["event_id"] == "fake-agent-message-1"
+    assert runtime.events_of("send_message") == [outbound]
+
+
 async def test_fake_runtime_interrupt_flag() -> None:
     runtime = FakeRuntime(interrupt=True, interrupt_reason="stop")
     assert await runtime.should_interrupt() is True

--- a/tests/core/agent/test_question_event_identity.py
+++ b/tests/core/agent/test_question_event_identity.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xagent.core.agent import PatternRuntime
+
+
+class OutboundCollector:
+    def __init__(self) -> None:
+        self.events: list[dict[str, Any]] = []
+
+    async def __call__(self, payload: dict[str, Any]) -> None:
+        self.events.append(dict(payload))
+
+
+@pytest.mark.asyncio
+async def test_waiting_message_has_one_identity_before_publication() -> None:
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(
+        execution_id="exec-1",
+        outbound_message_handler=outbound,
+    )
+
+    emitted = await runtime.send_message(
+        message="Which region should I use?",
+        message_type="question",
+        expect_response=True,
+    )
+
+    assert isinstance(emitted["event_id"], str)
+    assert emitted["event_id"]
+    assert outbound.events == [emitted]
+
+
+@pytest.mark.asyncio
+async def test_non_waiting_message_keeps_the_legacy_runtime_payload_shape() -> None:
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(
+        execution_id="exec-1",
+        outbound_message_handler=outbound,
+    )
+
+    emitted = await runtime.send_message(
+        message="Still working",
+        message_type="info",
+        expect_response=False,
+    )
+
+    assert "event_id" not in emitted
+    assert outbound.events == [emitted]
+
+
+@pytest.mark.asyncio
+async def test_question_message_has_identity_even_without_response_waiting() -> None:
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(
+        execution_id="exec-1",
+        outbound_message_handler=outbound,
+    )
+
+    emitted = await runtime.send_message(
+        message="Would you like a status summary?",
+        message_type="question",
+        expect_response=False,
+    )
+
+    assert emitted["event_id"]
+    assert outbound.events == [emitted]

--- a/tests/core/agent/test_react_clarification_draft.py
+++ b/tests/core/agent/test_react_clarification_draft.py
@@ -128,11 +128,12 @@ async def test_waiting_return_carries_draft_matching_recomputed_value(
     """
 
     pattern = ReActPattern(max_iterations=2)
+    runtime = PatternRuntime(execution_id="exec-tp1")
     context = ExecutionContext(execution_id="exec-tp1")
     context.add_user_message("Ask")
 
     result = await pattern.run(
-        context=context, tools=tools_factory(), llm=llm_factory()
+        context=context, tools=tools_factory(), llm=llm_factory(), runtime=runtime
     )
 
     assert result["status"] == "waiting_for_user"
@@ -143,6 +144,14 @@ async def test_waiting_return_carries_draft_matching_recomputed_value(
     )
     assert result["clarification_draft"] == expected
     assert result["clarification_draft"].source == expected_source
+    assert (
+        result["clarification_draft"].event_id
+        == runtime.outbound_messages[-1]["event_id"]
+    )
+    assert (
+        pattern.waiting_for_user_request["event_id"]
+        == result["clarification_draft"].event_id
+    )
 
 
 @pytest.mark.asyncio
@@ -153,6 +162,7 @@ async def test_waiting_return_via_tool_carries_tool_waiting_draft() -> None:
 
     tool = ResumableTool()
     pattern = ReActPattern(max_iterations=2)
+    runtime = PatternRuntime(execution_id="exec-tp1-tool")
     context = ExecutionContext(execution_id="exec-tp1-tool")
     context.add_user_message("Run the gated action.")
     llm = FakeLLM(
@@ -171,7 +181,7 @@ async def test_waiting_return_via_tool_carries_tool_waiting_draft() -> None:
         ]
     )
 
-    result = await pattern.run(context=context, tools=[tool], llm=llm)
+    result = await pattern.run(context=context, tools=[tool], llm=llm, runtime=runtime)
 
     assert result["status"] == "waiting_for_user"
     expected = draft_from_waiting_request(
@@ -181,6 +191,14 @@ async def test_waiting_return_via_tool_carries_tool_waiting_draft() -> None:
     )
     assert result["clarification_draft"] == expected
     assert result["clarification_draft"].source == "tool_waiting"
+    assert (
+        result["clarification_draft"].event_id
+        == runtime.outbound_messages[-1]["event_id"]
+    )
+    assert (
+        pattern.waiting_for_user_request["event_id"]
+        == result["clarification_draft"].event_id
+    )
 
 
 @pytest.mark.asyncio
@@ -277,6 +295,10 @@ async def test_reentry_without_new_message_returns_stable_draft_and_sends_nothin
     assert resumed_llm.calls == []
     assert len(resumed_runtime.outbound_messages) == 0
     assert resumed["clarification_draft"] == first["clarification_draft"]
+    assert resumed["clarification_draft"].event_id
+    assert (
+        resumed["clarification_draft"].event_id == first["clarification_draft"].event_id
+    )
 
 
 @pytest.mark.asyncio
@@ -548,6 +570,10 @@ async def test_pattern_end_trace_payload_with_draft_survives_real_serializer(
     assert serialized["result"]["status"] == "waiting_for_user"
     assert serialized["result"]["clarification_draft"]["source"] == "send_message"
     assert serialized["result"]["clarification_draft"]["message"] == "Choose A or B"
+    assert (
+        serialized["result"]["clarification_draft"]["event_id"]
+        == runtime.outbound_messages[-1]["event_id"]
+    )
     requests = serialized["result"]["clarification_draft"]["requests"]
     assert isinstance(requests, list)
     assert requests and all(isinstance(item, dict) for item in requests)

--- a/tests/web/services/test_task_clarification_draft.py
+++ b/tests/web/services/test_task_clarification_draft.py
@@ -180,6 +180,24 @@ def test_waiting_draft_without_question_event_identity_fails_closed() -> None:
     assert resolution.fail_closed_reason == "missing_event_id"
 
 
+@pytest.mark.parametrize(
+    "event_id",
+    [None, 0, False, [], " id ", "bad/id", "bad\x00id", "a" * 65],
+)
+def test_invalid_question_event_identity_fails_closed(event_id: Any) -> None:
+    result = {
+        "status": "waiting_for_user",
+        "clarification_draft": _draft(event_id=event_id),
+    }
+
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()
+    )
+
+    assert isinstance(resolution, FailClosed)
+    assert resolution.fail_closed_reason == "invalid_event_id"
+
+
 def test_waiting_without_draft_fails_closed_as_missing_draft() -> None:
     result = {"status": "waiting_for_user"}
     resolution = resolve_publishable_clarification(

--- a/tests/web/services/test_task_clarification_draft.py
+++ b/tests/web/services/test_task_clarification_draft.py
@@ -92,6 +92,7 @@ def _draft(
     """
 
     values: dict[str, Any] = {
+        "event_id": "11111111-1111-4111-8111-111111111111",
         "source": "send_message",
         "message": message,
         "message_type": "info",
@@ -165,6 +166,18 @@ def test_waiting_with_draft_is_publishable() -> None:
     )
     assert isinstance(resolution, Publishable)
     assert resolution.fail_closed_reason is None
+
+
+def test_waiting_draft_without_question_event_identity_fails_closed() -> None:
+    result = {
+        "status": "waiting_for_user",
+        "clarification_draft": _draft(event_id=""),
+    }
+    resolution = resolve_publishable_clarification(
+        result, task=_task(), lease=_lease(), anchor=_anchor(), now=_now()
+    )
+    assert isinstance(resolution, FailClosed)
+    assert resolution.fail_closed_reason == "missing_event_id"
 
 
 def test_waiting_without_draft_fails_closed_as_missing_draft() -> None:
@@ -899,13 +912,22 @@ def test_idempotency_key_matches_the_command_id_pattern() -> None:
     draft = _draft()
     key = clarification_idempotency_key(draft)
     assert COMMAND_ID_PATTERN.fullmatch(key) is not None
-    assert key.startswith("clarification.")
-    assert len(key) == 46
+    assert key == draft.event_id
+
+
+def test_question_event_identity_is_carried_in_the_v1_payload() -> None:
+    draft = _draft()
+    assert build_clarification_payload(draft)["event_id"] == draft.event_id
+
+
+def test_idempotency_key_changes_with_question_event_identity() -> None:
+    base = _draft(event_id="11111111-1111-4111-8111-111111111111")
+    changed = _draft(event_id="22222222-2222-4222-8222-222222222222")
+    assert clarification_idempotency_key(base) != clarification_idempotency_key(changed)
 
 
 def test_idempotency_key_ignores_message_content() -> None:
-    """The key is derived only from ``turn_marker``; changing ``message``
-    (including via truncation) must never change it."""
+    """Changing payload content cannot rename the published question."""
 
     base = _draft(message="short")
     changed = _draft(message="a completely different, much longer question")
@@ -913,11 +935,7 @@ def test_idempotency_key_ignores_message_content() -> None:
 
 
 def test_idempotency_key_ignores_source() -> None:
-    """``turn_marker`` is composed from ``turn_message_count``,
-    ``origin_step_id``, and ``requests`` only (see ``_compose_turn_marker``);
-    ``source`` is not one of its inputs. Two drafts differing only in
-    ``source`` -- e.g. the same turn reported by ``send_message`` versus
-    ``ask_user_question`` -- must therefore produce the same key."""
+    """The question event identity stays authoritative across draft sources."""
 
     base = _draft(source="send_message")
     changed = _draft(source="ask_user_question")
@@ -925,9 +943,7 @@ def test_idempotency_key_ignores_source() -> None:
 
 
 def test_idempotency_key_ignores_origin_execution_id() -> None:
-    """Same reasoning as ``test_idempotency_key_ignores_source`` above:
-    ``origin_execution_id`` is not one of ``_compose_turn_marker``'s inputs
-    either, so two drafts differing only in it must produce the same key."""
+    """Execution bookkeeping cannot create a second question identity."""
 
     base = _draft(origin_execution_id="exec-1")
     changed = _draft(origin_execution_id="exec-2")
@@ -999,9 +1015,7 @@ def test_request_leaf_control_characters_are_stripped_from_the_payload() -> None
         }
     ]
 
-    # The idempotency key is derived only from turn_marker (computed from
-    # the *raw*, unfiltered requests), so filtering the payload's requests
-    # leaves must not move it.
+    # Filtering payload leaves must not move the event-derived identity.
     key_before = clarification_idempotency_key(draft)
     build_clarification_payload(draft)
     assert clarification_idempotency_key(draft) == key_before
@@ -1021,9 +1035,7 @@ def test_message_type_control_characters_are_stripped_from_the_payload() -> None
     payload = build_clarification_payload(draft)
     assert payload["message_type"] == "infoBEL-AND-NUL"
 
-    # Same independence check as the requests-leaf test above: filtering
-    # message_type must not move the idempotency key, since that key is
-    # derived only from turn_marker.
+    # Filtering message_type must not move the event-derived identity.
     key_before = clarification_idempotency_key(draft)
     build_clarification_payload(draft)
     assert clarification_idempotency_key(draft) == key_before

--- a/tests/web/test_question_event_identity.py
+++ b/tests/web/test_question_event_identity.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from xagent.core.agent import PatternRuntime
+from xagent.web.api.websocket import create_stream_event, make_agent_outbound_handler
+
+
+@pytest.mark.asyncio
+async def test_question_identity_is_shared_by_runtime_persistence_and_broadcast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    persisted: list[dict[str, Any]] = []
+    broadcast: list[dict[str, Any]] = []
+
+    def fake_persist(_task_id: int, event: dict[str, Any]) -> None:
+        persisted.append(dict(event))
+
+    async def fake_broadcast(event: dict[str, Any], _task_id: int) -> None:
+        broadcast.append(dict(event))
+
+    monkeypatch.setattr(
+        "xagent.web.api.websocket._persist_agent_outbound_event",
+        fake_persist,
+    )
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.manager.broadcast_to_task",
+        fake_broadcast,
+    )
+
+    runtime = PatternRuntime(
+        execution_id="exec-1",
+        outbound_message_handler=make_agent_outbound_handler(365),
+    )
+    emitted = await runtime.send_message(
+        message="Which region should I use?",
+        message_type="question",
+        expect_response=True,
+    )
+
+    assert len(persisted) == len(broadcast) == 1
+    assert persisted[0]["event_id"] == emitted["event_id"]
+    assert broadcast[0]["event_id"] == emitted["event_id"]
+    assert persisted[0]["data"]["event_id"] == emitted["event_id"]
+    assert broadcast[0]["data"]["event_id"] == emitted["event_id"]
+
+
+def test_generic_stream_event_does_not_promote_nested_domain_identity() -> None:
+    event = create_stream_event(
+        "tool_event",
+        365,
+        {"event_id": "tool-domain-event-1"},
+    )
+
+    assert event["event_id"] != "tool-domain-event-1"
+    assert event["data"]["event_id"] == "tool-domain-event-1"


### PR DESCRIPTION
## Summary

- allocate a stable question event identity before the runtime invokes an outbound handler
- carry the same identity through every waiting producer, checkpoint state, clarification draft, v1 payload, and publication idempotency key
- reuse the producer identity for agent outbound persistence and broadcast while keeping generic stream events and non-question payloads compatible
- fail closed when a native clarification draft lacks the required identity

## Verification

- 228 focused runtime, clarification, WebSocket, persistence, and production-gate tests passed
- Ruff formatting and lint checks passed
- mypy passed for all five touched production modules
- production native-writer gates remain closed

## Scope

This PR only establishes the stable question identity required by the later native interaction wiring.

Known follow-up gaps in the touched area are explicitly out of scope:

- production native clarification publication/finalizer wiring: #1077
- typed task interaction continuation API: #1079
- xagent-saas transport integration: xorbitsai/xagent-saas#675

Closes #1799