### PR TITLE
fix(agent): skip legacy-resume close on a replayed injection

### DIFF
--- a/src/xagent/core/agent/execution_adapter.py
+++ b/src/xagent/core/agent/execution_adapter.py
@@ -15,7 +15,7 @@ from .attachments import build_image_context_references
 from .pattern import AutoPattern, DAGPattern, LLMPlanGenerator, ReActPattern
 from .registry import ExecutionRegistry
 from .result import NO_OUTPUT_PLACEHOLDER
-from .runner import AgentRunner
+from .runner import AgentRunner, UserMessageInjectionOutcome
 from .tracing import TraceEventCallback
 
 logger = logging.getLogger(__name__)
@@ -203,7 +203,7 @@ class AgentExecutionAdapter:
         turn_id: str | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
-    ) -> bool:
+    ) -> UserMessageInjectionOutcome:
         if self.registry.get(execution_id) is None:
             runner, execution_type = self._build_runner()
             self.registry.register(
@@ -211,7 +211,7 @@ class AgentExecutionAdapter:
                 runner,
                 metadata=self._execution_metadata(execution_type=execution_type),
             )
-        context = await self.registry.post_user_message(
+        result = await self.registry.post_user_message(
             execution_id,
             message,
             execution_message=execution_message,
@@ -221,7 +221,7 @@ class AgentExecutionAdapter:
             request_interrupt=request_interrupt,
             reason=reason,
         )
-        return context is not None
+        return result.outcome
 
     def cancel(self, execution_id: str, reason: str | None = None) -> bool:
         return self.registry.cancel(execution_id, reason=reason)

--- a/src/xagent/core/agent/registry.py
+++ b/src/xagent/core/agent/registry.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Callable
 
-from .context import ExecutionContext
+from .runner import UserMessageInjectionOutcome, UserMessageInjectionResult
 
 if TYPE_CHECKING:
     from .runner import AgentRunner
@@ -212,10 +212,13 @@ class ExecutionRegistry:
         turn_id: str | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
-    ) -> ExecutionContext | None:
+    ) -> UserMessageInjectionResult:
         handle = self.get(execution_id)
         if handle is None:
-            return None
+            return UserMessageInjectionResult(
+                context=None,
+                outcome=UserMessageInjectionOutcome.NOT_POSTED,
+            )
         handle.updated_at = _utcnow()
         return await handle.runner.inject_user_message(
             execution_id,
@@ -239,8 +242,8 @@ class ExecutionRegistry:
         turn_id: str | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
-    ) -> ExecutionContext | None:
-        context = await self.inject_user_message(
+    ) -> UserMessageInjectionResult:
+        result = await self.inject_user_message(
             execution_id,
             message,
             execution_message=execution_message,
@@ -251,7 +254,7 @@ class ExecutionRegistry:
             reason=reason,
         )
         handle = self.get(execution_id)
-        if handle is not None and context is not None:
+        if handle is not None and result.context is not None:
             resolved_execution_message = (
                 execution_message if execution_message is not None else message
             )
@@ -270,7 +273,7 @@ class ExecutionRegistry:
                     "request_interrupt": request_interrupt,
                 },
             )
-        return context
+        return result
 
     def _on_task_done(
         self,

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import inspect
 import logging
 from dataclasses import dataclass
+from enum import Enum
 from pathlib import Path
 from typing import Any, cast
 from uuid import uuid4
@@ -32,6 +33,47 @@ class ExecutionControl:
 
     runtime: PatternRuntime
     task: str | None
+
+
+class UserMessageInjectionOutcome(str, Enum):
+    """What ``AgentRunner.inject_user_message`` actually did on a given
+    call, threaded unmodified through every layer that forwards its
+    result (``ExecutionRegistry``, ``AgentExecutionAdapter``,
+    ``AgentService.post_user_message``).
+
+    ``POSTED_FRESH`` and ``POSTED_REPLAY`` both mean a live, durable user
+    turn answers the caller's message -- a short-circuited repeat
+    ``turn_id`` (``POSTED_REPLAY``) returns the same context the first
+    attempt did without writing anything new, while ``POSTED_FRESH``
+    persisted one. ``NOT_POSTED`` is the empty string and the other two
+    members are not, so an unmodified ``if not posted`` / ``bool(posted)``
+    caller keeps asking exactly the question it always asked -- "did this
+    hand back a usable context at all" -- unaffected by the fresh/replay
+    split. Telling a replay apart from a fresh write requires comparing
+    identity against ``POSTED_REPLAY``; truthiness alone cannot and must
+    not be used for that.
+    """
+
+    NOT_POSTED = ""
+    POSTED_FRESH = "posted_fresh"
+    POSTED_REPLAY = "posted_replay"
+
+
+@dataclass(frozen=True)
+class UserMessageInjectionResult:
+    """Bundles the execution context an injection attempt produced (or
+    found already holding the answered turn) with what kind of write, if
+    any, produced it.
+
+    ``context`` is ``None`` only when there was no execution context to
+    inject into at all (``outcome`` is then ``NOT_POSTED``); every layer
+    downstream of the registry drops the raw context and forwards only
+    ``outcome``, since nothing past that boundary reads the context
+    object itself today.
+    """
+
+    context: ExecutionContext | None
+    outcome: UserMessageInjectionOutcome
 
 
 class AgentRunner:
@@ -446,13 +488,16 @@ class AgentRunner:
         turn_id: str | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
-    ) -> ExecutionContext | None:
+    ) -> UserMessageInjectionResult:
         context = self.context_manager.get_context(execution_id)
         cold_start_checkpoint: dict[str, Any] | None = None
         if context is None:
             checkpoint = await self._load_latest_checkpoint(execution_id)
             if checkpoint is None:
-                return None
+                return UserMessageInjectionResult(
+                    context=None,
+                    outcome=UserMessageInjectionOutcome.NOT_POSTED,
+                )
             if not isinstance(checkpoint.get("context"), dict):
                 raise CheckpointCorruptError(
                     "Stored checkpoint carries no execution context to restore."
@@ -497,7 +542,10 @@ class AgentRunner:
                     )
                 if request_interrupt:
                     self.pause(execution_id, reason=reason or "new user message")
-                return context
+                return UserMessageInjectionResult(
+                    context=context,
+                    outcome=UserMessageInjectionOutcome.POSTED_REPLAY,
+                )
 
         # Resolve the checkpoint-merge baseline before any context mutation
         # below (add_user_message, pending marker) so a failed read leaves
@@ -608,7 +656,10 @@ class AgentRunner:
                 )
         if request_interrupt:
             self.pause(execution_id, reason=reason or "new user message")
-        return context
+        return UserMessageInjectionResult(
+            context=context,
+            outcome=UserMessageInjectionOutcome.POSTED_FRESH,
+        )
 
     @staticmethod
     def _read_trace_watermark(context: ExecutionContext) -> str | None:
@@ -696,7 +747,7 @@ class AgentRunner:
         turn_id: str | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
-    ) -> ExecutionContext | None:
+    ) -> UserMessageInjectionResult:
         """Alias for external callers to inject a user message into an execution.
 
         `send_message` is an agent-side tool (`agent -> user`).

--- a/src/xagent/core/agent/service.py
+++ b/src/xagent/core/agent/service.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, Callable, cast
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from ...config import get_uploads_dir
 from ..memory import MemoryStore
@@ -28,6 +28,9 @@ from ..tools.adapters.vibe.connector_runtime import ConnectorRuntimeError
 from ..workspace import TaskWorkspace, create_workspace
 from .trace import Tracer
 from .transcript import normalize_transcript_messages
+
+if TYPE_CHECKING:
+    from .runner import UserMessageInjectionOutcome
 
 logger = logging.getLogger(__name__)
 
@@ -349,10 +352,11 @@ class AgentService:
         turn_id: str | None = None,
         request_interrupt: bool = True,
         reason: str | None = None,
-    ) -> bool:
+    ) -> "UserMessageInjectionOutcome":
         if self._execution_adapter is None:
             self._execution_adapter = self._build_execution_adapter()
-        return bool(
+        return cast(
+            "UserMessageInjectionOutcome",
             await self._execution_adapter.post_user_message(
                 execution_id,
                 message,
@@ -362,7 +366,7 @@ class AgentService:
                 turn_id=turn_id,
                 request_interrupt=request_interrupt,
                 reason=reason,
-            )
+            ),
         )
 
     async def resume_execution_by_id(

--- a/src/xagent/core/agent/tracing.py
+++ b/src/xagent/core/agent/tracing.py
@@ -26,7 +26,9 @@ TRACE_TURN_IDS_KEY = "_user_message_trace_turn_ids"
 # Stamped on ``context.metadata`` by ``runner.inject_user_message`` just
 # before persisting a freshly-injected user message, and cleared when the
 # follow-up persist records the advanced watermark. Carries the injected
-# message's ISO-UTC timestamp.
+# message's ISO-UTC timestamp. Only reached on a POSTED_FRESH outcome (see
+# ``UserMessageInjectionOutcome``): a short-circuited replay returns before
+# this stamp, or any other mutation of the context, ever happens.
 #
 # The catch-up loop on resume uses this to disambiguate three cases:
 # - both absent  -> old/pre-PR checkpoint, do nothing (don't replay history)
@@ -85,9 +87,11 @@ class TraceEventCallback:
 
         # Resume / checkpoint replay: emit any user messages the prior turn
         # did not get to trace. This handles two real scenarios:
-        #   1. ``inject_user_message`` was called, the checkpoint was
-        #      persisted, but the in-process trace emission was lost
-        #      (worker crash between persist and emit).
+        #   1. ``inject_user_message`` returned POSTED_FRESH, the checkpoint
+        #      was persisted, but the in-process trace emission was lost
+        #      (worker crash between persist and emit). A POSTED_REPLAY
+        #      outcome never reaches this scenario -- it persists nothing,
+        #      so there is no fresh turn here to catch up on.
         #   2. Defensive double-coverage for the continuation flow even
         #      though ``on_user_message_posted`` already covers the happy
         #      path — keeps the chip from disappearing if the callback
@@ -103,6 +107,11 @@ class TraceEventCallback:
         files: list[dict[str, Any]] | None = None,
     ) -> None:
         """Fire when ``runner.inject_user_message`` lands a fresh user turn.
+
+        Only a ``POSTED_FRESH`` outcome (see ``UserMessageInjectionOutcome``)
+        reaches here: the short-circuit that produces ``POSTED_REPLAY``
+        returns before the runner dispatches this callback, so a replayed
+        turn id never re-fires it.
 
         ``message`` is the freshly added ``Message`` instance. ``files`` is
         the normalized attachment list the websocket layer received; when

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -17,6 +17,7 @@ from ...core.agent.checkpoint import (
     CheckpointCorruptError,
     CheckpointReadError,
 )
+from ...core.agent.runner import UserMessageInjectionOutcome
 from ..models.agent import Agent
 from ..models.database import get_session_local
 from ..models.task import Task, TaskStatus
@@ -328,6 +329,7 @@ def _update_a2a_resume_input_sync(
     task_lease: TaskLease,
     text: str,
     interaction_id: int | None,
+    injection_outcome: UserMessageInjectionOutcome,
 ) -> bool:
     """Persist A2A input only while the exact prelease remains current.
 
@@ -336,6 +338,11 @@ def _update_a2a_resume_input_sync(
     function's session does not open until after the injection has already
     committed. See ``task_interaction_close``'s module docstring for why
     the read has to precede the injection.
+
+    ``injection_outcome`` is the caller's own ``post_user_message`` report,
+    not re-derived here: a replayed turn id must not retire the close, and
+    only the call that produced the short circuit can say whether this was
+    one.
     """
 
     SessionLocal = get_session_local()
@@ -381,12 +388,27 @@ def _update_a2a_resume_input_sync(
         # ordering obligation above means.
         assert task_lease.run_id is not None
         if interaction_requests_table_exists(db):
-            close_legacy_resume_interaction(
-                db,
-                task_id=task_lease.task_id,
-                run_id=task_lease.run_id,
-                interaction_id=interaction_id,
-            )
+            # A retried A2A message replays this site's deterministic turn
+            # id (f"a2a:{task_id}:{message_id}"), and inject_user_message
+            # short-circuits a repeated turn id without persisting
+            # anything -- reported here as injection_outcome being
+            # POSTED_REPLAY rather than folded into the same truthy
+            # "posted" a fresh write produces. On such a replay,
+            # interaction_id above is not the question this call answered
+            # -- the first attempt already retired that one -- it is
+            # whatever question the resumed agent has staged since, and a
+            # cross-run retry closing on it would retire a live question
+            # nobody has answered. The v1 reply resume-input path
+            # (task_reply.py) needs no equivalent guard: its turn id
+            # embeds a fresh uuid on every call and can never hit the
+            # short circuit that produces a replay.
+            if injection_outcome is not UserMessageInjectionOutcome.POSTED_REPLAY:
+                close_legacy_resume_interaction(
+                    db,
+                    task_id=task_lease.task_id,
+                    run_id=task_lease.run_id,
+                    interaction_id=interaction_id,
+                )
         db.commit()
         return True
 
@@ -473,26 +495,18 @@ async def _resume_input_required_a2a_task(
         # See task_interaction_close's module docstring for why.
         #
         # This site's turn id is deterministic (f"a2a:{task_id}:{message_id}"
-        # below), so a retried A2A message replays the same turn:
-        # AgentRunner.inject_user_message short-circuits a repeated turn id
-        # by returning the existing context without persisting anything, and
-        # reports the same truthy `posted` a first attempt does. On such a
-        # replay the id read here is not the question the replayed message
-        # answered but whatever the resumed agent has asked since, and the
-        # close would retire a live question. Nothing can be retired today:
-        # the only INSERT into task_interaction_requests is
-        # stage_interaction_request (task_interaction_staging.py), which has
-        # no caller in src/ and is held at none by
-        # tests/web/services/test_interaction_staging_production_gate.py, so
-        # this read returns None on every call. Closing the window is a
-        # precondition on the change that wires the first production writer,
-        # stated once at the online WebSocket injection site (websocket.py)
-        # and binding here identically.
+        # below), so a retried A2A message replays the same turn.
+        # AgentRunner.inject_user_message reports that replay explicitly
+        # (see UserMessageInjectionOutcome) instead of folding it into the
+        # same truthy value a fresh write produces, and
+        # _update_a2a_resume_input_sync reads that report to decide whether
+        # to skip its close call -- see the guard inside that function for
+        # why a replay must skip it.
         active_interaction_id = await run_db_io_cancellation_safe(
             lambda: active_interaction_id_sync(task_id)
         )
 
-        async def inject_user_message() -> tuple[Any, bool]:
+        async def inject_user_message() -> tuple[Any, UserMessageInjectionOutcome]:
             from .chat import get_agent_manager
 
             agent_service = await get_agent_manager().get_agent_for_task(
@@ -508,7 +522,7 @@ async def _resume_input_required_a2a_task(
                 request_interrupt=False,
                 reason="A2A input-required response",
             )
-            return agent_service, bool(posted)
+            return agent_service, posted
 
         with bind_task_lease_context(task_lease):
             agent_service, posted = await run_while_task_lease_owned(
@@ -535,7 +549,7 @@ async def _resume_input_required_a2a_task(
 
         updated = await run_db_io_cancellation_safe(
             lambda: _update_a2a_resume_input_sync(
-                task_lease, text, active_interaction_id
+                task_lease, text, active_interaction_id, posted
             )
         )
         if not updated:

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -391,18 +391,14 @@ def _update_a2a_resume_input_sync(
             # A retried A2A message replays this site's deterministic turn
             # id (f"a2a:{task_id}:{message_id}"), and inject_user_message
             # short-circuits a repeated turn id without persisting
-            # anything -- reported here as injection_outcome being
-            # POSTED_REPLAY rather than folded into the same truthy
-            # "posted" a fresh write produces. On such a replay,
-            # interaction_id above is not the question this call answered
-            # -- the first attempt already retired that one -- it is
-            # whatever question the resumed agent has staged since, and a
-            # cross-run retry closing on it would retire a live question
-            # nobody has answered. The v1 reply resume-input path
-            # (task_reply.py) needs no equivalent guard: its turn id
-            # embeds a fresh uuid on every call and can never hit the
-            # short circuit that produces a replay.
-            if injection_outcome is not UserMessageInjectionOutcome.POSTED_REPLAY:
+            # anything. interaction_id above was read fresh by this
+            # attempt, so on such a replay it names whatever the resumed
+            # agent has staged since rather than the question this call
+            # answered, and closing on it would retire a live question.
+            # See task_interaction_close's module docstring for the rule,
+            # the other sites, and why the v1 reply resume-input path
+            # needs no guard at all.
+            if injection_outcome is UserMessageInjectionOutcome.POSTED_FRESH:
                 close_legacy_resume_interaction(
                     db,
                     task_id=task_lease.task_id,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -3553,15 +3553,17 @@ async def execute_resume_background(
             # condition: this task can itself be retried across runs with
             # the same pending_user_message, and post_user_message reports
             # that retry explicitly as a replay instead of a bare truthy
-            # `posted`. On a replay, the interaction id carried above is
-            # not the question this turn answered -- the first attempt
-            # already retired that one -- it is whatever question the
-            # resumed agent has staged since, so closing here would retire
-            # a live question nobody has answered. The v1 reply resume-
-            # input path (task_reply.py) needs no equivalent guard: its
-            # turn id embeds a fresh uuid on every call and can never hit
-            # the short circuit that produces a replay.
-            if posted is not UserMessageInjectionOutcome.POSTED_REPLAY:
+            # `posted`. What the guard buys here is narrower than at the
+            # sites that read their own id: the id carried above is a
+            # primary key the first attempt already retired, and the close
+            # statement binds to it, so on a replay the close would be a
+            # no-op rather than a retirement of a live question. The guard
+            # stays as defense in depth -- it is what keeps this site safe
+            # if it ever stops carrying the id forward and starts deriving
+            # its own. See task_interaction_close's module docstring for
+            # the rule, the other sites, and why the v1 reply resume-input
+            # path needs no guard at all.
+            if posted is UserMessageInjectionOutcome.POSTED_FRESH:
                 try:
                     await run_db_io_cancellation_safe(
                         lambda: close_legacy_resume_interaction_sync(
@@ -6814,34 +6816,27 @@ async def _handle_chat_message_unserialized(
                                 turn_id,
                                 exc_info=True,
                             )
-                        # `posted` being truthy means a message with this
-                        # turn id is in a live checkpoint. For a first
-                        # attempt, retiring the interaction row observed
-                        # before the injection and clearing the task's
-                        # marker in the same short transaction is correct:
-                        # the message went in outside the native
+                        # For a first attempt, retiring the interaction row
+                        # observed before the injection and clearing the
+                        # task's marker in the same short transaction is
+                        # correct: the message went in outside the native
                         # interaction protocol's answer path, so a question
                         # this run had open under that protocol was
                         # answered by other means.
                         #
-                        # That reading breaks on a replay of an
-                        # already-seen turn id: the id read above is not
-                        # the question the replayed message answered --
-                        # the first attempt already retired that one -- it
-                        # is whatever question the resumed agent has staged
-                        # since, and closing on it would retire a live
-                        # question nobody has answered. `posted` alone
-                        # cannot tell a fresh write from a replay, so this
-                        # site does not try to; AgentRunner.inject_user_message
-                        # reports the distinction explicitly (see
-                        # UserMessageInjectionOutcome) and this guard reads
-                        # that report instead of the bare truthy value. The
-                        # v1 reply resume-input path (task_reply.py) needs
-                        # no equivalent guard: its turn id embeds a fresh
-                        # uuid on every call and can never hit the short
-                        # circuit that produces a replay. The A2A injection
-                        # site (a2a.py) carries the same guard for the same
-                        # reason.
+                        # That reading breaks on a replay. This site reads
+                        # its own id fresh on every attempt, so on a replay
+                        # the id above is not the question the replayed
+                        # message answered -- the first attempt retired
+                        # that one -- it is whatever the resumed agent has
+                        # staged since, and closing on it would retire a
+                        # live question. `posted` alone cannot tell a fresh
+                        # write from a replay; AgentRunner.inject_user_message
+                        # reports the distinction explicitly and this guard
+                        # reads that report. See task_interaction_close's
+                        # module docstring for the rule, the other sites,
+                        # and why the v1 reply resume-input path needs no
+                        # guard at all.
                         #
                         # The run fence
                         # is live_task_lease.run_id, not task_run_id: posted
@@ -6856,7 +6851,7 @@ async def _handle_chat_message_unserialized(
                         assert live_task_lease.run_id is not None
                         close_run_id = live_task_lease.run_id
                         close_interaction_id = active_interaction_id
-                        if posted is not UserMessageInjectionOutcome.POSTED_REPLAY:
+                        if posted is UserMessageInjectionOutcome.POSTED_FRESH:
                             try:
                                 await run_db_io_cancellation_safe(
                                     lambda: close_legacy_resume_interaction_sync(

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -3279,6 +3279,11 @@ async def execute_resume_background(
     delivery_already_dispatched: bool = False,
     delivery_websocket: WebSocket | None = None,
     delivery_client_message_id: str | None = None,
+    # Defaulting to None is a structurally open door, not exercised by any
+    # caller today: acquire_task_lease_no_commit (task_lease_service.py)
+    # mints a fresh uuid for a None here, so a future call site that
+    # forgets to pass its own run id would silently claim a lease under a
+    # run nobody else knows about instead of failing loudly.
     expected_run_id: str | None = None,
     resolved_execution_scope: Union[
         ExecutionScope, None, ExecutionScopeNotProvided

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -53,6 +53,7 @@ from ...core.agent.checkpoint import (
     CheckpointReadError,
     CheckpointUnavailableError,
 )
+from ...core.agent.runner import UserMessageInjectionOutcome
 from ...core.agent.trace import TraceEvent, TraceHandler
 from ...core.execution_scope import (
     EXECUTION_SCOPE_NOT_PROVIDED,
@@ -3542,35 +3543,50 @@ async def execute_resume_background(
             # staged since, not the one the message answered. Bound to a
             # plain local before the lambda below, like close_run_id above.
             close_interaction_id = pending_user_message.get("interaction_id")
-            try:
-                await run_db_io_cancellation_safe(
-                    lambda: close_legacy_resume_interaction_sync(
-                        task_id=task_id,
-                        run_id=close_run_id,
-                        interaction_id=close_interaction_id,
+            # Distinct from the "unconditional" argument above, which is
+            # only about not borrowing the delivery_turn_id branch's
+            # condition: this task can itself be retried across runs with
+            # the same pending_user_message, and post_user_message reports
+            # that retry explicitly as a replay instead of a bare truthy
+            # `posted`. On a replay, the interaction id carried above is
+            # not the question this turn answered -- the first attempt
+            # already retired that one -- it is whatever question the
+            # resumed agent has staged since, so closing here would retire
+            # a live question nobody has answered. The v1 reply resume-
+            # input path (task_reply.py) needs no equivalent guard: its
+            # turn id embeds a fresh uuid on every call and can never hit
+            # the short circuit that produces a replay.
+            if posted is not UserMessageInjectionOutcome.POSTED_REPLAY:
+                try:
+                    await run_db_io_cancellation_safe(
+                        lambda: close_legacy_resume_interaction_sync(
+                            task_id=task_id,
+                            run_id=close_run_id,
+                            interaction_id=close_interaction_id,
+                        )
                     )
-                )
-            except Exception:
-                logger.warning(
-                    "legacy resume interaction close failed after deferred "
-                    "message seal for task %s run %s",
-                    task_id,
-                    close_run_id,
-                    exc_info=True,
-                )
-            except asyncio.CancelledError:
-                # See run_db_io_cancellation_safe's docstring: it drains its
-                # worker to completion before propagating a cancellation
-                # raised while awaiting it, so the close-and-clear
-                # transaction has already committed or failed by the time
-                # this branch runs. Only the log statement was interrupted.
-                logger.warning(
-                    "legacy resume interaction close was cancelled after "
-                    "deferred message seal for task %s run %s; continuing "
-                    "resume",
-                    task_id,
-                    close_run_id,
-                )
+                except Exception:
+                    logger.warning(
+                        "legacy resume interaction close failed after deferred "
+                        "message seal for task %s run %s",
+                        task_id,
+                        close_run_id,
+                        exc_info=True,
+                    )
+                except asyncio.CancelledError:
+                    # See run_db_io_cancellation_safe's docstring: it drains
+                    # its worker to completion before propagating a
+                    # cancellation raised while awaiting it, so the
+                    # close-and-clear transaction has already committed or
+                    # failed by the time this branch runs. Only the log
+                    # statement was interrupted.
+                    logger.warning(
+                        "legacy resume interaction close was cancelled after "
+                        "deferred message seal for task %s run %s; continuing "
+                        "resume",
+                        task_id,
+                        close_run_id,
+                    )
             if delivery_turn_id is not None:
                 try:
                     await run_db_io_cancellation_safe(
@@ -6644,7 +6660,7 @@ async def _handle_chat_message_unserialized(
                         lambda: active_interaction_id_sync(task_id)
                     )
 
-                    posted = False
+                    posted = UserMessageInjectionOutcome.NOT_POSTED
                     if live_task_lease is not None:
                         with bind_task_lease_context(live_task_lease):
                             try:
@@ -6658,14 +6674,14 @@ async def _handle_chat_message_unserialized(
                                     reason="new websocket user message",
                                 )
                             except CheckpointUnavailableError:
-                                # Fold into the existing posted=False path
+                                # Fold into the existing not-posted path
                                 # below: the durable message is deferred to
                                 # the resume owner instead of injected live,
                                 # exactly as when there was no exact lease
                                 # or checkpoint to inject into. Distinct
                                 # from corrupt/refused, which are not
                                 # retryable by simply deferring.
-                                posted = False
+                                posted = UserMessageInjectionOutcome.NOT_POSTED
                             except CheckpointReadError:
                                 # Corrupt and refused reach here today. The
                                 # base class is deliberate: a read failure
@@ -6685,7 +6701,7 @@ async def _handle_chat_message_unserialized(
                                     ClientErrorCode.TASK_CHECKPOINT_UNREADABLE
                                 )
                                 return
-                    delivery_injected = posted
+                    delivery_injected = bool(posted)
                     if not posted:
                         logger.warning(
                             "Agent execution %s had no exact live lease or "
@@ -6745,7 +6761,7 @@ async def _handle_chat_message_unserialized(
                                 }
                             ),
                             delivery_turn_id=turn_id,
-                            delivery_already_dispatched=posted,
+                            delivery_already_dispatched=bool(posted),
                             delivery_websocket=(
                                 None if posted or suppress_delivery_ack else websocket
                             ),
@@ -6793,44 +6809,34 @@ async def _handle_chat_message_unserialized(
                                 turn_id,
                                 exc_info=True,
                             )
-                        # `posted` is true, meaning a message with this turn
-                        # id is in a live checkpoint. Retire the interaction
-                        # row observed before the injection and clear the
-                        # task's marker in the same short transaction: the
-                        # message went in outside the native interaction
-                        # protocol's answer path, so a question this run had
-                        # open under that protocol was answered by other
-                        # means.
+                        # `posted` being truthy means a message with this
+                        # turn id is in a live checkpoint. For a first
+                        # attempt, retiring the interaction row observed
+                        # before the injection and clearing the task's
+                        # marker in the same short transaction is correct:
+                        # the message went in outside the native
+                        # interaction protocol's answer path, so a question
+                        # this run had open under that protocol was
+                        # answered by other means.
                         #
-                        # That reading holds for a first attempt and not for
-                        # a replay, and `posted` cannot tell the two apart.
-                        # AgentRunner.inject_user_message short-circuits a
-                        # repeated turn id by returning the existing context
-                        # without persisting anything, which reaches here as
-                        # the same `True`. On a replay the id read just above
-                        # is not the question the replayed message answered
-                        # -- that one was retired by the first attempt -- but
-                        # whatever the resumed agent has asked since, and
-                        # retiring it discards a live question nobody
-                        # answered. This close call is live production code --
-                        # it runs on every websocket chat message that
-                        # reaches a running task -- so what makes the window
-                        # harmless today is not that the code is dormant. It
-                        # is that there is nothing for it to retire: the only
-                        # INSERT into task_interaction_requests is
-                        # stage_interaction_request
-                        # (task_interaction_staging.py), which has no caller
-                        # in src/ and is held at none by
-                        # tests/web/services/test_interaction_staging_production_gate.py.
-                        # The pre-injection read therefore returns None on
-                        # every call, and the close matches zero rows. The
-                        # change that wires the first production writer has
-                        # to close this window before that writer ships:
-                        # the runner has to report whether it persisted a
-                        # new message or replayed an existing turn, and this
-                        # site has to skip the close on the replay answer.
-                        # The A2A injection site (a2a.py) carries the same
-                        # window and the same precondition.
+                        # That reading breaks on a replay of an
+                        # already-seen turn id: the id read above is not
+                        # the question the replayed message answered --
+                        # the first attempt already retired that one -- it
+                        # is whatever question the resumed agent has staged
+                        # since, and closing on it would retire a live
+                        # question nobody has answered. `posted` alone
+                        # cannot tell a fresh write from a replay, so this
+                        # site does not try to; AgentRunner.inject_user_message
+                        # reports the distinction explicitly (see
+                        # UserMessageInjectionOutcome) and this guard reads
+                        # that report instead of the bare truthy value. The
+                        # v1 reply resume-input path (task_reply.py) needs
+                        # no equivalent guard: its turn id embeds a fresh
+                        # uuid on every call and can never hit the short
+                        # circuit that produces a replay. The A2A injection
+                        # site (a2a.py) carries the same guard for the same
+                        # reason.
                         #
                         # The run fence
                         # is live_task_lease.run_id, not task_run_id: posted
@@ -6845,40 +6851,41 @@ async def _handle_chat_message_unserialized(
                         assert live_task_lease.run_id is not None
                         close_run_id = live_task_lease.run_id
                         close_interaction_id = active_interaction_id
-                        try:
-                            await run_db_io_cancellation_safe(
-                                lambda: close_legacy_resume_interaction_sync(
-                                    task_id=task_id,
-                                    run_id=close_run_id,
-                                    interaction_id=close_interaction_id,
+                        if posted is not UserMessageInjectionOutcome.POSTED_REPLAY:
+                            try:
+                                await run_db_io_cancellation_safe(
+                                    lambda: close_legacy_resume_interaction_sync(
+                                        task_id=task_id,
+                                        run_id=close_run_id,
+                                        interaction_id=close_interaction_id,
+                                    )
                                 )
-                            )
-                        except Exception:
-                            logger.warning(
-                                "legacy resume interaction close failed after "
-                                "registered resume handoff for task %s run %s",
-                                task_id,
-                                close_run_id,
-                                exc_info=True,
-                            )
-                        except asyncio.CancelledError:
-                            # run_db_io_cancellation_safe drains its worker
-                            # thread to completion before propagating a
-                            # cancellation raised while awaiting it, so by the
-                            # time this branch runs the close-and-clear
-                            # transaction has already committed or failed on
-                            # its own; there is nothing left in flight to
-                            # protect. This only logs the interruption instead
-                            # of letting it escape as an unhandled
-                            # cancellation. Unlike the delivery marker above,
-                            # this branch is deliberate, not a gap to copy.
-                            logger.warning(
-                                "legacy resume interaction close was cancelled "
-                                "for task %s run %s; the resume proceeds "
-                                "unaffected",
-                                task_id,
-                                close_run_id,
-                            )
+                            except Exception:
+                                logger.warning(
+                                    "legacy resume interaction close failed after "
+                                    "registered resume handoff for task %s run %s",
+                                    task_id,
+                                    close_run_id,
+                                    exc_info=True,
+                                )
+                            except asyncio.CancelledError:
+                                # run_db_io_cancellation_safe drains its worker
+                                # thread to completion before propagating a
+                                # cancellation raised while awaiting it, so by the
+                                # time this branch runs the close-and-clear
+                                # transaction has already committed or failed on
+                                # its own; there is nothing left in flight to
+                                # protect. This only logs the interruption instead
+                                # of letting it escape as an unhandled
+                                # cancellation. Unlike the delivery marker above,
+                                # this branch is deliberate, not a gap to copy.
+                                logger.warning(
+                                    "legacy resume interaction close was cancelled "
+                                    "for task %s run %s; the resume proceeds "
+                                    "unaffected",
+                                    task_id,
+                                    close_run_id,
+                                )
                 except BaseException:
                     if bg_task is not None and not handoff_registered:
                         bg_task.cancel()

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -68,17 +68,20 @@ reason as the reader fallback documented above: a reader keys off
 asking the legacy question again.
 
 The replay ``AgentRunner.inject_user_message`` short-circuits on a
-repeated turn id is not a window of that same benign family, and is
-not covered by the argument above. A replay persists nothing and still
-reports success to its caller, so an injection site cannot tell it from
-a first attempt; the row that site observed before calling is then not
-the question the replayed message answered but whatever the resumed
-agent has asked since, and closing it retires a live question instead
-of leaving a stale one behind. That is the opposite failure from the
-one this paragraph describes, and it is not fixed here -- see the
-comment at the online WebSocket injection site (``websocket.py``) for
-the precondition it puts on the change that wires the first production
-writer.
+repeated turn id is not a window of that same benign family. A replay
+persists nothing, and the row an injection site observed before calling
+is then not the question the replayed message answered but whatever the
+resumed agent has asked since; closing on it would retire a live
+question instead of leaving a stale one behind. The injection layer
+reports which case it is -- ``UserMessageInjectionOutcome`` on
+``AgentRunner.inject_user_message`` and everything that forwards its
+result, rather than the same truthy value a fresh write produces -- and
+each of the three sites that call into this module (the two WebSocket
+injection sites and the A2A resume-input site) reads that report and
+skips its close call on a replay before ever reaching the statements
+below. This module's own close statement, and the lock-ordering
+obligation each caller carries, are unchanged by that guard: it decides
+whether the call happens, not what the call does.
 
 The close statement binds to one primary key, read before the injection
 by ``active_interaction_id_sync`` and carried to the close by whichever

--- a/src/xagent/web/services/task_interaction_close.py
+++ b/src/xagent/web/services/task_interaction_close.py
@@ -69,19 +69,39 @@ asking the legacy question again.
 
 The replay ``AgentRunner.inject_user_message`` short-circuits on a
 repeated turn id is not a window of that same benign family. A replay
-persists nothing, and the row an injection site observed before calling
-is then not the question the replayed message answered but whatever the
-resumed agent has asked since; closing on it would retire a live
+persists nothing, so the first attempt has already retired the question
+it answered, and an id read for a later attempt names whatever the
+resumed agent has staged since; closing on that id would retire a live
 question instead of leaving a stale one behind. The injection layer
 reports which case it is -- ``UserMessageInjectionOutcome`` on
 ``AgentRunner.inject_user_message`` and everything that forwards its
 result, rather than the same truthy value a fresh write produces -- and
-each of the three sites that call into this module (the two WebSocket
-injection sites and the A2A resume-input site) reads that report and
-skips its close call on a replay before ever reaching the statements
-below. This module's own close statement, and the lock-ordering
-obligation each caller carries, are unchanged by that guard: it decides
-whether the call happens, not what the call does.
+the three injection sites that can see a replay close only on
+``POSTED_FRESH``.
+
+Those three are not exposed to the same degree, and the guard means
+something different at each. The online WebSocket site and the A2A
+resume-input site both read the id fresh on every attempt
+(``active_interaction_id_sync`` immediately before their own injection
+call), so on a replay the id they hold is exactly the live question
+described above and the guard is what keeps them off it. The deferred
+WebSocket site does not re-read: it carries the id the online handler
+observed on the first attempt through ``pending_user_message``, and the
+close statement binds to that primary key, so a replay there can only
+name the row the first attempt already retired -- the close would be a
+no-op, not a hazard. Its guard is defense in depth, held in place so the
+site cannot quietly become dangerous if it is ever changed to derive its
+own key.
+
+The fourth production caller, the v1 ``POST .../reply`` resume-input
+path (``task_reply.py``), carries no guard at all and needs none: it
+builds its turn id as ``f"v1:reply:{task_id}:{uuid4()}"``, a value that
+is fresh on every single call, so it can never present a repeated turn
+id and can never reach the short circuit that produces a replay.
+
+This module's own close statement, and the lock-ordering obligation each
+caller carries, are unchanged by that guard: it decides whether the call
+happens, not what the call does.
 
 The close statement binds to one primary key, read before the injection
 by ``active_interaction_id_sync`` and carried to the close by whichever

--- a/tests/core/agent/test_agent_service_post_user_message.py
+++ b/tests/core/agent/test_agent_service_post_user_message.py
@@ -1,0 +1,211 @@
+"""``AgentService.post_user_message``'s fresh-vs-replay report.
+
+These tests drive the real ``AgentService`` -> ``AgentExecutionAdapter`` ->
+``ExecutionRegistry`` -> ``AgentRunner`` chain, the same seam
+``test_agent_service_pause.py`` uses. ``post_user_message`` is never
+mocked: the outcome this test pins is produced by
+``AgentRunner.inject_user_message`` and must reach this boundary without
+being folded into a bare bool anywhere along the way.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from xagent.core.agent import Agent, ContextManager, ExecutionContext, PatternRuntime
+from xagent.core.agent.execution_adapter import (
+    AgentExecutionAdapter,
+    AgentExecutionConfig,
+)
+from xagent.core.agent.registry import ExecutionRegistry
+from xagent.core.agent.runner import AgentRunner, UserMessageInjectionOutcome
+from xagent.core.agent.service import AgentService
+
+
+@pytest.fixture(autouse=True)
+def reset_context_manager() -> None:
+    manager = ContextManager()
+    manager._contexts.clear()  # type: ignore[attr-defined]
+    yield
+    manager._contexts.clear()  # type: ignore[attr-defined]
+
+
+@dataclass
+class FakeWorkspace:
+    id: str
+    workspace_dir: Path
+    input_dir: Path
+    output_dir: Path
+    temp_dir: Path
+    allowed_external_dirs: list[Path]
+
+
+class FakeWorkspaceManager:
+    def __init__(self, tmp_path: Path) -> None:
+        self.tmp_path = tmp_path
+
+    def get_or_create_workspace(
+        self,
+        base_dir: str,
+        task_id: str,
+        allowed_external_dirs: list[str] | None = None,
+        scope_segments: tuple[str, ...] = (),
+    ) -> FakeWorkspace:
+        del base_dir, scope_segments
+        workspace_dir = self.tmp_path / task_id
+        return FakeWorkspace(
+            id=task_id,
+            workspace_dir=workspace_dir,
+            input_dir=workspace_dir / "input",
+            output_dir=workspace_dir / "output",
+            temp_dir=workspace_dir / "temp",
+            allowed_external_dirs=[Path(path) for path in allowed_external_dirs or []],
+        )
+
+
+class TracerCheckpointStore:
+    def __init__(self) -> None:
+        self.by_execution_id: dict[str, dict[str, Any]] = {}
+
+    async def checkpoint(self, **payload: Any) -> None:
+        self.by_execution_id[str(payload["execution_id"])] = dict(payload)
+
+    async def load_latest_checkpoint(self, execution_id: str) -> dict[str, Any] | None:
+        payload = self.by_execution_id.get(execution_id)
+        return dict(payload) if payload is not None else None
+
+
+class PollingPattern:
+    """Runs until the runtime reports an interrupt, like a real pattern loop."""
+
+    def __init__(self) -> None:
+        self.started = asyncio.Event()
+
+    async def run(
+        self,
+        *,
+        context: ExecutionContext,
+        runtime: PatternRuntime,
+        **_: Any,
+    ) -> dict[str, Any]:
+        self.started.set()
+        while not await runtime.should_interrupt():
+            await asyncio.sleep(0)
+        await runtime.checkpoint(
+            "interrupted",
+            context=context,
+            pattern=self,
+            status="interrupted",
+            metadata={"safe_point": "during_pattern"},
+        )
+        return {
+            "success": False,
+            "status": "interrupted",
+            "error": "PollingPattern interrupted.",
+        }
+
+
+class StubLLM:
+    """Only ever inspected for logging / "is an LLM configured" checks."""
+
+    model_name = "stub-model"
+
+
+def _build_service(execution_id: str) -> tuple[AgentService, ExecutionRegistry, Any]:
+    """Real service wired to a real registry, sharing one tracer.
+
+    ``current_task_id`` is set to ``execution_id`` so ``pause_execution``
+    (which resolves ``self._current_task_id or self.id`` internally,
+    taking no argument) targets the same run this test starts.
+    """
+
+    tracer = TracerCheckpointStore()
+    registry = ExecutionRegistry()
+    service = AgentService(
+        name="fresh-replay", id="svc-fresh-replay", tools=[], llm=StubLLM()
+    )
+    service._current_task_id = execution_id
+    service._execution_adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="fresh-replay",
+            pattern="react",
+            llm=StubLLM(),
+            tracer=tracer,
+            current_task_id=execution_id,
+            service_id=service.id,
+            registry=registry,
+        )
+    )
+    return service, registry, tracer
+
+
+async def _start_interrupted_run(
+    service: AgentService,
+    registry: ExecutionRegistry,
+    tracer: Any,
+    tmp_path: Path,
+    *,
+    execution_id: str,
+) -> None:
+    """Start one real run, pause it, and wait for it to land in an
+    interrupted (and therefore resumable) state, so its handle stays in
+    the registry for ``post_user_message`` to find."""
+
+    pattern = PollingPattern()
+    runner = AgentRunner(
+        agent=Agent(name="fresh-replay", patterns=[pattern]),
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    handle = registry.start(runner, execution_id=execution_id, task="Wait")
+    await asyncio.wait_for(pattern.started.wait(), timeout=5)
+    assert handle.task is not None
+    assert await service.pause_execution() is True
+    await handle.task
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scenario", ["fresh", "replay", "conflicting_content"])
+async def test_service_post_user_message_reports_fresh_vs_replay(
+    tmp_path: Path, scenario: str
+) -> None:
+    """The outermost layer forwards the execution adapter's report
+    unmodified, no ``bool(...)`` fold: a first write is POSTED_FRESH, a
+    repeat of the same turn id with the same content short-circuits as
+    POSTED_REPLAY, and a repeat with different content still raises --
+    the pre-existing conflict behavior, untouched by this contract."""
+    execution_id = "exec-service-fresh-replay"
+    service, registry, tracer = _build_service(execution_id)
+    await _start_interrupted_run(
+        service, registry, tracer, tmp_path, execution_id=execution_id
+    )
+
+    first = await service.post_user_message(
+        execution_id,
+        "Choose B",
+        turn_id="turn-service-fresh-replay",
+        request_interrupt=False,
+    )
+    assert first is UserMessageInjectionOutcome.POSTED_FRESH
+
+    if scenario == "replay":
+        second = await service.post_user_message(
+            execution_id,
+            "Choose B",
+            turn_id="turn-service-fresh-replay",
+            request_interrupt=False,
+        )
+        assert second is UserMessageInjectionOutcome.POSTED_REPLAY
+    elif scenario == "conflicting_content":
+        with pytest.raises(ValueError, match="different user message"):
+            await service.post_user_message(
+                execution_id,
+                "Choose C",
+                turn_id="turn-service-fresh-replay",
+                request_interrupt=False,
+            )

--- a/tests/core/agent/test_execution_adapter.py
+++ b/tests/core/agent/test_execution_adapter.py
@@ -13,6 +13,7 @@ import pytest
 from xagent.core.agent import AgentExecutionAdapter, AgentExecutionConfig, ReActPattern
 from xagent.core.agent.execution_adapter import INTERRUPTED_USER_MESSAGE
 from xagent.core.agent.result import NO_OUTPUT_PLACEHOLDER
+from xagent.core.agent.runner import UserMessageInjectionOutcome
 from xagent.core.agent.service import AgentService
 from xagent.core.task_runtime import PREFERRED_INPUT_MODALITIES_METADATA_KEY
 
@@ -1239,6 +1240,73 @@ async def test_execution_adapter_exposes_pause_and_message_controls() -> None:
     assert final_status is not None
     assert final_status["status"] == "interrupted"
     assert final_status["is_resumable"] is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scenario", ["fresh", "replay", "conflicting_content"])
+async def test_execution_adapter_post_user_message_reports_fresh_vs_replay(
+    scenario: str,
+) -> None:
+    """This layer forwards the registry's report unmodified as a bare
+    UserMessageInjectionOutcome (dropping the raw context, which nothing
+    past this boundary reads): a first write is POSTED_FRESH, a repeat of
+    the same turn id with the same content short-circuits as
+    POSTED_REPLAY, and a repeat with different content still raises."""
+    llm = BlockingLLM(
+        {
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call-noop",
+                    "name": "noop",
+                    "args": {},
+                }
+            ],
+        }
+    )
+    adapter = AgentExecutionAdapter(
+        AgentExecutionConfig(
+            name="fresh-replay",
+            pattern="react",
+            llm=llm,
+            tools=[FakeTool()],
+            service_id="fresh-replay-service",
+            skill_manager=NoSkillManager(),
+        )
+    )
+    adapter.start(task="Wait", task_id="fresh-replay-exec")
+    handle = adapter.registry.get("fresh-replay-exec")
+    assert handle is not None
+    await llm.started.wait()
+    assert adapter.pause("fresh-replay-exec", reason="pause from test") is True
+
+    first = await adapter.post_user_message(
+        "fresh-replay-exec",
+        "Choose B",
+        turn_id="turn-adapter-fresh-replay",
+        request_interrupt=False,
+    )
+    assert first is UserMessageInjectionOutcome.POSTED_FRESH
+
+    if scenario == "replay":
+        second = await adapter.post_user_message(
+            "fresh-replay-exec",
+            "Choose B",
+            turn_id="turn-adapter-fresh-replay",
+            request_interrupt=False,
+        )
+        assert second is UserMessageInjectionOutcome.POSTED_REPLAY
+    elif scenario == "conflicting_content":
+        with pytest.raises(ValueError, match="different user message"):
+            await adapter.post_user_message(
+                "fresh-replay-exec",
+                "Choose C",
+                turn_id="turn-adapter-fresh-replay",
+                request_interrupt=False,
+            )
+
+    llm.release.set()
+    await handle.task
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_registry.py
+++ b/tests/core/agent/test_registry.py
@@ -16,7 +16,7 @@ from xagent.core.agent import (
 )
 from xagent.core.agent import registry as registry_module
 from xagent.core.agent.registry import ExecutionRegistry
-from xagent.core.agent.runner import AgentRunner
+from xagent.core.agent.runner import AgentRunner, UserMessageInjectionOutcome
 
 
 @pytest.fixture(autouse=True)
@@ -151,15 +151,15 @@ async def test_registry_routes_live_execution_control_and_resume(
     assert registry.get_status(execution_id) == stored.to_dict()
     assert registry.list_statuses() == [stored.to_dict()]
 
-    context = await registry.post_user_message(
+    result = await registry.post_user_message(
         execution_id,
         "Reply with only the number.",
         request_interrupt=False,
     )
-    assert context is not None
+    assert result.context is not None
     assert any(
         message.role == "user" and message.content == "Reply with only the number."
-        for message in context.messages
+        for message in result.context.messages
     )
 
     resumed_agent = Agent(
@@ -359,9 +359,10 @@ async def test_registry_unregisters_completed_execution_tasks(tmp_path: Path) ->
 async def test_registry_returns_none_for_unknown_execution_on_message_post() -> None:
     registry = ExecutionRegistry()
 
-    context = await registry.post_user_message("missing", "hello")
+    result = await registry.post_user_message("missing", "hello")
 
-    assert context is None
+    assert result.context is None
+    assert result.outcome is UserMessageInjectionOutcome.NOT_POSTED
 
 
 @pytest.mark.asyncio
@@ -449,6 +450,62 @@ async def test_registry_cancel_non_running_handle_marks_terminal_and_unregisters
         "execution.cancelled",
     ]
     assert events[-1]["handle"]["status"] == "cancelled"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("scenario", ["fresh", "replay", "conflicting_content"])
+async def test_registry_post_user_message_reports_fresh_vs_replay(
+    tmp_path: Path, scenario: str
+) -> None:
+    """The registry layer forwards AgentRunner.inject_user_message's report
+    unmodified: a first write is POSTED_FRESH, a repeat of the same turn id
+    with the same content short-circuits as POSTED_REPLAY without a second
+    write, and a repeat with different content still raises -- the
+    pre-existing conflict behavior, untouched by this contract."""
+    tracer = TracerCheckpointStore()
+    execution_id = "exec-registry-fresh-replay"
+    registry = ExecutionRegistry()
+    agent = Agent(name="writer", patterns=[])
+    runner = AgentRunner(
+        agent=agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    agent.patterns = [InterruptingPattern(runner, execution_id)]
+    handle = registry.start(runner, execution_id=execution_id, task="Calculate 6*7")
+    await handle.task
+
+    first = await registry.post_user_message(
+        execution_id,
+        "Choose B",
+        turn_id="turn-registry-fresh-replay",
+        request_interrupt=False,
+    )
+    assert first.outcome is UserMessageInjectionOutcome.POSTED_FRESH
+    assert first.context is not None
+
+    if scenario == "fresh":
+        return
+
+    if scenario == "replay":
+        second = await registry.post_user_message(
+            execution_id,
+            "Choose B",
+            turn_id="turn-registry-fresh-replay",
+            request_interrupt=False,
+        )
+        assert second.outcome is UserMessageInjectionOutcome.POSTED_REPLAY
+        assert second.context is first.context
+        return
+
+    assert scenario == "conflicting_content"
+    with pytest.raises(ValueError, match="different user message"):
+        await registry.post_user_message(
+            execution_id,
+            "Choose C",
+            turn_id="turn-registry-fresh-replay",
+            request_interrupt=False,
+        )
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -299,6 +299,22 @@ class EmptyCanonicalCheckpointStore:
         raise AssertionError("canonical empty result must end checkpoint lookup")
 
 
+def test_user_message_injection_outcome_truthiness_contract() -> None:
+    """``NOT_POSTED`` is the empty string, and the other two members are
+    not. That is the whole reason an unmodified ``if not posted`` /
+    ``bool(posted)`` caller keeps asking exactly the question it always
+    asked -- "did this hand back a usable context at all" -- across the
+    fresh/replay split. Roughly a dozen call sites in ``websocket.py``,
+    ``a2a.py`` and ``task_reply.py`` rest on it, and none of them names
+    the enum, so an edit to these values would break them all silently.
+    Assert the contract here instead, where the values live.
+    """
+    assert UserMessageInjectionOutcome.NOT_POSTED == ""
+    assert not UserMessageInjectionOutcome.NOT_POSTED
+    assert UserMessageInjectionOutcome.POSTED_FRESH
+    assert UserMessageInjectionOutcome.POSTED_REPLAY
+
+
 @pytest.mark.asyncio
 async def test_runner_treats_canonical_empty_checkpoint_as_authoritative() -> None:
     checkpoint_store = EmptyCanonicalCheckpointStore()

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -24,7 +24,7 @@ from xagent.core.agent.language import (
     OUTPUT_LANGUAGE_SOURCE_METADATA_KEY,
     reset_output_language_to_request_context,
 )
-from xagent.core.agent.runner import AgentRunner
+from xagent.core.agent.runner import AgentRunner, UserMessageInjectionOutcome
 from xagent.core.agent.runtime import LLMCallInterrupted
 from xagent.core.task_runtime import PREFERRED_INPUT_MODALITIES_METADATA_KEY
 
@@ -169,7 +169,7 @@ class InjectingPattern:
         )
         return {
             "success": True,
-            "same_context": injected is context,
+            "same_context": injected.context is context,
             "messages": [message.content for message in context.messages],
         }
 
@@ -307,13 +307,14 @@ async def test_runner_treats_canonical_empty_checkpoint_as_authoritative() -> No
         tracer=checkpoint_store,
     )
 
-    context = await runner.inject_user_message(
+    result = await runner.inject_user_message(
         "missing-execution",
         "Continue",
         request_interrupt=False,
     )
 
-    assert context is None
+    assert result.context is None
+    assert result.outcome is UserMessageInjectionOutcome.NOT_POSTED
     assert checkpoint_store.legacy_reads == 0
 
 
@@ -435,7 +436,8 @@ async def test_inject_rejection_leaves_no_dedupe_residue() -> None:
         request_interrupt=False,
     )
 
-    assert result is context
+    assert result.context is context
+    assert result.outcome is UserMessageInjectionOutcome.POSTED_FRESH
     assert len(context.messages) == 1
     assert tracer.by_execution_id["exec-residue"]["context"]["messages"]
 
@@ -1304,16 +1306,16 @@ async def test_runner_inject_user_message_with_files_dispatches_trace_callback(
             "type": "application/pdf",
         }
     ]
-    context = await runner.post_user_message(
+    result = await runner.post_user_message(
         "exec-cont-files",
         "Use the attached PDF.",
         request_interrupt=False,
         files=files,
     )
 
-    assert context is not None
+    assert result.context is not None
     new_user_message = next(
-        msg for msg in reversed(context.messages) if msg.role == "user"
+        msg for msg in reversed(result.context.messages) if msg.role == "user"
     )
     assert new_user_message.metadata.get("files") == files
     turn_id = new_user_message.metadata.get("turn_id")
@@ -1355,15 +1357,15 @@ async def test_runner_post_user_message_alias_matches_inject_behavior(
         metadata={},
     )
 
-    context = await runner.post_user_message(
+    result = await runner.post_user_message(
         "exec-alias",
         "Follow-up from user.",
         request_interrupt=False,
     )
 
-    assert context is not None
+    assert result.context is not None
     user_messages = [
-        message.content for message in context.messages if message.role == "user"
+        message.content for message in result.context.messages if message.role == "user"
     ]
     assert user_messages == ["Original task", "Follow-up from user."]
 
@@ -1401,7 +1403,8 @@ async def test_runner_post_user_message_deduplicates_explicit_turn_id_after_fail
         request_interrupt=True,
     )
 
-    assert accepted is not None
+    assert accepted.context is not None
+    assert accepted.outcome is UserMessageInjectionOutcome.POSTED_FRESH
     failing_runner.pause.assert_called_once_with(
         execution_id,
         reason="new user message",
@@ -1413,17 +1416,21 @@ async def test_runner_post_user_message_deduplicates_explicit_turn_id_after_fail
         tracer=tracer,
         workspace_manager=FakeWorkspaceManager(tmp_path),
     )
-    context = await retry_runner.post_user_message(
+    result = await retry_runner.post_user_message(
         execution_id,
         "Choose B",
         turn_id="a2a:42:msg-1",
         request_interrupt=False,
     )
 
-    assert context is not None
+    # The retry cold-starts from the checkpoint the first (pre-callback-
+    # failure) attempt already persisted, so this is the short-circuit
+    # replaying an already-seen turn id, not a second fresh write.
+    assert result.context is not None
+    assert result.outcome is UserMessageInjectionOutcome.POSTED_REPLAY
     retried_messages = [
         message
-        for message in context.messages
+        for message in result.context.messages
         if message.role == "user" and message.metadata.get("turn_id") == "a2a:42:msg-1"
     ]
     assert len(retried_messages) == 1
@@ -1467,6 +1474,66 @@ async def test_runner_rejects_reused_turn_id_with_different_content(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("scenario", ["fresh", "replay", "conflicting_content"])
+async def test_runner_inject_user_message_reports_fresh_vs_replay(
+    tmp_path: Path, scenario: str
+) -> None:
+    """The three states this contract exists to name: a first write reports
+    POSTED_FRESH, a repeat of the same turn id with the same content
+    short-circuits and reports POSTED_REPLAY without persisting anything
+    new, and a repeat with different content still raises -- unchanged from
+    before this contract existed."""
+    tracer = TracerCheckpointStore()
+    execution_id = "exec-fresh-replay-grid"
+    agent = Agent(name="writer", patterns=[FakePattern({"success": True})])
+    runner = AgentRunner(
+        agent=agent,
+        tracer=tracer,
+        workspace_manager=FakeWorkspaceManager(tmp_path),
+    )
+    await runner.run(task="Original task", execution_id=execution_id)
+
+    first = await runner.inject_user_message(
+        execution_id,
+        "Choose B",
+        turn_id="turn-fresh-replay-grid",
+        request_interrupt=False,
+    )
+    assert first.outcome is UserMessageInjectionOutcome.POSTED_FRESH
+    assert first.context is not None
+
+    if scenario == "fresh":
+        return
+
+    if scenario == "replay":
+        second = await runner.inject_user_message(
+            execution_id,
+            "Choose B",
+            turn_id="turn-fresh-replay-grid",
+            request_interrupt=False,
+        )
+        assert second.outcome is UserMessageInjectionOutcome.POSTED_REPLAY
+        assert second.context is first.context
+        matching = [
+            message
+            for message in second.context.messages
+            if message.role == "user"
+            and message.metadata.get("turn_id") == "turn-fresh-replay-grid"
+        ]
+        assert len(matching) == 1
+        return
+
+    assert scenario == "conflicting_content"
+    with pytest.raises(ValueError, match="different user message"):
+        await runner.inject_user_message(
+            execution_id,
+            "Choose C",
+            turn_id="turn-fresh-replay-grid",
+            request_interrupt=False,
+        )
+
+
+@pytest.mark.asyncio
 async def test_runner_post_user_message_preserves_display_and_execution_contract(
     tmp_path: Path,
 ) -> None:
@@ -1492,7 +1559,7 @@ async def test_runner_post_user_message_preserves_display_and_execution_contract
 
     execution_message = "Read file\n\n## UPLOADED FILES\nfile_id=file-123"
     files = [{"file_id": "file-123", "name": "notes.txt"}]
-    context = await runner.post_user_message(
+    result = await runner.post_user_message(
         "exec-display-contract",
         execution_message=execution_message,
         display_message="Read file",
@@ -1501,10 +1568,10 @@ async def test_runner_post_user_message_preserves_display_and_execution_contract
         request_interrupt=False,
     )
 
-    assert context is not None
-    latest_user = [message for message in context.messages if message.role == "user"][
-        -1
-    ]
+    assert result.context is not None
+    latest_user = [
+        message for message in result.context.messages if message.role == "user"
+    ][-1]
     assert latest_user.content == execution_message
     assert latest_user.metadata["display_message"] == "Read file"
     assert latest_user.metadata["files"] == files
@@ -1603,15 +1670,15 @@ async def test_runner_attaches_uploaded_image_refs_to_injected_user_message(
     )
     await runner.run(task="Start", execution_id="exec-injected-image")
 
-    context = await runner.inject_user_message(
+    result = await runner.inject_user_message(
         "exec-injected-image",
         "Inspect the new image",
         files=[{"file_id": "image-456", "name": "screen.jpg", "type": "image/jpeg"}],
         request_interrupt=False,
     )
 
-    assert context is not None
-    assert context.messages[-1].context_refs[0].file_id == "image-456"
+    assert result.context is not None
+    assert result.context.messages[-1].context_refs[0].file_id == "image-456"
 
 
 @pytest.mark.asyncio
@@ -1938,14 +2005,14 @@ async def test_inject_user_message_cold_start_drops_legacy_output_language() -> 
     stored.metadata[OUTPUT_LANGUAGE_SOURCE_METADATA_KEY] = "auto_router"
     stored.add_user_message("Summarize the release notes.")
 
-    context = await _cold_start_runner(stored).inject_user_message(
+    result = await _cold_start_runner(stored).inject_user_message(
         "exec-inject-legacy-language",
         message="continue",
     )
 
-    assert context is not None
-    assert OUTPUT_LANGUAGE_METADATA_KEY not in context.metadata
-    assert OUTPUT_LANGUAGE_SOURCE_METADATA_KEY not in context.metadata
+    assert result.context is not None
+    assert OUTPUT_LANGUAGE_METADATA_KEY not in result.context.metadata
+    assert OUTPUT_LANGUAGE_SOURCE_METADATA_KEY not in result.context.metadata
 
 
 @pytest.mark.asyncio
@@ -1956,14 +2023,14 @@ async def test_inject_user_message_cold_start_keeps_caller_output_language() -> 
     stored.metadata[OUTPUT_LANGUAGE_SOURCE_METADATA_KEY] = "auto_router"
     stored.add_user_message("Summarize the release notes.")
 
-    context = await _cold_start_runner(stored).inject_user_message(
+    result = await _cold_start_runner(stored).inject_user_message(
         "exec-inject-caller-language",
         message="continue",
     )
 
-    assert context is not None
-    assert context.metadata[OUTPUT_LANGUAGE_METADATA_KEY] == "French"
-    assert OUTPUT_LANGUAGE_SOURCE_METADATA_KEY not in context.metadata
+    assert result.context is not None
+    assert result.context.metadata[OUTPUT_LANGUAGE_METADATA_KEY] == "French"
+    assert OUTPUT_LANGUAGE_SOURCE_METADATA_KEY not in result.context.metadata
 
 
 def test_resume_migration_only_touches_execution_context_nodes() -> None:

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -24,6 +24,7 @@ from xagent.core.agent.checkpoint import (
     CheckpointReadError,
     CheckpointUnavailableError,
 )
+from xagent.core.agent.runner import UserMessageInjectionOutcome
 from xagent.web.api import a2a as a2a_api
 from xagent.web.models.agent import Agent
 from xagent.web.models.agent_api_key import AgentApiKey
@@ -851,7 +852,10 @@ def test_update_a2a_resume_input_rolls_back_the_interaction_close_with_the_fence
         task_id=task_id, runner_id="a-different-runner", run_id="run-atomicity"
     )
     updated = a2a_api._update_a2a_resume_input_sync(
-        stale_lease, "attempted text", row_id
+        stale_lease,
+        "attempted text",
+        row_id,
+        UserMessageInjectionOutcome.POSTED_FRESH,
     )
 
     assert updated is False
@@ -950,6 +954,89 @@ def test_message_send_closes_the_legacy_resume_interaction_row_on_successful_inj
         assert row.terminal_reason == "answered_via_legacy_resume"
         refreshed = db.query(Task).filter(Task.id == task_id).one()
         assert refreshed.interaction_protocol_version is None
+    finally:
+        db.close()
+
+
+def test_message_send_skips_the_close_on_a_replayed_injection() -> None:
+    """A retried A2A message replays this site's deterministic turn id
+    (f"a2a:{task_id}:{message_id}"). AgentRunner.inject_user_message
+    short-circuits that repeat and reports POSTED_REPLAY; the interaction
+    row this test seeds is not the question the replay answered, so the
+    close must leave it untouched -- neither retired nor its rowcount
+    matching anything -- and the task's protocol marker must survive."""
+    agent_id, full_key = _create_published_agent_with_key()
+    db = _direct_db_session()
+    try:
+        owner_id = int(db.query(Agent).filter(Agent.id == agent_id).one().user_id)
+        task = Task(
+            user_id=owner_id,
+            title="legacy resume close skipped on replay",
+            status=TaskStatus.PAUSED,
+            control_state=TaskControlState.PAUSED.value,
+            run_id="run-close-replay",
+            agent_id=agent_id,
+            source="a2a",
+            is_visible=False,
+            agent_config={"a2a_context_id": "ctx-close-replay"},
+            interaction_protocol_version=1,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        task_id = int(task.id)
+        row_id = _seed_active_interaction_row(
+            db,
+            task_id=task_id,
+            run_id="run-close-replay",
+            idempotency_key="close-replay-q1",
+        )
+    finally:
+        db.close()
+
+    agent_service = MagicMock()
+    agent_service.post_user_message = AsyncMock(
+        return_value=UserMessageInjectionOutcome.POSTED_REPLAY
+    )
+    agent_manager = MagicMock()
+    agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
+    with (
+        patch(
+            "xagent.web.api.chat.get_agent_manager",
+            return_value=agent_manager,
+        ),
+        patch("xagent.web.api.a2a._schedule_waiting_a2a_resume"),
+        patch(
+            "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
+            new=AsyncMock(),
+        ),
+    ):
+        response = client.post(
+            f"/api/a2a/agents/{agent_id}/message:send",
+            headers=_bearer(full_key),
+            json={
+                "message": {
+                    "messageId": "msg-close-replay",
+                    "taskId": task_id,
+                    "role": "ROLE_USER",
+                    "parts": [{"text": "a retried delivery"}],
+                },
+                "configuration": {"returnImmediately": True},
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    agent_service.post_user_message.assert_awaited_once()
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskInteractionRequest)
+            .filter(TaskInteractionRequest.id == row_id)
+            .one()
+        )
+        assert row.status == "active"
+        refreshed = db.query(Task).filter(Task.id == task_id).one()
+        assert refreshed.interaction_protocol_version == 1
     finally:
         db.close()
 

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -649,7 +649,9 @@ def test_follow_up_infers_context_for_input_required_task() -> None:
 
     observed_lease: dict[str, object] = {}
 
-    async def post_user_message(*_args: object, **_kwargs: object) -> bool:
+    async def post_user_message(
+        *_args: object, **_kwargs: object
+    ) -> UserMessageInjectionOutcome:
         lease = current_task_lease()
         assert lease is not None
         assert lease.run_id is not None
@@ -663,7 +665,7 @@ def test_follow_up_infers_context_for_input_required_task() -> None:
             assert leased.lease_expires_at is not None
         finally:
             lease_db.close()
-        return True
+        return UserMessageInjectionOutcome.POSTED_FRESH
 
     agent_service = MagicMock()
     agent_service.post_user_message = AsyncMock(side_effect=post_user_message)
@@ -747,7 +749,9 @@ def test_checkpoint_resume_schedule_failure_exactly_restores_waiting_task() -> N
         db.close()
 
     agent_service = MagicMock()
-    agent_service.post_user_message = AsyncMock(return_value=True)
+    agent_service.post_user_message = AsyncMock(
+        return_value=UserMessageInjectionOutcome.POSTED_FRESH
+    )
     agent_manager = MagicMock()
     agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
     scheduled_lease: dict[str, object] = {}
@@ -912,7 +916,9 @@ def test_message_send_closes_the_legacy_resume_interaction_row_on_successful_inj
         db.close()
 
     agent_service = MagicMock()
-    agent_service.post_user_message = AsyncMock(return_value=True)
+    agent_service.post_user_message = AsyncMock(
+        return_value=UserMessageInjectionOutcome.POSTED_FRESH
+    )
     agent_manager = MagicMock()
     agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
     begin_turn = AsyncMock()
@@ -963,11 +969,12 @@ def test_message_send_skips_the_close_on_a_replayed_injection() -> None:
     (f"a2a:{task_id}:{message_id}"). AgentRunner.inject_user_message
     short-circuits that repeat and reports POSTED_REPLAY; the interaction
     row this test seeds is not the question the replay answered, so the
-    close must leave it untouched -- neither retired nor its rowcount
-    matching anything -- and the task's protocol marker must survive.
-    close_legacy_resume_interaction is asserted uncalled directly too:
-    replacing the guard with `if True:` calls it for real and turns this
-    assertion red on its own."""
+    close must not run at all. That is asserted directly on the mock:
+    replacing the guard with `if True:` calls close_legacy_resume_interaction
+    for real and turns assert_not_called red. No DB-state assertion is
+    made here -- with the close function mocked out, nothing writes to the
+    row or the marker, so "still active" would hold no matter what the
+    guard did."""
     agent_id, full_key = _create_published_agent_with_key()
     db = _direct_db_session()
     try:
@@ -988,7 +995,7 @@ def test_message_send_skips_the_close_on_a_replayed_injection() -> None:
         db.commit()
         db.refresh(task)
         task_id = int(task.id)
-        row_id = _seed_active_interaction_row(
+        _seed_active_interaction_row(
             db,
             task_id=task_id,
             run_id="run-close-replay",
@@ -1034,18 +1041,6 @@ def test_message_send_skips_the_close_on_a_replayed_injection() -> None:
     assert response.status_code == 200, response.text
     agent_service.post_user_message.assert_awaited_once()
     close_mock.assert_not_called()
-    db = _direct_db_session()
-    try:
-        row = (
-            db.query(TaskInteractionRequest)
-            .filter(TaskInteractionRequest.id == row_id)
-            .one()
-        )
-        assert row.status == "active"
-        refreshed = db.query(Task).filter(Task.id == task_id).one()
-        assert refreshed.interaction_protocol_version == 1
-    finally:
-        db.close()
 
 
 # A fabricated id, not the seeded row's -- test_message_send_reads_the_
@@ -1103,9 +1098,11 @@ def test_message_send_reads_the_interaction_row_before_injecting() -> None:
         order.append("read")
         return _OBSERVED_INTERACTION_ID
 
-    async def record_injection(*_args: object, **_kwargs: object) -> bool:
+    async def record_injection(
+        *_args: object, **_kwargs: object
+    ) -> UserMessageInjectionOutcome:
         order.append("inject")
-        return True
+        return UserMessageInjectionOutcome.POSTED_FRESH
 
     agent_service = MagicMock()
     agent_service.post_user_message = AsyncMock(side_effect=record_injection)
@@ -1183,7 +1180,9 @@ async def test_a2a_handover_restores_input_required_on_unreadable_checkpoint() -
         db.close()
 
     agent_service = MagicMock()
-    agent_service.post_user_message = AsyncMock(return_value=True)
+    agent_service.post_user_message = AsyncMock(
+        return_value=UserMessageInjectionOutcome.POSTED_FRESH
+    )
     agent_service.resume_execution_by_id = AsyncMock(
         side_effect=CheckpointUnavailableError("checkpoint store unavailable")
     )
@@ -1259,7 +1258,9 @@ def test_recovered_paused_checkpoint_resumes_without_transcript_fallback() -> No
         db.close()
 
     agent_service = MagicMock()
-    agent_service.post_user_message = AsyncMock(return_value=True)
+    agent_service.post_user_message = AsyncMock(
+        return_value=UserMessageInjectionOutcome.POSTED_FRESH
+    )
     agent_manager = MagicMock()
     agent_manager.get_agent_for_task = AsyncMock(return_value=agent_service)
     begin_turn = AsyncMock()

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -964,7 +964,10 @@ def test_message_send_skips_the_close_on_a_replayed_injection() -> None:
     short-circuits that repeat and reports POSTED_REPLAY; the interaction
     row this test seeds is not the question the replay answered, so the
     close must leave it untouched -- neither retired nor its rowcount
-    matching anything -- and the task's protocol marker must survive."""
+    matching anything -- and the task's protocol marker must survive.
+    close_legacy_resume_interaction is asserted uncalled directly too:
+    replacing the guard with `if True:` calls it for real and turns this
+    assertion red on its own."""
     agent_id, full_key = _create_published_agent_with_key()
     db = _direct_db_session()
     try:
@@ -1010,6 +1013,9 @@ def test_message_send_skips_the_close_on_a_replayed_injection() -> None:
             "xagent.web.api.a2a.TaskTurnOrchestrator.begin_turn",
             new=AsyncMock(),
         ),
+        patch(
+            "xagent.web.api.a2a.close_legacy_resume_interaction",
+        ) as close_mock,
     ):
         response = client.post(
             f"/api/a2a/agents/{agent_id}/message:send",
@@ -1027,6 +1033,7 @@ def test_message_send_skips_the_close_on_a_replayed_injection() -> None:
 
     assert response.status_code == 200, response.text
     agent_service.post_user_message.assert_awaited_once()
+    close_mock.assert_not_called()
     db = _direct_db_session()
     try:
         row = (

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -2144,7 +2144,7 @@ async def test_live_injection_skips_the_close_on_a_replayed_turn_id(
         send_personal_message=AsyncMock(),
     )
     bg_mgr = MagicMock()
-    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.try_reserve_resume.return_value = ResumeReservationOutcome.RESERVED
     bg_mgr.running_tasks.get.return_value = None
 
     with (

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -2106,7 +2106,10 @@ async def test_live_injection_skips_the_close_on_a_replayed_turn_id(
     fresh write produces. The interaction row this test seeds is not the
     question the replay answered, so the online injection site must leave
     it untouched: still active, uncleared marker, and the close statement
-    must not run at all."""
+    must not run at all -- asserted directly on the mock, not only inferred
+    from the unchanged row: replacing the guard with `if True:` calls the
+    close for real and turns this assertion red on its own, independent of
+    the DB-state assertions below."""
     owner = _user(db_session, "close-replay-owner")
     task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
     task.runner_id = "close-replay-runner"
@@ -2143,6 +2146,9 @@ async def test_live_injection_skips_the_close_on_a_replayed_turn_id(
         patch("xagent.web.api.websocket.manager", ws_manager),
         patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
         patch("xagent.web.api.websocket.execute_resume_background", AsyncMock()),
+        patch(
+            "xagent.web.api.websocket.close_legacy_resume_interaction_sync",
+        ) as close_mock,
     ):
         await _handle_chat_message_unserialized(
             MagicMock(),
@@ -2156,6 +2162,7 @@ async def test_live_injection_skips_the_close_on_a_replayed_turn_id(
         )
 
     agent.post_user_message.assert_awaited_once()
+    close_mock.assert_not_called()
     db_session.expire_all()
     row = (
         db_session.query(TaskInteractionRequest)
@@ -4428,7 +4435,9 @@ async def test_deferred_injection_skips_the_close_on_a_replayed_turn_id(
     using the carried one would retire this live question; asserting
     active_interaction_id_sync is never called pins that the deferred path
     still takes no read of its own, replay or not -- the same technique
-    the carried-vs-observed test above uses."""
+    the carried-vs-observed test above uses. close_legacy_resume_interaction_sync
+    is asserted uncalled directly too: replacing the guard with `if True:`
+    calls it for real and turns this assertion red on its own."""
     owner = _user(db_session, "deferred-replay-owner")
     task = _task(db_session, owner.id, status=TaskStatus.PAUSED)
     task.interaction_protocol_version = 1
@@ -4483,6 +4492,9 @@ async def test_deferred_injection_skips_the_close_on_a_replayed_turn_id(
             "xagent.web.api.websocket.active_interaction_id_sync",
             side_effect=AssertionError("the deferred path must not read its own"),
         ),
+        patch(
+            "xagent.web.api.websocket.close_legacy_resume_interaction_sync",
+        ) as close_mock,
     ):
         await execute_resume_background(
             task_id=task_id,
@@ -4503,6 +4515,7 @@ async def test_deferred_injection_skips_the_close_on_a_replayed_turn_id(
         )
 
     agent.post_user_message.assert_awaited_once()
+    close_mock.assert_not_called()
     db_session.expire_all()
     row = (
         db_session.query(TaskInteractionRequest)

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -30,6 +30,7 @@ from xagent.core.agent.checkpoint import (
     CheckpointCorruptError,
     CheckpointUnavailableError,
 )
+from xagent.core.agent.runner import UserMessageInjectionOutcome
 from xagent.core.execution_scope import (
     ExecutionScope,
 )
@@ -52,8 +53,9 @@ from xagent.web.api.websocket import (
 )
 from xagent.web.models.chat_message import TaskChatMessage
 from xagent.web.models.database import Base, get_db, get_engine, init_db
-from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task import Task, TaskStatus, TraceEvent
 from xagent.web.models.task_command import TaskExecutionCommand
+from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
 from xagent.web.services import task_orchestrator
@@ -108,6 +110,45 @@ def _task(db, owner_id: int, status: TaskStatus = TaskStatus.RUNNING) -> Task:
     db.commit()
     db.refresh(t)
     return t
+
+
+def _seed_active_interaction_row(
+    db: Session, *, task_id: int, run_id: str, idempotency_key: str
+) -> int:
+    """One legal active TaskInteractionRequest row, for the replay-skips-
+    close tests below. Mirrors test_a2a_api.py's local, single-purpose row
+    builder of the same name rather than sharing it across test files."""
+    anchor = TraceEvent(
+        task_id=task_id,
+        event_id=f"anchor-{idempotency_key}",
+        event_type="agent_execution_checkpoint",
+        timestamp=datetime.now(timezone.utc),
+        data={},
+    )
+    db.add(anchor)
+    db.flush()
+    row = TaskInteractionRequest(
+        task_id=task_id,
+        run_id=run_id,
+        kind="clarification",
+        protocol_version=1,
+        status="active",
+        active_slot=1,
+        origin="sdk",
+        request_payload={"prompt": "example"},
+        request_idempotency_key=idempotency_key,
+        resume_trace_event_id=int(anchor.id),
+        resume_event_id="resume-event-1",
+        resume_execution_id="resume-execution-1",
+        resume_locator_format="trace_event_pk_v1",
+        resume_checkpoint_type="agent_execution_checkpoint",
+        resume_run_partition=run_id,
+        expires_at=datetime.now(timezone.utc) + timedelta(minutes=15),
+    )
+    db.add(row)
+    db.commit()
+    db.refresh(row)
+    return int(row.id)
 
 
 # Anti-hang bounds, not latency assertions. Nothing here is measuring speed:
@@ -2054,6 +2095,76 @@ async def test_live_resume_reads_the_interaction_row_before_injecting(
     close_mock.assert_called_once_with(
         task_id=int(task.id), run_id="close-order-run", interaction_id=4321
     )
+
+
+@pytest.mark.asyncio
+async def test_live_injection_skips_the_close_on_a_replayed_turn_id(
+    db_session,
+) -> None:
+    """A replayed turn id short-circuits inside AgentRunner.inject_user_message
+    and is reported back as POSTED_REPLAY, not the same truthy value a
+    fresh write produces. The interaction row this test seeds is not the
+    question the replay answered, so the online injection site must leave
+    it untouched: still active, uncleared marker, and the close statement
+    must not run at all."""
+    owner = _user(db_session, "close-replay-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
+    task.runner_id = "close-replay-runner"
+    task.run_id = "close-replay-run"
+    task.interaction_protocol_version = 1
+    db_session.commit()
+    task_id = int(task.id)
+    row_id = _seed_active_interaction_row(
+        db_session,
+        task_id=task_id,
+        run_id="close-replay-run",
+        idempotency_key="close-replay-q1",
+    )
+
+    agent = MagicMock()
+    agent.supports_live_control.return_value = True
+    agent.get_dag_pattern.return_value = None
+    agent.post_user_message = AsyncMock(
+        return_value=UserMessageInjectionOutcome.POSTED_REPLAY
+    )
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+    bg_mgr = MagicMock()
+    bg_mgr.reserve_resume.return_value = True
+    bg_mgr.running_tasks.get.return_value = None
+
+    with (
+        patch(
+            "xagent.web.api.chat.get_agent_manager",
+            return_value=MagicMock(get_agent_for_task=AsyncMock(return_value=agent)),
+        ),
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.background_task_manager", bg_mgr),
+        patch("xagent.web.api.websocket.execute_resume_background", AsyncMock()),
+    ):
+        await _handle_chat_message_unserialized(
+            MagicMock(),
+            task_id,
+            {
+                "message": "a retried delivery",
+                "client_message_id": "close-replay-turn",
+                "user": owner,
+                "files": [],
+            },
+        )
+
+    agent.post_user_message.assert_awaited_once()
+    db_session.expire_all()
+    row = (
+        db_session.query(TaskInteractionRequest)
+        .filter(TaskInteractionRequest.id == row_id)
+        .one()
+    )
+    assert row.status == "active"
+    refreshed = db_session.query(Task).filter(Task.id == task_id).one()
+    assert refreshed.interaction_protocol_version == 1
 
 
 @pytest.mark.asyncio
@@ -4300,6 +4411,107 @@ async def test_deferred_injection_closes_the_row_the_online_handler_observed(
     close_mock.assert_called_once()
     assert close_mock.call_args.kwargs["task_id"] == int(task.id)
     assert close_mock.call_args.kwargs["interaction_id"] == 9876
+
+
+@pytest.mark.asyncio
+async def test_deferred_injection_skips_the_close_on_a_replayed_turn_id(
+    db_session,
+) -> None:
+    """A cross-run retry of this background task re-enters with the same
+    pending_user_message. post_user_message short-circuits the repeated
+    turn id and reports POSTED_REPLAY, so the close must be skipped
+    entirely -- not just matched against the carried (stale) interaction
+    id, but never attempted. The row this test seeds is the question the
+    resumed agent has staged *since* the first attempt (a different id
+    from the one carried in pending_user_message), so a site that
+    re-derived its close key by reading the current active row instead of
+    using the carried one would retire this live question; asserting
+    active_interaction_id_sync is never called pins that the deferred path
+    still takes no read of its own, replay or not -- the same technique
+    the carried-vs-observed test above uses."""
+    owner = _user(db_session, "deferred-replay-owner")
+    task = _task(db_session, owner.id, status=TaskStatus.PAUSED)
+    task.interaction_protocol_version = 1
+    db_session.add(
+        TaskChatMessage(
+            task_id=int(task.id),
+            user_id=int(owner.id),
+            role="user",
+            content="Deferred guidance",
+            message_type="user_message",
+            turn_id="deferred-replay-turn",
+            delivery_status=DELIVERY_PENDING,
+        )
+    )
+    db_session.commit()
+    task_id = int(task.id)
+    # The question staged since the first attempt -- a different row from
+    # the one named in pending_user_message below.
+    row_id = _seed_active_interaction_row(
+        db_session,
+        task_id=task_id,
+        run_id="deferred-replay-run",
+        idempotency_key="deferred-replay-q1",
+    )
+    context = SimpleNamespace(
+        messages=[
+            SimpleNamespace(role="user", metadata={"turn_id": "deferred-replay-turn"})
+        ]
+    )
+    agent = MagicMock(
+        post_user_message=AsyncMock(
+            return_value=UserMessageInjectionOutcome.POSTED_REPLAY
+        ),
+        resume_execution_by_id=AsyncMock(
+            return_value={
+                "status": "completed",
+                "success": True,
+                "output": "Applied",
+                "agent_result": {"context": context},
+            }
+        ),
+    )
+    ws_manager = MagicMock(
+        broadcast_to_task=AsyncMock(),
+        send_personal_message=AsyncMock(),
+    )
+
+    with (
+        patch("xagent.web.api.websocket.manager", ws_manager),
+        patch("xagent.web.api.websocket.background_task_manager.promote_resume_task"),
+        patch(
+            "xagent.web.api.websocket.active_interaction_id_sync",
+            side_effect=AssertionError("the deferred path must not read its own"),
+        ),
+    ):
+        await execute_resume_background(
+            task_id=task_id,
+            agent_service=agent,
+            task_owner_user_id=int(owner.id),
+            pending_user_message={
+                "execution_message": "Deferred guidance",
+                "display_message": "Deferred guidance",
+                "files": [],
+                "turn_id": "deferred-replay-turn",
+                # The stale id carried from the first attempt -- not the
+                # row seeded above, which is what a re-read would find.
+                "interaction_id": 424242,
+            },
+            delivery_turn_id="deferred-replay-turn",
+            delivery_websocket=MagicMock(),
+            delivery_client_message_id="deferred-replay-turn",
+        )
+
+    agent.post_user_message.assert_awaited_once()
+    db_session.expire_all()
+    row = (
+        db_session.query(TaskInteractionRequest)
+        .filter(TaskInteractionRequest.id == row_id)
+        .one()
+    )
+    assert row.status == "active"
+    refreshed = db_session.query(Task).filter(Task.id == task_id).one()
+    assert refreshed.interaction_protocol_version == 1
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -1271,9 +1271,9 @@ async def test_running_chat_message_is_persisted_before_resume(db_session) -> No
     agent.get_dag_pattern.return_value = None
     observed_leases: list[TaskLease | None] = []
 
-    async def post_user_message(*_args, **_kwargs) -> bool:
+    async def post_user_message(*_args, **_kwargs) -> UserMessageInjectionOutcome:
         observed_leases.append(current_task_lease())
-        return True
+        return UserMessageInjectionOutcome.POSTED_FRESH
 
     agent.post_user_message = AsyncMock(side_effect=post_user_message)
     mgr = MagicMock(get_agent_for_task=AsyncMock(return_value=agent))
@@ -1444,7 +1444,9 @@ async def test_running_chat_message_uses_one_offloop_scope_and_no_request_sessio
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
-    agent.post_user_message = AsyncMock(return_value=True)
+    agent.post_user_message = AsyncMock(
+        return_value=UserMessageInjectionOutcome.POSTED_FRESH
+    )
     manager_calls: list[tuple[object, dict]] = []
     claim_threads: list[int] = []
 
@@ -1916,7 +1918,9 @@ async def test_resume_registration_failure_keeps_injected_delivery_pending(
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
-    agent.post_user_message = AsyncMock(return_value=True)
+    agent.post_user_message = AsyncMock(
+        return_value=UserMessageInjectionOutcome.POSTED_FRESH
+    )
     mgr = MagicMock(get_agent_for_task=AsyncMock(return_value=agent))
     ws_manager = MagicMock(
         broadcast_to_task=AsyncMock(),
@@ -1983,7 +1987,9 @@ async def test_live_marker_failure_after_registered_handoff_is_still_accepted(
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
-    agent.post_user_message = AsyncMock(return_value=True)
+    agent.post_user_message = AsyncMock(
+        return_value=UserMessageInjectionOutcome.POSTED_FRESH
+    )
     ws_manager = MagicMock(
         broadcast_to_task=AsyncMock(),
         send_personal_message=AsyncMock(),
@@ -2050,9 +2056,11 @@ async def test_live_resume_reads_the_interaction_row_before_injecting(
         order.append("read")
         return 4321
 
-    async def record_injection(*_args: object, **_kwargs: object) -> bool:
+    async def record_injection(
+        *_args: object, **_kwargs: object
+    ) -> UserMessageInjectionOutcome:
         order.append("inject")
-        return True
+        return UserMessageInjectionOutcome.POSTED_FRESH
 
     agent.post_user_message = AsyncMock(side_effect=record_injection)
     ws_manager = MagicMock(
@@ -2106,10 +2114,11 @@ async def test_live_injection_skips_the_close_on_a_replayed_turn_id(
     fresh write produces. The interaction row this test seeds is not the
     question the replay answered, so the online injection site must leave
     it untouched: still active, uncleared marker, and the close statement
-    must not run at all -- asserted directly on the mock, not only inferred
-    from the unchanged row: replacing the guard with `if True:` calls the
-    close for real and turns this assertion red on its own, independent of
-    the DB-state assertions below."""
+    must not run at all. That is asserted directly on the mock: replacing
+    the guard with `if True:` calls the close for real and turns
+    assert_not_called red. No DB-state assertion is made here -- with the
+    close function mocked out, nothing writes to the row or the marker, so
+    "still active" would hold no matter what the guard did."""
     owner = _user(db_session, "close-replay-owner")
     task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
     task.runner_id = "close-replay-runner"
@@ -2117,7 +2126,7 @@ async def test_live_injection_skips_the_close_on_a_replayed_turn_id(
     task.interaction_protocol_version = 1
     db_session.commit()
     task_id = int(task.id)
-    row_id = _seed_active_interaction_row(
+    _seed_active_interaction_row(
         db_session,
         task_id=task_id,
         run_id="close-replay-run",
@@ -2163,15 +2172,6 @@ async def test_live_injection_skips_the_close_on_a_replayed_turn_id(
 
     agent.post_user_message.assert_awaited_once()
     close_mock.assert_not_called()
-    db_session.expire_all()
-    row = (
-        db_session.query(TaskInteractionRequest)
-        .filter(TaskInteractionRequest.id == row_id)
-        .one()
-    )
-    assert row.status == "active"
-    refreshed = db_session.query(Task).filter(Task.id == task_id).one()
-    assert refreshed.interaction_protocol_version == 1
 
 
 @pytest.mark.asyncio
@@ -2188,7 +2188,9 @@ async def test_live_close_failure_after_registered_handoff_is_still_accepted(
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
-    agent.post_user_message = AsyncMock(return_value=True)
+    agent.post_user_message = AsyncMock(
+        return_value=UserMessageInjectionOutcome.POSTED_FRESH
+    )
     ws_manager = MagicMock(
         broadcast_to_task=AsyncMock(),
         send_personal_message=AsyncMock(),
@@ -2247,7 +2249,9 @@ async def test_live_close_cancellation_does_not_abort_registered_handoff(
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
-    agent.post_user_message = AsyncMock(return_value=True)
+    agent.post_user_message = AsyncMock(
+        return_value=UserMessageInjectionOutcome.POSTED_FRESH
+    )
     ws_manager = MagicMock(
         broadcast_to_task=AsyncMock(),
         send_personal_message=AsyncMock(),
@@ -2540,7 +2544,9 @@ async def test_live_marker_cancellation_does_not_cancel_registered_handoff(
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
-    agent.post_user_message = AsyncMock(return_value=True)
+    agent.post_user_message = AsyncMock(
+        return_value=UserMessageInjectionOutcome.POSTED_FRESH
+    )
     ws_manager = MagicMock(
         broadcast_to_task=AsyncMock(),
         send_personal_message=AsyncMock(),
@@ -4109,7 +4115,9 @@ async def test_deferred_injection_marker_failure_does_not_abort_resume(
         ]
     )
     agent = MagicMock(
-        post_user_message=AsyncMock(return_value=True),
+        post_user_message=AsyncMock(
+            return_value=UserMessageInjectionOutcome.POSTED_FRESH
+        ),
         resume_execution_by_id=AsyncMock(
             return_value={
                 "status": "completed",
@@ -4188,7 +4196,9 @@ async def test_deferred_injection_marker_cancellation_does_not_abort_resume(
         ]
     )
     agent = MagicMock(
-        post_user_message=AsyncMock(return_value=True),
+        post_user_message=AsyncMock(
+            return_value=UserMessageInjectionOutcome.POSTED_FRESH
+        ),
         resume_execution_by_id=AsyncMock(
             return_value={
                 "status": "completed",
@@ -4269,7 +4279,9 @@ async def test_deferred_injection_close_failure_does_not_abort_resume(
         ]
     )
     agent = MagicMock(
-        post_user_message=AsyncMock(return_value=True),
+        post_user_message=AsyncMock(
+            return_value=UserMessageInjectionOutcome.POSTED_FRESH
+        ),
         resume_execution_by_id=AsyncMock(
             return_value={
                 "status": "completed",
@@ -4372,7 +4384,9 @@ async def test_deferred_injection_closes_the_row_the_online_handler_observed(
         ]
     )
     agent = MagicMock(
-        post_user_message=AsyncMock(return_value=True),
+        post_user_message=AsyncMock(
+            return_value=UserMessageInjectionOutcome.POSTED_FRESH
+        ),
         resume_execution_by_id=AsyncMock(
             return_value={
                 "status": "completed",
@@ -4436,7 +4450,7 @@ async def test_deferred_injection_skips_the_close_on_a_replayed_turn_id(
     active_interaction_id_sync is never called pins that the deferred path
     still takes no read of its own, replay or not -- the same technique
     the carried-vs-observed test above uses. close_legacy_resume_interaction_sync
-    is asserted uncalled directly too: replacing the guard with `if True:`
+    is asserted uncalled directly: replacing the guard with `if True:`
     calls it for real and turns this assertion red on its own."""
     owner = _user(db_session, "deferred-replay-owner")
     task = _task(db_session, owner.id, status=TaskStatus.PAUSED)
@@ -4456,7 +4470,7 @@ async def test_deferred_injection_skips_the_close_on_a_replayed_turn_id(
     task_id = int(task.id)
     # The question staged since the first attempt -- a different row from
     # the one named in pending_user_message below.
-    row_id = _seed_active_interaction_row(
+    _seed_active_interaction_row(
         db_session,
         task_id=task_id,
         run_id="deferred-replay-run",
@@ -4516,15 +4530,6 @@ async def test_deferred_injection_skips_the_close_on_a_replayed_turn_id(
 
     agent.post_user_message.assert_awaited_once()
     close_mock.assert_not_called()
-    db_session.expire_all()
-    row = (
-        db_session.query(TaskInteractionRequest)
-        .filter(TaskInteractionRequest.id == row_id)
-        .one()
-    )
-    assert row.status == "active"
-    refreshed = db_session.query(Task).filter(Task.id == task_id).one()
-    assert refreshed.interaction_protocol_version == 1
 
 
 @pytest.mark.asyncio
@@ -4555,7 +4560,9 @@ async def test_deferred_injection_close_cancellation_does_not_abort_resume(
         ]
     )
     agent = MagicMock(
-        post_user_message=AsyncMock(return_value=True),
+        post_user_message=AsyncMock(
+            return_value=UserMessageInjectionOutcome.POSTED_FRESH
+        ),
         resume_execution_by_id=AsyncMock(
             return_value={
                 "status": "completed",
@@ -4642,7 +4649,9 @@ async def test_deferred_injection_rejects_before_post_when_lease_is_denied(
     )
     db_session.commit()
     agent = MagicMock(
-        post_user_message=AsyncMock(return_value=True),
+        post_user_message=AsyncMock(
+            return_value=UserMessageInjectionOutcome.POSTED_FRESH
+        ),
         resume_execution_by_id=AsyncMock(),
     )
     ws_manager = MagicMock(

--- a/tests/web/api/v1/test_task_reply.py
+++ b/tests/web/api/v1/test_task_reply.py
@@ -247,6 +247,74 @@ def test_reply_happy_path_resumes_the_same_run(mock_start_task):
         db.close()
 
 
+def test_reply_turn_id_is_never_reused_across_retries(mock_start_task):
+    """Documents a known structural boundary, not a behavior this endpoint
+    is expected to provide: every call mints ``turn_id`` from a fresh
+    ``uuid4()``, so even a client retry that resubmits the identical reply
+    body can never land on the same turn id twice. That means this call
+    site can never trigger AgentRunner.inject_user_message's turn_id
+    short-circuit and can never observe a POSTED_REPLAY outcome -- there is
+    no replay-skip guard to add here, and none should be, because the
+    condition it would guard against is unreachable through this path."""
+    agent_id, full_key = _create_agent_with_key()
+    task_id = _create_waiting_task(full_key, agent_id, run_id="run-original")
+    _insert_question_message(task_id)
+
+    first_post = AsyncMock(return_value=True)
+    agent_patch, agent_service = _patch_agent_service(first_post)
+    with (
+        agent_patch,
+        patch(
+            "xagent.web.api.v1.task_reply._schedule_waiting_reply_resume",
+            new=AsyncMock(),
+        ),
+    ):
+        first_resp = client.post(
+            f"/v1/chat/tasks/{task_id}/reply",
+            headers=_bearer(full_key),
+            json=_reply_body(agent_id),
+        )
+    assert first_resp.status_code == 202, first_resp.text
+    first_turn_id = agent_service.post_user_message.call_args.kwargs["turn_id"]
+
+    # Simulate a client retry: the same task, back in the same
+    # waiting_for_user state with the same run, resubmitting the identical
+    # reply body -- the only thing a real retry could differ on is nothing
+    # at all from this endpoint's point of view.
+    db = _direct_db_session()
+    try:
+        task = db.query(Task).filter(Task.id == task_id).one()
+        task.status = TaskStatus.WAITING_FOR_USER
+        task.control_state = TaskControlState.WAITING_FOR_USER.value
+        task.run_id = "run-original"
+        task.runner_id = None
+        task.lease_expires_at = None
+        db.commit()
+    finally:
+        db.close()
+
+    second_post = AsyncMock(return_value=True)
+    agent_patch, agent_service = _patch_agent_service(second_post)
+    with (
+        agent_patch,
+        patch(
+            "xagent.web.api.v1.task_reply._schedule_waiting_reply_resume",
+            new=AsyncMock(),
+        ),
+    ):
+        second_resp = client.post(
+            f"/v1/chat/tasks/{task_id}/reply",
+            headers=_bearer(full_key),
+            json=_reply_body(agent_id),
+        )
+    assert second_resp.status_code == 202, second_resp.text
+    second_turn_id = agent_service.post_user_message.call_args.kwargs["turn_id"]
+
+    assert first_turn_id.startswith(f"v1:reply:{task_id}:")
+    assert second_turn_id.startswith(f"v1:reply:{task_id}:")
+    assert first_turn_id != second_turn_id
+
+
 # ===== status matrix =====
 
 

--- a/tests/web/api/v1/test_task_reply.py
+++ b/tests/web/api/v1/test_task_reply.py
@@ -20,6 +20,7 @@ from xagent.core.agent.checkpoint import (
     CheckpointReadError,
     CheckpointUnavailableError,
 )
+from xagent.core.agent.runner import UserMessageInjectionOutcome
 from xagent.web.api.v1 import task_reply as task_reply_module
 from xagent.web.models.agent import Agent
 from xagent.web.models.chat_message import TaskChatMessage
@@ -203,7 +204,7 @@ def test_reply_happy_path_resumes_the_same_run(mock_start_task):
     task_id = _create_waiting_task(full_key, agent_id, run_id="run-original")
     _insert_question_message(task_id)
 
-    post_user_message = AsyncMock(return_value=True)
+    post_user_message = AsyncMock(return_value=UserMessageInjectionOutcome.POSTED_FRESH)
     agent_patch, agent_service = _patch_agent_service(post_user_message)
     with (
         agent_patch,
@@ -260,7 +261,7 @@ def test_reply_turn_id_is_never_reused_across_retries(mock_start_task):
     task_id = _create_waiting_task(full_key, agent_id, run_id="run-original")
     _insert_question_message(task_id)
 
-    first_post = AsyncMock(return_value=True)
+    first_post = AsyncMock(return_value=UserMessageInjectionOutcome.POSTED_FRESH)
     agent_patch, agent_service = _patch_agent_service(first_post)
     with (
         agent_patch,
@@ -293,7 +294,7 @@ def test_reply_turn_id_is_never_reused_across_retries(mock_start_task):
     finally:
         db.close()
 
-    second_post = AsyncMock(return_value=True)
+    second_post = AsyncMock(return_value=UserMessageInjectionOutcome.POSTED_FRESH)
     agent_patch, agent_service = _patch_agent_service(second_post)
     with (
         agent_patch,
@@ -356,7 +357,7 @@ def test_reply_waiting_status_is_not_rejected_by_the_status_gate(mock_start_task
     task_id = _create_waiting_task(full_key, agent_id)
     _insert_question_message(task_id)
 
-    post_user_message = AsyncMock(return_value=True)
+    post_user_message = AsyncMock(return_value=UserMessageInjectionOutcome.POSTED_FRESH)
     agent_patch, _ = _patch_agent_service(post_user_message)
     with (
         agent_patch,
@@ -576,7 +577,7 @@ def test_reply_closes_the_legacy_resume_interaction_row_on_successful_injection(
         task_id, run_id="run-close-success", idempotency_key="reply-close-success-q1"
     )
 
-    post_user_message = AsyncMock(return_value=True)
+    post_user_message = AsyncMock(return_value=UserMessageInjectionOutcome.POSTED_FRESH)
     agent_patch, agent_service = _patch_agent_service(post_user_message)
     with (
         agent_patch,
@@ -641,9 +642,11 @@ def test_reply_reads_the_interaction_row_before_injecting(mock_start_task):
         order.append("read")
         return _OBSERVED_INTERACTION_ID
 
-    async def record_injection(*_args: object, **_kwargs: object) -> bool:
+    async def record_injection(
+        *_args: object, **_kwargs: object
+    ) -> UserMessageInjectionOutcome:
         order.append("inject")
-        return True
+        return UserMessageInjectionOutcome.POSTED_FRESH
 
     agent_patch, _agent_service = _patch_agent_service(
         AsyncMock(side_effect=record_injection)
@@ -906,7 +909,7 @@ async def test_concurrent_reply_race_exactly_one_winner(mock_start_task):
     finally:
         db.close()
 
-    post_user_message = AsyncMock(return_value=True)
+    post_user_message = AsyncMock(return_value=UserMessageInjectionOutcome.POSTED_FRESH)
     agent_patch, _ = _patch_agent_service(post_user_message)
 
     from xagent.web.api.v1.deps import (

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -17,6 +17,7 @@ from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from xagent.core.agent.runner import UserMessageInjectionOutcome
 from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
 from xagent.web.api import websocket as websocket_api
 from xagent.web.api.websocket import (
@@ -1042,7 +1043,9 @@ async def test_recovery_dispatches_committed_message_across_run_rotation(
 
     runtime_agent = MagicMock()
     runtime_agent.supports_live_control.return_value = True
-    runtime_agent.post_user_message = AsyncMock(return_value=True)
+    runtime_agent.post_user_message = AsyncMock(
+        return_value=UserMessageInjectionOutcome.POSTED_FRESH
+    )
     runtime_manager = MagicMock(
         get_agent_for_task=AsyncMock(return_value=runtime_agent)
     )


### PR DESCRIPTION
`AgentRunner.inject_user_message` short-circuits on a repeated turn id: it returns the same context the first attempt produced and writes nothing. It reported that outcome with the same truthy value a fresh write produces, so a caller could not tell the two apart.

Three call sites inject a user message outside the native interaction protocol and then close the interaction row they observed just before the call — the online WebSocket path, the deferred WebSocket path, and the A2A resume-input path. On a replay, the row those sites observed is no longer the question the replayed message answered; it is whatever the resumed agent has asked since. Closing it retires a live question instead of clearing a stale one.

`inject_user_message` now returns `UserMessageInjectionResult` — the execution context plus a `UserMessageInjectionOutcome` — instead of a bare `ExecutionContext`. The outcome has three members: `NOT_POSTED`, `POSTED_FRESH`, and `POSTED_REPLAY`. `NOT_POSTED` is the empty string and the other two are not, so an unmodified `if not posted` or `bool(posted)` caller keeps asking exactly the question it always asked. The outcome threads unmodified through `ExecutionRegistry`, `AgentExecutionAdapter`, and `AgentService.post_user_message`, and each of the three close sites reads it and skips its close call when the outcome is `POSTED_REPLAY`.

The v1 reply resume-input path needs no equivalent guard: its turn id embeds a fresh `uuid4()` on every call, so it can never take the short-circuit.

`task_interaction_close.py` is otherwise untouched. Its module docstring described this replay window as indistinguishable and unfixed, both of which are now false, so that one paragraph is rewritten to state the current invariant: the injection layer reports which case it is, the three call sites skip on a replay, and neither this module's close statement nor the lock-ordering obligation each caller carries changes — the guard decides whether the call happens, not what the call does.

A separate comment records an adjacent gap this change does not close: a `None` `expected_run_id` reaching `acquire_task_lease_no_commit` mints a fresh uuid rather than claiming under the caller's own run. Every call site today passes its run id explicitly, so the gap is structurally open but unreachable; a future caller that omitted it would claim a lease under a run nobody else knows about instead of failing loudly.

**Verification** — `uv run pytest`, Python 3.12, local SQLite-backed default configuration. 1134 passed across:

- `tests/core/agent/` (960 tests, whole directory), which covers the four threading layers directly — `test_runner.py` (60), `test_registry.py` (18), `test_execution_adapter.py` (50), `test_agent_service_post_user_message.py` (3).
- `tests/web/api/test_a2a_api.py` (69) — the A2A resume-input close site.
- `tests/web/api/test_websocket_owner_actor.py` (77) — the two WebSocket close sites.
- `tests/web/api/v1/test_task_reply.py` (28) — the v1 path that needs no guard.

Each of the three close-site cases asserts both the resulting database state and a direct `assert_not_called()` on the close mock.
