### PR TITLE
feat: route external-scope MESSAGE commands through a registered seam

### DIFF
--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -119,6 +119,7 @@ from ..services.external_task_cancel import (
     cancel_external_task_unserialized,
     external_cancel_exhausted_message,
 )
+from ..services.external_task_input import execute_external_task_input_command
 from ..services.file_reference_output_service import (
     load_assistant_file_reference_records,
     reconcile_assistant_file_references,
@@ -5672,6 +5673,16 @@ async def _enqueue_websocket_task_command(
         for key, value in message_data.items()
         if key not in {"user", "user_id"} and not key.startswith("_durable_")
     }
+    if "scope" in payload:
+        # ``scope`` routes a durable command to a non-first-party execution
+        # core (see ``_execute_durable_task_command``); only server-side
+        # producers may name one. A client frame that carries it is refused
+        # rather than silently stripped, so the sender learns the frame was
+        # not accepted as written.
+        raise ClientVisibleValidationError(
+            "Reserved field 'scope' is not accepted from clients",
+            error_code=ClientErrorCode.INVALID_MESSAGE,
+        )
     if kind == TaskCommandKind.MESSAGE:
         # The durable command identity is also the delivery/turn identity.
         # This remains stable across retries even when an API client omitted
@@ -9418,6 +9429,26 @@ async def _execute_durable_task_command(
     task-level state/error events are still broadcast normally.
     """
 
+    if command.kind == TaskCommandKind.MESSAGE and "scope" in command.payload:
+        # The first-party chat adapter below resolves its actor, origin
+        # socket, and delivery ledger from first-party rows. A MESSAGE that
+        # names a scope is not that command: "external" belongs to the
+        # embedding application's execution core, reached through the
+        # registered seam, and any other value names a core that does not
+        # exist here -- running the first-party core against it would inject
+        # the message while attributing it to the wrong audience. Equality
+        # rather than set membership so an unhashable payload value lands in
+        # the terminal rejection instead of raising ``TypeError`` into the
+        # retry path.
+        scope_value = command.payload["scope"]
+        if scope_value != EXTERNAL_COMMAND_SCOPE:
+            raise TaskCommandRejected(
+                f"Message command {command.command_id} names task scope "
+                f"{scope_value!r}, which has no execution core",
+                reason="unsupported_scope",
+            )
+        return await execute_external_task_input_command(command)
+
     websocket: Any = _command_origins.resolve(command.command_id, command.task_id)
     if websocket is None:
         websocket = _DiscardingCommandWebSocket()
@@ -9738,6 +9769,13 @@ async def _terminal_command_event_draft(
         resend_safe=(
             error.resend_safe if isinstance(error, TaskCommandDeferred) else False
         ),
+        # The disclosure rule the cancel branch above states — an anonymous
+        # external audience cannot act on durable command identity and is not
+        # shown it — holds for every external-scope command, including the
+        # external input MESSAGEs routed through the registered seam. This
+        # rebind runs after the executor's own draft and would otherwise
+        # silently restore the identity the executor withheld.
+        include_command_identity=scope != EXTERNAL_COMMAND_SCOPE,
     )
 
 

--- a/src/xagent/web/services/external_task_input.py
+++ b/src/xagent/web/services/external_task_input.py
@@ -1,0 +1,96 @@
+"""Transport-neutral execution seam for external-scope MESSAGE commands.
+
+The durable task-command transport (``task_command_transport``) owns
+admission for commands that must survive worker restarts and defer under
+contention. External task input -- an end user's answer to a task parked
+``WAITING_FOR_USER``, submitted from outside the first-party WebSocket --
+is executed by the embedding application, which owns the external identity
+fences, the delivery ledger, and the answer/turn identities. This module is
+the seam the dispatcher routes those commands through: the embedding
+application registers one executor at startup, and the dispatcher's command
+adapter hands it every claimed ``MESSAGE`` command whose payload names the
+external scope.
+
+The executor reports outcomes exactly the way first-party command handlers
+do: return a JSON-safe result dict on success, raise ``TaskCommandDeferred``
+to retry without consuming the failure budget (for example while the parked
+run still holds the resume lease), or raise ``TaskCommandRejected`` for a
+terminal domain refusal. Any other exception consumes the failure budget.
+An executor may attach a ``TerminalTaskEventDraft`` to the exceptions it
+raises (``bind_terminal_event_draft``) to control the durable terminal
+outcome's client-safe presentation.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Awaitable, Callable
+
+from .task_command_transport import ClaimedTaskCommand, TaskCommandRejected
+
+ExternalTaskInputExecutor = Callable[
+    [ClaimedTaskCommand], Awaitable[dict[str, Any] | None]
+]
+
+_executor_lock = threading.Lock()
+_executor: ExternalTaskInputExecutor | None = None
+
+
+def register_external_task_input_executor(
+    executor: ExternalTaskInputExecutor,
+) -> None:
+    """Register the process-wide external input executor.
+
+    Re-registering the same object is a no-op so embedding applications can
+    run their startup wiring idempotently; a different object is refused
+    rather than silently replaced, because two owners would race each
+    other's claimed commands.
+    """
+
+    if not callable(executor):
+        raise TypeError("external task input executor must be callable")
+    global _executor
+    with _executor_lock:
+        if _executor is executor:
+            return
+        if _executor is not None:
+            raise ValueError("An external task input executor is already registered")
+        _executor = executor
+
+
+def unregister_external_task_input_executor() -> ExternalTaskInputExecutor | None:
+    """Remove and return the registered executor, if any."""
+
+    global _executor
+    with _executor_lock:
+        executor, _executor = _executor, None
+        return executor
+
+
+def registered_external_task_input_executor() -> ExternalTaskInputExecutor | None:
+    """The registered executor, or ``None`` when no embedding app owns one."""
+
+    with _executor_lock:
+        return _executor
+
+
+async def execute_external_task_input_command(
+    command: ClaimedTaskCommand,
+) -> dict[str, Any] | None:
+    """Execute one claimed external-scope input command via the seam.
+
+    A deployment with no registered executor has no external execution core:
+    the command is rejected terminally rather than deferred, because no
+    amount of retrying will grow one, and an unbounded PENDING command would
+    also block every later command for the same task behind the per-task
+    FIFO.
+    """
+
+    executor = registered_external_task_input_executor()
+    if executor is None:
+        raise TaskCommandRejected(
+            f"Message command {command.command_id} names the external task "
+            "scope, but no external input execution core is registered",
+            reason="unsupported_scope",
+        )
+    return await executor(command)

--- a/tests/web/api/test_external_input_command_seam.py
+++ b/tests/web/api/test_external_input_command_seam.py
@@ -1,0 +1,521 @@
+"""External-scope MESSAGE commands: routing, registration, and the boundary.
+
+The seam under test lets an embedding application execute external task
+input through the durable command transport. Every test drives one edge:
+the dispatcher adapter routes an external-scope MESSAGE to the registered
+executor and nothing else, a deferral crosses the adapter untouched so the
+transport's defer budget (not the failure budget) absorbs lease contention,
+a deployment without a registered core refuses terminally, a scoped command
+never runs the first-party chat core, and a client frame cannot mint a
+scoped command at the WebSocket enqueue boundary.
+"""
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from xagent.web.api import websocket as websocket_api
+from xagent.web.models.agent import Agent
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.models.task_command import TaskExecutionCommand
+from xagent.web.models.task_command_terminal_event import TaskCommandTerminalEvent
+from xagent.web.services.external_task_input import (
+    execute_external_task_input_command,
+    register_external_task_input_executor,
+    registered_external_task_input_executor,
+    unregister_external_task_input_executor,
+)
+from xagent.web.services.task_command_transport import (
+    COMMAND_COMPLETED,
+    COMMAND_FAILED,
+    COMMAND_PENDING,
+    MAX_COMMAND_DEFERS,
+    ClaimedTaskCommand,
+    TaskCommandDeferred,
+    TaskCommandKind,
+    TaskCommandRejected,
+    dispatch_one_task_command,
+    enqueue_task_command,
+)
+from xagent.web.services.task_execution_controller import TaskControlState
+
+from .conftest import _admin_headers, _direct_db_session, client
+
+pytestmark = pytest.mark.usefixtures("_test_db")
+
+
+@pytest.fixture(autouse=True)
+def _clean_executor_registry():
+    unregister_external_task_input_executor()
+    yield
+    unregister_external_task_input_executor()
+
+
+def _claimed_message_command(
+    *,
+    task_id: int = 101,
+    payload: dict[str, Any],
+    command_id: str = "ext-input-1",
+    defer_count: int = 0,
+) -> ClaimedTaskCommand:
+    return ClaimedTaskCommand(
+        id=1,
+        task_id=task_id,
+        actor_user_id=None,
+        command_id=command_id,
+        kind=TaskCommandKind.MESSAGE,
+        payload=payload,
+        target_run_id=None,
+        attempt_count=1,
+        defer_count=defer_count,
+    )
+
+
+def _create_agent() -> tuple[int, int]:
+    headers = _admin_headers()
+    response = client.post(
+        "/api/agents",
+        headers=headers,
+        json={
+            "name": "External input agent",
+            "description": "External input test agent",
+            "instructions": "You are an external input test agent.",
+            "execution_mode": "balanced",
+        },
+    )
+    assert response.status_code == 200, response.text
+    agent_id = int(response.json()["id"])
+    db = _direct_db_session()
+    try:
+        owner_user_id = int(db.query(Agent).filter(Agent.id == agent_id).one().user_id)
+    finally:
+        db.close()
+    return agent_id, owner_user_id
+
+
+def _create_waiting_task(*, agent_id: int, owner_user_id: int) -> int:
+    db = _direct_db_session()
+    try:
+        task = Task(
+            user_id=owner_user_id,
+            title="external input task",
+            status=TaskStatus.WAITING_FOR_USER,
+            control_state=TaskControlState.RUNNING.value,
+            run_id="run-external",
+            state_version=4,
+            agent_id=agent_id,
+            source="external",
+            is_visible=False,
+        )
+        db.add(task)
+        db.commit()
+        db.refresh(task)
+        return int(task.id)
+    finally:
+        db.close()
+
+
+def _forbid_first_party_chat(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def _fail(*_args: Any, **_kwargs: Any) -> None:
+        raise AssertionError(
+            "the first-party chat core must not run for a scoped MESSAGE"
+        )
+
+    monkeypatch.setattr(websocket_api, "_handle_chat_message_unserialized", _fail)
+
+
+# ---------------------------------------------------------------------------
+# Registration semantics
+# ---------------------------------------------------------------------------
+
+
+def test_registering_the_same_executor_twice_is_a_no_op() -> None:
+    async def executor(_command: ClaimedTaskCommand) -> None:
+        return None
+
+    register_external_task_input_executor(executor)
+    register_external_task_input_executor(executor)
+    assert registered_external_task_input_executor() is executor
+
+
+def test_registering_a_different_executor_is_refused() -> None:
+    async def first(_command: ClaimedTaskCommand) -> None:
+        return None
+
+    async def second(_command: ClaimedTaskCommand) -> None:
+        return None
+
+    register_external_task_input_executor(first)
+    with pytest.raises(ValueError, match="already registered"):
+        register_external_task_input_executor(second)
+    assert registered_external_task_input_executor() is first
+
+
+def test_unregister_returns_the_executor_and_frees_the_slot() -> None:
+    async def first(_command: ClaimedTaskCommand) -> None:
+        return None
+
+    async def second(_command: ClaimedTaskCommand) -> None:
+        return None
+
+    register_external_task_input_executor(first)
+    assert unregister_external_task_input_executor() is first
+    register_external_task_input_executor(second)
+    assert registered_external_task_input_executor() is second
+
+
+def test_a_non_callable_executor_is_refused() -> None:
+    with pytest.raises(TypeError, match="callable"):
+        register_external_task_input_executor("not-callable")  # type: ignore[arg-type]
+    assert registered_external_task_input_executor() is None
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher adapter routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_external_scope_message_routes_to_the_registered_executor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The adapter hands the claimed command to the seam verbatim.
+
+    The actor load, origin resolution, and delivery-ledger probes of the
+    first-party arm belong to first-party rows; none of them may run for an
+    external-scope command, so the routing must happen before all of them
+    (``actor_user_id=None`` would otherwise fail the actor load).
+    """
+
+    _forbid_first_party_chat(monkeypatch)
+    observed: list[ClaimedTaskCommand] = []
+
+    async def executor(command: ClaimedTaskCommand) -> dict[str, Any]:
+        observed.append(command)
+        return {"delivered": True}
+
+    register_external_task_input_executor(executor)
+    command = _claimed_message_command(
+        payload={"scope": "external", "message": "the answer"}
+    )
+
+    result = await websocket_api._execute_durable_task_command(command)
+
+    assert observed == [command]
+    assert result == {"delivered": True}
+
+
+@pytest.mark.asyncio
+async def test_external_scope_message_deferral_crosses_the_adapter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A deferral must reach the dispatcher as ``TaskCommandDeferred``.
+
+    That exception type is what routes the disposition to the defer budget
+    instead of the failure budget; wrapping or swallowing it would consume
+    terminal failure attempts on a condition that clears by itself.
+    """
+
+    _forbid_first_party_chat(monkeypatch)
+
+    async def executor(_command: ClaimedTaskCommand) -> None:
+        raise TaskCommandDeferred("the parked run still holds the resume lease")
+
+    register_external_task_input_executor(executor)
+    command = _claimed_message_command(
+        payload={"scope": "external", "message": "the answer"}
+    )
+
+    with pytest.raises(TaskCommandDeferred, match="resume lease"):
+        await websocket_api._execute_durable_task_command(command)
+
+
+@pytest.mark.asyncio
+async def test_external_scope_message_without_a_registered_core_is_terminal(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No registered core means no retry can succeed: reject, don't defer.
+
+    An indefinitely PENDING command would also block every later command
+    for the same task behind the per-task FIFO.
+    """
+
+    _forbid_first_party_chat(monkeypatch)
+    command = _claimed_message_command(
+        payload={"scope": "external", "message": "the answer"}
+    )
+
+    with pytest.raises(TaskCommandRejected, match="no external input execution core"):
+        await websocket_api._execute_durable_task_command(command)
+
+
+@pytest.mark.asyncio
+async def test_foreign_scope_message_is_rejected_terminally(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A scope naming no execution core must not run the first-party core."""
+
+    _forbid_first_party_chat(monkeypatch)
+
+    async def executor(_command: ClaimedTaskCommand) -> None:
+        raise AssertionError("the external core must not run for a foreign scope")
+
+    register_external_task_input_executor(executor)
+
+    for scope_value in ("workforce", {"nested": "dict"}):
+        command = _claimed_message_command(
+            payload={"scope": scope_value, "message": "x"}
+        )
+        with pytest.raises(TaskCommandRejected, match="has no execution core"):
+            await websocket_api._execute_durable_task_command(command)
+
+
+@pytest.mark.asyncio
+async def test_scopeless_message_stays_on_the_first_party_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The pre-external payload shape keeps its first-party execution core."""
+
+    async def seam_must_not_run(_command: ClaimedTaskCommand) -> None:
+        raise AssertionError("the external seam must not run for a scopeless MESSAGE")
+
+    register_external_task_input_executor(seam_must_not_run)
+
+    first_party_calls: list[int] = []
+
+    async def record_chat(_ws: Any, task_id: int, _data: dict[str, Any]) -> None:
+        first_party_calls.append(task_id)
+
+    monkeypatch.setattr(websocket_api, "_handle_chat_message_unserialized", record_chat)
+    monkeypatch.setattr(
+        websocket_api,
+        "_load_command_actor",
+        lambda _actor_id: SimpleNamespace(id=7, is_admin=False),
+    )
+    monkeypatch.setattr(
+        websocket_api,
+        "_load_command_message_delivery_status",
+        lambda _task_id, _turn_id: "dispatched",
+    )
+
+    command = ClaimedTaskCommand(
+        id=1,
+        task_id=55,
+        actor_user_id=7,
+        command_id="chat-1",
+        kind=TaskCommandKind.MESSAGE,
+        payload={"message": "hello"},
+        target_run_id=None,
+        attempt_count=1,
+    )
+
+    result = await websocket_api._execute_durable_task_command(command)
+
+    assert first_party_calls == [55]
+    assert result == {"task_id": 55, "command_id": "chat-1", "kind": "message"}
+
+
+# ---------------------------------------------------------------------------
+# The seam itself
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_seam_rejects_with_unsupported_scope_reason_when_unregistered() -> None:
+    command = _claimed_message_command(payload={"scope": "external", "message": "x"})
+    with pytest.raises(TaskCommandRejected) as excinfo:
+        await execute_external_task_input_command(command)
+    assert excinfo.value.reason == "unsupported_scope"
+
+
+# ---------------------------------------------------------------------------
+# First-party WebSocket enqueue boundary
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_client_frames_cannot_name_a_command_scope() -> None:
+    """``scope`` is server-owned: a client frame carrying it is refused.
+
+    Without this boundary a first-party chat frame could route its MESSAGE
+    command into the external execution core with a forged identity payload.
+    Loud rejection rather than a silent strip, so the sender learns the
+    frame was not accepted as written.
+    """
+
+    for kind in (
+        TaskCommandKind.MESSAGE,
+        TaskCommandKind.PAUSE,
+        TaskCommandKind.RESUME,
+    ):
+        with pytest.raises(websocket_api.ClientVisibleValidationError, match="scope"):
+            await websocket_api._enqueue_websocket_task_command(
+                task_id=1,
+                message_data={
+                    "user": SimpleNamespace(id=7, is_admin=False),
+                    "message": "hello",
+                    "scope": "external",
+                },
+                kind=kind,
+                command_id="forged-1",
+            )
+
+
+# ---------------------------------------------------------------------------
+# End to end through the durable transport
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deferred_external_input_spends_the_defer_budget_not_failures() -> None:
+    """Contention defers durably and the retry converges on one delivery.
+
+    This is the transport chain an embedding application relies on: enqueue
+    while the parked run holds the resume lease, observe a defer (status
+    back to PENDING, ``defer_count`` up, ``failure_count`` untouched), then
+    complete on the next claim once the lease is free.
+    """
+
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
+
+    attempts: list[int] = []
+
+    async def executor(command: ClaimedTaskCommand) -> dict[str, Any]:
+        attempts.append(command.attempt_count)
+        if len(attempts) == 1:
+            raise TaskCommandDeferred("the parked run still holds the resume lease")
+        return {"delivered": True}
+
+    register_external_task_input_executor(executor)
+
+    db = _direct_db_session()
+    try:
+        enqueued = enqueue_task_command(
+            db,
+            task_id=task_id,
+            actor_user_id=owner_user_id,
+            command_id="ext-input-e2e",
+            kind=TaskCommandKind.MESSAGE,
+            payload={"scope": "external", "message": "the answer"},
+        )
+        assert enqueued.created
+    finally:
+        db.close()
+
+    processed = await dispatch_one_task_command(
+        websocket_api.execute_durable_task_command
+    )
+    assert processed is True
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.command_id == "ext-input-e2e")
+            .one()
+        )
+        assert row.status == COMMAND_PENDING
+        assert int(row.defer_count or 0) == 1
+        assert int(row.failure_count or 0) == 0
+        # The defer backoff parks the claim briefly; expire it so the second
+        # dispatch below can claim without sleeping through real time.
+        row.claim_expires_at = datetime.now(UTC) - timedelta(seconds=1)
+        db.commit()
+    finally:
+        db.close()
+
+    processed = await dispatch_one_task_command(
+        websocket_api.execute_durable_task_command
+    )
+    assert processed is True
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.command_id == "ext-input-e2e")
+            .one()
+        )
+        assert row.status == COMMAND_COMPLETED
+        assert row.result == {"delivered": True}
+        assert int(row.failure_count or 0) == 0
+    finally:
+        db.close()
+
+    assert attempts == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_exhausted_external_deferral_withholds_command_identity() -> None:
+    """An external audience never sees durable command identity.
+
+    The terminal rebind in ``execute_durable_task_command`` runs *after* the
+    executor's own draft, so the disclosure decision has to live in
+    ``_terminal_command_event_draft`` itself: an exhausted external-scope
+    deferral must persist ``include_command_identity=False`` (same policy as
+    the external cancel) while still carrying the exception's own
+    ``resend_safe`` evidence.
+    """
+
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
+
+    async def executor(_command: ClaimedTaskCommand) -> dict[str, Any]:
+        raise TaskCommandDeferred(
+            "the parked run still holds the resume lease",
+            resend_safe=True,
+        )
+
+    register_external_task_input_executor(executor)
+
+    db = _direct_db_session()
+    try:
+        enqueued = enqueue_task_command(
+            db,
+            task_id=task_id,
+            actor_user_id=owner_user_id,
+            command_id="ext-input-exhausted",
+            kind=TaskCommandKind.MESSAGE,
+            payload={"scope": "external", "message": "the answer"},
+        )
+        assert enqueued.created
+        # Spend all but the last unit of the defer budget so the next
+        # deferral is the terminal one -- MAX_COMMAND_DEFERS real round
+        # trips would prove nothing more about the disposition under test.
+        db.query(TaskExecutionCommand).filter(
+            TaskExecutionCommand.command_id == "ext-input-exhausted"
+        ).update(
+            {TaskExecutionCommand.defer_count: MAX_COMMAND_DEFERS - 1},
+            synchronize_session=False,
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    processed = await dispatch_one_task_command(
+        websocket_api.execute_durable_task_command
+    )
+    assert processed is True
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.command_id == "ext-input-exhausted")
+            .one()
+        )
+        assert row.status == COMMAND_FAILED
+        event = (
+            db.query(TaskCommandTerminalEvent)
+            .filter(TaskCommandTerminalEvent.task_command_id == int(row.id))
+            .one()
+        )
+        assert event.outcome == "failed"
+        assert event.message_code == "task_command_deferred"
+        assert event.resend_safe is True
+        assert event.include_command_identity is False
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary

- add `xagent.web.services.external_task_input`: a transport-neutral execution seam for external-scope `MESSAGE` commands. An embedding application registers one executor at startup; the dispatcher's command adapter (`_execute_durable_task_command`) hands it every claimed MESSAGE whose payload names the external scope, before any first-party actor/origin/delivery machinery runs. The executor reports outcomes in the transport's existing vocabulary (result dict / `TaskCommandDeferred` / `TaskCommandRejected`), so the defer budget, failure budget, and #1901/#1933 terminal-event persistence apply unchanged.
- a MESSAGE naming any *other* scope is rejected terminally (`unsupported_scope`), mirroring the external-cancel precedent, instead of running the first-party core against the wrong audience.
- make the `scope` key server-owned at the first-party WebSocket enqueue boundary: a client frame carrying it is refused with `invalid_message`. Without this, a first-party chat frame could mint an externally scoped command with a forged identity payload. This is a (narrow) client-contract change: no legitimate client sends `scope` today, and the refusal is loud rather than a silent strip.
- extend `_terminal_command_event_draft` (#1933) so *every* external-scope command withholds durable command identity in its terminal event, not only the external cancel — the terminal rebind runs after the executor's own draft and would otherwise restore the identity the executor withheld. Covered end-to-end by `test_exhausted_external_deferral_withholds_command_identity`.

Groundwork for xorbitsai/xagent-saas#944 (Widget clarification answers failing with `CheckpointAccessRefusedError` while the parked run's resume lease is held): the SaaS continuation becomes this seam's registered executor and defers on contention instead of failing terminally. The consuming PR follows in xagent-saas.

## Verification

- new `tests/web/api/test_external_input_command_seam.py` (13 tests): registration semantics, adapter routing (external / foreign / scopeless), deferral propagation, unregistered-core terminal rejection, the client `scope` boundary, and two end-to-end transport runs (defer budget vs failure budget; exhausted deferral's terminal event withholding identity and carrying `resend_safe`).
- adjacent suites green: `test_durable_message_resume_contention.py`, `test_external_task_cancel.py`, `test_websocket_owner_actor.py`, `test_websocket_client_safe_errors.py`, `test_task_command_transport.py`, `test_task_command_terminal_events.py` — 415 passed, PostgreSQL-parametrized cases skipped locally.
- ruff check/format clean; mypy clean on touched files.

## Out of scope (tracked)

- Exporting the resume-lease acquisition helper as a service seam and bundling the `preacquired_*` transfer quadruple: #1972.
- A2A / task_reply synchronous 409/500 on resume contention: unchanged, per the #1933 review's scope note.