### PR TITLE
feat(skill-hub): Give personal-skill writes an attempt-owned identity

### DIFF
--- a/src/xagent/web/api/skill_hub.py
+++ b/src/xagent/web/api/skill_hub.py
@@ -47,6 +47,7 @@ from typing import Any, Dict, List, Optional
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import Response
 from pydantic import BaseModel, Field
+from sqlalchemy.exc import IntegrityError
 
 from xagent.skills.library import SkillScopeContext
 from xagent.web.api.skill_hub_registry import (
@@ -400,6 +401,107 @@ def _normalize_skill_files(files: dict[str, bytes]) -> dict[str, bytes]:
     return out
 
 
+# The only files ``SkillParser.parse_bundle`` decodes, in the order it reads
+# them. Everything else in a bundle is carried as opaque bytes, so a decode
+# failure can only have come from one of these.
+_PARSER_DECODED_FILES = ("SKILL.md", "template.md")
+
+
+def _is_utf8(content: bytes) -> bool:
+    try:
+        content.decode("utf-8")
+    except UnicodeDecodeError:
+        return False
+    return True
+
+
+def _assert_bundle_parses(files: dict[str, bytes]) -> None:
+    """Refuse a bundle that ``SkillManager.reload`` would fail to load.
+
+    This is what makes the write safe to trust once it commits. ``reload``
+    skips a record only when ``SkillParser.parse_bundle`` raises, so running
+    that same call over the same bytes here matches its failure surface by
+    construction rather than by restating the parser's rules -- including
+    whatever the parser starts rejecting later.
+
+    Today that surface is narrow: a missing ``SKILL.md``, and non-UTF-8 bytes
+    in ``SKILL.md`` or ``template.md``, which are the only two files
+    ``parse_bundle`` decodes. Malformed frontmatter is *not* in it --
+    ``_extract_frontmatter`` swallows YAML errors -- so a bundle with broken
+    YAML loads fine and must not be refused here. Checking more than the
+    parser does would reject bundles ``reload`` would happily serve; the
+    clauses below only translate what it raises into an HTTP response.
+
+    Validating first is what lets the write be final. Committing and then
+    re-reading would mean answering for a row that is already durable, and the
+    only remedy at that point is a compensating delete -- which has to identify
+    the row it is undoing, and gets it wrong whenever the name has been reused
+    or the primary key recycled.
+    """
+    from xagent.skills.parser import SkillParser
+
+    try:
+        SkillParser.parse_bundle(name="candidate", files=files)
+    except HTTPException:
+        raise
+    except UnicodeDecodeError as exc:
+        # parse_bundle does not say which file failed, and that is the
+        # actionable half of the message. Only the files the parser actually
+        # decodes can be the cause: scanning every file instead would blame a
+        # binary asset the parser never reads and hide the real culprit.
+        culprit = next(
+            (
+                path
+                for path in _PARSER_DECODED_FILES
+                if path in files and not _is_utf8(files[path])
+            ),
+            None,
+        )
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"{culprit} must be UTF-8 text."
+                if culprit
+                else "SKILL.md and template.md must be UTF-8 text."
+            ),
+        ) from exc
+    except ValueError as exc:
+        # The parser's own way of saying the bundle is unusable -- today, a
+        # missing SKILL.md. Anything else propagates: a service defect must
+        # keep its 5xx rather than be presented to the caller as bad input,
+        # and nothing has been written yet, so letting it through cannot
+        # leave a partial write behind.
+        raise HTTPException(
+            status_code=400, detail=f"Skill bundle could not be parsed: {exc}"
+        ) from exc
+
+
+def _is_skill_name_unique_violation(error: BaseException) -> bool:
+    """Recognize the authoritative ``(user_id, name)`` unique-constraint failure.
+
+    PostgreSQL names the constraint (``uq_user_skill_name``) in its message;
+    SQLite names the columns (``user_skills.user_id, user_skills.name``).
+    Matching either keeps an unrelated IntegrityError -- a foreign-key
+    violation, or the ``(skill_id, path)`` file constraint -- from being
+    reported as a duplicate name.
+    """
+    current: BaseException | None = error
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        message = str(current).lower()
+        if "uq_user_skill_name" in message:
+            return True
+        if (
+            "user_skills.user_id" in message
+            and "user_skills.name" in message
+            and ("unique" in message or "duplicate" in message)
+        ):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
 def _write_personal_skill(
     *,
     db: Any,
@@ -410,12 +512,21 @@ def _write_personal_skill(
     clawhub_slug: str | None = None,
     clawhub_version: str | None = None,
 ) -> None:
+    """Persist one personal skill, refusing anything that would not load.
+
+    The bundle is validated against the parser *before* the commit, so a
+    committed row is one the skill machinery can read. Nothing here has to be
+    undone afterwards, which is the point: a compensating delete would have to
+    identify the row it is undoing, and a name or a recycled primary key does
+    not identify it.
+    """
     from xagent.skills.library import guess_media_type
     from xagent.web.models.skill import UserSkill, UserSkillFile
 
     _validate_skill_name(name)
     user_id = int(user.id)
     normalized = _normalize_skill_files(files)
+    _assert_bundle_parses(normalized)
     existing = (
         db.query(UserSkill)
         .filter(UserSkill.user_id == user_id, UserSkill.name == name)
@@ -436,19 +547,39 @@ def _write_personal_skill(
         updated_by_user_id=user_id,
     )
     db.add(skill)
-    db.flush()
-    for path, content in sorted(normalized.items()):
-        db.add(
-            UserSkillFile(
-                skill_id=skill.id,
-                path=path,
-                content=content,
-                size_bytes=len(content),
-                sha256=hashlib.sha256(content).hexdigest(),
-                media_type=guess_media_type(path),
+    # The pre-check SELECT above and this write are not atomic: two concurrent
+    # requests for the same (user, name) both see "no row" and both proceed.
+    # The loser must still get the documented 409 rather than leaking an
+    # IntegrityError as a 500. The guard spans the flush as well as the commit
+    # because the INSERT reaches the database at flush time -- that is where
+    # SQLite raises, while a deferred constraint would not surface until the
+    # commit. Anything that is not this constraint is re-raised untouched.
+    try:
+        db.flush()
+        # Read the key while the instance is guaranteed live. After the commit
+        # the session may expire it, and re-reading would emit another SELECT
+        # -- or fail outright once #1888 closes the session behind us.
+        skill_id = int(skill.id)
+        for path, content in sorted(normalized.items()):
+            db.add(
+                UserSkillFile(
+                    skill_id=skill_id,
+                    path=path,
+                    content=content,
+                    size_bytes=len(content),
+                    sha256=hashlib.sha256(content).hexdigest(),
+                    media_type=guess_media_type(path),
+                )
             )
-        )
-    db.commit()
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        if not _is_skill_name_unique_violation(exc):
+            raise
+        raise HTTPException(
+            status_code=409,
+            detail=f"A personal skill named {name!r} already exists.",
+        ) from exc
 
 
 def _update_personal_skill_md(*, db: Any, user: User, name: str, skill_md: str) -> None:
@@ -476,6 +607,7 @@ def _update_personal_skill_md(*, db: Any, user: User, name: str, skill_md: str) 
 
 
 def _delete_personal_skill(*, db: Any, user: User, name: str) -> None:
+    """Delete one personal skill the caller owns, addressed by name."""
     from xagent.web.models.skill import UserSkill
 
     skill = (
@@ -487,6 +619,27 @@ def _delete_personal_skill(*, db: Any, user: User, name: str) -> None:
         raise HTTPException(status_code=404, detail="Personal skill not found")
     db.delete(skill)
     db.commit()
+
+
+def _summary_for_committed_write(*, name: str, files: dict[str, bytes]) -> SkillSummary:
+    """Describe a personal skill that is committed but not visible yet.
+
+    The write is durable and was parsed before it landed, so the request
+    succeeded; only the read-side view is behind. Answering 5xx here would be
+    a lie the client cannot act on: a replay re-enters the ``(user, name)``
+    pre-check and gets a deterministic 409, so "retry" is guidance that cannot
+    work, and generic 5xx retry logic would replay a non-idempotent create.
+
+    The bytes re-parsed here are the ones just validated -- the same source
+    the manager would have read -- and the result goes through
+    ``_skill_to_summary`` like every other response, so this cannot drift away
+    from the shape the normal path returns.
+    """
+    from xagent.skills.parser import SkillParser
+
+    parsed = SkillParser.parse_bundle(name=name, files=files)
+    parsed["scope"] = "personal"
+    return _skill_to_summary(parsed)
 
 
 def _summary_from_registry_item(
@@ -754,7 +907,14 @@ async def delete_installed(
     db: Any = Depends(get_db),
     _user: User = Depends(get_current_user),
 ) -> Response:
-    """Remove a user-installed skill. Builtin / external are refused."""
+    """Remove a user-installed skill. Builtin / external are refused.
+
+    ``name`` is resolved through the manager, so every provider keeps its own
+    namespace here. Recovery by primary key lives on its own route rather than
+    as a prefix of this one: ``:`` is not reserved by the provider contracts,
+    and the team create path does not run ``_validate_skill_name``, so a
+    compliant provider may legitimately own a record named ``id:42``.
+    """
     mgr = await _get_scoped_manager(request, context, db)
     skill = await mgr.get_skill(name)
     if not skill:
@@ -824,19 +984,29 @@ async def create_skill(
             files={"SKILL.md": body.skill_md.encode("utf-8")},
         )
 
+    files = {"SKILL.md": body.skill_md.encode("utf-8")}
     mgr = await _get_scoped_manager(request, context, db)
     skill = await mgr.get_skill(body.name)
     if skill is None:
-        # Most likely cause: malformed YAML frontmatter that the parser
-        # rejected. Leave the file on disk so the user can fix it via
-        # PUT, but tell them why nothing showed up.
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                "Skill written to disk but failed to re-parse — check the "
-                "YAML frontmatter at the top of SKILL.md."
-            ),
+        if body.scope != "personal":
+            # Provider-owned scopes validate inside their own writer, so an
+            # absent record here is that provider's failure to report.
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    f"Skill {body.name!r} was written to the {body.scope} scope "
+                    "but the provider does not serve it back."
+                ),
+            )
+        # The personal write is durable and was parsed before it landed, so
+        # the request succeeded and the read side is merely behind. See
+        # _summary_for_committed_write for why this is not a 5xx.
+        logger.warning(
+            "Skill Hub: created user skill %r but the library does not serve "
+            "it yet; answering from the validated bundle",
+            body.name,
         )
+        return _summary_for_committed_write(name=body.name, files=files)
     logger.info(
         "Skill Hub: created user skill %r (%d bytes)", body.name, len(body.skill_md)
     )
@@ -1053,13 +1223,20 @@ async def install_skill(
     mgr = await _get_scoped_manager(request, context, db)
     skill = await mgr.get_skill(body.slug)
     if skill is None:
-        raise HTTPException(
-            status_code=500,
-            detail=(
-                f"{registry.display_name} skill {body.slug!r} installed but failed "
-                "to re-parse. Inspect SKILL.md by hand or remove and retry."
-            ),
+        if body.scope == "team":
+            raise HTTPException(
+                status_code=500,
+                detail=(
+                    f"{registry.display_name} skill {body.slug!r} was written to "
+                    "the team scope but the provider does not serve it back."
+                ),
+            )
+        logger.warning(
+            "Skill Hub: installed %r but the library does not serve it yet; "
+            "answering from the validated bundle",
+            body.slug,
         )
+        return _summary_for_committed_write(name=body.slug, files=files)
     logger.info(
         "Skill Hub: installed %s skill %r (v%s, scan=%s)",
         registry.id,

--- a/src/xagent/web/api/skill_hub.py
+++ b/src/xagent/web/api/skill_hub.py
@@ -406,6 +406,11 @@ def _normalize_skill_files(files: dict[str, bytes]) -> dict[str, bytes]:
 # failure can only have come from one of these.
 _PARSER_DECODED_FILES = ("SKILL.md", "template.md")
 
+# ``parse_bundle`` wants a name, but validation happens before naming matters
+# and the value is never surfaced. Say so, so it reads as deliberate if it
+# ever does reach a message.
+_VALIDATION_PLACEHOLDER_NAME = "<bundle under validation>"
+
 
 def _is_utf8(content: bytes) -> bool:
     try:
@@ -441,9 +446,7 @@ def _assert_bundle_parses(files: dict[str, bytes]) -> None:
     from xagent.skills.parser import SkillParser
 
     try:
-        SkillParser.parse_bundle(name="candidate", files=files)
-    except HTTPException:
-        raise
+        SkillParser.parse_bundle(name=_VALIDATION_PLACEHOLDER_NAME, files=files)
     except UnicodeDecodeError as exc:
         # parse_bundle does not say which file failed, and that is the
         # actionable half of the message. Only the files the parser actually
@@ -514,11 +517,10 @@ def _write_personal_skill(
 ) -> None:
     """Persist one personal skill, refusing anything that would not load.
 
-    The bundle is validated against the parser *before* the commit, so a
-    committed row is one the skill machinery can read. Nothing here has to be
-    undone afterwards, which is the point: a compensating delete would have to
-    identify the row it is undoing, and a name or a recycled primary key does
-    not identify it.
+    The bundle goes through ``_assert_bundle_parses`` before the commit, so a
+    committed row is one the skill machinery can read and nothing here has to
+    be undone afterwards. See that function for why undoing is the thing worth
+    avoiding.
     """
     from xagent.skills.library import guess_media_type
     from xagent.web.models.skill import UserSkill, UserSkillFile
@@ -621,7 +623,9 @@ def _delete_personal_skill(*, db: Any, user: User, name: str) -> None:
     db.commit()
 
 
-def _summary_for_committed_write(*, name: str, files: dict[str, bytes]) -> SkillSummary:
+def _personal_summary_from_bundle(
+    *, name: str, files: dict[str, bytes]
+) -> SkillSummary:
     """Describe a personal skill that is committed but not visible yet.
 
     The write is durable and was parsed before it landed, so the request
@@ -910,10 +914,16 @@ async def delete_installed(
     """Remove a user-installed skill. Builtin / external are refused.
 
     ``name`` is resolved through the manager, so every provider keeps its own
-    namespace here. Recovery by primary key lives on its own route rather than
-    as a prefix of this one: ``:`` is not reserved by the provider contracts,
-    and the team create path does not run ``_validate_skill_name``, so a
-    compliant provider may legitimately own a record named ``id:42``.
+    namespace here -- including names that look like an addressing scheme.
+    ``:`` is not reserved by the provider contracts and the team create path
+    does not run ``_validate_skill_name``, so a compliant provider may
+    legitimately own a record named ``id:42``; parsing such a prefix here
+    would delete the caller's unrelated personal row 42 instead.
+
+    There is deliberately no by-primary-key counterpart: the column has no
+    AUTOINCREMENT, so a client retrying a lost delete would remove whatever
+    reused the id. A row the skill library cannot load is therefore stuck
+    rather than recoverable -- tracked in #1911.
     """
     mgr = await _get_scoped_manager(request, context, db)
     skill = await mgr.get_skill(name)
@@ -1000,13 +1010,18 @@ async def create_skill(
             )
         # The personal write is durable and was parsed before it landed, so
         # the request succeeded and the read side is merely behind. See
-        # _summary_for_committed_write for why this is not a 5xx.
+        # _personal_summary_from_bundle for why this is not a 5xx.
+        logger.info(
+            "Skill Hub: created user skill %r (%d bytes)",
+            body.name,
+            len(body.skill_md),
+        )
         logger.warning(
             "Skill Hub: created user skill %r but the library does not serve "
             "it yet; answering from the validated bundle",
             body.name,
         )
-        return _summary_for_committed_write(name=body.name, files=files)
+        return _personal_summary_from_bundle(name=body.name, files=files)
     logger.info(
         "Skill Hub: created user skill %r (%d bytes)", body.name, len(body.skill_md)
     )
@@ -1231,12 +1246,19 @@ async def install_skill(
                     "the team scope but the provider does not serve it back."
                 ),
             )
+        logger.info(
+            "Skill Hub: installed %s skill %r (v%s, scan=%s)",
+            registry.id,
+            body.slug,
+            body.version or "latest",
+            scan_status,
+        )
         logger.warning(
             "Skill Hub: installed %r but the library does not serve it yet; "
             "answering from the validated bundle",
             body.slug,
         )
-        return _summary_for_committed_write(name=body.slug, files=files)
+        return _personal_summary_from_bundle(name=body.slug, files=files)
     logger.info(
         "Skill Hub: installed %s skill %r (v%s, scan=%s)",
         registry.id,

--- a/tests/skills/test_skill_write_validation.py
+++ b/tests/skills/test_skill_write_validation.py
@@ -1,0 +1,663 @@
+"""Personal-skill writes are validated before they commit.
+
+The alternative -- commit, reload, and delete the row if it cannot be proved
+to be ours -- needs the compensating delete to identify the row it is undoing,
+and neither a name nor a primary key does that: names are reusable and SQLite
+recycles the id of a deleted row. Validating first removes the need to undo
+anything, so there is no delete that can hit the wrong row.
+
+These drive the real writer and the real routes against a live SQLite session
+and assert on the table.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from xagent.skills.library import SkillRecord, SkillScopeContext
+from xagent.web.api import skill_hub
+from xagent.web.api.skill_hub import (
+    _assert_bundle_parses,
+    _delete_personal_skill,
+    _write_personal_skill,
+)
+
+SKILL_MD = b"# Test Skill\n\n## Description\nA test skill.\n"
+
+
+def _factory(tmp_path, name="skills.db", user_ids=(7,)):
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from xagent.web.models.database import Base
+    from xagent.web.models.skill import UserSkill, UserSkillFile
+    from xagent.web.models.user import User
+
+    engine = create_engine(f"sqlite:///{tmp_path / name}")
+    Base.metadata.create_all(
+        engine, tables=[User.__table__, UserSkill.__table__, UserSkillFile.__table__]
+    )
+    factory = sessionmaker(bind=engine)
+    with factory() as db:
+        for uid in user_ids:
+            db.execute(
+                User.__table__.insert().values(
+                    id=uid, username=f"u{uid}", password_hash="h", is_admin=False
+                )
+            )
+        db.commit()
+    return factory
+
+
+def _user(uid=7):
+    return SimpleNamespace(id=uid)
+
+
+def _rows(db):
+    from xagent.web.models.skill import UserSkill
+
+    return sorted((int(r.id), str(r.name)) for r in db.query(UserSkill).all())
+
+
+# ── validation happens before the write ──────────────────────────────────────
+
+
+class TestValidationPrecedesTheWrite:
+    """Whatever ``SkillManager.reload`` would skip must be refused up front."""
+
+    @pytest.mark.parametrize(
+        "files,expected",
+        [
+            ({"SKILL.md": b"\xe9\xff\xfe latin-1"}, "UTF-8"),
+            ({"SKILL.md": SKILL_MD, "template.md": b"\xff\xfe not utf8"}, "UTF-8"),
+        ],
+        ids=["skill-md-not-utf8", "template-md-not-utf8"],
+    )
+    def test_an_unloadable_bundle_never_reaches_the_table(
+        self, tmp_path, files, expected
+    ):
+        db = _factory(tmp_path)()
+        with pytest.raises(HTTPException) as exc:
+            _write_personal_skill(db=db, user=_user(), name="bad", files=files)
+        assert exc.value.status_code == 400
+        assert expected in exc.value.detail
+        assert _rows(db) == [], "nothing may be written when validation fails"
+        db.close()
+
+    def test_the_name_stays_free_after_a_refused_write(self, tmp_path):
+        """The failure the pre-commit check exists to prevent: a row that is
+        invisible to every name-keyed verb but still squats the name."""
+        db = _factory(tmp_path)()
+        with pytest.raises(HTTPException):
+            _write_personal_skill(
+                db=db, user=_user(), name="alpha", files={"SKILL.md": b"\xff\xfe"}
+            )
+        _write_personal_skill(
+            db=db, user=_user(), name="alpha", files={"SKILL.md": SKILL_MD}
+        )
+        assert _rows(db) == [(1, "alpha")]
+        db.close()
+
+    def test_validation_runs_on_the_normalized_bundle(self, tmp_path):
+        """Normalization rewrites paths, so the raw input and the bundle that
+        actually gets stored can parse differently.
+
+        ``/template.md`` is invisible to the parser as written -- it only
+        decodes the exact keys ``SKILL.md`` and ``template.md`` -- but
+        normalization strips the leading slash, and the stored bundle then has
+        a ``template.md`` the parser does decode and chokes on. Validating the
+        raw input would wave this through and commit a row reload cannot load,
+        which is the whole failure the pre-commit check exists to stop.
+        """
+        db = _factory(tmp_path)()
+        raw = {"SKILL.md": SKILL_MD, "/template.md": b"\xff\xfe"}
+
+        from xagent.skills.parser import SkillParser
+
+        SkillParser.parse_bundle(name="c", files=raw)  # premise: raw parses
+
+        with pytest.raises(HTTPException) as exc:
+            _write_personal_skill(db=db, user=_user(), name="alpha", files=raw)
+        assert exc.value.status_code == 400
+        assert _rows(db) == [], "the stored form is what must be judged"
+        db.close()
+
+    def test_archive_cruft_is_dropped_rather_than_validated(self, tmp_path):
+        """The other half of normalizing first: cruft never reaches the parser
+        and never reaches the table, so a stray .DS_Store cannot fail a write."""
+        db = _factory(tmp_path)()
+        _write_personal_skill(
+            db=db,
+            user=_user(),
+            name="alpha",
+            files={"SKILL.md": SKILL_MD, ".DS_Store": b"\x00\x01\xff"},
+        )
+        from xagent.web.models.skill import UserSkillFile
+
+        stored = sorted(f.path for f in db.query(UserSkillFile).all())
+        assert stored == ["SKILL.md"]
+        db.close()
+
+
+class TestAssertBundleParses:
+    """The validator tracks the parser rather than restating its rules."""
+
+    def test_a_good_bundle_passes(self):
+        _assert_bundle_parses({"SKILL.md": SKILL_MD})
+
+    def test_it_refuses_exactly_what_the_parser_refuses(self):
+        """The guarantee that makes a committed row trustworthy: reload skips
+        a record only when parse_bundle raises, so anything the validator lets
+        through must be something parse_bundle accepts."""
+        from xagent.skills.parser import SkillParser
+
+        cases = [
+            {"SKILL.md": SKILL_MD},
+            {"SKILL.md": b"---\nname: x\n---\n\n# X\n"},
+            {"SKILL.md": b"\xe9\xff\xfe"},
+            {"SKILL.md": SKILL_MD, "template.md": b"\xff\xfe"},
+            {"SKILL.md": b"---\n: : :\n---\n# X\n"},
+            {"SKILL.md": SKILL_MD, "logo.png": b"\x89PNG\r\n\x1a\n"},
+            {"other.md": b"x"},
+        ]
+        for files in cases:
+            try:
+                SkillParser.parse_bundle(name="candidate", files=files)
+                parser_ok = True
+            except Exception:
+                parser_ok = False
+            try:
+                _assert_bundle_parses(files)
+                validator_ok = True
+            except HTTPException:
+                validator_ok = False
+            assert parser_ok == validator_ok, files
+
+    def test_a_non_utf8_decoded_file_names_the_offending_file(self):
+        """parse_bundle decodes SKILL.md and template.md; the message has to
+        say which of them failed, since the exception itself does not."""
+        with pytest.raises(HTTPException) as exc:
+            _assert_bundle_parses({"SKILL.md": SKILL_MD, "template.md": b"\xff\xfe"})
+        assert "template.md" in exc.value.detail
+
+    def test_an_unexpected_parser_failure_keeps_its_5xx(self, monkeypatch):
+        """A service defect must not be presented to the caller as bad input.
+
+        The broad catch used to turn any exception into a 400, so a bug in the
+        parser looked like a malformed bundle and lost its 5xx signal. Nothing
+        has been written when this runs, so letting it propagate cannot leave
+        a partial write behind.
+        """
+        from xagent.skills import parser as parser_mod
+
+        def boom(*a, **k):
+            raise RuntimeError("a defect, not bad input")
+
+        monkeypatch.setattr(parser_mod.SkillParser, "parse_bundle", boom)
+        with pytest.raises(RuntimeError):
+            _assert_bundle_parses({"SKILL.md": SKILL_MD})
+
+    def test_a_missing_skill_md_is_a_400(self):
+        """The parser's own ValueError is genuine bad input and stays a 400."""
+        with pytest.raises(HTTPException) as exc:
+            _assert_bundle_parses({"other.md": b"x"})
+        assert exc.value.status_code == 400
+
+    def test_the_culprit_named_is_one_the_parser_actually_decodes(self):
+        """parse_bundle only decodes SKILL.md and template.md. Scanning every
+        file blamed a binary asset the parser never reads and hid the real
+        cause, sending the user to delete a perfectly good logo."""
+        with pytest.raises(HTTPException) as exc:
+            _assert_bundle_parses(
+                {
+                    "SKILL.md": SKILL_MD,
+                    "logo.png": b"\x89PNG\r\n\x1a\n\xff",
+                    "template.md": b"\xff\xfe",
+                }
+            )
+        assert "template.md" in exc.value.detail
+        assert "logo.png" not in exc.value.detail
+
+    def test_a_non_decoded_asset_is_not_rejected(self):
+        """parse_bundle only decodes SKILL.md and template.md, so a binary
+        asset is not a load failure and must not be refused. Validating more
+        than the parser does would reject bundles reload would happily serve."""
+        _assert_bundle_parses({"SKILL.md": SKILL_MD, "logo.png": b"\x89PNG\r\n\x1a\n"})
+
+
+# ── deletion addressing ──────────────────────────────────────────────────────
+
+
+class TestDeletePersonalSkill:
+    @pytest.mark.parametrize("target", ["alpha", "beta"], ids=["first", "second"])
+    def test_deleting_by_name_removes_exactly_that_row(self, tmp_path, target):
+        """Both positions are exercised on purpose. Deleting only the first
+        row happens to look right when the name filter is missing entirely --
+        the query would return row 1 either way -- so a same-owner wrong-row
+        delete would go unnoticed."""
+        db = _factory(tmp_path)()
+        for name in ("alpha", "beta"):
+            _write_personal_skill(
+                db=db, user=_user(), name=name, files={"SKILL.md": SKILL_MD}
+            )
+        _delete_personal_skill(db=db, user=_user(), name=target)
+        survivor = "beta" if target == "alpha" else "alpha"
+        assert [name for _, name in _rows(db)] == [survivor]
+        db.close()
+
+    def test_another_owners_skill_is_refused(self, tmp_path):
+        db = _factory(tmp_path, user_ids=(7, 8))()
+        _write_personal_skill(
+            db=db, user=_user(8), name="theirs", files={"SKILL.md": SKILL_MD}
+        )
+        with pytest.raises(HTTPException) as exc:
+            _delete_personal_skill(db=db, user=_user(7), name="theirs")
+        assert exc.value.status_code == 404
+        assert _rows(db) == [(1, "theirs")], "no cross-owner delete"
+        db.close()
+
+
+# ── the duplicate-name race ──────────────────────────────────────────────────
+
+
+class TestDuplicateNameRace:
+    """The pre-check SELECT and the INSERT are not atomic across sessions.
+
+    The interleaving that matters is: *both* attempts pass the pre-check, and
+    only then does either insert. Synchronising after the first flush cannot
+    produce it -- under SQLite the first flusher holds the write lock, so the
+    second attempt can fail before it ever reaches the barrier, and the test
+    then passes for a reason unrelated to what it claims. The barrier here sits
+    between the pre-check and the flush.
+    """
+
+    @staticmethod
+    def _run_race(factory, *, tags=("a", "b"), name="dup"):
+        precheck_done = threading.Barrier(len(tags), timeout=30)
+        results: dict[str, object] = {}
+        reached: set[str] = set()
+        lock = threading.Lock()
+
+        def attempt(tag: str) -> None:
+            db = factory()
+            original_query = db.query
+            synced = False
+
+            def query_then_sync(*args, **kwargs):
+                nonlocal synced
+                out = original_query(*args, **kwargs)
+                if synced:
+                    return out
+                synced = True
+
+                class _Synced:
+                    """Block after the pre-check SELECT has been evaluated.
+
+                    ``.first()`` is what runs the statement, so waiting inside
+                    it -- not at ``query()`` -- guarantees this attempt really
+                    saw an empty table before the other one inserts.
+                    """
+
+                    def filter(self, *a, **k):
+                        self._inner = out.filter(*a, **k)
+                        return self
+
+                    def first(self):
+                        row = self._inner.first()
+                        with lock:
+                            reached.add(tag)
+                        precheck_done.wait()
+                        return row
+
+                return _Synced()
+
+            db.query = query_then_sync  # type: ignore[method-assign]
+            try:
+                _write_personal_skill(
+                    db=db, user=_user(), name=name, files={"SKILL.md": SKILL_MD}
+                )
+                results[tag] = "committed"
+            except HTTPException as exc:
+                results[tag] = f"http-{exc.status_code}"
+            except BaseException as exc:
+                results[tag] = f"raised-{type(exc).__name__}: {exc}"
+            finally:
+                db.close()
+
+        threads = [threading.Thread(target=attempt, args=(t,)) for t in tags]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+        assert not any(t.is_alive() for t in threads), "a racing thread hung"
+        return results, reached
+
+    def test_both_prechecks_really_run_before_either_insert(self, tmp_path):
+        """The premise the outcome assertion rests on. If a writer could fail
+        before the barrier -- the flaw in the original test -- this fails."""
+        _, reached = self._run_race(_factory(tmp_path))
+        assert reached == {"a", "b"}, (
+            "both attempts must clear the pre-check before either inserts; "
+            f"only {sorted(reached)} got there"
+        )
+
+    def test_the_loser_gets_409_and_one_row_survives(self, tmp_path):
+        """Without the IntegrityError guard the loser leaks a 500."""
+        factory = _factory(tmp_path)
+        results, _ = self._run_race(factory)
+        assert sorted(results.values()) == ["committed", "http-409"], results
+
+        db = factory()
+        assert _rows(db) == [(1, "dup")]
+        from xagent.web.models.skill import UserSkillFile
+
+        assert db.query(UserSkillFile).count() == 1, "no orphaned file rows"
+        db.close()
+
+    def test_an_unrelated_integrity_error_is_not_reported_as_a_duplicate(
+        self, tmp_path
+    ):
+        """The guard must not swallow every IntegrityError. A foreign-key
+        violation is a bug, not a name conflict, and has to stay loud.
+
+        Raised by the real INSERT against a real constraint, not by a
+        monkeypatched ``flush``: patching flush makes the *pre-check query's*
+        autoflush raise, so the error never reaches the guard at all and the
+        test passes whatever the guard does.
+        """
+        from sqlalchemy import text
+        from sqlalchemy.exc import IntegrityError
+
+        db = _factory(tmp_path)()
+        db.execute(text("PRAGMA foreign_keys=ON"))
+        with pytest.raises(IntegrityError) as exc:
+            _write_personal_skill(
+                db=db, user=_user(9999), name="orphan", files={"SKILL.md": SKILL_MD}
+            )
+        assert "foreign key" in str(exc.value).lower(), str(exc.value)
+        db.close()
+
+    def test_the_guard_only_recognises_the_skill_name_constraint(self):
+        from sqlalchemy.exc import IntegrityError
+
+        from xagent.web.api.skill_hub import _is_skill_name_unique_violation
+
+        def err(message):
+            return IntegrityError("INSERT", {}, Exception(message))
+
+        assert _is_skill_name_unique_violation(err("uq_user_skill_name violated"))
+        assert _is_skill_name_unique_violation(
+            err("UNIQUE constraint failed: user_skills.user_id, user_skills.name")
+        )
+        assert not _is_skill_name_unique_violation(err("FOREIGN KEY constraint failed"))
+        assert not _is_skill_name_unique_violation(
+            err(
+                "UNIQUE constraint failed: user_skill_files.skill_id, "
+                "user_skill_files.path"
+            )
+        ), "the per-file constraint is a different failure"
+        assert not _is_skill_name_unique_violation(
+            err("NOT NULL constraint failed: user_skills.name")
+        )
+
+
+# ── route behaviour ──────────────────────────────────────────────────────────
+
+
+def _install_manager(monkeypatch, loader):
+    class _Manager:
+        async def get_skill(self, name):
+            return loader(name)
+
+    async def _scoped(*args):
+        return _Manager()
+
+    monkeypatch.setattr(skill_hub, "_get_scoped_manager", _scoped)
+
+
+async def _create(db, name="alpha", user_id=7):
+    return await skill_hub.create_skill(
+        skill_hub.CreateSkillRequest(
+            name=name, skill_md=SKILL_MD.decode(), scope="personal"
+        ),
+        SimpleNamespace(),
+        SkillScopeContext(user_id=user_id, metadata={}),
+        db,
+        SimpleNamespace(id=user_id),
+    )
+
+
+class TestCreateAcceptsAnyCompliantProvider:
+    """A committed row is never removed on the strength of how a provider
+    chose to represent it.
+
+    ``SkillRecord.path`` is ``str | None`` and provider-defined, and
+    ``_all_file_names`` exists so a provider may list an asset without
+    eagerly loading its bytes. A custom provider replaces the default one
+    wholesale, so inferring "is this row mine?" from the default's display
+    path or from an in-memory bundle would reject a valid readback -- and,
+    under a compensating design, delete the skill the user just created.
+    """
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "record",
+        [
+            SkillRecord(
+                name="alpha",
+                source="personal",
+                scope="personal",
+                files={"SKILL.md": SKILL_MD},
+                path="saas://skills/alpha",
+            ),
+            SkillRecord(
+                name="alpha",
+                source="personal",
+                scope="personal",
+                files={"SKILL.md": SKILL_MD},
+            ),
+            SkillRecord(
+                name="alpha",
+                source="personal",
+                scope="personal",
+                files={"SKILL.md": SKILL_MD},
+                path="db://personal/1",
+                _all_file_names=["SKILL.md", "logo.png"],
+            ),
+        ],
+        ids=["provider-owned-path", "no-path", "lazy-assets"],
+    )
+    async def test_the_write_survives_and_is_returned(
+        self, monkeypatch, tmp_path, record
+    ):
+        db = _factory(tmp_path)()
+        _install_manager(
+            monkeypatch,
+            lambda name: {
+                "name": name,
+                "scope": record.scope,
+                "source": record.source,
+                "path": record.path,
+                "_record": record,
+            },
+        )
+        summary = await _create(db)
+        assert summary.name == "alpha"
+        assert _rows(db) == [(1, "alpha")], "a valid write is never removed"
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_an_invisible_skill_still_reports_success(
+        self, monkeypatch, tmp_path
+    ):
+        """The write is durable and was parsed before it landed, so the
+        request succeeded and only the read side is behind.
+
+        Answering 5xx here was guidance the client could not act on: a replay
+        re-enters the (user, name) pre-check and gets a deterministic 409, and
+        generic 5xx retry logic would replay a non-idempotent create.
+        """
+        db = _factory(tmp_path)()
+        _install_manager(monkeypatch, lambda name: None)
+
+        summary = await _create(db)
+
+        assert summary.name == "alpha"
+        assert summary.source == "user"
+        assert summary.description == "A test skill.", (
+            "the summary comes from the bytes that were validated"
+        )
+        assert _rows(db) == [(1, "alpha")]
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_a_second_create_after_an_invisible_one_still_conflicts(
+        self, monkeypatch, tmp_path
+    ):
+        """The 409 that made 'retry' bad advice is still correct behaviour --
+        the point is that the first call no longer asks for the retry."""
+        db = _factory(tmp_path)()
+        _install_manager(monkeypatch, lambda name: None)
+        await _create(db)
+        with pytest.raises(HTTPException) as exc:
+            await _create(db)
+        assert exc.value.status_code == 409
+        assert _rows(db) == [(1, "alpha")]
+        db.close()
+
+    async def test_a_cancelled_readback_leaves_the_row_intact(
+        self, monkeypatch, tmp_path
+    ):
+        """Nothing to compensate: the row is valid whether or not the client
+        is still listening, so a disconnect cannot cost the user their skill."""
+        db = _factory(tmp_path)()
+
+        async def explode(*args, **kwargs):
+            raise asyncio.CancelledError()
+
+        monkeypatch.setattr(skill_hub, "_get_scoped_manager", explode)
+        with pytest.raises(asyncio.CancelledError):
+            await _create(db)
+        assert _rows(db) == [(1, "alpha")]
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_a_bad_bundle_is_refused_before_any_row_exists(
+        self, monkeypatch, tmp_path
+    ):
+        """``/create`` always sends valid UTF-8, so drive the refusal through
+        the writer the way an upload or an install would reach it."""
+        db = _factory(tmp_path)()
+        _install_manager(monkeypatch, lambda name: None)
+        with pytest.raises(HTTPException) as exc:
+            _write_personal_skill(
+                db=db,
+                user=_user(),
+                name="alpha",
+                files={"SKILL.md": SKILL_MD, "template.md": b"\xff\xfe"},
+            )
+        assert exc.value.status_code == 400
+        assert _rows(db) == []
+
+        # And the name is still free afterwards.
+        _install_manager(
+            monkeypatch,
+            lambda name: {"name": name, "scope": "personal", "path": "db://personal/1"},
+        )
+        await _create(db)
+        assert _rows(db) == [(1, "alpha")]
+        db.close()
+
+
+class TestDeleteKeepsProviderNamespaces:
+    """``/installed/{name}`` resolves every name through the manager.
+
+    ``:`` is not reserved by the provider contracts and the team create path
+    does not run ``_validate_skill_name``, so a provider may own a record
+    genuinely named ``id:42``. An earlier revision parsed that prefix as a row
+    id and deleted the caller's unrelated personal row 42 instead; there is no
+    such prefix now, and no route addresses a personal row by primary key.
+    """
+
+    @pytest.mark.asyncio
+    async def test_a_provider_skill_named_like_a_row_id_goes_to_the_provider(
+        self, monkeypatch, tmp_path
+    ):
+        db = _factory(tmp_path)()
+        _write_personal_skill(
+            db=db, user=_user(), name="my-important-skill", files={"SKILL.md": SKILL_MD}
+        )
+        row_id = _rows(db)[0][0]
+
+        _install_manager(
+            monkeypatch,
+            lambda name: {
+                "name": name,
+                "scope": "team",
+                "source": "team",
+                "path": f"team://{name}",
+            },
+        )
+        seen: list[tuple] = []
+
+        async def _spy(_provider, method, _ctx, **kwargs):
+            seen.append((method, kwargs.get("name")))
+
+        monkeypatch.setattr(skill_hub, "invoke_skill_write_provider", _spy)
+
+        await skill_hub.delete_installed(
+            f"id:{row_id}",
+            SimpleNamespace(),
+            SkillScopeContext(user_id=7, metadata={}),
+            db,
+            _user(),
+        )
+        assert seen == [("delete_skill", f"id:{row_id}")], (
+            "the name must reach the provider that owns it"
+        )
+        assert _rows(db) == [(row_id, "my-important-skill")], (
+            "the caller's unrelated personal row must survive"
+        )
+        db.close()
+
+    def test_no_route_addresses_a_personal_row_by_primary_key(self):
+        """A numeric primary key is not a safe public recovery identity: the
+        column has no AUTOINCREMENT, so SQLite hands a deleted row's id to the
+        next insert, and a client retrying a lost 204 would delete whatever
+        took its place. Recovery for rows the manager cannot load is tracked
+        separately rather than shipped with that hazard.
+        """
+        from xagent.web.api.skill_hub import router
+
+        paths = [
+            r.path for r in router.routes if "DELETE" in getattr(r, "methods", set())
+        ]
+        assert paths == ["/api/skill-hub/installed/{name}"], paths
+
+    @pytest.mark.asyncio
+    async def test_a_row_the_manager_cannot_load_is_reported_missing(
+        self, monkeypatch, tmp_path
+    ):
+        """Documents the limitation this PR leaves open: such a row is
+        unreachable by name. It is a stuck row, not a deleted one."""
+        db = _factory(tmp_path)()
+        _write_personal_skill(
+            db=db, user=_user(), name="broken", files={"SKILL.md": SKILL_MD}
+        )
+        _install_manager(monkeypatch, lambda name: None)
+        with pytest.raises(HTTPException) as exc:
+            await skill_hub.delete_installed(
+                "broken",
+                SimpleNamespace(),
+                SkillScopeContext(user_id=7, metadata={}),
+                db,
+                _user(),
+            )
+        assert exc.value.status_code == 404
+        assert _rows(db) == [(1, "broken")], "the row is stuck, not lost"
+        db.close()


### PR DESCRIPTION
Part 2 of #1889 (splitting #1854), addressing #1891.

**Scope.** No route is added or removed — the route table is identical to `main`. What changes is the behaviour of the existing `/create`, `/install/{source}` and `DELETE /installed/{name}` routes, which do consume this work; the earlier "no production caller" wording was wrong and is retracted. The upload endpoint remains a later part.

## The change

Personal-skill writes are validated **before** they commit. `_assert_bundle_parses` runs the same `SkillParser.parse_bundle` that `SkillManager.reload` runs, over the same normalized bytes, before the INSERT. `reload` skips a record only when that call raises, so this matches its failure surface by construction rather than by restating the parser's rules. A committed row is therefore one the skill machinery can read, nothing has to be undone afterwards, and no code path deletes a row on behalf of a failed write.

That surface is narrow and the code says so rather than overreaching: a missing `SKILL.md`, and non-UTF-8 bytes in `SKILL.md` or `template.md`, the only two files `parse_bundle` decodes. Malformed frontmatter is deliberately *not* refused — `_extract_frontmatter` swallows YAML errors, so such a bundle loads fine, and checking more than the parser does would reject bundles `reload` would serve.

**A committed write is authoritative.** When the manager cannot serve the row back, the route re-parses the bytes it just validated and answers 200 through `_skill_to_summary`, logging a warning. Answering 5xx was guidance no client could act on: a replay re-enters the `(user_id, name)` pre-check and gets a deterministic 409, and generic 5xx retry logic would replay a non-idempotent create. Provider-owned scopes keep the 500, since nothing here validated their write.

**Client-visible note.** Because a committed personal write now answers 200 even when the library cannot serve the row back yet, a client that navigates straight to the detail page can land on a page that does not load until the library catches up. The window is narrow (a concurrent delete of the same name, or a transient DB error swallowed by reload), and the alternative is worse: a 5xx here invites a replay that can only return 409, leaving the user believing a successful create failed.

**No personal row is addressable by primary key.** A numeric id is not a safe public recovery identity: the column has no `AUTOINCREMENT`, so a client retrying a lost delete removes whatever reused the id.

## Findings from review

Every one was reproduced before being changed, and each reproduction re-run afterwards.

Round 2 (all four confirmed fixed by the reviewer): compensation deleting by a reusable row id; the identity check hard-coding the default provider's representation; compensation outcomes collapsed into one boolean; and `id:` stealing the provider namespace.

Round 3:

- **N1 / N3 / N5 — the `by-id` recovery route is removed.** A stale retry after SQLite id reuse deleted an unrelated replacement (reproduced). It was also unreachable in practice: it recovers rows `SkillManager` omits, and no client can obtain their id — my tests reached it through private database helpers. Removing it retires the unbounded path parameter with it. **Known gap:** a row the manager cannot load is now stuck rather than recoverable. A test documents it as stuck-not-lost, and a reachable identity needs a stable non-reused token plus a migration, which is follow-up work rather than something to ship with the id-reuse hazard — tracked in #1911.
- **N2 / N6 — commit success is authoritative and the diagnostics are scope-aware.** Reproduced: first call 500 saying "retry", replay 409, row durable throughout. The shared message also claimed a validation team scopes never receive; both are gone.
- **N4 — the UTF-8 culprit scan walks only the files the parser decodes.** Reproduced: a good `SKILL.md`, a good binary `logo.png` and a bad `template.md` blamed `logo.png`, sending the user to delete a file the parser accepts.
- **N7 — an unexpected parser failure keeps its 5xx.** The broad catch presented service defects as invalid input, and my own test had pinned that misclassification. Only the parser's `ValueError` is a 400 now; nothing is written at that point, so the rest can propagate safely.

## Verification

Every guard is mutation-tested: 10 mutants, all caught. Three survivors across the rounds drove changes rather than being waved through — validating raw input (distinguished only by `/template.md`, since the earlier case used a `.DS_Store` both orderings drop); narrowing the validator's catch (an equivalent mutant, so the defensive contract is pinned with a patched parser); and dropping the delete's name filter (which only shows up when the *second* row is the target).

`tests/skills/` passes; ruff, ruff format, isort, codespell and mypy are clean on the changed files.

## Acceptance

Two concurrent write attempts for the same `(user, name)`: the loser gets 409, and neither can cause the other's row to be deleted — because no failure path deletes a row at all.
