### PR TITLE
fix(widget): require reload for unreplayable sessions

### DIFF
--- a/frontend/src/components/widget/session-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.test.tsx
@@ -230,6 +230,7 @@ describe("SessionAgentChatPage", () => {
       ],
       expectedProtocol: "xagent-session-v1",
       chatTaskIdMode: "omit",
+      taskBindingMode: "session-subprotocol",
       credentialOwner: { kind: "external" },
     })
     expect(app.provider?.transport?.session?.onConnectionFailure).toBe(

--- a/frontend/src/components/widget/session-agent-chat-page.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.tsx
@@ -252,6 +252,7 @@ export function SessionAgentChatPage() {
       ],
       expectedProtocol: SESSION_PROTOCOL,
       chatTaskIdMode: "omit",
+      taskBindingMode: "session-subprotocol",
       credentialOwner: { kind: "external" },
     }
   }, [bridge.session, bridge.status])

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -4553,6 +4553,129 @@ describe("AppProvider websocket message routing", () => {
     })
   })
 
+  it("requires reload before replacing a rebound Session task the server cannot replay", async () => {
+    const { rerender } = render(
+      <AppProvider token="token" transport={makeSessionTransport(makeSessionConnection("unreplayable-old"))}>
+        <SessionControlsProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+    act(() => {
+      webSocketOptions.current?.onMessage?.(taskInfoMessage(102))
+      webSocketOptions.current?.onMessage?.(assistantMessage("Preserved transcript", 102))
+    })
+
+    rerender(
+      <AppProvider token="token" transport={makeSessionTransport(makeSessionConnection("unreplayable-new"))}>
+        <SessionControlsProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+    act(() => {
+      webSocketOptions.current?.onMessage?.({
+        type: "conversation_reload_required",
+        timestamp: "2026-05-27T05:00:03Z",
+        task_id: 102,
+        data: {},
+      })
+    })
+
+    expect(screen.getByTestId("session-conversation-state").textContent).toBe("reload_required")
+    expect(screen.getByTestId("task-id").textContent).toBe("102")
+    expect(screen.getByTestId("messages").textContent).toContain("Preserved transcript")
+    await expect(getSessionControls().sendMessage("Replacement")).rejects.toThrow(/reload required/i)
+    await expect(getSessionControls().startNewConversation()).rejects.toThrow(/reload required/i)
+    expect(sendChatMessageMock).not.toHaveBeenCalled()
+    expect(sendRawMessageMock).not.toHaveBeenCalled()
+  })
+
+  it("requires reload when a stale sibling reset is fenced before acknowledgement", async () => {
+    render(
+      <AppProvider token="token" transport={makeSessionTransport(makeSessionConnection("stale-reset"))}>
+        <SessionControlsProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+    act(() => webSocketOptions.current?.onMessage?.(taskInfoMessage(102)))
+
+    let reset!: Promise<void>
+    act(() => {
+      reset = getSessionControls().startNewConversation()
+    })
+    act(() => {
+      webSocketOptions.current?.onMessage?.({
+        type: "conversation_reload_required",
+        timestamp: "2026-05-27T05:00:03Z",
+        task_id: 102,
+        data: {},
+      })
+    })
+
+    await expect(reset).rejects.toThrow(/reload required/i)
+    expect(screen.getByTestId("session-conversation-state").textContent).toBe("reload_required")
+    expect(screen.getByTestId("task-id").textContent).toBe("102")
+    await expect(getSessionControls().sendMessage("Must not send")).rejects.toThrow(/reload required/i)
+    await expect(getSessionControls().startNewConversation()).rejects.toThrow(/reload required/i)
+  })
+
+  it("ignores a stale, invalid, or mismatched server reload requirement", () => {
+    const { rerender } = render(
+      <AppProvider token="token" transport={makeSessionTransport(makeSessionConnection("unreplayable-old"))}>
+        <SessionControlsProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+    act(() => webSocketOptions.current?.onMessage?.(taskInfoMessage(102)))
+    const staleOnMessage = webSocketOptions.current?.onMessage
+
+    rerender(
+      <AppProvider token="token" transport={makeSessionTransport(makeSessionConnection("unreplayable-current"))}>
+        <SessionControlsProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    act(() => staleOnMessage?.({
+      type: "conversation_reload_required",
+      timestamp: "2026-05-27T05:00:03Z",
+      task_id: 102,
+      data: {},
+    }))
+
+    for (const taskId of [undefined, true, 0, 103]) {
+      act(() => {
+        webSocketOptions.current?.onMessage?.({
+          type: "conversation_reload_required",
+          timestamp: "2026-05-27T05:00:03Z",
+          ...(taskId === undefined ? {} : { task_id: taskId as unknown as number }),
+          data: {},
+        })
+      })
+    }
+
+    expect(screen.getByTestId("session-conversation-state").textContent).toBe("bound")
+    expect(screen.getByTestId("task-id").textContent).toBe("102")
+  })
+
+  it("ignores a server reload requirement before the Session adopts a task", () => {
+    render(
+      <AppProvider token="token" transport={makeSessionTransport()}>
+        <SessionControlsProbe />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    act(() => webSocketOptions.current?.onMessage?.({
+      type: "conversation_reload_required",
+      timestamp: "2026-05-27T05:00:03Z",
+      task_id: 102,
+      data: {},
+    }))
+
+    expect(screen.getByTestId("session-conversation-state").textContent).toBe("unbound")
+    expect(screen.getByTestId("task-id").textContent).toBe("")
+  })
+
   it("rejects an outstanding reset when AppProvider unmounts", async () => {
     const { unmount } = render(
       <AppProvider token="token" transport={makeSessionTransport()}>

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -5678,6 +5678,28 @@ export function AppProvider({
       return
     }
 
+    if (message.type === "conversation_reload_required") {
+      const binding = extractSessionTaskBinding(message)
+      const lifecycle = sessionConversationRef.current
+      if (
+        !binding.present
+        || !binding.valid
+        || (
+          lifecycle.phase !== "bound"
+          && lifecycle.phase !== "reset_requested"
+        )
+        || lifecycle.connectionIdentity !== owner.connectionIdentity
+        || lifecycle.taskId !== binding.taskId
+        || sessionTaskIdRef.current !== binding.taskId
+      ) {
+        return
+      }
+      requireSessionReload(
+        new Error("The current conversation cannot be restored; reload required.")
+      )
+      return
+    }
+
     if (message.type === "conversation_reset") {
       const resetFlight = sessionResetFlightRef.current
       if (

--- a/frontend/src/hooks/use-websocket.test.ts
+++ b/frontend/src/hooks/use-websocket.test.ts
@@ -1230,6 +1230,52 @@ describe("useWebSocket normalized connections", () => {
     })
   })
 
+  it("offers an explicit unbound Session binding on the initial physical connection", async () => {
+    renderHook(() => useWebSocket({
+      connection: sessionConnection({
+        taskBindingMode: "session-subprotocol",
+      }),
+    }))
+
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+    expect(MockWebSocket.instances[0].protocols).toEqual([
+      "xagent-session-v1",
+      "xagent-session-token.st_secret",
+      "xagent-session-binding-v1",
+      "xagent-session-task.unbound",
+    ])
+  })
+
+  it("offers the current bound task when establishing a replacement physical connection", async () => {
+    const connection = sessionConnection({
+      taskBindingMode: "session-subprotocol",
+    })
+    const hook = renderHook(
+      ({ taskId }: { taskId: number | undefined }) => useWebSocket({
+        connection,
+        taskId,
+      }),
+      { initialProps: { taskId: undefined as number | undefined } },
+    )
+    await waitFor(() => expect(MockWebSocket.instances).toHaveLength(1))
+    expect(MockWebSocket.instances[0].protocols).toContain(
+      "xagent-session-task.unbound",
+    )
+
+    hook.rerender({ taskId: 42 })
+    expect(MockWebSocket.instances).toHaveLength(1)
+    act(() => hook.result.current.disconnect())
+    act(() => hook.result.current.connect())
+
+    expect(MockWebSocket.instances).toHaveLength(2)
+    expect(MockWebSocket.instances[1].protocols).toEqual([
+      "xagent-session-v1",
+      "xagent-session-token.st_secret",
+      "xagent-session-binding-v1",
+      "xagent-session-task.42",
+    ])
+  })
+
   it.each([4001, 4003, 1011])(
     "runs the Session close delegate first and suppresses legacy handling for %s",
     async (code) => {

--- a/frontend/src/hooks/use-websocket.ts
+++ b/frontend/src/hooks/use-websocket.ts
@@ -21,6 +21,8 @@ interface RecentMessage {
 const MESSAGE_DUPLICATE_THRESHOLD = 2000 // Same message within 2 seconds is considered duplicate
 const HANDSHAKE_TIMEOUT_MS = 10_000
 const MAX_AUTH_REFRESH_RETRIES = 3
+const SESSION_BINDING_PROTOCOL = "xagent-session-binding-v1"
+const SESSION_TASK_PROTOCOL_PREFIX = "xagent-session-task."
 
 // Connection values may carry credentials. Lifecycle fencing keeps the
 // normalized connection object opaque; it is never serialized or hashed.
@@ -125,7 +127,30 @@ export interface WebSocketConnection {
   expectedProtocol?: string
   taskId?: number
   chatTaskIdMode: "required" | "omit"
+  taskBindingMode?: "session-subprotocol"
   credentialOwner: WebSocketCredentialOwner
+}
+
+const getConnectionProtocols = (
+  connection: WebSocketConnection,
+  currentTaskId: number | undefined,
+): string[] | undefined => {
+  if (connection.taskBindingMode !== "session-subprotocol") {
+    return connection.protocols
+  }
+
+  const baseProtocols = (connection.protocols ?? []).filter(protocol => (
+    protocol !== SESSION_BINDING_PROTOCOL
+    && !protocol.startsWith(SESSION_TASK_PROTOCOL_PREFIX)
+  ))
+  const taskBinding = Number.isInteger(currentTaskId) && Number(currentTaskId) > 0
+    ? String(currentTaskId)
+    : "unbound"
+  return [
+    ...baseProtocols,
+    SESSION_BINDING_PROTOCOL,
+    `${SESSION_TASK_PROTOCOL_PREFIX}${taskBinding}`,
+  ]
 }
 
 export type WebSocketSendResult = "sent" | "not_sent"
@@ -333,6 +358,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
   const socketRef = useRef<WebSocket | null>(null)
   const socketOwnerRef = useRef<SocketOwner | null>(null)
   const connectionRef = useRef<WebSocketConnection | null>(normalizedConnection)
+  const taskIdRef = useRef(taskId)
   const descriptorKeyRef = useRef<ConnectionDescriptorIdentity | null>(connectionDescriptorIdentity)
   const retryTimersRef = useRef(new Map<ReturnType<typeof setTimeout>, ScheduledRetry>())
   const reconnectAttemptsRef = useRef(0)
@@ -628,6 +654,7 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
 
     descriptorKeyRef.current = connectionDescriptorIdentity
     connectionRef.current = normalizedConnection
+    taskIdRef.current = taskId
     deliveryIdentityRef.current = nextIdentity
     deliveryGenerationRef.current = deliveryGeneration
     callbacksRef.current = {
@@ -688,8 +715,9 @@ export function useWebSocket(options: UseWebSocketOptions = {}) {
       }
 
       const attemptEpoch = ++attemptEpochRef.current
-      const socket = connection.protocols
-        ? new WebSocket(connection.url, connection.protocols)
+      const protocols = getConnectionProtocols(connection, taskIdRef.current)
+      const socket = protocols
+        ? new WebSocket(connection.url, protocols)
         : new WebSocket(connection.url)
       const owner: SocketOwner = {
         callbacks: callbacksRef.current,


### PR DESCRIPTION
## Summary

- advertise a stable Session binding capability and exactly one `unbound` or positive Task marker on every physical Session WebSocket connection
- handle `conversation_reload_required` for the current Session Task, including the race where a stale sibling reset is fenced before `conversation_reset` is acknowledged
- preserve the visible transcript while entering the existing absorbing `reload_required` state, and block both chat and raw reset egress until reload
- keep stale physical connections, invalid or mismatched Task identities, and taskless Session clients unable to trigger the reload latch

## Why

The coordinated xagent-saas change must reject work when a browser's adopted Task no longer matches durable Session continuity. This includes confirmed-unreplayable waiting Tasks and a stale sibling attempting to reset after another socket committed a replacement.

Without a stable connect-time Task binding, the server cannot distinguish those stale physical sockets. Without a task-bound reload signal that is accepted while reset is still pending, the browser can also miss the fence and remain in an unexplained lineage state.

This PR supplies the consumer side of that contract. It deliberately does not clear the old conversation when reload is required: the transcript remains visible and the user must reload, preserving the product contract established in #984. The producer, pointer fencing, and close-before-accept behavior remain in xorbitsai/xagent-saas#843.

## Rollout and scope

1. Deploy the coordinated xagent-saas#843 backend first.
2. Fully drain pre-cutover WebSocket workers so no old process continues serving the previous implementation.
3. Publish this xagent consumer and verify the updated frontend assets have propagated.

The backend keeps the original two-subprotocol handshake and id-less parked-answer path for rolling compatibility. Old already-loaded clients therefore remain accepted. The stable Task fence is capability-gated and activates only when a client advertises the binding subprotocol and Task marker introduced here.

Footprint exception: all 225 changed lines are in six existing Session state-machine and test files. Of those, 170 are focused test additions (about 76%) and 55 are production changes. Extracting the lifecycle guards or physical-socket Task ref into new shallow modules would expose the same internal state without reducing risk.

## Verification

- `npm run type-check`
- focused Session suites: 244 passed across AppProvider, `useWebSocket`, and Session page tests
- complete Widget suite: 971 passed
- parent production with candidate tests: 6 failed and 238 passed, demonstrating that the new tests are causal
- incremental ESLint comparison: no new diagnostics versus the base commit
- `git diff --check`

The review Minor about raw reset egress is covered explicitly: after `reload_required` is latched, the regression test proves neither chat delivery nor the raw `new_conversation` sender is called.

Closes #1894
