### PR TITLE
feat(auth): add actor OAuth flow state

### DIFF
--- a/src/xagent/migrations/versions/20260821_add_actor_oauth_flow_states.py
+++ b/src/xagent/migrations/versions/20260821_add_actor_oauth_flow_states.py
@@ -1,0 +1,37 @@
+"""add minimal actor OAuth flow nonce table
+
+Revision ID: 20260821_actor_oauth_flow_states
+Revises: 20260826_seed_deputy_mcp_app
+Create Date: 2026-08-21
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260821_actor_oauth_flow_states"
+down_revision: Union[str, None] = "20260826_seed_deputy_mcp_app"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "actor_oauth_flow_states"
+
+
+def upgrade() -> None:
+    """Create the nonce-only state consumed by trusted actor callbacks."""
+    context = op.get_context()
+    if not context.as_sql and sa.inspect(op.get_bind()).has_table(TABLE):
+        return
+
+    op.create_table(
+        TABLE,
+        sa.Column("nonce", sa.String(length=64), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("nonce", name="pk_actor_oauth_flow_states"),
+    )
+
+
+def downgrade() -> None:
+    """Remove actor OAuth flow state after entry points have been disabled."""
+    op.drop_table(TABLE)

--- a/src/xagent/migrations/versions/20260821_add_actor_oauth_flow_states.py
+++ b/src/xagent/migrations/versions/20260821_add_actor_oauth_flow_states.py
@@ -34,4 +34,8 @@ def upgrade() -> None:
 
 def downgrade() -> None:
     """Remove actor OAuth flow state after entry points have been disabled."""
+    context = op.get_context()
+    if not context.as_sql and not sa.inspect(op.get_bind()).has_table(TABLE):
+        return
+
     op.drop_table(TABLE)

--- a/src/xagent/web/models/__init__.py
+++ b/src/xagent/web/models/__init__.py
@@ -1,3 +1,4 @@
+from .actor_oauth_flow import ActorOAuthFlowState
 from .agent import Agent
 from .agent_api_key import AgentApiKey
 from .background_job import BackgroundJob, BackgroundJobStatus, BackgroundJobType
@@ -40,6 +41,7 @@ from .workforce import Workforce, WorkforceAgent, WorkforceBuilderMessage, Workf
 
 __all__ = [
     "Base",
+    "ActorOAuthFlowState",
     "get_engine",
     "get_db",
     "get_session_local",

--- a/src/xagent/web/models/actor_oauth_flow.py
+++ b/src/xagent/web/models/actor_oauth_flow.py
@@ -1,0 +1,18 @@
+"""Minimal single-use nonce storage for trusted actor OAuth callbacks."""
+
+from sqlalchemy import Column, DateTime, String
+
+from .database import Base
+
+
+class ActorOAuthFlowState(Base):  # type: ignore[no-any-unimported]
+    """One unexpired browser-bound actor OAuth nonce.
+
+    All actor, user, provider, and application claims remain exclusively in
+    signed state. Deleting this row atomically claims the callback flow.
+    """
+
+    __tablename__ = "actor_oauth_flow_states"
+
+    nonce = Column(String(64), primary_key=True, nullable=False)
+    expires_at = Column(DateTime(timezone=True), nullable=False)

--- a/tests/alembic/test_20260821_add_actor_oauth_flow_states.py
+++ b/tests/alembic/test_20260821_add_actor_oauth_flow_states.py
@@ -1,0 +1,86 @@
+"""Migration coverage for the minimal actor OAuth nonce table."""
+
+from importlib import import_module
+from pathlib import Path
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+from tests.shared.postgres_disposable import load_migration_module
+
+MIGRATION_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src/xagent/migrations/versions/20260821_add_actor_oauth_flow_states.py"
+)
+REVISION = "20260821_actor_oauth_flow_states"
+DOWN_REVISION = "20260826_seed_deputy_mcp_app"
+TABLE = "actor_oauth_flow_states"
+
+
+def _migration():
+    return load_migration_module(MIGRATION_PATH, "actor_oauth_flow_states_migration")
+
+
+def test_model_has_exact_minimal_shape() -> None:
+    model = getattr(import_module("xagent.web.models"), "ActorOAuthFlowState", None)
+
+    assert model is not None
+    columns = {column.name: column for column in model.__table__.columns}
+    assert set(columns) == {"nonce", "expires_at"}
+    assert columns["nonce"].primary_key is True
+    assert columns["nonce"].nullable is False
+    assert columns["nonce"].type.length == 64
+    assert columns["expires_at"].nullable is False
+
+
+def test_migration_file_exists() -> None:
+    assert MIGRATION_PATH.is_file()
+
+
+def _run(connection, operation: str) -> None:
+    context = MigrationContext.configure(connection)
+    with Operations.context(context):
+        getattr(_migration(), operation)()
+
+
+def test_revision_metadata() -> None:
+    migration = _migration()
+    assert migration.revision == REVISION
+    assert migration.down_revision == DOWN_REVISION
+
+
+def test_sqlite_upgrade_accepts_current_metadata_table(tmp_path) -> None:
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'current.db'}")
+    with engine.begin() as connection:
+        connection.execute(
+            sa.text(
+                """
+                CREATE TABLE actor_oauth_flow_states (
+                    nonce VARCHAR(64) PRIMARY KEY NOT NULL,
+                    expires_at DATETIME NOT NULL
+                )
+                """
+            )
+        )
+
+        _run(connection, "upgrade")
+
+        assert sa.inspect(connection).has_table(TABLE)
+    engine.dispose()
+
+
+def test_sqlite_upgrade_and_downgrade_have_exact_minimal_shape(tmp_path) -> None:
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'migration.db'}")
+    with engine.begin() as connection:
+        _run(connection, "upgrade")
+        inspector = sa.inspect(connection)
+        assert inspector.has_table(TABLE)
+        columns = {column["name"]: column for column in inspector.get_columns(TABLE)}
+        assert set(columns) == {"nonce", "expires_at"}
+        assert columns["nonce"]["primary_key"] == 1
+        assert columns["nonce"]["nullable"] is False
+        assert columns["expires_at"]["nullable"] is False
+        _run(connection, "downgrade")
+        assert not sa.inspect(connection).has_table(TABLE)
+    engine.dispose()

--- a/tests/alembic/test_20260821_add_actor_oauth_flow_states.py
+++ b/tests/alembic/test_20260821_add_actor_oauth_flow_states.py
@@ -1,6 +1,7 @@
 """Migration coverage for the minimal actor OAuth nonce table."""
 
 from importlib import import_module
+from io import StringIO
 from pathlib import Path
 
 import sqlalchemy as sa
@@ -34,10 +35,6 @@ def test_model_has_exact_minimal_shape() -> None:
     assert columns["expires_at"].nullable is False
 
 
-def test_migration_file_exists() -> None:
-    assert MIGRATION_PATH.is_file()
-
-
 def _run(connection, operation: str) -> None:
     context = MigrationContext.configure(connection)
     with Operations.context(context):
@@ -51,23 +48,38 @@ def test_revision_metadata() -> None:
 
 
 def test_sqlite_upgrade_accepts_current_metadata_table(tmp_path) -> None:
+    model = import_module("xagent.web.models").ActorOAuthFlowState
     engine = sa.create_engine(f"sqlite:///{tmp_path / 'current.db'}")
     with engine.begin() as connection:
-        connection.execute(
-            sa.text(
-                """
-                CREATE TABLE actor_oauth_flow_states (
-                    nonce VARCHAR(64) PRIMARY KEY NOT NULL,
-                    expires_at DATETIME NOT NULL
-                )
-                """
-            )
-        )
+        model.__table__.create(connection)
 
         _run(connection, "upgrade")
 
-        assert sa.inspect(connection).has_table(TABLE)
+        columns = {
+            column["name"]: column
+            for column in sa.inspect(connection).get_columns(TABLE)
+        }
+        assert set(columns) == {"nonce", "expires_at"}
+        assert columns["nonce"]["primary_key"] == 1
+        assert columns["nonce"]["nullable"] is False
+        assert columns["nonce"]["type"].length == 64
+        assert columns["expires_at"]["nullable"] is False
     engine.dispose()
+
+
+def test_postgresql_offline_upgrade_emits_create_table() -> None:
+    output = StringIO()
+    context = MigrationContext.configure(
+        url="postgresql://",
+        opts={"as_sql": True, "output_buffer": output},
+    )
+
+    with Operations.context(context):
+        _migration().upgrade()
+
+    sql = output.getvalue()
+    assert "CREATE TABLE actor_oauth_flow_states" in sql
+    assert "expires_at TIMESTAMP WITH TIME ZONE NOT NULL" in sql
 
 
 def test_sqlite_upgrade_and_downgrade_have_exact_minimal_shape(tmp_path) -> None:
@@ -82,5 +94,14 @@ def test_sqlite_upgrade_and_downgrade_have_exact_minimal_shape(tmp_path) -> None
         assert columns["nonce"]["nullable"] is False
         assert columns["expires_at"]["nullable"] is False
         _run(connection, "downgrade")
+        assert not sa.inspect(connection).has_table(TABLE)
+    engine.dispose()
+
+
+def test_sqlite_downgrade_without_table_is_noop(tmp_path) -> None:
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'missing.db'}")
+    with engine.begin() as connection:
+        _run(connection, "downgrade")
+
         assert not sa.inspect(connection).has_table(TABLE)
     engine.dispose()


### PR DESCRIPTION
## Background

Trusted actor OAuth needs a server-side, single-use flow claim. This first stack layer adds only the database contract required by the later security flow.

## Goal

Add `ActorOAuthFlowState` and Alembic revision `20260821_actor_oauth_flow_states`.

The table contains:

- `nonce`: `VARCHAR(64)`, non-null primary key
- `expires_at`: non-null timestamp

## Boundary

This PR changes only:

- the flow-state model and model export
- the additive Alembic migration
- focused migration and model tests

It does not add OAuth routes, cookies, owner keys, credential writes, catalog helpers, callback concurrency logic, CI registration, or activation documentation.

## Behavior

- A fresh online upgrade creates the table.
- An online upgrade accepts the table when current SQLAlchemy metadata created it first.
- Offline migration generation still emits `CREATE TABLE`.
- Downgrade removes the table and no-ops when it is already absent.
- The revision follows `20260826_seed_deputy_mcp_app` and leaves one Alembic head.

## Accepted trade-offs and error contract

This MVP supports two starting states: no table, or the exact table created by current SQLAlchemy metadata.

Arbitrary malformed pre-existing relations are unsupported. This PR does not inspect, repair, or diagnose them. It also defers expired-flow cleanup and cleanup indexes.

Please review this schema boundary. Do not require actor runtime, catalog, lifecycle, schema-forensics, or rollout work in this PR.

## Verification

- 6 focused model and migration tests passed.
- SQLite upgrade, idempotence, incremental, and downgrade operations passed.
- PostgreSQL upgrade, idempotence, incremental, and downgrade operations passed.
- The Alembic one-head check passed.
- All pre-commit hooks passed.
- `git diff --check` passed.

