### PR TITLE
test(web): relax Feishu shutdown timing guards

### DIFF
--- a/tests/web/test_feishu_message_queue.py
+++ b/tests/web/test_feishu_message_queue.py
@@ -10,6 +10,11 @@ from xagent.web.services.task_execution_context_service import (
 )
 from xagent.web.services.task_lease_service import TaskLease
 
+# Bound shutdown waits so a regression fails instead of hanging the CI job.
+# Five seconds also leaves enough headroom for a loaded xdist worker; the
+# production Feishu disconnect path deliberately yields for 100 ms first.
+_TEST_TIMEOUT_SECONDS = 5.0
+
 
 def make_bot() -> FeishuBotInstance:
     bot = object.__new__(FeishuBotInstance)
@@ -454,7 +459,7 @@ async def test_stop_drains_each_feishu_turn_once_before_clearing_runtime_state()
 
     stop_task = asyncio.create_task(bot.stop())
     try:
-        await asyncio.wait_for(cleanup_started.wait(), timeout=0.5)
+        await asyncio.wait_for(cleanup_started.wait(), timeout=_TEST_TIMEOUT_SECONDS)
         await asyncio.sleep(0)
 
         assert turn_task.cancelling() == 1
@@ -463,7 +468,7 @@ async def test_stop_drains_each_feishu_turn_once_before_clearing_runtime_state()
         assert bot.user_message_queues == {"one": ["queued"]}
 
         allow_cleanup.set()
-        await asyncio.wait_for(stop_task, timeout=1)
+        await asyncio.wait_for(stop_task, timeout=_TEST_TIMEOUT_SECONDS)
 
         assert cleanup_finished.is_set()
         assert bot.user_message_tasks == {}
@@ -501,14 +506,14 @@ async def test_stop_drains_feishu_ping_cleanup() -> None:
 
     stop_task = asyncio.create_task(bot.stop())
     try:
-        await asyncio.wait_for(cleanup_started.wait(), timeout=0.5)
+        await asyncio.wait_for(cleanup_started.wait(), timeout=_TEST_TIMEOUT_SECONDS)
         await asyncio.sleep(0)
 
         assert not stop_task.done()
         assert not cleanup_finished.is_set()
 
         allow_cleanup.set()
-        await asyncio.wait_for(stop_task, timeout=1)
+        await asyncio.wait_for(stop_task, timeout=_TEST_TIMEOUT_SECONDS)
 
         assert cleanup_finished.is_set()
         assert ping_task.done()
@@ -545,12 +550,12 @@ async def test_stop_drains_feishu_ping_cleanup_after_disconnect_failure() -> Non
 
     stop_task = asyncio.create_task(bot.stop())
     try:
-        await asyncio.wait_for(cleanup_started.wait(), timeout=0.5)
+        await asyncio.wait_for(cleanup_started.wait(), timeout=_TEST_TIMEOUT_SECONDS)
         assert not stop_task.done()
 
         allow_cleanup.set()
         with pytest.raises(RuntimeError, match="disconnect failed"):
-            await asyncio.wait_for(stop_task, timeout=1)
+            await asyncio.wait_for(stop_task, timeout=_TEST_TIMEOUT_SECONDS)
 
         assert ping_task.done()
         assert bot._ping_task is None
@@ -587,7 +592,7 @@ async def test_feishu_stop_cancellation_waits_for_turn_cleanup_before_propagatin
 
     stop_task = asyncio.create_task(bot.stop())
     try:
-        await asyncio.wait_for(cleanup_started.wait(), timeout=0.5)
+        await asyncio.wait_for(cleanup_started.wait(), timeout=_TEST_TIMEOUT_SECONDS)
         stop_task.cancel()
         await asyncio.sleep(0)
 
@@ -597,7 +602,7 @@ async def test_feishu_stop_cancellation_waits_for_turn_cleanup_before_propagatin
 
         allow_cleanup.set()
         with pytest.raises(asyncio.CancelledError):
-            await asyncio.wait_for(stop_task, timeout=1)
+            await asyncio.wait_for(stop_task, timeout=_TEST_TIMEOUT_SECONDS)
 
         assert turn_task.done()
         assert bot.user_message_tasks == {}
@@ -625,7 +630,7 @@ async def test_stop_fence_rejects_late_feishu_ingress() -> None:
 
     stop_task = asyncio.create_task(bot.stop())
     try:
-        await asyncio.wait_for(disconnect_started.wait(), timeout=0.5)
+        await asyncio.wait_for(disconnect_started.wait(), timeout=_TEST_TIMEOUT_SECONDS)
         bot._handle_message_sync(_feishu_message())
 
         assert bot.user_message_queues == {}
@@ -675,7 +680,7 @@ async def test_manager_stop_drains_feishu_polling_cleanup_before_removal() -> No
 
     stop_task = asyncio.create_task(manager._stop_bot_for_appid("app-id"))
     try:
-        await asyncio.wait_for(cleanup_started.wait(), timeout=0.5)
+        await asyncio.wait_for(cleanup_started.wait(), timeout=_TEST_TIMEOUT_SECONDS)
         await asyncio.sleep(0)
 
         assert not stop_task.done()
@@ -683,7 +688,7 @@ async def test_manager_stop_drains_feishu_polling_cleanup_before_removal() -> No
         assert not cleanup_finished.is_set()
 
         allow_cleanup.set()
-        await asyncio.wait_for(stop_task, timeout=1)
+        await asyncio.wait_for(stop_task, timeout=_TEST_TIMEOUT_SECONDS)
 
         assert cleanup_finished.is_set()
         assert polling_task.done()
@@ -731,16 +736,18 @@ async def test_manager_stop_is_single_flight_per_feishu_bot() -> None:
         asyncio.create_task(manager._stop_bot_for_appid("app-id")),
     ]
     try:
-        await asyncio.wait_for(stop_started.wait(), timeout=0.5)
+        await asyncio.wait_for(stop_started.wait(), timeout=_TEST_TIMEOUT_SECONDS)
         await asyncio.sleep(0)
         assert stop_calls == 1
 
         allow_stop.set()
-        await asyncio.wait_for(cleanup_started.wait(), timeout=0.5)
+        await asyncio.wait_for(cleanup_started.wait(), timeout=_TEST_TIMEOUT_SECONDS)
         assert polling_task.cancelling() == 1
 
         allow_cleanup.set()
-        await asyncio.wait_for(asyncio.gather(*stop_tasks), timeout=1)
+        await asyncio.wait_for(
+            asyncio.gather(*stop_tasks), timeout=_TEST_TIMEOUT_SECONDS
+        )
         assert "app-id" not in manager.bots
     finally:
         allow_stop.set()


### PR DESCRIPTION
## Summary

- use a shared five-second guard for Feishu shutdown synchronization tests
- leave production shutdown behavior unchanged while allowing headroom for loaded xdist workers
- keep every wait bounded so real cleanup regressions still fail instead of hanging CI

## Testing

- `python -m pytest tests/web/test_feishu_message_queue.py -q`
- `python -m pytest tests/web/test_feishu_message_queue.py -m "not slow and not postgresql" -n 4 --dist=loadscope -q`
- target ping-cleanup test invoked 50 times directly
- `python -m ruff format --check tests/web/test_feishu_message_queue.py`
- `python -m ruff check tests/web/test_feishu_message_queue.py`
- `git diff --check`