### PR TITLE
feat(auth): add builtin OAuth catalog

### DIFF
--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -222,6 +222,11 @@ def _strict_catalog_app_by_id(
     used only to detect an administrator-authored collision that a looser route
     or UI lookup could otherwise resolve inconsistently.
     """
+    if not isinstance(app_id, str) or not app_id or app_id != app_id.strip():
+        raise BuiltinOAuthServerDefinitionError(
+            "builtin OAuth app_id must be an exact non-empty string"
+        )
+
     app = db.query(PublicMCPApp).filter(PublicMCPApp.app_id == app_id).one_or_none()
     if app is None:
         raise BuiltinOAuthServerDefinitionError(
@@ -422,9 +427,12 @@ def _builtin_server_candidates(db: Session, app_info: Mapping[str, Any]) -> list
         ):
             candidates.append(server)
             continue
-        if _normalized_catalog_key(server.name) in normalized_names:
+        if (
+            _normalized_catalog_key(server_app_id) in normalized_names
+            or _normalized_catalog_key(server.name) in normalized_names
+        ):
             raise BuiltinOAuthServerDefinitionError(
-                f"builtin OAuth app {app_id!r} has an ambiguous reserved server name"
+                f"builtin OAuth app {app_id!r} has an ambiguous reserved server identity"
             )
 
     if not legacy_name_is_unique and any(
@@ -477,7 +485,7 @@ def ensure_builtin_oauth_server_definition(db: Session, *, app_id: str) -> Any:
         )
     app_info = _strict_catalog_app_by_id(
         db,
-        app_id.strip(),
+        app_id,
         require_builtin_oauth=True,
         require_visible=True,
     )

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -8,6 +8,7 @@ from collections.abc import Iterable, Mapping
 from copy import deepcopy
 from typing import Any, Dict, List
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from .builtin_mcp_registry import get_builtin_execution_fields_and_optional_scopes
@@ -194,6 +195,387 @@ def get_app_by_name(db: Session, name: str) -> Dict[str, Any] | None:
     """Retrieve an MCP app configuration by its exact name."""
     app = db.query(PublicMCPApp).filter(PublicMCPApp.name == name).first()
     return _app_to_dict(app) if app else None
+
+
+class BuiltinOAuthServerDefinitionError(ValueError):
+    """Raised when trusted builtin OAuth identity is absent or ambiguous."""
+
+
+def _normalized_catalog_key(value: object) -> str | None:
+    """Normalize only for collision detection, never for persisted identity."""
+    if value is None:
+        return None
+    normalized = "-".join(str(value).strip().lower().split())
+    return normalized or None
+
+
+def _strict_catalog_app_by_id(
+    db: Session,
+    app_id: str,
+    *,
+    require_builtin_oauth: bool = False,
+    require_visible: bool = False,
+) -> Dict[str, Any]:
+    """Resolve one exact app while rejecting normalized-ID collisions.
+
+    Stable identity remains the exact ``PublicMCPApp.app_id``. Normalization is
+    used only to detect an administrator-authored collision that a looser route
+    or UI lookup could otherwise resolve inconsistently.
+    """
+    app = db.query(PublicMCPApp).filter(PublicMCPApp.app_id == app_id).one_or_none()
+    if app is None:
+        raise BuiltinOAuthServerDefinitionError(
+            f"builtin OAuth catalog app {app_id!r} is unavailable"
+        )
+
+    normalized_id = _normalized_catalog_key(app_id)
+    collisions = [
+        candidate
+        for candidate in db.query(PublicMCPApp).all()
+        if _normalized_catalog_key(candidate.app_id) == normalized_id
+    ]
+    if len(collisions) != 1:
+        raise BuiltinOAuthServerDefinitionError(
+            f"builtin OAuth catalog app {app_id!r} has ambiguous normalized identity"
+        )
+
+    execution_fields, _optional_scopes = (
+        get_builtin_execution_fields_and_optional_scopes(app.app_id)
+    )
+    if require_builtin_oauth and execution_fields is None:
+        raise BuiltinOAuthServerDefinitionError(
+            f"OAuth catalog app {app_id!r} is absent from the builtin registry"
+        )
+    if execution_fields is not None:
+        persisted_execution = {
+            "name": app.name,
+            "transport": app.transport,
+            "provider_name": app.provider_name,
+            "oauth_scopes": list(app.oauth_scopes or []),
+            "launch_config": app.launch_config or {},
+        }
+        expected_execution = {
+            "name": execution_fields["name"],
+            "transport": execution_fields["transport"],
+            "provider_name": execution_fields["provider_name"],
+            "oauth_scopes": list(execution_fields["oauth_scopes"]),
+            "launch_config": execution_fields["launch_config"],
+        }
+        drifted_fields = sorted(
+            field
+            for field, expected in expected_execution.items()
+            if persisted_execution[field] != expected
+        )
+        if drifted_fields:
+            raise BuiltinOAuthServerDefinitionError(
+                f"builtin OAuth catalog app {app_id!r} has persisted catalog "
+                f"drift ({', '.join(drifted_fields)})"
+            )
+
+    app_info = _app_to_dict(app)
+    if require_builtin_oauth and app_info.get("auth_type") != "builtin_oauth":
+        raise BuiltinOAuthServerDefinitionError(
+            f"catalog app {app_id!r} is not builtin OAuth"
+        )
+    if require_visible and not app_info.get("is_visible_in_connector"):
+        raise BuiltinOAuthServerDefinitionError(
+            f"builtin OAuth catalog app {app_id!r} is unavailable"
+        )
+    return app_info
+
+
+_CANONICAL_EMPTY_SERVER_FIELDS = (
+    "command",
+    "args",
+    "url",
+    "env",
+    "cwd",
+    "headers",
+    "timeout",
+    "runtime_input_schema",
+    "runtime_bindings",
+    "docker_url",
+    "docker_image",
+    "docker_environment",
+    "docker_working_dir",
+    "volumes",
+    "bind_ports",
+    "auto_start",
+    "container_id",
+    "container_name",
+    "container_logs",
+)
+
+
+def _validate_canonical_builtin_oauth_server(
+    server: Any, app_info: Mapping[str, Any]
+) -> None:
+    """Reject every stored field that could supply non-catalog execution data."""
+    app_id = str(app_info["id"])
+    allowed_names = {app_id, str(app_info["name"])}
+    failures: list[str] = []
+    if str(getattr(server, "name", "")) not in allowed_names:
+        failures.append("name")
+    if getattr(server, "managed", None) != "external":
+        failures.append("managed")
+    if str(getattr(server, "transport", "")).lower() != "oauth":
+        failures.append("transport")
+
+    for field_name in _CANONICAL_EMPTY_SERVER_FIELDS:
+        value = getattr(server, field_name, None)
+        if value not in (None, "", [], {}):
+            failures.append(field_name)
+    if bool(getattr(server, "concurrency_safe", False)):
+        failures.append("concurrency_safe")
+    if getattr(server, "concurrent_tools", None) not in (None, []):
+        failures.append("concurrent_tools")
+    if bool(getattr(server, "allow_delegated_authorization", False)):
+        failures.append("allow_delegated_authorization")
+    if getattr(server, "restart_policy", None) not in (None, "no"):
+        failures.append("restart_policy")
+
+    expected_auth = {"app_id": app_id}
+    provider = app_info.get("provider")
+    if provider:
+        expected_auth["provider"] = str(provider)
+    auth = getattr(server, "auth", None)
+    if auth is not None and not isinstance(auth, Mapping):
+        failures.append("auth")
+    elif isinstance(auth, Mapping):
+        unknown_keys = set(auth) - set(expected_auth)
+        mismatched = any(
+            key in auth and str(auth[key]) != expected_value
+            for key, expected_value in expected_auth.items()
+        )
+        if unknown_keys or mismatched:
+            failures.append("auth")
+
+    if failures:
+        raise BuiltinOAuthServerDefinitionError(
+            f"OAuth app {app_id!r} conflicts with an existing MCP server: "
+            f"{getattr(server, 'name', '')!r} is not a canonical builtin OAuth "
+            f"definition ({', '.join(sorted(set(failures)))})"
+        )
+
+
+def _ensure_sqlite_savepoint_root(db: Session) -> None:
+    """Ensure SQLite SAVEPOINT writes remain owned by the caller transaction."""
+    connection = db.connection()
+    driver_connection = connection.connection.driver_connection
+    if connection.dialect.name == "sqlite" and not bool(
+        getattr(driver_connection, "in_transaction", False)
+    ):
+        connection.exec_driver_sql("BEGIN")
+
+
+def _is_expected_unique_violation(
+    exc: IntegrityError, *, constraint_names: set[str], sqlite_columns: str
+) -> bool:
+    """Classify only the unique races this helper can safely recover from."""
+    original = exc.orig
+    sqlstate = getattr(original, "sqlstate", None) or getattr(original, "pgcode", None)
+    constraint_name = getattr(getattr(original, "diag", None), "constraint_name", None)
+    if sqlstate == "23505":
+        return constraint_name in constraint_names
+    message = str(original).lower()
+    return "unique constraint failed" in message and sqlite_columns in message
+
+
+def _builtin_server_candidates(db: Session, app_info: Mapping[str, Any]) -> list[Any]:
+    """Return candidates for one app and reject reserved-name conflicts."""
+    from .models.mcp import MCPServer
+
+    app_id = str(app_info["id"])
+    app_name = str(app_info["name"])
+    normalized_names = {
+        key for key in map(_normalized_catalog_key, (app_id, app_name)) if key
+    }
+    legacy_name_matches = (
+        db.query(PublicMCPApp).filter(PublicMCPApp.name == app_name).all()
+    )
+    legacy_name_is_unique = len({str(app.app_id) for app in legacy_name_matches}) == 1
+
+    candidates: list[Any] = []
+    for server in db.query(MCPServer).all():
+        server_auth: Mapping[str, Any] = (
+            server.auth if isinstance(server.auth, Mapping) else {}
+        )
+        server_app_id = server_auth.get("app_id")
+        exact_name_candidate = server.name == app_id or (
+            server.name == app_name and legacy_name_is_unique
+        )
+        if server_app_id == app_id or (
+            "app_id" not in server_auth and exact_name_candidate
+        ):
+            candidates.append(server)
+            continue
+        if _normalized_catalog_key(server.name) in normalized_names:
+            raise BuiltinOAuthServerDefinitionError(
+                f"builtin OAuth app {app_id!r} has an ambiguous reserved server name"
+            )
+
+    if not legacy_name_is_unique and any(
+        server.name == app_name
+        and not (
+            isinstance(server.auth, Mapping) and server.auth.get("app_id") == app_id
+        )
+        for server in db.query(MCPServer).all()
+    ):
+        raise BuiltinOAuthServerDefinitionError(
+            f"builtin OAuth app {app_id!r} has ambiguous legacy catalog identity"
+        )
+    return candidates
+
+
+def require_builtin_oauth_server_definition(
+    db: Session, *, app_id: str, provider: str
+) -> Any:
+    """Require one canonical server for an exact visible app/provider pair."""
+    app_info = _strict_catalog_app_by_id(
+        db,
+        app_id,
+        require_builtin_oauth=True,
+        require_visible=True,
+    )
+    if app_info.get("provider") != provider:
+        raise BuiltinOAuthServerDefinitionError(
+            f"builtin OAuth app {app_id!r} does not use provider {provider!r}"
+        )
+    candidates = _builtin_server_candidates(db, app_info)
+    if len(candidates) != 1:
+        raise BuiltinOAuthServerDefinitionError(
+            f"builtin OAuth app {app_id!r} must have exactly one MCP server definition"
+        )
+    _validate_canonical_builtin_oauth_server(candidates[0], app_info)
+    return candidates[0]
+
+
+def ensure_builtin_oauth_server_definition(db: Session, *, app_id: str) -> Any:
+    """Resolve or create one canonical visible builtin OAuth server.
+
+    The caller owns commit/rollback. Expected concurrent insert races are
+    isolated to a SAVEPOINT so unrelated caller work is never rolled back.
+    """
+    from .models.mcp import MCPServer
+
+    if not isinstance(app_id, str) or not app_id.strip():
+        raise BuiltinOAuthServerDefinitionError(
+            "builtin OAuth app_id must be a non-empty string"
+        )
+    app_info = _strict_catalog_app_by_id(
+        db,
+        app_id.strip(),
+        require_builtin_oauth=True,
+        require_visible=True,
+    )
+    candidates = _builtin_server_candidates(db, app_info)
+    if len(candidates) > 1:
+        raise BuiltinOAuthServerDefinitionError(
+            f"builtin OAuth app {app_id!r} has multiple MCP server definitions"
+        )
+
+    server = candidates[0] if candidates else None
+    if server is None:
+        expected_auth = {"app_id": str(app_info["id"])}
+        if app_info.get("provider"):
+            expected_auth["provider"] = str(app_info["provider"])
+        proposed = MCPServer(
+            name=str(app_info["name"]),
+            description=app_info.get("description"),
+            managed="external",
+            transport="oauth",
+            auth=expected_auth,
+        )
+        _ensure_sqlite_savepoint_root(db)
+        try:
+            with db.begin_nested():
+                db.add(proposed)
+                db.flush()
+            server = proposed
+        except IntegrityError as exc:
+            if not _is_expected_unique_violation(
+                exc,
+                constraint_names={"mcp_servers_name_key", "ix_mcp_servers_name"},
+                sqlite_columns="mcp_servers.name",
+            ):
+                raise
+            candidates = _builtin_server_candidates(db, app_info)
+            if len(candidates) != 1:
+                raise BuiltinOAuthServerDefinitionError(
+                    f"builtin OAuth app {app_id!r} did not converge on one server"
+                ) from exc
+            server = candidates[0]
+
+    _validate_canonical_builtin_oauth_server(server, app_info)
+    expected_auth = {"app_id": str(app_info["id"])}
+    if app_info.get("provider"):
+        expected_auth["provider"] = str(app_info["provider"])
+    server.auth = expected_auth
+    server.description = app_info.get("description") or server.description
+    db.flush()
+    return server
+
+
+def ensure_builtin_oauth_server_visibility_for_user(
+    db: Session, *, user_id: int, app_id: str
+) -> Any:
+    """Ensure canonical builtin visibility for one trusted internal account."""
+    from .models.mcp import UserMCPServer
+
+    if isinstance(user_id, bool) or not isinstance(user_id, int) or user_id <= 0:
+        raise ValueError("user_id must be a persisted positive integer")
+    server = ensure_builtin_oauth_server_definition(db, app_id=app_id)
+    association = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user_id,
+            UserMCPServer.mcpserver_id == int(server.id),
+        )
+        .one_or_none()
+    )
+    if association is None:
+        proposed = UserMCPServer(
+            user_id=user_id,
+            mcpserver_id=int(server.id),
+            is_owner=False,
+            can_edit=False,
+            can_delete=False,
+            is_shared=False,
+            is_active=True,
+        )
+        _ensure_sqlite_savepoint_root(db)
+        try:
+            with db.begin_nested():
+                db.add(proposed)
+                db.flush()
+            association = proposed
+        except IntegrityError as exc:
+            if not _is_expected_unique_violation(
+                exc,
+                constraint_names={"uq_user_mcpservers"},
+                sqlite_columns="user_mcpservers.user_id, user_mcpservers.mcpserver_id",
+            ):
+                raise
+            association = (
+                db.query(UserMCPServer)
+                .filter(
+                    UserMCPServer.user_id == user_id,
+                    UserMCPServer.mcpserver_id == int(server.id),
+                )
+                .one_or_none()
+            )
+            if association is None:
+                raise BuiltinOAuthServerDefinitionError(
+                    "builtin OAuth visibility race did not converge"
+                ) from exc
+    cast_association: Any = association
+    if not cast_association.is_owner:
+        cast_association.can_edit = False
+        cast_association.can_delete = False
+        cast_association.is_shared = False
+    cast_association.is_active = True
+    db.flush()
+    return server
 
 
 def get_app_for_mcp_server(db: Session, server: Any) -> Dict[str, Any] | None:

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -577,10 +577,6 @@ def ensure_builtin_oauth_server_visibility_for_user(
                     "builtin OAuth visibility race did not converge"
                 ) from exc
     cast_association: Any = association
-    if not cast_association.is_owner:
-        cast_association.can_edit = False
-        cast_association.can_delete = False
-        cast_association.is_shared = False
     cast_association.is_active = True
     db.flush()
     return server

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -307,6 +307,31 @@ _CANONICAL_EMPTY_SERVER_FIELDS = (
 )
 
 
+def _expected_builtin_auth(app_info: Mapping[str, Any]) -> dict[str, str]:
+    expected = {"app_id": str(app_info["id"])}
+    if app_info.get("provider"):
+        expected["provider"] = str(app_info["provider"])
+    return expected
+
+
+def _adopt_builtin_auth(server: Any, app_info: Mapping[str, Any]) -> None:
+    """Repair only missing canonical auth fields on a legacy server."""
+    expected = _expected_builtin_auth(app_info)
+    auth = getattr(server, "auth", None)
+    if auth is None:
+        server.auth = expected
+        return
+    if not isinstance(auth, Mapping):
+        return
+
+    unknown_keys = set(auth) - set(expected)
+    mismatched = any(
+        key in auth and str(auth[key]) != value for key, value in expected.items()
+    )
+    if not unknown_keys and not mismatched:
+        server.auth = expected
+
+
 def _validate_canonical_builtin_oauth_server(
     server: Any, app_info: Mapping[str, Any]
 ) -> None:
@@ -318,7 +343,7 @@ def _validate_canonical_builtin_oauth_server(
         failures.append("name")
     if getattr(server, "managed", None) != "external":
         failures.append("managed")
-    if str(getattr(server, "transport", "")).lower() != "oauth":
+    if getattr(server, "transport", None) != "oauth":
         failures.append("transport")
 
     for field_name in _CANONICAL_EMPTY_SERVER_FIELDS:
@@ -334,21 +359,9 @@ def _validate_canonical_builtin_oauth_server(
     if getattr(server, "restart_policy", None) not in (None, "no"):
         failures.append("restart_policy")
 
-    expected_auth = {"app_id": app_id}
-    provider = app_info.get("provider")
-    if provider:
-        expected_auth["provider"] = str(provider)
     auth = getattr(server, "auth", None)
-    if auth is not None and not isinstance(auth, Mapping):
+    if not isinstance(auth, Mapping) or dict(auth) != _expected_builtin_auth(app_info):
         failures.append("auth")
-    elif isinstance(auth, Mapping):
-        unknown_keys = set(auth) - set(expected_auth)
-        mismatched = any(
-            key in auth and str(auth[key]) != expected_value
-            for key, expected_value in expected_auth.items()
-        )
-        if unknown_keys or mismatched:
-            failures.append("auth")
 
     if failures:
         raise BuiltinOAuthServerDefinitionError(
@@ -476,9 +489,7 @@ def ensure_builtin_oauth_server_definition(db: Session, *, app_id: str) -> Any:
 
     server = candidates[0] if candidates else None
     if server is None:
-        expected_auth = {"app_id": str(app_info["id"])}
-        if app_info.get("provider"):
-            expected_auth["provider"] = str(app_info["provider"])
+        expected_auth = _expected_builtin_auth(app_info)
         proposed = MCPServer(
             name=str(app_info["name"]),
             description=app_info.get("description"),
@@ -506,11 +517,8 @@ def ensure_builtin_oauth_server_definition(db: Session, *, app_id: str) -> Any:
                 ) from exc
             server = candidates[0]
 
+    _adopt_builtin_auth(server, app_info)
     _validate_canonical_builtin_oauth_server(server, app_info)
-    expected_auth = {"app_id": str(app_info["id"])}
-    if app_info.get("provider"):
-        expected_auth["provider"] = str(app_info["provider"])
-    server.auth = expected_auth
     server.description = app_info.get("description") or server.description
     db.flush()
     return server

--- a/tests/web/test_builtin_oauth_catalog.py
+++ b/tests/web/test_builtin_oauth_catalog.py
@@ -41,6 +41,7 @@ DIRECTLY_VALIDATED_SERVER_FIELDS = {
     "restart_policy",
 }
 NONCANONICAL_SERVER_VALUES = {
+    "managed": "internal",
     "command": "foreign-command",
     "args": ["foreign-argument"],
     "url": "https://foreign.example",
@@ -180,6 +181,9 @@ def test_visibility_creates_canonical_nonowning_personal_link(catalog_db) -> Non
     links = db.query(UserMCPServer).all()
     assert len(links) == 1
     assert links[0].is_owner is False
+    assert links[0].can_edit is False
+    assert links[0].can_delete is False
+    assert links[0].is_shared is False
     assert links[0].is_active is True
     assert db.query(UserOAuth).count() == 0
 
@@ -315,6 +319,68 @@ def test_visibility_rejects_normalized_reserved_alias(catalog_db) -> None:
     ):
         mcp_apps.ensure_builtin_oauth_server_visibility_for_user(
             db, user_id=int(user.id), app_id="google-calendar"
+        )
+
+
+def test_visibility_rejects_normalized_reserved_auth_alias(catalog_db) -> None:
+    db, user = catalog_db
+    execution, _optional_scopes = get_builtin_execution_fields_and_optional_scopes(
+        "google-calendar"
+    )
+    assert execution is not None
+    db.add_all(
+        [
+            PublicMCPApp(
+                app_id="google-calendar",
+                name=str(execution["name"]),
+                transport=str(execution["transport"]),
+                provider_name=str(execution["provider_name"]),
+                oauth_scopes=list(execution["oauth_scopes"]),
+                launch_config=dict(execution["launch_config"]),
+                is_visible_in_connector=True,
+            ),
+            MCPServer(
+                name="Foreign server",
+                managed="external",
+                transport="oauth",
+                auth={"app_id": " GOOGLE   CALENDAR "},
+            ),
+        ]
+    )
+    db.commit()
+
+    with pytest.raises(
+        mcp_apps.BuiltinOAuthServerDefinitionError,
+        match="ambiguous reserved",
+    ):
+        mcp_apps.ensure_builtin_oauth_server_visibility_for_user(
+            db, user_id=int(user.id), app_id="google-calendar"
+        )
+
+    assert db.query(MCPServer).count() == 1
+    assert db.query(UserMCPServer).count() == 0
+
+
+def test_visibility_rejects_padded_app_id(catalog_db) -> None:
+    db, user = catalog_db
+    _catalog_link(db, user)
+
+    with pytest.raises(
+        mcp_apps.BuiltinOAuthServerDefinitionError,
+        match="exact|whitespace",
+    ):
+        mcp_apps.ensure_builtin_oauth_server_visibility_for_user(
+            db, user_id=int(user.id), app_id=" calendar "
+        )
+
+
+def test_definition_rejects_padded_app_id(catalog_db) -> None:
+    db, user = catalog_db
+    _catalog_link(db, user)
+
+    with pytest.raises(mcp_apps.BuiltinOAuthServerDefinitionError):
+        mcp_apps.require_builtin_oauth_server_definition(
+            db, app_id=" calendar ", provider="custom"
         )
 
 

--- a/tests/web/test_builtin_oauth_catalog.py
+++ b/tests/web/test_builtin_oauth_catalog.py
@@ -366,7 +366,7 @@ def test_owner_drift_fails_closed_at_strict_definition(catalog_db) -> None:
     assert link.can_delete is True
 
 
-def test_visibility_repairs_existing_nonowning_link(catalog_db) -> None:
+def test_visibility_preserves_existing_nonowning_policy(catalog_db) -> None:
     db, user = catalog_db
     _server, link = _catalog_link(db, user)
     link.is_owner = False
@@ -384,7 +384,7 @@ def test_visibility_repairs_existing_nonowning_link(catalog_db) -> None:
     db.refresh(link)
 
     assert link.is_owner is False
-    assert link.can_edit is False
-    assert link.can_delete is False
-    assert link.is_shared is False
+    assert link.can_edit is True
+    assert link.can_delete is True
+    assert link.is_shared is True
     assert link.is_active is True

--- a/tests/web/test_builtin_oauth_catalog.py
+++ b/tests/web/test_builtin_oauth_catalog.py
@@ -112,6 +112,70 @@ def test_visibility_creates_canonical_nonowning_personal_link(catalog_db) -> Non
     assert db.query(UserOAuth).count() == 0
 
 
+@pytest.mark.parametrize("server_name", ["calendar", "Google Calendar"])
+@pytest.mark.parametrize(
+    "auth",
+    [
+        None,
+        {},
+        {"provider": "custom"},
+        {"app_id": "calendar"},
+    ],
+)
+def test_definition_requires_exact_auth_metadata(catalog_db, server_name, auth) -> None:
+    db, user = catalog_db
+    server, _link = _catalog_link(db, user)
+    server.name = server_name
+    server.auth = auth
+    db.commit()
+
+    with pytest.raises(
+        mcp_apps.BuiltinOAuthServerDefinitionError,
+        match="auth",
+    ):
+        mcp_apps.require_builtin_oauth_server_definition(
+            db, app_id="calendar", provider="custom"
+        )
+
+
+@pytest.mark.parametrize(
+    "auth",
+    [
+        None,
+        {},
+        {"provider": "custom"},
+        {"app_id": "calendar"},
+    ],
+)
+def test_visibility_repairs_incomplete_auth_metadata(catalog_db, auth) -> None:
+    db, user = catalog_db
+    server, _link = _catalog_link(db, user)
+    server.auth = auth
+    db.commit()
+
+    mcp_apps.ensure_builtin_oauth_server_visibility_for_user(
+        db, user_id=int(user.id), app_id="calendar"
+    )
+
+    db.refresh(server)
+    assert server.auth == {"app_id": "calendar", "provider": "custom"}
+
+
+def test_definition_rejects_mixed_case_transport(catalog_db) -> None:
+    db, user = catalog_db
+    server, _link = _catalog_link(db, user)
+    server.transport = "OAUTH"
+    db.commit()
+
+    with pytest.raises(
+        mcp_apps.BuiltinOAuthServerDefinitionError,
+        match="transport",
+    ):
+        mcp_apps.require_builtin_oauth_server_definition(
+            db, app_id="calendar", provider="custom"
+        )
+
+
 def test_definition_rejects_duplicate_builtin_servers(catalog_db) -> None:
     db, user = catalog_db
     _catalog_link(db, user)
@@ -251,6 +315,30 @@ def test_visibility_preserves_existing_owning_link(catalog_db) -> None:
     assert link.can_delete is True
     assert link.is_shared is True
     assert link.is_active is True
+
+
+def test_owner_drift_fails_closed_at_strict_definition(catalog_db) -> None:
+    db, user = catalog_db
+    server, link = _catalog_link(db, user)
+    link.is_owner = True
+    link.can_edit = True
+    link.can_delete = True
+    server.transport = "stdio"
+    server.command = "/bin/foreign-command"
+    db.commit()
+
+    with pytest.raises(
+        mcp_apps.BuiltinOAuthServerDefinitionError,
+        match="canonical builtin OAuth definition",
+    ):
+        mcp_apps.require_builtin_oauth_server_definition(
+            db, app_id="calendar", provider="custom"
+        )
+
+    db.refresh(link)
+    assert link.is_owner is True
+    assert link.can_edit is True
+    assert link.can_delete is True
 
 
 def test_visibility_repairs_existing_nonowning_link(catalog_db) -> None:

--- a/tests/web/test_builtin_oauth_catalog.py
+++ b/tests/web/test_builtin_oauth_catalog.py
@@ -112,6 +112,19 @@ def test_visibility_creates_canonical_nonowning_personal_link(catalog_db) -> Non
     assert db.query(UserOAuth).count() == 0
 
 
+def test_visibility_rejects_invalid_user_id_with_plain_value_error(
+    catalog_db,
+) -> None:
+    db, _user = catalog_db
+
+    with pytest.raises(ValueError, match="persisted positive integer") as exc_info:
+        mcp_apps.ensure_builtin_oauth_server_visibility_for_user(
+            db, user_id=0, app_id="calendar"
+        )
+
+    assert type(exc_info.value) is ValueError
+
+
 @pytest.mark.parametrize("server_name", ["calendar", "Google Calendar"])
 @pytest.mark.parametrize(
     "auth",
@@ -189,7 +202,10 @@ def test_definition_rejects_duplicate_builtin_servers(catalog_db) -> None:
     )
     db.commit()
 
-    with pytest.raises(ValueError, match="exactly one|multiple"):
+    with pytest.raises(
+        mcp_apps.BuiltinOAuthServerDefinitionError,
+        match="exactly one|multiple",
+    ):
         mcp_apps.require_builtin_oauth_server_definition(
             db, app_id="calendar", provider="custom"
         )
@@ -221,7 +237,10 @@ def test_visibility_rejects_normalized_reserved_alias(catalog_db) -> None:
     )
     db.commit()
 
-    with pytest.raises(ValueError, match="ambiguous reserved"):
+    with pytest.raises(
+        mcp_apps.BuiltinOAuthServerDefinitionError,
+        match="ambiguous reserved",
+    ):
         mcp_apps.ensure_builtin_oauth_server_visibility_for_user(
             db, user_id=int(user.id), app_id="google-calendar"
         )
@@ -249,7 +268,10 @@ def test_definition_rejects_app_missing_from_builtin_registry(catalog_db) -> Non
     )
     db.commit()
 
-    with pytest.raises(ValueError, match="builtin registry"):
+    with pytest.raises(
+        mcp_apps.BuiltinOAuthServerDefinitionError,
+        match="builtin registry",
+    ):
         mcp_apps.require_builtin_oauth_server_definition(
             db, app_id="admin-calendar", provider="custom"
         )
@@ -285,7 +307,10 @@ def test_definition_rejects_seeded_catalog_execution_drift(catalog_db) -> None:
     )
     db.commit()
 
-    with pytest.raises(ValueError, match="catalog.*drift|persisted"):
+    with pytest.raises(
+        mcp_apps.BuiltinOAuthServerDefinitionError,
+        match="catalog.*drift|persisted",
+    ):
         mcp_apps.require_builtin_oauth_server_definition(
             db,
             app_id="gmail",

--- a/tests/web/test_builtin_oauth_catalog.py
+++ b/tests/web/test_builtin_oauth_catalog.py
@@ -24,6 +24,47 @@ TEST_BUILTIN_EXECUTION = {
     "oauth_scopes": [],
     "launch_config": {"command": "calendar"},
 }
+NON_EXECUTION_SERVER_FIELDS = {
+    "id",
+    "description",
+    "created_at",
+    "updated_at",
+}
+DIRECTLY_VALIDATED_SERVER_FIELDS = {
+    "name",
+    "managed",
+    "transport",
+    "auth",
+    "concurrency_safe",
+    "concurrent_tools",
+    "allow_delegated_authorization",
+    "restart_policy",
+}
+NONCANONICAL_SERVER_VALUES = {
+    "command": "foreign-command",
+    "args": ["foreign-argument"],
+    "url": "https://foreign.example",
+    "env": {"FOREIGN": "value"},
+    "cwd": "/foreign",
+    "headers": {"X-Foreign": "value"},
+    "timeout": 1,
+    "runtime_input_schema": {"type": "object"},
+    "runtime_bindings": {"token": "foreign"},
+    "docker_url": "unix:///foreign.sock",
+    "docker_image": "foreign/image",
+    "docker_environment": {"FOREIGN": "value"},
+    "docker_working_dir": "/foreign",
+    "volumes": ["/foreign:/foreign"],
+    "bind_ports": {"8080": 8080},
+    "auto_start": True,
+    "container_id": "foreign-container",
+    "container_name": "foreign-container",
+    "container_logs": ["foreign-log"],
+    "concurrency_safe": True,
+    "concurrent_tools": ["foreign-tool"],
+    "allow_delegated_authorization": True,
+    "restart_policy": "always",
+}
 
 
 @pytest.fixture
@@ -79,6 +120,37 @@ def _catalog_link(db: Session, user: User) -> tuple[MCPServer, UserMCPServer]:
     db.add(link)
     db.commit()
     return server, link
+
+
+def test_canonical_validation_covers_mcp_server_schema() -> None:
+    covered_fields = (
+        NON_EXECUTION_SERVER_FIELDS
+        | DIRECTLY_VALIDATED_SERVER_FIELDS
+        | set(mcp_apps._CANONICAL_EMPTY_SERVER_FIELDS)
+    )
+
+    assert set(MCPServer.__table__.columns.keys()) == covered_fields
+
+
+@pytest.mark.parametrize(
+    ("field_name", "value"),
+    NONCANONICAL_SERVER_VALUES.items(),
+)
+def test_definition_rejects_noncanonical_server_fields(
+    catalog_db, field_name, value
+) -> None:
+    db, user = catalog_db
+    server, _link = _catalog_link(db, user)
+    setattr(server, field_name, value)
+    db.commit()
+
+    with pytest.raises(
+        mcp_apps.BuiltinOAuthServerDefinitionError,
+        match=field_name,
+    ):
+        mcp_apps.require_builtin_oauth_server_definition(
+            db, app_id="calendar", provider="custom"
+        )
 
 
 def test_visibility_creates_canonical_nonowning_personal_link(catalog_db) -> None:

--- a/tests/web/test_builtin_oauth_catalog.py
+++ b/tests/web/test_builtin_oauth_catalog.py
@@ -1,0 +1,277 @@
+"""Contract tests for canonical builtin OAuth server visibility."""
+
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from xagent.web import mcp_apps
+from xagent.web.builtin_mcp_registry import (
+    get_builtin_execution_fields_and_optional_scopes,
+)
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.models.user_oauth import UserOAuth
+
+TEST_BUILTIN_APP_ID = "calendar"
+TEST_BUILTIN_EXECUTION = {
+    "name": "Google Calendar",
+    "transport": "oauth",
+    "provider_name": "custom",
+    "oauth_scopes": [],
+    "launch_config": {"command": "calendar"},
+}
+
+
+@pytest.fixture
+def catalog_db(tmp_path, monkeypatch):
+    registry_lookup = mcp_apps.get_builtin_execution_fields_and_optional_scopes
+
+    def test_registry(app_id: str):
+        if app_id == TEST_BUILTIN_APP_ID:
+            return TEST_BUILTIN_EXECUTION, []
+        return registry_lookup(app_id)
+
+    monkeypatch.setattr(
+        mcp_apps, "get_builtin_execution_fields_and_optional_scopes", test_registry
+    )
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'builtin-oauth-catalog.db'}")
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    with factory() as db:
+        user = User(username="workspace-account", password_hash="hash")
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        yield db, user
+    engine.dispose()
+
+
+def _catalog_link(db: Session, user: User) -> tuple[MCPServer, UserMCPServer]:
+    app = PublicMCPApp(
+        app_id="calendar",
+        name="Google Calendar",
+        description="Calendar",
+        transport="oauth",
+        provider_name="custom",
+        launch_config={"command": "calendar"},
+        is_visible_in_connector=True,
+    )
+    server = MCPServer(
+        name="Google Calendar",
+        description="Calendar",
+        managed="external",
+        transport="oauth",
+        auth={"app_id": "calendar", "provider": "custom"},
+    )
+    db.add_all([app, server])
+    db.flush()
+    link = UserMCPServer(
+        user_id=int(user.id),
+        mcpserver_id=int(server.id),
+        is_owner=False,
+        is_active=True,
+    )
+    db.add(link)
+    db.commit()
+    return server, link
+
+
+def test_visibility_creates_canonical_nonowning_personal_link(catalog_db) -> None:
+    db, user = catalog_db
+    db.add(
+        PublicMCPApp(
+            app_id="calendar",
+            name="Google Calendar",
+            description="Calendar",
+            transport="oauth",
+            provider_name="custom",
+            launch_config={"command": "calendar"},
+            is_visible_in_connector=True,
+        )
+    )
+    db.commit()
+
+    first = mcp_apps.ensure_builtin_oauth_server_visibility_for_user(
+        db, user_id=int(user.id), app_id="calendar"
+    )
+    second = mcp_apps.ensure_builtin_oauth_server_visibility_for_user(
+        db, user_id=int(user.id), app_id="calendar"
+    )
+
+    assert first.id == second.id
+    assert first.auth == {"app_id": "calendar", "provider": "custom"}
+    links = db.query(UserMCPServer).all()
+    assert len(links) == 1
+    assert links[0].is_owner is False
+    assert links[0].is_active is True
+    assert db.query(UserOAuth).count() == 0
+
+
+def test_definition_rejects_duplicate_builtin_servers(catalog_db) -> None:
+    db, user = catalog_db
+    _catalog_link(db, user)
+    db.add(
+        MCPServer(
+            name="calendar",
+            managed="external",
+            transport="oauth",
+            auth={"app_id": "calendar", "provider": "custom"},
+        )
+    )
+    db.commit()
+
+    with pytest.raises(ValueError, match="exactly one|multiple"):
+        mcp_apps.require_builtin_oauth_server_definition(
+            db, app_id="calendar", provider="custom"
+        )
+
+
+def test_visibility_rejects_normalized_reserved_alias(catalog_db) -> None:
+    db, user = catalog_db
+    execution, _optional_scopes = get_builtin_execution_fields_and_optional_scopes(
+        "google-calendar"
+    )
+    assert execution is not None
+    db.add_all(
+        [
+            PublicMCPApp(
+                app_id="google-calendar",
+                name=str(execution["name"]),
+                transport=str(execution["transport"]),
+                provider_name=str(execution["provider_name"]),
+                oauth_scopes=list(execution["oauth_scopes"]),
+                launch_config=dict(execution["launch_config"]),
+                is_visible_in_connector=True,
+            ),
+            MCPServer(
+                name=" google   calendar ",
+                managed="external",
+                transport="oauth",
+            ),
+        ]
+    )
+    db.commit()
+
+    with pytest.raises(ValueError, match="ambiguous reserved"):
+        mcp_apps.ensure_builtin_oauth_server_visibility_for_user(
+            db, user_id=int(user.id), app_id="google-calendar"
+        )
+
+
+def test_definition_rejects_app_missing_from_builtin_registry(catalog_db) -> None:
+    db, _user = catalog_db
+    db.add_all(
+        [
+            PublicMCPApp(
+                app_id="admin-calendar",
+                name="Admin Calendar",
+                transport="oauth",
+                provider_name="custom",
+                launch_config={"command": "calendar"},
+                is_visible_in_connector=True,
+            ),
+            MCPServer(
+                name="Admin Calendar",
+                managed="external",
+                transport="oauth",
+                auth={"app_id": "admin-calendar", "provider": "custom"},
+            ),
+        ]
+    )
+    db.commit()
+
+    with pytest.raises(ValueError, match="builtin registry"):
+        mcp_apps.require_builtin_oauth_server_definition(
+            db, app_id="admin-calendar", provider="custom"
+        )
+
+
+def test_definition_rejects_seeded_catalog_execution_drift(catalog_db) -> None:
+    db, _user = catalog_db
+    execution, _optional_scopes = get_builtin_execution_fields_and_optional_scopes(
+        "gmail"
+    )
+    assert execution is not None
+    db.add_all(
+        [
+            PublicMCPApp(
+                app_id="gmail",
+                name=str(execution["name"]),
+                transport=str(execution["transport"]),
+                provider_name="evil",
+                oauth_scopes=list(execution["oauth_scopes"]),
+                launch_config=dict(execution["launch_config"]),
+                is_visible_in_connector=True,
+            ),
+            MCPServer(
+                name=str(execution["name"]),
+                managed="external",
+                transport="oauth",
+                auth={
+                    "app_id": "gmail",
+                    "provider": execution["provider_name"],
+                },
+            ),
+        ]
+    )
+    db.commit()
+
+    with pytest.raises(ValueError, match="catalog.*drift|persisted"):
+        mcp_apps.require_builtin_oauth_server_definition(
+            db,
+            app_id="gmail",
+            provider=str(execution["provider_name"]),
+        )
+
+
+def test_visibility_preserves_existing_owning_link(catalog_db) -> None:
+    db, user = catalog_db
+    _server, link = _catalog_link(db, user)
+    link.is_owner = True
+    link.can_edit = True
+    link.can_delete = True
+    link.is_shared = True
+    link.is_active = False
+    db.commit()
+
+    mcp_apps.ensure_builtin_oauth_server_visibility_for_user(
+        db,
+        user_id=int(user.id),
+        app_id="calendar",
+    )
+    db.refresh(link)
+
+    assert link.is_owner is True
+    assert link.can_edit is True
+    assert link.can_delete is True
+    assert link.is_shared is True
+    assert link.is_active is True
+
+
+def test_visibility_repairs_existing_nonowning_link(catalog_db) -> None:
+    db, user = catalog_db
+    _server, link = _catalog_link(db, user)
+    link.is_owner = False
+    link.can_edit = True
+    link.can_delete = True
+    link.is_shared = True
+    link.is_active = False
+    db.commit()
+
+    mcp_apps.ensure_builtin_oauth_server_visibility_for_user(
+        db,
+        user_id=int(user.id),
+        app_id="calendar",
+    )
+    db.refresh(link)
+
+    assert link.is_owner is False
+    assert link.can_edit is False
+    assert link.can_delete is False
+    assert link.is_shared is False
+    assert link.is_active is True


### PR DESCRIPTION
## Background

Trusted actor OAuth must use code-owned builtin execution fields. Existing owner-backed rows can remain visible, but strict consumers reject drift and never use noncanonical execution configuration.

This is the second layer of the actor OAuth stack. It follows the merged flow-state schema in [#1839](https://github.com/xorbitsai/xagent/pull/1839).

## Goal

Add a registry-backed builtin OAuth catalog contract and safe per-user visibility helpers.

## Boundary

This PR changes only:

- `src/xagent/web/mcp_apps.py`
- `tests/web/test_builtin_oauth_catalog.py`

It does not add OAuth start or callback handling, actor state, cookies, nonces, credential writes, migrations, PostgreSQL callback tests, CI registration, or activation documentation.

## Behavior

- Classify supported OAuth catalog entries without changing existing API-key, keyless, MCP OAuth, or unconnectable classifications.
- Require code-registry membership for trusted builtin OAuth definitions.
- Require exact persisted execution fields and canonical server fields.
- Reject duplicate definitions, normalized reserved name or auth aliases, and non-exact app IDs.
- Create the canonical server with bounded expected-race recovery.
- Create new personal visibility links with non-owning, non-editable, non-deletable, and non-shared defaults.
- Reactivate existing links without changing owner, edit, delete, or shared policy.

## Accepted errors and trade-offs

Strict definition helpers fail closed with `BuiltinOAuthServerDefinitionError` for unknown registry apps, persisted drift, duplicate definitions, reserved aliases, or invalid canonical servers.

This layer does not resynchronize changed registry definitions. Future registry changes require matching migration parity. It also does not start OAuth or activate actor dispatch. Existing owner rights are preserved by contract; an owner can make the shared row unavailable, but strict definition checks reject changed execution fields. Stronger immutable catalog provenance remains tracked in [#1778](https://github.com/xorbitsai/xagent/issues/1778).

Please review this catalog boundary. Do not require actor runtime, callback, schema, lifecycle, or rollout work in this PR.

## Stack delivery

This PR follows merged schema PR #1839. The trusted actor OAuth core will be rebuilt on upstream `main` only after this catalog layer merges.

## Verification

- 50 direct catalog identity, policy, legacy-repair, transport, and owner-drift tests passed.
- 233 catalog, classification, attachability, connect, deduplication, and visibility tests passed.
- All pre-commit hooks passed.
- `git diff --check` passed.
- The upstream diff owns exactly the two paths listed above.