### PR TITLE
fix(mcp): don't 409 a builtin connector reconnect over a stale args-only diff

### DIFF
--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -2793,16 +2793,52 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
         # Safe only because command/transport already proved this is the
         # official row, not a hijack, and the owned-check above proved it
         # isn't a user's own row.
-        current_args = launch.get("args") or []
+        #
+        # `or []` would also launder a malformed-but-falsy launch_config.args
+        # (a custom app's launch_config is admin-editable with no shape
+        # check) -- {}, 0, and False -- into a validation-passing empty
+        # list, silently wiping a row's real args. Only a genuinely absent
+        # value means "no args".
+        raw_args = launch.get("args")
+        current_args = raw_args if raw_args is not None else []
         if (server.args or []) != current_args:
-            # Validated the same way a fresh row would be (existing_server
-            # omitted deliberately: catalog args/env/cwd fully replace
-            # whatever this row had, not merge with it) rather than
-            # raw-assigning launch_config.args -- a custom (non-builtin)
-            # catalog app's launch_config is admin-editable with no shape
-            # check on args, so an unvalidated assignment could persist a
-            # non-list-of-strings value the MCP SDK later rejects at
-            # session-init time instead of at this request.
+            # This row is ownerless (the check above only rejects a
+            # *currently* owned row), which is also the normal, expected
+            # state of every legitimately catalog-connected row -- connect
+            # never marks an association is_owner=True. So ownerless alone
+            # can't distinguish "the official row, just pre-dating a
+            # registry args bump" (safe to heal) from "a pre-catalog
+            # orphan" (a user created a custom server under this name
+            # before the catalog app existed, matching today's command/
+            # transport, then was deleted, leaving policy we have no way to
+            # safely canonicalize here) or from "a real admin-configured
+            # platform key" (_app_platform_env_available reads MCPServer.env
+            # directly -- healing must never destroy it). Only heal a row
+            # that carries no other configured policy beyond command/
+            # transport/args; otherwise fall through to the same 409 every
+            # such row already got before this change, leaving it and
+            # whatever it holds untouched for an operator to resolve.
+            if (
+                any(
+                    getattr(server, field, None)
+                    for field in (
+                        "env",
+                        "cwd",
+                        "concurrent_tools",
+                        "runtime_input_schema",
+                        "runtime_bindings",
+                    )
+                )
+                or server.concurrency_safe
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_409_CONFLICT,
+                    detail="A server with this name already exists with a different configuration",
+                )
+            # Validated the same way a fresh row would be, rather than
+            # raw-assigning launch_config.args -- an unvalidated assignment
+            # could persist a non-list-of-strings value the MCP SDK later
+            # rejects at session-init time instead of at this request.
             try:
                 healed_config = _build_server_config(
                     MCPServerCreate(
@@ -2818,21 +2854,6 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
                     detail=f"Invalid app configuration: {str(e)}",
                 )
             cast(Any, server).args = healed_config.args or []
-            # Also reset env/cwd to the catalog's shape (empty, for every
-            # keyless/api_key app today) rather than leaving this row's own
-            # values untouched: this row can be a pre-catalog orphan (a user
-            # created a custom server under this name before the catalog
-            # app existed, matching today's command/transport, then was
-            # deleted -- _reject_user_owned_catalog_squat only rejects a
-            # *currently* owned row, not a since-orphaned one). Healing only
-            # args would let that orphan's own env/cwd survive adoption, and
-            # to_connection_dict() applies a row's env to every user's
-            # connection through it -- a former user's own key could become
-            # every other user's fallback credential.
-            cast(Any, server).env = healed_config.env
-            cast(Any, server).cwd = (
-                str(healed_config.cwd) if healed_config.cwd is not None else None
-            )
             db.commit()
     if not server:
         try:

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -1234,33 +1234,45 @@ def _validate_mcp_runtime_config(
     )
 
 
+# Every MCPServer field a generic server update/create request can set.
+# name==value on both sides (config attribute name equals the DB column
+# name for all of these) -- kept as a single source both
+# _update_server_from_config and _server_has_policy_beyond_catalog_identity
+# read, rather than each hand-listing its own subset: an earlier fix round
+# hand-picked env/cwd/concurrent_tools/runtime_input_schema/
+# runtime_bindings/concurrency_safe for the latter and missed docker_*,
+# auth, headers, timeout, volumes, bind_ports, managed, and restart_policy
+# entirely, letting a row carrying any of those alone slip past that gate.
+_MCP_SERVER_CONFIGURABLE_FIELDS = (
+    "name",
+    "description",
+    "transport",
+    "managed",
+    "command",
+    "args",
+    "url",
+    "env",
+    "cwd",
+    "headers",
+    "timeout",
+    "auth",
+    "concurrency_safe",
+    "concurrent_tools",
+    "docker_url",
+    "docker_image",
+    "docker_environment",
+    "docker_working_dir",
+    "volumes",
+    "bind_ports",
+    "restart_policy",
+    "auto_start",
+)
+
+
 def _update_server_from_config(server: MCPServer, config: MCPServerConfig) -> None:
     """Update database server object from MCPServerConfig."""
     # Map config fields to database fields
-    field_mapping = {
-        "name": "name",
-        "description": "description",
-        "transport": "transport",
-        "managed": "managed",
-        "command": "command",
-        "args": "args",
-        "url": "url",
-        "env": "env",
-        "cwd": "cwd",
-        "headers": "headers",
-        "timeout": "timeout",
-        "auth": "auth",
-        "concurrency_safe": "concurrency_safe",
-        "concurrent_tools": "concurrent_tools",
-        "docker_url": "docker_url",
-        "docker_image": "docker_image",
-        "docker_environment": "docker_environment",
-        "docker_working_dir": "docker_working_dir",
-        "volumes": "volumes",
-        "bind_ports": "bind_ports",
-        "restart_policy": "restart_policy",
-        "auto_start": "auto_start",
-    }
+    field_mapping = {field: field for field in _MCP_SERVER_CONFIGURABLE_FIELDS}
 
     for config_field, db_field in field_mapping.items():
         if hasattr(config, config_field) and hasattr(server, db_field):
@@ -2673,6 +2685,49 @@ def _reject_user_owned_catalog_squat(db: Session, server: MCPServer) -> None:
         )
 
 
+def _server_has_policy_beyond_catalog_identity(server: MCPServer) -> bool:
+    """Whether `server` carries any configured field beyond what a fresh
+    catalog-created row would have (name/transport/command already proved
+    as the identity; args is what the caller is about to heal).
+
+    Used to decide whether an existing row under a catalog app_id is safe
+    to heal in place: "no current owner" can't make that call by itself
+    (see _ensure_catalog_app_server) since it's the normal state of every
+    legitimate catalog row too, not just an orphan's. Checking every OTHER
+    configurable field is the fallback signal -- a row healing would
+    otherwise touch could hold a real admin-configured value (e.g.
+    MCPServer.env as a platform-global key, read directly by
+    _app_platform_env_available) or a pre-catalog orphan's own policy;
+    either way, healing must refuse rather than guess.
+
+    Walks _MCP_SERVER_CONFIGURABLE_FIELDS (the same list
+    _update_server_from_config uses) rather than a hand-picked subset --
+    an earlier fix round hand-picked env/cwd/concurrent_tools/
+    runtime_input_schema/runtime_bindings/concurrency_safe here and missed
+    docker_*, auth, headers, timeout, volumes, bind_ports, managed, and
+    restart_policy, letting a row carrying any of those alone slip past.
+    """
+    if server.managed != "external":
+        return True
+    if str(server.restart_policy or "no") != "no":
+        return True
+    if any(
+        getattr(server, field, None)
+        for field in (
+            "runtime_input_schema",
+            "runtime_bindings",
+        )
+    ):
+        return True
+    identity_fields = {"name", "description", "transport", "command", "args"}
+    already_checked = identity_fields | {"managed", "restart_policy"}
+    return any(
+        getattr(server, field, None)
+        for field in _MCP_SERVER_CONFIGURABLE_FIELDS
+        if field not in already_checked
+    )
+
+
 def _add_catalog_server_with_race_recovery(
     db: Session, config: Any, server_name: str
 ) -> MCPServer:
@@ -2818,19 +2873,7 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
             # transport/args; otherwise fall through to the same 409 every
             # such row already got before this change, leaving it and
             # whatever it holds untouched for an operator to resolve.
-            if (
-                any(
-                    getattr(server, field, None)
-                    for field in (
-                        "env",
-                        "cwd",
-                        "concurrent_tools",
-                        "runtime_input_schema",
-                        "runtime_bindings",
-                    )
-                )
-                or server.concurrency_safe
-            ):
+            if _server_has_policy_beyond_catalog_identity(server):
                 raise HTTPException(
                     status_code=status.HTTP_409_CONFLICT,
                     detail="A server with this name already exists with a different configuration",

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -2795,7 +2795,44 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
         # isn't a user's own row.
         current_args = launch.get("args") or []
         if (server.args or []) != current_args:
-            cast(Any, server).args = current_args
+            # Validated the same way a fresh row would be (existing_server
+            # omitted deliberately: catalog args/env/cwd fully replace
+            # whatever this row had, not merge with it) rather than
+            # raw-assigning launch_config.args -- a custom (non-builtin)
+            # catalog app's launch_config is admin-editable with no shape
+            # check on args, so an unvalidated assignment could persist a
+            # non-list-of-strings value the MCP SDK later rejects at
+            # session-init time instead of at this request.
+            try:
+                healed_config = _build_server_config(
+                    MCPServerCreate(
+                        name=server_name,
+                        transport="stdio",
+                        description=app_info.get("description"),
+                        config={"command": command, "args": current_args},
+                    )
+                )
+            except ValueError as e:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Invalid app configuration: {str(e)}",
+                )
+            cast(Any, server).args = healed_config.args or []
+            # Also reset env/cwd to the catalog's shape (empty, for every
+            # keyless/api_key app today) rather than leaving this row's own
+            # values untouched: this row can be a pre-catalog orphan (a user
+            # created a custom server under this name before the catalog
+            # app existed, matching today's command/transport, then was
+            # deleted -- _reject_user_owned_catalog_squat only rejects a
+            # *currently* owned row, not a since-orphaned one). Healing only
+            # args would let that orphan's own env/cwd survive adoption, and
+            # to_connection_dict() applies a row's env to every user's
+            # connection through it -- a former user's own key could become
+            # every other user's fallback credential.
+            cast(Any, server).env = healed_config.env
+            cast(Any, server).cwd = (
+                str(healed_config.cwd) if healed_config.cwd is not None else None
+            )
             db.commit()
     if not server:
         try:

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -2775,19 +2775,28 @@ def _ensure_catalog_app_server(db: Session, app_id: str) -> tuple[MCPServer, dic
     server = db.query(MCPServer).filter(MCPServer.name == server_name).first()
     # Server names are a single global namespace. A row under this catalog id may
     # be a hijack — a custom server someone created with their own command — so
-    # only reuse it if it matches the official launch config. Otherwise a victim
-    # would run a foreign command with their own key attached.
+    # only reuse it if the command/transport match the official launch config.
+    # Otherwise a victim would run a foreign command with their own key attached.
     if server:
-        if (
-            server.command != command
-            or (server.args or []) != (launch.get("args") or [])
-            or str(server.transport or "").lower() != "stdio"
-        ):
+        if server.command != command or str(server.transport or "").lower() != "stdio":
             raise HTTPException(
                 status_code=status.HTTP_409_CONFLICT,
                 detail="A server with this name already exists with a different configuration",
             )
         _reject_user_owned_catalog_squat(db, server)
+        # Unlike command/transport, args is not an identity check: the
+        # catalog stays the source of truth for it (mirroring how
+        # _ensure_catalog_mcp_oauth_server treats its "auth" config below),
+        # so a shared row created before a legitimate registry args change
+        # (a version bump, a new flag) is healed here instead of 409ing
+        # every connect attempt until an operator manually intervenes.
+        # Safe only because command/transport already proved this is the
+        # official row, not a hijack, and the owned-check above proved it
+        # isn't a user's own row.
+        current_args = launch.get("args") or []
+        if (server.args or []) != current_args:
+            cast(Any, server).args = current_args
+            db.commit()
     if not server:
         try:
             config = _build_server_config(

--- a/tests/web/api/test_mcp_apps_connect.py
+++ b/tests/web/api/test_mcp_apps_connect.py
@@ -6,6 +6,8 @@ with their own per-user env (their key). See PR #750 for the per-user env layer
 this builds on.
 """
 
+from typing import Any
+
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -680,6 +682,41 @@ def test_connect_heal_refuses_row_with_platform_env_configured(test_db):
     assert untouched.env == {"GOOGLE_MAPS_API_KEY": "encrypted-platform-key"}
 
 
+def test_connect_succeeds_on_already_healthy_platform_row_with_matching_args(
+    test_db,
+):
+    """The refuse-to-heal gate must only fire when there's actually
+    something to heal -- a row whose args already match the catalog (no
+    drift at all) must connect successfully regardless of what else it
+    has configured, since nothing about it needs touching. This is the
+    normal, everyday case for any already-working platform-configured
+    catalog app and must never regress into a spurious 409."""
+    from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
+
+    test_db.add(
+        MCPServer(
+            name="google-maps",
+            managed="external",
+            transport="stdio",
+            command="npx",
+            args=["-y", "@cablate/mcp-google-map", "--stdio"],  # already matches
+            env={"GOOGLE_MAPS_API_KEY": "encrypted-platform-key"},
+        )
+    )
+    test_db.commit()
+
+    connect_mcp_app(
+        "google-maps",
+        MCPAppConnectRequest(),
+        current_user=_user(test_db, 1),
+        db=test_db,
+    )
+
+    server = test_db.query(MCPServer).filter(MCPServer.name == "google-maps").first()
+    assert server.args == ["-y", "@cablate/mcp-google-map", "--stdio"]
+    assert server.env == {"GOOGLE_MAPS_API_KEY": "encrypted-platform-key"}
+
+
 def test_connect_heal_rejects_falsy_malformed_args_instead_of_wiping(test_db):
     """launch_config.args of {}, 0, or False must not be laundered into a
     validation-passing empty list by an `or []` fallback -- that would
@@ -711,6 +748,7 @@ def test_connect_heal_rejects_falsy_malformed_args_instead_of_wiping(test_db):
     )
     test_db.commit()
 
+    falsy_malformed_args: Any
     for falsy_malformed_args in ({}, 0, False):
         app = (
             test_db.query(PublicMCPApp)
@@ -735,6 +773,94 @@ def test_connect_heal_rejects_falsy_malformed_args_instead_of_wiping(test_db):
             .first()
         )
         assert untouched.args == ["-y", "totally-custom-mcp"]
+
+
+def test_connect_heal_refuses_row_with_policy_fields_the_gate_previously_missed(
+    test_db,
+):
+    """The refuse-to-heal gate must cover every configurable MCPServer
+    field, not a hand-picked subset. An earlier version of this gate only
+    checked env/cwd/concurrent_tools/runtime_input_schema/
+    runtime_bindings/concurrency_safe -- a row carrying real policy in any
+    OTHER configurable field (docker_image, auth, headers, timeout,
+    volumes, bind_ports, a non-default managed/restart_policy, ...) would
+    have slipped past that gate and gotten silently healed/adopted, which
+    is worse than this PR's own baseline (pre-heal, any args mismatch
+    always 409'd regardless of what else was configured)."""
+    from fastapi import HTTPException
+
+    from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
+
+    test_db.add(
+        MCPServer(
+            name="google-maps",
+            managed="internal",  # non-default managed alone should refuse healing
+            transport="stdio",
+            command="npx",
+            args=["-y", "@cablate/mcp-google-map"],  # stale, would trigger healing
+            docker_image="attacker/evil-image:latest",
+            docker_url="tcp://attacker-controlled-host:2375",
+            volumes=["/:/host-root"],
+            bind_ports={"8080": "8080"},
+            auth={"type": "bearer", "token": "leftover-or-attacker-token"},
+            headers={"X-Injected": "true"},
+            timeout=1,
+        )
+    )
+    test_db.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        connect_mcp_app(
+            "google-maps",
+            MCPAppConnectRequest(env={"GOOGLE_MAPS_API_KEY": "my-key"}),
+            current_user=_user(test_db, 1),
+            db=test_db,
+        )
+    assert exc.value.status_code == 409
+
+    untouched = test_db.query(MCPServer).filter(MCPServer.name == "google-maps").first()
+    assert untouched.args == ["-y", "@cablate/mcp-google-map"]
+    assert untouched.docker_image == "attacker/evil-image:latest"
+    assert untouched.docker_url == "tcp://attacker-controlled-host:2375"
+    assert untouched.volumes == ["/:/host-root"]
+    assert untouched.bind_ports == {"8080": "8080"}
+    assert untouched.auth == {"type": "bearer", "token": "leftover-or-attacker-token"}
+    assert untouched.headers == {"X-Injected": "true"}
+    assert untouched.timeout == 1
+
+
+def test_connect_heal_refuses_row_with_non_default_restart_policy(test_db):
+    """restart_policy is non-nullable with a "no" default, so it can't join
+    a plain truthiness check the way the other gated fields do -- it must
+    be compared against its actual default, not just checked for None."""
+    from fastapi import HTTPException
+
+    from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
+
+    test_db.add(
+        MCPServer(
+            name="google-maps",
+            managed="external",
+            transport="stdio",
+            command="npx",
+            args=["-y", "@cablate/mcp-google-map"],  # stale, would trigger healing
+            restart_policy="always",
+        )
+    )
+    test_db.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        connect_mcp_app(
+            "google-maps",
+            MCPAppConnectRequest(env={"GOOGLE_MAPS_API_KEY": "my-key"}),
+            current_user=_user(test_db, 1),
+            db=test_db,
+        )
+    assert exc.value.status_code == 409
+
+    untouched = test_db.query(MCPServer).filter(MCPServer.name == "google-maps").first()
+    assert untouched.args == ["-y", "@cablate/mcp-google-map"]
+    assert untouched.restart_policy == "always"
 
 
 def test_connect_rejects_malformed_catalog_args_instead_of_persisting(test_db):

--- a/tests/web/api/test_mcp_apps_connect.py
+++ b/tests/web/api/test_mcp_apps_connect.py
@@ -596,6 +596,101 @@ def test_connect_heals_stale_args_on_matching_command(test_db):
     assert healed.args == ["-y", "@cablate/mcp-google-map", "--stdio"]
 
 
+def test_connect_heal_resets_orphan_rows_env_and_cwd(test_db):
+    """Healing args must not leave a row's own env/cwd untouched: a row with
+    today's command/transport but no *current* owner can be a pre-catalog
+    orphan (a user created a custom server under this name before the
+    catalog app existed, then was deleted -- deleting a user drops their
+    UserMCPServer association, not the shared MCPServer row). Adopting it
+    without clearing env/cwd would apply that orphan's own values to every
+    future user's connection via MCPServer.to_connection_dict()."""
+    from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
+
+    test_db.add(
+        MCPServer(
+            name="google-maps",
+            managed="external",
+            transport="stdio",
+            command="npx",
+            args=["-y", "@cablate/mcp-google-map"],  # stale, triggers healing
+            env={"LEFTOVER_SECRET": "attacker-or-former-users-value"},
+            cwd="/some/orphaned/path",
+        )
+    )
+    test_db.commit()
+
+    connect_mcp_app(
+        "google-maps",
+        MCPAppConnectRequest(env={"GOOGLE_MAPS_API_KEY": "my-key"}),
+        current_user=_user(test_db, 1),
+        db=test_db,
+    )
+
+    healed = test_db.query(MCPServer).filter(MCPServer.name == "google-maps").first()
+    assert healed.args == ["-y", "@cablate/mcp-google-map", "--stdio"]
+    assert healed.env is None
+    assert healed.cwd is None
+
+
+def test_connect_rejects_malformed_catalog_args_instead_of_persisting(test_db):
+    """A custom (non-builtin) catalog app's launch_config is admin-editable
+    with no shape check on args (PublicMCPAppUpdate.launch_config is a plain
+    Dict[str, Any]) -- unlike a builtin app_id (e.g. "google-maps" is itself
+    a real registry entry, so a DB-row edit to it would just be overlaid
+    away by _app_to_dict and never reach this code path at all). Healing
+    must validate args the same way a fresh row would be, not raw-assign
+    whatever the catalog currently holds -- an admin PATCH that corrupts a
+    genuinely custom app's args into something other than list[str] must
+    surface as a 400 on the next connect, not get silently persisted onto
+    the shared row for the MCP SDK to reject later at session-init time."""
+    from fastapi import HTTPException
+
+    from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
+
+    test_db.add(
+        PublicMCPApp(
+            app_id="totally-custom-app",
+            name="Totally Custom App",
+            description="A hand-created, non-builtin catalog app",
+            transport="stdio",
+            is_visible_in_connector=True,
+            launch_config={"command": "npx", "args": ["-y", "totally-custom-mcp"]},
+        )
+    )
+    test_db.add(
+        MCPServer(
+            name="totally-custom-app",
+            managed="external",
+            transport="stdio",
+            command="npx",
+            args=["-y", "totally-custom-mcp"],
+        )
+    )
+    test_db.commit()
+
+    app = (
+        test_db.query(PublicMCPApp)
+        .filter(PublicMCPApp.app_id == "totally-custom-app")
+        .first()
+    )
+    app.launch_config = {"command": "npx", "args": {"unexpected": "object"}}
+    test_db.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        connect_mcp_app(
+            "totally-custom-app",
+            MCPAppConnectRequest(),
+            current_user=_user(test_db, 1),
+            db=test_db,
+        )
+    assert exc.value.status_code == 400
+
+    untouched = (
+        test_db.query(MCPServer).filter(MCPServer.name == "totally-custom-app").first()
+    )
+    assert untouched.args == ["-y", "totally-custom-mcp"]
+
+
 @pytest.mark.parametrize("name", ["google-maps", "Google-Maps", "google maps"])
 def test_create_server_rejects_catalog_app_id(test_db, name):
     """Custom servers can't squat a catalog app id (the hijack precondition),

--- a/tests/web/api/test_mcp_apps_connect.py
+++ b/tests/web/api/test_mcp_apps_connect.py
@@ -597,13 +597,22 @@ def test_connect_heals_stale_args_on_matching_command(test_db):
 
 
 def test_connect_heal_resets_orphan_rows_env_and_cwd(test_db):
-    """Healing args must not leave a row's own env/cwd untouched: a row with
-    today's command/transport but no *current* owner can be a pre-catalog
-    orphan (a user created a custom server under this name before the
-    catalog app existed, then was deleted -- deleting a user drops their
-    UserMCPServer association, not the shared MCPServer row). Adopting it
-    without clearing env/cwd would apply that orphan's own values to every
-    future user's connection via MCPServer.to_connection_dict()."""
+    """A row with today's command/transport but no *current* owner is not
+    safe to heal just because command/transport match: ownerless is also
+    the normal state of every legitimately catalog-connected row (connect
+    never marks an association is_owner=True), so it can't distinguish the
+    official row from a pre-catalog orphan (a user created a custom server
+    under this name before the catalog app existed, then was deleted --
+    deleting a user drops their UserMCPServer association, not the shared
+    MCPServer row) carrying its own env/cwd. Adopting it and blanking those
+    fields would be just as wrong as adopting it and keeping them: either
+    could destroy or leak real configuration
+    (MCPServer.to_connection_dict() applies a row's env to every user's
+    connection through it). Safe behavior is to leave a row with any
+    configured env/cwd/etc. untouched and 409, matching what it always got
+    before args-healing existed -- not adopt it, not silently wipe it."""
+    from fastapi import HTTPException
+
     from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
 
     test_db.add(
@@ -612,24 +621,120 @@ def test_connect_heal_resets_orphan_rows_env_and_cwd(test_db):
             managed="external",
             transport="stdio",
             command="npx",
-            args=["-y", "@cablate/mcp-google-map"],  # stale, triggers healing
+            args=["-y", "@cablate/mcp-google-map"],  # stale, would trigger healing
             env={"LEFTOVER_SECRET": "attacker-or-former-users-value"},
             cwd="/some/orphaned/path",
         )
     )
     test_db.commit()
 
-    connect_mcp_app(
-        "google-maps",
-        MCPAppConnectRequest(env={"GOOGLE_MAPS_API_KEY": "my-key"}),
-        current_user=_user(test_db, 1),
-        db=test_db,
-    )
+    with pytest.raises(HTTPException) as exc:
+        connect_mcp_app(
+            "google-maps",
+            MCPAppConnectRequest(env={"GOOGLE_MAPS_API_KEY": "my-key"}),
+            current_user=_user(test_db, 1),
+            db=test_db,
+        )
+    assert exc.value.status_code == 409
 
-    healed = test_db.query(MCPServer).filter(MCPServer.name == "google-maps").first()
-    assert healed.args == ["-y", "@cablate/mcp-google-map", "--stdio"]
-    assert healed.env is None
-    assert healed.cwd is None
+    untouched = test_db.query(MCPServer).filter(MCPServer.name == "google-maps").first()
+    assert untouched.args == ["-y", "@cablate/mcp-google-map"]
+    assert untouched.env == {"LEFTOVER_SECRET": "attacker-or-former-users-value"}
+    assert untouched.cwd == "/some/orphaned/path"
+
+
+def test_connect_heal_refuses_row_with_platform_env_configured(test_db):
+    """The same refuse-to-heal gate must also protect a *legitimate*
+    admin-configured platform key on a real catalog row (not just an
+    orphan's leftover env) -- _app_platform_env_available reads
+    MCPServer.env directly as the platform-global fallback key, and
+    healing must never destroy it just because args also happened to drift.
+    A row with a platform key configured stays 409 (unhealed, untouched)
+    rather than silently losing that key."""
+    from fastapi import HTTPException
+
+    from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
+
+    test_db.add(
+        MCPServer(
+            name="google-maps",
+            managed="external",
+            transport="stdio",
+            command="npx",
+            args=["-y", "@cablate/mcp-google-map"],  # stale, would trigger healing
+            env={"GOOGLE_MAPS_API_KEY": "encrypted-platform-key"},
+        )
+    )
+    test_db.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        connect_mcp_app(
+            "google-maps",
+            MCPAppConnectRequest(),
+            current_user=_user(test_db, 1),
+            db=test_db,
+        )
+    assert exc.value.status_code == 409
+
+    untouched = test_db.query(MCPServer).filter(MCPServer.name == "google-maps").first()
+    assert untouched.env == {"GOOGLE_MAPS_API_KEY": "encrypted-platform-key"}
+
+
+def test_connect_heal_rejects_falsy_malformed_args_instead_of_wiping(test_db):
+    """launch_config.args of {}, 0, or False must not be laundered into a
+    validation-passing empty list by an `or []` fallback -- that would
+    silently wipe a row's real args on a successful connect. Only a
+    genuinely absent (None) args means "no args"; any other falsy-but-
+    wrong-type value must still fail shape validation."""
+    from fastapi import HTTPException
+
+    from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
+
+    test_db.add(
+        PublicMCPApp(
+            app_id="totally-custom-app",
+            name="Totally Custom App",
+            description="A hand-created, non-builtin catalog app",
+            transport="stdio",
+            is_visible_in_connector=True,
+            launch_config={"command": "npx", "args": ["-y", "totally-custom-mcp"]},
+        )
+    )
+    test_db.add(
+        MCPServer(
+            name="totally-custom-app",
+            managed="external",
+            transport="stdio",
+            command="npx",
+            args=["-y", "totally-custom-mcp"],
+        )
+    )
+    test_db.commit()
+
+    for falsy_malformed_args in ({}, 0, False):
+        app = (
+            test_db.query(PublicMCPApp)
+            .filter(PublicMCPApp.app_id == "totally-custom-app")
+            .first()
+        )
+        app.launch_config = {"command": "npx", "args": falsy_malformed_args}
+        test_db.commit()
+
+        with pytest.raises(HTTPException) as exc:
+            connect_mcp_app(
+                "totally-custom-app",
+                MCPAppConnectRequest(),
+                current_user=_user(test_db, 1),
+                db=test_db,
+            )
+        assert exc.value.status_code == 400
+
+        untouched = (
+            test_db.query(MCPServer)
+            .filter(MCPServer.name == "totally-custom-app")
+            .first()
+        )
+        assert untouched.args == ["-y", "totally-custom-mcp"]
 
 
 def test_connect_rejects_malformed_catalog_args_instead_of_persisting(test_db):

--- a/tests/web/api/test_mcp_apps_connect.py
+++ b/tests/web/api/test_mcp_apps_connect.py
@@ -775,18 +775,39 @@ def test_connect_heal_rejects_falsy_malformed_args_instead_of_wiping(test_db):
         assert untouched.args == ["-y", "totally-custom-mcp"]
 
 
-def test_connect_heal_refuses_row_with_policy_fields_the_gate_previously_missed(
-    test_db,
+@pytest.mark.parametrize(
+    "field_name,field_value",
+    [
+        ("docker_url", "tcp://attacker-controlled-host:2375"),
+        ("docker_image", "attacker/evil-image:latest"),
+        ("docker_environment", {"LEFTOVER_SECRET": "attacker-or-former-users-value"}),
+        ("docker_working_dir", "/some/orphaned/path"),
+        ("volumes", ["/:/host-root"]),
+        ("bind_ports", {"8080": "8080"}),
+        ("auth", {"type": "bearer", "token": "leftover-or-attacker-token"}),
+        ("headers", {"X-Injected": "true"}),
+        ("timeout", 1),
+        ("concurrent_tools", ["some_tool"]),
+        ("runtime_input_schema", {"type": "object"}),
+        ("runtime_bindings", {"some_binding": "value"}),
+        ("concurrency_safe", True),
+    ],
+)
+def test_connect_heal_refuses_row_with_each_policy_field_independently(
+    test_db, field_name, field_value
 ):
-    """The refuse-to-heal gate must cover every configurable MCPServer
-    field, not a hand-picked subset. An earlier version of this gate only
-    checked env/cwd/concurrent_tools/runtime_input_schema/
-    runtime_bindings/concurrency_safe -- a row carrying real policy in any
-    OTHER configurable field (docker_image, auth, headers, timeout,
-    volumes, bind_ports, a non-default managed/restart_policy, ...) would
-    have slipped past that gate and gotten silently healed/adopted, which
-    is worse than this PR's own baseline (pre-heal, any args mismatch
-    always 409'd regardless of what else was configured)."""
+    """Each configurable MCPServer field must independently gate healing on
+    its own, not only in combination with others -- a single bundled test
+    covering several fields at once (e.g. alongside a non-default
+    `managed`, which short-circuits the check first) can stay green even
+    if the check for one specific OTHER field is later dropped, since the
+    other fields in the bundle would still trip the gate. Isolating one
+    field per case means a regression in any single field's check fails
+    exactly the case that covers it. Otherwise-clean row (managed=
+    "external", the default every catalog-created row gets) with exactly
+    one policy field set -- see the sibling tests for managed/
+    restart_policy/env/cwd, which are significant enough to warrant their
+    own dedicated, non-parameterized cases instead of joining this list."""
     from fastapi import HTTPException
 
     from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
@@ -794,17 +815,11 @@ def test_connect_heal_refuses_row_with_policy_fields_the_gate_previously_missed(
     test_db.add(
         MCPServer(
             name="google-maps",
-            managed="internal",  # non-default managed alone should refuse healing
+            managed="external",
             transport="stdio",
             command="npx",
             args=["-y", "@cablate/mcp-google-map"],  # stale, would trigger healing
-            docker_image="attacker/evil-image:latest",
-            docker_url="tcp://attacker-controlled-host:2375",
-            volumes=["/:/host-root"],
-            bind_ports={"8080": "8080"},
-            auth={"type": "bearer", "token": "leftover-or-attacker-token"},
-            headers={"X-Injected": "true"},
-            timeout=1,
+            **{field_name: field_value},
         )
     )
     test_db.commit()
@@ -820,13 +835,42 @@ def test_connect_heal_refuses_row_with_policy_fields_the_gate_previously_missed(
 
     untouched = test_db.query(MCPServer).filter(MCPServer.name == "google-maps").first()
     assert untouched.args == ["-y", "@cablate/mcp-google-map"]
-    assert untouched.docker_image == "attacker/evil-image:latest"
-    assert untouched.docker_url == "tcp://attacker-controlled-host:2375"
-    assert untouched.volumes == ["/:/host-root"]
-    assert untouched.bind_ports == {"8080": "8080"}
-    assert untouched.auth == {"type": "bearer", "token": "leftover-or-attacker-token"}
-    assert untouched.headers == {"X-Injected": "true"}
-    assert untouched.timeout == 1
+    assert getattr(untouched, field_name) == field_value
+
+
+def test_connect_heal_refuses_row_with_non_default_managed(test_db):
+    """managed is compared against its catalog-created default ("external")
+    directly, not via a plain truthiness check like most other gated
+    fields -- an internal (docker-lifecycle-managed) row is never what
+    this connect path creates, so a row that's internally managed alone,
+    with nothing else configured, must still refuse to heal."""
+    from fastapi import HTTPException
+
+    from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
+
+    test_db.add(
+        MCPServer(
+            name="google-maps",
+            managed="internal",
+            transport="stdio",
+            command="npx",
+            args=["-y", "@cablate/mcp-google-map"],  # stale, would trigger healing
+        )
+    )
+    test_db.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        connect_mcp_app(
+            "google-maps",
+            MCPAppConnectRequest(env={"GOOGLE_MAPS_API_KEY": "my-key"}),
+            current_user=_user(test_db, 1),
+            db=test_db,
+        )
+    assert exc.value.status_code == 409
+
+    untouched = test_db.query(MCPServer).filter(MCPServer.name == "google-maps").first()
+    assert untouched.args == ["-y", "@cablate/mcp-google-map"]
+    assert untouched.managed == "internal"
 
 
 def test_connect_heal_refuses_row_with_non_default_restart_policy(test_db):

--- a/tests/web/api/test_mcp_apps_connect.py
+++ b/tests/web/api/test_mcp_apps_connect.py
@@ -562,6 +562,40 @@ def test_connect_rejects_user_owned_server_even_with_matching_config(test_db):
     assert exc.value.status_code == 409
 
 
+def test_connect_heals_stale_args_on_matching_command(test_db):
+    """A pre-existing row with the right command/transport but args from
+    before a legitimate catalog update (a version bump, a new flag) must not
+    409 forever -- unlike a command mismatch (a real hijack), this is healed
+    in place so this and every future connect attempt succeeds with the
+    current official args, mirroring how _ensure_catalog_mcp_oauth_server
+    already syncs a drifted "auth" config instead of rejecting it."""
+    from xagent.web.api.mcp import MCPAppConnectRequest, connect_mcp_app
+
+    test_db.add(
+        MCPServer(
+            name="google-maps",
+            managed="external",
+            transport="stdio",
+            command="npx",
+            # Missing "--stdio": simulates a row created before that flag was
+            # added to the catalog's launch_config.
+            args=["-y", "@cablate/mcp-google-map"],
+        )
+    )
+    test_db.commit()
+
+    response = connect_mcp_app(
+        "google-maps",
+        MCPAppConnectRequest(env={"GOOGLE_MAPS_API_KEY": "my-key"}),
+        current_user=_user(test_db, 1),
+        db=test_db,
+    )
+    assert response is not None
+
+    healed = test_db.query(MCPServer).filter(MCPServer.name == "google-maps").first()
+    assert healed.args == ["-y", "@cablate/mcp-google-map", "--stdio"]
+
+
 @pytest.mark.parametrize("name", ["google-maps", "Google-Maps", "google maps"])
 def test_create_server_rejects_catalog_app_id(test_db, name):
     """Custom servers can't squat a catalog app id (the hijack precondition),


### PR DESCRIPTION
## Summary

Live failure reported after deploying #1791 to stage: connecting `chrome-devtools-mcp` returned

```
POST /api/mcp/apps/chrome-devtools/connect
409 {"detail": "A server with this name already exists with a different configuration"}
```

## Root cause

A shared `MCPServer` row for `chrome-devtools` already existed on stage from before #1791's `launch_config` change (`--chrome-arg=--disable-dev-shm-usage`). `_ensure_catalog_app_server` (`src/xagent/web/api/mcp.py`) treats `command`, `transport`, **and `args`** as identity fields when deciding whether an existing row under a catalog `app_id` is the official shared server or a hijack (a user-created server squatting the name). Since the registry's `args` legitimately changed after that row was created, every connect attempt — for any user — now 409s, indistinguishable from an actual hijack, until an operator manually intervenes.

This isn't specific to chrome-devtools-mcp: any builtin connector whose `launch_config.args` changes after a shared row already exists for it hits the same 409. This exact risk was flagged and filed as #1870 during #1791's review, before it reproduced live on stage.

## Fix

Only `command`/`transport` now identify a hijack (a different program entirely). An `args`-only mismatch on a row that already passed that check and isn't user-owned is healed in place — the catalog stays the source of truth and the row's `args` are updated to match, so this and every future connect succeeds with the current official args.

This mirrors `_ensure_catalog_mcp_oauth_server`'s existing, already-shipped handling of its own `auth` field a few lines below in the same file: it already syncs a drifted OAuth `auth` config the same way instead of rejecting it. Not a new precedent — bringing the keyless/api_key path in line with the OAuth path's existing behavior.

## Test plan

- [x] Added `test_connect_heals_stale_args_on_matching_command`, covering the exact reported scenario (matching command, stale args): asserts the connect succeeds and the row's `args` are updated to the current registry value.
- [x] Confirmed the existing hijack tests still reject as before — `test_connect_rejects_hijacked_server_with_foreign_config` (foreign `command`) and `test_connect_rejects_user_owned_server_even_with_matching_config` (user-owned row) — neither depends on the `args` check this removes.
- [x] `pytest tests/web/api/test_mcp_apps_connect.py tests/web/api/test_mcp_apps_catalog_dedupe.py` — 51 passed.
- [x] `ruff check` / `mypy` clean on both touched files.