### PR TITLE
feat: Harden shared skill-archive extraction

### DIFF
--- a/src/xagent/web/api/skill_hub.py
+++ b/src/xagent/web/api/skill_hub.py
@@ -345,6 +345,27 @@ def _summary_source(skill_dict: dict) -> str:
     return skill_dict.get("source") or _classify_source(skill_dict.get("path", ""))
 
 
+# Archiving a folder on macOS sweeps in Finder and resource-fork droppings.
+# Any skill folder that has been opened in Finder carries them, so refusing a
+# whole archive over a .DS_Store rejects an entirely ordinary bundle. They
+# carry nothing a skill needs: drop them rather than fail the archive.
+_IGNORED_ARCHIVE_NAMES = frozenset({".DS_Store", "Thumbs.db", "desktop.ini"})
+
+# Inflate archive members in slices so a decompression bomb cannot make the
+# peak footprint a multiple of the size budget.
+_ARCHIVE_CHUNK_BYTES = 1024 * 1024
+
+
+def _is_archive_cruft(path: str) -> bool:
+    """True for OS bookkeeping files that are never part of a skill."""
+    if path.startswith("__MACOSX/"):
+        return True
+    segments = path.split("/")
+    return any(
+        seg in _IGNORED_ARCHIVE_NAMES or seg.startswith("._") for seg in segments
+    )
+
+
 def _normalize_skill_files(files: dict[str, bytes]) -> dict[str, bytes]:
     out: dict[str, bytes] = {}
     total = 0
@@ -355,9 +376,18 @@ def _normalize_skill_files(files: dict[str, bytes]) -> dict[str, bytes]:
                 status_code=400,
                 detail="Skill file path contains a path-traversal sequence.",
             )
-        if path.startswith("."):
+        if _is_archive_cruft(path):
+            continue
+        # Check every segment, not just the first character of the whole path:
+        # ".env" at the root was refused while "sub/.env" sailed through.
+        dotted = next((seg for seg in path.split("/") if seg.startswith(".")), None)
+        if dotted is not None:
             raise HTTPException(
-                status_code=400, detail="Skill file path must not start with a dot."
+                status_code=400,
+                detail=(
+                    f"Skill bundle contains a hidden file ({dotted}). "
+                    "Remove it and try again."
+                ),
             )
         total += len(content)
         if total > _MAX_DOWNLOAD_BYTES:
@@ -510,41 +540,133 @@ def _installed_slugs(mgr: Any) -> set[str]:
 
 
 def _safe_zip_to_files(zip_bytes: bytes) -> dict[str, bytes]:
-    """Read a ClawHub ZIP into a normalized skill file bundle."""
-    try:
-        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
-    except zipfile.BadZipFile as exc:
-        raise HTTPException(
-            status_code=502, detail="ClawHub returned a bad ZIP."
-        ) from exc
+    """Read a skill ZIP into a normalized skill file bundle."""
+    files, _root = _safe_zip_extract(zip_bytes)
+    return files
 
+
+def _safe_zip_extract(
+    zip_bytes: bytes, *, bad_zip_status: int = 502
+) -> tuple[dict[str, bytes], str]:
+    """Read a skill ZIP into ``(normalized files, root dir name)``.
+
+    ``bad_zip_status`` is the status for an archive that cannot be read at
+    all, letting the caller say who supplied it: 502 when it arrived from a
+    registry proxy (the default), 4xx when the client handed it to us.
+    Rejections about an archive's *contents* keep their own status
+    regardless, so a caller cannot mask a traversal or a size overrun.
+
+    The size budget is enforced on the *actual* decompressed byte count,
+    not the sizes declared in the ZIP headers — a hostile archive can
+    declare small sizes for members that inflate far larger.
+    """
+    # One guard around the whole "read an untrusted archive" region, rather than
+    # naming exception types per call site. Enumerating them only ever covers
+    # what was thought of: a tampered end-of-central-directory offset raises
+    # ValueError from the constructor, an encrypted member RuntimeError, a
+    # broken DEFLATE stream zlib.error, BZIP2/LZMA corruption OSError or
+    # lzma.LZMAError — none of which subclass one another. Whatever zipfile
+    # raises next is covered here too. Our own HTTPExceptions re-raise unchanged
+    # so their specific status and message survive.
     total = 0
     raw_files: dict[str, bytes] = {}
-    for info in zf.infolist():
-        if info.is_dir():
-            continue
-        if info.file_size > _MAX_DOWNLOAD_BYTES:
-            raise HTTPException(status_code=413, detail="Skill ZIP member too large.")
-        total += info.file_size
-        if total > _MAX_DOWNLOAD_BYTES:
-            raise HTTPException(
-                status_code=413, detail="Skill ZIP exceeds size budget."
-            )
-        path = info.filename.replace("\\", "/").lstrip("/")
-        if not path or ".." in path.split("/"):
-            raise HTTPException(
-                status_code=400, detail="Skill ZIP contains unsafe paths."
-            )
-        raw_files[path] = zf.read(info)
+    try:
+        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+        for info in zf.infolist():
+            if info.is_dir():
+                continue
+            path = info.filename.replace("\\", "/").lstrip("/")
+            if not path or ".." in path.split("/"):
+                raise HTTPException(
+                    status_code=400, detail="Skill ZIP contains unsafe paths."
+                )
+            remaining = _MAX_DOWNLOAD_BYTES - total
+            # Reject on the declared size before inflating anything. zipfile
+            # validates each member against its declared length and CRC while
+            # reading, so a header that under-declares fails the read rather
+            # than smuggling bytes past this check; the running total below
+            # backstops it regardless.
+            if info.file_size > remaining:
+                raise HTTPException(
+                    status_code=413, detail="Skill ZIP exceeds size budget."
+                )
+            # Inflate in bounded chunks rather than one read(remaining + 1):
+            # a single read of the whole budget holds the result and zipfile's
+            # own growing buffer at once, so a ~800 KiB bomb peaked at twice
+            # the 50 MiB budget. Chunking caps the overshoot at one chunk.
+            chunks: list[bytes] = []
+            read_total = 0
+            with zf.open(info) as member:
+                while True:
+                    chunk = member.read(_ARCHIVE_CHUNK_BYTES)
+                    if not chunk:
+                        break
+                    read_total += len(chunk)
+                    if read_total > remaining:
+                        # Belt and braces, and deliberately not covered by a
+                        # test: every way to get here is already intercepted,
+                        # by the declared-size check above or by zipfile's own
+                        # CRC/length validation of the member. It stands so a
+                        # member that ever does out-produce its header -- a
+                        # zipfile change, a format we do not decompress today
+                        # -- cannot walk past the budget.
+                        raise HTTPException(
+                            status_code=413, detail="Skill ZIP exceeds size budget."
+                        )
+                    chunks.append(chunk)
+            content = b"".join(chunks)
+            total += len(content)
+            raw_files[path] = content
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "Skill Hub: unreadable archive (%s)", type(exc).__name__, exc_info=True
+        )
+        raise HTTPException(
+            status_code=bad_zip_status,
+            detail="Skill archive is not a readable ZIP.",
+        ) from exc
 
-    skill_md_paths = sorted(
-        path for path in raw_files if path.endswith("/SKILL.md") or path == "SKILL.md"
-    )
+    # Choose the root by depth, not by alphabet. A plain sort asserted the
+    # wrong invariant: a skill folder shipping its own "Examples/SKILL.md"
+    # sorts before the real root marker, so the example was imported *as* the
+    # skill — named "Examples", with the true root's files silently dropped and
+    # a 200 returned. Cruft is filtered first so a crafted "__MACOSX/SKILL.md"
+    # cannot win either.
+    skill_md_paths = [
+        path
+        for path in raw_files
+        if (path.endswith("/SKILL.md") or path == "SKILL.md")
+        and not _is_archive_cruft(path)
+    ]
     if not skill_md_paths:
         raise HTTPException(
-            status_code=400, detail="ClawHub artifact has no SKILL.md anywhere in it."
+            status_code=400, detail="Skill archive has no SKILL.md anywhere in it."
         )
-    skill_root = skill_md_paths[0].removesuffix("SKILL.md").rstrip("/")
+    min_depth = min(path.count("/") for path in skill_md_paths)
+    shallowest = sorted(p for p in skill_md_paths if p.count("/") == min_depth)
+    if len(shallowest) > 1:
+        # Two skills at the same depth: picking one would discard the other, so
+        # make the user say which. Bounded so a crafted archive cannot reflect
+        # an unlimited list of its own directory names back through the error.
+        roots = ", ".join(
+            (path.removesuffix("SKILL.md").rstrip("/") or ".")[:60]
+            for path in shallowest[:5]
+        )
+        if len(shallowest) > 5:
+            roots += f", and {len(shallowest) - 5} more"
+        # 400 on both paths, matching the "no SKILL.md" rejection above:
+        # ``bad_zip_status`` distinguishes who supplied an *unreadable* archive,
+        # and this one parsed fine — it just carries the wrong contents.
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Skill archive contains multiple skills ({roots}). "
+                "Upload one skill per archive."
+            ),
+        )
+    skill_root = shallowest[0].removesuffix("SKILL.md").rstrip("/")
     files: dict[str, bytes] = {}
     for path, content in raw_files.items():
         if skill_root:
@@ -556,7 +678,7 @@ def _safe_zip_to_files(zip_bytes: bytes) -> dict[str, bytes]:
             rel = path
         if rel:
             files[rel] = content
-    return _normalize_skill_files(files)
+    return _normalize_skill_files(files), skill_root.rsplit("/", 1)[-1]
 
 
 def _check_registry_security_gate(registry: Any, detail: dict) -> None:

--- a/tests/skills/test_skill_hub_security.py
+++ b/tests/skills/test_skill_hub_security.py
@@ -11,6 +11,7 @@ from fastapi import HTTPException
 from xagent.web.api.skill_hub import (
     _check_registry_security_gate,
     _normalize_skill_files,
+    _safe_zip_extract,
     _safe_zip_to_files,
 )
 
@@ -53,7 +54,8 @@ class TestNormalizeSkillFiles:
         with pytest.raises(HTTPException) as exc:
             _normalize_skill_files({"SKILL.md": SKILL_MD, ".env": b"SECRET=1"})
         assert exc.value.status_code == 400
-        assert "dot" in exc.value.detail.lower()
+        assert "hidden file" in exc.value.detail
+        assert ".env" in exc.value.detail
 
     def test_absolute_path_stripped(self):
         result = _normalize_skill_files({"/SKILL.md": SKILL_MD})
@@ -121,6 +123,321 @@ class TestSafeZipToFiles:
         with pytest.raises(HTTPException) as exc:
             _safe_zip_to_files(data)
         assert exc.value.status_code == 413
+
+
+# ── _safe_zip_extract ─────────────────────────────────────────────────────────
+
+
+def _tamper_declared_size(zip_bytes: bytes, declared: int) -> bytes:
+    """Rewrite the uncompressed-size field of the first member in both
+    the local header and the central directory."""
+    import struct
+
+    data = bytearray(zip_bytes)
+    local = data.find(b"PK\x03\x04")
+    data[local + 22 : local + 26] = struct.pack("<I", declared)
+    central = data.find(b"PK\x01\x02")
+    data[central + 24 : central + 28] = struct.pack("<I", declared)
+    return bytes(data)
+
+
+def _deflate_zip_with_corrupt_member() -> bytes:
+    """A DEFLATE member whose compressed stream has been overwritten."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("SKILL.md", b"B" * 20000)
+    data = bytearray(buf.getvalue())
+    local = data.find(b"PK\x03\x04")
+    header_len = 30 + data[local + 26] + data[local + 28]
+    for offset in range(header_len, header_len + 8):
+        data[local + offset] = 0xAB
+    return bytes(data)
+
+
+class TestSafeZipExtract:
+    def test_returns_nested_root_name(self):
+        data = _make_zip({"my-skill/SKILL.md": SKILL_MD, "my-skill/ref.md": b"hi"})
+        files, root = _safe_zip_extract(data)
+        assert root == "my-skill"
+        assert set(files) == {"SKILL.md", "ref.md"}
+
+    def test_returns_empty_root_for_flat_zip(self):
+        data = _make_zip({"SKILL.md": SKILL_MD})
+        files, root = _safe_zip_extract(data)
+        assert root == ""
+        assert "SKILL.md" in files
+
+    def test_bad_zip_status_is_configurable(self):
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(b"not a zip", bad_zip_status=400)
+        assert exc.value.status_code == 400
+
+    def test_error_wording_is_source_neutral(self):
+        # The extractor serves registry installs today and an upload route
+        # next, so its messages must not name a specific registry.
+        for build in (
+            lambda: _safe_zip_extract(b"not a zip"),
+            lambda: _safe_zip_extract(_make_zip({"README.md": b"no skill"})),
+        ):
+            with pytest.raises(HTTPException) as exc:
+                build()
+            assert "clawhub" not in exc.value.detail.lower()
+
+    def test_decompression_bomb_is_refused_without_inflating_it(self):
+        """A bomb must be rejected without its expansion ever being held.
+
+        Reading the whole remaining budget in one call holds the result and
+        zipfile's own growing buffer at the same time, so an ~800 KiB archive
+        peaked at twice the 50 MiB budget. The declared size stops it before
+        any inflation, and members are read in slices so the overshoot on a
+        lying header is one chunk rather than the whole budget.
+        """
+        import tracemalloc
+
+        from xagent.web.api.skill_hub import _MAX_DOWNLOAD_BYTES
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("SKILL.md", SKILL_MD)
+            for i in range(8):
+                zf.writestr(f"bomb{i}.bin", b"\0" * (_MAX_DOWNLOAD_BYTES * 2))
+        data = buf.getvalue()
+        assert len(data) < 4 * 1024 * 1024  # tiny on the wire, huge inflated
+
+        tracemalloc.start()
+        try:
+            with pytest.raises(HTTPException) as exc:
+                _safe_zip_extract(data)
+            _current, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        assert exc.value.status_code == 413
+        # Generous bound: the point is "not a multiple of the budget".
+        assert peak < _MAX_DOWNLOAD_BYTES / 2, f"peak {peak} bytes"
+
+    def test_over_declared_member_is_refused_on_its_header(self):
+        """An over-declared member is refused before it is inflated.
+
+        The declared size is the cheap first gate. Trusting it costs an
+        archive that under-states a small file nothing real -- writers emit
+        truthful headers -- while inflating first to find out costs the
+        whole budget per bomb, which is the shape an attacker can actually
+        produce. The real byte count is still checked as it is read.
+        """
+        from xagent.web.api.skill_hub import _MAX_DOWNLOAD_BYTES
+
+        data = _make_zip({"SKILL.md": SKILL_MD})
+        lying = _tamper_declared_size(data, _MAX_DOWNLOAD_BYTES + 1)
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(lying)
+        assert exc.value.status_code == 413
+
+    def test_honest_members_within_budget_are_read_whole(self):
+        # The chunked read must reassemble a member larger than one chunk
+        # byte-for-byte, not truncate it at the chunk boundary.
+        from xagent.web.api.skill_hub import _ARCHIVE_CHUNK_BYTES
+
+        body = bytes(range(256)) * ((_ARCHIVE_CHUNK_BYTES * 2) // 256 + 7)
+        data = _make_zip({"SKILL.md": SKILL_MD, "big.bin": body})
+        files, _root = _safe_zip_extract(data)
+        assert files["big.bin"] == body
+
+
+# ── archive root selection ───────────────────────────────────────────────────
+
+
+class TestArchiveRootSelection:
+    """The root is the shallowest SKILL.md, not the alphabetically first.
+
+    A skill folder that ships its own ``Examples/SKILL.md`` sorts before the
+    real root marker, so a plain sort imported the *example* as the skill —
+    named "Examples", with the true root's files silently dropped and a 200
+    returned. Ordinary shape, not an adversarial one.
+    """
+
+    def test_subfolder_does_not_beat_the_true_root(self):
+        data = _make_zip(
+            {
+                "SKILL.md": SKILL_MD,
+                "reference.md": b"reference material",
+                "Examples/SKILL.md": b"---\ndescription: an example\n---\n# Ex\n",
+            }
+        )
+        files, root = _safe_zip_extract(data)
+        assert root == ""
+        # The real skill wins and nothing is discarded.
+        assert files["SKILL.md"] == SKILL_MD
+        assert "reference.md" in files
+        assert "Examples/SKILL.md" in files
+
+    def test_wrapper_directory_still_resolves(self):
+        data = _make_zip(
+            {
+                "pdf-tools/SKILL.md": SKILL_MD,
+                "pdf-tools/ref.md": b"r",
+                "pdf-tools/examples/SKILL.md": b"---\ndescription: e\n---\n# E\n",
+            }
+        )
+        files, root = _safe_zip_extract(data)
+        assert root == "pdf-tools"
+        assert sorted(files) == ["SKILL.md", "examples/SKILL.md", "ref.md"]
+
+    def test_two_roots_at_the_same_depth_are_refused(self):
+        data = _make_zip({"a/SKILL.md": SKILL_MD, "b/SKILL.md": SKILL_MD})
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(data)
+        assert exc.value.status_code == 400
+        assert "multiple skills" in exc.value.detail
+
+    def test_multiple_roots_reported_without_reflecting_the_whole_archive(self):
+        """The rejection names a bounded sample, not every root it found.
+
+        The names come from the archive, so an unbounded list would let a
+        crafted upload reflect arbitrary attacker text back through the error.
+        """
+        long_name = "z" * 500
+        data = _make_zip(
+            {f"root{i}/SKILL.md": SKILL_MD for i in range(9)}
+            | {f"{long_name}/SKILL.md": SKILL_MD}
+        )
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(data)
+        assert exc.value.status_code == 400
+        assert len(exc.value.detail) < 400
+        assert long_name not in exc.value.detail
+        assert "5 more" in exc.value.detail
+
+    def test_cruft_is_not_a_root_candidate(self):
+        """Cruft must be excluded before candidates are compared.
+
+        At the *same* depth as the real skill it would otherwise look like a
+        second skill and trigger a spurious "multiple skills" rejection — which
+        is what a Finder-zipped folder actually produces. A deeper __MACOSX
+        would be beaten by depth alone, so that shape proves nothing here.
+        """
+        data = _make_zip(
+            {
+                "pdf-tools/SKILL.md": SKILL_MD,
+                "__MACOSX/SKILL.md": b"junk",
+            }
+        )
+        files, root = _safe_zip_extract(data)
+        assert root == "pdf-tools"
+        assert files["SKILL.md"] == SKILL_MD
+
+    def test_cruft_alone_is_not_a_skill(self):
+        data = _make_zip({"__MACOSX/SKILL.md": b"junk"})
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(data)
+        assert exc.value.status_code == 400
+        assert "no SKILL.md" in exc.value.detail
+
+
+# ── unreadable archives ──────────────────────────────────────────────────────
+
+
+class TestUnreadableArchives:
+    """Anything zipfile raises on an untrusted archive must be a 4xx/5xx.
+
+    Guarded at one boundary rather than by naming exception types, because the
+    per-type list kept missing cases: a tampered end-of-central-directory
+    offset raises ValueError from the constructor, well before any member read.
+    """
+
+    def test_tampered_eocd_offset(self):
+        import struct
+
+        raw = bytearray(_make_zip({"s/SKILL.md": SKILL_MD}))
+        eocd = raw.rfind(b"PK\x05\x06")
+        struct.pack_into("<I", raw, eocd + 16, 0xFFFFFFF0)
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(bytes(raw), bad_zip_status=400)
+        assert exc.value.status_code == 400
+
+    def test_truncated_central_directory(self):
+        raw = _make_zip({"s/SKILL.md": SKILL_MD})
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(raw[: len(raw) // 2], bad_zip_status=400)
+        assert exc.value.status_code == 400
+
+    def test_corrupt_deflate_member(self):
+        # zipfile only detects the damage while reading the member, not at
+        # open(): zlib.error subclasses neither BadZipFile nor RuntimeError,
+        # so it used to escape the extractor as a 500.
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(_deflate_zip_with_corrupt_member(), bad_zip_status=400)
+        assert exc.value.status_code == 400
+
+    def test_registry_source_keeps_its_status(self):
+        # The boundary guard must not flatten the caller-specific status.
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(b"not a zip at all")
+        assert exc.value.status_code == 502
+
+    def test_corrupt_member_keeps_the_registry_status(self):
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_to_files(_deflate_zip_with_corrupt_member())
+        assert exc.value.status_code == 502
+
+    def test_size_budget_still_reported_as_413(self):
+        # Our own HTTPExceptions must pass through the guard unchanged, or
+        # every rejection raised inside the try block collapses onto one code.
+        from xagent.web.api.skill_hub import _MAX_DOWNLOAD_BYTES
+
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("SKILL.md", SKILL_MD)
+            zf.writestr("big.bin", b"\0" * (_MAX_DOWNLOAD_BYTES + 1024))
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(buf.getvalue(), bad_zip_status=400)
+        assert exc.value.status_code == 413
+
+    def test_traversal_still_reported_as_400(self):
+        # The other in-try rejection: 400 here and 413 above must stay
+        # distinct even when the caller's bad-ZIP status is 502.
+        data = _make_zip({"SKILL.md": SKILL_MD, "../escape.py": b"x"})
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(data)
+        assert exc.value.status_code == 400
+
+
+# ── macOS archive cruft ──────────────────────────────────────────────────────
+
+
+class TestArchiveCruft:
+    """Zipping a folder in Finder sweeps in .DS_Store and resource forks.
+
+    A skill folder that has been opened in Finder carries them, so refusing
+    the whole archive over one would fail an entirely ordinary bundle —
+    while real hidden files stay refused.
+    """
+
+    @pytest.mark.parametrize(
+        "cruft",
+        [
+            "pdf-tools/.DS_Store",
+            "pdf-tools/refs/.DS_Store",
+            "__MACOSX/._pdf-tools",
+            "pdf-tools/._reference.md",
+            "pdf-tools/Thumbs.db",
+            "pdf-tools/desktop.ini",
+        ],
+    )
+    def test_cruft_is_dropped_not_rejected(self, cruft):
+        data = _make_zip({"pdf-tools/SKILL.md": SKILL_MD, cruft: b"\x00\x01"})
+        files, root = _safe_zip_extract(data)
+        assert root == "pdf-tools"
+        assert sorted(files) == ["SKILL.md"]
+
+    @pytest.mark.parametrize("hidden", [".env", "sub/.env", "a/b/.secret"])
+    def test_real_hidden_files_still_rejected(self, hidden):
+        # The old check only looked at the first character of the whole path,
+        # so ".env" was refused but "sub/.env" was not.
+        data = _make_zip({"SKILL.md": SKILL_MD, hidden: b"SECRET=1"})
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(data)
+        assert exc.value.status_code == 400
+        assert "hidden file" in exc.value.detail
 
 
 # ── _check_registry_security_gate ────────────────────────────────────────────


### PR DESCRIPTION
This is the first of two stacked PRs splitting #1749 ("import a skill from an uploaded file"). It changes only the shared archive-parsing layer, which already has a production caller: `POST /skill-hub/{source}/install` reaches it through `_safe_zip_to_files`. Every defect below is reachable on that registry path today, independently of any upload endpoint.

No route, request model, or frontend changes here. The upload endpoint follows in a second PR stacked on this one.

## What changes

### 1. The skill root is chosen by depth, not alphabetical order

`sorted(skill_md_paths)[0]` asserted that the alphabetically first `SKILL.md` is the archive's root. A skill folder that ships its own `Examples/SKILL.md` breaks that: `Examples/SKILL.md` sorts before `SKILL.md`, so the *example* was imported as the skill — named `Examples`, with the true root's `reference.md` silently discarded, and a `200` returned. A skill folder with an `Examples/` subdirectory is an ordinary shape, not a crafted one.

The shallowest `SKILL.md` now wins. Two candidates at the same depth are refused rather than silently resolved, because picking one would discard the other. The refusal names at most five roots, each truncated, so a crafted archive cannot reflect an unbounded amount of its own text back through the error message.

### 2. OS bookkeeping files are dropped, not fatal — and never root candidates

Zipping a folder that has been opened in Finder sweeps in `.DS_Store`, `__MACOSX/`, and `._*` resource forks; Windows adds `Thumbs.db` and `desktop.ini`. These were rejected by the hidden-file check, failing an otherwise valid archive. They are now dropped from the bundle.

They are also excluded *before* root candidates are compared. That ordering matters: `__MACOSX/SKILL.md` sits at the same depth as `pdf-tools/SKILL.md`, so filtering it later would make an ordinary Finder-zipped folder look like two skills and trigger a spurious "multiple skills" refusal.

### 3. The hidden-file check looks at every path segment

It tested `path.startswith(".")` — the first character of the whole path. `.env` was refused, but `sub/.env` was written into the skill bundle. Each segment is now checked, and the message names the offending file instead of stating a rule.

### 4. Archive reads are guarded once, at the boundary

Exception types were enumerated per call site, which only ever covers what was thought of:

| Corruption | Raises | Before |
| --- | --- | --- |
| Tampered end-of-central-directory offset | `ValueError` (from the constructor, before any member read) | 500 |
| Encrypted member | `RuntimeError` | 500 |
| Broken DEFLATE stream | `zlib.error` | 500 |
| BZIP2/LZMA corruption | `OSError` / `lzma.LZMAError` | 500 |

None of these subclass one another. The whole read region is now guarded once, so whatever `zipfile` raises next is covered too. Our own `HTTPException`s re-raise unchanged — without that, the 413 size budget and the 400 traversal refusal, both raised inside the guarded region, would collapse onto a single status.

`bad_zip_status` lets a caller say who supplied an unreadable archive (502 for a registry proxy, the default). Rejections about an archive's *contents* keep their own status regardless.

### 5. Members are inflated in bounded chunks

Reading the whole remaining budget in one `read(remaining + 1)` holds the result and `zipfile`'s own growing buffer simultaneously: an ~800 KiB decompression bomb drove a ~100 MiB peak against a 50 MiB budget. Members are now rejected on their declared size before any inflation (~0.1 MiB peak for that same archive) and read in 1 MiB slices, with a running byte total backstopping the header.

## Testing

`tests/skills/test_skill_hub_security.py` gains coverage for archive root selection, cruft handling, unreadable archives, and the size budget.

Each new guard was mutation-verified — reverted individually in the source to confirm the corresponding test actually fails. Two shapes were chosen specifically to avoid false greens:

- the cruft test places cruft at the *same* depth as the real skill; a deeper `__MACOSX` is beaten by depth alone and would prove nothing about the exclusion.
- `HTTPException` passthrough is asserted for both the 413 and the traversal 400, since a single case cannot distinguish "passed through" from "flattened onto the caller's status".

One guard is deliberately uncovered and marked as such in the source: the running-byte-total check is unreachable today (the declared-size check or `zipfile`'s own CRC/length validation intercepts every route to it) and stands as a backstop.

`test_size_budget_uses_actual_bytes_not_declared` is replaced by `test_over_declared_member_is_refused_on_its_header`. An archive that over-declares a small honest payload is now refused. Writers emit truthful headers, so trusting the declared size costs nothing real, while inflating first to find out costs the full budget per bomb — the shape an attacker can actually produce.
