### PR TITLE
feat: publish a Docker Hub overview for the sandbox image

### DIFF
--- a/.github/workflows/sandbox-publish.yml
+++ b/.github/workflows/sandbox-publish.yml
@@ -83,3 +83,13 @@ jobs:
           labels: ${{ steps.meta-sandbox.outputs.labels }}
           cache-from: type=registry,ref=${{ env.SANDBOX_IMAGE }}:buildcache
           cache-to: ${{ (github.event_name != 'workflow_dispatch' || github.event.inputs.push_to_dockerhub == 'true') && format('type=registry,ref={0}:buildcache,mode=max', env.SANDBOX_IMAGE) || '' }}
+
+      - name: Update Docker Hub repository description
+        if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.push_to_dockerhub == 'true' }}
+        uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          repository: ${{ env.SANDBOX_IMAGE }}
+          short-description: "Sandbox runtime image for Xagent: isolated Node.js and Python execution for agent tool calls"
+          readme-filepath: ./docker/README.sandbox.md

--- a/.github/workflows/sandbox-publish.yml
+++ b/.github/workflows/sandbox-publish.yml
@@ -86,6 +86,9 @@ jobs:
 
       - name: Update Docker Hub repository description
         if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.push_to_dockerhub == 'true' }}
+        # WHY: this PATCH needs a stronger Hub entitlement than the image push,
+        # so a 403 here must not fail a release whose image is already public.
+        continue-on-error: true
         uses: peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa # v5.0.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}

--- a/docker/README.md
+++ b/docker/README.md
@@ -389,7 +389,7 @@ group from the lockfile and checks all supported imports during the image build.
 The build stage does not copy `pyproject.toml` or `uv.lock` into the runtime
 image.
 
-Custom `SANDBOX_IMAGE` images must stay runtime-compatible with `docker/Dockerfile.sandbox`. On `PATH` they need `python` and `node` (tool code runs as `python -c ...` and `node -e ...`, see `Sandbox.run_code` in `src/xagent/sandbox/base.py`), `pip` for run-time dependency installs, and `cat`, `rm`, `mkdir`, `/bin/sh` plus a writable `/tmp` for staging and cleanup; the Docker backend additionally needs `tail`, since it replaces the image `CMD` with `tail -f /dev/null`. `npx` and `uvx` are required only for sandboxed `npx`/`uvx` MCP connections — Xagent no longer installs `uv` dynamically.
+Custom `SANDBOX_IMAGE` images must stay runtime-compatible with `docker/Dockerfile.sandbox`. On `PATH` they need `python` and `node` (tool code runs as `python -c ...` and `node -e ...`, see `Sandbox.run_code` in `src/xagent/sandbox/base.py`), `pip` for run-time dependency installs, and `cat`, `rm`, `mkdir`, `/bin/sh` plus a writable `/tmp` for staging and cleanup; the Docker backend additionally needs `tail`, since it replaces the image `CMD` with `tail -f /dev/null`, and the Boxlite backend additionally needs `test`, `cp`, `mv` and a writable `/var/tmp`, which it stages file transfers through because it cannot copy into the tmpfs `/tmp`. `npx` and `uvx` are required only for sandboxed `npx`/`uvx` MCP connections — Xagent no longer installs `uv` dynamically.
 
 ```bash
 docker buildx build \
@@ -520,8 +520,9 @@ GHCR publishing.
      - Create at: https://hub.docker.com/settings/security
      - "Read & Write" is enough to push images. The sandbox workflow also
        updates the `xprobe/xagent-sandbox` Hub description with this same
-       token, which needs "Read, Write, Delete" scope and Admin access on
-       the repository
+       token; that step additionally needs "Read, Write, Delete" scope and
+       Admin access on the repository, and is allowed to fail without
+       failing the release when the token lacks them
 
 2. Ensure Docker Hub repositories exist:
    - `xprobe/xagent-backend`

--- a/docker/README.md
+++ b/docker/README.md
@@ -389,8 +389,7 @@ group from the lockfile and checks all supported imports during the image build.
 The build stage does not copy `pyproject.toml` or `uv.lock` into the runtime
 image.
 
-Custom `SANDBOX_IMAGE` images used with sandboxed uvx MCP connections must
-provide `uvx` on `PATH`; Xagent no longer installs uv dynamically.
+Custom `SANDBOX_IMAGE` images must provide `python`, `node`, and `uvx` on `PATH`. Xagent runs Python and JavaScript tool code as `python -c ...` and `node -e ...` (see `Sandbox.run_code` in `src/xagent/sandbox/base.py`), and it no longer installs uv dynamically for sandboxed uvx MCP connections.
 
 ```bash
 docker buildx build \
@@ -406,6 +405,8 @@ manual tags. After a new sandbox tag is published, update the `SANDBOX_IMAGE`
 pins in `docker/docker-compose.sandbox.boxlite.yml` and
 `docker/docker-compose.sandbox.docker.yml` to reference it. Rolling back only
 requires restoring the previous sandbox image tag.
+
+The same workflow publishes `docker/README.sandbox.md` as the Docker Hub overview for [`xprobe/xagent-sandbox`](https://hub.docker.com/r/xprobe/xagent-sandbox). That file is the public description of the image, so keep it in step with changes to the `sandbox` dependency group, the runtime requirements above, or the sandbox lifecycle. It only reaches Docker Hub when the image is published, so an edit merged without a release tag will not appear until the next publish.
 
 ### Frontend
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -389,7 +389,7 @@ group from the lockfile and checks all supported imports during the image build.
 The build stage does not copy `pyproject.toml` or `uv.lock` into the runtime
 image.
 
-Custom `SANDBOX_IMAGE` images must provide `python`, `node`, and `uvx` on `PATH`. Xagent runs Python and JavaScript tool code as `python -c ...` and `node -e ...` (see `Sandbox.run_code` in `src/xagent/sandbox/base.py`), and it no longer installs uv dynamically for sandboxed uvx MCP connections.
+Custom `SANDBOX_IMAGE` images must provide `python`, `node`, and `uvx` on `PATH`. Xagent runs Python and JavaScript tool code as `python -c ...` and `node -e ...` (see `Sandbox.run_code` in `src/xagent/sandbox/base.py`), and it no longer installs `uv` dynamically for sandboxed `uvx` MCP connections.
 
 ```bash
 docker buildx build \

--- a/docker/README.md
+++ b/docker/README.md
@@ -389,7 +389,7 @@ group from the lockfile and checks all supported imports during the image build.
 The build stage does not copy `pyproject.toml` or `uv.lock` into the runtime
 image.
 
-Custom `SANDBOX_IMAGE` images must provide `python`, `node`, and `uvx` on `PATH`. Xagent runs Python and JavaScript tool code as `python -c ...` and `node -e ...` (see `Sandbox.run_code` in `src/xagent/sandbox/base.py`), and it no longer installs `uv` dynamically for sandboxed `uvx` MCP connections.
+Custom `SANDBOX_IMAGE` images must stay runtime-compatible with `docker/Dockerfile.sandbox`. On `PATH` they need `python` and `node` (tool code runs as `python -c ...` and `node -e ...`, see `Sandbox.run_code` in `src/xagent/sandbox/base.py`), `pip` for run-time dependency installs, and `cat`, `rm`, `mkdir`, `/bin/sh` plus a writable `/tmp` for staging and cleanup; the Docker backend additionally needs `tail`, since it replaces the image `CMD` with `tail -f /dev/null`. `npx` and `uvx` are required only for sandboxed `npx`/`uvx` MCP connections — Xagent no longer installs `uv` dynamically.
 
 ```bash
 docker buildx build \
@@ -403,8 +403,11 @@ The `Publish Sandbox Image` workflow in
 `.github/workflows/sandbox-publish.yml` publishes release tags and supports
 manual tags. After a new sandbox tag is published, update the `SANDBOX_IMAGE`
 pins in `docker/docker-compose.sandbox.boxlite.yml` and
-`docker/docker-compose.sandbox.docker.yml` to reference it. Rolling back only
-requires restoring the previous sandbox image tag.
+`docker/docker-compose.sandbox.docker.yml` to reference it. Rolling back means
+restoring the previous tag, but the change is not free: Xagent reconciles
+running sandboxes against the new image spec, so they are stopped, deleted and
+recreated. Bind-mounted workspace and upload data survives; the container's
+writable layer (`/tmp`, `$HOME`, packages a tool installed at run time) does not.
 
 The same workflow publishes `docker/README.sandbox.md` as the Docker Hub overview for [`xprobe/xagent-sandbox`](https://hub.docker.com/r/xprobe/xagent-sandbox). That file is the public description of the image, so keep it in step with changes to the `sandbox` dependency group, the runtime requirements above, or the sandbox lifecycle. It only reaches Docker Hub when the image is published, so an edit merged without a release tag will not appear until the next publish.
 
@@ -515,7 +518,10 @@ GHCR publishing.
    - Add `DOCKERHUB_USERNAME`: Your Docker Hub username
    - Add `DOCKERHUB_PASSWORD`: Your Docker Hub access token (not your password)
      - Create at: https://hub.docker.com/settings/security
-     - Use "Read & Write" permissions for pushing images
+     - "Read & Write" is enough to push images. The sandbox workflow also
+       updates the `xprobe/xagent-sandbox` Hub description with this same
+       token, which needs "Read, Write, Delete" scope and Admin access on
+       the repository
 
 2. Ensure Docker Hub repositories exist:
    - `xprobe/xagent-backend`

--- a/docker/README.sandbox.md
+++ b/docker/README.sandbox.md
@@ -1,8 +1,8 @@
 # Xagent Sandbox
 
-Sandbox runtime image for [Xagent](https://github.com/xorbitsai/xagent), an open-source framework for building and running AI agents. Agents delegate untrusted work — generated Python and JavaScript, shell commands, `uvx` MCP servers — to a sandbox built from this image, so tool calls never execute inside the Xagent backend.
+Sandbox runtime image for [Xagent](https://github.com/xorbitsai/xagent), an open-source framework for building and running AI agents. With sandboxing enabled, Xagent delegates untrusted work — generated Python and JavaScript, shell commands, `npx`/`uvx` MCP servers — to a sandbox built from this image rather than running it in the backend process.
 
-A sandbox is a **named, stateful workspace**, not a throwaway container. Xagent creates one on demand, keeps it alive, and execs into it for each subsequent tool call. Stopping a sandbox preserves its filesystem; the next request resumes it. Xagent can also commit a sandbox's filesystem to a snapshot and use that snapshot — rather than this image — as the template for a new one.
+A sandbox is a **named, stateful workspace**, not a throwaway container. Xagent creates one on demand, keeps it alive, and execs into it for each subsequent tool call. Stopping a sandbox preserves its filesystem; the next request resumes it. On the Docker backend, Xagent can also commit a sandbox's filesystem to a snapshot and use that snapshot — rather than this image — as the template for a new one; the Boxlite backend does not support snapshots.
 
 This image is that starting template. It has no service of its own: its `CMD` is a plain `bash`, which Xagent replaces with a long-running idle process.
 
@@ -18,18 +18,20 @@ The Python set comes only from the dedicated `sandbox` dependency group in Xagen
 
 ## Isolation
 
+Sandboxing is opt-in: Xagent runs tool calls in the backend process unless `SANDBOX_ENABLED=true`, and falls back to the backend when no sandbox backend is available or a tool cannot be wrapped. What follows applies to work that does reach a sandbox.
+
 The isolation comes from how the sandbox is run, not from this image. Xagent's Docker backend applies `no-new-privileges`, CPU and memory limits, and optional network isolation; its Boxlite backend runs the sandbox inside a KVM microVM. See [docker/README.md](https://github.com/xorbitsai/xagent/blob/main/docker/README.md) for the two modes and their trade-offs.
 
 The image itself defines an unprivileged `sandbox` user (uid 1100, gid 1010) as its default. Note that Xagent's Docker backend deliberately overrides this and runs the container as root, to match the file access behavior of the Boxlite backend.
 
 ## Tags
 
-- `latest` — the most recent release
-- `X.Y.Z` — semantic version tags matching [Xagent releases](https://github.com/xorbitsai/xagent/releases)
+- `latest` — the most recently published build
+- `X.Y.Z` — published from the matching Git tag; see [Xagent releases](https://github.com/xorbitsai/xagent/releases)
 
 Built for `linux/amd64` and `linux/arm64`.
 
-Pin an explicit version in production. Xagent's sandbox Compose overlays pin one, and rolling back is just restoring the previous tag.
+Pin an explicit version in production; Xagent's sandbox Compose overlays pin one. Changing that pin is not a free rollback: Xagent reconciles running sandboxes against the new image spec, stopping, deleting and recreating them. Bind-mounted workspace and upload data survives; the container's writable layer — `/tmp`, `$HOME`, packages a tool installed at run time — does not. Drain or back up that state before switching tags.
 
 ## Usage
 
@@ -48,13 +50,17 @@ docker run --rm -it xprobe/xagent-sandbox:latest bash
 
 ## Building a custom sandbox image
 
-A replacement image must provide, on `PATH`:
+A replacement image has to stay runtime-compatible with [`docker/Dockerfile.sandbox`](https://github.com/xorbitsai/xagent/blob/main/docker/Dockerfile.sandbox), which is the easiest starting point. Every sandbox needs, on `PATH`:
 
-- `python` — Xagent runs Python tool code as `python -c ...`
-- `node` — and JavaScript tool code as `node -e ...`
-- `uvx` — Xagent no longer installs `uv` dynamically
+- `python` and `node` — tool code runs as `python -c ...` and `node -e ...`
+- `pip` — tools install their declared dependencies after the container starts
+- `cat`, `rm`, `mkdir`, `/bin/sh`, and a writable `/tmp` — staging input, reading results back, cleanup
+- `tail` — the Docker backend replaces the image's `CMD` with `tail -f /dev/null` to hold the container open
 
-Start from [`docker/Dockerfile.sandbox`](https://github.com/xorbitsai/xagent/blob/main/docker/Dockerfile.sandbox).
+Only if you use the matching feature:
+
+- `npx` — sandboxed `npx` MCP servers
+- `uvx` — sandboxed `uvx` MCP servers; Xagent no longer installs `uv` dynamically
 
 ## Links
 

--- a/docker/README.sandbox.md
+++ b/docker/README.sandbox.md
@@ -1,0 +1,63 @@
+# Xagent Sandbox
+
+Sandbox runtime image for [Xagent](https://github.com/xorbitsai/xagent), an open-source framework for building and running AI agents. Agents delegate untrusted work — generated Python and JavaScript, shell commands, `uvx` MCP servers — to a sandbox built from this image, so tool calls never execute inside the Xagent backend.
+
+A sandbox is a **named, stateful workspace**, not a throwaway container. Xagent creates one on demand, keeps it alive, and execs into it for each subsequent tool call. Stopping a sandbox preserves its filesystem; the next request resumes it. Xagent can also commit a sandbox's filesystem to a snapshot and use that snapshot — rather than this image — as the template for a new one.
+
+This image is that starting template. It has no service of its own: its `CMD` is a plain `bash`, which Xagent replaces with a long-running idle process.
+
+## What's inside
+
+- **Node.js 22** (`node:22-slim` base) and **Python 3.11**, both on `PATH` as `node` and `python`
+- **`uv` / `uvx`**, for sandboxed `uvx` MCP server connections
+- A deliberately small, lockfile-pinned Python set: `pydantic`, `pydantic-settings`, `cloudpickle`, `mcp`, `pandas`, `numpy`, `matplotlib`, `openpyxl`, `python-docx`, `fsspec`
+- `ca-certificates`, `tzdata`, `netbase`, and `openssh-client`
+- `pip install` permitted without `--break-system-packages`, so tools can pull their own declared dependencies after the container starts
+
+The Python set comes only from the dedicated `sandbox` dependency group in Xagent's `pyproject.toml`, exported from `uv.lock` at build time. It intentionally does not inherit the backend image's much larger dependency set, and the build fails if any supported package is missing from the result.
+
+## Isolation
+
+The isolation comes from how the sandbox is run, not from this image. Xagent's Docker backend applies `no-new-privileges`, CPU and memory limits, and optional network isolation; its Boxlite backend runs the sandbox inside a KVM microVM. See [docker/README.md](https://github.com/xorbitsai/xagent/blob/main/docker/README.md) for the two modes and their trade-offs.
+
+The image itself defines an unprivileged `sandbox` user (uid 1100, gid 1010) as its default. Note that Xagent's Docker backend deliberately overrides this and runs the container as root, to match the file access behavior of the Boxlite backend.
+
+## Tags
+
+- `latest` — the most recent release
+- `X.Y.Z` — semantic version tags matching [Xagent releases](https://github.com/xorbitsai/xagent/releases)
+
+Built for `linux/amd64` and `linux/arm64`.
+
+Pin an explicit version in production. Xagent's sandbox Compose overlays pin one, and rolling back is just restoring the previous tag.
+
+## Usage
+
+Xagent selects the image through the `SANDBOX_IMAGE` environment variable, which defaults to `xprobe/xagent-sandbox:latest`:
+
+```yaml
+environment:
+  - SANDBOX_IMAGE=xprobe/xagent-sandbox:latest
+```
+
+To inspect the image directly:
+
+```bash
+docker run --rm -it xprobe/xagent-sandbox:latest bash
+```
+
+## Building a custom sandbox image
+
+A replacement image must provide, on `PATH`:
+
+- `python` — Xagent runs Python tool code as `python -c ...`
+- `node` — and JavaScript tool code as `node -e ...`
+- `uvx` — Xagent no longer installs `uv` dynamically
+
+Start from [`docker/Dockerfile.sandbox`](https://github.com/xorbitsai/xagent/blob/main/docker/Dockerfile.sandbox).
+
+## Links
+
+- [Source and documentation](https://github.com/xorbitsai/xagent)
+- [Dockerfile](https://github.com/xorbitsai/xagent/blob/main/docker/Dockerfile.sandbox)
+- [Issue tracker](https://github.com/xorbitsai/xagent/issues)

--- a/docker/README.sandbox.md
+++ b/docker/README.sandbox.md
@@ -4,7 +4,7 @@ Sandbox runtime image for [Xagent](https://github.com/xorbitsai/xagent), an open
 
 A sandbox is a **named, stateful workspace**, not a throwaway container. Xagent creates one on demand, keeps it alive, and execs into it for each subsequent tool call. Stopping a sandbox preserves its filesystem; the next request resumes it. On the Docker backend, Xagent can also commit a sandbox's filesystem to a snapshot and use that snapshot — rather than this image — as the template for a new one; the Boxlite backend does not support snapshots.
 
-This image is that starting template. It has no service of its own: its `CMD` is a plain `bash`, which Xagent replaces with a long-running idle process.
+This image is that starting template. It has no service of its own: its `CMD` is a plain `bash`, which the Docker backend replaces with a long-running idle process.
 
 ## What's inside
 
@@ -27,7 +27,7 @@ The image itself defines an unprivileged `sandbox` user (uid 1100, gid 1010) as 
 ## Tags
 
 - `latest` — the most recently published build
-- `X.Y.Z` — published from the matching Git tag; see [Xagent releases](https://github.com/xorbitsai/xagent/releases)
+- `X.Y.Z` — published by pushing the matching Git tag, though a manual run can publish an arbitrary tag; see [Xagent releases](https://github.com/xorbitsai/xagent/releases)
 
 Built for `linux/amd64` and `linux/arm64`.
 
@@ -56,6 +56,7 @@ A replacement image has to stay runtime-compatible with [`docker/Dockerfile.sand
 - `pip` — tools install their declared dependencies after the container starts
 - `cat`, `rm`, `mkdir`, `/bin/sh`, and a writable `/tmp` — staging input, reading results back, cleanup
 - `tail` — the Docker backend replaces the image's `CMD` with `tail -f /dev/null` to hold the container open
+- `test`, `cp`, `mv`, and a writable `/var/tmp` — the Boxlite backend stages every file transfer there before moving it into place, because `/tmp` is a tmpfs mount it cannot copy into
 
 Only if you use the matching feature:
 

--- a/tests/test_docker_workflow_versions.py
+++ b/tests/test_docker_workflow_versions.py
@@ -5,7 +5,9 @@ import re
 import subprocess
 import tomllib
 from pathlib import Path
+from typing import Any, cast
 
+import yaml
 from packaging.requirements import Requirement
 from packaging.utils import canonicalize_name
 from packaging.version import Version
@@ -405,3 +407,33 @@ def test_uv_export_locked_sandbox_group_contains_direct_distributions() -> None:
 
     for distribution in SANDBOX_DISTRIBUTION_IMPORTS:
         assert re.search(rf"^{re.escape(distribution)}==", result.stdout, re.MULTILINE)
+
+
+def sandbox_publish_step(name: str) -> dict[str, Any]:
+    workflow = yaml.safe_load(read_workflow("sandbox-publish.yml"))
+    for step in workflow["jobs"]["build-and-push"]["steps"]:
+        if step.get("name") == name:
+            return cast(dict[str, Any], step)
+    raise AssertionError(f"sandbox-publish.yml has no step named {name!r}")
+
+
+def test_sandbox_hub_description_step_is_sha_pinned_to_the_sandbox_repository() -> None:
+    step = sandbox_publish_step("Update Docker Hub repository description")
+
+    assert step["uses"] == (
+        "peter-evans/dockerhub-description@1b9a80c056b620d92cedb9d9b5a223409c68ddfa"
+    )
+    assert step["with"]["repository"] == "${{ env.SANDBOX_IMAGE }}"
+    assert step["with"]["readme-filepath"] == "./docker/README.sandbox.md"
+    assert step["with"]["username"] == "${{ secrets.DOCKERHUB_USERNAME }}"
+    assert step["with"]["password"] == "${{ secrets.DOCKERHUB_PASSWORD }}"
+
+
+# WHY: the Hub description is repository-global, not tag-scoped, so a
+# push_to_dockerhub=false dry run must not reach it.
+def test_sandbox_hub_description_gate_equals_the_image_push_gate() -> None:
+    description = sandbox_publish_step("Update Docker Hub repository description")
+    build = sandbox_publish_step("Build and push sandbox image")
+
+    assert description["if"] == build["with"]["push"]
+    assert "push_to_dockerhub == 'true'" in description["if"]

--- a/tests/test_docker_workflow_versions.py
+++ b/tests/test_docker_workflow_versions.py
@@ -437,3 +437,23 @@ def test_sandbox_hub_description_gate_equals_the_image_push_gate() -> None:
 
     assert description["if"] == build["with"]["push"]
     assert "push_to_dockerhub == 'true'" in description["if"]
+
+
+def test_sandbox_hub_description_failure_does_not_fail_the_release() -> None:
+    step = sandbox_publish_step("Update Docker Hub repository description")
+
+    assert step["continue-on-error"] is True
+
+
+# WHY: the action truncates an oversized readme or short description and only
+# warns, so drift past a Hub limit ships silently with the run still green.
+def test_sandbox_hub_description_inputs_fit_docker_hub_limits() -> None:
+    step = sandbox_publish_step("Update Docker Hub repository description")
+
+    readme = ROOT / step["with"]["readme-filepath"]
+    assert readme.is_file()
+    assert len(readme.read_bytes()) <= 25_000
+
+    short_description = step["with"]["short-description"]
+    assert short_description
+    assert len(short_description.encode("utf-8")) <= 100


### PR DESCRIPTION
## Background

The [`xprobe/xagent-sandbox`](https://hub.docker.com/r/xprobe/xagent-sandbox) page on Docker Hub is blank — no overview, no short description. Anyone who finds the image outside this repository has no way to tell what it is, what is inside it, or how it relates to Xagent.

This cannot be fixed from the Dockerfile. `LABEL description` never reaches the Hub page: the overview is a field on the Docker Hub *repository*, written through the Hub API, entirely separate from image metadata. So it is either edited by hand in the web UI on every change, or pushed from CI.

This PR does the latter, so the public description of the image is versioned and reviewable alongside the image itself.

## What changed

- **`docker/README.sandbox.md`** (new) — the Docker Hub overview. Written against the actual behaviour in `src/xagent/sandbox/` rather than assumptions: a sandbox is a *named, stateful, resumable* workspace (`get_or_create` resumes stopped sandboxes, `stop()` preserves the filesystem, snapshots can replace this image as the creation template), not a throwaway container. It also states plainly that the isolation comes from how the sandbox is run — `no-new-privileges`, CPU/memory limits, optional network isolation, or Boxlite's KVM boundary — and that the image's unprivileged `sandbox` user is deliberately overridden with `user: "root"` by the Docker backend, so the page does not advertise a property the default deployment does not have.
- **`.github/workflows/sandbox-publish.yml`** — one step after the build, publishing that file as the Hub overview. Its `if:` is identical to the build/push step, so a `workflow_dispatch` run with `push_to_dockerhub=false` never touches the live page.
- **`docker/README.md`** — points at the new file from the Sandbox section, and corrects the custom-image requirements. That section previously listed only `uvx`, but `Sandbox.run_code` invokes `python -c ...` and `node -e ...` directly in both backends, so `python` and `node` on `PATH` are just as mandatory. Included here because this PR would otherwise ship a README that contradicts the new Hub page.

## Why `peter-evans/dockerhub-description`

There is no first-party Docker tool for this, and the alternatives are worse:

| Option | Verdict |
|---|---|
| **`peter-evans/dockerhub-description`** | What [Docker's own documentation recommends](https://docs.docker.com/build/ci/github-actions/update-dockerhub-desc/) for exactly this task. Actively maintained — v5.0.0, October 2025. |
| [`docker-pushrm`](https://github.com/christian-korneck/docker-pushrm) | The most Docker-native option — a CLI plugin (`docker pushrm`) reusing the credential store. But dormant: last release v1.9.0 in July 2022. |
| [`docker/hub-tool`](https://github.com/docker/hub-tool) | Docker-authored, but self-described as an experiment "not meant to be a final product", and has no command for repository descriptions at all. |
| Raw `curl` against the Hub API | Two calls (`POST /v2/auth/token`, `PATCH /v2/repositories/{repo}`). No dependency, but we would own the auth handling, error codes, and payload escaping for no benefit. |

The action is pinned by commit SHA (`1b9a80c` = v5.0.0) rather than a mutable tag, matching Docker's documented example and the existing `endersonmenezes/free-disk-space` pin in this workflow.

## Verification

- `sandbox-publish.yml` parses; the short description is 92 bytes (Docker Hub's limit is 100) and the overview is 3.6 KB (limit 25,000).
- `readme-filepath` resolves from the repository root.
- The Hub write itself is only exercised by a real publish. The first tag push after merge will show whether the credential in `DOCKERHUB_PASSWORD` is accepted by the description endpoint; if it is not, the step fails loudly rather than silently, and can be dropped in favour of setting the overview once by hand.

## Note for reviewers

The overview only reaches Docker Hub when the image is published. A later edit to `docker/README.sandbox.md` merged without a release tag will not appear on the page until the next publish. Adding a separate trigger for that was considered and deliberately left out — the file should change rarely.
