### PR TITLE
chore: bump actions/checkout to v7

### DIFF
--- a/.github/workflows/ci-real-rag.yml
+++ b/.github/workflows/ci-real-rag.yml
@@ -77,7 +77,7 @@ jobs:
 
       - name: Checkout code
         if: steps.eligibility.outputs.run_tests == 'true' && steps.provider.outputs.configured == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Ensure uv is available
         if: steps.eligibility.outputs.run_tests == 'true' && steps.provider.outputs.configured == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Check Deepdoc cache
         id: deepdoc-cache
@@ -250,7 +250,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -345,7 +345,7 @@ jobs:
 
       - name: Checkout code
         if: needs.changes.outputs.code == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Ensure uv is available
         if: needs.changes.outputs.code == 'true'
@@ -441,7 +441,7 @@ jobs:
 
       - name: Checkout code
         if: needs.changes.outputs.code == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Ensure uv is available
         if: needs.changes.outputs.code == 'true'
@@ -589,7 +589,7 @@ jobs:
 
       - name: Checkout code
         if: needs.changes.outputs.code == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Ensure uv is available
         if: needs.changes.outputs.code == 'true'
@@ -728,7 +728,7 @@ jobs:
 
       - name: Checkout code
         if: needs.changes.outputs.code == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Ensure uv is available
         if: needs.changes.outputs.code == 'true'
@@ -790,7 +790,7 @@ jobs:
 
       - name: Checkout code
         if: needs.changes.outputs.frontend == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # full history + tags so hatch-vcs can derive the version
 

--- a/.github/workflows/deepdoc-cache.yml
+++ b/.github/workflows/deepdoc-cache.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Restore Deepdoc cache
         id: deepdoc-cache

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Free GitHub-hosted runner disk space
         uses: endersonmenezes/free-disk-space@e6ed9b02e683a3b55ed0252f1ee469ce3b39a885

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -18,7 +18,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v4
         with:
           node-version: "22" # node --test needs >=18; AbortSignal.timeout needs >=17.3
@@ -39,7 +39,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Run installer and verify the command works
         env:
           # Isolate the tool install so the runner's env stays clean and we

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -43,7 +43,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: main  # Build nightly version from main branch
 

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -15,7 +15,7 @@ jobs:
     permissions:
       id-token: write  # required for PyPI trusted publishing (OIDC)
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # full history + tags so hatch-vcs can derive the version
 

--- a/.github/workflows/sandbox-publish.yml
+++ b/.github/workflows/sandbox-publish.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Free GitHub-hosted runner disk space
         uses: endersonmenezes/free-disk-space@e6ed9b02e683a3b55ed0252f1ee469ce3b39a885

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -73,7 +73,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -177,7 +177,7 @@ jobs:
 
       - name: Checkout code
         if: needs.detect-migration-changes.outputs.should-test == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
         if: needs.detect-migration-changes.outputs.should-test == 'true'
@@ -262,7 +262,7 @@ jobs:
 
       - name: Checkout code
         if: needs.detect-migration-changes.outputs.should-test == 'true'
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Python
         if: needs.detect-migration-changes.outputs.should-test == 'true'


### PR DESCRIPTION
## Why

Every workflow run is annotated with:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4

`actions/checkout@v4` declares `runs.using: node20`. The runner is already overriding it to Node 24, so the action runs on a runtime it was never built or tested against, and that override goes away eventually. This moves us to the current major, which targets node24 natively.

| tag | runtime | released |
| --- | --- | --- |
| `v4` | node20 | 2023-10-17 |
| `v5` | node24 | 2025-08-11 |
| `v6` | node24 | 2025-11-20 |
| `v7` (latest `v7.0.1`) | node24 | 2026-06-18 |

Going straight to `v7` rather than the minimum hop to `v5`, because none of the intervening breaking changes touch this repo.

## Breaking-change review

- **v5** — node24 runtime, requires Actions Runner >= 2.327.1. Every job is `runs-on: ubuntu-latest` or a hosted `matrix.os`; no self-hosted runners and no `container:` jobs, so the runner floor is met.
- **v6** — [persists credentials to a separate file](https://github.com/actions/checkout/pull/2286) instead of `.git/config`'s `http.extraheader`. No workflow reads `.git/config`, sets `persist-credentials`, or runs an authenticated git command — the only post-checkout git usage is the two local `git diff` change-detection steps in `ci.yml` and `test-migrations.yml`.
- **v7** — [blocks checking out fork PR heads](https://github.com/actions/checkout/pull/2454) under `pull_request_target` and `workflow_run`. Neither trigger is used anywhere in `.github/workflows/`; the triggers in play are `pull_request`, `push`, `schedule`, `release`, and `workflow_dispatch`.
- The only inputs we pass are `ref:` (`nightly-build.yml`) and `fetch-depth: 0` (`ci.yml`, `pypi-publish.yml`, `test-migrations.yml`). Both are unchanged through v7.

## What changed

The version string, nothing else — 18 occurrences across 9 workflow files. No inputs, step names, or surrounding logic touched.

## No tests to update

Three files read `.github/workflows/`, and none pin `actions/checkout`:

- `tests/test_ci_summary_contract.py` pins exactly one action, `dorny/paths-filter`'s SHA (`PATHS_FILTER_PIN`).
- `tests/test_docker_workflow_versions.py` pins `peter-evans/dockerhub-description`'s SHA, plus Dockerfile/pyproject contents.
- `frontend/src/ci/frontend-test-manifest.test.ts` reads `ci.yml` for launcher/vitest-discovery drift; no `uses:` assertions.

`grep -rn "actions/checkout"` finds no hits outside `.github/workflows/`. Both Python contract files pass against the bumped workflows (67 passed).

The real verification is this PR's own CI: `ci.yml`, `ci-real-rag.yml`, `install-script.yml`, and `test-migrations.yml` all run on `pull_request`, and the Node 20 annotation should be gone from those runs. The four workflows that don't run on PRs (`docker-publish.yml`, `nightly-build.yml`, `sandbox-publish.yml`, `deepdoc-cache.yml`) all support `workflow_dispatch` if anyone wants to smoke-test them from this branch — the publish ones gate pushes behind `push_to_dockerhub` / `push_to_ghcr` inputs.

## Not in scope

`actions/checkout` was the action named in the annotation, so this PR bumps only that one and keeps the diff to a one-line-per-file change that is trivial to review and revert. Several other actions carry the same deprecation and are left for a follow-up PR. Current majors verified against the GitHub API, all node24:

| action | current | target | notes |
| --- | --- | --- | --- |
| `actions/setup-python` | `v4` (x2), `v5` (x2) | `v7` | the `v4` uses in `test-migrations.yml` are **node16** — `actionlint` already reports them as hard errors ("the runner of this action is too old to run on GitHub Actions"), so this is the most urgent of the batch. v7 removed the `pip-install` input; we don't use it |
| `actions/setup-node` | `v4` | `v7` | v5 added auto-caching from `packageManager`, v6 narrowed it to npm. There is no root `package.json`, so nothing auto-detects; the two uses that want caching already pass `cache: 'npm'` explicitly |
| `actions/cache/{restore,save}` | `v4` | `v6` | must move together — `deepdoc-cache.yml` writes the key `ci.yml` reads. Worst case is one cold deepdoc rebuild if the cache version key shifts |
| `actions/upload-artifact` | `v4` | `v7` | pair with download below |
| `actions/download-artifact` | `v4` | `v8` | v8 defaults `digest-mismatch` to `error` (desirable), and skips unzipping non-zipped uploads |
| `actions/github-script` | `v7` | `v9` | v9 drops `require('@actions/github')`; the nightly failure-notify script only uses `github.rest.*` and `context` |
| `docker/build-push-action` | `v6` | `v7` | drops the `DOCKER_BUILD_NO_SUMMARY` / `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs; we set neither |
| `docker/metadata-action` | `v5` | `v6` | changed `#` handling in list inputs; our `tags:` contain no `#` |
| `docker/setup-buildx-action` | `v3` | `v4` | v4 drops deprecated inputs; we pass none |
| `docker/setup-qemu-action` | `v3` | `v4` | we pass no inputs |

Already on node24, nothing to do: `docker/login-action@v4`, `dorny/paths-filter` and `peter-evans/dockerhub-description` (both SHA-pinned), `endersonmenezes/free-disk-space` (composite action, no node runtime), `pypa/gh-action-pypi-publish` (Docker action).
