### PR TITLE
fix(mcp): resolve a server's catalog app by stable identity on teardown

### DIFF
--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -3482,7 +3482,11 @@ async def delete_mcp_server(
             # named after the app id, silently skipping the cleanup below and
             # leaving usable tokens behind after a successful teardown.
             # ``get_app_for_mcp_server`` prefers the row's own ``auth.app_id``
-            # stamp and falls back to id-then-display-name for unstamped rows.
+            # stamp; an unstamped row resolves only when the id and display
+            # name namespaces agree on one owner, and answers ``None`` when
+            # they do not -- which lands on the ``if app_info:`` guard below
+            # and leaves the credentials in place rather than deleting some
+            # other app's.
             app_info = get_app_for_mcp_server(db, server)
             if app_info:
                 provider = app_info.get("provider")

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -36,7 +36,7 @@ from ...core.utils.encryption import decrypt_value, encrypt_value
 from ..auth_dependencies import get_current_user, is_admin_user
 from ..mcp_apps import (
     get_all_mcp_apps,
-    get_app_by_name,
+    get_app_for_mcp_server,
     restrict_to_app_scoped_oauth_grant,
 )
 from ..models.custom_api import CustomApi, UserCustomApi
@@ -1553,7 +1553,10 @@ def _enrich_oauth_server_info(
     if server.transport != "oauth":
         return None, None, None
 
-    app_info = get_app_by_name(db, str(server.name))
+    # Stable identity, not the mutable display name: an id-named row (the
+    # catalog-connect convention) resolved to nothing here, so its app_id,
+    # provider and connected account were all reported as absent.
+    app_info = get_app_for_mcp_server(db, server)
     if not app_info:
         return None, None, None
 
@@ -3471,10 +3474,16 @@ async def delete_mcp_server(
 
         # If it's an OAuth server, also delete the corresponding OAuth tokens
         if server.transport == "oauth":
-            from ..mcp_apps import get_app_by_name
-
-            # Find the corresponding app_id and provider
-            app_info = get_app_by_name(db, str(server.name))
+            # Resolve by stable identity rather than by ``server.name``.
+            # ``PublicMCPApp.name`` is mutable and carries no uniqueness
+            # constraint, so a name lookup here decided whose credentials to
+            # delete using a value an admin rename can change out from under an
+            # in-flight disconnect -- and it resolved nothing at all for rows
+            # named after the app id, silently skipping the cleanup below and
+            # leaving usable tokens behind after a successful teardown.
+            # ``get_app_for_mcp_server`` prefers the row's own ``auth.app_id``
+            # stamp and falls back to id-then-display-name for unstamped rows.
+            app_info = get_app_for_mcp_server(db, server)
             if app_info:
                 provider = app_info.get("provider")
                 app_id = app_info.get("id")
@@ -3503,8 +3512,6 @@ async def delete_mcp_server(
                 # that row anymore — delete it too rather than leaving an
                 # inert orphan token behind.
                 if provider and provider not in providers_to_delete:
-                    from ..mcp_apps import get_app_for_mcp_server
-
                     other_servers = (
                         db.query(MCPServer)
                         .join(

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -731,9 +731,16 @@ def get_app_for_mcp_server(db: Session, server: Any) -> Dict[str, Any] | None:
 
     Unstamped rows predate ``auth.app_id`` and are resolved by the exact name
     they were provisioned under -- the app id for catalog-connect rows, the
-    display name for builtin OAuth rows. Once a row carries ``app_id``, an
-    invalid value must not fall back to a same-named app because that could
-    select another connector's credentials or launch configuration.
+    display name for builtin OAuth rows. Because a bare name cannot say which
+    convention wrote it, such a row resolves only when both namespaces agree
+    on a single owner; anything ambiguous answers ``None`` so callers fail
+    closed. Once a row carries ``app_id``, an invalid value must not fall back
+    to a same-named app because that could select another connector's
+    credentials or launch configuration.
+
+    ``None`` therefore means "cannot prove whose this is", not merely "not
+    found": destructive callers must leave credentials in place rather than
+    treat it as nothing to do.
     """
     auth = getattr(server, "auth", None)
     if isinstance(auth, Mapping) and "app_id" in auth:
@@ -742,6 +749,8 @@ def get_app_for_mcp_server(db: Session, server: Any) -> Dict[str, Any] | None:
             return None
         return get_app_by_id(db, app_id)
     name = str(getattr(server, "name", ""))
+    if not name:
+        return None
     # Both provisioning conventions write ``MCPServer.name``: the catalog
     # connect helpers store the app **id** (``_ensure_catalog_app_server``,
     # ``_ensure_catalog_mcp_oauth_server``) while the builtin OAuth flow stores
@@ -750,7 +759,22 @@ def get_app_for_mcp_server(db: Session, server: Any) -> Dict[str, Any] | None:
     # whatever the caller does with the result -- for the disconnect path that
     # meant the user's OAuth credentials survived a successful teardown.
     #
-    # The id is checked first because it is unique, whereas ``name`` is not:
-    # preferring it also keeps a display-name collision from outranking an
-    # exact id match.
-    return get_app_by_id(db, name) or get_app_by_name(db, name)
+    # Both namespaces are therefore enumerated together, hidden rows included,
+    # and the row resolves only when they agree on a single owner. An unstamped
+    # row carries no provenance of its own, so preferring one namespace over
+    # the other would be a guess: ``app_id`` being unique proves that at most
+    # one app holds that id, not that this row was provisioned from it rather
+    # than from another app's (mutable, non-unique) display name. Both readings
+    # are legal, so ambiguity is reported as "cannot resolve" and every caller
+    # fails closed -- deletion keeps the credentials, listing and runtime
+    # decline to name an app -- rather than acting on a coin flip. Only the
+    # stamp settles it, which is what the branch above is for.
+    candidates = (
+        db.query(PublicMCPApp)
+        .filter((PublicMCPApp.app_id == name) | (PublicMCPApp.name == name))
+        .all()
+    )
+    owners = {str(candidate.app_id) for candidate in candidates}
+    if len(owners) != 1:
+        return None
+    return _app_to_dict(candidates[0])

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -729,10 +729,11 @@ def ensure_builtin_oauth_server_visibility_for_user(
 def get_app_for_mcp_server(db: Session, server: Any) -> Dict[str, Any] | None:
     """Resolve a server's catalog app by stable identity when it is available.
 
-    Older server rows predate ``auth.app_id`` and are still resolved by their
-    exact catalog name. Once a row carries ``app_id``, an invalid value must not
-    fall back to a same-named app because that could select another connector's
-    credentials or launch configuration.
+    Unstamped rows predate ``auth.app_id`` and are resolved by the exact name
+    they were provisioned under -- the app id for catalog-connect rows, the
+    display name for builtin OAuth rows. Once a row carries ``app_id``, an
+    invalid value must not fall back to a same-named app because that could
+    select another connector's credentials or launch configuration.
     """
     auth = getattr(server, "auth", None)
     if isinstance(auth, Mapping) and "app_id" in auth:
@@ -740,4 +741,16 @@ def get_app_for_mcp_server(db: Session, server: Any) -> Dict[str, Any] | None:
         if not isinstance(app_id, str) or not app_id:
             return None
         return get_app_by_id(db, app_id)
-    return get_app_by_name(db, str(getattr(server, "name", "")))
+    name = str(getattr(server, "name", ""))
+    # Both provisioning conventions write ``MCPServer.name``: the catalog
+    # connect helpers store the app **id** (``_ensure_catalog_app_server``,
+    # ``_ensure_catalog_mcp_oauth_server``) while the builtin OAuth flow stores
+    # the **display name** (``_ensure_user_mcp_server``). Resolving only by
+    # display name leaves every id-named row unresolvable, which silently skips
+    # whatever the caller does with the result -- for the disconnect path that
+    # meant the user's OAuth credentials survived a successful teardown.
+    #
+    # The id is checked first because it is unique, whereas ``name`` is not:
+    # preferring it also keeps a display-name collision from outranking an
+    # exact id match.
+    return get_app_by_id(db, name) or get_app_by_name(db, name)

--- a/tests/web/test_mcp_server_app_resolution.py
+++ b/tests/web/test_mcp_server_app_resolution.py
@@ -39,7 +39,7 @@ def _app(db, app_id, name, **kwargs):
             app_id=app_id,
             name=name,
             transport=kwargs.get("transport", "oauth"),
-            provider_name=kwargs.get("provider_name", "acme"),
+            provider_name=kwargs.get("provider_name", f"prov-{app_id}"),
             category="Email",
             oauth_scopes=[],
             is_visible_in_connector=kwargs.get("visible", True),
@@ -78,23 +78,55 @@ class TestAnUnstampedRow:
         _app(catalog_db, "acme-mail", "Acme Mail")
         assert get_app_for_mcp_server(catalog_db, _Row("no-such-thing")) is None
 
-    def test_an_exact_id_match_outranks_another_apps_display_name(self, catalog_db):
-        """``app_id`` is unique and ``name`` is not, so when one app's id
-        equals another app's display name the id must win -- otherwise the
-        answer would depend on which row the database happened to scan
-        first."""
-        _app(catalog_db, "acme-mail", "Acme Mail")
-        _app(catalog_db, "other-app", "acme-mail", visible=False)
-        resolved = get_app_for_mcp_server(catalog_db, _Row("acme-mail"))
-        assert resolved is not None and resolved["id"] == "acme-mail"
+    @pytest.mark.parametrize(
+        "id_owner_first", [True, False], ids=["id-owner-first", "name-owner-first"]
+    )
+    def test_a_cross_namespace_collision_refuses(self, catalog_db, id_owner_first):
+        """Two apps answer to this name -- one by ``app_id``, one by display
+        name -- and the row itself says nothing about which provisioned it.
 
-    def test_the_id_wins_regardless_of_catalog_insertion_order(self, catalog_db):
-        """Same claim, seeded the other way round: a scan-order-dependent
-        resolver passes one order and fails the other."""
-        _app(catalog_db, "other-app", "acme-mail", visible=False)
-        _app(catalog_db, "acme-mail", "Acme Mail")
-        resolved = get_app_for_mcp_server(catalog_db, _Row("acme-mail"))
-        assert resolved is not None and resolved["id"] == "acme-mail"
+        Picking either would be a guess. ``app_id`` being unique proves only
+        that at most one app carries that id; it does not prove this row came
+        from that app rather than from the other app's display name, and the
+        two readings are equally legal because both naming conventions are
+        supported. An earlier revision of this file asserted the opposite
+        ("the id must win") and would have locked in a resolver that deleted
+        the wrong app's credentials for a legacy display-named row.
+
+        Seeded in both catalog insertion orders: the refusal must not depend
+        on scan order either.
+        """
+        if id_owner_first:
+            _app(catalog_db, "acme-mail", "Acme Mail")
+            _app(catalog_db, "legacy-app", "acme-mail", visible=False)
+        else:
+            _app(catalog_db, "legacy-app", "acme-mail", visible=False)
+            _app(catalog_db, "acme-mail", "Acme Mail")
+
+        assert get_app_for_mcp_server(catalog_db, _Row("acme-mail")) is None
+
+    @pytest.mark.parametrize(
+        "duplicate_first", [True, False], ids=["duplicate-first", "original-first"]
+    )
+    def test_two_apps_sharing_a_display_name_refuse(self, catalog_db, duplicate_first):
+        """``PublicMCPApp.name`` has no uniqueness constraint, so the name
+        alone can have two owners. The base resolver answered with whichever
+        row an unordered ``.first()`` returned; both orders must refuse."""
+        if duplicate_first:
+            _app(catalog_db, "second-app", "Acme Mail", visible=False)
+            _app(catalog_db, "acme-mail", "Acme Mail")
+        else:
+            _app(catalog_db, "acme-mail", "Acme Mail")
+            _app(catalog_db, "second-app", "Acme Mail", visible=False)
+
+        assert get_app_for_mcp_server(catalog_db, _Row("Acme Mail")) is None
+
+    def test_one_app_matched_by_both_columns_still_resolves(self, catalog_db):
+        """An app whose id and display name are the same string matches twice
+        but has a single owner, so it is unambiguous and must resolve."""
+        _app(catalog_db, "acme", "acme")
+        resolved = get_app_for_mcp_server(catalog_db, _Row("acme"))
+        assert resolved is not None and resolved["id"] == "acme"
 
 
 class TestAStampedRow:
@@ -156,3 +188,121 @@ class TestAStampedRow:
             catalog_db, _Row("Acme Mail", auth={"provider": "acme"})
         )
         assert resolved is not None and resolved["id"] == "acme-mail"
+
+
+class TestTheChangedCallers:
+    """Caller-level guards.
+
+    The truth table above pins the resolver, but both production call sites
+    could be reverted to the old name-only lookup without failing any of it.
+    These exercise the real rows -- ``MCPServer``, ``UserMCPServer``,
+    ``PublicMCPApp``, ``UserOAuth`` -- through the endpoints themselves.
+    """
+
+    @pytest.fixture()
+    def db(self):
+        from sqlalchemy.pool import StaticPool
+
+        from xagent.web.models.database import Base
+
+        engine = create_engine(
+            "sqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        Base.metadata.create_all(bind=engine)
+        with Session(engine) as session:
+            yield session
+        engine.dispose()
+
+    def _connected_id_named_app(self, db):
+        """A catalog app connected through the id-naming convention: the
+        shared row is named after ``app_id`` while the display name differs.
+        """
+        from xagent.web.models.mcp import MCPServer, UserMCPServer
+        from xagent.web.models.user import User
+        from xagent.web.models.user_oauth import UserOAuth
+
+        user = User(username="someone", password_hash="h", is_admin=False)
+        db.add(user)
+        db.commit()
+        db.refresh(user)
+        _app(db, "acme-mail", "Acme Mail Displayed")
+        server = MCPServer(
+            name="acme-mail",
+            transport="oauth",
+            managed=False,
+            auth={"app_id": "acme-mail"},
+        )
+        db.add(server)
+        db.flush()
+        db.add(
+            UserMCPServer(
+                user_id=int(user.id),
+                mcpserver_id=server.id,
+                is_active=True,
+                is_owner=True,
+            )
+        )
+        db.add(
+            UserOAuth(
+                user_id=int(user.id),
+                provider="acme-mail",
+                access_token="live-token",
+                email="someone@acme.example",
+            )
+        )
+        db.commit()
+        return user, int(server.id)
+
+    async def test_teardown_deletes_the_credential_of_an_id_named_row(self, db):
+        """The regression this PR exists for: resolving by display name found
+        nothing for an id-named row, so the cleanup was skipped and the token
+        outlived a successful teardown."""
+        from xagent.web.api.mcp import delete_mcp_server
+        from xagent.web.models.user_oauth import UserOAuth
+
+        user, server_id = self._connected_id_named_app(db)
+
+        await delete_mcp_server(server_id=server_id, current_user=user, db=db)
+
+        assert db.query(UserOAuth).filter(UserOAuth.user_id == user.id).count() == 0
+
+    async def test_teardown_keeps_an_unrelated_apps_credential(self, db):
+        """Scope check: resolving the right app must not widen the deletion."""
+        from xagent.web.api.mcp import delete_mcp_server
+        from xagent.web.models.user_oauth import UserOAuth
+
+        user, server_id = self._connected_id_named_app(db)
+        _app(db, "other-app", "Other App")
+        db.add(
+            UserOAuth(
+                user_id=int(user.id),
+                provider="other-app",
+                access_token="untouched",
+                email="other@acme.example",
+            )
+        )
+        db.commit()
+
+        await delete_mcp_server(server_id=server_id, current_user=user, db=db)
+
+        survivors = {o.provider for o in db.query(UserOAuth).all()}
+        assert survivors == {"other-app"}
+
+    def test_listing_enrichment_names_the_app_of_an_id_named_row(self, db):
+        """``_enrich_oauth_server_info`` reported app_id, provider and the
+        connected account as absent for every id-named row."""
+        from xagent.web.api.mcp import _enrich_oauth_server_info
+        from xagent.web.models.mcp import MCPServer
+
+        user, server_id = self._connected_id_named_app(db)
+        server = db.query(MCPServer).filter(MCPServer.id == server_id).one()
+
+        app_id, provider, connected_account = _enrich_oauth_server_info(
+            db, server, {"acme-mail": "someone@acme.example"}
+        )
+
+        assert app_id == "acme-mail"
+        assert provider == "prov-acme-mail"
+        assert connected_account == "someone@acme.example"

--- a/tests/web/test_mcp_server_app_resolution.py
+++ b/tests/web/test_mcp_server_app_resolution.py
@@ -1,0 +1,158 @@
+"""How a stored ``MCPServer`` row is resolved back to its catalog app.
+
+``get_app_for_mcp_server`` decides which app's credentials a disconnect
+deletes and which app a connector listing reports, so the rule it encodes is
+load-bearing: identify the row by something stable, never by a value that is
+both mutable and non-unique.
+
+``PublicMCPApp.app_id`` is unique; ``PublicMCPApp.name`` is neither unique nor
+immutable (the admin API can rename an app). Resolving by name therefore had
+two failure modes, both fixed here and pinned below:
+
+* an id-named row -- the convention the catalog connect helpers write --
+  resolved to nothing, so callers silently skipped whatever they do with the
+  result (for the disconnect path, deleting the user's OAuth credentials);
+* a rename could move the answer to a *different* app between one caller's
+  check and its later use.
+"""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from xagent.web.mcp_apps import get_app_for_mcp_server
+from xagent.web.models.public_mcp import PublicMCPApp
+
+
+@pytest.fixture()
+def catalog_db():
+    engine = create_engine("sqlite:///:memory:")
+    PublicMCPApp.__table__.create(engine)
+    with Session(engine) as db:
+        yield db
+    engine.dispose()
+
+
+def _app(db, app_id, name, **kwargs):
+    db.add(
+        PublicMCPApp(
+            app_id=app_id,
+            name=name,
+            transport=kwargs.get("transport", "oauth"),
+            provider_name=kwargs.get("provider_name", "acme"),
+            category="Email",
+            oauth_scopes=[],
+            is_visible_in_connector=kwargs.get("visible", True),
+            launch_config={},
+        )
+    )
+    db.commit()
+
+
+class _Row:
+    """The two attributes the resolver reads off a stored server row."""
+
+    def __init__(self, name, auth=None):
+        self.name = name
+        self.auth = auth
+
+
+class TestAnUnstampedRow:
+    """Both provisioning conventions write ``MCPServer.name``: the catalog
+    connect helpers store the app id, the builtin OAuth flow the display
+    name. Neither may be unresolvable."""
+
+    def test_a_display_named_row_resolves(self, catalog_db):
+        _app(catalog_db, "acme-mail", "Acme Mail")
+        resolved = get_app_for_mcp_server(catalog_db, _Row("Acme Mail"))
+        assert resolved is not None and resolved["id"] == "acme-mail"
+
+    def test_an_id_named_row_resolves(self, catalog_db):
+        """The regression: this returned ``None``, so a disconnect of such a
+        row reported success while leaving the OAuth credentials stored."""
+        _app(catalog_db, "acme-mail", "Acme Mail")
+        resolved = get_app_for_mcp_server(catalog_db, _Row("acme-mail"))
+        assert resolved is not None and resolved["id"] == "acme-mail"
+
+    def test_a_name_matching_nothing_resolves_to_none(self, catalog_db):
+        _app(catalog_db, "acme-mail", "Acme Mail")
+        assert get_app_for_mcp_server(catalog_db, _Row("no-such-thing")) is None
+
+    def test_an_exact_id_match_outranks_another_apps_display_name(self, catalog_db):
+        """``app_id`` is unique and ``name`` is not, so when one app's id
+        equals another app's display name the id must win -- otherwise the
+        answer would depend on which row the database happened to scan
+        first."""
+        _app(catalog_db, "acme-mail", "Acme Mail")
+        _app(catalog_db, "other-app", "acme-mail", visible=False)
+        resolved = get_app_for_mcp_server(catalog_db, _Row("acme-mail"))
+        assert resolved is not None and resolved["id"] == "acme-mail"
+
+    def test_the_id_wins_regardless_of_catalog_insertion_order(self, catalog_db):
+        """Same claim, seeded the other way round: a scan-order-dependent
+        resolver passes one order and fails the other."""
+        _app(catalog_db, "other-app", "acme-mail", visible=False)
+        _app(catalog_db, "acme-mail", "Acme Mail")
+        resolved = get_app_for_mcp_server(catalog_db, _Row("acme-mail"))
+        assert resolved is not None and resolved["id"] == "acme-mail"
+
+
+class TestAStampedRow:
+    def test_the_stamp_decides(self, catalog_db):
+        _app(catalog_db, "acme-mail", "Acme Mail")
+        _app(catalog_db, "other-app", "Other App")
+        resolved = get_app_for_mcp_server(
+            catalog_db, _Row("Other App", auth={"app_id": "acme-mail"})
+        )
+        assert resolved is not None and resolved["id"] == "acme-mail"
+
+    @pytest.mark.parametrize(
+        "stamp", [pytest.param("", id="empty"), pytest.param(7, id="non-string")]
+    )
+    def test_a_malformed_stamp_refuses_rather_than_falling_back(
+        self, catalog_db, stamp
+    ):
+        """A present-but-invalid stamp must not fall back to the row's name:
+        that fallback is how one connector's teardown selects another
+        connector's credentials."""
+        _app(catalog_db, "acme-mail", "Acme Mail")
+        assert (
+            get_app_for_mcp_server(
+                catalog_db, _Row("Acme Mail", auth={"app_id": stamp})
+            )
+            is None
+        )
+
+    def test_an_unknown_stamp_resolves_to_none(self, catalog_db):
+        _app(catalog_db, "acme-mail", "Acme Mail")
+        row = _Row("Acme Mail", auth={"app_id": "no-such-app"})
+        assert get_app_for_mcp_server(catalog_db, row) is None
+
+    def test_a_stamped_row_survives_a_rename_of_another_app_onto_its_name(
+        self, catalog_db
+    ):
+        """The mutable-name race, at the resolver level: renaming app B onto
+        the stored server name must not move a stamped row's answer to B."""
+        _app(catalog_db, "acme-mail", "Acme Mail")
+        _app(catalog_db, "other-app", "Other App")
+        row = _Row("acme-mail", auth={"app_id": "acme-mail"})
+
+        renamed = (
+            catalog_db.query(PublicMCPApp)
+            .filter(PublicMCPApp.app_id == "other-app")
+            .one()
+        )
+        renamed.name = "acme-mail"
+        catalog_db.commit()
+
+        resolved = get_app_for_mcp_server(catalog_db, row)
+        assert resolved is not None and resolved["id"] == "acme-mail"
+
+    def test_auth_without_an_app_id_key_takes_the_name_path(self, catalog_db):
+        """Selection is by key presence, not truthiness: a provider-only blob
+        carries no stamp and must still resolve by name."""
+        _app(catalog_db, "acme-mail", "Acme Mail")
+        resolved = get_app_for_mcp_server(
+            catalog_db, _Row("Acme Mail", auth={"provider": "acme"})
+        )
+        assert resolved is not None and resolved["id"] == "acme-mail"


### PR DESCRIPTION
`DELETE /api/mcp/servers/{server_id}` decided whose OAuth credentials to delete with `get_app_by_name(db, str(server.name))`. `PublicMCPApp.app_id` is unique, but `name` is neither unique nor immutable, which made that lookup wrong in two distinct ways. Both are reproduced below against this repo's own code.

## 1. Id-named rows skipped credential cleanup entirely

Two provisioning conventions write `MCPServer.name`: the catalog connect helpers store the app **id** (`_ensure_catalog_app_server`, `_ensure_catalog_mcp_oauth_server`), while the builtin OAuth flow stores the **display name** (`_ensure_user_mcp_server`). `get_app_by_name` only understands the second, so for an id-named row it returned `None`, the `if app_info:` block never ran, and `delete_scoped_user_oauth_accounts` was never called.

The association and the server row were still removed, so the endpoint reported success — with the user's `access_token` and `refresh_token` still stored and still usable. `UserOAuth` does not cascade from those deletions.

```
app_id="acme-mail", name="Acme Mail", server row name="acme-mail"
before: UserOAuth(provider="acme-mail", access_token="LIVE-SECRET")
DELETE /api/mcp/servers/{id}  ->  204, association gone
after : UserOAuth(provider="acme-mail", access_token="LIVE-SECRET")   # still there
```

Reproduced for both the stamped (`auth={"app_id": ...}`) and unstamped shapes.

## 2. A rename could redirect the deletion to another app

Because the lookup key is mutable, an admin renaming a *different* catalog app onto that stored server name — between any caller's identity check and the delete — moved the resolution to that other app. Its provider and app-scoped credentials were then deleted while the request reported success:

```
A: app_id="acme-mail", server row name="acme-mail"   (the row being disconnected)
B: app_id="other-app", name -> renamed to "acme-mail"

before: ["acme-mail", "other-app", "prov-b"]
after : ["acme-mail"]            # B's credentials deleted, A's kept
```

## The change

Both call sites now resolve through `get_app_for_mcp_server`, which already prefers the row's own `auth.app_id` stamp — a value a catalog rename cannot move. Its unstamped path additionally learns the id-named convention:

```python
return get_app_by_id(db, name) or get_app_by_name(db, name)
```

`app_id` is checked first because it is unique while `name` is not: preferring it also stops a display-name collision from outranking an exact id match, deterministically rather than by whichever row the database scans first.

`_enrich_oauth_server_info` carried the same name-only lookup and the same blind spot — every id-named OAuth row reported `app_id`, `provider` and `connected_account` as absent — so it moves to the same resolver.

Deliberately unchanged: the credential scope itself, including the app-scoped restriction and the sibling-provider sweep, and the team-connector decision. This changes only *which app* is resolved, not what is done with it.

## Tests

`tests/web/test_mcp_server_app_resolution.py` pins the resolution table: both naming conventions, stamp precedence, a malformed stamp refusing rather than falling back to the name, an exact id match outranking another app's display name in **both** catalog insertion orders, and a stamped row surviving a rename of another app onto its stored name.

Mutation-verified — each of these makes the new tests fail:

| mutation | result |
| --- | --- |
| revert to name-only resolution | 3 failures |
| flip precedence to name-before-id | 2 failures (the insertion-order pair) |
| revert the teardown call site | the credential-retention reproduction returns |

264 existing tests across `test_meta_oauth`, `test_classify_app_auth`, `test_mcp_apps_connect`, `test_mcp_oauth_flow` and `test_oauth_token_resolver_hook` pass unchanged; `ruff`, `ruff format`, `isort` and `mypy` are clean on the touched files.

## Context

Found while building an app-scoped disconnect consumer in `xorbitsai/xagent-saas` (#916), where review established that a consumer cannot compensate for either issue: it cannot make this endpoint resolve by `app_id`, and it cannot hold `PublicMCPApp` still across an admin rename.

This is the narrow correctness half of #1757. It does **not** implement the `disconnect_app(user, app_id)` operation that issue proposes, and does not close the broader proof/delete serialization it describes — the deletion is simply no longer keyed on a mutable, non-unique column.
