### PR TITLE
feat(skill-hub): bound ZipFile construction cost for untrusted archives

### DIFF
--- a/src/xagent/web/api/skill_hub.py
+++ b/src/xagent/web/api/skill_hub.py
@@ -40,9 +40,10 @@ import hashlib
 import io
 import logging
 import re
+import struct
 import zipfile
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import Response
@@ -58,6 +59,9 @@ from xagent.web.api.skill_hub_registry import (
 )
 from xagent.web.auth_dependencies import get_current_user
 from xagent.web.models.database import get_db
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from _typeshed import WriteableBuffer
 from xagent.web.models.user import User
 from xagent.web.services.skill_runtime import (
     get_skill_runtime_scope,
@@ -355,6 +359,154 @@ _IGNORED_ARCHIVE_NAMES = frozenset({".DS_Store", "Thumbs.db", "desktop.ini"})
 # Inflate archive members in slices so a decompression bomb cannot make the
 # peak footprint a multiple of the size budget.
 _ARCHIVE_CHUNK_BYTES = 1024 * 1024
+
+
+# An archive is refused above this many central-directory entries. A skill
+# bundle is a handful of documents and a few resource folders; the largest
+# real ones sampled sit under a hundred files, so the cap is two orders of
+# magnitude of headroom rather than a tight fit.
+_MAX_ARCHIVE_ENTRIES = 2000
+
+# Central-directory file header: the signature, then a 46-byte fixed part
+# whose last three 16-bit fields (at offset 28) give the lengths of the
+# variable-length name, extra and comment that follow it.
+_CDH_SIGNATURE = b"PK\x01\x02"
+_CDH_FIXED_SIZE = 46
+_CDH_VARIABLE_LENGTHS_OFFSET = 28
+
+
+class _ArchiveTooManyEntries(Exception):
+    """Raised by ``_BoundedZipSource`` mid-construction, once the central
+    directory is known to hold more entries than we will accept."""
+
+
+class _BoundedZipSource(io.RawIOBase):
+    """A seekable read-only view of ``data`` that refuses an archive whose
+    central directory holds more than ``max_entries`` headers.
+
+    ``ZipFile.__init__`` builds a ``ZipInfo`` for every entry in the central
+    directory before any of our code runs, so a cap applied to ``infolist()``
+    bounds what happens *after* construction, not the construction itself. A
+    16 MiB archive of 100,000 padding directories -- comfortably inside the
+    ingress budget -- costs 2.9s and 56 MiB before the first line of ours
+    executes. Handing ``ZipFile`` this object instead refuses it in 0.01s and
+    5 MiB.
+
+    The count is taken from the bytes ``ZipFile`` itself reads, which is what
+    makes this safe to do without a second ZIP parser. CPython locates the
+    end-of-central-directory record (handling comments, self-extracting
+    prefixes and Zip64 for us) and then seeks straight to the directory and
+    reads it; the first read that *starts* on a central-directory signature is
+    therefore the directory itself, and from that offset the headers chain
+    end-to-end. We follow that chain and count, and stop the constructor the
+    moment the count goes over.
+
+    Two properties this relies on, both of which earlier attempts got wrong:
+
+    * **The count accumulates across reads.** A ``BufferedReader`` splits the
+      directory into fixed-size blocks, so a per-read tally saw 1,993 of a
+      2,001-entry directory and let it through. The walk keeps its position in
+      the chain between reads and resumes there, so the boundary is exact.
+    * **Only the real directory anchors it.** The anchor latches on a read
+      that begins on the signature, and thereafter advances by the declared
+      header lengths. Signatures inside member content, inside an archive
+      comment, or inside a self-extracting stub are not on that chain, so a
+      member holding a forged 5,000-header run still counts as one entry.
+
+    Nothing here parses the end record or scans for signatures: locating the
+    directory stays CPython's job, and this only walks the structure it lands
+    on.
+    """
+
+    def __init__(self, data: bytes, *, max_entries: int = _MAX_ARCHIVE_ENTRIES):
+        self._data = data
+        self._pos = 0
+        self._max_entries = max_entries
+        # Offset of the next central-directory header to count, or ``None``
+        # while the directory has not been reached (or has been walked past).
+        self._next_header: Optional[int] = None
+        self._entries = 0
+
+    # -- io.RawIOBase plumbing -------------------------------------------
+    def readable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return True
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        if whence == io.SEEK_SET:
+            if offset < 0:
+                raise ValueError(f"negative seek value {offset}")
+            target = offset
+        elif whence == io.SEEK_CUR:
+            target = self._pos + offset
+        elif whence == io.SEEK_END:
+            target = len(self._data) + offset
+        else:
+            raise ValueError(f"invalid whence: {whence}")
+        # Clamp exactly as ``io.BytesIO`` does. ``zipfile`` seeks a fixed
+        # distance back from the end to find the end record, so on an archive
+        # shorter than that record the target is negative; ``BytesIO`` answers
+        # 0 and ``zipfile`` goes on to reject the archive. Left unclamped, a
+        # negative position indexes ``bytes`` from the *end*, so reads would
+        # quietly return the wrong bytes -- and this object is what decides
+        # where the central directory is.
+        self._pos = max(target, 0)
+        return self._pos
+
+    def tell(self) -> int:
+        return self._pos
+
+    def read(self, size: int = -1) -> bytes:
+        if size is None or size < 0:
+            size = len(self._data) - self._pos
+        start = self._pos
+        if (
+            self._next_header is None
+            and self._data[start : start + 4] == _CDH_SIGNATURE
+        ):
+            self._next_header = start
+        end = min(start + size, len(self._data))
+        # Count before slicing: the refusal must not pay for a copy of the
+        # bytes it is refusing.
+        if self._next_header is not None:
+            self._count_headers(end)
+        chunk = self._data[start:end]
+        self._pos = start + len(chunk)
+        return chunk
+
+    def readinto(self, buffer: "WriteableBuffer") -> int:
+        view = memoryview(buffer).cast("B")
+        chunk = self.read(len(view))
+        view[: len(chunk)] = chunk
+        return len(chunk)
+
+    # -- the guard itself -------------------------------------------------
+    def _count_headers(self, limit: int) -> None:
+        """Walk the header chain as far as ``limit``, counting entries."""
+        while self._next_header is not None and (
+            self._next_header + _CDH_FIXED_SIZE <= limit
+        ):
+            offset = self._next_header
+            if self._data[offset : offset + 4] != _CDH_SIGNATURE:
+                # End of the directory (the end record follows it), or bytes
+                # that never were one. Either way there is nothing more to
+                # count, and re-anchoring on a later read would be exactly the
+                # double-count that sank an earlier attempt.
+                self._next_header = None
+                return
+            name_len, extra_len, comment_len = struct.unpack_from(
+                "<HHH", self._data, offset + _CDH_VARIABLE_LENGTHS_OFFSET
+            )
+            self._entries += 1
+            if self._entries > self._max_entries:
+                raise _ArchiveTooManyEntries(
+                    f"central directory holds more than {self._max_entries} entries"
+                )
+            self._next_header = (
+                offset + _CDH_FIXED_SIZE + name_len + extra_len + comment_len
+            )
 
 
 def _is_archive_cruft(path: str) -> bool:
@@ -728,7 +880,24 @@ def _safe_zip_extract(
     total = 0
     raw_files: dict[str, bytes] = {}
     try:
-        zf = zipfile.ZipFile(io.BytesIO(zip_bytes))
+        # Not ``io.BytesIO(zip_bytes)``: the constructor materializes a
+        # ``ZipInfo`` per directory entry before returning, and an archive
+        # well inside the ingress budget can hold enough of them to cost
+        # seconds and tens of MiB. ``_BoundedZipSource`` caps that, and the
+        # ``BufferedReader`` is what CPython would wrap a real file in --
+        # keeping the read pattern the same shape the stdlib is tuned for.
+        source = _BoundedZipSource(zip_bytes)
+        zf = zipfile.ZipFile(io.BufferedReader(source))
+        # Second gate, on the count the parser actually produced. The source
+        # above bounds construction from the byte stream; this bounds what we
+        # then do per entry -- a walk plus, for an install, a row per file --
+        # and does not depend on the walk having reached every header. Cheap,
+        # independent, and the one that stays correct if a future CPython
+        # changes how the directory is read.
+        if len(zf.infolist()) > _MAX_ARCHIVE_ENTRIES:
+            raise _ArchiveTooManyEntries(
+                f"archive holds more than {_MAX_ARCHIVE_ENTRIES} entries"
+            )
         for info in zf.infolist():
             if info.is_dir():
                 continue
@@ -776,6 +945,17 @@ def _safe_zip_extract(
             raw_files[path] = content
     except HTTPException:
         raise
+    except _ArchiveTooManyEntries as exc:
+        # Not ``bad_zip_status``: the archive is perfectly readable, it just
+        # carries more than we accept -- a statement about its contents, like
+        # the traversal and size rejections, so 400 whoever supplied it.
+        logger.warning("Skill Hub: archive over entry cap (%s)", exc)
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Skill archive contains more than {_MAX_ARCHIVE_ENTRIES} entries."
+            ),
+        ) from exc
     except Exception as exc:
         logger.warning(
             "Skill Hub: unreadable archive (%s)", type(exc).__name__, exc_info=True

--- a/tests/skills/test_skill_hub_security.py
+++ b/tests/skills/test_skill_hub_security.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import io
 import zipfile
+from unittest import mock
 
 import pytest
 from fastapi import HTTPException
@@ -605,3 +606,324 @@ async def test_team_write_routes_adopt_the_central_provider_invoker(
     assert context.user_id == scope.user_id
     assert context.metadata == scope.metadata
     assert kwargs["scope"] == "team"
+
+
+# ── construction-time entry bound ────────────────────────────────────────────
+
+
+def _entry_zip(
+    count: int, *, comment: bytes = b"", prefix: bytes = b"", name_len: int = 0
+) -> bytes:
+    """An archive of ``count`` empty members, optionally commented/prefixed.
+
+    ``prefix`` stands in for a self-extracting stub: bytes before the local
+    headers that shift every offset in the archive.
+    """
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for i in range(count):
+            name = f"skill/f{i:08d}"
+            zf.writestr(name.ljust(name_len, "x"), b"")
+        zf.comment = comment
+    return prefix + buf.getvalue()
+
+
+class TestArchiveEntryBound:
+    """An over-sized central directory is refused during construction.
+
+    ``ZipFile.__init__`` builds a ``ZipInfo`` per directory entry before any
+    of our code runs, so a cap read off ``infolist()`` bounds only what comes
+    after. These tests assert the mechanism rather than the status code: a
+    pre-construction and a post-construction refusal both answer 400, so a
+    status assertion cannot tell them apart.
+    """
+
+    def test_entry_cap_boundary(self):
+        """Exactly at the cap is accepted; one over is refused.
+
+        The boundary is the test that matters. Counting per read rather than
+        across reads under-counted a 2,001-entry directory as 1,993 because
+        ``BufferedReader`` splits it into blocks — a bug a 20,000-entry case
+        hides completely, since 20,000 trips any cap regardless.
+        """
+        from xagent.web.api.skill_hub import _MAX_ARCHIVE_ENTRIES
+
+        at_cap = _entry_zip(_MAX_ARCHIVE_ENTRIES)
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(at_cap, bad_zip_status=400)
+        # Accepted by the bound — it fails later, on having no SKILL.md.
+        assert "no SKILL.md" in exc.value.detail
+
+        over_cap = _entry_zip(_MAX_ARCHIVE_ENTRIES + 1)
+        with pytest.raises(HTTPException) as exc:
+            _safe_zip_extract(over_cap, bad_zip_status=400)
+        assert exc.value.status_code == 400
+        assert "more than" in exc.value.detail
+
+    def test_source_guard_holds_the_boundary_on_its_own(self):
+        """The construction-time bound, with the ``infolist()`` gate removed.
+
+        Both gates answer the same 400 with the same wording, so a test that
+        only calls ``_safe_zip_extract`` cannot see which one fired: weakening
+        the source guard leaves every such test green because the second gate
+        covers for it. Drive the source directly, past ``ZipFile``, and assert
+        the count it actually produced.
+
+        The exact boundary is the assertion that matters. A per-read tally
+        (rather than one accumulated across reads) saw 1,993 headers of a
+        2,001-entry directory, because ``BufferedReader`` splits the directory
+        into fixed-size blocks — invisible to any test that only tries a
+        clearly-hostile count.
+        """
+        from xagent.web.api.skill_hub import (
+            _MAX_ARCHIVE_ENTRIES,
+            _ArchiveTooManyEntries,
+            _BoundedZipSource,
+        )
+
+        source = _BoundedZipSource(_entry_zip(_MAX_ARCHIVE_ENTRIES))
+        zf = zipfile.ZipFile(io.BufferedReader(source))
+        assert len(zf.namelist()) == _MAX_ARCHIVE_ENTRIES
+        # Every header was counted — not a subset that happens to be under.
+        assert source._entries == _MAX_ARCHIVE_ENTRIES
+
+        over = _BoundedZipSource(_entry_zip(_MAX_ARCHIVE_ENTRIES + 1))
+        with pytest.raises(_ArchiveTooManyEntries):
+            zipfile.ZipFile(io.BufferedReader(over))
+        # Refused on the first entry past the cap, not somewhere well beyond.
+        assert over._entries == _MAX_ARCHIVE_ENTRIES + 1
+
+    def test_over_cap_is_a_content_rejection_not_an_unreadable_one(self):
+        """400 regardless of ``bad_zip_status``.
+
+        An archive over the cap parses fine; it just carries more than we
+        accept, which is a statement about its contents like the traversal and
+        size rejections. ``bad_zip_status`` says who supplied an *unreadable*
+        archive, and answering with it here would make a registry-sourced
+        upload a 502 the client cannot act on.
+        """
+        from xagent.web.api.skill_hub import _MAX_ARCHIVE_ENTRIES
+
+        over_cap = _entry_zip(_MAX_ARCHIVE_ENTRIES + 1)
+        for bad_zip_status in (400, 502):
+            with pytest.raises(HTTPException) as exc:
+                _safe_zip_extract(over_cap, bad_zip_status=bad_zip_status)
+            assert exc.value.status_code == 400
+            assert "more than" in exc.value.detail
+
+    def test_refusal_happens_before_the_directory_is_materialised(self):
+        """The refusal must beat ``ZipFile``, not follow it.
+
+        Spy on ``ZipInfo`` construction: an archive of 100,000 padding
+        directories costs ~3s and ~56 MiB to materialise, all of it spent
+        before a post-construction cap could look. Far fewer than the whole
+        directory may be built here — the bound trips partway through it.
+        """
+        from xagent.web.api import skill_hub
+        from xagent.web.api.skill_hub import _MAX_ARCHIVE_ENTRIES
+
+        built = 0
+        real_zipinfo = zipfile.ZipInfo
+
+        class CountingZipInfo(real_zipinfo):  # type: ignore[misc, valid-type]
+            def __init__(self, *args, **kwargs):
+                nonlocal built
+                built += 1
+                super().__init__(*args, **kwargs)
+
+        hostile = _entry_zip(50_000)
+        with mock.patch.object(zipfile, "ZipInfo", CountingZipInfo):
+            with pytest.raises(HTTPException) as exc:
+                skill_hub._safe_zip_extract(hostile, bad_zip_status=400)
+        assert exc.value.status_code == 400
+        # A materialise-then-check guard would build all 50,000.
+        assert built <= _MAX_ARCHIVE_ENTRIES + 1, f"built {built} ZipInfo objects"
+
+    def test_hostile_archive_is_refused_cheaply(self):
+        """The whole point is the cost, so bound the cost.
+
+        Unguarded, this archive takes seconds and tens of MiB in the
+        constructor; the ingress size limit does not stop it, because 100,000
+        empty entries compress to well under the budget.
+        """
+        import tracemalloc
+
+        hostile = _entry_zip(100_000)
+        assert len(hostile) < 16 * 1024 * 1024  # passes the ingress size gate
+
+        tracemalloc.start()
+        try:
+            with pytest.raises(HTTPException) as exc:
+                _safe_zip_extract(hostile, bad_zip_status=400)
+            _current, peak = tracemalloc.get_traced_memory()
+        finally:
+            tracemalloc.stop()
+        assert exc.value.status_code == 400
+        # Unguarded this peaks around 56 MiB; the archive itself is ~10 MiB.
+        assert peak < len(hostile) + 8 * 1024 * 1024, f"peak {peak} bytes"
+
+    @pytest.mark.parametrize(
+        "label,build",
+        [
+            ("plain", lambda n: _entry_zip(n)),
+            ("one-byte comment", lambda n: _entry_zip(n, comment=b"x")),
+            ("64 KiB comment", lambda n: _entry_zip(n, comment=b"y" * 65535)),
+            (
+                "comment holding header signatures",
+                lambda n: _entry_zip(n, comment=b"PK\x01\x02" * 2001 + b"z" * 100),
+            ),
+            ("self-extracting prefix", lambda n: _entry_zip(n, prefix=b"MZ" * 3000)),
+            ("400-character names", lambda n: _entry_zip(n, name_len=400)),
+        ],
+    )
+    def test_bound_holds_across_archive_shapes(self, label, build):
+        """Every shape must land on the same boundary.
+
+        These are the shapes that broke earlier attempts: a comment moves the
+        end record and makes CPython re-read the whole file; a comment may
+        legally contain a central-directory signature; a self-extracting stub
+        shifts every offset. A guard that mis-locates the directory fails
+        *open* on one side of this pair and *closed* on the other, so both
+        sides are asserted.
+        """
+        from xagent.web.api.skill_hub import _MAX_ARCHIVE_ENTRIES
+
+        with pytest.raises(HTTPException) as at_cap:
+            _safe_zip_extract(build(_MAX_ARCHIVE_ENTRIES), bad_zip_status=400)
+        assert "no SKILL.md" in at_cap.value.detail, f"{label} rejected at the cap"
+
+        with pytest.raises(HTTPException) as over:
+            _safe_zip_extract(build(_MAX_ARCHIVE_ENTRIES + 1), bad_zip_status=400)
+        assert "more than" in over.value.detail, f"{label} not bounded"
+
+    def test_zip64_directory_is_bounded(self):
+        """Zip64 must not be a way around the bound.
+
+        Over 65,535 entries the end record is Zip64 and the real values live
+        in a separate record CPython locates by its own rules. An attempt that
+        hand-mirrored that location was 76 bytes off and counted nothing.
+        """
+        buf = io.BytesIO()
+        with zipfile.ZipFile(buf, "w", allowZip64=True) as zf:
+            for i in range(70_000):
+                zf.writestr(f"f{i:08d}", b"")
+        zip64 = buf.getvalue()
+
+        for label, data in (("plain", zip64), ("with stub", b"MZ" * 3000 + zip64)):
+            with pytest.raises(HTTPException) as exc:
+                _safe_zip_extract(data, bad_zip_status=400)
+            assert exc.value.status_code == 400, label
+            assert "more than" in exc.value.detail, label
+
+    def test_member_content_cannot_forge_the_count(self):
+        """A member full of header signatures is still one entry.
+
+        The count follows the chain CPython seeks to, so bytes that merely
+        look like headers — inside a member, a comment or a stub — are not on
+        it. A signature-scanning attempt counted a valid one-entry archive as
+        2,002 and refused it.
+        """
+        forged_header = b"PK\x01\x02" + b"\x00" * 42
+        data = _make_zip(
+            {"SKILL.md": SKILL_MD, "decoy.bin": forged_header * 5000},
+        )
+        files, root = _safe_zip_extract(data, bad_zip_status=400)
+        assert root == ""
+        assert files["SKILL.md"] == SKILL_MD
+        assert files["decoy.bin"] == forged_header * 5000
+
+    def test_a_read_landing_on_forged_bytes_does_not_re_anchor(self):
+        """A member read that *begins* on a header signature must not re-anchor.
+
+        The anchor latches once, on the directory ``ZipFile`` seeks to, and is
+        dropped for good when the chain ends. Re-latching on any later read
+        that happens to start on a signature is the failure that sank an
+        earlier attempt: it double-counts, and refuses valid archives.
+
+        The shape is reachable, not theoretical. ``BufferedReader`` reads in
+        fixed-size blocks, so a member holding a run of forged headers only
+        needs its content shifted until a block boundary lands on one — a
+        padding member a few dozen bytes long does it. Under a re-anchoring
+        guard this three-entry archive counts past 2,000 and is refused.
+        """
+        forged_header = b"PK\x01\x02" + b"\x00" * 42  # declares 0/0/0 lengths
+
+        # Search the alignment rather than hard-coding it: the offset depends
+        # on the block size and on how the writer lays the archive out, and a
+        # stale constant would silently stop exercising the shape.
+        for pad in range(200):
+            data = _make_zip(
+                {
+                    "SKILL.md": SKILL_MD,
+                    "p": b"P" * pad,
+                    "decoy.bin": forged_header * 20_000,
+                }
+            )
+            files, root = _safe_zip_extract(data, bad_zip_status=400)
+            assert root == ""
+            assert files["SKILL.md"] == SKILL_MD
+            assert files["decoy.bin"] == forged_header * 20_000
+
+    def test_seek_matches_bytesio_semantics(self):
+        """The bounded source must behave as the ``BytesIO`` it replaces.
+
+        ``zipfile`` seeks a fixed distance back from the end to find the end
+        record, so an archive shorter than that record seeks past the start.
+        ``BytesIO`` clamps that to 0; an unclamped negative position indexes
+        ``bytes`` from the *end*, so reads return the wrong bytes — and this
+        object is what tells ``zipfile`` where the central directory is.
+        """
+        from xagent.web.api.skill_hub import _BoundedZipSource
+
+        payload = b"0123456789"
+        source = _BoundedZipSource(payload)
+        reference = io.BytesIO(payload)
+
+        for offset, whence in ((-22, io.SEEK_END), (-3, io.SEEK_END), (5, io.SEEK_SET)):
+            assert source.seek(offset, whence) == reference.seek(offset, whence)
+            assert source.read(4) == reference.read(4)
+
+        # Seeking before the start from the current position clamps too.
+        source.seek(0, io.SEEK_SET)
+        reference.seek(0, io.SEEK_SET)
+        assert source.seek(-4, io.SEEK_CUR) == reference.seek(-4, io.SEEK_CUR)
+
+        # An explicitly negative absolute seek is an error, as it is there.
+        with pytest.raises(ValueError):
+            source.seek(-1, io.SEEK_SET)
+
+    def test_short_archive_is_rejected_not_misread(self):
+        """An archive shorter than the end record is refused, not misparsed."""
+        for payload in (b"PK\x05\x06", b"PK", b"", b"\x00" * 8):
+            with pytest.raises(HTTPException) as exc:
+                _safe_zip_extract(payload, bad_zip_status=400)
+            assert exc.value.status_code == 400
+
+    def test_ordinary_archives_are_untouched(self):
+        """The bounded source must be transparent on archives we accept."""
+        data = _make_zip({"my-skill/SKILL.md": SKILL_MD, "my-skill/ref.md": b"hi"})
+        files, root = _safe_zip_extract(data)
+        assert root == "my-skill"
+        assert files == {"SKILL.md": SKILL_MD, "ref.md": b"hi"}
+
+    def test_post_construction_cap_stands_on_its_own(self):
+        """Defence in depth: the ``infolist()`` cap without the source guard.
+
+        The two gates are independent. If a future CPython stops reading the
+        directory in one pass from its own offset, the source guard could
+        under-count; this one bounds the per-entry work regardless, since it
+        reads the count the parser produced.
+        """
+        from xagent.web.api import skill_hub
+
+        class _Passthrough(skill_hub._BoundedZipSource):
+            def _count_headers(self, limit: int) -> None:
+                return None
+
+        with mock.patch.object(skill_hub, "_BoundedZipSource", _Passthrough):
+            with pytest.raises(HTTPException) as exc:
+                skill_hub._safe_zip_extract(
+                    _entry_zip(skill_hub._MAX_ARCHIVE_ENTRIES + 1), bad_zip_status=400
+                )
+        assert exc.value.status_code == 400
+        assert "more than" in exc.value.detail


### PR DESCRIPTION
Split out of #1906, which was split from #1889, which was split from #1854. Seven of the nine blocking findings on #1906 landed on this one concept, so it was separated to let the rest converge. This PR has no dependency on #1906 — it replaces a construction site that already exists on `main`.

Closes #1941

## Problem

`ZipFile.__init__` materializes a `ZipInfo` for every central-directory entry before any of our code runs. A cap read off `infolist()` therefore bounds the per-entry work that *follows* construction, not the construction itself.

Measured on a 16 MiB archive of 100,000 empty padding directories — comfortably inside the 50 MiB ingress budget, since empty entries compress to almost nothing:

| | time | peak |
| --- | --- | --- |
| `ZipFile(io.BytesIO(...))` on `main` | 2.86s | 55.9 MiB |
| this PR | 0.01s | 5.4 MiB |

## Approach

Hand `ZipFile` a read-counting source instead of a plain `BytesIO`.

CPython locates the end-of-central-directory record itself — handling comments, Zip64 and self-extracting prefixes — and then **seeks straight to the central directory and reads it**. That is the ground truth this rests on, and it is identical across shapes:

```
plain 5:      seek→406, read 22B (PK0506) → seek→386, read 42B → seek→164, read 264B (PK0102)  ← directory
5 + comment:  ...                                              → seek→164, read 269B (PK0102)  ← directory
5 + SFX stub: ...                                              → seek→4260, read 264B (PK0102) ← directory
```

So the first read that *begins* on a central-directory signature is the directory, and from that offset the headers chain end-to-end. Follow the chain, count, and stop the constructor when the count goes over.

Nothing here parses the end record or scans for signatures. Locating the directory stays CPython's job — it remains the authority on Zip64, SFX prefixes, comments and per-release format handling — and this only walks the structure it lands on.

## Two properties it depends on

Both verified rather than assumed:

* **The count accumulates across reads.** `BufferedReader` splits the directory into fixed-size blocks; a per-read tally saw 1,993 headers of a 2,001-entry directory and let it through. A 20,000-entry case trips any cap regardless and hides this completely, so the exact boundary pair (2,000 accepts / 2,001 refuses) is tested.
* **Only the directory CPython seeks to anchors the walk.** Signatures inside member content, an archive comment or a self-extracting stub are not on the chain. This one is *reachable, not theoretical*: a padding member a few dozen bytes long shifts a `BufferedReader` block boundary onto forged bytes, and a re-anchoring guard then counts a valid three-entry archive past 2,000 and refuses it. That shape is a regression test.

## A negative result worth recording

**A byte budget alone cannot bound entry count.** Construction reads track directory *size*, and legitimate and hostile archives overlap:

| archive | bytes read during construction |
| --- | --- |
| legitimate 2,000 entries, 400-char names | 891,694 |
| hostile 20,000 entries | 1,008,979 |

Bounding entries at 2,000 via bytes would need ≤ 92,000 (2000 × 46), which rejects the legitimate case.

## Defence in depth

The `infolist()` count is checked as well, as an independent second gate. It bounds the per-entry work that follows — the walk, plus one row per file on install — without depending on the walk having reached every header, and it stays correct if a future CPython changes how the directory is read. It is cheap (a `len()` on a list already built) and it is pinned by its own test that stubs the source guard out, so the two gates cannot silently collapse into one.

## Status code

An over-cap archive answers **400**, not `bad_zip_status`. It parses fine and merely carries more than we accept — a statement about its contents, like the traversal and size rejections. Per the #1822 convention, `bad_zip_status` is only for an archive that cannot be read at all. Tested at both `bad_zip_status=400` and `502`.

## Incidental fix

The source clamps a negative seek the way `BytesIO` does. `zipfile` seeks a fixed distance back from the end to find the end record, so an archive shorter than that record seeks past the start (`seek(-22, SEEK_END)` on a 4-byte input → `-18`). Left unclamped, a negative position indexes `bytes` from the *end*, so reads return the wrong bytes — in the object that decides where the central directory is. Found by reviewing the diff, not by a failing test; both the clamp and the explicit-negative-seek rejection now have one.

## Compatibility

Every shape below is asserted at the cap (accepted) **and** one over (refused), so a guard that mis-locates the directory fails visibly in either direction:

- plain, 1-byte comment, 64 KiB comment
- comment containing central-directory signatures
- self-extracting prefix
- 400-character member names
- Zip64 (70,000 entries), plain and with an SFX stub
- a member holding a forged 5,000-header run
- ordinary nested and flat skill archives, unchanged

The source is also transparent on **3,000 mutated archives** (corrupted, truncated, extended, commented, SFX-prefixed): the exception-type distribution is byte-identical to unguarded `BytesIO` — `{accepted: 2004, BadZipFile: 984, NotImplementedError: 12}` both ways.

## Verification

All of `tests/skills/` passes. **11 of 11 mutants killed**, each mutation applied to the production source with the suite re-run:

| mutation | |
| --- | --- |
| per-read counter reset (trap 1) | killed |
| source guard removed | killed |
| off-by-one refusing at the cap | killed |
| off-by-one accepting one over | killed |
| re-anchors after the directory ends | killed |
| anchors on a signature anywhere in the read | killed |
| chain advance ignores name/extra/comment lengths | killed |
| `infolist()` cap removed | killed |
| negative seek left unclamped | killed |
| negative absolute seek allowed | killed |
| over-cap answered with `bad_zip_status` | killed |

The first round found three survivors and it was worth it: the boundary test could not tell which of the two gates fired, so weakening the source guard left every test green. The tests now drive the source directly, past `ZipFile`, and assert the count it actually produced.

`ruff check`, `ruff format --check`, `isort`, `codespell` clean. `mypy` reports 0 errors in `skill_hub.py` (35 pre-existing errors in other files, matching `main`).