### PR TITLE
enh: install the Docker CLI instead of the full docker.io engine

### DIFF
--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -160,17 +160,22 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg -
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
 
-# Docker CLI only: no daemon runs in this container, so docker.io's engine +
-# containerd + runc are dead weight. Swapped rather than dropped because
-# command_policy.py gates the agent shell by path -- /usr/bin/docker must stay.
-# arch must come from `dpkg --print-architecture` or the arm64 image breaks;
-# --no-install-recommends keeps the buildx/compose plugins out.
+# Docker CLI only: no daemon runs here, so docker.io's engine + containerd +
+# runc are dead weight. Swapped rather than dropped because command_policy.py
+# gates the agent shell by path -- /usr/bin/docker must stay. arch must come
+# from `dpkg --print-architecture` or the arm64 image breaks.
+# --no-install-recommends drops buildx/compose (+109 MiB): plain `docker build`
+# still works via the legacy builder, DOCKER_BUILDKIT=1 hard-errors. Supported
+# paths are the Python SDK and the sandbox overlay, not ad-hoc CLI builds.
 # See https://github.com/xorbitsai/xagent/pull/1807
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker.gpg \
     && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
         > /etc/apt/sources.list.d/docker.list \
     && apt-get update \
     && apt-get install -y --no-install-recommends docker-ce-cli \
+    && test -x /usr/bin/docker \
+    && docker --version \
+    && ! command -v dockerd \
     && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/docker.list /usr/share/keyrings/docker.gpg
 
 # Browser for the built-in "chrome" MCP connector (chrome-devtools-mcp).

--- a/docker/Dockerfile.backend
+++ b/docker/Dockerfile.backend
@@ -120,7 +120,6 @@ RUN if [ -n "$APT_MIRROR" ]; then \
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
-    docker.io \
     gnupg \
     openssl \
     libreoffice \
@@ -160,6 +159,19 @@ RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg -
     && apt-get update \
     && apt-get install -y --no-install-recommends nodejs \
     && rm -rf /var/lib/apt/lists/*
+
+# Docker CLI only: no daemon runs in this container, so docker.io's engine +
+# containerd + runc are dead weight. Swapped rather than dropped because
+# command_policy.py gates the agent shell by path -- /usr/bin/docker must stay.
+# arch must come from `dpkg --print-architecture` or the arm64 image breaks;
+# --no-install-recommends keeps the buildx/compose plugins out.
+# See https://github.com/xorbitsai/xagent/pull/1807
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /usr/share/keyrings/docker.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg] https://download.docker.com/linux/debian $(. /etc/os-release && echo "$VERSION_CODENAME") stable" \
+        > /etc/apt/sources.list.d/docker.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends docker-ce-cli \
+    && rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/docker.list /usr/share/keyrings/docker.gpg
 
 # Browser for the built-in "chrome" MCP connector (chrome-devtools-mcp).
 # Gated behind INSTALL_CHROME (default true: the default build invocation is

--- a/tests/test_docker_workflow_versions.py
+++ b/tests/test_docker_workflow_versions.py
@@ -221,16 +221,38 @@ def test_backend_dockerfile_installs_docker_cli_without_the_daemon() -> None:
 
     dockerfile = read_repo_file("docker/Dockerfile.backend")
 
-    assert "docker-ce-cli" in dockerfile
-    assert "\n    docker.io \\" not in dockerfile
+    # `runtime` is FROM runtime-base and copies no apt layer out of the build
+    # stages, so an install that drifted into backend-base would ship an image
+    # with no /usr/bin/docker at all.
+    runtime_base = dockerfile.split(
+        "FROM python:${PYTHON_VERSION}-bookworm AS runtime-base\n", maxsplit=1
+    )[1].split("\nFROM ", maxsplit=1)[0]
+    block = next(
+        chunk for chunk in runtime_base.split("\n\n") if "docker-ce-cli" in chunk
+    )
+    install = "\n".join(line for line in block.splitlines() if not line.startswith("#"))
+
     # Hardcoding an arch here would break the arm64 image (docker-publish.yml
     # publishes amd64 + arm64); --no-install-recommends keeps
     # docker-buildx-plugin/docker-compose-plugin out.
     assert (
         "arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg"
-        in dockerfile
+        in install
     )
-    assert "--no-install-recommends docker-ce-cli" in dockerfile
+    assert "--no-install-recommends docker-ce-cli \\" in install
+    for daemon_package in ("docker.io", "docker-ce ", "containerd", "runc"):
+        assert daemon_package not in install
+
+    # The key and source list must be dropped by the same layer that added
+    # them, or download.docker.com stays resolvable in the running container.
+    assert (
+        "rm -rf /var/lib/apt/lists/* /etc/apt/sources.list.d/docker.list"
+        " /usr/share/keyrings/docker.gpg" in install
+    )
+    # Smoke-tested during the build so a broken swap fails on both published
+    # architectures instead of shipping.
+    assert "test -x /usr/bin/docker \\" in install
+    assert "! command -v dockerd \\" in install
 
 
 def test_backend_package_version_is_vcs_based_for_normal_builds() -> None:

--- a/tests/test_docker_workflow_versions.py
+++ b/tests/test_docker_workflow_versions.py
@@ -212,6 +212,27 @@ def test_backend_runtime_keeps_uv_binaries() -> None:
     assert dockerfile.count("COPY --from=uv /uv /uvx /usr/local/bin/") == 2
 
 
+def test_backend_dockerfile_installs_docker_cli_without_the_daemon() -> None:
+    """docker.io ships an engine + containerd + runc that a daemonless
+    container never uses, but /usr/bin/docker must survive the swap:
+    command_policy.py gates the agent shell by path, not by an allowlist.
+    See https://github.com/xorbitsai/xagent/pull/1807
+    """
+
+    dockerfile = read_repo_file("docker/Dockerfile.backend")
+
+    assert "docker-ce-cli" in dockerfile
+    assert "\n    docker.io \\" not in dockerfile
+    # Hardcoding an arch here would break the arm64 image (docker-publish.yml
+    # publishes amd64 + arm64); --no-install-recommends keeps
+    # docker-buildx-plugin/docker-compose-plugin out.
+    assert (
+        "arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker.gpg"
+        in dockerfile
+    )
+    assert "--no-install-recommends docker-ce-cli" in dockerfile
+
+
 def test_backend_package_version_is_vcs_based_for_normal_builds() -> None:
     pyproject = read_repo_file("pyproject.toml")
 


### PR DESCRIPTION
## What

Replace Debian's `docker.io` in the backend runtime stage with Docker's official `docker-ce-cli`.

## Why

`docker/Dockerfile.backend` installs `docker.io`, which ships the full Docker **daemon** plus `containerd`, `runc` and `tini`. **No daemon runs in this container.** Every Docker call xagent makes is a client call over a socket:

- `src/xagent/sandbox/docker_sandbox.py` and `src/xagent/core/tools/core/mcp/docker_manager.py` both go through the Python SDK.
- `docker/docker-compose.sandbox.docker.yml` bind-mounts the **host's** `/var/run/docker.sock` and sets `DOCKER_HOST`.

So the image has been carrying an engine, a container runtime and an init supervisor purely to get `/usr/bin/docker`. That cost is paid on every CI push, every registry pull, and three times over in `docker-compose.yml` — `backend`, `worker` and `scheduler` all run this image.

| package set | amd64 download | amd64 installed | arm64 download | arm64 installed |
|---|---|---|---|---|
| `docker.io` + `containerd` + `runc` + `tini` | 65.9 MB | 265 MB | 46.2 MB | 224 MB |
| `docker-ce-cli` | 17.0 MB | 45.9 MB | 15.3 MB | 43.4 MB |
| **net saving** | **−48.9 MB** | **−219 MB** | **−30.9 MB** | **−181 MB** |

Measured, not estimated — `apt-get` output from real installs into `python:3.11-bookworm` on both platforms (see Verification).

Side effect worth knowing: Debian's `docker.io` is a **20.10.24** client; `docker-ce-cli` is **29.7.2**. So this also moves the CLI forward nine major versions. The Docker CLI negotiates its API version down when talking to an older host daemon, so it stays compatible with whatever the host runs.

## Why swap the package instead of just deleting it

This is the part worth reviewing. `src/xagent/core/tools/core/command_policy.py` gates the agent's shell tool **by path, not by an allowlist** — any executable resolving under `/bin`, `/usr/bin` or `/usr/local/bin` is runnable. `docker.io` installs `/usr/bin/docker`, so an agent writing `docker ps` in a `command_executor` call works today.

No repo skill or prompt instructs it to, so this is undocumented-but-reachable behaviour rather than a designed feature — but the tool accepts free-form commands, and deleting the package outright would turn it into a silent `command not found` regression. Keeping the CLI preserves the binary at ~45 MB installed instead of 224–265 MB.

## Multi-arch care

`docker-publish.yml` publishes `linux/amd64,linux/arm64`, with arm64 built under QEMU. Two details are load-bearing and are commented in the Dockerfile:

- **`arch=$(dpkg --print-architecture)`, never a hardcoded arch.** The Chrome branch further down hardcodes `arch=amd64` because it sits *inside* an amd64-only branch; copying that pattern here would break the arm64 image. `download.docker.com`'s bookworm pool carries `docker-ce-cli` for both published arches.
- **`--no-install-recommends`**, or `docker-buildx-plugin` and `docker-compose-plugin` return as Recommends and eat the saving.

The keyring and source list are removed in the same layer once installed, mirroring the Chrome branch — otherwise `download.docker.com` stays resolvable via `apt-get update` inside a running container for no benefit.

The CLI negotiates its API version down when talking to an older host daemon, so it stays compatible with whatever the host runs.

## Scope

Two files. `docker/README.md` does not document the runtime apt list, so no doc change is needed. The X libs, LibreOffice, Chrome and the deepdoc models are all untouched.

## Verification

`pytest tests/test_docker_workflow_versions.py` — **23 passed**. The new test was confirmed to have teeth: reverting only the Dockerfile makes it fail on `assert "docker-ce-cli" in dockerfile`. `ruff format --check` and `ruff check` clean.

The new `RUN` block was then built in isolation on **both published architectures** (`linux/amd64`, `linux/arm64`) against the same `python:3.11-bookworm` base, asserting:

```
dpkg --print-architecture     # amd64 / arm64
docker --version              # Docker version 29.7.2, build a7dcaa6  (both)
test -x /usr/bin/docker       # the path command_policy.py resolves
! command -v dockerd          # no daemon
! command -v containerd       # no runtime
! docker buildx version       # --no-install-recommends held
test ! -f /etc/apt/sources.list.d/docker.list
test ! -f /usr/share/keyrings/docker.gpg
```

`ALL ASSERTIONS PASSED` on both. This exercises the parts that could actually regress — the repo definition, the `arch=$(dpkg --print-architecture)` expression, package availability per arch, Recommends suppression, and the same-layer cleanup — without waiting on a full multi-hour backend build.

Not run locally: the complete `docker/Dockerfile.backend` two-arch build and an end-to-end `docker compose up`. Those are left to CI. Nothing else in the image is touched by this change.
