### PR TITLE
fix: narrow Google Calendar connector scope to calendar.events

### DIFF
--- a/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
+++ b/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
@@ -40,7 +40,6 @@ PUBLIC_MCP_APPS_TABLE = sa.table(
 )
 
 APP_ID = "google-calendar"
-REQUIRED_COLUMNS = {"app_id", "oauth_scopes"}
 OLD_SCOPES = ("https://www.googleapis.com/auth/calendar",)
 NEW_SCOPES = ("https://www.googleapis.com/auth/calendar.events",)
 
@@ -50,11 +49,11 @@ def _columns_present(
 ) -> bool:
     """Whether ``table_name`` exists and has all of ``required_columns``.
 
-    Used by _set_calendar_scopes()'s online branch, called from both
-    upgrade() and downgrade(): this migration must be a no-op (not an
-    error) against a database mid-way through a schema this old, or an
-    admin's reduced-schema table, rather than assume a table shape that
-    matches only the current model.
+    Used by _set_calendar_scopes(), the online path upgrade() and
+    downgrade() both call: this migration must be a no-op (not an error)
+    against a database mid-way through a schema this old, or an admin's
+    reduced-schema table, rather than assume a table shape that matches
+    only the current model.
     """
     inspector = sa.inspect(bind)
     if table_name not in set(inspector.get_table_names()):
@@ -72,30 +71,27 @@ def _offline_scopes_literal(scopes: Sequence[str], dialect_name: str) -> object:
     return serialized_literal
 
 
+def _set_calendar_scopes_offline(scopes: Sequence[str]) -> None:
+    dialect_name = op.get_context().dialect.name
+    statement = (
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == op.inline_literal(APP_ID))
+        .values(oauth_scopes=_offline_scopes_literal(scopes, dialect_name))
+    )
+    op.execute(statement)
+
+
 def _set_calendar_scopes(scopes: Sequence[str]) -> None:
     """Write ``scopes`` to the google-calendar row's oauth_scopes column.
 
     oauth_scopes is in admin_mcp's _BUILTIN_PROTECTED_FIELDS, so an operator
     can never have customized it via the admin PATCH endpoint -- safe to
     overwrite unconditionally, with no prior-value check, in both
-    directions. Handles both the online and offline (``--sql``) paths itself
-    -- unlike the sibling migrations' ``_set_<app>_scopes(bind, scopes)``
-    helpers, this one has no live ``bind`` to take as a parameter until
-    after the as_sql check below, since none of those siblings support
-    offline SQL generation.
+    directions. Online-only: the caller has already handled the offline
+    (``--sql``) path, since there's no live ``bind`` to use here otherwise.
     """
-    if op.get_context().as_sql:
-        dialect_name = op.get_context().dialect.name
-        statement = (
-            sa.update(PUBLIC_MCP_APPS_TABLE)
-            .where(PUBLIC_MCP_APPS_TABLE.c.app_id == op.inline_literal(APP_ID))
-            .values(oauth_scopes=_offline_scopes_literal(scopes, dialect_name))
-        )
-        op.execute(statement)
-        return
-
     bind = op.get_bind()
-    if not _columns_present(bind, "public_mcp_apps", REQUIRED_COLUMNS):
+    if not _columns_present(bind, "public_mcp_apps", {"app_id", "oauth_scopes"}):
         return
 
     bind.execute(
@@ -106,8 +102,18 @@ def _set_calendar_scopes(scopes: Sequence[str]) -> None:
 
 
 def upgrade() -> None:
+    # Offline (--sql) generation has a MockConnection, so reflection is
+    # unavailable -- emit the unconditional UPDATE instead of inspecting.
+    if op.get_context().as_sql:
+        _set_calendar_scopes_offline(NEW_SCOPES)
+        return
+
     _set_calendar_scopes(NEW_SCOPES)
 
 
 def downgrade() -> None:
+    if op.get_context().as_sql:
+        _set_calendar_scopes_offline(OLD_SCOPES)
+        return
+
     _set_calendar_scopes(OLD_SCOPES)

--- a/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
+++ b/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
@@ -50,8 +50,9 @@ def _columns_present(
 ) -> bool:
     """Whether ``table_name`` exists and has all of ``required_columns``.
 
-    Shared by upgrade() and downgrade(): this migration must be a no-op (not
-    an error) against a database mid-way through a schema this old, or an
+    Used by _set_calendar_scopes()'s online branch, called from both
+    upgrade() and downgrade(): this migration must be a no-op (not an
+    error) against a database mid-way through a schema this old, or an
     admin's reduced-schema table, rather than assume a table shape that
     matches only the current model.
     """
@@ -71,11 +72,18 @@ def _offline_scopes_literal(scopes: Sequence[str], dialect_name: str) -> object:
     return serialized_literal
 
 
-def _apply_scope(scopes: Sequence[str]) -> None:
-    # oauth_scopes is in admin_mcp's _BUILTIN_PROTECTED_FIELDS, so an
-    # operator can never have customized it via the admin PATCH endpoint --
-    # safe to overwrite unconditionally, with no prior-value check, in both
-    # directions.
+def _set_calendar_scopes(scopes: Sequence[str]) -> None:
+    """Write ``scopes`` to the google-calendar row's oauth_scopes column.
+
+    oauth_scopes is in admin_mcp's _BUILTIN_PROTECTED_FIELDS, so an operator
+    can never have customized it via the admin PATCH endpoint -- safe to
+    overwrite unconditionally, with no prior-value check, in both
+    directions. Handles both the online and offline (``--sql``) paths itself
+    -- unlike the sibling migrations' ``_set_<app>_scopes(bind, scopes)``
+    helpers, this one has no live ``bind`` to take as a parameter until
+    after the as_sql check below, since none of those siblings support
+    offline SQL generation.
+    """
     if op.get_context().as_sql:
         dialect_name = op.get_context().dialect.name
         statement = (
@@ -98,8 +106,8 @@ def _apply_scope(scopes: Sequence[str]) -> None:
 
 
 def upgrade() -> None:
-    _apply_scope(NEW_SCOPES)
+    _set_calendar_scopes(NEW_SCOPES)
 
 
 def downgrade() -> None:
-    _apply_scope(OLD_SCOPES)
+    _set_calendar_scopes(OLD_SCOPES)

--- a/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
+++ b/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
@@ -1,0 +1,93 @@
+"""narrow the Google Calendar connector's OAuth scope to calendar.events
+
+The Calendar connector's tools (search/create/get/update/delete) only ever
+operate on events, never on calendar list management, so the full
+``.../auth/calendar`` scope requested more access than the feature set uses.
+This updates the persisted built-in catalog row to match the narrower scope
+now declared in ``builtin_mcp_registry.py``.
+
+Revision ID: 20260817_narrow_google_calendar_scope
+Revises: 20260725_add_uploaded_file_recovery_index
+Create Date: 2026-08-17
+
+"""
+
+import json
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260817_narrow_google_calendar_scope"
+down_revision: Union[str, None] = "20260725_add_uploaded_file_recovery_index"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+)
+
+APP_ID = "google-calendar"
+OLD_SCOPES = ["https://www.googleapis.com/auth/calendar"]
+NEW_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+
+
+def _offline_scopes_literal(scopes: list[str], dialect_name: str):
+    # Match the online sa.JSON binding contract (none_as_null=False) used
+    # elsewhere in this migration set: values are stored as JSON, not as a
+    # bare SQL string literal, on every supported dialect.
+    serialized_literal = op.inline_literal(json.dumps(scopes, sort_keys=True))
+    if dialect_name == "postgresql":
+        return sa.cast(serialized_literal, sa.JSON())
+    return serialized_literal
+
+
+def _upgrade_offline() -> None:
+    dialect_name = op.get_context().dialect.name
+    statement = (
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == op.inline_literal(APP_ID))
+        .values(oauth_scopes=_offline_scopes_literal(NEW_SCOPES, dialect_name))
+    )
+    op.execute(statement)
+
+
+def upgrade() -> None:
+    if op.get_context().as_sql:
+        _upgrade_offline()
+        return
+
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in inspector.get_table_names():
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("public_mcp_apps")}
+    if not {"app_id", "oauth_scopes"}.issubset(columns):
+        return
+
+    bind.execute(
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+        .values(oauth_scopes=NEW_SCOPES)
+    )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in inspector.get_table_names():
+        return
+
+    columns = {column["name"] for column in inspector.get_columns("public_mcp_apps")}
+    if not {"app_id", "oauth_scopes"}.issubset(columns):
+        return
+
+    bind.execute(
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+        .values(oauth_scopes=OLD_SCOPES)
+    )

--- a/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
+++ b/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
@@ -3,8 +3,15 @@
 The Calendar connector's tools (search/create/get/update/delete) only ever
 operate on events, never on calendar list management, so the full
 ``.../auth/calendar`` scope requested more access than the feature set uses.
-This updates the persisted built-in catalog row to match the narrower scope
-now declared in ``builtin_mcp_registry.py``.
+
+For a builtin app, the scope actually requested at authorize time is sourced
+live from ``builtin_mcp_registry.py``, not from this table -- this migration
+only converges the persisted ``public_mcp_apps.oauth_scopes`` row so
+``validate_builtin_public_mcp_apps`` stops reporting drift against that
+registry value on an already-seeded database. It deliberately does not touch
+already-issued ``user_oauth`` grants: narrowing a scope doesn't require
+re-consent for a token that already has the (now broader) old scope to keep
+working, so there's nothing to invalidate.
 
 Revision ID: 20260817_narrow_google_calendar_scope
 Revises: 20260825_add_slack_channels_join_scope
@@ -19,6 +26,8 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260817_narrow_google_calendar_scope"
+# This re-cut PR was rebased onto main after 20260825_add_slack_channels_join_scope
+# landed, which is why this (earlier-dated) revision's parent has a later date.
 down_revision: Union[str, None] = "20260825_add_slack_channels_join_scope"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
@@ -31,6 +40,7 @@ PUBLIC_MCP_APPS_TABLE = sa.table(
 )
 
 APP_ID = "google-calendar"
+REQUIRED_COLUMNS = {"app_id", "oauth_scopes"}
 OLD_SCOPES = ("https://www.googleapis.com/auth/calendar",)
 NEW_SCOPES = ("https://www.googleapis.com/auth/calendar.events",)
 
@@ -52,63 +62,44 @@ def _columns_present(
     return required_columns.issubset(columns)
 
 
-def _offline_scopes_literal(scopes: Sequence[str], dialect_name: str):
-    # Match the online sa.JSON binding contract (none_as_null=False) used
-    # elsewhere in this migration set: values are stored as JSON, not as a
-    # bare SQL string literal, on every supported dialect.
+def _offline_scopes_literal(scopes: Sequence[str], dialect_name: str) -> object:
+    # Match the online sa.JSON binding contract: values are stored as JSON,
+    # not as a bare SQL string literal, on every supported dialect.
     serialized_literal = op.inline_literal(json.dumps(scopes))
     if dialect_name == "postgresql":
         return sa.cast(serialized_literal, sa.JSON())
     return serialized_literal
 
 
-def _upgrade_offline() -> None:
-    dialect_name = op.get_context().dialect.name
-    statement = (
+def _apply_scope(scopes: Sequence[str]) -> None:
+    # oauth_scopes is in admin_mcp's _BUILTIN_PROTECTED_FIELDS, so an
+    # operator can never have customized it via the admin PATCH endpoint --
+    # safe to overwrite unconditionally, with no prior-value check, in both
+    # directions.
+    if op.get_context().as_sql:
+        dialect_name = op.get_context().dialect.name
+        statement = (
+            sa.update(PUBLIC_MCP_APPS_TABLE)
+            .where(PUBLIC_MCP_APPS_TABLE.c.app_id == op.inline_literal(APP_ID))
+            .values(oauth_scopes=_offline_scopes_literal(scopes, dialect_name))
+        )
+        op.execute(statement)
+        return
+
+    bind = op.get_bind()
+    if not _columns_present(bind, "public_mcp_apps", REQUIRED_COLUMNS):
+        return
+
+    bind.execute(
         sa.update(PUBLIC_MCP_APPS_TABLE)
-        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == op.inline_literal(APP_ID))
-        .values(oauth_scopes=_offline_scopes_literal(NEW_SCOPES, dialect_name))
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+        .values(oauth_scopes=scopes)
     )
-    op.execute(statement)
 
 
 def upgrade() -> None:
-    if op.get_context().as_sql:
-        _upgrade_offline()
-        return
-
-    bind = op.get_bind()
-    if not _columns_present(bind, "public_mcp_apps", {"app_id", "oauth_scopes"}):
-        return
-
-    bind.execute(
-        sa.update(PUBLIC_MCP_APPS_TABLE)
-        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
-        .values(oauth_scopes=NEW_SCOPES)
-    )
-
-
-def _downgrade_offline() -> None:
-    dialect_name = op.get_context().dialect.name
-    statement = (
-        sa.update(PUBLIC_MCP_APPS_TABLE)
-        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == op.inline_literal(APP_ID))
-        .values(oauth_scopes=_offline_scopes_literal(OLD_SCOPES, dialect_name))
-    )
-    op.execute(statement)
+    _apply_scope(NEW_SCOPES)
 
 
 def downgrade() -> None:
-    if op.get_context().as_sql:
-        _downgrade_offline()
-        return
-
-    bind = op.get_bind()
-    if not _columns_present(bind, "public_mcp_apps", {"app_id", "oauth_scopes"}):
-        return
-
-    bind.execute(
-        sa.update(PUBLIC_MCP_APPS_TABLE)
-        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
-        .values(oauth_scopes=OLD_SCOPES)
-    )
+    _apply_scope(OLD_SCOPES)

--- a/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
+++ b/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
@@ -35,11 +35,28 @@ OLD_SCOPES = ("https://www.googleapis.com/auth/calendar",)
 NEW_SCOPES = ("https://www.googleapis.com/auth/calendar.events",)
 
 
+def _columns_present(
+    bind: sa.engine.Connection, table_name: str, required_columns: set[str]
+) -> bool:
+    """Whether ``table_name`` exists and has all of ``required_columns``.
+
+    Shared by upgrade() and downgrade(): this migration must be a no-op (not
+    an error) against a database mid-way through a schema this old, or an
+    admin's reduced-schema table, rather than assume a table shape that
+    matches only the current model.
+    """
+    inspector = sa.inspect(bind)
+    if table_name not in set(inspector.get_table_names()):
+        return False
+    columns = {column["name"] for column in inspector.get_columns(table_name)}
+    return required_columns.issubset(columns)
+
+
 def _offline_scopes_literal(scopes: Sequence[str], dialect_name: str):
     # Match the online sa.JSON binding contract (none_as_null=False) used
     # elsewhere in this migration set: values are stored as JSON, not as a
     # bare SQL string literal, on every supported dialect.
-    serialized_literal = op.inline_literal(json.dumps(scopes, sort_keys=True))
+    serialized_literal = op.inline_literal(json.dumps(scopes))
     if dialect_name == "postgresql":
         return sa.cast(serialized_literal, sa.JSON())
     return serialized_literal
@@ -61,12 +78,7 @@ def upgrade() -> None:
         return
 
     bind = op.get_bind()
-    inspector = sa.inspect(bind)
-    if "public_mcp_apps" not in inspector.get_table_names():
-        return
-
-    columns = {column["name"] for column in inspector.get_columns("public_mcp_apps")}
-    if not {"app_id", "oauth_scopes"}.issubset(columns):
+    if not _columns_present(bind, "public_mcp_apps", {"app_id", "oauth_scopes"}):
         return
 
     bind.execute(
@@ -92,12 +104,7 @@ def downgrade() -> None:
         return
 
     bind = op.get_bind()
-    inspector = sa.inspect(bind)
-    if "public_mcp_apps" not in inspector.get_table_names():
-        return
-
-    columns = {column["name"] for column in inspector.get_columns("public_mcp_apps")}
-    if not {"app_id", "oauth_scopes"}.issubset(columns):
+    if not _columns_present(bind, "public_mcp_apps", {"app_id", "oauth_scopes"}):
         return
 
     bind.execute(

--- a/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
+++ b/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
@@ -31,11 +31,11 @@ PUBLIC_MCP_APPS_TABLE = sa.table(
 )
 
 APP_ID = "google-calendar"
-OLD_SCOPES = ["https://www.googleapis.com/auth/calendar"]
-NEW_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+OLD_SCOPES = ("https://www.googleapis.com/auth/calendar",)
+NEW_SCOPES = ("https://www.googleapis.com/auth/calendar.events",)
 
 
-def _offline_scopes_literal(scopes: list[str], dialect_name: str):
+def _offline_scopes_literal(scopes: Sequence[str], dialect_name: str):
     # Match the online sa.JSON binding contract (none_as_null=False) used
     # elsewhere in this migration set: values are stored as JSON, not as a
     # bare SQL string literal, on every supported dialect.
@@ -76,7 +76,21 @@ def upgrade() -> None:
     )
 
 
+def _downgrade_offline() -> None:
+    dialect_name = op.get_context().dialect.name
+    statement = (
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == op.inline_literal(APP_ID))
+        .values(oauth_scopes=_offline_scopes_literal(OLD_SCOPES, dialect_name))
+    )
+    op.execute(statement)
+
+
 def downgrade() -> None:
+    if op.get_context().as_sql:
+        _downgrade_offline()
+        return
+
     bind = op.get_bind()
     inspector = sa.inspect(bind)
     if "public_mcp_apps" not in inspector.get_table_names():

--- a/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
+++ b/src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py
@@ -7,7 +7,7 @@ This updates the persisted built-in catalog row to match the narrower scope
 now declared in ``builtin_mcp_registry.py``.
 
 Revision ID: 20260817_narrow_google_calendar_scope
-Revises: 20260725_add_uploaded_file_recovery_index
+Revises: 20260825_add_slack_channels_join_scope
 Create Date: 2026-08-17
 
 """
@@ -19,7 +19,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260817_narrow_google_calendar_scope"
-down_revision: Union[str, None] = "20260725_add_uploaded_file_recovery_index"
+down_revision: Union[str, None] = "20260825_add_slack_channels_join_scope"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -378,7 +378,7 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "transport": "oauth",
             "provider_name": "google",
             "category": "Scheduling",
-            "oauth_scopes": ["https://www.googleapis.com/auth/calendar"],
+            "oauth_scopes": ["https://www.googleapis.com/auth/calendar.events"],
             "is_visible_in_connector": True,
             "launch_config": {
                 "command": "python",

--- a/tests/alembic/test_20260817_narrow_google_calendar_scope.py
+++ b/tests/alembic/test_20260817_narrow_google_calendar_scope.py
@@ -222,4 +222,4 @@ def test_revision_metadata() -> None:
     migration = _load_migration_module()
 
     assert migration.revision == "20260817_narrow_google_calendar_scope"
-    assert migration.down_revision == "20260725_add_uploaded_file_recovery_index"
+    assert migration.down_revision == "20260825_add_slack_channels_join_scope"

--- a/tests/alembic/test_20260817_narrow_google_calendar_scope.py
+++ b/tests/alembic/test_20260817_narrow_google_calendar_scope.py
@@ -218,6 +218,57 @@ def test_offline_sqlite_upgrade_round_trips_json_scope_value() -> None:
     assert json.loads(stored[0]) == NEW_SCOPES
 
 
+def test_offline_postgresql_downgrade_emits_literal_update_only_sql() -> None:
+    migration = _load_migration_module()
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name="postgresql",
+        opts={"as_sql": True, "output_buffer": output},
+    )
+
+    with Operations.context(context):
+        migration.downgrade()
+
+    sql = output.getvalue()
+    assert sql.count("UPDATE public_mcp_apps SET") == 1
+    assert "oauth_scopes=" in sql
+    assert "public_mcp_apps.app_id = 'google-calendar'" in sql
+    assert "auth/calendar" in sql
+    assert "INSERT INTO public_mcp_apps" not in sql
+    assert "DELETE FROM public_mcp_apps" not in sql
+    assert "%(" not in sql
+
+
+def test_offline_sqlite_downgrade_round_trips_json_scope_value() -> None:
+    migration = _load_migration_module()
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name="sqlite",
+        opts={"as_sql": True, "output_buffer": output},
+    )
+
+    with Operations.context(context):
+        migration.downgrade()
+
+    connection = sqlite3.connect(":memory:")
+    connection.execute(
+        "CREATE TABLE public_mcp_apps (app_id TEXT PRIMARY KEY, oauth_scopes JSON)"
+    )
+    connection.execute(
+        "INSERT INTO public_mcp_apps (app_id, oauth_scopes) VALUES (?, ?)",
+        ("google-calendar", json.dumps(NEW_SCOPES)),
+    )
+    connection.executescript(output.getvalue())
+
+    stored = connection.execute(
+        "SELECT oauth_scopes FROM public_mcp_apps WHERE app_id = 'google-calendar'"
+    ).fetchone()
+    connection.close()
+
+    assert stored is not None
+    assert json.loads(stored[0]) == OLD_SCOPES
+
+
 def test_revision_metadata() -> None:
     migration = _load_migration_module()
 

--- a/tests/alembic/test_20260817_narrow_google_calendar_scope.py
+++ b/tests/alembic/test_20260817_narrow_google_calendar_scope.py
@@ -267,7 +267,8 @@ def test_offline_postgresql_downgrade_emits_literal_update_only_sql() -> None:
     # "auth/calendar" alone is a substring of both OLD_SCOPES and NEW_SCOPES
     # ("auth/calendar.events"), so it can't distinguish which one was
     # emitted; assert the narrower scope is absent to catch a swapped
-    # OLD_SCOPES/NEW_SCOPES argument in downgrade()'s _apply_scope() call.
+    # OLD_SCOPES/NEW_SCOPES argument in downgrade()'s _set_calendar_scopes()
+    # call.
     assert "auth/calendar" in sql
     assert "calendar.events" not in sql
     assert "INSERT INTO public_mcp_apps" not in sql
@@ -305,7 +306,7 @@ def test_offline_sqlite_downgrade_round_trips_json_scope_value() -> None:
     assert json.loads(stored[0]) == OLD_SCOPES
 
 
-def test_migration_scope_matches_registry() -> None:
+def test_migration_fields_match_registry() -> None:
     from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
 
     migration = _load_migration_module()

--- a/tests/alembic/test_20260817_narrow_google_calendar_scope.py
+++ b/tests/alembic/test_20260817_narrow_google_calendar_scope.py
@@ -1,0 +1,225 @@
+"""Tests for narrowing the Google Calendar connector's OAuth scope."""
+
+import importlib.util
+import json
+import sqlite3
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+MIGRATION_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py"
+)
+
+OLD_SCOPES = ["https://www.googleapis.com/auth/calendar"]
+NEW_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+
+
+def _load_migration_module():
+    spec = importlib.util.spec_from_file_location(
+        "narrow_google_calendar_scope_migration", MIGRATION_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection) -> Operations:
+    return Operations(MigrationContext.configure(connection))
+
+
+def _public_mcp_apps(metadata: sa.MetaData) -> sa.Table:
+    return sa.Table(
+        "public_mcp_apps",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("app_id", sa.String(100), nullable=False, unique=True),
+        sa.Column("oauth_scopes", sa.JSON),
+    )
+
+
+def _scopes_by_app_id(connection, table: sa.Table) -> dict[str, object]:
+    rows = connection.execute(sa.select(table.c.app_id, table.c.oauth_scopes))
+    return {row.app_id: row.oauth_scopes for row in rows}
+
+
+def test_upgrade_narrows_google_calendar_scope_without_touching_other_apps(
+    tmp_path,
+) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            [
+                {"app_id": "google-calendar", "oauth_scopes": OLD_SCOPES},
+                {"app_id": "gmail", "oauth_scopes": ["gmail-scope"]},
+            ],
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes["google-calendar"] == NEW_SCOPES
+    assert scopes["gmail"] == ["gmail-scope"]
+
+
+def test_upgrade_is_idempotent(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            {"app_id": "google-calendar", "oauth_scopes": OLD_SCOPES},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes["google-calendar"] == NEW_SCOPES
+
+
+def test_upgrade_skips_when_row_is_absent(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes == {}
+
+
+def test_upgrade_skips_when_catalog_table_is_absent() -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine("sqlite:///:memory:")
+
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+
+def test_upgrade_skips_when_oauth_scopes_column_is_absent() -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine("sqlite:///:memory:")
+    metadata = sa.MetaData()
+    table = sa.Table(
+        "public_mcp_apps",
+        metadata,
+        sa.Column("app_id", sa.String(100), primary_key=True),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(sa.insert(table), {"app_id": "google-calendar"})
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+
+        stored = connection.execute(sa.select(table)).mappings().one()
+
+    assert stored["app_id"] == "google-calendar"
+
+
+def test_downgrade_restores_the_full_calendar_scope(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            {"app_id": "google-calendar", "oauth_scopes": OLD_SCOPES},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes["google-calendar"] == OLD_SCOPES
+
+
+def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
+    migration = _load_migration_module()
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name="postgresql",
+        opts={"as_sql": True, "output_buffer": output},
+    )
+
+    with Operations.context(context):
+        migration.upgrade()
+
+    sql = output.getvalue()
+    assert sql.count("UPDATE public_mcp_apps SET") == 1
+    assert "oauth_scopes=" in sql
+    assert "public_mcp_apps.app_id = 'google-calendar'" in sql
+    assert "calendar.events" in sql
+    assert "INSERT INTO public_mcp_apps" not in sql
+    assert "DELETE FROM public_mcp_apps" not in sql
+    assert "%(" not in sql
+
+
+def test_offline_sqlite_upgrade_round_trips_json_scope_value() -> None:
+    migration = _load_migration_module()
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name="sqlite",
+        opts={"as_sql": True, "output_buffer": output},
+    )
+
+    with Operations.context(context):
+        migration.upgrade()
+
+    connection = sqlite3.connect(":memory:")
+    connection.execute(
+        "CREATE TABLE public_mcp_apps (app_id TEXT PRIMARY KEY, oauth_scopes JSON)"
+    )
+    connection.execute(
+        "INSERT INTO public_mcp_apps (app_id, oauth_scopes) VALUES (?, ?)",
+        ("google-calendar", json.dumps(OLD_SCOPES)),
+    )
+    connection.executescript(output.getvalue())
+
+    stored = connection.execute(
+        "SELECT oauth_scopes FROM public_mcp_apps WHERE app_id = 'google-calendar'"
+    ).fetchone()
+    connection.close()
+
+    assert stored is not None
+    assert json.loads(stored[0]) == NEW_SCOPES
+
+
+def test_revision_metadata() -> None:
+    migration = _load_migration_module()
+
+    assert migration.revision == "20260817_narrow_google_calendar_scope"
+    assert migration.down_revision == "20260725_add_uploaded_file_recovery_index"

--- a/tests/alembic/test_20260817_narrow_google_calendar_scope.py
+++ b/tests/alembic/test_20260817_narrow_google_calendar_scope.py
@@ -233,7 +233,12 @@ def test_offline_postgresql_downgrade_emits_literal_update_only_sql() -> None:
     assert sql.count("UPDATE public_mcp_apps SET") == 1
     assert "oauth_scopes=" in sql
     assert "public_mcp_apps.app_id = 'google-calendar'" in sql
+    # "auth/calendar" alone is a substring of both OLD_SCOPES and NEW_SCOPES
+    # ("auth/calendar.events"), so it can't distinguish which one was
+    # emitted; assert the narrower scope is absent to catch a swapped
+    # OLD_SCOPES/NEW_SCOPES argument in _downgrade_offline().
     assert "auth/calendar" in sql
+    assert "calendar.events" not in sql
     assert "INSERT INTO public_mcp_apps" not in sql
     assert "DELETE FROM public_mcp_apps" not in sql
     assert "%(" not in sql

--- a/tests/alembic/test_20260817_narrow_google_calendar_scope.py
+++ b/tests/alembic/test_20260817_narrow_google_calendar_scope.py
@@ -267,8 +267,8 @@ def test_offline_postgresql_downgrade_emits_literal_update_only_sql() -> None:
     # "auth/calendar" alone is a substring of both OLD_SCOPES and NEW_SCOPES
     # ("auth/calendar.events"), so it can't distinguish which one was
     # emitted; assert the narrower scope is absent to catch a swapped
-    # OLD_SCOPES/NEW_SCOPES argument in downgrade()'s _set_calendar_scopes()
-    # call.
+    # OLD_SCOPES/NEW_SCOPES argument in downgrade()'s
+    # _set_calendar_scopes_offline() call.
     assert "auth/calendar" in sql
     assert "calendar.events" not in sql
     assert "INSERT INTO public_mcp_apps" not in sql
@@ -317,6 +317,13 @@ def test_migration_fields_match_registry() -> None:
     )
 
     assert list(migration.NEW_SCOPES) == registry_row["oauth_scopes"]
+    # This file's own OLD_SCOPES/NEW_SCOPES (used throughout the tests above)
+    # are a separate copy of the migration's constants, not a reference to
+    # them -- if the migration's values ever changed without this file's
+    # copy following, every test above would keep passing against a stale
+    # expectation instead of failing loudly.
+    assert list(migration.OLD_SCOPES) == OLD_SCOPES
+    assert list(migration.NEW_SCOPES) == NEW_SCOPES
 
 
 def test_revision_metadata() -> None:

--- a/tests/alembic/test_20260817_narrow_google_calendar_scope.py
+++ b/tests/alembic/test_20260817_narrow_google_calendar_scope.py
@@ -122,6 +122,10 @@ def test_upgrade_skips_when_catalog_table_is_absent() -> None:
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
 
+        # Not just "didn't raise": confirm it truly no-op'd rather than, say,
+        # creating the table it was supposed to find missing.
+        assert sa.inspect(connection).get_table_names() == []
+
 
 def test_upgrade_skips_when_oauth_scopes_column_is_absent() -> None:
     migration = _load_migration_module()
@@ -165,6 +169,33 @@ def test_downgrade_restores_the_full_calendar_scope(tmp_path) -> None:
         scopes = _scopes_by_app_id(connection, table)
 
     assert scopes["google-calendar"] == OLD_SCOPES
+
+
+def test_downgrade_restores_the_full_calendar_scope_without_touching_other_apps(
+    tmp_path,
+) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            [
+                {"app_id": "google-calendar", "oauth_scopes": NEW_SCOPES},
+                {"app_id": "gmail", "oauth_scopes": ["gmail-scope"]},
+            ],
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.downgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes["google-calendar"] == OLD_SCOPES
+    assert scopes["gmail"] == ["gmail-scope"]
 
 
 def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
@@ -236,7 +267,7 @@ def test_offline_postgresql_downgrade_emits_literal_update_only_sql() -> None:
     # "auth/calendar" alone is a substring of both OLD_SCOPES and NEW_SCOPES
     # ("auth/calendar.events"), so it can't distinguish which one was
     # emitted; assert the narrower scope is absent to catch a swapped
-    # OLD_SCOPES/NEW_SCOPES argument in _downgrade_offline().
+    # OLD_SCOPES/NEW_SCOPES argument in downgrade()'s _apply_scope() call.
     assert "auth/calendar" in sql
     assert "calendar.events" not in sql
     assert "INSERT INTO public_mcp_apps" not in sql
@@ -272,6 +303,19 @@ def test_offline_sqlite_downgrade_round_trips_json_scope_value() -> None:
 
     assert stored is not None
     assert json.loads(stored[0]) == OLD_SCOPES
+
+
+def test_migration_scope_matches_registry() -> None:
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    migration = _load_migration_module()
+    registry_row = next(
+        row
+        for row in get_builtin_public_mcp_app_rows()
+        if row["app_id"] == "google-calendar"
+    )
+
+    assert list(migration.NEW_SCOPES) == registry_row["oauth_scopes"]
 
 
 def test_revision_metadata() -> None:


### PR DESCRIPTION
## Summary
- The Google Calendar connector's tools only ever operate on events (search, create, get, update, delete), never on calendar list management, so requesting the full `https://www.googleapis.com/auth/calendar` scope asked for more access than the feature set uses.
- Narrows the scope to `https://www.googleapis.com/auth/calendar.events` in the built-in connector registry — this is what actually narrows future first-time authorizations, since a builtin app's OAuth scope is sourced live from the registry at authorize time, not from the DB row.
- Adds a migration to converge the already-seeded `public_mcp_apps.oauth_scopes` catalog row to the new scope (online + offline SQL, upgrade + downgrade). The catalog row itself doesn't drive authorize-time behavior; this only keeps the startup drift-checker (`validate_builtin_public_mcp_apps`) from permanently flagging a mismatch on an already-seeded database, since the app seeder is insert-only and never re-runs. The online path safely no-ops when the table/columns are absent; the offline `--sql` path can't do that check (no live connection to inspect), which matches the existing offline-mode convention elsewhere in this migration set.

This is a re-cut of #1417, scoped down to just the original minimal fix (single commit), rebased onto current `main`. #1417 accumulated review rounds around a separate, larger question — how to handle already-issued OAuth grants when narrowing a scope (revocation, rollout sequencing, etc.) — which is a product/ops decision out of scope for this change and is being tracked separately. This PR intentionally does not touch already-issued `user_oauth` grants: narrowing a scope doesn't require re-consent for a token that already has the (now broader) old scope to keep working.

## Test plan
- [x] `pytest tests/alembic/test_20260817_narrow_google_calendar_scope.py` (13 cases: upgrade/downgrade, idempotency, missing row/table/column, offline SQL for postgres/sqlite, registry-parity, revision metadata)
- [x] `alembic heads` resolves to a single head with this migration on top
- [x] `ruff check`, `ruff format --check`, pre-commit hooks all pass
