### PR TITLE
fix(compaction): keep context compaction on the summary path

### DIFF
--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -54,6 +54,15 @@ from .skill_tool import (
 READ_FILE_CONTEXT_LIMIT = 12_000
 COMPACT_SUMMARY_MAX_TOKENS = 8192
 COMPACT_SUMMARY_MIN_TOKENS = 256
+# Budgets to fall back through when the requested one is refused, largest
+# first. The request is derived from the model's *input* window while
+# providers cap the *output* separately and much lower, and that limit is not
+# recorded anywhere -- so the budget is a guess and this ladder lets the
+# provider correct it. 1024 is here because it was the ceiling before this
+# change and is therefore known to work; skipping straight to the floor would
+# hand a reasoning model an allowance it can spend entirely on reasoning,
+# producing no summary and truncating anyway.
+COMPACT_SUMMARY_FALLBACK_BUDGETS = (1024, COMPACT_SUMMARY_MIN_TOKENS)
 COMPACT_CONTEXT_REF_MAX_TOKENS = 2048
 COMPACT_DROPPED_REF_NOTICE_MAX_CHARS = 2048
 COMPACT_DROPPED_TOOL_NOTICE_MAX_CHARS = 1024

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -58,11 +58,23 @@ COMPACT_SUMMARY_MIN_TOKENS = 256
 # first. The request is derived from the model's *input* window while
 # providers cap the *output* separately and much lower, and that limit is not
 # recorded anywhere -- so the budget is a guess and this ladder lets the
-# provider correct it. 1024 is here because it was the ceiling before this
-# change and is therefore known to work; skipping straight to the floor would
-# hand a reasoning model an allowance it can spend entirely on reasoning,
-# producing no summary and truncating anyway.
-COMPACT_SUMMARY_FALLBACK_BUDGETS = (1024, COMPACT_SUMMARY_MIN_TOKENS)
+# provider correct it.
+#
+# The rungs are dense between the ceiling and the floor because the first
+# budget the provider *accepts* is the one the summary gets written with, and
+# a reasoning model draws its reasoning from that same allowance: accepted is
+# not the same as sufficient. A ladder of only (1024, 256) meant a model
+# capped at 4096 fell from 8192 straight to 1024 -- the very allowance this
+# change raised the ceiling to get away from -- and produced a reasoning trace
+# instead of a summary. Halving keeps the first accepted rung as large as the
+# cap allows.
+#
+# Descending stops at the first accepted budget even when its response turns
+# out to be unusable. Usability is monotone in the budget: a response is
+# unusable because the allowance was too small for the model to finish, so
+# every smaller rung is unusable too and stepping further down only spends
+# requests to reach the same truncation.
+COMPACT_SUMMARY_FALLBACK_BUDGETS = (4096, 2048, 1024, COMPACT_SUMMARY_MIN_TOKENS)
 COMPACT_CONTEXT_REF_MAX_TOKENS = 2048
 COMPACT_DROPPED_REF_NOTICE_MAX_CHARS = 2048
 COMPACT_DROPPED_TOOL_NOTICE_MAX_CHARS = 1024

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -48,7 +48,7 @@ from .skill_tool import (
 )
 
 READ_FILE_CONTEXT_LIMIT = 12_000
-COMPACT_SUMMARY_MAX_TOKENS = 1024
+COMPACT_SUMMARY_MAX_TOKENS = 8192
 COMPACT_SUMMARY_MIN_TOKENS = 256
 COMPACT_CONTEXT_REF_MAX_TOKENS = 2048
 COMPACT_DROPPED_REF_NOTICE_MAX_CHARS = 2048
@@ -1399,6 +1399,25 @@ class ExecutionContext:
         ]
 
     def _llm_compact_max_tokens(self) -> int:
+        """Output budget for the compaction summary.
+
+        Two bounds, both load-bearing. ``threshold // 4`` is what keeps
+        compaction from looping: the post-compaction context is the summary
+        plus the latest user message, so a summary bounded by a quarter of the
+        threshold is necessarily well under the threshold that triggered this
+        pass. ``COMPACT_SUMMARY_MAX_TOKENS`` bounds it in absolute terms,
+        because the threshold scales with the *input* window while providers
+        cap the *output* separately and much lower -- at a 1M-token window,
+        ``threshold // 4`` alone would ask for ~187k output tokens and the
+        request would simply be rejected, collapsing compaction to the
+        message-dropping fallback it exists to avoid.
+
+        The absolute ceiling was 1024, which bound at every realistic window
+        and left no room for a reasoning model, whose reasoning is drawn from
+        this same allowance and could consume it entirely before any summary
+        text was emitted. 8192 clears that while staying under the output
+        limits mainstream providers actually enforce.
+        """
         return max(
             COMPACT_SUMMARY_MIN_TOKENS,
             min(COMPACT_SUMMARY_MAX_TOKENS, self.compact_config.threshold // 4),

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -17,6 +17,10 @@ from ...context_ref import (
     split_tool_result_supersedes_scope,
 )
 from ...file_ref import FILE_REF_MODEL_INSTRUCTIONS
+from ...model.chat.types import (
+    CONTENT_SOURCE_KEY,
+    CONTENT_SOURCE_REASONING_FALLBACK,
+)
 from ...tools.artifacts import (
     format_tool_result_for_observation,
     sanitize_tool_result_for_public_context,
@@ -1146,7 +1150,11 @@ class ExecutionContext:
         original_tokens: int | None = None,
     ) -> CompactResult:
         original_count = len(self.messages)
-        summary = self._compact_response_text(response).strip()
+        summary = (
+            ""
+            if self._is_reasoning_fallback(response)
+            else self._compact_response_text(response).strip()
+        )
         if not summary:
             return CompactResult(
                 compacted=False,
@@ -1441,6 +1449,28 @@ class ExecutionContext:
                 if context_refs_text:
                     chunks.append(context_refs_text)
         return "\n".join(chunks)
+
+    @staticmethod
+    def _is_reasoning_fallback(response: Any) -> bool:
+        """True when the client substituted a reasoning trace for content.
+
+        A reasoning model that spends its whole output budget thinking returns
+        no content, and the OpenAI-compatible client surfaces the trace in its
+        place so a caller does not read a truncated-but-healthy response as an
+        empty one -- reasonable for a connection test, wrong here. The summary
+        replaces every prior message, so accepting a chain of thought as the
+        summary rewrites the agent's history into deliberation it never
+        concluded. Better to have no summary and fall back to dropping
+        messages, which at least leaves real ones.
+
+        The client declares the substitution rather than leaving it to be
+        recognised by shape, so this cannot drift apart from the code that
+        performs it.
+        """
+        return (
+            isinstance(response, dict)
+            and response.get(CONTENT_SOURCE_KEY) == CONTENT_SOURCE_REASONING_FALLBACK
+        )
 
     def _compact_response_text(self, response: Any) -> str:
         if isinstance(response, str):

--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -763,9 +763,21 @@ class AutoPattern(AgentPattern):
         # Every fresh routing decision drops all derived labels and re-derives the
         # caller's; a resumed pattern skips _decide, so the runner migration does it.
         self._clear_response_language(context)
+        # Resolve a virtual model before compacting, the order
+        # prepare_llm_for_context documents and ReAct already follows. The
+        # resolver recomputes the compaction threshold from the selected
+        # model's context window, which is useless once compaction has
+        # already run -- so this stays unconditional even when a separate
+        # compact model makes the returned handle itself unused.
+        route_llm = await prepare_llm_for_context(
+            llm=llm,
+            messages=context.get_messages_for_llm(),
+            context=context,
+        )
         await runtime.compact_context_if_needed(
             context=context,
-            llm=compact_llm,
+            # See ReActPattern for why the fallback lives at the call site.
+            llm=compact_llm if compact_llm is not None else route_llm,
             metadata={"phase": "auto_decision"},
         )
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -672,7 +672,21 @@ class ReActPattern(AgentPattern):
             }
             await runtime.compact_context_if_needed(
                 context=context,
-                llm=compact_llm,
+                # Fall back to the main model when no compact model is
+                # configured. PatternRuntime skips summarization entirely
+                # without one and drops all but the last few messages
+                # instead, losing what the agent actually did; agent preview
+                # and delegated sub-agents resolve the compact slot on their
+                # own and validate only the default model, so an empty slot
+                # is ordinary rather than exceptional.
+                #
+                # Substituting here, rather than defaulting the field further
+                # up, keeps "unset" distinguishable from "explicitly set to
+                # the main model" -- and hands compaction the *resolved*
+                # per-call model, so a virtual model reuses this turn's
+                # routing decision instead of routing again on the compaction
+                # prompt, whose only user message is the whole transcript.
+                llm=compact_llm if compact_llm is not None else call_llm,
                 metadata={"iteration": iteration},
             )
 

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -34,7 +34,7 @@ from ..tools.user_interaction import (
     WAITING_FOR_USER_STATUS,
     tool_result_waits_for_user,
 )
-from .context.execution import COMPACT_SUMMARY_MIN_TOKENS
+from .context.execution import COMPACT_SUMMARY_FALLBACK_BUDGETS
 from .result import normalize_tool_failure_code, tool_result_succeeded
 from .streaming import merge_streamed_tool_call_arguments
 
@@ -1276,7 +1276,12 @@ class PatternRuntime:
         except LLMCallInterrupted:
             raise
         except Exception as exc:  # noqa: BLE001
-            if max_tokens <= COMPACT_SUMMARY_MIN_TOKENS:
+            budgets = [
+                budget
+                for budget in COMPACT_SUMMARY_FALLBACK_BUDGETS
+                if budget < max_tokens
+            ]
+            if not budgets:
                 raise
             if retry_on(exc):
                 # Transient by class -- the LLM object is already wrapped in
@@ -1287,24 +1292,32 @@ class PatternRuntime:
                 raise
             if self._interrupt_requested:
                 raise
-            logger.warning(
-                "Context compaction summary failed at max_tokens=%d; retrying "
-                "at %d. Error: %s",
-                max_tokens,
-                COMPACT_SUMMARY_MIN_TOKENS,
-                exc,
-            )
-            try:
-                response = await self.run_llm_call(
-                    llm, messages=messages, max_tokens=COMPACT_SUMMARY_MIN_TOKENS
+            first_exc = exc
+            for budget in budgets:
+                logger.warning(
+                    "Context compaction summary failed at max_tokens=%d; "
+                    "retrying at %d. Error: %s",
+                    max_tokens,
+                    budget,
+                    exc,
                 )
-            except Exception as retry_exc:
-                # Surface both: the retry's error is what stopped us, but the
-                # first one is the one that says the budget was suspect.
-                raise retry_exc from exc
-            metadata["compact_budget_reduced_to"] = COMPACT_SUMMARY_MIN_TOKENS
-            outcome["compact_budget_reduced_to"] = COMPACT_SUMMARY_MIN_TOKENS
-            return response
+                try:
+                    response = await self.run_llm_call(
+                        llm, messages=messages, max_tokens=budget
+                    )
+                except LLMCallInterrupted:
+                    raise
+                except Exception as retry_exc:  # noqa: BLE001
+                    exc = retry_exc
+                    if retry_on(retry_exc) or self._interrupt_requested:
+                        break
+                    continue
+                metadata["compact_budget_reduced_to"] = budget
+                outcome["compact_budget_reduced_to"] = budget
+                return response
+            # Surface the last failure, chained to the first: the first one is
+            # the one that says the budget was suspect.
+            raise exc from first_exc
 
     async def compact_context_if_needed(
         self,

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -21,6 +21,7 @@ from ..context_materializer import (
     materialize_llm_kwargs,
 )
 from ..model.chat.basic.base import BaseLLM
+from ..model.chat.error import retry_on
 from ..model.chat.exceptions import LLMToolProtocolError
 from ..model.chat.token_context import extract_cached_input_tokens
 from ..model.chat.tool_protocol import TOOL_PROTOCOL_ERROR_KEY
@@ -33,6 +34,7 @@ from ..tools.user_interaction import (
     WAITING_FOR_USER_STATUS,
     tool_result_waits_for_user,
 )
+from .context.execution import COMPACT_SUMMARY_MIN_TOKENS
 from .result import normalize_tool_failure_code, tool_result_succeeded
 from .streaming import merge_streamed_tool_call_arguments
 
@@ -1242,6 +1244,68 @@ class PatternRuntime:
             },
         )
 
+    async def _run_compact_llm_call(
+        self,
+        llm: Any,
+        *,
+        messages: list[dict[str, Any]],
+        max_tokens: int,
+        metadata: dict[str, Any],
+        outcome: dict[str, Any],
+    ) -> Any:
+        """Ask for a summary, and if the budget was the problem, ask for less.
+
+        The requested budget is derived from the compaction threshold, which
+        follows the model's *input* window; providers cap the *output*
+        separately and much lower, and nothing in the model config records
+        that limit -- the one number stored per model is a default to send,
+        not a ceiling the model can produce. So the budget is a guess, and a
+        wrong guess previously meant the whole summary was abandoned and
+        compaction fell back to dropping messages, which is the outcome this
+        whole path exists to avoid.
+
+        Retrying smaller lets the provider answer the question we cannot:
+        ``COMPACT_SUMMARY_MIN_TOKENS`` is the floor the code used before the
+        budget was raised, so it is a value known to have worked. This also
+        keeps a future mis-set ceiling from silently costing the summary.
+        """
+        try:
+            return await self.run_llm_call(
+                llm, messages=messages, max_tokens=max_tokens
+            )
+        except LLMCallInterrupted:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            if max_tokens <= COMPACT_SUMMARY_MIN_TOKENS:
+                raise
+            if retry_on(exc):
+                # Transient by class -- the LLM object is already wrapped in
+                # backoff retries, so reaching here means those are spent.
+                # Sending the same request again with a smaller output budget
+                # would not address the cause and would double an outage's
+                # cost, for a fallback that is free.
+                raise
+            if self._interrupt_requested:
+                raise
+            logger.warning(
+                "Context compaction summary failed at max_tokens=%d; retrying "
+                "at %d. Error: %s",
+                max_tokens,
+                COMPACT_SUMMARY_MIN_TOKENS,
+                exc,
+            )
+            try:
+                response = await self.run_llm_call(
+                    llm, messages=messages, max_tokens=COMPACT_SUMMARY_MIN_TOKENS
+                )
+            except Exception as retry_exc:
+                # Surface both: the retry's error is what stopped us, but the
+                # first one is the one that says the budget was suspect.
+                raise retry_exc from exc
+            metadata["compact_budget_reduced_to"] = COMPACT_SUMMARY_MIN_TOKENS
+            outcome["compact_budget_reduced_to"] = COMPACT_SUMMARY_MIN_TOKENS
+            return response
+
     async def compact_context_if_needed(
         self,
         *,
@@ -1263,6 +1327,10 @@ class PatternRuntime:
         # is indistinguishable in the trace from compaction that never tried
         # to summarize at all.
         unusable_summary_metadata: dict[str, Any] | None = None
+        # Written by ``_run_compact_llm_call`` when it had to lower the
+        # budget, so the compact trace event can say so alongside the other
+        # degrade markers.
+        compact_outcome: dict[str, Any] = {}
         if (
             llm is not None
             and callable(getattr(llm, "chat", None))
@@ -1279,10 +1347,12 @@ class PatternRuntime:
                         messages=request["messages"],
                         metadata=llm_metadata,
                     )
-                    response = await self.run_llm_call(
+                    response = await self._run_compact_llm_call(
                         llm,
                         messages=request["messages"],
                         max_tokens=request["max_tokens"],
+                        metadata=llm_metadata,
+                        outcome=compact_outcome,
                     )
                     await self.on_llm_end(
                         context=context,
@@ -1296,6 +1366,7 @@ class PatternRuntime:
                     )
                     for key, value in request_metadata.items():
                         result.metadata.setdefault(key, value)
+                    result.metadata.update(compact_outcome)
                     if not getattr(result, "compacted", False):
                         logger.warning(
                             "Context compaction summary was unusable; falling "

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -1255,6 +1255,14 @@ class PatternRuntime:
         compact_with_llm_response = getattr(context, "compact_with_llm_response", None)
         compact_if_needed = getattr(context, "compact_if_needed", None)
         result = None
+        # Set when the summary path ran but produced nothing usable, so the
+        # message-dropping fallback below can say why it is running. The error
+        # path already records ``llm_compact_error``; without this, a summary
+        # that was requested, paid for, and then discarded -- an empty
+        # completion, or a reasoning trace the client marked as substituted --
+        # is indistinguishable in the trace from compaction that never tried
+        # to summarize at all.
+        unusable_summary_metadata: dict[str, Any] | None = None
         if (
             llm is not None
             and callable(getattr(llm, "chat", None))
@@ -1288,6 +1296,16 @@ class PatternRuntime:
                     )
                     for key, value in request_metadata.items():
                         result.metadata.setdefault(key, value)
+                    if not getattr(result, "compacted", False):
+                        logger.warning(
+                            "Context compaction summary was unusable; falling "
+                            "back to dropping messages. execution_id=%s",
+                            getattr(context, "execution_id", None),
+                        )
+                        unusable_summary_metadata = {
+                            "llm_summary_unusable": True,
+                            **request_metadata,
+                        }
                 except LLMCallInterrupted:
                     raise
                 except Exception as exc:  # noqa: BLE001
@@ -1307,6 +1325,11 @@ class PatternRuntime:
             if not callable(compact_if_needed):
                 return result
             result = compact_if_needed(llm)
+            if inspect.isawaitable(result):
+                result = await result
+            if result is not None and unusable_summary_metadata is not None:
+                result.metadata.update(unusable_summary_metadata)
+                result.metadata["fallback_strategy"] = result.strategy
 
         if result is None:
             return None

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -69,6 +69,42 @@ def _openai_error_details(error: BaseException) -> list[str]:
     return details
 
 
+def _degrade_rejected_params(
+    completion_params: dict[str, Any], error_msg: str
+) -> list[str]:
+    """Drop or rename request parameters a compatible endpoint rejected.
+
+    Returns the names degraded, empty when the 400 was about something else
+    and the caller should re-raise. Each parameter is judged independently:
+    one 400 can name both, and treating them as alternatives would silently
+    skip a degrade that was also needed.
+
+    ``max_tokens`` is renamed rather than dropped -- reasoning models spell
+    the same budget ``max_completion_tokens``, and for context compaction that
+    budget is what keeps a summary small enough not to re-trigger the next
+    compaction. The trigger is anchored on the replacement name, or on
+    "unsupported parameter": ``error_msg`` carries ``provider_raw`` and
+    ``previous_errors`` blobs (see ``_openai_error_details``), i.e. arbitrary
+    upstream text that can mention ``max_tokens`` for unrelated reasons -- an
+    out-of-range value, or a provider echoing the request back.
+    """
+    lowered = error_msg.lower()
+    degraded: list[str] = []
+
+    if "max_tokens" in completion_params and (
+        "max_completion_tokens" in lowered
+        or ("max_tokens" in lowered and "unsupported parameter" in lowered)
+    ):
+        completion_params["max_completion_tokens"] = completion_params.pop("max_tokens")
+        degraded.append("max_tokens")
+
+    if "response_format" in completion_params and "response_format" in lowered:
+        completion_params.pop("response_format")
+        degraded.append("response_format")
+
+    return degraded
+
+
 def _format_openai_error(prefix: str, error: BaseException) -> str:
     message = str(getattr(error, "message", None) or error)
     status_code = getattr(error, "status_code", None)
@@ -589,30 +625,26 @@ class OpenAICompatibleLLM(BaseLLM):
             try:
                 response = await _make_api_call()
             except openai.BadRequestError as e:
-                # Check if error is related to response_format
                 error_msg = _format_openai_error("OpenAI bad request", e)
-                if (
-                    "response_format" in error_msg.lower()
-                    and "response_format" in completion_params
-                ):
-                    # Remove response_format and retry
-                    logger.warning(
-                        f"API doesn't support response_format, retrying without it. Error: {error_msg}"
-                    )
-                    completion_params.pop("response_format")
+                degraded = _degrade_rejected_params(completion_params, error_msg)
+                if not degraded:
+                    raise
+                logger.warning(
+                    "API rejected %s, retrying without it. Error: %s",
+                    " and ".join(degraded),
+                    error_msg,
+                )
+                if "response_format" in degraded:
+                    # Fall through to the main flow with response_format now
+                    # None, which is what the structured-output degrade check
+                    # below is gated on.
                     response_format = None
 
-                    # Retry without response_format and fall through to the
-                    # main flow (the structured-output degrade check below is
-                    # gated on response_format, now None). A BadRequestError
-                    # raised here is not caught by this clause -- it
-                    # propagates to the outer ``except openai.BadRequestError``
-                    # below, which wraps it into RuntimeError like every other
-                    # failure path.
-                    response = await _make_api_call()
-
-                else:
-                    raise
+                # A BadRequestError raised here is not caught by this clause
+                # -- it propagates to the outer ``except openai
+                # .BadRequestError`` below, which wraps it into RuntimeError
+                # like every other failure path.
+                response = await _make_api_call()
 
             result = _process_response(response, request_thinking=thinking)
 
@@ -814,25 +846,20 @@ class OpenAICompatibleLLM(BaseLLM):
             try:
                 response = await _make_api_call()
             except openai.BadRequestError as e:
-                # Check if error is related to response_format
                 error_msg = _format_openai_error("OpenAI bad request", e)
-                if (
-                    "response_format" in error_msg.lower()
-                    and "response_format" in completion_params
-                ):
-                    # Remove response_format and retry
-                    logger.warning(
-                        f"API doesn't support response_format, retrying without it. Error: {error_msg}"
-                    )
-                    completion_params.pop("response_format")
-
-                    # Retry without response_format. A BadRequestError raised
-                    # here is not caught by this clause -- it propagates to
-                    # the outer ``except openai.BadRequestError`` below, which
-                    # wraps it into RuntimeError like every other failure path.
-                    response = await _make_api_call()
-                else:
+                degraded = _degrade_rejected_params(completion_params, error_msg)
+                if not degraded:
                     raise
+                logger.warning(
+                    "API rejected %s, retrying without it. Error: %s",
+                    " and ".join(degraded),
+                    error_msg,
+                )
+                # A BadRequestError raised here is not caught by this clause
+                # -- it propagates to the outer ``except openai
+                # .BadRequestError`` below, which wraps it into RuntimeError
+                # like every other failure path.
+                response = await _make_api_call()
 
             # Validate response
             if not hasattr(response, "choices") or not response.choices:
@@ -1061,28 +1088,23 @@ class OpenAICompatibleLLM(BaseLLM):
                         **completion_params
                     )
             except openai.BadRequestError as e:
-                # Check if error is related to response_format
                 error_msg = _format_openai_error("OpenAI bad request", e)
-                if (
-                    "response_format" in error_msg.lower()
-                    and "response_format" in completion_params
-                ):
-                    # Remove response_format and retry
-                    logger.warning(
-                        f"API doesn't support response_format, retrying without it. Error: {error_msg}"
-                    )
-                    completion_params.pop("response_format")
-
-                    if extra_body:
-                        stream = await self._client.chat.completions.create(
-                            extra_body=extra_body, **completion_params
-                        )
-                    else:
-                        stream = await self._client.chat.completions.create(
-                            **completion_params
-                        )
-                else:
+                degraded = _degrade_rejected_params(completion_params, error_msg)
+                if not degraded:
                     raise
+                logger.warning(
+                    "API rejected %s, retrying without it. Error: %s",
+                    " and ".join(degraded),
+                    error_msg,
+                )
+                if extra_body:
+                    stream = await self._client.chat.completions.create(
+                        extra_body=extra_body, **completion_params
+                    )
+                else:
+                    stream = await self._client.chat.completions.create(
+                        **completion_params
+                    )
 
             # Timeout control
             first_token = True

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -11,7 +11,13 @@ from ....utils.security import redact_sensitive_text
 from ..exceptions import LLMEmptyContentError, LLMRetryableError, LLMTimeoutError
 from ..timeout_config import TimeoutConfig
 from ..token_context import add_token_usage, extract_cached_input_tokens
-from ..types import PROVIDER_STATE_METADATA_KEY, ChunkType, StreamChunk
+from ..types import (
+    CONTENT_SOURCE_KEY,
+    CONTENT_SOURCE_REASONING_FALLBACK,
+    PROVIDER_STATE_METADATA_KEY,
+    ChunkType,
+    StreamChunk,
+)
 from .base import BaseLLM
 
 logger = logging.getLogger(__name__)
@@ -601,6 +607,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     return {
                         "type": "text",
                         "content": reasoning_content,
+                        CONTENT_SOURCE_KEY: CONTENT_SOURCE_REASONING_FALLBACK,
                         "reasoning_content": reasoning_content,
                         "reasoning": reasoning_content,
                         "raw": resp.model_dump(),
@@ -950,6 +957,7 @@ class OpenAICompatibleLLM(BaseLLM):
                     return {
                         "type": "text",
                         "content": reasoning_content,
+                        CONTENT_SOURCE_KEY: CONTENT_SOURCE_REASONING_FALLBACK,
                         "reasoning_content": reasoning_content,
                         "reasoning": reasoning_content,
                         "raw": response.model_dump(),

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -51,6 +51,45 @@ def _openai_error_body(error: BaseException) -> Any:
         return None
 
 
+def _openai_error_code(error: BaseException) -> str | None:
+    """The machine-readable code for a 400, when the endpoint sends one."""
+    body = _openai_error_body(error)
+    if not isinstance(body, dict):
+        return None
+    error_payload = body.get("error")
+    if not isinstance(error_payload, dict):
+        return None
+    code = error_payload.get("code")
+    return code if isinstance(code, str) and code else None
+
+
+def _openai_rejected_param(error: BaseException) -> str | None:
+    """The parameter the endpoint said was at fault, when it says so.
+
+    OpenAI-shaped error bodies name the offending parameter in
+    ``error.param``. That is worth reaching for because the human-readable
+    message is not a reliable substitute: ``_format_openai_error`` appends
+    ``provider_raw`` and ``previous_errors`` blobs, so for a gateway that
+    tried several upstreams the text is several providers' complaints
+    concatenated, and a keyword found there may belong to an attempt that has
+    nothing to do with this failure. ``param`` describes only this one.
+    """
+    body = _openai_error_body(error)
+    if not isinstance(body, dict):
+        return None
+    error_payload = body.get("error")
+    if not isinstance(error_payload, dict):
+        return None
+    param = error_payload.get("param")
+    if not isinstance(param, str) or not param:
+        return None
+    # Structured-output rejections name a path ("response_format.json_schema
+    # .schema"); the parameter is its first segment. Returning the full path
+    # would satisfy "an explicit param exists" while matching nothing, which
+    # would skip the text fallback and lose a recovery that works today.
+    return param.split(".", 1)[0]
+
+
 def _openai_error_details(error: BaseException) -> list[str]:
     details: list[str] = []
     body = _openai_error_body(error)
@@ -76,7 +115,10 @@ def _openai_error_details(error: BaseException) -> list[str]:
 
 
 def _degrade_rejected_params(
-    completion_params: dict[str, Any], error_msg: str
+    completion_params: dict[str, Any],
+    error_msg: str,
+    rejected_param: str | None = None,
+    error_code: str | None = None,
 ) -> list[str]:
     """Drop or rename request parameters a compatible endpoint rejected.
 
@@ -85,26 +127,47 @@ def _degrade_rejected_params(
     one 400 can name both, and treating them as alternatives would silently
     skip a degrade that was also needed.
 
+    ``rejected_param`` is the endpoint's own answer (see
+    ``_openai_rejected_param``) and settles it outright when present. Only
+    without one does this fall back to reading ``error_msg``, which is a
+    weaker signal: it carries ``provider_raw`` and ``previous_errors`` blobs,
+    so a keyword in it may come from a different upstream attempt in a
+    gateway's fallback chain rather than from this failure. The fallback
+    therefore requires the parameter name and the complaint to appear
+    together, not merely both somewhere in the text.
+
     ``max_tokens`` is renamed rather than dropped -- reasoning models spell
     the same budget ``max_completion_tokens``, and for context compaction that
     budget is what keeps a summary small enough not to re-trigger the next
-    compaction. The trigger is anchored on the replacement name, or on
-    "unsupported parameter": ``error_msg`` carries ``provider_raw`` and
-    ``previous_errors`` blobs (see ``_openai_error_details``), i.e. arbitrary
-    upstream text that can mention ``max_tokens`` for unrelated reasons -- an
-    out-of-range value, or a provider echoing the request back.
+    compaction.
     """
     lowered = error_msg.lower()
     degraded: list[str] = []
 
-    if "max_tokens" in completion_params and (
-        "max_completion_tokens" in lowered
-        or ("max_tokens" in lowered and "unsupported parameter" in lowered)
+    # ``param`` says *which* parameter, never that renaming it would help:
+    # a plain out-of-range value ("max_tokens is too large") reports the same
+    # param, and renaming that one wastes the retry that could have recovered
+    # some other way. So an unsupported-parameter signal is required either
+    # way; ``param`` only narrows which parameter it applies to.
+    names_replacement = (
+        error_code == "unsupported_parameter" or "max_completion_tokens" in lowered
+    )
+    if (
+        "max_tokens" in completion_params
+        and names_replacement
+        and (rejected_param is None or rejected_param == "max_tokens")
     ):
         completion_params["max_completion_tokens"] = completion_params.pop("max_tokens")
         degraded.append("max_tokens")
 
-    if "response_format" in completion_params and "response_format" in lowered:
+    if "response_format" in completion_params and (
+        rejected_param == "response_format"
+        if rejected_param is not None
+        # Unchanged from before this degrade path existed: presence of the
+        # name anywhere in the text. Tightening it here would narrow a
+        # recovery that has been working, which is not this change's business.
+        else "response_format" in lowered
+    ):
         completion_params.pop("response_format")
         degraded.append("response_format")
 
@@ -629,29 +692,35 @@ class OpenAICompatibleLLM(BaseLLM):
 
         try:
             # Make the API call
-            try:
-                response = await _make_api_call()
-            except openai.BadRequestError as e:
-                error_msg = _format_openai_error("OpenAI bad request", e)
-                degraded = _degrade_rejected_params(completion_params, error_msg)
-                if not degraded:
-                    raise
-                logger.warning(
-                    "API rejected %s, retrying without it. Error: %s",
-                    " and ".join(degraded),
-                    error_msg,
-                )
-                if "response_format" in degraded:
-                    # Fall through to the main flow with response_format now
-                    # None, which is what the structured-output degrade check
-                    # below is gated on.
-                    response_format = None
-
-                # A BadRequestError raised here is not caught by this clause
-                # -- it propagates to the outer ``except openai
-                # .BadRequestError`` below, which wraps it into RuntimeError
-                # like every other failure path.
-                response = await _make_api_call()
+            while True:
+                try:
+                    response = await _make_api_call()
+                    break
+                except openai.BadRequestError as e:
+                    error_msg = _format_openai_error("OpenAI bad request", e)
+                    degraded = _degrade_rejected_params(
+                        completion_params,
+                        error_msg,
+                        _openai_rejected_param(e),
+                        _openai_error_code(e),
+                    )
+                    if not degraded:
+                        raise
+                    logger.warning(
+                        "API rejected %s, retrying without it. Error: %s",
+                        " and ".join(degraded),
+                        error_msg,
+                    )
+                    if "response_format" in degraded:
+                        # The structured-output degrade check below is gated
+                        # on response_format, so clear it here too.
+                        response_format = None
+                    # Bounded by construction: every degrade removes or
+                    # renames a parameter, and each is triggered only while
+                    # that parameter is still in the request, so at most one
+                    # round per supported degrade. Endpoints commonly report
+                    # one invalid parameter per response, so a single round
+                    # is not always enough.
 
             result = _process_response(response, request_thinking=thinking)
 
@@ -706,7 +775,7 @@ class OpenAICompatibleLLM(BaseLLM):
 
         except openai.BadRequestError as e:
             # Handle bad request errors, including a response_format resend
-            # that failed again (see the nested try/except above).
+            # that failed again (see the degrade loop above).
             raise RuntimeError(_format_openai_error("OpenAI bad request", e)) from e
 
         except openai.APITimeoutError as e:
@@ -850,23 +919,29 @@ class OpenAICompatibleLLM(BaseLLM):
 
         try:
             # Make the API call with extra_body if needed
-            try:
-                response = await _make_api_call()
-            except openai.BadRequestError as e:
-                error_msg = _format_openai_error("OpenAI bad request", e)
-                degraded = _degrade_rejected_params(completion_params, error_msg)
-                if not degraded:
-                    raise
-                logger.warning(
-                    "API rejected %s, retrying without it. Error: %s",
-                    " and ".join(degraded),
-                    error_msg,
-                )
-                # A BadRequestError raised here is not caught by this clause
-                # -- it propagates to the outer ``except openai
-                # .BadRequestError`` below, which wraps it into RuntimeError
-                # like every other failure path.
-                response = await _make_api_call()
+            while True:
+                try:
+                    response = await _make_api_call()
+                    break
+                except openai.BadRequestError as e:
+                    error_msg = _format_openai_error("OpenAI bad request", e)
+                    degraded = _degrade_rejected_params(
+                        completion_params,
+                        error_msg,
+                        _openai_rejected_param(e),
+                        _openai_error_code(e),
+                    )
+                    if not degraded:
+                        raise
+                    logger.warning(
+                        "API rejected %s, retrying without it. Error: %s",
+                        " and ".join(degraded),
+                        error_msg,
+                    )
+                    # Loop because endpoints commonly report one invalid
+                    # parameter per response. Bounded by construction: each
+                    # degrade removes or renames a parameter and fires only
+                    # while it is still in the request.
 
             # Validate response
             if not hasattr(response, "choices") or not response.choices:
@@ -994,7 +1069,7 @@ class OpenAICompatibleLLM(BaseLLM):
 
         except openai.BadRequestError as e:
             # Handle bad request errors, including a response_format resend
-            # that failed again (see the nested try/except above).
+            # that failed again (see the degrade loop above).
             raise RuntimeError(_format_openai_error("OpenAI bad request", e)) from e
 
         except openai.APIError as e:
@@ -1086,33 +1161,39 @@ class OpenAICompatibleLLM(BaseLLM):
 
         try:
             # Create streaming response
-            try:
+            client = self._client
+            assert client is not None
+
+            async def _create_stream() -> Any:
                 if extra_body:
-                    stream = await self._client.chat.completions.create(
+                    return await client.chat.completions.create(
                         extra_body=extra_body, **completion_params
                     )
-                else:
-                    stream = await self._client.chat.completions.create(
-                        **completion_params
+                return await client.chat.completions.create(**completion_params)
+
+            while True:
+                try:
+                    stream = await _create_stream()
+                    break
+                except openai.BadRequestError as e:
+                    error_msg = _format_openai_error("OpenAI bad request", e)
+                    degraded = _degrade_rejected_params(
+                        completion_params,
+                        error_msg,
+                        _openai_rejected_param(e),
+                        _openai_error_code(e),
                     )
-            except openai.BadRequestError as e:
-                error_msg = _format_openai_error("OpenAI bad request", e)
-                degraded = _degrade_rejected_params(completion_params, error_msg)
-                if not degraded:
-                    raise
-                logger.warning(
-                    "API rejected %s, retrying without it. Error: %s",
-                    " and ".join(degraded),
-                    error_msg,
-                )
-                if extra_body:
-                    stream = await self._client.chat.completions.create(
-                        extra_body=extra_body, **completion_params
+                    if not degraded:
+                        raise
+                    logger.warning(
+                        "API rejected %s, retrying without it. Error: %s",
+                        " and ".join(degraded),
+                        error_msg,
                     )
-                else:
-                    stream = await self._client.chat.completions.create(
-                        **completion_params
-                    )
+                    # Loop because endpoints commonly report one invalid
+                    # parameter per response. Bounded by construction: each
+                    # degrade removes or renames a parameter and fires only
+                    # while it is still in the request.
 
             # Timeout control
             first_token = True

--- a/src/xagent/core/model/chat/basic/openai.py
+++ b/src/xagent/core/model/chat/basic/openai.py
@@ -51,16 +51,36 @@ def _openai_error_body(error: BaseException) -> Any:
         return None
 
 
-def _openai_error_code(error: BaseException) -> str | None:
-    """The machine-readable code for a 400, when the endpoint sends one."""
+def _openai_error_payload(error: BaseException) -> dict[str, Any] | None:
+    """The error object itself, whichever shape it arrives in.
+
+    The wire format wraps it (``{"error": {...}}``), but the SDK unwraps that
+    in ``_make_status_error``, so ``BadRequestError.body`` is the inner object
+    already. Code that only looked for the wrapper therefore found nothing on
+    any error the SDK actually produced -- and passed its tests, because the
+    fixtures hand-built the wire shape. Normalize here so both work.
+    """
     body = _openai_error_body(error)
     if not isinstance(body, dict):
         return None
-    error_payload = body.get("error")
-    if not isinstance(error_payload, dict):
+    inner = body.get("error")
+    return inner if isinstance(inner, dict) else body
+
+
+def _openai_error_code(error: BaseException) -> str | None:
+    """The machine-readable code for a 400, when the endpoint sends one.
+
+    The SDK lifts it onto the exception; the payload is the fallback for
+    anything that did not come through the SDK.
+    """
+    code = getattr(error, "code", None)
+    if isinstance(code, str) and code:
+        return code
+    error_payload = _openai_error_payload(error)
+    if error_payload is None:
         return None
-    code = error_payload.get("code")
-    return code if isinstance(code, str) and code else None
+    payload_code = error_payload.get("code")
+    return payload_code if isinstance(payload_code, str) and payload_code else None
 
 
 def _openai_rejected_param(error: BaseException) -> str | None:
@@ -74,13 +94,10 @@ def _openai_rejected_param(error: BaseException) -> str | None:
     concatenated, and a keyword found there may belong to an attempt that has
     nothing to do with this failure. ``param`` describes only this one.
     """
-    body = _openai_error_body(error)
-    if not isinstance(body, dict):
-        return None
-    error_payload = body.get("error")
-    if not isinstance(error_payload, dict):
-        return None
-    param = error_payload.get("param")
+    param = getattr(error, "param", None)
+    if not isinstance(param, str) or not param:
+        error_payload = _openai_error_payload(error)
+        param = error_payload.get("param") if error_payload is not None else None
     if not isinstance(param, str) or not param:
         return None
     # Structured-output rejections name a path ("response_format.json_schema
@@ -92,25 +109,23 @@ def _openai_rejected_param(error: BaseException) -> str | None:
 
 def _openai_error_details(error: BaseException) -> list[str]:
     details: list[str] = []
-    body = _openai_error_body(error)
-    if isinstance(body, dict):
-        error_payload = body.get("error")
-        if isinstance(error_payload, dict):
-            metadata = error_payload.get("metadata")
-            if isinstance(metadata, dict):
-                provider_name = metadata.get("provider_name")
-                if provider_name:
-                    details.append(f"provider_name={provider_name}")
-                raw = metadata.get("raw")
-                if raw:
-                    details.append("provider_raw=" + _truncate_error_detail(raw))
-                previous_errors = metadata.get("previous_errors")
-                if previous_errors:
-                    details.append(
-                        "previous_errors=" + _truncate_error_detail(previous_errors)
-                    )
-            elif metadata is not None:
-                details.append("metadata=" + _truncate_error_detail(metadata))
+    error_payload = _openai_error_payload(error)
+    if error_payload is not None:
+        metadata = error_payload.get("metadata")
+        if isinstance(metadata, dict):
+            provider_name = metadata.get("provider_name")
+            if provider_name:
+                details.append(f"provider_name={provider_name}")
+            raw = metadata.get("raw")
+            if raw:
+                details.append("provider_raw=" + _truncate_error_detail(raw))
+            previous_errors = metadata.get("previous_errors")
+            if previous_errors:
+                details.append(
+                    "previous_errors=" + _truncate_error_detail(previous_errors)
+                )
+        elif metadata is not None:
+            details.append("metadata=" + _truncate_error_detail(metadata))
     return details
 
 

--- a/src/xagent/core/model/chat/types.py
+++ b/src/xagent/core/model/chat/types.py
@@ -12,6 +12,19 @@ from typing import Any, Dict, List
 # transport implementation module.
 PROVIDER_STATE_METADATA_KEY = "_xagent_provider_state"
 
+# Response-dict key marking that ``content`` was not produced as content.
+# A reasoning model whose output budget runs out while it is still thinking
+# returns an empty ``content`` alongside a ``reasoning_content`` trace; the
+# OpenAI-compatible client surfaces that trace as ``content`` so a caller
+# does not read a truncated-but-healthy response as an empty one. That is a
+# reasonable default for, say, a connection test, and wrong for any caller
+# that treats content as an answer -- so the substitution is declared rather
+# than left to be inferred from the response's shape. Lives here, next to
+# PROVIDER_STATE_METADATA_KEY and for the same reason: consumers can honour
+# it without importing a transport module.
+CONTENT_SOURCE_KEY = "content_source"
+CONTENT_SOURCE_REASONING_FALLBACK = "reasoning_fallback"
+
 
 class ChunkType(Enum):
     """Streaming response chunk types"""

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -28,6 +28,7 @@ from xagent.core.agent.language import (
     response_language_rules,
 )
 from xagent.core.agent.pattern.auto.auto import DECISION_TOOL_NAME, _AutoChildRuntime
+from xagent.core.model.chat.basic.router import RouterLLM
 from xagent.core.model.chat.exceptions import LLMToolProtocolError
 from xagent.core.model.chat.tool_protocol import (
     ToolProtocolViolation,
@@ -1292,10 +1293,24 @@ async def test_auto_pattern_react_decision_delegates_to_react() -> None:
 
 
 @pytest.mark.asyncio
-async def test_auto_pattern_does_not_use_main_llm_for_compaction() -> None:
+async def test_auto_pattern_falls_back_to_the_main_llm_for_compaction() -> None:
+    """Deliberate reversal of a previous policy.
+
+    This test used to assert the opposite -- that an unconfigured compact slot
+    left the main model untouched, so compaction cost nothing. What it cost
+    instead was the summary: ``PatternRuntime.compact_context_if_needed``
+    skips summarization without a compact LLM and drops all but the last few
+    messages, so the resumed conversation loses the tool observations that
+    explain what the agent already did. Spending main-model tokens is the
+    lesser price, and an empty slot is ordinary rather than exceptional --
+    agent preview and delegated sub-agents resolve it themselves and validate
+    only the default model.
+    """
     llm = FakeLLM(
         [
+            {"content": "summary for the routing decision"},
             decision_tool_response("react", "Ordinary response."),
+            {"content": "summary for the child pattern"},
             "react done",
         ]
     )
@@ -1309,8 +1324,18 @@ async def test_auto_pattern_does_not_use_main_llm_for_compaction() -> None:
 
     assert result["success"] is True
     assert result["output"] == "react done"
-    assert len(llm.calls) == 2
-    assert has_tool(llm.calls[0], DECISION_TOOL_NAME)
+    # Four calls: Auto compacts before routing, routes, then the child ReAct
+    # pattern compacts again (this fixture's threshold of 1 keeps every
+    # context over budget) before its own call.
+    assert len(llm.calls) == 4
+    compaction_calls = [
+        call
+        for call in llm.calls
+        if "Compress agent conversation history"
+        in call["messages"][0].get("content", "")
+    ]
+    assert len(compaction_calls) == 2
+    assert has_tool(llm.calls[1], DECISION_TOOL_NAME)
 
 
 @pytest.mark.asyncio
@@ -2306,3 +2331,85 @@ async def test_direct_final_answer_allows_an_explicit_target_language() -> None:
     system_content = context.get_messages_for_llm()[0]["content"]
     assert request in system_content
     assert target_rule in system_content
+
+
+class RoutedDecisionLLM:
+    """Downstream selection behind a router, for the Auto decision path.
+
+    Both entry points are needed: compaction goes through ``run_llm_call`` ->
+    ``chat``, while the routing decision streams (``_ResolvedRouterLLM``
+    defines ``stream_chat``, so the runtime takes the native streaming path).
+    """
+
+    def __init__(self, chat_responses: list[Any], decision: dict[str, Any]) -> None:
+        self.chat_responses = chat_responses
+        self.decision = decision
+        self.calls: list[dict[str, Any]] = []
+
+    async def chat(self, messages: Any = None, **kwargs: Any) -> Any:
+        self.calls.append({"messages": messages, **kwargs})
+        return self.chat_responses.pop(0)
+
+    async def stream_chat(self, messages: Any = None, **kwargs: Any) -> Any:
+        self.calls.append({"messages": messages, **kwargs})
+        yield StreamChunk(
+            type=ChunkType.TOOL_CALL,
+            tool_calls=self.decision["tool_calls"],
+        )
+
+
+def _auto_routing_router(downstream: Any, route_prompts: list[str]) -> RouterLLM:
+    """A real ``RouterLLM`` with its selection stubbed to record the prompt.
+
+    ``context_window`` is set, as production always does via ``adapter.py``;
+    4 gives a compaction threshold of 3, so any context compacts.
+    """
+    router = RouterLLM(downstream_resolver=lambda _model_id: downstream)
+    router.context_window = 4
+
+    async def select_model(prompt: str) -> str:
+        route_prompts.append(prompt)
+        return "test/model"
+
+    router._select_model = select_model  # type: ignore[assignment]
+    return router
+
+
+@pytest.mark.asyncio
+async def test_auto_summarizes_with_the_main_model_when_no_compact_model() -> None:
+    """Same substitution as ReAct, and the resolve-before-compact order.
+
+    Auto compacted before resolving the virtual model, the reverse of what
+    ``prepare_llm_for_context`` documents: the resolver recomputes the
+    compaction threshold from the selected model's window, which is useless
+    once compaction has run, and compaction would otherwise route a second
+    time on the compaction prompt -- whose only user message is the whole
+    transcript.
+    """
+    downstream = RoutedDecisionLLM(
+        [{"content": "summary of prior work"}],
+        decision=decision_tool_response("final_answer", "Greeting only.", answer="hi"),
+    )
+    route_prompts: list[str] = []
+    router = _auto_routing_router(downstream, route_prompts)
+    context = ExecutionContext()
+    context.add_user_message("hi")
+    context.add_tool_result("read_file", {"output": "x" * 200}, tool_call_id="call-1")
+
+    result = await AutoPattern().run(
+        context=context,
+        tools=[],
+        llm=router,
+        compact_llm=None,
+        runtime=PatternRuntime(),
+    )
+
+    assert result["success"] is True
+    # The summary call happened, and it went to the main model.
+    assert len(downstream.calls) == 2
+    # Exactly two routing decisions -- the one hoisted above compaction and
+    # the per-attempt one in the decision loop. Never on the transcript.
+    assert len(route_prompts) == 2
+    assert not any(
+        "Conversation history to compact" in prompt for prompt in route_prompts
+    )

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -1885,3 +1885,56 @@ def test_clock_timezone_survives_serialization_and_child_contexts() -> None:
 
     child = context.create_child_context(task="sub-task")
     assert child.clock_zone().key == "Australia/Melbourne"
+
+
+def _context_over_threshold(threshold: int) -> ExecutionContext:
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = threshold
+    ctx.add_user_message("current request")
+    # Token estimation is chars//4, so this clears the threshold and makes the
+    # request materialize.
+    ctx.add_tool_result(
+        "read_file", {"output": "x" * (threshold * 8)}, tool_call_id="call-1"
+    )
+    return ctx
+
+
+def test_llm_compact_budget_scales_with_the_threshold() -> None:
+    """Below the absolute ceiling the budget tracks the threshold.
+
+    The old ceiling of 1024 bound at every realistic window, leaving a
+    reasoning model no room -- its reasoning comes out of this same allowance.
+    """
+    request = _context_over_threshold(20_000).build_llm_compact_request_if_needed()
+
+    assert request is not None
+    assert request["max_tokens"] == 5_000
+
+
+def test_llm_compact_budget_stays_under_provider_output_limits() -> None:
+    """The absolute ceiling is what makes a large window safe.
+
+    The threshold scales with the *input* window, while providers cap the
+    *output* separately and much lower. Without a ceiling a 1M-token window
+    asks for ~187k output tokens, the request is rejected, and compaction
+    collapses into the message-dropping fallback it exists to avoid.
+    """
+    for window_threshold in (96_000, 150_000, 750_000):
+        request = _context_over_threshold(
+            window_threshold
+        ).build_llm_compact_request_if_needed()
+
+        assert request is not None
+        assert request["max_tokens"] == 8192
+
+
+def test_llm_compact_budget_keeps_its_floor_for_a_tiny_threshold() -> None:
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    ctx.add_user_message("current request")
+    ctx.add_tool_result("read_file", {"output": "x" * 400}, tool_call_id="call-1")
+
+    request = ctx.build_llm_compact_request_if_needed()
+
+    assert request is not None
+    assert request["max_tokens"] == 256

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -32,6 +32,10 @@ from xagent.core.agent.language import (
 )
 from xagent.core.agent.utils.context_builder import ContextBuilder
 from xagent.core.context_ref import CONTEXT_REFS_KEY, SUPERSEDES_SCOPE_KEY
+from xagent.core.model.chat.types import (
+    CONTENT_SOURCE_KEY,
+    CONTENT_SOURCE_REASONING_FALLBACK,
+)
 from xagent.web.user_isolated_memory import current_user_id
 
 
@@ -1938,3 +1942,59 @@ def test_llm_compact_budget_keeps_its_floor_for_a_tiny_threshold() -> None:
 
     assert request is not None
     assert request["max_tokens"] == 256
+
+
+def _compactable_context() -> ExecutionContext:
+    ctx = ExecutionContext()
+    ctx.compact_config.threshold = 1
+    ctx.add_user_message("current request")
+    ctx.add_tool_result("read_file", {"output": "x" * 200}, tool_call_id="call-1")
+    return ctx
+
+
+def test_compact_rejects_content_the_client_marked_as_a_reasoning_fallback() -> None:
+    """Accepting one would rewrite the whole history into a chain of thought.
+
+    The summary replaces every prior message, so a substituted reasoning trace
+    does not merely add noise -- it becomes the agent's account of what it
+    already did, describing deliberation it never concluded. Having no summary
+    is better: the fallback keeps real messages.
+    """
+    ctx = _compactable_context()
+    original = list(ctx.messages)
+
+    result = ctx.compact_with_llm_response(
+        {
+            "type": "text",
+            "content": "Let me think. The user wants a report. First I should",
+            CONTENT_SOURCE_KEY: CONTENT_SOURCE_REASONING_FALLBACK,
+            "reasoning_content": "Let me think. The user wants a report. First I should",
+        },
+        llm=None,
+    )
+
+    assert not result.compacted
+    assert result.strategy == "none"
+    assert ctx.messages == original
+
+
+def test_compact_keeps_an_unmarked_summary_that_ran_out_of_length() -> None:
+    """Only the declared substitution is rejected.
+
+    A summary clipped by the output budget is still a summary; falling back to
+    dropping messages would be strictly worse than keeping it.
+    """
+    ctx = _compactable_context()
+
+    result = ctx.compact_with_llm_response(
+        {
+            "type": "text",
+            "content": "Read the config file and found the timeout setting",
+            "reasoning_content": "I should summarize the read_file call.",
+        },
+        llm=None,
+    )
+
+    assert result.compacted
+    assert result.strategy == "llm_summary"
+    assert "found the timeout setting" in ctx.messages[0].content

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -1932,18 +1932,6 @@ def test_llm_compact_budget_stays_under_provider_output_limits() -> None:
         assert request["max_tokens"] == 8192
 
 
-def test_llm_compact_budget_keeps_its_floor_for_a_tiny_threshold() -> None:
-    ctx = ExecutionContext()
-    ctx.compact_config.threshold = 1
-    ctx.add_user_message("current request")
-    ctx.add_tool_result("read_file", {"output": "x" * 400}, tool_call_id="call-1")
-
-    request = ctx.build_llm_compact_request_if_needed()
-
-    assert request is not None
-    assert request["max_tokens"] == 256
-
-
 def _compactable_context() -> ExecutionContext:
     ctx = ExecutionContext()
     ctx.compact_config.threshold = 1
@@ -1976,25 +1964,3 @@ def test_compact_rejects_content_the_client_marked_as_a_reasoning_fallback() -> 
     assert not result.compacted
     assert result.strategy == "none"
     assert ctx.messages == original
-
-
-def test_compact_keeps_an_unmarked_summary_that_ran_out_of_length() -> None:
-    """Only the declared substitution is rejected.
-
-    A summary clipped by the output budget is still a summary; falling back to
-    dropping messages would be strictly worse than keeping it.
-    """
-    ctx = _compactable_context()
-
-    result = ctx.compact_with_llm_response(
-        {
-            "type": "text",
-            "content": "Read the config file and found the timeout setting",
-            "reasoning_content": "I should summarize the read_file call.",
-        },
-        llm=None,
-    )
-
-    assert result.compacted
-    assert result.strategy == "llm_summary"
-    assert "found the timeout setting" in ctx.messages[0].content

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -8574,33 +8574,3 @@ async def test_react_summarizes_with_the_main_model_when_no_compact_model() -> N
     # One routing decision for the whole turn, taken on the conversation.
     assert len(route_prompts) == 1
     assert "Conversation history to compact" not in route_prompts[0]
-
-
-@pytest.mark.asyncio
-async def test_react_keeps_an_explicitly_configured_compact_model() -> None:
-    """Guards the ``is not None`` half of the substitution.
-
-    This cannot fail by reverting the change -- the base already passed
-    ``compact_llm`` straight through. It fails against the plausible wrong
-    implementation, one that hands compaction the resolved main model
-    unconditionally and quietly ignores the configured compact model.
-    """
-    downstream = RoutedDownstreamLLM([], final_text="done")
-    route_prompts: list[str] = []
-    router = _routing_router(downstream, route_prompts)
-    compact_llm = FakeLLM([{"content": "summarized tool result"}])
-    context = _react_context_with_tool_history("compact-explicit-model")
-
-    result = await ReActPattern(max_iterations=1).run(
-        context=context,
-        tools=[],
-        llm=router,
-        compact_llm=compact_llm,
-        runtime=PatternRuntime(tracer=TraceEventRecorder()),
-    )
-
-    assert result["success"] is True
-    assert len(compact_llm.calls) == 1
-    # The main model summarized nothing, and routed only for its own call.
-    assert len(downstream.calls) == 1
-    assert len(route_prompts) == 1

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -5577,7 +5577,10 @@ async def test_react_pattern_traces_context_compaction() -> None:
     result = await ReActPattern(max_iterations=1).run(
         context=context,
         tools=[],
-        llm=FakeLLM([{"content": "done"}]),
+        # Two responses: compaction now summarizes with the main model when no
+        # compact model is configured, so it consumes one before the turn's
+        # own call.
+        llm=FakeLLM([{"content": "summary"}, {"content": "done"}]),
         runtime=runtime,
     )
 
@@ -8473,3 +8476,131 @@ async def test_react_close_streamed_answer_fails_open_stream_without_deliverable
 
     assert streamer.finish_calls == []
     assert streamer.fail_calls == [NO_DELIVERABLE_FINAL_ANSWER_REASON]
+
+
+class RoutedDownstreamLLM:
+    """Downstream selection behind a router.
+
+    It needs both entry points: compaction goes through ``run_llm_call`` ->
+    ``chat``, while the turn's own call streams (``_ResolvedRouterLLM``
+    defines ``stream_chat``, so the runtime takes the native streaming path).
+    Both record into one list so call ordering is assertable.
+    """
+
+    def __init__(self, chat_responses: list[Any], final_text: str) -> None:
+        self.chat_responses = chat_responses
+        self.final_text = final_text
+        self.calls: list[dict[str, Any]] = []
+
+    async def chat(self, messages: Any = None, **kwargs: Any) -> Any:
+        self.calls.append({"messages": messages, **kwargs})
+        return self.chat_responses.pop(0)
+
+    async def stream_chat(self, messages: Any = None, **kwargs: Any) -> Any:
+        self.calls.append({"messages": messages, **kwargs})
+        yield StreamChunk(type=ChunkType.TOKEN, delta=self.final_text)
+        yield StreamChunk(type=ChunkType.END)
+
+
+def _routing_router(
+    downstream: Any, route_prompts: list[str], *, context_window: int = 4
+) -> RouterLLM:
+    """A real ``RouterLLM`` whose selection is stubbed to record its prompt.
+
+    ``context_window`` is deliberately set, matching production: ``adapter.py``
+    always stamps it from the model row, and ``prepare_llm_for_context``
+    recomputes the compaction threshold from it. Leaving it unset would put the
+    fixture in a state a real router never reaches. A window of 4 yields a
+    threshold of 3, small enough that any context compacts.
+    """
+    router = RouterLLM(downstream_resolver=lambda _model_id: downstream)
+    router.context_window = context_window
+
+    async def select_model(prompt: str) -> str:
+        route_prompts.append(prompt)
+        return "test/model"
+
+    router._select_model = select_model  # type: ignore[assignment]
+    return router
+
+
+def _react_context_with_tool_history(execution_id: str) -> ExecutionContext:
+    context = ExecutionContext(execution_id=execution_id)
+    context.add_user_message("current request")
+    context.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "type": "function", "function": {"name": "read_file"}},
+        ],
+    )
+    context.add_tool_result("read_file", {"output": "x" * 200}, tool_call_id="call-1")
+    return context
+
+
+@pytest.mark.asyncio
+async def test_react_summarizes_with_the_main_model_when_no_compact_model() -> None:
+    """An unset compact slot must not silently disable summary compaction.
+
+    ``PatternRuntime.compact_context_if_needed`` skips summarization entirely
+    without a compact LLM and drops all but the last few messages instead.
+    Agent preview and delegated sub-agents resolve that slot themselves and
+    validate only the default model, so an empty slot is ordinary -- and made
+    the same agent behave differently depending on how it was launched.
+    """
+    downstream = RoutedDownstreamLLM(
+        [{"content": "summarized tool result"}], final_text="done"
+    )
+    route_prompts: list[str] = []
+    router = _routing_router(downstream, route_prompts)
+    context = _react_context_with_tool_history("compact-inherits-main")
+
+    result = await ReActPattern(max_iterations=1).run(
+        context=context,
+        tools=[],
+        llm=router,
+        compact_llm=None,
+        runtime=PatternRuntime(tracer=TraceEventRecorder()),
+    )
+
+    assert result["success"] is True
+    # Two downstream calls: the summary, then the turn's own call -- and the
+    # summary reached that call, which is what proves compaction summarized
+    # rather than truncated.
+    assert len(downstream.calls) == 2
+    assert any(
+        "summarized tool result" in message.get("content", "")
+        for message in downstream.calls[1]["messages"]
+    )
+    # One routing decision for the whole turn, taken on the conversation.
+    assert len(route_prompts) == 1
+    assert "Conversation history to compact" not in route_prompts[0]
+
+
+@pytest.mark.asyncio
+async def test_react_keeps_an_explicitly_configured_compact_model() -> None:
+    """Guards the ``is not None`` half of the substitution.
+
+    This cannot fail by reverting the change -- the base already passed
+    ``compact_llm`` straight through. It fails against the plausible wrong
+    implementation, one that hands compaction the resolved main model
+    unconditionally and quietly ignores the configured compact model.
+    """
+    downstream = RoutedDownstreamLLM([], final_text="done")
+    route_prompts: list[str] = []
+    router = _routing_router(downstream, route_prompts)
+    compact_llm = FakeLLM([{"content": "summarized tool result"}])
+    context = _react_context_with_tool_history("compact-explicit-model")
+
+    result = await ReActPattern(max_iterations=1).run(
+        context=context,
+        tools=[],
+        llm=router,
+        compact_llm=compact_llm,
+        runtime=PatternRuntime(tracer=TraceEventRecorder()),
+    )
+
+    assert result["success"] is True
+    assert len(compact_llm.calls) == 1
+    # The main model summarized nothing, and routed only for its own call.
+    assert len(downstream.calls) == 1
+    assert len(route_prompts) == 1

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -1521,34 +1521,6 @@ async def test_compaction_retries_with_a_smaller_budget_before_truncating() -> N
 
 
 @pytest.mark.asyncio
-async def test_compaction_does_not_retry_when_already_at_the_floor() -> None:
-    """A failure at the smallest budget is not a budget problem."""
-    context = ExecutionContext(execution_id="budget-floor")
-    context.compact_config.threshold = 1
-    context.add_user_message("current request")
-    context.add_tool_result("read_file", {"output": "x" * 200}, tool_call_id="call-1")
-
-    class AlwaysFailingLLM:
-        model_name = "compact-test"
-
-        def __init__(self) -> None:
-            self.calls = 0
-
-        async def chat(self, **kwargs: Any) -> Any:
-            self.calls += 1
-            raise RuntimeError("upstream is down")
-
-    llm = AlwaysFailingLLM()
-    result = await PatternRuntime().compact_context_if_needed(
-        context=context, llm=llm, metadata={"phase": "test"}
-    )
-
-    assert llm.calls == 1
-    assert result.strategy == "truncate"
-    assert "upstream is down" in result.metadata["llm_compact_error"]
-
-
-@pytest.mark.asyncio
 async def test_compaction_ladder_skips_a_budget_the_model_cannot_use() -> None:
     """The step down must not go straight to the floor.
 

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -1513,8 +1513,9 @@ async def test_compaction_retries_with_a_smaller_budget_before_truncating() -> N
     )
 
     # Asked big, was refused, stepped down, succeeded -- and summarized rather
-    # than dropping messages.
-    assert llm.budgets == [8000, 1024]
+    # than dropping messages. The step lands on the largest rung the cap
+    # allows, not the smallest one available.
+    assert llm.budgets == [8000, 4096]
     assert result.compacted
     assert result.strategy == "llm_summary"
     assert "output cap" in context.messages[0].content
@@ -1565,7 +1566,49 @@ async def test_compaction_ladder_skips_a_budget_the_model_cannot_use() -> None:
         context=context, llm=llm, metadata={"phase": "test"}
     )
 
-    assert llm.budgets == [8000, 1024]
+    assert llm.budgets == [8000, 4096]
     assert result.compacted
     assert result.strategy == "llm_summary"
     assert "a real summary" in context.messages[0].content
+
+
+@pytest.mark.asyncio
+async def test_compaction_stops_descending_once_a_budget_is_accepted() -> None:
+    """Accepted-but-unusable ends the ladder rather than continuing down.
+
+    A response is unusable because the allowance was too small for the model
+    to finish, so usability is monotone in the budget: every smaller rung is
+    unusable too. Continuing to step down would spend requests to arrive at
+    the same truncation. Here the model accepts anything but can never
+    produce a summary, so the ladder must stop at the first accepted rung.
+    """
+    context = ExecutionContext(execution_id="budget-monotone")
+    context.compact_config.threshold = 32000
+    context.add_user_message("current request")
+    context.add_tool_result(
+        "read_file", {"output": "x" * 200_000}, tool_call_id="call-1"
+    )
+
+    class AlwaysReasoningLLM:
+        model_name = "compact-test"
+
+        def __init__(self) -> None:
+            self.budgets: list[int] = []
+
+        async def chat(self, **kwargs: Any) -> Any:
+            self.budgets.append(kwargs["max_tokens"])
+            return {
+                "content": "still thinking",
+                CONTENT_SOURCE_KEY: CONTENT_SOURCE_REASONING_FALLBACK,
+                "reasoning_content": "still thinking",
+            }
+
+    llm = AlwaysReasoningLLM()
+    result = await PatternRuntime().compact_context_if_needed(
+        context=context, llm=llm, metadata={"phase": "test"}
+    )
+
+    # One request, not one per rung.
+    assert llm.budgets == [8000]
+    assert result.strategy == "truncate"
+    assert result.metadata["llm_summary_unusable"] is True

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -17,7 +17,12 @@ from xagent.core.agent.runtime import (
     prepare_llm_for_context,
     resolved_llm_metadata,
 )
-from xagent.core.model.chat.types import ChunkType, StreamChunk
+from xagent.core.model.chat.types import (
+    CONTENT_SOURCE_KEY,
+    CONTENT_SOURCE_REASONING_FALLBACK,
+    ChunkType,
+    StreamChunk,
+)
 from xagent.core.task_runtime import PREFERRED_INPUT_MODALITIES_METADATA_KEY
 
 
@@ -1498,7 +1503,7 @@ async def test_compaction_retries_with_a_smaller_budget_before_truncating() -> N
         async def chat(self, **kwargs: Any) -> Any:
             budget = kwargs["max_tokens"]
             self.budgets.append(budget)
-            if budget > 1024:
+            if budget > 4096:
                 raise RuntimeError("max_tokens is too large for this model")
             return {"content": "summary within the model's output cap"}
 
@@ -1507,9 +1512,9 @@ async def test_compaction_retries_with_a_smaller_budget_before_truncating() -> N
         context=context, llm=llm, metadata={"phase": "test"}
     )
 
-    # Asked big, was refused, asked small, succeeded -- and summarized rather
+    # Asked big, was refused, stepped down, succeeded -- and summarized rather
     # than dropping messages.
-    assert llm.budgets == [8000, 256]
+    assert llm.budgets == [8000, 1024]
     assert result.compacted
     assert result.strategy == "llm_summary"
     assert "output cap" in context.messages[0].content
@@ -1541,3 +1546,54 @@ async def test_compaction_does_not_retry_when_already_at_the_floor() -> None:
     assert llm.calls == 1
     assert result.strategy == "truncate"
     assert "upstream is down" in result.metadata["llm_compact_error"]
+
+
+@pytest.mark.asyncio
+async def test_compaction_ladder_skips_a_budget_the_model_cannot_use() -> None:
+    """The step down must not go straight to the floor.
+
+    A reasoning model draws its reasoning from the same allowance, so a
+    budget that is merely *accepted* can still produce no summary -- the
+    client marks such a response as a substituted reasoning trace and
+    compaction rejects it. 1024 is on the ladder because it was the ceiling
+    before this PR raised it, and is therefore known to leave room for an
+    answer; jumping from 8000 to 256 would spend a request to arrive at the
+    same truncation.
+    """
+    context = ExecutionContext(execution_id="budget-ladder")
+    context.compact_config.threshold = 32000
+    context.add_user_message("current request")
+    context.add_tool_result(
+        "read_file", {"output": "x" * 200_000}, tool_call_id="call-1"
+    )
+
+    class CappedReasoningLLM:
+        model_name = "compact-test"
+
+        def __init__(self) -> None:
+            self.budgets: list[int] = []
+
+        async def chat(self, **kwargs: Any) -> Any:
+            budget = kwargs["max_tokens"]
+            self.budgets.append(budget)
+            if budget > 4096:
+                raise RuntimeError("max_tokens is too large for this model")
+            if budget < 1024:
+                # Whole allowance spent reasoning; the client surfaces the
+                # trace in place of content and marks it.
+                return {
+                    "content": "thinking about the file",
+                    CONTENT_SOURCE_KEY: CONTENT_SOURCE_REASONING_FALLBACK,
+                    "reasoning_content": "thinking about the file",
+                }
+            return {"content": "a real summary of the prior work"}
+
+    llm = CappedReasoningLLM()
+    result = await PatternRuntime().compact_context_if_needed(
+        context=context, llm=llm, metadata={"phase": "test"}
+    )
+
+    assert llm.budgets == [8000, 1024]
+    assert result.compacted
+    assert result.strategy == "llm_summary"
+    assert "a real summary" in context.messages[0].content

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -1410,3 +1410,62 @@ async def test_compact_context_if_needed_falls_back_to_truncate_without_orphans(
             for message in ctx.messages
         ]
     )
+
+
+@pytest.mark.asyncio
+async def test_compaction_records_that_an_unusable_summary_was_discarded() -> None:
+    """A summary that was requested and then discarded must leave a trace.
+
+    The error path already records ``llm_compact_error``. Without an
+    equivalent here, a summary that came back empty -- or that the client
+    marked as a substituted reasoning trace -- is indistinguishable in the
+    trace from compaction that never attempted to summarize, which is exactly
+    the case an operator would want to see.
+    """
+
+    class CompactTracer:
+        """Accepts the full trace_event signature, including ``step_id``,
+        which the compaction events carry."""
+
+        def __init__(self) -> None:
+            self.events: list[dict[str, Any]] = []
+
+        async def trace_event(
+            self, event_type: Any, *, data: dict[str, Any] | None = None, **_: Any
+        ) -> None:
+            self.events.append(
+                {
+                    "event_type": getattr(event_type, "value", str(event_type)),
+                    "data": data or {},
+                }
+            )
+
+    tracer = CompactTracer()
+    runtime = PatternRuntime(tracer=tracer)
+    context = ExecutionContext(execution_id="unusable-summary")
+    context.compact_config.threshold = 1
+    context.add_user_message("current request")
+    context.add_tool_result("read_file", {"output": "x" * 200}, tool_call_id="call-1")
+
+    class EmptySummaryLLM:
+        model_name = "compact-test"
+
+        async def chat(self, **_: Any) -> Any:
+            return {"content": ""}
+
+    result = await runtime.compact_context_if_needed(
+        context=context,
+        llm=EmptySummaryLLM(),
+        metadata={"phase": "test"},
+    )
+
+    assert result.compacted
+    # Fell back to dropping messages, and said so.
+    assert result.strategy == "truncate"
+    assert result.metadata["llm_summary_unusable"] is True
+    assert result.metadata["fallback_strategy"] == "truncate"
+    # The emitted compact event carries it too, so this is visible without
+    # reading the return value.
+    assert any(
+        event["data"].get("llm_summary_unusable") is True for event in tracer.events
+    )

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -1469,3 +1469,75 @@ async def test_compaction_records_that_an_unusable_summary_was_discarded() -> No
     assert any(
         event["data"].get("llm_summary_unusable") is True for event in tracer.events
     )
+
+
+@pytest.mark.asyncio
+async def test_compaction_retries_with_a_smaller_budget_before_truncating() -> None:
+    """The requested budget is a guess; a wrong guess must not cost the summary.
+
+    It follows the model's *input* window, while providers cap the *output*
+    separately and much lower. Nothing in the model config records that limit
+    -- the one number stored per model is a default to send, not a ceiling the
+    model can produce -- so a model whose output cap sits below the requested
+    budget would previously have lost its summary entirely and fallen back to
+    dropping messages, the outcome this path exists to avoid.
+    """
+    context = ExecutionContext(execution_id="budget-retry")
+    context.compact_config.threshold = 32000
+    context.add_user_message("current request")
+    context.add_tool_result(
+        "read_file", {"output": "x" * 200_000}, tool_call_id="call-1"
+    )
+
+    class OutputCappedLLM:
+        model_name = "compact-test"
+
+        def __init__(self) -> None:
+            self.budgets: list[int] = []
+
+        async def chat(self, **kwargs: Any) -> Any:
+            budget = kwargs["max_tokens"]
+            self.budgets.append(budget)
+            if budget > 1024:
+                raise RuntimeError("max_tokens is too large for this model")
+            return {"content": "summary within the model's output cap"}
+
+    llm = OutputCappedLLM()
+    result = await PatternRuntime().compact_context_if_needed(
+        context=context, llm=llm, metadata={"phase": "test"}
+    )
+
+    # Asked big, was refused, asked small, succeeded -- and summarized rather
+    # than dropping messages.
+    assert llm.budgets == [8000, 256]
+    assert result.compacted
+    assert result.strategy == "llm_summary"
+    assert "output cap" in context.messages[0].content
+
+
+@pytest.mark.asyncio
+async def test_compaction_does_not_retry_when_already_at_the_floor() -> None:
+    """A failure at the smallest budget is not a budget problem."""
+    context = ExecutionContext(execution_id="budget-floor")
+    context.compact_config.threshold = 1
+    context.add_user_message("current request")
+    context.add_tool_result("read_file", {"output": "x" * 200}, tool_call_id="call-1")
+
+    class AlwaysFailingLLM:
+        model_name = "compact-test"
+
+        def __init__(self) -> None:
+            self.calls = 0
+
+        async def chat(self, **kwargs: Any) -> Any:
+            self.calls += 1
+            raise RuntimeError("upstream is down")
+
+    llm = AlwaysFailingLLM()
+    result = await PatternRuntime().compact_context_if_needed(
+        context=context, llm=llm, metadata={"phase": "test"}
+    )
+
+    assert llm.calls == 1
+    assert result.strategy == "truncate"
+    assert "upstream is down" in result.metadata["llm_compact_error"]

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -1731,6 +1731,14 @@ def _bad_request(
     code: str | None = None,
     metadata: dict | None = None,
 ) -> openai.BadRequestError:
+    """Build the error the way the SDK does, from a wire-shaped response.
+
+    Constructing ``BadRequestError`` by hand invites getting the body shape
+    wrong: the wire format wraps the error object, but the SDK unwraps it in
+    ``_make_status_error``, so a hand-built wrapped body is a shape no real
+    error has -- and code that reads it passes its tests while doing nothing
+    in production. Going through the SDK removes the choice.
+    """
     error_payload: dict = {"message": message, "type": "invalid_request_error"}
     if code is not None:
         error_payload["code"] = code
@@ -1738,14 +1746,16 @@ def _bad_request(
         error_payload["param"] = param
     if metadata is not None:
         error_payload["metadata"] = metadata
-    return openai.BadRequestError(
-        f"Error code: 400 - {{'error': {{'message': '{message}'}}}}",
-        response=httpx.Response(
-            400,
-            request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
-        ),
-        body={"error": error_payload},
+    response = httpx.Response(
+        400,
+        request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+        json={"error": error_payload},
     )
+    error = openai.AsyncOpenAI(api_key="test-key")._make_status_error_from_response(
+        response
+    )
+    assert isinstance(error, openai.BadRequestError)
+    return error
 
 
 _MAX_TOKENS_REJECTION = (
@@ -2102,6 +2112,51 @@ class TestRejectedParameterIdentification:
         )
 
         assert mock_client.chat.completions.create.await_count == 2
+        retry_kwargs = mock_client.chat.completions.create.call_args_list[1].kwargs
+        assert "response_format" not in retry_kwargs
+        assert retry_kwargs["max_tokens"] == 5000
+        assert "max_completion_tokens" not in retry_kwargs
+
+    @pytest.mark.asyncio
+    async def test_upstream_blob_naming_the_replacement_does_not_rename(
+        self, openai_llm_config, mock_chat_completion, mocker
+    ):
+        """The sharpest form of the problem.
+
+        Here the echoed upstream text names ``max_completion_tokens`` itself,
+        which is the one phrase the text-only rule trusts. Only the endpoint's
+        own ``param`` can say that this rejection is about response_format --
+        so this fails unless that field is actually readable, which it is not
+        when the code looks for a wrapper the SDK has already unwrapped.
+        """
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _bad_request(
+                "Unsupported parameter: 'response_format' is not supported "
+                "with this model.",
+                param="response_format",
+                code="unsupported_parameter",
+                metadata={
+                    "provider_name": "upstream-a",
+                    "previous_errors": (
+                        '{"error": "use max_completion_tokens for this model"}'
+                    ),
+                },
+            ),
+            mock_chat_completion,
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+        await llm.chat(
+            [{"role": "user", "content": "Summarize."}],
+            max_tokens=5000,
+            response_format={"type": "json_object"},
+        )
+
         retry_kwargs = mock_client.chat.completions.create.call_args_list[1].kwargs
         assert "response_format" not in retry_kwargs
         assert retry_kwargs["max_tokens"] == 5000

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -2221,3 +2221,76 @@ class TestSequentiallyRejectedParameters:
             )
 
         assert mock_client.chat.completions.create.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_vision_chat_degrades_two_rejections_in_a_row(
+        self, openai_llm_config, mock_chat_completion, mocker
+    ):
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _bad_request(
+                _MAX_TOKENS_REJECTION, param="max_tokens", code="unsupported_parameter"
+            ),
+            _bad_request(
+                "Unsupported parameter: 'response_format'.", param="response_format"
+            ),
+            mock_chat_completion,
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config, abilities=["chat", "vision"])
+        response = await llm.vision_chat(
+            [{"role": "user", "content": "Describe this image."}],
+            max_tokens=5000,
+            response_format={"type": "json_object"},
+        )
+
+        assert response["content"] == "Hello World"
+        assert mock_client.chat.completions.create.await_count == 3
+        final_kwargs = mock_client.chat.completions.create.call_args_list[2].kwargs
+        assert final_kwargs["max_completion_tokens"] == 5000
+        assert "response_format" not in final_kwargs
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_degrades_two_rejections_in_a_row(
+        self, openai_llm_config, mocker
+    ):
+        """The streaming path rebuilds the stream inside the loop rather than
+        calling the shared helper the other two use, so its second round needs
+        its own coverage."""
+
+        async def one_chunk_stream():
+            yield _stream_chunk(finish_reason="stop")
+
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _bad_request(
+                _MAX_TOKENS_REJECTION, param="max_tokens", code="unsupported_parameter"
+            ),
+            _bad_request(
+                "Unsupported parameter: 'response_format'.", param="response_format"
+            ),
+            one_chunk_stream(),
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+        _ = [
+            chunk
+            async for chunk in llm.stream_chat(
+                [{"role": "user", "content": "Summarize."}],
+                max_tokens=5000,
+                response_format={"type": "json_object"},
+            )
+        ]
+
+        assert mock_client.chat.completions.create.await_count == 3
+        final_kwargs = mock_client.chat.completions.create.call_args_list[2].kwargs
+        assert final_kwargs["max_completion_tokens"] == 5000
+        assert "response_format" not in final_kwargs

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -11,6 +11,7 @@ import pytest
 from openai.types.chat.chat_completion_chunk import ChoiceDelta
 from pydantic import BaseModel, ConfigDict
 
+from xagent.core.agent.context.execution import ExecutionContext
 from xagent.core.model.chat.basic.base import BaseLLM
 from xagent.core.model.chat.basic.openai import (
     PROVIDER_STATE_METADATA_KEY,
@@ -20,6 +21,10 @@ from xagent.core.model.chat.basic.openai import (
 )
 from xagent.core.model.chat.error import retry_on
 from xagent.core.model.chat.exceptions import LLMEmptyContentError, LLMRetryableError
+from xagent.core.model.chat.types import (
+    CONTENT_SOURCE_KEY,
+    CONTENT_SOURCE_REASONING_FALLBACK,
+)
 from xagent.core.retry.strategy import FixedDelay
 from xagent.core.retry.wrapper import create_retry_wrapper
 
@@ -1945,3 +1950,91 @@ class TestRejectedParameterDegrade:
         retry_kwargs = mock_client.chat.completions.create.call_args_list[1].kwargs
         assert retry_kwargs["max_completion_tokens"] == 5000
         assert retry_kwargs["extra_body"] == {"probe": 1}
+
+
+class TestReasoningFallbackIsDeclared:
+    """The client marks content it substituted, and compaction honours it.
+
+    These two live in different packages; without a test that runs the real
+    producer into the real consumer, a change to the response shape on one
+    side would silently stop the other from recognising it.
+    """
+
+    @staticmethod
+    def _truncated_reasoning_completion():
+        message = SimpleNamespace(
+            role="assistant",
+            content="",
+            tool_calls=None,
+            reasoning_content="Let me think about the file first",
+        )
+        return SimpleNamespace(
+            choices=[SimpleNamespace(message=message, finish_reason="length")],
+            usage=None,
+            model_dump=lambda: {"choices": [{"finish_reason": "length"}]},
+        )
+
+    @pytest.mark.asyncio
+    async def test_client_marks_a_substituted_reasoning_trace(
+        self, openai_llm_config, mocker
+    ):
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.return_value = (
+            self._truncated_reasoning_completion()
+        )
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+        response = await llm.chat([{"role": "user", "content": "Summarize."}])
+
+        assert response["content"] == "Let me think about the file first"
+        assert response[CONTENT_SOURCE_KEY] == CONTENT_SOURCE_REASONING_FALLBACK
+
+    @pytest.mark.asyncio
+    async def test_compaction_rejects_what_the_client_marked(
+        self, openai_llm_config, mocker
+    ):
+        """The producer's real output, fed to the real consumer."""
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.return_value = (
+            self._truncated_reasoning_completion()
+        )
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+        response = await llm.chat([{"role": "user", "content": "Summarize."}])
+
+        context = ExecutionContext()
+        context.compact_config.threshold = 1
+        context.add_user_message("current request")
+        context.add_tool_result(
+            "read_file", {"output": "x" * 200}, tool_call_id="call-1"
+        )
+        before = list(context.messages)
+
+        result = context.compact_with_llm_response(response, llm=None)
+
+        assert not result.compacted
+        assert context.messages == before
+
+    @pytest.mark.asyncio
+    async def test_an_ordinary_answer_carries_no_marker(
+        self, openai_llm_config, mock_chat_completion, mocker
+    ):
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.return_value = mock_chat_completion
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+        response = await llm.chat([{"role": "user", "content": "Summarize."}])
+
+        assert CONTENT_SOURCE_KEY not in response

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -1733,17 +1733,18 @@ def _bad_request(
 ) -> openai.BadRequestError:
     """Build the error the way the SDK does, from a wire-shaped response.
 
-    Constructing ``BadRequestError`` by hand invites getting the body shape
-    wrong: the wire format wraps the error object, but the SDK unwraps it in
-    ``_make_status_error``, so a hand-built wrapped body is a shape no real
-    error has -- and code that reads it passes its tests while doing nothing
-    in production. Going through the SDK removes the choice.
+    Constructing the exception directly with a hand-written ``body`` is what
+    made an earlier revision's structural lookup look tested when it could
+    never fire in production: the SDK unwraps the outer ``error`` object in
+    ``_make_status_error``, so a fixture that passes the wrapped shape is
+    testing a shape no real error has. Going through
+    ``_make_status_error_from_response`` keeps the fixture honest.
     """
     error_payload: dict = {"message": message, "type": "invalid_request_error"}
-    if code is not None:
-        error_payload["code"] = code
     if param is not None:
         error_payload["param"] = param
+    if code is not None:
+        error_payload["code"] = code
     if metadata is not None:
         error_payload["metadata"] = metadata
     response = httpx.Response(
@@ -1751,7 +1752,7 @@ def _bad_request(
         request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
         json={"error": error_payload},
     )
-    error = openai.AsyncOpenAI(api_key="test-key")._make_status_error_from_response(
+    error = openai.AsyncOpenAI(api_key="test")._make_status_error_from_response(
         response
     )
     assert isinstance(error, openai.BadRequestError)
@@ -1838,12 +1839,17 @@ class TestRejectedParameterDegrade:
     async def test_response_format_degrade_survives_a_max_tokens_mention(
         self, openai_llm_config, mock_chat_completion, mocker
     ):
-        """Regression guard: an error that merely echoes ``max_tokens`` in its
-        upstream blob must not consume the response_format degrade.
+        """An error that merely echoes ``max_tokens`` in its upstream blob
+        must not consume the response_format degrade.
 
-        Here max_tokens is present in the request but the rejection is about
-        response_format alone, so only response_format is degraded and
-        max_tokens is left as it was.
+        Here max_tokens is in the request but the rejection is about
+        response_format alone, so only response_format is degraded.
+        Passes against the pre-PR code too, because renaming max_tokens did
+        not exist there -- so this is not a regression test for main. It
+        guards a mistake this PR made and had to correct: an
+        earlier revision judged the two degrades with if/elif, which let a
+        response_format rejection be skipped whenever the same text mentioned
+        max_tokens.
         """
         mock_client = mocker.AsyncMock()
         mock_client.chat.completions.create.side_effect = [
@@ -1874,9 +1880,16 @@ class TestRejectedParameterDegrade:
     async def test_an_out_of_range_value_does_not_trigger_the_rename(
         self, openai_llm_config, mocker
     ):
-        """Anchoring on the replacement name keeps arbitrary upstream text --
-        ``provider_raw`` can echo a whole request body -- from starting a
-        retry that cannot help."""
+        """Anchoring on an unsupported-parameter signal keeps arbitrary
+        upstream text -- ``provider_raw`` can echo a whole request body --
+        from starting a retry that cannot help.
+        Passes against the pre-PR code too, because renaming max_tokens did
+        not exist there -- so this is not a regression test for main. It
+        guards a mistake this PR made and had to correct: an earlier
+        revision treated ``param == "max_tokens"`` as sufficient on its own,
+        which re-opened exactly this hole, and went unnoticed because the
+        fixture did not set ``param``.
+        """
         mock_client = mocker.AsyncMock()
         # A real out-of-range rejection names the same param as an
         # unsupported-parameter one; the param alone must not be taken as
@@ -1894,25 +1907,6 @@ class TestRejectedParameterDegrade:
             await llm.chat(
                 [{"role": "user", "content": "Summarize."}], max_tokens=200000
             )
-
-        assert mock_client.chat.completions.create.await_count == 1
-
-    @pytest.mark.asyncio
-    async def test_no_budget_in_the_request_means_no_rename(
-        self, openai_llm_config, mocker
-    ):
-        mock_client = mocker.AsyncMock()
-        mock_client.chat.completions.create.side_effect = _bad_request(
-            _MAX_TOKENS_REJECTION
-        )
-        mocker.patch(
-            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
-            return_value=mock_client,
-        )
-
-        llm = OpenAILLM(**openai_llm_config)
-        with pytest.raises(RuntimeError):
-            await llm.chat([{"role": "user", "content": "Summarize."}])
 
         assert mock_client.chat.completions.create.await_count == 1
 
@@ -2049,22 +2043,6 @@ class TestReasoningFallbackIsDeclared:
         assert not result.compacted
         assert context.messages == before
 
-    @pytest.mark.asyncio
-    async def test_an_ordinary_answer_carries_no_marker(
-        self, openai_llm_config, mock_chat_completion, mocker
-    ):
-        mock_client = mocker.AsyncMock()
-        mock_client.chat.completions.create.return_value = mock_chat_completion
-        mocker.patch(
-            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
-            return_value=mock_client,
-        )
-
-        llm = OpenAILLM(**openai_llm_config)
-        response = await llm.chat([{"role": "user", "content": "Summarize."}])
-
-        assert CONTENT_SOURCE_KEY not in response
-
 
 class TestRejectedParameterIdentification:
     """Which parameter a 400 is about, when the text alone cannot say.
@@ -2081,8 +2059,12 @@ class TestRejectedParameterIdentification:
     ):
         """The rejection is about response_format; an earlier upstream in the
         gateway's chain merely grumbled about max_tokens. Renaming max_tokens
-        here would spend the one retry on a parameter this endpoint accepts,
-        and lose the response_format recovery that would have worked.
+        here would spend the retry on a parameter this endpoint accepts, and
+        lose the response_format recovery that would have worked.
+        Passes against the pre-PR code too, because renaming max_tokens did
+        not exist there -- so this is not a regression test for main. It
+        guards a mistake this PR made and had to correct: the
+        case a reviewer reproduced against an earlier revision of this branch.
         """
         mock_client = mocker.AsyncMock()
         mock_client.chat.completions.create.side_effect = [
@@ -2161,37 +2143,6 @@ class TestRejectedParameterIdentification:
         assert "response_format" not in retry_kwargs
         assert retry_kwargs["max_tokens"] == 5000
         assert "max_completion_tokens" not in retry_kwargs
-
-    @pytest.mark.asyncio
-    async def test_explicit_param_settles_it_without_reading_the_text(
-        self, openai_llm_config, mock_chat_completion, mocker
-    ):
-        """Even a message that names max_completion_tokens does not override
-        the endpoint's own answer about which parameter it rejected."""
-        mock_client = mocker.AsyncMock()
-        mock_client.chat.completions.create.side_effect = [
-            _bad_request(
-                "response_format rejected; note this model wants "
-                "max_completion_tokens in general.",
-                param="response_format",
-            ),
-            mock_chat_completion,
-        ]
-        mocker.patch(
-            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
-            return_value=mock_client,
-        )
-
-        llm = OpenAILLM(**openai_llm_config)
-        await llm.chat(
-            [{"role": "user", "content": "Summarize."}],
-            max_tokens=5000,
-            response_format={"type": "json_object"},
-        )
-
-        retry_kwargs = mock_client.chat.completions.create.call_args_list[1].kwargs
-        assert "response_format" not in retry_kwargs
-        assert retry_kwargs["max_tokens"] == 5000
 
 
 class TestSequentiallyRejectedParameters:

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -1717,3 +1717,231 @@ class TestFieldContent:
 
         assert "reasoning_content" not in delta.model_fields_set
         assert field_content(delta, "reasoning_content") == (True, "step 1")
+
+
+def _bad_request(message: str) -> openai.BadRequestError:
+    return openai.BadRequestError(
+        f"Error code: 400 - {{'error': {{'message': '{message}'}}}}",
+        response=httpx.Response(
+            400,
+            request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+        ),
+        body={"error": {"message": message, "code": 400}},
+    )
+
+
+_MAX_TOKENS_REJECTION = (
+    "Unsupported parameter: 'max_tokens' is not supported with this model. "
+    "Use 'max_completion_tokens' instead."
+)
+
+
+class TestRejectedParameterDegrade:
+    """Reasoning models spell the output budget ``max_completion_tokens``.
+
+    Context compaction is the only caller that sends an output budget at all,
+    so without this a reasoning model converses normally while every
+    compaction fails and falls back to dropping messages.
+    """
+
+    @pytest.mark.asyncio
+    async def test_chat_renames_max_tokens(
+        self, openai_llm_config, mock_chat_completion, mocker
+    ):
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _bad_request(_MAX_TOKENS_REJECTION),
+            mock_chat_completion,
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+        response = await llm.chat(
+            [{"role": "user", "content": "Summarize."}], max_tokens=5000
+        )
+
+        assert response["content"] == "Hello World"
+        retry_kwargs = mock_client.chat.completions.create.call_args_list[1].kwargs
+        # Renamed, not dropped: for compaction the budget is what keeps a
+        # summary from re-triggering the next compaction.
+        assert "max_tokens" not in retry_kwargs
+        assert retry_kwargs["max_completion_tokens"] == 5000
+
+    @pytest.mark.asyncio
+    async def test_one_rejection_naming_both_degrades_both(
+        self, openai_llm_config, mock_chat_completion, mocker
+    ):
+        """The two degrades are independent, not alternatives.
+
+        Judging them with if/elif let a response_format rejection be skipped
+        whenever the same error text also mentioned max_tokens -- and
+        ``vision_chat`` always sends both parameters together, so the
+        precondition is routinely met.
+        """
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _bad_request(
+                "Unsupported parameter: 'max_tokens' is not supported with this "
+                "model. Use 'max_completion_tokens' instead. response_format is "
+                "also not supported."
+            ),
+            mock_chat_completion,
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+        await llm.chat(
+            [{"role": "user", "content": "Summarize."}],
+            max_tokens=5000,
+            response_format={"type": "json_object"},
+        )
+
+        retry_kwargs = mock_client.chat.completions.create.call_args_list[1].kwargs
+        assert retry_kwargs["max_completion_tokens"] == 5000
+        assert "response_format" not in retry_kwargs
+
+    @pytest.mark.asyncio
+    async def test_response_format_degrade_survives_a_max_tokens_mention(
+        self, openai_llm_config, mock_chat_completion, mocker
+    ):
+        """Regression guard: an error that merely echoes ``max_tokens`` in its
+        upstream blob must not consume the response_format degrade.
+
+        Here max_tokens is present in the request but the rejection is about
+        response_format alone, so only response_format is degraded and
+        max_tokens is left as it was.
+        """
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _bad_request(
+                "response_format is not supported by this model "
+                "(request had max_tokens=5000)"
+            ),
+            mock_chat_completion,
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+        await llm.chat(
+            [{"role": "user", "content": "Summarize."}],
+            max_tokens=5000,
+            response_format={"type": "json_object"},
+        )
+
+        retry_kwargs = mock_client.chat.completions.create.call_args_list[1].kwargs
+        assert "response_format" not in retry_kwargs
+        assert retry_kwargs["max_tokens"] == 5000
+        assert "max_completion_tokens" not in retry_kwargs
+
+    @pytest.mark.asyncio
+    async def test_an_out_of_range_value_does_not_trigger_the_rename(
+        self, openai_llm_config, mocker
+    ):
+        """Anchoring on the replacement name keeps arbitrary upstream text --
+        ``provider_raw`` can echo a whole request body -- from starting a
+        retry that cannot help."""
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = _bad_request(
+            "max_tokens is too large: 200000"
+        )
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+        with pytest.raises(RuntimeError, match="too large"):
+            await llm.chat(
+                [{"role": "user", "content": "Summarize."}], max_tokens=200000
+            )
+
+        assert mock_client.chat.completions.create.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_no_budget_in_the_request_means_no_rename(
+        self, openai_llm_config, mocker
+    ):
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = _bad_request(
+            _MAX_TOKENS_REJECTION
+        )
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+        with pytest.raises(RuntimeError):
+            await llm.chat([{"role": "user", "content": "Summarize."}])
+
+        assert mock_client.chat.completions.create.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_vision_chat_renames_max_tokens(
+        self, openai_llm_config, mock_chat_completion, mocker
+    ):
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _bad_request(_MAX_TOKENS_REJECTION),
+            mock_chat_completion,
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config, abilities=["chat", "vision"])
+        response = await llm.vision_chat(
+            [{"role": "user", "content": "Describe this image."}], max_tokens=5000
+        )
+
+        assert response["content"] == "Hello World"
+        retry_kwargs = mock_client.chat.completions.create.call_args_list[1].kwargs
+        assert retry_kwargs["max_completion_tokens"] == 5000
+
+    @pytest.mark.asyncio
+    async def test_stream_chat_renames_max_tokens_and_keeps_extra_body(
+        self, openai_llm_config, mocker
+    ):
+        """The streaming path rebuilds the stream itself rather than reusing
+        the non-streaming helper, so its retry needs its own coverage --
+        including the ``extra_body`` branch, which the sibling methods do not
+        have."""
+
+        async def one_chunk_stream():
+            yield _stream_chunk(finish_reason="stop")
+
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _bad_request(_MAX_TOKENS_REJECTION),
+            one_chunk_stream(),
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+        mocker.patch.object(
+            llm, "_prepare_provider_reasoning_extra_body", return_value={"probe": 1}
+        )
+        _ = [
+            chunk
+            async for chunk in llm.stream_chat(
+                [{"role": "user", "content": "Summarize."}], max_tokens=5000
+            )
+        ]
+
+        assert mock_client.chat.completions.create.await_count == 2
+        retry_kwargs = mock_client.chat.completions.create.call_args_list[1].kwargs
+        assert retry_kwargs["max_completion_tokens"] == 5000
+        assert retry_kwargs["extra_body"] == {"probe": 1}

--- a/tests/core/model/chat/basic/test_openai.py
+++ b/tests/core/model/chat/basic/test_openai.py
@@ -1724,14 +1724,27 @@ class TestFieldContent:
         assert field_content(delta, "reasoning_content") == (True, "step 1")
 
 
-def _bad_request(message: str) -> openai.BadRequestError:
+def _bad_request(
+    message: str,
+    *,
+    param: str | None = None,
+    code: str | None = None,
+    metadata: dict | None = None,
+) -> openai.BadRequestError:
+    error_payload: dict = {"message": message, "type": "invalid_request_error"}
+    if code is not None:
+        error_payload["code"] = code
+    if param is not None:
+        error_payload["param"] = param
+    if metadata is not None:
+        error_payload["metadata"] = metadata
     return openai.BadRequestError(
         f"Error code: 400 - {{'error': {{'message': '{message}'}}}}",
         response=httpx.Response(
             400,
             request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
         ),
-        body={"error": {"message": message, "code": 400}},
+        body={"error": error_payload},
     )
 
 
@@ -1855,8 +1868,11 @@ class TestRejectedParameterDegrade:
         ``provider_raw`` can echo a whole request body -- from starting a
         retry that cannot help."""
         mock_client = mocker.AsyncMock()
+        # A real out-of-range rejection names the same param as an
+        # unsupported-parameter one; the param alone must not be taken as
+        # licence to rename.
         mock_client.chat.completions.create.side_effect = _bad_request(
-            "max_tokens is too large: 200000"
+            "max_tokens is too large: 200000", param="max_tokens"
         )
         mocker.patch(
             "xagent.core.model.chat.basic.openai.AsyncOpenAI",
@@ -2038,3 +2054,164 @@ class TestReasoningFallbackIsDeclared:
         response = await llm.chat([{"role": "user", "content": "Summarize."}])
 
         assert CONTENT_SOURCE_KEY not in response
+
+
+class TestRejectedParameterIdentification:
+    """Which parameter a 400 is about, when the text alone cannot say.
+
+    ``_format_openai_error`` appends ``provider_raw`` and ``previous_errors``,
+    so for a gateway that tried several upstreams the message is several
+    providers' complaints concatenated. A keyword found there may belong to an
+    attempt unrelated to this failure.
+    """
+
+    @pytest.mark.asyncio
+    async def test_echoed_request_does_not_condemn_an_unrejected_parameter(
+        self, openai_llm_config, mock_chat_completion, mocker
+    ):
+        """The rejection is about response_format; an earlier upstream in the
+        gateway's chain merely grumbled about max_tokens. Renaming max_tokens
+        here would spend the one retry on a parameter this endpoint accepts,
+        and lose the response_format recovery that would have worked.
+        """
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _bad_request(
+                "Unsupported parameter: 'response_format' is not supported "
+                "with this model.",
+                param="response_format",
+                metadata={
+                    "provider_name": "upstream-a",
+                    "previous_errors": (
+                        '{"error": "max_tokens must be <= 4096 for this model"}'
+                    ),
+                },
+            ),
+            mock_chat_completion,
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+        await llm.chat(
+            [{"role": "user", "content": "Summarize."}],
+            max_tokens=5000,
+            response_format={"type": "json_object"},
+        )
+
+        assert mock_client.chat.completions.create.await_count == 2
+        retry_kwargs = mock_client.chat.completions.create.call_args_list[1].kwargs
+        assert "response_format" not in retry_kwargs
+        assert retry_kwargs["max_tokens"] == 5000
+        assert "max_completion_tokens" not in retry_kwargs
+
+    @pytest.mark.asyncio
+    async def test_explicit_param_settles_it_without_reading_the_text(
+        self, openai_llm_config, mock_chat_completion, mocker
+    ):
+        """Even a message that names max_completion_tokens does not override
+        the endpoint's own answer about which parameter it rejected."""
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _bad_request(
+                "response_format rejected; note this model wants "
+                "max_completion_tokens in general.",
+                param="response_format",
+            ),
+            mock_chat_completion,
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+        await llm.chat(
+            [{"role": "user", "content": "Summarize."}],
+            max_tokens=5000,
+            response_format={"type": "json_object"},
+        )
+
+        retry_kwargs = mock_client.chat.completions.create.call_args_list[1].kwargs
+        assert "response_format" not in retry_kwargs
+        assert retry_kwargs["max_tokens"] == 5000
+
+
+class TestSequentiallyRejectedParameters:
+    """Endpoints commonly report one invalid parameter per response."""
+
+    @pytest.mark.asyncio
+    async def test_two_rejections_in_a_row_are_both_degraded(
+        self, openai_llm_config, mock_chat_completion, mocker
+    ):
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _bad_request(
+                _MAX_TOKENS_REJECTION, param="max_tokens", code="unsupported_parameter"
+            ),
+            _bad_request(
+                "Unsupported parameter: 'response_format'.",
+                param="response_format",
+            ),
+            mock_chat_completion,
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+        response = await llm.chat(
+            [{"role": "user", "content": "Summarize."}],
+            max_tokens=5000,
+            response_format={"type": "json_object"},
+        )
+
+        assert response["content"] == "Hello World"
+        assert mock_client.chat.completions.create.await_count == 3
+        final_kwargs = mock_client.chat.completions.create.call_args_list[2].kwargs
+        assert final_kwargs["max_completion_tokens"] == 5000
+        assert "response_format" not in final_kwargs
+
+    @pytest.mark.asyncio
+    async def test_the_loop_is_bounded_by_the_supported_degrades(
+        self, openai_llm_config, mocker
+    ):
+        """Bounded by construction: each degrade removes or renames a
+        parameter and fires only while that parameter is still present, so an
+        endpoint that keeps rejecting the same one cannot spin.
+
+        Four identical rejections are queued for two degradable parameters;
+        the loop must stop after three requests, not consume them all.
+        """
+        mock_client = mocker.AsyncMock()
+        mock_client.chat.completions.create.side_effect = [
+            _bad_request(
+                _MAX_TOKENS_REJECTION, param="max_tokens", code="unsupported_parameter"
+            ),
+            _bad_request(
+                "Unsupported parameter: 'response_format'.", param="response_format"
+            ),
+            _bad_request(
+                _MAX_TOKENS_REJECTION, param="max_tokens", code="unsupported_parameter"
+            ),
+            _bad_request(
+                _MAX_TOKENS_REJECTION, param="max_tokens", code="unsupported_parameter"
+            ),
+        ]
+        mocker.patch(
+            "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+            return_value=mock_client,
+        )
+
+        llm = OpenAILLM(**openai_llm_config)
+        with pytest.raises(RuntimeError):
+            await llm.chat(
+                [{"role": "user", "content": "Summarize."}],
+                max_tokens=5000,
+                response_format={"type": "json_object"},
+            )
+
+        assert mock_client.chat.completions.create.await_count == 3


### PR DESCRIPTION
Context compaction has two strategies: summarize with an LLM, or drop all but the last few messages. Only the first preserves what the agent did. Several paths reached the second without meaning to, and one of them could write a chain of thought into the conversation as if it were history.

Five self-contained commits, each with its own regression coverage.

### 1. Summarize with the main model when no compact model is set

`PatternRuntime` skips summary compaction entirely when no compact LLM is present. An empty compact slot is ordinary rather than exceptional — agent preview and delegated sub-agents resolve that slot themselves and validate only the default model — so the same agent behaved differently depending on how it was launched.

This reverses a previous policy: `test_auto_pattern_does_not_use_main_llm_for_compaction` asserted that an unconfigured slot left the main model untouched, so compaction cost nothing. What it cost instead was the summary. The test is rewritten to state the new intent rather than deleted.

The substitution happens at the two compaction call sites, not by defaulting the field on `Agent` or `AgentService`. Defaulting it further up would erase the difference between "unset" and "explicitly set to the main model", which the call sites would then have to recover by object identity — and identity only holds for the alias, so a user who picks the same model in both slots would not match. At the call site both values are in scope, `AgentService` keeps reporting the configured state, and compaction receives the model already resolved for this turn, so a virtual model reuses the turn's routing decision instead of routing again on the compaction prompt (whose only user message is the entire transcript).

Auto additionally resolves before compacting, the order `prepare_llm_for_context` documents and ReAct already followed.

### 2. Raise the summary budget ceiling to 8192 tokens

The budget was `min(1024, threshold // 4)`. The 1024 ceiling bound at every realistic window, and it is the whole allowance a reasoning model has — reasoning tokens come out of it, so such a model can spend the budget thinking and emit no summary at all.

Raised rather than removed. Both bounds do work: `threshold // 4` keeps a summary from re-triggering the next compaction, while the absolute ceiling accounts for the threshold scaling with the *input* window when providers cap the *output* separately and much lower. With no ceiling a 1M-token window would ask for ~187k output tokens; the request is rejected and compaction collapses into the message-dropping fallback it exists to avoid.

### 3. Rename `max_tokens` for models that require `max_completion_tokens`

Reasoning models reject `max_tokens`. Compaction is the only caller that sends an output budget at all, so a reasoning main model converses normally while every compaction fails and silently degrades.

The three near-identical degrade blocks in `chat`, `vision_chat` and `stream_chat` become one helper, which also fixes how the two degrades relate: as another branch of the existing `if`/`elif` they would be alternatives, so a `response_format` rejection whose text also mentioned `max_tokens` would lose its degrade entirely — and `vision_chat` sends both parameters on every call. Each parameter is now judged independently. The trigger is anchored on the replacement name or on "unsupported parameter", because `error_msg` carries `provider_raw` and `previous_errors` blobs that can mention `max_tokens` for unrelated reasons.

### 4. Declare when content is a substituted reasoning trace

When a reasoning model runs out of budget mid-thought, the OpenAI-compatible client surfaces the trace as `content` so a caller does not read a truncated-but-healthy response as an empty one. That suits a connection test and is wrong for compaction, where the summary replaces every prior message — a chain of thought accepted as the summary rewrites the agent's history into deliberation it never concluded.

The client now marks the substitution and compaction rejects what is marked. Marking it at the point of substitution keeps the two sides from drifting; recognising it by shape instead would put the agent context layer in the business of decoding a provider's wire format. A test runs the real client into the real `ExecutionContext`.

### 5. Record when a summary was produced and then discarded

An unusable summary caused the result to be replaced wholesale by the fallback, taking the request metadata with it, so the trace showed a plain truncate — indistinguishable from compaction that never tried. The error path already recorded `llm_compact_error`; the non-error case now gets the same treatment plus a warning log.

Not hypothetical: while writing these tests a signature mismatch in a test double raised inside the summary call, was swallowed by the broad `except`, and silently degraded compaction to truncation. It was noticed only because the test counted calls.

## Behavior changes

| Change | Effect |
|---|---|
| Unset compact slot now summarizes on the main model | New main-model calls where there were none. Affects agent preview, delegated sub-agents, and two `chat.py` error paths. Normal task chat is unaffected — it already resolves `compact_llm` to the default model. |
| Summary budget ceiling 1024 → 8192 | At the default threshold of 32000 the budget goes 1024 → 8000; at any threshold below 4096 it is unchanged. Longer, more complete summaries; more output tokens per compaction. |
| Auto resolves the virtual model before compacting | For `auto` routing, Auto may now compact at a different (correct) threshold. Concrete models are unaffected. One extra `get_messages_for_llm()` per decision. |
| A 400 naming both parameters degrades both | Previously only `response_format` was degraded. |
| `response_format` degrade log text | `API doesn't support response_format, …` → `API rejected response_format, …`. Alerting rules matching the old string would need updating. |
| New `content_source` key on substituted responses | No existing consumer reads that position (grepped). |
| New warning + two trace fields on discarded summaries | Observability only. |

No migration, no new config, no API or frontend change.

## Follow-up, not in this PR

The `truncate` strategy itself remains. After these commits its only reachable paths are a summary call that fails all retries, and genuine bugs. Removing it needs one more change first: bounding the summary prompt, which is currently unbounded and can exceed the compact model's own window. That belongs in its own PR.
