### PR TITLE
feat: add an expand/collapse toggle to the widget's overflow menu

### DIFF
--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -634,6 +634,21 @@
     // that on release), end the drag cleanly here. The user can just grab
     // the handle again if they still want to resize.
     cancelDrag();
+    // A resize can carry an already-expanded panel across the mobile
+    // breakpoint just as easily as a click can arrive there in the first
+    // place. The .expanded CSS rule stops applying (it's scoped above the
+    // breakpoint), so the panel would render as a plain mobile-sized panel
+    // while isExpanded stays true on both sides -- then widening back past
+    // the breakpoint with no further click reactivates the CSS rule and
+    // silently snaps the panel back to full size, the exact thing
+    // expandPanel()'s own mobile guard exists to prevent for a fresh
+    // request. Force the same correction path a click-time rejection uses.
+    if (isExpanded && isMobileViewport()) {
+      collapsePanel();
+      if (iframe.contentWindow) {
+        iframe.contentWindow.postMessage({ xagent: true, v: 1, type: 'widget_expand_rejected' }, host);
+      }
+    }
   }
   window.addEventListener('resize', onWindowResize);
 

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -691,6 +691,16 @@
     // (see onWindowResize below), so growing past the breakpoint afterward
     // would silently expand the panel with no further click from the user.
     if (isMobileViewport()) return;
+    // Expanding invalidates a drag's frozen startX/startWidth anchors the
+    // same way a viewport-width change does (see onWindowResize's own
+    // cancelDrag() call) -- a drag can only still be active here via a
+    // second, independent pointer (e.g. one finger holding the handle while
+    // another taps this menu item on a touch-capable desktop-width device),
+    // since isMobileViewport()/isExpanded already block a *new* drag from
+    // starting once expanded. Without this, that drag's very next
+    // pointermove would go on setting an inline width, desyncing the
+    // panel's rendered width from the .expanded class it now also carries.
+    cancelDrag();
     isExpanded = true;
     panel.classList.add('expanded');
     // Let the .expanded rule's own width win -- an inline width from a

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -378,6 +378,24 @@
       display: none;
     }
 
+    /* Expand mode jumps straight to the same max width the drag-resize
+       handle already clamps to, rather than a separate arbitrary size.
+       min-width, not nested in the max-width block below, so its two-class
+       selector can never outrank the mobile layout by specificity alone --
+       structurally impossible to apply under the mobile breakpoint at all. */
+    @media (min-width: ${MOBILE_BREAKPOINT + 1}px) {
+      .xagent-widget-panel.expanded {
+        width: ${MAX_PANEL_WIDTH}px;
+        height: calc(100vh - 100px);
+      }
+
+      /* Dragging the handle sets an inline width that would win over (and
+         desync from) the expanded class's own width by specificity. */
+      .xagent-widget-panel.expanded .xagent-widget-resize-handle {
+        display: none;
+      }
+    }
+
     @media (max-width: ${MOBILE_BREAKPOINT}px) {
       .xagent-widget-panel {
         width: calc(100vw - ${HORIZONTAL_VIEWPORT_MARGIN}px);
@@ -413,6 +431,14 @@
   // viewport (a shrunk window, a rotated device) must not permanently shrink
   // the user's stored preference once the viewport widens again.
   function applyPanelWidth() {
+    // Expand mode's own CSS rule owns width while active; setting an inline
+    // width here would outrank it by specificity regardless of viewport,
+    // desyncing the panel's width from its still-expanded height -- a plain
+    // window resize that stays well above the mobile breakpoint still calls
+    // this via onWindowResize below. collapsePanel() calls this itself,
+    // after already flipping isExpanded false, specifically to restore the
+    // width this skips while expanded.
+    if (isExpanded) return;
     panel.style.width = isMobileViewport() ? '' : clampPanelWidth(panelWidth) + 'px';
   }
   applyPanelWidth();
@@ -438,7 +464,7 @@
     // whose CSP blocks that inline <style> would leave it visually
     // draggable with no CSS backing it up -- check the open class directly
     // too, as defense in depth that doesn't depend on the stylesheet loading.
-    if (torndown || isMobileViewport() || dragState || (event.button || 0) !== 0 || !panel.classList.contains('open')) return;
+    if (torndown || isMobileViewport() || isExpanded || dragState || (event.button || 0) !== 0 || !panel.classList.contains('open')) return;
     dragState = {
       pointerId: event.pointerId,
       startX: event.clientX,
@@ -633,6 +659,7 @@
   fab.innerHTML = chatIcon;
 
   var isOpen = false;
+  var isExpanded = false;
 
   function openPanel() {
     isOpen = true;
@@ -644,6 +671,22 @@
     isOpen = false;
     panel.classList.remove('open');
     fab.innerHTML = chatIcon;
+  }
+
+  function expandPanel() {
+    isExpanded = true;
+    panel.classList.add('expanded');
+    // Let the .expanded rule's own width win -- an inline width from a
+    // prior drag would otherwise outrank it by specificity regardless.
+    // A no-op under the mobile breakpoint: the .expanded CSS rule is
+    // itself scoped to min-width, so this class has nothing to apply.
+    panel.style.width = '';
+  }
+
+  function collapsePanel() {
+    isExpanded = false;
+    panel.classList.remove('expanded');
+    applyPanelWidth();
   }
 
   fab.onclick = function () {
@@ -682,6 +725,10 @@
     if (!data || data.xagent !== true || data.v !== 1) return;
     if (data.type === 'widget_close') {
       closePanel();
+    } else if (data.type === 'widget_expand') {
+      expandPanel();
+    } else if (data.type === 'widget_collapse') {
+      collapsePanel();
     }
   }
   window.addEventListener('message', onChromeMessage);

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -278,6 +278,12 @@
   // so a viewport narrower than the stored preference at load never
   // overwrites it (e.g. via a later, otherwise-unmoved drag release).
   var panelWidth = readStoredWidth();
+  // Declared here, next to the other panel-sizing state, even though it's
+  // first read (via var hoisting) much later in applyPanelWidth() below --
+  // that read only works today because the value is `undefined` (falsy)
+  // until this line runs; keep it here so a future var -> let/const
+  // conversion can't turn it into a load-time ReferenceError.
+  var isExpanded = false;
 
   // Styles
   var style = document.createElement('style');
@@ -328,7 +334,11 @@
       right: 0;
       width: ${DEFAULT_PANEL_WIDTH}px;
       height: 600px;
-      max-height: calc(100vh - 100px);
+      /* The panel's bottom edge sits buttonSize + 40px above the viewport
+         bottom (container's own 20px, plus the panel's own bottom offset
+         above -- both referenced from the rule right above), so that's the
+         most height can grow to before the top edge goes off-screen. */
+      max-height: calc(100vh - ${buttonSize} - 40px);
       background: ${panelBgColor};
       border-radius: 12px;
       box-shadow: 0 8px 24px rgba(0, 0, 0, 0.16);
@@ -379,14 +389,16 @@
     }
 
     /* Expand mode jumps straight to the same max width the drag-resize
-       handle already clamps to, rather than a separate arbitrary size.
-       min-width, not nested in the max-width block below, so its two-class
-       selector can never outrank the mobile layout by specificity alone --
-       structurally impossible to apply under the mobile breakpoint at all. */
-    @media (min-width: ${MOBILE_BREAKPOINT + 1}px) {
+       handle already clamps to, rather than a separate arbitrary size. The
+       exact logical complement of the max-width block below (not a
+       min-width one pixel above it, which would leave a sub-pixel gap
+       neither query matches), so its two-class selector can never outrank
+       the mobile layout by specificity alone -- structurally impossible to
+       apply under the mobile breakpoint at all. */
+    @media not all and (max-width: ${MOBILE_BREAKPOINT}px) {
       .xagent-widget-panel.expanded {
         width: ${MAX_PANEL_WIDTH}px;
-        height: calc(100vh - 100px);
+        height: calc(100vh - ${buttonSize} - 40px);
       }
 
       /* Dragging the handle sets an inline width that would win over (and
@@ -659,7 +671,6 @@
   fab.innerHTML = chatIcon;
 
   var isOpen = false;
-  var isExpanded = false;
 
   function openPanel() {
     isOpen = true;
@@ -674,12 +685,16 @@
   }
 
   function expandPanel() {
+    // The .expanded CSS rule is itself scoped above the mobile breakpoint,
+    // so this would already be a visual no-op there -- but isExpanded would
+    // still latch true, and nothing rechecks it on a later resize/rotation
+    // (see onWindowResize below), so growing past the breakpoint afterward
+    // would silently expand the panel with no further click from the user.
+    if (isMobileViewport()) return;
     isExpanded = true;
     panel.classList.add('expanded');
     // Let the .expanded rule's own width win -- an inline width from a
     // prior drag would otherwise outrank it by specificity regardless.
-    // A no-op under the mobile breakpoint: the .expanded CSS rule is
-    // itself scoped to min-width, so this class has nothing to apply.
     panel.style.width = '';
   }
 

--- a/frontend/public/widget.js
+++ b/frontend/public/widget.js
@@ -397,7 +397,11 @@
        apply under the mobile breakpoint at all. */
     @media not all and (max-width: ${MOBILE_BREAKPOINT}px) {
       .xagent-widget-panel.expanded {
-        width: ${MAX_PANEL_WIDTH}px;
+        /* Same viewport clamp the drag-resize handle already enforces via
+           clampPanelWidth() -- a flat 720px would push the right-anchored
+           panel (and its left-edge resize handle) off the left of the
+           screen on any supported desktop width narrower than 760px. */
+        width: min(${MAX_PANEL_WIDTH}px, 100vw - ${HORIZONTAL_VIEWPORT_MARGIN}px);
         height: calc(100vh - ${buttonSize} - 40px);
       }
 
@@ -684,13 +688,15 @@
     fab.innerHTML = chatIcon;
   }
 
+  // Returns whether it actually expanded -- onChromeMessage uses this to
+  // tell the iframe when its optimistic isExpanded guess needs correcting.
   function expandPanel() {
     // The .expanded CSS rule is itself scoped above the mobile breakpoint,
     // so this would already be a visual no-op there -- but isExpanded would
     // still latch true, and nothing rechecks it on a later resize/rotation
     // (see onWindowResize below), so growing past the breakpoint afterward
     // would silently expand the panel with no further click from the user.
-    if (isMobileViewport()) return;
+    if (isMobileViewport()) return false;
     // Expanding invalidates a drag's frozen startX/startWidth anchors the
     // same way a viewport-width change does (see onWindowResize's own
     // cancelDrag() call) -- a drag can only still be active here via a
@@ -706,6 +712,7 @@
     // Let the .expanded rule's own width win -- an inline width from a
     // prior drag would otherwise outrank it by specificity regardless.
     panel.style.width = '';
+    return true;
   }
 
   function collapsePanel() {
@@ -751,7 +758,14 @@
     if (data.type === 'widget_close') {
       closePanel();
     } else if (data.type === 'widget_expand') {
-      expandPanel();
+      // Correct the iframe's optimistic isExpanded guess when the mobile
+      // guard above rejects it -- otherwise the menu keeps reading "Collapse
+      // window" with nothing actually expanded, and the visitor's next click
+      // (a no-op collapse from the iframe's perspective) needs a second
+      // click on an eventual desktop-width resize to actually expand.
+      if (!expandPanel()) {
+        iframe.contentWindow.postMessage({ xagent: true, v: 1, type: 'widget_expand_rejected' }, host);
+      }
     } else if (data.type === 'widget_collapse') {
       collapsePanel();
     }

--- a/frontend/src/components/widget/public-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/public-agent-chat-page.test.tsx
@@ -399,10 +399,11 @@ describe("PublicAgentChatPage", () => {
 
     expect(await screen.findByRole("button", { name: "start:Support Agent" })).toBeInTheDocument()
     expect(fetchMock).toHaveBeenCalledTimes(1)
-    // No conversation yet — nothing to end, so the "..." menu (which would
-    // only ever hold the new-conversation action) doesn't render either.
+    // No conversation yet — nothing to end, so that particular menu item is
+    // absent, but the "..." trigger itself still renders since expand/
+    // collapse is always offered regardless of conversation state.
     expect(screen.queryByRole("button", { name: "widgetChat.newConversation" })).toBeNull()
-    expect(screen.queryByRole("button", { name: "widgetChat.moreOptions" })).toBeNull()
+    expect(screen.getByRole("button", { name: "widgetChat.moreOptions" })).toBeInTheDocument()
     // The close control still renders — it toggles the host panel, not the
     // chat itself, so it's independent of whether a conversation exists.
     expect(screen.getByRole("button", { name: "widgetChat.close" })).toBeInTheDocument()

--- a/frontend/src/components/widget/session-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.test.tsx
@@ -312,12 +312,9 @@ describe("SessionAgentChatPage", () => {
       { mode: "balanced" },
       [],
     )
-    // No conversation yet — nothing to reset, so the "..." menu (which would
-    // only ever hold the new-conversation action) doesn't render either. (Not
-    // asserting the menuitem itself is absent here: the menu was never
-    // opened, so that check can't fail regardless of whether this logic
-    // works — the trigger's own absence, below, is what actually proves it.)
-    expect(screen.queryByRole("button", { name: "widgetChat.moreOptions" })).toBeNull()
+    // No conversation yet — nothing to reset, but the "..." trigger still
+    // renders since expand/collapse is always offered regardless.
+    expect(screen.getByRole("button", { name: "widgetChat.moreOptions" })).toBeInTheDocument()
     expect(screen.getByRole("button", { name: "widgetChat.close" })).toBeInTheDocument()
   })
 

--- a/frontend/src/components/widget/session-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.test.tsx
@@ -449,6 +449,45 @@ describe("SessionAgentChatPage", () => {
     expect(app.provider?.transport?.session?.connection).toBeNull()
   })
 
+  it("keeps an accepted expansion across a degraded/active remount instead of resetting to Expand", () => {
+    // WidgetChromeControls is torn down and rebuilt across this transition
+    // (the degraded branch renders a completely different subtree with no
+    // header at all), so its own isExpanded state can't survive it -- this
+    // is why SessionAgentChatPage lifts and passes it down as a controlled
+    // prop instead of leaving it as the component's internal useState.
+    const postMessageSpy = vi.fn()
+    vi.stubGlobal("parent", { postMessage: postMessageSpy })
+    setBridge("active", activeSession())
+    app.state.taskId = 71
+    app.isConnected = true
+
+    const { rerender } = render(<SessionAgentChatPage />)
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.expandWindow" }))
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { xagent: true, v: 1, type: "widget_expand" },
+      "*",
+    )
+
+    setBridge("degraded", null)
+    rerender(<SessionAgentChatPage />)
+    expect(screen.getByRole("heading", {
+      name: "widgetSession.unavailable.title",
+    })).toBeInTheDocument()
+
+    setBridge("active", activeSession())
+    app.state.taskId = 71
+    rerender(<SessionAgentChatPage />)
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    expect(screen.getByRole("menuitem", { name: "widgetChat.collapseWindow" })).toBeInTheDocument()
+    fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.collapseWindow" }))
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { xagent: true, v: 1, type: "widget_collapse" },
+      "*",
+    )
+  })
+
   it.each([
     ["session_expired", "widgetSession.expired.title", "widgetSession.expired.description"],
     ["grant_expired", "widgetSession.expired.title", "widgetSession.expired.description"],

--- a/frontend/src/components/widget/session-agent-chat-page.test.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.test.tsx
@@ -366,10 +366,11 @@ describe("SessionAgentChatPage", () => {
     app.isConversationResetPending = true
     rerender(<SessionAgentChatPage />)
 
-    expect(trigger).toBeDisabled()
     expect(screen.queryByRole("menu")).toBeNull()
-    // Not just "disabled" -- the whole point of this prop is a visible
-    // in-progress indicator on the trigger once the menu itself has closed.
+    // The spinner is status feedback, not a lockout -- sizing has no
+    // dependency on the conversation reset, so the trigger itself must stay
+    // reachable even while pending.
+    expect(trigger).not.toBeDisabled()
     expect(trigger.querySelector("svg.animate-spin")).not.toBeNull()
   })
 

--- a/frontend/src/components/widget/session-agent-chat-page.tsx
+++ b/frontend/src/components/widget/session-agent-chat-page.tsx
@@ -42,6 +42,13 @@ interface SessionConversationContentProps {
   agent: WidgetSessionAgent | null
   terminalCode: string | null
   isAbsoluteExpiryWarningVisible: boolean
+  // Lifted to the never-unmounting SessionAgentChatPage below: this
+  // component's own "active" JSX branch unmounts on a degraded/reconnect
+  // transition (see the status check further down), which would otherwise
+  // silently reset an accepted expand back to the collapsed label/icon while
+  // the panel itself is still actually expanded.
+  isExpanded: boolean
+  onExpandedChange: (expanded: boolean) => void
 }
 
 function SessionConversationContent({
@@ -49,6 +56,8 @@ function SessionConversationContent({
   agent,
   terminalCode,
   isAbsoluteExpiryWarningVisible,
+  isExpanded,
+  onExpandedChange,
 }: SessionConversationContentProps) {
   const {
     state,
@@ -164,6 +173,8 @@ function SessionConversationContent({
               disabled: resetDisabled,
               pending: isConversationResetPending,
             } : undefined}
+            expanded={isExpanded}
+            onExpandedChange={onExpandedChange}
           />
         </div>
         {isAbsoluteExpiryWarningVisible ? (
@@ -239,6 +250,7 @@ function SessionConversationContent({
 
 export function SessionAgentChatPage() {
   const bridge = useWidgetSession()
+  const [isExpanded, setIsExpanded] = useState(false)
 
   const connection = useMemo<WebSocketConnection | null>(() => {
     if (bridge.status !== "active" || !bridge.session) return null
@@ -293,6 +305,8 @@ export function SessionAgentChatPage() {
         isAbsoluteExpiryWarningVisible={
           bridge.isAbsoluteExpiryWarningVisible
         }
+        isExpanded={isExpanded}
+        onExpandedChange={setIsExpanded}
       />
     </AppProvider>
   )

--- a/frontend/src/components/widget/widget-bootstrap.test.ts
+++ b/frontend/src/components/widget/widget-bootstrap.test.ts
@@ -433,6 +433,28 @@ describe("widget bootstrap", () => {
       expect(panel().style.width).toBe("")
     })
 
+    it("ignores a drag start while expanded", () => {
+      // The expanded rule's own width would otherwise get fought over an
+      // inline width from a drag that isn't blocked here.
+      runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
+      window.dispatchEvent(new MessageEvent("message", {
+        data: { xagent: true, v: 1, type: "widget_expand" },
+        origin: "https://chat.example",
+        source: widgetIframe().contentWindow as Window,
+      }))
+      expect(panel()).toHaveClass("expanded")
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 1, clientX: 100 })
+
+      expect(document.body.style.userSelect).toBe("")
+      // Proves dragState was never created, not just that userSelect happens
+      // to be unset: a real drag would set an inline width here, clobbering
+      // the .expanded rule's own width.
+      firePointerEvent(handle(), "pointermove", { pointerId: 1, clientX: 250 })
+      expect(panel().style.width).toBe("")
+    })
+
     it("boundary: applies the mobile CSS at exactly the breakpoint width, not just below it", () => {
       // isMobileViewport() uses <=, matching the CSS media query's own
       // max-width: 480px (also <= in CSS terms) -- off by one here would

--- a/frontend/src/components/widget/widget-bootstrap.test.ts
+++ b/frontend/src/components/widget/widget-bootstrap.test.ts
@@ -455,6 +455,44 @@ describe("widget bootstrap", () => {
       expect(panel().style.width).toBe("")
     })
 
+    it("cancels an already-active drag when expand arrives mid-drag", () => {
+      // isMobileViewport()/isExpanded in the pointerdown guard only block a
+      // *new* drag from starting once expanded -- they don't touch a drag
+      // already under way. That's reachable in practice: this drag's
+      // pointerId is independent of whatever pointer taps "Expand window"
+      // inside the iframe (e.g. a second finger, on a touch-capable
+      // desktop-width device, while the first still holds the handle down).
+      // Without expandPanel() cancelling it, this pointerId's next
+      // pointermove would go on setting an inline width, desyncing the
+      // panel's rendered width from the .expanded class it now also carries.
+      runWidget({ "data-widget-key": "widget-secret" })
+      openPanel()
+
+      firePointerEvent(handle(), "pointerdown", { pointerId: 30, clientX: 300 })
+      firePointerEvent(handle(), "pointermove", { pointerId: 30, clientX: 200 })
+      expect(panel().style.width).toBe("480px")
+      expect(document.body.style.userSelect).toBe("none")
+
+      window.dispatchEvent(new MessageEvent("message", {
+        data: { xagent: true, v: 1, type: "widget_expand" },
+        origin: "https://chat.example",
+        source: widgetIframe().contentWindow as Window,
+      }))
+
+      expect(panel()).toHaveClass("expanded")
+      expect(panel().style.width).toBe("")
+      expect(document.body.style.userSelect).toBe("")
+      // The abandoned in-progress width (480) must not have been committed
+      // as the user's stored preference -- cancelDrag(), not endDrag().
+      expect(localStorage.getItem("xagent_widget_width")).toBeNull()
+
+      // The drag is over: this pointerId's continuation is a no-op, not a
+      // desync between an inline width and the .expanded class.
+      firePointerEvent(handle(), "pointermove", { pointerId: 30, clientX: 50 })
+      expect(panel().style.width).toBe("")
+      expect(panel()).toHaveClass("expanded")
+    })
+
     it("boundary: applies the mobile CSS at exactly the breakpoint width, not just below it", () => {
       // isMobileViewport() uses <=, matching the CSS media query's own
       // max-width: 480px (also <= in CSS terms) -- off by one here would

--- a/frontend/src/components/widget/widget-chrome-controls.test.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.test.tsx
@@ -216,6 +216,26 @@ describe("WidgetChromeControls", () => {
     expect(screen.getByRole("menuitem", { name: "widgetChat.collapseWindow" })).toBeInTheDocument()
   })
 
+  it("ignores a same-window rejection message on a direct (non-embedded) visit", () => {
+    // window.parent === window here, so event.source === window also equals
+    // window.parent -- the "not sourced from window.parent" check above
+    // alone would NOT catch this; only an explicit window.parent === window
+    // check does, mirroring postToParentWidget's own direct-visit guard.
+    vi.stubGlobal("parent", window)
+    render(<WidgetChromeControls />)
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.expandWindow" }))
+
+    fireEvent(window, new MessageEvent("message", {
+      data: { xagent: true, v: 1, type: "widget_expand_rejected" },
+      source: window as unknown as MessageEventSource,
+    }))
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    expect(screen.getByRole("menuitem", { name: "widgetChat.collapseWindow" })).toBeInTheDocument()
+  })
+
   it("keeps the new-conversation item and the expand toggle as two independent menu items", () => {
     render(<WidgetChromeControls newConversation={{ label: "Start over", onClick: onNewConversation }} />)
 

--- a/frontend/src/components/widget/widget-chrome-controls.test.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.test.tsx
@@ -131,6 +131,9 @@ describe("WidgetChromeControls", () => {
     render(<WidgetChromeControls />)
 
     fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    expect(
+      screen.getByRole("menuitem", { name: "widgetChat.expandWindow" }).querySelector("svg[data-icon='expand']"),
+    ).not.toBeNull()
     fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.expandWindow" }))
 
     expect(postMessageSpy).toHaveBeenCalledWith(
@@ -141,7 +144,9 @@ describe("WidgetChromeControls", () => {
     expect(screen.queryByRole("menu")).toBeNull()
 
     fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
-    expect(screen.getByRole("menuitem", { name: "widgetChat.collapseWindow" })).toBeInTheDocument()
+    expect(
+      screen.getByRole("menuitem", { name: "widgetChat.collapseWindow" }).querySelector("svg[data-icon='collapse']"),
+    ).not.toBeNull()
 
     fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.collapseWindow" }))
 

--- a/frontend/src/components/widget/widget-chrome-controls.test.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.test.tsx
@@ -120,11 +120,36 @@ describe("WidgetChromeControls", () => {
       />,
     )
 
-    expect(trigger).toBeDisabled()
     expect(screen.queryByRole("menu")).toBeNull()
-    // Not just "disabled" -- the whole point of this prop is a visible
-    // in-progress indicator on the trigger once the menu itself has closed.
+    // The spinner is status feedback, not a lockout -- sizing has no
+    // dependency on the conversation reset, so the trigger itself must stay
+    // reachable (the reset item's own `disabled` is what actually blocks
+    // re-triggering it while pending).
+    expect(trigger).not.toBeDisabled()
     expect(trigger.querySelector("svg.animate-spin")).not.toBeNull()
+  })
+
+  it("keeps expand/collapse reachable while a conversation reset is pending", () => {
+    render(
+      <WidgetChromeControls
+        newConversation={{
+          label: "Resetting...",
+          onClick: onNewConversation,
+          disabled: true,
+          pending: true,
+        }}
+      />,
+    )
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    expect(screen.getByRole("menuitem", { name: "Resetting..." })).toBeDisabled()
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.expandWindow" }))
+
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { xagent: true, v: 1, type: "widget_expand" },
+      "*",
+    )
   })
 
   it("toggles expand/collapse: posts the right message each way and flips the item's icon and label", () => {
@@ -154,6 +179,41 @@ describe("WidgetChromeControls", () => {
       { xagent: true, v: 1, type: "widget_collapse" },
       "*",
     )
+  })
+
+  it("corrects the optimistic expand guess when the host rejects it (its own mobile guard)", () => {
+    // widget.js's expandPanel() no-ops under the mobile breakpoint and
+    // replies with widget_expand_rejected instead -- without listening for
+    // that, this component's own optimistic setIsExpanded(true) is never
+    // corrected, and the menu keeps reading "Collapse window" with nothing
+    // actually expanded.
+    render(<WidgetChromeControls />)
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.expandWindow" }))
+
+    fireEvent(window, new MessageEvent("message", {
+      data: { xagent: true, v: 1, type: "widget_expand_rejected" },
+      source: window.parent as unknown as MessageEventSource,
+    }))
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    expect(screen.getByRole("menuitem", { name: "widgetChat.expandWindow" })).toBeInTheDocument()
+  })
+
+  it("ignores a rejection message not sourced from window.parent", () => {
+    render(<WidgetChromeControls />)
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.expandWindow" }))
+
+    fireEvent(window, new MessageEvent("message", {
+      data: { xagent: true, v: 1, type: "widget_expand_rejected" },
+      source: window as unknown as MessageEventSource,
+    }))
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    expect(screen.getByRole("menuitem", { name: "widgetChat.collapseWindow" })).toBeInTheDocument()
   })
 
   it("keeps the new-conversation item and the expand toggle as two independent menu items", () => {

--- a/frontend/src/components/widget/widget-chrome-controls.test.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.test.tsx
@@ -22,19 +22,25 @@ describe("WidgetChromeControls", () => {
     vi.unstubAllGlobals()
   })
 
-  it("renders only the close button when there is no new-conversation action", () => {
+  it("renders the close button and a collapsed menu trigger even with no new-conversation action", () => {
+    // Expand/collapse is always offered regardless of newConversation, so
+    // the "..." trigger has something to open onto even without it.
     render(<WidgetChromeControls />)
 
     expect(screen.getByRole("button", { name: "widgetChat.close" })).toBeInTheDocument()
-    expect(screen.queryByRole("button", { name: "widgetChat.moreOptions" })).toBeNull()
-  })
-
-  it("renders a collapsed menu trigger when a new-conversation action is given", () => {
-    render(<WidgetChromeControls newConversation={{ label: "Start over", onClick: onNewConversation }} />)
-
     const menuTrigger = screen.getByRole("button", { name: "widgetChat.moreOptions" })
     expect(menuTrigger).toHaveAttribute("aria-expanded", "false")
     expect(screen.queryByRole("menu")).toBeNull()
+  })
+
+  it("omits the new-conversation menu item when no action is given, but still offers expand", () => {
+    render(<WidgetChromeControls />)
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    const items = screen.getAllByRole("menuitem")
+
+    expect(items).toHaveLength(1)
+    expect(items[0]).toHaveTextContent("widgetChat.expandWindow")
   })
 
   it("posts widget_close to the parent window when the close button is clicked", () => {
@@ -119,6 +125,46 @@ describe("WidgetChromeControls", () => {
     // Not just "disabled" -- the whole point of this prop is a visible
     // in-progress indicator on the trigger once the menu itself has closed.
     expect(trigger.querySelector("svg.animate-spin")).not.toBeNull()
+  })
+
+  it("toggles expand/collapse: posts the right message each way and flips the item's icon and label", () => {
+    render(<WidgetChromeControls />)
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.expandWindow" }))
+
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { xagent: true, v: 1, type: "widget_expand" },
+      "*",
+    )
+    // The menu closes on click, same as every other menu item.
+    expect(screen.queryByRole("menu")).toBeNull()
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    expect(screen.getByRole("menuitem", { name: "widgetChat.collapseWindow" })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.collapseWindow" }))
+
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { xagent: true, v: 1, type: "widget_collapse" },
+      "*",
+    )
+  })
+
+  it("keeps the new-conversation item and the expand toggle as two independent menu items", () => {
+    render(<WidgetChromeControls newConversation={{ label: "Start over", onClick: onNewConversation }} />)
+
+    fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
+    const items = screen.getAllByRole("menuitem")
+
+    expect(items).toHaveLength(2)
+    fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.expandWindow" }))
+
+    expect(onNewConversation).not.toHaveBeenCalled()
+    expect(postMessageSpy).toHaveBeenCalledWith(
+      { xagent: true, v: 1, type: "widget_expand" },
+      "*",
+    )
   })
 
   it("closes the menu on Escape", () => {

--- a/frontend/src/components/widget/widget-chrome-controls.test.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.test.tsx
@@ -156,9 +156,15 @@ describe("WidgetChromeControls", () => {
     render(<WidgetChromeControls />)
 
     fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
-    expect(
-      screen.getByRole("menuitem", { name: "widgetChat.expandWindow" }).querySelector("svg[data-icon='expand']"),
-    ).not.toBeNull()
+    const expandIcon = screen.getByRole("menuitem", { name: "widgetChat.expandWindow" })
+      .querySelector("svg[data-icon='expand']")
+    expect(expandIcon).not.toBeNull()
+    // data-icon is authored by this component's own branch, so it survives a
+    // source edit that swaps which Lucide icon actually renders there. The
+    // polyline's `points` geometry comes from lucide-react's own icon
+    // definition and differs per icon, so it can't drift out of sync the
+    // same way -- a real assertion of icon identity, not just the label.
+    expect(expandIcon?.querySelector("polyline[points='15 3 21 3 21 9']")).not.toBeNull()
     fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.expandWindow" }))
 
     expect(postMessageSpy).toHaveBeenCalledWith(
@@ -169,9 +175,10 @@ describe("WidgetChromeControls", () => {
     expect(screen.queryByRole("menu")).toBeNull()
 
     fireEvent.click(screen.getByRole("button", { name: "widgetChat.moreOptions" }))
-    expect(
-      screen.getByRole("menuitem", { name: "widgetChat.collapseWindow" }).querySelector("svg[data-icon='collapse']"),
-    ).not.toBeNull()
+    const collapseIcon = screen.getByRole("menuitem", { name: "widgetChat.collapseWindow" })
+      .querySelector("svg[data-icon='collapse']")
+    expect(collapseIcon).not.toBeNull()
+    expect(collapseIcon?.querySelector("polyline[points='4 14 10 14 10 20']")).not.toBeNull()
 
     fireEvent.click(screen.getByRole("menuitem", { name: "widgetChat.collapseWindow" }))
 

--- a/frontend/src/components/widget/widget-chrome-controls.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.tsx
@@ -85,12 +85,12 @@ export function WidgetChromeControls({ newConversation }: WidgetChromeControlsPr
     // Optimistic: widget.js owns the actual panel size and can't confirm
     // back, but this is the same origin/deployment on both sides of the
     // postMessage, not an untrusted round-trip -- nothing else can disagree
-    // with this state.
-    setIsExpanded((expanded) => {
-      const next = !expanded
-      postToParentWidget(next ? "widget_expand" : "widget_collapse")
-      return next
-    })
+    // with this state. The postMessage call is a side effect, so it belongs
+    // here in the click handler, not inside setIsExpanded's updater (React
+    // may invoke that updater more than once, e.g. under StrictMode).
+    const next = !isExpanded
+    setIsExpanded(next)
+    postToParentWidget(next ? "widget_expand" : "widget_collapse")
   }
 
   const handleClose = () => {
@@ -141,9 +141,9 @@ export function WidgetChromeControls({ newConversation }: WidgetChromeControlsPr
               className="flex w-full items-center gap-2 whitespace-nowrap px-3 py-2 text-left text-sm hover:bg-muted/50 transition-colors focus-visible:bg-muted/50 focus-visible:outline-none"
             >
               {isExpanded ? (
-                <Minimize2 className="w-4 h-4 shrink-0" />
+                <Minimize2 className="w-4 h-4 shrink-0" data-icon="collapse" />
               ) : (
-                <Maximize2 className="w-4 h-4 shrink-0" />
+                <Maximize2 className="w-4 h-4 shrink-0" data-icon="expand" />
               )}
               {isExpanded ? t("widgetChat.collapseWindow") : t("widgetChat.expandWindow")}
             </button>

--- a/frontend/src/components/widget/widget-chrome-controls.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import React, { useEffect, useRef, useState } from "react"
-import { Loader2, MessageSquarePlus, MoreHorizontal, X } from "lucide-react"
+import { Loader2, Maximize2, MessageSquarePlus, Minimize2, MoreHorizontal, X } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context"
 import { postToParentWidget } from "@/lib/widget-parent-message"
 
@@ -13,10 +13,11 @@ export const iconButtonClassName =
   + "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
 
 interface WidgetChromeControlsProps {
-  // Undefined hides the "..." menu entirely -- it would otherwise open onto
-  // nothing. Each host page supplies its own already-resolved label/handler
-  // since "new conversation" means something different (and is disabled/
-  // pending differently) in guest vs. Session mode.
+  // Undefined omits the new-conversation menu item -- expand/collapse is
+  // always offered regardless, so the "..." trigger itself always renders.
+  // Each host page supplies its own already-resolved label/handler since
+  // "new conversation" means something different (and is disabled/pending
+  // differently) in guest vs. Session mode.
   newConversation?: {
     label: string
     onClick: () => void
@@ -33,6 +34,7 @@ interface WidgetChromeControlsProps {
 export function WidgetChromeControls({ newConversation }: WidgetChromeControlsProps) {
   const { t } = useI18n()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const [isExpanded, setIsExpanded] = useState(false)
   const menuRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -78,6 +80,19 @@ export function WidgetChromeControls({ newConversation }: WidgetChromeControlsPr
     newConversation?.onClick()
   }
 
+  const handleToggleExpand = () => {
+    setIsMenuOpen(false)
+    // Optimistic: widget.js owns the actual panel size and can't confirm
+    // back, but this is the same origin/deployment on both sides of the
+    // postMessage, not an untrusted round-trip -- nothing else can disagree
+    // with this state.
+    setIsExpanded((expanded) => {
+      const next = !expanded
+      postToParentWidget(next ? "widget_expand" : "widget_collapse")
+      return next
+    })
+  }
+
   const handleClose = () => {
     setIsMenuOpen(false)
     postToParentWidget("widget_close")
@@ -85,29 +100,29 @@ export function WidgetChromeControls({ newConversation }: WidgetChromeControlsPr
 
   return (
     <div className="ml-auto flex items-center gap-1">
-      {newConversation ? (
-        <div ref={menuRef} className="relative">
-          <button
-            type="button"
-            onClick={() => setIsMenuOpen((open) => !open)}
-            disabled={newConversation.pending}
-            title={t("widgetChat.moreOptions")}
-            aria-label={t("widgetChat.moreOptions")}
-            aria-haspopup="menu"
-            aria-expanded={isMenuOpen}
-            className={iconButtonClassName}
+      <div ref={menuRef} className="relative">
+        <button
+          type="button"
+          onClick={() => setIsMenuOpen((open) => !open)}
+          disabled={newConversation?.pending}
+          title={t("widgetChat.moreOptions")}
+          aria-label={t("widgetChat.moreOptions")}
+          aria-haspopup="menu"
+          aria-expanded={isMenuOpen}
+          className={iconButtonClassName}
+        >
+          {newConversation?.pending ? (
+            <Loader2 className="w-4 h-4 animate-spin" />
+          ) : (
+            <MoreHorizontal className="w-4 h-4" />
+          )}
+        </button>
+        {isMenuOpen ? (
+          <div
+            role="menu"
+            className="absolute right-0 top-full z-20 mt-1 w-max max-w-xs rounded-md border bg-popover py-1 text-popover-foreground shadow-md"
           >
-            {newConversation.pending ? (
-              <Loader2 className="w-4 h-4 animate-spin" />
-            ) : (
-              <MoreHorizontal className="w-4 h-4" />
-            )}
-          </button>
-          {isMenuOpen ? (
-            <div
-              role="menu"
-              className="absolute right-0 top-full z-20 mt-1 w-max max-w-xs rounded-md border bg-popover py-1 text-popover-foreground shadow-md"
-            >
+            {newConversation ? (
               <button
                 type="button"
                 role="menuitem"
@@ -118,10 +133,23 @@ export function WidgetChromeControls({ newConversation }: WidgetChromeControlsPr
                 <MessageSquarePlus className="w-4 h-4 shrink-0" />
                 {newConversation.label}
               </button>
-            </div>
-          ) : null}
-        </div>
-      ) : null}
+            ) : null}
+            <button
+              type="button"
+              role="menuitem"
+              onClick={handleToggleExpand}
+              className="flex w-full items-center gap-2 whitespace-nowrap px-3 py-2 text-left text-sm hover:bg-muted/50 transition-colors focus-visible:bg-muted/50 focus-visible:outline-none"
+            >
+              {isExpanded ? (
+                <Minimize2 className="w-4 h-4 shrink-0" />
+              ) : (
+                <Maximize2 className="w-4 h-4 shrink-0" />
+              )}
+              {isExpanded ? t("widgetChat.collapseWindow") : t("widgetChat.expandWindow")}
+            </button>
+          </div>
+        ) : null}
+      </div>
       <button
         type="button"
         onClick={handleClose}

--- a/frontend/src/components/widget/widget-chrome-controls.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useRef, useState } from "react"
 import { Loader2, Maximize2, MessageSquarePlus, Minimize2, MoreHorizontal, X } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context"
-import { postToParentWidget } from "@/lib/widget-parent-message"
+import { listenForWidgetHostMessage, postToParentWidget } from "@/lib/widget-parent-message"
 
 // Exported so the standalone share-mode reset button (public-agent-chat-page.tsx)
 // can match this styling instead of drifting with its own duplicate string.
@@ -75,6 +75,15 @@ export function WidgetChromeControls({ newConversation }: WidgetChromeControlsPr
     }
   }, [isMenuOpen])
 
+  useEffect(() => (
+    // Correct the optimistic setIsExpanded(true) below when widget.js's own
+    // mobile guard rejects the widget_expand that caused it -- otherwise the
+    // menu keeps reading "Collapse window" with nothing actually expanded,
+    // and the next click (a no-op collapse from here) needs a second click
+    // after an eventual desktop-width resize to actually expand.
+    listenForWidgetHostMessage("widget_expand_rejected", () => setIsExpanded(false))
+  ), [])
+
   const handleNewConversation = () => {
     setIsMenuOpen(false)
     newConversation?.onClick()
@@ -104,7 +113,11 @@ export function WidgetChromeControls({ newConversation }: WidgetChromeControlsPr
         <button
           type="button"
           onClick={() => setIsMenuOpen((open) => !open)}
-          disabled={newConversation?.pending}
+          // Sizing (expand/collapse) has no dependency on the conversation
+          // reset, so a pending reset must not block reaching it -- the
+          // reset item already carries its own `disabled` for that action
+          // specifically. The spinner below still surfaces reset-in-flight
+          // status on the trigger itself.
           title={t("widgetChat.moreOptions")}
           aria-label={t("widgetChat.moreOptions")}
           aria-haspopup="menu"

--- a/frontend/src/components/widget/widget-chrome-controls.tsx
+++ b/frontend/src/components/widget/widget-chrome-controls.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import React, { useEffect, useRef, useState } from "react"
+import React, { useCallback, useEffect, useRef, useState } from "react"
 import { Loader2, Maximize2, MessageSquarePlus, Minimize2, MoreHorizontal, X } from "lucide-react"
 import { useI18n } from "@/contexts/i18n-context"
 import { listenForWidgetHostMessage, postToParentWidget } from "@/lib/widget-parent-message"
@@ -29,12 +29,33 @@ interface WidgetChromeControlsProps {
     // visible with the menu closed.
     pending?: boolean
   }
+  // Expand/collapse state is owned here (uncontrolled) by default, which is
+  // fine as long as this component's own mount lifetime matches the panel's.
+  // Session mode's header can remount independently of the panel (its
+  // conversation content swaps to an error subtree on reconnect), which would
+  // silently reset this back to false under the panel's back; passing both
+  // props lets that caller lift the state to somewhere that doesn't unmount.
+  expanded?: boolean
+  onExpandedChange?: (expanded: boolean) => void
 }
 
-export function WidgetChromeControls({ newConversation }: WidgetChromeControlsProps) {
+export function WidgetChromeControls({
+  newConversation,
+  expanded: controlledExpanded,
+  onExpandedChange,
+}: WidgetChromeControlsProps) {
   const { t } = useI18n()
   const [isMenuOpen, setIsMenuOpen] = useState(false)
-  const [isExpanded, setIsExpanded] = useState(false)
+  const [internalExpanded, setInternalExpanded] = useState(false)
+  const isControlled = controlledExpanded !== undefined
+  const isExpanded = isControlled ? controlledExpanded : internalExpanded
+  const setIsExpanded = useCallback((next: boolean) => {
+    if (isControlled) {
+      onExpandedChange?.(next)
+    } else {
+      setInternalExpanded(next)
+    }
+  }, [isControlled, onExpandedChange])
   const menuRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -82,7 +103,7 @@ export function WidgetChromeControls({ newConversation }: WidgetChromeControlsPr
     // and the next click (a no-op collapse from here) needs a second click
     // after an eventual desktop-width resize to actually expand.
     listenForWidgetHostMessage("widget_expand_rejected", () => setIsExpanded(false))
-  ), [])
+  ), [setIsExpanded])
 
   const handleNewConversation = () => {
     setIsMenuOpen(false)

--- a/frontend/src/components/widget/widget-chrome.test.ts
+++ b/frontend/src/components/widget/widget-chrome.test.ts
@@ -256,12 +256,22 @@ describe("widget chrome", () => {
     // for the mobile block. Without this, a future edit that moves .expanded
     // into the mobile block, or duplicates it there, would pass every other
     // test here while silently breaking "can't expand on mobile."
-    runWidget({ "data-widget-key": "widget-secret" })
+    //
+    // A non-default data-button-size is used deliberately: both the base
+    // max-height and the expanded height are button-size-derived, and the
+    // default 60px happens to make the old hardcoded "100px" offset produce
+    // the same result (60px + 40px = 100px) -- so only a distinguishing size
+    // can catch a regression back to that hardcode.
+    runWidget({ "data-widget-key": "widget-secret", "data-button-size": "100px" })
 
     const block = expandedBlock()
     expect(block).toMatch(/\.xagent-widget-panel\.expanded\s*\{[^}]*width:\s*min\(720px, 100vw - 40px\);/)
+    expect(block).toMatch(
+      /\.xagent-widget-panel\.expanded\s*\{[^}]*height:\s*calc\(100vh - 100px - 40px\);/,
+    )
     expect(block).toMatch(/\.xagent-widget-panel\.expanded\s+\.xagent-widget-resize-handle\s*\{[^}]*display:\s*none;/)
     expect(mobileBlock()).not.toMatch(/\.xagent-widget-panel\.expanded/)
+    expect(styleText()).toMatch(/max-height:\s*calc\(100vh - 100px - 40px\);/)
   })
 
   it("collapses the panel, restoring its normal width, when the iframe posts widget_collapse", () => {

--- a/frontend/src/components/widget/widget-chrome.test.ts
+++ b/frontend/src/components/widget/widget-chrome.test.ts
@@ -79,14 +79,17 @@ describe("widget close chrome", () => {
     vi.restoreAllMocks()
   })
 
-  it("keeps the widget_close message type literal in sync with the host script", () => {
+  it("keeps every WidgetParentMessageType literal in sync with the host script", () => {
     // widget.js is a hand-authored static asset with no build-time import
     // from TS source, so nothing else ties these two literals together --
-    // a rename on one side without the other would silently break the close
-    // button (a same-origin, same-source, correctly-enveloped message the
-    // host would now just ignore) with no compiler error to catch it.
-    const messageType: WidgetParentMessageType = "widget_close"
-    expect(widgetScript).toContain(`data.type === '${messageType}'`)
+    // a rename on one side without the other would silently break the
+    // corresponding control (a same-origin, same-source, correctly-enveloped
+    // message the host would now just ignore) with no compiler error to
+    // catch it.
+    const messageTypes: WidgetParentMessageType[] = ["widget_close", "widget_expand", "widget_collapse"]
+    for (const messageType of messageTypes) {
+      expect(widgetScript).toContain(`data.type === '${messageType}'`)
+    }
   })
 
   it("starts closed for a first-time visitor", () => {
@@ -179,6 +182,64 @@ describe("widget close chrome", () => {
     fromIframe("widget_minimize")
 
     expect(panelEl()).toHaveClass("open")
+  })
+
+  it("expands the panel when the iframe posts widget_expand", () => {
+    runWidget()
+    fabEl()?.click()
+
+    fromIframe("widget_expand")
+
+    expect(panelEl()).toHaveClass("expanded")
+  })
+
+  it("collapses the panel, restoring its normal width, when the iframe posts widget_collapse", () => {
+    localStorage.setItem("xagent_widget_width", "500")
+    runWidget()
+    fabEl()?.click()
+    fromIframe("widget_expand")
+    // The .expanded rule's own width would otherwise lose to a lingering
+    // inline one -- expanding must clear whatever the resize handle left.
+    // toHaveStyle checks computed style, which jsdom never resolves for
+    // anything behind a media query (confirmed empirically), so this reads
+    // the raw inline style directly like the resize-handle tests already do.
+    expect((panelEl() as HTMLElement).style.width).toBe("")
+
+    fromIframe("widget_collapse")
+
+    expect(panelEl()).not.toHaveClass("expanded")
+    expect((panelEl() as HTMLElement).style.width).toBe("500px")
+  })
+
+  it("does not let a same-side window resize clobber the expanded width", () => {
+    // applyPanelWidth() (called from onWindowResize on every horizontal
+    // resize) used to unconditionally set an inline width, which outranks
+    // the .expanded CSS rule's own width by specificity regardless of
+    // viewport -- desyncing the panel's width from its still-expanded
+    // height on any resize that stays well above the mobile breakpoint.
+    runWidget()
+    fabEl()?.click()
+    fromIframe("widget_expand")
+    expect((panelEl() as HTMLElement).style.width).toBe("")
+
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: window.innerWidth - 50 })
+    window.dispatchEvent(new Event("resize"))
+
+    expect(panelEl()).toHaveClass("expanded")
+    expect((panelEl() as HTMLElement).style.width).toBe("")
+  })
+
+  it("stays expanded across a close/reopen within the same page view", () => {
+    // No persistence for this (unlike width): a JS variable that's simply
+    // never reset by closePanel(), so it only resets on an actual reload.
+    runWidget()
+    fabEl()?.click()
+    fromIframe("widget_expand")
+
+    fabEl()?.click()
+    fabEl()?.click()
+
+    expect(panelEl()).toHaveClass("expanded")
   })
 
   it("ignores a chrome message from a different origin", () => {

--- a/frontend/src/components/widget/widget-chrome.test.ts
+++ b/frontend/src/components/widget/widget-chrome.test.ts
@@ -292,12 +292,45 @@ describe("widget chrome", () => {
     fabEl()?.click()
     fromIframe("widget_expand")
     expect((panelEl() as HTMLElement).style.width).toBe("")
+    const postToIframe = vi.spyOn(iframeEl()!.contentWindow!, "postMessage")
 
     Object.defineProperty(window, "innerWidth", { configurable: true, value: window.innerWidth - 50 })
     window.dispatchEvent(new Event("resize"))
 
     expect(panelEl()).toHaveClass("expanded")
     expect((panelEl() as HTMLElement).style.width).toBe("")
+    // Still on the desktop side of the breakpoint -- nothing to correct.
+    expect(postToIframe).not.toHaveBeenCalled()
+  })
+
+  it("force-collapses an already-expanded panel when a resize carries it across the mobile breakpoint", () => {
+    // The .expanded CSS rule is scoped above the mobile breakpoint, so
+    // nothing previously re-validated isExpanded against a resize the way
+    // expandPanel() already does for a fresh click -- the panel would
+    // render mobile-sized while isExpanded stayed true on both sides, then
+    // silently snap back to full size if the window later widened past the
+    // breakpoint again with no further click from the visitor.
+    runWidget()
+    fabEl()?.click()
+    fromIframe("widget_expand")
+    expect(panelEl()).toHaveClass("expanded")
+    const postToIframe = vi.spyOn(iframeEl()!.contentWindow!, "postMessage")
+
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 400 })
+    window.dispatchEvent(new Event("resize"))
+
+    expect(panelEl()).not.toHaveClass("expanded")
+    expect(postToIframe).toHaveBeenCalledWith(
+      { xagent: true, v: 1, type: "widget_expand_rejected" },
+      HOST,
+    )
+
+    // Widening back past the breakpoint afterward must not silently
+    // re-expand the panel with no further click.
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 1024 })
+    window.dispatchEvent(new Event("resize"))
+
+    expect(panelEl()).not.toHaveClass("expanded")
   })
 
   it("stays expanded across a close/reopen within the same page view", () => {

--- a/frontend/src/components/widget/widget-chrome.test.ts
+++ b/frontend/src/components/widget/widget-chrome.test.ts
@@ -218,6 +218,37 @@ describe("widget chrome", () => {
     expect(panelEl()).toHaveClass("expanded")
   })
 
+  it("tells the iframe to correct itself when the mobile guard rejects widget_expand", () => {
+    // Without this, the iframe's own optimistic setIsExpanded(true) is never
+    // corrected: the menu keeps reading "Collapse window" with nothing
+    // actually expanded, and the visitor's next click (a no-op collapse from
+    // the iframe's perspective) needs a second click after an eventual
+    // desktop-width resize to actually expand.
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: 400 })
+    runWidget()
+    fabEl()?.click()
+    const postToIframe = vi.spyOn(iframeEl()!.contentWindow!, "postMessage")
+
+    fromIframe("widget_expand")
+
+    expect(panelEl()).not.toHaveClass("expanded")
+    expect(postToIframe).toHaveBeenCalledWith(
+      { xagent: true, v: 1, type: "widget_expand_rejected" },
+      HOST,
+    )
+  })
+
+  it("does not tell the iframe to correct itself when widget_expand actually succeeds", () => {
+    runWidget()
+    fabEl()?.click()
+    const postToIframe = vi.spyOn(iframeEl()!.contentWindow!, "postMessage")
+
+    fromIframe("widget_expand")
+
+    expect(panelEl()).toHaveClass("expanded")
+    expect(postToIframe).not.toHaveBeenCalled()
+  })
+
   it("keeps the .expanded rule (and its resize-handle override) scoped above the mobile breakpoint", () => {
     // jsdom never evaluates @media against getComputedStyle (confirmed
     // empirically), so this asserts against the generated CSS text instead --
@@ -228,7 +259,7 @@ describe("widget chrome", () => {
     runWidget({ "data-widget-key": "widget-secret" })
 
     const block = expandedBlock()
-    expect(block).toMatch(/\.xagent-widget-panel\.expanded\s*\{[^}]*width:\s*720px;/)
+    expect(block).toMatch(/\.xagent-widget-panel\.expanded\s*\{[^}]*width:\s*min\(720px, 100vw - 40px\);/)
     expect(block).toMatch(/\.xagent-widget-panel\.expanded\s+\.xagent-widget-resize-handle\s*\{[^}]*display:\s*none;/)
     expect(mobileBlock()).not.toMatch(/\.xagent-widget-panel\.expanded/)
   })

--- a/frontend/src/components/widget/widget-chrome.test.ts
+++ b/frontend/src/components/widget/widget-chrome.test.ts
@@ -41,12 +41,36 @@ function fromIframe(type: string) {
   }))
 }
 
-describe("widget close chrome", () => {
+function styleText() {
+  return document.head.querySelector("style")!.innerHTML
+}
+
+// Slices from the desktop-scoped @media marker up to the next @media marker
+// (the mobile block that follows it) -- narrow enough that a rule can't leak
+// in from a later, unrelated block the way slicing to end-of-string would.
+function expandedBlock() {
+  const text = styleText()
+  const start = text.indexOf("@media not all and (max-width: 480px)")
+  if (start === -1) throw new Error("expanded media query block not found in generated <style>")
+  const end = text.indexOf("@media", start + 1)
+  return end === -1 ? text.slice(start) : text.slice(start, end)
+}
+
+function mobileBlock() {
+  const text = styleText()
+  const start = text.indexOf("@media (max-width: 480px)")
+  if (start === -1) throw new Error("mobile media query block not found in generated <style>")
+  return text.slice(start)
+}
+
+describe("widget chrome", () => {
   let currentScriptDescriptor: PropertyDescriptor | undefined
+  let originalInnerWidth: number
   const fetchMock = vi.fn()
 
   beforeEach(() => {
     currentScriptDescriptor = Object.getOwnPropertyDescriptor(document, "currentScript")
+    originalInnerWidth = window.innerWidth
     document.head.innerHTML = ""
     document.body.innerHTML = ""
     localStorage.clear()
@@ -60,6 +84,7 @@ describe("widget close chrome", () => {
   })
 
   afterEach(async () => {
+    Object.defineProperty(window, "innerWidth", { configurable: true, value: originalInnerWidth })
     for (const container of document.querySelectorAll(".xagent-widget-container")) {
       container.remove()
     }
@@ -191,6 +216,21 @@ describe("widget close chrome", () => {
     fromIframe("widget_expand")
 
     expect(panelEl()).toHaveClass("expanded")
+  })
+
+  it("keeps the .expanded rule (and its resize-handle override) scoped above the mobile breakpoint", () => {
+    // jsdom never evaluates @media against getComputedStyle (confirmed
+    // empirically), so this asserts against the generated CSS text instead --
+    // the same pattern the sibling widget-bootstrap.test.ts file already uses
+    // for the mobile block. Without this, a future edit that moves .expanded
+    // into the mobile block, or duplicates it there, would pass every other
+    // test here while silently breaking "can't expand on mobile."
+    runWidget({ "data-widget-key": "widget-secret" })
+
+    const block = expandedBlock()
+    expect(block).toMatch(/\.xagent-widget-panel\.expanded\s*\{[^}]*width:\s*720px;/)
+    expect(block).toMatch(/\.xagent-widget-panel\.expanded\s+\.xagent-widget-resize-handle\s*\{[^}]*display:\s*none;/)
+    expect(mobileBlock()).not.toMatch(/\.xagent-widget-panel\.expanded/)
   })
 
   it("collapses the panel, restoring its normal width, when the iframe posts widget_collapse", () => {

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -542,6 +542,8 @@ Build when you need.`,
     newConversation: "New conversation",
     close: "Close",
     moreOptions: "More options",
+    expandWindow: "Expand window",
+    collapseWindow: "Collapse window",
     status: {
       initializing: "Initializing...",
       connecting: "Connecting...",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -542,6 +542,8 @@ const zh = {
     newConversation: "新建会话",
     close: "关闭",
     moreOptions: "更多选项",
+    expandWindow: "展开窗口",
+    collapseWindow: "收起窗口",
     status: {
       initializing: "正在初始化...",
       connecting: "连接中...",

--- a/frontend/src/lib/widget-parent-message.ts
+++ b/frontend/src/lib/widget-parent-message.ts
@@ -13,3 +13,31 @@ export function postToParentWidget(type: WidgetParentMessageType): void {
     window.parent.postMessage({ xagent: true, v: 1, type }, "*")
   }
 }
+
+// The other direction: widget.js can reject a widget_expand (its own mobile
+// guard rejects it) and needs to correct the iframe's optimistic guess about
+// its own state -- this is the only message the host currently ever
+// initiates on this channel. event.source, not origin, is the check here:
+// the embedding page is an arbitrary third-party origin the iframe can't
+// allowlist in advance (unlike the host, which set iframe.src itself and so
+// already knows this iframe's real origin for its own sends).
+export type WidgetHostMessageType = "widget_expand_rejected"
+
+export function listenForWidgetHostMessage(
+  type: WidgetHostMessageType,
+  onMessage: () => void,
+): () => void {
+  const handleMessage = (event: MessageEvent) => {
+    if (event.source !== window.parent) return
+    const data: unknown = event.data
+    if (
+      !data || typeof data !== "object"
+      || (data as Record<string, unknown>).xagent !== true
+      || (data as Record<string, unknown>).v !== 1
+      || (data as Record<string, unknown>).type !== type
+    ) return
+    onMessage()
+  }
+  window.addEventListener("message", handleMessage)
+  return () => window.removeEventListener("message", handleMessage)
+}

--- a/frontend/src/lib/widget-parent-message.ts
+++ b/frontend/src/lib/widget-parent-message.ts
@@ -28,7 +28,11 @@ export function listenForWidgetHostMessage(
   onMessage: () => void,
 ): () => void {
   const handleMessage = (event: MessageEvent) => {
-    if (event.source !== window.parent) return
+    // On a direct (non-embedded) visit window.parent === window, so without
+    // this a same-document script's own window.postMessage(..., "*") would
+    // satisfy `event.source === window.parent` trivially -- mirrors the
+    // same direct-visit guard postToParentWidget already applies above.
+    if (window.parent === window || event.source !== window.parent) return
     const data: unknown = event.data
     if (
       !data || typeof data !== "object"

--- a/frontend/src/lib/widget-parent-message.ts
+++ b/frontend/src/lib/widget-parent-message.ts
@@ -4,7 +4,7 @@
 // third-party origin from in here, so targetOrigin can't be pinned tighter
 // than "*" -- every message sent this way carries no sensitive payload,
 // unlike the parent -> iframe session protocol.
-export type WidgetParentMessageType = "widget_close"
+export type WidgetParentMessageType = "widget_close" | "widget_expand" | "widget_collapse"
 
 export function postToParentWidget(type: WidgetParentMessageType): void {
   // A direct (non-embedded) visit to this page has window.parent === window;

--- a/frontend/src/lib/widget-parent-message.ts
+++ b/frontend/src/lib/widget-parent-message.ts
@@ -1,6 +1,6 @@
-// The host page's widget.js owns panel visibility and the auto-open decision;
-// it has no direct handle into this iframe's React tree, so intent is
-// signalled back over postMessage instead. The host is an arbitrary
+// The host page's widget.js owns panel visibility, sizing, and the auto-open
+// decision; it has no direct handle into this iframe's React tree, so intent
+// is signalled back over postMessage instead. The host is an arbitrary
 // third-party origin from in here, so targetOrigin can't be pinned tighter
 // than "*" -- every message sent this way carries no sensitive payload,
 // unlike the parent -> iframe session protocol.


### PR DESCRIPTION
## Summary
- Adds "Expand window" / "Collapse window" to the widget header's "..." menu (styled after the same competitor reference used for the earlier close/new-conversation PR — see the attached screenshots there). Always offered, even before a conversation starts, since more room is useful on the start screen too.
- Expanding jumps the panel straight to the same max width the drag-resize handle already clamps to (720px), and grows its height to `calc(100vh - 100px)` — the same margin the panel's height cap already uses elsewhere. Collapsing restores whatever width the visitor had before (their drag-resize preference, or the default).
- Desktop only: the `.expanded` CSS rule lives inside a `min-width` media query that's the exact complement of the existing mobile `max-width` breakpoint, so it's structurally impossible for it to apply under the mobile layout — not just "loses on specificity," genuinely cannot match at the same time.
- Based on current `main` (PR #1789 and #1742 already merged); PR #1849 (mobile full-screen) hasn't merged yet, so this doesn't build on or interact with it.

This is the last item from the original widget layout request. The user's earlier "minimize" ask (freeing up screen space to see content behind the widget, e.g. a calendar view) turned out to already be satisfied by the existing close control, once traced through — closing only hides the panel via CSS, it never destroys the iframe or the conversation, so reopening resumes exactly where the visitor left off.

Caught and fixed in self-review before opening this PR: `applyPanelWidth()` (called on every horizontal window resize, not just ones crossing the mobile breakpoint) used to unconditionally set an inline width, which outranks the `.expanded` rule's own width by specificity regardless of viewport. Reproduced live in a browser: expand the panel, resize the window slightly while staying well above 480px, and the panel's width snapped back to normal while its height stayed expanded — a narrow, oddly tall box, with the menu still claiming "Collapse window." Fixed by guarding `isExpanded` centrally inside `applyPanelWidth()` itself, the same place the mobile-viewport special case already lives.

## Test plan
- [x] `npm run test:widget:coverage` / `npm run lint` / `npm run type-check` / `npm run build` all clean (1025 tests, `widget-chrome-controls.tsx` at 100%).
- [x] `widget-chrome-controls.test.tsx`: the "..." trigger always renders (even with no new-conversation action); toggling Expand/Collapse posts the right message each way and flips the item's icon and label; new-conversation and expand coexist as two independent menu items when both are offered.
- [x] `widget-chrome.test.ts`: `widget_expand`/`widget_collapse` messages toggle the `expanded` class; collapsing restores the pre-expand width (including a persisted drag-resize preference); expand state survives a close/reopen within the same page view (no persistence — it's a plain JS variable, so it does reset on an actual reload); the window-resize regression found in self-review, verified both broken-before and fixed-after.
- [x] `widget-bootstrap.test.ts`: dragging the resize handle is ignored while expanded, proven the same way the existing mobile-viewport drag guard is (no `dragState` side effects at all, not just that the drag "looks" blocked).
- [x] Manually verified end-to-end against a local backend + a real agent: expand grows the panel to 720×(viewport-relative) with the inline width cleared, the menu item flips to "Collapse window" with the inward-arrow icon, and collapsing restores the exact original 380×600 box with its inline width put back.