### PR TITLE
Validate skill bundles at the shared write boundary

### DIFF
--- a/src/xagent/web/api/skill_hub.py
+++ b/src/xagent/web/api/skill_hub.py
@@ -70,6 +70,25 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/skill-hub", tags=["skill-hub"])
 
 
+# ``CreateSkillRequest``/``EditSkillRequest`` cap ``skill_md`` at this many
+# characters. SKILL.md is injected into the system prompt on every model turn,
+# so an upload that bypassed the cap would push the context past what providers
+# accept. Both write paths answer to the same number.
+_MAX_SKILL_MD_CHARS = 200_000
+
+# The longest a single character can be in UTF-8. Used to reject an oversized
+# SKILL.md on its byte length, before anything is decoded.
+_MAX_UTF8_BYTES_PER_CHAR = 4
+
+# Characters that render as nothing but are *not* Unicode whitespace, so
+# ``str.strip()`` leaves them: BOM / zero-width no-break space, zero-width
+# space, and the zero-width non-joiner, joiner and word joiner. Stripped in
+# addition to the default set, never instead of it -- passing an explicit
+# argument to ``str.strip`` *replaces* the default, which silently dropped 21
+# of the 29 characters ``isspace()`` recognizes, U+2003 EM SPACE among them.
+_ZERO_WIDTH_CHARS = "\ufeff\u200b\u200c\u200d\u2060"
+
+
 # ──────────────────────────────────────────────────────────────────────
 # Schemas — local
 # ──────────────────────────────────────────────────────────────────────
@@ -106,7 +125,7 @@ class CreateSkillRequest(BaseModel):
     (xagent always uses the dir name as the source of truth)."""
 
     name: str = Field(..., min_length=1, max_length=64)
-    skill_md: str = Field(..., min_length=1, max_length=200_000)
+    skill_md: str = Field(..., min_length=1, max_length=_MAX_SKILL_MD_CHARS)
     scope: str = Field("personal", pattern="^(personal|team)$")
 
 
@@ -114,7 +133,7 @@ class EditSkillRequest(BaseModel):
     """``PUT /installed/{name}`` body. ``name`` is taken from the URL;
     only the SKILL.md content is mutable in v0."""
 
-    skill_md: str = Field(..., min_length=1, max_length=200_000)
+    skill_md: str = Field(..., min_length=1, max_length=_MAX_SKILL_MD_CHARS)
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -356,6 +375,23 @@ _IGNORED_ARCHIVE_NAMES = frozenset({".DS_Store", "Thumbs.db", "desktop.ini"})
 # peak footprint a multiple of the size budget.
 _ARCHIVE_CHUNK_BYTES = 1024 * 1024
 
+# A skill bundle is a handful of documents. The byte budget alone does not bound
+# the *count*: a 16 MiB archive of 100k empty padding directories passes it, and
+# costs ~3s of CPU and ~62 MiB of allocation inside ``ZipFile(...)`` itself —
+# before a single member is read. Cap the count, directories included: they are
+# skipped for content but still cost a central-directory entry to walk, so
+# excluding them would leave the cap evadable with padding folders. The same
+# goes for AppleDouble cruft: a Finder-zipped bundle carries an "__MACOSX/._x"
+# entry per file, so the cap is effectively halved for those. That is
+# deliberate -- the cap is applied to what the archive actually contains,
+# before anything knows which entries will be filtered out later.
+_MAX_ARCHIVE_ENTRIES = 2000
+
+# ``UserSkillFile.path`` is String(500). Beyond it PostgreSQL raises DataError
+# at commit and the request dies as a 500; SQLite silently accepts, so this
+# bound has to be enforced here rather than left to the database.
+_MAX_SKILL_FILE_PATH_CHARS = 500
+
 
 def _is_archive_cruft(path: str) -> bool:
     """True for OS bookkeeping files that are never part of a skill."""
@@ -367,12 +403,36 @@ def _is_archive_cruft(path: str) -> bool:
     )
 
 
+def _canonical_skill_path(raw_path: str) -> str:
+    """Canonical POSIX form of a bundle path, or "" if nothing is left.
+
+    One place decides what a path *is*, so root selection, containment and
+    storage cannot disagree about it. Backslashes become separators (archives
+    written on Windows use them), "." segments and repeated or leading slashes
+    collapse. ".." is deliberately *not* resolved here: this returns a shape,
+    and the caller rejects traversal rather than quietly resolving it into
+    somewhere else.
+    """
+    segments = [
+        seg for seg in str(raw_path).replace("\\", "/").split("/") if seg and seg != "."
+    ]
+    return "/".join(segments)
+
+
 def _normalize_skill_files(files: dict[str, bytes]) -> dict[str, bytes]:
     out: dict[str, bytes] = {}
     total = 0
     for raw_path, content in files.items():
-        path = str(raw_path).replace("\\", "/").lstrip("/")
-        if not path or ".." in path.split("/"):
+        path = _canonical_skill_path(raw_path)
+        if not path:
+            # Nothing survived canonicalization ("///", ".", "./"). Refusing is
+            # right, but it is not traversal, and saying so sent people looking
+            # for a ".." that is not there.
+            raise HTTPException(
+                status_code=400,
+                detail=f"Skill bundle contains an empty file path ({raw_path!r}).",
+            )
+        if ".." in path.split("/"):
             raise HTTPException(
                 status_code=400,
                 detail="Skill file path contains a path-traversal sequence.",
@@ -390,6 +450,31 @@ def _normalize_skill_files(files: dict[str, bytes]) -> dict[str, bytes]:
                     "Remove it and try again."
                 ),
             )
+        # Bound the path before the database has to. UserSkillFile.path is
+        # String(500): PostgreSQL raises DataError at commit and the request
+        # dies as a 500, while SQLite accepts it silently, so the check cannot
+        # be left to the storage layer.
+        if len(path) > _MAX_SKILL_FILE_PATH_CHARS:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Skill file path is longer than "
+                    f"{_MAX_SKILL_FILE_PATH_CHARS} characters: {path[:60]}…"
+                ),
+            )
+        # Two distinct inputs can canonicalize to one path -- "./SKILL.md" and
+        # "SKILL.md", or "a\\b.md" and "a/b.md". Writing both meant the last
+        # one silently won and its neighbour vanished from a bundle the route
+        # then reported as installed. Refuse instead: which of the two the
+        # uploader meant is not ours to guess.
+        if path in out:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Skill bundle contains two entries for {path!r}. "
+                    "Remove the duplicate and try again."
+                ),
+            )
         total += len(content)
         if total > _MAX_DOWNLOAD_BYTES:
             raise HTTPException(
@@ -398,12 +483,43 @@ def _normalize_skill_files(files: dict[str, bytes]) -> dict[str, bytes]:
         out[path] = bytes(content)
     if "SKILL.md" not in out:
         raise HTTPException(status_code=400, detail="Skill has no SKILL.md.")
+    _check_skill_md_content(out["SKILL.md"])
+    # Last gate before any caller writes. Everything above bounds the bundle's
+    # shape; this asks the parser whether it can actually be loaded, so a
+    # bundle that would fail on read-back is refused with a 400 naming the
+    # file instead of being persisted and then surfacing as a post-write 500
+    # with an orphaned row. Every write path -- registry install, personal
+    # create, the migration loader -- reaches it through here.
+    _assert_bundle_parses(out)
     return out
+
+
+def _reject_oversized_text(content: bytes, label: str) -> None:
+    """Refuse text past the character cap without decoding it.
+
+    A UTF-8 character is at most four bytes, so anything longer than
+    ``4 * _MAX_SKILL_MD_CHARS`` is over the cap whatever it decodes to, and no
+    string has to be built to know it. The cost this avoids is real, not
+    theoretical: a 40 KiB archive holding a 40 MiB member peaked at 120 MiB
+    before being refused, because the decoded copy joined the extractor's
+    chunks and joined bytes, all of it synchronous inside the install path.
+    """
+    if len(content) > _MAX_UTF8_BYTES_PER_CHAR * _MAX_SKILL_MD_CHARS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"{label} is over {_MAX_SKILL_MD_CHARS} characters "
+                f"({len(content)} bytes); the limit is {_MAX_SKILL_MD_CHARS}."
+            ),
+        )
 
 
 # The only files ``SkillParser.parse_bundle`` decodes, in the order it reads
 # them. Everything else in a bundle is carried as opaque bytes, so a decode
-# failure can only have come from one of these.
+# failure can only have come from one of these. Kept in step with the parser
+# by a test that reads parse_bundle's source, since a third decoded file added
+# there would otherwise leave this list silently stale -- and silently skip
+# the byte bound above.
 _PARSER_DECODED_FILES = ("SKILL.md", "template.md")
 
 # ``parse_bundle`` wants a name, but validation happens before naming matters
@@ -444,6 +560,15 @@ def _assert_bundle_parses(files: dict[str, bytes]) -> None:
     or the primary key recycled.
     """
     from xagent.skills.parser import SkillParser
+
+    # Bound every file the parser will decode, not just SKILL.md: both are
+    # decoded in full by ``parse_bundle``, so leaving template.md unbounded
+    # reproduced the allocation spike SKILL.md was fixed for -- 120 MiB peak
+    # for a 41 KiB archive.
+    for path in _PARSER_DECODED_FILES:
+        content = files.get(path)
+        if content is not None:
+            _reject_oversized_text(content, path)
 
     try:
         SkillParser.parse_bundle(name=_VALIDATION_PLACEHOLDER_NAME, files=files)
@@ -505,6 +630,46 @@ def _is_skill_name_unique_violation(error: BaseException) -> bool:
     return False
 
 
+def _check_skill_md_content(skill_md: bytes) -> None:
+    """Enforce the non-empty and character-count contract on SKILL.md.
+
+    The byte bound runs first so nothing large is decoded to be rejected; past
+    it the content is small by construction, so the remaining two questions
+    are cheap to answer from text. ``errors="replace"`` keeps a non-UTF-8
+    SKILL.md from raising here -- naming that file is the parser's job -- and a
+    replacement character still occupies one character, so the cap holds
+    either way.
+    """
+    _reject_oversized_text(skill_md, "SKILL.md")
+    text = skill_md.decode("utf-8", errors="replace")
+    # Match the non-empty contract Create/Edit enforce. A blank SKILL.md
+    # persists happily and returns 200, then contributes nothing but a name to
+    # every system prompt that loads it.
+    #
+    # Asked as a property of every character, not by stripping. Stripping only
+    # peels the ends, so no fixed number of passes converges: three passes let
+    # "\u200b \u200b \u200b" through, because each pass exposes the next
+    # layer and the last one still leaves a zero-width character standing.
+    # ``str.strip()`` also cannot be given the zero-width set as an argument --
+    # that *replaces* the default rather than extending it, and drops 21 of the
+    # 29 characters ``isspace()`` knows.
+    if all(char.isspace() or char in _ZERO_WIDTH_CHARS for char in text):
+        raise HTTPException(status_code=400, detail="SKILL.md is empty.")
+    # Hold every write path to the character cap the Create/Edit schemas
+    # already enforce. SKILL.md reaches the system prompt on every model turn,
+    # so a bundle that skipped the cap would fail far from here, at inference
+    # time. Counted in characters, not bytes, to match those schemas.
+    char_count = len(text)
+    if char_count > _MAX_SKILL_MD_CHARS:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"SKILL.md is {char_count} characters; the limit is "
+                f"{_MAX_SKILL_MD_CHARS}."
+            ),
+        )
+
+
 def _write_personal_skill(
     *,
     db: Any,
@@ -517,18 +682,23 @@ def _write_personal_skill(
 ) -> None:
     """Persist one personal skill, refusing anything that would not load.
 
-    The bundle goes through ``_assert_bundle_parses`` before the commit, so a
-    committed row is one the skill machinery can read and nothing here has to
-    be undone afterwards. See that function for why undoing is the thing worth
-    avoiding.
+    The bundle goes through ``_assert_bundle_parses`` before the commit -- by
+    way of ``_normalize_skill_files`` below -- so a committed row is one the
+    skill machinery can read and nothing here has to be undone afterwards. See
+    that function for why undoing is the thing worth avoiding.
     """
     from xagent.skills.library import guess_media_type
     from xagent.web.models.skill import UserSkill, UserSkillFile
 
     _validate_skill_name(name)
     user_id = int(user.id)
+    # Re-normalize rather than trusting the caller: this is the boundary the
+    # registry install, personal create and migration paths all reach, and the
+    # only place all three are guaranteed to be validated. The parse check the
+    # commit depends on runs inside that call, so it is not repeated here --
+    # it lives in the normalizer rather than in this writer because the team
+    # scope reaches the write provider without passing through here at all.
     normalized = _normalize_skill_files(files)
-    _assert_bundle_parses(normalized)
     existing = (
         db.query(UserSkill)
         .filter(UserSkill.user_id == user_id, UserSkill.name == name)
@@ -729,13 +899,49 @@ def _safe_zip_extract(
     raw_files: dict[str, bytes] = {}
     try:
         zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
-        for info in zf.infolist():
+        # Cap the entry count. This runs *after* ZipFile has materialized the
+        # central directory, so it bounds the per-entry work that follows --
+        # the ORM insert per file, the walk over every member -- but not the
+        # construction itself. Bounding construction needs the archive's cost
+        # to be limited before CPython parses it, which is a separate problem
+        # with its own failure history; it is tracked in #1941 rather than
+        # solved here. Measured, the worst archive this admits costs ~0.6s and
+        # ~11 MiB inside the constructor before this rejects it.
+        entries = zf.infolist()
+        if len(entries) > _MAX_ARCHIVE_ENTRIES:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    f"Skill archive holds {len(entries)} entries; the limit is "
+                    f"{_MAX_ARCHIVE_ENTRIES}."
+                ),
+            )
+        for info in entries:
             if info.is_dir():
                 continue
-            path = info.filename.replace("\\", "/").lstrip("/")
+            # Canonicalize here, not at the tail. Root selection, the
+            # containment check below and the normalizer all key off this
+            # string, and they only agree if one function decides its shape:
+            # "./SKILL.md" counts as depth 0 rather than losing to a nested
+            # real root, and "my-skill\\notes.md" is seen as living under
+            # "my-skill/" instead of being dropped as outside it.
+            path = _canonical_skill_path(info.filename)
             if not path or ".." in path.split("/"):
                 raise HTTPException(
                     status_code=400, detail="Skill ZIP contains unsafe paths."
+                )
+            # Distinct members can canonicalize to one path. Left alone the
+            # later one overwrote the earlier, so a bundle came back missing a
+            # file with a 200 attached. The normalizer refuses duplicates too;
+            # this one has to exist as well because that check runs on the
+            # already-collapsed dict, after the loss it is meant to catch.
+            if path in raw_files:
+                raise HTTPException(
+                    status_code=400,
+                    detail=(
+                        f"Skill archive contains two entries for {path!r}. "
+                        "Remove the duplicate and try again."
+                    ),
                 )
             remaining = _MAX_DOWNLOAD_BYTES - total
             # Reject on the declared size before inflating anything. zipfile

--- a/tests/migration/test_platform_migration.py
+++ b/tests/migration/test_platform_migration.py
@@ -734,3 +734,66 @@ def test_dry_run_never_initializes_the_db(
     assert cli.run(args) == 0
     out = capsys.readouterr().out
     assert "dry-run: no changes made." in out
+
+
+def test_loader_reports_skills_refused_by_the_shared_validation_gate(
+    db_session,
+) -> None:
+    """A bundle the archive layer refuses becomes a report error, not a crash.
+
+    ``_write_skill`` delegates to Skill Hub's ``_write_personal_skill``, so the
+    validation added to that shared boundary — blank ``SKILL.md``, duplicate
+    canonical paths, over-long paths, unparsable bundles — now governs
+    migration too. That is intended, but it changes what an import does with a
+    bundle the source platform happily held, so the per-skill error path needs
+    to hold: one bad skill is reported and skipped, and the good ones around it
+    still import.
+    """
+    from xagent.web.models.skill import UserSkill
+
+    user = _make_user(db_session)
+    good = SkillItem(
+        name="keeper",
+        files={"SKILL.md": b"---\ndescription: fine\n---\n# Keeper\n"},
+        source_path="/src/keeper",
+    )
+    blank = SkillItem(
+        name="blank-one",
+        files={"SKILL.md": b"   \n\t"},
+        source_path="/src/blank-one",
+    )
+    unparsable = SkillItem(
+        name="bad-template",
+        files={
+            "SKILL.md": b"---\ndescription: fine\n---\n# Bad\n",
+            "template.md": b"\xff\xfe not utf-8",
+        },
+        source_path="/src/bad-template",
+    )
+    # Ordered so a valid skill follows both rejections. With the good one
+    # first, the only successful write precedes every failure and the test
+    # cannot fail if a rejection left the session unusable for what comes
+    # after it -- which is the half that actually needs guarding.
+    trailing = SkillItem(
+        name="after-the-failures",
+        files={"SKILL.md": b"---\ndescription: fine\n---\n# After\n"},
+        source_path="/src/after-the-failures",
+    )
+    bundle = MigrationBundle(
+        source="openclaw",
+        source_root="/src",
+        skills=[good, blank, unparsable, trailing],
+    )
+
+    report = MigrationLoader(db_session, user=user).load(bundle)
+
+    assert report.skills_imported == ["keeper", "after-the-failures"]
+    stored = db_session.query(UserSkill).filter(UserSkill.user_id == user.id).all()
+    assert {s.name for s in stored} == {"keeper", "after-the-failures"}
+
+    errors = "\n".join(report.errors)
+    assert "blank-one" in errors
+    assert "bad-template" in errors
+    # The rejection reason has to survive into the operator-facing report.
+    assert "empty" in errors.lower()
+    assert "template.md" in errors

--- a/tests/skills/test_skill_hub_security.py
+++ b/tests/skills/test_skill_hub_security.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import io
+import struct
+import tracemalloc
 import zipfile
 
 import pytest
@@ -605,3 +607,592 @@ async def test_team_write_routes_adopt_the_central_provider_invoker(
     assert context.user_id == scope.user_id
     assert context.metadata == scope.metadata
     assert kwargs["scope"] == "team"
+
+
+# ── hostile-archive bounds (P2a) ──────────────────────────────────────────────
+
+
+def _archive_with_padded_directory(*, entries: int, padding: int) -> bytes:
+    """An archive whose central directory is inflated by per-entry extra fields.
+
+    Names stay short and the count stays under the cap, so the only bound that
+    can reject it is the one on bytes read during construction.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("SKILL.md", SKILL_MD)
+        for i in range(entries):
+            info = zipfile.ZipInfo(f"f{i}.md")
+            # 0xFFFF is an unassigned extra-field header id, so readers carry
+            # the block along without interpreting it.
+            info.extra = b"\xff\xff" + padding.to_bytes(2, "little") + b"\x00" * padding
+            zf.writestr(info, b"x")
+    return buf.getvalue()
+
+
+def _zip64_archive_under_the_byte_cap(entries: int) -> bytes:
+    """A genuine Zip64 archive whose directory stays under the byte cap.
+
+    Assembled by hand: the stdlib only emits a Zip64 end record past 65,535
+    entries, and such an archive's directory is far over the byte cap, so the
+    byte bound answers it before the entry count is ever consulted. This shape
+    -- short names, a small directory, a real Zip64 record made authoritative
+    by pinning the legacy count to the sentinel -- is the one that exercises
+    the Zip64 read path against the *entry* cap.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("SKILL.md", SKILL_MD)
+        for i in range(entries - 1):
+            zf.writestr(str(i), b"")
+    base = buf.getvalue()
+    eocd_start = base.rfind(_EOCD_SIGNATURE)
+    _sig, _d1, _d2, _eth, total, size_cd, offset_cd, _cl = struct.unpack(
+        "<4s4H2LH", base[eocd_start : eocd_start + 22]
+    )
+    body = base[:eocd_start]
+    eocd = bytearray(base[eocd_start:])
+    zip64_eocd = struct.pack(
+        "<4sQ2H2L4Q",
+        b"PK\x06\x06",
+        44,
+        45,
+        45,
+        0,
+        0,
+        total,
+        total,
+        size_cd,
+        offset_cd,
+    )
+    locator = struct.pack("<4sLQL", b"PK\x06\x07", 0, len(body), 1)
+    struct.pack_into("<H", eocd, 10, 0xFFFF)
+    return body + zip64_eocd + locator + bytes(eocd)
+
+
+def _comment_boundary_archive() -> bytes:
+    """An archive whose EOCD sits exactly 65536 bytes from EOF.
+
+    CPython 3.11 searches ``filesize - 65536 - 22`` and 3.12+ searches
+    ``filesize - 65535 - 22``, so this shape is findable on one and not the
+    other. Any hand-written window had to pick a side and be wrong on the
+    rest; the bounded reader never searches, so it is right on both.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("SKILL.md", SKILL_MD)
+        for i in range(20000):
+            zf.writestr(str(i), b"")
+        zf.comment = b"C" * 65535
+    return buf.getvalue() + b"X"
+
+
+def _archive_with_entries(count: int, *, dirs: bool = False) -> bytes:
+    """``count`` entries under one-character names, keeping the directory small.
+
+    Short names are the point: an archive can then be far over the *entry* cap
+    while its central directory stays under the *byte* cap, which is the shape
+    that separates the two bounds.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", allowZip64=True) as zf:
+        zf.writestr("SKILL.md", SKILL_MD)
+        for i in range(count - 1):
+            zf.writestr(str(i) + ("/" if dirs else ""), b"")
+    return buf.getvalue()
+
+
+def _with_eocd_count_decoy(zip_bytes: bytes, *, size_cd: int | None = None) -> bytes:
+    """Rewrite the legacy EOCD counts to small, non-sentinel decoys.
+
+    EOCD layout (``<4s4H2LH``): entries-this-disk at +8, entries-total at +10,
+    central-directory size at +12.
+    """
+    raw = bytearray(zip_bytes)
+    eocd = raw.rfind(_EOCD_SIGNATURE)
+    struct.pack_into("<HH", raw, eocd + 8, 10, 10)
+    if size_cd is not None:
+        struct.pack_into("<L", raw, eocd + 12, size_cd)
+    return bytes(raw)
+
+
+# A self-extracting archive's stub: arbitrary bytes before the logical ZIP.
+_STUB_PREFIX = b"MZ" + b"\x00" * 4094
+_EOCD_SIGNATURE = b"PK\x05\x06"
+
+
+class TestEntryCap:
+    """The entry cap, and what it does and does not promise.
+
+    It is applied to ``zf.infolist()`` after ``ZipFile`` has parsed the
+    directory, so it bounds the per-entry work that follows -- one ORM insert
+    per file, the walk over every member -- but *not* the construction itself.
+    Bounding construction is a separate problem, tracked in #1941; these tests
+    assert the cap that exists rather than one that does not.
+    """
+
+    @pytest.mark.parametrize(
+        "label,build",
+        [
+            ("plain", lambda: _archive_with_entries(2001)),
+            ("directories count too", lambda: _archive_with_entries(2001, dirs=True)),
+            (
+                "count decoyed in the EOCD",
+                lambda: _with_eocd_count_decoy(_archive_with_entries(2001)),
+            ),
+            ("behind an SFX stub", lambda: _STUB_PREFIX + _archive_with_entries(2001)),
+            (
+                "zip64, directory under the old byte cap",
+                lambda: _zip64_archive_under_the_byte_cap(2001),
+            ),
+        ],
+    )
+    def test_over_the_cap_is_refused(self, label, build):
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(build(), bad_zip_status=400)
+        assert exc.value.status_code == 400
+        assert "entries" in exc.value.detail
+
+    @pytest.mark.parametrize(
+        "label,build",
+        [
+            ("exactly at the cap", lambda: _archive_with_entries(2000)),
+            (
+                "ordinary bundle",
+                lambda: _make_zip({"SKILL.md": SKILL_MD, "n.md": b"h"}),
+            ),
+            (
+                "behind an SFX stub",
+                lambda: _STUB_PREFIX + _make_zip({"SKILL.md": SKILL_MD, "n.md": b"h"}),
+            ),
+            ("zip64 at the cap", lambda: _zip64_archive_under_the_byte_cap(2000)),
+        ],
+    )
+    def test_within_the_cap_is_accepted(self, label, build):
+        files, _root = _safe_zip_extract(build(), bad_zip_status=400)
+        assert files["SKILL.md"] == SKILL_MD
+
+    def test_valid_comments_do_not_affect_the_count(self):
+        """A comment is not entries, whatever it contains.
+
+        Worth keeping even though nothing counts byte patterns any more: an
+        earlier revision bounded the count by scanning the byte stream for
+        central-header signatures, and rejected a valid 2,000-entry archive
+        carrying a one-byte comment (the end-record scan overlaps the
+        directory, so the same headers were counted twice) as well as a
+        one-entry archive whose comment legally contained 2,001 copies of that
+        signature.
+        """
+        for comment in (b"x", b"C" * 65535, b"PK\x01\x02" * 2001):
+            buf = io.BytesIO()
+            with zipfile.ZipFile(buf, "w") as zf:
+                zf.writestr("SKILL.md", SKILL_MD)
+                for i in range(1999):
+                    zf.writestr(str(i), b"")
+                zf.comment = comment
+            data = buf.getvalue()
+            assert len(zipfile.ZipFile(io.BytesIO(data)).namelist()) == 2000
+            files, _root = _safe_zip_extract(data, bad_zip_status=400)
+            assert files["SKILL.md"] == SKILL_MD
+
+    def test_signatures_inside_member_content_do_not_affect_the_count(self):
+        data = _make_zip({"SKILL.md": SKILL_MD, "decoy.bin": b"PK\x01\x02" * 100000})
+        files, _root = _safe_zip_extract(data, bad_zip_status=400)
+        assert len(files["decoy.bin"]) == 400000
+
+    def test_non_zip_is_left_to_zipfile_to_reject(self):
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(b"not a zip", bad_zip_status=400)
+        assert exc.value.status_code == 400
+        assert "readable ZIP" in exc.value.detail
+
+
+class TestCanonicalizationAndDuplicates:
+    """N2 — canonicalize before root selection; refuse duplicates."""
+
+    def test_dot_slash_prefix_does_not_lose_the_root(self):
+        """ "./SKILL.md" must count as depth 0, not lose to a nested root."""
+        data = _make_zip(
+            {"./SKILL.md": SKILL_MD, "nested/SKILL.md": b"# wrong", "./notes.md": b"n"}
+        )
+        files, root = _safe_zip_extract(data)
+        assert files["SKILL.md"] == SKILL_MD
+        assert "notes.md" in files
+        assert root == ""
+
+    def test_backslash_member_stays_inside_the_root(self):
+        """A Windows-written path must not fall outside the containment check."""
+        data = _make_zip({"my-skill/SKILL.md": SKILL_MD, "my-skill\\notes.md": b"kept"})
+        files, root = _safe_zip_extract(data)
+        assert root == "my-skill"
+        # Before canonicalization moved ahead of root selection this file did
+        # not start with "my-skill/" and was silently dropped, with a 200.
+        assert files["notes.md"] == b"kept"
+
+    def test_duplicate_canonical_paths_in_zip_rejected(self):
+        data = _make_zip({"SKILL.md": SKILL_MD, "./SKILL.md": b"# other"})
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(data)
+        assert exc.value.status_code == 400
+        assert "two entries" in exc.value.detail
+
+    def test_duplicate_via_backslash_rejected(self):
+        data = _make_zip({"a/b.md": b"one", "a\\b.md": b"two", "SKILL.md": SKILL_MD})
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(data)
+        assert exc.value.status_code == 400
+
+    def test_duplicate_canonical_paths_in_normalizer_rejected(self):
+        with pytest.raises(HTTPException) as exc:
+            _normalize_skill_files(
+                {"SKILL.md": SKILL_MD, "docs/a.md": b"one", "docs//a.md": b"two"}
+            )
+        assert exc.value.status_code == 400
+        assert "two entries" in exc.value.detail
+
+    def test_redundant_separators_collapse(self):
+        result = _normalize_skill_files({"SKILL.md": SKILL_MD, "a//./b.md": b"hi"})
+        assert result["a/b.md"] == b"hi"
+
+    @pytest.mark.parametrize("raw", ["///", ".", "./", "/", "\\\\"])
+    def test_degenerate_paths_never_reach_the_bundle(self, raw):
+        """A path that canonicalizes to nothing must be refused, not stored.
+
+        Asserted on the resulting keys as well as the status. Without the
+        check the empty string is written as a key and the bundle is returned
+        with it -- a shape no consumer expects -- and a status-only assertion
+        cannot see that, because a second degenerate entry would be caught by
+        the duplicate check and a single one is simply accepted.
+        """
+        with pytest.raises(HTTPException) as exc:
+            _normalize_skill_files({"SKILL.md": SKILL_MD, raw: b"x"})
+        assert exc.value.status_code == 400
+        assert "empty file path" in exc.value.detail
+
+    def test_a_bundle_never_carries_an_empty_key(self):
+        """The invariant behind the check above, stated directly."""
+        result = _normalize_skill_files({"SKILL.md": SKILL_MD, "docs/a.md": b"a"})
+        assert all(key for key in result), result
+        assert set(result) == {"SKILL.md", "docs/a.md"}
+
+    def test_traversal_still_refused_not_resolved(self):
+        """Canonicalization must not quietly resolve ".." into somewhere else."""
+        with pytest.raises(HTTPException) as exc:
+            _normalize_skill_files({"SKILL.md": SKILL_MD, "a/../../x.md": b"e"})
+        assert exc.value.status_code == 400
+        assert "traversal" in exc.value.detail.lower()
+
+
+class TestSkillMdContentBounds:
+    """N7 / H4 / H5 — the shared preparation boundary's content contract."""
+
+    @pytest.mark.parametrize("body", [b"", b"   ", b"\n\t \r\n"])
+    def test_empty_skill_md_rejected(self, body):
+        with pytest.raises(HTTPException) as exc:
+            _normalize_skill_files({"SKILL.md": body})
+        assert exc.value.status_code == 400
+        assert "empty" in exc.value.detail.lower()
+
+    def test_empty_skill_md_rejected_from_zip(self):
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(_make_zip({"SKILL.md": b"  \n"}))
+        assert exc.value.status_code == 400
+        assert "empty" in exc.value.detail.lower()
+
+    def test_oversized_skill_md_rejected(self):
+        from xagent.web.api.skill_hub import _MAX_SKILL_MD_CHARS
+
+        with pytest.raises(HTTPException) as exc:
+            _normalize_skill_files({"SKILL.md": b"x" * (_MAX_SKILL_MD_CHARS + 1)})
+        assert exc.value.status_code == 400
+        assert str(_MAX_SKILL_MD_CHARS) in exc.value.detail
+
+    def test_oversized_skill_md_is_rejected_without_decoding_it(self):
+        """Finding #3: the rejection must not cost a full decoded copy.
+
+        Asserted on peak allocation, not on the status code. The character cap
+        returns the same 400 either way, so a status-only test stays green
+        with the byte bound deleted -- measured, 120 MiB instead of 80 MiB.
+        """
+        payload = b"a" * (40 * 1024 * 1024)
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("SKILL.md", payload)
+        data = buf.getvalue()
+        # A high-compression archive: tiny on the wire, huge once inflated.
+        assert len(data) < 1024 * 1024
+
+        tracemalloc.start()
+        try:
+            with pytest.raises(HTTPException) as exc:
+                _safe_zip_extract(data, bad_zip_status=400)
+            _peak = tracemalloc.get_traced_memory()[1]
+        finally:
+            tracemalloc.stop()
+        assert exc.value.status_code == 400
+        # The inflated member and the joined copy are unavoidable here; a
+        # third full-size string is not. Threshold measured, not guessed: with
+        # the byte bound the peak is ~80 MiB, without it 120 MiB, so it has to
+        # sit between them. The first version of this used 3.5x (140 MiB) --
+        # above *both* -- and could not fail.
+        assert _peak < 2.5 * len(payload), (
+            f"peak {_peak / 1048576:.1f} MiB suggests SKILL.md was decoded "
+            "before the byte bound rejected it"
+        )
+
+    def test_skill_md_at_the_cap_is_accepted(self):
+        from xagent.web.api.skill_hub import _MAX_SKILL_MD_CHARS
+
+        result = _normalize_skill_files({"SKILL.md": b"x" * _MAX_SKILL_MD_CHARS})
+        assert len(result["SKILL.md"]) == _MAX_SKILL_MD_CHARS
+
+    def test_skill_md_cap_counts_characters_not_bytes(self):
+        """Matches the Create/Edit schemas, which bound characters."""
+        from xagent.web.api.skill_hub import _MAX_SKILL_MD_CHARS
+
+        # 3 bytes per character in UTF-8: over the byte count, under the cap.
+        body = ("€" * _MAX_SKILL_MD_CHARS).encode("utf-8")
+        assert len(body) == 3 * _MAX_SKILL_MD_CHARS
+        assert _normalize_skill_files({"SKILL.md": body})["SKILL.md"] == body
+
+    def test_oversized_template_md_is_also_bounded(self):
+        """The same byte bound applies to every parser-decoded key.
+
+        ``template.md`` is decoded in full by ``parse_bundle`` exactly as
+        ``SKILL.md`` is, so leaving it unbounded reproduced the allocation
+        spike SKILL.md had just been fixed for -- 120 MiB peak for a 41 KiB
+        archive.
+        """
+        payload = b"t" * (40 * 1024 * 1024)
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("SKILL.md", SKILL_MD)
+            zf.writestr("template.md", payload)
+        data = buf.getvalue()
+        assert len(data) < 1024 * 1024
+
+        tracemalloc.start()
+        try:
+            with pytest.raises(HTTPException) as exc:
+                _safe_zip_extract(data, bad_zip_status=400)
+            peak = tracemalloc.get_traced_memory()[1]
+        finally:
+            tracemalloc.stop()
+        assert exc.value.status_code == 400
+        assert "template.md" in exc.value.detail
+        assert peak < 2.5 * len(payload), f"peak {peak / 1048576:.1f} MiB"
+
+    @pytest.mark.parametrize(
+        "label,body",
+        [
+            ("ascii spaces", "   \t\n"),
+            ("ideographic space U+3000", "\u3000" * 9),
+            ("no-break space U+00A0", "\u00a0" * 9),
+            ("zero-width space U+200B", "\u200b" * 9),
+            ("zero-width non-joiner U+200C", "\u200c" * 9),
+            ("word joiner U+2060", "\u2060" * 9),
+            ("bare BOM", "\ufeff"),
+            ("mixed invisible", "  \ufeff\u200b\u3000\n\t"),
+        ],
+    )
+    def test_invisible_only_skill_md_rejected(self, label, body):
+        """``bytes.strip()`` knew only ASCII, so all of these read as content.
+
+        The zero-width ones are not Unicode whitespace either -- ``isspace()``
+        is False for every one of them -- so ``str.strip()`` alone does not
+        cover them, but a SKILL.md made of them carries no more meaning than
+        an empty one.
+        """
+        with pytest.raises(HTTPException) as exc:
+            _normalize_skill_files({"SKILL.md": body.encode("utf-8")})
+        assert exc.value.status_code == 400
+        assert "empty" in exc.value.detail.lower()
+
+    @pytest.mark.parametrize(
+        "label,body",
+        [
+            ("ascii", "# Hi\n\n## Description\nd\n"),
+            ("cjk", "# 技能\n\n## Description\nd\n"),
+            ("content behind a BOM", "\ufeff# Hi\n\n## Description\nd\n"),
+            ("emoji", "😀"),
+        ],
+    )
+    def test_real_content_is_not_mistaken_for_blank(self, label, body):
+        """The other direction: widening the strip must not eat real content."""
+        raw = body.encode("utf-8")
+        assert _normalize_skill_files({"SKILL.md": raw})["SKILL.md"] == raw
+
+    def test_overlong_path_rejected(self):
+        from xagent.web.api.skill_hub import _MAX_SKILL_FILE_PATH_CHARS
+
+        long_path = "d/" + "n" * _MAX_SKILL_FILE_PATH_CHARS + ".md"
+        with pytest.raises(HTTPException) as exc:
+            _normalize_skill_files({"SKILL.md": SKILL_MD, long_path: b"x"})
+        assert exc.value.status_code == 400
+        assert str(_MAX_SKILL_FILE_PATH_CHARS) in exc.value.detail
+
+    def test_path_at_the_cap_is_accepted(self):
+        from xagent.web.api.skill_hub import _MAX_SKILL_FILE_PATH_CHARS
+
+        path = "n" * (_MAX_SKILL_FILE_PATH_CHARS - 3) + ".md"
+        assert len(path) == _MAX_SKILL_FILE_PATH_CHARS
+        assert path in _normalize_skill_files({"SKILL.md": SKILL_MD, path: b"x"})
+
+
+class TestParseGateIsWired:
+    """The parser check must guard the shared write boundary, not just exist.
+
+    Asserted through ``_normalize_skill_files`` -- the function every write
+    path goes through -- rather than by calling the helper directly. A helper
+    that is defined, tested and never called is what the previous round
+    shipped: an unparsable bundle reached persistence and surfaced as a
+    post-write 500 with an orphaned row instead of a pre-write 400.
+    """
+
+    def test_unparsable_template_is_refused_by_the_normalizer(self):
+        with pytest.raises(HTTPException) as exc:
+            _normalize_skill_files(
+                {"SKILL.md": SKILL_MD, "template.md": b"\xff\xfe bad"}
+            )
+        assert exc.value.status_code == 400
+        assert "template.md" in exc.value.detail
+
+    def test_unparsable_bundle_is_refused_before_extraction_returns(self):
+        data = _make_zip({"SKILL.md": SKILL_MD, "template.md": b"\xff\xfe bad"})
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(data, bad_zip_status=400)
+        assert exc.value.status_code == 400
+
+    def test_valid_bundle_still_passes_the_gate(self):
+        result = _normalize_skill_files(
+            {"SKILL.md": SKILL_MD, "assets/logo.png": bytes(range(200, 256))}
+        )
+        assert set(result) == {"SKILL.md", "assets/logo.png"}
+
+    def test_every_builtin_skill_still_normalizes(self):
+        """Calibration: the gate must not reject skills already shipping."""
+        import pathlib
+
+        roots = sorted(pathlib.Path("src/xagent/skills/builtin").glob("*/SKILL.md"))
+        assert roots, "no builtin skills found -- fixture path is wrong"
+        for skill_md in roots:
+            directory = skill_md.parent
+            files = {
+                str(item.relative_to(directory)): item.read_bytes()
+                for item in directory.rglob("*")
+                if item.is_file()
+            }
+            assert _normalize_skill_files(files)["SKILL.md"]
+
+
+class TestParseCulpritSelection:
+    """N8 — blame only the files the parser actually decodes."""
+
+    def test_invalid_template_is_named_not_a_valid_png(self):
+        from xagent.web.api.skill_hub import _assert_bundle_parses
+
+        png = b"\x89PNG\r\n\x1a\n" + bytes(range(200, 256))
+        # The fixture only tests anything if it really is non-UTF-8.
+        with pytest.raises(UnicodeDecodeError):
+            png.decode("utf-8")
+        with pytest.raises(HTTPException) as exc:
+            _assert_bundle_parses(
+                {
+                    "SKILL.md": SKILL_MD,
+                    "assets/logo.png": png,
+                    "template.md": b"\xff\xfe bad",
+                }
+            )
+        assert exc.value.status_code == 400
+        assert "template.md" in exc.value.detail
+        assert "logo.png" not in exc.value.detail
+
+    def test_invalid_skill_md_is_named(self):
+        from xagent.web.api.skill_hub import _assert_bundle_parses
+
+        with pytest.raises(HTTPException) as exc:
+            _assert_bundle_parses({"SKILL.md": b"\xff\xfe"})
+        assert exc.value.status_code == 400
+        assert "SKILL.md" in exc.value.detail
+
+    def test_binary_attachments_alone_do_not_fail_the_parse(self):
+        """A non-UTF-8 PNG is ordinary bundle content, not an error."""
+        from xagent.web.api.skill_hub import _assert_bundle_parses
+
+        _assert_bundle_parses(
+            {"SKILL.md": SKILL_MD, "assets/logo.png": bytes(range(200, 256))}
+        )
+
+
+class TestParserKeySynchronization:
+    """``_PARSER_DECODED_FILES`` must track what the parser actually reads.
+
+    The tuple drives both the pre-decode byte bound and the UTF-8 culprit
+    message, so a file the parser decodes without an entry here silently skips
+    the size guard and is mis-named in errors.
+
+    Asserted by *running* the parser against a recording mapping rather than
+    by reading its source. An AST scan only sees literal ``files["x"]`` /
+    ``files.get("x")`` shapes, so a refactor through a local variable, a
+    helper, or a mapping alias would leave it green while the invariant broke.
+    """
+
+    def test_tuple_matches_every_key_the_parser_reads(self):
+        from xagent.skills.parser import SkillParser
+        from xagent.web.api.skill_hub import _PARSER_DECODED_FILES
+
+        class _Recorder(dict):
+            """A bundle that remembers which keys were asked for."""
+
+            def __init__(self, *args, **kwargs):
+                super().__init__(*args, **kwargs)
+                self.seen: list[str] = []
+
+            def __getitem__(self, key):
+                self.seen.append(key)
+                return super().__getitem__(key)
+
+            def __contains__(self, key):
+                self.seen.append(key)
+                return super().__contains__(key)
+
+            def get(self, key, default=None):
+                self.seen.append(key)
+                return super().get(key, default)
+
+        # Every declared file present, so the parser reaches all of them
+        # rather than short-circuiting on a missing one.
+        files = _Recorder({name: SKILL_MD for name in _PARSER_DECODED_FILES})
+        SkillParser.parse_bundle(name="probe", files=files)
+
+        # Only keys that name a bundle *file* matter; the parser may also look
+        # up unrelated things. Compare against what it asked for.
+        asked = [key for key in files.seen if isinstance(key, str)]
+        assert asked, "the recorder saw no key lookups -- the probe is broken"
+        assert set(asked) == set(_PARSER_DECODED_FILES), (
+            f"SkillParser.parse_bundle reads {sorted(set(asked))} but "
+            f"_PARSER_DECODED_FILES is {sorted(_PARSER_DECODED_FILES)}. A file "
+            "the parser reads without an entry here skips the pre-decode size "
+            "bound and is mis-named in UTF-8 errors."
+        )
+
+    def test_every_declared_file_is_actually_bounded(self):
+        """The consumer side: each declared file gets the byte bound.
+
+        Pairs with the invariant above -- that one keeps the tuple honest
+        about the parser, this one keeps the bound honest about the tuple.
+        """
+        from xagent.web.api.skill_hub import (
+            _MAX_SKILL_MD_CHARS,
+            _MAX_UTF8_BYTES_PER_CHAR,
+            _PARSER_DECODED_FILES,
+            _assert_bundle_parses,
+        )
+
+        oversized = b"x" * (_MAX_UTF8_BYTES_PER_CHAR * _MAX_SKILL_MD_CHARS + 1)
+        for name in _PARSER_DECODED_FILES:
+            files = {"SKILL.md": SKILL_MD, name: oversized}
+            with pytest.raises(HTTPException) as exc:
+                _assert_bundle_parses(files)
+            assert exc.value.status_code == 400
+            assert name in exc.value.detail


### PR DESCRIPTION
Part 1 of 4 in the #1854 split. Tracking issue: #1889. Closes #1890.

**Scope reduced this round.** Construction bounding — the concern behind 7 of this PR's 9 blocking findings across four rounds — has been split out to **#1941**. What remains had no blocking findings left, and no longer waits on a problem that has taken four attempts.

## Why the split

31 findings across four rounds, classified by what they touch:

| round | test quality | **archive bounds** | content bounds | dead code | docs | architecture | other | total |
|---|---|---|---|---|---|---|---|---|
| 1 | 2 | **3** | 1 | 0 | 0 | 0 | 2 | 8 |
| 2 | 4 | **3** | 1 | 1 | 1 | 1 | 0 | 11 |
| 3 | 3 | **1** | 1 | 1 | 0 | 0 | 0 | 6 |
| 4 | 1 | **2** | 1 | 0 | 1 | 1 | 0 | 6 |
| **total** | 10 | **9** | 4 | 2 | 2 | 2 | 2 | **31** |

Archive bounds is the only category present in every round, and holds **7 of the 9 blocking findings**. Remove it and the remaining 22 are: 17 fixed, 3 tracked elsewhere (#1909, #1927), 2 minor partials — all addressed here.

Four mechanisms were tried for it, each wrong in a different way:

| attempt | failure |
| --- | --- |
| parse EOCD/Zip64 declarations | the declared count is not what drives CPython's loop; Zip64 gated on a sentinel, so non-sentinel decoys bypassed it |
| hand-mirror the stdlib's record location | Zip64 offset never rebased (76 bytes off, counted zero); comment window one byte narrower than 3.11's. Both failed **open** |
| read-counting reader counting header signatures | the end-record scan overlaps the directory and is re-read, and comments may legally contain the signature. Both failed **closed**, rejecting valid archives |
| reader bounding bytes only | sound but incomplete — cost tracks entry count, not directory length, and the slice was materialized before the budget check |

That is one hard, self-contained problem, and it kept everything else queued behind it. #1941 carries the reproductions, measurements and all four failure modes.

## What this PR does now

Shared by three existing callers — `POST /api/skill-hub/install/{source}`, personal create, and `src/xagent/migration/loaders.py` — so it changes what all three accept and how they fail. Personal edit and team create/edit bypass the normalizer; tracked in #1909.

- **Path canonicalization ahead of root selection.** `./SKILL.md` counts as depth 0 rather than losing the root to a nested `SKILL.md`; `my-skill\notes.md` is seen as inside `my-skill/` rather than dropped. Entries canonicalizing to one path are refused instead of overwriting each other; a path canonicalizing to nothing gets its own message rather than being called traversal.
- **Entry cap** on the parsed entry list. This bounds the per-entry work that follows — one ORM insert per file, the walk over every member — not the construction before it. Stated that way in the code rather than overclaimed; `main` has no cap at all today.
- **Byte bound before decoding**, for every file the parser decodes. A 41 KiB archive holding a 40 MiB member peaked at 120 MiB before being refused.
- **Blank `SKILL.md` judged by predicate**, not by stripping. Three strip passes admitted `U+200B SPACE U+200B SPACE U+200B`; `all(isspace or zero-width)` is independent of length and interleaving. Passing an explicit set to `str.strip` *replaces* the default, dropping 21 of the 29 characters `isspace()` knows.
- **Parser gate at the normalizer**, not the writer — the team scope reaches its provider without passing through `_write_personal_skill`, so the writer is the wrong place for it. The writer's own now-redundant call is dropped.
- 200,000-character cap referenced from the schemas rather than repeated; 500-character path bound (`UserSkillFile.path` is `String(500)`; PostgreSQL raises `DataError` at commit, SQLite accepts silently).

## Verification

Every finding was reproduced before being fixed; none declined.

**Mutation: 15 mutants, 15 caught.** Including three that target the new blank predicate specifically (removed, zero-width dropped, `all`→`any`).

**Exhaustive rather than enumerated where enumeration failed before.** The blank check is swept over all 29 `isspace()` code points × 3 patterns (scalar, alternating both ways) plus arbitrary-length alternations — the previous round's hand-listed set is what let the alternating case through. The parser-key invariant now drives the parser against a recording mapping instead of scanning its source, and is mutation-verified against a **dynamically constructed** key, which the source scan could not see.

223 tests green locally; `ruff`, `isort`, `codespell`, mypy clean (zero errors in `skill_hub.py`; the 35 elsewhere match `main`). Two pre-existing `test_platform_migration.py` failures reproduce unchanged on clean `main` (a local adapter picks up the developer's real `~/.claude` skills).
