### PR TITLE
feat(connectors): add an optional team access hook to the connector seam

### DIFF
--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -269,7 +269,8 @@ def team_connector_hook_installed() -> bool:
 def _normalize_connector_refs(
     refs: "Collection[ConnectorRef]",
 ) -> "frozenset[ConnectorRef]":
-    """Canonicalize a batch of connector refs, coercing every id to ``int``.
+    """Canonicalize a batch of connector refs, rejecting any id that is not
+    already an ``int``.
 
     Written once because the result is not merely an argument passed on to
     the hook -- it is also the baseline the hook's answer is checked
@@ -279,14 +280,31 @@ def _normalize_connector_refs(
     different notion of canonical shape than the one it was built from,
     with nothing failing to say so.
 
-    An id that will not coerce to ``int`` is deliberately not tolerated,
-    skipped, or defaulted here. Callers are expected to build their refs
-    from FastAPI-validated ``int`` path parameters or from non-nullable
-    integer primary keys, so an un-coercible id means xagent's own code
-    built the list wrong; it surfaces as the ``TypeError``/``ValueError``
-    it is. Dropping such a ref instead would silently turn a caller's bug
-    into a connector the hook was never asked about, and the caller would
-    read the resulting gap as "the team does not link it".
+    An id that is not already an ``int`` is rejected here -- never coerced,
+    skipped, or defaulted. Callers are expected to build their refs from
+    FastAPI-validated ``int`` path parameters or from non-nullable integer
+    primary keys, so anything else means xagent's own code built the list
+    wrong; it surfaces as the ``TypeError``/``ValueError`` it is. Dropping
+    such a ref instead would silently turn a caller's bug into a connector
+    the hook was never asked about, and the caller would read the resulting
+    gap as "the team does not link it".
+
+    Coercing was worse than either, which is why it is gone. ``int("11")``
+    looked harmless, because the batch answer did come back correct -- but it
+    asked about a different tuple than the caller was holding. The answer came
+    back keyed ``("mcp", 11)`` while the caller still had ``("mcp", "11")``,
+    so ``resolve_one_connector_access_or_raise`` looked its own ref up, missed,
+    and returned ``None`` -- this seam's word for "the team does not link it"
+    -- about a connector the hook had just granted. Rejecting instead means
+    the ref the hook is asked about is always the ref the caller passed, so an
+    answer key can never fail to match the ref it answers.
+
+    ``bool`` is excluded explicitly, the same way
+    ``_validate_connector_access_answer`` and
+    ``_validate_team_connector_answer`` exclude it: ``isinstance(True, int)``
+    is ``True`` in Python, and ``("mcp", True)`` compares and hashes equal to
+    ``("mcp", 1)``, so tolerating it would resolve a different connector's
+    access with nothing failing to say so.
 
     Only the id half is checked at run time. The connector type is carried
     by the ``ConnectorRef`` annotation, so a non-``str`` type is not
@@ -297,9 +315,16 @@ def _normalize_connector_refs(
     type checker has not already constrained is the one that owes a
     run-time check.
     """
-    return frozenset(
-        (connector_type, int(connector_id)) for connector_type, connector_id in refs
-    )
+    validated: "set[ConnectorRef]" = set()
+    for connector_type, connector_id in refs:
+        if isinstance(connector_id, bool) or not isinstance(connector_id, int):
+            raise TypeError(
+                "connector ref id must already be an int (bool is a subclass "
+                "of int in Python and is never a legitimate connector id), got "
+                f"{connector_id!r} for connector type {connector_type!r}"
+            )
+        validated.add((connector_type, connector_id))
+    return frozenset(validated)
 
 
 def _validate_connector_access_answer(
@@ -442,6 +467,12 @@ def resolve_connector_access(
     all, when no hook is installed or when ``refs`` is empty: an empty
     request is never worth a call, and a standalone deployment with no
     hook installed sees zero queries and zero behavior change.
+
+    The returned map is keyed on the refs as the caller passed them. That is
+    a consequence of ``_normalize_connector_refs`` rejecting an id that is not
+    already an ``int`` rather than coercing it: there is no input that reaches
+    the hook under one key and comes back under another, so a caller may look
+    its own ref straight back up in this map.
 
     A ref missing from the returned map means "the caller's team does not
     link this connector" -- the only way that fact is ever expressed (see
@@ -622,15 +653,15 @@ def resolve_connector_access_or_raise(
     would ever produce. The rest of this docstring describes what happens once
     one is installed.
 
-    Normalizing ``refs`` then happens before the 503 conversion and is
-    deliberately outside it. An id that will not coerce to ``int`` is a defect
+    Validating ``refs`` then happens before the 503 conversion and is
+    deliberately outside it. An id that is not already an ``int`` is a defect
     in the calling route, not an outage of the installing application: every
     caller builds its refs from FastAPI-validated ``int`` path parameters or
-    from non-nullable integer primary keys, so an un-coercible id means
-    xagent's own code is wrong. It surfaces as the ``TypeError``/``ValueError``
-    it is, raised before the hook is reached, rather than as a retryable
-    "connector access is unavailable" that would send an operator to look at
-    the application instead of at the route.
+    from non-nullable integer primary keys, so an id that is not already an
+    ``int`` means xagent's own code is wrong. It surfaces as the
+    ``TypeError``/``ValueError`` it is, raised before the hook is reached,
+    rather than as a retryable "connector access is unavailable" that would
+    send an operator to look at the application instead of at the route.
 
     Only the id half is checked that way. The connector type is carried by the
     ``ConnectorRef`` annotation and is not re-checked at run time, so a
@@ -649,12 +680,13 @@ def resolve_connector_access_or_raise(
     "connector_access_resolution_failed"}, status_code=503)``. Unlike
     ``resolve_team_connector_ids_or_raise``, there is no separate
     ``log_subject`` parameter: ``user_id`` here already identifies the
-    caller directly, so it doubles as the value logged. The logged refs
-    are the normalized ``(connector_type, int(id))`` tuples this function
-    resolved with -- ``('mcp', '5')`` in, ``('mcp', 5)`` logged -- sorted
-    for a stable log line, and never an ORM attribute read off a row,
-    which could itself fail if the session is left unusable by whatever
-    just failed.
+    caller directly, so it doubles as the value logged. The logged refs are
+    the validated ``(connector_type, int)`` tuples this function resolved
+    with, which are the caller's own refs -- ids are rejected rather than
+    rewritten, so nothing appears in the log under a shape the caller never
+    passed. They are sorted for a stable log line, and are never an ORM
+    attribute read off a row, which could itself fail if the session is left
+    unusable by whatever just failed.
 
     The session restore lives on ``_call_connector_hook_gate``, the single
     door every installed hook is invoked through, rather than on either

--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -320,12 +320,16 @@ def _validate_connector_access_answer(
     question than the one it was asked, and silently dropping it would
     hide that the hook and the caller have gone out of sync.
 
-    Each value must be a ``ConnectorAccess`` with ``team_owned`` exactly
-    ``True`` (an identity check, not a truthiness check, matching
-    ``knowledge_base_team_scope.py``'s ``element.team_owned is not True``)
-    and ``can_edit`` exactly ``True`` or ``False`` -- ``bool`` is a
-    subclass of ``int`` in Python, so a merely truthy value is never
-    accepted as a legitimate grant.
+    Each value must be a ``ConnectorAccess`` whose ``team_owned`` is
+    exactly ``True`` and whose ``can_edit`` is a ``bool``. The two are
+    deliberately spelled differently because they are different
+    requirements: ``team_owned`` admits one specific value, so it is an
+    identity check matching ``knowledge_base_team_scope.py``'s
+    ``element.team_owned is not True``, while ``can_edit`` admits either
+    ``True`` or ``False``, which is a type check and reads as one. Neither
+    is a truthiness check: ``bool`` is a subclass of ``int`` in Python, so
+    a merely truthy stand-in such as ``1`` is never accepted as a
+    legitimate grant.
 
     Each key must be an exact ``(str, int)`` pair before it is even checked
     for membership: ``bool``, ``float`` and ``Decimal`` all compare equal
@@ -383,7 +387,7 @@ def _validate_connector_access_answer(
                 "caller's team does not link is expressed by leaving it "
                 f"out of the answer, not by a verdict, got {verdict.team_owned!r}"
             )
-        if verdict.can_edit is not True and verdict.can_edit is not False:
+        if not isinstance(verdict.can_edit, bool):
             raise ValueError(
                 "connector access hook returned a malformed answer for "
                 f"{key!r}: can_edit must be exactly True or False (bool is "

--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -632,7 +632,11 @@ def resolve_connector_access_or_raise(
             "Failed to resolve connector access for user %s across %s connectors: %s",
             user_id,
             len(requested),
-            sorted(requested),
+            # ``key=str`` because the failure arm must not fail: the refs a caller
+            # hands in are only type-checked statically, so a mixed-type collection
+            # reaches here intact and a bare ``sorted`` would raise TypeError from
+            # inside this handler, replacing the typed 503 with an untyped error.
+            sorted(requested, key=str),
             exc_info=True,
         )
         raise ConnectorRuntimeError(

--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -513,9 +513,16 @@ def _restore_session_after_hook_failure(db: Any) -> None:
     later statement in the request, including the ones a degradation path
     needs to build its response, would be refused. Rolling back here, at
     the one door every hook call and every answer check passes through, is
-    what keeps the degradation contract true; the roll back happens after
-    the route's own ``db.commit()`` on the post-commit decoration paths, so
-    it never discards durable work.
+    what keeps the degradation contract true.
+
+    No durable work is discarded, and not because of where the rollback
+    sits relative to a commit: every call site today invokes its hook
+    *before* the route's own ``db.commit()`` -- both rename paths and both
+    delete paths do. What the rollback can reach is therefore only the
+    aborting request's own pending mutations, which the re-raised
+    exception was going to strand uncommitted anyway. A call site that
+    ever decorated *after* committing would keep the same property for
+    the opposite reason, its work already being durable by then.
 
     A rollback that itself fails is logged and swallowed: this runs on an
     already-failing path, the original failure is re-raised by the caller
@@ -524,6 +531,13 @@ def _restore_session_after_hook_failure(db: Any) -> None:
     rollback = getattr(db, "rollback", None)
     if rollback is None:
         return
+    # Unconditional, unlike ``release_db_connection_if_clean``
+    # (``models/database.py``), which refuses to roll back a session
+    # carrying pending ORM changes: that helper runs on the success path,
+    # where discarding work the request still intends to commit would be
+    # data loss. Here the request is aborting -- the caller re-raises --
+    # so there is no such work to protect, and leaving the session
+    # unusable is the worse outcome.
     try:
         rollback()
     except Exception:

--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -266,6 +266,42 @@ def team_connector_hook_installed() -> bool:
     return _team_connector_visibility_hook is not None
 
 
+def _normalize_connector_refs(
+    refs: "Collection[ConnectorRef]",
+) -> "frozenset[ConnectorRef]":
+    """Canonicalize a batch of connector refs, coercing every id to ``int``.
+
+    Written once because the result is not merely an argument passed on to
+    the hook -- it is also the baseline the hook's answer is checked
+    against: ``_validate_connector_access_answer`` rejects every key that
+    is not a member of this set. Two separately written normalizations
+    could drift, and the question asked would then be measured against a
+    different notion of canonical shape than the one it was built from,
+    with nothing failing to say so.
+
+    An id that will not coerce to ``int`` is deliberately not tolerated,
+    skipped, or defaulted here. Callers are expected to build their refs
+    from FastAPI-validated ``int`` path parameters or from non-nullable
+    integer primary keys, so an un-coercible id means xagent's own code
+    built the list wrong; it surfaces as the ``TypeError``/``ValueError``
+    it is. Dropping such a ref instead would silently turn a caller's bug
+    into a connector the hook was never asked about, and the caller would
+    read the resulting gap as "the team does not link it".
+
+    Only the id half is checked at run time. The connector type is carried
+    by the ``ConnectorRef`` annotation, so a non-``str`` type is not
+    rejected here and reaches the hook as it was passed in: if the hook
+    answers with a verdict for it, the answer validator rejects the key,
+    and if the hook leaves it out, the caller reads that gap as "the team
+    does not link it". Whichever route first feeds this seam something a
+    type checker has not already constrained is the one that owes a
+    run-time check.
+    """
+    return frozenset(
+        (connector_type, int(connector_id)) for connector_type, connector_id in refs
+    )
+
+
 def _validate_connector_access_answer(
     answer: Any, requested: "frozenset[ConnectorRef]"
 ) -> "dict[ConnectorRef, ConnectorAccess]":
@@ -394,9 +430,7 @@ def resolve_connector_access(
     """
     if _connector_access_hook is None:
         return {}
-    requested = frozenset(
-        (connector_type, int(connector_id)) for connector_type, connector_id in refs
-    )
+    requested = _normalize_connector_refs(refs)
     if not requested:
         return {}
     return _call_connector_hook_gate(
@@ -588,9 +622,7 @@ def resolve_connector_access_or_raise(
     rejects. Neither is something the generic-exception arm below could
     own, and both are restored before either arm sees the exception.
     """
-    requested = frozenset(
-        (connector_type, int(connector_id)) for connector_type, connector_id in refs
-    )
+    requested = _normalize_connector_refs(refs)
     try:
         return resolve_connector_access(db, user_id, requested)
     except ConnectorRuntimeError:

--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -588,14 +588,30 @@ def resolve_connector_access_or_raise(
     """``resolve_connector_access(db, user_id, refs)``, with every failure of the
     hook call and of its answer validation converted into the seam's one typed 503.
 
-    Normalizing ``refs`` happens before that conversion and is deliberately
-    outside it. A ref that is not a ``(str, int-coercible)`` pair is a defect in
-    the calling route, not an outage of the installing application: every caller
-    builds its refs from FastAPI-validated ``int`` path parameters or from
-    non-nullable integer primary keys, so a malformed ref means xagent's own code
-    is wrong. It surfaces as the ``TypeError``/``ValueError`` it is, rather than
-    as a retryable "connector access is unavailable" that would send an operator
-    to look at the application instead of at the route.
+    Returns ``{}`` without reading ``refs`` at all when no hook is installed,
+    before any normalization -- the same first move ``resolve_connector_access``
+    makes, and for the same reason: a deployment with no application installed
+    must not be able to raise on a ref shape only an installing application
+    would ever produce. The rest of this docstring describes what happens once
+    one is installed.
+
+    Normalizing ``refs`` then happens before the 503 conversion and is
+    deliberately outside it. An id that will not coerce to ``int`` is a defect
+    in the calling route, not an outage of the installing application: every
+    caller builds its refs from FastAPI-validated ``int`` path parameters or
+    from non-nullable integer primary keys, so an un-coercible id means
+    xagent's own code is wrong. It surfaces as the ``TypeError``/``ValueError``
+    it is, raised before the hook is reached, rather than as a retryable
+    "connector access is unavailable" that would send an operator to look at
+    the application instead of at the route.
+
+    Only the id half is checked that way. The connector type is carried by the
+    ``ConnectorRef`` annotation and is not re-checked at run time, so a
+    non-``str`` type reaches the hook as it was passed in: if the hook answers
+    with a verdict for it, the answer validator rejects the key and the generic
+    arm below folds that into the same 503; if the hook leaves it out, the
+    caller reads the gap as "the team does not link it" and nothing raises at
+    all.
 
     A ``ConnectorRuntimeError`` -- whether raised by the hook itself or by
     ``resolve_connector_access``'s own answer validation -- passes through
@@ -622,6 +638,13 @@ def resolve_connector_access_or_raise(
     rejects. Neither is something the generic-exception arm below could
     own, and both are restored before either arm sees the exception.
     """
+    # Not redundant with the identical gate inside ``resolve_connector_access``:
+    # this one has to run before the normalization below, which is itself
+    # deliberately above the ``try``. Without it a standalone deployment raises
+    # on a malformed ref through this entry point while the other one returns
+    # ``{}`` for the very same input.
+    if _connector_access_hook is None:
+        return {}
     requested = _normalize_connector_refs(refs)
     try:
         return resolve_connector_access(db, user_id, requested)

--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -392,10 +392,12 @@ def resolve_connector_access(
     the other omits is not a defect in xagent -- it is what the installed
     answers said.
     """
+    if _connector_access_hook is None:
+        return {}
     requested = frozenset(
         (connector_type, int(connector_id)) for connector_type, connector_id in refs
     )
-    if _connector_access_hook is None or not requested:
+    if not requested:
         return {}
     return _call_connector_hook_gate(
         db,
@@ -549,8 +551,17 @@ def resolve_team_connector_ids_or_raise(
 def resolve_connector_access_or_raise(
     db: Any, user_id: int, refs: "Collection[ConnectorRef]"
 ) -> "dict[ConnectorRef, ConnectorAccess]":
-    """``resolve_connector_access(db, user_id, refs)``, with every
-    non-typed failure converted into the seam's one typed 503.
+    """``resolve_connector_access(db, user_id, refs)``, with every failure of the
+    hook call and of its answer validation converted into the seam's one typed 503.
+
+    Normalizing ``refs`` happens before that conversion and is deliberately
+    outside it. A ref that is not a ``(str, int-coercible)`` pair is a defect in
+    the calling route, not an outage of the installing application: every caller
+    builds its refs from FastAPI-validated ``int`` path parameters or from
+    non-nullable integer primary keys, so a malformed ref means xagent's own code
+    is wrong. It surfaces as the ``TypeError``/``ValueError`` it is, rather than
+    as a retryable "connector access is unavailable" that would send an operator
+    to look at the application instead of at the route.
 
     A ``ConnectorRuntimeError`` -- whether raised by the hook itself or by
     ``resolve_connector_access``'s own answer validation -- passes through
@@ -562,8 +573,9 @@ def resolve_connector_access_or_raise(
     ``resolve_team_connector_ids_or_raise``, there is no separate
     ``log_subject`` parameter: ``user_id`` here already identifies the
     caller directly, so it doubles as the value logged. The logged refs
-    are the plain ``(connector_type, id)`` tuples the caller passed in,
-    sorted for a stable log line -- never an ORM attribute read off a row,
+    are the normalized ``(connector_type, int(id))`` tuples this function
+    resolved with -- ``('mcp', '5')`` in, ``('mcp', 5)`` logged -- sorted
+    for a stable log line, and never an ORM attribute read off a row,
     which could itself fail if the session is left unusable by whatever
     just failed.
 

--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -8,9 +8,10 @@ the application's team tables.
 from __future__ import annotations
 
 import logging
-from collections.abc import Callable, Collection
+from collections.abc import Callable, Collection, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, Protocol
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar
 
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -41,6 +42,34 @@ class ConnectorDeleteDecision:
 
 
 ConnectorDeletedHook = Callable[[Any, int, ConnectorType, int], ConnectorDeleteDecision]
+
+
+@dataclass(frozen=True)
+class ConnectorAccess:
+    """Whether the caller's team links a connector, and may edit it.
+
+    A verdict that reaches a caller always carries ``team_owned=True``:
+    the only way to say "the caller's team does not link this connector"
+    is to leave its ref out of the hook's answer map entirely, not to
+    return a verdict with ``team_owned=False``. ``can_edit`` is otherwise
+    independent -- a team can link a connector without granting edit
+    rights to it, which is a legal answer on its own, not an intermediate
+    or partial state. Both fields are validated as exact bools on the way
+    in (see ``_validate_connector_access_answer``); the dataclass defaults
+    below stay ``False``/``False`` on purpose so that constructing a bare
+    ``ConnectorAccess()`` remains the shape the validator rejects, rather
+    than quietly becoming a legitimate "not linked" answer.
+    """
+
+    team_owned: bool = False
+    can_edit: bool = False
+
+
+ConnectorRef = tuple[ConnectorType, int]
+
+ConnectorAccessHook = Callable[
+    [Any, int, "Collection[ConnectorRef]"], "dict[ConnectorRef, ConnectorAccess]"
+]
 
 ConnectorVisibilityHook = Callable[[Any, int], dict[str, set[int]]]
 
@@ -110,6 +139,7 @@ _connector_deleted_hook: ConnectorDeletedHook | None = None
 _connector_renamed_hook: ConnectorRenamedHook | None = None
 _connector_visibility_hook: ConnectorVisibilityHook | None = None
 _team_connector_visibility_hook: TeamConnectorVisibilityHook | None = None
+_connector_access_hook: ConnectorAccessHook | None = None
 
 
 def set_connector_team_hooks(
@@ -118,6 +148,7 @@ def set_connector_team_hooks(
     renamed: ConnectorRenamedHook | None = None,
     visibility: ConnectorVisibilityHook | None = None,
     team_visibility: TeamConnectorVisibilityHook | None = None,
+    access: ConnectorAccessHook | None = None,
 ) -> None:
     """Install application-owned connector lifecycle hooks.
 
@@ -129,17 +160,35 @@ def set_connector_team_hooks(
 
     global _connector_deleted_hook, _connector_renamed_hook
     global _connector_visibility_hook, _team_connector_visibility_hook
+    global _connector_access_hook
     _connector_deleted_hook = deleted
     _connector_renamed_hook = renamed
     _connector_visibility_hook = visibility
     _team_connector_visibility_hook = team_visibility
+    _connector_access_hook = access
 
 
 def visible_team_connector_ids(db: Any, user_id: int) -> dict[str, set[int]]:
-    """Team-shared connector ids visible to user; empty when no hook/standalone."""
+    """Team-shared connector ids visible to user; empty when no hook/standalone.
+
+    Answers list membership only. Direct-id reachability and edit
+    authority come from a different hook -- ``resolve_connector_access``
+    -- and xagent enforces no relationship between the two answers:
+    they are separate module-level slots, installed separately, and
+    nothing cross-checks them. An installing application must derive
+    both from one and the same link query, because it is the only side
+    that can see its own link table; xagent cannot verify that and does
+    not try.
+
+    When the two answers disagree, xagent does not reconcile them: each
+    question is answered from the hook that owns it, and whatever that
+    hook said is what the caller gets. A connector one hook reports and
+    the other omits is not a defect in xagent -- it is what the installed
+    answers said.
+    """
     if _connector_visibility_hook is None:
         return {"mcp": set(), "custom_api": set()}
-    return _connector_visibility_hook(db, int(user_id))
+    return _call_connector_hook_gate(db, _connector_visibility_hook, db, int(user_id))
 
 
 def _validate_team_connector_answer(answer: Any) -> dict[str, set[int]]:
@@ -199,8 +248,13 @@ def team_connector_ids(db: Any, *, team_id: int | None) -> dict[str, set[int]]:
     """
     if team_id is None or _team_connector_visibility_hook is None:
         return {"mcp": set(), "custom_api": set()}
-    answer = _team_connector_visibility_hook(db, team_id=int(team_id))
-    return _validate_team_connector_answer(answer)
+    return _call_connector_hook_gate(
+        db,
+        _team_connector_visibility_hook,
+        db,
+        team_id=int(team_id),
+        validate=_validate_team_connector_answer,
+    )
 
 
 def team_connector_hook_installed() -> bool:
@@ -210,6 +264,233 @@ def team_connector_hook_installed() -> bool:
     hook legitimately answers with empty sets for a team that owns nothing.
     """
     return _team_connector_visibility_hook is not None
+
+
+def _validate_connector_access_answer(
+    answer: Any, requested: "frozenset[ConnectorRef]"
+) -> "dict[ConnectorRef, ConnectorAccess]":
+    """Validate the access hook's batch answer shape.
+
+    An authorization input, not user-facing data: a malformed answer must
+    fail loudly, never be normalized, coerced, or defaulted to empty. The
+    hook answers a ``dict`` keyed on the connectors it was asked about; a
+    connector the caller's team does not link is expressed by leaving its
+    ref out of the answer entirely, never by a verdict with
+    ``team_owned=False`` -- unlike the team-visibility hook's
+    ``_validate_team_connector_answer`` above, where extra keys beyond the
+    two required ones are silently accepted because nothing ever reads
+    them, here the keys of the answer *are* the question: a verdict for a
+    ref that was never asked about means the hook answered a different
+    question than the one it was asked, and silently dropping it would
+    hide that the hook and the caller have gone out of sync.
+
+    Each value must be a ``ConnectorAccess`` with ``team_owned`` exactly
+    ``True`` (an identity check, not a truthiness check, matching
+    ``knowledge_base_team_scope.py``'s ``element.team_owned is not True``)
+    and ``can_edit`` exactly ``True`` or ``False`` -- ``bool`` is a
+    subclass of ``int`` in Python, so a merely truthy value is never
+    accepted as a legitimate grant.
+
+    Each key must be an exact ``(str, int)`` pair before it is even checked
+    for membership: ``bool``, ``float`` and ``Decimal`` all compare equal
+    to the ``int`` they alias (``True == 1``, ``1.0 == 1``,
+    ``Decimal("1") == 1``), and Python's ordinary tuple equality carries
+    that through to a key like ``("mcp", True)`` -- which would compare
+    equal to, and pass the membership check for, ``("mcp", 1)``. The keys
+    of this answer *are* the question (see above), so a key that only
+    resembles one of the refs asked about is not a legitimate answer to
+    the question, and must fail loudly here rather than being accepted as
+    the connector it merely aliases.
+    """
+    if not isinstance(answer, dict):
+        raise ValueError(
+            "connector access hook returned a malformed answer: expected a "
+            f"dict, got {type(answer).__name__}"
+        )
+    validated: "dict[ConnectorRef, ConnectorAccess]" = {}
+    for key, verdict in answer.items():
+        if not isinstance(key, tuple) or len(key) != 2:
+            raise ValueError(
+                "connector access hook returned a malformed answer: key "
+                f"{key!r} is not a (connector_type, connector_id) pair"
+            )
+        connector_type, connector_id = key
+        if not isinstance(connector_type, str):
+            raise ValueError(
+                "connector access hook returned a malformed answer: key "
+                f"{key!r} has a connector type that is not a str, got "
+                f"{type(connector_type).__name__}"
+            )
+        if isinstance(connector_id, bool) or not isinstance(connector_id, int):
+            raise ValueError(
+                "connector access hook returned a malformed answer: key "
+                f"{key!r} has a connector id that is not an int (bool is a "
+                "subclass of int in Python and is never a legitimate "
+                f"connector id), got {connector_id!r}"
+            )
+        if key not in requested:
+            raise ValueError(
+                "connector access hook returned a malformed answer: a "
+                f"verdict for {key!r}, which was not among the connectors "
+                "asked about"
+            )
+        if not isinstance(verdict, ConnectorAccess):
+            raise ValueError(
+                "connector access hook returned a malformed answer: "
+                f"expected ConnectorAccess values, got "
+                f"{type(verdict).__name__} for {key!r}"
+            )
+        if verdict.team_owned is not True:
+            raise ValueError(
+                "connector access hook returned a malformed answer for "
+                f"{key!r}: team_owned must be True -- a connector the "
+                "caller's team does not link is expressed by leaving it "
+                f"out of the answer, not by a verdict, got {verdict.team_owned!r}"
+            )
+        if verdict.can_edit is not True and verdict.can_edit is not False:
+            raise ValueError(
+                "connector access hook returned a malformed answer for "
+                f"{key!r}: can_edit must be exactly True or False (bool is "
+                "a subclass of int in Python, and a truthy value is never "
+                f"a legitimate grant), got {verdict.can_edit!r}"
+            )
+        validated[key] = verdict
+    return validated
+
+
+def resolve_connector_access(
+    db: Any, user_id: int, refs: "Collection[ConnectorRef]"
+) -> "dict[ConnectorRef, ConnectorAccess]":
+    """Whether the caller's team links each of ``refs``, and may edit it.
+
+    Asks the installed access hook, if any, at most once per call
+    regardless of how many refs are passed -- batching is the point of
+    this signature, not an incidental property, because the seam's whole
+    reason to exist is to answer "what is this caller's team's
+    relationship to these connectors" without paying one hook call per
+    connector. Returns ``{}`` immediately, without calling the hook at
+    all, when no hook is installed or when ``refs`` is empty: an empty
+    request is never worth a call, and a standalone deployment with no
+    hook installed sees zero queries and zero behavior change.
+
+    A ref missing from the returned map means "the caller's team does not
+    link this connector" -- the only way that fact is ever expressed (see
+    ``_validate_connector_access_answer``). The answer is shape-validated
+    before it reaches any caller.
+
+    Answers direct-id reachability and edit authority only. List
+    membership comes from a different hook -- ``visible_team_connector_ids``
+    -- and xagent enforces no relationship between the two answers: they
+    are separate module-level slots, installed separately, and nothing
+    cross-checks them. An installing application must derive both from one
+    and the same link query, because it is the only side that can see its
+    own link table; xagent cannot verify that and does not try.
+
+    When the two answers disagree, xagent does not reconcile them: each
+    question is answered from the hook that owns it, and whatever that
+    hook said is what the caller gets. A connector one hook reports and
+    the other omits is not a defect in xagent -- it is what the installed
+    answers said.
+    """
+    requested = frozenset(
+        (connector_type, int(connector_id)) for connector_type, connector_id in refs
+    )
+    if _connector_access_hook is None or not requested:
+        return {}
+    return _call_connector_hook_gate(
+        db,
+        _connector_access_hook,
+        db,
+        int(user_id),
+        requested,
+        validate=lambda answer: _validate_connector_access_answer(answer, requested),
+    )
+
+
+def _restore_session_after_hook_failure(db: Any) -> None:
+    """Roll back whatever a hook left on the shared session before its call
+    failed -- whether the hook raised, or answered with a shape this seam
+    rejected.
+
+    Hooks are handed the endpoint's own live session (see
+    ``delete_team_connector``'s contract note). A hook whose own statement
+    failed leaves that transaction unusable on PostgreSQL, and an ORM
+    ``flush`` failure leaves it unusable on every backend -- so every
+    later statement in the request, including the ones a degradation path
+    needs to build its response, would be refused. Rolling back here, at
+    the one door every hook call and every answer check passes through, is
+    what keeps the degradation contract true; the roll back happens after
+    the route's own ``db.commit()`` on the post-commit decoration paths, so
+    it never discards durable work.
+
+    A rollback that itself fails is logged and swallowed: this runs on an
+    already-failing path, the original failure is re-raised by the caller
+    either way, and there is no further recovery available.
+    """
+    rollback = getattr(db, "rollback", None)
+    if rollback is None:
+        return
+    try:
+        rollback()
+    except Exception:
+        logger.warning(
+            "Rolling back after a failed connector hook failed", exc_info=True
+        )
+
+
+_HookResult = TypeVar("_HookResult")
+
+
+def _call_connector_hook_gate(
+    db: Any,
+    hook: "Callable[..., _HookResult]",
+    *args: Any,
+    validate: "Callable[[Any], _HookResult] | None" = None,
+    **kwargs: Any,
+) -> _HookResult:
+    """The one door every installed connector hook is called through, and
+    the one place its answer is checked.
+
+    Hooks run on the endpoint's own live session (see
+    ``delete_team_connector``'s contract note). A hook whose own statement
+    failed leaves that transaction unusable on PostgreSQL, and a failed
+    ORM ``flush`` leaves it unusable on every backend -- so restoring the
+    session belongs to the invocation itself, not to whichever caller
+    happens to wrap it. Placing it here is what makes the property hold
+    for a hook slot added to this module later, without that slot's author
+    having to know about it: every one of the five slots this module
+    defines is invoked through this one function.
+
+    ``validate``, when given, runs inside the same ``try`` because a hook
+    can poison the session *without* raising: run a statement that fails,
+    catch that itself, and answer with a shape this seam then rejects. The
+    rejection is this module's own exception rather than the hook's, so a
+    restore placed around the call alone would not fire for it -- the
+    session would stay unusable for everything the request does next. Two
+    of the five slots have an answer this seam validates; the other three
+    pass nothing, which says at the call site that this seam checks
+    nothing about those answers, rather than leaving that silent.
+
+    The exception is re-raised unchanged, whichever of the two raised it;
+    this function decides nothing about how the failure is classified or
+    translated. That stays with the ``*_or_raise`` wrappers below, which
+    own the seam's typed-error contract.
+
+    One shape stays uncovered, deliberately: a hook that poisons the
+    session, swallows its own failure, and still returns a well-formed
+    answer produces no exception at all -- neither here nor in a
+    validator -- so nothing triggers a restore. Closing it would mean
+    probing the session's health after every hook call, which is a
+    different design than a failure path.
+    """
+    try:
+        answer = hook(*args, **kwargs)
+        if validate is None:
+            return answer
+        return validate(answer)
+    except Exception:
+        _restore_session_after_hook_failure(db)
+        raise
 
 
 def resolve_team_connector_ids_or_raise(
@@ -237,6 +518,15 @@ def resolve_team_connector_ids_or_raise(
     no identity guard of its own; production only reaches it through its
     guarded public wrapper). It is only ever formatted into the log
     message, never interpreted.
+
+    The session restore lives on ``_call_connector_hook_gate``, the single
+    door every installed hook is invoked through, rather than on either
+    failure arm below, and it covers both ways that call can fail: a
+    hook can leave a statement failed on the session and *then* raise its
+    own ``ConnectorRuntimeError``, and a hook can leave one failed, swallow
+    that itself, and answer with a shape this seam's own validator then
+    rejects. Neither is something the generic-exception arm below could
+    own, and both are restored before either arm sees the exception.
     """
     try:
         return team_connector_ids(db, team_id=team_id)
@@ -254,6 +544,114 @@ def resolve_team_connector_ids_or_raise(
             details={"reason": "team_scope_resolution_failed"},
             status_code=503,
         ) from exc
+
+
+def resolve_connector_access_or_raise(
+    db: Any, user_id: int, refs: "Collection[ConnectorRef]"
+) -> "dict[ConnectorRef, ConnectorAccess]":
+    """``resolve_connector_access(db, user_id, refs)``, with every
+    non-typed failure converted into the seam's one typed 503.
+
+    A ``ConnectorRuntimeError`` -- whether raised by the hook itself or by
+    ``resolve_connector_access``'s own answer validation -- passes through
+    unchanged (same object, not re-wrapped). Any other exception is logged
+    at ``WARNING`` and converted into
+    ``ConnectorRuntimeError(ERROR_CONNECTOR_RUNTIME_UNAVAILABLE, "Connector
+    access is unavailable.", details={"reason":
+    "connector_access_resolution_failed"}, status_code=503)``. Unlike
+    ``resolve_team_connector_ids_or_raise``, there is no separate
+    ``log_subject`` parameter: ``user_id`` here already identifies the
+    caller directly, so it doubles as the value logged. The logged refs
+    are the plain ``(connector_type, id)`` tuples the caller passed in,
+    sorted for a stable log line -- never an ORM attribute read off a row,
+    which could itself fail if the session is left unusable by whatever
+    just failed.
+
+    The session restore lives on ``_call_connector_hook_gate``, the single
+    door every installed hook is invoked through, rather than on either
+    failure arm below, and it covers both ways that call can fail: a
+    hook can leave a statement failed on the session and *then* raise its
+    own ``ConnectorRuntimeError``, and a hook can leave one failed, swallow
+    that itself, and answer with a shape this seam's own validator then
+    rejects. Neither is something the generic-exception arm below could
+    own, and both are restored before either arm sees the exception.
+    """
+    requested = frozenset(
+        (connector_type, int(connector_id)) for connector_type, connector_id in refs
+    )
+    try:
+        return resolve_connector_access(db, user_id, requested)
+    except ConnectorRuntimeError:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "Failed to resolve connector access for user %s across %s connectors: %s",
+            user_id,
+            len(requested),
+            sorted(requested),
+            exc_info=True,
+        )
+        raise ConnectorRuntimeError(
+            ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
+            "Connector access is unavailable.",
+            details={"reason": "connector_access_resolution_failed"},
+            status_code=503,
+        ) from exc
+
+
+def resolve_one_connector_access_or_raise(
+    db: Any, user_id: int, ref: "ConnectorRef"
+) -> "ConnectorAccess | None":
+    """Single-``ref`` convenience wrapper around
+    ``resolve_connector_access_or_raise``: wraps ``ref`` in a one-element
+    collection, calls the batch resolver, and unwraps the answer for that
+    ref. ``None`` means the same thing it means for any ref missing from a
+    batch answer -- not linked, or a legitimate answer the hook chose to
+    omit -- never a failure, which still raises ``ConnectorRuntimeError``
+    same as the batch form. Exists so a caller resolving a single
+    connector does not repeat the wrap-then-``.get(ref)`` shape by hand.
+    """
+    return resolve_connector_access_or_raise(db, user_id, [ref]).get(ref)
+
+
+@contextmanager
+def snapshot_connector_team_hooks() -> Iterator[None]:
+    """Save every module-level hook slot, restore it on exit.
+
+    Intended for tests: entering the block, replacing any slot (through
+    ``set_connector_team_hooks`` or a direct module-attribute monkeypatch),
+    and leaving restores every slot to the exact object it held before the
+    block, including a slot the block never touched. A slot added to this
+    module later must be added here too, or a snapshot taken before that
+    slot exists will silently fail to restore it -- covered by the
+    discovery-based coverage test in
+    tests/web/services/test_connector_team_scope.py, which enumerates every
+    module global ending in ``_hook`` and asserts this snapshot restores
+    each one by identity. Saving and restoring lives on the module because
+    the state being saved lives on the module: a test-side helper would
+    have to name and reach these globals from outside, and would go stale
+    the moment a slot is added here.
+    """
+    global _connector_deleted_hook, _connector_renamed_hook
+    global _connector_visibility_hook, _team_connector_visibility_hook
+    global _connector_access_hook
+    saved = (
+        _connector_deleted_hook,
+        _connector_renamed_hook,
+        _connector_visibility_hook,
+        _team_connector_visibility_hook,
+        _connector_access_hook,
+    )
+    try:
+        yield
+    finally:
+        (
+            _connector_deleted_hook,
+            _connector_renamed_hook,
+            _connector_visibility_hook,
+            _team_connector_visibility_hook,
+            _connector_access_hook,
+        ) = saved
 
 
 def connector_visible_to_user(
@@ -361,7 +759,9 @@ def delete_team_connector(
 
     if _connector_deleted_hook is None:
         return ConnectorDeleteDecision()
-    return _connector_deleted_hook(db, user_id, connector_type, connector_id)
+    return _call_connector_hook_gate(
+        db, _connector_deleted_hook, db, user_id, connector_type, connector_id
+    )
 
 
 def rename_team_connector(
@@ -375,6 +775,13 @@ def rename_team_connector(
     """Keep application-owned connector selectors aligned after a rename."""
 
     if _connector_renamed_hook is not None and old_name != new_name:
-        _connector_renamed_hook(
-            db, user_id, connector_type, connector_id, old_name, new_name
+        _call_connector_hook_gate(
+            db,
+            _connector_renamed_hook,
+            db,
+            user_id,
+            connector_type,
+            connector_id,
+            old_name,
+            new_name,
         )

--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -398,6 +398,36 @@ def _validate_connector_access_answer(
     return validated
 
 
+def _resolve_normalized_connector_access(
+    db: Any,
+    user_id: int,
+    hook: "ConnectorAccessHook",
+    requested: "frozenset[ConnectorRef]",
+) -> "dict[ConnectorRef, ConnectorAccess]":
+    """Ask an already-resolved hook about an already-normalized ref set.
+
+    Exists so each public entry point normalizes exactly once.
+    ``resolve_connector_access_or_raise`` has to normalize above its ``try``,
+    so it cannot hand ``refs`` down; before this split it handed the
+    normalized set to ``resolve_connector_access``, which normalized it again.
+
+    ``hook`` is a parameter rather than a read of the module global, so "is a
+    hook installed" is answered once per call, by the entry point, and that
+    same answer is what gets used. Reading the global here instead would make
+    the ``None`` check every future caller's job to remember.
+    """
+    if not requested:
+        return {}
+    return _call_connector_hook_gate(
+        db,
+        hook,
+        db,
+        int(user_id),
+        requested,
+        validate=lambda answer: _validate_connector_access_answer(answer, requested),
+    )
+
+
 def resolve_connector_access(
     db: Any, user_id: int, refs: "Collection[ConnectorRef]"
 ) -> "dict[ConnectorRef, ConnectorAccess]":
@@ -432,18 +462,11 @@ def resolve_connector_access(
     the other omits is not a defect in xagent -- it is what the installed
     answers said.
     """
-    if _connector_access_hook is None:
+    hook = _connector_access_hook
+    if hook is None:
         return {}
-    requested = _normalize_connector_refs(refs)
-    if not requested:
-        return {}
-    return _call_connector_hook_gate(
-        db,
-        _connector_access_hook,
-        db,
-        int(user_id),
-        requested,
-        validate=lambda answer: _validate_connector_access_answer(answer, requested),
+    return _resolve_normalized_connector_access(
+        db, user_id, hook, _normalize_connector_refs(refs)
     )
 
 
@@ -618,9 +641,9 @@ def resolve_connector_access_or_raise(
     all.
 
     A ``ConnectorRuntimeError`` -- whether raised by the hook itself or by
-    ``resolve_connector_access``'s own answer validation -- passes through
-    unchanged (same object, not re-wrapped). Any other exception is logged
-    at ``WARNING`` and converted into
+    ``_validate_connector_access_answer`` rejecting what the hook answered --
+    passes through unchanged (same object, not re-wrapped). Any other
+    exception is logged at ``WARNING`` and converted into
     ``ConnectorRuntimeError(ERROR_CONNECTOR_RUNTIME_UNAVAILABLE, "Connector
     access is unavailable.", details={"reason":
     "connector_access_resolution_failed"}, status_code=503)``. Unlike
@@ -642,16 +665,19 @@ def resolve_connector_access_or_raise(
     rejects. Neither is something the generic-exception arm below could
     own, and both are restored before either arm sees the exception.
     """
-    # Not redundant with the identical gate inside ``resolve_connector_access``:
-    # this one has to run before the normalization below, which is itself
-    # deliberately above the ``try``. Without it a standalone deployment raises
-    # on a malformed ref through this entry point while the other one returns
-    # ``{}`` for the very same input.
-    if _connector_access_hook is None:
+    # Answered before the normalization below, which is itself deliberately
+    # above the ``try``. Both public entry points owe the same answer here:
+    # without this gate a standalone deployment raises on a malformed ref
+    # through this entry point while ``resolve_connector_access`` returns
+    # ``{}`` for the very same input. Each entry point reads the slot once and
+    # passes what it read down, so the call below cannot act on a hook other
+    # than the one this check just cleared.
+    hook = _connector_access_hook
+    if hook is None:
         return {}
     requested = _normalize_connector_refs(refs)
     try:
-        return resolve_connector_access(db, user_id, requested)
+        return _resolve_normalized_connector_access(db, user_id, hook, requested)
     except ConnectorRuntimeError:
         raise
     except Exception as exc:

--- a/src/xagent/web/services/knowledge_base_team_scope.py
+++ b/src/xagent/web/services/knowledge_base_team_scope.py
@@ -299,9 +299,12 @@ def snapshot_knowledge_base_team_hooks() -> Iterator[None]:
     slot added to this module later must be added here too, or a snapshot
     taken before that slot exists will silently fail to restore it.
 
-    The connector seam this module otherwise mirrors has no counterpart, and
-    that asymmetry is deliberate rather than a gap to close in either
-    direction. Its tests reset by calling the setter with no arguments,
+    The connector seam this module otherwise mirrors has its own equivalent,
+    ``connector_team_scope.snapshot_connector_team_hooks``, with the same
+    save-and-restore shape. The two primitives are independent: each saves
+    and restores only its own module's hook slots, and installing or
+    resetting one has no effect on the other. Tests that do not use either
+    primitive reset by calling the relevant setter with no arguments,
     which restores the *empty* state, not the state the test found. Every
     slot here is process-global, so a test that installs one and resets by
     clearing leaves any hook the process had installed before it gone, and

--- a/tests/web/services/test_connector_team_scope.py
+++ b/tests/web/services/test_connector_team_scope.py
@@ -47,9 +47,11 @@ def _reset_hooks_scope() -> Iterator[None]:
     # ``test_the_reset_scope_restores_a_pre_installed_hook_rather_than_clearing_it``),
     # since the fixture itself wraps the whole test body and cannot be
     # asserted on from inside one.
-    with connector_team_scope.snapshot_connector_team_hooks():
-        yield
-    agent_team_scope.set_agent_team_scope_hook(None)
+    try:
+        with connector_team_scope.snapshot_connector_team_hooks():
+            yield
+    finally:
+        agent_team_scope.set_agent_team_scope_hook(None)
 
 
 @pytest.fixture(autouse=True)
@@ -76,6 +78,19 @@ def test_the_reset_scope_restores_a_pre_installed_hook_rather_than_clearing_it()
     with _reset_hooks_scope():
         connector_team_scope.set_connector_team_hooks(access=lambda *_a, **_k: {})
     assert connector_team_scope._connector_access_hook is sentinel
+
+
+def test_the_reset_scope_releases_the_agent_team_hook_when_the_body_raises():
+    """The scope is also used as a plain ``with`` block, not only through
+    the autouse fixture, and on that path an exception inside the block
+    must not leave the agent-team hook installed for whatever runs next.
+    Written against the extracted scope directly, since that is the path
+    where the release is not otherwise guaranteed."""
+    agent_team_scope.set_agent_team_scope_hook(lambda db, user_id: None)
+    with pytest.raises(RuntimeError):
+        with _reset_hooks_scope():
+            raise RuntimeError("boom inside the block")
+    assert agent_team_scope._agent_team_scope_hook is None
 
 
 def test_team_connector_ids_empty_without_hook_installed():
@@ -160,6 +175,22 @@ def test_connector_access_defaults_are_both_false():
 def test_resolve_connector_access_returns_an_empty_map_without_a_hook_installed():
     for refs in ([("mcp", 1), ("custom_api", 1), ("mcp", 999)], [("mcp", 1)]):
         assert connector_team_scope.resolve_connector_access(None, 7, refs) == {}
+
+
+def test_resolve_connector_access_reads_no_ref_at_all_without_a_hook_installed():
+    """With no hook installed this seam does no work whatsoever -- it does
+    not even look at the refs. Deciding that before normalizing is what
+    keeps the "standalone xagent is byte-for-byte unchanged" property
+    true: a ref shape only the installing application would ever produce
+    must not be able to raise in a deployment that has no application
+    installed."""
+    assert connector_team_scope._connector_access_hook is None
+    assert (
+        connector_team_scope.resolve_connector_access(
+            None, 7, [("mcp", "not-an-int"), ("custom_api", None), ("mcp",)]
+        )
+        == {}
+    )
 
 
 def test_resolve_connector_access_asks_no_hook_when_no_ref_needs_one():
@@ -472,6 +503,75 @@ def test_resolve_connector_access_or_raise_converts_malformed_answer_too():
     with pytest.raises(ConnectorRuntimeError) as excinfo:
         connector_team_scope.resolve_connector_access_or_raise(None, 7, [("mcp", 11)])
     assert excinfo.value.status_code == 503
+
+
+MALFORMED_REFS = [
+    ("mcp", "abc"),
+    ("mcp", None),
+    ("mcp",),
+    ("mcp", 1, 2),
+]
+
+
+@pytest.mark.parametrize("malformed_ref", MALFORMED_REFS)
+def test_resolve_connector_access_or_raise_lets_a_malformed_ref_raise_raw(
+    malformed_ref,
+):
+    """A ref that is not a ``(str, int-coercible)`` pair is a defect in the
+    calling route, not an outage of the installing application, so it stays
+    the ``ValueError``/``TypeError`` it is instead of being converted into
+    the seam's retryable 503. A hook is installed here on purpose: without
+    one the seam returns ``{}`` before it ever reads a ref, so this check
+    would pass vacuously."""
+    calls: list[object] = []
+
+    def _hook(db, user_id, refs):
+        calls.append(refs)
+        return {}
+
+    connector_team_scope.set_connector_team_hooks(access=_hook)
+    with pytest.raises((ValueError, TypeError)) as excinfo:
+        connector_team_scope.resolve_connector_access_or_raise(None, 7, [malformed_ref])
+    assert not isinstance(excinfo.value, ConnectorRuntimeError)
+    assert calls == []
+
+
+@pytest.mark.parametrize("malformed_ref", MALFORMED_REFS)
+def test_resolve_one_connector_access_or_raise_lets_a_malformed_ref_raise_raw(
+    malformed_ref,
+):
+    """The single-ref wrapper inherits the batch resolver's boundary: it
+    wraps the ref and calls the batch form, so a malformed ref surfaces raw
+    there too rather than as the seam's 503."""
+    calls: list[object] = []
+
+    def _hook(db, user_id, refs):
+        calls.append(refs)
+        return {}
+
+    connector_team_scope.set_connector_team_hooks(access=_hook)
+    with pytest.raises((ValueError, TypeError)) as excinfo:
+        connector_team_scope.resolve_one_connector_access_or_raise(
+            None, 7, malformed_ref
+        )
+    assert not isinstance(excinfo.value, ConnectorRuntimeError)
+    assert calls == []
+
+
+def test_resolve_connector_access_or_raise_still_converts_with_well_formed_refs():
+    """The opposite direction of the two checks above, so that widening the
+    raw-error path cannot go unnoticed: with the refs well formed, a hook
+    that raises the very same ``ValueError`` still becomes the seam's one
+    typed 503, carrying its reason."""
+
+    def _hook(db, user_id, refs):
+        raise ValueError("hook blew up")
+
+    connector_team_scope.set_connector_team_hooks(access=_hook)
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        connector_team_scope.resolve_connector_access_or_raise(None, 7, [("mcp", 11)])
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.details["reason"] == "connector_access_resolution_failed"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/web/services/test_connector_team_scope.py
+++ b/tests/web/services/test_connector_team_scope.py
@@ -9,10 +9,12 @@ surrounding tests in this file only exercise MCP.
 from __future__ import annotations
 
 from collections.abc import Iterator
+from contextlib import contextmanager
+from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, select
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
@@ -33,11 +35,47 @@ T2 = 102
 # ---------------------------------------------------------------------------
 
 
+@contextmanager
+def _reset_hooks_scope() -> Iterator[None]:
+    # Snapshot-and-restore, not clear-everything: this module's own
+    # ``set_connector_team_hooks`` docstring says it clears every slot it
+    # is not given, so calling it bare to "reset" would drop whatever the
+    # process had installed before this file ran. ``snapshot_connector_team_hooks``
+    # is what the newer suites in this repo use, and this file is the last
+    # one that did not. Pulled out of the fixture below so a test can
+    # exercise this scope directly (see
+    # ``test_the_reset_scope_restores_a_pre_installed_hook_rather_than_clearing_it``),
+    # since the fixture itself wraps the whole test body and cannot be
+    # asserted on from inside one.
+    with connector_team_scope.snapshot_connector_team_hooks():
+        yield
+    agent_team_scope.set_agent_team_scope_hook(None)
+
+
 @pytest.fixture(autouse=True)
 def _reset_hooks() -> Iterator[None]:
-    yield
-    connector_team_scope.set_connector_team_hooks()
-    agent_team_scope.set_agent_team_scope_hook(None)
+    with _reset_hooks_scope():
+        yield
+
+
+def test_the_reset_scope_restores_a_pre_installed_hook_rather_than_clearing_it():
+    """This file's autouse reset must restore what the process had, not
+    clear everything: a bare ``set_connector_team_hooks()`` drops any hook
+    installed before this file ran (its own docstring says so), which is
+    what the newer suites in this repo use ``snapshot_connector_team_hooks``
+    to avoid. Asserted directly against the extracted scope rather than
+    from inside a fixture-wrapped test, since the fixture wraps the whole
+    test body and so cannot observe its own effect on itself."""
+    # No manual cleanup needed here: this whole test body already runs
+    # inside the autouse fixture's own ``_reset_hooks_scope()``, which
+    # restores whatever was installed before this test to whatever it was
+    # before, once this test returns -- a bare ``set_connector_team_hooks()``
+    # here would be exactly the clear-everything pattern this fix removes.
+    sentinel = lambda *_a, **_k: {}  # noqa: E731
+    connector_team_scope.set_connector_team_hooks(access=sentinel)
+    with _reset_hooks_scope():
+        connector_team_scope.set_connector_team_hooks(access=lambda *_a, **_k: {})
+    assert connector_team_scope._connector_access_hook is sentinel
 
 
 def test_team_connector_ids_empty_without_hook_installed():
@@ -52,10 +90,13 @@ def test_team_connector_hook_installed_reflects_presence():
     connector_team_scope.set_connector_team_hooks(
         team_visibility=lambda db, *, team_id: {"mcp": set(), "custom_api": set()}
     )
-    try:
-        assert connector_team_scope.team_connector_hook_installed() is True
-    finally:
-        connector_team_scope.set_connector_team_hooks()
+    assert connector_team_scope.team_connector_hook_installed() is True
+    # Load-bearing, not teardown: this line is what the assertion below is
+    # actually exercising -- that clearing the hook flips the reported
+    # presence back to False. The autouse fixture's own snapshot restore
+    # still runs after this test regardless, so nothing here is relied on
+    # for cleanup.
+    connector_team_scope.set_connector_team_hooks()
     assert connector_team_scope.team_connector_hook_installed() is False
 
 
@@ -67,14 +108,11 @@ def test_team_connector_ids_resolves_none_team_without_calling_hook():
         return {"mcp": {1}, "custom_api": set()}
 
     connector_team_scope.set_connector_team_hooks(team_visibility=_hook)
-    try:
-        assert connector_team_scope.team_connector_ids(None, team_id=None) == {
-            "mcp": set(),
-            "custom_api": set(),
-        }
-        assert calls == []
-    finally:
-        connector_team_scope.set_connector_team_hooks()
+    assert connector_team_scope.team_connector_ids(None, team_id=None) == {
+        "mcp": set(),
+        "custom_api": set(),
+    }
+    assert calls == []
 
 
 def test_team_hook_invocation_contract():
@@ -86,16 +124,13 @@ def test_team_hook_invocation_contract():
         return {"mcp": set(), "custom_api": set()}
 
     connector_team_scope.set_connector_team_hooks(team_visibility=_record)
-    try:
-        assert connector_team_scope.team_connector_ids(None, team_id=None) == {
-            "mcp": set(),
-            "custom_api": set(),
-        }
-        assert calls == []
-        connector_team_scope.team_connector_ids(None, team_id=T1)
-        assert calls == [("kw", T1)]
-    finally:
-        connector_team_scope.set_connector_team_hooks()
+    assert connector_team_scope.team_connector_ids(None, team_id=None) == {
+        "mcp": set(),
+        "custom_api": set(),
+    }
+    assert calls == []
+    connector_team_scope.team_connector_ids(None, team_id=T1)
+    assert calls == [("kw", T1)]
 
 
 def test_team_hook_positional_only_callable_raises():
@@ -107,11 +142,385 @@ def test_team_hook_positional_only_callable_raises():
         return {"mcp": set(), "custom_api": set()}
 
     connector_team_scope.set_connector_team_hooks(team_visibility=_positional_only)
-    try:
-        with pytest.raises(TypeError):
-            connector_team_scope.team_connector_ids(None, team_id=T1)
-    finally:
-        connector_team_scope.set_connector_team_hooks()
+    with pytest.raises(TypeError):
+        connector_team_scope.team_connector_ids(None, team_id=T1)
+
+
+# ---------------------------------------------------------------------------
+# ConnectorAccess and the access hook slot.
+# ---------------------------------------------------------------------------
+
+
+def test_connector_access_defaults_are_both_false():
+    access = connector_team_scope.ConnectorAccess()
+    assert access.team_owned is False
+    assert access.can_edit is False
+
+
+def test_resolve_connector_access_returns_an_empty_map_without_a_hook_installed():
+    for refs in ([("mcp", 1), ("custom_api", 1), ("mcp", 999)], [("mcp", 1)]):
+        assert connector_team_scope.resolve_connector_access(None, 7, refs) == {}
+
+
+def test_resolve_connector_access_asks_no_hook_when_no_ref_needs_one():
+    """An installed hook is never called when there is nothing to ask about
+    -- an empty ``refs`` collection short-circuits before the hook, the
+    same way no hook installed does."""
+    calls: list[object] = []
+
+    def _hook(db, user_id, refs):
+        calls.append(refs)
+        return {}
+
+    connector_team_scope.set_connector_team_hooks(access=_hook)
+    assert connector_team_scope.resolve_connector_access(None, 7, []) == {}
+    assert calls == []
+
+
+def test_resolve_connector_access_calls_the_hook_once_with_the_requested_refs():
+    calls = []
+
+    def _hook(db, user_id, refs):
+        calls.append((db, user_id, refs))
+        return {
+            ("mcp", 11): connector_team_scope.ConnectorAccess(
+                team_owned=True, can_edit=True
+            )
+        }
+
+    connector_team_scope.set_connector_team_hooks(access=_hook)
+    result = connector_team_scope.resolve_connector_access(None, 7, [("mcp", 11)])
+    assert result == {
+        ("mcp", 11): connector_team_scope.ConnectorAccess(
+            team_owned=True, can_edit=True
+        )
+    }
+    assert len(calls) == 1
+    called_db, called_user_id, called_refs = calls[0]
+    assert (called_db, called_user_id) == (None, 7)
+    assert called_refs == frozenset({("mcp", 11)})
+
+
+def test_resolve_connector_access_a_ref_missing_from_the_answer_means_not_linked():
+    """Leaving a ref out of the answer is the only way to say "the caller's
+    team does not link this connector" -- distinct from a rejected
+    malformed verdict for that same ref."""
+    connector_team_scope.set_connector_team_hooks(access=lambda *a: {})
+    assert connector_team_scope.resolve_connector_access(None, 7, [("mcp", 11)]) == {}
+
+
+# ---------------------------------------------------------------------------
+# Validation of the access hook's answer shape at the boundary.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "malformed_answer",
+    [
+        "dict-of-fields",
+        "connector-delete-decision",
+        "tuple",
+        "truthy-object-with-right-attrs",
+        "none",
+        "list",
+    ],
+)
+def test_resolve_connector_access_rejects_a_non_dict_answer(malformed_answer):
+    # Built inside the test body, not the parametrize list: a couple of
+    # these shapes are instances of types this module defines, and
+    # constructing them at collection time would make the whole file
+    # uncollectable while those types don't exist yet.
+    answer = {
+        "dict-of-fields": {"team_owned": True, "can_edit": True},
+        "connector-delete-decision": connector_team_scope.ConnectorDeleteDecision(
+            team_owned=True, authorized=True
+        ),
+        "tuple": (True, True),
+        "truthy-object-with-right-attrs": SimpleNamespace(
+            team_owned=True, can_edit=True
+        ),
+        "none": None,
+        "list": [connector_team_scope.ConnectorAccess(team_owned=True, can_edit=True)],
+    }[malformed_answer]
+
+    connector_team_scope.set_connector_team_hooks(access=lambda *a: answer)
+    with pytest.raises(ValueError):
+        connector_team_scope.resolve_connector_access(None, 7, [("mcp", 11)])
+
+
+def test_resolve_connector_access_rejects_a_verdict_for_a_connector_nobody_asked_about():
+    """A verdict keyed on a ref outside the requested set means the hook
+    answered a different question than the one it was asked -- silently
+    dropping it would hide that the hook and the caller have gone out of
+    sync, so this must fail loudly instead."""
+    connector_team_scope.set_connector_team_hooks(
+        access=lambda *a: {
+            ("mcp", 999): connector_team_scope.ConnectorAccess(
+                team_owned=True, can_edit=True
+            )
+        }
+    )
+    with pytest.raises(ValueError):
+        connector_team_scope.resolve_connector_access(None, 7, [("mcp", 11)])
+
+
+@pytest.mark.parametrize(
+    "connector_type,requested_id,alias_id",
+    [
+        ("mcp", 1, True),
+        ("mcp", 1, 1.0),
+        ("mcp", 1, Decimal("1")),
+        ("custom_api", 2, 2.0),
+        ("custom_api", 1, True),
+    ],
+    ids=["mcp-bool", "mcp-float", "mcp-decimal", "custom-api-float", "custom-api-bool"],
+)
+def test_resolve_connector_access_rejects_a_key_whose_id_is_only_equal_to_an_int(
+    connector_type, requested_id, alias_id
+):
+    """``True == 1``, ``1.0 == 1`` and ``Decimal("1") == 1`` in Python, so a
+    key carrying any of those in place of the requested connector id would
+    pass an ``in``-based membership check against ``requested`` -- and be
+    stored as a grant for the connector it merely aliases, not the one it
+    actually is. The exact-type check must reject it before membership is
+    ever checked."""
+    connector_team_scope.set_connector_team_hooks(
+        access=lambda *a: {
+            (connector_type, alias_id): connector_team_scope.ConnectorAccess(
+                team_owned=True, can_edit=True
+            )
+        }
+    )
+    with pytest.raises(ValueError, match="not an int"):
+        connector_team_scope.resolve_connector_access(
+            None, 7, [(connector_type, requested_id)]
+        )
+
+
+def test_resolve_connector_access_rejects_a_key_that_is_not_a_tuple():
+    connector_team_scope.set_connector_team_hooks(
+        access=lambda *a: {
+            "mcp": connector_team_scope.ConnectorAccess(team_owned=True, can_edit=True)
+        }
+    )
+    with pytest.raises(
+        ValueError, match=r"not a \(connector_type, connector_id\) pair"
+    ):
+        connector_team_scope.resolve_connector_access(None, 7, [("mcp", 1)])
+
+
+def test_resolve_connector_access_rejects_a_key_of_the_wrong_length():
+    connector_team_scope.set_connector_team_hooks(
+        access=lambda *a: {
+            ("mcp", 1, "x"): connector_team_scope.ConnectorAccess(
+                team_owned=True, can_edit=True
+            )
+        }
+    )
+    with pytest.raises(
+        ValueError, match=r"not a \(connector_type, connector_id\) pair"
+    ):
+        connector_team_scope.resolve_connector_access(None, 7, [("mcp", 1)])
+
+
+def test_resolve_connector_access_rejects_a_key_whose_connector_type_is_not_a_str():
+    connector_team_scope.set_connector_team_hooks(
+        access=lambda *a: {
+            (1, 1): connector_team_scope.ConnectorAccess(team_owned=True, can_edit=True)
+        }
+    )
+    with pytest.raises(ValueError, match="connector type that is not a str"):
+        connector_team_scope.resolve_connector_access(None, 7, [(1, 1)])
+
+
+@pytest.mark.parametrize(
+    "wrong_value",
+    ["dict", "duck-typed", "delete-decision", "none", "true"],
+)
+def test_resolve_connector_access_rejects_a_verdict_value_that_is_not_a_connector_access(
+    wrong_value,
+):
+    """The key was asked about and the key's shape is fine -- what is
+    wrong is the value. A duck-typed object carrying ``team_owned=True``
+    and ``can_edit=True`` would satisfy every attribute check below it, so
+    the type check is the only thing that stops a hook from answering with
+    something that merely resembles a verdict. Built in the body, not the
+    parametrize list, because two of these are instances of types this
+    module defines."""
+    value = {
+        "dict": {"team_owned": True, "can_edit": True},
+        "duck-typed": SimpleNamespace(team_owned=True, can_edit=True),
+        "delete-decision": connector_team_scope.ConnectorDeleteDecision(
+            team_owned=True, authorized=True
+        ),
+        "none": None,
+        "true": True,
+    }[wrong_value]
+
+    connector_team_scope.set_connector_team_hooks(
+        access=lambda *_a: {("mcp", 11): value}
+    )
+    with pytest.raises(ValueError, match="expected ConnectorAccess values"):
+        connector_team_scope.resolve_connector_access(None, 7, [("mcp", 11)])
+
+
+@pytest.mark.parametrize(
+    "bad_team_owned",
+    [False, "yes", 1],
+    ids=["false", "truthy-string", "truthy-int"],
+)
+def test_resolve_connector_access_rejects_a_team_owned_that_is_not_true(
+    bad_team_owned,
+):
+    """``team_owned`` must be exactly ``True`` on every verdict that
+    reaches a caller -- "not linked" is expressed by leaving the ref out
+    of the answer, never by a verdict carrying a falsy or merely-truthy
+    ``team_owned``."""
+    verdict = connector_team_scope.ConnectorAccess(
+        team_owned=bad_team_owned, can_edit=True
+    )
+    connector_team_scope.set_connector_team_hooks(
+        access=lambda *a: {("mcp", 11): verdict}
+    )
+    with pytest.raises(ValueError):
+        connector_team_scope.resolve_connector_access(None, 7, [("mcp", 11)])
+
+
+def test_resolve_connector_access_rejects_a_bare_connector_access_default():
+    """``ConnectorAccess()`` -- the dataclass's own all-``False`` default --
+    is rejected the same way: constructing a bare instance must never
+    become a legitimate "not linked" answer."""
+    connector_team_scope.set_connector_team_hooks(
+        access=lambda *a: {("mcp", 11): connector_team_scope.ConnectorAccess()}
+    )
+    with pytest.raises(ValueError):
+        connector_team_scope.resolve_connector_access(None, 7, [("mcp", 11)])
+
+
+@pytest.mark.parametrize(
+    "bad_can_edit",
+    ["false", 1, 0],
+    ids=["string", "truthy-int", "falsy-int"],
+)
+def test_resolve_connector_access_rejects_a_can_edit_that_is_not_exactly_bool(
+    bad_can_edit,
+):
+    """``bool`` is a subclass of ``int`` in Python, so ``1``/``0`` would
+    pass a truthiness check -- this seam requires an exact ``True``/
+    ``False`` instead, since a truthy value is never a legitimate grant."""
+    verdict = connector_team_scope.ConnectorAccess(
+        team_owned=True, can_edit=bad_can_edit
+    )
+    connector_team_scope.set_connector_team_hooks(
+        access=lambda *a: {("mcp", 11): verdict}
+    )
+    with pytest.raises(ValueError):
+        connector_team_scope.resolve_connector_access(None, 7, [("mcp", 11)])
+
+
+def test_resolve_connector_access_accepts_linked_but_not_editable():
+    """A linked-but-not-editable answer is legal on its own -- the seam does
+    not require can_edit to be True just because team_owned is."""
+    answer = connector_team_scope.ConnectorAccess(team_owned=True, can_edit=False)
+    connector_team_scope.set_connector_team_hooks(
+        access=lambda *a: {("mcp", 11): answer}
+    )
+    assert connector_team_scope.resolve_connector_access(None, 7, [("mcp", 11)]) == {
+        ("mcp", 11): answer
+    }
+
+
+# ---------------------------------------------------------------------------
+# The typed-failure wrapper.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_connector_access_or_raise_converts_value_error_to_503():
+    def _hook(db, user_id, refs):
+        raise ValueError("hook returned garbage")
+
+    connector_team_scope.set_connector_team_hooks(access=_hook)
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        connector_team_scope.resolve_connector_access_or_raise(None, 7, [("mcp", 11)])
+    assert excinfo.value.status_code == 503
+
+
+def test_resolve_connector_access_or_raise_passes_through_planted_error():
+    planted = ConnectorRuntimeError(
+        "planted_code", "planted", details={"reason": "planted_reason"}
+    )
+
+    def _hook(db, user_id, refs):
+        raise planted
+
+    connector_team_scope.set_connector_team_hooks(access=_hook)
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        connector_team_scope.resolve_connector_access_or_raise(None, 7, [("mcp", 11)])
+    assert excinfo.value is planted
+
+
+def test_resolve_connector_access_or_raise_converts_malformed_answer_too():
+    """The validator's ValueError for a malformed answer goes through the
+    same conversion as any other hook-side failure."""
+    connector_team_scope.set_connector_team_hooks(
+        access=lambda *a: {
+            ("mcp", 11): connector_team_scope.ConnectorAccess(
+                team_owned=False, can_edit=True
+            )
+        }
+    )
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        connector_team_scope.resolve_connector_access_or_raise(None, 7, [("mcp", 11)])
+    assert excinfo.value.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# snapshot_connector_team_hooks and its discovery-based coverage test.
+# ---------------------------------------------------------------------------
+
+
+def _connector_hook_slot_names() -> list[str]:
+    return [name for name in vars(connector_team_scope) if name.endswith("_hook")]
+
+
+def test_connector_hook_slot_names_are_discoverable():
+    # Sanity check the enumeration itself finds all five known slots, so
+    # the coverage test below is not vacuously true.
+    names = _connector_hook_slot_names()
+    assert names.count("_connector_deleted_hook") == 1
+    assert names.count("_connector_renamed_hook") == 1
+    assert names.count("_connector_visibility_hook") == 1
+    assert names.count("_team_connector_visibility_hook") == 1
+    assert names.count("_connector_access_hook") == 1
+    assert len(names) == 5
+
+
+def test_snapshot_connector_team_hooks_restores_every_slot_by_identity():
+    names = _connector_hook_slot_names()
+    originals = {name: getattr(connector_team_scope, name) for name in names}
+
+    with connector_team_scope.snapshot_connector_team_hooks():
+        for name in names:
+            setattr(connector_team_scope, name, lambda *a, **k: None)
+        for name in names:
+            assert getattr(connector_team_scope, name) is not originals[name]
+
+    for name in names:
+        assert getattr(connector_team_scope, name) is originals[name]
+
+
+def test_snapshot_connector_team_hooks_restores_on_exception():
+    names = _connector_hook_slot_names()
+    originals = {name: getattr(connector_team_scope, name) for name in names}
+
+    with pytest.raises(RuntimeError):
+        with connector_team_scope.snapshot_connector_team_hooks():
+            for name in names:
+                setattr(connector_team_scope, name, lambda *a, **k: None)
+            raise RuntimeError("boom inside the block")
+
+    for name in names:
+        assert getattr(connector_team_scope, name) is originals[name]
 
 
 # ---------------------------------------------------------------------------
@@ -142,6 +551,144 @@ def _create_user(db: Session, username: str) -> User:
     db.add(user)
     db.flush()
     return user
+
+
+def _poisoning_hook_by_orm_flush(colliding_user_id: int):
+    """A hook that leaves a failed ORM flush on the shared session and then
+    raises. A failed flush marks the session's transaction inactive on
+    every backend, so any later statement raises ``PendingRollbackError``
+    until something rolls back -- which is exactly what the seam's hook
+    door must do before the exception leaves the module."""
+
+    def hook(db, *_args, **_kwargs):
+        db.add(
+            User(id=colliding_user_id, username="flush-poison-dup", password_hash="x")
+        )
+        db.flush()
+
+    return hook
+
+
+@pytest.mark.parametrize(
+    "slot,invoke",
+    [
+        (
+            "visibility",
+            lambda db: connector_team_scope.visible_team_connector_ids(db, 1),
+        ),
+        (
+            "deleted",
+            lambda db: connector_team_scope.delete_team_connector(db, 1, "mcp", 1),
+        ),
+        (
+            "renamed",
+            lambda db: connector_team_scope.rename_team_connector(
+                db, 1, "mcp", 1, "old", "new"
+            ),
+        ),
+    ],
+    ids=["visibility-hook", "deleted-hook", "renamed-hook"],
+)
+def test_every_hook_door_restores_the_session_when_the_hook_fails(
+    db_session, slot, invoke
+):
+    """The session restore lives on the single invocation door rather than
+    on the ``*_or_raise`` wrappers, so every slot has it -- including a
+    slot added to this module later. These three are the slots whose
+    answers this seam does not validate. The two this parametrization
+    leaves out are the two whose answers it does validate; they are
+    covered by the sister test below, where the hook does not raise at
+    all."""
+    existing = _create_user(db_session, "already-here")
+    db_session.commit()
+
+    with connector_team_scope.snapshot_connector_team_hooks():
+        connector_team_scope.set_connector_team_hooks(
+            **{slot: _poisoning_hook_by_orm_flush(int(existing.id))}
+        )
+        with pytest.raises(Exception):
+            invoke(db_session)
+
+    # Without the restore this raises PendingRollbackError instead.
+    assert db_session.query(User).count() == 1
+
+
+def _swallowing_poisoning_hook_answering(colliding_user_id: int, answer: object):
+    """A hook that leaves a failed ORM flush on the shared session,
+    swallows that failure itself, and then answers with a shape the seam's
+    own validator rejects.
+
+    The sister of ``_poisoning_hook_by_orm_flush`` above: there the hook
+    lets its failure propagate, so the door's ``except`` fires on the hook
+    call. Here nothing propagates out of the hook at all -- the door's
+    ``except`` fires on the validator's rejection instead, which is the
+    other half the restore has to cover.
+    """
+
+    def hook(db, *_args, **_kwargs):
+        try:
+            db.add(
+                User(
+                    id=colliding_user_id,
+                    username="swallowed-poison-dup",
+                    password_hash="x",
+                )
+            )
+            db.flush()
+        except Exception:
+            pass
+        return answer
+
+    return hook
+
+
+@pytest.mark.parametrize(
+    "slot,answer,invoke",
+    [
+        (
+            "team_visibility",
+            {"mcp": "not-a-set", "custom_api": set()},
+            lambda db: connector_team_scope.resolve_team_connector_ids_or_raise(
+                db, team_id=T1, log_subject=None
+            ),
+        ),
+        (
+            "access",
+            {"not-a-ref": object()},
+            lambda db: connector_team_scope.resolve_connector_access_or_raise(
+                db, 1, [("mcp", 11)]
+            ),
+        ),
+    ],
+    ids=["team-visibility-hook", "access-hook"],
+)
+def test_a_hook_that_swallows_its_failure_and_answers_malformed_restores_too(
+    db_session, slot, answer, invoke
+):
+    """The two slots whose answers this seam validates are the two where
+    it can notice a hook that poisoned the shared session without ever
+    raising: the hook runs a statement that fails, catches that itself,
+    and returns an answer the validator then rejects. A hook can do the
+    same on the other three slots, where nothing checks the answer and so
+    nothing raises -- see the door's docstring on the shape that stays
+    uncovered. The rejection is the seam's own exception, not
+    the hook's, so the restore has to sit where it sees both -- inside the
+    door, around the validation as well as around the call."""
+    existing = _create_user(db_session, "already-here")
+    db_session.commit()
+
+    with connector_team_scope.snapshot_connector_team_hooks():
+        connector_team_scope.set_connector_team_hooks(
+            **{slot: _swallowing_poisoning_hook_answering(int(existing.id), answer)}
+        )
+        with pytest.raises(ConnectorRuntimeError) as excinfo:
+            invoke(db_session)
+        assert excinfo.value.status_code == 503
+
+    # No rollback of our own before this line: the query is the statement
+    # that proves the door restored the session, and its count proves the
+    # poisoning insert never landed.
+    assert db_session.query(User).count() == 1
 
 
 def _create_mcp(db: Session, name: str, *, owner: User | None = None) -> MCPServer:
@@ -263,22 +810,18 @@ async def test_scope_keys_on_agent_team_not_runner(db_session, seed, owner_team)
                 team_id=_team, is_team_admin=False
             )
         )
-    try:
-        cfg = WebToolConfig(
-            db=db_session,
-            request=None,
-            user_id=int(seed.c.id),
-            connector_team_id=T1,
-            include_mcp_tools=True,
-        )
-        configs = await cfg._load_mcp_server_configs()
-        assert {c["name"] for c in configs} == {
-            seed.active_own.name,
-            seed.team_s.name,
-        }
-    finally:
-        connector_team_scope.set_connector_team_hooks()
-        agent_team_scope.set_agent_team_scope_hook(None)
+    cfg = WebToolConfig(
+        db=db_session,
+        request=None,
+        user_id=int(seed.c.id),
+        connector_team_id=T1,
+        include_mcp_tools=True,
+    )
+    configs = await cfg._load_mcp_server_configs()
+    assert {c["name"] for c in configs} == {
+        seed.active_own.name,
+        seed.team_s.name,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -303,31 +846,28 @@ async def test_legacy_visibility_hook_alone_is_unchanged(db_session, seed):
             else {"mcp": set(), "custom_api": set()}
         )
     )
-    try:
-        assert connector_team_scope.team_connector_hook_installed() is False
+    assert connector_team_scope.team_connector_hook_installed() is False
 
-        # The tool loader consults no hook today and must not widen.
-        cfg = WebToolConfig(
-            db=db_session,
-            request=None,
-            user_id=int(seed.c.id),
-            connector_team_id=T1,
-            include_mcp_tools=True,
-        )
-        configs = await cfg._load_mcp_server_configs()
-        assert {c["name"] for c in configs} == {seed.active_own.name}
+    # The tool loader consults no hook today and must not widen.
+    cfg = WebToolConfig(
+        db=db_session,
+        request=None,
+        user_id=int(seed.c.id),
+        connector_team_id=T1,
+        include_mcp_tools=True,
+    )
+    configs = await cfg._load_mcp_server_configs()
+    assert {c["name"] for c in configs} == {seed.active_own.name}
 
-        # The runtime-connector loader keeps exactly today's answer via the
-        # fallback, for both connector kinds.
-        visible = _load_visible_runtime_connectors(
-            db_session, user_id=int(seed.c.id), agent_team_id=T1
-        )
-        mcp_ids = {r.connector_id for r in visible if r.connector_type == "mcp"}
-        capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
-        assert mcp_ids == {int(seed.active_own.id), int(seed.team_s.id)}
-        assert capi_ids == {int(seed.capi_own.id), int(seed.a_capi.id)}
-    finally:
-        connector_team_scope.set_connector_team_hooks()
+    # The runtime-connector loader keeps exactly today's answer via the
+    # fallback, for both connector kinds.
+    visible = _load_visible_runtime_connectors(
+        db_session, user_id=int(seed.c.id), agent_team_id=T1
+    )
+    mcp_ids = {r.connector_id for r in visible if r.connector_type == "mcp"}
+    capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
+    assert mcp_ids == {int(seed.active_own.id), int(seed.team_s.id)}
+    assert capi_ids == {int(seed.capi_own.id), int(seed.a_capi.id)}
 
 
 # ---------------------------------------------------------------------------
@@ -338,14 +878,11 @@ async def test_legacy_visibility_hook_alone_is_unchanged(db_session, seed):
 
 def test_personal_agent_gets_no_team_custom_api(db_session, seed):
     connector_team_scope.set_connector_team_hooks(team_visibility=_team_hook(seed))
-    try:
-        visible = _load_visible_runtime_connectors(
-            db_session, user_id=int(seed.c.id), agent_team_id=None
-        )
-        capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
-        assert capi_ids == {int(seed.capi_own.id)}
-    finally:
-        connector_team_scope.set_connector_team_hooks()
+    visible = _load_visible_runtime_connectors(
+        db_session, user_id=int(seed.c.id), agent_team_id=None
+    )
+    capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
+    assert capi_ids == {int(seed.capi_own.id)}
 
 
 # ---------------------------------------------------------------------------
@@ -364,16 +901,13 @@ def test_installed_hook_returning_empty_does_not_fall_back(db_session, seed):
         ),
         team_visibility=lambda db, *, team_id: {"mcp": set(), "custom_api": set()},
     )
-    try:
-        visible = _load_visible_runtime_connectors(
-            db_session, user_id=int(seed.c.id), agent_team_id=T1
-        )
-        mcp_ids = {r.connector_id for r in visible if r.connector_type == "mcp"}
-        capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
-        assert mcp_ids == {int(seed.active_own.id)}
-        assert capi_ids == {int(seed.capi_own.id)}
-    finally:
-        connector_team_scope.set_connector_team_hooks()
+    visible = _load_visible_runtime_connectors(
+        db_session, user_id=int(seed.c.id), agent_team_id=T1
+    )
+    mcp_ids = {r.connector_id for r in visible if r.connector_type == "mcp"}
+    capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
+    assert mcp_ids == {int(seed.active_own.id)}
+    assert capi_ids == {int(seed.capi_own.id)}
 
 
 # ---------------------------------------------------------------------------
@@ -401,19 +935,16 @@ def test_installed_hook_with_no_governing_agent_supersedes_legacy_overlay(
         ),
         team_visibility=_team_hook(seed),
     )
-    try:
-        visible = _load_visible_runtime_connectors(
-            db_session, user_id=int(seed.c.id), agent_team_id=None
-        )
-        mcp_ids = {r.connector_id for r in visible if r.connector_type == "mcp"}
-        capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
-        # Personal-only on both connector kinds: seed.team_s / seed.a_capi
-        # (the legacy hook's answer) do NOT appear, even though the legacy
-        # hook alone would have granted them.
-        assert mcp_ids == {int(seed.active_own.id)}
-        assert capi_ids == {int(seed.capi_own.id)}
-    finally:
-        connector_team_scope.set_connector_team_hooks()
+    visible = _load_visible_runtime_connectors(
+        db_session, user_id=int(seed.c.id), agent_team_id=None
+    )
+    mcp_ids = {r.connector_id for r in visible if r.connector_type == "mcp"}
+    capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
+    # Personal-only on both connector kinds: seed.team_s / seed.a_capi
+    # (the legacy hook's answer) do NOT appear, even though the legacy
+    # hook alone would have granted them.
+    assert mcp_ids == {int(seed.active_own.id)}
+    assert capi_ids == {int(seed.capi_own.id)}
 
 
 # ---------------------------------------------------------------------------
@@ -432,18 +963,15 @@ def test_installed_hook_with_no_governing_agent_supersedes_legacy_overlay(
 
 def test_new_hook_branch_unions_team_custom_api_too(db_session, seed):
     connector_team_scope.set_connector_team_hooks(team_visibility=_team_hook(seed))
-    try:
-        visible = _load_visible_runtime_connectors(
-            db_session, user_id=int(seed.c.id), agent_team_id=T1
-        )
-        mcp_ids = {r.connector_id for r in visible if r.connector_type == "mcp"}
-        capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
-        # T1's hook (see _team_hook above) grants both seed.team_s (mcp) and
-        # seed.a_capi (custom_api). Both grants union in now.
-        assert mcp_ids == {int(seed.active_own.id), int(seed.team_s.id)}
-        assert capi_ids == {int(seed.capi_own.id), int(seed.a_capi.id)}
-    finally:
-        connector_team_scope.set_connector_team_hooks()
+    visible = _load_visible_runtime_connectors(
+        db_session, user_id=int(seed.c.id), agent_team_id=T1
+    )
+    mcp_ids = {r.connector_id for r in visible if r.connector_type == "mcp"}
+    capi_ids = {r.connector_id for r in visible if r.connector_type == "custom_api"}
+    # T1's hook (see _team_hook above) grants both seed.team_s (mcp) and
+    # seed.a_capi (custom_api). Both grants union in now.
+    assert mcp_ids == {int(seed.active_own.id), int(seed.team_s.id)}
+    assert capi_ids == {int(seed.capi_own.id), int(seed.a_capi.id)}
 
 
 # ---------------------------------------------------------------------------
@@ -498,11 +1026,8 @@ def test_team_connector_ids_raises_on_malformed_hook_answer(malformed_answer):
     connector_team_scope.set_connector_team_hooks(
         team_visibility=lambda db, *, team_id: malformed_answer
     )
-    try:
-        with pytest.raises(ValueError):
-            connector_team_scope.team_connector_ids(None, team_id=T1)
-    finally:
-        connector_team_scope.set_connector_team_hooks()
+    with pytest.raises(ValueError):
+        connector_team_scope.team_connector_ids(None, team_id=T1)
 
 
 def test_team_connector_ids_accepts_and_ignores_extra_keys():
@@ -516,12 +1041,9 @@ def test_team_connector_ids_accepts_and_ignores_extra_keys():
             "unexpected_extra_key": object(),
         }
     )
-    try:
-        result = connector_team_scope.team_connector_ids(None, team_id=T1)
-        assert result["mcp"] == {1, 2}
-        assert result["custom_api"] == {3}
-    finally:
-        connector_team_scope.set_connector_team_hooks()
+    result = connector_team_scope.team_connector_ids(None, team_id=T1)
+    assert result["mcp"] == {1, 2}
+    assert result["custom_api"] == {3}
 
 
 @pytest.mark.asyncio
@@ -533,21 +1055,18 @@ async def test_mcp_loader_seam_retypes_malformed_hook_answer(db_session, seed):
     connector_team_scope.set_connector_team_hooks(
         team_visibility=lambda db, *, team_id: {"mcp": "12", "custom_api": set()}
     )
-    try:
-        cfg = WebToolConfig(
-            db=db_session,
-            request=None,
-            user_id=int(seed.c.id),
-            connector_team_id=T1,
-            include_mcp_tools=True,
-        )
-        with pytest.raises(ConnectorRuntimeError) as excinfo:
-            await cfg._load_mcp_server_configs()
-        assert excinfo.value.status_code == 503
-        assert excinfo.value.details["reason"] == "team_scope_resolution_failed"
-        assert isinstance(excinfo.value.__cause__, ValueError)
-    finally:
-        connector_team_scope.set_connector_team_hooks()
+    cfg = WebToolConfig(
+        db=db_session,
+        request=None,
+        user_id=int(seed.c.id),
+        connector_team_id=T1,
+        include_mcp_tools=True,
+    )
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        await cfg._load_mcp_server_configs()
+    assert excinfo.value.status_code == 503
+    assert excinfo.value.details["reason"] == "team_scope_resolution_failed"
+    assert isinstance(excinfo.value.__cause__, ValueError)
 
 
 def test_runtime_view_seam_retypes_malformed_hook_answer(db_session, seed):
@@ -566,19 +1085,16 @@ def test_runtime_view_seam_retypes_malformed_hook_answer(db_session, seed):
     connector_team_scope.set_connector_team_hooks(
         team_visibility=lambda db, *, team_id: {"mcp": "12", "custom_api": set()}
     )
-    try:
-        with pytest.raises(ConnectorRuntimeError) as excinfo:
-            _load_custom_api_runtime_view_sync(
-                db_session,
-                task_id=str(task.id),
-                connector_runtime_turn_id=None,
-                user_id=int(seed.c.id),
-                agent_team_id=T1,
-            )
-        assert excinfo.value.status_code == 503
-        assert isinstance(excinfo.value.__cause__, ValueError)
-    finally:
-        connector_team_scope.set_connector_team_hooks()
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        _load_custom_api_runtime_view_sync(
+            db_session,
+            task_id=str(task.id),
+            connector_runtime_turn_id=None,
+            user_id=int(seed.c.id),
+            agent_team_id=T1,
+        )
+    assert excinfo.value.status_code == 503
+    assert isinstance(excinfo.value.__cause__, ValueError)
 
 
 def test_resolve_or_raise_passes_a_typed_error_through_unchanged():
@@ -597,12 +1113,47 @@ def test_resolve_or_raise_passes_a_typed_error_through_unchanged():
         raise planted
 
     connector_team_scope.set_connector_team_hooks(team_visibility=_raising_hook)
-    try:
-        with pytest.raises(ConnectorRuntimeError) as excinfo:
-            connector_team_scope.resolve_team_connector_ids_or_raise(
-                None, team_id=T1, log_subject="passthrough-probe"
-            )
-        assert excinfo.value is planted
-        assert excinfo.value.details["reason"] == "planted_inner_reason"
-    finally:
-        connector_team_scope.set_connector_team_hooks()
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        connector_team_scope.resolve_team_connector_ids_or_raise(
+            None, team_id=T1, log_subject="passthrough-probe"
+        )
+    assert excinfo.value is planted
+    assert excinfo.value.details["reason"] == "planted_inner_reason"
+
+
+# ---------------------------------------------------------------------------
+# The team-visibility wrapper restores the shared session after a failed
+# hook too -- the sister guarantee to resolve_connector_access_or_raise's,
+# on the sister wrapper.
+# ---------------------------------------------------------------------------
+
+
+def test_the_team_scope_wrapper_also_restores_the_session(db_session):
+    """A hook that poisons the shared session via a failed ORM flush, then
+    lets that failure propagate, must not leave the session unusable for
+    whatever runs next in the same request."""
+    poisoning_user_id = 900001
+    db_session.add(
+        User(id=poisoning_user_id, username="team-scope-poison", password_hash="x")
+    )
+    db_session.commit()
+
+    def poisoning_team_visibility(db, *, team_id):
+        # A duplicate primary key -- a real ORM flush failure, not a
+        # simulated one -- propagates out of this hook uncaught.
+        db.add(User(id=poisoning_user_id, username="dup", password_hash="x"))
+        db.flush()
+        return {"mcp": set(), "custom_api": set()}  # pragma: no cover - unreachable
+
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=poisoning_team_visibility
+    )
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        connector_team_scope.resolve_team_connector_ids_or_raise(
+            db_session, team_id=T1, log_subject=None
+        )
+    assert excinfo.value.status_code == 503
+
+    # The session must be usable again immediately afterward.
+    result = db_session.execute(select(1)).scalar()
+    assert result == 1

--- a/tests/web/services/test_connector_team_scope.py
+++ b/tests/web/services/test_connector_team_scope.py
@@ -527,6 +527,16 @@ MALFORMED_REFS = [
     ("mcp", None),
     ("mcp",),
     ("mcp", 1, 2),
+    # An id that WOULD have converted to an int is malformed too, not something
+    # to convert quietly. Converting asked the hook about ``("mcp", 11)`` while
+    # the caller still held ``("mcp", "11")``, so the answer came back under a
+    # key the caller could not look up, and the single-ref wrapper read the
+    # miss as "the team does not link it".
+    ("mcp", "11"),
+    # ``isinstance(True, int)`` is ``True`` in Python and ``("mcp", True)``
+    # hashes and compares equal to ``("mcp", 1)``, so tolerating it resolved
+    # connector 1's access under another connector's name.
+    ("mcp", True),
 ]
 
 
@@ -534,12 +544,12 @@ MALFORMED_REFS = [
 def test_resolve_connector_access_or_raise_lets_a_malformed_ref_raise_raw(
     malformed_ref,
 ):
-    """A ref that is not a ``(str, int-coercible)`` pair is a defect in the
-    calling route, not an outage of the installing application, so it stays
-    the ``ValueError``/``TypeError`` it is instead of being converted into
-    the seam's retryable 503. A hook is installed here on purpose: it is
-    what gives the trailing ``assert calls == []`` its meaning, by showing
-    the raise lands before the hook is ever reached."""
+    """A ref whose id is not already an ``int`` is a defect in the calling
+    route, not an outage of the installing application, so it stays the
+    ``ValueError``/``TypeError`` it is instead of being converted into the
+    seam's retryable 503. A hook is installed here on purpose: it is what
+    gives the trailing ``assert calls == []`` its meaning, by showing the
+    raise lands before the hook is ever reached."""
     calls: list[object] = []
 
     def _hook(db, user_id, refs):
@@ -609,6 +619,44 @@ def test_resolve_connector_access_or_raise_still_converts_with_well_formed_refs(
     assert excinfo.value.details["reason"] == "connector_access_resolution_failed"
 
 
+def test_resolve_one_connector_access_or_raise_returns_what_the_batch_form_resolved():
+    """The single-ref wrapper agrees with the batch form it wraps.
+
+    It unwraps with ``.get(ref)``, which is only correct while every answer
+    comes back keyed on the ref the caller passed. That holds because
+    ``_normalize_connector_refs`` rejects an id that is not already an ``int``
+    instead of rewriting it -- back when it coerced, ``("mcp", "11")`` was
+    asked about as ``("mcp", 11)`` and this lookup missed, reporting ``None``
+    for a connector the hook had granted. The malformed-ref cases above pin
+    the rejecting half; this pins that a legitimate ref still round-trips.
+    """
+    grant = connector_team_scope.ConnectorAccess(team_owned=True, can_edit=True)
+    connector_team_scope.set_connector_team_hooks(
+        access=lambda db, user_id, requested: {r: grant for r in requested}
+    )
+
+    batch = connector_team_scope.resolve_connector_access_or_raise(
+        None, 7, [("mcp", 11)]
+    )
+    one = connector_team_scope.resolve_one_connector_access_or_raise(
+        None, 7, ("mcp", 11)
+    )
+
+    assert batch == {("mcp", 11): grant}
+    assert one == grant, f"batch resolved {batch!r} but the wrapper said {one!r}"
+
+
+def test_resolve_one_connector_access_or_raise_still_reports_an_unlinked_connector():
+    """The other direction, so the check above cannot be satisfied by a
+    wrapper that returns a grant for everything: a hook that links nothing
+    still unwraps to ``None``."""
+    connector_team_scope.set_connector_team_hooks(access=lambda *a: {})
+    assert (
+        connector_team_scope.resolve_one_connector_access_or_raise(None, 7, ("mcp", 11))
+        is None
+    )
+
+
 @pytest.mark.parametrize(
     "entry_point",
     ["resolve_connector_access", "resolve_connector_access_or_raise"],
@@ -639,8 +687,11 @@ def test_each_entry_point_normalizes_the_refs_exactly_once(entry_point, monkeypa
         }
     )
 
+    # A duplicated ref rather than a text id: the seam rejects a text id
+    # outright now, and this test is about the number of passes, not about
+    # what a pass does.
     resolved = getattr(connector_team_scope, entry_point)(
-        None, 7, [("mcp", "5"), ("mcp", 5)]
+        None, 7, [("mcp", 5), ("mcp", 5)]
     )
 
     assert len(calls) == 1, f"normalized {len(calls)} times, received {calls}"

--- a/tests/web/services/test_connector_team_scope.py
+++ b/tests/web/services/test_connector_team_scope.py
@@ -609,6 +609,46 @@ def test_resolve_connector_access_or_raise_still_converts_with_well_formed_refs(
     assert excinfo.value.details["reason"] == "connector_access_resolution_failed"
 
 
+@pytest.mark.parametrize(
+    "entry_point",
+    ["resolve_connector_access", "resolve_connector_access_or_raise"],
+)
+def test_each_entry_point_normalizes_the_refs_exactly_once(entry_point, monkeypatch):
+    """Both public entry points share one normalization pass.
+
+    The raising entry point has to normalize above its ``try``, so it cannot
+    simply hand ``refs`` down; it hands the normalized set to
+    ``_resolve_normalized_connector_access`` instead, which is the same
+    function the non-raising entry point calls. Nothing else in the suite can
+    see this: a second normalization is idempotent over an already-normalized,
+    already-deduplicated set, so every observable result stays identical and
+    only the call count changes.
+    """
+    calls = []
+    original = connector_team_scope._normalize_connector_refs
+
+    def _counting(refs):
+        calls.append(list(refs))
+        return original(refs)
+
+    monkeypatch.setattr(connector_team_scope, "_normalize_connector_refs", _counting)
+    connector_team_scope.set_connector_team_hooks(
+        access=lambda db, user_id, requested: {
+            ref: connector_team_scope.ConnectorAccess(team_owned=True, can_edit=True)
+            for ref in requested
+        }
+    )
+
+    resolved = getattr(connector_team_scope, entry_point)(
+        None, 7, [("mcp", "5"), ("mcp", 5)]
+    )
+
+    assert len(calls) == 1, f"normalized {len(calls)} times, received {calls}"
+    assert resolved == {
+        ("mcp", 5): connector_team_scope.ConnectorAccess(team_owned=True, can_edit=True)
+    }
+
+
 # ---------------------------------------------------------------------------
 # snapshot_connector_team_hooks and its discovery-based coverage test.
 # ---------------------------------------------------------------------------

--- a/tests/web/services/test_connector_team_scope.py
+++ b/tests/web/services/test_connector_team_scope.py
@@ -913,6 +913,10 @@ def test_a_hook_that_swallows_its_failure_and_answers_malformed_restores_too(
         with pytest.raises(ConnectorRuntimeError) as excinfo:
             invoke(db_session)
         assert excinfo.value.status_code == 503
+        # The cause is the seam's own rejection of the answer, not the DB
+        # failure the hook swallowed: the two failure modes stay apart.
+        assert isinstance(excinfo.value.__cause__, ValueError)
+        assert not isinstance(excinfo.value.__cause__, SQLAlchemyError)
 
     # No rollback of our own before this line: the query is the statement
     # that proves the door restored the session, and its count proves the
@@ -1386,3 +1390,42 @@ def test_the_team_scope_wrapper_also_restores_the_session(db_session):
     # The session must be usable again immediately afterward.
     result = db_session.execute(select(1)).scalar()
     assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# The access wrapper restores the shared session after a hook that raises
+# outright, on a real session rather than the ``None`` stand-in the
+# conversion tests use.
+# ---------------------------------------------------------------------------
+
+
+def test_the_access_wrapper_restores_the_session_when_the_hook_raises(db_session):
+    """The conversion tests above hand this wrapper ``None`` for the session,
+    so they say nothing about the restore. A hook that poisons the shared
+    session via a failed ORM flush and lets that failure propagate must leave
+    the session usable for whatever runs next in the same request, and the
+    typed error must still carry the hook's own failure as its cause -- which
+    is what tells this failure mode apart from a rejected answer."""
+    poisoning_user_id = 900002
+    db_session.add(
+        User(id=poisoning_user_id, username="access-poison", password_hash="x")
+    )
+    db_session.commit()
+
+    def poisoning_access(db, user_id, refs):
+        # A duplicate primary key -- a real ORM flush failure, not a
+        # simulated one -- propagates out of this hook uncaught.
+        db.add(User(id=poisoning_user_id, username="dup", password_hash="x"))
+        db.flush()
+        return {}  # pragma: no cover - unreachable
+
+    connector_team_scope.set_connector_team_hooks(access=poisoning_access)
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        connector_team_scope.resolve_connector_access_or_raise(
+            db_session, 7, [("mcp", 11)]
+        )
+    assert excinfo.value.status_code == 503
+    assert isinstance(excinfo.value.__cause__, SQLAlchemyError)
+
+    # The session must be usable again immediately afterward.
+    assert db_session.execute(select(1)).scalar() == 1

--- a/tests/web/services/test_connector_team_scope.py
+++ b/tests/web/services/test_connector_team_scope.py
@@ -15,6 +15,7 @@ from types import SimpleNamespace
 
 import pytest
 from sqlalchemy import create_engine, select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import StaticPool
 
@@ -41,8 +42,9 @@ def _reset_hooks_scope() -> Iterator[None]:
     # ``set_connector_team_hooks`` docstring says it clears every slot it
     # is not given, so calling it bare to "reset" would drop whatever the
     # process had installed before this file ran. ``snapshot_connector_team_hooks``
-    # is what the newer suites in this repo use, and this file is the last
-    # one that did not. Pulled out of the fixture below so a test can
+    # is what the newer suites in this repo use; older suites elsewhere in
+    # tests/ still reset by clearing, which is a separate cleanup and not
+    # this file's to make. Pulled out of the fixture below so a test can
     # exercise this scope directly (see
     # ``test_the_reset_scope_restores_a_pre_installed_hook_rather_than_clearing_it``),
     # since the fixture itself wraps the whole test body and cannot be
@@ -328,40 +330,37 @@ def test_resolve_connector_access_rejects_a_key_whose_id_is_only_equal_to_an_int
         )
 
 
-def test_resolve_connector_access_rejects_a_key_that_is_not_a_tuple():
+@pytest.mark.parametrize(
+    "bad_key,requested,expected_message",
+    [
+        ("mcp", [("mcp", 1)], r"not a \(connector_type, connector_id\) pair"),
+        (
+            ("mcp", 1, "x"),
+            [("mcp", 1)],
+            r"not a \(connector_type, connector_id\) pair",
+        ),
+        ((1, 1), [(1, 1)], "connector type that is not a str"),
+    ],
+    ids=["not-a-tuple", "wrong-length", "connector-type-not-a-str"],
+)
+def test_resolve_connector_access_rejects_a_structurally_malformed_answer_key(
+    bad_key, requested, expected_message
+):
+    """A key the seam cannot even read as a ref is rejected before it is
+    matched against what was asked. The three shapes differ only in how
+    they fail to be a ``(connector_type, connector_id)`` pair -- not a
+    tuple at all, a tuple of the wrong length, or a pair whose type half
+    is not a ``str`` -- so they share one body and differ only in the key
+    and the message it must produce."""
     connector_team_scope.set_connector_team_hooks(
         access=lambda *a: {
-            "mcp": connector_team_scope.ConnectorAccess(team_owned=True, can_edit=True)
-        }
-    )
-    with pytest.raises(
-        ValueError, match=r"not a \(connector_type, connector_id\) pair"
-    ):
-        connector_team_scope.resolve_connector_access(None, 7, [("mcp", 1)])
-
-
-def test_resolve_connector_access_rejects_a_key_of_the_wrong_length():
-    connector_team_scope.set_connector_team_hooks(
-        access=lambda *a: {
-            ("mcp", 1, "x"): connector_team_scope.ConnectorAccess(
+            bad_key: connector_team_scope.ConnectorAccess(
                 team_owned=True, can_edit=True
             )
         }
     )
-    with pytest.raises(
-        ValueError, match=r"not a \(connector_type, connector_id\) pair"
-    ):
-        connector_team_scope.resolve_connector_access(None, 7, [("mcp", 1)])
-
-
-def test_resolve_connector_access_rejects_a_key_whose_connector_type_is_not_a_str():
-    connector_team_scope.set_connector_team_hooks(
-        access=lambda *a: {
-            (1, 1): connector_team_scope.ConnectorAccess(team_owned=True, can_edit=True)
-        }
-    )
-    with pytest.raises(ValueError, match="connector type that is not a str"):
-        connector_team_scope.resolve_connector_access(None, 7, [(1, 1)])
+    with pytest.raises(ValueError, match=expected_message):
+        connector_team_scope.resolve_connector_access(None, 7, requested)
 
 
 @pytest.mark.parametrize(
@@ -832,7 +831,11 @@ def test_every_hook_door_restores_the_session_when_the_hook_fails(
         connector_team_scope.set_connector_team_hooks(
             **{slot: _poisoning_hook_by_orm_flush(int(existing.id))}
         )
-        with pytest.raises(Exception):
+        # Narrow on purpose: the hook fails by colliding on a primary key,
+        # so what leaves the door is the driver's own IntegrityError. A bare
+        # ``Exception`` here would also swallow a TypeError from a mis-built
+        # ``invoke`` and let a broken setup pass as a passing test.
+        with pytest.raises(SQLAlchemyError):
             invoke(db_session)
 
     # Without the restore this raises PendingRollbackError instead.

--- a/tests/web/services/test_connector_team_scope.py
+++ b/tests/web/services/test_connector_team_scope.py
@@ -575,6 +575,24 @@ def test_resolve_one_connector_access_or_raise_lets_a_malformed_ref_raise_raw(
     assert calls == []
 
 
+@pytest.mark.parametrize("malformed_ref", MALFORMED_REFS)
+def test_resolve_connector_access_or_raise_reads_no_ref_at_all_without_a_hook_installed(
+    malformed_ref,
+):
+    """The sibling of
+    ``test_resolve_connector_access_reads_no_ref_at_all_without_a_hook_installed``
+    for the raising entry point. The two checks above install a hook on
+    purpose, so they pin the malformed-ref boundary only for a deployment that
+    has an application installed; without this one, nothing pins the other
+    deployment, and this entry point raised there while
+    ``resolve_connector_access`` returned ``{}`` for the very same ref."""
+    assert connector_team_scope._connector_access_hook is None
+    assert (
+        connector_team_scope.resolve_connector_access_or_raise(None, 7, [malformed_ref])
+        == {}
+    )
+
+
 def test_resolve_connector_access_or_raise_still_converts_with_well_formed_refs():
     """The opposite direction of the two checks above, so that widening the
     raw-error path cannot go unnoticed: with the refs well formed, a hook

--- a/tests/web/services/test_connector_team_scope.py
+++ b/tests/web/services/test_connector_team_scope.py
@@ -476,6 +476,23 @@ def test_resolve_connector_access_or_raise_converts_value_error_to_503():
     assert excinfo.value.status_code == 503
 
 
+def test_resolve_connector_access_or_raise_converts_even_with_uncomparable_refs():
+    """The failure arm logs the refs it resolved with, and those refs are only
+    type-checked statically. A collection whose members do not compare against
+    each other must still leave through the typed 503 rather than through a
+    TypeError raised by the logging call itself."""
+
+    def _hook(db, user_id, refs):
+        raise RuntimeError("hook exploded")
+
+    connector_team_scope.set_connector_team_hooks(access=_hook)
+    with pytest.raises(ConnectorRuntimeError) as excinfo:
+        connector_team_scope.resolve_connector_access_or_raise(
+            None, 7, [("mcp", 11), (5, 12)]
+        )
+    assert excinfo.value.status_code == 503
+
+
 def test_resolve_connector_access_or_raise_passes_through_planted_error():
     planted = ConnectorRuntimeError(
         "planted_code", "planted", details={"reason": "planted_reason"}

--- a/tests/web/services/test_connector_team_scope.py
+++ b/tests/web/services/test_connector_team_scope.py
@@ -520,9 +520,9 @@ def test_resolve_connector_access_or_raise_lets_a_malformed_ref_raise_raw(
     """A ref that is not a ``(str, int-coercible)`` pair is a defect in the
     calling route, not an outage of the installing application, so it stays
     the ``ValueError``/``TypeError`` it is instead of being converted into
-    the seam's retryable 503. A hook is installed here on purpose: without
-    one the seam returns ``{}`` before it ever reads a ref, so this check
-    would pass vacuously."""
+    the seam's retryable 503. A hook is installed here on purpose: it is
+    what gives the trailing ``assert calls == []`` its meaning, by showing
+    the raise lands before the hook is ever reached."""
     calls: list[object] = []
 
     def _hook(db, user_id, refs):

--- a/tests/web/test_team_sharing_hooks.py
+++ b/tests/web/test_team_sharing_hooks.py
@@ -27,27 +27,27 @@ def test_connector_team_hooks_delegate_and_reset():
     renamed_calls = []
     access_calls = []
 
-    connector_scope.set_connector_team_hooks(
-        visibility=lambda db, user_id: {"mcp": {11}, "custom_api": {22}},
-        team_visibility=lambda db, *, team_id: {"mcp": {33}, "custom_api": {44}},
-        deleted=lambda db, user_id, kind, connector_id: (
-            deleted_calls.append((db, user_id, kind, connector_id))
-            or connector_scope.ConnectorDeleteDecision(
-                team_owned=True, authorized=True, delete_definition=False
-            )
-        ),
-        renamed=lambda db, user_id, kind, connector_id, old, new: renamed_calls.append(
-            (db, user_id, kind, connector_id, old, new)
-        ),
-        access=lambda db, user_id, refs: (
-            access_calls.append((db, user_id, refs))
-            or {
-                ref: connector_scope.ConnectorAccess(team_owned=True, can_edit=True)
-                for ref in refs
-            }
-        ),
-    )
-    try:
+    with connector_scope.snapshot_connector_team_hooks():
+        connector_scope.set_connector_team_hooks(
+            visibility=lambda db, user_id: {"mcp": {11}, "custom_api": {22}},
+            team_visibility=lambda db, *, team_id: {"mcp": {33}, "custom_api": {44}},
+            deleted=lambda db, user_id, kind, connector_id: (
+                deleted_calls.append((db, user_id, kind, connector_id))
+                or connector_scope.ConnectorDeleteDecision(
+                    team_owned=True, authorized=True, delete_definition=False
+                )
+            ),
+            renamed=lambda db, user_id, kind, cid, old, new: renamed_calls.append(
+                (db, user_id, kind, cid, old, new)
+            ),
+            access=lambda db, user_id, refs: (
+                access_calls.append((db, user_id, refs))
+                or {
+                    ref: connector_scope.ConnectorAccess(team_owned=True, can_edit=True)
+                    for ref in refs
+                }
+            ),
+        )
         assert connector_scope.visible_team_connector_ids(None, 7) == {
             "mcp": {11},
             "custom_api": {22},
@@ -66,10 +66,14 @@ def test_connector_team_hooks_delegate_and_reset():
         assert deleted_calls == [(None, 7, "mcp", 11)]
         assert renamed_calls == [(None, 7, "mcp", 11, "old", "new")]
         assert access_calls == [(None, 7, frozenset({("mcp", 11)}))]
-    finally:
+
+        # A reset-all call clears every slot, including the access one --
+        # this is the property the snapshot primitive above restores after
+        # this block exits, so the reset stays inside the block rather than
+        # standing in for one.
         connector_scope.set_connector_team_hooks()
-    assert connector_scope.team_connector_hook_installed() is False
-    assert connector_scope.resolve_connector_access(None, 7, [("mcp", 11)]) == {}
+        assert connector_scope.team_connector_hook_installed() is False
+        assert connector_scope.resolve_connector_access(None, 7, [("mcp", 11)]) == {}
 
 
 def test_knowledge_base_team_hooks_delegate_with_none_session():

--- a/tests/web/test_team_sharing_hooks.py
+++ b/tests/web/test_team_sharing_hooks.py
@@ -25,6 +25,7 @@ def test_agent_team_hooks_install_as_one_group():
 def test_connector_team_hooks_delegate_and_reset():
     deleted_calls = []
     renamed_calls = []
+    access_calls = []
 
     connector_scope.set_connector_team_hooks(
         visibility=lambda db, user_id: {"mcp": {11}, "custom_api": {22}},
@@ -37,6 +38,13 @@ def test_connector_team_hooks_delegate_and_reset():
         ),
         renamed=lambda db, user_id, kind, connector_id, old, new: renamed_calls.append(
             (db, user_id, kind, connector_id, old, new)
+        ),
+        access=lambda db, user_id, refs: (
+            access_calls.append((db, user_id, refs))
+            or {
+                ref: connector_scope.ConnectorAccess(team_owned=True, can_edit=True)
+                for ref in refs
+            }
         ),
     )
     try:
@@ -51,11 +59,17 @@ def test_connector_team_hooks_delegate_and_reset():
         decision = connector_scope.delete_team_connector(None, 7, "mcp", 11)
         assert decision.team_owned and decision.authorized
         connector_scope.rename_team_connector(None, 7, "mcp", 11, "old", "new")
+        access = connector_scope.resolve_connector_access(None, 7, [("mcp", 11)])
+        assert access == {
+            ("mcp", 11): connector_scope.ConnectorAccess(team_owned=True, can_edit=True)
+        }
         assert deleted_calls == [(None, 7, "mcp", 11)]
         assert renamed_calls == [(None, 7, "mcp", 11, "old", "new")]
+        assert access_calls == [(None, 7, frozenset({("mcp", 11)}))]
     finally:
         connector_scope.set_connector_team_hooks()
     assert connector_scope.team_connector_hook_installed() is False
+    assert connector_scope.resolve_connector_access(None, 7, [("mcp", 11)]) == {}
 
 
 def test_knowledge_base_team_hooks_delegate_with_none_session():


### PR DESCRIPTION
Split out of #1661, which is being broken into pieces that can each be reviewed on
their own. This one carries the seam and nothing else; the routing changes that
consume it stay on that branch.

## What this changes

Standalone xagent keeps MCP servers and custom APIs user-owned: whoever created a
connector is the only one who can edit it. `connector_team_scope` already exists as the
place where a downstream application that installs the hooks can overlay team ownership
on top of that, and it already carries slots for delete, rename, and two flavours of
visibility.

This adds the one slot that was missing: an **access** hook, which answers whether the
caller's team links a given connector, and whether the caller may edit it.

Nothing is wired to a route in this PR. This is the type, the validation, the failure
handling, and the tests for that hook — and only those.

## The hook contract

`resolve_connector_access(db, user_id, refs)` takes a collection of
`(connector_type, connector_id)` refs and asks the installed hook **once**, no matter how
many refs are passed. Batching is the point of the signature: the question a caller
actually has is "what is this caller's team's relationship to these connectors", and
answering it should not cost one hook call per connector.

Two rules make the answer unambiguous:

- **Absence is the only way to say "not linked."** A ref the caller's team does not link
  is left out of the answer map. It is never expressed by returning a verdict with
  `team_owned=False`. `ConnectorAccess` still defaults to `False`/`False` so that a bare
  `ConnectorAccess()` stays a shape the validator rejects, rather than quietly becoming a
  legitimate "not linked" answer.
- **`can_edit` is independent of linkage.** A team can link a connector without granting
  edit rights on it. That is a complete answer on its own, not a partial one.

The answer is treated as an authorization input, not as user-facing data, so a malformed
answer raises instead of being normalized, coerced, or defaulted to empty. Both booleans
are checked by identity rather than truthiness, and connector ids are rejected when they
are `bool` — `bool` subclasses `int` in Python, and a truthy value is never a legitimate
grant or a legitimate id.

Keys are validated as exact `(str, int)` pairs before membership is checked at all.
`True`, `1.0` and `Decimal("1")` all compare equal to `1`, and ordinary tuple equality
carries that through, so `("mcp", True)` would otherwise pass a membership check against
`("mcp", 1)`. Since the keys of the answer *are* the question, a key that merely resembles
a requested ref has to fail loudly rather than be accepted as the connector it aliases.

## Session safety

Hooks run on the endpoint's own live session. A hook whose own statement failed leaves
that transaction unusable on PostgreSQL, and a failed ORM `flush` leaves it unusable on
every backend — so every later statement in the request, including the ones a degradation
path needs to build its response, would be refused.

Hook invocation is therefore consolidated behind one internal door that rolls the session
back before the exception reaches the caller. Answer validation runs inside the same
guard, because a hook can poison the session *without* raising: run a statement that
fails, catch that itself, and return a shape this seam then rejects. In that case the
exception is the seam's own, so a guard placed around the call alone would not fire.

All five slots now go through that door, which is what makes the property hold for a slot
added to this module later without that slot's author having to know about it.

One shape stays uncovered on purpose: a hook that poisons the session, swallows its own
failure, and still returns a well-formed answer produces no exception anywhere, so nothing
triggers a restore. Closing that would mean probing session health after every hook call,
which is a different design than a failure path.

## Test isolation

`snapshot_connector_team_hooks` saves every module-level slot and restores it on exit.
The slots are process-global, so a test that installs one and "cleans up" by calling the
setter with no arguments restores the *empty* state, not the state the test found — which
silently drops any hook the process had installed before it.

A discovery-based test enumerates every module global ending in `_hook` and asserts the
snapshot restores each one by identity. A slot added later and not added to the snapshot
fails the suite rather than failing silently.

## Why merge this with no production callers

There are none, and the grep is honest about it:

```
$ grep -rn "ConnectorAccess" src | grep -v connector_team_scope.py
$ grep -rn "resolve_connector_access\|resolve_one_connector_access" src | grep -v connector_team_scope.py
```

Both return nothing. Merged on its own, this PR adds a hook that no route calls and no
in-tree code installs. With no hook installed every function here returns empty without
querying, so a standalone deployment sees no behavior change — but by the same token it
also gains no behavior.

The honest reason to merge it separately is review economics, not urgency. The routing
change that consumes this hook touches connector read and write paths where the failure
mode is a permission check that silently passes. Reviewing the shape of the answer, the
validation rules, and the session-failure handling *at the same time* as the call sites
means the contract questions and the routing questions compete for attention in one diff,
and the contract questions are the ones that are cheap to get wrong and expensive to
notice later. Landing the contract first makes the follow-up diff a question about call
sites against a contract already settled.

The cost is real and worth stating plainly: if the follow-up never lands, this is dead
code carrying its own test suite. It is a seam whose value is entirely in what is built on
it. Reviewers who would rather see the hook and its first consumer together are asking a
reasonable question, and the answer is a judgement call about review surface, not a
technical constraint.

The precedent is in the tree already: `knowledge_base_team_scope` is the same seam shape
for knowledge bases, including the same snapshot primitive, and this change also updates
that module's docstring where it says the connector seam has no snapshot counterpart —
which is no longer true.
