### PR TITLE
refactor(events-stream): require the steps-version reader on the attach fast paths

### DIFF
--- a/src/xagent/web/api/v1/_events_stream.py
+++ b/src/xagent/web/api/v1/_events_stream.py
@@ -1584,8 +1584,8 @@ def _fast_path_steps_read_error_frame(
     exc: BaseException, task_id: int, path_name: str
 ) -> str:
     """Close frame for a failure preparing the fast path's step snapshot
-    -- either the cursor baseline read (``read_task_steps_version``, when
-    supplied) or the steps read itself (``_fast_path_step_snapshot``).
+    -- either the cursor baseline read (``read_task_steps_version``) or
+    the steps read itself (``_fast_path_step_snapshot``).
     Both run inside the same ``try`` in ``_fast_path_snapshot_stream``,
     shared by both attach-time fast paths' ``except`` blocks below, so
     this is called whichever of the two actually raised and the wording
@@ -1825,7 +1825,7 @@ async def _fast_path_snapshot_stream(
     *,
     build_conclusion: ConclusionFrameBuilder,
     path_name: str,
-    read_task_steps_version: TaskStepsVersionReader | None = None,
+    read_task_steps_version: TaskStepsVersionReader,
 ) -> AsyncIterator[str]:
     """Body shared by both attach-time fast paths (``_terminal_snapshot_stream``,
     ``_input_required_snapshot_stream``): emit ``task.status``, the
@@ -1853,9 +1853,8 @@ async def _fast_path_snapshot_stream(
 
     ``task.status`` is emitted first, then the steps read runs inside a
     ``try``/``except`` that also covers the cursor baseline capture
-    below (when ``read_task_steps_version`` is supplied) -- both reads
-    have to succeed before any step content is trusted, so a failure in
-    either is handled identically. A bare exception here
+    below -- both reads have to succeed before any step content is trusted,
+    so a failure in either is handled identically. A bare exception here
     would not produce a different HTTP status: ``StreamingResponse``
     sends the response start (200, headers) before ever pulling a chunk
     from this generator, so letting the read's exception propagate
@@ -1890,8 +1889,7 @@ async def _fast_path_snapshot_stream(
     conclusion already sent. Step content is the part that can go
     stale, so it goes out only once the task row has been read once
     more and confirmed to still be ``snapshot``'s own generation
-    (``_fast_path_generation_changed``), and, when
-    ``read_task_steps_version`` is supplied, once the steps cursor
+    (``_fast_path_generation_changed``), and once the steps cursor
     (``max_event_id``) is confirmed unmoved too
     (``_fast_path_steps_cursor_changed``). A trace row can land after
     the steps read and before this recheck; the same commit that lands
@@ -1899,25 +1897,25 @@ async def _fast_path_snapshot_stream(
     (``last_checkpoint_event_id``/``last_checkpoint_trace_event_id``,
     ``trace_handlers.py``, gated on the task being ``RUNNING``) without
     ever setting ``run_id`` or ``state_version``, so the
-    run_id/state_version reread alone cannot see that write either way.
-    ``read_task_steps_version`` defaults to ``None`` for callers that
-    don't need this second signal (existing unit tests exercising the
-    run_id/state_version fence on its own); the live attach endpoint
-    always supplies it. When it is supplied, its *baseline* read is
-    unconditional -- captured before the steps read even runs, inside
-    the same guard block described above, whether or not that read
-    ends up returning any steps or fails outright -- because the window
-    this second signal guards starts at that read, not after it. The
-    *recheck* against that baseline is what actually gates on step
-    content: like the run_id/state_version reread, it runs only once
-    there is step content to protect, so a failed steps read and an
-    empty one both skip the recheck (not the baseline, which already
-    ran by then). A step-carrying attach that reaches this fence
-    therefore costs two cursor queries when ``read_task_steps_version``
-    is supplied -- the baseline and the recheck -- on top of the one
-    run_id/state_version reread it already paid, except when that
-    reread already confirmed a change, which short-circuits the
-    recheck; an attach whose steps
+    run_id/state_version reread alone cannot see that write either way
+    -- ``read_task_steps_version`` is what closes that gap, which is
+    why it is required here rather than defaulted: a caller with no way
+    to check the cursor would have no way to catch a row landing in
+    that window.
+
+    Its *baseline* read is unconditional -- captured before the steps
+    read even runs, inside the same guard block described above,
+    whether or not that read ends up returning any steps or fails
+    outright -- because the window this second signal guards starts at
+    that read, not after it. The *recheck* against that baseline is
+    what actually gates on step content: like the run_id/state_version
+    reread, it runs only once there is step content to protect, so a
+    failed steps read and an empty one both skip the recheck (not the
+    baseline, which already ran by then). A step-carrying attach that
+    reaches this fence therefore costs two cursor queries -- the
+    baseline and the recheck -- on top of the one run_id/state_version
+    reread it already paid, except when that reread already confirmed a
+    change, which short-circuits the recheck; an attach whose steps
     turn out empty, or whose steps read fails, still pays for the
     baseline alone. A confirmed match on both signals sends the steps,
     then the conclusion. A confirmed change on either means the steps
@@ -1941,12 +1939,9 @@ async def _fast_path_snapshot_stream(
         # guards is "a trace row lands after steps are read, before the
         # fence rechecks", so the reference point has to predate the read
         # it is meant to protect. See ``_fast_path_steps_cursor_changed``.
-        steps_version_before = None
-        if read_task_steps_version is not None:
-            version_reader = read_task_steps_version
-            steps_version_before = await run_db_io_cancellation_safe(
-                lambda: version_reader(task_id, principal)
-            )
+        steps_version_before = await run_db_io_cancellation_safe(
+            lambda: read_task_steps_version(task_id, principal)
+        )
         steps, snapshot_total_steps = await _fast_path_step_snapshot(
             task_id, principal, read_task_steps_response
         )
@@ -1964,12 +1959,7 @@ async def _fast_path_snapshot_stream(
             changed = await _fast_path_generation_changed(
                 snapshot, principal, read_task_snapshot
             )
-            if not changed and read_task_steps_version is not None:
-                # ``steps_version_before`` was captured above under the
-                # same ``read_task_steps_version is not None`` guard, so
-                # it is never ``None`` here -- mypy can't carry that
-                # invariant across the two ``if`` blocks on its own.
-                assert steps_version_before is not None
+            if not changed:
                 changed = await _fast_path_steps_cursor_changed(
                     task_id,
                     steps_version_before.max_event_id,
@@ -2015,7 +2005,7 @@ def _terminal_snapshot_stream(
     principal: "ApiKeyPrincipal",
     read_task_steps_response: TaskStepsResponseReader,
     read_task_snapshot: TaskSnapshotReader,
-    read_task_steps_version: TaskStepsVersionReader | None = None,
+    read_task_steps_version: TaskStepsVersionReader,
 ) -> AsyncIterator[str]:
     """Attach-time fast path for an already-terminal task: emit
     ``task.status``, the task's current steps, then ``task.completed``,
@@ -2059,7 +2049,7 @@ def _input_required_snapshot_stream(
     principal: "ApiKeyPrincipal",
     read_task_steps_response: TaskStepsResponseReader,
     read_task_snapshot: TaskSnapshotReader,
-    read_task_steps_version: TaskStepsVersionReader | None = None,
+    read_task_steps_version: TaskStepsVersionReader,
 ) -> AsyncIterator[str]:
     """Attach-time fast path for a task already waiting on user input (and
     not mid-resume): emit ``task.status``, the task's current steps, then
@@ -2252,7 +2242,7 @@ async def build_event_stream_response(
     initial_snapshot: "_TaskInfoSnapshot",
     read_task_snapshot: TaskSnapshotReader,
     read_task_steps_response: TaskStepsResponseReader,
-    read_task_steps_version: TaskStepsVersionReader | None = None,
+    read_task_steps_version: TaskStepsVersionReader,
     watchdog_interval_seconds: float = WATCHDOG_INTERVAL_SECONDS,
     stream_max_duration_seconds: float = STREAM_MAX_DURATION_SECONDS,
     heartbeat_interval_seconds: float = HEARTBEAT_INTERVAL_SECONDS,
@@ -2278,9 +2268,9 @@ async def build_event_stream_response(
     write the task row itself (a checkpoint-pointer ``UPDATE``, see
     ``_fast_path_steps_cursor_changed``) never touch ``run_id`` or
     ``state_version``, so the run_id/state_version reread alone cannot
-    see it either way. Defaults to ``None``
-    (skips the cursor reread) only so callers that aren't exercising it
-    don't have to supply a reader; the router below always does.
+    see it either way. ``read_task_steps_version`` is required rather
+    than defaulted: a caller with no way to check the cursor would have
+    no way to catch a row landing in that window.
     """
     close_reason = _stream_close_reason(
         initial_snapshot.status, initial_snapshot.control_state

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -4612,7 +4612,15 @@ def test_fast_paths_without_a_steps_version_reader_is_a_call_error():
     between the steps read and the fence, and a reader-less call would
     otherwise run the fast path with that signal silently absent. This
     pins the call itself as the failure point -- a ``TypeError`` naming
-    the argument, raised before any reader runs."""
+    the argument, raised before any reader runs.
+
+    ``build_event_stream_response`` is pinned the same way. It is the
+    only entry point a caller outside this module reaches, so a default
+    restored there would accept reader-less attaches even with all three
+    inner entry points still required. Its own missing-argument
+    ``TypeError`` is raised at the call, not at the await: binding
+    happens before the coroutine object exists, so nothing is left
+    un-awaited by the assertion below."""
 
     def _unused(task_id_, principal_):
         raise AssertionError("must not run before the missing-argument TypeError")
@@ -4650,6 +4658,15 @@ def test_fast_paths_without_a_steps_version_reader_is_a_call_error():
             read_task_snapshot=_unused,
             build_conclusion=lambda snapshot_total_steps: "",
             path_name="terminal",
+        )
+
+    with pytest.raises(TypeError, match="read_task_steps_version"):
+        es.build_event_stream_response(
+            task_id=1,
+            principal=None,
+            initial_snapshot=terminal_snapshot,
+            read_task_snapshot=_unused,
+            read_task_steps_response=_unused,
         )
 
 

--- a/tests/web/api/v1/test_events_stream.py
+++ b/tests/web/api/v1/test_events_stream.py
@@ -494,6 +494,7 @@ async def test_events_paused_attach_does_not_take_a_fast_path():
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
     )
     first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
@@ -535,6 +536,7 @@ async def test_sse_responses_disable_proxy_buffering(task_state):
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
     )
     try:
@@ -591,6 +593,7 @@ async def test_fast_path_failure_sends_the_response_start_before_its_close_frame
         initial_snapshot=snapshot,
         read_task_snapshot=_unreachable_read_task_snapshot,
         read_task_steps_response=_broken_read_task_steps_response,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
     )
 
     messages: list[dict] = []
@@ -732,6 +735,7 @@ async def test_generator_read_path_keeps_queued_wire_bytes_at_zero_between_frame
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
     )
     first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
@@ -960,6 +964,7 @@ async def test_real_delete_route_closes_stream_with_task_deleted():
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(watchdog_interval_seconds=0.01),
     )
     first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
@@ -1013,6 +1018,7 @@ async def test_watchdog_survives_transient_check_failure_and_still_closes():
         initial_snapshot=snapshot,
         read_task_snapshot=flaky_reader,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(watchdog_interval_seconds=0.01),
     )
     first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
@@ -1101,6 +1107,7 @@ async def test_sink_unregistered_after_generator_teardown():
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
     )
     first = await resp.body_iterator.__anext__()
@@ -1139,6 +1146,7 @@ async def test_unstarted_generator_leaves_no_registration_or_reservation():
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
     )
     # No __anext__() call at all -- the generator body has never run.
@@ -1195,6 +1203,7 @@ async def test_principal_slot_released_after_real_stream_teardown():
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
     )
     await resp.body_iterator.__anext__()
@@ -1282,6 +1291,7 @@ async def test_absolute_deadline_emits_expired_then_closes():
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(
             stream_max_duration_seconds=0.05, heartbeat_interval_seconds=0.01
         ),
@@ -1316,6 +1326,7 @@ async def test_deadline_wait_budget_shrinks_below_the_heartbeat():
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(
             stream_max_duration_seconds=0.05, heartbeat_interval_seconds=5.0
         ),
@@ -1420,6 +1431,7 @@ async def test_close_exactly_once_under_watchdog_deadline_race():
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         watchdog_interval_seconds=0.001,
         stream_max_duration_seconds=0.001,
         heartbeat_interval_seconds=0.001,
@@ -1457,6 +1469,7 @@ async def test_events_per_task_cap_third_stream_429():
             initial_snapshot=snapshot,
             read_task_snapshot=v1_tasks._load_task_info_snapshot,
             read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+            read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
             **_long_intervals(),
         )
         # Real delivery (Starlette) always pulls the first chunk before a
@@ -1473,6 +1486,7 @@ async def test_events_per_task_cap_third_stream_429():
             initial_snapshot=snapshot,
             read_task_snapshot=v1_tasks._load_task_info_snapshot,
             read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+            read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         )
     assert exc_info.value.code is V1ErrorCode.RATE_LIMITED
     assert exc_info.value.http_status == 429
@@ -1544,6 +1558,7 @@ async def test_fast_path_attach_exempt_from_both_caps(fast_path_status, closing_
                 initial_snapshot=running_snapshot,
                 read_task_snapshot=v1_tasks._load_task_info_snapshot,
                 read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+                read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
                 **_long_intervals(),
             )
             await resp.body_iterator.__anext__()
@@ -1664,6 +1679,7 @@ async def test_heartbeat_actually_sent_when_idle():
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(heartbeat_interval_seconds=0.01),
     )
     pings = 0
@@ -1717,6 +1733,7 @@ async def test_broadcast_frame_reaches_generator_output_as_task_status():
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
     )
     first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
@@ -1771,6 +1788,7 @@ async def test_broadcast_content_frames_reach_generator_output_as_step_and_messa
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
     )
     first = await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
@@ -1917,6 +1935,7 @@ async def test_completion_hint_wakes_watchdog_before_its_next_periodic_tick():
         initial_snapshot=snapshot,
         read_task_snapshot=v1_tasks._load_task_info_snapshot,
         read_task_steps_response=v1_tasks._get_chat_task_steps_sync,
+        read_task_steps_version=v1_tasks._load_task_steps_version_snapshot,
         **_long_intervals(),
     )
     await asyncio.wait_for(resp.body_iterator.__anext__(), timeout=2)
@@ -2785,6 +2804,9 @@ async def test_fast_path_step_read_failure_closes_with_resync_required_not_a_bar
             "the generation reread must not run when the steps read itself failed"
         )
 
+    def _read_task_steps_version(task_id_, principal_):
+        return SimpleNamespace(max_event_id=1)
+
     terminal_snapshot = SimpleNamespace(
         task_id=1, agent_id=1, status=TaskStatus.COMPLETED, output="done", error=None
     )
@@ -2795,6 +2817,7 @@ async def test_fast_path_step_read_failure_closes_with_resync_required_not_a_bar
             principal=None,
             read_task_steps_response=_broken_read_task_steps_response,
             read_task_snapshot=_unused_read_task_snapshot,
+            read_task_steps_version=_read_task_steps_version,
         )
     ]
     terminal_body = "".join(terminal_frames)
@@ -2826,6 +2849,7 @@ async def test_fast_path_step_read_failure_closes_with_resync_required_not_a_bar
             principal=None,
             read_task_steps_response=_broken_read_task_steps_response,
             read_task_snapshot=_unused_read_task_snapshot,
+            read_task_steps_version=_read_task_steps_version,
         )
     ]
     waiting_body = "".join(waiting_frames)
@@ -2869,6 +2893,9 @@ async def test_fast_path_task_not_found_closes_with_task_deleted_not_resync_requ
             "the generation reread must not run when the steps read itself failed"
         )
 
+    def _read_task_steps_version(task_id_, principal_):
+        return SimpleNamespace(max_event_id=1)
+
     terminal_snapshot = SimpleNamespace(
         task_id=1, agent_id=1, status=TaskStatus.COMPLETED, output="done", error=None
     )
@@ -2879,6 +2906,7 @@ async def test_fast_path_task_not_found_closes_with_task_deleted_not_resync_requ
             principal=None,
             read_task_steps_response=_deleted_read_task_steps_response,
             read_task_snapshot=_unused_read_task_snapshot,
+            read_task_steps_version=_read_task_steps_version,
         )
     ]
     terminal_body = "".join(terminal_frames)
@@ -2901,6 +2929,7 @@ async def test_fast_path_task_not_found_closes_with_task_deleted_not_resync_requ
             principal=None,
             read_task_steps_response=_deleted_read_task_steps_response,
             read_task_snapshot=_unused_read_task_snapshot,
+            read_task_steps_version=_read_task_steps_version,
         )
     ]
     waiting_body = "".join(waiting_frames)
@@ -2972,6 +3001,9 @@ async def test_fast_path_step_snapshot_is_bounded_by_replay_max_steps(
     def _unchanged_read_task_snapshot(task_id_, principal_):
         return SimpleNamespace(run_id="run-1", state_version=1)
 
+    def _unchanged_read_task_steps_version(task_id_, principal_):
+        return SimpleNamespace(max_event_id=1)
+
     snapshot = SimpleNamespace(
         task_id=1,
         agent_id=1,
@@ -2987,6 +3019,7 @@ async def test_fast_path_step_snapshot_is_bounded_by_replay_max_steps(
             principal=None,
             read_task_steps_response=_read_task_steps_response,
             read_task_snapshot=_unchanged_read_task_snapshot,
+            read_task_steps_version=_unchanged_read_task_steps_version,
         )
     ]
     body = "".join(frames)
@@ -3079,6 +3112,9 @@ async def test_fast_path_step_snapshot_applies_the_replay_cap_before_the_byte_bu
     def _unchanged_read_task_snapshot(task_id_, principal_):
         return SimpleNamespace(run_id="run-1", state_version=1)
 
+    def _unchanged_read_task_steps_version(task_id_, principal_):
+        return SimpleNamespace(max_event_id=1)
+
     snapshot = SimpleNamespace(
         task_id=1,
         agent_id=1,
@@ -3094,6 +3130,7 @@ async def test_fast_path_step_snapshot_applies_the_replay_cap_before_the_byte_bu
             principal=None,
             read_task_steps_response=_read_task_steps_response,
             read_task_snapshot=_unchanged_read_task_snapshot,
+            read_task_steps_version=_unchanged_read_task_steps_version,
         )
     ]
     body = "".join(frames)
@@ -3168,6 +3205,9 @@ async def test_fast_path_step_snapshot_replay_max_steps_boundary(
     def _unchanged_read_task_snapshot(task_id_, principal_):
         return SimpleNamespace(run_id="run-1", state_version=1)
 
+    def _unchanged_read_task_steps_version(task_id_, principal_):
+        return SimpleNamespace(max_event_id=1)
+
     snapshot = SimpleNamespace(
         task_id=1,
         agent_id=1,
@@ -3183,6 +3223,7 @@ async def test_fast_path_step_snapshot_replay_max_steps_boundary(
             principal=None,
             read_task_steps_response=_read_task_steps_response,
             read_task_snapshot=_unchanged_read_task_snapshot,
+            read_task_steps_version=_unchanged_read_task_steps_version,
         )
     ]
     body = "".join(frames)
@@ -3249,6 +3290,9 @@ async def test_fast_path_step_snapshot_is_bounded_by_the_wire_byte_budget(
     def _unchanged_read_task_snapshot(task_id_, principal_):
         return SimpleNamespace(run_id="run-1", state_version=1)
 
+    def _unchanged_read_task_steps_version(task_id_, principal_):
+        return SimpleNamespace(max_event_id=1)
+
     snapshot = SimpleNamespace(
         task_id=1,
         agent_id=1,
@@ -3264,6 +3308,7 @@ async def test_fast_path_step_snapshot_is_bounded_by_the_wire_byte_budget(
             principal=None,
             read_task_steps_response=_read_task_steps_response,
             read_task_snapshot=_unchanged_read_task_snapshot,
+            read_task_steps_version=_unchanged_read_task_steps_version,
         )
     ]
     body = "".join(frames)
@@ -3349,6 +3394,9 @@ async def test_fast_path_snapshot_marks_truncation_when_the_budget_admits_no_ste
             "the generation reread must not run when no step was admitted"
         )
 
+    def _read_task_steps_version(task_id_, principal_):
+        return SimpleNamespace(max_event_id=1)
+
     snapshot = SimpleNamespace(
         task_id=1,
         agent_id=1,
@@ -3364,6 +3412,7 @@ async def test_fast_path_snapshot_marks_truncation_when_the_budget_admits_no_ste
             principal=None,
             read_task_steps_response=_read_task_steps_response,
             read_task_snapshot=_unused_read_task_snapshot,
+            read_task_steps_version=_read_task_steps_version,
         )
     ]
     body = "".join(frames)
@@ -3547,6 +3596,9 @@ async def test_fast_path_generation_change_withholds_steps_but_still_concludes(
         reread_calls.append((task_id_, principal_))
         return SimpleNamespace(**{**original, changed_field: changed_value})
 
+    def _read_task_steps_version(task_id_, principal_):
+        return SimpleNamespace(max_event_id=1)
+
     snapshot = SimpleNamespace(
         task_id=1, agent_id=1, status=status, **original, **extra_snapshot
     )
@@ -3557,6 +3609,7 @@ async def test_fast_path_generation_change_withholds_steps_but_still_concludes(
             principal=_FENCE_PRINCIPAL,
             read_task_steps_response=_read_task_steps_response,
             read_task_snapshot=_reread_task_snapshot,
+            read_task_steps_version=_read_task_steps_version,
         )
     ]
     body = "".join(frames)
@@ -3753,6 +3806,9 @@ async def test_fast_path_failure_exits_never_carry_the_truncation_marker(
         def _read_task_snapshot(task_id_, principal_):
             return SimpleNamespace(run_id="run-new", state_version=1)
 
+    def _read_task_steps_version(task_id_, principal_):
+        return SimpleNamespace(max_event_id=1)
+
     snapshot = SimpleNamespace(
         task_id=1,
         agent_id=1,
@@ -3768,6 +3824,7 @@ async def test_fast_path_failure_exits_never_carry_the_truncation_marker(
             principal=None,
             read_task_steps_response=_read_task_steps_response,
             read_task_snapshot=_read_task_snapshot,
+            read_task_steps_version=_read_task_steps_version,
         )
     ]
     body = "".join(frames)
@@ -4218,6 +4275,9 @@ async def test_fast_path_empty_steps_skips_the_generation_reread(
         reread_calls.append((task_id_, principal_))
         return SimpleNamespace(run_id="run-1", state_version=1)
 
+    def _read_task_steps_version(task_id_, principal_):
+        return SimpleNamespace(max_event_id=1)
+
     snapshot = SimpleNamespace(
         task_id=1,
         agent_id=1,
@@ -4233,6 +4293,7 @@ async def test_fast_path_empty_steps_skips_the_generation_reread(
             principal=_FENCE_PRINCIPAL,
             read_task_steps_response=_read_task_steps_response,
             read_task_snapshot=_reread_task_snapshot,
+            read_task_steps_version=_read_task_steps_version,
         )
     ]
     body = "".join(frames)
@@ -4272,11 +4333,14 @@ async def test_fast_path_generation_reread_failure_concludes_then_closes_for_res
     this path read is withheld since its generation was never confirmed,
     and the accompanying ``stream.error`` must describe what actually
     happened -- the reread itself failed -- not claim the task moved to a
-    new run, which was never established either way. ``read_task_steps_version``
-    is not supplied here, so this exercises
-    ``_fast_path_generation_reread_error_frame``'s generic wording on
-    its own, independent of the cursor recheck that can also route
-    through it (see ``test_fast_path_steps_cursor_recheck_failure_closes_for_resync_or_deleted``).
+    new run, which was never established either way. The raise happens
+    on the run_id/state_version reread itself, before the cursor recheck
+    that can also route through the same error frame ever runs (see
+    ``_fast_path_snapshot_stream``'s ``if not changed:`` guard), so this
+    exercises ``_fast_path_generation_reread_error_frame``'s generic
+    wording for that reread on its own (see
+    ``test_fast_path_steps_cursor_recheck_failure_closes_for_resync_or_deleted``
+    for the cursor-recheck leg of the same error frame).
     """
     base = datetime(2026, 1, 1, 12, 0, 0, tzinfo=UTC)
     step = es.PublicStep(
@@ -4299,6 +4363,9 @@ async def test_fast_path_generation_reread_failure_concludes_then_closes_for_res
         reread_calls.append((task_id_, principal_))
         raise RuntimeError("transient DB error rereading task snapshot")
 
+    def _read_task_steps_version(task_id_, principal_):
+        return SimpleNamespace(max_event_id=1)
+
     snapshot = SimpleNamespace(
         task_id=1,
         agent_id=1,
@@ -4314,6 +4381,7 @@ async def test_fast_path_generation_reread_failure_concludes_then_closes_for_res
             principal=_FENCE_PRINCIPAL,
             read_task_steps_response=_read_task_steps_response,
             read_task_snapshot=_raising_reread,
+            read_task_steps_version=_read_task_steps_version,
         )
     ]
     body = "".join(frames)
@@ -4387,6 +4455,9 @@ async def test_fast_path_generation_reread_task_deleted_closes_with_task_deleted
         reread_calls.append((task_id_, principal_))
         raise V1ApiError(V1ErrorCode.TASK_NOT_FOUND, 404)
 
+    def _read_task_steps_version(task_id_, principal_):
+        return SimpleNamespace(max_event_id=1)
+
     snapshot = SimpleNamespace(
         task_id=1,
         agent_id=1,
@@ -4402,6 +4473,7 @@ async def test_fast_path_generation_reread_task_deleted_closes_with_task_deleted
             principal=_FENCE_PRINCIPAL,
             read_task_steps_response=_read_task_steps_response,
             read_task_snapshot=_deleted_reread,
+            read_task_steps_version=_read_task_steps_version,
         )
     ]
     body = "".join(frames)
@@ -4490,6 +4562,9 @@ async def test_fast_path_unserializable_step_concludes_then_closes_for_resync(
     def _reread_task_snapshot(task_id_, principal_):
         return SimpleNamespace(run_id="run-1", state_version=1)
 
+    def _read_task_steps_version(task_id_, principal_):
+        return SimpleNamespace(max_event_id=1)
+
     snapshot = SimpleNamespace(
         task_id=1,
         agent_id=1,
@@ -4505,6 +4580,7 @@ async def test_fast_path_unserializable_step_concludes_then_closes_for_resync(
             principal=None,
             read_task_steps_response=_read_task_steps_response,
             read_task_snapshot=_reread_task_snapshot,
+            read_task_steps_version=_read_task_steps_version,
         )
     ]
     body = "".join(frames)
@@ -4519,6 +4595,62 @@ async def test_fast_path_unserializable_step_concludes_then_closes_for_resync(
     # The wording names serialization, not a read and not a restart.
     assert "Serializing the task's steps failed" in body
     assert "moved to a new run" not in body
+
+
+def test_fast_paths_without_a_steps_version_reader_is_a_call_error():
+    """``read_task_steps_version`` is a required argument on all three
+    attach-time fast-path entry points -- ``_terminal_snapshot_stream``,
+    ``_input_required_snapshot_stream``, and the
+    ``_fast_path_snapshot_stream`` body they share -- not one carrying a
+    default.
+
+    ``build_event_stream_response`` always forwards its own reader into
+    whichever of the three it picks, so no caller inside this module can
+    reach one of them without a reader in hand. Requiredness is what
+    keeps that true for a caller outside it: the cursor baseline read
+    and its recheck are the only signal that catches a trace row landing
+    between the steps read and the fence, and a reader-less call would
+    otherwise run the fast path with that signal silently absent. This
+    pins the call itself as the failure point -- a ``TypeError`` naming
+    the argument, raised before any reader runs."""
+
+    def _unused(task_id_, principal_):
+        raise AssertionError("must not run before the missing-argument TypeError")
+
+    terminal_snapshot = SimpleNamespace(
+        task_id=1, agent_id=1, status=TaskStatus.COMPLETED, output="done", error=None
+    )
+    with pytest.raises(TypeError, match="read_task_steps_version"):
+        es._terminal_snapshot_stream(
+            terminal_snapshot,
+            principal=None,
+            read_task_steps_response=_unused,
+            read_task_snapshot=_unused,
+        )
+
+    waiting_snapshot = SimpleNamespace(
+        task_id=1,
+        agent_id=1,
+        status=TaskStatus.WAITING_FOR_USER,
+        pending_question="what next?",
+    )
+    with pytest.raises(TypeError, match="read_task_steps_version"):
+        es._input_required_snapshot_stream(
+            waiting_snapshot,
+            principal=None,
+            read_task_steps_response=_unused,
+            read_task_snapshot=_unused,
+        )
+
+    with pytest.raises(TypeError, match="read_task_steps_version"):
+        es._fast_path_snapshot_stream(
+            terminal_snapshot,
+            principal=None,
+            read_task_steps_response=_unused,
+            read_task_snapshot=_unused,
+            build_conclusion=lambda snapshot_total_steps: "",
+            path_name="terminal",
+        )
 
 
 # ===== single-frame content byte cap =====


### PR DESCRIPTION
The two attach-time fast paths in `src/xagent/web/api/v1/_events_stream.py` --
`_terminal_snapshot_stream` and `_input_required_snapshot_stream`, plus
`_fast_path_snapshot_stream`, the body they share -- declared
`read_task_steps_version` as `TaskStepsVersionReader | None = None` and gated two
blocks on `read_task_steps_version is not None`: the steps-cursor baseline read
that runs before the steps read, and the recheck of that baseline that runs
before any step content is released. `build_event_stream_response` carried the
same optional parameter and forwarded whatever it was handed.

Neither `is not None` branch could take its `None` leg in production.

## Why the branches were dead

`build_event_stream_response` is the only caller of either fast path:

```
$ grep -rn --include='*.py' -E '_terminal_snapshot_stream\(|_input_required_snapshot_stream\(' src/
src/xagent/web/api/v1/_events_stream.py:2280:            _terminal_snapshot_stream(
src/xagent/web/api/v1/_events_stream.py:2291:            _input_required_snapshot_stream(
```

and `build_event_stream_response` itself has exactly one caller, the
`GET /v1/tasks/{task_id}/events` handler, which has always passed a real reader:

```
$ grep -rn --include='*.py' 'build_event_stream_response(' src/
src/xagent/web/api/v1/tasks.py:1550:    return await _events_stream.build_event_stream_response(
src/xagent/web/api/v1/_events_stream.py:2238:async def build_event_stream_response(
```

```python
# src/xagent/web/api/v1/tasks.py:1550
return await _events_stream.build_event_stream_response(
    task_id=task_id,
    principal=principal,
    initial_snapshot=snapshot,
    read_task_snapshot=_load_task_info_snapshot,
    read_task_steps_response=_get_chat_task_steps_sync,
    read_task_steps_version=_load_task_steps_version_snapshot,
)
```

So on every real attach both guarded blocks ran. The `None` legs were reachable
only from tests that constructed the generators directly and left the argument
off.

Optional is also the wrong shape for this parameter. The steps cursor is the
only signal that catches a trace row landing between the fast path's steps read
and its fence: the commit that lands such a row updates the task's checkpoint
pointer (`last_checkpoint_event_id` / `last_checkpoint_trace_event_id`) without
ever touching `run_id` or `state_version`, so the run_id/state_version reread
cannot see it either way. A caller that omitted the reader would not get a
smaller guarantee announced at the boundary -- it would run the fast path with
that signal silently absent and still send the steps.

## What changed

- Drop the `| None = None` default on `_fast_path_snapshot_stream`,
  `_terminal_snapshot_stream`, `_input_required_snapshot_stream` and
  `build_event_stream_response`, making the reader required.
- Delete the two `is not None` branches. The baseline read and the recheck now
  run unconditionally, which is what every real attach already did.
- Delete the `assert steps_version_before is not None` that existed only to
  carry the invariant from the first branch into the second for mypy; with one
  unconditional assignment it is no longer needed.
- Rewrite the docstring paragraphs that described the "when supplied"
  conditional behaviour, in `_fast_path_snapshot_stream`,
  `build_event_stream_response` and `_fast_path_steps_read_error_frame`.
- Update 34 call sites in `tests/web/api/v1/test_events_stream.py` that relied
  on the default. These have to move in the same commit: once the parameter is
  required, a call that omits it raises `TypeError` before any of the test body
  runs. 19 of them go through `build_event_stream_response` and now pass
  the router's own `_load_task_steps_version_snapshot`; the other 15 construct a
  fast-path generator directly and pass a small stub returning a constant
  `max_event_id`. A constant reader can never report the cursor as moved, so
  none of those tests' assertions change -- they were written to isolate the
  run_id/state_version fence and still do.
- Add `test_fast_paths_without_a_steps_version_reader_is_a_call_error`, pinning
  requiredness on all three fast-path entry points: a `TypeError` naming the
  argument, raised before any reader runs.

## Verification

```
$ pytest tests/web/api/v1/test_events_stream.py -q
155 passed in 40.52s

$ mypy --package xagent
(no errors reported in _events_stream.py or api/v1/tasks.py)

$ ruff check src/xagent/web/api/v1/_events_stream.py tests/web/api/v1/test_events_stream.py
All checks passed!

$ ruff format --check src/xagent/web/api/v1/_events_stream.py tests/web/api/v1/test_events_stream.py
2 files already formatted
```
