### PR TITLE
fix(connectors): lock the connector definition row on edit and delete

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -51,6 +51,10 @@ on:
       - 'tests/web/test_user_oauth_actor_ownership.py'
       - 'tests/shared/postgres_disposable.py'
       - 'tests/web/services/checkpoint_anchor_shared.py'
+      - 'tests/web/api/test_mcp_server_edit_lock_postgresql.py'
+      - 'tests/web/api/test_custom_api_edit_lock_postgresql.py'
+      - 'src/xagent/web/api/mcp.py'
+      - 'src/xagent/web/api/custom_api.py'
   pull_request:
     branches: [main]
   # Required by the merge queue: without this the two required contexts below
@@ -138,6 +142,10 @@ jobs:
             tests/web/test_user_oauth_actor_ownership.py
             tests/shared/postgres_disposable.py
             tests/web/services/checkpoint_anchor_shared.py
+            tests/web/api/test_mcp_server_edit_lock_postgresql.py
+            tests/web/api/test_custom_api_edit_lock_postgresql.py
+            src/xagent/web/api/mcp.py
+            src/xagent/web/api/custom_api.py
           )
 
           case "$EVENT_NAME" in
@@ -445,6 +453,20 @@ jobs:
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
           pytest tests/web/services/test_supersede_savepoint_postgresql.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
+      - name: Test MCP server edit row lock (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/web/api/test_mcp_server_edit_lock_postgresql.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
+      - name: Test Custom API edit row lock (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/web/api/test_custom_api_edit_lock_postgresql.py -m postgresql -q
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -55,6 +55,9 @@ on:
       - 'tests/web/api/test_custom_api_edit_lock_postgresql.py'
       - 'src/xagent/web/api/mcp.py'
       - 'src/xagent/web/api/custom_api.py'
+      - 'src/xagent/web/services/connector_team_scope.py'
+      - 'src/xagent/web/models/custom_api.py'
+      - 'src/xagent/web/models/mcp.py'
   pull_request:
     branches: [main]
   # Required by the merge queue: without this the two required contexts below
@@ -146,6 +149,9 @@ jobs:
             tests/web/api/test_custom_api_edit_lock_postgresql.py
             src/xagent/web/api/mcp.py
             src/xagent/web/api/custom_api.py
+            src/xagent/web/services/connector_team_scope.py
+            src/xagent/web/models/custom_api.py
+            src/xagent/web/models/mcp.py
           )
 
           case "$EVENT_NAME" in

--- a/src/xagent/web/api/custom_api.py
+++ b/src/xagent/web/api/custom_api.py
@@ -7,7 +7,7 @@ in the web application.
 
 import logging
 from datetime import datetime
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from pydantic import BaseModel, Field
@@ -286,7 +286,7 @@ async def get_custom_api(
 
 
 @custom_api_router.put("/{api_id}", response_model=CustomApiResponse)
-async def update_custom_api(
+def update_custom_api(
     api_id: int,
     api_data: CustomApiUpdate,
     current_user: User = Depends(get_current_user),
@@ -315,8 +315,43 @@ async def update_custom_api(
             detail="You do not have permission to edit this Custom API",
         )
 
-    api = user_api.custom_api
+    # A second, single-table lock on the definition row, taken before any
+    # field below reads or mutates it. The read above comes through the
+    # personal link row's relationship and cannot itself lock just this
+    # table; this is a fresh statement, so a row deleted between the two
+    # still yields None here (handled as the same 404) rather than
+    # surfacing as an unrelated error out of the write path below.
+    # ``populate_existing()`` makes the locked row the one the rest of this
+    # route reads: without it the already-identity-mapped instance the
+    # relationship loaded would be returned unrefreshed, and every field
+    # below would still be the pre-lock snapshot.
+    locked_api = (
+        db.query(CustomApi)
+        .filter(CustomApi.id == api_id)
+        .populate_existing()
+        .with_for_update()
+        .first()
+    )
+    if locked_api is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Custom API not found",
+        )
+    api = locked_api
+
+    # Read only after the lock: rename_team_connector's "old" argument must
+    # be the name this transaction actually holds locked, not whatever the
+    # pre-lock read above saw -- a concurrent committed rename in between
+    # would otherwise make this stale, and the rewrite below would look for
+    # a name that no longer exists anywhere, leaving the previous renamer's
+    # selectors dangling with no error.
     old_name = str(api.name)
+
+    # The row's declared type from here on is loosened for mypy's sake: the
+    # column-typed attributes below (name, description, env, ...) are all
+    # mutated directly by this route, exactly as they were when this local
+    # came off the relationship instead of off the locked query.
+    mutable_api = cast(Any, api)
 
     # Check name uniqueness if name is changed
     if api_data.name and api_data.name != api.name:
@@ -326,23 +361,25 @@ async def update_custom_api(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Custom API with name '{api_data.name}' already exists",
             )
-        api.name = api_data.name
+        mutable_api.name = api_data.name
 
     # Update fields
     if api_data.description is not None:
-        api.description = api_data.description
+        mutable_api.description = api_data.description
     if api_data.url is not None:
-        api.url = api_data.url
+        mutable_api.url = api_data.url
     if api_data.method is not None:
-        api.method = api_data.method
+        mutable_api.method = api_data.method
     if api_data.headers is not None:
-        api.headers = api_data.headers
+        mutable_api.headers = api_data.headers
     if api_data.body is not None:
-        api.body = api_data.body
+        mutable_api.body = api_data.body
 
     # Process env variables
     if api_data.env is not None:
-        existing_env = api.env if isinstance(api.env, dict) else {}
+        existing_env: Dict[str, str] = (
+            mutable_api.env if isinstance(api.env, dict) else {}
+        )
         try:
             processed_env = _process_env_vars(api_data.env, existing_env)
         except ValueError as exc:
@@ -350,7 +387,7 @@ async def update_custom_api(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Invalid environment variables: {exc}",
             ) from exc
-        api.env = processed_env
+        mutable_api.env = processed_env
 
     fields_set = api_data.model_fields_set
     runtime_input_schema = (
@@ -374,7 +411,7 @@ async def update_custom_api(
             runtime_input_schema=runtime_input_schema,
             runtime_bindings=runtime_bindings,
             allow_delegated_authorization=allow_delegated_authorization,
-            static_headers=api.headers,
+            static_headers=mutable_api.headers,
         )
     except ValueError as exc:
         raise HTTPException(
@@ -382,11 +419,11 @@ async def update_custom_api(
             detail=f"Invalid runtime configuration: {exc}",
         ) from exc
     if "runtime_input_schema" in fields_set:
-        api.runtime_input_schema = runtime_input_schema
+        mutable_api.runtime_input_schema = runtime_input_schema
     if "runtime_bindings" in fields_set:
-        api.runtime_bindings = runtime_bindings
+        mutable_api.runtime_bindings = runtime_bindings
     if "allow_delegated_authorization" in fields_set:
-        api.allow_delegated_authorization = allow_delegated_authorization
+        mutable_api.allow_delegated_authorization = allow_delegated_authorization
 
     from ..services.connector_team_scope import rename_team_connector
 
@@ -410,7 +447,7 @@ async def update_custom_api(
 
 
 @custom_api_router.delete("/{api_id}", status_code=status.HTTP_204_NO_CONTENT)
-async def delete_custom_api(
+def delete_custom_api(
     api_id: int,
     current_user: User = Depends(get_current_user),
     db: Session = Depends(get_db),
@@ -438,8 +475,6 @@ async def delete_custom_api(
             detail="You do not have permission to delete this Custom API",
         )
 
-    api = user_api.custom_api
-
     from ..services.connector_team_scope import delete_team_connector
 
     team_delete = delete_team_connector(
@@ -455,6 +490,43 @@ async def delete_custom_api(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only a team admin can delete a team Custom API",
         )
+
+    # One global lock order over this pair of tables. ``update_custom_api``
+    # locks the ``CustomApi`` definition row first and writes the
+    # ``UserCustomApi`` link row afterwards; both branches below delete the
+    # link row first and the definition row second, inside one transaction.
+    # Without this statement the two routes take the same two rows in
+    # opposite orders and a concurrent edit/delete pair can deadlock
+    # (PostgreSQL 40P01). Taken after every refusal above, so a request that
+    # is going to be refused never acquires the lock. ``populate_existing``
+    # matches the PUT's own lock: the row this transaction holds is the one
+    # the deletion below acts on, not whatever the relationship read above
+    # happened to see.
+    #
+    # This statement orders THIS repository's two tables and nothing else. A
+    # connector team hook writes its own tables, which this lock does not
+    # cover, and the two routes reach it in opposite orders relative to this
+    # lock: the PUT takes the lock above and calls rename_team_connector
+    # afterwards, while this route calls delete_team_connector before taking
+    # the lock at all. So an installing application whose hooks lock a row of
+    # its own can still deadlock against a concurrent edit/delete pair on the
+    # same connector, and no ordering statement inside this repository can
+    # prevent that -- the hook side has to take its rows in an order
+    # compatible with this one, and only the application can arrange that.
+    locked_api = (
+        db.query(CustomApi)
+        .filter(CustomApi.id == api_id)
+        .populate_existing()
+        .with_for_update()
+        .first()
+    )
+    if locked_api is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Custom API not found",
+        )
+    api = locked_api
+
     if team_delete.team_owned:
         db.delete(user_api)
         db.flush([user_api])

--- a/src/xagent/web/api/custom_api.py
+++ b/src/xagent/web/api/custom_api.py
@@ -315,42 +315,79 @@ def update_custom_api(
             detail="You do not have permission to edit this Custom API",
         )
 
-    # A second, single-table lock on the definition row, taken before any
-    # field below reads or mutates it. The read above comes through the
-    # personal link row's relationship and cannot itself lock just this
-    # table; this is a fresh statement, so a row deleted between the two
-    # still yields None here (handled as the same 404) rather than
-    # surfacing as an unrelated error out of the write path below.
-    # ``populate_existing()`` makes the locked row the one the rest of this
-    # route reads: without it the already-identity-mapped instance the
+    # Which row a request writes decides which row it locks. Every field of
+    # ``CustomApiUpdate`` except ``is_active`` writes the shared
+    # ``CustomApi`` definition row; ``is_active`` writes this caller's own
+    # ``UserCustomApi`` link row and nothing else. Locking the definition
+    # row for a payload that never writes it made an activate/deactivate
+    # queue behind an unrelated edit of the same connector -- a wait that
+    # request has no write to justify, and one that surfaces as an error
+    # rather than a delay wherever a lock timeout is configured.
+    #
+    # ``model_fields_set`` decides this, not the values: an explicitly-null
+    # ``runtime_input_schema`` is written to the definition row below even
+    # though its value is ``None``, while an absent field is not written at
+    # all. The set is a superset of the writes below -- a payload carrying
+    # ``description=None`` is counted here and then skipped by the write at
+    # its own ``is not None`` guard -- so this takes the lock in a few
+    # cases that did not need it and skips it in none that do.
+    fields_set = api_data.model_fields_set
+    writes_definition_row = bool(fields_set - {"is_active"})
+
+    # A fresh single-table read of the definition row, on both paths. The
+    # read above comes through the personal link row's relationship and
+    # cannot itself address just this table; this is a separate statement,
+    # so a row deleted between the two yields None here (handled as the
+    # same 404) rather than surfacing as an unrelated error out of the
+    # write path or out of ``db.refresh`` below. ``populate_existing()``
+    # makes this statement's row the one the rest of this route reads and
+    # responds with: without it the already-identity-mapped instance the
     # relationship loaded would be returned unrefreshed, and every field
-    # below would still be the pre-lock snapshot.
-    locked_api = (
-        db.query(CustomApi)
-        .filter(CustomApi.id == api_id)
-        .populate_existing()
-        .with_for_update()
-        .first()
+    # below would still be that earlier snapshot.
+    #
+    # ``FOR UPDATE`` is added only on the path that writes this row, so a
+    # request that writes it still waits for another request holding it.
+    # That clause is a PostgreSQL/MySQL row lock only: SQLAlchemy renders
+    # no locking clause at all on SQLite -- the statement it emits there is
+    # byte-for-byte the one it emits without this call -- so on a SQLite
+    # deployment the read-modify-write below is not serialized and two
+    # concurrent edits of one connector can still interleave. The
+    # single-statement conditional ``UPDATE``s elsewhere in this repository
+    # (services/task_interaction_staging.py,
+    # services/chat_history_service.py) are safe on SQLite without a lock
+    # because one statement is atomic there; that reasoning does not carry
+    # to this route, which reads the row, computes in Python, and writes it
+    # back. Closing the SQLite window needs the dual-dialect fence
+    # ``_lock_user_row_for_preferences_update`` (api/auth.py) and
+    # ``acquire_runtime_key_transition_fence`` (services/api_keys.py) use
+    # -- a no-op ``UPDATE`` that takes SQLite's writer lock -- and is left
+    # to a change of its own.
+    definition_query = (
+        db.query(CustomApi).filter(CustomApi.id == api_id).populate_existing()
     )
-    if locked_api is None:
+    if writes_definition_row:
+        definition_query = definition_query.with_for_update()
+    current_api = definition_query.first()
+    if current_api is None:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="Custom API not found",
         )
-    api = locked_api
+    api = current_api
 
-    # Read only after the lock: rename_team_connector's "old" argument must
-    # be the name this transaction actually holds locked, not whatever the
-    # pre-lock read above saw -- a concurrent committed rename in between
-    # would otherwise make this stale, and the rewrite below would look for
-    # a name that no longer exists anywhere, leaving the previous renamer's
-    # selectors dangling with no error.
+    # Read only after the statement above: rename_team_connector's "old"
+    # argument must be the name this transaction's own read established --
+    # under the lock, on the path that renames -- not whatever the
+    # relationship read further up saw. A concurrent committed rename in
+    # between would otherwise make this stale, and the rewrite below would
+    # look for a name that no longer exists anywhere, leaving the previous
+    # renamer's selectors dangling with no error.
     old_name = str(api.name)
 
     # The row's declared type from here on is loosened for mypy's sake: the
     # column-typed attributes below (name, description, env, ...) are all
     # mutated directly by this route, exactly as they were when this local
-    # came off the relationship instead of off the locked query.
+    # came off the relationship instead of off the definition query above.
     mutable_api = cast(Any, api)
 
     # Check name uniqueness if name is changed
@@ -389,7 +426,6 @@ def update_custom_api(
             ) from exc
         mutable_api.env = processed_env
 
-    fields_set = api_data.model_fields_set
     runtime_input_schema = (
         api_data.runtime_input_schema
         if "runtime_input_schema" in fields_set
@@ -475,10 +511,10 @@ def delete_custom_api(
             detail="You do not have permission to delete this Custom API",
         )
 
-    # One lock order across every row this pair of routes touches.
-    # ``update_custom_api`` locks this same ``CustomApi`` definition row
-    # first, calls ``rename_team_connector`` afterwards, and writes the
-    # ``UserCustomApi`` link row afterwards too; both branches below delete
+    # One lock order across every row this pair of routes touches. An
+    # ``update_custom_api`` call that writes the definition row locks this
+    # same row first, calls ``rename_team_connector`` afterwards, and
+    # writes the ``UserCustomApi`` link row afterwards too; both branches below delete
     # the link row first and the definition row second, inside one
     # transaction. Taking the lock here -- before ``delete_team_connector``
     # rather than after it -- puts both routes in one order on both sides of
@@ -503,12 +539,24 @@ def delete_custom_api(
     # route holds the row for longer than it did with the lock last.
     #
     # What this statement orders is this route against ``update_custom_api``
-    # on the same connector: those two can no longer form a cycle with each
-    # other, whatever the hook locks, because both reach the hook with this
-    # row already held and so cannot be inside the hook at the same time. A
-    # hook that additionally locks rows of its own in some other order
-    # relative to this repository's statements is outside what this
+    # on the same connector. A PUT that writes the definition row cannot
+    # form a cycle with this route, whatever the hook locks, because both
+    # reach the hook with this row already held and so cannot be inside the
+    # hook at the same time. A PUT that writes only the caller's own
+    # ``UserCustomApi`` link row takes no lock on this row at all: it reads
+    # the definition row without locking it and waits only for the link
+    # row, so it has nothing this route waits for and cannot close a cycle
+    # either. A hook that additionally locks rows of its own in some other
+    # order relative to this repository's statements is outside what this
     # statement arranges; only the installing application can order those.
+    #
+    # ``FOR UPDATE`` here is a PostgreSQL/MySQL row lock only: SQLAlchemy
+    # renders no locking clause at all on SQLite, so on a SQLite deployment
+    # this statement does not order this route against anything. Closing
+    # that window needs the dual-dialect fence
+    # ``acquire_runtime_key_transition_fence`` (services/api_keys.py) uses
+    # -- a no-op ``UPDATE`` that takes SQLite's writer lock -- and is left
+    # to a change of its own.
     locked_api = (
         db.query(CustomApi)
         .filter(CustomApi.id == api_id)

--- a/src/xagent/web/api/custom_api.py
+++ b/src/xagent/web/api/custom_api.py
@@ -375,6 +375,58 @@ def update_custom_api(
         )
     api = current_api
 
+    if writes_definition_row:
+        # The access gate above ran before the lock statement; the lock
+        # statement waits. Everything this route decided from the gate's
+        # ``UserCustomApi`` row -- that the caller still has a link to this
+        # connector at all, and that the link grants edit -- was therefore
+        # established before a wait of unbounded length, and nothing has
+        # re-established it since. A supported admin user deletion
+        # (``admin_users.py``, which removes a user's association rows and
+        # leaves every definition row standing) or a connector-team delete
+        # that removes only the caller's link can commit inside that wait.
+        # The request would then resume on a row that is gone, write the
+        # shared definition row anyway, commit it, and only fail afterwards
+        # in response construction -- an HTTP 500 over a durable shared
+        # mutation the caller was no longer authorized to make.
+        #
+        # ``populate_existing()`` on the definition query above refreshes
+        # the row of that statement and nothing else, so it does not cover
+        # this: the link row needs its own statement. This one is a
+        # single-table read of the caller's link, with
+        # ``populate_existing()`` so its columns are overwritten with the
+        # database's current values rather than the ones the gate loaded,
+        # and the object it returns replaces ``user_api`` for the rest of
+        # the route -- the link-row write below and the response both read it.
+        # A revocation that commits after this statement is the window
+        # this route had before it took any lock at all: in-process, with
+        # no wait in it. Closing that one needs the authorization fence
+        # designed for the team-edit changes and is not attempted here.
+        #
+        # Same order as the gate, so the same request gets the same answer
+        # it would have got had it arrived a moment later: gone is a 404,
+        # present but no longer permitted is a 403.
+        current_user_api = (
+            db.query(UserCustomApi)
+            .filter(
+                UserCustomApi.custom_api_id == api_id,
+                UserCustomApi.user_id == current_user.id,
+            )
+            .populate_existing()
+            .first()
+        )
+        if current_user_api is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Custom API not found",
+            )
+        if not current_user_api.can_edit:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not have permission to edit this Custom API",
+            )
+        user_api = current_user_api
+
     # Read only after the statement above: rename_team_connector's "old"
     # argument must be the name this transaction's own read established --
     # under the lock, on the path that renames -- not whatever the
@@ -570,6 +622,46 @@ def delete_custom_api(
             detail="Custom API not found",
         )
     api = locked_api
+
+    # This route's gate ran before the lock statement, and the lock
+    # statement waits. The gate's two answers -- the caller has a link to
+    # this connector, and that link grants delete -- were both established
+    # before that wait, and this route's effects are the widest in the
+    # pair: with no connector-team hook installed it takes the ``db.delete(api)``
+    # branch below, which removes the shared definition row and cascades
+    # away every other user's link to it. A supported admin user deletion
+    # or a team delete of the caller's own link can commit inside the
+    # wait, and the request would then answer 204 and delete the shared
+    # row for a caller who no longer had any link to it.
+    #
+    # Re-read the link row here, before ``delete_team_connector`` is
+    # called and before anything is deleted, so a revoked request produces
+    # its refusal with zero shared effect: no hook call, no delete, no
+    # commit. ``populate_existing()`` on the lock statement above refreshes
+    # the definition row only, so the link row needs this separate
+    # statement; the object it returns replaces ``user_api`` for the
+    # team-owned branch's own ``db.delete``. Same order and same answers as
+    # the gate: gone is a 404, present but no longer permitted is a 403.
+    current_user_api = (
+        db.query(UserCustomApi)
+        .filter(
+            UserCustomApi.custom_api_id == api_id,
+            UserCustomApi.user_id == current_user.id,
+        )
+        .populate_existing()
+        .first()
+    )
+    if current_user_api is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Custom API not found",
+        )
+    if not current_user_api.can_delete:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="You do not have permission to delete this Custom API",
+        )
+    user_api = current_user_api
 
     from ..services.connector_team_scope import delete_team_connector
 

--- a/src/xagent/web/api/custom_api.py
+++ b/src/xagent/web/api/custom_api.py
@@ -475,6 +475,54 @@ def delete_custom_api(
             detail="You do not have permission to delete this Custom API",
         )
 
+    # One lock order across every row this pair of routes touches.
+    # ``update_custom_api`` locks this same ``CustomApi`` definition row
+    # first, calls ``rename_team_connector`` afterwards, and writes the
+    # ``UserCustomApi`` link row afterwards too; both branches below delete
+    # the link row first and the definition row second, inside one
+    # transaction. Taking the lock here -- before ``delete_team_connector``
+    # rather than after it -- puts both routes in one order on both sides of
+    # the hook boundary: definition row first, then the link row and
+    # whatever rows a connector team hook locks. With the lock after the
+    # hook instead, the two routes waited in opposite directions across that
+    # boundary and a concurrent edit/delete pair on the same connector could
+    # deadlock (PostgreSQL 40P01, surfacing to the caller as HTTP 500).
+    # ``populate_existing`` matches the PUT's own lock: the row this
+    # transaction holds is the one the deletion below acts on, not whatever
+    # the relationship read above happened to see. This is also a fresh
+    # statement, so a row deleted between the access read above and here
+    # still yields None (handled as the same 404) rather than reaching
+    # ``db.delete`` with nothing to delete.
+    #
+    # Two costs come with taking it here rather than last. The two 403
+    # refusals below read ``delete_team_connector``'s answer and so now
+    # happen after this statement: a request that is going to be refused
+    # does briefly hold this row, until the raised ``HTTPException``
+    # propagates out and the request's session is closed without
+    # committing. And the hook's own work now runs inside the lock, so this
+    # route holds the row for longer than it did with the lock last.
+    #
+    # What this statement orders is this route against ``update_custom_api``
+    # on the same connector: those two can no longer form a cycle with each
+    # other, whatever the hook locks, because both reach the hook with this
+    # row already held and so cannot be inside the hook at the same time. A
+    # hook that additionally locks rows of its own in some other order
+    # relative to this repository's statements is outside what this
+    # statement arranges; only the installing application can order those.
+    locked_api = (
+        db.query(CustomApi)
+        .filter(CustomApi.id == api_id)
+        .populate_existing()
+        .with_for_update()
+        .first()
+    )
+    if locked_api is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Custom API not found",
+        )
+    api = locked_api
+
     from ..services.connector_team_scope import delete_team_connector
 
     team_delete = delete_team_connector(
@@ -490,42 +538,6 @@ def delete_custom_api(
             status_code=status.HTTP_403_FORBIDDEN,
             detail="Only a team admin can delete a team Custom API",
         )
-
-    # One global lock order over this pair of tables. ``update_custom_api``
-    # locks the ``CustomApi`` definition row first and writes the
-    # ``UserCustomApi`` link row afterwards; both branches below delete the
-    # link row first and the definition row second, inside one transaction.
-    # Without this statement the two routes take the same two rows in
-    # opposite orders and a concurrent edit/delete pair can deadlock
-    # (PostgreSQL 40P01). Taken after every refusal above, so a request that
-    # is going to be refused never acquires the lock. ``populate_existing``
-    # matches the PUT's own lock: the row this transaction holds is the one
-    # the deletion below acts on, not whatever the relationship read above
-    # happened to see.
-    #
-    # This statement orders THIS repository's two tables and nothing else. A
-    # connector team hook writes its own tables, which this lock does not
-    # cover, and the two routes reach it in opposite orders relative to this
-    # lock: the PUT takes the lock above and calls rename_team_connector
-    # afterwards, while this route calls delete_team_connector before taking
-    # the lock at all. So an installing application whose hooks lock a row of
-    # its own can still deadlock against a concurrent edit/delete pair on the
-    # same connector, and no ordering statement inside this repository can
-    # prevent that -- the hook side has to take its rows in an order
-    # compatible with this one, and only the application can arrange that.
-    locked_api = (
-        db.query(CustomApi)
-        .filter(CustomApi.id == api_id)
-        .populate_existing()
-        .with_for_update()
-        .first()
-    )
-    if locked_api is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Custom API not found",
-        )
-    api = locked_api
 
     if team_delete.team_owned:
         db.delete(user_api)

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -3305,6 +3305,58 @@ def update_mcp_server(
             )
         server = current_server
 
+        if writes_definition_row:
+            # The join gate above ran before the lock statement, and the
+            # lock statement waits. Both things that read established --
+            # that the caller still has a ``UserMCPServer`` link to this
+            # server, and whether that link owns it (``can_edit_global``)
+            # -- were fixed before a wait of unbounded length. A supported
+            # admin user deletion removes association rows and leaves
+            # every definition row standing, and an MCP disconnect removes
+            # the caller's own link while another user's link keeps the
+            # definition alive; either can commit inside the wait. The
+            # request would then write and commit the shared definition
+            # row on a revoked authority, and fail only afterwards, in
+            # ``db.refresh(user_mcp)`` below -- which runs after the
+            # commit, so the generic handler's rollback cannot take the
+            # shared write back and the caller sees a 500 over a durable
+            # change.
+            #
+            # ``populate_existing()`` on the definition query above
+            # refreshes that statement's row and nothing else, so the link
+            # row needs its own statement. This is a single-table read of
+            # it -- the gate above is a two-table join and cannot address
+            # this table alone -- and the row it returns replaces
+            # ``user_mcp`` and re-derives ``can_edit_global`` for the rest
+            # of the route: the per-user env write, the activation write,
+            # the refresh and the response all read it.
+            #
+            # A gone link is this route's existing 404, matching the gate.
+            # A link that is still there but no longer owns the server is
+            # not an error by itself here -- the gate does not refuse a
+            # non-owner either -- so it is answered exactly as the gate
+            # would have answered it: the owner-only guard below rejects a
+            # payload that changes the shared configuration and drops one
+            # that does not.
+            current_user_mcp = (
+                db.query(UserMCPServer)
+                .filter(
+                    UserMCPServer.user_id == user_id,
+                    UserMCPServer.mcpserver_id == server_id,
+                )
+                .populate_existing()
+                .first()
+            )
+            if current_user_mcp is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="MCP server not found",
+                )
+            user_mcp = current_user_mcp
+            can_edit_global = _check_mcp_permission(
+                user_mcp, getattr(current_user, "is_admin", False), require="edit"
+            )
+
         # Read from the fresh definition-row read above, not the pre-lock
         # read further up: rename_team_connector's "old" argument must be
         # the name that read actually returned. On the path that writes

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -3239,10 +3239,41 @@ def update_mcp_server(
             )
 
         user_mcp, server = result
-        old_name = str(server.name)
         can_edit_global = _check_mcp_permission(
             user_mcp, getattr(current_user, "is_admin", False), require="edit"
         )
+
+        # A second, single-table lock on the definition row, taken before any
+        # tamper check or config build below reads or mutates it. The read
+        # above is a two-table join and cannot itself lock just this table;
+        # this is a fresh statement, so a row deleted between the two still
+        # yields None here (handled as the same 404) rather than surfacing
+        # as an unrelated error out of the write path below.
+        # ``populate_existing()`` makes the locked row the one the rest of
+        # this route reads: without it the already-identity-mapped instance
+        # from the join above would be returned unrefreshed, and every field
+        # below would still be the pre-lock snapshot.
+        locked_server = (
+            db.query(MCPServer)
+            .filter(MCPServer.id == server_id)
+            .populate_existing()
+            .with_for_update()
+            .first()
+        )
+        if locked_server is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="MCP server not found"
+            )
+        server = locked_server
+
+        # Read only after the lock: rename_team_connector's "old" argument
+        # must be the name this transaction actually holds locked, not
+        # whatever was there at the pre-lock read above -- a concurrent
+        # committed rename in between would otherwise make this stale, and
+        # the rewrite below would then look for a name that no longer
+        # exists anywhere, leaving the previous renamer's selectors
+        # dangling with no error.
+        old_name = str(server.name)
 
         # Non-owners may not touch the shared global config (env, command, etc.);
         # they only get to set their own per-user env override below. Reject a

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -3243,45 +3243,80 @@ def update_mcp_server(
             user_mcp, getattr(current_user, "is_admin", False), require="edit"
         )
 
-        # A second, single-table lock on the definition row, taken before any
-        # tamper check or config build below reads or mutates it. The read
-        # above is a two-table join and cannot itself lock just this table;
-        # this is a fresh statement, so a row deleted between the two still
-        # yields None here (handled as the same 404) rather than surfacing
-        # as an unrelated error out of the write path below.
-        # ``populate_existing()`` makes the locked row the one the rest of
-        # this route reads: without it the already-identity-mapped instance
-        # from the join above would be returned unrefreshed, and every field
-        # below would still be the pre-lock snapshot.
+        # Which row a request writes decides which row it locks. Seven of the
+        # nine fields of ``MCPServerUpdate`` target the shared ``MCPServer``
+        # definition row; ``is_active`` and ``user_env`` write this caller's
+        # own ``UserMCPServer`` link row and nothing else. Locking the
+        # definition row for a payload that carries only those two made an
+        # activate/deactivate queue behind an unrelated edit of the same
+        # connector -- and, under PostgreSQL REPEATABLE READ, made it fail
+        # outright: the lock statement follows the snapshot the joined read
+        # above already established, so a definition edit committed in between
+        # raises SQLSTATE 40001 and the route's generic handler answers 500
+        # with the requested activation state unwritten.
         #
-        # ``FOR UPDATE`` here is a PostgreSQL/MySQL row lock only:
-        # SQLAlchemy renders no locking clause at all on SQLite, so on a
-        # SQLite deployment the read-modify-write below is not serialized
-        # and two concurrent edits of one server can still interleave.
-        # Closing that window needs the dual-dialect fence
-        # ``acquire_runtime_key_transition_fence`` (services/api_keys.py)
-        # uses -- a no-op ``UPDATE`` that takes SQLite's writer lock -- and
-        # is left to a change of its own.
-        locked_server = (
-            db.query(MCPServer)
-            .filter(MCPServer.id == server_id)
-            .populate_existing()
-            .with_for_update()
-            .first()
+        # ``model_fields_set`` decides this, not the values, the same way
+        # ``update_custom_api`` decides it: an explicitly-null
+        # ``runtime_input_schema`` is written to the definition row below even
+        # though its value is ``None``, while an absent field is not written at
+        # all. So a payload carrying ``description=None`` is counted here and
+        # then skipped by the write at its own ``is not None`` guard -- the
+        # lock is taken in a few cases that did not need it, and skipped in
+        # none whose fields target that row.
+        #
+        # One difference from the custom-api route: this set is not a superset
+        # of the writes that follow. ``_update_server_from_config`` below
+        # re-encrypts a global ``env`` or ``auth`` on every call and Fernet
+        # ciphertext differs each time, so on a server carrying one of those
+        # the rebuild still writes the definition row on this lock-free path.
+        # That write is the pre-existing behavior of this route, unchanged
+        # here; the isolation-level contract governing it is tracked in #1945.
+        fields_set = server_data.model_fields_set
+        writes_definition_row = bool(fields_set - {"is_active", "user_env"})
+
+        # A fresh single-table read of the definition row, on both paths. The
+        # read above is a two-table join and cannot itself address just this
+        # table; this is a separate statement, so a row deleted between the two
+        # still yields None here (handled as the same 404) rather than
+        # surfacing as an unrelated error out of the write path below.
+        # ``populate_existing()`` makes this statement's row the one the rest
+        # of this route reads: without it the already-identity-mapped instance
+        # from the join above would be returned unrefreshed, and every field
+        # below would still be that earlier snapshot.
+        #
+        # ``FOR UPDATE`` is added only on the path that writes this row, so a
+        # request that writes it still waits for another request holding it.
+        # That clause is a PostgreSQL/MySQL row lock only: SQLAlchemy renders
+        # no locking clause at all on SQLite, so on a SQLite deployment the
+        # read-modify-write below is not serialized and two concurrent edits of
+        # one server can still interleave. Closing that window needs the
+        # dual-dialect fence ``acquire_runtime_key_transition_fence``
+        # (services/api_keys.py) uses -- a no-op ``UPDATE`` that takes SQLite's
+        # writer lock -- and is left to a change of its own.
+        definition_query = (
+            db.query(MCPServer).filter(MCPServer.id == server_id).populate_existing()
         )
-        if locked_server is None:
+        if writes_definition_row:
+            definition_query = definition_query.with_for_update()
+        current_server = definition_query.first()
+        if current_server is None:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="MCP server not found"
             )
-        server = locked_server
+        server = current_server
 
-        # Read only after the lock: rename_team_connector's "old" argument
-        # must be the name this transaction actually holds locked, not
-        # whatever was there at the pre-lock read above -- a concurrent
-        # committed rename in between would otherwise make this stale, and
-        # the rewrite below would then look for a name that no longer
-        # exists anywhere, leaving the previous renamer's selectors
-        # dangling with no error.
+        # Read from the fresh definition-row read above, not the pre-lock
+        # read further up: rename_team_connector's "old" argument must be
+        # the name that read actually returned. On the path that writes
+        # this row, that read is also the locked one, so this is the name
+        # this transaction holds locked -- a concurrent committed rename in
+        # between would otherwise make this stale, and the rewrite below
+        # would then look for a name that no longer exists anywhere,
+        # leaving the previous renamer's selectors dangling with no error.
+        # On the lock-free path this concern does not arise: a payload that
+        # skips the lock never carries ``name`` in ``fields_set``, so
+        # ``old_name`` and the name written back below are always the same
+        # string, and the rename hook below never fires for it.
         old_name = str(server.name)
 
         # Non-owners may not touch the shared global config (env, command, etc.);
@@ -3338,7 +3373,6 @@ def update_mcp_server(
         # Build and validate config
         try:
             config = _build_server_config(update_data, server)
-            fields_set = server_data.model_fields_set
             runtime_input_schema = (
                 server_data.runtime_input_schema
                 if can_edit_global and "runtime_input_schema" in fields_set

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -3253,6 +3253,15 @@ def update_mcp_server(
         # this route reads: without it the already-identity-mapped instance
         # from the join above would be returned unrefreshed, and every field
         # below would still be the pre-lock snapshot.
+        #
+        # ``FOR UPDATE`` here is a PostgreSQL/MySQL row lock only:
+        # SQLAlchemy renders no locking clause at all on SQLite, so on a
+        # SQLite deployment the read-modify-write below is not serialized
+        # and two concurrent edits of one server can still interleave.
+        # Closing that window needs the dual-dialect fence
+        # ``acquire_runtime_key_transition_fence`` (services/api_keys.py)
+        # uses -- a no-op ``UPDATE`` that takes SQLite's writer lock -- and
+        # is left to a change of its own.
         locked_server = (
             db.query(MCPServer)
             .filter(MCPServer.id == server_id)

--- a/tests/web/api/test_custom_api.py
+++ b/tests/web/api/test_custom_api.py
@@ -588,11 +588,15 @@ def _count_custom_apis_selects_before_first_delete(statements: list[str]) -> int
 
 
 class TestDeleteLockOrderMatchesThePutsLockOrder:
-    """``update_custom_api`` locks the ``CustomApi`` definition row first and
-    writes the ``UserCustomApi`` link row afterwards. For the two routes to
-    share one global lock order, ``delete_custom_api`` must take the same
-    definition-row lock before it deletes the link row, in both of its
-    branches.
+    """``update_custom_api`` locks the ``CustomApi`` definition row first,
+    calls ``rename_team_connector`` after that lock, and writes the
+    ``UserCustomApi`` link row after that. For the two routes to share one
+    lock order, ``delete_custom_api`` must take the same definition-row
+    lock before it calls ``delete_team_connector`` and before it deletes
+    the link row, in both of its branches. The hook boundary matters as
+    much as the two tables do: a hook that locks rows of its own sees both
+    routes arrive holding the definition row, so the two cannot be inside
+    the hook at the same time on the same connector.
 
     SQLite silently drops ``FOR UPDATE`` (it is a no-op on this dialect), so
     nothing here demonstrates that the lock actually blocks a second writer
@@ -651,4 +655,53 @@ class TestDeleteLockOrderMatchesThePutsLockOrder:
             "expected the not-found guard's relationship load AND the new "
             "lock statement's own SELECT against custom_apis, both before "
             "the first DELETE"
+        )
+
+    def test_the_lock_is_taken_before_the_delete_hook_is_called(self):
+        """``delete_team_connector`` runs with the definition row already
+        held. That is what puts this route in the same direction as
+        ``update_custom_api``, which calls ``rename_team_connector`` after
+        its own lock -- and is therefore what stops the two from forming a
+        cycle through rows the hook locks. The hook counts the
+        ``custom_apis`` ``SELECT``s issued so far: the not-found guard's
+        relationship load, plus the lock's own query.
+        """
+        session_factory, engine = _lock_order_session_factory()
+        owner_id, api_id = _seed_owned_api_for_lock_order(
+            session_factory, name="lock-order-before-hook"
+        )
+        db = session_factory()
+        current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+        statements: list[str] = []
+        selects_seen_by_the_hook: list[int] = []
+
+        def record_query(conn, cursor, statement, parameters, context, executemany):
+            del conn, cursor, parameters, context, executemany
+            statements.append(statement)
+
+        def deleted_hook(_db, _user_id, _connector_type, _connector_id):
+            selects_seen_by_the_hook.append(
+                sum(
+                    1
+                    for statement in statements
+                    if statement.strip().upper().startswith("SELECT")
+                    and "FROM CUSTOM_APIS" in statement.strip().upper()
+                )
+            )
+            return ConnectorDeleteDecision()
+
+        event.listen(engine, "before_cursor_execute", record_query)
+        set_connector_team_hooks(deleted=deleted_hook)
+        try:
+            delete_custom_api(api_id, current_user=current_user, db=db)
+        finally:
+            set_connector_team_hooks()
+            event.remove(engine, "before_cursor_execute", record_query)
+            db.close()
+
+        assert selects_seen_by_the_hook == [2], (
+            "expected the delete hook to be called once, with both the "
+            "not-found guard's relationship load and the lock statement's "
+            "own SELECT against custom_apis already issued"
         )

--- a/tests/web/api/test_custom_api.py
+++ b/tests/web/api/test_custom_api.py
@@ -1,10 +1,13 @@
+import inspect
 from datetime import datetime
+from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import pytest
 from fastapi import HTTPException
 from pydantic import ValidationError
-from sqlalchemy.orm import Session
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
 
 from xagent.web.api.custom_api import (
     CustomApiCreate,
@@ -18,8 +21,12 @@ from xagent.web.api.custom_api import (
     update_custom_api,
 )
 from xagent.web.models.custom_api import CustomApi, UserCustomApi
+from xagent.web.models.database import Base
 from xagent.web.models.user import User
-from xagent.web.services.connector_team_scope import ConnectorDeleteDecision
+from xagent.web.services.connector_team_scope import (
+    ConnectorDeleteDecision,
+    set_connector_team_hooks,
+)
 
 
 def test_custom_api_models_env_validation():
@@ -296,6 +303,13 @@ async def test_update_custom_api():
     # Return user api on first query
     # Return None for existing name check
     db.query().filter().first.side_effect = [mock_user_api, None]
+    # The row lock's own fresh query is a separate mock chain
+    # (.populate_existing().with_for_update() sits between .filter() and
+    # .first()), so it needs its own return value rather than sharing the
+    # side_effect list above.
+    db.query().filter().populate_existing().with_for_update().first.return_value = (
+        mock_api
+    )
 
     api_data = CustomApiUpdate(
         name="new_name",
@@ -311,7 +325,7 @@ async def test_update_custom_api():
     with patch(
         "xagent.web.api.custom_api.encrypt_value", side_effect=lambda x: f"enc_{x}"
     ):
-        await update_custom_api(10, api_data, current_user=user, db=db)
+        update_custom_api(10, api_data, current_user=user, db=db)
 
         assert mock_api.name == "new_name"
         assert mock_api.env == {"k1": "enc_old1", "k2": "enc_v2"}
@@ -347,11 +361,16 @@ async def test_update_custom_api_env_replacement_deletes_only_the_omitted_secret
         custom_api=mock_api,
     )
     db.query().filter().first.return_value = mock_user_api
+    # The row lock's own fresh query is a separate mock chain -- see the
+    # comment in test_update_custom_api.
+    db.query().filter().populate_existing().with_for_update().first.return_value = (
+        mock_api
+    )
 
     with patch(
         "xagent.web.api.custom_api.encrypt_value", side_effect=lambda x: f"enc_{x}"
     ):
-        await update_custom_api(
+        update_custom_api(
             10,
             CustomApiUpdate(env={"TENANT": "********"}),
             current_user=user,
@@ -381,9 +400,14 @@ async def test_update_custom_api_rejects_renamed_masked_secret():
         custom_api=mock_api,
     )
     db.query().filter().first.return_value = mock_user_api
+    # The row lock's own fresh query is a separate mock chain -- see the
+    # comment in test_update_custom_api.
+    db.query().filter().populate_existing().with_for_update().first.return_value = (
+        mock_api
+    )
 
     with pytest.raises(HTTPException) as exc_info:
-        await update_custom_api(
+        update_custom_api(
             10,
             CustomApiUpdate(env={"RENAMED_TOKEN": "********"}),
             current_user=user,
@@ -423,6 +447,11 @@ async def test_update_custom_api_explicit_null_clears_runtime_config():
         custom_api=mock_api,
     )
     db.query().filter().first.return_value = mock_user_api
+    # The row lock's own fresh query is a separate mock chain -- see the
+    # comment in test_update_custom_api.
+    db.query().filter().populate_existing().with_for_update().first.return_value = (
+        mock_api
+    )
 
     api_data = CustomApiUpdate(
         runtime_input_schema=None,
@@ -430,7 +459,7 @@ async def test_update_custom_api_explicit_null_clears_runtime_config():
         allow_delegated_authorization=False,
     )
 
-    await update_custom_api(10, api_data, current_user=user, db=db)
+    update_custom_api(10, api_data, current_user=user, db=db)
 
     assert mock_api.runtime_input_schema is None
     assert mock_api.runtime_bindings is None
@@ -449,8 +478,11 @@ async def test_delete_custom_api():
     )
 
     db.query().filter().first.return_value = mock_user_api
+    db.query().filter().populate_existing().with_for_update().first.return_value = (
+        mock_api
+    )
 
-    await delete_custom_api(10, current_user=user, db=db)
+    delete_custom_api(10, current_user=user, db=db)
 
     db.delete.assert_called_once_with(mock_api)
     db.commit.assert_called()
@@ -465,6 +497,9 @@ async def test_delete_team_custom_api_flushes_only_current_user_link():
         user_id=1, custom_api_id=10, can_delete=True, custom_api=mock_api
     )
     db.query().filter().first.side_effect = [mock_user_api, None]
+    db.query().filter().populate_existing().with_for_update().first.return_value = (
+        mock_api
+    )
 
     decision = ConnectorDeleteDecision(
         team_owned=True,
@@ -475,9 +510,145 @@ async def test_delete_team_custom_api_flushes_only_current_user_link():
         "xagent.web.services.connector_team_scope.delete_team_connector",
         return_value=decision,
     ):
-        await delete_custom_api(10, current_user=user, db=db)
+        delete_custom_api(10, current_user=user, db=db)
 
     db.flush.assert_called_once_with([mock_user_api])
     assert db.no_autoflush.__enter__.called
     assert db.delete.call_args_list == [call(mock_user_api), call(mock_api)]
     db.commit.assert_called_once()
+
+
+def test_the_locking_routes_are_sync_defs_so_a_lock_wait_never_holds_the_event_loop():
+    """Each route below runs a ``SELECT ... FOR UPDATE`` that can wait
+    indefinitely on a concurrent writer holding the same definition row.
+    FastAPI runs a coroutine route on the event loop thread itself, so such
+    a wait inside an ``async def`` route stalls every other request the
+    process is serving, not just this one. Declaring them as plain ``def``
+    puts them in the threadpool instead, where the wait occupies one worker.
+    """
+    from xagent.web.api import custom_api as custom_api_api
+    from xagent.web.api import mcp as mcp_api
+
+    assert not inspect.iscoroutinefunction(custom_api_api.update_custom_api)
+    assert not inspect.iscoroutinefunction(custom_api_api.delete_custom_api)
+    assert not inspect.iscoroutinefunction(mcp_api.update_mcp_server)
+
+
+def _lock_order_session_factory():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return sessionmaker(autocommit=False, autoflush=False, bind=engine), engine
+
+
+def _seed_owned_api_for_lock_order(session_factory, *, name: str) -> tuple[int, int]:
+    db = session_factory()
+    owner = User(username=f"user-{name}", password_hash="x", is_admin=False)
+    db.add(owner)
+    db.flush()
+    api = CustomApi(name=name, url="https://example.test/api", method="GET")
+    db.add(api)
+    db.flush()
+    db.add(
+        UserCustomApi(
+            user_id=owner.id,
+            custom_api_id=api.id,
+            is_owner=True,
+            can_edit=True,
+            can_delete=True,
+            is_active=True,
+        )
+    )
+    db.commit()
+    owner_id, api_id = int(owner.id), int(api.id)
+    db.close()
+    return owner_id, api_id
+
+
+def _count_custom_apis_selects_before_first_delete(statements: list[str]) -> int:
+    """How many ``SELECT``s against ``custom_apis`` land before the first
+    ``DELETE`` of either table.
+
+    The route's own not-found guard (``not user_api or not
+    user_api.custom_api``) always lazy-loads the ``custom_api`` relationship,
+    which is one such ``SELECT`` on its own -- with or without the lock
+    statement this test exists to pin. So *presence* of a ``custom_apis``
+    ``SELECT`` before the delete is true either way and proves nothing; the
+    *count* is what distinguishes them -- one without the lock statement,
+    two with it, because ``populate_existing()`` forces the lock's query to
+    hit the database again rather than reuse the already-loaded row.
+    """
+    count = 0
+    for statement in statements:
+        upper = statement.strip().upper()
+        if upper.startswith("DELETE"):
+            break
+        if upper.startswith("SELECT") and "FROM CUSTOM_APIS" in upper:
+            count += 1
+    return count
+
+
+class TestDeleteLockOrderMatchesThePutsLockOrder:
+    """``update_custom_api`` locks the ``CustomApi`` definition row first and
+    writes the ``UserCustomApi`` link row afterwards. For the two routes to
+    share one global lock order, ``delete_custom_api`` must take the same
+    definition-row lock before it deletes the link row, in both of its
+    branches.
+
+    SQLite silently drops ``FOR UPDATE`` (it is a no-op on this dialect), so
+    nothing here demonstrates that the lock actually blocks a second writer
+    -- that proof lives in test_custom_api_edit_lock_postgresql.py, against
+    a real server. What this proves instead is statement *order*, which is
+    dialect-independent and exercisable without one.
+    """
+
+    def _run(self, *, team_owned: bool) -> list[str]:
+        session_factory, engine = _lock_order_session_factory()
+        owner_id, api_id = _seed_owned_api_for_lock_order(
+            session_factory,
+            name="lock-order-team" if team_owned else "lock-order-cascade",
+        )
+        db = session_factory()
+        current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+        statements: list[str] = []
+
+        def record_query(conn, cursor, statement, parameters, context, executemany):
+            del conn, cursor, parameters, context, executemany
+            statements.append(statement)
+
+        event.listen(engine, "before_cursor_execute", record_query)
+        try:
+            if team_owned:
+
+                def deleted_hook(_db, _user_id, _connector_type, _connector_id):
+                    return ConnectorDeleteDecision(
+                        team_owned=True, authorized=True, delete_definition=True
+                    )
+
+                set_connector_team_hooks(deleted=deleted_hook)
+                try:
+                    delete_custom_api(api_id, current_user=current_user, db=db)
+                finally:
+                    set_connector_team_hooks()
+            else:
+                delete_custom_api(api_id, current_user=current_user, db=db)
+        finally:
+            event.remove(engine, "before_cursor_execute", record_query)
+            db.close()
+        return statements
+
+    def test_lock_order_team_owned_branch(self):
+        statements = self._run(team_owned=True)
+        assert _count_custom_apis_selects_before_first_delete(statements) == 2, (
+            "expected the not-found guard's relationship load AND the new "
+            "lock statement's own SELECT against custom_apis, both before "
+            "the first DELETE"
+        )
+
+    def test_lock_order_cascade_branch(self):
+        statements = self._run(team_owned=False)
+        assert _count_custom_apis_selects_before_first_delete(statements) == 2, (
+            "expected the not-found guard's relationship load AND the new "
+            "lock statement's own SELECT against custom_apis, both before "
+            "the first DELETE"
+        )

--- a/tests/web/api/test_custom_api.py
+++ b/tests/web/api/test_custom_api.py
@@ -588,9 +588,9 @@ def _count_custom_apis_selects_before_first_delete(statements: list[str]) -> int
 
 
 class TestDeleteLockOrderMatchesThePutsLockOrder:
-    """``update_custom_api`` locks the ``CustomApi`` definition row first,
-    calls ``rename_team_connector`` after that lock, and writes the
-    ``UserCustomApi`` link row after that. For the two routes to share one
+    """An ``update_custom_api`` call that writes the definition row locks
+    it first, calls ``rename_team_connector`` after that lock, and writes
+    the ``UserCustomApi`` link row after that. For the two routes to share one
     lock order, ``delete_custom_api`` must take the same definition-row
     lock before it calls ``delete_team_connector`` and before it deletes
     the link row, in both of its branches. The hook boundary matters as
@@ -661,8 +661,9 @@ class TestDeleteLockOrderMatchesThePutsLockOrder:
         """``delete_team_connector`` runs with the definition row already
         held. That is what puts this route in the same direction as
         ``update_custom_api``, which calls ``rename_team_connector`` after
-        its own lock -- and is therefore what stops the two from forming a
-        cycle through rows the hook locks. The hook counts the
+        its own definition-row lock, on the path that takes one -- and is
+        therefore what stops the two from forming a cycle through rows the
+        hook locks. The hook counts the
         ``custom_apis`` ``SELECT``s issued so far: the not-found guard's
         relationship load, plus the lock's own query.
         """

--- a/tests/web/api/test_custom_api.py
+++ b/tests/web/api/test_custom_api.py
@@ -500,6 +500,10 @@ async def test_delete_team_custom_api_flushes_only_current_user_link():
     db.query().filter().populate_existing().with_for_update().first.return_value = (
         mock_api
     )
+    # The lock-order re-read of the link row is a third mock chain, distinct
+    # from the access gate's plain ``.filter().first()`` above: unrevoked,
+    # it must return the same still-``can_delete`` link the gate saw.
+    db.query().filter().populate_existing().first.return_value = mock_user_api
 
     decision = ConnectorDeleteDecision(
         team_owned=True,
@@ -540,12 +544,16 @@ def _lock_order_session_factory():
     return sessionmaker(autocommit=False, autoflush=False, bind=engine), engine
 
 
-def _seed_owned_api_for_lock_order(session_factory, *, name: str) -> tuple[int, int]:
+def _seed_owned_api_for_lock_order(
+    session_factory, *, name: str, description: str | None = None
+) -> tuple[int, int]:
     db = session_factory()
     owner = User(username=f"user-{name}", password_hash="x", is_admin=False)
     db.add(owner)
     db.flush()
-    api = CustomApi(name=name, url="https://example.test/api", method="GET")
+    api = CustomApi(
+        name=name, url="https://example.test/api", method="GET", description=description
+    )
     db.add(api)
     db.flush()
     db.add(
@@ -585,6 +593,117 @@ def _count_custom_apis_selects_before_first_delete(statements: list[str]) -> int
         if upper.startswith("SELECT") and "FROM CUSTOM_APIS" in upper:
             count += 1
     return count
+
+
+def _updated_table_names(statements: list[str]) -> list[str]:
+    """The table name out of each recorded ``UPDATE`` statement, in order.
+
+    Matched off the second token rather than a substring check: SQLite
+    renders ``UPDATE user_custom_apis SET ...``, and a plain ``"CUSTOM_APIS"
+    in statement`` check would also match that table's own name, since it
+    contains the shorter table name as a substring.
+    """
+    tables = []
+    for statement in statements:
+        tokens = statement.strip().split()
+        if tokens and tokens[0].upper() == "UPDATE":
+            tables.append(tokens[1].strip('"').upper())
+    return tables
+
+
+def _assert_is_active_edit_writes_link_row_only(
+    *,
+    seed_name: str,
+    payload_kwargs: dict,
+    expected_description,
+    seed_description: str | None = None,
+) -> None:
+    """Shared body for the two ``is_active``-plus-sibling-field tests
+    below: run the edit, assert the response and the persisted link row,
+    then assert that no ``UPDATE`` reached ``custom_apis`` while exactly
+    one reached ``user_custom_apis``.
+    """
+    session_factory, engine = _lock_order_session_factory()
+    owner_id, api_id = _seed_owned_api_for_lock_order(
+        session_factory, name=seed_name, description=seed_description
+    )
+    db = session_factory()
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+    statements: list[str] = []
+
+    def record_query(conn, cursor, statement, parameters, context, executemany):
+        del conn, cursor, parameters, context, executemany
+        statements.append(statement)
+
+    event.listen(engine, "before_cursor_execute", record_query)
+    try:
+        response = update_custom_api(
+            api_id,
+            CustomApiUpdate(is_active=False, **payload_kwargs),
+            current_user=current_user,
+            db=db,
+        )
+    finally:
+        event.remove(engine, "before_cursor_execute", record_query)
+        db.close()
+
+    assert isinstance(response, CustomApiResponse)
+    assert response.is_active is False
+
+    with session_factory() as fresh:
+        link = (
+            fresh.query(UserCustomApi)
+            .filter(
+                UserCustomApi.custom_api_id == api_id,
+                UserCustomApi.user_id == owner_id,
+            )
+            .one()
+        )
+        assert link.is_active is False
+        api = fresh.query(CustomApi).filter(CustomApi.id == api_id).one()
+        assert api.name == seed_name
+        assert api.description == expected_description
+
+    updated_tables = _updated_table_names(statements)
+    assert updated_tables.count("CUSTOM_APIS") == 0, (
+        f"an is_active edit for {seed_name!r} must not write the "
+        f"definition row -- saw UPDATEs against {updated_tables!r}"
+    )
+    assert updated_tables.count("USER_CUSTOM_APIS") == 1
+
+
+def test_an_is_active_edit_with_an_explicit_null_description_writes_no_definition_field():
+    """``model_fields_set`` decides ``writes_definition_row``, not the
+    values -- so a payload pairing ``is_active`` with an explicit-null
+    ``description`` still counts ``description`` into that set and takes
+    the lock, even though the write below it is skipped by its own
+    ``is not None`` guard. Despite taking the lock, only the caller's own
+    link row may see an ``UPDATE``.
+
+    The seed's own description is non-``None`` (``"seed-desc"``): if the
+    guard were ever bypassed, assigning the payload's ``None`` over that
+    would be an observable change, not a same-value no-op silently skipped
+    by SQLAlchemy's own dirty-tracking.
+    """
+    _assert_is_active_edit_writes_link_row_only(
+        seed_name="is-active-null-description",
+        seed_description="seed-desc",
+        payload_kwargs={"description": None},
+        expected_description="seed-desc",
+    )
+
+
+def test_an_is_active_edit_repeating_the_current_name_writes_no_definition_field():
+    """Same shape as the explicit-null-description case above, with
+    ``name`` as the sibling field: it counts into ``fields_set`` and takes
+    the lock, but the name-change guard (``api_data.name != api.name``) is
+    false, so the definition row must still see no ``UPDATE``.
+    """
+    _assert_is_active_edit_writes_link_row_only(
+        seed_name="is-active-repeated-name",
+        payload_kwargs={"name": "is-active-repeated-name"},
+        expected_description=None,
+    )
 
 
 class TestDeleteLockOrderMatchesThePutsLockOrder:

--- a/tests/web/api/test_custom_api_edit_lock_postgresql.py
+++ b/tests/web/api/test_custom_api_edit_lock_postgresql.py
@@ -7,10 +7,14 @@ against SQLite, so nothing there can tell a genuine second-writer block
 from a lock statement that silently does nothing. This file is the one
 place that runs the real statement against a real server and proves it
 actually blocks a second writer: two concurrent edits, an edit and a
-concurrent delete both taking the same lock in the same order, and the
-companion path where the row vanishes between the route's first read and
-this lock. Mirrors test_mcp_server_edit_lock_postgresql.py's structure for
-the MCP side of the edit lock. The MCP side's delete route takes no such
+concurrent delete both taking the same lock in the same order, and -- for
+the edit route and the delete route each -- the companion path where the
+row vanishes between the route's first read and this lock. The delete
+route's version of that path additionally pins where the lock sits
+relative to ``delete_team_connector``: it is taken first, so a vanished
+row is refused before the hook is called at all. Mirrors
+test_mcp_server_edit_lock_postgresql.py's structure for the MCP side of
+the edit lock. The MCP side's delete route takes no such
 lock and needs none: it commits its link-row deletion before it goes near
 the definition row, so it never holds both rows in one transaction and
 cannot form the cycle the ordering lock here exists to rule out.
@@ -37,7 +41,10 @@ from tests.shared.postgres_disposable import disposable_database_factory
 from xagent.web.models.custom_api import CustomApi, UserCustomApi
 from xagent.web.models.database import Base
 from xagent.web.models.user import User
-from xagent.web.services.connector_team_scope import set_connector_team_hooks
+from xagent.web.services.connector_team_scope import (
+    ConnectorDeleteDecision,
+    set_connector_team_hooks,
+)
 
 pytestmark = pytest.mark.postgresql
 
@@ -401,3 +408,93 @@ def test_a_delete_blocks_until_a_concurrent_edits_transaction_finishes(
         custom_api_api.validate_runtime_config_declaration = real_validate
         session_a.close()
         session_b.close()
+
+
+def test_a_delete_whose_row_vanishes_after_the_gate_but_before_the_lock_is_a_404(
+    session_factory, seeded
+) -> None:
+    """``delete_custom_api`` has the same window ``update_custom_api`` has:
+    its access read can find the row and still lose a race to a concurrent
+    delete that commits before the lock statement runs. Without the lock's
+    own ``None`` guard the route reaches ``db.delete(None)``, which raises
+    ``UnmappedInstanceError`` out of the write path -- an HTTP 500 where a
+    404 is correct.
+
+    The concurrent delete is fired from a wrapper around this session's own
+    ``query``, which lands it strictly between the two reads: the lock is
+    the first statement in this route that asks for ``CustomApi`` (the
+    access read above asks for ``UserCustomApi``, and reaches the
+    definition row through its relationship rather than through ``query``),
+    so the wrapper can recognise the lock query and nothing else. The
+    recorded entity sequence is asserted rather than assumed, so this test
+    cannot quietly pass on a 404 raised by the access gate instead of by
+    the lock.
+
+    Two side-effect assertions come with it. The installed delete hook must
+    never be called: the lock precedes ``delete_team_connector``, so a
+    vanished row is refused before any hook-side mutation is attempted. And
+    the route must not commit: the only ``db.commit()`` in this route is
+    after the deletion, and the refusal returns before it.
+    """
+    import xagent.web.api.custom_api as custom_api_api
+
+    owner_id, api_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    db = session_factory()
+    real_query = db.query
+    real_commit = db.commit
+    deleted_already = threading.Event()
+    queried_entities: list[tuple] = []
+    commits: list[str] = []
+    hook_calls: list[int] = []
+
+    def spy_deleted_hook(_db, _user_id, _connector_type, connector_id):
+        hook_calls.append(int(connector_id))
+        return ConnectorDeleteDecision()
+
+    def delete_the_row_when_the_lock_query_starts(*entities, **kwargs):
+        queried_entities.append(entities)
+        if entities == (CustomApi,) and not deleted_already.is_set():
+            deleted_already.set()
+            with session_factory() as other:
+                other.execute(
+                    sa.delete(UserCustomApi).where(
+                        UserCustomApi.custom_api_id == api_id
+                    )
+                )
+                other.execute(sa.delete(CustomApi).where(CustomApi.id == api_id))
+                other.commit()
+        return real_query(*entities, **kwargs)
+
+    def record_commit():
+        commits.append("commit")
+        return real_commit()
+
+    db.query = delete_the_row_when_the_lock_query_starts
+    db.commit = record_commit
+    set_connector_team_hooks(deleted=spy_deleted_hook)
+    try:
+        with pytest.raises(HTTPException) as exc:
+            custom_api_api.delete_custom_api(
+                api_id,
+                current_user=current_user,
+                db=db,
+            )
+        assert exc.value.status_code == 404
+        assert deleted_already.is_set(), "the concurrent delete never ran"
+        assert queried_entities[:2] == [(UserCustomApi,), (CustomApi,)], (
+            "the concurrent delete must land after the access gate's own "
+            "read and before the lock; otherwise the 404 under test could "
+            f"be the access gate's rather than the lock's -- saw "
+            f"{queried_entities!r}"
+        )
+        assert hook_calls == [], (
+            "the lock's 404 must precede delete_team_connector, so a "
+            "vanished row is refused before any hook-side mutation is "
+            "attempted"
+        )
+        assert commits == [], "the refused delete must commit nothing"
+    finally:
+        set_connector_team_hooks()
+        db.close()

--- a/tests/web/api/test_custom_api_edit_lock_postgresql.py
+++ b/tests/web/api/test_custom_api_edit_lock_postgresql.py
@@ -1,6 +1,10 @@
 """Real-PostgreSQL coverage for the row lock ``update_custom_api`` and
 ``delete_custom_api`` take on the ``CustomApi`` definition row before
-propagating a rename or removing the link row, respectively.
+propagating a rename or removing the link row, respectively -- and, for
+the edit route, for the payloads that must *not* take it: a PUT that sets
+only ``is_active`` writes the caller's own ``UserCustomApi`` link row and
+never the definition row, so it reads the definition row without locking
+it.
 
 ``FOR UPDATE`` is a no-op on SQLite -- every other suite in this repo runs
 against SQLite, so nothing there can tell a genuine second-writer block
@@ -175,6 +179,25 @@ def test_a_second_editor_blocks_until_the_first_editors_transaction_finishes(
         session_a.close()
         session_b.close()
 
+    # Both writer sessions are closed above, so this reads what actually
+    # committed rather than either session's own uncommitted view. The
+    # block above proves the second editor waited; without this it would
+    # still pass if neither editor's write survived.
+    with session_factory() as fresh:
+        row = fresh.query(CustomApi).filter(CustomApi.id == api_id).one()
+        assert row.name == "renamed-by-first-editor"
+        assert row.description == "edited-by-second-editor"
+        assert (
+            fresh.query(UserCustomApi)
+            .filter(
+                UserCustomApi.custom_api_id == api_id,
+                UserCustomApi.user_id == owner_id,
+            )
+            .one()
+            .is_active
+            is True
+        )
+
 
 def test_the_second_editors_rename_reports_the_first_editors_committed_name_as_old(
     session_factory, seeded
@@ -272,6 +295,23 @@ def test_the_second_editors_rename_reports_the_first_editors_committed_name_as_o
         session_a.close()
         session_b.close()
 
+    # The hook tuples above are in-process call records; this reads what
+    # actually committed, so a rename that reported the right pair of names
+    # and then failed to persist cannot pass.
+    with session_factory() as fresh:
+        row = fresh.query(CustomApi).filter(CustomApi.id == api_id).one()
+        assert row.name == "renamed-by-second-editor"
+        assert (
+            fresh.query(UserCustomApi)
+            .filter(
+                UserCustomApi.custom_api_id == api_id,
+                UserCustomApi.user_id == owner_id,
+            )
+            .one()
+            .is_active
+            is True
+        )
+
 
 def test_a_row_that_vanishes_after_the_gate_but_before_the_lock_is_a_404_not_a_500(
     session_factory, seeded
@@ -331,16 +371,23 @@ def test_a_row_that_vanishes_after_the_gate_but_before_the_lock_is_a_404_not_a_5
 def test_a_delete_blocks_until_a_concurrent_edits_transaction_finishes(
     session_factory, seeded
 ) -> None:
-    """``delete_custom_api`` takes the same definition-row lock
-    ``update_custom_api`` does, in the same order (``CustomApi`` first),
-    precisely so that a concurrent edit/delete pair cannot deadlock
-    (PostgreSQL 40P01): the edit's transaction below must finish -- commit
-    or roll back -- before the delete's own lock statement can proceed,
-    the same block ``test_a_second_editor_blocks_until_the_first_editors_
-    transaction_finishes`` above demonstrates between two edits. Before
+    """``delete_custom_api`` takes the same definition-row lock an
+    ``update_custom_api`` call that writes the definition row does, in the
+    same order (``CustomApi`` first), precisely so that a concurrent
+    edit/delete pair cannot deadlock (PostgreSQL 40P01): the edit's
+    transaction below must finish -- commit or roll back -- before the
+    delete's own lock statement can proceed, the same block
+    ``test_a_second_editor_blocks_until_the_first_editors_transaction_
+    finishes`` above demonstrates between two edits. Before
     delete_custom_api took this lock, its own child-row-first deletion
     order (see custom_api.py) and the PUT's parent-row-first order let the
     two routes take these same two rows in opposite orders.
+
+    The concurrent editor below sets a definition field, not ``is_active``.
+    That is load-bearing: an ``is_active``-only PUT writes the caller's own
+    link row and takes no lock on the definition row at all, so it would
+    hold nothing for this delete to wait on and this test would prove
+    nothing about lock order.
     """
     import xagent.web.api.custom_api as custom_api_api
     from xagent.web.api.custom_api import CustomApiUpdate
@@ -370,7 +417,7 @@ def test_a_delete_blocks_until_a_concurrent_edits_transaction_finishes(
         def run_edit():
             return custom_api_api.update_custom_api(
                 api_id,
-                CustomApiUpdate(is_active=False),
+                CustomApiUpdate(description="edited-by-the-concurrent-editor"),
                 current_user=current_user,
                 db=session_a,
             )
@@ -497,4 +544,172 @@ def test_a_delete_whose_row_vanishes_after_the_gate_but_before_the_lock_is_a_404
         assert commits == [], "the refused delete must commit nothing"
     finally:
         set_connector_team_hooks()
+        db.close()
+
+
+def test_an_activation_only_edit_does_not_wait_on_a_concurrent_definition_edit(
+    session_factory, seeded
+) -> None:
+    """A payload that sets only ``is_active`` writes this caller's own
+    ``UserCustomApi`` link row and never the shared ``CustomApi``
+    definition row, so it must not queue behind a concurrent editor that
+    holds the definition row.
+
+    Same barrier as
+    ``test_a_second_editor_blocks_until_the_first_editors_transaction_finishes``
+    above, with the two roles kept apart: the holder edits a definition
+    field and stops inside the patched validation call with its
+    transaction still open, and the activation-only request then has to
+    finish while that transaction is still open. When this route took the
+    definition row's lock for every payload, this request waited for the
+    holder instead.
+    """
+    import xagent.web.api.custom_api as custom_api_api
+    from xagent.web.api.custom_api import CustomApiUpdate
+
+    owner_id, api_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    lock_acquired = threading.Event()
+    release_lock = threading.Event()
+    second_finished = threading.Event()
+    first_call_claimed = threading.Event()
+    first_call_lock = threading.Lock()
+
+    real_validate = custom_api_api.validate_runtime_config_declaration
+
+    def paced_validate(**kwargs):
+        with first_call_lock:
+            is_first_call = not first_call_claimed.is_set()
+            first_call_claimed.set()
+        if is_first_call:
+            lock_acquired.set()
+            assert release_lock.wait(timeout=10), "the holder was never released"
+        return real_validate(**kwargs)
+
+    custom_api_api.validate_runtime_config_declaration = paced_validate
+    session_a = session_factory()
+    session_b = session_factory()
+    try:
+
+        def run_definition_edit():
+            return custom_api_api.update_custom_api(
+                api_id,
+                CustomApiUpdate(description="held-by-the-definition-editor"),
+                current_user=current_user,
+                db=session_a,
+            )
+
+        def run_activation_only():
+            result = custom_api_api.update_custom_api(
+                api_id,
+                CustomApiUpdate(is_active=False),
+                current_user=current_user,
+                db=session_b,
+            )
+            second_finished.set()
+            return result
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            holder = executor.submit(run_definition_edit)
+            assert lock_acquired.wait(timeout=5), (
+                "the definition editor never reached the lock"
+            )
+
+            activator = executor.submit(run_activation_only)
+            # Released in ``finally`` before anything is asserted: a
+            # failure here means the activation-only call is still parked
+            # on the holder's lock, and leaving the holder paused would
+            # hang this executor's shutdown instead of failing the test.
+            try:
+                finished_while_held = second_finished.wait(timeout=5.0)
+            finally:
+                release_lock.set()
+            holder.result(timeout=10)
+            activator.result(timeout=10)
+
+        assert finished_while_held, (
+            "the activation-only edit did not finish while the definition "
+            "editor still held the definition row -- it is waiting on a "
+            "lock for a row it does not write"
+        )
+    finally:
+        custom_api_api.validate_runtime_config_declaration = real_validate
+        session_a.close()
+        session_b.close()
+
+    with session_factory() as fresh:
+        assert (
+            fresh.query(UserCustomApi)
+            .filter(
+                UserCustomApi.custom_api_id == api_id,
+                UserCustomApi.user_id == owner_id,
+            )
+            .one()
+            .is_active
+            is False
+        )
+        assert (
+            fresh.query(CustomApi).filter(CustomApi.id == api_id).one().description
+            == "held-by-the-definition-editor"
+        )
+
+
+def test_an_activation_only_edit_whose_row_vanishes_before_its_read_is_a_404(
+    session_factory, seeded
+) -> None:
+    """The activation-only path skips the lock but keeps the same
+    vanished-definition handling: its own fresh read of ``CustomApi`` must
+    return ``None`` and raise the route's 404, rather than leaving
+    ``db.refresh`` to fail on a row that is no longer there.
+
+    Same wrapper as
+    ``test_a_row_that_vanishes_after_the_gate_but_before_the_lock_is_a_404_not_a_500``
+    above: the concurrent delete fires from this session's own ``query``,
+    which lands it strictly between the access read (which asks for
+    ``UserCustomApi``) and this route's only ``CustomApi`` query.
+    """
+    import xagent.web.api.custom_api as custom_api_api
+    from xagent.web.api.custom_api import CustomApiUpdate
+
+    owner_id, api_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    db = session_factory()
+    real_query = db.query
+    deleted_already = threading.Event()
+    queried_entities: list[tuple] = []
+
+    def delete_the_row_when_the_definition_query_starts(*entities, **kwargs):
+        queried_entities.append(entities)
+        if entities == (CustomApi,) and not deleted_already.is_set():
+            deleted_already.set()
+            with session_factory() as other:
+                other.execute(
+                    sa.delete(UserCustomApi).where(
+                        UserCustomApi.custom_api_id == api_id
+                    )
+                )
+                other.execute(sa.delete(CustomApi).where(CustomApi.id == api_id))
+                other.commit()
+        return real_query(*entities, **kwargs)
+
+    db.query = delete_the_row_when_the_definition_query_starts
+    try:
+        with pytest.raises(HTTPException) as exc:
+            custom_api_api.update_custom_api(
+                api_id,
+                CustomApiUpdate(is_active=False),
+                current_user=current_user,
+                db=db,
+            )
+        assert exc.value.status_code == 404
+        assert deleted_already.is_set(), "the concurrent delete never ran"
+        assert queried_entities[:2] == [(UserCustomApi,), (CustomApi,)], (
+            "the concurrent delete must land after the access gate's own "
+            "read and before this route's definition read; otherwise the "
+            "404 under test could be the access gate's -- saw "
+            f"{queried_entities!r}"
+        )
+    finally:
         db.close()

--- a/tests/web/api/test_custom_api_edit_lock_postgresql.py
+++ b/tests/web/api/test_custom_api_edit_lock_postgresql.py
@@ -1,0 +1,403 @@
+"""Real-PostgreSQL coverage for the row lock ``update_custom_api`` and
+``delete_custom_api`` take on the ``CustomApi`` definition row before
+propagating a rename or removing the link row, respectively.
+
+``FOR UPDATE`` is a no-op on SQLite -- every other suite in this repo runs
+against SQLite, so nothing there can tell a genuine second-writer block
+from a lock statement that silently does nothing. This file is the one
+place that runs the real statement against a real server and proves it
+actually blocks a second writer: two concurrent edits, an edit and a
+concurrent delete both taking the same lock in the same order, and the
+companion path where the row vanishes between the route's first read and
+this lock. Mirrors test_mcp_server_edit_lock_postgresql.py's structure for
+the MCP side of the edit lock. The MCP side's delete route takes no such
+lock and needs none: it commits its link-row deletion before it goes near
+the definition row, so it never holds both rows in one transaction and
+cannot form the cycle the ordering lock here exists to rule out.
+
+Obtains its database through ``tests/shared/postgres_disposable.py``
+(``disposable_database_factory``), the same disposable-CREATE-DATABASE
+helper the other ``*_postgresql.py`` suites in this repo use, rather than
+opening a hand-rolled connection. That helper reads
+``XAGENT_TEST_POSTGRES_URL`` and skips the whole module when it is unset.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+import sqlalchemy as sa
+from fastapi import HTTPException
+from sqlalchemy.orm import sessionmaker
+
+from tests.shared.postgres_disposable import disposable_database_factory
+from xagent.web.models.custom_api import CustomApi, UserCustomApi
+from xagent.web.models.database import Base
+from xagent.web.models.user import User
+from xagent.web.services.connector_team_scope import set_connector_team_hooks
+
+pytestmark = pytest.mark.postgresql
+
+
+@pytest.fixture()
+def session_factory():
+    with disposable_database_factory("xagent_custom_api_edit_lock") as make_database:
+        engine = make_database("edit_lock")
+        Base.metadata.create_all(bind=engine)
+        yield sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture()
+def seeded(session_factory):
+    """One owner, one owned Custom API, in their own committed rows."""
+    with session_factory() as db:
+        owner = User(
+            username="custom-api-edit-lock-owner", password_hash="x", is_admin=False
+        )
+        db.add(owner)
+        db.flush()
+        api = CustomApi(
+            name="edit-lock-target",
+            url="https://example.com/api",
+            method="GET",
+        )
+        db.add(api)
+        db.flush()
+        db.add(
+            UserCustomApi(
+                user_id=int(owner.id),
+                custom_api_id=int(api.id),
+                is_owner=True,
+                can_edit=True,
+                can_delete=True,
+                is_active=True,
+            )
+        )
+        db.commit()
+        return int(owner.id), int(api.id)
+
+
+def test_a_second_editor_blocks_until_the_first_editors_transaction_finishes(
+    session_factory, seeded
+) -> None:
+    """Two real connections, barrier-synchronised: the second call's own
+    lock statement must not return until the first call's transaction
+    commits or rolls back -- the actual behavior ``FOR UPDATE`` exists to
+    provide, and the one thing no SQLite-backed test can demonstrate.
+    """
+    import xagent.web.api.custom_api as custom_api_api
+    from xagent.web.api.custom_api import CustomApiUpdate
+
+    owner_id, api_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    lock_acquired = threading.Event()
+    release_lock = threading.Event()
+    second_finished = threading.Event()
+    first_call_claimed = threading.Event()
+    first_call_lock = threading.Lock()
+
+    real_validate = custom_api_api.validate_runtime_config_declaration
+
+    def paced_validate(**kwargs):
+        # Both threads run through this same patched function once each
+        # gets past its own lock statement. Only the call that gets here
+        # *first* pauses: that is the first editor, holding its row lock
+        # open via this still-uncommitted transaction. A second call that
+        # reaches this point too (rather than staying blocked earlier,
+        # inside its own lock statement) is not made to wait a second
+        # time here -- pausing it too would prove nothing about the
+        # database lock, only about this Python-level barrier.
+        with first_call_lock:
+            is_first_call = not first_call_claimed.is_set()
+            first_call_claimed.set()
+        if is_first_call:
+            lock_acquired.set()
+            assert release_lock.wait(timeout=10), "the first editor was never released"
+        return real_validate(**kwargs)
+
+    custom_api_api.validate_runtime_config_declaration = paced_validate
+    session_a = session_factory()
+    session_b = session_factory()
+    try:
+
+        def run_first():
+            return custom_api_api.update_custom_api(
+                api_id,
+                CustomApiUpdate(name="renamed-by-first-editor"),
+                current_user=current_user,
+                db=session_a,
+            )
+
+        def run_second():
+            result = custom_api_api.update_custom_api(
+                api_id,
+                CustomApiUpdate(description="edited-by-second-editor"),
+                current_user=current_user,
+                db=session_b,
+            )
+            second_finished.set()
+            return result
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(run_first)
+            assert lock_acquired.wait(timeout=5), (
+                "the first editor never reached the lock"
+            )
+
+            second = executor.submit(run_second)
+            # The second call's own lock statement should still be blocked
+            # on the database at this point. If the lock were not real (or
+            # a no-op, as on SQLite), the second call would sail through
+            # almost immediately and this would flip to True.
+            assert not second_finished.wait(timeout=1.0), (
+                "the second editor finished before the first one released "
+                "the row -- the lock did not actually block it"
+            )
+
+            release_lock.set()
+            first.result(timeout=10)
+            second.result(timeout=10)
+
+        assert second_finished.is_set()
+    finally:
+        custom_api_api.validate_runtime_config_declaration = real_validate
+        session_a.close()
+        session_b.close()
+
+
+def test_the_second_editors_rename_reports_the_first_editors_committed_name_as_old(
+    session_factory, seeded
+) -> None:
+    """``rename_team_connector``'s ``old`` argument must be the name this
+    transaction's own lock actually holds once acquired, not whatever the
+    pre-lock read saw.
+
+    Interleaving under test: the first editor renames the connector and
+    commits while the second editor is blocked on the lock. The second
+    editor then acquires the lock, refreshed to the first editor's
+    committed name, and renames again. If the second editor's ``old``
+    argument were captured before its own lock instead, it would report
+    the connector's *original* name -- not the name every team agent's
+    selector was already rewritten to by the first editor's own call --
+    and the second rewrite would search for a name nothing holds anymore,
+    leaving the first rewrite's result permanently dangling with no error.
+    """
+    import xagent.web.api.custom_api as custom_api_api
+    from xagent.web.api.custom_api import CustomApiUpdate
+
+    owner_id, api_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    lock_acquired = threading.Event()
+    release_lock = threading.Event()
+    second_finished = threading.Event()
+    first_call_claimed = threading.Event()
+    first_call_lock = threading.Lock()
+
+    renamed_calls: list[tuple[str, str]] = []
+    renamed_calls_lock = threading.Lock()
+
+    def spy_renamed_hook(_db, _user_id, _connector_type, _connector_id, old, new):
+        with renamed_calls_lock:
+            renamed_calls.append((old, new))
+
+    real_validate = custom_api_api.validate_runtime_config_declaration
+
+    def paced_validate(**kwargs):
+        with first_call_lock:
+            is_first_call = not first_call_claimed.is_set()
+            first_call_claimed.set()
+        if is_first_call:
+            lock_acquired.set()
+            assert release_lock.wait(timeout=10), "the first editor was never released"
+        return real_validate(**kwargs)
+
+    custom_api_api.validate_runtime_config_declaration = paced_validate
+    session_a = session_factory()
+    session_b = session_factory()
+    set_connector_team_hooks(renamed=spy_renamed_hook)
+    try:
+
+        def run_first():
+            return custom_api_api.update_custom_api(
+                api_id,
+                CustomApiUpdate(name="renamed-by-first-editor"),
+                current_user=current_user,
+                db=session_a,
+            )
+
+        def run_second():
+            result = custom_api_api.update_custom_api(
+                api_id,
+                CustomApiUpdate(name="renamed-by-second-editor"),
+                current_user=current_user,
+                db=session_b,
+            )
+            second_finished.set()
+            return result
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(run_first)
+            assert lock_acquired.wait(timeout=5), (
+                "the first editor never reached the lock"
+            )
+
+            second = executor.submit(run_second)
+            assert not second_finished.wait(timeout=1.0), (
+                "the second editor finished before the first one released the row"
+            )
+
+            release_lock.set()
+            first.result(timeout=10)
+            second.result(timeout=10)
+
+        assert renamed_calls == [
+            ("edit-lock-target", "renamed-by-first-editor"),
+            ("renamed-by-first-editor", "renamed-by-second-editor"),
+        ]
+    finally:
+        set_connector_team_hooks()
+        custom_api_api.validate_runtime_config_declaration = real_validate
+        session_a.close()
+        session_b.close()
+
+
+def test_a_row_that_vanishes_after_the_gate_but_before_the_lock_is_a_404_not_a_500(
+    session_factory, seeded
+) -> None:
+    """The route's own access read can find the row and still lose a race
+    to a concurrent delete that commits before the lock statement runs. The
+    lock statement must see that as an ordinary "row not found" (``None``)
+    and let the route's existing 404 handle it, rather than leaving the
+    write path below to fail on a row that is no longer there.
+
+    The concurrent delete is fired from a wrapper around this session's own
+    ``query``, which lands it strictly between the two reads: the lock is
+    the first statement in this route that asks for ``CustomApi`` (the
+    access read above asks for ``UserCustomApi``, and reaches the
+    definition row through its relationship rather than through
+    ``query``), so the wrapper can recognise the lock query and nothing
+    else.
+    """
+    import xagent.web.api.custom_api as custom_api_api
+    from xagent.web.api.custom_api import CustomApiUpdate
+
+    owner_id, api_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    db = session_factory()
+    real_query = db.query
+    deleted_already = threading.Event()
+
+    def delete_the_row_when_the_lock_query_starts(*entities, **kwargs):
+        if entities == (CustomApi,) and not deleted_already.is_set():
+            deleted_already.set()
+            with session_factory() as other:
+                other.execute(
+                    sa.delete(UserCustomApi).where(
+                        UserCustomApi.custom_api_id == api_id
+                    )
+                )
+                other.execute(sa.delete(CustomApi).where(CustomApi.id == api_id))
+                other.commit()
+        return real_query(*entities, **kwargs)
+
+    db.query = delete_the_row_when_the_lock_query_starts
+    try:
+        with pytest.raises(HTTPException) as exc:
+            custom_api_api.update_custom_api(
+                api_id,
+                CustomApiUpdate(name="renamed-after-vanish"),
+                current_user=current_user,
+                db=db,
+            )
+        assert deleted_already.is_set(), "the concurrent delete never ran"
+        assert exc.value.status_code == 404
+    finally:
+        db.close()
+
+
+def test_a_delete_blocks_until_a_concurrent_edits_transaction_finishes(
+    session_factory, seeded
+) -> None:
+    """``delete_custom_api`` takes the same definition-row lock
+    ``update_custom_api`` does, in the same order (``CustomApi`` first),
+    precisely so that a concurrent edit/delete pair cannot deadlock
+    (PostgreSQL 40P01): the edit's transaction below must finish -- commit
+    or roll back -- before the delete's own lock statement can proceed,
+    the same block ``test_a_second_editor_blocks_until_the_first_editors_
+    transaction_finishes`` above demonstrates between two edits. Before
+    delete_custom_api took this lock, its own child-row-first deletion
+    order (see custom_api.py) and the PUT's parent-row-first order let the
+    two routes take these same two rows in opposite orders.
+    """
+    import xagent.web.api.custom_api as custom_api_api
+    from xagent.web.api.custom_api import CustomApiUpdate
+
+    owner_id, api_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    lock_acquired = threading.Event()
+    release_lock = threading.Event()
+    second_finished = threading.Event()
+
+    real_validate = custom_api_api.validate_runtime_config_declaration
+
+    def paced_validate(**kwargs):
+        # The editor's own lock statement runs earlier in the route, before
+        # this patched call -- by the time this pauses, the editor already
+        # holds the definition row lock in an uncommitted transaction.
+        lock_acquired.set()
+        assert release_lock.wait(timeout=10), "the editor was never released"
+        return real_validate(**kwargs)
+
+    custom_api_api.validate_runtime_config_declaration = paced_validate
+    session_a = session_factory()
+    session_b = session_factory()
+    try:
+
+        def run_edit():
+            return custom_api_api.update_custom_api(
+                api_id,
+                CustomApiUpdate(is_active=False),
+                current_user=current_user,
+                db=session_a,
+            )
+
+        def run_delete():
+            result = custom_api_api.delete_custom_api(
+                api_id,
+                current_user=current_user,
+                db=session_b,
+            )
+            second_finished.set()
+            return result
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            editor = executor.submit(run_edit)
+            assert lock_acquired.wait(timeout=5), "the editor never reached the lock"
+
+            deleter = executor.submit(run_delete)
+            # The delete's own lock statement should still be blocked on
+            # the database at this point. If the two routes took this pair
+            # of rows in opposite orders (or if either lock were a no-op,
+            # as on SQLite), the delete would sail through almost
+            # immediately and this would flip to True.
+            assert not second_finished.wait(timeout=1.0), (
+                "the delete finished before the concurrent editor released "
+                "the row -- the lock did not actually block it"
+            )
+
+            release_lock.set()
+            editor.result(timeout=10)
+            deleter.result(timeout=10)
+
+        assert second_finished.is_set()
+    finally:
+        custom_api_api.validate_runtime_config_declaration = real_validate
+        session_a.close()
+        session_b.close()

--- a/tests/web/api/test_custom_api_edit_lock_postgresql.py
+++ b/tests/web/api/test_custom_api_edit_lock_postgresql.py
@@ -28,6 +28,10 @@ Obtains its database through ``tests/shared/postgres_disposable.py``
 helper the other ``*_postgresql.py`` suites in this repo use, rather than
 opening a hand-rolled connection. That helper reads
 ``XAGENT_TEST_POSTGRES_URL`` and skips the whole module when it is unset.
+
+Also covers the caller's own ``UserCustomApi`` link row being revoked --
+deleted, or stripped of its edit/delete flag -- by a second connection
+while a locking route holds the definition row, one case per route.
 """
 
 from __future__ import annotations
@@ -713,3 +717,200 @@ def test_an_activation_only_edit_whose_row_vanishes_before_its_read_is_a_404(
         )
     finally:
         db.close()
+
+
+def _revoke_link_after_lock(
+    db, session_factory, owner_id, api_id, revocation, clear_column
+):
+    """Revoke the caller's own link row -- via a second, committing
+    connection -- on the *second* time this session asks for
+    ``(UserCustomApi,)``: the gate's ask is the first, the re-read added
+    after the lock is the second, landing inside the window the lock holds.
+    """
+    real_query = db.query
+    revoked_already = threading.Event()
+    queried_entities: list[tuple] = []
+    occurrences = 0
+
+    def revoke_when_the_recheck_query_starts(*entities, **kwargs):
+        nonlocal occurrences
+        queried_entities.append(entities)
+        if entities == (UserCustomApi,):
+            occurrences += 1
+            if occurrences == 2 and not revoked_already.is_set():
+                revoked_already.set()
+                with session_factory() as other:
+                    if revocation == "link-deleted":
+                        other.execute(
+                            sa.delete(UserCustomApi).where(
+                                UserCustomApi.user_id == owner_id,
+                                UserCustomApi.custom_api_id == api_id,
+                            )
+                        )
+                    else:
+                        other.execute(
+                            sa.update(UserCustomApi)
+                            .where(
+                                UserCustomApi.user_id == owner_id,
+                                UserCustomApi.custom_api_id == api_id,
+                            )
+                            .values(**{clear_column: False})
+                        )
+                    other.commit()
+        return real_query(*entities, **kwargs)
+
+    db.query = revoke_when_the_recheck_query_starts
+    return revoked_already, queried_entities
+
+
+@pytest.mark.parametrize(
+    ("revocation", "expected_status"),
+    [("link-deleted", 404), ("can-edit-cleared", 403)],
+)
+def test_a_put_whose_association_is_revoked_after_the_lock_is_refused_with_no_shared_write(
+    session_factory, seeded, revocation, expected_status
+) -> None:
+    """A revoked caller (link deleted, or ``can_edit`` cleared) committed
+    by a second connection while this route holds the definition row
+    locked must get the gate's own 404/403 from the re-read added after
+    the lock, with the shared definition row left untouched either way.
+
+    The payload carries a real rename (not just a description edit): the
+    unrevoked path would call ``rename_team_connector`` for it, so its
+    absence here is only meaningful because the hook had something to fire
+    on. Without that, a passing ``hook_calls == []`` would prove nothing --
+    the hook only fires when the name actually changes.
+    """
+    import xagent.web.api.custom_api as custom_api_api
+    from xagent.web.api.custom_api import CustomApiUpdate
+
+    owner_id, api_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    db = session_factory()
+    real_commit = db.commit
+    commits: list[str] = []
+    hook_calls: list[tuple] = []
+
+    def record_commit():
+        commits.append("commit")
+        return real_commit()
+
+    def spy_renamed_hook(_db, _user_id, _connector_type, _connector_id, old, new):
+        hook_calls.append((old, new))
+
+    db.commit = record_commit
+    revoked_already, queried_entities = _revoke_link_after_lock(
+        db, session_factory, owner_id, api_id, revocation, "can_edit"
+    )
+    set_connector_team_hooks(renamed=spy_renamed_hook)
+    try:
+        with pytest.raises(HTTPException) as exc:
+            custom_api_api.update_custom_api(
+                api_id,
+                CustomApiUpdate(
+                    description="edited-after-revocation",
+                    name="renamed-after-revocation",
+                ),
+                current_user=current_user,
+                db=db,
+            )
+        assert exc.value.status_code == expected_status
+        assert revoked_already.is_set(), "the concurrent revocation never ran"
+        assert queried_entities[:3] == [
+            (UserCustomApi,),
+            (CustomApi,),
+            (UserCustomApi,),
+        ], (
+            "the revocation must land after the gate's own read and after "
+            f"the lock, caught by the re-read -- saw {queried_entities!r}"
+        )
+        assert hook_calls == [], "the re-read must precede rename_team_connector"
+        assert commits == [], "the refused edit must commit nothing"
+    finally:
+        set_connector_team_hooks()
+        db.close()
+
+    with session_factory() as fresh:
+        row = fresh.query(CustomApi).filter(CustomApi.id == api_id).one()
+        assert row.description is None, (
+            "the shared definition row must be untouched by a refused edit"
+        )
+        assert row.name == "edit-lock-target", (
+            "the shared definition row's name must be untouched by a refused edit"
+        )
+        if revocation == "can-edit-cleared":
+            link = (
+                fresh.query(UserCustomApi)
+                .filter(
+                    UserCustomApi.custom_api_id == api_id,
+                    UserCustomApi.user_id == owner_id,
+                )
+                .one()
+            )
+            assert link.can_edit is False
+            assert link.is_active is True
+
+
+@pytest.mark.parametrize(
+    ("revocation", "expected_status"),
+    [("link-deleted", 404), ("can-delete-cleared", 403)],
+)
+def test_a_delete_whose_association_is_revoked_after_the_lock_is_refused_before_the_hook(
+    session_factory, seeded, revocation, expected_status
+) -> None:
+    """Same window as the PUT test above, on the delete route: the re-read
+    added after the lock, before ``delete_team_connector`` is ever called,
+    must catch a revoked link with the route's existing 404/403, touching
+    neither the hook nor the shared definition row.
+    """
+    import xagent.web.api.custom_api as custom_api_api
+
+    owner_id, api_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    db = session_factory()
+    real_commit = db.commit
+    commits: list[str] = []
+    hook_calls: list[int] = []
+
+    def record_commit():
+        commits.append("commit")
+        return real_commit()
+
+    def spy_deleted_hook(_db, _user_id, _connector_type, connector_id):
+        hook_calls.append(int(connector_id))
+        return ConnectorDeleteDecision()
+
+    db.commit = record_commit
+    revoked_already, queried_entities = _revoke_link_after_lock(
+        db, session_factory, owner_id, api_id, revocation, "can_delete"
+    )
+    set_connector_team_hooks(deleted=spy_deleted_hook)
+    try:
+        with pytest.raises(HTTPException) as exc:
+            custom_api_api.delete_custom_api(
+                api_id,
+                current_user=current_user,
+                db=db,
+            )
+        assert exc.value.status_code == expected_status
+        assert revoked_already.is_set(), "the concurrent revocation never ran"
+        assert queried_entities[:3] == [
+            (UserCustomApi,),
+            (CustomApi,),
+            (UserCustomApi,),
+        ], (
+            "the revocation must land after the gate's own read and after "
+            f"the lock, caught by the re-read -- saw {queried_entities!r}"
+        )
+        assert hook_calls == [], "the re-read must precede delete_team_connector"
+        assert commits == [], "the refused delete must commit nothing"
+    finally:
+        set_connector_team_hooks()
+        db.close()
+
+    with session_factory() as fresh:
+        assert fresh.query(CustomApi).filter(CustomApi.id == api_id).one(), (
+            "the shared definition row must survive a refused delete"
+        )

--- a/tests/web/api/test_mcp_server_edit_lock_postgresql.py
+++ b/tests/web/api/test_mcp_server_edit_lock_postgresql.py
@@ -158,6 +158,28 @@ def test_a_second_editor_blocks_until_the_first_editors_transaction_finishes(
         session_a.close()
         session_b.close()
 
+    # Both writer sessions are closed above, so this reads what actually
+    # committed rather than either session's own uncommitted view. The
+    # block above proves the second editor waited; without this it would
+    # still pass if neither editor's write survived.
+    with session_factory() as fresh:
+        row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+        assert row.name == "renamed-by-first-editor"
+        assert row.description == "edited-by-second-editor"
+        assert row.transport == "stdio"
+        assert row.command == "true"
+        assert row.managed == "external"
+        assert (
+            fresh.query(UserMCPServer)
+            .filter(
+                UserMCPServer.mcpserver_id == server_id,
+                UserMCPServer.user_id == owner_id,
+            )
+            .one()
+            .is_active
+            is True
+        )
+
 
 def test_the_second_editors_rename_reports_the_first_editors_committed_name_as_old(
     session_factory, seeded
@@ -254,6 +276,26 @@ def test_the_second_editors_rename_reports_the_first_editors_committed_name_as_o
         mcp_api._build_server_config = real_build_server_config
         session_a.close()
         session_b.close()
+
+    # The hook tuples above are in-process call records; this reads what
+    # actually committed, so a rename that reported the right pair of names
+    # and then failed to persist cannot pass.
+    with session_factory() as fresh:
+        row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+        assert row.name == "renamed-by-second-editor"
+        assert row.transport == "stdio"
+        assert row.command == "true"
+        assert row.managed == "external"
+        assert (
+            fresh.query(UserMCPServer)
+            .filter(
+                UserMCPServer.mcpserver_id == server_id,
+                UserMCPServer.user_id == owner_id,
+            )
+            .one()
+            .is_active
+            is True
+        )
 
 
 def test_a_row_that_vanishes_after_the_gate_but_before_the_lock_is_a_404_not_a_500(

--- a/tests/web/api/test_mcp_server_edit_lock_postgresql.py
+++ b/tests/web/api/test_mcp_server_edit_lock_postgresql.py
@@ -1,0 +1,310 @@
+"""Real-PostgreSQL coverage for the row lock ``update_mcp_server`` takes on
+the ``MCPServer`` definition row before building the new config.
+
+``FOR UPDATE`` is a no-op on SQLite -- every other suite in this repo runs
+against SQLite, so nothing there can tell a genuine second-writer block
+from a lock statement that silently does nothing. This file is the one
+place that runs the real statement against a real server and proves it
+actually blocks a second writer, plus the companion path where the row
+vanishes between the route's first read and this lock.
+
+Obtains its database through ``tests/shared/postgres_disposable.py``
+(``disposable_database_factory``), the same disposable-CREATE-DATABASE
+helper the other ``*_postgresql.py`` suites in this repo use, rather than
+opening a hand-rolled connection. That helper reads
+``XAGENT_TEST_POSTGRES_URL`` and skips the whole module when it is unset.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+import sqlalchemy as sa
+from fastapi import HTTPException
+from sqlalchemy.orm import sessionmaker
+
+from tests.shared.postgres_disposable import disposable_database_factory
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.user import User
+from xagent.web.services.connector_team_scope import set_connector_team_hooks
+
+pytestmark = pytest.mark.postgresql
+
+
+@pytest.fixture()
+def session_factory():
+    with disposable_database_factory("xagent_mcp_edit_lock") as make_database:
+        engine = make_database("edit_lock")
+        Base.metadata.create_all(bind=engine)
+        yield sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture()
+def seeded(session_factory):
+    """One owner, one owned MCP server, in their own committed rows."""
+    with session_factory() as db:
+        owner = User(username="mcp-edit-lock-owner", password_hash="x", is_admin=False)
+        db.add(owner)
+        db.flush()
+        server = MCPServer(
+            name="edit-lock-target",
+            transport="stdio",
+            managed="external",
+            command="true",
+        )
+        db.add(server)
+        db.flush()
+        db.add(
+            UserMCPServer(
+                user_id=int(owner.id),
+                mcpserver_id=int(server.id),
+                is_owner=True,
+                is_active=True,
+            )
+        )
+        db.commit()
+        return int(owner.id), int(server.id)
+
+
+def test_a_second_editor_blocks_until_the_first_editors_transaction_finishes(
+    session_factory, seeded
+) -> None:
+    """Two real connections, barrier-synchronised: the second call's own
+    lock statement must not return until the first call's transaction
+    commits or rolls back -- the actual behavior ``FOR UPDATE`` exists to
+    provide, and the one thing no SQLite-backed test can demonstrate.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    owner_id, server_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    lock_acquired = threading.Event()
+    release_lock = threading.Event()
+    second_finished = threading.Event()
+    first_call_claimed = threading.Event()
+    first_call_lock = threading.Lock()
+
+    real_build_server_config = mcp_api._build_server_config
+
+    def paced_build_server_config(update_data, server):
+        # Both threads run through this same patched function once each
+        # gets past its own lock statement. Only the call that gets here
+        # *first* pauses: that is the first editor, holding its row lock
+        # open via this still-uncommitted transaction. A second call that
+        # reaches this point too (rather than staying blocked earlier,
+        # inside its own lock statement) is not made to wait a second
+        # time here -- pausing it too would prove nothing about the
+        # database lock, only about this Python-level barrier.
+        with first_call_lock:
+            is_first_call = not first_call_claimed.is_set()
+            first_call_claimed.set()
+        if is_first_call:
+            lock_acquired.set()
+            assert release_lock.wait(timeout=10), "the first editor was never released"
+        return real_build_server_config(update_data, server)
+
+    mcp_api._build_server_config = paced_build_server_config
+    session_a = session_factory()
+    session_b = session_factory()
+    try:
+
+        def run_first():
+            return mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(name="renamed-by-first-editor"),
+                current_user=current_user,
+                db=session_a,
+            )
+
+        def run_second():
+            result = mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(description="edited-by-second-editor"),
+                current_user=current_user,
+                db=session_b,
+            )
+            second_finished.set()
+            return result
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(run_first)
+            assert lock_acquired.wait(timeout=5), (
+                "the first editor never reached the lock"
+            )
+
+            second = executor.submit(run_second)
+            # The second call's own lock statement should still be blocked
+            # on the database at this point. If the lock were not real (or
+            # a no-op, as on SQLite), the second call would sail through
+            # almost immediately and this would flip to True.
+            assert not second_finished.wait(timeout=1.0), (
+                "the second editor finished before the first one released "
+                "the row -- the lock did not actually block it"
+            )
+
+            release_lock.set()
+            first.result(timeout=10)
+            second.result(timeout=10)
+
+        assert second_finished.is_set()
+    finally:
+        mcp_api._build_server_config = real_build_server_config
+        session_a.close()
+        session_b.close()
+
+
+def test_the_second_editors_rename_reports_the_first_editors_committed_name_as_old(
+    session_factory, seeded
+) -> None:
+    """``rename_team_connector``'s ``old`` argument must be the name this
+    transaction's own lock actually holds once acquired, not whatever the
+    pre-lock read saw.
+
+    Interleaving under test: the first editor renames the connector and
+    commits while the second editor is blocked on the lock. The second
+    editor then acquires the lock, refreshed to the first editor's
+    committed name, and renames again. If the second editor's ``old``
+    argument were captured before its own lock instead, it would report
+    the connector's *original* name -- not the name every team agent's
+    selector was already rewritten to by the first editor's own call --
+    and the second rewrite would search for a name nothing holds anymore,
+    leaving the first rewrite's result permanently dangling with no error.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    owner_id, server_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    lock_acquired = threading.Event()
+    release_lock = threading.Event()
+    second_finished = threading.Event()
+    first_call_claimed = threading.Event()
+    first_call_lock = threading.Lock()
+
+    renamed_calls: list[tuple[str, str]] = []
+    renamed_calls_lock = threading.Lock()
+
+    def spy_renamed_hook(_db, _user_id, _connector_type, _connector_id, old, new):
+        with renamed_calls_lock:
+            renamed_calls.append((old, new))
+
+    real_build_server_config = mcp_api._build_server_config
+
+    def paced_build_server_config(update_data, server):
+        with first_call_lock:
+            is_first_call = not first_call_claimed.is_set()
+            first_call_claimed.set()
+        if is_first_call:
+            lock_acquired.set()
+            assert release_lock.wait(timeout=10), "the first editor was never released"
+        return real_build_server_config(update_data, server)
+
+    mcp_api._build_server_config = paced_build_server_config
+    session_a = session_factory()
+    session_b = session_factory()
+    set_connector_team_hooks(renamed=spy_renamed_hook)
+    try:
+
+        def run_first():
+            return mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(name="renamed-by-first-editor"),
+                current_user=current_user,
+                db=session_a,
+            )
+
+        def run_second():
+            result = mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(name="renamed-by-second-editor"),
+                current_user=current_user,
+                db=session_b,
+            )
+            second_finished.set()
+            return result
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(run_first)
+            assert lock_acquired.wait(timeout=5), (
+                "the first editor never reached the lock"
+            )
+
+            second = executor.submit(run_second)
+            assert not second_finished.wait(timeout=1.0), (
+                "the second editor finished before the first one released the row"
+            )
+
+            release_lock.set()
+            first.result(timeout=10)
+            second.result(timeout=10)
+
+        assert renamed_calls == [
+            ("edit-lock-target", "renamed-by-first-editor"),
+            ("renamed-by-first-editor", "renamed-by-second-editor"),
+        ]
+    finally:
+        set_connector_team_hooks()
+        mcp_api._build_server_config = real_build_server_config
+        session_a.close()
+        session_b.close()
+
+
+def test_a_row_that_vanishes_after_the_gate_but_before_the_lock_is_a_404_not_a_500(
+    session_factory, seeded
+) -> None:
+    """The route's own access read can find the row and still lose a race
+    to a concurrent delete that commits before the lock statement runs. The
+    lock statement must see that as an ordinary "row not found" (``None``)
+    and let the route's existing 404 handle it, rather than leaving the
+    write path below to fail on a row that is no longer there.
+
+    The concurrent delete is fired from a wrapper around this session's own
+    ``query``, which lands it strictly between the two reads: the lock is
+    the only statement in this route that asks for ``MCPServer`` as its
+    sole entity (the access read above asks for ``UserMCPServer`` joined to
+    it, passing ``MCPServer`` as a second entity), so the wrapper can
+    recognise the lock query and nothing else.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    owner_id, server_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    db = session_factory()
+    real_query = db.query
+    deleted_already = threading.Event()
+
+    def delete_the_row_when_the_lock_query_starts(*entities, **kwargs):
+        if entities == (MCPServer,) and not deleted_already.is_set():
+            deleted_already.set()
+            with session_factory() as other:
+                other.execute(
+                    sa.delete(UserMCPServer).where(
+                        UserMCPServer.mcpserver_id == server_id
+                    )
+                )
+                other.execute(sa.delete(MCPServer).where(MCPServer.id == server_id))
+                other.commit()
+        return real_query(*entities, **kwargs)
+
+    db.query = delete_the_row_when_the_lock_query_starts
+    try:
+        with pytest.raises(HTTPException) as exc:
+            mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(name="renamed-after-vanish"),
+                current_user=current_user,
+                db=db,
+            )
+        assert deleted_already.is_set(), "the concurrent delete never ran"
+        assert exc.value.status_code == 404
+    finally:
+        db.close()

--- a/tests/web/api/test_mcp_server_edit_lock_postgresql.py
+++ b/tests/web/api/test_mcp_server_edit_lock_postgresql.py
@@ -1,5 +1,14 @@
 """Real-PostgreSQL coverage for the row lock ``update_mcp_server`` takes on
-the ``MCPServer`` definition row before building the new config.
+the ``MCPServer`` definition row before building the new config -- and, for
+the payloads that must *not* take it: a PUT that sets only ``is_active``
+and/or ``user_env`` writes the caller's own ``UserMCPServer`` link row. On
+a server carrying no global ``env`` or ``auth`` the rebuild writes nothing
+back to the definition row, so it reads that row without locking it (a
+server with a global ``env`` or ``auth`` still gets its re-encrypted
+secret written back on this path -- pre-existing behavior, tracked in
+#1945). Under PostgreSQL REPEATABLE READ that distinction is the
+difference between HTTP 200 and a serialization failure surfacing as
+HTTP 500.
 
 ``FOR UPDATE`` is a no-op on SQLite -- every other suite in this repo runs
 against SQLite, so nothing there can tell a genuine second-writer block
@@ -68,6 +77,74 @@ def seeded(session_factory):
         )
         db.commit()
         return int(owner.id), int(server.id)
+
+
+def _seed_by_the_create_route(session_factory) -> tuple[int, int]:
+    """One owner and one server created the way the API actually creates
+    one -- through ``create_mcp_server`` itself, not hand-built rows.
+
+    The shape matters for the activation-only tests below. ``MCPServer``
+    rows the create route makes store ``concurrent_tools`` as an empty
+    list (``MCPServerConfig`` declares it ``default_factory=list`` and
+    ``MCPServer.from_config`` normalizes it), while a hand-built row
+    leaves the column NULL. An update rebuilds the shared config on every
+    payload and assigns ``[]`` back, which is a no-op against ``[]`` and a
+    real ``UPDATE`` against NULL -- so a hand-built row would make the
+    activation-only request write the definition row for a reason that
+    exists nowhere in production, and the tests below would be measuring
+    that instead of what they claim to measure.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerCreate
+
+    with session_factory() as db:
+        owner = User(username="mcp-activation-owner", password_hash="x", is_admin=False)
+        db.add(owner)
+        db.commit()
+        owner_id = int(owner.id)
+
+        mcp_api.create_mcp_server(
+            MCPServerCreate(
+                name="activation-target",
+                transport="stdio",
+                config={"command": "true"},
+            ),
+            current_user=SimpleNamespace(id=owner_id, is_admin=False),
+            db=db,
+        )
+
+    with session_factory() as db:
+        server = db.query(MCPServer).filter(MCPServer.name == "activation-target").one()
+        # The anchor for the docstring above: if the create route ever stops
+        # storing an empty list here, these tests must be re-derived rather
+        # than silently start measuring a different row shape.
+        assert server.concurrent_tools == [], (
+            "the create route no longer stores concurrent_tools as an empty "
+            f"list (saw {server.concurrent_tools!r}); the activation-only "
+            "tests below depend on that shape"
+        )
+        return owner_id, int(server.id)
+
+
+@pytest.fixture()
+def repeatable_read_sessions():
+    """Two session factories on one disposable database: the first at the
+    server's default isolation level (used to seed and to read back what
+    committed), the second at REPEATABLE READ -- the level the route runs
+    at on a deployment configured that way, and the one under which the
+    interleaving below used to fail.
+    """
+    with disposable_database_factory("xagent_mcp_activation_rr") as make_database:
+        engine = make_database("rr")
+        Base.metadata.create_all(bind=engine)
+        yield (
+            sessionmaker(autocommit=False, autoflush=False, bind=engine),
+            sessionmaker(
+                autocommit=False,
+                autoflush=False,
+                bind=engine.execution_options(isolation_level="REPEATABLE READ"),
+            ),
+        )
 
 
 def test_a_second_editor_blocks_until_the_first_editors_transaction_finishes(
@@ -348,5 +425,149 @@ def test_a_row_that_vanishes_after_the_gate_but_before_the_lock_is_a_404_not_a_5
             )
         assert deleted_already.is_set(), "the concurrent delete never ran"
         assert exc.value.status_code == 404
+    finally:
+        db.close()
+
+
+def test_an_activation_only_edit_survives_a_concurrent_definition_commit_under_repeatable_read(
+    repeatable_read_sessions,
+) -> None:
+    """A payload that sets only ``is_active`` writes this caller's own
+    ``UserMCPServer`` link row. Under PostgreSQL REPEATABLE READ the
+    route's own snapshot is fixed by its first read, so a definition edit
+    another request commits after that read is invisible to this one --
+    which is harmless for a request that does not write the definition
+    row, and fatal for one that asks the database to lock it: the lock
+    statement raises SQLSTATE 40001 and this route's generic handler turns
+    that into HTTP 500 with the requested activation state unwritten.
+
+    The concurrent commit is fired from a wrapper around this session's
+    own ``query``, which lands it strictly between the access read (which
+    asks for ``UserMCPServer`` joined to ``MCPServer``) and this route's
+    first single-entity ``MCPServer`` read.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    default_factory, rr_factory = repeatable_read_sessions
+    owner_id, server_id = _seed_by_the_create_route(default_factory)
+
+    db = rr_factory()
+    real_query = db.query
+    committed = threading.Event()
+    queried_entities: list[tuple] = []
+
+    def commit_a_definition_edit_when_the_definition_query_starts(*entities, **kwargs):
+        queried_entities.append(entities)
+        if entities == (MCPServer,) and not committed.is_set():
+            committed.set()
+            with default_factory() as other:
+                other.execute(
+                    sa.update(MCPServer)
+                    .where(MCPServer.id == server_id)
+                    .values(description="edited-by-the-concurrent-definition-editor")
+                )
+                other.commit()
+        return real_query(*entities, **kwargs)
+
+    db.query = commit_a_definition_edit_when_the_definition_query_starts
+    try:
+        response = mcp_api.update_mcp_server(
+            server_id,
+            MCPServerUpdate(is_active=False),
+            current_user=SimpleNamespace(id=owner_id, is_admin=False),
+            db=db,
+        )
+    finally:
+        db.close()
+
+    assert committed.is_set(), "the concurrent definition edit never ran"
+    assert queried_entities[:2] == [(UserMCPServer, MCPServer), (MCPServer,)], (
+        "the concurrent commit must land after the access read's own read and "
+        "before this route's definition read; otherwise this test is not "
+        "exercising the window it claims to -- saw "
+        f"{queried_entities!r}"
+    )
+    assert response.is_active is False
+
+    with default_factory() as fresh:
+        assert (
+            fresh.query(UserMCPServer)
+            .filter(
+                UserMCPServer.mcpserver_id == server_id,
+                UserMCPServer.user_id == owner_id,
+            )
+            .one()
+            .is_active
+            is False
+        )
+        assert (
+            fresh.query(MCPServer).filter(MCPServer.id == server_id).one().description
+            == "edited-by-the-concurrent-definition-editor"
+        )
+
+
+def test_an_activation_only_edit_whose_row_vanishes_before_its_read_is_a_404(
+    session_factory, seeded
+) -> None:
+    """The activation-only path skips the lock but keeps the same
+    vanished-definition handling: its own fresh read of ``MCPServer`` must
+    return ``None`` and raise the route's 404, rather than leaving the
+    write path below to fail on a row that is no longer there.
+
+    Uses the plain hand-built ``seeded`` fixture rather than the
+    create-route seeding helper: this request 404s before any write is
+    attempted, so the row's shape (NULL vs. ``[]`` ``concurrent_tools``)
+    plays no part in what this test measures.
+
+    Same wrapper shape as
+    ``test_a_row_that_vanishes_after_the_gate_but_before_the_lock_is_a_404_not_a_500``
+    above: the concurrent delete fires from this session's own ``query``,
+    which lands it strictly between the access read (which asks for
+    ``UserMCPServer`` joined to ``MCPServer``) and this route's first
+    single-entity ``MCPServer`` read.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    owner_id, server_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    db = session_factory()
+    real_query = db.query
+    deleted_already = threading.Event()
+    queried_entities: list[tuple] = []
+
+    def delete_the_row_when_the_definition_query_starts(*entities, **kwargs):
+        queried_entities.append(entities)
+        if entities == (MCPServer,) and not deleted_already.is_set():
+            deleted_already.set()
+            with session_factory() as other:
+                other.execute(
+                    sa.delete(UserMCPServer).where(
+                        UserMCPServer.mcpserver_id == server_id
+                    )
+                )
+                other.execute(sa.delete(MCPServer).where(MCPServer.id == server_id))
+                other.commit()
+        return real_query(*entities, **kwargs)
+
+    db.query = delete_the_row_when_the_definition_query_starts
+    try:
+        with pytest.raises(HTTPException) as exc:
+            mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(is_active=False),
+                current_user=current_user,
+                db=db,
+            )
+        assert exc.value.status_code == 404
+        assert deleted_already.is_set(), "the concurrent delete never ran"
+        assert queried_entities[:2] == [(UserMCPServer, MCPServer), (MCPServer,)], (
+            "the concurrent delete must land after the access read's own "
+            "read and before this route's definition read; otherwise the "
+            "404 under test could be the access read's -- saw "
+            f"{queried_entities!r}"
+        )
     finally:
         db.close()

--- a/tests/web/api/test_mcp_server_edit_lock_postgresql.py
+++ b/tests/web/api/test_mcp_server_edit_lock_postgresql.py
@@ -22,6 +22,10 @@ Obtains its database through ``tests/shared/postgres_disposable.py``
 helper the other ``*_postgresql.py`` suites in this repo use, rather than
 opening a hand-rolled connection. That helper reads
 ``XAGENT_TEST_POSTGRES_URL`` and skips the whole module when it is unset.
+
+Also covers the caller's own ``UserMCPServer`` link row being revoked --
+deleted, or stripped of ownership -- by a second connection while the
+route holds the definition row locked.
 """
 
 from __future__ import annotations
@@ -571,3 +575,111 @@ def test_an_activation_only_edit_whose_row_vanishes_before_its_read_is_a_404(
         )
     finally:
         db.close()
+
+
+@pytest.mark.parametrize(
+    ("revocation", "expected_status"),
+    [("link-deleted", 404), ("ownership-cleared", 403)],
+)
+def test_a_put_whose_association_is_revoked_after_the_lock_is_refused_with_no_shared_write(
+    session_factory, seeded, revocation, expected_status
+) -> None:
+    """A second connection can revoke the caller's own link -- delete it,
+    or clear ``is_owner`` -- and commit while this route still holds the
+    definition row locked, after the gate already let the request through.
+    The re-read added after the lock, which re-derives ``can_edit_global``,
+    must catch that: a gone link is the gate's own 404. A link that no
+    longer owns the server is not an error by itself -- the gate does not
+    refuse a non-owner either -- so a payload that changes the shared
+    configuration is refused by the existing owner-only guard instead.
+
+    The revocation fires on this route's first single-entity
+    ``UserMCPServer`` read -- the gate's own read joins it to ``MCPServer``,
+    so a bare ``(UserMCPServer,)`` can only be the re-read after the lock.
+    The recorded sequence is filtered to the three statements under test
+    (``DatabaseMCPServerManager`` may issue queries of its own).
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    owner_id, server_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    db = session_factory()
+    real_query = db.query
+    real_commit = db.commit
+    revoked_already = threading.Event()
+    queried_entities: list[tuple] = []
+    tracked_keys = {(UserMCPServer, MCPServer), (MCPServer,), (UserMCPServer,)}
+    commits: list[str] = []
+
+    def revoke_when_the_recheck_query_starts(*entities, **kwargs):
+        if entities in tracked_keys:
+            queried_entities.append(entities)
+        if entities == (UserMCPServer,) and not revoked_already.is_set():
+            revoked_already.set()
+            with session_factory() as other:
+                if revocation == "link-deleted":
+                    other.execute(
+                        sa.delete(UserMCPServer).where(
+                            UserMCPServer.user_id == owner_id,
+                            UserMCPServer.mcpserver_id == server_id,
+                        )
+                    )
+                else:
+                    other.execute(
+                        sa.update(UserMCPServer)
+                        .where(
+                            UserMCPServer.user_id == owner_id,
+                            UserMCPServer.mcpserver_id == server_id,
+                        )
+                        .values(is_owner=False)
+                    )
+                other.commit()
+        return real_query(*entities, **kwargs)
+
+    def record_commit():
+        commits.append("commit")
+        return real_commit()
+
+    db.query = revoke_when_the_recheck_query_starts
+    db.commit = record_commit
+    try:
+        with pytest.raises(HTTPException) as exc:
+            mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(name="renamed-after-revocation"),
+                current_user=current_user,
+                db=db,
+            )
+        assert exc.value.status_code == expected_status
+        assert revoked_already.is_set(), "the concurrent revocation never ran"
+        assert queried_entities[:3] == [
+            (UserMCPServer, MCPServer),
+            (MCPServer,),
+            (UserMCPServer,),
+        ], (
+            "the concurrent revocation must land after the gate's own read "
+            "and after the lock statement, and be caught by the re-read "
+            "added after the lock -- otherwise the status under test could "
+            f"be the gate's rather than the re-read's -- saw "
+            f"{queried_entities!r}"
+        )
+        if revocation == "ownership-cleared":
+            assert (
+                exc.value.detail
+                == "Only the server owner can change the shared configuration"
+            ), (
+                "the 403 for a link that no longer owns the server must come "
+                "from the route's existing owner-only guard, not a new error "
+                f"shape -- saw {exc.value.detail!r}"
+            )
+        assert commits == [], "the refused edit must commit nothing"
+    finally:
+        db.close()
+
+    with session_factory() as fresh:
+        row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+        assert row.name == "edit-lock-target", (
+            "the shared definition row must be untouched by a refused edit"
+        )


### PR DESCRIPTION
Split out of #1661, which is being broken into pieces that can each be reviewed on
their own. The lock is independent of the team-ownership work on that branch: it
fixes concurrency defects that exist today, on routes that have no team overlay,
so it stands on its own.

Three connector routes read a definition row and then write it, with no lock in
between:

| Route | How it reads the definition row |
|---|---|
| `PUT /api/custom-apis/{id}` | through the caller's link row relationship |
| `DELETE /api/custom-apis/{id}` | through the caller's link row relationship |
| `PUT /api/mcp/servers/{id}` | a two-table join with the caller's link row |

A relationship load and a two-table join both read the definition row without
locking it, so two requests can hold the same snapshot at the same time. This PR
takes a `SELECT ... FOR UPDATE` on that row, ahead of anything that reads or
mutates it, in every request that writes it — which is every request on two of
the three routes, and every request but one payload shape on the third. The
exception is described under "Which requests take the lock" below.

## What goes wrong without the lock

**Two concurrent edits lose one of them.** Alice sends
`PUT {"description": "billing lookup"}` and Bob sends `PUT {"url": ".../v2"}` at
the same moment against Custom API 7, which starts as
`{url: ".../v1", description: "old"}`.

```
   Alice                                  Bob
   read row -> {url: v1, desc: old}
                                          read row -> {url: v1, desc: old}
   set desc = "billing lookup"
                                          set url = ".../v2"
   COMMIT -> {url: v1, desc: billing}
                                          COMMIT -> {url: v2, desc: old}
```

Final row: `{url: ".../v2", description: "old"}`. Alice got HTTP 200 and her
description is gone. With the lock, Bob's transaction blocks on Alice's until she
commits, re-reads `{url: v1, desc: billing}`, and the final row is
`{url: ".../v2", description: "billing lookup"}` — both edits kept.

**A rename tells the connector team hook a name that is already stale.** The PUT
routes call `rename_team_connector(db, ..., old, new)` so an installing
application can rewrite agent selectors that refer to the connector by name. The
`old` argument used to be read before the write, off an unlocked row.

```
   first renamer                          second renamer
   read name -> "billing"
                                          read name -> "billing"
   rename to "billing-api", COMMIT
   hook called with ("billing" -> "billing-api")
                                          rename to "billing-v2", COMMIT
                                          hook called with ("billing" -> "billing-v2")
```

The second call asks the application to rewrite selectors that say `"billing"`.
Nothing says `"billing"` any more — the first renamer already rewrote them all to
`"billing-api"`. The second rewrite matches nothing, reports no error, and every
selector the first rename produced is left pointing at a name the row no longer
has. With the lock, the second renamer reads its `old` off the row it holds
locked, gets `"billing-api"`, and the hook is called with
`("billing-api" -> "billing-v2")`.

**An edit and a delete of the same connector can deadlock.** `PUT` locks the
definition row and writes the link row afterwards. `DELETE` deletes the link row
and the definition row in that order, in one transaction. That is the same two
rows in opposite orders, which is the textbook deadlock shape, and PostgreSQL
resolves it by killing one of the two transactions with a `40P01`. Removing just
the `FOR UPDATE` from the delete route and running the suite added here
reproduces it directly:

```
psycopg2.errors.DeadlockDetected: deadlock detected
DETAIL:  Process 269 waits for ShareLock on transaction 959; blocked by process 268.
         Process 268 waits for ShareLock on transaction 960; blocked by process 269.
CONTEXT: while deleting tuple (0,1) in relation "custom_apis"
```

The delete route now takes the same definition-row lock, and takes it before it
calls the connector-team delete hook — the position the `PUT` already had
relative to its own rename hook. Both routes therefore reach the same two rows in
one order, and cross the hook boundary in the same direction: definition row
first, hook-side rows second.

That ordering matters beyond this repository's two tables. An earlier revision of
this PR took the delete route's lock *after* the hook, which left the two routes
waiting in opposite directions across the hook boundary. A probe that installed
hooks taking their own `SELECT ... FOR UPDATE` on a second table reproduced a
`40P01` against that arrangement — the cycle closing on the hook's own table —
and stopped reproducing it once the lock moved ahead of the hook. What remains
outside this repository's reach is a hook that locks rows of its own in some
other order relative to the statements here; only the installing application can
arrange those.

**A row that vanishes mid-request produces a confusing 500.** The access read can
find the row and still lose a race to a concurrent delete. The lock statement is
a fresh query, so it returns `None` in that case and the route answers with the
404 it already has for a missing connector. Without that branch the write path
runs against a row that is gone and surfaces as:

```
500 Failed to update MCP server: UPDATE statement on table 'mcp_servers'
    expected to update 1 row(s); 0 were matched.
```

## Why the two custom-api routes become plain `def`

`FOR UPDATE` waits. When another transaction holds the row, the statement does
not return until that transaction commits or rolls back — that waiting is the
whole point of the lock, and there is no bound on how long it lasts.

FastAPI runs an `async def` route on the event loop thread itself. A blocking
wait there is not a wait for one request; it is a wait for every request the
process is serving, because nothing else can run on that thread meanwhile. A
plain `def` route runs in the threadpool, where the same wait occupies one worker
and leaves the loop free.

So "this route takes a row lock" and "this route must not be a coroutine" are the
same fact, and both custom-api routes are converted here. The MCP `PUT` is
already a plain `def` and needs no change. `test_custom_api.py` pins all three.

## Which requests take the lock

`PUT /api/custom-apis/{id}` is the one route whose payload decides which row the
request writes. Ten of the eleven fields of `CustomApiUpdate` write the shared
`CustomApi` definition row; `is_active` writes the caller's own `UserCustomApi`
link row and nothing else. A payload that sets only `is_active` therefore has no
write on the definition row to serialize, and taking the definition-row lock for
it made an activate/deactivate request queue behind an unrelated concurrent edit
of the same connector.

The route now decides from `api_data.model_fields_set`: any field other than
`is_active` takes the lock, `is_active` alone does not. The set is used rather
than the values because an explicitly-null `runtime_input_schema` is written to
the definition row even though its value is `None`, while an absent field is not
written at all. The set is a superset of the writes that follow, so the lock is
taken in a few cases that turn out not to need it and skipped in none that do.

Both paths run the same fresh single-table read with `populate_existing()`; only
the `FOR UPDATE` clause is conditional. The vanished-definition 404 and the
response snapshot are therefore identical on both, and cannot drift apart.

`PUT /api/mcp/servers/{id}` is split the same way. Seven of the nine fields of
`MCPServerUpdate` target the shared `MCPServer` definition row; `is_active` and
`user_env` write the caller's own `UserMCPServer` link row and nothing else, so a
payload carrying only those two takes no lock. An earlier revision of this
description said the MCP update path writes the shared row for every payload.
That is not right: the rebuild assigns the existing values back, and SQLAlchemy
emits no `UPDATE` when the assigned value equals the loaded one, so on a server
created through the normal route that carries no global env or auth, there is
no shared-row write at all. The difference is not only a wait — under
PostgreSQL REPEATABLE READ the lock statement follows a snapshot the route's
first read already fixed, so a definition edit committed in between raises
SQLSTATE 40001 and the request ends as HTTP 500 with the requested activation
state unwritten.

Unlike the custom-api route, the field set here is not a superset of the writes
that follow: a server carrying a global `env` or `auth` has its secret
re-encrypted on every update, and Fernet ciphertext differs each time, so the
rebuild still writes the definition row on the lock-free path. That write, and
its behavior under REPEATABLE READ, is what this route already did before this
change; the isolation-level contract is tracked in #1945.

## Lock placement

Each lock is taken after the access and permission gates that precede it in its
route, so a request refused by those gates never acquires it. Refusals that need
data read under the lock necessarily come after it: both `PUT` routes validate
the payload once locked — the MCP `PUT` including a 403 when a non-owner submits
a changed shared configuration — and the custom-api `DELETE` additionally has two
403s that read the delete hook's answer, because the hook has to be called with
the definition row already held for the lock order above to hold. So a delete
that is going to be refused does briefly hold the row, until the raised exception
propagates out and the request's session is closed without committing, and it
holds the row for the duration of the hook's own work. Both are accepted costs of
the single lock order. Each query uses
`populate_existing()`, which forces the locked row to replace the one already in
the session's identity map — without it the query would return the unrefreshed
pre-lock instance and the lock would protect a row the route does not actually
read.

### Authority after the wait

`FOR UPDATE` waits, and the gates above it ran before that wait. Everything a
route decided from the caller's link row -- that the link exists at all, and what
it permits -- was therefore established before a wait with no bound on its length,
and nothing re-established it afterwards. Two supported operations can commit
inside that wait: an administrator deleting a user removes that user's link rows
and leaves every definition row standing, and a disconnect removes the caller's
own link while another user's link keeps the definition alive. A request that
resumes after either one would write the shared definition row on an authority it
no longer has, commit it, and fail only later -- while building its response off
the row that is gone, which surfaces as HTTP 500 over a durable change. The
delete route was worse: it answered 204 and removed the shared definition row,
cascading away every other user's link, for a caller who no longer had one.

Each locking path now re-reads the caller's link row once it holds the definition
row, before it calls a connector-team hook and before it writes or deletes
anything shared, and re-derives its authority from that read: a link that is gone
is the route's existing 404, and a link that no longer permits the operation is
the route's existing 403. The object that read returns replaces the pre-lock one
for the rest of the route, so the mutation, the hook, the refresh and the response
all read the row the transaction actually verified. `populate_existing()` on the
definition query covers the definition row and only it, which is why the link row
needs a statement of its own.

The two routes read "no longer permits the operation" differently. On the two
custom-api routes the link row carries its own `can_edit`/`can_delete` flags, so a
link with either flag cleared is refused with 403 directly. The MCP edit path gates a
shared-config change on ownership rather than on those flags -- the link row's own
`can_edit` column is not read here: what the re-read changes is `can_edit_global`,
which the route's existing owner-only guard already consumes -- a non-owner's
payload that actually changes the shared configuration still gets that guard's
403, while a non-owner's payload that changes nothing gets 200 with the shared
configuration silently dropped, exactly as a request from a non-owner always did.

Two boundaries this does not move. The window between that re-read and the commit
is the window these routes had before they took any lock -- in process, with no
wait in it -- and closing that one belongs with the team-authorization work, not
here. The paths that skip the definition lock add no wait, so they add no exposure
and are left alone; the MCP delete route takes no definition lock at all and is
likewise unchanged.

## Tests

## Which backends this actually serializes

`FOR UPDATE` is a PostgreSQL/MySQL row lock. SQLAlchemy renders no locking clause
at all on SQLite — the statement emitted there is byte-for-byte the one emitted
without the call — so on a SQLite deployment these read-modify-write sequences are
not serialized and the interleavings above remain possible. All three lock sites
now say so in a comment, so a reader is not left believing otherwise.

Closing that gap needs a dual-dialect fence (a no-op write that takes SQLite's
writer lock before the read), which this repository already has in two places.
That is repo-wide work across 33 `with_for_update()` call sites in 18 files
rather than a change to these three, and is tracked in #1944. Two further findings
from this PR's review are likewise tracked rather than changed here: the engine
never checks the isolation level a PostgreSQL server hands it (#1945), and no lock
site bounds how long a waiter may wait (#1946).

## Tests

`FOR UPDATE` is a no-op on SQLite, so nothing in the ordinary suite can tell a
real lock from a statement that silently does nothing. Two Postgres-only suites
run the real statement against a real server:

- `tests/web/api/test_mcp_server_edit_lock_postgresql.py`
- `tests/web/api/test_custom_api_edit_lock_postgresql.py`

They cover, on two real connections with a barrier between them: a second editor
blocking until the first commits; the second editor's rename reporting the first
editor's committed name; an edit and a delete blocking each other in the same
order; an `is_active`-only edit completing while a concurrent definition edit
holds the row; and the vanished-row 404 for the edit route's locking path, for the
edit route's association-only path, and for the delete route, the delete case also
asserting that the refusal happens before the delete hook is called and that
nothing is committed.

Both suites also cover revocation on the other side of the lock: the caller's link
row deleted, and the link row's permission flag cleared, each committed by a second
connection while the route holds the definition row locked -- asserting the
404/403, that no shared row was written or deleted, that nothing was committed,
and (for the delete route) that the connector-team hook was never called.

Each timing test now also reopens an independent session once both writer sessions
have closed and asserts the committed definition, association and configuration
fields. Without that, a route that produced the right hook calls and the right
timing but wrote nothing durable would still pass.

The delete-versus-edit test's concurrent editor sets a definition field rather than
`is_active`, since an `is_active`-only edit no longer holds the row that test is
ordered against.

Both suites are wired into the existing Postgres job in `test-migrations.yml`,
alongside the other `*_postgresql.py` suites. That workflow's two hand-maintained
path lists also gain the three production modules these suites import beyond the
two route files already listed — `connector_team_scope.py`, `models/custom_api.py`
and `models/mcp.py` — so a change confined to one of them can no longer leave the
Postgres jobs skipped while CI reports success.

Lock *ordering* between the two custom-api routes is statement order, which is
dialect-independent, so it is pinned in the ordinary SQLite suite by counting the
statements the delete route issues before its first `DELETE`, and by counting the
statements already issued when the delete hook is called.

The ordinary suite also pins the two mixed payloads that carry `is_active` next to a
field the write guards skip -- an explicit-null `description`, and the definition's
current name -- as writing no definition field: the link row's activation is
persisted and no `UPDATE` against `custom_apis` is emitted.




