### PR TITLE
feat：MCP transport: canonicalize on write

### DIFF
--- a/src/xagent/web/api/admin_mcp.py
+++ b/src/xagent/web/api/admin_mcp.py
@@ -3,7 +3,13 @@ from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from pydantic import BaseModel, Field, ValidationError, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    ValidationError,
+    field_validator,
+    model_validator,
+)
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -90,9 +96,25 @@ class PublicMCPAppBase(BaseModel):
 
 
 class PublicMCPAppCreate(PublicMCPAppBase):
-    # Validator lives on the write model only, not PublicMCPAppBase — otherwise
-    # PublicMCPAppResponse would inherit it and re-run on response serialization,
-    # turning one legacy/partial DB row into a full-list 500 on read.
+    # Validators live on the write models only, not PublicMCPAppBase — otherwise
+    # PublicMCPAppResponse would inherit them and re-run on response serialization,
+    # turning one legacy/partial DB row into a full-list 500 on read (and, for
+    # the transport normalizer below, reporting a lowercased transport for a row
+    # that is still stored mixed-case).
+
+    # Canonicalize the stored transport: it is a free-form string, and an
+    # admin-authored mixed-case value ("Streamable_HTTP") passes the shape check
+    # below (classify_app_auth compares case-insensitively) yet produces a shared
+    # server row that the connect path's exact comparisons reject. Storing the
+    # lowercase form keeps the catalog and the connect path from disagreeing
+    # about the same app.
+    @field_validator("transport")
+    @classmethod
+    def _normalize_transport(cls, value: str) -> str:
+        from ..services.mcp_runtime import normalize_transport
+
+        return normalize_transport(value)
+
     @model_validator(mode="after")
     def _enforce_auth_classification(self) -> "PublicMCPAppCreate":
         # Reuse the single source of truth (classify_app_auth) rather than
@@ -145,6 +167,15 @@ class PublicMCPAppUpdate(BaseModel):
         default=None,
         description=_LAUNCH_CONFIG_DESCRIPTION,
     )
+
+    # Same canonicalization as PublicMCPAppCreate, so a PATCH that re-cases a
+    # transport can't reintroduce a mixed-case row.
+    @field_validator("transport")
+    @classmethod
+    def _normalize_transport(cls, value: Optional[str]) -> Optional[str]:
+        from ..services.mcp_runtime import normalize_transport
+
+        return None if value is None else normalize_transport(value)
 
 
 _PUBLIC_MCP_APP_FIELDS = tuple(PublicMCPAppBase.model_fields)

--- a/src/xagent/web/api/admin_mcp.py
+++ b/src/xagent/web/api/admin_mcp.py
@@ -3,13 +3,7 @@ from typing import Any, Dict, List, Optional
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
-from pydantic import (
-    BaseModel,
-    Field,
-    ValidationError,
-    field_validator,
-    model_validator,
-)
+from pydantic import BaseModel, Field, ValidationError, model_validator
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -24,6 +18,11 @@ from ..models.database import get_db
 from ..models.oauth_provider import OAuthProvider
 from ..models.public_mcp import PublicMCPApp, PublicMCPAppAudit
 from ..models.user import User
+from ..services.mcp_runtime import (
+    NormalizedTransport,
+    OptionalNormalizedTransport,
+    normalize_transport,
+)
 
 admin_mcp_router = APIRouter(prefix="/api/admin/mcp", tags=["Admin MCP"])
 
@@ -96,24 +95,19 @@ class PublicMCPAppBase(BaseModel):
 
 
 class PublicMCPAppCreate(PublicMCPAppBase):
-    # Validators live on the write models only, not PublicMCPAppBase — otherwise
-    # PublicMCPAppResponse would inherit them and re-run on response serialization,
-    # turning one legacy/partial DB row into a full-list 500 on read (and, for
-    # the transport normalizer below, reporting a lowercased transport for a row
-    # that is still stored mixed-case).
-
-    # Canonicalize the stored transport: it is a free-form string, and an
-    # admin-authored mixed-case value ("Streamable_HTTP") passes the shape check
-    # below (classify_app_auth compares case-insensitively) yet produces a shared
-    # server row that the connect path's exact comparisons reject. Storing the
-    # lowercase form keeps the catalog and the connect path from disagreeing
-    # about the same app.
-    @field_validator("transport")
-    @classmethod
-    def _normalize_transport(cls, value: str) -> str:
-        from ..services.mcp_runtime import normalize_transport
-
-        return normalize_transport(value)
+    # Both the transport override below and _enforce_auth_classification live on
+    # the write models only, not on PublicMCPAppBase — PublicMCPAppResponse
+    # inherits from that base, so putting them there would re-run them on
+    # response serialization: one legacy/partial DB row would turn a full-list
+    # read into a 500, and a row still stored mixed-case would be *reported*
+    # lowercased, a read that lies about the table.
+    #
+    # Redeclaring the field narrows the inherited `str` to the shared
+    # annotated type. Transport is free-form, and an admin-authored
+    # "Streamable_HTTP" passes the shape check below (classify_app_auth compares
+    # case-insensitively) yet produces a shared server row the connect path's
+    # exact comparisons reject.
+    transport: NormalizedTransport = "oauth"
 
     @model_validator(mode="after")
     def _enforce_auth_classification(self) -> "PublicMCPAppCreate":
@@ -158,7 +152,7 @@ class PublicMCPAppUpdate(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     icon: Optional[str] = None
-    transport: Optional[str] = None
+    transport: OptionalNormalizedTransport = None
     provider_name: Optional[str] = None
     category: Optional[str] = None
     oauth_scopes: Optional[List[str]] = None
@@ -167,15 +161,6 @@ class PublicMCPAppUpdate(BaseModel):
         default=None,
         description=_LAUNCH_CONFIG_DESCRIPTION,
     )
-
-    # Same canonicalization as PublicMCPAppCreate, so a PATCH that re-cases a
-    # transport can't reintroduce a mixed-case row.
-    @field_validator("transport")
-    @classmethod
-    def _normalize_transport(cls, value: Optional[str]) -> Optional[str]:
-        from ..services.mcp_runtime import normalize_transport
-
-        return None if value is None else normalize_transport(value)
 
 
 _PUBLIC_MCP_APP_FIELDS = tuple(PublicMCPAppBase.model_fields)
@@ -315,6 +300,22 @@ def _apply_public_mcp_app_update(db_app: PublicMCPApp, changes: Dict[str, Any]) 
         writable_changes = {
             field: value for field, value in changes.items() if field != "app_id"
         }
+
+    # Heal the stored transport even when this PATCH doesn't touch it. The
+    # write models normalize what they receive, but `exclude_unset=True` means
+    # an edit to an unrelated field (icon, category) persists nothing for
+    # transport, so a row authored before normalization stays padded/mixed-case
+    # forever. That un-healed value is then compared against the *normalized*
+    # value written into `mcp_servers`, and the catalog connect path 409s on
+    # every connect after the first. Only rewrite when normalization actually
+    # changes something, so an already-canonical row is a byte-identical no-op
+    # and this never shows up as a spurious change in the audit trail.
+    if "transport" not in writable_changes:
+        stored_transport = persisted.get("transport")
+        if isinstance(stored_transport, str):
+            healed = normalize_transport(stored_transport)
+            if healed != stored_transport:
+                writable_changes = {**writable_changes, "transport": healed}
 
     for field, value in writable_changes.items():
         setattr(db_app, field, value)

--- a/src/xagent/web/api/admin_mcp.py
+++ b/src/xagent/web/api/admin_mcp.py
@@ -256,6 +256,22 @@ def _validate_public_mcp_app_values(
     try:
         model.model_validate(values)
     except ValidationError:
+        # A legacy row can hold a blank transport (there is no DB-level
+        # non-empty constraint, and these models only started rejecting it
+        # recently). Such a row cannot be healed -- there is no canonical value
+        # to strip down to, and writing "" would be the very state this
+        # rejection exists to prevent -- so the edit genuinely cannot proceed.
+        # Name the reason rather than answering with a bare "invalid
+        # configuration" about a field the admin may not have touched.
+        if not str(values.get("transport") or "").strip():
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=(
+                    "This app has no transport set. Include a valid "
+                    "'transport' in this request to repair it before "
+                    "editing its other fields."
+                ),
+            ) from None
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Invalid MCP app configuration",
@@ -266,6 +282,35 @@ def _apply_public_mcp_app_update(db_app: PublicMCPApp, changes: Dict[str, Any]) 
     canonical = get_builtin_public_mcp_app(db_app.app_id)
     persisted = _public_mcp_app_values(db_app)
     enforce_connect_shape = bool({"transport", "launch_config"} & changes.keys())
+
+    # Heal a legacy stored transport *before* validation, not after, and by
+    # folding it into `persisted` so it flows through the same validated model
+    # as every other value.
+    #
+    # `exclude_unset=True` means a PATCH of an unrelated field persists nothing
+    # for transport, so a row authored before the write models normalized would
+    # otherwise stay padded forever while the `mcp_servers` row written on
+    # connect is canonical -- the two then disagree and the connect path 409s.
+    #
+    # Ordering matters in both directions. Healing after validation left the
+    # dirty value in the merged dict, so a routine launch_config edit on such a
+    # row was rejected with an opaque 422 about a field the admin never
+    # touched; and because that late write bypassed the model entirely, a
+    # whitespace-only legacy transport was normalized to "" and persisted --
+    # precisely the silently-unconnectable state these validators exist to
+    # prevent. Healing here means a blank result is caught by the same
+    # validation as any other blank.
+    stored_transport = persisted.get("transport")
+    if (
+        "transport" not in changes
+        and isinstance(stored_transport, str)
+        and normalize_transport(stored_transport)
+        and normalize_transport(stored_transport) != stored_transport
+    ):
+        healed_transport: Optional[str] = normalize_transport(stored_transport)
+        persisted["transport"] = healed_transport
+    else:
+        healed_transport = None
 
     if canonical is not None:
         for field in _BUILTIN_PROTECTED_FIELDS.intersection(changes):
@@ -301,21 +346,13 @@ def _apply_public_mcp_app_update(db_app: PublicMCPApp, changes: Dict[str, Any]) 
             field: value for field, value in changes.items() if field != "app_id"
         }
 
-    # Heal the stored transport even when this PATCH doesn't touch it. The
-    # write models normalize what they receive, but `exclude_unset=True` means
-    # an edit to an unrelated field (icon, category) persists nothing for
-    # transport, so a row authored before normalization stays padded/mixed-case
-    # forever. That un-healed value is then compared against the *normalized*
-    # value written into `mcp_servers`, and the catalog connect path 409s on
-    # every connect after the first. Only rewrite when normalization actually
-    # changes something, so an already-canonical row is a byte-identical no-op
-    # and this never shows up as a spurious change in the audit trail.
-    if "transport" not in writable_changes:
-        stored_transport = persisted.get("transport")
-        if isinstance(stored_transport, str):
-            healed = normalize_transport(stored_transport)
-            if healed != stored_transport:
-                writable_changes = {**writable_changes, "transport": healed}
+    # Only persist the heal once the merged state above validated cleanly. A
+    # builtin's transport is a protected field, so it is excluded from
+    # writable_changes by design -- but healing only ever strips and lowercases,
+    # never moves a row away from its canonical value, so applying it there is
+    # safe and converges the row.
+    if healed_transport is not None:
+        writable_changes = {**writable_changes, "transport": healed_transport}
 
     for field, value in writable_changes.items():
         setattr(db_app, field, value)

--- a/src/xagent/web/api/admin_mcp.py
+++ b/src/xagent/web/api/admin_mcp.py
@@ -283,34 +283,31 @@ def _apply_public_mcp_app_update(db_app: PublicMCPApp, changes: Dict[str, Any]) 
     persisted = _public_mcp_app_values(db_app)
     enforce_connect_shape = bool({"transport", "launch_config"} & changes.keys())
 
-    # Heal a legacy stored transport *before* validation, not after, and by
-    # folding it into `persisted` so it flows through the same validated model
-    # as every other value.
+    # Decide the heal up front, before validation runs.
     #
     # `exclude_unset=True` means a PATCH of an unrelated field persists nothing
     # for transport, so a row authored before the write models normalized would
     # otherwise stay padded forever while the `mcp_servers` row written on
     # connect is canonical -- the two then disagree and the connect path 409s.
     #
-    # Ordering matters in both directions. Healing after validation left the
-    # dirty value in the merged dict, so a routine launch_config edit on such a
-    # row was rejected with an opaque 422 about a field the admin never
-    # touched; and because that late write bypassed the model entirely, a
-    # whitespace-only legacy transport was normalized to "" and persisted --
-    # precisely the silently-unconnectable state these validators exist to
-    # prevent. Healing here means a blank result is caught by the same
-    # validation as any other blank.
+    # Deciding it here rather than after validation is what keeps the blank
+    # case safe: an earlier revision computed the heal *after* the merged state
+    # was validated and assigned it with no re-check, so a whitespace-only
+    # legacy transport was normalized to "" and persisted -- precisely the
+    # silently-unconnectable state these validators exist to prevent. The
+    # `normalize_transport(...)` truthiness test below is that guard: a value
+    # with nothing left after trimming is not healed at all, and the row is
+    # left for the backfill migration.
+    #
+    # (Only the write below matters, not the validated dict: the write models
+    # normalize transport on the way in, so a padded value validates
+    # identically either way.)
     stored_transport = persisted.get("transport")
-    if (
-        "transport" not in changes
-        and isinstance(stored_transport, str)
-        and normalize_transport(stored_transport)
-        and normalize_transport(stored_transport) != stored_transport
-    ):
-        healed_transport: Optional[str] = normalize_transport(stored_transport)
-        persisted["transport"] = healed_transport
-    else:
-        healed_transport = None
+    healed_transport: Optional[str] = None
+    if "transport" not in changes and isinstance(stored_transport, str):
+        candidate = normalize_transport(stored_transport)
+        if candidate and candidate != stored_transport:
+            healed_transport = candidate
 
     if canonical is not None:
         for field in _BUILTIN_PROTECTED_FIELDS.intersection(changes):

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -2769,6 +2769,27 @@ def _reject_hidden_catalog_app(app_info: dict) -> None:
         )
 
 
+def _heal_server_transport(server: MCPServer) -> None:
+    """Canonicalize a shared row's stored transport in place.
+
+    Called from the catalog reuse branches, which compare transport
+    tolerantly and would otherwise leave a legacy row dirty for every
+    exact-match consumer downstream.
+
+    Skips a value that normalizes to blank rather than persisting "": that is
+    the one state the write models exist to prevent, and healing must never be
+    the thing that creates it. Such a row is left alone for the backfill
+    migration to deal with -- it was already unusable, and blanking it would
+    make it silently unconnectable instead.
+    """
+    stored = getattr(server, "transport", None)
+    if not isinstance(stored, str):
+        return
+    healed = normalize_transport(stored)
+    if healed and healed != stored:
+        cast(Any, server).transport = healed
+
+
 def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dict]:
     """Idempotently ensure the shared server row for a key-based or keyless
     catalog app exists, without creating any per-user association. Returns
@@ -2821,6 +2842,14 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
                 detail="A server with this name already exists with a different configuration",
             )
         _reject_user_owned_catalog_squat(db, server)
+        # Accepting a legacy row obliges us to heal it. The comparison above
+        # is deliberately tolerant, but everything downstream is not:
+        # MCPServerConfig.to_connection_dict() dispatches on an exact
+        # transport match, so a row left as " Stdio " reaches the runtime with
+        # no command/args/env at all -- a silently broken connection where the
+        # un-normalized row used to produce a loud 409. Tolerate on read,
+        # canonicalize on write, in the same breath.
+        _heal_server_transport(server)
     if not server:
         try:
             config = _build_server_config(
@@ -2888,6 +2917,11 @@ def _ensure_catalog_mcp_oauth_server(
                 detail="A server with this name already exists with a different configuration",
             )
         _reject_user_owned_catalog_squat(db, server)
+        # Same obligation as the stdio path above: the tolerant comparison
+        # admits a legacy row, so canonicalize it before any exact-match
+        # consumer (the runtime's transport dispatch, _is_mcp_oauth_http_server)
+        # sees it.
+        _heal_server_transport(server)
         # The catalog stays the source of truth for the row's auth config: if
         # the registry entry's auth changed since this shared row was created
         # (e.g. a scope hint or static client_id was added), sync it so

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -21,7 +21,7 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse, Response
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -71,7 +71,7 @@ from ..services.mcp_oauth import (
     select_mcp_oauth_grants,
     validate_mcp_oauth_persisted_value,
 )
-from ..services.mcp_runtime import HTTP_MCP_TRANSPORTS
+from ..services.mcp_runtime import HTTP_MCP_TRANSPORTS, normalize_transport
 from ..services.user_oauth import (
     delete_scoped_user_oauth_accounts,
     list_scoped_user_oauth_accounts,
@@ -121,6 +121,17 @@ class MCPServerCreate(BaseModel):
         False, description="Allow runtime Authorization header binding"
     )
 
+    # Canonicalize before anything reads it: transport is free-form here, and
+    # the value validated by TransportFieldValidator / stored on the row is the
+    # one every later comparison (exact and case-insensitive alike) must agree
+    # on. Also applies to the update endpoint, which rebuilds this model from
+    # the request and the stored row, so editing a legacy mixed-case server
+    # heals it.
+    @field_validator("transport")
+    @classmethod
+    def _normalize_transport(cls, value: str) -> str:
+        return normalize_transport(value)
+
 
 class MCPServerUpdate(BaseModel):
     """Request model for updating MCP server."""
@@ -144,6 +155,15 @@ class MCPServerUpdate(BaseModel):
     allow_delegated_authorization: Optional[bool] = Field(
         None, description="Allow runtime Authorization header binding"
     )
+
+    # Same canonicalization as MCPServerCreate, applied before
+    # _global_config_tampered compares the incoming transport with the stored
+    # one — otherwise a payload that only re-cases an unchanged transport would
+    # read as a global-config edit by a non-owner.
+    @field_validator("transport")
+    @classmethod
+    def _normalize_transport(cls, value: Optional[str]) -> Optional[str]:
+        return None if value is None else normalize_transport(value)
 
 
 class MCPAppConnectRequest(BaseModel):
@@ -210,6 +230,16 @@ class MCPConnectionTest(BaseModel):
     name: str = Field(..., description="Connection name")
     transport: str = Field(..., description="Transport type")
     config: dict[str, Any] = Field(..., description="Connection configuration")
+
+    # Same case/whitespace canonicalization as the save path
+    # (MCPServerCreate), so Test and Save agree on how a transport is spelled.
+    # This is spelling parity only: Test still does not validate against
+    # MCPServerConfig's allowed-value list, so an unknown transport is accepted
+    # here and fails at connect time, where Save rejects it up front.
+    @field_validator("transport")
+    @classmethod
+    def _normalize_transport(cls, value: str) -> str:
+        return normalize_transport(value)
 
 
 class MCPConnectionTestResponse(BaseModel):
@@ -1402,7 +1432,14 @@ def _global_config_tampered(server_data: MCPServerUpdate, server: MCPServer) -> 
     fields_set = server_data.model_fields_set
     if server_data.name is not None and server_data.name != server.name:
         return True
-    if server_data.transport is not None and server_data.transport != server.transport:
+    # Both sides normalized: server_data.transport has already been through the
+    # MCPServerUpdate validator, while server.transport is the raw stored value,
+    # which for a row written before that validator shipped may still be
+    # mixed-case or padded. Comparing normalized-vs-raw would flag a non-owner
+    # who merely echoes the row's own unchanged transport as tampering.
+    if server_data.transport is not None and normalize_transport(
+        server_data.transport
+    ) != normalize_transport(server.transport):
         return True
     if (
         server_data.description is not None
@@ -3282,10 +3319,25 @@ def update_mcp_server(
 
         # Build update config - only include provided fields. Non-owners keep the
         # existing global config untouched.
+        # An explicitly-supplied transport must not fall back to the stored
+        # value just because it normalized to "". Before write-time
+        # normalization a blank/whitespace-only transport failed
+        # MCPServerConfig.validate_transport with a 400; the `or` fallback
+        # below would silently keep the old transport instead, turning a
+        # rejected edit into a no-op the caller never learns about.
+        if can_edit_global and server_data.transport is not None:
+            if not server_data.transport:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail="Transport must not be blank",
+                )
+            requested_transport = server_data.transport
+        else:
+            requested_transport = server.transport
+
         update_data = MCPServerCreate(
             name=(server_data.name if can_edit_global else None) or server.name,
-            transport=(server_data.transport if can_edit_global else None)
-            or server.transport,
+            transport=requested_transport,
             description=server_data.description
             if can_edit_global and server_data.description is not None
             else server.description,

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -21,7 +21,7 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse, Response
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -71,7 +71,12 @@ from ..services.mcp_oauth import (
     select_mcp_oauth_grants,
     validate_mcp_oauth_persisted_value,
 )
-from ..services.mcp_runtime import HTTP_MCP_TRANSPORTS, normalize_transport
+from ..services.mcp_runtime import (
+    HTTP_MCP_TRANSPORTS,
+    NormalizedTransport,
+    OptionalNormalizedTransport,
+    normalize_transport,
+)
 from ..services.user_oauth import (
     delete_scoped_user_oauth_accounts,
     list_scoped_user_oauth_accounts,
@@ -102,7 +107,12 @@ class MCPServerCreate(BaseModel):
     """Request model for creating MCP server."""
 
     name: str = Field(..., min_length=1, max_length=100, description="Server name")
-    transport: str = Field(
+    # Trimmed, lowercased and blank-rejected by the shared annotated type, so
+    # the value TransportFieldValidator reads and the row stores is the one
+    # every later comparison must agree on. Also applies to the update
+    # endpoint, which rebuilds this model from the request and the stored row,
+    # so editing a legacy mixed-case server heals it.
+    transport: NormalizedTransport = Field(
         ..., description="Transport type (stdio, sse, websocket, streamable_http)"
     )
     description: Optional[str] = Field(None, description="Server description")
@@ -121,17 +131,6 @@ class MCPServerCreate(BaseModel):
         False, description="Allow runtime Authorization header binding"
     )
 
-    # Canonicalize before anything reads it: transport is free-form here, and
-    # the value validated by TransportFieldValidator / stored on the row is the
-    # one every later comparison (exact and case-insensitive alike) must agree
-    # on. Also applies to the update endpoint, which rebuilds this model from
-    # the request and the stored row, so editing a legacy mixed-case server
-    # heals it.
-    @field_validator("transport")
-    @classmethod
-    def _normalize_transport(cls, value: str) -> str:
-        return normalize_transport(value)
-
 
 class MCPServerUpdate(BaseModel):
     """Request model for updating MCP server."""
@@ -139,7 +138,12 @@ class MCPServerUpdate(BaseModel):
     name: Optional[str] = Field(
         None, min_length=1, max_length=100, description="Server name"
     )
-    transport: Optional[str] = Field(None, description="Transport type")
+    # Normalized before _global_config_tampered compares the incoming transport
+    # with the stored one, so a payload that only re-cases an unchanged
+    # transport doesn't read as a global-config edit by a non-owner. Blank is
+    # rejected here rather than in the endpoint body so it 400s uniformly and
+    # ahead of the ownership branch.
+    transport: OptionalNormalizedTransport = Field(None, description="Transport type")
     description: Optional[str] = Field(None, description="Server description")
     config: Optional[dict] = Field(None, description="Transport-specific configuration")
     is_active: Optional[bool] = Field(None, description="Whether the server is active")
@@ -155,15 +159,6 @@ class MCPServerUpdate(BaseModel):
     allow_delegated_authorization: Optional[bool] = Field(
         None, description="Allow runtime Authorization header binding"
     )
-
-    # Same canonicalization as MCPServerCreate, applied before
-    # _global_config_tampered compares the incoming transport with the stored
-    # one — otherwise a payload that only re-cases an unchanged transport would
-    # read as a global-config edit by a non-owner.
-    @field_validator("transport")
-    @classmethod
-    def _normalize_transport(cls, value: Optional[str]) -> Optional[str]:
-        return None if value is None else normalize_transport(value)
 
 
 class MCPAppConnectRequest(BaseModel):
@@ -228,18 +223,13 @@ class MCPConnectionTest(BaseModel):
     """Request model for testing MCP connection."""
 
     name: str = Field(..., description="Connection name")
-    transport: str = Field(..., description="Transport type")
+    # Same spelling rules as the save path (MCPServerCreate), so Test and Save
+    # agree on how a transport is written. Spelling only: Test still does not
+    # validate against MCPServerConfig's allowed-value list, so an unknown
+    # transport is accepted here and fails at connect time, where Save rejects
+    # it up front.
+    transport: NormalizedTransport = Field(..., description="Transport type")
     config: dict[str, Any] = Field(..., description="Connection configuration")
-
-    # Same case/whitespace canonicalization as the save path
-    # (MCPServerCreate), so Test and Save agree on how a transport is spelled.
-    # This is spelling parity only: Test still does not validate against
-    # MCPServerConfig's allowed-value list, so an unknown transport is accepted
-    # here and fails at connect time, where Save rejects it up front.
-    @field_validator("transport")
-    @classmethod
-    def _normalize_transport(cls, value: str) -> str:
-        return normalize_transport(value)
 
 
 class MCPConnectionTestResponse(BaseModel):
@@ -1432,11 +1422,14 @@ def _global_config_tampered(server_data: MCPServerUpdate, server: MCPServer) -> 
     fields_set = server_data.model_fields_set
     if server_data.name is not None and server_data.name != server.name:
         return True
-    # Both sides normalized: server_data.transport has already been through the
-    # MCPServerUpdate validator, while server.transport is the raw stored value,
-    # which for a row written before that validator shipped may still be
-    # mixed-case or padded. Comparing normalized-vs-raw would flag a non-owner
-    # who merely echoes the row's own unchanged transport as tampering.
+    # Both sides normalized. The right side is the raw stored value, which for
+    # a row written before this validator shipped may still be mixed-case or
+    # padded; comparing it against the already-normalized left side would flag
+    # a non-owner who merely echoes the row's own unchanged transport as
+    # tampering. The left side is re-normalized only so the two sides are
+    # visibly symmetric -- it has already been through the model's annotated
+    # type, and normalize_transport is idempotent, so that call is a no-op
+    # kept for the reader rather than for the result.
     if server_data.transport is not None and normalize_transport(
         server_data.transport
     ) != normalize_transport(server.transport):
@@ -2818,7 +2811,10 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
         if (
             server.command != command
             or (server.args or []) != (launch.get("args") or [])
-            or str(server.transport or "").lower() != "stdio"
+            # Normalized like the mcp_oauth reuse check below. Inert today
+            # (the right side is a literal), but the same shape, and the row
+            # on the left is the one this feature keeps un-normalized.
+            or normalize_transport(server.transport) != "stdio"
         ):
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
@@ -2877,8 +2873,14 @@ def _ensure_catalog_mcp_oauth_server(
     # may be a hijack (a custom server someone created with a different remote
     # URL), so only reuse it if it matches the official configuration.
     if server:
+        # Both sides through the shared helper, not a bare .lower(): the
+        # catalog value may still be padded (a PATCH that doesn't touch
+        # transport persists the stored value unchanged), while the shared row
+        # was written through MCPServerCreate and is therefore normalized.
+        # Lowercasing without stripping compares " sse " against "sse" and
+        # 409s every connect after the first, with no way to fix it from the UI.
         if (
-            str(server.transport or "").lower() != transport.lower()
+            normalize_transport(server.transport) != normalize_transport(transport)
             or server.url != url
         ):
             raise HTTPException(
@@ -3317,23 +3319,26 @@ def update_mcp_server(
                     detail=f"MCP server '{server_data.name}' already exists",
                 )
 
-        # Build update config - only include provided fields. Non-owners keep the
-        # existing global config untouched.
-        # An explicitly-supplied transport must not fall back to the stored
-        # value just because it normalized to "". Before write-time
-        # normalization a blank/whitespace-only transport failed
-        # MCPServerConfig.validate_transport with a 400; the `or` fallback
-        # below would silently keep the old transport instead, turning a
-        # rejected edit into a no-op the caller never learns about.
-        if can_edit_global and server_data.transport is not None:
-            if not server_data.transport:
-                raise HTTPException(
-                    status_code=status.HTTP_400_BAD_REQUEST,
-                    detail="Transport must not be blank",
-                )
-            requested_transport = server_data.transport
-        else:
-            requested_transport = server.transport
+        # Build update config - only include provided fields. Non-owners keep
+        # the existing global config: _global_config_tampered above already
+        # rejected any payload that would change it, so the values below fall
+        # back to the stored row. (Transport is the one exception, and only in
+        # spelling: a non-owner's request still round-trips the stored value
+        # through MCPServerCreate, which canonicalizes it, so a legacy
+        # mixed-case row is healed as a byproduct. The transport *type* is
+        # unchanged -- a real change would have been caught as tampering.)
+        #
+        # An explicitly-supplied transport is passed through rather than
+        # `or`-ed against the stored value: normalization maps a
+        # whitespace-only transport to "", which is falsy, so the old fallback
+        # would have silently kept the stored transport. MCPServerUpdate now
+        # rejects a blank transport outright, before this point and before the
+        # ownership branch above, so nothing blank reaches here.
+        requested_transport = (
+            server_data.transport
+            if can_edit_global and server_data.transport is not None
+            else server.transport
+        )
 
         update_data = MCPServerCreate(
             name=(server_data.name if can_edit_global else None) or server.name,

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -106,12 +106,16 @@ def classify_app_auth(transport: Any, launch_config: Any) -> str:
     """
     # Reuses the runtime's notion of which transports are remote ("oauth"
     # here instead means a static-provider redirect wrapping our own stdio
-    # module). Lowercased like the builtin_oauth check above: an admin PATCH
-    # can store a mixed-case transport, and the two halves of this feature
-    # must not disagree about the same row.
-    from .services.mcp_runtime import HTTP_MCP_TRANSPORTS
+    # module). Normalized through the same helper the write path uses:
+    # transport is canonicalized on write now, but rows stored before that may
+    # still be mixed-case or padded, and the two halves of this feature must
+    # not disagree about the same row. Going through the shared helper rather
+    # than a local .lower() keeps this from drifting out of step with it again.
+    from .services.mcp_runtime import HTTP_MCP_TRANSPORTS, normalize_transport
 
-    if str(transport or "").lower() == "oauth":
+    normalized_transport = normalize_transport(transport)
+
+    if normalized_transport == "oauth":
         return "builtin_oauth"
     launch = launch_config if isinstance(launch_config, dict) else {}
     if launch.get("required_env") and launch.get("command"):
@@ -125,7 +129,7 @@ def classify_app_auth(transport: Any, launch_config: Any) -> str:
     # keyless would offer a no-secrets Connect button for a server that fails
     # at tool-call time for a missing token.
     if (
-        str(transport or "").lower() == "stdio"
+        normalized_transport == "stdio"
         and launch.get("command")
         and not launch.get("required_env")
         and not launch.get("env_mapping")
@@ -133,7 +137,7 @@ def classify_app_auth(transport: Any, launch_config: Any) -> str:
         return "keyless"
     auth = launch.get("auth")
     if (
-        str(transport or "").lower() in HTTP_MCP_TRANSPORTS
+        normalized_transport in HTTP_MCP_TRANSPORTS
         and launch.get("url")
         and isinstance(auth, dict)
         and auth.get("type") == "mcp_oauth"

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -14,6 +14,20 @@ from .mcp_oauth import MCPOAuthRuntimeError, resolve_mcp_oauth_runtime_auth
 HTTP_MCP_TRANSPORTS = frozenset({"sse", "websocket", "streamable_http"})
 
 
+def normalize_transport(transport: Any) -> str:
+    """Canonicalize a transport identifier to its stored lowercase form.
+
+    Transport is a free-form string on the API models, so a mixed-case value
+    ("Streamable_HTTP") can be authored through the admin catalog or the
+    server create/update endpoints. Half of this feature compares it
+    case-insensitively and half compares it exactly, so an un-normalized row
+    is classified as connectable by one half and rejected by the other.
+    Normalizing at every write keeps the stored value in the one form all of
+    those comparisons agree on.
+    """
+    return str(transport or "").strip().lower()
+
+
 @dataclass(frozen=True)
 class MCPRuntimeConnectionBuild:
     """Executable MCP connection plus any runtime authorization diagnostic."""

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import logging
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import Any, Callable, Iterator, Protocol
+from typing import Annotated, Any, Callable, Iterator, Optional, Protocol
+
+from pydantic import AfterValidator, BeforeValidator
 
 from ...core.tools.adapters.vibe.connector_runtime import (
     ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
@@ -26,6 +28,43 @@ def normalize_transport(transport: Any) -> str:
     those comparisons agree on.
     """
     return str(transport or "").strip().lower()
+
+
+def _reject_blank_transport(transport: str) -> str:
+    """Reject a transport that normalized away to nothing.
+
+    Kept as a validator rather than an endpoint-body check so it fires the
+    same way for every write model and *before* any permission branching: an
+    endpoint-level check inside an owner-only branch makes a non-owner who
+    sends a blank transport fail the ownership comparison first and receive a
+    403 about the shared configuration instead of a 400 about their input.
+    """
+    if not transport:
+        raise ValueError("Transport must not be blank")
+    return transport
+
+
+# The one spelling every write model uses. Declared here, next to the helper
+# and the transport set it has to agree with, so a sixth write model added
+# later picks up trimming, lowercasing and the blank check by construction
+# instead of by remembering to copy a validator.
+#
+# BeforeValidator, not AfterValidator, for the normalizing step: it has to run
+# on the raw input, ahead of the str type check, so a non-string body value
+# reaches normalize_transport rather than failing with a bare type error.
+NormalizedTransport = Annotated[
+    str,
+    BeforeValidator(normalize_transport),
+    AfterValidator(_reject_blank_transport),
+]
+
+# Optional variant for PATCH-shaped models: an omitted transport stays None
+# and means "unchanged", while a supplied one gets the full treatment above.
+OptionalNormalizedTransport = Annotated[
+    Optional[str],
+    BeforeValidator(lambda v: None if v is None else normalize_transport(v)),
+    AfterValidator(lambda v: None if v is None else _reject_blank_transport(v)),
+]
 
 
 @dataclass(frozen=True)

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -37,7 +37,13 @@ def _reject_blank_transport(transport: str) -> str:
     same way for every write model and *before* any permission branching: an
     endpoint-level check inside an owner-only branch makes a non-owner who
     sends a blank transport fail the ownership comparison first and receive a
-    403 about the shared configuration instead of a 400 about their input.
+    403 about the shared configuration instead of an error about their input.
+
+    Raising here surfaces as FastAPI's 422 for a request-body validation
+    failure -- the /api/mcp/* routes have no handler that rewrites that to a
+    400 (the app's RequestValidationError handler only reshapes /v1/ and
+    /api/a2a/ responses). 422 rather than 400 is the shape callers should
+    expect for every blank-transport rejection on these endpoints.
     """
     if not transport:
         raise ValueError("Transport must not be blank")

--- a/tests/web/api/test_mcp_api.py
+++ b/tests/web/api/test_mcp_api.py
@@ -664,6 +664,28 @@ class TestMCPApiFunctions:
         # Changed top-level name -> tampered
         assert _global_config_tampered(MCPServerUpdate(name="other"), server)
 
+    def test_global_config_tampered_normalizes_both_sides_of_transport(self):
+        """MCPServerUpdate.transport is normalized by its validator, but the
+        stored value on a row written before that validator shipped is not.
+        Comparing normalized-vs-raw would flag a non-owner who merely echoes
+        the row's own unchanged transport as tampering (spurious 403)."""
+        server = MCPServer.from_config(
+            {
+                "name": "svc",
+                "managed": "external",
+                "transport": "streamable_http",
+                "url": "https://mcp.example.com/mcp",
+            }
+        )
+        # Simulate a legacy row stored before write-time normalization.
+        server.transport = "Streamable_HTTP"
+
+        echoed = MCPServerUpdate(transport="Streamable_HTTP")
+        assert _global_config_tampered(echoed, server) is False
+
+        # A genuinely different transport is still caught.
+        assert _global_config_tampered(MCPServerUpdate(transport="sse"), server)
+
     def test_auth_metadata_tampered(self):
         """Non-secret auth metadata is diffed; secrets/masked values are ignored."""
         current = {"type": "oauth2", "client_id": "abc", "client_secret": "enc"}

--- a/tests/web/api/test_mcp_api.py
+++ b/tests/web/api/test_mcp_api.py
@@ -877,3 +877,94 @@ class TestMCPApiModels:
         response = MCPConnectionTestResponse(**minimal_response)
         assert response.success is False
         assert response.details is None
+
+
+class TestTransportNormalizationOnWriteModels:
+    """All five write models share one annotated type, so they must agree on
+    spelling and on rejecting a transport that normalizes away to nothing."""
+
+    @staticmethod
+    def _build(model_name: str, transport: str):
+        from xagent.web.api.admin_mcp import PublicMCPAppCreate, PublicMCPAppUpdate
+        from xagent.web.api.mcp import MCPConnectionTest
+
+        url = "https://mcp.example.com/mcp"
+        builders = {
+            "MCPServerCreate": lambda t: MCPServerCreate(
+                name="remote", transport=t, config={"url": url}
+            ),
+            "MCPServerUpdate": lambda t: MCPServerUpdate(transport=t),
+            "MCPConnectionTest": lambda t: MCPConnectionTest(
+                name="remote", transport=t, config={"url": url}
+            ),
+            "PublicMCPAppCreate": lambda t: PublicMCPAppCreate(
+                app_id="a", name="A", transport=t
+            ),
+            "PublicMCPAppUpdate": lambda t: PublicMCPAppUpdate(transport=t),
+        }
+        return builders[model_name](transport)
+
+    ALL_MODELS = [
+        "MCPServerCreate",
+        "MCPServerUpdate",
+        "MCPConnectionTest",
+        "PublicMCPAppCreate",
+        "PublicMCPAppUpdate",
+    ]
+
+    @pytest.mark.parametrize("model_name", ALL_MODELS)
+    @pytest.mark.parametrize(
+        "raw",
+        ["streamable_http", "Streamable_HTTP", "  STREAMABLE_HTTP\t", " sse "],
+        ids=["canonical", "mixed-case", "padded-upper", "padded"],
+    )
+    def test_transport_is_canonicalized(self, model_name: str, raw: str):
+        expected = raw.strip().lower()
+        assert self._build(model_name, raw).transport == expected
+
+    @pytest.mark.parametrize("model_name", ALL_MODELS)
+    @pytest.mark.parametrize(
+        "blank", ["", "   ", "\t\n"], ids=["empty", "spaces", "tabs"]
+    )
+    def test_blank_transport_is_rejected(self, model_name: str, blank: str):
+        """Uniform across all five: an endpoint-level guard on one model let a
+        blank transport persist through the other four (a catalog app with
+        transport="" is silently unconnectable, answered with a 200)."""
+        with pytest.raises(ValidationError):
+            self._build(model_name, blank)
+
+    @pytest.mark.parametrize("model_name", ["MCPServerUpdate", "PublicMCPAppUpdate"])
+    def test_omitted_transport_stays_none_on_patch_models(self, model_name: str):
+        """None means "unchanged" and must not be swept up by the blank check."""
+        from xagent.web.api.admin_mcp import PublicMCPAppUpdate
+
+        model = {
+            "MCPServerUpdate": MCPServerUpdate,
+            "PublicMCPAppUpdate": PublicMCPAppUpdate,
+        }[model_name]
+        assert model().transport is None
+        assert model(transport=None).transport is None
+
+    def test_catalog_create_keeps_its_default_transport(self):
+        """The annotated type is applied by redeclaring the inherited field;
+        the default must survive that redeclaration."""
+        from xagent.web.api.admin_mcp import PublicMCPAppCreate
+
+        assert PublicMCPAppCreate(app_id="a", name="A").transport == "oauth"
+
+    def test_non_string_transport_reaches_the_normalizer_not_a_type_error(self):
+        """The normalizing step is a BeforeValidator, so a non-string body
+        value is normalized rather than failing the str type check first. 123
+        normalizes to "123", which is not blank, so it is accepted here and
+        rejected later by MCPServerConfig's allowed-value list."""
+        assert (
+            MCPServerCreate(
+                name="remote", transport=123, config={"url": "https://e/x"}
+            ).transport
+            == "123"
+        )
+        # None is falsy, so it normalizes to "" and is rejected as blank.
+        with pytest.raises(ValidationError):
+            MCPServerCreate(
+                name="remote", transport=None, config={"url": "https://e/x"}
+            )

--- a/tests/web/api/test_mcp_api.py
+++ b/tests/web/api/test_mcp_api.py
@@ -952,17 +952,39 @@ class TestTransportNormalizationOnWriteModels:
 
         assert PublicMCPAppCreate(app_id="a", name="A").transport == "oauth"
 
-    def test_non_string_transport_reaches_the_normalizer_not_a_type_error(self):
-        """The normalizing step is a BeforeValidator, so a non-string body
-        value is normalized rather than failing the str type check first. 123
-        normalizes to "123", which is not blank, so it is accepted here and
-        rejected later by MCPServerConfig's allowed-value list."""
-        assert (
-            MCPServerCreate(
-                name="remote", transport=123, config={"url": "https://e/x"}
-            ).transport
-            == "123"
+    def test_non_string_transport_is_coerced_not_rejected(self):
+        """Known gap, pinned so it cannot drift silently.
+
+        The normalizing step is a BeforeValidator, so it runs ahead of
+        pydantic's own `str` check and a non-string body value is stringified
+        rather than rejected. For MCPServerCreate that is contained --
+        MCPServerConfig's allowed-value list rejects the result downstream, as
+        asserted below. It is *not* contained for the catalog write models,
+        where a payload like {"transport": ["sse"]} with no recognized
+        launch_config shape persists transport="['sse']".
+
+        Tightening this means splitting normalization from coercion so the
+        type check runs first, which changes the shared annotated type used by
+        all five models; tracked with the other normalization-consolidation
+        work in #1828 rather than widened into this PR. This test documents
+        the current behaviour, it does not endorse it."""
+        coerced = MCPServerCreate(
+            name="remote", transport=123, config={"url": "https://e/x"}
         )
+        assert coerced.transport == "123"
+
+        # Contained here: the allowed-value list rejects it before storage.
+        with pytest.raises(ValueError, match="Invalid transport"):
+            _build_server_config(coerced)
+
+        # Not contained on the catalog write models.
+        from xagent.web.api.admin_mcp import PublicMCPAppCreate
+
+        assert (
+            PublicMCPAppCreate(app_id="a", name="A", transport=["sse"]).transport
+            == "['sse']"
+        )
+
         # None is falsy, so it normalizes to "" and is rejected as blank.
         with pytest.raises(ValidationError):
             MCPServerCreate(

--- a/tests/web/api/test_mcp_apps_connect.py
+++ b/tests/web/api/test_mcp_apps_connect.py
@@ -1237,3 +1237,38 @@ def test_connect_coerces_scalar_env_values(test_db):
     )
     assoc2 = test_db.query(UserMCPServer).filter(UserMCPServer.user_id == 2).first()
     assert assoc2.env is None
+
+
+def test_connect_reuses_shared_stdio_row_with_padded_transport(test_db):
+    """The stdio reuse guard must normalize like its mcp_oauth sibling.
+
+    This comparison's right side is a literal "stdio", so lowercasing alone
+    was enough while nothing normalized the left side. It is the same shape as
+    the mcp_oauth check that produced a permanent 409 lockout for catalog
+    apps, and the row on the left is exactly the one this feature leaves
+    un-normalized until the backfill lands: a legacy " stdio " row is the same
+    stdio server, and rejecting it as a different configuration would strand
+    the catalog app for every user until someone hand-edits the database."""
+    from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
+    from xagent.web.models.mcp import MCPServer
+
+    test_db.add(
+        MCPServer(
+            name="google-maps",
+            managed="external",
+            transport=" Stdio ",
+            command="npx",
+            args=["-y", "@cablate/mcp-google-map", "--stdio"],
+        )
+    )
+    test_db.commit()
+
+    connect_mcp_app(
+        "google-maps",
+        MCPAppConnectRequest(env={"GOOGLE_MAPS_API_KEY": "alice-key"}),
+        current_user=_user(test_db, 1),
+        db=test_db,
+    )
+
+    # Reused, not duplicated or rejected with a 409.
+    assert test_db.query(MCPServer).filter(MCPServer.name == "google-maps").count() == 1

--- a/tests/web/api/test_mcp_apps_connect.py
+++ b/tests/web/api/test_mcp_apps_connect.py
@@ -1329,7 +1329,13 @@ def test_connect_does_not_blank_a_transport_it_cannot_heal(test_db):
     assert row.transport == "   "
 
     # A non-string stored value is left alone rather than stringified.
-    row2 = MCPServer(name="odd", managed="external", transport="stdio")
-    row2.transport = None
-    _heal_server_transport(row2)
-    assert row2.transport is None
+    # `None` alone doesn't discriminate -- it normalizes to "" and the blank
+    # guard above would block the write anyway. A value that normalizes to
+    # something non-blank is what proves the isinstance check is load-bearing:
+    # healing canonicalizes a transport, it does not coerce whatever type
+    # happens to be in the column.
+    for odd in (None, 123, ["sse"], True):
+        row2 = MCPServer(name="odd", managed="external", transport="stdio")
+        row2.transport = odd
+        _heal_server_transport(row2)
+        assert row2.transport is odd

--- a/tests/web/api/test_mcp_apps_connect.py
+++ b/tests/web/api/test_mcp_apps_connect.py
@@ -1272,3 +1272,64 @@ def test_connect_reuses_shared_stdio_row_with_padded_transport(test_db):
 
     # Reused, not duplicated or rejected with a 409.
     assert test_db.query(MCPServer).filter(MCPServer.name == "google-maps").count() == 1
+
+
+def test_connect_heals_a_padded_transport_on_the_shared_row(test_db):
+    """Accepting a legacy row obliges the reuse path to canonicalize it.
+
+    The reuse guard compares transport tolerantly so a padded row isn't
+    rejected as a different configuration. Everything downstream is not
+    tolerant: MCPServerConfig.to_connection_dict() dispatches on an exact
+    match, so leaving the row dirty produces a connection with no
+    command/args/env and no error surfaced -- strictly worse than the 409 the
+    tolerant comparison replaced. Tolerate on read, canonicalize on write."""
+    from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
+    from xagent.web.models.mcp import MCPServer
+
+    test_db.add(
+        MCPServer(
+            name="google-maps",
+            managed="external",
+            transport=" Stdio ",
+            command="npx",
+            args=["-y", "@cablate/mcp-google-map", "--stdio"],
+        )
+    )
+    test_db.commit()
+
+    connect_mcp_app(
+        "google-maps",
+        MCPAppConnectRequest(env={"GOOGLE_MAPS_API_KEY": "alice-key"}),
+        current_user=_user(test_db, 1),
+        db=test_db,
+    )
+
+    row = test_db.query(MCPServer).filter(MCPServer.name == "google-maps").one()
+    assert row.transport == "stdio"
+
+    # The point of healing: the exact-match consumer downstream still works.
+    connection = row.to_connection_dict()
+    assert connection["transport"] == "stdio"
+    assert connection["command"] == "npx"
+    assert connection["args"] == ["-y", "@cablate/mcp-google-map", "--stdio"]
+
+
+def test_connect_does_not_blank_a_transport_it_cannot_heal(test_db):
+    """Healing must never create the blank state the write models prevent.
+
+    A row whose transport normalizes to "" has nothing to be healed to.
+    Writing "" would turn an already-unusable row into a silently
+    unconnectable one, so the heal is skipped and the row is left for the
+    backfill migration."""
+    from xagent.web.api.mcp import _heal_server_transport
+    from xagent.web.models.mcp import MCPServer
+
+    row = MCPServer(name="blank", managed="external", transport="   ")
+    _heal_server_transport(row)
+    assert row.transport == "   "
+
+    # A non-string stored value is left alone rather than stringified.
+    row2 = MCPServer(name="odd", managed="external", transport="stdio")
+    row2.transport = None
+    _heal_server_transport(row2)
+    assert row2.transport is None

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -3251,6 +3251,57 @@ def test_blank_transport_400s_for_a_non_owner_rather_than_403(db_session):
     assert server.transport == "streamable_http"
 
 
+def test_update_does_not_fall_back_to_stored_transport_for_a_blank_value(
+    db_session,
+):
+    """Defense in depth for the `or server.transport` fallback that was here.
+
+    MCPServerUpdate now rejects a blank transport, so `""` cannot reach this
+    endpoint through the API -- the model is built with validation bypassed to
+    exercise the endpoint's own handling of a value the model would refuse.
+    The old `or` fallback treated `""` as "not supplied" and silently kept the
+    stored transport, answering 200 for an edit that never happened. The
+    explicit `is not None` check passes the blank through instead, where
+    MCPServerCreate rejects it and the endpoint surfaces a failure.
+
+    The status here is 500 rather than 400: a ValidationError raised while
+    rebuilding MCPServerCreate lands in the endpoint's generic handler. That
+    is acceptable precisely because this path is unreachable through the API
+    -- the 400 for a blank transport is produced by the model, before the
+    endpoint runs (see test_update_rejects_blank_transport_at_the_model_
+    boundary). What this test pins is that the value is not silently
+    swallowed."""
+    db, user, _ = db_session
+    server = MCPServer(
+        name="editable",
+        managed="external",
+        transport="streamable_http",
+        url="https://mcp.example.com/mcp",
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    db.add(
+        UserMCPServer(
+            user_id=user.id,
+            mcpserver_id=server.id,
+            is_owner=True,
+            is_active=True,
+            can_edit=True,
+        )
+    )
+    db.commit()
+
+    blank = MCPServerUpdate.model_construct(transport="")
+    with pytest.raises(mcp_api.HTTPException) as exc:
+        update_mcp_server(server.id, blank, user, db)
+    assert exc.value.status_code >= 400
+    assert "blank" in str(exc.value.detail).lower()
+
+    db.refresh(server)
+    assert server.transport == "streamable_http"
+
+
 def test_update_keeps_stored_transport_when_none_is_supplied(db_session):
     """The `or server.transport` fallback was replaced with an explicit
     `is not None` check. An omitted transport must still leave the stored

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import json
 from datetime import timedelta
-from typing import Any, cast
 from types import SimpleNamespace
+from typing import Any, cast
 from urllib.parse import parse_qs, urlparse
 
 import httpx

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -3193,3 +3193,68 @@ async def test_status_reports_discovered_grant_without_configured_selectors(db_s
     status_response = await get_mcp_oauth_status(server.id, user, db)
 
     assert [item.id for item in status_response.grants] == [grant.id]
+
+
+def test_mcp_server_create_normalizes_transport():
+    """Write-time normalization is what keeps mixed-case rows from being
+    created in the first place."""
+    created = mcp_api.MCPServerCreate(
+        name="remote",
+        transport="  Streamable_HTTP ",
+        config={"url": "https://mcp.example.com/mcp"},
+    )
+    assert created.transport == "streamable_http"
+
+    updated = MCPServerUpdate(transport="SSE")
+    assert updated.transport == "sse"
+    assert MCPServerUpdate().transport is None
+
+    # The test-connection path must agree with the save path, so a transport
+    # spelling can't be accepted by one and rejected by the other.
+    tested = mcp_api.MCPConnectionTest(
+        name="remote",
+        transport=" Streamable_HTTP ",
+        config={"url": "https://mcp.example.com/mcp"},
+    )
+    assert tested.transport == "streamable_http"
+
+
+def test_update_rejects_blank_transport_instead_of_silently_keeping_the_old_one(
+    db_session,
+):
+    """`normalize_transport("   ")` is `""`, which is falsy. The update path's
+    `or server.transport` fallback would therefore silently keep the stored
+    transport, turning an invalid edit into a no-op the caller never learns
+    about -- before write-time normalization this failed with a 400."""
+    db, user, _ = db_session
+    server = MCPServer(
+        name="editable",
+        managed="external",
+        transport="streamable_http",
+        url="https://mcp.example.com/mcp",
+    )
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    db.add(
+        UserMCPServer(
+            user_id=user.id,
+            mcpserver_id=server.id,
+            is_owner=True,
+            is_active=True,
+            can_edit=True,
+        )
+    )
+    db.commit()
+
+    with pytest.raises(mcp_api.HTTPException) as exc:
+        update_mcp_server(
+            server.id,
+            MCPServerUpdate(transport="   "),
+            user,
+            db,
+        )
+    assert exc.value.status_code == 400
+
+    db.refresh(server)
+    assert server.transport == "streamable_http"

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -8,6 +8,7 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 import pytest
 from fastapi import HTTPException
+from pydantic import ValidationError
 from sqlalchemy import create_engine
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
@@ -3195,37 +3196,65 @@ async def test_status_reports_discovered_grant_without_configured_selectors(db_s
     assert [item.id for item in status_response.grants] == [grant.id]
 
 
-def test_mcp_server_create_normalizes_transport():
-    """Write-time normalization is what keeps mixed-case rows from being
-    created in the first place."""
-    created = mcp_api.MCPServerCreate(
-        name="remote",
-        transport="  Streamable_HTTP ",
-        config={"url": "https://mcp.example.com/mcp"},
+@pytest.mark.parametrize("blank", ["", "   ", "\t\n"], ids=["empty", "spaces", "tabs"])
+def test_update_rejects_blank_transport_at_the_model_boundary(blank: str):
+    """A blank transport is rejected when the request model is built, not in
+    the endpoint body.
+
+    Pre-PR the two blank shapes behaved differently and neither was safe: a
+    whitespace-only transport reached MCPServerConfig.validate_transport and
+    400'd there, while a literal "" was already falsy and hit the update
+    path's `or server.transport` fallback -- silently keeping the stored
+    transport with no error at all. Normalization collapses both to "", so
+    both must be rejected, and rejecting at the model means it happens before
+    any permission branching (see the non-owner test below)."""
+    with pytest.raises(ValidationError):
+        MCPServerUpdate(transport=blank)
+
+
+def test_blank_transport_400s_for_a_non_owner_rather_than_403(db_session):
+    """Regression guard for where this check lives.
+
+    While the blank check sat in the endpoint body it was only reachable
+    inside the `can_edit_global` branch, so a non-owner sending a blank
+    transport was measured against the stored value by
+    _global_config_tampered first ("" != "streamable_http" -> tampering) and
+    got a 403 about the shared configuration -- a permission error for what is
+    really a malformed field. Rejecting at the model boundary means the caller
+    never reaches the ownership branch."""
+    db, user, _ = db_session
+    server = MCPServer(
+        name="shared",
+        managed="external",
+        transport="streamable_http",
+        url="https://mcp.example.com/mcp",
     )
-    assert created.transport == "streamable_http"
-
-    updated = MCPServerUpdate(transport="SSE")
-    assert updated.transport == "sse"
-    assert MCPServerUpdate().transport is None
-
-    # The test-connection path must agree with the save path, so a transport
-    # spelling can't be accepted by one and rejected by the other.
-    tested = mcp_api.MCPConnectionTest(
-        name="remote",
-        transport=" Streamable_HTTP ",
-        config={"url": "https://mcp.example.com/mcp"},
+    db.add(server)
+    db.commit()
+    db.refresh(server)
+    db.add(
+        UserMCPServer(
+            user_id=user.id,
+            mcpserver_id=server.id,
+            is_owner=False,
+            is_active=True,
+            can_edit=False,
+        )
     )
-    assert tested.transport == "streamable_http"
+    db.commit()
+
+    with pytest.raises(ValidationError):
+        MCPServerUpdate(transport="   ")
+
+    # And the stored row is untouched: nothing got as far as the endpoint.
+    db.refresh(server)
+    assert server.transport == "streamable_http"
 
 
-def test_update_rejects_blank_transport_instead_of_silently_keeping_the_old_one(
-    db_session,
-):
-    """`normalize_transport("   ")` is `""`, which is falsy. The update path's
-    `or server.transport` fallback would therefore silently keep the stored
-    transport, turning an invalid edit into a no-op the caller never learns
-    about -- before write-time normalization this failed with a 400."""
+def test_update_keeps_stored_transport_when_none_is_supplied(db_session):
+    """The `or server.transport` fallback was replaced with an explicit
+    `is not None` check. An omitted transport must still leave the stored
+    value alone -- that is the case the old fallback existed to serve."""
     db, user, _ = db_session
     server = MCPServer(
         name="editable",
@@ -3247,14 +3276,75 @@ def test_update_rejects_blank_transport_instead_of_silently_keeping_the_old_one(
     )
     db.commit()
 
-    with pytest.raises(mcp_api.HTTPException) as exc:
-        update_mcp_server(
-            server.id,
-            MCPServerUpdate(transport="   "),
-            user,
-            db,
-        )
-    assert exc.value.status_code == 400
+    update_mcp_server(server.id, MCPServerUpdate(description="edited"), user, db)
 
     db.refresh(server)
     assert server.transport == "streamable_http"
+    assert server.description == "edited"
+
+
+@pytest.mark.asyncio
+async def test_padded_catalog_transport_does_not_lock_out_repeat_connects(
+    db_session, monkeypatch
+):
+    """Regression: write-side normalization must not strand a legacy catalog row.
+
+    A catalog row authored before normalization can hold " streamable_http ".
+    The first connect writes the shared `mcp_servers` row through
+    MCPServerCreate, which canonicalizes it. Every later connect then compares
+    the normalized stored row against the still-padded catalog value; a
+    comparison that lowercases without stripping sees " streamable_http " !=
+    "streamable_http" and raises a permanent 409 that no admin action taken
+    from the UI can clear. Both sides go through normalize_transport now."""
+    db, user, _ = db_session
+    monkeypatch.setenv("XAGENT_PUBLIC_API_BASE_URL", "https://api.xagent.test/")
+    db.add(
+        PublicMCPApp(
+            app_id="padded-notes",
+            name="PaddedNotes",
+            transport=" Streamable_HTTP ",
+            launch_config={
+                "url": "https://mcp.example.com/mcp",
+                "auth": {"type": "mcp_oauth"},
+            },
+        )
+    )
+    db.commit()
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    def registration_handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            201,
+            json={
+                "client_id": "dynamic-client-123",
+                "token_endpoint_auth_method": "none",
+            },
+        )
+
+    registration_client = httpx.AsyncClient(
+        transport=httpx.MockTransport(registration_handler)
+    )
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+    monkeypatch.setattr(
+        mcp_oauth_service,
+        "create_mcp_oauth_http_client",
+        lambda **kwargs: registration_client,
+    )
+
+    first = await connect_mcp_oauth_app(
+        "padded-notes", MCPOAuthConnectRequest(redirect_after="/x"), user, db
+    )
+    assert first.status_code == 303
+
+    # The shared row was written canonical...
+    row = db.query(MCPServer).filter(MCPServer.name == "padded-notes").one()
+    assert row.transport == "streamable_http"
+
+    # ...and the second connect must reuse it rather than 409.
+    second = await connect_mcp_oauth_app(
+        "padded-notes", MCPOAuthConnectRequest(redirect_after="/x"), user, db
+    )
+    assert second.status_code == 303
+    assert db.query(MCPServer).filter(MCPServer.name == "padded-notes").count() == 1

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from datetime import timedelta
+from typing import Any, cast
 from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
 
@@ -3212,45 +3213,6 @@ def test_update_rejects_blank_transport_at_the_model_boundary(blank: str):
         MCPServerUpdate(transport=blank)
 
 
-def test_blank_transport_400s_for_a_non_owner_rather_than_403(db_session):
-    """Regression guard for where this check lives.
-
-    While the blank check sat in the endpoint body it was only reachable
-    inside the `can_edit_global` branch, so a non-owner sending a blank
-    transport was measured against the stored value by
-    _global_config_tampered first ("" != "streamable_http" -> tampering) and
-    got a 403 about the shared configuration -- a permission error for what is
-    really a malformed field. Rejecting at the model boundary means the caller
-    never reaches the ownership branch."""
-    db, user, _ = db_session
-    server = MCPServer(
-        name="shared",
-        managed="external",
-        transport="streamable_http",
-        url="https://mcp.example.com/mcp",
-    )
-    db.add(server)
-    db.commit()
-    db.refresh(server)
-    db.add(
-        UserMCPServer(
-            user_id=user.id,
-            mcpserver_id=server.id,
-            is_owner=False,
-            is_active=True,
-            can_edit=False,
-        )
-    )
-    db.commit()
-
-    with pytest.raises(ValidationError):
-        MCPServerUpdate(transport="   ")
-
-    # And the stored row is untouched: nothing got as far as the endpoint.
-    db.refresh(server)
-    assert server.transport == "streamable_http"
-
-
 def test_update_does_not_fall_back_to_stored_transport_for_a_blank_value(
     db_session,
 ):
@@ -3391,6 +3353,16 @@ async def test_padded_catalog_transport_does_not_lock_out_repeat_connects(
 
     # The shared row was written canonical...
     row = db.query(MCPServer).filter(MCPServer.name == "padded-notes").one()
+    assert row.transport == "streamable_http"
+
+    # ...and a legacy shared row admitted by the tolerant comparison is healed
+    # rather than left dirty for the exact-match consumers downstream.
+    cast(Any, row).transport = " Streamable_HTTP "
+    db.commit()
+    await connect_mcp_oauth_app(
+        "padded-notes", MCPOAuthConnectRequest(redirect_after="/x"), user, db
+    )
+    db.refresh(row)
     assert row.transport == "streamable_http"
 
     # ...and the second connect must reuse it rather than 409.

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -2312,3 +2312,61 @@ def test_admin_custom_catalog_writes_record_before_after_audits() -> None:
             shutil.rmtree(temp_dir)
         except OSError:
             pass
+
+
+def test_admin_catalog_write_normalizes_transport_case() -> None:
+    """`transport` is a free-form string, and the shape check that guards these
+    writes (classify_app_auth) compares it case-insensitively — so a mixed-case
+    "Streamable_HTTP" is accepted here, while the connect path it feeds compares
+    exactly. Normalize on write so the stored row can't be classified
+    connectable by one half of the feature and rejected by the other."""
+    temp_dir = _setup_test_db()
+    try:
+        _setup_admin()
+        admin_headers = _login("admin", "admin123")
+
+        created = client.post(
+            "/api/admin/mcp/apps",
+            headers=admin_headers,
+            json={
+                "app_id": "remote-mixed",
+                "name": "RemoteMixed",
+                "transport": "Streamable_HTTP",
+                "launch_config": {
+                    "url": "https://mcp.example.com/mcp",
+                    "auth": {"type": "mcp_oauth"},
+                },
+            },
+        )
+        assert created.status_code == 200
+        app_pk = created.json()["id"]
+
+        db = next(get_db())
+        try:
+            stored = db.query(PublicMCPApp).filter(PublicMCPApp.id == app_pk).one()
+            assert stored.transport == "streamable_http"
+        finally:
+            db.close()
+
+        # A PATCH must not be able to reintroduce a mixed-case row either.
+        patched = client.patch(
+            f"/api/admin/mcp/apps/{app_pk}",
+            headers=admin_headers,
+            json={"transport": "SSE"},
+        )
+        assert patched.status_code == 200
+
+        db = next(get_db())
+        try:
+            stored = db.query(PublicMCPApp).filter(PublicMCPApp.id == app_pk).one()
+            assert stored.transport == "sse"
+        finally:
+            db.close()
+    finally:
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -2625,3 +2625,64 @@ def test_apply_update_heals_a_padded_transport_on_an_unrelated_edit() -> None:
     _apply_public_mcp_app_update(row, {"icon": "new-icon"})
     assert row.transport == "streamable_http"
     assert row.icon == "new-icon"
+
+
+def test_admin_catalog_heal_is_recorded_in_the_audit_trail() -> None:
+    """A heal genuinely changes the row, so it must appear in the audit as a
+    before/after difference rather than being applied invisibly."""
+    temp_dir = _setup_test_db()
+    try:
+        _setup_admin()
+        admin_headers = _login("admin", "admin123")
+
+        db = next(get_db())
+        try:
+            db.add(
+                PublicMCPApp(
+                    app_id="legacy-audited",
+                    name="LegacyAudited",
+                    transport=" Streamable_HTTP ",
+                    launch_config={
+                        "url": "https://mcp.example.com/mcp",
+                        "auth": {"type": "mcp_oauth"},
+                    },
+                )
+            )
+            db.commit()
+            app_pk = (
+                db.query(PublicMCPApp)
+                .filter(PublicMCPApp.app_id == "legacy-audited")
+                .one()
+                .id
+            )
+        finally:
+            db.close()
+
+        assert (
+            client.patch(
+                f"/api/admin/mcp/apps/{app_pk}",
+                headers=admin_headers,
+                json={"icon": "new-icon"},
+            ).status_code
+            == 200
+        )
+
+        db = next(get_db())
+        try:
+            entry = (
+                db.query(PublicMCPAppAudit)
+                .filter(PublicMCPAppAudit.app_id == "legacy-audited")
+                .one()
+            )
+            assert (entry.before_values or {})["transport"] == " Streamable_HTTP "
+            assert (entry.after_values or {})["transport"] == "streamable_http"
+        finally:
+            db.close()
+    finally:
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -2850,3 +2850,17 @@ def test_blank_transport_update_returns_422_over_http_for_a_non_owner() -> None:
             shutil.rmtree(temp_dir)
         except OSError:
             pass
+
+
+def test_an_explicit_transport_change_is_not_overwritten_by_the_heal() -> None:
+    """The heal must never win over what the admin actually asked for.
+
+    It is computed from the *stored* value, so without the `"transport" not in
+    changes` guard a PATCH that deliberately changes a legacy row's transport
+    would have that edit silently replaced by the canonicalized old value --
+    the admin sees 200 and a transport they did not choose."""
+    from xagent.web.api.admin_mcp import _apply_public_mcp_app_update
+
+    row = _legacy_catalog_row(" Streamable_HTTP ")
+    _apply_public_mcp_app_update(row, {"transport": "sse"})
+    assert row.transport == "sse"

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -2340,10 +2340,14 @@ def test_admin_catalog_write_normalizes_transport_case() -> None:
         )
         assert created.status_code == 200
         app_pk = created.json()["id"]
+        # The response body, not just the row: an endpoint that echoed the raw
+        # input back would leave the caller believing a mixed-case value stuck.
+        assert created.json()["transport"] == "streamable_http"
 
         db = next(get_db())
         try:
-            stored = db.query(PublicMCPApp).filter(PublicMCPApp.id == app_pk).one()
+            stored = db.get(PublicMCPApp, app_pk)
+            assert stored is not None
             assert stored.transport == "streamable_http"
         finally:
             db.close()
@@ -2355,11 +2359,196 @@ def test_admin_catalog_write_normalizes_transport_case() -> None:
             json={"transport": "SSE"},
         )
         assert patched.status_code == 200
+        assert patched.json()["transport"] == "sse"
 
         db = next(get_db())
         try:
-            stored = db.query(PublicMCPApp).filter(PublicMCPApp.id == app_pk).one()
+            stored = db.get(PublicMCPApp, app_pk)
+            assert stored is not None
             assert stored.transport == "sse"
+        finally:
+            db.close()
+    finally:
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass
+
+
+def test_admin_catalog_patch_heals_a_legacy_transport_it_does_not_touch() -> None:
+    """Write-side normalization alone leaves legacy rows stranded.
+
+    `exclude_unset=True` means a PATCH of an unrelated field persists nothing
+    for `transport`, so a row authored before normalization keeps its padded
+    value forever while the `mcp_servers` row the connect path writes is
+    canonical -- and the two are then compared. Heal the stored value on any
+    edit so the catalog converges instead of drifting further apart."""
+    temp_dir = _setup_test_db()
+    try:
+        _setup_admin()
+        admin_headers = _login("admin", "admin123")
+
+        db = next(get_db())
+        try:
+            # Written directly: the API would reject this shape now, which is
+            # exactly why only a pre-existing row can be in this state.
+            db.add(
+                PublicMCPApp(
+                    app_id="legacy-padded",
+                    name="LegacyPadded",
+                    transport=" Streamable_HTTP ",
+                    launch_config={
+                        "url": "https://mcp.example.com/mcp",
+                        "auth": {"type": "mcp_oauth"},
+                    },
+                )
+            )
+            db.commit()
+            app_pk = (
+                db.query(PublicMCPApp)
+                .filter(PublicMCPApp.app_id == "legacy-padded")
+                .one()
+                .id
+            )
+        finally:
+            db.close()
+
+        # Edit something entirely unrelated to transport.
+        patched = client.patch(
+            f"/api/admin/mcp/apps/{app_pk}",
+            headers=admin_headers,
+            json={"icon": "new-icon"},
+        )
+        assert patched.status_code == 200
+
+        db = next(get_db())
+        try:
+            stored = db.get(PublicMCPApp, app_pk)
+            assert stored is not None
+            assert stored.icon == "new-icon"
+            assert stored.transport == "streamable_http"
+        finally:
+            db.close()
+    finally:
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass
+
+
+def test_admin_catalog_patch_leaves_a_canonical_transport_byte_identical() -> None:
+    """The healing write must fire only when normalization changes something,
+    so an ordinary edit to an already-canonical row doesn't show up in the
+    audit trail as a transport change it never made."""
+    temp_dir = _setup_test_db()
+    try:
+        _setup_admin()
+        admin_headers = _login("admin", "admin123")
+
+        created = client.post(
+            "/api/admin/mcp/apps",
+            headers=admin_headers,
+            json={
+                "app_id": "already-canonical",
+                "name": "AlreadyCanonical",
+                "transport": "streamable_http",
+                "launch_config": {
+                    "url": "https://mcp.example.com/mcp",
+                    "auth": {"type": "mcp_oauth"},
+                },
+            },
+        )
+        assert created.status_code == 200
+        app_pk = created.json()["id"]
+
+        patched = client.patch(
+            f"/api/admin/mcp/apps/{app_pk}",
+            headers=admin_headers,
+            json={"icon": "another-icon"},
+        )
+        assert patched.status_code == 200
+
+        db = next(get_db())
+        try:
+            stored = db.get(PublicMCPApp, app_pk)
+            assert stored is not None
+            assert stored.transport == "streamable_http"
+
+            # No audit row may report a transport change: the healing write is
+            # gated on normalization actually altering the value.
+            audits = (
+                db.query(PublicMCPAppAudit)
+                .filter(PublicMCPAppAudit.app_id == "already-canonical")
+                .all()
+            )
+            assert audits, "expected the create and patch to be audited"
+            for entry in audits:
+                before = (entry.before_values or {}).get("transport")
+                after = (entry.after_values or {}).get("transport")
+                if before is not None and after is not None:
+                    assert before == after == "streamable_http"
+        finally:
+            db.close()
+    finally:
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass
+
+
+def test_admin_builtin_patch_treats_a_case_only_transport_change_as_a_no_op() -> None:
+    """Documented behaviour change, previously unlisted.
+
+    The builtin protected-field guard compares the incoming value against the
+    registry's canonical one. That incoming value is now normalized before the
+    comparison, so `{"transport": "OAuth"}` against a canonical "oauth" no
+    longer 409s "managed by code" -- it compares equal and changes nothing.
+    A transport that differs by more than case is still rejected."""
+    temp_dir = _setup_test_db()
+    try:
+        _setup_admin()
+        admin_headers = _login("admin", "admin123")
+
+        db = next(get_db())
+        try:
+            builtin = (
+                db.query(PublicMCPApp).filter(PublicMCPApp.transport == "oauth").first()
+            )
+            assert builtin is not None, "expected a seeded builtin oauth app"
+            app_pk = builtin.id
+        finally:
+            db.close()
+
+        case_only = client.patch(
+            f"/api/admin/mcp/apps/{app_pk}",
+            headers=admin_headers,
+            json={"transport": "OAuth"},
+        )
+        assert case_only.status_code == 200
+        assert case_only.json()["transport"] == "oauth"
+
+        # A genuinely different transport is still managed by code.
+        real_change = client.patch(
+            f"/api/admin/mcp/apps/{app_pk}",
+            headers=admin_headers,
+            json={"transport": "sse"},
+        )
+        assert real_change.status_code == 409
+
+        db = next(get_db())
+        try:
+            stored = db.get(PublicMCPApp, app_pk)
+            assert stored is not None
+            assert stored.transport == "oauth"
         finally:
             db.close()
     finally:

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -2559,3 +2559,69 @@ def test_admin_builtin_patch_treats_a_case_only_transport_change_as_a_no_op() ->
             shutil.rmtree(temp_dir)
         except OSError:
             pass
+
+
+def test_apply_update_does_not_touch_an_already_canonical_transport() -> None:
+    """The healing write is gated on normalization changing the value.
+
+    Asserting the stored value alone cannot detect an ungated write --
+    rewriting "streamable_http" over "streamable_http" is invisible in the
+    row and in the audit diff. Watch the attribute instead: an ungated heal
+    sets `transport` on every edit, which dirties the ORM row (and the audit's
+    changed-field set) for a value nobody changed."""
+    from xagent.web.api.admin_mcp import _apply_public_mcp_app_update
+
+    class _Recorder:
+        app_id = "already-canonical"
+        name = "AlreadyCanonical"
+        description = None
+        icon = "old-icon"
+        transport = "streamable_http"
+        provider_name = None
+        category = None
+        oauth_scopes: list = []
+        is_visible_in_connector = True
+        launch_config = {
+            "url": "https://mcp.example.com/mcp",
+            "auth": {"type": "mcp_oauth"},
+        }
+
+        def __init__(self) -> None:
+            self.assigned: list = []
+
+        def __setattr__(self, key, value):
+            if key != "assigned":
+                self.assigned.append(key)
+            object.__setattr__(self, key, value)
+
+    row = _Recorder()
+    _apply_public_mcp_app_update(row, {"icon": "new-icon"})
+    assert row.icon == "new-icon"
+    assert "transport" not in row.assigned
+    assert row.transport == "streamable_http"
+
+
+def test_apply_update_heals_a_padded_transport_on_an_unrelated_edit() -> None:
+    """Mirror of the test above: when normalization *does* change the value,
+    the heal must fire even though the PATCH never mentioned transport."""
+    from xagent.web.api.admin_mcp import _apply_public_mcp_app_update
+
+    class _Row:
+        app_id = "legacy-padded"
+        name = "LegacyPadded"
+        description = None
+        icon = "old-icon"
+        transport = " Streamable_HTTP "
+        provider_name = None
+        category = None
+        oauth_scopes: list = []
+        is_visible_in_connector = True
+        launch_config = {
+            "url": "https://mcp.example.com/mcp",
+            "auth": {"type": "mcp_oauth"},
+        }
+
+    row = _Row()
+    _apply_public_mcp_app_update(row, {"icon": "new-icon"})
+    assert row.transport == "streamable_http"
+    assert row.icon == "new-icon"

--- a/tests/web/api/test_public_mcp_connector_visibility.py
+++ b/tests/web/api/test_public_mcp_connector_visibility.py
@@ -2686,3 +2686,167 @@ def test_admin_catalog_heal_is_recorded_in_the_audit_trail() -> None:
             shutil.rmtree(temp_dir)
         except OSError:
             pass
+
+
+def _legacy_catalog_row(transport: str):
+    """A catalog row shaped like one written before the write models validated
+    transport. Built as a plain stand-in so the test can seed states the API
+    would now refuse to create."""
+
+    class _Row:
+        app_id = "legacy"
+        name = "Legacy"
+        description = None
+        icon = "old-icon"
+        provider_name = None
+        category = None
+        is_visible_in_connector = True
+        launch_config = {
+            "url": "https://mcp.example.com/mcp",
+            "auth": {"type": "mcp_oauth"},
+        }
+
+        def __init__(self) -> None:
+            self.transport = transport
+            self.oauth_scopes: list = []
+
+    return _Row()
+
+
+def test_blank_legacy_transport_is_never_healed_to_empty_string() -> None:
+    """Healing must not create the state the validators exist to prevent.
+
+    A whitespace-only legacy transport normalizes to "". Persisting that would
+    turn an already-broken row into a silently unconnectable one, answered with
+    a 200 and no audit anomaly. The row is left exactly as found for the
+    backfill migration."""
+    from xagent.web.api.admin_mcp import _apply_public_mcp_app_update
+
+    row = _legacy_catalog_row("   ")
+    _apply_public_mcp_app_update(row, {"icon": "new-icon"})
+
+    assert row.transport == "   "
+    assert row.icon == "new-icon"
+
+
+def test_blank_legacy_transport_does_not_block_an_edit_opaquely() -> None:
+    """A shape-checked edit on a blank-transport row still cannot proceed --
+    there is no transport to validate a connect shape against -- but the error
+    must name the actual problem and the way out, not answer with a bare
+    "invalid configuration" about a field the admin never touched."""
+    from xagent.web.api.admin_mcp import _apply_public_mcp_app_update
+
+    row = _legacy_catalog_row("   ")
+    with pytest.raises(HTTPException) as exc:
+        _apply_public_mcp_app_update(
+            row,
+            {"launch_config": {"url": "https://e/y", "auth": {"type": "mcp_oauth"}}},
+        )
+    assert exc.value.status_code == 422
+    assert "transport" in str(exc.value.detail).lower()
+
+    # And the way out the message names actually works.
+    row2 = _legacy_catalog_row("   ")
+    _apply_public_mcp_app_update(
+        row2,
+        {
+            "transport": "sse",
+            "launch_config": {"url": "https://e/y", "auth": {"type": "mcp_oauth"}},
+        },
+    )
+    assert row2.transport == "sse"
+
+
+def test_padded_legacy_transport_does_not_block_an_unrelated_shape_edit() -> None:
+    """The regression that motivated moving the heal ahead of validation.
+
+    With healing after validation, the merged dict still carried the dirty
+    stored transport, so a routine launch_config edit on a legacy row was
+    rejected with an opaque 422 about a field the request never mentioned."""
+    from xagent.web.api.admin_mcp import _apply_public_mcp_app_update
+
+    row = _legacy_catalog_row(" Streamable_HTTP ")
+    _apply_public_mcp_app_update(
+        row,
+        {"launch_config": {"url": "https://e/y", "auth": {"type": "mcp_oauth"}}},
+    )
+    assert row.transport == "streamable_http"
+    assert row.launch_config["url"] == "https://e/y"
+
+
+def test_blank_transport_update_returns_422_over_http_for_a_non_owner() -> None:
+    """End-to-end status for the layering fix, asserted over a real request.
+
+    Two things this pins that a direct model construction cannot. First, the
+    status is 422, not the 400 an earlier revision of this PR claimed: the
+    /api/mcp/* routes have no handler rewriting FastAPI's request-validation
+    response. Second, a non-owner gets that 422 rather than the 403 the check
+    produced while it lived in the endpoint body -- the model rejects the
+    payload before any ownership branch runs."""
+    temp_dir = _setup_test_db()
+    try:
+        _setup_admin()
+        owner_headers = _login("admin", "admin123")
+
+        created = client.post(
+            "/api/mcp/servers",
+            headers=owner_headers,
+            json={
+                "name": "shared-server",
+                "transport": "streamable_http",
+                "config": {"url": "https://mcp.example.com/mcp"},
+            },
+        )
+        assert created.status_code == 201, created.text
+        server_id = created.json()["id"]
+
+        registered = client.post(
+            "/api/auth/register",
+            json={
+                "username": "outsider",
+                "email": "outsider@example.com",
+                "password": "outsider123",
+            },
+        )
+        assert registered.status_code in (200, 201), registered.text
+
+        db = next(get_db())
+        try:
+            outsider = db.query(User).filter(User.username == "outsider").one()
+            db.add(
+                UserMCPServer(
+                    user_id=outsider.id,
+                    mcpserver_id=server_id,
+                    is_owner=False,
+                    can_edit=False,
+                    is_active=True,
+                )
+            )
+            db.commit()
+        finally:
+            db.close()
+
+        outsider_headers = _login("outsider", "outsider123")
+        response = client.put(
+            f"/api/mcp/servers/{server_id}",
+            headers=outsider_headers,
+            json={"transport": "   "},
+        )
+        assert response.status_code == 422, response.text
+
+        # The stored row is untouched: nothing reached the endpoint body.
+        db = next(get_db())
+        try:
+            stored = db.get(MCPServer, server_id)
+            assert stored is not None
+            assert stored.transport == "streamable_http"
+        finally:
+            db.close()
+    finally:
+        Base.metadata.drop_all(bind=get_engine())
+        try:
+            import shutil
+
+            shutil.rmtree(temp_dir)
+        except OSError:
+            pass

--- a/tests/web/test_classify_app_auth.py
+++ b/tests/web/test_classify_app_auth.py
@@ -332,3 +332,45 @@ def test_invalid_stable_app_id_does_not_fall_back_to_name(
     )
 
     assert app is None
+
+
+@pytest.mark.parametrize(
+    "transport",
+    [
+        "streamable_http",
+        "Streamable_HTTP",
+        " streamable_http ",
+        "  STREAMABLE_HTTP\t",
+    ],
+    ids=["canonical", "mixed-case", "padded", "padded-upper"],
+)
+def test_classify_app_auth_normalizes_transport_like_the_write_path(transport: str):
+    """This must agree with normalize_transport(), which the write-time
+    validators use. A local .lower() here would still disagree about a padded
+    legacy row, reintroducing the same class of chain-disagreement bug via
+    whitespace instead of case."""
+    assert (
+        classify_app_auth(
+            transport,
+            {"url": "https://mcp.example.com/mcp", "auth": {"type": "mcp_oauth"}},
+        )
+        == "mcp_oauth"
+    )
+
+
+@pytest.mark.parametrize(
+    "transport",
+    ["stdio", "STDIO", " stdio "],
+    ids=["canonical", "upper", "padded"],
+)
+def test_classify_app_auth_normalizes_transport_for_keyless(transport: str):
+    assert classify_app_auth(transport, {"command": "npx"}) == "keyless"
+
+
+@pytest.mark.parametrize(
+    "transport",
+    ["oauth", "OAuth", " oauth "],
+    ids=["canonical", "mixed-case", "padded"],
+)
+def test_classify_app_auth_normalizes_transport_for_builtin_oauth(transport: str):
+    assert classify_app_auth(transport, {"command": "npx"}) == "builtin_oauth"


### PR DESCRIPTION
Part of #1828
Closes #1829

First of three layers split out of #1758. This one covers the **write side only**: every path that persists a `transport` now stores it canonical. The read-side comparisons and the backfill migration follow in PR-U1-2 and PR-U1-3.

## Problem

`transport` is a free-form string on the MCP API models. Half of this feature compares it case-insensitively (`classify_app_auth`, the catalog shape check) and half compares it exactly (the connect path, the core session layer's transport dispatch). A mixed-case or whitespace-padded value therefore passes the write-time shape check and is then rejected downstream — one row classified connectable by one half of the feature and unconnectable by the other.

## Change

- `normalize_transport()` (trim + lowercase) in `mcp_runtime.py`, next to `HTTP_MCP_TRANSPORTS`.
- Two shared annotated types beside it — `NormalizedTransport` and `OptionalNormalizedTransport` — that trim, lowercase and reject blank in one place. All five write models use them: `MCPServerCreate`, `MCPServerUpdate`, `MCPConnectionTest`, `PublicMCPAppCreate`, `PublicMCPAppUpdate`. A sixth write model added later picks up all three rules by construction rather than by remembering to copy a validator.
- `classify_app_auth` routes through the same helper instead of a local `.lower()`.
- The catalog reuse guards (`_ensure_catalog_mcp_oauth_server`, `_ensure_catalog_app_server`) normalize both sides, and a catalog PATCH heals a legacy `transport` it doesn't otherwise touch.

The catalog type override lives on the **write models only**, not on `PublicMCPAppBase`. `PublicMCPAppResponse` inherits from that base, so putting it there would make the admin list report a lowercased transport for a row still stored mixed-case — a read that lies about the table contents.

## Healing: tolerate on read, canonicalize on write

Two rounds of review landed on the same principle from opposite sides, so it is worth stating directly: **anywhere this PR makes a comparison tolerant of a legacy value, it must also canonicalize that value.** A tolerant comparison that leaves the row dirty is worse than the rejection it replaced — it turns a loud, actionable failure into a silent one.

- The catalog reuse guards (`_ensure_catalog_app_server`, `_ensure_catalog_mcp_oauth_server`) now call `_heal_server_transport` on the branch that accepts a legacy row. Without it, a shared row seeded as `" Stdio "` connected fine and then produced a connection with no `command`, `args` or `env` at all, because `MCPServerConfig.to_connection_dict()` dispatches on an exact match.
- `_heal_server_transport` deliberately refuses to write a value that normalizes to blank. Healing must never be the thing that creates the `transport=""` state the write models exist to prevent; such a row is left for the backfill migration in PR-U1-3.
- `_apply_public_mcp_app_update` decides its heal *before* validation. An earlier revision computed it after the merged state had been validated and assigned it with no re-check, which both blocked legitimate edits (a `launch_config` edit on a legacy row was rejected with an opaque 422 naming a field the admin never touched) and corrupted data (a whitespace-only transport was normalized to `""` and persisted with a 200).
- A genuinely blank legacy catalog row still cannot pass a shape-checked edit — there is no canonical value to heal it to — but the 422 now names the problem and the way out (supply a `transport` in the same request), and that path is tested.

## Why the catalog reuse guards are in this PR

Write-side normalization alone strands legacy catalog rows, so this PR would otherwise ship a permanent lockout:

`_apply_public_mcp_app_update` persists only the fields present in the PATCH body (`exclude_unset=True`), so an edit that never touches `transport` leaves a padded value on `public_mcp_apps`. The first connect writes the `mcp_servers` row through `MCPServerCreate`, which canonicalizes it. `_ensure_catalog_mcp_oauth_server` then compares the two with `.lower()` but no `.strip()` — `" streamable_http " != "streamable_http"` — and every connect after the first raises a 409 no admin action from the UI can clear.

Reproduced end to end before fixing: a catalog row stored as `" streamable_http "` connects once, then 409s forever.

Fixed at both ends rather than at the comparison alone — both sides of the reuse checks normalize, **and** the catalog heals on any edit so the two stores converge instead of drifting further apart. The healing write is gated on normalization actually changing the value, so an already-canonical row stays byte-identical and produces no spurious audit entry; a row that is genuinely healed is recorded in the audit trail as a real before/after change.

## Intentional behaviour changes

1. **`transport: "STDIO"` is now accepted where it previously returned 400.** `MCPServerConfig.validate_transport` checks membership in a lowercase set, so a mixed-case spelling used to be rejected outright. The value is now canonicalized and accepted. This is a deliberate contract relaxation.

2. **A blank transport is rejected on all five write models, at the model boundary, with a 422.** Previously only the update endpoint guarded it, and only partially: whitespace-only input 400'd via `MCPServerConfig`, while a literal `""` was falsy and fell through an `or server.transport` fallback that silently kept the stored value and answered 200. The other four models had no guard at all, so a catalog app could persist `transport=""` and become silently unconnectable. Rejecting at the model also means a non-owner sending a blank transport gets a 4xx about their input rather than a misleading 403 about the shared configuration — the endpoint-body check only ran inside the owner branch.

   The status is **422**, not 400: `/api/mcp/*` has no handler rewriting FastAPI's request-validation response (the app's `RequestValidationError` handler only reshapes `/v1/` and `/api/a2a/`). An earlier revision of this description, a code comment and a test name all said 400 — corrected, and now asserted by an HTTP-level test rather than a direct model construction.

3. **A case-only transport PATCH on a builtin catalog app is now a no-op where it previously returned 409 "managed by code".** The protected-field guard compares the incoming value against the registry's canonical one, and that incoming value is now normalized first. No state changes; a transport that differs by more than case is still rejected. Covered by a test.

4. **`_global_config_tampered` normalizes both sides.** This is the one read-side comparison this PR must carry, because this PR creates the asymmetry: the incoming value has been through the new annotated type while `server.transport` is the raw stored value. Comparing normalized-vs-raw would flag a non-owner who merely echoes the row's own unchanged `"Streamable_HTTP"` as tampering — a spurious 403 on a payload that changes nothing.

## Correction to an earlier version of this description

An earlier revision claimed this PR closed a hole where `transport="STDIO"` with no `command` was silently accepted, because `TRANSPORT_REQUIRED_FIELDS.get("STDIO")` missed the lowercase key. **That was wrong.** The lookup miss is real, but unreachable: `MCPServerConfig.validate_transport`'s exact-match check rejected that input with a 400 first, on a separate always-fired path. Verified against `upstream/main`. No row was ever persisted through it, and this PR changes only which check fires and the resulting message. Thanks to @rogercloud for catching the false premise.

## Deferred

Four non-blocking findings from the second review round are deliberately left for the read-side follow-up rather than widened into this PR:

- `update_mcp_server` builds `MCPServerCreate` outside its inner `except ValueError`, so a legacy row with a dirty stored transport that reaches it returns a 500 with the raw pydantic message instead of a clean 4xx. Every reachable path now heals before getting there.
- `NormalizedTransport`'s `BeforeValidator` runs ahead of pydantic's `str` check, so a non-string body value is stringified rather than rejected. Contained for `MCPServerCreate` by the downstream allowed-value list; not contained for the two catalog models. Splitting normalization from coercion changes the shared type used by all five models, so it belongs with the consolidation work. The existing test is reframed to document this as a known gap rather than assert it as correct.
- `test_mcp_connection` merges an unrestricted `config` dict over the already-normalized transport, unlike the save path which filters protected keys.
- `delete_mcp_server` gates OAuth token deletion on an exact `server.transport == "oauth"`, so a legacy `" oauth "` row would leave stale credentials behind. This is the one member of the normalization-dialect family with a credential-retention angle and is called out explicitly in #1828 rather than left as a generic footnote.


Three transport-normalization strategies coexist (`normalize_transport`, `_normalize_app_key`, and inline `str(x or "").lower()`) with differing null semantics. Not currently exploitable — every remaining site compares a stored value against a literal or a constant set, with no normalized counterpart — so consolidating spans layers beyond this PR's write-side scope. Tracked for #1828.

`_is_mcp_oauth_server` (`mcp.py:1948`) still uses a bare `.lower()`. Verified identical before and after this PR (both operands are the stored row and a constant set), so it is a pre-existing read-side gap and belongs to PR-U1-2.

## Tests

All mutation-verified — 12 mutants across the fixes, 12/12 killed, plus the original 9 from the first revision. Four survived the first mutation round and the tests were strengthened until they didn't; one of those four turned out to be a harness error rather than a coverage gap (removing `MCPServerUpdate`'s normalization does not change `_global_config_tampered`, which normalizes both sides itself).

- All five write models parameterized over canonical / mixed-case / padded input and over three blank shapes (`""`, spaces, tabs), plus `None`-stays-`None` on the PATCH models and the catalog default surviving the field redeclaration.
- The catalog lockout regression: connect twice against a padded row.
- Catalog healing on an unrelated edit, the no-op on an already-canonical row (asserted on attribute assignment — the stored value and audit diff cannot detect an ungated write), and the audit entry for a genuine heal.
- The builtin case-only no-op, with a real transport change still rejected.
- The non-owner blank-transport path, and the omitted-transport fallback the `or` used to serve.
- The stdio reuse guard against a padded row — inert today since its right side is a literal, but the same shape as the one that produced the lockout.

Admin catalog assertions check the HTTP response body as well as the stored row, and use `db.get()` for primary-key lookups.

## Verification

`test_classify_app_auth.py`, `test_mcp_api.py`, `test_mcp_oauth_flow.py`, `test_public_mcp_connector_visibility.py`, `test_mcp_apps_connect.py` — 285 passed. `ruff check`, `ruff format --check`, `isort --check-only` clean; `mypy --package xagent` shows no new errors (73 pre-existing local stub errors, identical before and after).
