### PR TITLE
fix: defer contended durable form responses on #1901's base

### DIFF
--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -156,7 +156,12 @@ from ..services.mcp_runtime import (
     MCPBuiltinOAuthActorPolicy,
     MCPBuiltinOAuthActorPolicyRequiredError,
 )
-from ..services.task_command_terminal_events import is_external_cancel_command
+from ..services.task_command_terminal_events import (
+    TerminalTaskEventDraft,
+    TerminalTaskEventMessageCode,
+    bind_terminal_event_draft,
+    is_external_cancel_command,
+)
 from ..services.task_command_transport import (
     COMMAND_FAILED,
     COMMAND_ID_PATTERN,
@@ -4222,6 +4227,7 @@ class BackgroundTaskManager:
         # a newer run as an idempotent success.
         self._resume_run_ids: dict[int, str | None] = {}
         self._resume_reservations: set[int] = set()
+        self._resume_owner_started_at: dict[int, float] = {}
         self._shutting_down = False
         self._shutdown_lock = asyncio.Lock()
 
@@ -4234,6 +4240,7 @@ class BackgroundTaskManager:
             or self.resume_tasks
             or self._resume_run_ids
             or self._resume_reservations
+            or self._resume_owner_started_at
         ):
             raise RuntimeError("Background task manager still owns background work")
         # asyncio synchronization primitives are bound to the event loop that
@@ -4307,7 +4314,16 @@ class BackgroundTaskManager:
         if existing is not None:
             self.resume_tasks.pop(task_id, None)
             self._resume_run_ids.pop(task_id, None)
+            self._resume_owner_started_at.pop(task_id, None)
         return None
+
+    def resume_holder_age_seconds(self, task_id: int) -> float | None:
+        """Return the local resume-slot holder's monotonic age, if known."""
+
+        started_at = self._resume_owner_started_at.get(task_id)
+        if started_at is None:
+            return None
+        return max(0.0, time.monotonic() - started_at)
 
     def try_reserve_resume(
         self,
@@ -4326,6 +4342,7 @@ class BackgroundTaskManager:
         if existing_state is not None:
             return existing_state
         self._resume_reservations.add(task_id)
+        self._resume_owner_started_at[task_id] = time.monotonic()
         return ResumeReservationOutcome.RESERVED
 
     def reserve_resume(self, task_id: int) -> bool:
@@ -4353,6 +4370,7 @@ class BackgroundTaskManager:
         if task_id not in self._resume_reservations:
             raise RuntimeError(f"Task {task_id} has no reserved resume slot")
         self._resume_reservations.discard(task_id)
+        self._resume_owner_started_at.setdefault(task_id, time.monotonic())
         self.resume_tasks[task_id] = task
         self._resume_run_ids[task_id] = run_id
         logger.info("Registered resume coordinator for task %s", task_id)
@@ -4361,6 +4379,7 @@ class BackgroundTaskManager:
         if self._shutting_down:
             return
         self._resume_reservations.discard(task_id)
+        self._resume_owner_started_at.pop(task_id, None)
 
     def promote_resume_task(self, task_id: int, task: asyncio.Task) -> None:
         if self._shutting_down:
@@ -4397,6 +4416,7 @@ class BackgroundTaskManager:
         if resume_task is not None and owns_registration(resume_task):
             self.resume_tasks.pop(task_id, None)
             self._resume_run_ids.pop(task_id, None)
+            self._resume_owner_started_at.pop(task_id, None)
             logger.info("Cleaned up resume coordinator for task %s", task_id)
 
     async def cancel_task(
@@ -4412,6 +4432,12 @@ class BackgroundTaskManager:
             )
             if task is not None
         }
+        if not self._shutting_down:
+            # A cancel can race the await between reservation and coordinator
+            # registration. Clear that pre-registration owner even when there
+            # is no asyncio task to cancel yet.
+            self._resume_reservations.discard(task_id)
+            self._resume_owner_started_at.pop(task_id, None)
         if not tasks:
             return BackgroundTaskCancelOutcome(requested=False)
 
@@ -4441,7 +4467,6 @@ class BackgroundTaskManager:
             self.running_tasks.pop(task_id, None)
             self.resume_tasks.pop(task_id, None)
             self._resume_run_ids.pop(task_id, None)
-            self._resume_reservations.discard(task_id)
         return BackgroundTaskCancelOutcome(requested=requested)
 
     async def shutdown(self) -> None:
@@ -4473,6 +4498,7 @@ class BackgroundTaskManager:
                 self.resume_tasks.clear()
                 self._resume_run_ids.clear()
                 self._resume_reservations.clear()
+                self._resume_owner_started_at.clear()
 
 
 # Global background task manager
@@ -6512,7 +6538,46 @@ async def _handle_chat_message_unserialized(
             if task_uses_live_control and supports_live_control:
                 logger.info(f"Using agent message control for task {task_id}")
                 assert agent_service is not None
-                if not background_task_manager.reserve_resume(task_id):
+                reservation = background_task_manager.try_reserve_resume(
+                    task_id,
+                    expected_run_id=task_run_id,
+                )
+                if reservation is not ResumeReservationOutcome.RESERVED:
+                    if suppress_delivery_ack:
+                        # Durable commands own their retry budget. All three
+                        # occupied states can clear without this attempt doing
+                        # anything: a reservation can register or release, a
+                        # coordinator can finish, and shutdown is retained as
+                        # a defensive state even though normal shutdown stops
+                        # the dispatcher before setting the manager flag.
+                        holder_age_seconds = (
+                            background_task_manager.resume_holder_age_seconds(task_id)
+                        )
+                        holder_age_text = (
+                            f"{holder_age_seconds:.3f}"
+                            if holder_age_seconds is not None
+                            else "unknown"
+                        )
+                        logger.info(
+                            "Deferring message %s for task %s: resume slot "
+                            "unavailable (%s), holder_age_seconds=%s",
+                            turn_id,
+                            task_id,
+                            reservation.value,
+                            holder_age_text,
+                        )
+                        message_data["_durable_command_defer"] = turn_id
+                        message_data["_durable_command_defer_reason"] = (
+                            f"Message {turn_id} is waiting for the live-control "
+                            f"resume slot ({reservation.value})"
+                        )
+                        if recovered_delivery is not None:
+                            # A prior attempt claimed the durable delivery and
+                            # may have injected it. Task/run-local occupancy is
+                            # not evidence that this command owns the live
+                            # coordinator after a worker handoff.
+                            message_data["_durable_command_defer_unsafe"] = turn_id
+                        return
                     await finish_delivery(
                         False,
                         CLIENT_SAFE_GUIDANCE_IN_PROGRESS,
@@ -9394,6 +9459,21 @@ async def _execute_durable_task_command(
         await _handle_chat_message_unserialized(
             websocket, command.task_id, message_data
         )
+        if message_data.get("_durable_command_defer") == command.command_id:
+            # This marker is mutually exclusive with commit-outcome-unknown:
+            # the handler returns immediately after recording contention.
+            raise TaskCommandDeferred(
+                str(message_data["_durable_command_defer_reason"]),
+                resend_safe=(
+                    # Every settled contention increments defer_count once.
+                    # Equality proves there is no extra expired/failed claim
+                    # whose worker might still resume and inject after this
+                    # attempt observed no delivery row.
+                    command.attempt_count == command.defer_count + 1
+                    and message_data.get("_durable_command_defer_unsafe")
+                    != command.command_id
+                ),
+            )
         if message_data.get("_commit_outcome_unknown") == command.command_id:
             raise ClientVisibleTaskCommandDeferred(
                 f"Message {command.command_id} has an unknown commit outcome"
@@ -9614,6 +9694,45 @@ async def _broadcast_terminal_command_error(
     )
 
 
+async def _terminal_command_event_draft(
+    command: ClaimedTaskCommand,
+    error: BaseException,
+) -> TerminalTaskEventDraft:
+    """Build safe presentation metadata; disposition code persists it."""
+
+    scope = _command_scope(command)
+    if is_external_cancel_command(kind=command.kind.value, scope=scope):
+        try:
+            task_status = await _load_terminal_command_task_status(command.task_id)
+        except Exception as exc:
+            logger.warning(
+                "Could not classify external terminal command outcome; "
+                "using conservative client message task_id=%s error_type=%s",
+                command.task_id,
+                type(exc).__name__,
+            )
+            task_status = None
+        return TerminalTaskEventDraft(
+            message_code=(
+                TerminalTaskEventMessageCode.EXTERNAL_TURN_INTERRUPTED
+                if task_status in {TaskStatus.COMPLETED, TaskStatus.FAILED}
+                else TerminalTaskEventMessageCode.EXTERNAL_CANCEL_NOT_APPLIED
+            ),
+            resend_safe=False,
+            include_command_identity=False,
+        )
+    return TerminalTaskEventDraft(
+        message_code=(
+            TerminalTaskEventMessageCode.TASK_COMMAND_DEFERRED
+            if isinstance(error, TaskCommandDeferred)
+            else TerminalTaskEventMessageCode.TASK_COMMAND_FAILED
+        ),
+        resend_safe=(
+            error.resend_safe if isinstance(error, TaskCommandDeferred) else False
+        ),
+    )
+
+
 async def execute_durable_task_command(
     command: ClaimedTaskCommand,
 ) -> dict[str, Any] | None:
@@ -9624,6 +9743,10 @@ async def execute_durable_task_command(
     except TaskCommandDeferred as exc:
         if command.defer_count + 1 >= MAX_COMMAND_DEFERS:
             _command_origins.discard_command(command.command_id, command.task_id)
+            bind_terminal_event_draft(
+                exc,
+                await _terminal_command_event_draft(command, exc),
+            )
             await _broadcast_terminal_command_error(command, exc)
         # A deferral that will retry keeps its origin entry.
         raise
@@ -9635,6 +9758,10 @@ async def execute_durable_task_command(
     except Exception as exc:
         if command.failure_count + 1 >= MAX_COMMAND_FAILURES:
             _command_origins.discard_command(command.command_id, command.task_id)
+            bind_terminal_event_draft(
+                exc,
+                await _terminal_command_event_draft(command, exc),
+            )
             await _broadcast_terminal_command_error(command, exc)
         raise
     _command_origins.discard_command(command.command_id, command.task_id)

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -4467,6 +4467,7 @@ class BackgroundTaskManager:
             self.running_tasks.pop(task_id, None)
             self.resume_tasks.pop(task_id, None)
             self._resume_run_ids.pop(task_id, None)
+            self._resume_owner_started_at.pop(task_id, None)
         return BackgroundTaskCancelOutcome(requested=requested)
 
     async def shutdown(self) -> None:
@@ -9469,6 +9470,13 @@ async def _execute_durable_task_command(
                     # Equality proves there is no extra expired/failed claim
                     # whose worker might still resume and inject after this
                     # attempt observed no delivery row.
+                    #
+                    # The equality couples two write sites: claiming is the
+                    # only writer of attempt_count and defer_task_command the
+                    # only writer of defer_count. retry_failed_task_command
+                    # resets defer_count but not attempt_count, so an
+                    # operator-retried command can never prove safety again
+                    # (the safe direction for a duplicate-send decision).
                     command.attempt_count == command.defer_count + 1
                     and message_data.get("_durable_command_defer_unsafe")
                     != command.command_id

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -77,7 +77,16 @@ class TaskCommandTaskMissing(ValueError):
 
 
 class TaskCommandDeferred(RuntimeError):
-    """The command is durable but its downstream handoff is still pending."""
+    """The command is durable but its downstream handoff is still pending.
+
+    ``resend_safe`` is true only when the failed handoff proves this command
+    never reached the downstream operation. The terminal-event projection can
+    then tell the sender to retry without risking a duplicate.
+    """
+
+    def __init__(self, message: str, *, resend_safe: bool = False) -> None:
+        super().__init__(message)
+        self.resend_safe = resend_safe
 
 
 class TaskCommandRejected(RuntimeError):

--- a/tests/web/api/test_durable_message_resume_contention.py
+++ b/tests/web/api/test_durable_message_resume_contention.py
@@ -1,0 +1,380 @@
+"""Durable form responses defer while the live-control resume slot is busy."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from typing import Iterator
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from xagent.web.api import websocket as websocket_api
+from xagent.web.api.websocket import (
+    ResumeReservationOutcome,
+    execute_durable_task_command,
+)
+from xagent.web.models.chat_message import TaskChatMessage
+from xagent.web.models.database import Base, get_db, get_engine, init_db
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task_command import TaskExecutionCommand
+from xagent.web.models.task_command_terminal_event import TaskCommandTerminalEvent
+from xagent.web.models.user import User
+from xagent.web.services.chat_history_service import DELIVERY_PENDING
+from xagent.web.services.task_command_transport import (
+    COMMAND_COMPLETED,
+    COMMAND_FAILED,
+    COMMAND_PENDING,
+    COMMAND_PROCESSING,
+    MAX_COMMAND_DEFERS,
+    ClaimedTaskCommand,
+    TaskCommandDeferred,
+    TaskCommandKind,
+    dispatch_one_task_command,
+    enqueue_task_command,
+    get_runner_id,
+)
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    init_db(db_url=f"sqlite:///{tmp_path / 'resume_contention.db'}")
+    db = next(get_db())
+    try:
+        yield db
+    finally:
+        db.close()
+        Base.metadata.drop_all(bind=get_engine())
+
+
+def _user(db, username: str) -> User:
+    user = User(username=username, password_hash="x", is_admin=False)
+    db.add(user)
+    db.commit()
+    db.refresh(user)
+    return user
+
+
+def _live_task(db, owner_id: int) -> Task:
+    task = Task(
+        user_id=owner_id,
+        title="t",
+        description="d",
+        status=TaskStatus.RUNNING,
+        execution_mode="balanced",
+        source="sdk",
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    task.runner_id = "live-runner"
+    task.run_id = "live-run"
+    db.commit()
+    return task
+
+
+def _message_command(
+    task: Task,
+    owner: User,
+    command_id: str,
+    *,
+    attempt_count: int = 1,
+) -> ClaimedTaskCommand:
+    return ClaimedTaskCommand(
+        id=1,
+        task_id=int(task.id),
+        actor_user_id=int(owner.id),
+        command_id=command_id,
+        kind=TaskCommandKind.MESSAGE,
+        payload={
+            "type": "chat_message",
+            "message": "apply this form response once",
+            "client_message_id": command_id,
+            "files": [],
+        },
+        target_run_id="live-run",
+        attempt_count=attempt_count,
+    )
+
+
+@contextmanager
+def _live_control_environment(
+    *,
+    outcome: ResumeReservationOutcome | None = None,
+    background_manager=None,
+) -> Iterator[tuple[MagicMock, object]]:
+    agent = MagicMock()
+    agent.supports_live_control.return_value = True
+    agent.get_dag_pattern.return_value = None
+    agent.post_user_message = AsyncMock(return_value=True)
+    if background_manager is None:
+        background_manager = MagicMock()
+        background_manager.try_reserve_resume.return_value = outcome
+        background_manager.resume_holder_age_seconds.return_value = None
+        background_manager.running_tasks.get.return_value = None
+
+    with (
+        patch(
+            "xagent.web.api.chat.get_agent_manager",
+            return_value=MagicMock(get_agent_for_task=AsyncMock(return_value=agent)),
+        ),
+        patch(
+            "xagent.web.api.websocket.manager",
+            MagicMock(
+                broadcast_to_task=AsyncMock(),
+                send_personal_message=AsyncMock(),
+            ),
+        ),
+        patch("xagent.web.api.websocket.execute_resume_background", AsyncMock()),
+        patch(
+            "xagent.web.api.websocket.background_task_manager",
+            background_manager,
+        ),
+    ):
+        yield agent, background_manager
+
+
+@pytest.mark.asyncio
+async def test_cancel_clears_pre_registration_resume_reservation() -> None:
+    background_manager = websocket_api.BackgroundTaskManager()
+    assert (
+        background_manager.try_reserve_resume(7, expected_run_id="live-run")
+        is ResumeReservationOutcome.RESERVED
+    )
+    assert background_manager.resume_holder_age_seconds(7) is not None
+
+    outcome = await background_manager.cancel_task(7)
+
+    assert outcome.requested is False
+    assert background_manager.resume_holder_age_seconds(7) is None
+    assert (
+        background_manager.try_reserve_resume(7, expected_run_id="live-run")
+        is ResumeReservationOutcome.RESERVED
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        ResumeReservationOutcome.RESERVATION_HELD,
+        ResumeReservationOutcome.COORDINATOR_RUNNING,
+        ResumeReservationOutcome.SHUTTING_DOWN,
+    ],
+)
+async def test_contended_durable_message_defers_without_injection(
+    db_session,
+    outcome: ResumeReservationOutcome,
+) -> None:
+    owner = _user(db_session, f"contention-owner-{outcome.value}")
+    task = _live_task(db_session, int(owner.id))
+    command = _message_command(task, owner, "form-turn")
+
+    with (
+        _live_control_environment(outcome=outcome) as (agent, _),
+        pytest.raises(TaskCommandDeferred) as exc_info,
+    ):
+        await execute_durable_task_command(command)
+
+    assert "resume slot" in str(exc_info.value)
+    assert exc_info.value.resend_safe is True
+    agent.post_user_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_recovered_delivery_makes_contention_unsafe_to_resend(
+    db_session,
+) -> None:
+    owner = _user(db_session, "recovered-delivery-owner")
+    task = _live_task(db_session, int(owner.id))
+    command_id = "recovered-form-turn"
+    db_session.add(
+        TaskChatMessage(
+            task_id=int(task.id),
+            user_id=int(owner.id),
+            role="user",
+            message_type="user_message",
+            content="apply this form response once",
+            turn_id=command_id,
+            delivery_status=DELIVERY_PENDING,
+        )
+    )
+    db_session.commit()
+    command = _message_command(
+        task,
+        owner,
+        command_id,
+        attempt_count=2,
+    )
+
+    with (
+        _live_control_environment(
+            outcome=ResumeReservationOutcome.RESERVATION_HELD
+        ) as (agent, _),
+        pytest.raises(TaskCommandDeferred) as exc_info,
+    ):
+        await execute_durable_task_command(command)
+
+    assert exc_info.value.resend_safe is False
+    agent.post_user_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_reclaims_and_applies_message_after_contention_clears(
+    db_session,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    caplog.set_level("INFO", logger=websocket_api.__name__)
+    owner = _user(db_session, "eventual-delivery-owner")
+    task = _live_task(db_session, int(owner.id))
+    task.runner_id = get_runner_id()
+    task.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=1)
+    db_session.commit()
+
+    enqueued = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(owner.id),
+        command_id="eventual-form-turn",
+        kind=TaskCommandKind.MESSAGE,
+        payload={
+            "type": "chat_message",
+            "message": "apply this form response once",
+            "client_message_id": "eventual-form-turn",
+            "files": [],
+        },
+    )
+    db_session.commit()
+
+    background_manager = websocket_api.BackgroundTaskManager()
+    assert (
+        background_manager.try_reserve_resume(
+            int(task.id),
+            expected_run_id="live-run",
+        )
+        is ResumeReservationOutcome.RESERVED
+    )
+    with _live_control_environment(background_manager=background_manager) as (
+        agent,
+        _,
+    ):
+        assert await dispatch_one_task_command(
+            execute_durable_task_command,
+            command_db_id=enqueued.command_id,
+        )
+
+        db_session.expire_all()
+        stored = db_session.get(TaskExecutionCommand, enqueued.command_id)
+        assert stored is not None
+        assert stored.status == COMMAND_PENDING
+        assert stored.failure_count == 0
+        assert stored.defer_count == 1
+        assert "holder_age_seconds=" in caplog.text
+        assert "holder_age_seconds=unknown" not in caplog.text
+
+        background_manager.release_resume_reservation(int(task.id))
+        stored.claim_expires_at = None
+        db_session.commit()
+        assert await dispatch_one_task_command(
+            execute_durable_task_command,
+            command_db_id=enqueued.command_id,
+        )
+        await asyncio.sleep(0)
+
+    db_session.expire_all()
+    stored = db_session.get(TaskExecutionCommand, enqueued.command_id)
+    assert stored is not None
+    assert stored.status == COMMAND_COMPLETED
+    assert stored.failure_count == 0
+    assert stored.defer_count == 1
+    agent.post_user_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("unsettled_prior_claim", "recovered_delivery", "expected_resend_safe"),
+    [
+        (False, False, True),
+        # Models worker B reclaiming an expired attempt from worker A before
+        # worker A notices claim loss. The missing delivery row is not durable
+        # proof that worker A cannot resume and inject after this read.
+        (True, False, False),
+        (True, True, False),
+    ],
+)
+async def test_exhausted_contention_persists_evidence_based_resend_safety(
+    db_session,
+    unsettled_prior_claim: bool,
+    recovered_delivery: bool,
+    expected_resend_safe: bool,
+) -> None:
+    owner = _user(
+        db_session,
+        f"terminal-owner-{unsettled_prior_claim}-{recovered_delivery}",
+    )
+    task = _live_task(db_session, int(owner.id))
+    task.runner_id = get_runner_id()
+    task.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=1)
+    db_session.commit()
+    command_id = f"terminal-form-turn-{unsettled_prior_claim}-{recovered_delivery}"
+    enqueued = enqueue_task_command(
+        db_session,
+        task_id=int(task.id),
+        actor_user_id=int(owner.id),
+        command_id=command_id,
+        kind=TaskCommandKind.MESSAGE,
+        payload={
+            "type": "chat_message",
+            "message": "apply this form response once",
+            "client_message_id": command_id,
+            "files": [],
+        },
+    )
+    stored = db_session.get(TaskExecutionCommand, enqueued.command_id)
+    assert stored is not None
+    stored.defer_count = MAX_COMMAND_DEFERS - 1
+    # Each prior clean contention both claimed and deferred once. A stale
+    # worker adds one unmatched claim that the reclaiming worker must treat as
+    # possible in-flight injection evidence even when no delivery row exists.
+    stored.attempt_count = MAX_COMMAND_DEFERS - 1
+    if unsettled_prior_claim:
+        stored.status = COMMAND_PROCESSING
+        stored.claimed_by = "stale-worker"
+        stored.claim_expires_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+        stored.attempt_count += 1
+    if recovered_delivery:
+        db_session.add(
+            TaskChatMessage(
+                task_id=int(task.id),
+                user_id=int(owner.id),
+                role="user",
+                message_type="user_message",
+                content="apply this form response once",
+                turn_id=command_id,
+                delivery_status=DELIVERY_PENDING,
+            )
+        )
+    db_session.commit()
+
+    with _live_control_environment(
+        outcome=ResumeReservationOutcome.RESERVATION_HELD
+    ) as (agent, _):
+        assert await dispatch_one_task_command(
+            execute_durable_task_command,
+            command_db_id=enqueued.command_id,
+        )
+
+    db_session.expire_all()
+    stored = db_session.get(TaskExecutionCommand, enqueued.command_id)
+    assert stored is not None
+    assert stored.status == COMMAND_FAILED
+    assert stored.failure_count == 0
+    assert stored.defer_count == MAX_COMMAND_DEFERS
+    event = (
+        db_session.query(TaskCommandTerminalEvent)
+        .filter(TaskCommandTerminalEvent.task_command_id == enqueued.command_id)
+        .one()
+    )
+    assert event.resend_safe is expected_resend_safe
+    agent.post_user_message.assert_not_awaited()

--- a/tests/web/api/test_durable_message_resume_contention.py
+++ b/tests/web/api/test_durable_message_resume_contention.py
@@ -270,6 +270,13 @@ async def test_dispatcher_reclaims_and_applies_message_after_contention_clears(
         assert stored.status == COMMAND_PENDING
         assert stored.failure_count == 0
         assert stored.defer_count == 1
+        # A defer that still has budget must not stage a terminal event.
+        assert (
+            db_session.query(TaskCommandTerminalEvent)
+            .filter(TaskCommandTerminalEvent.task_command_id == enqueued.command_id)
+            .count()
+            == 0
+        )
         assert "holder_age_seconds=" in caplog.text
         assert "holder_age_seconds=unknown" not in caplog.text
 
@@ -300,6 +307,9 @@ async def test_dispatcher_reclaims_and_applies_message_after_contention_clears(
         # worker A notices claim loss. The missing delivery row is not durable
         # proof that worker A cannot resume and inject after this read.
         (True, False, False),
+        # A recovered delivery row alone must force unsafe even when the
+        # claim arithmetic is clean: this pins the marker term in isolation.
+        (False, True, False),
         (True, True, False),
     ],
 )

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -2247,7 +2247,9 @@ async def test_chat_validation_redacts_both_the_ack_and_the_broadcast(
         send_personal_message=AsyncMock(),
     )
     bg_mgr = MagicMock()
-    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.try_reserve_resume.return_value = (
+        websocket_api.ResumeReservationOutcome.RESERVED
+    )
 
     def _fake_error_payload(task_id: int, message: str, **kwargs: object) -> dict:
         payload = {"type": "agent_error", "message": message, "task_id": task_id}
@@ -2307,7 +2309,9 @@ def _chat_runtime_error_harness(secret_error: Exception):
         send_personal_message=AsyncMock(),
     )
     bg_mgr = MagicMock()
-    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.try_reserve_resume.return_value = (
+        websocket_api.ResumeReservationOutcome.RESERVED
+    )
 
     def _fake_error_payload(task_id: int, message: str, **kwargs: object) -> dict:
         payload = {"type": "agent_error", "message": message, "task_id": task_id}

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -1242,7 +1242,7 @@ async def test_running_chat_message_is_persisted_before_resume(db_session) -> No
     )
     resume_bg = AsyncMock()
     bg_mgr = MagicMock()
-    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.try_reserve_resume.return_value = ResumeReservationOutcome.RESERVED
     bg_mgr.running_tasks.get.return_value = None
 
     with (
@@ -1434,7 +1434,7 @@ async def test_running_chat_message_uses_one_offloop_scope_and_no_request_sessio
     )
     resume_bg = AsyncMock()
     bg_manager = MagicMock()
-    bg_manager.reserve_resume.return_value = True
+    bg_manager.try_reserve_resume.return_value = ResumeReservationOutcome.RESERVED
     bg_manager.running_tasks.get.return_value = None
 
     try:
@@ -1501,7 +1501,7 @@ async def test_deferred_chat_message_is_acked_after_durable_command_commit(
     )
     resume_bg = AsyncMock()
     bg_mgr = MagicMock()
-    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.try_reserve_resume.return_value = ResumeReservationOutcome.RESERVED
     bg_mgr.running_tasks.get.return_value = None
     websocket = MagicMock()
 
@@ -1581,7 +1581,7 @@ async def test_live_lease_injection_degrades_to_deferred_on_checkpoint_unavailab
     )
     resume_bg = AsyncMock()
     bg_mgr = MagicMock()
-    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.try_reserve_resume.return_value = ResumeReservationOutcome.RESERVED
     bg_mgr.running_tasks.get.return_value = None
     websocket = MagicMock()
 
@@ -1703,7 +1703,7 @@ async def test_durable_failure_keeps_detail_sender_only(
     )
     resume_bg = AsyncMock()
     bg_mgr = MagicMock()
-    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.try_reserve_resume.return_value = ResumeReservationOutcome.RESERVED
     bg_mgr.running_tasks.get.return_value = None
     origin_socket = MagicMock(name="origin-socket")
     payload = {
@@ -1817,7 +1817,7 @@ async def test_attachment_bind_race_keeps_specific_failure_on_origin_lane(
     agent.get_dag_pattern.return_value = None
     agent_manager = MagicMock(get_agent_for_task=AsyncMock(return_value=agent))
     bg_manager = MagicMock()
-    bg_manager.reserve_resume.return_value = True
+    bg_manager.try_reserve_resume.return_value = ResumeReservationOutcome.RESERVED
     bg_manager.running_tasks.get.return_value = None
 
     with (
@@ -1882,7 +1882,7 @@ async def test_resume_registration_failure_keeps_injected_delivery_pending(
         send_personal_message=AsyncMock(),
     )
     bg_mgr = MagicMock()
-    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.try_reserve_resume.return_value = ResumeReservationOutcome.RESERVED
     bg_mgr.running_tasks.get.return_value = None
     bg_mgr.register_reserved_resume.side_effect = RuntimeError("reservation lost")
     bg_handle = MagicMock()
@@ -1948,7 +1948,7 @@ async def test_live_marker_failure_after_registered_handoff_is_still_accepted(
         send_personal_message=AsyncMock(),
     )
     bg_mgr = MagicMock()
-    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.try_reserve_resume.return_value = ResumeReservationOutcome.RESERVED
     bg_mgr.running_tasks.get.return_value = None
 
     with (
@@ -2019,7 +2019,7 @@ async def test_live_resume_reads_the_interaction_row_before_injecting(
         send_personal_message=AsyncMock(),
     )
     bg_mgr = MagicMock()
-    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.try_reserve_resume.return_value = ResumeReservationOutcome.RESERVED
     bg_mgr.running_tasks.get.return_value = None
 
     with (
@@ -2076,7 +2076,7 @@ async def test_live_close_failure_after_registered_handoff_is_still_accepted(
         send_personal_message=AsyncMock(),
     )
     bg_mgr = MagicMock()
-    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.try_reserve_resume.return_value = ResumeReservationOutcome.RESERVED
     bg_mgr.running_tasks.get.return_value = None
 
     with (
@@ -2135,7 +2135,7 @@ async def test_live_close_cancellation_does_not_abort_registered_handoff(
         send_personal_message=AsyncMock(),
     )
     bg_mgr = MagicMock()
-    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.try_reserve_resume.return_value = ResumeReservationOutcome.RESERVED
     bg_mgr.running_tasks.get.return_value = None
 
     def raise_cancelled(*_args: object, **_kwargs: object) -> int:
@@ -2348,7 +2348,7 @@ async def test_message_handoff_registers_the_minted_run_not_the_stale_one(
         send_personal_message=AsyncMock(),
     )
     bg_mgr = MagicMock()
-    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.try_reserve_resume.return_value = ResumeReservationOutcome.RESERVED
     bg_mgr.running_tasks.get.return_value = None
     registered_run_ids: list[str | None] = []
     registered_handles: list[asyncio.Task] = []
@@ -2428,7 +2428,7 @@ async def test_live_marker_cancellation_does_not_cancel_registered_handoff(
         send_personal_message=AsyncMock(),
     )
     bg_mgr = MagicMock()
-    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.try_reserve_resume.return_value = ResumeReservationOutcome.RESERVED
     bg_mgr.running_tasks.get.return_value = None
     marker_started = threading.Event()
     marker_release = threading.Event()
@@ -2734,7 +2734,7 @@ async def test_live_control_delivery_failure_pool_timeout_is_not_retried(
         send_personal_message=AsyncMock(),
     )
     bg_mgr = MagicMock()
-    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.try_reserve_resume.return_value = ResumeReservationOutcome.RESERVED
     mark_delivery = MagicMock(
         side_effect=SQLAlchemyTimeoutError("delivery pool exhausted")
     )
@@ -2800,7 +2800,7 @@ async def test_delivery_failure_persistence_drains_before_cancellation(
         send_personal_message=AsyncMock(),
     )
     bg_manager = MagicMock()
-    bg_manager.reserve_resume.return_value = True
+    bg_manager.try_reserve_resume.return_value = ResumeReservationOutcome.RESERVED
     persistence_started = threading.Event()
     allow_persistence = threading.Event()
     persistence_finished = threading.Event()


### PR DESCRIPTION
## Summary

- defer durable `message` commands when any live-control resume-slot contention state is observed (`reservation_held`, `coordinator_running`, `shutting_down`) instead of consuming the failure budget
- bound contention retries with the existing `defer_count` budget and preserve reclaim-to-completion behavior
- persist evidence-based terminal resend safety through #1901's `bind_terminal_event_draft` seam: a cleanly settled deferral history (`attempt_count == defer_count + 1`, no recovered delivery) is safe to resend; a recovered delivery or unmatched claim remains unsafe
- track and log resume-slot holder age, including symmetric cleanup for reservation-only cancellation racing ahead of coordinator registration

Closes #1469.
Supersedes #1926 (and, transitively, the closed #1484).

## Why this re-slice

#1926 carried the same layer on top of the full terminal-event stack (#1901 → #1902 → #1903 → #1904), which put four unmerged PRs in front of #1469 and therefore in front of #1500's groundwork. This PR rebuilds the identical behavior directly on #1901:

- the `resend_safe` evidence now lands via `bind_terminal_event_draft` (the seam #1901 ships exactly for this), so the persisted `TaskCommandTerminalEvent` row carries the disposition without any delivery/replay machinery;
- the small draft-builder helper (`_terminal_command_event_draft`) is ported here; when #1904 rebases, that hunk collapses into its layer;
- the process-local terminal broadcast is kept intact — durable cross-worker delivery and reconnect replay remain #1858's open half, implemented by #1904.

Dependency: #1901 — **merged 2026-08-31** (`19f503fa`). This branch is now based directly on current `main`, so GitHub's full diff against `main` is the correct standalone diff for this layer.

The rebase onto merged `main` surfaced one more stale `reserve_resume` mock in a test added on `main` during the prerequisite window (`test_attachment_bind_race_keeps_specific_failure_on_origin_lane`); it is adapted to `try_reserve_resume` the same way as the other fourteen. Focused suites re-run green after the rebase: 490 passed.

Ride-along fix: 14 stale `reserve_resume` mocks in `tests/web/api/test_websocket_owner_actor.py` are updated to `try_reserve_resume` — the production switch in this layer makes them fail otherwise (they fail the same way on #1926's branch, whose verification list did not include this suite).

## Verification

- new focused regression module `tests/web/api/test_durable_message_resume_contention.py` (9 tests): all three contention states defer without injection, dispatcher reclaims and applies after contention clears, exhausted contention persists evidence-based resend safety (3 parametrizations), recovered delivery makes the outcome unsafe
- related suites green: `test_websocket_owner_actor.py` (75), `test_websocket_client_safe_errors.py`, `test_external_task_cancel.py`, `test_durable_resume_contention.py`, `test_task_command_transport.py`, `test_task_command_terminal_events.py`, `test_a2a_api.py` — 379 passed, 0 failed
- full `tests/web` run: green except the two `test_svg_preview_cache.py` tests, which fail locally for lack of libcairo (environment-only; unrelated module)
- Ruff check/format clean; mypy reports no new errors in touched files
- PostgreSQL-parametrized tests were skipped locally because `XAGENT_TEST_POSTGRES_URL` is not configured

## Out of scope (pre-existing, tracked)

- exhausted-deferral client wording that states the command was **not applied** (instead of restating the waited-on condition): moved into #1500's scope on 2026-08-26 per the tracking issue #1487
- frontend consumption of structured terminal command outcomes and the retry decision: #1500
- durable cross-worker terminal-event delivery and reconnect replay: #1858 (remaining half, PR #1904)
- exhausted-deferral message delivery row reconciliation: #1736
- terminal notice being sent before the terminal write is confirmed: #1735
- frontend upload retry and rejection surfacing: #1468

