### PR TITLE
fix(model): recognize provider-level tool_choice rejections and widen the connection-test timeout

### DIFF
--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -222,10 +222,14 @@ def _extract_openrouter_structured_error(
     ``(error_message, provider_name)`` read from its parsed ``.body``
     (OpenRouter nests both under a top-level ``"error"`` key; a provider that
     responds without that wrapper is also accepted by falling back to the
-    body itself). Returns ``(None, None)`` if the chain never reaches a
-    ``BadRequestError``, its body is not a dict, or the payload carries no
-    string ``message`` -- callers treat that as "structured read failed,
-    fall back to matching ``str(exc)`` instead". Never raises.
+    body itself). The returned message is ``None`` whenever the chain never
+    reaches a ``BadRequestError``, that error's body is not a dict, or the
+    payload carries no string ``message``; callers key off that alone and
+    treat it as "structured read failed, fall back to matching ``str(exc)``
+    instead", so a provider name recovered alongside a missing message is
+    never acted on by itself. Only ``openai.BadRequestError`` is read here:
+    every other shape reaching the compat-retry predicates keeps the plain
+    ``str(exc)`` behavior. Never raises.
     """
     current: Optional[BaseException] = exc
     seen: set[int] = set()

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -18,7 +18,7 @@ from .deepseek_tool_protocol import (
     reasoning_field_names,
     restore_deepseek_reasoning_content,
 )
-from .openai import OpenAILLM, field_content
+from .openai import OpenAILLM, _openai_error_body, field_content
 
 logger = logging.getLogger(__name__)
 
@@ -210,6 +210,47 @@ def _should_retry_without_thinking(
     )
 
 
+def _extract_openrouter_structured_error(
+    exc: BaseException,
+) -> tuple[Optional[str], Optional[str]]:
+    """Read OpenRouter's structured 400 body off an exception's cause chain.
+
+    ``OpenAILLM`` always wraps a caught ``openai.BadRequestError`` as
+    ``raise RuntimeError(...) from e``, so the SDK exception is usually one
+    ``__cause__`` hop below what compat-retry predicates see. This walks that
+    chain looking for the first ``openai.BadRequestError`` and returns
+    ``(error_message, provider_name)`` read from its parsed ``.body``
+    (OpenRouter nests both under a top-level ``"error"`` key; a provider that
+    responds without that wrapper is also accepted by falling back to the
+    body itself). Returns ``(None, None)`` if the chain never reaches a
+    ``BadRequestError``, its body is not a dict, or the payload carries no
+    string ``message`` -- callers treat that as "structured read failed,
+    fall back to matching ``str(exc)`` instead". Never raises.
+    """
+    current: Optional[BaseException] = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, openai.BadRequestError):
+            body = _openai_error_body(current)
+            if not isinstance(body, dict):
+                return None, None
+            payload = body.get("error")
+            if not isinstance(payload, dict):
+                payload = body
+            message = payload.get("message")
+            metadata = payload.get("metadata")
+            provider_name = (
+                metadata.get("provider_name") if isinstance(metadata, dict) else None
+            )
+            return (
+                message if isinstance(message, str) else None,
+                provider_name if isinstance(provider_name, str) else None,
+            )
+        current = current.__cause__
+    return None, None
+
+
 def _should_retry_with_relaxed_tool_choice(
     exc: Exception,
     *,
@@ -220,9 +261,24 @@ def _should_retry_with_relaxed_tool_choice(
         return False
 
     # Deliberate OpenRouter compatibility bridge: official provider routing can
-    # reject strict tool_choice values before selecting an endpoint. This
-    # degrades forced tool use to "auto" instead of failing the whole agent run.
-    # Replace string matching with typed provider errors when available.
+    # reject strict tool_choice values before selecting an endpoint, and a
+    # provider endpoint can separately reject a strict tool_choice itself.
+    # This degrades forced tool use to "auto" instead of failing the whole
+    # agent run. The structured path matches on OpenRouter's own
+    # ``error.message`` field alone, which excludes the provider-controlled
+    # ``metadata.raw`` echo that ``_openai_error_details`` folds into
+    # ``str(exc)``; the plain string match below is only reached when the
+    # cause chain does not yield a parseable structured body, and it keeps
+    # today's exact behavior for that case.
+    error_message, provider_name = _extract_openrouter_structured_error(exc)
+    if error_message is not None:
+        normalized = error_message.lower().replace("tool choice", "tool_choice")
+        if "tool_choice" not in normalized:
+            return False
+        if "no endpoints found" in normalized:
+            return True
+        return provider_name is not None and "must be auto" in normalized
+
     exc_msg = str(exc).lower()
     return "no endpoints found" in exc_msg and "tool_choice" in exc_msg
 

--- a/src/xagent/core/model/chat/basic/openrouter.py
+++ b/src/xagent/core/model/chat/basic/openrouter.py
@@ -217,9 +217,22 @@ def _extract_openrouter_structured_error(
 
     ``OpenAILLM`` always wraps a caught ``openai.BadRequestError`` as
     ``raise RuntimeError(...) from e``, so the SDK exception is usually one
-    ``__cause__`` hop below what compat-retry predicates see. This walks that
-    chain looking for the first ``openai.BadRequestError`` and returns
-    ``(error_message, provider_name)`` read from its parsed ``.body``
+    ``__cause__`` hop below what compat-retry predicates see. This walks only
+    ``__cause__``, deliberately: every ``OpenAILLM`` entrypoint raises with
+    explicit ``from e`` chaining, so the current request's
+    ``BadRequestError`` is always reachable that way. ``__context__`` is not
+    walked because the one place a ``BadRequestError`` lands there is the
+    response_format degrade-and-resend in ``openai.py``, where the retried
+    call sits inside the ``except openai.BadRequestError`` block handling the
+    first attempt's rejection; if that retry also fails, Python implicitly
+    sets its ``__context__`` to the superseded first-attempt error rather
+    than anything about the retry itself. Reading ``__context__`` there would
+    attribute the current failure to a different, already-discarded
+    request's rejection reason, which is the opposite of this function's
+    contract of reporting the current failure's own provider message.
+
+    This walks the chain looking for the first ``openai.BadRequestError`` and
+    returns ``(error_message, provider_name)`` read from its parsed ``.body``
     (OpenRouter nests both under a top-level ``"error"`` key; a provider that
     responds without that wrapper is also accepted by falling back to the
     body itself). The returned message is ``None`` whenever the chain never

--- a/src/xagent/web/api/model.py
+++ b/src/xagent/web/api/model.py
@@ -58,6 +58,15 @@ from ..user_isolated_memory import UserContext
 
 logger = logging.getLogger(__name__)
 
+# Single source of truth for the connection-test wait budget: how long this
+# endpoint waits for a provider to answer before giving up, not a statement
+# about the provider's own health. Shared by the per-category probes in
+# ``test_model_connection`` and by ``_validate_provider_model_listing``,
+# which those probes call for the "image"/"speech" categories -- passing it
+# through as a parameter there keeps this the only literal, so the two
+# layers of ``asyncio.wait_for`` around a listing call can never diverge.
+_CONNECTION_TEST_TIMEOUT_SECONDS = 60.0
+
 # ---------------------------------------------------------------------------
 # Hook infrastructure for dynamic model sharing
 # ---------------------------------------------------------------------------
@@ -320,9 +329,20 @@ async def _validate_provider_model_listing(
     model_name: str,
     api_key: Optional[str],
     base_url: Optional[str],
+    timeout_seconds: float,
     requested_abilities: Optional[List[str]] = None,
 ) -> None:
-    """Validate provider connectivity by fetching the provider model list."""
+    """Validate provider connectivity by fetching the provider model list.
+
+    ``timeout_seconds`` is the caller's connection-test budget
+    (``_CONNECTION_TEST_TIMEOUT_SECONDS`` in ``test_model_connection``), not
+    a separate value owned by this function -- it must be threaded through
+    rather than re-hardcoded here, or the outer ``wait_for`` around this call
+    and this one can silently diverge. The aiohttp transport-level ``total``
+    timeout inside ``fetch_models_from_provider`` (30s, in
+    ``model_list_service.py``) is a different, lower-level bound and is
+    unaffected by this parameter.
+    """
 
     import asyncio
 
@@ -339,7 +359,7 @@ async def _validate_provider_model_listing(
 
     models = await asyncio.wait_for(
         fetch_models_from_provider(provider, api_key or "", base_url),
-        timeout=10.0,
+        timeout=timeout_seconds,
     )
     # "auto" is a virtual OpenRouter model routed in-process by xrouter-llm; it is
     # not a real OpenRouter slug, so the fetch above only confirms connectivity —
@@ -678,7 +698,7 @@ async def test_model_connection(
     from xagent.core.model.xinference_base import BaseXinferenceModel
 
     start_time = time.time()
-    timeout_seconds = 10.0
+    timeout_seconds = _CONNECTION_TEST_TIMEOUT_SECONDS
     try:
         provider = canonical_provider_name(request.model_provider)
         base_url = request.base_url or default_base_url_for_provider(provider)
@@ -775,6 +795,7 @@ async def test_model_connection(
                     model_name=request.model_name,
                     api_key=request.api_key,
                     base_url=base_url,
+                    timeout_seconds=timeout_seconds,
                     requested_abilities=request.abilities,
                 ),
                 timeout=timeout_seconds,
@@ -822,6 +843,7 @@ async def test_model_connection(
                     model_name=request.model_name,
                     api_key=request.api_key,
                     base_url=base_url,
+                    timeout_seconds=timeout_seconds,
                     requested_abilities=requested_abilities,
                 ),
                 timeout=timeout_seconds,
@@ -955,7 +977,11 @@ async def test_model_connection(
             status="failed",
             response_time=response_time,
             message="Connection timed out",
-            error=f"Connection timed out after {int(timeout_seconds)} seconds. Please check your network connection and provider status.",
+            error=(
+                f"The model did not respond within {int(timeout_seconds)} seconds "
+                "(this application's waiting limit). Slow or reasoning-heavy "
+                "models may need longer; the provider may still be healthy."
+            ),
         )
     except Exception as e:
         logger.error(f"Model connection test failed: {e}")

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -1471,7 +1471,7 @@ async def test_openrouter_direct_relaxes_tool_choice_on_provider_level_400(
 ):
     """Z.AI's provider-level 400 is recognized through the structured body.
 
-    Regression test for xagent#1960: Z.AI rejects a strict ``tool_choice``
+    Regression test for xorbitsai/xagent#1960: Z.AI rejects a strict ``tool_choice``
     with ``{'error': {'message': 'Tool choice must be auto', 'metadata':
     {'provider_name': 'Z.AI'}}}``. That message spells ``tool choice`` with
     a space (not the ``tool_choice`` token the old flattened-string match
@@ -1510,18 +1510,28 @@ async def test_openrouter_direct_relaxes_tool_choice_on_provider_level_400(
     assert second_call["tool_choice"] == "auto"
 
 
-def test_relaxed_tool_choice_ignores_unrelated_400_with_provider_name():
-    """A provider-level 400 unrelated to tool_choice must not trigger relax.
+@pytest.mark.parametrize(
+    "provider_message",
+    [
+        "This model's maximum context length is 4096 tokens",
+        "The tool choice you made is not available on this plan",
+    ],
+    ids=["unrelated-subject", "names-tool-choice-but-is-not-a-must-be-auto-rejection"],
+)
+def test_relaxed_tool_choice_ignores_unrelated_400_with_provider_name(provider_message):
+    """A provider-level 400 that is not a "must be auto" rejection stays False.
 
-    Same ``provider_name``-bearing shape as the Z.AI regression above, but
-    the message itself is about context length. Guards against a structured
-    implementation that only checks "did some provider respond" instead of
-    "did it reject tool_choice specifically" -- ``metadata.provider_name``
-    alone says the former, not the latter (see design note in
-    ``_should_retry_with_relaxed_tool_choice``).
+    ``metadata.provider_name`` only says that some provider endpoint
+    answered; it never says that endpoint rejected ``tool_choice``. Both
+    halves of that distinction need pinning: the first message is about an
+    entirely different subject, while the second one does name the tool
+    choice and still is not the "must be auto" rejection this relax retry
+    exists to answer. Resending with ``tool_choice="auto"`` in either case
+    would repeat a request the provider gave no reason to expect would fare
+    any better.
     """
     unrelated_error = _bad_request_error_with_metadata(
-        "This model's maximum context length is 4096 tokens",
+        provider_message,
         metadata={"provider_name": "Z.AI"},
     )
 
@@ -1559,21 +1569,48 @@ def test_relaxed_tool_choice_does_not_match_on_provider_raw_echo():
     )
 
 
-def test_relaxed_tool_choice_falls_back_to_string_match_without_structured_body():
-    """A bare exception with no parseable body still relies on string matching.
+def _bad_request_error_with_non_dict_body(message: str) -> openai.BadRequestError:
+    """Build an SDK ``BadRequestError`` whose error body is not a JSON object.
 
-    OpenRouter's own route-level 404 sometimes reaches this predicate as a
-    plain ``RuntimeError`` with no ``openai.BadRequestError`` anywhere in its
-    cause chain (e.g. raised directly by a test double, or by any future
-    non-SDK transport). The structured extractor can only return
-    ``(None, None)`` for that shape, and the predicate must fall back to
-    exactly the old flattened-string check rather than treating "no
-    structured body" as "do not retry".
+    A provider can answer a 400 with a bare JSON array or string instead of
+    the ``{"error": {...}}`` object OpenRouter itself sends. The structured
+    read has to decline such a body instead of indexing into it.
     """
-    bare_error = RuntimeError(_OPENROUTER_TOOL_CHOICE_ERROR)
+    return openai.BadRequestError(
+        f"Error code: 400 - {message}",
+        response=httpx.Response(
+            400,
+            request=httpx.Request(
+                "POST", "https://openrouter.ai/api/v1/chat/completions"
+            ),
+        ),
+        body=[message],
+    )
 
+
+@pytest.mark.parametrize(
+    "build_error",
+    [
+        lambda: RuntimeError(_OPENROUTER_TOOL_CHOICE_ERROR),
+        lambda: _bad_request_error_with_non_dict_body(_OPENROUTER_TOOL_CHOICE_ERROR),
+    ],
+    ids=["no-sdk-error-in-cause-chain", "sdk-error-with-non-dict-body"],
+)
+def test_relaxed_tool_choice_falls_back_to_string_match_without_structured_body(
+    build_error,
+):
+    """An error with no readable structured body still relies on string matching.
+
+    Two shapes reach the predicate without a usable structured body: a plain
+    ``RuntimeError`` with no ``openai.BadRequestError`` anywhere in its cause
+    chain (a test double, or any future non-SDK transport), and a real SDK
+    error whose body is not a JSON object. The structured extractor returns
+    ``(None, None)`` for both without raising, and the predicate must then
+    fall back to exactly the old flattened-string check rather than treating
+    "no structured body" as "do not retry".
+    """
     assert openrouter_module._should_retry_with_relaxed_tool_choice(
-        bare_error, tools=_two_tool_schema(), tool_choice="required"
+        build_error(), tools=_two_tool_schema(), tool_choice="required"
     )
 
 

--- a/tests/core/model/chat/basic/test_openrouter.py
+++ b/tests/core/model/chat/basic/test_openrouter.py
@@ -1353,6 +1353,29 @@ def _bad_request_error(message: str) -> openai.BadRequestError:
     )
 
 
+def _bad_request_error_with_metadata(
+    message: str, metadata: dict
+) -> openai.BadRequestError:
+    """Build a real SDK ``BadRequestError`` carrying an ``error.metadata`` body.
+
+    Used to reproduce OpenRouter's provider-level 400 shape (a
+    ``provider_name`` and sometimes a ``raw`` echo of the provider's own
+    response nested under ``metadata``), which ``_bad_request_error`` above
+    does not model.
+    """
+    payload = {"message": message, "code": 400, "metadata": metadata}
+    return openai.BadRequestError(
+        f"Error code: 400 - {payload!r}",
+        response=httpx.Response(
+            400,
+            request=httpx.Request(
+                "POST", "https://openrouter.ai/api/v1/chat/completions"
+            ),
+        ),
+        body={"error": payload},
+    )
+
+
 @pytest.mark.asyncio
 async def test_openrouter_direct_relaxes_tool_choice_after_wrapped_resend_failure(
     mock_chat_completion, mocker
@@ -1440,6 +1463,118 @@ async def test_openrouter_vision_relaxes_tool_choice_after_wrapped_resend_failur
     assert mock_client.chat.completions.create.await_count == 3
     final_call = mock_client.chat.completions.create.call_args_list[2].kwargs
     assert final_call["tool_choice"] == "auto"
+
+
+@pytest.mark.asyncio
+async def test_openrouter_direct_relaxes_tool_choice_on_provider_level_400(
+    mock_chat_completion, mocker
+):
+    """Z.AI's provider-level 400 is recognized through the structured body.
+
+    Regression test for xagent#1960: Z.AI rejects a strict ``tool_choice``
+    with ``{'error': {'message': 'Tool choice must be auto', 'metadata':
+    {'provider_name': 'Z.AI'}}}``. That message spells ``tool choice`` with
+    a space (not the ``tool_choice`` token the old flattened-string match
+    looked for) and never contains ``no endpoints found``, so the
+    pre-existing string match never fired for this shape -- the whole reason
+    #1960 was filed. The structured path reads ``error.message`` directly and
+    normalizes the spacing, so it must fire here.
+    """
+    zai_error = _bad_request_error_with_metadata(
+        "Tool choice must be auto", metadata={"provider_name": "Z.AI"}
+    )
+    assert openrouter_module._should_retry_with_relaxed_tool_choice(
+        zai_error, tools=_two_tool_schema(), tool_choice="required"
+    )
+
+    mock_client = mocker.AsyncMock()
+    mock_client.chat.completions.create.side_effect = [
+        zai_error,
+        mock_chat_completion,
+    ]
+    mocker.patch(
+        "xagent.core.model.chat.basic.openai.AsyncOpenAI",
+        return_value=mock_client,
+    )
+    llm = OpenRouterLLM(model_name="z-ai/glm-5.2", api_key="test-key")
+
+    result = await llm.chat(
+        [{"role": "user", "content": "score?"}],
+        tools=_two_tool_schema(),
+        tool_choice="required",
+    )
+
+    assert result["content"] == "Hello World"
+    assert mock_client.chat.completions.create.await_count == 2
+    second_call = mock_client.chat.completions.create.call_args_list[1].kwargs
+    assert second_call["tool_choice"] == "auto"
+
+
+def test_relaxed_tool_choice_ignores_unrelated_400_with_provider_name():
+    """A provider-level 400 unrelated to tool_choice must not trigger relax.
+
+    Same ``provider_name``-bearing shape as the Z.AI regression above, but
+    the message itself is about context length. Guards against a structured
+    implementation that only checks "did some provider respond" instead of
+    "did it reject tool_choice specifically" -- ``metadata.provider_name``
+    alone says the former, not the latter (see design note in
+    ``_should_retry_with_relaxed_tool_choice``).
+    """
+    unrelated_error = _bad_request_error_with_metadata(
+        "This model's maximum context length is 4096 tokens",
+        metadata={"provider_name": "Z.AI"},
+    )
+
+    assert not openrouter_module._should_retry_with_relaxed_tool_choice(
+        unrelated_error, tools=_two_tool_schema(), tool_choice="required"
+    )
+
+
+def test_relaxed_tool_choice_does_not_match_on_provider_raw_echo():
+    """A route-level phrase echoed only in ``metadata.raw`` must not trigger relax.
+
+    ``_openai_error_details`` folds ``metadata.raw`` (up to 4000 characters
+    of provider-controlled text) into the flattened ``str(exc)`` used by the
+    string-matching fallback. Here the real ``error.message`` is unrelated
+    ("Upstream provider error"), but a provider echoed a route-level 404's
+    wording inside ``metadata.raw``. The structured path reads only
+    ``error.message`` and must ignore ``raw`` entirely, so this must stay
+    False even though the flattened string contains both trigger tokens.
+    """
+    raw_echo_error = _bad_request_error_with_metadata(
+        "Upstream provider error",
+        metadata={
+            "provider_name": "SomeProvider",
+            "raw": _OPENROUTER_TOOL_CHOICE_ERROR,
+        },
+    )
+
+    # Sanity check on the premise: the flattened string this test guards
+    # against really does contain both tokens the old code searched for.
+    assert "no endpoints found" in str(raw_echo_error).lower()
+    assert "tool_choice" in str(raw_echo_error).lower()
+
+    assert not openrouter_module._should_retry_with_relaxed_tool_choice(
+        raw_echo_error, tools=_two_tool_schema(), tool_choice="required"
+    )
+
+
+def test_relaxed_tool_choice_falls_back_to_string_match_without_structured_body():
+    """A bare exception with no parseable body still relies on string matching.
+
+    OpenRouter's own route-level 404 sometimes reaches this predicate as a
+    plain ``RuntimeError`` with no ``openai.BadRequestError`` anywhere in its
+    cause chain (e.g. raised directly by a test double, or by any future
+    non-SDK transport). The structured extractor can only return
+    ``(None, None)`` for that shape, and the predicate must fall back to
+    exactly the old flattened-string check rather than treating "no
+    structured body" as "do not retry".
+    """
+    bare_error = RuntimeError(_OPENROUTER_TOOL_CHOICE_ERROR)
+
+    assert openrouter_module._should_retry_with_relaxed_tool_choice(
+        bare_error, tools=_two_tool_schema(), tool_choice="required"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_model_api.py
+++ b/tests/web/test_model_api.py
@@ -228,7 +228,7 @@ async def test_validate_provider_model_listing_honors_caller_supplied_timeout():
 
     Guards against reintroducing the second hardcoded timeout this helper
     used to carry independently of ``test_model_connection``'s own budget
-    (xagent#1960): the two ``asyncio.wait_for`` layers wrapping a listing
+    (xorbitsai/xagent#1960): the two ``asyncio.wait_for`` layers wrapping a listing
     call (the endpoint's own, and this helper's inner one around the actual
     provider fetch) must always share the exact same number, sourced from
     the ``timeout_seconds`` parameter -- never a second literal in here.
@@ -547,7 +547,7 @@ class TestModelAPI:
     ):
         """A connection-test timeout must name the app's own wait budget.
 
-        xagent#1960: the old message ("Please check your network connection
+        xorbitsai/xagent#1960: the old message ("Please check your network connection
         and provider status") told the user to go check their network when
         the actual cause was this endpoint's own wait budget (10 seconds at
         the time) expiring before a slow or reasoning-heavy model answered.

--- a/tests/web/test_model_api.py
+++ b/tests/web/test_model_api.py
@@ -578,8 +578,11 @@ class TestModelAPI:
         data = response.json()
         assert data["status"] == "failed"
         assert data["message"] == "Connection timed out"
-        configured_seconds = int(model_module._CONNECTION_TEST_TIMEOUT_SECONDS)
-        assert f"{configured_seconds} seconds" in data["error"]
+        # Pin the contract value independently of the production constant:
+        # deriving the expected copy from _CONNECTION_TEST_TIMEOUT_SECONDS
+        # would keep this test green if the budget silently regressed.
+        assert model_module._CONNECTION_TEST_TIMEOUT_SECONDS == 60.0
+        assert "60 seconds" in data["error"]
         assert "network" not in data["error"].lower()
 
     def test_create_model_as_admin(

--- a/tests/web/test_model_api.py
+++ b/tests/web/test_model_api.py
@@ -1,5 +1,6 @@
 """Test model management API functionality"""
 
+import asyncio
 import os
 import tempfile
 from unittest.mock import AsyncMock, Mock, patch
@@ -9,6 +10,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from xagent.web.api import model as model_module
 from xagent.web.api.auth import auth_router
 from xagent.web.api.model import model_router
 from xagent.web.models.database import Base, get_db, get_engine
@@ -218,6 +220,49 @@ def sample_video_model_data():
         "description": "Test Seedance video model",
         "share_with_users": False,
     }
+
+
+@pytest.mark.asyncio
+async def test_validate_provider_model_listing_honors_caller_supplied_timeout():
+    """The listing helper must use the caller's budget, not a literal of its own.
+
+    Guards against reintroducing the second hardcoded timeout this helper
+    used to carry independently of ``test_model_connection``'s own budget
+    (xagent#1960): the two ``asyncio.wait_for`` layers wrapping a listing
+    call (the endpoint's own, and this helper's inner one around the actual
+    provider fetch) must always share the exact same number, sourced from
+    the ``timeout_seconds`` parameter -- never a second literal in here.
+    """
+
+    async def slow_fetch(*_args, **_kwargs):
+        await asyncio.sleep(0.2)
+        return [{"id": "gpt-4o-mini", "abilities": ["chat"]}]
+
+    with patch(
+        "xagent.web.services.model_list_service.fetch_models_from_provider",
+        side_effect=slow_fetch,
+    ):
+        with pytest.raises(asyncio.TimeoutError):
+            await model_module._validate_provider_model_listing(
+                provider="openai",
+                model_name="gpt-4o-mini",
+                api_key="key",
+                base_url=None,
+                timeout_seconds=0.05,
+            )
+
+        # A budget comfortably larger than the fetch's delay must succeed.
+        # This is what actually pins the parameter as the value in effect:
+        # a mutant that reverts to a hardcoded 10.0 inside the helper would
+        # also pass this half alone, but would fail the 0.05s case above by
+        # never timing out.
+        await model_module._validate_provider_model_listing(
+            provider="openai",
+            model_name="gpt-4o-mini",
+            api_key="key",
+            base_url=None,
+            timeout_seconds=1.0,
+        )
 
 
 class TestModelAPI:
@@ -496,6 +541,46 @@ class TestModelAPI:
         assert create_model.call_args.args[0].model_name == "future-sfx-model"
         sound_effect_model.validate_connection.assert_awaited_once_with()
         sound_effect_model.aclose.assert_awaited_once_with()
+
+    def test_test_connection_llm_timeout_reports_app_budget_not_network(
+        self, test_db, regular_user, regular_headers
+    ):
+        """A connection-test timeout must name the app's own wait budget.
+
+        xagent#1960: the old message ("Please check your network connection
+        and provider status") told the user to go check their network when
+        the actual cause was this endpoint's own wait budget (10 seconds at
+        the time) expiring before a slow or reasoning-heavy model answered.
+        The provider was never shown to be unhealthy.
+        """
+
+        class SlowLLM:
+            async def chat(self, messages, **kwargs):
+                raise asyncio.TimeoutError()
+
+        with patch(
+            "xagent.core.model.chat.basic.adapter.create_base_llm",
+            return_value=SlowLLM(),
+        ):
+            response = client.post(
+                "/api/models/test-connection",
+                json={
+                    "model_provider": "openai",
+                    "model_name": "gpt-4o-mini",
+                    "api_key": "test-api-key",
+                    "base_url": "https://api.openai.com/v1",
+                    "category": "llm",
+                },
+                headers=regular_headers,
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "failed"
+        assert data["message"] == "Connection timed out"
+        configured_seconds = int(model_module._CONNECTION_TEST_TIMEOUT_SECONDS)
+        assert f"{configured_seconds} seconds" in data["error"]
+        assert "network" not in data["error"].lower()
 
     def test_create_model_as_admin(
         self, test_db, admin_user, admin_headers, sample_model_data


### PR DESCRIPTION
Two independent defects share one incident — a strict-and-slow OpenRouter model (observed with `z-ai/glm-5.3` under official-provider pinning) failed both the connection test and the first real turn — but live in different layers and are fixed independently below.

## Defect 1: the tool_choice relax retry never recognized a provider-level rejection

### What

`_should_retry_with_relaxed_tool_choice` in `src/xagent/core/model/chat/basic/openrouter.py` degrades a forced `tool_choice` to `"auto"` and resends when a provider rejects the strict value, so a forced-tool-use agent turn does not fail outright. It only ever matched OpenRouter's own routing-layer phrasing: the flattened `str(exc)` had to contain both `"no endpoints found"` and the underscored token `"tool_choice"`. Z.AI's official endpoint rejects a strict `tool_choice` with `{'error': {'message': 'Tool choice must be auto', 'metadata': {'provider_name': 'Z.AI'}}}` — no `"no endpoints found"`, and the parameter spelled with a space, not an underscore — so the predicate stayed cold, the 400 propagated, and the whole turn failed. Official-provider pinning (`allow_fallbacks: false`) makes this terminal: the request cannot fall over to a third-party endpoint that accepts `required`.

This was the third revision of this string-matched predicate. Rather than adding a fourth phrase to the flattened-string search, this PR adds a helper that reads the error's own structured body and matches on its `error.message` field alone — a field the provider cannot pad with unrelated text, unlike the flattened string the old match searched.

### Why this shape

The existing flattened-string match has a real false-positive: `_openai_error_details` folds a provider's own `metadata.raw` — up to 4000 characters of provider-controlled text — into the same string the predicate searches. A provider that echoes an unrelated request body containing both `"no endpoints found"` and `"tool_choice"` inside that echo makes the old predicate fire on a 400 that has nothing to do with tool choice (`test_relaxed_tool_choice_does_not_match_on_provider_raw_echo` reproduces this). Reading `error.message` off the structured body instead of the flattened string removes that echo from the search entirely. Extending the phrase list would only have made this search string longer and the false-positive surface larger; matching a single already-parsed field does not carry that risk, and the repository has no catalog of real-world provider rejection phrasings that a phrase-list approach could claim to be complete against — the only two phrases in this predicate's history are the ones already here.

### How

`_extract_openrouter_structured_error` walks `exc.__cause__` for the first `openai.BadRequestError`, reusing `openai.py`'s existing `_openai_error_body` rather than re-parsing anything, and reads `.body["error"]["message"]` and `.body["error"]["metadata"]["provider_name"]` (falling back to reading `message`/`metadata` off the body itself when it carries no `"error"` wrapper). It returns `(None, None)` — never raises — when the cause chain never reaches a `BadRequestError`, the body is not a dict, or there is no string `message`, and callers read that as "structured read failed, fall back to the old string match." `OpenAILLM` already wraps every caught SDK error as `raise RuntimeError(...) from e`, so the SDK exception normally sits one `__cause__` hop below what this predicate sees; `retry_on` in `chat/error.py` already walks the same chain, so this is not a new mechanism.

`_should_retry_with_relaxed_tool_choice` normalizes the extracted message (lowercase, `"tool choice"` folded to `"tool_choice"`) and then branches: the routing-level phrasing (`"no endpoints found"`) keeps its exact old meaning, and a provider-level rejection now also matches when a `provider_name` is present and the normalized message contains `"must be auto"`. When the structured read comes back empty, the function falls through to exactly the previous `str(exc)` match — the fallback path is strictly the old behavior, not a new one, so no case that retried before stops retrying.

The stale comment above the function ("Replace string matching with typed provider errors when available") is removed — it describes what the function no longer does.

Not touched: `_should_retry_without_thinking`, `_should_retry_with_thinking`, and `retry_on`'s priority ordering. The issue names `_should_retry_without_thinking` as a neighbor with the same underscore-only weakness, but no failing instance of it exists in this repository or its tests, and Z.AI's rejection here is not a thinking-mode conflict; changing that predicate's matching without an observed failure would be a guess, not a fix.

## Defect 2: the connection test gave every model a hardcoded 10-second budget and blamed the network on timeout

### What

`test_model_connection` (`POST /api/models/test-connection`, `src/xagent/web/api/model.py`) wrapped its provider probe in `asyncio.wait_for(timeout_seconds=10.0)`. A second, independent `10.0` literal lived inside `_validate_provider_model_listing`, wrapping the actual listing fetch for the `image` and `speech` categories — so those two categories were bounded by the inner 10s regardless of what the outer budget said. A reasoning-heavy or otherwise slow-to-first-token model routinely needs longer than 10 seconds and is perfectly reachable; the test could not tell that apart from an actually dead connection, and on timeout reported: `Connection timed out after 10 seconds. Please check your network connection and provider status.` — sending the user to debug their own network and the provider's status page for a limit this endpoint imposed on itself.

### Why this shape

A tiered budget by ability (e.g. skip the short timeout when `supports_thinking_mode` is true) was considered and ruled out: `supports_thinking_mode` is `"thinking_mode" in self._abilities`, and the code path that builds the probe LLM for this endpoint never sets `abilities` on `ModelConfig` — it defaults to `None`, and `OpenAILLM.__init__` then falls back to `["chat", "tool_calling"]`. The probe instance's `supports_thinking_mode` is therefore always `False`, independent of the real model, so tiering on it would silently apply the short timeout to every model regardless of its actual ability. A single higher budget was chosen instead. 60 seconds leaves headroom under both the transport-level ceilings this call sits inside — nginx's 300s `proxy_read_timeout` on `/api/` and the LLM client's own 180s default `AsyncOpenAI` timeout — while still failing well before either of them, so this endpoint keeps deciding its own timeout outcome and message rather than a lower layer cutting the connection first.

### How

Both `10.0` literals collapse into one module-level constant, `_CONNECTION_TEST_TIMEOUT_SECONDS = 60.0`, defined next to `test_model_connection`. `_validate_provider_model_listing` no longer owns a timeout value of its own: it takes `timeout_seconds` as a required parameter and threads it into its own inner `asyncio.wait_for`, so the outer budget in `test_model_connection` and the inner one wrapping the actual listing fetch can no longer diverge. Both of `test_model_connection`'s call sites pass `timeout_seconds=timeout_seconds` (the local variable already set from the module constant) through explicitly.

The timeout message changes from blaming the network to naming the application's own wait limit: `f"The model did not respond within {int(timeout_seconds)} seconds (this application's waiting limit). Slow or reasoning-heavy models may need longer; the provider may still be healthy."` The response shape is unchanged — still a 200 with `status="failed"`.

Not touched: the aiohttp transport-level `total=30.0` timeout inside `fetch_models_from_provider` (a lower, independent bound, documented in a comment rather than changed), and `POST /api/models/test` (the saved-model probe, which has no timeout of its own at all) — that is a separate endpoint with no timeout to widen, tracked as #1964.

## Behavior changes

| | Before | After |
|---|---|---|
| Z.AI-style provider 400 (`"Tool choice must be auto"`, `metadata.provider_name` set) | predicate returns `False`; 400 propagates, turn fails | predicate returns `True`; resent with `tool_choice="auto"` |
| OpenRouter routing-level 404 (`"no endpoints found"` + `tool_choice`) | predicate returns `True` | unchanged, still `True` |
| Provider 400 that carries a `provider_name` but is unrelated to tool choice (e.g. context-length) | predicate returns `False` | unchanged, still `False` |
| A 400 whose `metadata.raw` echo happens to contain both matched phrases | predicate returns `True` (false positive) | predicate returns `False` |
| No structured body reachable (bare exception, or SDK error with a non-dict body) | flattened string match | same flattened string match (fallback path, unchanged) |
| `/api/models/test-connection` wait budget, all categories | 10s (outer), plus a second independent 10s inside `_validate_provider_model_listing` for `image`/`speech` | 60s, single source, threaded through to both layers |
| Timeout error text | "Connection timed out after 10 seconds. Please check your network connection and provider status." | "The model did not respond within 60 seconds (this application's waiting limit). Slow or reasoning-heavy models may need longer; the provider may still be healthy." |
| Timeout response shape | 200, `status="failed"` | unchanged |

## Testing

All counts below were run against this worktree's actual test files, not assumed.

- `tests/core/model/chat/basic/test_openrouter.py`: 116 collected (was 110 on the pre-fix baseline, `4ffbb3928`) — 6 net new test cases from this change, all passed.
- `tests/web/test_model_api.py`: 63 collected (was 61 on the same baseline) — 2 new tests, both passed.
- Combined run of both files: 179 collected, 179 passed, 0 failed.
- `pre-commit run` on all four changed files (`ruff check`, `ruff format`, `mypy`, `isort`, `codespell`, end-of-file/whitespace hooks): all passed.

Test data for the relax predicate is built as real SDK exceptions (`openai.BadRequestError` with an `httpx.Response` and a parsed `body=` dict), not hand-written strings — the existing test suite's synthetic strings are why this predicate went through two prior revisions without the provider-level gap being caught.

Coverage against the specific failure modes this PR guards, one test (or parametrized case) per row:

| Guarded behavior | Test |
|---|---|
| Z.AI-style provider-level 400 now triggers relax | `test_openrouter_direct_relaxes_tool_choice_on_provider_level_400` |
| Routing-level 404 keeps triggering (unchanged) | `test_openrouter_direct_relaxes_tool_choice_on_endpoint_404` (pre-existing, still green) |
| A `provider_name`-bearing 400 unrelated to tool choice, and one that names tool choice without being a must-be-auto rejection, both stay `False` | `test_relaxed_tool_choice_ignores_unrelated_400_with_provider_name`, parametrized over both messages |
| A `metadata.raw` echo containing both old phrases does not cause a false match | `test_relaxed_tool_choice_does_not_match_on_provider_raw_echo` |
| No structured body (bare exception, or a real SDK error with a non-dict body) falls back to the old string match | `test_relaxed_tool_choice_falls_back_to_string_match_without_structured_body`, parametrized over both shapes |
| `_validate_provider_model_listing` uses the caller-supplied budget, not a literal of its own | `test_validate_provider_model_listing_honors_caller_supplied_timeout` |
| Timeout error text names the app's own budget and drops the network-blaming language | `test_test_connection_llm_timeout_reports_app_budget_not_network` |

## Size

Production and tests, counted separately:

- Production: `src/xagent/core/model/chat/basic/openrouter.py` +64/-4, `src/xagent/web/api/model.py` +30/-4 (`git diff 4ffbb3928..HEAD --numstat`).
- Tests: `tests/core/model/chat/basic/test_openrouter.py` +172/-0 (net +6 cases via parametrization), `tests/web/test_model_api.py` +85/-0.

Fixes #1960

Related: #1964 (the saved-model probe endpoint has no timeout of its own; kept as a separate issue so this fix stays a single point)
