### PR TITLE
fix: stabilize Telegram voice cleanup test

### DIFF
--- a/tests/web/test_connector_runtime_entrypoints_e2e.py
+++ b/tests/web/test_connector_runtime_entrypoints_e2e.py
@@ -358,13 +358,17 @@ async def test_telegram_cancellation_during_voice_cleanup_closes_managed_lease(
         assert 123 not in bot.user_preparing_executions
     finally:
         allow_close.set()
-        if process_task is not None:
-            if not process_task.done():
-                process_task.cancel()
-            await asyncio.gather(process_task, return_exceptions=True)
-        if managed_lease is not None and not managed_lease._closed:
-            await managed_lease.close()
-        db.close()
+        try:
+            if process_task is not None:
+                if not process_task.done():
+                    process_task.cancel()
+                await asyncio.gather(process_task, return_exceptions=True)
+        finally:
+            try:
+                if managed_lease is not None and not managed_lease._closed:
+                    await managed_lease.close()
+            finally:
+                db.close()
 
 
 def _context_row_count(task_id: int) -> int:

--- a/tests/web/test_connector_runtime_entrypoints_e2e.py
+++ b/tests/web/test_connector_runtime_entrypoints_e2e.py
@@ -306,6 +306,7 @@ async def test_telegram_cancellation_during_voice_cleanup_closes_managed_lease(
     _setup_admin_headers()
     db = _db_session()
     managed_lease = None
+    process_task: asyncio.Task[None] | None = None
     close_started = asyncio.Event()
     allow_close = asyncio.Event()
     try:
@@ -344,7 +345,7 @@ async def test_telegram_cancellation_during_voice_cleanup_closes_managed_lease(
         process_task = asyncio.create_task(
             bot._process_user_messages_batch(123, [message])
         )
-        await asyncio.wait_for(close_started.wait(), timeout=2)
+        await asyncio.wait_for(close_started.wait(), timeout=10)
         managed_lease = captured_leases[0]
 
         process_task.cancel()
@@ -357,6 +358,10 @@ async def test_telegram_cancellation_during_voice_cleanup_closes_managed_lease(
         assert 123 not in bot.user_preparing_executions
     finally:
         allow_close.set()
+        if process_task is not None:
+            if not process_task.done():
+                process_task.cancel()
+            await asyncio.gather(process_task, return_exceptions=True)
         if managed_lease is not None and not managed_lease._closed:
             await managed_lease.close()
         db.close()


### PR DESCRIPTION
## Summary

- increase the voice-cleanup synchronization timeout to tolerate loaded CI runners
- always cancel and await the background Telegram processing task during test cleanup
- prevent timed-out test tasks from leaking into SQLite fixture teardown

## Testing

- ruff check tests/web/test_connector_runtime_entrypoints_e2e.py
- pytest -q -n 4 tests/web/test_connector_runtime_entrypoints_e2e.py (16 passed)