### PR TITLE
feat(auth): add trusted actor-owned OAuth

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -49,6 +49,7 @@ on:
       - 'src/xagent/web/models/user.py'
       - 'src/xagent/web/models/user_oauth.py'
       - 'tests/web/test_user_oauth_actor_ownership.py'
+      - 'tests/web/test_trusted_actor_oauth_postgresql.py'
       - 'tests/shared/postgres_disposable.py'
       - 'tests/web/services/checkpoint_anchor_shared.py'
   pull_request:
@@ -136,6 +137,7 @@ jobs:
             src/xagent/web/models/user.py
             src/xagent/web/models/user_oauth.py
             tests/web/test_user_oauth_actor_ownership.py
+            tests/web/test_trusted_actor_oauth_postgresql.py
             tests/shared/postgres_disposable.py
             tests/web/services/checkpoint_anchor_shared.py
           )
@@ -336,6 +338,13 @@ jobs:
           pytest tests/migrations/test_migration_integration.py -m postgresql -q
         env:
           DATABASE_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
+      - name: Test trusted actor OAuth concurrency (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/web/test_trusted_actor_oauth_postgresql.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 
       - name: Test Gmail provisioning Postgres-only behavior
         if: needs.detect-migration-changes.outputs.should-test == 'true'

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -72,6 +72,7 @@ EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 _MAX_USER_ID = 2_147_483_647
 _ACTOR_OAUTH_FLOW_TTL = timedelta(minutes=10)
 _ACTOR_OAUTH_COOKIE_PREFIX = "xagent_actor_oauth_"
+_ACTOR_OWNER_CLAIM_VERSION = 1
 
 
 def _best_effort_ensure_gmail_watches_for_user(db: Session, *, user_id: int) -> None:
@@ -1868,6 +1869,34 @@ def _actor_oauth_cookie_scope(provider: str, db_provider: Any) -> tuple[bool, st
     return redirect_uri.scheme.lower() == "https", redirect_uri.path or "/"
 
 
+def _encrypt_actor_owner_claim(owner_key: str) -> str:
+    """Encrypt one typed owner claim without ciphertext pass-through."""
+    from ...core.utils.encryption import get_cipher
+
+    envelope = json.dumps(
+        {"owner": owner_key, "version": _ACTOR_OWNER_CLAIM_VERSION},
+        separators=(",", ":"),
+        sort_keys=True,
+    )
+    return get_cipher().encrypt(envelope.encode()).decode()
+
+
+def _decrypt_actor_owner_claim(claim: str) -> str:
+    """Decrypt and validate one typed actor owner claim."""
+    from ...core.utils.encryption import decrypt_value_strict
+
+    envelope = json.loads(decrypt_value_strict(claim))
+    if (
+        not isinstance(envelope, dict)
+        or set(envelope) != {"owner", "version"}
+        or type(envelope.get("version")) is not int
+        or envelope.get("version") != _ACTOR_OWNER_CLAIM_VERSION
+        or not isinstance(envelope.get("owner"), str)
+    ):
+        raise ValueError("invalid actor owner envelope")
+    return cast(str, envelope["owner"])
+
+
 def _actor_link_query(db: Session, *, user_id: int, provider: str, app_id: str) -> Any:
     """Select the exact active personal link for one builtin app."""
     from ..mcp_apps import require_builtin_oauth_server_definition
@@ -2095,10 +2124,8 @@ def _generic_oauth_login(
     if actor_flow_nonce is not None:
         if resource_owner_key is None:
             raise RuntimeError("actor OAuth flow requires an owner key")
-        from ...core.utils.encryption import encrypt_value
-
         try:
-            encrypted_owner_key = encrypt_value(resource_owner_key)
+            encrypted_owner_key = _encrypt_actor_owner_claim(resource_owner_key)
         except ValueError:
             return HTMLResponse(
                 content=(
@@ -2343,13 +2370,17 @@ def generic_oauth_callback(
     code = request.query_params.get("code")
     state = request.query_params.get("state")
     error = request.query_params.get("error")
-
-    if error:
-        return HTMLResponse(
+    provider_error_response = (
+        HTMLResponse(
             content=f"<h1>Error: {html.escape(str(error))}</h1>", status_code=400
         )
+        if error
+        else None
+    )
 
-    if not code or not state:
+    if provider_error_response is not None and not state:
+        return provider_error_response
+    if not state or (not code and provider_error_response is None):
         return HTMLResponse(
             content="<h1>Error: Missing code or state</h1>", status_code=400
         )
@@ -2360,9 +2391,17 @@ def generic_oauth_callback(
         or payload.get("type") != "oauth_state"
         or payload.get("provider") != provider
     ):
+        if provider_error_response is not None:
+            return provider_error_response
         return HTMLResponse(
             content="<h1>Error: Invalid or expired state</h1>", status_code=400
         )
+
+    actor_flow_nonce = payload.get("actor_flow_nonce")
+    actor_owner_claim = payload.get("resource_owner_key")
+    is_actor_flow = actor_flow_nonce is not None or actor_owner_claim is not None
+    if provider_error_response is not None and not is_actor_flow:
+        return provider_error_response
 
     user_id_claim = payload.get("user_id")
     if user_id_claim is not None and (
@@ -2400,9 +2439,6 @@ def generic_oauth_callback(
                 ),
                 status_code=400,
             )
-    actor_flow_nonce = payload.get("actor_flow_nonce")
-    actor_owner_claim = payload.get("resource_owner_key")
-    is_actor_flow = actor_flow_nonce is not None or actor_owner_claim is not None
     resource_owner_key: str | None = None
 
     if is_actor_flow:
@@ -2421,13 +2457,8 @@ def generic_oauth_callback(
                 raise ValueError("invalid actor OAuth claims")
             if not isinstance(actor_owner_claim, str):
                 raise ValueError("missing actor owner")
-            from ...core.utils.encryption import decrypt_value_strict
-
-            decrypted_owner_key = decrypt_value_strict(actor_owner_claim)
-            if decrypted_owner_key == actor_owner_claim:
-                raise ValueError("actor owner claim is not encrypted")
             resource_owner_key = normalize_user_oauth_resource_owner_key(
-                decrypted_owner_key
+                _decrypt_actor_owner_claim(actor_owner_claim)
             )
             if resource_owner_key is None:
                 raise ValueError("missing actor owner")
@@ -2473,6 +2504,9 @@ def generic_oauth_callback(
         # The nonce claim is durable before any provider exchange. A failed
         # exchange cannot make the authorization code replayable.
         db.commit()
+
+        if provider_error_response is not None:
+            return provider_error_response
 
     if not app_id:
         from ..mcp_apps import requires_app_scoped_oauth_grant

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -43,7 +43,12 @@ from ..auth_config import (
     REFRESH_TOKEN_EXPIRE_DAYS,
 )
 from ..auth_dependencies import get_current_user
-from ..models.database import get_db, get_session_local, release_db_connection_if_clean
+from ..models.actor_oauth_flow import ActorOAuthFlowState
+from ..models.database import (
+    get_db,
+    get_session_local,
+    release_db_connection_if_clean,
+)
 from ..models.system_setting import SystemSetting
 from ..models.user import User
 from ..models.user_oauth import UserOAuth
@@ -51,7 +56,10 @@ from ..oauth_provider_quirks import requires_json_accept_header
 from ..services import gmail_provisioning
 from ..services.auth_email import send_password_reset_email
 from ..services.db_runtime import await_task_settlement, propagate_deferred_cancellation
-from ..services.user_oauth import delete_scoped_user_oauth_accounts
+from ..services.user_oauth import (
+    delete_scoped_user_oauth_accounts,
+    normalize_user_oauth_resource_owner_key,
+)
 from ..utils.graphql_errors import graphql_errors_message, truncate_error_text
 
 logger = logging.getLogger(__name__)
@@ -62,6 +70,8 @@ REGISTRATION_ENABLED_SETTING_KEY = "registration_enabled"
 SETUP_COMPLETED_SETTING_KEY = "setup_completed"
 EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 _MAX_USER_ID = 2_147_483_647
+_ACTOR_OAUTH_FLOW_TTL = timedelta(minutes=10)
+_ACTOR_OAUTH_COOKIE_PREFIX = "xagent_actor_oauth_"
 
 
 def _best_effort_ensure_gmail_watches_for_user(db: Session, *, user_id: int) -> None:
@@ -1831,7 +1841,121 @@ def generic_oauth_login(
     db: Optional[Session] = None,
     db_provider: Optional[Any] = None,
 ) -> Any:
-    """Start generic OAuth flow"""
+    """Start the ordinary public OAuth flow without actor claims or cookies."""
+    return _generic_oauth_login(
+        provider,
+        token=token,
+        app_id=app_id,
+        redirect=redirect,
+        db=db,
+        db_provider=db_provider,
+        trusted_user_id=None,
+        resource_owner_key=None,
+        actor_flow_nonce=None,
+    )
+
+
+def _actor_oauth_cookie_name(nonce: str) -> str:
+    """Return a distinct cookie name for one signed flow nonce digest."""
+    return f"{_ACTOR_OAUTH_COOKIE_PREFIX}{nonce[:24]}"
+
+
+def _require_actor_oauth_personal_link(
+    db: Session, *, user_id: int, provider: str, app_id: str
+) -> None:
+    """Require one canonical builtin definition and its active personal link."""
+    from ..mcp_apps import require_builtin_oauth_server_definition
+    from ..models.mcp import UserMCPServer
+
+    server = require_builtin_oauth_server_definition(
+        db, app_id=app_id, provider=provider
+    )
+    link_count = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user_id,
+            UserMCPServer.mcpserver_id == int(server.id),
+            UserMCPServer.is_active.is_(True),
+        )
+        .count()
+    )
+    if link_count != 1:
+        raise ValueError(
+            f"actor builtin OAuth app {app_id!r} requires exactly one active "
+            "personal MCP server link"
+        )
+
+
+def start_builtin_oauth_for_resource_owner(
+    *,
+    provider: str,
+    app_id: str,
+    user: User,
+    resource_owner_key: str,
+    redirect: str | None = None,
+    db: Session,
+    db_provider: Any,
+) -> Any:
+    """Start OAuth for a trusted xagent user and exact actor owner namespace."""
+    if not isinstance(app_id, str) or not app_id.strip():
+        raise ValueError("actor builtin OAuth app_id must be a non-empty string")
+    if user.id is None:
+        raise ValueError("user must be persisted before starting actor OAuth")
+    owner_key = normalize_user_oauth_resource_owner_key(resource_owner_key)
+    if owner_key is None:  # pragma: no cover - normalization preserves only None
+        raise ValueError("resource_owner_key must not be null")
+    app_id = app_id.strip()
+    _require_actor_oauth_personal_link(
+        db,
+        user_id=int(user.id),
+        provider=provider,
+        app_id=app_id,
+    )
+
+    browser_nonce = secrets.token_urlsafe(32)
+    nonce_digest = hashlib.sha256(browser_nonce.encode()).hexdigest()
+    expires_at = datetime.now(timezone.utc) + _ACTOR_OAUTH_FLOW_TTL
+    db.add(ActorOAuthFlowState(nonce=nonce_digest, expires_at=expires_at))
+    response = _generic_oauth_login(
+        provider,
+        token=None,
+        app_id=app_id,
+        redirect=redirect,
+        db=db,
+        db_provider=db_provider,
+        trusted_user_id=int(user.id),
+        resource_owner_key=owner_key,
+        actor_flow_nonce=nonce_digest,
+    )
+    if not isinstance(response, RedirectResponse):
+        db.rollback()
+        return response
+    db.commit()
+    response.set_cookie(
+        _actor_oauth_cookie_name(nonce_digest),
+        browser_nonce,
+        max_age=int(_ACTOR_OAUTH_FLOW_TTL.total_seconds()),
+        secure=True,
+        httponly=True,
+        samesite="lax",
+        path=f"/api/auth/{provider}/callback",
+    )
+    return response
+
+
+def _generic_oauth_login(
+    provider: str,
+    *,
+    token: str | None,
+    app_id: str | None,
+    redirect: str | None,
+    db: Session | None,
+    db_provider: Any | None,
+    trusted_user_id: int | None,
+    resource_owner_key: str | None,
+    actor_flow_nonce: str | None,
+) -> Any:
+    """Build an ordinary or trusted actor provider authorization redirect."""
     if db is None:
         raise RuntimeError("db session is required")
     if not db_provider:
@@ -1848,14 +1972,14 @@ def generic_oauth_login(
 
     redirect_uri = _resolve_oauth_redirect_uri(provider, db_provider)
 
-    user_id = None
-    if token:
+    user_id = trusted_user_id
+    if user_id is None and token:
         payload = verify_token(token)
         if payload and payload.get("type") == "access":
             username = payload.get("sub")
             user = db.query(User).filter(User.username == username).first()
             if user:
-                user_id = user.id
+                user_id = int(user.id)
 
     if not user_id:
         return HTMLResponse(
@@ -1942,6 +2066,27 @@ def generic_oauth_login(
                 ),
                 status_code=500,
             )
+    if actor_flow_nonce is not None:
+        if resource_owner_key is None:
+            raise RuntimeError("actor OAuth flow requires an owner key")
+        from ...core.utils.encryption import encrypt_value
+
+        try:
+            encrypted_owner_key = encrypt_value(resource_owner_key)
+        except ValueError:
+            return HTMLResponse(
+                content=(
+                    "<h1>Error: Server misconfigured</h1>"
+                    "<p>The ENCRYPTION_KEY environment variable is not set. "
+                    "This is required to connect an actor-owned account; set "
+                    "it and restart the backend.</p>"
+                ),
+                status_code=500,
+            )
+        state_payload.update(
+            resource_owner_key=encrypted_owner_key,
+            actor_flow_nonce=actor_flow_nonce,
+        )
     state = create_access_token(data=state_payload, expires_delta=timedelta(minutes=10))
 
     app_scopes: list[str] | None = None
@@ -2229,6 +2374,79 @@ def generic_oauth_callback(
                 ),
                 status_code=400,
             )
+    actor_flow_nonce = payload.get("actor_flow_nonce")
+    actor_owner_claim = payload.get("resource_owner_key")
+    is_actor_flow = actor_flow_nonce is not None or actor_owner_claim is not None
+    resource_owner_key: str | None = None
+
+    if is_actor_flow:
+        try:
+            if (
+                not isinstance(actor_flow_nonce, str)
+                or len(actor_flow_nonce) != 64
+                or any(
+                    character not in "0123456789abcdef"
+                    for character in actor_flow_nonce
+                )
+                or not isinstance(app_id, str)
+                or not app_id
+                or user_id is None
+            ):
+                raise ValueError("invalid actor OAuth claims")
+            if not isinstance(actor_owner_claim, str):
+                raise ValueError("missing actor owner")
+            from ...core.utils.encryption import decrypt_value_strict
+
+            decrypted_owner_key = decrypt_value_strict(actor_owner_claim)
+            if decrypted_owner_key == actor_owner_claim:
+                raise ValueError("actor owner claim is not encrypted")
+            resource_owner_key = normalize_user_oauth_resource_owner_key(
+                decrypted_owner_key
+            )
+            if resource_owner_key is None:
+                raise ValueError("missing actor owner")
+            cookie_value = request.cookies.get(
+                _actor_oauth_cookie_name(actor_flow_nonce)
+            )
+            cookie_digest = (
+                hashlib.sha256(cookie_value.encode()).hexdigest()
+                if isinstance(cookie_value, str)
+                else ""
+            )
+            if not secrets.compare_digest(cookie_digest, actor_flow_nonce):
+                raise ValueError("actor OAuth browser cookie mismatch")
+            if db.query(User.id).filter(User.id == user_id).one_or_none() is None:
+                raise ValueError("actor OAuth user no longer exists")
+            _require_actor_oauth_personal_link(
+                db,
+                user_id=user_id,
+                provider=provider,
+                app_id=app_id,
+            )
+        except ValueError:
+            db.rollback()
+            return HTMLResponse(
+                content="<h1>Error: Invalid or expired actor OAuth flow</h1>",
+                status_code=400,
+            )
+
+        deleted = (
+            db.query(ActorOAuthFlowState)
+            .filter(
+                ActorOAuthFlowState.nonce == actor_flow_nonce,
+                ActorOAuthFlowState.expires_at > datetime.now(timezone.utc),
+            )
+            .delete(synchronize_session=False)
+        )
+        if deleted != 1:
+            db.rollback()
+            return HTMLResponse(
+                content="<h1>Error: Invalid or expired actor OAuth flow</h1>",
+                status_code=400,
+            )
+        # The nonce claim is durable before any provider exchange. A failed
+        # exchange cannot make the authorization code replayable.
+        db.commit()
 
     if not app_id:
         from ..mcp_apps import requires_app_scoped_oauth_grant
@@ -2748,17 +2966,21 @@ def generic_oauth_callback(
             email = info_data.get(db_provider.email_path or "email")
 
         if user_id:
+            if is_actor_flow:
+                # Serialize replacement in the stable user namespace.
+                db.query(User.id).filter(User.id == user_id).with_for_update().one()
+
             delete_scoped_user_oauth_accounts(
                 db,
                 user_id=user_id,
-                resource_owner_key=None,
+                resource_owner_key=resource_owner_key,
                 providers=[app_id or provider],
             )
 
             oauth_account = UserOAuth(
                 user_id=user_id,
                 provider=(app_id or provider),
-                resource_owner_key=None,
+                resource_owner_key=resource_owner_key,
                 provider_user_id=str(provider_user_id) if provider_user_id else None,
             )
             db.add(oauth_account)
@@ -2815,7 +3037,9 @@ def generic_oauth_callback(
                 # mutates public_mcp_apps between there and here, so a second
                 # fetch would just be redundant, not more correct.
                 app_info = target_app_info
-                if app_info:
+                # A concurrent personal disconnect must win. Actor callbacks
+                # persist only the credential and never recreate its link.
+                if app_info and not is_actor_flow:
                     # A stale/crafted app_id in the OAuth state can point at a
                     # non-oauth app. Fail with a clear error instead of a generic
                     # 500 after the user already completed provider consent —
@@ -2889,9 +3113,10 @@ def generic_oauth_callback(
             # Everything past the commit belongs in the helper, which cannot
             # change what this callback returns. Add new post-commit work
             # there, not here.
-            _run_post_commit_oauth_side_effects(
-                db, user_id=user_id, connector_key=(app_id or provider)
-            )
+            if not is_actor_flow:
+                _run_post_commit_oauth_side_effects(
+                    db, user_id=user_id, connector_key=(app_id or provider)
+                )
 
         from urllib.parse import urlparse
 

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -1860,30 +1860,55 @@ def _actor_oauth_cookie_name(nonce: str) -> str:
     return f"{_ACTOR_OAUTH_COOKIE_PREFIX}{nonce[:24]}"
 
 
-def _require_actor_oauth_personal_link(
-    db: Session, *, user_id: int, provider: str, app_id: str
-) -> None:
-    """Require one canonical builtin definition and its active personal link."""
+def _actor_oauth_cookie_scope(provider: str, db_provider: Any) -> tuple[bool, str]:
+    """Match the browser cookie to the configured callback URL."""
+    from urllib.parse import urlparse
+
+    redirect_uri = urlparse(_resolve_oauth_redirect_uri(provider, db_provider))
+    return redirect_uri.scheme.lower() == "https", redirect_uri.path or "/"
+
+
+def _actor_link_query(db: Session, *, user_id: int, provider: str, app_id: str) -> Any:
+    """Select the exact active personal link for one builtin app."""
     from ..mcp_apps import require_builtin_oauth_server_definition
     from ..models.mcp import UserMCPServer
 
     server = require_builtin_oauth_server_definition(
         db, app_id=app_id, provider=provider
     )
-    link_count = (
-        db.query(UserMCPServer)
-        .filter(
-            UserMCPServer.user_id == user_id,
-            UserMCPServer.mcpserver_id == int(server.id),
-            UserMCPServer.is_active.is_(True),
-        )
-        .count()
+    return db.query(UserMCPServer).filter(
+        UserMCPServer.user_id == user_id,
+        UserMCPServer.mcpserver_id == int(server.id),
+        UserMCPServer.is_active.is_(True),
     )
-    if link_count != 1:
+
+
+def _require_one_actor_link(links: list[Any], app_id: str) -> None:
+    if len(links) != 1:
         raise ValueError(
             f"actor builtin OAuth app {app_id!r} requires exactly one active "
             "personal MCP server link"
         )
+
+
+def _require_actor_oauth_personal_link(
+    db: Session, *, user_id: int, provider: str, app_id: str
+) -> None:
+    """Require one canonical builtin definition and its active personal link."""
+    links = _actor_link_query(
+        db, user_id=user_id, provider=provider, app_id=app_id
+    ).all()
+    _require_one_actor_link(links, app_id)
+
+
+def _lock_actor_link(db: Session, *, user_id: int, provider: str, app_id: str) -> None:
+    """Lock one active personal link before actor credential persistence."""
+    links = (
+        _actor_link_query(db, user_id=user_id, provider=provider, app_id=app_id)
+        .with_for_update()
+        .all()
+    )
+    _require_one_actor_link(links, app_id)
 
 
 def start_builtin_oauth_for_resource_owner(
@@ -1931,14 +1956,15 @@ def start_builtin_oauth_for_resource_owner(
         db.rollback()
         return response
     db.commit()
+    cookie_secure, cookie_path = _actor_oauth_cookie_scope(provider, db_provider)
     response.set_cookie(
         _actor_oauth_cookie_name(nonce_digest),
         browser_nonce,
         max_age=int(_ACTOR_OAUTH_FLOW_TTL.total_seconds()),
-        secure=True,
+        secure=cookie_secure,
         httponly=True,
         samesite="lax",
-        path=f"/api/auth/{provider}/callback",
+        path=cookie_path,
     )
     return response
 
@@ -2964,6 +2990,26 @@ def generic_oauth_callback(
                 )
             provider_user_id = info_data.get(db_provider.user_id_path or "id")
             email = info_data.get(db_provider.email_path or "email")
+
+        if is_actor_flow:
+            assert user_id is not None
+            assert isinstance(app_id, str)
+
+            try:
+                # Provider I/O can overlap a personal disconnect. Recheck and
+                # lock the exact link before persisting the actor credential.
+                _lock_actor_link(
+                    db,
+                    user_id=user_id,
+                    provider=provider,
+                    app_id=app_id,
+                )
+            except ValueError:
+                db.rollback()
+                return HTMLResponse(
+                    content="<h1>Error: Invalid or expired actor OAuth flow</h1>",
+                    status_code=400,
+                )
 
         if user_id:
             if is_actor_flow:

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -1885,7 +1885,11 @@ def _decrypt_actor_owner_claim(claim: str) -> str:
     """Decrypt and validate one typed actor owner claim."""
     from ...core.utils.encryption import decrypt_value_strict
 
-    envelope = json.loads(decrypt_value_strict(claim))
+    decrypted = decrypt_value_strict(claim)
+    if decrypted == claim:
+        raise ValueError("actor owner claim is not encrypted")
+
+    envelope = json.loads(decrypted)
     if (
         not isinstance(envelope, dict)
         or set(envelope) != {"owner", "version"}

--- a/tests/web/test_trusted_actor_oauth.py
+++ b/tests/web/test_trusted_actor_oauth.py
@@ -140,7 +140,12 @@ def _request(state: str, *, cookie: tuple[str, str] | None = None, code: str = "
     )
 
 
-def _start(db: Session, user: User, owner: str = ACTOR_ALICE):
+def _start(
+    db: Session,
+    user: User,
+    owner: str = ACTOR_ALICE,
+    db_provider: SimpleNamespace | None = None,
+):
     start = getattr(auth_api, "start_builtin_oauth_for_resource_owner")
     return start(
         provider="custom",
@@ -149,7 +154,7 @@ def _start(db: Session, user: User, owner: str = ACTOR_ALICE):
         resource_owner_key=owner,
         redirect="https://toby.example/settings",
         db=db,
-        db_provider=_provider(),
+        db_provider=db_provider or _provider(),
     )
 
 
@@ -206,6 +211,30 @@ def test_actor_start_uses_browser_bound_cookie_and_minimal_nonce(oauth_db) -> No
         "expires_at",
     }
     assert db.query(flow_model).count() == 1
+
+
+def test_actor_cookie_allows_http_callback(oauth_db) -> None:
+    db, user = oauth_db
+    _catalog_link(db, user)
+    provider = _provider()
+    provider.redirect_uri = "http://xagent.example/api/auth/custom/callback"
+
+    response = _start(db, user, db_provider=provider)
+
+    cookie_name, _cookie_value, parsed = _flow_cookie(response)
+    assert not parsed[cookie_name]["secure"]
+
+
+def test_actor_cookie_uses_callback_path(oauth_db) -> None:
+    db, user = oauth_db
+    _catalog_link(db, user)
+    provider = _provider()
+    provider.redirect_uri = "https://xagent.example/proxy/api/auth/custom/callback"
+
+    response = _start(db, user, db_provider=provider)
+
+    cookie_name, _cookie_value, parsed = _flow_cookie(response)
+    assert parsed[cookie_name]["path"] == "/proxy/api/auth/custom/callback"
 
 
 @pytest.mark.parametrize("active", [False, None])

--- a/tests/web/test_trusted_actor_oauth.py
+++ b/tests/web/test_trusted_actor_oauth.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from datetime import datetime, timedelta, timezone
 from http.cookies import SimpleCookie
 from types import SimpleNamespace
@@ -140,6 +141,13 @@ def _request(state: str, *, cookie: tuple[str, str] | None = None, code: str = "
     )
 
 
+def _error_request(state: str, cookie: tuple[str, str]):
+    return SimpleNamespace(
+        query_params={"state": state, "error": "access_denied"},
+        cookies={cookie[0]: cookie[1]},
+    )
+
+
 def _start(
     db: Session,
     user: User,
@@ -194,7 +202,10 @@ def test_actor_start_uses_browser_bound_cookie_and_minimal_nonce(oauth_db) -> No
     encrypted_owner = state["resource_owner_key"]
     assert encrypted_owner != ACTOR_ALICE
     assert ACTOR_ALICE not in str(state)
-    assert decrypt_value_strict(encrypted_owner) == ACTOR_ALICE
+    assert json.loads(decrypt_value_strict(encrypted_owner)) == {
+        "owner": ACTOR_ALICE,
+        "version": 1,
+    }
     assert "governing_team_id" not in state
     cookie_name, cookie_value, parsed = _flow_cookie(response)
     morsel = parsed[cookie_name]
@@ -344,6 +355,35 @@ def test_actor_callback_rejects_missing_or_wrong_cookie_before_exchange(
     post.assert_not_called()
 
 
+def test_actor_provider_error_consumes_flow_without_exchange(
+    oauth_db, monkeypatch
+) -> None:
+    db, user = oauth_db
+    _catalog_link(db, user)
+    start = _start(db, user)
+    state = _state(start)
+    cookie = _flow_cookie(start)[:2]
+    post = Mock()
+    monkeypatch.setattr(auth_api.requests, "post", post)
+
+    denied = generic_oauth_callback(
+        "custom", _error_request(state, cookie), db, _provider()
+    )
+    replay = generic_oauth_callback(
+        "custom", _request(state, cookie=cookie), db, _provider()
+    )
+
+    assert denied.status_code == 400
+    assert replay.status_code == 400
+    post.assert_not_called()
+    flow_model = getattr(
+        __import__("xagent.web.models", fromlist=["ActorOAuthFlowState"]),
+        "ActorOAuthFlowState",
+    )
+    assert db.query(flow_model).count() == 0
+    assert db.query(UserOAuth).count() == 0
+
+
 def test_actor_callback_replay_fails_before_second_exchange(
     oauth_db, monkeypatch
 ) -> None:
@@ -418,6 +458,45 @@ def test_actor_callback_revalidates_link_and_catalog_before_exchange(
     assert response.status_code in {400, 409}
     post.assert_not_called()
     assert db.query(UserOAuth).count() == 0
+
+
+def test_actor_owner_ciphertext_round_trips_exact_namespace(
+    oauth_db, monkeypatch
+) -> None:
+    db, user = oauth_db
+    _catalog_link(db, user)
+    ciphertext_owner = encrypt_value(ACTOR_BOB)
+    db.add(
+        UserOAuth(
+            user_id=user.id,
+            provider="calendar",
+            resource_owner_key=ACTOR_BOB,
+            access_token="bob",
+        )
+    )
+    db.commit()
+
+    start = _start(db, user, owner=ciphertext_owner)
+    payload = auth_api.verify_token(_state(start))
+    assert payload is not None
+    assert payload["resource_owner_key"] != ciphertext_owner
+    _mock_exchange(monkeypatch)
+
+    response = generic_oauth_callback(
+        "custom",
+        _request(_state(start), cookie=_flow_cookie(start)[:2]),
+        db,
+        _provider(),
+    )
+
+    assert response.status_code == 200
+    credentials = {
+        row.resource_owner_key: row.access_token for row in db.query(UserOAuth).all()
+    }
+    assert credentials == {
+        ACTOR_BOB: "bob",
+        ciphertext_owner: "new-access",
+    }
 
 
 def test_actor_callback_rejects_tampered_state_before_exchange(

--- a/tests/web/test_trusted_actor_oauth.py
+++ b/tests/web/test_trusted_actor_oauth.py
@@ -455,7 +455,7 @@ def test_actor_callback_revalidates_link_and_catalog_before_exchange(
         _provider(),
     )
 
-    assert response.status_code in {400, 409}
+    assert response.status_code == 400
     post.assert_not_called()
     assert db.query(UserOAuth).count() == 0
 
@@ -506,7 +506,10 @@ def test_actor_callback_rejects_tampered_state_before_exchange(
     _catalog_link(db, user)
     start = _start(db, user)
     state = _state(start)
-    tampered = state[:-1] + ("a" if state[-1] != "a" else "b")
+    header, payload, signature = state.split(".")
+    tampered_signature = ("a" if signature[0] != "a" else "b") + signature[1:]
+    tampered = ".".join((header, payload, tampered_signature))
+    assert auth_api.verify_token(tampered) is None
     post = Mock()
     monkeypatch.setattr(auth_api.requests, "post", post)
 
@@ -518,7 +521,9 @@ def test_actor_callback_rejects_tampered_state_before_exchange(
     post.assert_not_called()
 
 
-@pytest.mark.parametrize("owner_claim_kind", ["plaintext", "foreign-ciphertext"])
+@pytest.mark.parametrize(
+    "owner_claim_kind", ["plaintext", "plaintext-envelope", "foreign-ciphertext"]
+)
 def test_actor_callback_rejects_unreadable_owner_claim_before_exchange(
     oauth_db, monkeypatch, owner_claim_kind: str
 ) -> None:
@@ -528,7 +533,9 @@ def test_actor_callback_rejects_unreadable_owner_claim_before_exchange(
     payload = auth_api.verify_token(_state(start))
     assert payload is not None
     owner_claim = ACTOR_ALICE
-    if owner_claim_kind == "foreign-ciphertext":
+    if owner_claim_kind == "plaintext-envelope":
+        owner_claim = json.dumps({"owner": ACTOR_ALICE, "version": 1})
+    elif owner_claim_kind == "foreign-ciphertext":
         owner_claim = (
             Fernet(Fernet.generate_key()).encrypt(ACTOR_ALICE.encode()).decode()
         )

--- a/tests/web/test_trusted_actor_oauth.py
+++ b/tests/web/test_trusted_actor_oauth.py
@@ -1,0 +1,466 @@
+"""Security contract for trusted actor-owned builtin OAuth flows."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from http.cookies import SimpleCookie
+from types import SimpleNamespace
+from unittest.mock import Mock
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from cryptography.fernet import Fernet
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from xagent.core.utils.encryption import decrypt_value_strict, encrypt_value
+from xagent.web import mcp_apps
+from xagent.web.api import auth as auth_api
+from xagent.web.api.auth import (
+    create_access_token,
+    generic_oauth_callback,
+    generic_oauth_login,
+)
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.models.user_oauth import UserOAuth
+
+ACTOR_ALICE = "toby:slack:41:UALICE"
+ACTOR_BOB = "toby:slack:41:UBOB"
+TEST_BUILTIN_APP_ID = "calendar"
+TEST_BUILTIN_EXECUTION = {
+    "name": "Google Calendar",
+    "transport": "oauth",
+    "provider_name": "custom",
+    "oauth_scopes": [],
+    "launch_config": {"command": "calendar"},
+}
+
+
+class _ProviderResponse:
+    def __init__(self, data: dict[str, object], status_code: int = 200) -> None:
+        self._data = data
+        self.status_code = status_code
+
+    def json(self) -> dict[str, object]:
+        return self._data
+
+
+@pytest.fixture
+def oauth_db(tmp_path, monkeypatch):
+    registry_lookup = mcp_apps.get_builtin_execution_fields_and_optional_scopes
+
+    def test_registry(app_id: str):
+        if app_id == TEST_BUILTIN_APP_ID:
+            return TEST_BUILTIN_EXECUTION, []
+        return registry_lookup(app_id)
+
+    monkeypatch.setattr(
+        mcp_apps, "get_builtin_execution_fields_and_optional_scopes", test_registry
+    )
+
+    engine = create_engine(f"sqlite:///{tmp_path / 'actor-oauth.db'}")
+    Base.metadata.create_all(engine)
+    factory = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    with factory() as db:
+        user = User(username="workspace-account", password_hash="hash")
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        yield db, user
+    engine.dispose()
+
+
+def _provider() -> SimpleNamespace:
+    return SimpleNamespace(
+        client_id=encrypt_value("client-id"),
+        client_secret=encrypt_value("client-secret"),
+        auth_url="https://provider.example/authorize",
+        token_url="https://provider.example/token",
+        userinfo_url="https://provider.example/me",
+        redirect_uri="https://xagent.example/api/auth/custom/callback",
+        default_scopes=["profile.read"],
+        user_id_path="id",
+        email_path="email",
+    )
+
+
+def _catalog_link(db: Session, user: User) -> tuple[MCPServer, UserMCPServer]:
+    app = PublicMCPApp(
+        app_id="calendar",
+        name="Google Calendar",
+        description="Calendar",
+        transport="oauth",
+        provider_name="custom",
+        launch_config={"command": "calendar"},
+        is_visible_in_connector=True,
+    )
+    server = MCPServer(
+        name="Google Calendar",
+        description="Calendar",
+        managed="external",
+        transport="oauth",
+        auth={"app_id": "calendar", "provider": "custom"},
+    )
+    db.add_all([app, server])
+    db.flush()
+    link = UserMCPServer(
+        user_id=int(user.id),
+        mcpserver_id=int(server.id),
+        is_owner=False,
+        is_active=True,
+    )
+    db.add(link)
+    db.commit()
+    return server, link
+
+
+def _state(response) -> str:
+    return parse_qs(urlparse(response.headers["location"]).query)["state"][0]
+
+
+def _flow_cookie(response) -> tuple[str, str, SimpleCookie]:
+    parsed = SimpleCookie()
+    parsed.load(response.headers["set-cookie"])
+    matches = [
+        (name, morsel.value)
+        for name, morsel in parsed.items()
+        if name.startswith("xagent_actor_oauth_")
+    ]
+    assert len(matches) == 1
+    return matches[0][0], matches[0][1], parsed
+
+
+def _request(state: str, *, cookie: tuple[str, str] | None = None, code: str = "code"):
+    return SimpleNamespace(
+        query_params={"state": state, "code": code},
+        cookies={} if cookie is None else {cookie[0]: cookie[1]},
+    )
+
+
+def _start(db: Session, user: User, owner: str = ACTOR_ALICE):
+    start = getattr(auth_api, "start_builtin_oauth_for_resource_owner")
+    return start(
+        provider="custom",
+        app_id="calendar",
+        user=user,
+        resource_owner_key=owner,
+        redirect="https://toby.example/settings",
+        db=db,
+        db_provider=_provider(),
+    )
+
+
+def _mock_exchange(monkeypatch) -> Mock:
+    post = Mock(
+        return_value=_ProviderResponse(
+            {
+                "access_token": "new-access",
+                "refresh_token": "new-refresh",
+                "expires_in": 3600,
+                "scope": "profile.read",
+            }
+        )
+    )
+    monkeypatch.setattr(auth_api.requests, "post", post)
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(
+            return_value=_ProviderResponse({"id": "account", "email": "a@example.com"})
+        ),
+    )
+    return post
+
+
+def test_actor_start_uses_browser_bound_cookie_and_minimal_nonce(oauth_db) -> None:
+    db, user = oauth_db
+    _catalog_link(db, user)
+
+    response = _start(db, user)
+
+    state = auth_api.verify_token(_state(response))
+    assert state is not None
+    assert state["user_id"] == user.id
+    assert state["provider"] == "custom"
+    assert state["app_id"] == "calendar"
+    encrypted_owner = state["resource_owner_key"]
+    assert encrypted_owner != ACTOR_ALICE
+    assert ACTOR_ALICE not in str(state)
+    assert decrypt_value_strict(encrypted_owner) == ACTOR_ALICE
+    assert "governing_team_id" not in state
+    cookie_name, cookie_value, parsed = _flow_cookie(response)
+    morsel = parsed[cookie_name]
+    assert cookie_value not in _state(response)
+    assert morsel["secure"]
+    assert morsel["httponly"]
+    assert morsel["samesite"].lower() == "lax"
+    flow_model = getattr(
+        __import__("xagent.web.models", fromlist=["ActorOAuthFlowState"]),
+        "ActorOAuthFlowState",
+    )
+    assert {column.name for column in flow_model.__table__.columns} == {
+        "nonce",
+        "expires_at",
+    }
+    assert db.query(flow_model).count() == 1
+
+
+@pytest.mark.parametrize("active", [False, None])
+def test_actor_start_requires_exact_active_personal_link(oauth_db, active) -> None:
+    db, user = oauth_db
+    _server, link = _catalog_link(db, user)
+    if active is None:
+        db.delete(link)
+    else:
+        link.is_active = active
+    db.commit()
+
+    with pytest.raises(ValueError, match="active personal"):
+        _start(db, user)
+
+
+def test_actor_start_rejects_provider_catalog_mismatch(oauth_db) -> None:
+    db, user = oauth_db
+    _catalog_link(db, user)
+
+    with pytest.raises(ValueError, match="provider"):
+        getattr(auth_api, "start_builtin_oauth_for_resource_owner")(
+            provider="wrong",
+            app_id="calendar",
+            user=user,
+            resource_owner_key=ACTOR_ALICE,
+            db=db,
+            db_provider=_provider(),
+        )
+
+
+def test_actor_callback_claims_nonce_before_exchange_and_persists_exact_owner(
+    oauth_db, monkeypatch
+) -> None:
+    db, user = oauth_db
+    _catalog_link(db, user)
+    db.add_all(
+        [
+            UserOAuth(
+                user_id=user.id,
+                provider="calendar",
+                resource_owner_key=None,
+                access_token="ordinary",
+            ),
+            UserOAuth(
+                user_id=user.id,
+                provider="calendar",
+                resource_owner_key=ACTOR_BOB,
+                access_token="bob",
+            ),
+        ]
+    )
+    db.commit()
+    start = _start(db, user)
+    cookie = _flow_cookie(start)[:2]
+    post = _mock_exchange(monkeypatch)
+
+    def assert_claimed(*args, **kwargs):
+        flow_model = getattr(
+            __import__("xagent.web.models", fromlist=["ActorOAuthFlowState"]),
+            "ActorOAuthFlowState",
+        )
+        assert db.query(flow_model).count() == 0
+        return _ProviderResponse(
+            {
+                "access_token": "new-access",
+                "refresh_token": "new-refresh",
+                "scope": "profile.read",
+            }
+        )
+
+    post.side_effect = assert_claimed
+    side_effects = Mock(
+        side_effect=AssertionError("ordinary callback work must be skipped")
+    )
+    monkeypatch.setattr(auth_api, "_run_post_commit_oauth_side_effects", side_effects)
+
+    response = generic_oauth_callback(
+        "custom", _request(_state(start), cookie=cookie), db, _provider()
+    )
+
+    assert response.status_code == 200
+    rows = {
+        (row.resource_owner_key, row.access_token) for row in db.query(UserOAuth).all()
+    }
+    assert rows == {(None, "ordinary"), (ACTOR_BOB, "bob"), (ACTOR_ALICE, "new-access")}
+    side_effects.assert_not_called()
+
+
+@pytest.mark.parametrize("cookie_mode", ["missing", "wrong"])
+def test_actor_callback_rejects_missing_or_wrong_cookie_before_exchange(
+    oauth_db, monkeypatch, cookie_mode
+) -> None:
+    db, user = oauth_db
+    _catalog_link(db, user)
+    start = _start(db, user)
+    cookie_name, cookie_value = _flow_cookie(start)[:2]
+    cookie = None if cookie_mode == "missing" else (cookie_name, cookie_value + "wrong")
+    post = Mock()
+    monkeypatch.setattr(auth_api.requests, "post", post)
+
+    response = generic_oauth_callback(
+        "custom", _request(_state(start), cookie=cookie), db, _provider()
+    )
+
+    assert response.status_code == 400
+    post.assert_not_called()
+
+
+def test_actor_callback_replay_fails_before_second_exchange(
+    oauth_db, monkeypatch
+) -> None:
+    db, user = oauth_db
+    _catalog_link(db, user)
+    start = _start(db, user)
+    request = _request(_state(start), cookie=_flow_cookie(start)[:2])
+    post = _mock_exchange(monkeypatch)
+
+    first = generic_oauth_callback("custom", request, db, _provider())
+    second = generic_oauth_callback("custom", request, db, _provider())
+
+    assert first.status_code == 200
+    assert second.status_code == 400
+    assert post.call_count == 1
+
+
+def test_actor_callback_rejects_expired_nonce_before_exchange(
+    oauth_db, monkeypatch
+) -> None:
+    db, user = oauth_db
+    _catalog_link(db, user)
+    start = _start(db, user)
+    flow_model = getattr(
+        __import__("xagent.web.models", fromlist=["ActorOAuthFlowState"]),
+        "ActorOAuthFlowState",
+    )
+    db.query(flow_model).update(
+        {flow_model.expires_at: datetime.now(timezone.utc) - timedelta(seconds=1)}
+    )
+    db.commit()
+    post = Mock()
+    monkeypatch.setattr(auth_api.requests, "post", post)
+
+    response = generic_oauth_callback(
+        "custom",
+        _request(_state(start), cookie=_flow_cookie(start)[:2]),
+        db,
+        _provider(),
+    )
+
+    assert response.status_code == 400
+    post.assert_not_called()
+
+
+@pytest.mark.parametrize("drift", ["removed-link", "catalog-provider", "server-auth"])
+def test_actor_callback_revalidates_link_and_catalog_before_exchange(
+    oauth_db, monkeypatch, drift
+) -> None:
+    db, user = oauth_db
+    server, link = _catalog_link(db, user)
+    start = _start(db, user)
+    if drift == "removed-link":
+        db.delete(link)
+    elif drift == "catalog-provider":
+        db.query(PublicMCPApp).filter_by(
+            app_id="calendar"
+        ).one().provider_name = "wrong"
+    else:
+        server.auth = {"app_id": "other", "provider": "custom"}
+    db.commit()
+    post = Mock()
+    monkeypatch.setattr(auth_api.requests, "post", post)
+
+    response = generic_oauth_callback(
+        "custom",
+        _request(_state(start), cookie=_flow_cookie(start)[:2]),
+        db,
+        _provider(),
+    )
+
+    assert response.status_code in {400, 409}
+    post.assert_not_called()
+    assert db.query(UserOAuth).count() == 0
+
+
+def test_actor_callback_rejects_tampered_state_before_exchange(
+    oauth_db, monkeypatch
+) -> None:
+    db, user = oauth_db
+    _catalog_link(db, user)
+    start = _start(db, user)
+    state = _state(start)
+    tampered = state[:-1] + ("a" if state[-1] != "a" else "b")
+    post = Mock()
+    monkeypatch.setattr(auth_api.requests, "post", post)
+
+    response = generic_oauth_callback(
+        "custom", _request(tampered, cookie=_flow_cookie(start)[:2]), db, _provider()
+    )
+
+    assert response.status_code == 400
+    post.assert_not_called()
+
+
+@pytest.mark.parametrize("owner_claim_kind", ["plaintext", "foreign-ciphertext"])
+def test_actor_callback_rejects_unreadable_owner_claim_before_exchange(
+    oauth_db, monkeypatch, owner_claim_kind: str
+) -> None:
+    db, user = oauth_db
+    _catalog_link(db, user)
+    start = _start(db, user)
+    payload = auth_api.verify_token(_state(start))
+    assert payload is not None
+    owner_claim = ACTOR_ALICE
+    if owner_claim_kind == "foreign-ciphertext":
+        owner_claim = (
+            Fernet(Fernet.generate_key()).encrypt(ACTOR_ALICE.encode()).decode()
+        )
+    payload["resource_owner_key"] = owner_claim
+    state = create_access_token(data=payload, expires_delta=timedelta(minutes=10))
+    post = Mock()
+    monkeypatch.setattr(auth_api.requests, "post", post)
+
+    response = generic_oauth_callback(
+        "custom", _request(state, cookie=_flow_cookie(start)[:2]), db, _provider()
+    )
+
+    assert response.status_code == 400
+    post.assert_not_called()
+
+
+def test_ordinary_oauth_flow_keeps_cookie_free_state_and_provisioning(
+    oauth_db, monkeypatch
+) -> None:
+    db, user = oauth_db
+    token = create_access_token(
+        data={"sub": user.username, "type": "access"},
+        expires_delta=timedelta(minutes=5),
+    )
+    start = generic_oauth_login(
+        "custom", token=token, app_id="calendar", db=db, db_provider=_provider()
+    )
+    payload = auth_api.verify_token(_state(start))
+    assert payload is not None
+    assert "resource_owner_key" not in payload
+    assert "actor_flow_nonce" not in payload
+    assert "set-cookie" not in start.headers
+    _mock_exchange(monkeypatch)
+    side_effects = Mock()
+    monkeypatch.setattr(auth_api, "_run_post_commit_oauth_side_effects", side_effects)
+
+    response = generic_oauth_callback(
+        "custom", _request(_state(start)), db, _provider()
+    )
+
+    assert response.status_code == 200
+    assert db.query(UserOAuth).one().resource_owner_key is None
+    side_effects.assert_called_once_with(db, user_id=user.id, connector_key="calendar")

--- a/tests/web/test_trusted_actor_oauth_postgresql.py
+++ b/tests/web/test_trusted_actor_oauth_postgresql.py
@@ -9,7 +9,6 @@ from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
 
 import pytest
-from sqlalchemy import event
 from sqlalchemy.orm import sessionmaker
 
 from tests.shared.postgres_disposable import disposable_database_factory
@@ -347,26 +346,13 @@ def test_independent_actor_flows_replace_one_credential(
             )
         )
 
-    delete_barrier = threading.Barrier(2)
+    exchange_barrier = threading.Barrier(2)
 
-    def synchronize_deletes(
-        _conn, _cursor, statement, _parameters, _context, _executemany
-    ) -> None:
-        if not statement.lstrip().upper().startswith("DELETE FROM USER_OAUTH"):
-            return
-        try:
-            delete_barrier.wait(timeout=1)
-        except threading.BrokenBarrierError:
-            pass
+    def exchange(*_args, **_kwargs) -> _Response:
+        exchange_barrier.wait(timeout=10)
+        return _Response({"access_token": "actor-token", "scope": "profile.read"})
 
-    event.listen(postgresql_engine, "before_cursor_execute", synchronize_deletes)
-    monkeypatch.setattr(
-        auth_api.requests,
-        "post",
-        lambda *_args, **_kwargs: _Response(
-            {"access_token": "actor-token", "scope": "profile.read"}
-        ),
-    )
+    monkeypatch.setattr(auth_api.requests, "post", exchange)
 
     def callback(request) -> int:
         with factory() as callback_db:
@@ -374,11 +360,8 @@ def test_independent_actor_flows_replace_one_credential(
                 "custom", request, callback_db, _provider()
             ).status_code
 
-    try:
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            statuses = sorted(executor.map(callback, requests))
-    finally:
-        event.remove(postgresql_engine, "before_cursor_execute", synchronize_deletes)
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        statuses = sorted(executor.map(callback, requests))
 
     assert statuses == [200, 200]
     with factory() as db:

--- a/tests/web/test_trusted_actor_oauth_postgresql.py
+++ b/tests/web/test_trusted_actor_oauth_postgresql.py
@@ -1,0 +1,388 @@
+"""PostgreSQL release gate for concurrent trusted actor OAuth callbacks."""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
+from http.cookies import SimpleCookie
+from types import SimpleNamespace
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from sqlalchemy import event
+from sqlalchemy.orm import sessionmaker
+
+from tests.shared.postgres_disposable import disposable_database_factory
+from xagent.core.utils.encryption import encrypt_value
+from xagent.web import mcp_apps
+from xagent.web.api import auth as auth_api
+from xagent.web.models.actor_oauth_flow import ActorOAuthFlowState
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.models.user_oauth import UserOAuth
+
+pytestmark = pytest.mark.postgresql
+
+TEST_BUILTIN_APP_ID = "calendar"
+TEST_BUILTIN_EXECUTION = {
+    "name": "Google Calendar",
+    "transport": "oauth",
+    "provider_name": "custom",
+    "oauth_scopes": [],
+    "launch_config": {"command": "calendar"},
+}
+
+
+class _Response:
+    status_code = 200
+
+    def __init__(self, data: dict[str, object]) -> None:
+        self._data = data
+
+    def json(self) -> dict[str, object]:
+        return self._data
+
+
+def _provider() -> SimpleNamespace:
+    return SimpleNamespace(
+        client_id=encrypt_value("client-id"),
+        client_secret=encrypt_value("client-secret"),
+        auth_url="https://provider.example/authorize",
+        token_url="https://provider.example/token",
+        userinfo_url="",
+        redirect_uri="https://xagent.example/api/auth/custom/callback",
+        default_scopes=[],
+        user_id_path="id",
+        email_path="email",
+    )
+
+
+@pytest.fixture
+def postgresql_engine(monkeypatch):
+    registry_lookup = mcp_apps.get_builtin_execution_fields_and_optional_scopes
+
+    def test_registry(app_id: str):
+        if app_id == TEST_BUILTIN_APP_ID:
+            return TEST_BUILTIN_EXECUTION, []
+        return registry_lookup(app_id)
+
+    monkeypatch.setattr(
+        mcp_apps, "get_builtin_execution_fields_and_optional_scopes", test_registry
+    )
+
+    # The shared factory skips only when this explicit release-gate URL is absent.
+    with disposable_database_factory("xagent_actor_oauth") as make:
+        yield make("callback_claim")
+
+
+def test_concurrent_callbacks_exchange_and_persist_only_once(
+    postgresql_engine, monkeypatch
+) -> None:
+    tables = [
+        User.__table__,
+        PublicMCPApp.__table__,
+        MCPServer.__table__,
+        UserMCPServer.__table__,
+        ActorOAuthFlowState.__table__,
+        UserOAuth.__table__,
+    ]
+    Base.metadata.create_all(postgresql_engine, tables=tables)
+    factory = sessionmaker(bind=postgresql_engine, autoflush=False, autocommit=False)
+    with factory() as db:
+        user = User(username="workspace-account", password_hash="hash")
+        app = PublicMCPApp(
+            app_id="calendar",
+            name="Google Calendar",
+            transport="oauth",
+            provider_name="custom",
+            launch_config={"command": "calendar"},
+            is_visible_in_connector=True,
+        )
+        server = MCPServer(
+            name="Google Calendar",
+            managed="external",
+            transport="oauth",
+            auth={"app_id": "calendar", "provider": "custom"},
+        )
+        db.add_all([user, app, server])
+        db.flush()
+        db.add(
+            UserMCPServer(
+                user_id=user.id,
+                mcpserver_id=server.id,
+                is_owner=False,
+                is_active=True,
+            )
+        )
+        db.commit()
+        start = auth_api.start_builtin_oauth_for_resource_owner(
+            provider="custom",
+            app_id="calendar",
+            user=user,
+            resource_owner_key="toby:slack:41:UALICE",
+            db=db,
+            db_provider=_provider(),
+        )
+
+    state = parse_qs(urlparse(start.headers["location"]).query)["state"][0]
+    cookies = SimpleCookie()
+    cookies.load(start.headers["set-cookie"])
+    cookie_name, morsel = next(iter(cookies.items()))
+    request = SimpleNamespace(
+        query_params={"state": state, "code": "provider-code"},
+        cookies={cookie_name: morsel.value},
+    )
+
+    exchange_entered = threading.Event()
+    release_exchange = threading.Event()
+    exchange_count = 0
+    exchange_lock = threading.Lock()
+
+    def post(*_args, **_kwargs):
+        nonlocal exchange_count
+        with exchange_lock:
+            exchange_count += 1
+        exchange_entered.set()
+        assert release_exchange.wait(timeout=10)
+        return _Response({"access_token": "actor-token", "scope": "profile.read"})
+
+    monkeypatch.setattr(auth_api.requests, "post", post)
+
+    def callback() -> int:
+        with factory() as callback_db:
+            return auth_api.generic_oauth_callback(
+                "custom", request, callback_db, _provider()
+            ).status_code
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(callback) for _ in range(2)]
+        assert exchange_entered.wait(timeout=10)
+        completed, _pending = wait(futures, timeout=10, return_when=FIRST_COMPLETED)
+        assert len(completed) == 1
+        assert next(iter(completed)).result() == 400
+        release_exchange.set()
+        statuses = sorted(future.result(timeout=10) for future in futures)
+
+    assert statuses == [200, 400]
+    assert exchange_count == 1
+    with factory() as db:
+        assert db.query(ActorOAuthFlowState).count() == 0
+        row = db.query(UserOAuth).one()
+        assert row.resource_owner_key == "toby:slack:41:UALICE"
+        assert row.access_token == "actor-token"
+
+
+def test_disconnect_during_actor_exchange_does_not_recreate_link(
+    postgresql_engine, monkeypatch
+) -> None:
+    tables = [
+        User.__table__,
+        PublicMCPApp.__table__,
+        MCPServer.__table__,
+        UserMCPServer.__table__,
+        ActorOAuthFlowState.__table__,
+        UserOAuth.__table__,
+    ]
+    Base.metadata.create_all(postgresql_engine, tables=tables)
+    factory = sessionmaker(bind=postgresql_engine, autoflush=False, autocommit=False)
+    with factory() as db:
+        user = User(username="workspace-account", password_hash="hash")
+        app = PublicMCPApp(
+            app_id="calendar",
+            name="Google Calendar",
+            transport="oauth",
+            provider_name="custom",
+            launch_config={"command": "calendar"},
+            is_visible_in_connector=True,
+        )
+        server = MCPServer(
+            name="Google Calendar",
+            managed="external",
+            transport="oauth",
+            auth={"app_id": "calendar", "provider": "custom"},
+        )
+        db.add_all([user, app, server])
+        db.flush()
+        db.add(
+            UserMCPServer(
+                user_id=user.id,
+                mcpserver_id=server.id,
+                is_owner=False,
+                is_active=True,
+            )
+        )
+        db.commit()
+        user_id = int(user.id)
+        server_id = int(server.id)
+        start = auth_api.start_builtin_oauth_for_resource_owner(
+            provider="custom",
+            app_id="calendar",
+            user=user,
+            resource_owner_key="toby:slack:41:UALICE",
+            db=db,
+            db_provider=_provider(),
+        )
+
+    state = parse_qs(urlparse(start.headers["location"]).query)["state"][0]
+    cookies = SimpleCookie()
+    cookies.load(start.headers["set-cookie"])
+    cookie_name, morsel = next(iter(cookies.items()))
+    request = SimpleNamespace(
+        query_params={"state": state, "code": "provider-code"},
+        cookies={cookie_name: morsel.value},
+    )
+
+    exchange_entered = threading.Event()
+    release_exchange = threading.Event()
+
+    def post(*_args, **_kwargs):
+        exchange_entered.set()
+        assert release_exchange.wait(timeout=10)
+        return _Response({"access_token": "actor-token", "scope": "profile.read"})
+
+    monkeypatch.setattr(auth_api.requests, "post", post)
+
+    def callback() -> int:
+        with factory() as callback_db:
+            return auth_api.generic_oauth_callback(
+                "custom", request, callback_db, _provider()
+            ).status_code
+
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(callback)
+        try:
+            assert exchange_entered.wait(timeout=10)
+            with factory() as disconnect_db:
+                link = (
+                    disconnect_db.query(UserMCPServer)
+                    .filter(
+                        UserMCPServer.user_id == user_id,
+                        UserMCPServer.mcpserver_id == server_id,
+                    )
+                    .one()
+                )
+                disconnect_db.delete(link)
+                disconnect_db.commit()
+        finally:
+            release_exchange.set()
+        assert future.result(timeout=10) == 200
+
+    with factory() as db:
+        assert (
+            db.query(UserMCPServer)
+            .filter(
+                UserMCPServer.user_id == user_id,
+                UserMCPServer.mcpserver_id == server_id,
+            )
+            .count()
+            == 0
+        )
+        credential = db.query(UserOAuth).one()
+        assert credential.resource_owner_key == "toby:slack:41:UALICE"
+
+
+def test_independent_actor_flows_replace_one_credential(
+    postgresql_engine, monkeypatch
+) -> None:
+    tables = [
+        User.__table__,
+        PublicMCPApp.__table__,
+        MCPServer.__table__,
+        UserMCPServer.__table__,
+        ActorOAuthFlowState.__table__,
+        UserOAuth.__table__,
+    ]
+    Base.metadata.create_all(postgresql_engine, tables=tables)
+    factory = sessionmaker(bind=postgresql_engine, autoflush=False, autocommit=False)
+    with factory() as db:
+        user = User(username="workspace-account", password_hash="hash")
+        app = PublicMCPApp(
+            app_id="calendar",
+            name="Google Calendar",
+            transport="oauth",
+            provider_name="custom",
+            launch_config={"command": "calendar"},
+            is_visible_in_connector=True,
+        )
+        server = MCPServer(
+            name="Google Calendar",
+            managed="external",
+            transport="oauth",
+            auth={"app_id": "calendar", "provider": "custom"},
+        )
+        db.add_all([user, app, server])
+        db.flush()
+        db.add(
+            UserMCPServer(
+                user_id=user.id,
+                mcpserver_id=server.id,
+                is_owner=False,
+                is_active=True,
+            )
+        )
+        db.commit()
+        starts = [
+            auth_api.start_builtin_oauth_for_resource_owner(
+                provider="custom",
+                app_id="calendar",
+                user=user,
+                resource_owner_key="toby:slack:41:UALICE",
+                db=db,
+                db_provider=_provider(),
+            )
+            for _ in range(2)
+        ]
+
+    requests = []
+    for index, start in enumerate(starts):
+        state = parse_qs(urlparse(start.headers["location"]).query)["state"][0]
+        cookies = SimpleCookie()
+        cookies.load(start.headers["set-cookie"])
+        cookie_name, morsel = next(iter(cookies.items()))
+        requests.append(
+            SimpleNamespace(
+                query_params={"state": state, "code": f"provider-code-{index}"},
+                cookies={cookie_name: morsel.value},
+            )
+        )
+
+    delete_barrier = threading.Barrier(2)
+
+    def synchronize_deletes(
+        _conn, _cursor, statement, _parameters, _context, _executemany
+    ) -> None:
+        if not statement.lstrip().upper().startswith("DELETE FROM USER_OAUTH"):
+            return
+        try:
+            delete_barrier.wait(timeout=1)
+        except threading.BrokenBarrierError:
+            pass
+
+    event.listen(postgresql_engine, "before_cursor_execute", synchronize_deletes)
+    monkeypatch.setattr(
+        auth_api.requests,
+        "post",
+        lambda *_args, **_kwargs: _Response(
+            {"access_token": "actor-token", "scope": "profile.read"}
+        ),
+    )
+
+    def callback(request) -> int:
+        with factory() as callback_db:
+            return auth_api.generic_oauth_callback(
+                "custom", request, callback_db, _provider()
+            ).status_code
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            statuses = sorted(executor.map(callback, requests))
+    finally:
+        event.remove(postgresql_engine, "before_cursor_execute", synchronize_deletes)
+
+    assert statuses == [200, 200]
+    with factory() as db:
+        rows = db.query(UserOAuth).all()
+        assert len(rows) == 1
+        assert rows[0].resource_owner_key == "toby:slack:41:UALICE"

--- a/tests/web/test_trusted_actor_oauth_postgresql.py
+++ b/tests/web/test_trusted_actor_oauth_postgresql.py
@@ -174,7 +174,7 @@ def test_concurrent_callbacks_exchange_and_persist_only_once(
         assert row.access_token == "actor-token"
 
 
-def test_disconnect_during_actor_exchange_does_not_recreate_link(
+def test_disconnect_during_actor_exchange_rejects_credential(
     postgresql_engine, monkeypatch
 ) -> None:
     tables = [
@@ -267,7 +267,7 @@ def test_disconnect_during_actor_exchange_does_not_recreate_link(
                 disconnect_db.commit()
         finally:
             release_exchange.set()
-        assert future.result(timeout=10) == 200
+        assert future.result(timeout=10) == 400
 
     with factory() as db:
         assert (
@@ -279,8 +279,7 @@ def test_disconnect_during_actor_exchange_does_not_recreate_link(
             .count()
             == 0
         )
-        credential = db.query(UserOAuth).one()
-        assert credential.resource_owner_key == "toby:slack:41:UALICE"
+        assert db.query(UserOAuth).count() == 0
 
 
 def test_independent_actor_flows_replace_one_credential(


### PR DESCRIPTION
## Background

The actor OAuth flow-state schema and builtin OAuth catalog are now merged in #1839 and #1852.

This third layer adds trusted actor OAuth behavior without changing those foundations or activating actor dispatch.

## Goal

Add actor OAuth start, callback, replay protection, and exact-owner credential persistence for code-owned builtin OAuth apps.

## Boundary

This PR changes only:

- `.github/workflows/test-migrations.yml`
- `src/xagent/web/api/auth.py`
- `tests/web/test_trusted_actor_oauth.py`
- `tests/web/test_trusted_actor_oauth_postgresql.py`

It does not change models, migrations, builtin catalog helpers, MCP runtime authorization, task context, deployment documentation, or xagent-saas.

## Behavior

- Require a trusted builtin OAuth definition and one active personal server link before actor OAuth starts.
- Encrypt `resource_owner_key` inside signed OAuth state.
- Bind each actor flow to a short-lived browser cookie and one-time nonce.
- Validate state, cookie, link, and nonce before provider exchange, including provider-error callbacks.
- Revalidate the trusted catalog and personal link before actor credential persistence.
- Serialize actor credential replacement through the stable user row.
- Store credentials only in the exact actor owner namespace.
- Preserve a concurrent personal disconnect instead of recreating the link.
- Preserve ordinary OAuth behavior for flows without actor claims.

## Accepted errors and trade-offs

Actor callbacks fail closed with HTTP 400 for invalid, expired, replayed, plaintext, foreign-key-encrypted, disconnected, or catalog-drifted actor state. Missing encryption configuration returns HTTP 500 before actor state is emitted.

The nonce is consumed before provider I/O. A provider failure therefore requires a new actor OAuth flow. This PR does not add flow cleanup, retries, diagnostics, catalog redesign, or a uniqueness migration.

## Current limitations

Actor dispatch must remain disabled until the owner-aware runtime and immutable task-context layer in [bsbds/xagent#86](https://github.com/bsbds/xagent/pull/86), plus the required xagent-saas integration, are merged and deployed together. Activation and rollout documentation will be submitted after those layers are deployable.

Please review the actor OAuth security boundary. Do not require runtime, task-context, lifecycle, migration, catalog, or activation work in this PR.

## Verification

- 49 actor and ordinary OAuth tests passed.
- 3 PostgreSQL actor callback concurrency gates passed.
- Actor PostgreSQL workflow registration is present.
- All pre-commit hooks passed.
- `git diff --check` passed.
- The upstream diff owns exactly the four paths listed above.
