### PR TITLE
feat(channel): continue waiting actor tasks

### DIFF
--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -139,6 +139,7 @@ from ..services.task_runtime import (
     create_task_extensions,
     delete_task_extensions,
     get_task_runtime_public_metadata,
+    mcp_runtime_authorization_policy_identity,
     mcp_runtime_authorization_policy_required,
     registered_task_extensions,
     sanitize_client_agent_config,
@@ -1299,6 +1300,8 @@ class AgentServiceManager:
         # task_id-keyed cache must not silently hand back an instance built
         # under a different user (e.g. once built with the wrong identity).
         self._agent_owner_ids: Dict[int, Optional[int]] = {}
+        # Run generation that currently owns each cached runtime.
+        self._agent_run_ids: Dict[int, str] = {}
         # Keep only the owner needed to retry a failed workspace cleanup.
         self._agent_cleanup_owner_ids: Dict[int, int] = {}
         self._agent_sandbox_keys: Dict[int, str] = {}
@@ -2162,7 +2165,7 @@ class AgentServiceManager:
             lock = asyncio.Lock()
             self._agent_build_locks[task_id] = lock
         async with lock:
-            return await self._get_agent_for_task_unlocked(
+            agent = await self._get_agent_for_task_unlocked(
                 task_id,
                 db=db,
                 user=user,
@@ -2173,6 +2176,9 @@ class AgentServiceManager:
                 task_mode=task_mode,
                 resolved_execution_scope=resolved_execution_scope,
             )
+            if task_setup_snapshot is not None and task_setup_snapshot.task.run_id:
+                self._agent_run_ids[task_id] = task_setup_snapshot.task.run_id
+            return agent
 
     async def _get_agent_for_task_unlocked(
         self,
@@ -2237,6 +2243,9 @@ class AgentServiceManager:
             task_id in self._mcp_actor_policies
             or mcp_runtime_authorization_policy_required(persisted_agent_config)
         )
+        persisted_policy_identity = mcp_runtime_authorization_policy_identity(
+            persisted_agent_config
+        )
         if actor_marked and mcp_runtime_authorization_policy is None:
             raise MCPBuiltinOAuthActorPolicyRequiredError(
                 f"Task {task_id} requires an MCP runtime authorization policy; "
@@ -2247,6 +2256,22 @@ class AgentServiceManager:
                 raise MCPBuiltinOAuthActorPolicyRequiredError(
                     f"Task {task_id} is not marked for MCP actor execution"
                 )
+            if (
+                persisted_policy_identity is not None
+                and persisted_policy_identity
+                != mcp_runtime_authorization_policy.resource_owner_key
+            ):
+                raise MCPBuiltinOAuthActorPolicyMismatchError(
+                    f"Task {task_id} MCP actor policy does not match its durable identity"
+                )
+            if (
+                task_mode is ChannelTaskMode.ACTOR_INTERACTION
+                and persisted_policy_identity is None
+            ):
+                raise MCPBuiltinOAuthActorPolicyRequiredError(
+                    f"Task {task_id} has no durable MCP actor policy identity"
+                )
+
             bound_policy = self._mcp_actor_policies.get(task_id)
             if (
                 bound_policy is not None
@@ -2260,6 +2285,15 @@ class AgentServiceManager:
                 self._mcp_actor_policies[task_id] = mcp_runtime_authorization_policy
 
         if actor_marked and task_setup_snapshot is not None:
+            if (
+                task_mode is ChannelTaskMode.ACTOR_INTERACTION
+                and task_setup_snapshot.task.agent_id is not None
+                and task_setup_snapshot.agent is None
+            ):
+                raise MCPBuiltinOAuthActorPolicyRequiredError(
+                    f"Task {task_id} claimed agent is unavailable"
+                )
+
             marked_status = task_setup_snapshot.task.status
             fresh_direct_build = marked_status in {
                 TaskStatus.PENDING,
@@ -3214,11 +3248,28 @@ class AgentServiceManager:
                 deferred_task_ids,
             )
 
-    def remove_agent(self, task_id: int, user_id: Optional[int] = None) -> None:
-        """Clean a task workspace and unconditionally evict its live runtime.
+    def remove_agent(
+        self,
+        task_id: int,
+        user_id: Optional[int] = None,
+        *,
+        expected_run_id: Optional[str] = None,
+    ) -> None:
+        """Clean a task runtime only for the run that scheduled cleanup."""
+        current_run_id = self._agent_run_ids.get(task_id)
+        build_lock = self._agent_build_locks.get(task_id)
+        if expected_run_id is not None and (
+            (current_run_id is not None and current_run_id != expected_run_id)
+            or (build_lock is not None and build_lock.locked())
+        ):
+            logger.info(
+                "Skipping stale runtime cleanup for task %s run %s; current run is %s",
+                task_id,
+                expected_run_id,
+                current_run_id,
+            )
+            return
 
-        A failed cleanup retains only the owner needed for a later cold retry.
-        """
         agent = self._agents.get(task_id)
         cleanup_user_id = user_id
         if cleanup_user_id is None:
@@ -3252,6 +3303,7 @@ class AgentServiceManager:
 
             self._agents.pop(task_id, None)
             self._agent_owner_ids.pop(task_id, None)
+            self._agent_run_ids.pop(task_id, None)
             self._agent_sandbox_keys.pop(task_id, None)
             self._agent_sandbox_providers.pop(task_id, None)
             self._agent_scope_fingerprints.pop(task_id, None)

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1991,6 +1991,8 @@ class AgentServiceManager:
         parent_tracer: Optional[Any] = None,
         scope: Optional[ExecutionScope] = None,
         task_setup_snapshot: Optional[TaskSetupSnapshot] = None,
+        connector_runtime_turn_id: Optional[str] = None,
+        mcp_runtime_authorization_policy: MCPBuiltinOAuthActorPolicy | None = None,
     ) -> tuple[list[Any], Any]:
         """Build the tool set configured for a web task."""
         if task_setup_snapshot is not None:
@@ -2059,8 +2061,13 @@ class AgentServiceManager:
                         "agent tools"
                     )
 
+        actor_execution = mcp_runtime_authorization_policy is not None
         tool_selection_spec = _build_tool_selection_spec_for_task(
-            agent_config, workforce_runtime, task_id=task_id
+            agent_config,
+            workforce_runtime,
+            task_id=task_id,
+            omit_published_agent_tools=actor_execution,
+            include_mcp_tools=actor_execution,
         )
         workspace_owner_id = int(task.user_id)
         # Actor-logical access policy + CA mount intent, built by
@@ -2123,7 +2130,9 @@ class AgentServiceManager:
             agent_call_stack=workforce_runtime.agent_call_stack
             if workforce_runtime
             else None,
-            connector_runtime_turn_id=None,
+            connector_runtime_turn_id=connector_runtime_turn_id,
+            mcp_runtime_authorization_policy=mcp_runtime_authorization_policy,
+            force_mcp_tools=actor_execution,
             mcp_failure_policy=_mcp_failure_policy_for_task_source(task.source),
             mcp_load_summary_tracer=parent_tracer,
             mcp_load_summary_trace_task_id=str(task_id),
@@ -2525,6 +2534,10 @@ class AgentServiceManager:
                                 db,
                                 scope=scope,
                                 task_setup_snapshot=task_setup_snapshot,
+                                connector_runtime_turn_id=connector_runtime_turn_id,
+                                mcp_runtime_authorization_policy=(
+                                    mcp_runtime_authorization_policy
+                                ),
                             )
                             self._agent_owner_ids[task_id] = runtime_user_id
                             self._agent_scope_fingerprints[task_id] = fingerprint
@@ -3818,6 +3831,8 @@ class AgentServiceManager:
         db: Optional[Session],
         scope: Optional[ExecutionScope] = None,
         task_setup_snapshot: Optional[TaskSetupSnapshot] = None,
+        connector_runtime_turn_id: Optional[str] = None,
+        mcp_runtime_authorization_policy: MCPBuiltinOAuthActorPolicy | None = None,
     ) -> None:
         """Reconstruct from the detached task-runtime snapshot.
 
@@ -3884,6 +3899,8 @@ class AgentServiceManager:
                 parent_tracer=tracer,
                 scope=scope,
                 task_setup_snapshot=snapshot,
+                connector_runtime_turn_id=connector_runtime_turn_id,
+                mcp_runtime_authorization_policy=(mcp_runtime_authorization_policy),
             )
 
             from .agents import (

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -82,6 +82,7 @@ from ..services.agent_team_scope import (
     resolve_authorized_agent,
 )
 from ..services.assistant_history_safety import ASSISTANT_RESPONSE_MESSAGE_TYPE
+from ..services.channel_runtime import ChannelTaskMode
 from ..services.chat_history_service import (
     load_task_transcript,
     persist_assistant_message_no_commit,
@@ -2142,6 +2143,7 @@ class AgentServiceManager:
         task_owner_user_id: Optional[int] = None,
         connector_runtime_turn_id: Optional[str] = None,
         mcp_runtime_authorization_policy: MCPBuiltinOAuthActorPolicy | None = None,
+        task_mode: ChannelTaskMode = ChannelTaskMode.DEFAULT,
         resolved_execution_scope: Union[
             ExecutionScope, None, ExecutionScopeNotProvided
         ] = EXECUTION_SCOPE_NOT_PROVIDED,
@@ -2159,6 +2161,7 @@ class AgentServiceManager:
                 task_owner_user_id=task_owner_user_id,
                 connector_runtime_turn_id=connector_runtime_turn_id,
                 mcp_runtime_authorization_policy=(mcp_runtime_authorization_policy),
+                task_mode=task_mode,
                 resolved_execution_scope=resolved_execution_scope,
             )
 
@@ -2171,6 +2174,7 @@ class AgentServiceManager:
         task_owner_user_id: Optional[int] = None,
         connector_runtime_turn_id: Optional[str] = None,
         mcp_runtime_authorization_policy: MCPBuiltinOAuthActorPolicy | None = None,
+        task_mode: ChannelTaskMode = ChannelTaskMode.DEFAULT,
         resolved_execution_scope: Union[
             ExecutionScope, None, ExecutionScopeNotProvided
         ] = EXECUTION_SCOPE_NOT_PROVIDED,
@@ -2191,6 +2195,9 @@ class AgentServiceManager:
         user's task; callers that loaded/authorized the task should pass it.
         When omitted it falls back to the snapshot owner, then the task row's
         owner, then ``user.id``.
+
+        ``task_mode=ACTOR_INTERACTION`` permits reconstruction only after the
+        channel boundary claims the exact waiting actor task as a new run.
         """
         # Track whether this invocation already tried the worker-owned snapshot
         # boundary. Active-task reconstruction and normal creation must share
@@ -2252,7 +2259,11 @@ class AgentServiceManager:
                 marked_status == TaskStatus.RUNNING
                 and task_setup_snapshot.has_reconstructable_history
             )
-            if not fresh_direct_build:
+            actor_interaction_reconstruction = (
+                task_mode is ChannelTaskMode.ACTOR_INTERACTION
+                and marked_status == TaskStatus.RUNNING
+            )
+            if not (fresh_direct_build or actor_interaction_reconstruction):
                 raise MCPBuiltinOAuthActorPolicyRequiredError(
                     f"Task {task_id} actor-marked reuse or reconstruction is unsupported"
                 )

--- a/src/xagent/web/services/channel_runtime.py
+++ b/src/xagent/web/services/channel_runtime.py
@@ -841,7 +841,16 @@ def _prepare_channel_task_sync(
                 db.flush()
 
             task_id = int(task.id)
-            lease = acquire_task_lease_no_commit(db, task_id, new_run=True)
+            lease = acquire_task_lease_no_commit(
+                db,
+                task_id,
+                expected_status=(
+                    TaskStatus.WAITING_FOR_USER
+                    if task_mode is ChannelTaskMode.ACTOR_INTERACTION
+                    else None
+                ),
+                new_run=True,
+            )
             if lease is None:
                 db.rollback()
                 return None

--- a/src/xagent/web/services/channel_runtime.py
+++ b/src/xagent/web/services/channel_runtime.py
@@ -17,6 +17,8 @@ from pathlib import Path
 from typing import Any, Iterable, Sequence
 from uuid import uuid4
 
+from sqlalchemy import or_
+
 from ...config import get_default_task_execution_mode
 from ...core.file_storage.keys import build_task_output_storage_key
 from ...core.workspace import WorkspaceFileRegistration
@@ -39,8 +41,9 @@ from .managed_task_lease import (
     start_managed_task_lease,
 )
 from .mcp_runtime import MCPBuiltinOAuthActorPolicyRequiredError
-from .task_lease_service import TaskLease, acquire_task_lease_no_commit
+from .task_lease_service import TaskLease, acquire_task_lease_no_commit, utc_now
 from .task_runtime import (
+    MCP_RUNTIME_AUTHORIZATION_POLICY_IDENTITY_KEY,
     MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY,
 )
 from .task_runtime import (
@@ -649,6 +652,7 @@ def _actor_interaction_claim_predicates(
     owner_id: int,
     agent_id: int,
 ) -> tuple[Any, ...]:
+    now = utc_now()
     return (
         Task.user_id == owner_id,
         Task.agent_id == agent_id,
@@ -657,6 +661,13 @@ def _actor_interaction_claim_predicates(
         Task.agent_config[MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY]
         .as_boolean()
         .is_(True),
+        # WAITING_FOR_USER can be visible before the prior run releases its
+        # lease. Do not let the same process overwrite that live lease.
+        or_(
+            Task.runner_id.is_(None),
+            Task.lease_expires_at.is_(None),
+            Task.lease_expires_at < now,
+        ),
     )
 
 
@@ -705,6 +716,7 @@ def _prepare_channel_task_sync(
     agent_id: int | None = None,
     new_task_is_visible: bool = True,
     mcp_runtime_authorization_policy_required: bool = False,
+    mcp_runtime_authorization_policy_identity: str | None = None,
     task_mode: ChannelTaskMode = ChannelTaskMode.DEFAULT,
 ) -> _ChannelTaskClaimSnapshot | None:
     if not isinstance(task_mode, ChannelTaskMode):
@@ -862,7 +874,18 @@ def _prepare_channel_task_sync(
                         else new_task_is_visible
                     ),
                     agent_config=(
-                        {MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY: True}
+                        {
+                            MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY: True,
+                            **(
+                                {
+                                    MCP_RUNTIME_AUTHORIZATION_POLICY_IDENTITY_KEY: (
+                                        mcp_runtime_authorization_policy_identity
+                                    )
+                                }
+                                if mcp_runtime_authorization_policy_identity
+                                else {}
+                            ),
+                        }
                         if mcp_runtime_authorization_policy_required is True
                         else None
                     ),
@@ -949,6 +972,7 @@ async def prepare_channel_task(
     agent_id: int | None = None,
     new_task_is_visible: bool = True,
     mcp_runtime_authorization_policy_required: bool = False,
+    mcp_runtime_authorization_policy_identity: str | None = None,
     task_mode: ChannelTaskMode = ChannelTaskMode.DEFAULT,
 ) -> ClaimedChannelTask | None:
     """Authorize, resolve or create, and claim one channel run atomically.
@@ -971,6 +995,9 @@ async def prepare_channel_task(
             new_task_is_visible=new_task_is_visible,
             mcp_runtime_authorization_policy_required=(
                 mcp_runtime_authorization_policy_required
+            ),
+            mcp_runtime_authorization_policy_identity=(
+                mcp_runtime_authorization_policy_identity
             ),
             task_mode=task_mode,
         )

--- a/src/xagent/web/services/channel_runtime.py
+++ b/src/xagent/web/services/channel_runtime.py
@@ -622,6 +622,44 @@ async def get_channel_owner_agent(
     )
 
 
+def _actor_interaction_task_matches(
+    task: Task | None,
+    agent: Agent | None,
+    *,
+    owner_id: int,
+    agent_id: int,
+    status: TaskStatus,
+) -> bool:
+    return bool(
+        agent is not None
+        and task is not None
+        and int(task.user_id) == owner_id
+        and task.agent_id is not None
+        and int(task.agent_id) == agent_id
+        and int(agent.id) == agent_id
+        and task.source == ACTOR_TASK_SOURCE
+        and task.status == status
+        and task.is_visible is False
+        and task_requires_mcp_actor_policy(task.agent_config)
+    )
+
+
+def _actor_interaction_claim_predicates(
+    *,
+    owner_id: int,
+    agent_id: int,
+) -> tuple[Any, ...]:
+    return (
+        Task.user_id == owner_id,
+        Task.agent_id == agent_id,
+        Task.source == ACTOR_TASK_SOURCE,
+        Task.is_visible.is_(False),
+        Task.agent_config[MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY]
+        .as_boolean()
+        .is_(True),
+    )
+
+
 def _load_actor_interaction_task(
     db: Any,
     *,
@@ -642,17 +680,17 @@ def _load_actor_interaction_task(
         )
         .first()
     )
-    if (
-        agent is None
-        or task is None
-        or task.agent_id is None
-        or int(task.agent_id) != int(agent.id)
-        or task.source != ACTOR_TASK_SOURCE
-        or task.status != TaskStatus.WAITING_FOR_USER
-        or not task_requires_mcp_actor_policy(task.agent_config)
+    if not _actor_interaction_task_matches(
+        task,
+        agent,
+        owner_id=owner_id,
+        agent_id=agent_id,
+        status=TaskStatus.WAITING_FOR_USER,
     ):
         raise ChannelAuthorizationError("The actor interaction task is unavailable")
 
+    assert task is not None
+    assert agent is not None
     return task, agent
 
 
@@ -841,6 +879,14 @@ def _prepare_channel_task_sync(
                 db.flush()
 
             task_id = int(task.id)
+            claim_predicates = ()
+            if task_mode is ChannelTaskMode.ACTOR_INTERACTION:
+                assert agent_id is not None
+                claim_predicates = _actor_interaction_claim_predicates(
+                    owner_id=owner_id,
+                    agent_id=agent_id,
+                )
+
             lease = acquire_task_lease_no_commit(
                 db,
                 task_id,
@@ -850,6 +896,7 @@ def _prepare_channel_task_sync(
                     else None
                 ),
                 new_run=True,
+                claim_predicates=claim_predicates,
             )
             if lease is None:
                 db.rollback()
@@ -860,6 +907,23 @@ def _prepare_channel_task_sync(
             # PENDING row before its RUNNING owner is durable.
             db.expire_all()
             claimed_task = db.query(Task).filter(Task.id == task_id).one()
+            if task_mode is ChannelTaskMode.ACTOR_INTERACTION:
+                assert agent_id is not None
+                claimed_agent = (
+                    _owned_channel_agents_query(db, owner_id)
+                    .filter(Agent.id == agent_id)
+                    .with_for_update()
+                    .first()
+                )
+                if not _actor_interaction_task_matches(
+                    claimed_task,
+                    claimed_agent,
+                    owner_id=owner_id,
+                    agent_id=agent_id,
+                    status=TaskStatus.RUNNING,
+                ):
+                    db.rollback()
+                    return None
             sync_workforce_run_status(db, claimed_task, TaskStatus.RUNNING)
             db.commit()
             return _ChannelTaskClaimSnapshot(

--- a/src/xagent/web/services/channel_runtime.py
+++ b/src/xagent/web/services/channel_runtime.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass
+from enum import StrEnum
 from pathlib import Path
 from typing import Any, Iterable, Sequence
 from uuid import uuid4
@@ -56,6 +57,14 @@ from .workforce_runtime import sync_workforce_run_status
 logger = logging.getLogger(__name__)
 
 TELEGRAM_TASK_LIST_LIMIT = 50
+ACTOR_TASK_SOURCE = "external"
+
+
+class ChannelTaskMode(StrEnum):
+    """The trusted task-selection contract for one channel turn."""
+
+    DEFAULT = "default"
+    ACTOR_INTERACTION = "actor_interaction"
 
 
 class ChannelConfigurationError(RuntimeError):
@@ -613,6 +622,40 @@ async def get_channel_owner_agent(
     )
 
 
+def _load_actor_interaction_task(
+    db: Any,
+    *,
+    owner_id: int,
+    active_task_id: int,
+    agent_id: int,
+) -> tuple[Task, Agent]:
+    """Load one exact waiting actor task without a fresh-task fallback."""
+
+    agent = (
+        _owned_channel_agents_query(db, owner_id).filter(Agent.id == agent_id).first()
+    )
+    task = (
+        db.query(Task)
+        .filter(
+            Task.id == active_task_id,
+            Task.user_id == owner_id,
+        )
+        .first()
+    )
+    if (
+        agent is None
+        or task is None
+        or task.agent_id is None
+        or int(task.agent_id) != int(agent.id)
+        or task.source != ACTOR_TASK_SOURCE
+        or task.status != TaskStatus.WAITING_FOR_USER
+        or not task_requires_mcp_actor_policy(task.agent_config)
+    ):
+        raise ChannelAuthorizationError("The actor interaction task is unavailable")
+
+    return task, agent
+
+
 def _prepare_channel_task_sync(
     *,
     channel_id: int | None,
@@ -624,7 +667,20 @@ def _prepare_channel_task_sync(
     agent_id: int | None = None,
     new_task_is_visible: bool = True,
     mcp_runtime_authorization_policy_required: bool = False,
+    task_mode: ChannelTaskMode = ChannelTaskMode.DEFAULT,
 ) -> _ChannelTaskClaimSnapshot | None:
+    if not isinstance(task_mode, ChannelTaskMode):
+        raise ValueError("Unsupported channel task mode")
+    if task_mode is ChannelTaskMode.ACTOR_INTERACTION:
+        if active_task_id is None or active_task_id <= 0:
+            raise ValueError("Actor interaction requires an active task")
+        if expected_owner_user_id is None:
+            raise ValueError("Actor interaction requires an expected owner")
+        if agent_id is None:
+            raise ValueError("Actor interaction requires an agent")
+        if not mcp_runtime_authorization_policy_required:
+            raise ValueError("Actor interaction requires an actor policy")
+
     SessionLocal = get_session_local()
     with SessionLocal() as db:
         try:
@@ -646,7 +702,7 @@ def _prepare_channel_task_sync(
                 )
 
             is_telegram = str(channel.channel_type) == "telegram"
-            if is_telegram:
+            if is_telegram and task_mode is ChannelTaskMode.DEFAULT:
                 claimed_legacy_task = _claim_legacy_active_telegram_task_sync(
                     db,
                     channel=channel,
@@ -663,12 +719,29 @@ def _prepare_channel_task_sync(
                     db.flush()
 
             task = None
-            # Actor-owned channel turns are fresh-only. Ignoring an active id
-            # on the trusted marked path prevents it from becoming an
-            # accidental resume API while preserving ordinary channel reuse.
-            if mcp_runtime_authorization_policy_required is True:
-                active_task_id = None
-            if active_task_id is not None and active_task_id != -1:
+            agent_row = None
+            requested_agent_missing = False
+            if task_mode is ChannelTaskMode.ACTOR_INTERACTION:
+                assert active_task_id is not None
+                assert agent_id is not None
+                task, agent_row = _load_actor_interaction_task(
+                    db,
+                    owner_id=owner_id,
+                    active_task_id=active_task_id,
+                    agent_id=agent_id,
+                )
+            else:
+                # Actor-owned channel turns are fresh-only. Ignoring an active
+                # id on the default marked path prevents it from becoming an
+                # accidental continuation API.
+                if mcp_runtime_authorization_policy_required is True:
+                    active_task_id = None
+
+            if (
+                task_mode is ChannelTaskMode.DEFAULT
+                and active_task_id is not None
+                and active_task_id != -1
+            ):
                 active_config = (
                     db.query(Task.agent_config)
                     .filter(
@@ -709,14 +782,9 @@ def _prepare_channel_task_sync(
                         f"Task {int(task.id)} is actor-marked; channel reuse is unsupported"
                     )
 
-            # Revalidate the requested selection on every turn, not only for
-            # new tasks. A conversation may only continue when its task binding
-            # still matches the selection: a stale selection (agent deleted or
-            # visibility revoked) or a drifted binding evicts to a fresh task
-            # instead of resuming with stale cached agent state.
-            agent_row = None
-            requested_agent_missing = False
-            if agent_id is not None:
+            # Revalidate the requested selection on every ordinary turn. Actor
+            # interaction mode uses the stricter exact-task check above.
+            if task_mode is ChannelTaskMode.DEFAULT and agent_id is not None:
                 agent_row = (
                     _owned_channel_agents_query(db, owner_id)
                     .filter(Agent.id == int(agent_id))
@@ -808,6 +876,7 @@ async def prepare_channel_task(
     agent_id: int | None = None,
     new_task_is_visible: bool = True,
     mcp_runtime_authorization_policy_required: bool = False,
+    task_mode: ChannelTaskMode = ChannelTaskMode.DEFAULT,
 ) -> ClaimedChannelTask | None:
     """Authorize, resolve or create, and claim one channel run atomically.
 
@@ -830,6 +899,7 @@ async def prepare_channel_task(
             mcp_runtime_authorization_policy_required=(
                 mcp_runtime_authorization_policy_required
             ),
+            task_mode=task_mode,
         )
     )
     snapshot, cancellation = await await_task_settlement(worker)

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -12,11 +12,12 @@ from contextvars import ContextVar
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Any, Callable, Coroutine, Iterator, TypeVar, cast
+from typing import Any, Callable, Coroutine, Iterator, Sequence, TypeVar, cast
 
 from sqlalchemy import and_, case, func, or_, update
 from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.orm import Query, Session
+from sqlalchemy.sql.elements import ColumnElement
 
 from ...config import (
     get_task_lease_heartbeat_seconds,
@@ -749,6 +750,7 @@ def acquire_task_lease_no_commit(
     expected_run_id: str | None = None,
     expected_status: TaskStatus | None = None,
     new_run: bool = False,
+    claim_predicates: Sequence[ColumnElement[bool]] = (),
 ) -> TaskLease | None:
     """Stage one atomic lease claim; the caller owns commit/rollback."""
     runner = runner_id or get_runner_id()
@@ -810,6 +812,8 @@ def acquire_task_lease_no_commit(
         stmt = stmt.where(Task.run_id == expected_run_id)
     if expected_status is not None:
         stmt = stmt.where(task_status_predicate.eq(expected_status))
+    if claim_predicates:
+        stmt = stmt.where(*claim_predicates)
     result = db.execute(
         stmt.returning(Task.run_id).execution_options(synchronize_session=False)
     )

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -747,6 +747,7 @@ def acquire_task_lease_no_commit(
     *,
     runner_id: str | None = None,
     expected_run_id: str | None = None,
+    expected_status: TaskStatus | None = None,
     new_run: bool = False,
 ) -> TaskLease | None:
     """Stage one atomic lease claim; the caller owns commit/rollback."""
@@ -807,6 +808,8 @@ def acquire_task_lease_no_commit(
         stmt = stmt.where(task_status_predicate.ne(TaskStatus.RUNNING))
     if expected_run_id is not None:
         stmt = stmt.where(Task.run_id == expected_run_id)
+    if expected_status is not None:
+        stmt = stmt.where(task_status_predicate.eq(expected_status))
     result = db.execute(
         stmt.returning(Task.run_id).execution_options(synchronize_session=False)
     )

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -2112,6 +2112,9 @@ def _schedule_bg(
                         lambda: _get_agent_manager().remove_agent(
                             task_id,
                             task_owner_user_id,
+                            expected_run_id=(
+                                task_lease.run_id if task_lease is not None else run_id
+                            ),
                         )
                     )
                 except asyncio.CancelledError as exc:

--- a/src/xagent/web/services/task_runtime.py
+++ b/src/xagent/web/services/task_runtime.py
@@ -87,6 +87,9 @@ SELECTED_FILE_IDS_AGENT_CONFIG_KEY = "selected_file_ids"
 MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY = (
     "__xagent_mcp_runtime_authorization_policy_required"
 )
+MCP_RUNTIME_AUTHORIZATION_POLICY_IDENTITY_KEY = (
+    "mcp_runtime_authorization_policy_identity"
+)
 # Keys in ``tasks.agent_config`` that only the server may write. Task-create
 # request bodies carry a free-form ``agent_config`` dict that endpoints copy
 # wholesale, so anything the server later reads back as authoritative has to
@@ -194,6 +197,7 @@ CLIENT_RESERVED_AGENT_CONFIG_KEYS: frozenset[str] = frozenset(
         TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY,
         EXECUTION_SCOPE_AGENT_CONFIG_KEY,
         MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY,
+        MCP_RUNTIME_AUTHORIZATION_POLICY_IDENTITY_KEY,
         SELECTED_FILE_IDS_AGENT_CONFIG_KEY,
         FILE_OPERATION_ACCESS_VERSION_KEY,
         "auth_mode",
@@ -216,6 +220,17 @@ def mcp_runtime_authorization_policy_required(agent_config: Any) -> bool:
         isinstance(agent_config, Mapping)
         and agent_config.get(MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY) is True
     )
+
+
+def mcp_runtime_authorization_policy_identity(agent_config: Any) -> str | None:
+    """Return the durable actor-policy identity for one task."""
+
+    if not isinstance(agent_config, Mapping):
+        return None
+    value = agent_config.get(MCP_RUNTIME_AUTHORIZATION_POLICY_IDENTITY_KEY)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value
 
 
 def sanitize_client_agent_config(agent_config: Any) -> dict[str, Any]:

--- a/tests/web/api/test_actor_task_context.py
+++ b/tests/web/api/test_actor_task_context.py
@@ -23,6 +23,7 @@ from xagent.web.services.task_runtime import (
 )
 from xagent.web.services.task_setup_snapshot import (
     RuntimeUserFields,
+    TaskReconstructionSnapshot,
     TaskSetupSnapshot,
     _TaskFields,
 )
@@ -34,6 +35,7 @@ def _snapshot(
     status: TaskStatus = TaskStatus.PENDING,
     has_reconstructable_history: bool = False,
     agent_config: dict[str, Any] | None = None,
+    task_llm: Any = None,
 ) -> TaskSetupSnapshot:
     return TaskSetupSnapshot(
         task=_TaskFields(
@@ -51,13 +53,31 @@ def _snapshot(
         runtime_user=RuntimeUserFields(id=1, is_admin=False),
         has_reconstructable_history=has_reconstructable_history,
         task_pattern="single_call",
-        task_llm=None,
+        task_llm=task_llm,
         task_fast_llm=None,
         task_vision_llm=None,
         task_compact_llm=None,
         agent=None,
         agent_config=agent_config,
         excluded_agent_id=None,
+        reconstruction=TaskReconstructionSnapshot(
+            tracer_events=(
+                (
+                    {
+                        "id": "actor-event",
+                        "event_type": "agent_step",
+                        "task_id": "42",
+                        "step_id": None,
+                        "timestamp": None,
+                        "data": {},
+                        "parent_id": None,
+                    },
+                )
+                if has_reconstructable_history
+                else ()
+            ),
+            has_history=has_reconstructable_history,
+        ),
     )
 
 
@@ -72,6 +92,8 @@ class _Agent:
     def set_execution_context_messages(self, _messages: list[Any]) -> None: ...
 
     def set_recovered_skill_context(self, _context: Any) -> None: ...
+
+    async def reconstruct_from_history(self, *_args: Any) -> None: ...
 
     def cleanup_workspace(self) -> None: ...
 
@@ -226,34 +248,47 @@ async def test_marked_task_reconstruction_is_rejected_even_with_policy(
 
 
 @pytest.mark.asyncio
-async def test_actor_interaction_reconstructs_marked_running_task(
+async def test_actor_interaction_reconstruction_preserves_tool_context(
     actor_policy: MCPBuiltinOAuthActorPolicy,
 ) -> None:
     manager = AgentServiceManager()
-    reconstructed = MagicMock()
+    tool_config = MagicMock()
+    tool_config.set_execution_scope.return_value = False
+    create_tools = AsyncMock(return_value=([], tool_config))
+    reconstructed = _Agent(tool_config)
 
-    async def reconstruct(*_args: Any, **_kwargs: Any) -> None:
-        manager._agents[42] = reconstructed
-
-    with patch.object(
-        manager,
-        "_reconstruct_agent_from_history",
-        new=AsyncMock(side_effect=reconstruct),
-    ) as reconstruct_agent:
+    with (
+        patch("xagent.web.api.chat.create_default_tools", new=create_tools),
+        patch("xagent.web.api.chat.create_task_tracer", return_value=MagicMock()),
+        patch("xagent.web.sandbox_manager.get_sandbox_manager", return_value=None),
+        patch("xagent.web.api.chat.AgentService", return_value=reconstructed),
+    ):
         result = await manager.get_agent_for_task(
             42,
             task_setup_snapshot=_snapshot(
                 status=TaskStatus.RUNNING,
                 has_reconstructable_history=True,
+                agent_config={
+                    "knowledge_bases": [],
+                    "skills": [],
+                    "tool_categories": ["web_search", "file"],
+                },
+                task_llm=MagicMock(),
             ),
             task_owner_user_id=1,
+            connector_runtime_turn_id="approval-turn",
             mcp_runtime_authorization_policy=actor_policy,
             task_mode=ChannelTaskMode.ACTOR_INTERACTION,
             resolved_execution_scope=None,
         )
 
     assert result is reconstructed
-    reconstruct_agent.assert_awaited_once()
+    kwargs = create_tools.await_args.kwargs
+    assert kwargs["connector_runtime_turn_id"] == "approval-turn"
+    assert kwargs["mcp_runtime_authorization_policy"] is actor_policy
+    assert kwargs["force_mcp_tools"] is True
+    assert _spec_wants_mcp(kwargs["tool_selection_spec"])
+    assert not kwargs["tool_selection_spec"].includes_published_agent()
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_actor_task_context.py
+++ b/tests/web/api/test_actor_task_context.py
@@ -12,6 +12,7 @@ from xagent.core.tools.adapters.vibe.selection_spec import (
 )
 from xagent.web.api.chat import AgentServiceManager, _spec_wants_mcp
 from xagent.web.models.task import TaskStatus
+from xagent.web.services.channel_runtime import ChannelTaskMode
 from xagent.web.services.mcp_runtime import (
     MCPBuiltinOAuthActorPolicy,
     MCPBuiltinOAuthActorPolicyMismatchError,
@@ -218,6 +219,63 @@ async def test_marked_task_reconstruction_is_rejected_even_with_policy(
             ),
             task_owner_user_id=1,
             mcp_runtime_authorization_policy=actor_policy,
+            resolved_execution_scope=None,
+        )
+
+    reconstruct.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_actor_interaction_reconstructs_marked_running_task(
+    actor_policy: MCPBuiltinOAuthActorPolicy,
+) -> None:
+    manager = AgentServiceManager()
+    reconstructed = MagicMock()
+
+    async def reconstruct(*_args: Any, **_kwargs: Any) -> None:
+        manager._agents[42] = reconstructed
+
+    with patch.object(
+        manager,
+        "_reconstruct_agent_from_history",
+        new=AsyncMock(side_effect=reconstruct),
+    ) as reconstruct_agent:
+        result = await manager.get_agent_for_task(
+            42,
+            task_setup_snapshot=_snapshot(
+                status=TaskStatus.RUNNING,
+                has_reconstructable_history=True,
+            ),
+            task_owner_user_id=1,
+            mcp_runtime_authorization_policy=actor_policy,
+            task_mode=ChannelTaskMode.ACTOR_INTERACTION,
+            resolved_execution_scope=None,
+        )
+
+    assert result is reconstructed
+    reconstruct_agent.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_actor_interaction_reconstruction_requires_running_claim(
+    actor_policy: MCPBuiltinOAuthActorPolicy,
+) -> None:
+    manager = AgentServiceManager()
+    reconstruct = AsyncMock()
+
+    with (
+        patch.object(manager, "_reconstruct_agent_from_history", new=reconstruct),
+        pytest.raises(MCPBuiltinOAuthActorPolicyRequiredError, match="reconstruction"),
+    ):
+        await manager.get_agent_for_task(
+            42,
+            task_setup_snapshot=_snapshot(
+                status=TaskStatus.WAITING_FOR_USER,
+                has_reconstructable_history=True,
+            ),
+            task_owner_user_id=1,
+            mcp_runtime_authorization_policy=actor_policy,
+            task_mode=ChannelTaskMode.ACTOR_INTERACTION,
             resolved_execution_scope=None,
         )
 

--- a/tests/web/api/test_actor_task_context.py
+++ b/tests/web/api/test_actor_task_context.py
@@ -35,6 +35,9 @@ def _snapshot(
     status: TaskStatus = TaskStatus.PENDING,
     has_reconstructable_history: bool = False,
     agent_config: dict[str, Any] | None = None,
+    task_agent_id: int | None = None,
+    task_agent_config: dict[str, Any] | None = None,
+    runtime_agent: Any = None,
     task_llm: Any = None,
 ) -> TaskSetupSnapshot:
     return TaskSetupSnapshot(
@@ -43,8 +46,19 @@ def _snapshot(
             user_id=1,
             status=status,
             source="external",
-            agent_id=None,
-            agent_config={MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY: marker},
+            agent_id=task_agent_id,
+            agent_config=(
+                task_agent_config
+                if task_agent_config is not None
+                else {
+                    MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY: marker,
+                    **(
+                        {"mcp_runtime_authorization_policy_identity": "actor:alice"}
+                        if marker is True
+                        else {}
+                    ),
+                }
+            ),
             model_name=None,
             compact_model_name=None,
             execution_mode="flash",
@@ -57,7 +71,7 @@ def _snapshot(
         task_fast_llm=None,
         task_vision_llm=None,
         task_compact_llm=None,
-        agent=None,
+        agent=runtime_agent,
         agent_config=agent_config,
         excluded_agent_id=None,
         reconstruction=TaskReconstructionSnapshot(
@@ -162,6 +176,72 @@ async def test_marked_task_binds_policy_and_omits_published_agent_tools(
     assert _spec_wants_mcp(kwargs["tool_selection_spec"])
     assert not kwargs["tool_selection_spec"].includes_published_agent()
     assert manager._mcp_actor_policies[42] is actor_policy
+
+
+@pytest.mark.asyncio
+async def test_actor_interaction_rejects_different_persisted_policy(
+    actor_policy: MCPBuiltinOAuthActorPolicy,
+) -> None:
+    manager = AgentServiceManager()
+    create_tools = AsyncMock()
+
+    with (
+        patch("xagent.web.api.chat.create_default_tools", new=create_tools),
+        pytest.raises(
+            MCPBuiltinOAuthActorPolicyMismatchError,
+            match="durable identity",
+        ),
+    ):
+        await manager.get_agent_for_task(
+            42,
+            task_setup_snapshot=_snapshot(
+                status=TaskStatus.RUNNING,
+                has_reconstructable_history=True,
+                task_agent_id=7,
+                runtime_agent=MagicMock(id=7),
+                task_agent_config={
+                    MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY: True,
+                    "mcp_runtime_authorization_policy_identity": "actor:bob",
+                },
+            ),
+            task_owner_user_id=1,
+            mcp_runtime_authorization_policy=actor_policy,
+            task_mode=ChannelTaskMode.ACTOR_INTERACTION,
+            resolved_execution_scope=None,
+        )
+
+    create_tools.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_actor_interaction_rejects_deleted_claimed_agent(
+    actor_policy: MCPBuiltinOAuthActorPolicy,
+) -> None:
+    manager = AgentServiceManager()
+    create_tools = AsyncMock()
+
+    with (
+        patch("xagent.web.api.chat.create_default_tools", new=create_tools),
+        pytest.raises(
+            MCPBuiltinOAuthActorPolicyRequiredError,
+            match="claimed agent is unavailable",
+        ),
+    ):
+        await manager.get_agent_for_task(
+            42,
+            task_setup_snapshot=_snapshot(
+                status=TaskStatus.RUNNING,
+                has_reconstructable_history=True,
+                task_agent_id=7,
+                runtime_agent=None,
+            ),
+            task_owner_user_id=1,
+            mcp_runtime_authorization_policy=actor_policy,
+            task_mode=ChannelTaskMode.ACTOR_INTERACTION,
+            resolved_execution_scope=None,
+        )
+
+    create_tools.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -353,6 +433,7 @@ async def test_non_literal_true_marker_preserves_ordinary_task_behavior(
 def _seed_manager_maps(manager: AgentServiceManager, agent: Any) -> None:
     manager._agents[42] = agent
     manager._agent_owner_ids[42] = 7
+    manager._agent_run_ids[42] = "current-run"
     manager._agent_sandbox_keys[42] = "user:7"
     manager._agent_sandbox_providers[42] = object()
     manager._agent_scope_fingerprints[42] = None
@@ -360,6 +441,18 @@ def _seed_manager_maps(manager: AgentServiceManager, agent: Any) -> None:
     manager._mcp_actor_policies[42] = MCPBuiltinOAuthActorPolicy(
         resource_owner_key="actor:alice"
     )
+
+
+def test_remove_agent_ignores_stale_run_cleanup() -> None:
+    manager = AgentServiceManager()
+    agent = MagicMock()
+    _seed_manager_maps(manager, agent)
+
+    manager.remove_agent(42, expected_run_id="finished-run")
+
+    assert manager._agents[42] is agent
+    assert manager._agent_run_ids[42] == "current-run"
+    agent.cleanup_workspace.assert_not_called()
 
 
 @pytest.mark.parametrize("cleanup_fails", [False, True])
@@ -382,6 +475,7 @@ def test_remove_agent_evicts_runtime_and_retains_failed_cleanup_owner(
     for runtime_map in (
         manager._agents,
         manager._agent_owner_ids,
+        manager._agent_run_ids,
         manager._agent_sandbox_keys,
         manager._agent_sandbox_providers,
         manager._agent_scope_fingerprints,

--- a/tests/web/api/test_get_agent_for_task_reconstruct_precheck.py
+++ b/tests/web/api/test_get_agent_for_task_reconstruct_precheck.py
@@ -335,6 +335,8 @@ async def test_running_with_prior_trace_event_runs_reconstruct() -> None:
         db,
         scope=None,
         task_setup_snapshot=snapshot,
+        connector_runtime_turn_id=None,
+        mcp_runtime_authorization_policy=None,
     )
     snapshot_loader.assert_called_once_with(42, None)
 
@@ -458,6 +460,8 @@ async def test_running_with_dag_plan_runs_reconstruct() -> None:
         db,
         scope=None,
         task_setup_snapshot=snapshot,
+        connector_runtime_turn_id=None,
+        mcp_runtime_authorization_policy=None,
     )
     snapshot_loader.assert_called_once_with(42, None)
 
@@ -505,6 +509,8 @@ async def test_paused_with_no_history_still_runs_reconstruct() -> None:
         db,
         scope=None,
         task_setup_snapshot=snapshot,
+        connector_runtime_turn_id=None,
+        mcp_runtime_authorization_policy=None,
     )
     snapshot_loader.assert_called_once_with(42, None)
 
@@ -548,6 +554,8 @@ async def test_waiting_for_user_with_no_history_still_runs_reconstruct() -> None
         db,
         scope=None,
         task_setup_snapshot=snapshot,
+        connector_runtime_turn_id=None,
+        mcp_runtime_authorization_policy=None,
     )
     snapshot_loader.assert_called_once_with(42, None)
 
@@ -586,8 +594,12 @@ async def test_reconstruct_return_path_syncs_connector_runtime_turn() -> None:
         _db: Any,
         scope: Any = None,
         task_setup_snapshot: TaskSetupSnapshot | None = None,
+        connector_runtime_turn_id: str | None = None,
+        mcp_runtime_authorization_policy: Any = None,
     ) -> None:
         assert task_setup_snapshot is snapshot
+        assert connector_runtime_turn_id == "turn-reconstructed"
+        assert mcp_runtime_authorization_policy is None
         manager._agents[task_id] = reconstructed_agent
 
     with (

--- a/tests/web/services/test_channel_runtime.py
+++ b/tests/web/services/test_channel_runtime.py
@@ -83,6 +83,35 @@ def _add_agent(
         return int(agent.id)
 
 
+async def _create_waiting_actor_task(
+    SessionLocal,
+    *,
+    channel_id: int,
+    agent_id: int,
+) -> int:
+    prepared = await prepare_channel_task(
+        channel_id=channel_id,
+        external_user_id="telegram-user",
+        active_task_id=None,
+        text="prepare approval",
+        channel_name="Trusted direct channel",
+        agent_id=agent_id,
+        new_task_is_visible=False,
+        mcp_runtime_authorization_policy_required=True,
+    )
+    assert prepared is not None
+    with SessionLocal() as db:
+        task = db.get(Task, prepared.task_id)
+        assert task is not None
+        task.source = "external"
+        db.commit()
+    assert await prepared.managed_lease.finalize_result(
+        status=TaskStatus.WAITING_FOR_USER
+    )
+    return prepared.task_id
+
+
+
 @pytest.mark.asyncio
 async def test_prepare_channel_task_binds_owned_agent(
     monkeypatch: pytest.MonkeyPatch,
@@ -214,6 +243,205 @@ async def test_actor_marker_forces_new_channel_task_hidden(
         }
     assert await prepared.managed_lease.finalize_result(status=TaskStatus.FAILED)
     engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_actor_interaction_reuses_exact_waiting_task(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+) -> None:
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    agent_id = _add_agent(SessionLocal, user_id=user_id, name="Actor Agent")
+    monkeypatch.setattr(channel_runtime, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    task_id = await _create_waiting_actor_task(
+        SessionLocal,
+        channel_id=channel_id,
+        agent_id=agent_id,
+    )
+    with SessionLocal() as db:
+        task = db.get(Task, task_id)
+        assert task is not None
+        previous_run_id = task.run_id
+        task.last_checkpoint_event_id = "waiting-checkpoint"
+        task.output = "waiting output"
+        task.error_message = "waiting error"
+        db.commit()
+
+    prepared = await prepare_channel_task(
+        channel_id=channel_id,
+        external_user_id="telegram-user",
+        active_task_id=task_id,
+        text="approve",
+        channel_name="Trusted direct channel",
+        expected_owner_user_id=user_id,
+        agent_id=agent_id,
+        new_task_is_visible=False,
+        mcp_runtime_authorization_policy_required=True,
+        task_mode=channel_runtime.ChannelTaskMode.ACTOR_INTERACTION,
+    )
+
+    assert prepared is not None
+    assert prepared.task_id == task_id
+    assert prepared.is_new_task is False
+    assert prepared.requested_agent_missing is False
+    with SessionLocal() as db:
+        assert db.query(Task).count() == 1
+        task = db.get(Task, task_id)
+        assert task is not None
+        assert task.status == TaskStatus.RUNNING
+        assert task.run_id != previous_run_id
+        assert task.last_checkpoint_event_id is None
+        assert task.output is None
+        assert task.error_message is None
+    assert await prepared.managed_lease.finalize_result(status=TaskStatus.FAILED)
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid_field", ["source", "status", "policy"])
+async def test_actor_interaction_rejects_invalid_task_without_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+    invalid_field: str,
+) -> None:
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    agent_id = _add_agent(SessionLocal, user_id=user_id, name="Actor Agent")
+    monkeypatch.setattr(channel_runtime, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    task_id = await _create_waiting_actor_task(
+        SessionLocal,
+        channel_id=channel_id,
+        agent_id=agent_id,
+    )
+    with SessionLocal() as db:
+        task = db.get(Task, task_id)
+        assert task is not None
+        if invalid_field == "source":
+            task.source = None
+        elif invalid_field == "status":
+            task.status = TaskStatus.FAILED
+        else:
+            task.agent_config = None
+        db.commit()
+
+    with pytest.raises(ChannelAuthorizationError, match="actor interaction task"):
+        await prepare_channel_task(
+            channel_id=channel_id,
+            external_user_id="telegram-user",
+            active_task_id=task_id,
+            text="approve",
+            channel_name="Trusted direct channel",
+            expected_owner_user_id=user_id,
+            agent_id=agent_id,
+            new_task_is_visible=False,
+            mcp_runtime_authorization_policy_required=True,
+            task_mode=channel_runtime.ChannelTaskMode.ACTOR_INTERACTION,
+        )
+
+    with SessionLocal() as db:
+        assert db.query(Task).count() == 1
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_actor_interaction_requires_task_and_policy(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+) -> None:
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    agent_id = _add_agent(SessionLocal, user_id=user_id, name="Actor Agent")
+    monkeypatch.setattr(channel_runtime, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+
+    with pytest.raises(ValueError, match="active task"):
+        await prepare_channel_task(
+            channel_id=channel_id,
+            external_user_id="telegram-user",
+            active_task_id=None,
+            text="approve",
+            channel_name="Trusted direct channel",
+            expected_owner_user_id=user_id,
+            agent_id=agent_id,
+            new_task_is_visible=False,
+            mcp_runtime_authorization_policy_required=True,
+            task_mode=channel_runtime.ChannelTaskMode.ACTOR_INTERACTION,
+        )
+
+    with pytest.raises(ChannelAuthorizationError, match="actor interaction task"):
+        await prepare_channel_task(
+            channel_id=channel_id,
+            external_user_id="telegram-user",
+            active_task_id=1,
+            text="approve",
+            channel_name="Trusted direct channel",
+            expected_owner_user_id=user_id,
+            agent_id=agent_id,
+            new_task_is_visible=False,
+            mcp_runtime_authorization_policy_required=True,
+            task_mode=channel_runtime.ChannelTaskMode.ACTOR_INTERACTION,
+        )
+
+    with pytest.raises(ValueError, match="actor policy"):
+        await prepare_channel_task(
+            channel_id=channel_id,
+            external_user_id="telegram-user",
+            active_task_id=1,
+            text="approve",
+            channel_name="Trusted direct channel",
+            expected_owner_user_id=user_id,
+            agent_id=agent_id,
+            new_task_is_visible=False,
+            mcp_runtime_authorization_policy_required=False,
+            task_mode=channel_runtime.ChannelTaskMode.ACTOR_INTERACTION,
+        )
+
+    with SessionLocal() as db:
+        assert db.query(Task).count() == 0
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_actor_interaction_rejects_unavailable_agent_without_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+) -> None:
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    agent_id = _add_agent(SessionLocal, user_id=user_id, name="Actor Agent")
+    monkeypatch.setattr(channel_runtime, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    task_id = await _create_waiting_actor_task(
+        SessionLocal,
+        channel_id=channel_id,
+        agent_id=agent_id,
+    )
+
+    with pytest.raises(ChannelAuthorizationError, match="actor interaction task"):
+        await prepare_channel_task(
+            channel_id=channel_id,
+            external_user_id="telegram-user",
+            active_task_id=task_id,
+            text="approve",
+            channel_name="Trusted direct channel",
+            expected_owner_user_id=user_id,
+            agent_id=agent_id + 1,
+            new_task_is_visible=False,
+            mcp_runtime_authorization_policy_required=True,
+            task_mode=channel_runtime.ChannelTaskMode.ACTOR_INTERACTION,
+        )
+
+    with SessionLocal() as db:
+        assert db.query(Task).count() == 1
+    engine.dispose()
+
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_channel_runtime.py
+++ b/tests/web/services/test_channel_runtime.py
@@ -111,7 +111,6 @@ async def _create_waiting_actor_task(
     return prepared.task_id
 
 
-
 @pytest.mark.asyncio
 async def test_prepare_channel_task_binds_owned_agent(
     monkeypatch: pytest.MonkeyPatch,
@@ -441,7 +440,6 @@ async def test_actor_interaction_rejects_unavailable_agent_without_fallback(
     with SessionLocal() as db:
         assert db.query(Task).count() == 1
     engine.dispose()
-
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_channel_runtime.py
+++ b/tests/web/services/test_channel_runtime.py
@@ -353,6 +353,124 @@ async def test_actor_interaction_claim_rechecks_waiting_status(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("changed_field", ["agent_id", "source", "policy"])
+async def test_actor_interaction_claim_rechecks_task_lineage(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+    changed_field: str,
+) -> None:
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    agent_id = _add_agent(SessionLocal, user_id=user_id, name="Actor Agent")
+    monkeypatch.setattr(channel_runtime, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    task_id = await _create_waiting_actor_task(
+        SessionLocal,
+        channel_id=channel_id,
+        agent_id=agent_id,
+    )
+    load_task = channel_runtime._load_actor_interaction_task
+
+    def change_lineage_after_validation(db, **kwargs):
+        task, agent = load_task(db, **kwargs)
+        if changed_field == "agent_id":
+            task.agent_id = None
+        elif changed_field == "source":
+            task.source = None
+        else:
+            task.agent_config = {}
+        db.commit()
+        return task, agent
+
+    monkeypatch.setattr(
+        channel_runtime,
+        "_load_actor_interaction_task",
+        change_lineage_after_validation,
+    )
+
+    prepared = await prepare_channel_task(
+        channel_id=channel_id,
+        external_user_id="telegram-user",
+        active_task_id=task_id,
+        text="approve",
+        channel_name="Trusted direct channel",
+        expected_owner_user_id=user_id,
+        agent_id=agent_id,
+        new_task_is_visible=False,
+        mcp_runtime_authorization_policy_required=True,
+        task_mode=channel_runtime.ChannelTaskMode.ACTOR_INTERACTION,
+    )
+
+    if prepared is not None:
+        await prepared.managed_lease.finalize_result(status=TaskStatus.FAILED)
+        pytest.fail(f"Actor task with changed {changed_field} was claimed")
+    with SessionLocal() as db:
+        task = db.get(Task, task_id)
+        assert task is not None
+        assert task.status == TaskStatus.WAITING_FOR_USER
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_actor_interaction_claim_rechecks_agent_visibility(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+) -> None:
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    agent_id = _add_agent(SessionLocal, user_id=user_id, name="Actor Agent")
+    with SessionLocal() as db:
+        other_user = User(username="other-owner", password_hash="hash")
+        db.add(other_user)
+        db.commit()
+        other_user_id = int(other_user.id)
+    monkeypatch.setattr(channel_runtime, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    task_id = await _create_waiting_actor_task(
+        SessionLocal,
+        channel_id=channel_id,
+        agent_id=agent_id,
+    )
+    load_task = channel_runtime._load_actor_interaction_task
+
+    def hide_agent_after_validation(db, **kwargs):
+        task, agent = load_task(db, **kwargs)
+        agent.user_id = other_user_id
+        db.commit()
+        return task, agent
+
+    monkeypatch.setattr(
+        channel_runtime,
+        "_load_actor_interaction_task",
+        hide_agent_after_validation,
+    )
+
+    prepared = await prepare_channel_task(
+        channel_id=channel_id,
+        external_user_id="telegram-user",
+        active_task_id=task_id,
+        text="approve",
+        channel_name="Trusted direct channel",
+        expected_owner_user_id=user_id,
+        agent_id=agent_id,
+        new_task_is_visible=False,
+        mcp_runtime_authorization_policy_required=True,
+        task_mode=channel_runtime.ChannelTaskMode.ACTOR_INTERACTION,
+    )
+
+    if prepared is not None:
+        await prepared.managed_lease.finalize_result(status=TaskStatus.FAILED)
+        pytest.fail("Actor task with a hidden agent was claimed")
+    with SessionLocal() as db:
+        task = db.get(Task, task_id)
+        assert task is not None
+        assert task.status == TaskStatus.WAITING_FOR_USER
+    engine.dispose()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("invalid_field", ["source", "status", "policy"])
 async def test_actor_interaction_rejects_invalid_task_without_fallback(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/web/services/test_channel_runtime.py
+++ b/tests/web/services/test_channel_runtime.py
@@ -300,6 +300,59 @@ async def test_actor_interaction_reuses_exact_waiting_task(
 
 
 @pytest.mark.asyncio
+async def test_actor_interaction_claim_rechecks_waiting_status(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+) -> None:
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    agent_id = _add_agent(SessionLocal, user_id=user_id, name="Actor Agent")
+    monkeypatch.setattr(channel_runtime, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    task_id = await _create_waiting_actor_task(
+        SessionLocal,
+        channel_id=channel_id,
+        agent_id=agent_id,
+    )
+    load_task = channel_runtime._load_actor_interaction_task
+
+    def terminate_after_validation(db, **kwargs):
+        task, agent = load_task(db, **kwargs)
+        task.status = TaskStatus.COMPLETED
+        db.commit()
+        return task, agent
+
+    monkeypatch.setattr(
+        channel_runtime,
+        "_load_actor_interaction_task",
+        terminate_after_validation,
+    )
+
+    prepared = await prepare_channel_task(
+        channel_id=channel_id,
+        external_user_id="telegram-user",
+        active_task_id=task_id,
+        text="approve",
+        channel_name="Trusted direct channel",
+        expected_owner_user_id=user_id,
+        agent_id=agent_id,
+        new_task_is_visible=False,
+        mcp_runtime_authorization_policy_required=True,
+        task_mode=channel_runtime.ChannelTaskMode.ACTOR_INTERACTION,
+    )
+
+    if prepared is not None:
+        await prepared.managed_lease.finalize_result(status=TaskStatus.FAILED)
+        pytest.fail("The terminal actor task was claimed again")
+    with SessionLocal() as db:
+        task = db.get(Task, task_id)
+        assert task is not None
+        assert task.status == TaskStatus.COMPLETED
+    engine.dispose()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("invalid_field", ["source", "status", "policy"])
 async def test_actor_interaction_rejects_invalid_task_without_fallback(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/web/services/test_channel_runtime.py
+++ b/tests/web/services/test_channel_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from datetime import timedelta
 from pathlib import Path
 
 import pytest
@@ -30,7 +31,7 @@ from xagent.web.services.channel_runtime import (
     prepare_channel_task,
     register_channel_uploaded_files,
 )
-from xagent.web.services.task_lease_service import TaskLease
+from xagent.web.services.task_lease_service import TaskLease, utc_now
 from xagent.web.services.task_runtime import (
     MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY,
 )
@@ -245,6 +246,39 @@ async def test_actor_marker_forces_new_channel_task_hidden(
 
 
 @pytest.mark.asyncio
+async def test_actor_task_persists_policy_identity(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+) -> None:
+    del mock_workspace_db
+    engine, SessionLocal, _user_id, channel_id = _create_channel_session_local(tmp_path)
+    monkeypatch.setattr(channel_runtime, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+
+    prepared = await prepare_channel_task(
+        channel_id=channel_id,
+        external_user_id="telegram-user",
+        active_task_id=None,
+        text="trusted actor message",
+        channel_name="Trusted direct channel",
+        mcp_runtime_authorization_policy_required=True,
+        mcp_runtime_authorization_policy_identity="actor:alice",
+    )
+
+    assert prepared is not None
+    with SessionLocal() as db:
+        task = db.get(Task, prepared.task_id)
+        assert task is not None
+        assert task.agent_config == {
+            MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY: True,
+            "mcp_runtime_authorization_policy_identity": "actor:alice",
+        }
+    assert await prepared.managed_lease.finalize_result(status=TaskStatus.FAILED)
+    engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_actor_interaction_reuses_exact_waiting_task(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
@@ -296,6 +330,61 @@ async def test_actor_interaction_reuses_exact_waiting_task(
         assert task.output is None
         assert task.error_message is None
     assert await prepared.managed_lease.finalize_result(status=TaskStatus.FAILED)
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_actor_interaction_rejects_live_waiting_lease(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+) -> None:
+    """A waiting task is not reclaimable until its prior lease is released."""
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    agent_id = _add_agent(SessionLocal, user_id=user_id, name="Actor Agent")
+    monkeypatch.setattr(channel_runtime, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(
+        "xagent.web.services.task_lease_service.get_runner_id",
+        lambda: "shared-runner",
+    )
+    task_id = await _create_waiting_actor_task(
+        SessionLocal,
+        channel_id=channel_id,
+        agent_id=agent_id,
+    )
+    with SessionLocal() as db:
+        task = db.get(Task, task_id)
+        assert task is not None
+        task.runner_id = "shared-runner"
+        task.run_id = "waiting-run"
+        task.lease_attempt_id = "waiting-attempt"
+        task.lease_expires_at = utc_now() + timedelta(minutes=5)
+        db.commit()
+
+    prepared = await prepare_channel_task(
+        channel_id=channel_id,
+        external_user_id="telegram-user",
+        active_task_id=task_id,
+        text="approve",
+        channel_name="Trusted direct channel",
+        expected_owner_user_id=user_id,
+        agent_id=agent_id,
+        new_task_is_visible=False,
+        mcp_runtime_authorization_policy_required=True,
+        task_mode=channel_runtime.ChannelTaskMode.ACTOR_INTERACTION,
+    )
+
+    if prepared is not None:
+        await prepared.managed_lease.finalize_result(status=TaskStatus.FAILED)
+        pytest.fail("The live waiting lease was overwritten")
+    with SessionLocal() as db:
+        task = db.get(Task, task_id)
+        assert task is not None
+        assert task.status == TaskStatus.WAITING_FOR_USER
+        assert task.run_id == "waiting-run"
+        assert task.lease_attempt_id == "waiting-attempt"
     engine.dispose()
 
 

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -2814,7 +2814,11 @@ async def test_schedule_bg_forwards_execution_message_to_execute_task_background
     assert kwargs["context"]["turn_id"] == payload.turn_id
     assert kwargs["context"]["existing"] == "value"
     assert kwargs["mcp_runtime_authorization_policy"] is actor_policy
-    agent_manager.remove_agent.assert_called_once_with(int(task.id), int(user.id))
+    agent_manager.remove_agent.assert_called_once_with(
+        int(task.id),
+        int(user.id),
+        expected_run_id=fake_lease.run_id,
+    )
     assert get_ephemeral_runtime_values(payload.turn_id) is None
     assert pop_ephemeral_runtime_values(payload.turn_id) is None
 

--- a/tests/web/services/test_task_runtime_bindings.py
+++ b/tests/web/services/test_task_runtime_bindings.py
@@ -20,6 +20,7 @@ from xagent.core.task_runtime import (
 )
 from xagent.web.services.task_runtime import (
     CLIENT_RESERVED_AGENT_CONFIG_KEYS,
+    MCP_RUNTIME_AUTHORIZATION_POLICY_IDENTITY_KEY,
     MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY,
     SELECTED_FILE_IDS_AGENT_CONFIG_KEY,
     TASK_RUNTIME_BINDINGS_AGENT_CONFIG_KEY,
@@ -259,14 +260,15 @@ async def test_delete_reports_bindings_whose_provider_is_no_longer_registered(
 def test_actor_policy_marker_is_reserved_from_client_config() -> None:
     forged = {
         MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY: True,
+        MCP_RUNTIME_AUTHORIZATION_POLICY_IDENTITY_KEY: "actor:forged",
         "keep": "client value",
     }
 
     assert sanitize_client_agent_config(forged) == {"keep": "client value"}
-    assert (
-        MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY
-        in CLIENT_RESERVED_AGENT_CONFIG_KEYS
-    )
+    assert {
+        MCP_RUNTIME_AUTHORIZATION_POLICY_REQUIRED_KEY,
+        MCP_RUNTIME_AUTHORIZATION_POLICY_IDENTITY_KEY,
+    }.issubset(CLIENT_RESERVED_AGENT_CONFIG_KEYS)
 
 
 def test_execution_scope_is_reserved_so_a_request_cannot_choose_a_namespace() -> None:
@@ -306,6 +308,7 @@ def test_the_reserved_key_set_has_exactly_the_audited_members() -> None:
             "runtime_extension_bindings",
             "execution_scope",
             "__xagent_mcp_runtime_authorization_policy_required",
+            "mcp_runtime_authorization_policy_identity",
             "selected_file_ids",
             "__xagent_file_operation_access_version",
             # Public-channel identity/quota markers (#1108).


### PR DESCRIPTION
## Background

The actor task-context foundation is now available on upstream `main` through #1916. The remaining approval-continuation seam previously lived in [bsbds/xagent#91](https://github.com/bsbds/xagent/pull/91).

A trusted channel can claim the exact external actor task that is waiting for user input. Before this change, agent reconstruction still applied the default actor-task reuse guard after that claim. The continuation therefore failed even though the boundary had already validated and claimed the intended task.

## Goal

Permit an explicit actor interaction to start a new model turn in the exact existing task. This supports approval-button continuation without creating a replacement task.

## Behavior

- Add `ChannelTaskMode.ACTOR_INTERACTION` at the channel task boundary.
- Require the exact active task, expected owner and agent, external source, `WAITING_FOR_USER` state, and actor-policy marker before claim.
- Claim that task through the existing lease path and move it to `RUNNING`.
- Permit agent reconstruction only for the explicitly claimed actor-interaction task.
- Restore the existing task conversation, execution, and recovered-skill context.
- Keep default actor messages fresh-task-only.
- Reject invalid or unavailable tasks without a replacement-task fallback.

## Boundaries

This PR does not add a public reply endpoint, checkpoint resume, a migration, generic actor-task reuse, or approval persistence.

## Rejected behavior

- Default actor turns cannot reuse an existing task.
- An unclaimed `WAITING_FOR_USER` task cannot be reconstructed.
- A stale, foreign, non-external, non-waiting, or unmarked task cannot continue.
- A failed actor continuation cannot create a replacement task.

## Accepted errors and trade-offs

Invalid lineage or policy fails closed. Agent unavailability also fails without fallback. Lease contention keeps the existing busy/claim behavior. This is a model-guided new turn from task history, not exact tool-checkpoint resume.

## Validation

- `pytest -n auto tests/web/services/test_channel_runtime.py tests/web/api/test_actor_task_context.py` — 45 passed
- `pre-commit run --all-files` — passed