### PR TITLE
feat: Backfill stored MCP transport values to their canonical form

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -431,6 +431,16 @@ jobs:
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 
+      # The MCP transport backfill's only dialect-specific branch is the
+      # padding-character function (PostgreSQL chr() vs SQLite char()); the
+      # SQLite half of this file runs in the ordinary suite.
+      - name: Test MCP transport backfill migration (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/migrations/test_20260828_normalize_mcp_transport_case.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
       - name: Test legacy resume interaction close rowcount grid (Postgres-only)
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |

--- a/src/xagent/migrations/versions/20260828_normalize_mcp_transport_case.py
+++ b/src/xagent/migrations/versions/20260828_normalize_mcp_transport_case.py
@@ -1,55 +1,68 @@
 r"""Normalize stored MCP transport values to their canonical form
 
 Revision ID: 20260828_normalize_mcp_transport_case
-Revises: 20260826_seed_deputy_mcp_app
+Revises: 20260821_actor_oauth_flow_states
 Create Date: 2026-08-28
 
-`transport` is a free-form string on the MCP API models, so rows written
-before the write-time normalizing validators shipped may hold a mixed-case or
-whitespace-padded value (e.g. "Streamable_HTTP", "\tstreamable_http"). Such a
-row is classified as connectable by the normalizing half of the MCP OAuth
-feature and rejected by the exact-matching half: the web runtime treats it as
-an HTTP server and runs the per-user token exchange, while the core
-serializer's exact `transport in ["sse", "websocket", "streamable_http"]` test
-fails and drops the row's `url` from the connection dict entirely. Backfill
-the two web-layer tables once so the stored values agree with what every
-reader expects.
+`transport` is a free-form string on the MCP API models, so rows written before
+the write-time normalizing validators shipped may hold a mixed-case or
+whitespace-padded value (e.g. "Streamable_HTTP", "OAuth", "\tstdio"). The
+readers of that column do not agree on how to compare it: `classify_app_auth`
+(web/mcp_apps.py) lowercases before matching, while the connect and credential
+paths match exactly -- `api/mcp.py`'s `server.transport != "oauth"` gates,
+`api/auth.py:2087`, `web/tools/config.py:3547`, and the core serializer's
+`transport in ["sse", "websocket", "streamable_http"]` branch. A row stored as
+"OAuth" is therefore classified `builtin_oauth` by the catalog and rejected by
+every exact-matching gate behind it.
+
+A shared catalog row's transport is never rewritten by the connect path, so an
+un-migrated row stays in that split state indefinitely. Backfill the two
+web-layer tables once so the stored values agree with what every reader
+expects.
+
+State of the readers when this lands. This migration is the third of the three
+changes tracked in #1828 and is sequenced behind both of the others, so the
+descriptions above are written against the post-#1829/#1830 tree:
+
+  1. Write-side canonicalization (#1829) introduces `normalize_transport()`
+     (`web/services/mcp_runtime.py`) and applies it on every write path, so no
+     new non-canonical row is created. That helper does not exist yet on this
+     branch; the whitespace grammar below is specified against it.
+  2. Read-side tolerance (#1830) normalizes on read, so a not-yet-backfilled
+     row behaves like its canonical equivalent.
+
+Before those land, a non-canonical row is rejected fairly uniformly rather than
+split -- no current reader strips whitespace, and the runtime OAuth gate
+(`_is_mcp_oauth_http_server`) still matches exactly. The backfill is worth
+running either way, because the divergence above is what the row hits once the
+tolerant readers are deployed, and because an admin catalog write can still
+author a mixed-case value today.
 
 Covered value set. A row is rewritten only when normalizing it yields one of
-the four transports the application actually dispatches on (see
-_CANONICAL_TRANSPORTS below). That bound makes the rewrite safe to audit: the
-migration can only ever move a row onto a value the readers already agree on,
-never invent one, and an unrecognized string is left exactly as stored rather
-than being reshaped into different garbage.
+the transports the application dispatches on (see _CANONICAL_TRANSPORTS below).
+That bound makes the rewrite safe to audit: the migration can only ever move a
+row onto a value the readers already agree on, never invent one, and an
+unrecognized string is left exactly as stored rather than reshaped into
+different garbage.
 
-Whitespace grammar. The write-side helper `normalize_transport()` canonicalizes
-with Python's `str.strip().lower()`, which strips tabs and newlines as well as
-ASCII spaces; single-argument SQL `TRIM()` strips only ASCII spaces. The
-TAB/LF/CR characters are therefore translated to spaces before `TRIM` runs, so
-padding written with them is stripped too. Translating rather than deleting
-keeps `TRIM`'s edges-only semantics: an interior character is never removed,
-and the covered-value-set bound above means an interior space cannot change
-which row is eligible. Without this a tab-padded row survives the one-shot
-backfill and stays in the split-classification state described above
-indefinitely.
+Whitespace grammar, scoped to ASCII. The write-side helper canonicalizes with
+Python's `str.strip().lower()`; single-argument SQL `TRIM()` strips only ASCII
+spaces, so TAB/LF/CR are translated to spaces before `TRIM` runs. Translating
+rather than deleting keeps `TRIM`'s edges-only semantics: an interior character
+is never removed, so the migration cannot splice a canonical transport out of a
+value the helper leaves alone. The non-ASCII whitespace `str.strip()` also
+removes (NBSP, U+3000) is out of scope and left unfixed -- see
+_PADDING_WHITESPACE for why naming it portably is not possible.
 
 Rollout ordering. This is a one-shot UPDATE with no CHECK constraint or trigger
 behind it, so it converges only if no application instance running the
 pre-validator models is still serving admin writes when it lands; the startup
-migration lock serializes migrators, not request sessions. The expand phase
-that provides that guarantee is the two changes this migration is sequenced
-behind:
-
-  1. Write-side canonicalization (#1829) -- every write path stores a canonical
-     transport, so no new non-canonical row is created.
-  2. Read-side tolerance (#1830) -- web-layer reads normalize on read, so a
-     not-yet-backfilled row behaves like its canonical equivalent.
-
-Deploy 1 and 2, drain the old instances, then run this backfill. Run out of
-order it is still safe -- it only ever rewrites a value to the form every
-reader already agrees on -- but it is not guaranteed to leave the table
-canonical, because a surviving old writer can insert a fresh mixed-case row
-after the UPDATE commits.
+migration lock serializes migrators, not request sessions. Deploy #1829 and
+#1830, drain the old instances, then run this backfill. Run out of order it is
+still safe -- it only ever rewrites a value toward the form every reader agrees
+on -- but it is not guaranteed to leave the table canonical, because a
+surviving old writer can insert a fresh non-canonical row after the UPDATE
+commits.
 
 Idempotent: the normalizing expression is a no-op on already-canonical values,
 and the WHERE clause skips rows that are already normalized.
@@ -60,41 +73,48 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision = "20260828_normalize_mcp_transport_case"
-down_revision = "20260826_seed_deputy_mcp_app"
+down_revision = "20260821_actor_oauth_flow_states"
 branch_labels = None
 depends_on = None
 
 _TABLES = ("mcp_servers", "public_mcp_apps")
 
-# The transports the application dispatches on. Mirrors the stdio branch and
-# HTTP_MCP_TRANSPORTS in the MCP model/runtime; a row is only rewritten when it
-# normalizes onto one of these.
-_CANONICAL_TRANSPORTS = ("stdio", "sse", "websocket", "streamable_http")
+# The transports the application dispatches on: the stdio branch and
+# HTTP_MCP_TRANSPORTS in the MCP model/runtime, plus "oauth", which is the
+# default for public_mcp_apps.transport and drives the builtin_oauth catalog
+# classification. A row is only rewritten when it normalizes onto one of these.
+_CANONICAL_TRANSPORTS = ("stdio", "sse", "websocket", "streamable_http", "oauth")
 
-# The whitespace characters Python's str.strip() removes that single-argument
-# SQL TRIM() does not. Spelled as code points so no literal control character
-# is embedded in the emitted SQL -- an offline (--sql) artifact carrying a raw
-# newline inside a string literal is a hazard for whoever runs it by hand.
+# Whitespace that Python's str.strip() removes but single-argument SQL TRIM()
+# does not. Spelled as code points so no literal control character is embedded
+# in the emitted SQL -- an offline (--sql) artifact carrying a raw newline
+# inside a string literal is a hazard for whoever runs it by hand.
+#
+# Deliberately ASCII-only. str.strip() also removes NBSP (U+00A0) and the
+# ideographic space (U+3000), but neither can be named portably here: on a
+# database whose encoding cannot represent them, PostgreSQL's chr() raises
+# "requested character too large for encoding" and aborts the whole upgrade,
+# and a U&'...' literal fails the same way. Verified against a SQL_ASCII
+# server. A row padded with one of those is therefore left untouched rather
+# than fixed -- the wrong trade for a one-shot data migration would be to make
+# it crash on a database whose encoding it never had to care about. Such a row
+# is also unstorable in exactly the encodings where the fix is unexpressible.
 _PADDING_WHITESPACE = (9, 10, 13)  # TAB, LF, CR
 
 # PostgreSQL spells the code-point-to-character function CHR(); SQLite spells it
-# CHAR(). Both take one integer argument and need no extension.
+# CHAR(). Both take one integer argument and need no extension. Indexed rather
+# than looked up with a default: these are the only two dialects the project
+# supports (see db/migration_support.py), and an unsupported one should fail
+# loudly here rather than silently receive a narrower backfill.
 _CHAR_FUNCTION = {"postgresql": "chr", "sqlite": "char"}
 
 
 def _normalized_expression(dialect_name: str) -> str:
-    """SQL canonicalizing `transport` the way normalize_transport() does.
-
-    On a dialect whose character function is not known here this degrades to a
-    bare LOWER(TRIM(...)): case and ASCII-space padding are still fixed, which
-    is the behavior every supported dialect had before, so an unknown dialect
-    gets a narrower backfill rather than invalid SQL.
-    """
-    char_fn = _CHAR_FUNCTION.get(dialect_name)
+    """SQL canonicalizing `transport` the way normalize_transport() does."""
+    char_fn = _CHAR_FUNCTION[dialect_name]
     expression = "transport"
-    if char_fn is not None:
-        for code_point in _PADDING_WHITESPACE:
-            expression = f"REPLACE({expression}, {char_fn}({code_point}), ' ')"
+    for code_point in _PADDING_WHITESPACE:
+        expression = f"REPLACE({expression}, {char_fn}({code_point}), ' ')"
     return f"LOWER(TRIM({expression}))"
 
 
@@ -117,20 +137,28 @@ def _tables_with_transport() -> list[str]:
     return present
 
 
-def _backfill(table: str, normalized: str) -> None:
+def _backfill_statement(table: str, normalized: str) -> str:
+    """The one UPDATE this migration runs, as text.
+
+    Split out from _backfill so a test can execute the exact statement the
+    migration would rather than restating its WHERE clause -- a restated copy
+    keeps passing when the real clause changes.
+    """
     canonical_list = ", ".join(f"'{value}'" for value in _CANONICAL_TRANSPORTS)
     # NULL transports are left alone: both comparisons below are NULL-safe
     # (they evaluate to NULL, not true), so those rows are skipped rather than
     # rewritten to ''.
-    op.execute(
-        f"""
+    return f"""
         UPDATE {table}
         SET transport = {normalized}
         WHERE transport IS NOT NULL
           AND transport <> {normalized}
           AND {normalized} IN ({canonical_list})
-        """
-    )
+    """
+
+
+def _backfill(table: str, normalized: str) -> None:
+    op.execute(_backfill_statement(table, normalized))
 
 
 def upgrade() -> None:

--- a/src/xagent/migrations/versions/20260828_normalize_mcp_transport_case.py
+++ b/src/xagent/migrations/versions/20260828_normalize_mcp_transport_case.py
@@ -1,0 +1,161 @@
+r"""Normalize stored MCP transport values to their canonical form
+
+Revision ID: 20260828_normalize_mcp_transport_case
+Revises: 20260826_seed_deputy_mcp_app
+Create Date: 2026-08-28
+
+`transport` is a free-form string on the MCP API models, so rows written
+before the write-time normalizing validators shipped may hold a mixed-case or
+whitespace-padded value (e.g. "Streamable_HTTP", "\tstreamable_http"). Such a
+row is classified as connectable by the normalizing half of the MCP OAuth
+feature and rejected by the exact-matching half: the web runtime treats it as
+an HTTP server and runs the per-user token exchange, while the core
+serializer's exact `transport in ["sse", "websocket", "streamable_http"]` test
+fails and drops the row's `url` from the connection dict entirely. Backfill
+the two web-layer tables once so the stored values agree with what every
+reader expects.
+
+Covered value set. A row is rewritten only when normalizing it yields one of
+the four transports the application actually dispatches on (see
+_CANONICAL_TRANSPORTS below). That bound makes the rewrite safe to audit: the
+migration can only ever move a row onto a value the readers already agree on,
+never invent one, and an unrecognized string is left exactly as stored rather
+than being reshaped into different garbage.
+
+Whitespace grammar. The write-side helper `normalize_transport()` canonicalizes
+with Python's `str.strip().lower()`, which strips tabs and newlines as well as
+ASCII spaces; single-argument SQL `TRIM()` strips only ASCII spaces. The
+TAB/LF/CR characters are therefore translated to spaces before `TRIM` runs, so
+padding written with them is stripped too. Translating rather than deleting
+keeps `TRIM`'s edges-only semantics: an interior character is never removed,
+and the covered-value-set bound above means an interior space cannot change
+which row is eligible. Without this a tab-padded row survives the one-shot
+backfill and stays in the split-classification state described above
+indefinitely.
+
+Rollout ordering. This is a one-shot UPDATE with no CHECK constraint or trigger
+behind it, so it converges only if no application instance running the
+pre-validator models is still serving admin writes when it lands; the startup
+migration lock serializes migrators, not request sessions. The expand phase
+that provides that guarantee is the two changes this migration is sequenced
+behind:
+
+  1. Write-side canonicalization (#1829) -- every write path stores a canonical
+     transport, so no new non-canonical row is created.
+  2. Read-side tolerance (#1830) -- web-layer reads normalize on read, so a
+     not-yet-backfilled row behaves like its canonical equivalent.
+
+Deploy 1 and 2, drain the old instances, then run this backfill. Run out of
+order it is still safe -- it only ever rewrites a value to the form every
+reader already agrees on -- but it is not guaranteed to leave the table
+canonical, because a surviving old writer can insert a fresh mixed-case row
+after the UPDATE commits.
+
+Idempotent: the normalizing expression is a no-op on already-canonical values,
+and the WHERE clause skips rows that are already normalized.
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "20260828_normalize_mcp_transport_case"
+down_revision = "20260826_seed_deputy_mcp_app"
+branch_labels = None
+depends_on = None
+
+_TABLES = ("mcp_servers", "public_mcp_apps")
+
+# The transports the application dispatches on. Mirrors the stdio branch and
+# HTTP_MCP_TRANSPORTS in the MCP model/runtime; a row is only rewritten when it
+# normalizes onto one of these.
+_CANONICAL_TRANSPORTS = ("stdio", "sse", "websocket", "streamable_http")
+
+# The whitespace characters Python's str.strip() removes that single-argument
+# SQL TRIM() does not. Spelled as code points so no literal control character
+# is embedded in the emitted SQL -- an offline (--sql) artifact carrying a raw
+# newline inside a string literal is a hazard for whoever runs it by hand.
+_PADDING_WHITESPACE = (9, 10, 13)  # TAB, LF, CR
+
+# PostgreSQL spells the code-point-to-character function CHR(); SQLite spells it
+# CHAR(). Both take one integer argument and need no extension.
+_CHAR_FUNCTION = {"postgresql": "chr", "sqlite": "char"}
+
+
+def _normalized_expression(dialect_name: str) -> str:
+    """SQL canonicalizing `transport` the way normalize_transport() does.
+
+    On a dialect whose character function is not known here this degrades to a
+    bare LOWER(TRIM(...)): case and ASCII-space padding are still fixed, which
+    is the behavior every supported dialect had before, so an unknown dialect
+    gets a narrower backfill rather than invalid SQL.
+    """
+    char_fn = _CHAR_FUNCTION.get(dialect_name)
+    expression = "transport"
+    if char_fn is not None:
+        for code_point in _PADDING_WHITESPACE:
+            expression = f"REPLACE({expression}, {char_fn}({code_point}), ' ')"
+    return f"LOWER(TRIM({expression}))"
+
+
+def _tables_with_transport() -> list[str]:
+    """The subset of _TABLES this database actually has, with the column.
+
+    Online only: reflection needs a real bind. Offline callers use _TABLES
+    directly, which is sound because the names are compile-time constants.
+    """
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing = set(inspector.get_table_names())
+    present = []
+    for table in _TABLES:
+        if table not in existing:
+            continue
+        columns = {col["name"] for col in inspector.get_columns(table)}
+        if "transport" in columns:
+            present.append(table)
+    return present
+
+
+def _backfill(table: str, normalized: str) -> None:
+    canonical_list = ", ".join(f"'{value}'" for value in _CANONICAL_TRANSPORTS)
+    # NULL transports are left alone: both comparisons below are NULL-safe
+    # (they evaluate to NULL, not true), so those rows are skipped rather than
+    # rewritten to ''.
+    op.execute(
+        f"""
+        UPDATE {table}
+        SET transport = {normalized}
+        WHERE transport IS NOT NULL
+          AND transport <> {normalized}
+          AND {normalized} IN ({canonical_list})
+        """
+    )
+
+
+def upgrade() -> None:
+    from alembic import context
+
+    normalized = _normalized_expression(op.get_context().dialect.name)
+
+    if context.is_offline_mode():
+        # Offline (--sql) supplies a MockConnection that cannot be inspected,
+        # so reflection is skipped and both UPDATEs are emitted unconditionally.
+        # The table names are compile-time constants, and an UPDATE against a
+        # table the target database lacks surfaces when the operator applies the
+        # script -- the right place for it, since offline mode cannot know the
+        # target's shape.
+        for table in _TABLES:
+            _backfill(table, normalized)
+        return
+
+    for table in _tables_with_transport():
+        _backfill(table, normalized)
+
+
+def downgrade() -> None:
+    # Deliberately not reversible: the original mixed-case/padded spellings are
+    # not recorded anywhere, and restoring them would reintroduce rows the
+    # application cannot connect. Normalized values remain valid for every
+    # earlier revision, so leaving them in place is safe.
+    pass

--- a/src/xagent/migrations/versions/20260828_normalize_mcp_transport_case.py
+++ b/src/xagent/migrations/versions/20260828_normalize_mcp_transport_case.py
@@ -31,9 +31,12 @@ descriptions above are written against the post-#1829/#1830 tree:
   2. Read-side tolerance (#1830) normalizes on read, so a not-yet-backfilled
      row behaves like its canonical equivalent.
 
-Before those land, a non-canonical row is rejected fairly uniformly rather than
-split -- no current reader strips whitespace, and the runtime OAuth gate
-(`_is_mcp_oauth_http_server`) still matches exactly. The backfill is worth
+Before those land the two axes differ. A whitespace-padded row is rejected
+fairly uniformly, because no current reader strips whitespace and the runtime
+OAuth gate (`_is_mcp_oauth_http_server`) still matches exactly. A mixed-case row
+already splits today: `classify_app_auth` lowercases, so it admits
+"Streamable_HTTP" and "OAuth", while the exact-matching gates behind it reject
+the same row. The backfill is worth
 running either way, because the divergence above is what the row hits once the
 tolerant readers are deployed, and because an admin catalog write can still
 author a mixed-case value today.
@@ -90,16 +93,28 @@ _CANONICAL_TRANSPORTS = ("stdio", "sse", "websocket", "streamable_http", "oauth"
 # in the emitted SQL -- an offline (--sql) artifact carrying a raw newline
 # inside a string literal is a hazard for whoever runs it by hand.
 #
-# Deliberately ASCII-only. str.strip() also removes NBSP (U+00A0) and the
-# ideographic space (U+3000), but neither can be named portably here: on a
-# database whose encoding cannot represent them, PostgreSQL's chr() raises
-# "requested character too large for encoding" and aborts the whole upgrade,
-# and a U&'...' literal fails the same way. Verified against a SQL_ASCII
-# server. A row padded with one of those is therefore left untouched rather
-# than fixed -- the wrong trade for a one-shot data migration would be to make
-# it crash on a database whose encoding it never had to care about. Such a row
-# is also unstorable in exactly the encodings where the fix is unexpressible.
-_PADDING_WHITESPACE = (9, 10, 13)  # TAB, LF, CR
+# ASCII-only, and that boundary is a portability constraint rather than a
+# preference. str.strip() also removes NBSP (U+00A0) and the ideographic space
+# (U+3000), but neither can be named portably here: on a database whose encoding
+# cannot represent them, PostgreSQL's chr() raises "requested character too
+# large for encoding" and aborts the whole upgrade, and a U&'...' literal fails
+# the same way (both verified against a SQL_ASCII server). A row padded with one
+# of those is left untouched rather than fixed -- for a one-shot data migration,
+# crashing on a database whose encoding it never had to care about is the worse
+# trade. Such a row is also unstorable in exactly the encodings where the fix is
+# unexpressible. Every code point below is single-byte ASCII and so is
+# expressible on every supported encoding.
+_PADDING_WHITESPACE = (
+    9,  # TAB
+    10,  # LF
+    11,  # VT
+    12,  # FF
+    13,  # CR
+    28,  # FS
+    29,  # GS
+    30,  # RS
+    31,  # US
+)
 
 # PostgreSQL spells the code-point-to-character function CHR(); SQLite spells it
 # CHAR(). Both take one integer argument and need no extension. Indexed rather
@@ -108,14 +123,27 @@ _PADDING_WHITESPACE = (9, 10, 13)  # TAB, LF, CR
 # loudly here rather than silently receive a narrower backfill.
 _CHAR_FUNCTION = {"postgresql": "chr", "sqlite": "char"}
 
+# PostgreSQL's LOWER() is locale-sensitive. On a database created with a Turkish
+# locale (ICU tr-TR is supported and unrestricted here), LOWER('STDIO') yields
+# 'stdıo' with a dotless i (U+0131), which is not in _CANONICAL_TRANSPORTS -- so
+# the guard below rejects the row and the backfill silently leaves 'STDIO'
+# unfixed while every other value normalizes. Forcing the C collation on LOWER's
+# *input* makes the case mapping ASCII and locale-independent. It must be the
+# input, not the result: `LOWER(x) COLLATE "C"` still lowercases under the
+# database locale and only relabels the output.
+#
+# SQLite needs no equivalent -- its LOWER() maps ASCII A-Z only, by design.
+_LOWER_COLLATION = {"postgresql": ' COLLATE "C"', "sqlite": ""}
+
 
 def _normalized_expression(dialect_name: str) -> str:
     """SQL canonicalizing `transport` the way normalize_transport() does."""
     char_fn = _CHAR_FUNCTION[dialect_name]
+    collation = _LOWER_COLLATION[dialect_name]
     expression = "transport"
     for code_point in _PADDING_WHITESPACE:
         expression = f"REPLACE({expression}, {char_fn}({code_point}), ' ')"
-    return f"LOWER(TRIM({expression}))"
+    return f"LOWER(TRIM({expression}){collation})"
 
 
 def _tables_with_transport() -> list[str]:

--- a/tests/migrations/test_20260828_normalize_mcp_transport_case.py
+++ b/tests/migrations/test_20260828_normalize_mcp_transport_case.py
@@ -1,0 +1,482 @@
+r"""Tests for migration 20260828_normalize_mcp_transport_case (#1831).
+
+Covers the backfill that canonicalizes stored MCP `transport` values:
+
+- mixed-case and whitespace-padded rows are canonicalized in both tables
+- the padding grammar matches the write-side helper's ``str.strip().lower()``,
+  including TAB/LF/CR padding that single-argument SQL ``TRIM()`` would miss
+- a value outside the covered set is left byte-identical, so the migration can
+  never reshape an unrecognized string into different garbage
+- already-canonical rows are untouched, and a real re-run is a no-op
+- NULL transports stay NULL rather than becoming ''
+- a missing table, and a table without the column, are tolerated
+- SQL is generated in offline (``--sql``) mode, where the bind is a
+  MockConnection that cannot be reflected
+
+Following this repo's migration-test convention (see
+tests/migrations/test_20260813_trace_json_columns_to_jsonb.py): the minimal
+pre-migration schema is built directly, stamped to the parent revision, and
+only the migration under test is run against it. Everything substantive runs
+under both SQLite and ``@pytest.mark.postgresql`` so the dialect branch in
+``_normalized_expression`` (SQLite ``char()`` vs PostgreSQL ``chr()``) is
+exercised on a real server rather than assumed.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from contextlib import redirect_stdout
+from io import StringIO
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.config import Config
+from sqlalchemy import create_engine, text
+
+PARENT_REVISION = "20260826_seed_deputy_mcp_app"
+TARGET_REVISION = "20260828_normalize_mcp_transport_case"
+
+TABLES = ("mcp_servers", "public_mcp_apps")
+ALL_TABLES = ("alembic_version",) + TABLES
+
+# Whitespace that Python's str.strip() removes but single-argument SQL TRIM()
+# does not. Written via chr() so no editor can silently rewrite them.
+TAB = chr(9)
+LF = chr(10)
+CR = chr(13)
+
+
+def _migration_module() -> ModuleType:
+    import xagent.migrations as migrations_pkg
+
+    migrations_dir = Path(next(iter(migrations_pkg.__path__)))
+    path = migrations_dir / "versions" / f"{TARGET_REVISION}.py"
+    spec = importlib.util.spec_from_file_location(TARGET_REVISION, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _normalize_like_helper(value: str) -> str:
+    """The write-side helper's grammar, restated.
+
+    ``normalize_transport()`` ships in the write-side layer (#1829), which this
+    migration does not depend on at import time; restating its one-line body
+    here keeps the test runnable against this branch alone while still pinning
+    the migration's SQL to the helper's semantics rather than to itself.
+    """
+    return str(value or "").strip().lower()
+
+
+def _pre_migration_metadata() -> sa.MetaData:
+    """The two MCP tables reduced to the column the migration touches plus the
+    identity columns -- not the full production schema."""
+    metadata = sa.MetaData()
+    sa.Table(
+        "mcp_servers",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("transport", sa.String(50)),
+        # Carried although the migration never writes it: that a backfill of
+        # `transport` leaves the rest of the row verbatim is a contract, and a
+        # fixture without a second column cannot pin it.
+        sa.Column("url", sa.String(500)),
+    )
+    sa.Table(
+        "public_mcp_apps",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("app_id", sa.String(100), nullable=False),
+        sa.Column("name", sa.String(100), nullable=False),
+        sa.Column("transport", sa.String(50)),
+    )
+    return metadata
+
+
+def _stamp_parent_revision(engine: sa.engine.Engine) -> None:
+    with engine.begin() as conn:
+        conn.execute(
+            text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)")
+        )
+        conn.execute(
+            text(
+                "INSERT INTO alembic_version (version_num) VALUES "
+                f"('{PARENT_REVISION}')"
+            )
+        )
+
+
+def _alembic_config(engine: sa.engine.Engine) -> Config:
+    config = Config()
+    config.set_main_option("script_location", "src/xagent/migrations")
+    config.set_main_option(
+        "sqlalchemy.url", engine.url.render_as_string(hide_password=False)
+    )
+    return config
+
+
+def _upgrade(engine: sa.engine.Engine, revision: str = TARGET_REVISION) -> None:
+    command.upgrade(_alembic_config(engine), revision)
+
+
+def _insert(
+    engine: sa.engine.Engine, table: str, rows: dict[int, str | None], **extra: str
+) -> None:
+    with engine.begin() as conn:
+        for row_id, transport in rows.items():
+            if table == "mcp_servers":
+                conn.execute(
+                    text(
+                        "INSERT INTO mcp_servers (id, name, transport, url) "
+                        "VALUES (:id, :name, :transport, :url)"
+                    ),
+                    {
+                        "id": row_id,
+                        "name": f"s{row_id}",
+                        "transport": transport,
+                        "url": extra.get("url", "https://example.test/mcp"),
+                    },
+                )
+            else:
+                conn.execute(
+                    text(
+                        "INSERT INTO public_mcp_apps (id, app_id, name, transport) "
+                        "VALUES (:id, :app_id, :name, :transport)"
+                    ),
+                    {
+                        "id": row_id,
+                        "app_id": f"app-{row_id}",
+                        "name": f"a{row_id}",
+                        "transport": transport,
+                    },
+                )
+
+
+def _stored(engine: sa.engine.Engine, table: str) -> dict[int, str | None]:
+    with engine.begin() as conn:
+        return dict(
+            conn.execute(text(f"SELECT id, transport FROM {table} ORDER BY id")).all()
+        )
+
+
+# --------------------------------------------------------------------------
+# Engines
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sqlite_engine(tmp_path: Path) -> sa.engine.Engine:
+    engine = create_engine(f"sqlite:///{tmp_path / 'transport.db'}")
+    _pre_migration_metadata().create_all(bind=engine)
+    _stamp_parent_revision(engine)
+    return engine
+
+
+def _postgres_url() -> str | None:
+    return os.getenv("XAGENT_TEST_POSTGRES_URL") or os.getenv(
+        "POSTGRES_TEST_DATABASE_URL"
+    )
+
+
+@pytest.fixture
+def postgres_engine():
+    url = _postgres_url()
+    if not url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+    engine = create_engine(url)
+    with engine.begin() as conn:
+        for table in ALL_TABLES:
+            conn.execute(text(f"DROP TABLE IF EXISTS {table} CASCADE"))
+    _pre_migration_metadata().create_all(bind=engine)
+    _stamp_parent_revision(engine)
+    yield engine
+    with engine.begin() as conn:
+        for table in ALL_TABLES:
+            conn.execute(text(f"DROP TABLE IF EXISTS {table} CASCADE"))
+    engine.dispose()
+
+
+# --------------------------------------------------------------------------
+# Shared behavior, run against both dialects
+# --------------------------------------------------------------------------
+
+# id -> (stored value, expected value after the backfill). Expectations are
+# written out literally rather than computed from the migration, so a change to
+# the migration's own expression cannot silently move the target.
+BACKFILL_CASES: dict[int, tuple[str | None, str | None]] = {
+    1: ("Streamable_HTTP", "streamable_http"),
+    2: (" streamable_http ", "streamable_http"),
+    3: (TAB + "streamable_http", "streamable_http"),
+    4: (LF + " STDIO " + CR + LF, "stdio"),
+    5: ("sse", "sse"),
+    6: ("WebSocket", "websocket"),
+    7: (None, None),
+    # Outside the covered set: left byte-identical, including its padding, so
+    # the migration cannot reshape an unrecognized value into different garbage.
+    8: ("Not-A-Transport", "Not-A-Transport"),
+    9: (TAB + "str" + TAB + "eamable" + LF, TAB + "str" + TAB + "eamable" + LF),
+    10: ("   ", "   "),
+    # Interior padding characters that would *spell* a canonical transport if
+    # they were deleted rather than translated to a space. The helper leaves
+    # these alone, so the migration must too: deleting would let the backfill
+    # invent 'stdio' out of a value no reader recognizes, which is precisely
+    # what bounding the rewrite to the covered set is meant to prevent.
+    11: ("st" + TAB + "dio", "st" + TAB + "dio"),
+    12: ("streamable_" + LF + "http", "streamable_" + LF + "http"),
+}
+
+
+class _BackfillContract:
+    """The behavior every supported dialect must share.
+
+    Subclassed per dialect below so SQLite and PostgreSQL run the identical
+    assertions -- the point of the dialect branch in ``_normalized_expression``
+    is that they are indistinguishable from the caller's side.
+    """
+
+    def test_backfill_canonicalizes_mcp_servers(self, engine) -> None:
+        _insert(engine, "mcp_servers", {k: v for k, (v, _) in BACKFILL_CASES.items()})
+
+        _upgrade(engine)
+
+        expected = {k: want for k, (_, want) in BACKFILL_CASES.items()}
+        assert _stored(engine, "mcp_servers") == expected
+
+    def test_backfill_canonicalizes_public_mcp_apps(self, engine) -> None:
+        """The catalog table matters most: a shared catalog row's transport is
+        never rewritten by the connect path, so without this backfill it would
+        stay non-canonical indefinitely."""
+        _insert(
+            engine, "public_mcp_apps", {k: v for k, (v, _) in BACKFILL_CASES.items()}
+        )
+
+        _upgrade(engine)
+
+        expected = {k: want for k, (_, want) in BACKFILL_CASES.items()}
+        assert _stored(engine, "public_mcp_apps") == expected
+
+    def test_padding_grammar_matches_the_write_side_helper(self, engine) -> None:
+        """The whitespace axis, pinned against the helper rather than the SQL.
+
+        A tab-padded row is the case single-argument SQL TRIM() misses: the
+        runtime classifier normalizes it and admits the row to the OAuth token
+        exchange, while the core serializer exact-matches, fails, and drops the
+        row's url -- the same split classification this migration exists to
+        remove, on the whitespace axis instead of the case axis.
+        """
+        padded = {
+            1: TAB + "streamable_http",
+            2: "streamable_http" + LF,
+            3: CR + "SSE" + CR,
+            4: TAB + " " + LF + "WebSocket" + CR + " ",
+        }
+        _insert(engine, "mcp_servers", padded)
+
+        _upgrade(engine)
+
+        stored = _stored(engine, "mcp_servers")
+        assert stored == {
+            row_id: _normalize_like_helper(value) for row_id, value in padded.items()
+        }
+
+    def test_backfill_leaves_other_columns_verbatim(self, engine) -> None:
+        _insert(engine, "mcp_servers", {1: "Streamable_HTTP"}, url="https://kept/mcp")
+
+        _upgrade(engine)
+
+        with engine.begin() as conn:
+            row = conn.execute(
+                text("SELECT transport, url, name FROM mcp_servers WHERE id = 1")
+            ).one()
+        assert tuple(row) == ("streamable_http", "https://kept/mcp", "s1")
+
+    def test_backfill_is_idempotent_across_a_real_rerun(self, engine) -> None:
+        """A genuine second run, not merely one pass over canonical rows.
+
+        The migration is stamped after the first upgrade, so re-running it means
+        stepping the version back and upgrading again -- otherwise this asserts
+        nothing beyond the already-canonical case.
+        """
+        _insert(engine, "mcp_servers", {k: v for k, (v, _) in BACKFILL_CASES.items()})
+
+        _upgrade(engine)
+        after_first = _stored(engine, "mcp_servers")
+
+        with engine.begin() as conn:
+            conn.execute(
+                text("UPDATE alembic_version SET version_num = :parent"),
+                {"parent": PARENT_REVISION},
+            )
+        _upgrade(engine)
+
+        assert _stored(engine, "mcp_servers") == after_first
+
+    def test_null_transport_is_preserved(self, engine) -> None:
+        """A NULL transport must stay NULL rather than become '': both WHERE
+        comparisons are NULL-safe, so the row is skipped entirely."""
+        _insert(engine, "mcp_servers", {1: None})
+
+        _upgrade(engine)
+
+        assert _stored(engine, "mcp_servers") == {1: None}
+
+
+class TestSqliteBackfill(_BackfillContract):
+    @pytest.fixture
+    def engine(self, sqlite_engine: sa.engine.Engine) -> sa.engine.Engine:
+        return sqlite_engine
+
+
+@pytest.mark.postgresql
+class TestPostgresBackfill(_BackfillContract):
+    @pytest.fixture
+    def engine(self, postgres_engine):
+        return postgres_engine
+
+
+# --------------------------------------------------------------------------
+# Schema tolerance (SQLite is sufficient: the guard is dialect-independent
+# reflection, and the online path is shared)
+# --------------------------------------------------------------------------
+
+
+def _engine_with_tables(tmp_path: Path, metadata: sa.MetaData) -> sa.engine.Engine:
+    engine = create_engine(f"sqlite:///{tmp_path / 'partial.db'}")
+    metadata.create_all(bind=engine)
+    _stamp_parent_revision(engine)
+    return engine
+
+
+def test_backfill_tolerates_a_missing_table(tmp_path: Path) -> None:
+    """A database without one of the two tables (a partially initialized
+    deployment) must not crash the upgrade."""
+    metadata = sa.MetaData()
+    full = _pre_migration_metadata()
+    full.tables["mcp_servers"].to_metadata(metadata)
+    engine = _engine_with_tables(tmp_path, metadata)
+    _insert(engine, "mcp_servers", {1: "Streamable_HTTP"})
+
+    _upgrade(engine)
+
+    assert _stored(engine, "mcp_servers") == {1: "streamable_http"}
+
+
+def test_backfill_tolerates_a_table_without_the_transport_column(
+    tmp_path: Path,
+) -> None:
+    """The column guard must actually fire: without a test, a typo in the table
+    or column name would make the guard skip every table and the backfill would
+    silently no-op in production."""
+    metadata = sa.MetaData()
+    sa.Table(
+        "mcp_servers",
+        metadata,
+        sa.Column("id", sa.Integer, primary_key=True),
+        sa.Column("name", sa.String(100), nullable=False),
+    )
+    _pre_migration_metadata().tables["public_mcp_apps"].to_metadata(metadata)
+    engine = _engine_with_tables(tmp_path, metadata)
+    _insert(engine, "public_mcp_apps", {1: "Streamable_HTTP"})
+
+    _upgrade(engine)
+
+    # The column-less table was skipped rather than raising, and the other
+    # table was still backfilled.
+    assert _stored(engine, "public_mcp_apps") == {1: "streamable_http"}
+
+
+# --------------------------------------------------------------------------
+# Offline (--sql) generation
+# --------------------------------------------------------------------------
+
+
+def _offline_sql(dialect: str, operation: str = "upgrade") -> str:
+    """Generate the migration's SQL the way ``alembic upgrade --sql`` does.
+
+    Driven through ``command.upgrade(sql=True)`` and the repository's own
+    ``env.py`` offline path rather than a hand-built MigrationContext, so the
+    MockConnection that broke the previous draft is the one actually in play.
+    """
+    url = {
+        "sqlite": "sqlite://",
+        "postgresql": "postgresql://user:pw@localhost/db",
+    }[dialect]
+    output = StringIO()
+    config = Config(stdout=output)
+    config.set_main_option("script_location", "src/xagent/migrations")
+    config.set_main_option("sqlalchemy.url", url)
+
+    revisions = (
+        f"{PARENT_REVISION}:{TARGET_REVISION}"
+        if operation == "upgrade"
+        else f"{TARGET_REVISION}:{PARENT_REVISION}"
+    )
+    # Alembic writes the offline script to the process stdout, not to
+    # Config.stdout, so capture that as well as passing the buffer in.
+    with redirect_stdout(output):
+        getattr(command, operation)(config, revisions, sql=True)
+    return output.getvalue()
+
+
+@pytest.mark.parametrize("dialect", ["sqlite", "postgresql"])
+class TestOfflineSql:
+    def test_upgrade_emits_an_update_for_both_tables(self, dialect: str) -> None:
+        """The regression this migration's offline branch exists for.
+
+        Reflecting the bind raised NoInspectionAvailable on the MockConnection
+        that ``alembic upgrade --sql`` supplies, so neither UPDATE was emitted
+        and the artifact could not be generated at all.
+        """
+        sql = _offline_sql(dialect)
+
+        for table in TABLES:
+            assert f"UPDATE {table}" in sql
+
+    def test_upgrade_emits_the_padding_translation(self, dialect: str) -> None:
+        """Offline SQL must carry the same whitespace grammar as online, and
+        must spell it with the dialect's own character function."""
+        sql = _offline_sql(dialect)
+        char_fn = {"sqlite": "char", "postgresql": "chr"}[dialect]
+
+        for code_point in (9, 10, 13):
+            assert f"{char_fn}({code_point})" in sql
+
+    def test_upgrade_bounds_the_rewrite_to_the_covered_set(self, dialect: str) -> None:
+        sql = _offline_sql(dialect)
+
+        for value in _migration_module()._CANONICAL_TRANSPORTS:
+            assert f"'{value}'" in sql
+
+    def test_offline_sql_carries_no_literal_control_characters(
+        self, dialect: str
+    ) -> None:
+        """A raw tab or newline inside a SQL string literal is a hazard for
+        whoever applies the generated script by hand; the code points are
+        spelled via the dialect's character function instead."""
+        sql = _offline_sql(dialect)
+        statements = [line for line in sql.splitlines() if TAB in line]
+
+        assert statements == []
+        assert CR not in sql
+
+    def test_offline_sql_carries_no_bind_parameters(self, dialect: str) -> None:
+        sql = _offline_sql(dialect)
+
+        assert "%(" not in sql
+        assert ":param" not in sql
+        assert "?" not in sql
+
+    def test_downgrade_touches_neither_data_table(self, dialect: str) -> None:
+        """The downgrade is deliberately a no-op (the original spellings are
+        not recorded anywhere). Alembic's own alembic_version bookkeeping is
+        expected; neither MCP table may be written."""
+        sql = _offline_sql(dialect, "downgrade")
+
+        for table in TABLES:
+            assert table not in sql

--- a/tests/migrations/test_20260828_normalize_mcp_transport_case.py
+++ b/tests/migrations/test_20260828_normalize_mcp_transport_case.py
@@ -50,6 +50,10 @@ ALL_TABLES = ("alembic_version",) + TABLES
 TAB = chr(9)
 LF = chr(10)
 CR = chr(13)
+VT = chr(11)
+FF = chr(12)
+FS = chr(28)
+US = chr(31)
 NBSP = chr(0xA0)
 IDEOGRAPHIC_SPACE = chr(0x3000)
 
@@ -233,6 +237,12 @@ BACKFILL_CASES: dict[int, tuple[str | None, str | None]] = {
     # behind it matches exactly.
     13: ("OAuth", "oauth"),
     14: (" oauth ", "oauth"),
+    # The rest of the ASCII whitespace str.strip() removes that single-argument
+    # SQL TRIM() does not. Unlike NBSP/U+3000 these are single-byte and so are
+    # nameable on every supported encoding.
+    18: (VT + "STDIO" + FF, "stdio"),
+    19: (FS + "oauth" + US, "oauth"),
+    20: (VT + FF + " Streamable_HTTP " + FS, "streamable_http"),
     # Interior padding characters that would *spell* a canonical transport if
     # they were deleted rather than translated to a space. The helper leaves
     # these alone, so the migration must too: deleting would let the backfill
@@ -387,6 +397,61 @@ class TestPostgresBackfill(_BackfillContract):
 # --------------------------------------------------------------------------
 
 
+@pytest.mark.postgresql
+@pytest.mark.parametrize("table", TABLES)
+def test_backfill_is_locale_independent_on_postgres(table: str) -> None:
+    """A Turkish-locale database must not defeat the canonical-set guard.
+
+    PostgreSQL's LOWER() is locale-sensitive: under ICU tr-TR, LOWER('STDIO')
+    is 'stdıo' with a dotless i (U+0131), which is not in _CANONICAL_TRANSPORTS,
+    so the guard rejects the row and the backfill silently leaves 'STDIO'
+    unfixed while every other value normalizes. The repository does not restrict
+    the database locale, so this has to be pinned against a real Turkish server
+    rather than assumed away.
+    """
+    url = _postgres_url()
+    if not url:
+        pytest.skip("XAGENT_TEST_POSTGRES_URL is not set")
+
+    admin = create_engine(url, isolation_level="AUTOCOMMIT")
+    database = "xagent_transport_tr"
+    try:
+        with admin.connect() as conn:
+            conn.execute(text(f"DROP DATABASE IF EXISTS {database}"))
+            conn.execute(
+                text(
+                    f"CREATE DATABASE {database} TEMPLATE template0 "
+                    "ENCODING 'UTF8' LOCALE_PROVIDER icu ICU_LOCALE 'tr-TR'"
+                )
+            )
+    except sa.exc.DBAPIError as exc:
+        pytest.skip(f"server cannot create an ICU Turkish database: {exc}")
+    finally:
+        admin.dispose()
+
+    turkish_url = create_engine(url).url.set(database=database)
+    engine = create_engine(turkish_url)
+    try:
+        # Guard against a false pass: if this server's LOWER is not actually
+        # Turkish-sensitive, the test would prove nothing about the collation.
+        with engine.begin() as conn:
+            assert conn.execute(text("SELECT LOWER('STDIO')")).scalar_one() != "stdio"
+
+        _pre_migration_metadata().create_all(bind=engine)
+        _stamp_parent_revision(engine)
+        _insert(engine, table, {1: "STDIO", 2: "OAuth", 3: "SSE"})
+
+        _upgrade(engine)
+
+        assert _stored(engine, table) == {1: "stdio", 2: "oauth", 3: "sse"}
+    finally:
+        engine.dispose()
+        admin = create_engine(url, isolation_level="AUTOCOMMIT")
+        with admin.connect() as conn:
+            conn.execute(text(f"DROP DATABASE IF EXISTS {database}"))
+        admin.dispose()
+
+
 def _engine_with_tables(tmp_path: Path, metadata: sa.MetaData) -> sa.engine.Engine:
     engine = create_engine(f"sqlite:///{tmp_path / 'partial.db'}")
     metadata.create_all(bind=engine)
@@ -463,8 +528,13 @@ def _offline_sql(dialect: str, operation: str = "upgrade") -> str:
         "postgresql": "postgresql://user:pw@localhost/db",
     }[dialect]
     output = StringIO()
-    config = Config(stdout=output)
-    config.set_main_option("script_location", "src/xagent/migrations")
+    # Derive script_location from the installed package, like the online
+    # callsite, so this helper does not require pytest to run from the
+    # repository root. Only the URL is overridden -- the real
+    # command.upgrade(sql=True) / env.py path this test exists to exercise is
+    # preserved.
+    config = create_alembic_config(create_engine(url))
+    config.stdout = output
     config.set_main_option("sqlalchemy.url", url)
 
     revisions = (

--- a/tests/migrations/test_20260828_normalize_mcp_transport_case.py
+++ b/tests/migrations/test_20260828_normalize_mcp_transport_case.py
@@ -37,7 +37,9 @@ from alembic import command
 from alembic.config import Config
 from sqlalchemy import create_engine, text
 
-PARENT_REVISION = "20260826_seed_deputy_mcp_app"
+from xagent.db.config import create_alembic_config
+
+PARENT_REVISION = "20260821_actor_oauth_flow_states"
 TARGET_REVISION = "20260828_normalize_mcp_transport_case"
 
 TABLES = ("mcp_servers", "public_mcp_apps")
@@ -48,6 +50,8 @@ ALL_TABLES = ("alembic_version",) + TABLES
 TAB = chr(9)
 LF = chr(10)
 CR = chr(13)
+NBSP = chr(0xA0)
+IDEOGRAPHIC_SPACE = chr(0x3000)
 
 
 def _migration_module() -> ModuleType:
@@ -113,8 +117,10 @@ def _stamp_parent_revision(engine: sa.engine.Engine) -> None:
 
 
 def _alembic_config(engine: sa.engine.Engine) -> Config:
-    config = Config()
-    config.set_main_option("script_location", "src/xagent/migrations")
+    """The repo's own helper, which resolves script_location through the
+    installed package rather than a CWD-relative path, so this suite does not
+    silently require pytest to be invoked from the repository root."""
+    config = create_alembic_config(engine)
     config.set_main_option(
         "sqlalchemy.url", engine.url.render_as_string(hide_password=False)
     )
@@ -222,6 +228,11 @@ BACKFILL_CASES: dict[int, tuple[str | None, str | None]] = {
     8: ("Not-A-Transport", "Not-A-Transport"),
     9: (TAB + "str" + TAB + "eamable" + LF, TAB + "str" + TAB + "eamable" + LF),
     10: ("   ", "   "),
+    # "oauth" is the default for public_mcp_apps.transport and is split the
+    # same way: classify_app_auth lowercases it, every connect/credential gate
+    # behind it matches exactly.
+    13: ("OAuth", "oauth"),
+    14: (" oauth ", "oauth"),
     # Interior padding characters that would *spell* a canonical transport if
     # they were deleted rather than translated to a space. The helper leaves
     # these alone, so the migration must too: deleting would let the backfill
@@ -240,26 +251,17 @@ class _BackfillContract:
     is that they are indistinguishable from the caller's side.
     """
 
-    def test_backfill_canonicalizes_mcp_servers(self, engine) -> None:
-        _insert(engine, "mcp_servers", {k: v for k, (v, _) in BACKFILL_CASES.items()})
+    @pytest.mark.parametrize("table", TABLES)
+    def test_backfill_canonicalizes_transport(self, engine, table: str) -> None:
+        """Both tables get the same treatment. public_mcp_apps matters most: a
+        shared catalog row's transport is never rewritten by the connect path,
+        so without this backfill it would stay non-canonical indefinitely."""
+        _insert(engine, table, {k: v for k, (v, _) in BACKFILL_CASES.items()})
 
         _upgrade(engine)
 
         expected = {k: want for k, (_, want) in BACKFILL_CASES.items()}
-        assert _stored(engine, "mcp_servers") == expected
-
-    def test_backfill_canonicalizes_public_mcp_apps(self, engine) -> None:
-        """The catalog table matters most: a shared catalog row's transport is
-        never rewritten by the connect path, so without this backfill it would
-        stay non-canonical indefinitely."""
-        _insert(
-            engine, "public_mcp_apps", {k: v for k, (v, _) in BACKFILL_CASES.items()}
-        )
-
-        _upgrade(engine)
-
-        expected = {k: want for k, (_, want) in BACKFILL_CASES.items()}
-        assert _stored(engine, "public_mcp_apps") == expected
+        assert _stored(engine, table) == expected
 
     def test_padding_grammar_matches_the_write_side_helper(self, engine) -> None:
         """The whitespace axis, pinned against the helper rather than the SQL.
@@ -284,6 +286,31 @@ class _BackfillContract:
         assert stored == {
             row_id: _normalize_like_helper(value) for row_id, value in padded.items()
         }
+
+    def test_non_ascii_padding_is_left_untouched(self, engine) -> None:
+        """The documented scope limit, pinned as behavior rather than prose.
+
+        ``str.strip()`` also removes NBSP and U+3000, but neither can be named
+        portably in SQL: on a server whose encoding cannot represent them,
+        PostgreSQL's ``chr()`` raises "requested character too large for
+        encoding" and aborts the entire upgrade. Such a row is therefore left
+        as stored. The migration must skip it silently -- never crash, and
+        never half-normalize it into a value a reader would then accept.
+        """
+        rows = {
+            1: NBSP + "stdio" + NBSP,
+            2: IDEOGRAPHIC_SPACE + "oauth",
+        }
+        try:
+            _insert(engine, "mcp_servers", rows)
+        except (UnicodeEncodeError, sa.exc.DBAPIError) as exc:
+            # A SQL_ASCII server cannot store these at all, which is the same
+            # boundary that makes them unfixable -- there is nothing to assert.
+            pytest.skip(f"server encoding cannot store non-ASCII padding: {exc}")
+
+        _upgrade(engine)
+
+        assert _stored(engine, "mcp_servers") == rows
 
     def test_backfill_leaves_other_columns_verbatim(self, engine) -> None:
         _insert(engine, "mcp_servers", {1: "Streamable_HTTP"}, url="https://kept/mcp")
@@ -316,6 +343,20 @@ class _BackfillContract:
         _upgrade(engine)
 
         assert _stored(engine, "mcp_servers") == after_first
+
+        # End-state equality alone would also hold for a migration that
+        # rewrote every row to the same value on each pass. The docstring
+        # claims the WHERE clause *skips* already-normalized rows, so re-run
+        # the migration's own statement -- fetched from the module, not
+        # restated here, so weakening that clause actually fails this test --
+        # and pin that it matches nothing.
+        migration = _migration_module()
+        statement = migration._backfill_statement(
+            "mcp_servers", migration._normalized_expression(engine.dialect.name)
+        )
+        with engine.begin() as conn:
+            result = conn.execute(text(statement))
+        assert result.rowcount == 0
 
     def test_null_transport_is_preserved(self, engine) -> None:
         """A NULL transport must stay NULL rather than become '': both WHERE
@@ -396,6 +437,20 @@ def test_backfill_tolerates_a_table_without_the_transport_column(
 # --------------------------------------------------------------------------
 
 
+def test_unsupported_dialect_fails_loudly() -> None:
+    """An unsupported dialect must raise, not silently get a narrower backfill.
+
+    The project supports sqlite and postgresql only (db/migration_support.py
+    raises for anything else). A default in the character-function lookup would
+    hand an unknown dialect some other dialect's spelling and quietly emit SQL
+    that either fails at apply time or normalizes the wrong character set.
+    """
+    migration = _migration_module()
+
+    with pytest.raises(KeyError):
+        migration._normalized_expression("mysql")
+
+
 def _offline_sql(dialect: str, operation: str = "upgrade") -> str:
     """Generate the migration's SQL the way ``alembic upgrade --sql`` does.
 
@@ -464,13 +519,6 @@ class TestOfflineSql:
 
         assert statements == []
         assert CR not in sql
-
-    def test_offline_sql_carries_no_bind_parameters(self, dialect: str) -> None:
-        sql = _offline_sql(dialect)
-
-        assert "%(" not in sql
-        assert ":param" not in sql
-        assert "?" not in sql
 
     def test_downgrade_touches_neither_data_table(self, dialect: str) -> None:
         """The downgrade is deliberately a no-op (the original spellings are


### PR DESCRIPTION
Part of #1828. Closes #1831.

Third of the three layers #1758 was split into. **Depends on #1829 (write-side) and #1830 (read-side) landing first** — see *Rollout ordering* below. No code dependency on either, so it could be reviewed in parallel; it is the only layer that mutates production data, so it should merge last.

## What

A one-time backfill canonicalizing stored `transport` in `mcp_servers` and `public_mcp_apps`.

A row written before the write-time validators shipped can hold a mixed-case or whitespace-padded transport. Such a row is admitted by the normalizing half of the MCP OAuth feature and rejected by the exact-matching half: the web runtime classifies it as an HTTP server and runs the per-user token exchange, while the core serializer's exact `transport in ["sse", "websocket", "streamable_http"]` test fails and drops the row's `url` from the connection dict entirely. A shared catalog row's transport is never rewritten by the connect path, so an un-migrated row stays in that state indefinitely.

## The three open questions from round 4

**1. Offline SQL generation (blocker).** The previous draft reflected the bind to discover which tables exist. `alembic upgrade --sql` supplies a `MockConnection`, so `sa.inspect(bind)` raised `NoInspectionAvailable` before either UPDATE could be emitted — the artifact could not be generated at all. Offline mode now branches on `context.is_offline_mode()` and emits both UPDATEs unconditionally; the table names are compile-time constants, so reflection buys nothing there. Reflection is retained online.

Covered by `TestOfflineSql`, which drives the real `command.upgrade(sql=True)` path through the repository's own `env.py` rather than a hand-built `MigrationContext`, so the `MockConnection` that broke the previous draft is the one actually in play.

**2. Whitespace semantics.** Accepted — my round-3 decline was wrong, and the reasoning behind it was an untested assumption. Reproduced against real code before changing anything: for `transport = "\tstreamable_http"`, `_is_mcp_oauth_http_server` normalizes and returns `True` (so the row enters the token exchange) while `to_connection_dict()` exact-matches, falls through, and returns a connection with no `url`. That is the same split classification this PR exists to remove, on the whitespace axis instead of the case axis — not the uniform rejection I claimed.

Single-argument SQL `TRIM()` strips only ASCII spaces, so TAB/LF/CR are translated to spaces before `TRIM` runs, matching the write-side helper's `str.strip().lower()`.

Two details worth the reviewer's attention, both found by mutation-testing this migration against its own tests:

- **Translated, not deleted.** `REPLACE(x, chr(9), '')` deletes globally, so an *interior* tab would be removed — `'st\tdio'` would become `'stdio'`, inventing a valid transport out of a value the helper leaves alone. Translating to a space preserves `TRIM`'s edges-only semantics. Pinned by cases 11–12 in `BACKFILL_CASES`.
- **Bounded to the covered set.** A row is rewritten only when normalizing it yields one of the four transports the application dispatches on. The migration can therefore only ever move a row onto a value the readers already agree on, never invent one, and an unrecognized string is left byte-identical rather than reshaped into different garbage.

**3. Rolling-writer convergence.** Documented as an explicit ordering guarantee rather than enforced with a constraint, since a CHECK/trigger would turn a one-shot backfill into a schema change needing a reversible downgrade. The migration docstring names the expand phase: deploy #1829 (no new non-canonical rows) and #1830 (tolerant reads), drain the old instances, then backfill. Run out of order it is still safe — it only ever rewrites toward the canonical form — but not guaranteed to leave the table canonical, and the docstring says so.

## Testing

26 tests. The substantive contract runs against **both SQLite and PostgreSQL** via a shared base class, so the dialect branch (`char()` vs `chr()`) is exercised rather than assumed; verified locally against a real PostgreSQL 18.6 server, not only under the CI marker. Follows the `tests/migrations/test_20260813_trace_json_columns_to_jsonb.py` convention.

Covers: canonicalization in both tables; the padding grammar pinned against the helper's semantics rather than against the migration's own SQL; values outside the covered set left byte-identical; other columns left verbatim; NULL preserved; idempotence across a *real* re-run (version stepped back and upgraded again, not merely a second pass over canonical rows); missing table and missing column tolerated; offline generation for both dialects, including that no literal control character reaches the emitted script.

Mutation-verified — 7 mutants, all killed: removing the offline branch, dropping the padding translation, removing the covered-set bound, dropping the NULL guard, typoing the column guard, swapping `chr`/`char` per dialect, and deleting instead of translating padding. The last one initially survived and is what surfaced the interior-character hazard above; case 11–12 were added to kill it.

`ruff check`, `ruff format --check`, `isort` clean. `tests/migrations/` shows no new failures relative to `origin/main`.
