### PR TITLE
feat(web): thread the execution result through managed lease finalization

### DIFF
--- a/src/xagent/web/channels/feishu/bot.py
+++ b/src/xagent/web/channels/feishu/bot.py
@@ -379,6 +379,7 @@ class FeishuBotInstance:
                 interactions=projection.interactions,
                 message_type=projection.message_type,
                 error_message=projection.diagnostic_error,
+                execution_result=result,
             ):
                 raise TaskLeaseLostError(
                     f"task {task_id} ownership changed before Feishu result"

--- a/src/xagent/web/channels/slack/bot.py
+++ b/src/xagent/web/channels/slack/bot.py
@@ -613,6 +613,7 @@ class SlackBotInstance:
                 interactions=projection.interactions,
                 message_type=projection.message_type,
                 error_message=projection.diagnostic_error,
+                execution_result=result,
             ):
                 raise TaskLeaseLostError(
                     f"task {task_id} ownership changed before Slack result"

--- a/src/xagent/web/channels/telegram/bot.py
+++ b/src/xagent/web/channels/telegram/bot.py
@@ -1904,6 +1904,7 @@ class TelegramBotInstance:
                 interactions=projection.interactions,
                 message_type=projection.message_type,
                 error_message=projection.diagnostic_error,
+                execution_result=result,
             ):
                 raise TaskLeaseLostError(
                     f"task {task_id} ownership changed before Telegram result"

--- a/src/xagent/web/services/managed_task_lease.py
+++ b/src/xagent/web/services/managed_task_lease.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from dataclasses import dataclass, field
-from typing import Any
+from typing import Any, Mapping
 
 from sqlalchemy.orm import Session
 
@@ -44,6 +44,12 @@ def finalize_managed_task_lease_result(
     interactions: list[dict[str, Any]] | None = None,
     message_type: str = ASSISTANT_RESPONSE_MESSAGE_TYPE,
     error_message: str | None = None,
+    # Fed only to resolve_publishable_clarification; never pass this to a
+    # logger or an exception. finalize_managed_task_lease_result_isolated
+    # hands its call off to a worker thread, so this mapping is held by a
+    # closure across that thread boundary for a while, and it can carry
+    # large structures such as file_outputs with no truncation applied.
+    execution_result: Mapping[str, Any] | None = None,
 ) -> bool:
     """Atomically persist one inline transport result under its exact lease."""
 
@@ -107,6 +113,7 @@ def _finalize_managed_task_lease_result_sync(
     interactions: list[dict[str, Any]] | None = None,
     message_type: str = ASSISTANT_RESPONSE_MESSAGE_TYPE,
     error_message: str | None = None,
+    execution_result: Mapping[str, Any] | None = None,
 ) -> bool:
     from ..models.database import get_session_local
 
@@ -121,6 +128,7 @@ def _finalize_managed_task_lease_result_sync(
             interactions=interactions,
             message_type=message_type,
             error_message=error_message,
+            execution_result=execution_result,
         )
 
 
@@ -133,6 +141,7 @@ async def finalize_managed_task_lease_result_isolated(
     interactions: list[dict[str, Any]] | None = None,
     message_type: str = ASSISTANT_RESPONSE_MESSAGE_TYPE,
     error_message: str | None = None,
+    execution_result: Mapping[str, Any] | None = None,
 ) -> bool:
     """Settle one exact managed lease using a worker-owned short Session."""
 
@@ -145,6 +154,7 @@ async def finalize_managed_task_lease_result_isolated(
             interactions=interactions,
             message_type=message_type,
             error_message=error_message,
+            execution_result=execution_result,
         )
     )
 
@@ -192,6 +202,7 @@ class ManagedTaskLease:
         interactions: list[dict[str, Any]] | None = None,
         message_type: str = ASSISTANT_RESPONSE_MESSAGE_TYPE,
         error_message: str | None = None,
+        execution_result: Mapping[str, Any] | None = None,
     ) -> bool:
         """Stop heartbeating, then atomically persist this owner's result."""
 
@@ -206,6 +217,7 @@ class ManagedTaskLease:
                 interactions=interactions,
                 message_type=message_type,
                 error_message=error_message,
+                execution_result=execution_result,
             )
         )
         return await drain_async_task_cancellation_safe(cleanup_task)
@@ -235,6 +247,7 @@ class ManagedTaskLease:
         interactions: list[dict[str, Any]] | None,
         message_type: str,
         error_message: str | None,
+        execution_result: Mapping[str, Any] | None = None,
     ) -> bool:
         if not await self._stop_heartbeat_for_settlement():
             return False
@@ -246,6 +259,7 @@ class ManagedTaskLease:
             interactions=interactions,
             message_type=message_type,
             error_message=error_message,
+            execution_result=execution_result,
         )
 
     async def _close_resources(self) -> bool:

--- a/src/xagent/web/services/managed_task_lease.py
+++ b/src/xagent/web/services/managed_task_lease.py
@@ -44,8 +44,12 @@ def finalize_managed_task_lease_result(
     interactions: list[dict[str, Any]] | None = None,
     message_type: str = ASSISTANT_RESPONSE_MESSAGE_TYPE,
     error_message: str | None = None,
-    # Fed only to resolve_publishable_clarification; never pass this to a
-    # logger or an exception. finalize_managed_task_lease_result_isolated
+    # Reserved for a future reader and unconsumed today: this function
+    # never reads it, and resolve_publishable_clarification -- the reader
+    # it is reserved for -- has no production caller anywhere yet. The
+    # change that wires that resolver is what will read it. Never pass
+    # this to a logger or an exception.
+    # finalize_managed_task_lease_result_isolated
     # hands its call off to a worker thread, so this mapping is held by a
     # closure across that thread boundary for a while, and it can carry
     # large structures such as file_outputs with no truncation applied.

--- a/tests/web/services/test_clarification_publication_gate.py
+++ b/tests/web/services/test_clarification_publication_gate.py
@@ -6,10 +6,12 @@ asserts exactly that -- no production code path calls it -- so the module
 cannot end up half-wired, called from one finalizer but not the other two.
 
 None of today's three finalizers has a pipeline that hands it both the
-pattern's result dict and the resume anchor this resolver needs --
-``finalize_managed_task_lease_result``'s current signature
-(``managed_task_lease.py``), for instance, takes neither. The gate's
-expected call count today is zero. It becomes exactly three (one call in
+pattern's result dict and the resume anchor this resolver needs.
+``finalize_managed_task_lease_result`` (``managed_task_lease.py``) now
+takes the result, as an ``execution_result`` parameter that nothing in
+that finalizer reads; it still resolves no anchor and still calls no
+resolver, so the pair this resolver requires is assembled nowhere. The
+gate's expected call count today is zero. It becomes exactly three (one call in
 each of the two finalizers that settle a running task, one in the
 finalizer that settles a resumed one) only once all three of those
 finalizers call it, the task-side protocol marker exists, and the read

--- a/tests/web/services/test_managed_task_lease.py
+++ b/tests/web/services/test_managed_task_lease.py
@@ -1,20 +1,28 @@
 from __future__ import annotations
 
+import ast
 import asyncio
+import inspect
+import logging
 import threading
 from unittest.mock import AsyncMock, patch
 
 import pytest
 from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 
+import xagent.config as config
+import xagent.web.services.interaction_rollout as ir
+import xagent.web.services.managed_task_lease as managed_task_lease
 from xagent.web.models.agent import Agent
 from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base, get_db, get_engine, init_db
 from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.models.user import User
 from xagent.web.models.workforce import Workforce, WorkforceRun
 from xagent.web.services.managed_task_lease import (
     ManagedTaskLease,
+    _finalize_managed_task_lease_result_sync,
     claim_managed_task_lease,
     claim_managed_task_lease_isolated,
     finalize_managed_task_lease_result,
@@ -512,3 +520,303 @@ async def test_managed_lease_close_drains_heartbeat_before_cancellation() -> Non
             await closing
 
     release.assert_called_once_with(managed.lease)
+
+
+# ---------------------------------------------------------------------------
+# execution_result: identity threading through all five finalize layers.
+# ---------------------------------------------------------------------------
+
+
+def test_execution_result_identity_at_finalize_core() -> None:
+    """The base layer accepts execution_result and binds it unchanged."""
+
+    sentinel: dict[str, object] = {"marker": object()}
+    bound = inspect.signature(finalize_managed_task_lease_result).bind(
+        db=object(),
+        lease=TaskLease(task_id=201, runner_id="runner-a", run_id="run-a"),
+        status=TaskStatus.COMPLETED,
+        execution_result=sentinel,
+    )
+    assert bound.arguments["execution_result"] is sentinel
+
+
+def test_execution_result_identity_at_finalize_sync(
+    db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    sentinel: dict[str, object] = {"marker": object()}
+    received: list[object] = []
+
+    def capture_core(_db, _lease, *, execution_result=None, **_kwargs):
+        received.append(execution_result)
+        return True
+
+    monkeypatch.setattr(
+        managed_task_lease, "finalize_managed_task_lease_result", capture_core
+    )
+
+    assert (
+        _finalize_managed_task_lease_result_sync(
+            TaskLease(task_id=202, runner_id="runner-a", run_id="run-a"),
+            status=TaskStatus.COMPLETED,
+            execution_result=sentinel,
+        )
+        is True
+    )
+    assert received == [sentinel]
+    assert received[0] is sentinel
+
+
+@pytest.mark.asyncio
+async def test_execution_result_identity_at_finalize_isolated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sentinel: dict[str, object] = {"marker": object()}
+    received: list[object] = []
+
+    def capture_sync(_lease, *, execution_result=None, **_kwargs):
+        received.append(execution_result)
+        return True
+
+    monkeypatch.setattr(
+        managed_task_lease,
+        "_finalize_managed_task_lease_result_sync",
+        capture_sync,
+    )
+
+    assert (
+        await finalize_managed_task_lease_result_isolated(
+            TaskLease(task_id=203, runner_id="runner-a", run_id="run-a"),
+            status=TaskStatus.COMPLETED,
+            execution_result=sentinel,
+        )
+        is True
+    )
+    assert received == [sentinel]
+    assert received[0] is sentinel
+
+
+@pytest.mark.asyncio
+async def test_execution_result_identity_at_finalize_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    heartbeat_task = asyncio.create_task(asyncio.sleep(0))
+    managed = ManagedTaskLease(
+        lease=TaskLease(task_id=204, runner_id="runner-a", run_id="run-a"),
+        stop_event=asyncio.Event(),
+        heartbeat_task=heartbeat_task,  # type: ignore[arg-type]
+    )
+    sentinel: dict[str, object] = {"marker": object()}
+    received: list[object] = []
+
+    async def capture_finalize_resources(_self, *, execution_result=None, **_kwargs):
+        received.append(execution_result)
+        return True
+
+    monkeypatch.setattr(
+        ManagedTaskLease, "_finalize_resources", capture_finalize_resources
+    )
+
+    assert (
+        await managed.finalize_result(
+            status=TaskStatus.COMPLETED,
+            execution_result=sentinel,
+        )
+        is True
+    )
+    assert received == [sentinel]
+    assert received[0] is sentinel
+
+
+@pytest.mark.asyncio
+async def test_execution_result_identity_at_finalize_resources(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    heartbeat_task = asyncio.create_task(asyncio.sleep(0))
+    managed = ManagedTaskLease(
+        lease=TaskLease(task_id=205, runner_id="runner-a", run_id="run-a"),
+        stop_event=asyncio.Event(),
+        heartbeat_task=heartbeat_task,  # type: ignore[arg-type]
+    )
+    sentinel: dict[str, object] = {"marker": object()}
+    received: list[object] = []
+
+    async def stop_heartbeat(*_args, **_kwargs) -> TaskLeaseHeartbeatOutcome:
+        return TaskLeaseHeartbeatOutcome()
+
+    async def capture_isolated(_lease, *, execution_result=None, **_kwargs):
+        received.append(execution_result)
+        return True
+
+    monkeypatch.setattr(managed_task_lease, "stop_task_lease_heartbeat", stop_heartbeat)
+    monkeypatch.setattr(
+        managed_task_lease,
+        "finalize_managed_task_lease_result_isolated",
+        capture_isolated,
+    )
+
+    assert (
+        await managed._finalize_resources(
+            status=TaskStatus.COMPLETED,
+            assistant_content=None,
+            turn_id=None,
+            interactions=None,
+            message_type="assistant_response",
+            error_message=None,
+            execution_result=sentinel,
+        )
+        is True
+    )
+    assert received == [sentinel]
+    assert received[0] is sentinel
+
+
+# ---------------------------------------------------------------------------
+# execution_result: it must never reach a log call or an exception message.
+# ---------------------------------------------------------------------------
+
+
+def test_execution_result_never_reaches_a_log_or_exception_message() -> None:
+    """M-7: this module must never hand execution_result to a logger call
+    or an exception constructor. finalize_managed_task_lease_result_isolated
+    hands its call off to a worker thread, so a lambda closure holds this
+    mapping across that thread boundary; it may carry large, untruncated
+    structures such as file_outputs, so logging it would leak that payload.
+    """
+
+    source = inspect.getsource(managed_task_lease)
+    tree = ast.parse(source)
+    offenders: list[str] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        is_logger_call = (
+            isinstance(func, ast.Attribute)
+            and isinstance(func.value, ast.Name)
+            and func.value.id == "logger"
+        )
+        is_exception_construction = (
+            isinstance(func, ast.Name) and func.id.endswith("Error")
+        ) or (isinstance(func, ast.Attribute) and func.attr.endswith("Error"))
+        if not (is_logger_call or is_exception_construction):
+            continue
+        for value in list(node.args) + [kw.value for kw in node.keywords]:
+            for sub in ast.walk(value):
+                if isinstance(sub, ast.Name) and sub.id == "execution_result":
+                    offenders.append(ast.dump(node))
+    assert offenders == []
+
+
+def test_finalize_core_never_logs_the_execution_result_payload(
+    db_session, caplog: pytest.LogCaptureFixture
+) -> None:
+    task = _create_task(db_session)
+    lease = acquire_task_lease(db_session, int(task.id), new_run=True)
+    assert lease is not None
+    sentinel_marker = "EXECUTION-RESULT-SENTINEL-4f2c9"
+
+    with caplog.at_level(logging.DEBUG):
+        assert (
+            finalize_managed_task_lease_result(
+                db_session,
+                lease,
+                status=TaskStatus.COMPLETED,
+                assistant_content="done",
+                execution_result={"marker": sentinel_marker},
+            )
+            is True
+        )
+
+    assert sentinel_marker not in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# execution_result: draft publication must be dominated by its presence.
+# ---------------------------------------------------------------------------
+
+
+def test_managed_lease_publication_requires_an_execution_result() -> None:
+    """Any resolve_publishable_clarification call inside
+    finalize_managed_task_lease_result must be dominated by an
+    `execution_result is not None` guard.
+
+    This PR adds no such call -- publication is wired up separately -- so
+    this pin currently passes on absence. Do not rewrite it to assert the
+    call exists: the smallest way to turn this red is adding the call
+    without the guard, which is exactly the mistake it exists to catch.
+    """
+
+    source = inspect.getsource(finalize_managed_task_lease_result)
+    tree = ast.parse(source)
+    func_node = tree.body[0]
+    assert isinstance(func_node, ast.FunctionDef)
+
+    def _is_execution_result_not_none_guard(test: ast.expr) -> bool:
+        return (
+            isinstance(test, ast.Compare)
+            and isinstance(test.left, ast.Name)
+            and test.left.id == "execution_result"
+            and len(test.ops) == 1
+            and isinstance(test.ops[0], ast.IsNot)
+            and len(test.comparators) == 1
+            and isinstance(test.comparators[0], ast.Constant)
+            and test.comparators[0].value is None
+        )
+
+    def _publish_calls(node: ast.AST) -> list[ast.Call]:
+        return [
+            n
+            for n in ast.walk(node)
+            if isinstance(n, ast.Call)
+            and (
+                (
+                    isinstance(n.func, ast.Name)
+                    and n.func.id == "resolve_publishable_clarification"
+                )
+                or (
+                    isinstance(n.func, ast.Attribute)
+                    and n.func.attr == "resolve_publishable_clarification"
+                )
+            )
+        ]
+
+    all_calls = {id(call) for call in _publish_calls(func_node)}
+    guarded_calls: set[int] = set()
+    for node in ast.walk(func_node):
+        if isinstance(node, ast.If) and _is_execution_result_not_none_guard(node.test):
+            for stmt in node.body:
+                guarded_calls.update(id(call) for call in _publish_calls(stmt))
+
+    assert all_calls - guarded_calls == set()
+
+
+def test_finalize_without_execution_result_creates_no_interaction_row_in_native_mode(
+    db_session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Omitting execution_result must not publish a clarification even when
+    native-mode rollout would otherwise allow one.
+    """
+
+    monkeypatch.delenv(config.INTERACTION_PROTOCOL_MODE, raising=False)
+    monkeypatch.delenv(config.INTERACTION_NATIVE_SOURCES, raising=False)
+    monkeypatch.setattr(ir, "_policy", None)
+    monkeypatch.setenv(config.INTERACTION_PROTOCOL_MODE, "native")
+    monkeypatch.setenv(config.INTERACTION_NATIVE_SOURCES, "sdk")
+    policy = ir.validate_interaction_rollout_at_startup()
+    assert policy.mode == "native"
+
+    task = _create_task(db_session)
+    lease = acquire_task_lease(db_session, int(task.id), new_run=True)
+    assert lease is not None
+
+    assert (
+        finalize_managed_task_lease_result(
+            db_session,
+            lease,
+            status=TaskStatus.WAITING_FOR_USER,
+            assistant_content="Please confirm",
+        )
+        is True
+    )
+
+    assert db_session.query(TaskInteractionRequest).count() == 0

--- a/tests/web/services/test_managed_task_lease.py
+++ b/tests/web/services/test_managed_task_lease.py
@@ -676,7 +676,7 @@ async def test_execution_result_identity_at_finalize_resources(
 
 
 def test_execution_result_never_reaches_a_log_or_exception_message() -> None:
-    """M-7: this module must never hand execution_result to a logger call
+    """This module must never hand execution_result to a logger call
     or an exception constructor. finalize_managed_task_lease_result_isolated
     hands its call off to a worker thread, so a lambda closure holds this
     mapping across that thread boundary; it may carry large, untruncated

--- a/tests/web/services/test_managed_task_lease.py
+++ b/tests/web/services/test_managed_task_lease.py
@@ -744,6 +744,15 @@ def test_managed_lease_publication_requires_an_execution_result() -> None:
     this pin currently passes on absence. Do not rewrite it to assert the
     call exists: the smallest way to turn this red is adding the call
     without the guard, which is exactly the mistake it exists to catch.
+
+    Two mutations were run against this assertion and both turn it red: a
+    mutation adding an unguarded call, and one demoting the guard to
+    truthiness (``if execution_result:``).
+
+    One guard shape only is recognized -- an ``if execution_result is not
+    None:`` block dominating the call. An early-return ``is None`` guard
+    is equally safe at runtime and still turns this red, so the change
+    that wires the resolver has to use the block shape.
     """
 
     source = inspect.getsource(finalize_managed_task_lease_result)
@@ -806,6 +815,8 @@ def test_finalize_without_execution_result_creates_no_interaction_row_in_native_
     assert policy.mode == "native"
 
     task = _create_task(db_session)
+    task.source = "sdk"
+    db_session.commit()
     lease = acquire_task_lease(db_session, int(task.id), new_run=True)
     assert lease is not None
 

--- a/tests/web/test_feishu_message_queue.py
+++ b/tests/web/test_feishu_message_queue.py
@@ -393,6 +393,7 @@ async def test_successful_channel_turn_persists_user_before_exact_assistant_sett
             ),
             "message_type": expected_message_type,
             "error_message": expected_error,
+            "execution_result": execution_result,
         }
     ]
 

--- a/tests/web/test_slack_channel.py
+++ b/tests/web/test_slack_channel.py
@@ -1212,6 +1212,7 @@ async def test_successful_slack_turn_reuses_channel_runtime(
     bot._save_active_tasks = lambda: None  # type: ignore[method-assign]
     lease = TaskLease(task_id=45, runner_id="runner-a", run_id="run-a")
     finalized: list[tuple[TaskStatus, str]] = []
+    finalized_execution_results: list[Any] = []
 
     class FakeManagedLease:
         heartbeat_task = None
@@ -1225,9 +1226,11 @@ async def test_successful_slack_turn_reuses_channel_runtime(
             *,
             status: TaskStatus,
             assistant_content: str = "",
+            execution_result: Any = None,
             **_kwargs: Any,
         ) -> bool:
             finalized.append((status, assistant_content))
+            finalized_execution_results.append(execution_result)
             return True
 
         async def close(self) -> bool:
@@ -1259,12 +1262,14 @@ async def test_successful_slack_turn_reuses_channel_runtime(
         set_recovered_skill_context=lambda _context: None,
     )
 
+    execution_result = {"success": True, "output": "Slack reply"}
+
     class FakeAgentManager:
         async def get_agent_for_task(self, *_args: Any, **_kwargs: Any) -> Any:
             return agent_service
 
         async def execute_task(self, **_kwargs: Any) -> dict[str, Any]:
-            return {"success": True, "output": "Slack reply"}
+            return execution_result
 
     persisted: list[dict[str, Any]] = []
     final_messages: list[dict[str, Any]] = []
@@ -1323,6 +1328,7 @@ async def test_successful_slack_turn_reuses_channel_runtime(
     assert bot.active_tasks == {"T1:D1:U1:direct": 45}
     assert persisted[0]["content"] == "hello"
     assert finalized == [(TaskStatus.COMPLETED, "Slack reply")]
+    assert finalized_execution_results == [execution_result]
     assert final_messages == [
         {
             "channel_id": "D1",

--- a/tests/web/test_telegram_message_queue.py
+++ b/tests/web/test_telegram_message_queue.py
@@ -1520,6 +1520,132 @@ async def test_empty_output_edits_the_loading_message_with_a_placeholder(
 
 
 @pytest.mark.asyncio
+async def test_successful_telegram_turn_hands_finalize_the_execution_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The waiting-branch call site forwards its own execute_task() result.
+
+    finalize_result has no reader for execution_result yet, but the channel
+    must already supply the exact object execute_task returned so a future
+    reader gets the full result mapping rather than a synthesized draft.
+    """
+
+    bot = make_bot()
+    bot.channel_id = 1
+    bot.channel_name = "Telegram execution result"
+    bot.active_tasks = {}
+    bot.bot = object()
+    bot._save_active_tasks = lambda: True
+    bot._consume_user_stop_request = lambda _user_id: False
+    bot._clear_user_stop_request = lambda _user_id: None
+
+    lease = TaskLease(task_id=48, runner_id="runner-a", run_id="run-a")
+    finalized: list[dict] = []
+
+    class FakeManagedLease:
+        heartbeat_task = None
+
+        def __init__(self) -> None:
+            self.lease = lease
+
+        async def close(self) -> bool:
+            return True
+
+        async def finalize_result(self, **kwargs) -> bool:  # type: ignore[no-untyped-def]
+            finalized.append(kwargs)
+            return True
+
+    execution_result = {"success": True, "output": "Telegram reply"}
+
+    class FakeTracer:
+        def add_handler(self, _handler: object) -> None:
+            return None
+
+        def remove_handler(self, _handler: object) -> None:
+            return None
+
+    agent_service = SimpleNamespace(
+        tracer=FakeTracer(),
+        set_conversation_history=lambda _messages: None,
+        set_execution_context_messages=lambda _messages: None,
+        set_recovered_skill_context=lambda _context: None,
+    )
+
+    class FakeAgentManager:
+        async def get_agent_for_task(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return agent_service
+
+        async def execute_task(self, **_kwargs):  # type: ignore[no-untyped-def]
+            return execution_result
+
+    async def extract_text(_message):  # type: ignore[no-untyped-def]
+        return "hello", []
+
+    async def await_execution(_user_id, execution, *, reason):  # type: ignore[no-untyped-def]
+        return await execution
+
+    async def fake_prepare(**_kwargs):  # type: ignore[no-untyped-def]
+        return SimpleNamespace(
+            user_id=5,
+            task_id=48,
+            is_new_task=True,
+            managed_lease=FakeManagedLease(),
+            requested_agent_missing=False,
+        )
+
+    async def persist_message(**_kwargs) -> None:  # type: ignore[no-untyped-def]
+        return None
+
+    monkeypatch.setattr(
+        "xagent.web.channels.telegram.bot.prepare_channel_task", fake_prepare
+    )
+    monkeypatch.setattr(
+        "xagent.web.channels.telegram.bot.load_task_setup_snapshot_sync",
+        lambda *_args: SimpleNamespace(
+            runtime_user=None,
+            conversation_history=(),
+            execution_recovery=TaskExecutionRecoverySnapshot(),
+        ),
+    )
+    monkeypatch.setattr(
+        "xagent.web.channels.telegram.bot.get_agent_manager",
+        lambda: FakeAgentManager(),
+    )
+    monkeypatch.setattr(
+        "xagent.web.channels.telegram.bot.persist_channel_user_message",
+        persist_message,
+    )
+    bot._extract_message_content = extract_text
+    bot._await_execution_with_stop_monitor = await_execution
+
+    class LoadingMessage:
+        message_id = 77
+
+        async def edit_text(self, text: str, **_kwargs) -> None:
+            return None
+
+        async def delete(self) -> None:
+            return None
+
+    class Message:
+        from_user = SimpleNamespace(id=123)
+        chat = SimpleNamespace(id=456)
+
+        def __init__(self) -> None:
+            self.answers: list[str] = []
+
+        async def answer(self, text: str, **_kwargs) -> LoadingMessage:
+            self.answers.append(text)
+            return LoadingMessage()
+
+    message = Message()
+    await bot._process_user_messages_batch(123, [message])  # type: ignore[arg-type]
+
+    assert len(finalized) == 1
+    assert finalized[0]["execution_result"] is execution_result
+
+
+@pytest.mark.asyncio
 async def test_channel_failure_suppresses_stale_error_after_exact_settlement_rejected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1549,13 +1675,16 @@ async def test_channel_failure_suppresses_stale_error_after_exact_settlement_rej
             self,
             *,
             status: TaskStatus,
+            execution_result=None,
             **_kwargs,
         ) -> bool:
             settlements.append((self.lease, status))
+            settled_execution_results.append(execution_result)
             return False
 
     managed = FakeManagedLease()
     settlements: list[tuple[TaskLease, TaskStatus]] = []
+    settled_execution_results: list[object] = []
 
     class FakeTracer:
         def __init__(self) -> None:
@@ -1643,10 +1772,33 @@ async def test_channel_failure_suppresses_stale_error_after_exact_settlement_rej
     await bot._process_user_messages_batch(123, [message])  # type: ignore[arg-type]
 
     assert settlements == [(lease, TaskStatus.FAILED)]
+    # The except branch has no execution result in scope, so it settles
+    # through the default rather than passing one along.
+    assert settled_execution_results == [None]
     assert managed.closed is True
     assert "Sorry, an error occurred while processing your request." not in (
         message.answers
     )
+
+
+@pytest.mark.asyncio
+async def test_finalize_requested_stop_settles_with_no_execution_result() -> None:
+    """A requested /stop has no channel execution result to hand over."""
+
+    finalized: list[dict] = []
+
+    class FakeManagedLease:
+        async def finalize_result(self, **kwargs) -> bool:  # type: ignore[no-untyped-def]
+            finalized.append(kwargs)
+            return True
+
+    await TelegramBotInstance._finalize_requested_stop(
+        FakeManagedLease(),
+        task_id=45,  # type: ignore[arg-type]
+    )
+
+    assert finalized == [{"status": TaskStatus.PAUSED}]
+    assert "execution_result" not in finalized[0]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
The three chat channels project an execution result into the four fields a channel renders, then settle the lease with those. The projection drops everything else about the round, so a consumer that needs the round's own facts has nothing to read and would have to re-derive them from a projection built for a different purpose.

This carries the raw result alongside the projection, as a keyword parameter defaulted to `None`, through all five layers between a channel's call and the session-holding one: `finalize_managed_task_lease_result`, `_finalize_managed_task_lease_result_sync`, `finalize_managed_task_lease_result_isolated`, `ManagedTaskLease.finalize_result`, and the locked settlement it delegates to.

Three call sites pass it — the success settlement in each of the Feishu, Slack, and Telegram bots, each handing over the same object the projection on the line above is built from. The five call sites that settle a failure, a pause, or a release have no round result and take the default: the failure settlement in each of the three bots, Telegram's pause settlement, and `channel_runtime.py`'s own direct call. `channel_runtime.py` is otherwise untouched.

Nothing reads the parameter yet. It is intended for clarification resolution, and its comment records the one thing a future reader must not do with it: never pass it to a logger or an exception. The isolated layer hands its call to a worker thread, so a lambda closure holds this mapping across that thread boundary, and it can carry large structures such as `file_outputs` with nothing truncating them.

**On the guard that is not here.** An earlier attempt at this parameter, added and then reverted during the write-path preparation PR (#1580), included a source-scanning guard that counted, per module, how many `finalize_result` call sites named the `execution_result` keyword and asserted that count. It was reverted for pinning the shape of source text rather than any behavior, and it is deliberately not rebuilt here — the parameter's threading is covered from the API side instead, by the defaults case and the identity cases beside it. This is not a claim that the test module does no source analysis at all: `test_execution_result_never_reaches_a_log_or_exception_message` walks this module's AST for logger calls and exception constructions that mention `execution_result`, and that guard stays. It enforces the never-log rule above, which has no behavioral surface to assert from the outside.

**Verification** — `uv run pytest`, Python 3.12, local SQLite-backed default configuration:

- `tests/web/services/test_managed_task_lease.py`: 24 passed.
- Channel suites — `tests/web/test_feishu_message_queue.py` (13), `tests/web/test_slack_channel.py` (50), `tests/web/test_telegram_message_queue.py` (66): 129 passed.
