### PR TITLE
fix: surface terminal external-input rejections and couple the defer budget to the lease TTL

### DIFF
--- a/example.env
+++ b/example.env
@@ -48,8 +48,11 @@ PORT="80"
 # one process wins each recovery.
 # The TTL also sizes the durable task-command defer budget: a deferred command
 # retries roughly once per second for max(60, 2 * TTL) deferrals before it
-# fails terminally, so the default budget is 120 and raising the TTL raises
-# the budget with it.
+# fails terminally, so the default budget is 120. TTLs below 30 stay on the
+# 60-deferral floor, and values below 10 (or non-integers) fall back to a
+# TTL of 60, i.e. budget 120. A larger budget also widens the window in
+# which a CANCEL can queue behind a deferring command in the per-task FIFO
+# (see xorbitsai/xagent#1978).
 # XAGENT_TASK_LEASE_TTL_SECONDS="60"
 # XAGENT_TASK_LEASE_HEARTBEAT_SECONDS="20"
 # XAGENT_TASK_LEASE_RECOVERY_INTERVAL_SECONDS="20"

--- a/example.env
+++ b/example.env
@@ -46,6 +46,10 @@ PORT="80"
 # The heartbeat defaults to one third of the TTL. Expired leases are recovered
 # automatically by every backend process; final conditional updates ensure only
 # one process wins each recovery.
+# The TTL also sizes the durable task-command defer budget: a deferred command
+# retries roughly once per second for max(60, 2 * TTL) deferrals before it
+# fails terminally, so the default budget is 120 and raising the TTL raises
+# the budget with it.
 # XAGENT_TASK_LEASE_TTL_SECONDS="60"
 # XAGENT_TASK_LEASE_HEARTBEAT_SECONDS="20"
 # XAGENT_TASK_LEASE_RECOVERY_INTERVAL_SECONDS="20"

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -9604,10 +9604,16 @@ async def _execute_durable_task_command(
                     target_state_version,
                     int,
                 ):
+                    # ``invalid_target``, not ``stale_run``: nothing about
+                    # the run moved — the command payload itself carries no
+                    # usable version. Labelling it stale told the A2A error
+                    # renderer to advise a retry that can never succeed, and
+                    # let the broadcast gate below mistake a malformed stop
+                    # for a target-gone case whose silence is by design.
                     raise TaskCommandRejected(
                         f"Cancel command {command.command_id} has no exact "
                         "state-version target",
-                        reason="stale_run",
+                        reason="invalid_target",
                     )
                 # The A2A execution core loads its target as an A2A task, so
                 # a cancel for any other task source needs its own core. The
@@ -9846,22 +9852,34 @@ async def execute_durable_task_command(
         # Rejections come from handlers that already expose their durable
         # domain-level outcome. The dispatcher makes them terminal immediately.
         _command_origins.discard_command(command.command_id, command.task_id)
-        if (
+        _rejected_scope = _command_scope(command)
+        # Rejection reasons whose silence external_task_cancel.py's module
+        # docstring owns: the stop's target no longer exists as addressed
+        # (the run rotated, settled, or the task is gone), and that target's
+        # own settlement owns the transcript and the terminal event. A
+        # validation-class rejection is the opposite case — the target may
+        # be perfectly alive and the stop simply did not apply — and staying
+        # silent there strands an anonymous visitor with a stop button that
+        # did nothing (#1979 review, prior blocking finding).
+        _cancel_target_gone = exc.reason in {"stale_run", "task_not_found"}
+        if _rejected_scope == EXTERNAL_COMMAND_SCOPE and (
             command.kind == TaskCommandKind.MESSAGE
-            and _command_scope(command) == EXTERNAL_COMMAND_SCOPE
+            or (command.kind == TaskCommandKind.CANCEL and not _cancel_target_gone)
         ):
-            # The one command whose handler has no channel of its own: the
+            # The commands whose handlers have no channel of their own: the
             # external audience's answer travels through the seam executor,
-            # which reports outcomes only as these exceptions. Without a
-            # broadcast, a deferred answer that is later terminally rejected
-            # (revoked principal, stale request, spent id, quota) vanishes
-            # silently — the task stays parked and nobody is told
-            # (xorbitsai/xagent-saas#952 B2). First-party rejections keep
-            # their handler-owned notifications and are deliberately not
-            # re-broadcast here. An executor-bound presentation draft is
-            # preserved; the standard one is derived only when none was
-            # bound, so the persisted terminal event is classified either
-            # way.
+            # and its stop through the external cancel core — both report
+            # outcomes only as these exceptions. Without a broadcast, a
+            # deferred answer that is later terminally rejected (revoked
+            # principal, stale request, spent id, quota), or a stop whose
+            # command payload failed validation, vanishes silently — the
+            # task stays parked or running and nobody is told
+            # (xorbitsai/xagent-saas#952 B2; #1979 review round 3).
+            # First-party rejections keep their handler-owned notifications
+            # and are deliberately not re-broadcast here. An executor-bound
+            # presentation draft is preserved; the standard one is derived
+            # only when none was bound, so the persisted terminal event is
+            # classified either way.
             if terminal_event_draft_for_error(exc) is None:
                 bind_terminal_event_draft(
                     exc,
@@ -9872,8 +9890,11 @@ async def execute_durable_task_command(
             except Exception:
                 # The rejection is already classified and its draft is
                 # bound; a failed notification must not supersede the
-                # terminal rejection into a retried failure (the finalize
-                # broadcast in external_task_cancel.py keeps the same rule).
+                # terminal rejection into a retried failure. Unlike
+                # external_task_cancel.py's finalize, which commits its
+                # terminal row before broadcasting, this broadcast runs
+                # before the transport persists the disposition — the
+                # persist-then-notify ordering here is #1996's follow-up.
                 # Exception, never BaseException: cancellation propagates.
                 logger.warning(
                     "task %s external input rejection is terminal but its "

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -163,11 +163,11 @@ from ..services.task_command_terminal_events import (
     TerminalTaskEventMessageCode,
     bind_terminal_event_draft,
     is_external_cancel_command,
+    terminal_event_draft_for_error,
 )
 from ..services.task_command_transport import (
     COMMAND_FAILED,
     COMMAND_ID_PATTERN,
-    MAX_COMMAND_DEFERS,
     MAX_COMMAND_FAILURES,
     ClaimedTaskCommand,
     EnqueuedTaskCommand,
@@ -177,6 +177,7 @@ from ..services.task_command_transport import (
     TaskCommandTaskMissing,
     dispatch_task_command_promptly,
     enqueue_task_command,
+    max_command_defers,
     task_has_live_foreign_runner,
     task_has_live_runner,
 )
@@ -9794,7 +9795,7 @@ async def execute_durable_task_command(
     try:
         result = await _execute_durable_task_command(command)
     except TaskCommandDeferred as exc:
-        if command.defer_count + 1 >= MAX_COMMAND_DEFERS:
+        if command.defer_count + 1 >= max_command_defers():
             _command_origins.discard_command(command.command_id, command.task_id)
             bind_terminal_event_draft(
                 exc,
@@ -9803,10 +9804,32 @@ async def execute_durable_task_command(
             await _broadcast_terminal_command_error(command, exc)
         # A deferral that will retry keeps its origin entry.
         raise
-    except TaskCommandRejected:
+    except TaskCommandRejected as exc:
         # Rejections come from handlers that already expose their durable
         # domain-level outcome. The dispatcher makes them terminal immediately.
         _command_origins.discard_command(command.command_id, command.task_id)
+        if (
+            command.kind == TaskCommandKind.MESSAGE
+            and _command_scope(command) == EXTERNAL_COMMAND_SCOPE
+        ):
+            # The one command whose handler has no channel of its own: the
+            # external audience's answer travels through the seam executor,
+            # which reports outcomes only as these exceptions. Without a
+            # broadcast, a deferred answer that is later terminally rejected
+            # (revoked principal, stale request, spent id, quota) vanishes
+            # silently — the task stays parked and nobody is told
+            # (xorbitsai/xagent-saas#952 B2). First-party rejections keep
+            # their handler-owned notifications and are deliberately not
+            # re-broadcast here. An executor-bound presentation draft is
+            # preserved; the standard one is derived only when none was
+            # bound, so the persisted terminal event is classified either
+            # way.
+            if terminal_event_draft_for_error(exc) is None:
+                bind_terminal_event_draft(
+                    exc,
+                    await _terminal_command_event_draft(command, exc),
+                )
+            await _broadcast_terminal_command_error(command, exc)
         raise
     except Exception as exc:
         if command.failure_count + 1 >= MAX_COMMAND_FAILURES:

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -467,6 +467,8 @@ def client_safe_task_command_failure(
         return external_cancel_exhausted_message(task_status)
     if scope == EXTERNAL_COMMAND_SCOPE and kind == TaskCommandKind.MESSAGE:
         return external_input_terminal_message(error)
+    # kind.value in the text is safe only while every external-scope kind is
+    # handled above; a new external-scope kind needs its own branch first.
     return f"Task command {kind.value} failed: {client_safe_error_message(error)}"
 
 
@@ -9865,7 +9867,20 @@ async def execute_durable_task_command(
                     exc,
                     await _terminal_command_event_draft(command, exc),
                 )
-            await _broadcast_terminal_command_error(command, exc)
+            try:
+                await _broadcast_terminal_command_error(command, exc)
+            except Exception:
+                # The rejection is already classified and its draft is
+                # bound; a failed notification must not supersede the
+                # terminal rejection into a retried failure (the finalize
+                # broadcast in external_task_cancel.py keeps the same rule).
+                # Exception, never BaseException: cancellation propagates.
+                logger.warning(
+                    "task %s external input rejection is terminal but its "
+                    "broadcast failed",
+                    command.task_id,
+                    exc_info=True,
+                )
         raise
     except Exception as exc:
         if command.failure_count + 1 >= MAX_COMMAND_FAILURES:

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -120,7 +120,10 @@ from ..services.external_task_cancel import (
     cancel_external_task_unserialized,
     external_cancel_exhausted_message,
 )
-from ..services.external_task_input import execute_external_task_input_command
+from ..services.external_task_input import (
+    EXTERNAL_INPUT_NOT_APPLIED_MESSAGE,
+    execute_external_task_input_command,
+)
 from ..services.file_reference_output_service import (
     load_assistant_file_reference_records,
     reconcile_assistant_file_references,
@@ -451,9 +454,18 @@ def client_safe_task_command_failure(
     status in. Saying the response was interrupted when the task is still
     running would be false, and the visitor would keep waiting on a turn
     nobody stopped.
+
+    An external-scope MESSAGE gets the same courtesy for the opposite
+    reason: the generic fallback ends in "Please try again.", which is
+    false for the non-retryable rejections this broadcast exists to
+    surface (revoked principal, stale request, spent id). Its sentence
+    asserts only the refusal and needs no task status, so the caller does
+    not read the task for it.
     """
     if is_external_cancel_command(kind=kind.value, scope=scope):
         return external_cancel_exhausted_message(task_status)
+    if scope == EXTERNAL_COMMAND_SCOPE and kind == TaskCommandKind.MESSAGE:
+        return EXTERNAL_INPUT_NOT_APPLIED_MESSAGE
     return f"Task command {kind.value} failed: {client_safe_error_message(error)}"
 
 
@@ -9700,7 +9712,7 @@ async def _broadcast_terminal_command_error(
     # wording has to be true about the turn, which takes reading the task.
     # And ``command_kind``/``command_id`` are operator handles: an anonymous
     # visitor cannot act on them and should not be shown the durable command
-    # identity of a task they do not own. Two payload literals rather than
+    # identity of a task they do not own. Three payload literals rather than
     # one built and trimmed: the client-safe guard only inspects dict
     # literals passed straight to the sink, and a payload assembled in a
     # variable would drop this site out of its view entirely.
@@ -9714,6 +9726,29 @@ async def _broadcast_terminal_command_error(
                     error,
                     scope=scope,
                     task_status=task_status,
+                ),
+                "task_id": command.task_id,
+                "timestamp": datetime.now(timezone.utc).timestamp(),
+            },
+            command.task_id,
+        )
+        return
+    if scope == EXTERNAL_COMMAND_SCOPE:
+        # Every other external-scope command mirrors the persisted-event
+        # rule (``include_command_identity=scope != EXTERNAL_COMMAND_SCOPE``):
+        # the live frame must not disclose what the durable record withholds,
+        # because an embedding application's stream projection may forward
+        # ``agent_error`` frames verbatim to the anonymous audience. No task
+        # status read either -- the wording asserts nothing about the turn,
+        # and this branch runs inside exception handlers where an unguarded
+        # database read would escape the disposition that is being reported.
+        await manager.broadcast_to_task(
+            {
+                "type": "agent_error",
+                "message": client_safe_task_command_failure(
+                    command.kind,
+                    error,
+                    scope=scope,
                 ),
                 "task_id": command.task_id,
                 "timestamp": datetime.now(timezone.utc).timestamp(),

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -121,8 +121,8 @@ from ..services.external_task_cancel import (
     external_cancel_exhausted_message,
 )
 from ..services.external_task_input import (
-    EXTERNAL_INPUT_NOT_APPLIED_MESSAGE,
     execute_external_task_input_command,
+    external_input_terminal_message,
 )
 from ..services.file_reference_output_service import (
     load_assistant_file_reference_records,
@@ -458,14 +458,15 @@ def client_safe_task_command_failure(
     An external-scope MESSAGE gets the same courtesy for the opposite
     reason: the generic fallback ends in "Please try again.", which is
     false for the non-retryable rejections this broadcast exists to
-    surface (revoked principal, stale request, spent id). Its sentence
-    asserts only the refusal and needs no task status, so the caller does
-    not read the task for it.
+    surface (revoked principal, stale request, spent id). Its wording is
+    picked by what the terminal exception proves -- non-application is
+    asserted only when it is established, uncertainty otherwise -- and
+    needs no task status, so the caller does not read the task for it.
     """
     if is_external_cancel_command(kind=kind.value, scope=scope):
         return external_cancel_exhausted_message(task_status)
     if scope == EXTERNAL_COMMAND_SCOPE and kind == TaskCommandKind.MESSAGE:
-        return EXTERNAL_INPUT_NOT_APPLIED_MESSAGE
+        return external_input_terminal_message(error)
     return f"Task command {kind.value} failed: {client_safe_error_message(error)}"
 
 

--- a/src/xagent/web/services/external_task_input.py
+++ b/src/xagent/web/services/external_task_input.py
@@ -28,6 +28,15 @@ from typing import Any, Awaitable, Callable
 
 from .task_command_transport import ClaimedTaskCommand, TaskCommandRejected
 
+# Broadcast, never stored -- the same single-consumer rule as the external
+# cancel sentences in external_task_cancel.py. Every terminal outcome of an
+# external-scope MESSAGE ends the same way for its audience: the answer was
+# not applied to the turn. The sentence instructs neither retry nor
+# abandonment, because either instruction would sometimes be false --
+# resubmitting the identical answer reopens a spent budget, while a revoked
+# principal or a stale request makes any retry futile.
+EXTERNAL_INPUT_NOT_APPLIED_MESSAGE = "This answer was not applied to the task."
+
 ExternalTaskInputExecutor = Callable[
     [ClaimedTaskCommand], Awaitable[dict[str, Any] | None]
 ]

--- a/src/xagent/web/services/external_task_input.py
+++ b/src/xagent/web/services/external_task_input.py
@@ -26,16 +26,46 @@ from __future__ import annotations
 import threading
 from typing import Any, Awaitable, Callable
 
-from .task_command_transport import ClaimedTaskCommand, TaskCommandRejected
+from .task_command_transport import (
+    ClaimedTaskCommand,
+    TaskCommandDeferred,
+    TaskCommandRejected,
+)
 
 # Broadcast, never stored -- the same single-consumer rule as the external
-# cancel sentences in external_task_cancel.py. Every terminal outcome of an
-# external-scope MESSAGE ends the same way for its audience: the answer was
-# not applied to the turn. The sentence instructs neither retry nor
-# abandonment, because either instruction would sometimes be false --
+# cancel sentences in external_task_cancel.py. Neither sentence instructs
+# retry or abandonment, because either instruction would sometimes be false:
 # resubmitting the identical answer reopens a spent budget, while a revoked
-# principal or a stale request makes any retry futile.
+# principal or a stale request makes any retry futile. They differ on the
+# one axis the transport can actually prove -- whether the answer reached
+# the downstream operation. The categorical sentence is reserved for
+# outcomes that prove non-application; everything else gets the sentence
+# that asserts only uncertainty, because a worker may have injected the
+# answer before crashing and the reclaiming attempt cannot know.
 EXTERNAL_INPUT_NOT_APPLIED_MESSAGE = "This answer was not applied to the task."
+EXTERNAL_INPUT_UNCONFIRMED_MESSAGE = (
+    "We could not confirm whether this answer was applied to the task."
+)
+
+
+def external_input_terminal_message(error: BaseException) -> str:
+    """Wording for a terminal external MESSAGE outcome, by what is provable.
+
+    A ``TaskCommandRejected`` is a durable domain refusal: the executor
+    established that the answer was not applied. A ``TaskCommandDeferred``
+    with ``resend_safe=True`` carries the same proof by its own contract --
+    the flag is set only when the failed handoff shows the command never
+    reached the downstream operation. Every other terminal -- an exhausted
+    ``resend_safe=False`` deferral, a generic failure -- ends with the
+    outcome unknown, and asserting non-application there could send the
+    audience a false statement about a turn their answer already reached.
+    """
+
+    if isinstance(error, TaskCommandRejected):
+        return EXTERNAL_INPUT_NOT_APPLIED_MESSAGE
+    if isinstance(error, TaskCommandDeferred) and error.resend_safe:
+        return EXTERNAL_INPUT_NOT_APPLIED_MESSAGE
+    return EXTERNAL_INPUT_UNCONFIRMED_MESSAGE
 
 ExternalTaskInputExecutor = Callable[
     [ClaimedTaskCommand], Awaitable[dict[str, Any] | None]

--- a/src/xagent/web/services/external_task_input.py
+++ b/src/xagent/web/services/external_task_input.py
@@ -19,6 +19,14 @@ terminal domain refusal. Any other exception consumes the failure budget.
 An executor may attach a ``TerminalTaskEventDraft`` to the exceptions it
 raises (``bind_terminal_event_draft``) to control the durable terminal
 outcome's client-safe presentation.
+
+Contract note on ``TaskCommandRejected``: raise it only when the refusal
+also *establishes non-application* -- the answer verifiably never reached
+the downstream operation. ``external_input_terminal_message`` renders every
+rejection with the categorical not-applied sentence on the strength of this
+contract; an executor that cannot prove non-application (for example, a
+spent delivery id whose original attempt may have landed) must raise a
+plain failure instead, whose wording asserts only uncertainty.
 """
 
 from __future__ import annotations

--- a/src/xagent/web/services/external_task_input.py
+++ b/src/xagent/web/services/external_task_input.py
@@ -67,6 +67,7 @@ def external_input_terminal_message(error: BaseException) -> str:
         return EXTERNAL_INPUT_NOT_APPLIED_MESSAGE
     return EXTERNAL_INPUT_UNCONFIRMED_MESSAGE
 
+
 ExternalTaskInputExecutor = Callable[
     [ClaimedTaskCommand], Awaitable[dict[str, Any] | None]
 ]

--- a/src/xagent/web/services/task_command_terminal_events.py
+++ b/src/xagent/web/services/task_command_terminal_events.py
@@ -147,9 +147,15 @@ def stage_terminal_event(
         outcome=outcome,
         message_code=(draft.message_code.value if draft.message_code else None),
         resend_safe=bool(draft.resend_safe),
+        # Any external-scope command, not only the cancel: the audience is
+        # anonymous, cannot act on durable command identity, and must not be
+        # shown it. Enforced here — the single persistence chokepoint —
+        # rather than at each draft-building call site, so a caller that
+        # forgets (or a defaulted draft on the success path, which carries
+        # include_command_identity=True) cannot leak the identity for an
+        # external MESSAGE terminal (#1979 review NEW-1).
         include_command_identity=bool(
-            draft.include_command_identity
-            and not is_external_cancel_command(kind=str(command.kind), scope=scope)
+            draft.include_command_identity and scope != _EXTERNAL_COMMAND_SCOPE
         ),
     )
     try:

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -55,6 +55,27 @@ COMMAND_TERMINAL = (COMMAND_COMPLETED, COMMAND_FAILED)
 COMMAND_ID_PATTERN = re.compile(r"[A-Za-z0-9._:-]{1,64}")
 MAX_COMMAND_FAILURES = 5
 MAX_COMMAND_DEFERS = 60
+
+
+def max_command_defers() -> int:
+    """The defer budget, coupled to the configured task lease TTL.
+
+    A deferral's canonical wait is a task lease another holder has not
+    released yet, and a lease on a non-RUNNING row cannot be refreshed, so
+    it clears within one TTL. The budget (spent roughly once per second —
+    ``defer_task_command`` re-arms the claim one second out) must outlast
+    that with real margin: a fixed 60 was silently smaller than any raised
+    ``XAGENT_TASK_LEASE_TTL_SECONDS``, turning every long park into a
+    terminal failure for an already-accepted command
+    (xorbitsai/xagent-saas#952 B3). Twice the TTL keeps 100% headroom at
+    every setting; the historical constant stays as the floor so short-TTL
+    deployments keep their existing patience. Read per call, not cached:
+    the TTL is env-driven and tests vary it.
+    """
+
+    return max(MAX_COMMAND_DEFERS, int(get_task_lease_ttl_seconds()) * 2)
+
+
 DISPATCHER_IDLE_SECONDS = 0.5
 DISPATCHER_CONCURRENCY = 4
 
@@ -963,7 +984,7 @@ def defer_task_command(
         observed_defer_count = int(snapshot.defer_count or 0)
         observed_attempt_count = int(snapshot.attempt_count or 0)
         defer_count = observed_defer_count + 1
-        terminal = defer_count >= MAX_COMMAND_DEFERS
+        terminal = defer_count >= max_command_defers()
         updated = (
             db.query(TaskExecutionCommand)
             .filter(
@@ -1205,6 +1226,16 @@ async def dispatch_one_task_command(
             {"rejection_reason": exc.reason} if exc.reason is not None else None
         )
 
+        # An executor that bound its own presentation draft wins; the neutral
+        # literal is only the fallback. The other two dispositions already
+        # read the bound draft — hardcoding here silently discarded the
+        # external input executor's identity-withholding draft
+        # (xorbitsai/xagent-saas#952 M3).
+        rejection_event = terminal_event_draft_for_error(exc) or TerminalTaskEventDraft(
+            message_code=None,
+            resend_safe=False,
+        )
+
         def persist_rejection() -> bool:
             return fail_task_command(
                 command.id,
@@ -1213,10 +1244,7 @@ async def dispatch_one_task_command(
                 force_terminal=True,
                 expected_attempt_count=command.attempt_count,
                 result=rejection_result,
-                terminal_event=TerminalTaskEventDraft(
-                    message_code=None,
-                    resend_safe=False,
-                ),
+                terminal_event=rejection_event,
             )
 
         disposition_name = "fail_task_command"

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -58,10 +58,10 @@ MAX_COMMAND_DEFERS = 60
 
 
 def max_command_defers() -> int:
-    """The defer budget, coupled to the configured task lease TTL.
+    """The defer budget, a TTL-coupled heuristic rather than a guarantee.
 
-    A deferral's canonical wait is a task lease another holder has not
-    released yet, and a lease on a non-RUNNING row cannot be refreshed, so
+    A deferral's shortest canonical wait is a task lease another holder has
+    not released yet: on a non-RUNNING row the lease cannot be refreshed, so
     it clears within one TTL. The budget (spent roughly once per second —
     ``defer_task_command`` re-arms the claim one second out) must outlast
     that with real margin: a fixed 60 was silently smaller than any raised
@@ -71,9 +71,15 @@ def max_command_defers() -> int:
     every setting; the historical constant stays as the floor so short-TTL
     deployments keep their existing patience. Read per call, not cached:
     the TTL is env-driven and tests vary it.
+
+    This mitigates rather than closes the exhaustion: a RUNNING row's lease
+    is heartbeat-refreshed for the whole turn, so a command deferring behind
+    a turn longer than the budget still fails terminally. The structural
+    fix — patience as a wall-clock deadline against the command's
+    ``created_at`` instead of a defer count — is #1995.
     """
 
-    return max(MAX_COMMAND_DEFERS, int(get_task_lease_ttl_seconds()) * 2)
+    return max(MAX_COMMAND_DEFERS, get_task_lease_ttl_seconds() * 2)
 
 
 DISPATCHER_IDLE_SECONDS = 0.5

--- a/src/xagent/web/services/task_command_transport.py
+++ b/src/xagent/web/services/task_command_transport.py
@@ -54,6 +54,9 @@ COMMAND_TERMINAL = (COMMAND_COMPLETED, COMMAND_FAILED)
 
 COMMAND_ID_PATTERN = re.compile(r"[A-Za-z0-9._:-]{1,64}")
 MAX_COMMAND_FAILURES = 5
+# Since the budget was coupled to the lease TTL, this constant is the FLOOR
+# of the effective defer budget, not the budget itself — compare against
+# max_command_defers(), never against this constant directly.
 MAX_COMMAND_DEFERS = 60
 
 

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -39,11 +39,11 @@ from xagent.web.services.a2a_protocol import (
 )
 from xagent.web.services.task_command_transport import (
     COMMAND_FAILED,
-    MAX_COMMAND_DEFERS,
     MAX_COMMAND_FAILURES,
     ClaimedTaskCommand,
     TaskCommandKind,
     TaskCommandRejected,
+    max_command_defers,
 )
 from xagent.web.services.task_execution_controller import TaskControlState
 from xagent.web.services.task_lease_service import TaskLease, current_task_lease
@@ -2533,7 +2533,7 @@ def test_cancel_retries_a_pre_upgrade_terminal_transport_failure() -> None:
                 status=COMMAND_FAILED,
                 attempt_count=1,
                 failure_count=MAX_COMMAND_FAILURES,
-                defer_count=MAX_COMMAND_DEFERS,
+                defer_count=max_command_defers(),
                 error="temporary transport failure",
                 completed_at=datetime.now(UTC),
             )

--- a/tests/web/api/test_durable_message_resume_contention.py
+++ b/tests/web/api/test_durable_message_resume_contention.py
@@ -27,13 +27,13 @@ from xagent.web.services.task_command_transport import (
     COMMAND_FAILED,
     COMMAND_PENDING,
     COMMAND_PROCESSING,
-    MAX_COMMAND_DEFERS,
     ClaimedTaskCommand,
     TaskCommandDeferred,
     TaskCommandKind,
     dispatch_one_task_command,
     enqueue_task_command,
     get_runner_id,
+    max_command_defers,
 )
 
 
@@ -343,11 +343,11 @@ async def test_exhausted_contention_persists_evidence_based_resend_safety(
     )
     stored = db_session.get(TaskExecutionCommand, enqueued.command_id)
     assert stored is not None
-    stored.defer_count = MAX_COMMAND_DEFERS - 1
+    stored.defer_count = max_command_defers() - 1
     # Each prior clean contention both claimed and deferred once. A stale
     # worker adds one unmatched claim that the reclaiming worker must treat as
     # possible in-flight injection evidence even when no delivery row exists.
-    stored.attempt_count = MAX_COMMAND_DEFERS - 1
+    stored.attempt_count = max_command_defers() - 1
     if unsettled_prior_claim:
         stored.status = COMMAND_PROCESSING
         stored.claimed_by = "stale-worker"
@@ -380,7 +380,7 @@ async def test_exhausted_contention_persists_evidence_based_resend_safety(
     assert stored is not None
     assert stored.status == COMMAND_FAILED
     assert stored.failure_count == 0
-    assert stored.defer_count == MAX_COMMAND_DEFERS
+    assert stored.defer_count == max_command_defers()
     event = (
         db_session.query(TaskCommandTerminalEvent)
         .filter(TaskCommandTerminalEvent.task_command_id == enqueued.command_id)

--- a/tests/web/api/test_external_input_command_seam.py
+++ b/tests/web/api/test_external_input_command_seam.py
@@ -23,6 +23,7 @@ from xagent.web.models.task_command import TaskExecutionCommand
 from xagent.web.models.task_command_terminal_event import TaskCommandTerminalEvent
 from xagent.web.services.external_task_input import (
     EXTERNAL_INPUT_NOT_APPLIED_MESSAGE,
+    EXTERNAL_INPUT_UNCONFIRMED_MESSAGE,
     execute_external_task_input_command,
     register_external_task_input_executor,
     registered_external_task_input_executor,
@@ -32,6 +33,8 @@ from xagent.web.services.task_command_transport import (
     COMMAND_COMPLETED,
     COMMAND_FAILED,
     COMMAND_PENDING,
+    MAX_COMMAND_DEFERS,
+    MAX_COMMAND_FAILURES,
     ClaimedTaskCommand,
     TaskCommandDeferred,
     TaskCommandKind,
@@ -543,6 +546,211 @@ async def test_exhausted_external_deferral_withholds_command_identity(
 
 
 @pytest.mark.asyncio
+async def test_defer_exhaustion_boundary_uses_the_effective_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Both budget consumers must use the effective budget, not the constant.
+
+    With a raised TTL the budget is 2*TTL, so the historical constant's
+    boundary (defer count 60) must stay non-terminal: the wrapper must not
+    broadcast and the transport must keep the row PENDING. At the effective
+    boundary the command terminalizes -- and because an exhausted
+    ``resend_safe=False`` deferral proves nothing about the downstream
+    handoff, the broadcast must assert only uncertainty, never
+    non-application.
+    """
+
+    from unittest.mock import AsyncMock, MagicMock
+
+    monkeypatch.setenv("XAGENT_TASK_LEASE_TTL_SECONDS", "300")
+    budget = max_command_defers()
+    assert budget == 600
+
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
+
+    async def executor(_command: ClaimedTaskCommand) -> dict[str, Any]:
+        raise TaskCommandDeferred("the delivery handoff is still pending")
+
+    register_external_task_input_executor(executor)
+
+    broadcast_manager = MagicMock()
+    broadcast_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", broadcast_manager)
+
+    def seed_defer_count(count: int) -> None:
+        # The command's own claim_expires_at, not a next-attempt column --
+        # this transport has none -- gates whether a PENDING row is
+        # claimable (``_claim_availability_predicate``). The first seed
+        # relies on the fresh row's NULL default; the second clears the
+        # one-second backoff the prior deferral armed so the row is
+        # claimable again without sleeping through real time.
+        db = _direct_db_session()
+        try:
+            db.query(TaskExecutionCommand).filter(
+                TaskExecutionCommand.command_id == "ext-input-boundary"
+            ).update(
+                {
+                    TaskExecutionCommand.defer_count: count,
+                    TaskExecutionCommand.claim_expires_at: None,
+                },
+                synchronize_session=False,
+            )
+            db.commit()
+        finally:
+            db.close()
+
+    db = _direct_db_session()
+    try:
+        enqueued = enqueue_task_command(
+            db,
+            task_id=task_id,
+            actor_user_id=owner_user_id,
+            command_id="ext-input-boundary",
+            kind=TaskCommandKind.MESSAGE,
+            payload={"scope": "external", "message": "the answer"},
+        )
+        assert enqueued.created
+    finally:
+        db.close()
+
+    # The historical constant's boundary: one deferral past count 59 must
+    # spend budget, not terminalize.
+    seed_defer_count(MAX_COMMAND_DEFERS - 1)
+    processed = await dispatch_one_task_command(
+        websocket_api.execute_durable_task_command
+    )
+    assert processed is True
+    broadcast_manager.broadcast_to_task.assert_not_awaited()
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.command_id == "ext-input-boundary")
+            .one()
+        )
+        assert row.status == COMMAND_PENDING
+        assert int(row.defer_count or 0) == MAX_COMMAND_DEFERS
+        assert (
+            db.query(TaskCommandTerminalEvent)
+            .filter(TaskCommandTerminalEvent.task_command_id == int(row.id))
+            .count()
+            == 0
+        )
+    finally:
+        db.close()
+
+    # The effective boundary: the six-hundredth deferral is terminal, and
+    # its broadcast asserts only uncertainty.
+    seed_defer_count(budget - 1)
+    processed = await dispatch_one_task_command(
+        websocket_api.execute_durable_task_command
+    )
+    assert processed is True
+
+    payloads = [
+        call.args[0] for call in broadcast_manager.broadcast_to_task.await_args_list
+    ]
+    assert [payload["type"] for payload in payloads] == ["agent_error"]
+    (exhausted_payload,) = payloads
+    assert exhausted_payload["message"] == EXTERNAL_INPUT_UNCONFIRMED_MESSAGE
+    assert "command_id" not in exhausted_payload
+    assert "command_kind" not in exhausted_payload
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.command_id == "ext-input-boundary")
+            .one()
+        )
+        assert row.status == COMMAND_FAILED
+        event = (
+            db.query(TaskCommandTerminalEvent)
+            .filter(TaskCommandTerminalEvent.task_command_id == int(row.id))
+            .one()
+        )
+        assert event.outcome == "failed"
+        assert event.resend_safe is False
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_exhausted_generic_failure_reports_an_unconfirmed_outcome(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A generic failure proves nothing about the downstream handoff.
+
+    The failure-budget exhaustion arm broadcasts through the same external
+    branch; a worker may have injected the answer before the exception, so
+    the audience must get the uncertainty sentence, never categorical
+    non-application.
+    """
+
+    from unittest.mock import AsyncMock, MagicMock
+
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
+
+    async def executor(_command: ClaimedTaskCommand) -> dict[str, Any]:
+        raise RuntimeError("the runtime broke mid-delivery")
+
+    register_external_task_input_executor(executor)
+
+    broadcast_manager = MagicMock()
+    broadcast_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", broadcast_manager)
+
+    db = _direct_db_session()
+    try:
+        enqueued = enqueue_task_command(
+            db,
+            task_id=task_id,
+            actor_user_id=owner_user_id,
+            command_id="ext-input-generic-failure",
+            kind=TaskCommandKind.MESSAGE,
+            payload={"scope": "external", "message": "the answer"},
+        )
+        assert enqueued.created
+        db.query(TaskExecutionCommand).filter(
+            TaskExecutionCommand.command_id == "ext-input-generic-failure"
+        ).update(
+            {TaskExecutionCommand.failure_count: MAX_COMMAND_FAILURES - 1},
+            synchronize_session=False,
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    processed = await dispatch_one_task_command(
+        websocket_api.execute_durable_task_command
+    )
+    assert processed is True
+
+    payloads = [
+        call.args[0] for call in broadcast_manager.broadcast_to_task.await_args_list
+    ]
+    assert [payload["type"] for payload in payloads] == ["agent_error"]
+    (failure_payload,) = payloads
+    assert failure_payload["message"] == EXTERNAL_INPUT_UNCONFIRMED_MESSAGE
+    assert "command_id" not in failure_payload
+    assert "command_kind" not in failure_payload
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.command_id == "ext-input-generic-failure")
+            .one()
+        )
+        assert row.status == COMMAND_FAILED
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
 async def test_rejected_external_input_broadcasts_and_keeps_the_bound_draft(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -555,27 +763,35 @@ async def test_rejected_external_input_broadcasts_and_keeps_the_bound_draft(
     persist the draft the executor bound -- hardcoding a neutral one
     silently discarded its identity-withholding (#952 M3) -- proven here
     through the real dispatch path, not by reading back the attribute.
+
+    The bound draft uses ``message_code=None`` rather than the more obvious
+    ``TASK_COMMAND_FAILED``: the fallback ``_terminal_command_event_draft``
+    derives exactly ``task_command_failed``/``resend_safe=False``/identity
+    withheld for this exact command (a rejection on an external-scope
+    MESSAGE), so a fallback-equivalent bound value would pass even if
+    precedence were broken and the fallback ran instead. ``None`` is a value
+    ``TerminalTaskEventDraft`` accepts but the fallback never produces, so
+    only the bound draft winning can explain the assertion below.
     """
 
     from unittest.mock import AsyncMock, MagicMock
 
     from xagent.web.services.task_command_terminal_events import (
         TerminalTaskEventDraft,
-        TerminalTaskEventMessageCode,
         bind_terminal_event_draft,
     )
 
     agent_id, owner_user_id = _create_agent()
     task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
 
-    async def executor(command: ClaimedTaskCommand) -> dict[str, Any]:
+    async def executor(_command: ClaimedTaskCommand) -> dict[str, Any]:
         rejection = TaskCommandRejected(
             "the continuation was refused", reason="continuation_refused"
         )
         bind_terminal_event_draft(
             rejection,
             TerminalTaskEventDraft(
-                message_code=TerminalTaskEventMessageCode.TASK_COMMAND_FAILED,
+                message_code=None,
                 resend_safe=False,
                 include_command_identity=False,
             ),
@@ -626,6 +842,80 @@ async def test_rejected_external_input_broadcasts_and_keeps_the_bound_draft(
         row = (
             db.query(TaskExecutionCommand)
             .filter(TaskExecutionCommand.command_id == "ext-input-rejected")
+            .one()
+        )
+        assert row.status == COMMAND_FAILED
+        event = (
+            db.query(TaskCommandTerminalEvent)
+            .filter(TaskCommandTerminalEvent.task_command_id == int(row.id))
+            .one()
+        )
+        assert event.outcome == "failed"
+        assert event.message_code is None
+        assert event.include_command_identity is False
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_rejected_external_input_without_a_bound_draft_gets_the_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """An executor that binds nothing still gets a classified terminal event.
+
+    The rejection arm derives the standard draft only when the executor
+    bound none, so the fallback must classify the outcome
+    (``task_command_failed``) and withhold identity for the external scope
+    -- the other half of the precedence contract pinned above.
+    """
+
+    from unittest.mock import AsyncMock, MagicMock
+
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
+
+    async def executor(_command: ClaimedTaskCommand) -> dict[str, Any]:
+        raise TaskCommandRejected(
+            "the continuation was refused", reason="continuation_refused"
+        )
+
+    register_external_task_input_executor(executor)
+
+    broadcast_manager = MagicMock()
+    broadcast_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", broadcast_manager)
+
+    db = _direct_db_session()
+    try:
+        enqueued = enqueue_task_command(
+            db,
+            task_id=task_id,
+            actor_user_id=owner_user_id,
+            command_id="ext-input-rejected-unbound",
+            kind=TaskCommandKind.MESSAGE,
+            payload={"scope": "external", "message": "the answer"},
+        )
+        assert enqueued.created
+    finally:
+        db.close()
+
+    processed = await dispatch_one_task_command(
+        websocket_api.execute_durable_task_command
+    )
+    assert processed is True
+
+    payloads = [
+        call.args[0] for call in broadcast_manager.broadcast_to_task.await_args_list
+    ]
+    assert [payload["type"] for payload in payloads] == ["agent_error"]
+    (rejection_payload,) = payloads
+    assert rejection_payload["message"] == EXTERNAL_INPUT_NOT_APPLIED_MESSAGE
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.command_id == "ext-input-rejected-unbound")
             .one()
         )
         assert row.status == COMMAND_FAILED

--- a/tests/web/api/test_external_input_command_seam.py
+++ b/tests/web/api/test_external_input_command_seam.py
@@ -13,6 +13,7 @@ scoped command at the WebSocket enqueue boundary.
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -469,8 +470,6 @@ async def test_exhausted_external_deferral_withholds_command_identity(
     same chokepoint.
     """
 
-    from unittest.mock import AsyncMock, MagicMock
-
     agent_id, owner_user_id = _create_agent()
     task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
 
@@ -559,8 +558,6 @@ async def test_defer_exhaustion_boundary_uses_the_effective_budget(
     handoff, the broadcast must assert only uncertainty, never
     non-application.
     """
-
-    from unittest.mock import AsyncMock, MagicMock
 
     monkeypatch.setenv("XAGENT_TASK_LEASE_TTL_SECONDS", "300")
     budget = max_command_defers()
@@ -689,8 +686,6 @@ async def test_exhausted_generic_failure_reports_an_unconfirmed_outcome(
     non-application.
     """
 
-    from unittest.mock import AsyncMock, MagicMock
-
     agent_id, owner_user_id = _create_agent()
     task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
 
@@ -773,8 +768,6 @@ async def test_rejected_external_input_broadcasts_and_keeps_the_bound_draft(
     ``TerminalTaskEventDraft`` accepts but the fallback never produces, so
     only the bound draft winning can explain the assertion below.
     """
-
-    from unittest.mock import AsyncMock, MagicMock
 
     from xagent.web.services.task_command_terminal_events import (
         TerminalTaskEventDraft,
@@ -869,8 +862,6 @@ async def test_rejected_external_input_without_a_bound_draft_gets_the_fallback(
     -- the other half of the precedence contract pinned above.
     """
 
-    from unittest.mock import AsyncMock, MagicMock
-
     agent_id, owner_user_id = _create_agent()
     task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
 
@@ -947,8 +938,6 @@ async def test_rejection_broadcast_failure_does_not_supersede_the_disposition(
     draft persisted.
     """
 
-    from unittest.mock import AsyncMock, MagicMock
-
     from xagent.web.services.task_command_terminal_events import (
         TerminalTaskEventDraft,
         bind_terminal_event_draft,
@@ -1014,6 +1003,232 @@ async def test_rejection_broadcast_failure_does_not_supersede_the_disposition(
         )
         assert event.outcome == "failed"
         assert event.message_code is None
+        assert event.include_command_identity is False
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_rejected_external_cancel_validation_broadcasts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stop whose payload fails validation must not vanish silently.
+
+    The target may be perfectly alive; only the command was malformed. The
+    visitor pressed a button that did nothing, and the cancel core's own
+    success-path broadcast is never reached — the wrapper owns this
+    notification (#1979 review, prior blocking finding). The broadcast uses
+    the external-cancel wording branch and never carries durable command
+    identity.
+    """
+
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
+
+    broadcast_manager = MagicMock()
+    broadcast_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", broadcast_manager)
+
+    db = _direct_db_session()
+    try:
+        enqueued = enqueue_task_command(
+            db,
+            task_id=task_id,
+            actor_user_id=None,
+            command_id="ext-cancel-invalid",
+            kind=TaskCommandKind.CANCEL,
+            payload={
+                "agent_id": agent_id,
+                "scope": "external",
+                # No target_state_version: the validation-class rejection.
+            },
+        )
+        assert enqueued.created
+    finally:
+        db.close()
+
+    processed = await dispatch_one_task_command(
+        websocket_api.execute_durable_task_command
+    )
+    assert processed is True
+
+    payloads = [
+        call.args[0] for call in broadcast_manager.broadcast_to_task.await_args_list
+    ]
+    assert [payload["type"] for payload in payloads] == ["agent_error"]
+    assert "command_id" not in payloads[0]
+    assert "command_kind" not in payloads[0]
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.command_id == "ext-cancel-invalid")
+            .one()
+        )
+        assert row.status == COMMAND_FAILED
+        assert row.result == {"rejection_reason": "invalid_target"}
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_rejected_external_cancel_stale_target_stays_silent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stop whose target moved on keeps its documented silence.
+
+    ``external_task_cancel``'s module contract: a rejected command is
+    terminal without a client-visible error frame when the stop no longer
+    has a target — that run's own settlement owns the transcript and the
+    event. The broadcast gate must not widen into this family.
+    """
+
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
+
+    broadcast_manager = MagicMock()
+    broadcast_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", broadcast_manager)
+
+    db = _direct_db_session()
+    try:
+        enqueued = enqueue_task_command(
+            db,
+            task_id=task_id,
+            actor_user_id=None,
+            command_id="ext-cancel-stale",
+            kind=TaskCommandKind.CANCEL,
+            payload={
+                "agent_id": agent_id,
+                "scope": "external",
+                # Valid shape, wrong version: the run moved on.
+                "target_state_version": 999,
+            },
+        )
+        assert enqueued.created
+    finally:
+        db.close()
+
+    processed = await dispatch_one_task_command(
+        websocket_api.execute_durable_task_command
+    )
+    assert processed is True
+
+    broadcast_manager.broadcast_to_task.assert_not_awaited()
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.command_id == "ext-cancel-stale")
+            .one()
+        )
+        assert row.status == COMMAND_FAILED
+        assert row.result == {"rejection_reason": "stale_run"}
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_first_party_message_rejection_does_not_broadcast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First-party rejections keep their handler-owned notifications.
+
+    The broadcast gate exists for audiences with no channel of their own;
+    a scopeless MESSAGE whose delivery is already FAILED must reject
+    without adding a task-wide agent_error on top of the handler's
+    personal reply (#1979 review NEW-7).
+    """
+
+    async def quiet_chat(_ws: Any, _task_id: int, _data: dict[str, Any]) -> None:
+        return None
+
+    monkeypatch.setattr(websocket_api, "_handle_chat_message_unserialized", quiet_chat)
+    monkeypatch.setattr(
+        websocket_api,
+        "_load_command_actor",
+        lambda _actor_id: SimpleNamespace(id=7, is_admin=False),
+    )
+    monkeypatch.setattr(
+        websocket_api,
+        "_load_command_message_delivery_status",
+        lambda _task_id, _turn_id: "failed",
+    )
+    broadcast_manager = MagicMock()
+    broadcast_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", broadcast_manager)
+
+    command = ClaimedTaskCommand(
+        id=1,
+        task_id=55,
+        actor_user_id=7,
+        command_id="chat-rejected",
+        kind=TaskCommandKind.MESSAGE,
+        payload={"message": "hello"},
+        target_run_id=None,
+        attempt_count=1,
+    )
+
+    with pytest.raises(TaskCommandRejected, match="could not be applied"):
+        await websocket_api.execute_durable_task_command(command)
+
+    broadcast_manager.broadcast_to_task.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_successful_external_message_terminal_event_withholds_identity() -> None:
+    """The disclosure rule holds on the success path too.
+
+    ``finish_task_command`` stages its terminal event with a defaulted
+    draft whose ``include_command_identity`` is True; the persistence
+    chokepoint must strip it for any external-scope command, or a
+    successful answer leaks the durable command identity the failure paths
+    withhold (#1979 review NEW-1).
+    """
+
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
+
+    async def executor(_command: ClaimedTaskCommand) -> dict[str, Any]:
+        return {"admitted": "dispatched"}
+
+    register_external_task_input_executor(executor)
+
+    db = _direct_db_session()
+    try:
+        enqueued = enqueue_task_command(
+            db,
+            task_id=task_id,
+            actor_user_id=None,
+            command_id="ext-input-success",
+            kind=TaskCommandKind.MESSAGE,
+            payload={"scope": "external", "message": "the answer"},
+        )
+        assert enqueued.created
+    finally:
+        db.close()
+
+    processed = await dispatch_one_task_command(
+        websocket_api.execute_durable_task_command
+    )
+    assert processed is True
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.command_id == "ext-input-success")
+            .one()
+        )
+        assert row.status == COMMAND_COMPLETED
+        event = (
+            db.query(TaskCommandTerminalEvent)
+            .filter(TaskCommandTerminalEvent.task_command_id == int(row.id))
+            .one()
+        )
+        assert event.outcome == "completed"
         assert event.include_command_identity is False
     finally:
         db.close()

--- a/tests/web/api/test_external_input_command_seam.py
+++ b/tests/web/api/test_external_input_command_seam.py
@@ -929,3 +929,91 @@ async def test_rejected_external_input_without_a_bound_draft_gets_the_fallback(
         assert event.include_command_identity is False
     finally:
         db.close()
+
+
+@pytest.mark.asyncio
+async def test_rejection_broadcast_failure_does_not_supersede_the_disposition(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed broadcast must not turn a terminal rejection into a retry.
+
+    ``broadcast_to_task`` re-raises non-connection errors (its control-state
+    snapshot read can fail), and an exception escaping the rejection arm
+    would supersede ``TaskCommandRejected``: the dispatcher's generic
+    disposition would then spend the failure budget on a command whose
+    outcome is already durably decided, and the executor-bound draft would
+    be lost with it. The broadcast is fire-and-forget for the disposition:
+    one dispatch must leave the command terminally failed with the bound
+    draft persisted.
+    """
+
+    from unittest.mock import AsyncMock, MagicMock
+
+    from xagent.web.services.task_command_terminal_events import (
+        TerminalTaskEventDraft,
+        bind_terminal_event_draft,
+    )
+
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
+
+    async def executor(_command: ClaimedTaskCommand) -> dict[str, Any]:
+        rejection = TaskCommandRejected(
+            "the continuation was refused", reason="continuation_refused"
+        )
+        bind_terminal_event_draft(
+            rejection,
+            TerminalTaskEventDraft(
+                message_code=None,
+                resend_safe=False,
+                include_command_identity=False,
+            ),
+        )
+        raise rejection
+
+    register_external_task_input_executor(executor)
+
+    broadcast_manager = MagicMock()
+    broadcast_manager.broadcast_to_task = AsyncMock(
+        side_effect=Exception("the control-state snapshot read failed")
+    )
+    monkeypatch.setattr(websocket_api, "manager", broadcast_manager)
+
+    db = _direct_db_session()
+    try:
+        enqueued = enqueue_task_command(
+            db,
+            task_id=task_id,
+            actor_user_id=owner_user_id,
+            command_id="ext-input-broadcast-broke",
+            kind=TaskCommandKind.MESSAGE,
+            payload={"scope": "external", "message": "the answer"},
+        )
+        assert enqueued.created
+    finally:
+        db.close()
+
+    processed = await dispatch_one_task_command(
+        websocket_api.execute_durable_task_command
+    )
+    assert processed is True
+    broadcast_manager.broadcast_to_task.assert_awaited()
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.command_id == "ext-input-broadcast-broke")
+            .one()
+        )
+        assert row.status == COMMAND_FAILED
+        event = (
+            db.query(TaskCommandTerminalEvent)
+            .filter(TaskCommandTerminalEvent.task_command_id == int(row.id))
+            .one()
+        )
+        assert event.outcome == "failed"
+        assert event.message_code is None
+        assert event.include_command_identity is False
+    finally:
+        db.close()

--- a/tests/web/api/test_external_input_command_seam.py
+++ b/tests/web/api/test_external_input_command_seam.py
@@ -31,13 +31,13 @@ from xagent.web.services.task_command_transport import (
     COMMAND_COMPLETED,
     COMMAND_FAILED,
     COMMAND_PENDING,
-    MAX_COMMAND_DEFERS,
     ClaimedTaskCommand,
     TaskCommandDeferred,
     TaskCommandKind,
     TaskCommandRejected,
     dispatch_one_task_command,
     enqueue_task_command,
+    max_command_defers,
 )
 from xagent.web.services.task_execution_controller import TaskControlState
 
@@ -483,12 +483,12 @@ async def test_exhausted_external_deferral_withholds_command_identity() -> None:
         )
         assert enqueued.created
         # Spend all but the last unit of the defer budget so the next
-        # deferral is the terminal one -- MAX_COMMAND_DEFERS real round
+        # deferral is the terminal one -- max_command_defers() real round
         # trips would prove nothing more about the disposition under test.
         db.query(TaskExecutionCommand).filter(
             TaskExecutionCommand.command_id == "ext-input-exhausted"
         ).update(
-            {TaskExecutionCommand.defer_count: MAX_COMMAND_DEFERS - 1},
+            {TaskExecutionCommand.defer_count: max_command_defers() - 1},
             synchronize_session=False,
         )
         db.commit()
@@ -516,6 +516,96 @@ async def test_exhausted_external_deferral_withholds_command_identity() -> None:
         assert event.outcome == "failed"
         assert event.message_code == "task_command_deferred"
         assert event.resend_safe is True
+        assert event.include_command_identity is False
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_rejected_external_input_broadcasts_and_keeps_the_bound_draft(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A terminal rejection must surface, and the executor's draft must win.
+
+    The seam executor is the one MESSAGE handler with no notification
+    channel of its own: without the broadcast, a deferred answer that is
+    later terminally rejected vanishes silently while the task stays parked
+    (xorbitsai/xagent-saas#952 B2). And the rejection disposition must
+    persist the draft the executor bound -- hardcoding a neutral one
+    silently discarded its identity-withholding (#952 M3) -- proven here
+    through the real dispatch path, not by reading back the attribute.
+    """
+
+    from unittest.mock import AsyncMock, MagicMock
+
+    from xagent.web.services.task_command_terminal_events import (
+        TerminalTaskEventDraft,
+        TerminalTaskEventMessageCode,
+        bind_terminal_event_draft,
+    )
+
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
+
+    async def executor(command: ClaimedTaskCommand) -> dict[str, Any]:
+        rejection = TaskCommandRejected(
+            "the continuation was refused", reason="continuation_refused"
+        )
+        bind_terminal_event_draft(
+            rejection,
+            TerminalTaskEventDraft(
+                message_code=TerminalTaskEventMessageCode.TASK_COMMAND_FAILED,
+                resend_safe=False,
+                include_command_identity=False,
+            ),
+        )
+        raise rejection
+
+    register_external_task_input_executor(executor)
+
+    broadcast_manager = MagicMock()
+    broadcast_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", broadcast_manager)
+
+    db = _direct_db_session()
+    try:
+        enqueued = enqueue_task_command(
+            db,
+            task_id=task_id,
+            actor_user_id=owner_user_id,
+            command_id="ext-input-rejected",
+            kind=TaskCommandKind.MESSAGE,
+            payload={"scope": "external", "message": "the answer"},
+        )
+        assert enqueued.created
+    finally:
+        db.close()
+
+    processed = await dispatch_one_task_command(
+        websocket_api.execute_durable_task_command
+    )
+    assert processed is True
+
+    payloads = [
+        call.args[0] for call in broadcast_manager.broadcast_to_task.await_args_list
+    ]
+    assert [payload["type"] for payload in payloads] == ["agent_error"]
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.command_id == "ext-input-rejected")
+            .one()
+        )
+        assert row.status == COMMAND_FAILED
+        event = (
+            db.query(TaskCommandTerminalEvent)
+            .filter(TaskCommandTerminalEvent.task_command_id == int(row.id))
+            .one()
+        )
+        assert event.outcome == "failed"
+        assert event.message_code == "task_command_failed"
         assert event.include_command_identity is False
     finally:
         db.close()

--- a/tests/web/api/test_external_input_command_seam.py
+++ b/tests/web/api/test_external_input_command_seam.py
@@ -22,6 +22,7 @@ from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.task_command import TaskExecutionCommand
 from xagent.web.models.task_command_terminal_event import TaskCommandTerminalEvent
 from xagent.web.services.external_task_input import (
+    EXTERNAL_INPUT_NOT_APPLIED_MESSAGE,
     execute_external_task_input_command,
     register_external_task_input_executor,
     registered_external_task_input_executor,
@@ -449,7 +450,9 @@ async def test_deferred_external_input_spends_the_defer_budget_not_failures() ->
 
 
 @pytest.mark.asyncio
-async def test_exhausted_external_deferral_withholds_command_identity() -> None:
+async def test_exhausted_external_deferral_withholds_command_identity(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """An external audience never sees durable command identity.
 
     The terminal rebind in ``execute_durable_task_command`` runs *after* the
@@ -457,8 +460,13 @@ async def test_exhausted_external_deferral_withholds_command_identity() -> None:
     ``_terminal_command_event_draft`` itself: an exhausted external-scope
     deferral must persist ``include_command_identity=False`` (same policy as
     the external cancel) while still carrying the exception's own
-    ``resend_safe`` evidence.
+    ``resend_safe`` evidence. The live ``agent_error`` frame follows the
+    same rule: identity withheld and a purpose-built terminal sentence,
+    pinned here because the exhausted-deferral path broadcasts through the
+    same chokepoint.
     """
+
+    from unittest.mock import AsyncMock, MagicMock
 
     agent_id, owner_user_id = _create_agent()
     task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
@@ -470,6 +478,10 @@ async def test_exhausted_external_deferral_withholds_command_identity() -> None:
         )
 
     register_external_task_input_executor(executor)
+
+    broadcast_manager = MagicMock()
+    broadcast_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", broadcast_manager)
 
     db = _direct_db_session()
     try:
@@ -499,6 +511,15 @@ async def test_exhausted_external_deferral_withholds_command_identity() -> None:
         websocket_api.execute_durable_task_command
     )
     assert processed is True
+
+    payloads = [
+        call.args[0] for call in broadcast_manager.broadcast_to_task.await_args_list
+    ]
+    assert [payload["type"] for payload in payloads] == ["agent_error"]
+    (exhausted_payload,) = payloads
+    assert exhausted_payload["message"] == EXTERNAL_INPUT_NOT_APPLIED_MESSAGE
+    assert "command_id" not in exhausted_payload
+    assert "command_kind" not in exhausted_payload
 
     db = _direct_db_session()
     try:
@@ -590,6 +611,15 @@ async def test_rejected_external_input_broadcasts_and_keeps_the_bound_draft(
         call.args[0] for call in broadcast_manager.broadcast_to_task.await_args_list
     ]
     assert [payload["type"] for payload in payloads] == ["agent_error"]
+
+    (rejection_payload,) = payloads
+    # The live frame mirrors the persisted-event disclosure rule: the
+    # external audience never sees durable command identity, and the generic
+    # fallback's "Please try again." would be false for the non-retryable
+    # rejections this broadcast exists to surface.
+    assert rejection_payload["message"] == EXTERNAL_INPUT_NOT_APPLIED_MESSAGE
+    assert "command_id" not in rejection_payload
+    assert "command_kind" not in rejection_payload
 
     db = _direct_db_session()
     try:

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -198,8 +198,11 @@ def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
     # frame in favour of the control-only ``task_resumed`` shape. The inner
     # RuntimeError arm now also reuses ``answer_durable_turn_failure`` instead
     # of spelling out three error payloads locally, bringing the census to 50.
-    assert result.error_payloads == 50, (
-        f"expected exactly 50 error payloads, matched {result.error_payloads}; "
+    # ``_broadcast_terminal_command_error`` gained a third payload literal for
+    # external-scope non-cancel commands, mirroring the persisted-event
+    # identity rule for the live frame too, bringing the census to 51.
+    assert result.error_payloads == 51, (
+        f"expected exactly 51 error payloads, matched {result.error_payloads}; "
         "review the changed sites and bump deliberately"
     )
     # Every allowlist entry must be earned by a live call site: a stale entry

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -2672,7 +2672,7 @@ async def test_origin_entry_dies_with_its_command_or_socket(
         "retrying deferral keeps the origin"
     )
     exhausted = _pause_command(command_id="pause:cleanup")
-    exhausted.defer_count = websocket_api.MAX_COMMAND_DEFERS
+    exhausted.defer_count = websocket_api.max_command_defers()
     with pytest.raises(websocket_api.TaskCommandDeferred):
         await websocket_api.execute_durable_task_command(exhausted)
     assert not origins.has(command.command_id, command.task_id)

--- a/tests/web/services/test_task_command_terminal_events.py
+++ b/tests/web/services/test_task_command_terminal_events.py
@@ -271,7 +271,11 @@ def test_external_cancel_suppresses_command_identity_projection(
             TaskCommandKind.PAUSE,
             {"scope": "external"},
             True,
-            True,
+            # The disclosure rule is scope-based, not kind-based: any
+            # external-scope command withholds durable command identity,
+            # because the audience is anonymous whatever the kind
+            # (#1979 review NEW-1 widened this from cancel-only).
+            False,
             id="external-scope-on-non-cancel",
         ),
         pytest.param(

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -62,6 +62,7 @@ from xagent.web.services.task_command_transport import (
     fail_task_command,
     finish_task_command,
     load_task_command,
+    max_command_defers,
     notify_task_command_dispatcher,
     renew_task_command_claim,
     retry_failed_task_command,
@@ -706,7 +707,7 @@ async def test_final_command_deferral_is_broadcast(db_session) -> None:
         payload={"agent_id": 1},
         target_run_id=None,
         attempt_count=1,
-        defer_count=MAX_COMMAND_DEFERS - 1,
+        defer_count=max_command_defers() - 1,
     )
 
     with patch.object(
@@ -911,7 +912,7 @@ async def test_deferred_message_eventually_fails_and_unblocks_cancel(
     )
     row = db_session.get(TaskExecutionCommand, message.command_id)
     assert row is not None
-    row.defer_count = MAX_COMMAND_DEFERS - 1
+    row.defer_count = max_command_defers() - 1
     db_session.commit()
 
     async def defer(_command):
@@ -923,7 +924,7 @@ async def test_deferred_message_eventually_fails_and_unblocks_cancel(
     assert row is not None
     assert row.status == COMMAND_FAILED
     assert row.failure_count == 0
-    assert row.defer_count == MAX_COMMAND_DEFERS
+    assert row.defer_count == max_command_defers()
     event = (
         db_session.query(TaskCommandTerminalEvent)
         .filter(TaskCommandTerminalEvent.task_command_id == message.command_id)
@@ -980,7 +981,7 @@ def test_failed_command_retry_preserves_immutable_target(db_session) -> None:
     assert row is not None
     row.status = COMMAND_FAILED
     row.failure_count = MAX_COMMAND_FAILURES
-    row.defer_count = MAX_COMMAND_DEFERS
+    row.defer_count = max_command_defers()
     row.error = "temporary cancellation failure"
     row.completed_at = datetime.utcnow()
     db_session.commit()
@@ -2901,3 +2902,22 @@ def test_enqueue_notifies_only_after_commit(db_session, monkeypatch) -> None:
     )
 
     assert order == ["commit", "notify"]
+
+
+def test_defer_budget_is_coupled_to_the_lease_ttl(monkeypatch):
+    """The defer budget must outlast the configured lease TTL with margin.
+
+    A deferral's canonical wait is an unreleased task lease, which clears
+    within one TTL; a fixed budget silently smaller than a raised
+    ``XAGENT_TASK_LEASE_TTL_SECONDS`` turned every long park into a terminal
+    failure for an already-accepted command (xorbitsai/xagent-saas#952 B3).
+    """
+
+    from xagent.web.services.task_command_transport import max_command_defers
+
+    monkeypatch.setenv("XAGENT_TASK_LEASE_TTL_SECONDS", "300")
+    assert max_command_defers() == 600
+
+    # The historical constant stays as the floor for short TTLs.
+    monkeypatch.setenv("XAGENT_TASK_LEASE_TTL_SECONDS", "10")
+    assert max_command_defers() == MAX_COMMAND_DEFERS

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -2904,7 +2904,9 @@ def test_enqueue_notifies_only_after_commit(db_session, monkeypatch) -> None:
     assert order == ["commit", "notify"]
 
 
-def test_defer_budget_is_coupled_to_the_lease_ttl(monkeypatch):
+def test_defer_budget_is_coupled_to_the_lease_ttl(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """The defer budget must outlast the configured lease TTL with margin.
 
     A deferral's canonical wait is an unreleased task lease, which clears
@@ -2913,11 +2915,17 @@ def test_defer_budget_is_coupled_to_the_lease_ttl(monkeypatch):
     failure for an already-accepted command (xorbitsai/xagent-saas#952 B3).
     """
 
-    from xagent.web.services.task_command_transport import max_command_defers
-
     monkeypatch.setenv("XAGENT_TASK_LEASE_TTL_SECONDS", "300")
     assert max_command_defers() == 600
 
     # The historical constant stays as the floor for short TTLs.
     monkeypatch.setenv("XAGENT_TASK_LEASE_TTL_SECONDS", "10")
     assert max_command_defers() == MAX_COMMAND_DEFERS
+
+    # The default (no env var) doubles the historical constant.
+    monkeypatch.delenv("XAGENT_TASK_LEASE_TTL_SECONDS", raising=False)
+    assert max_command_defers() == 120
+
+    # An invalid value falls back to the default TTL, not the floor.
+    monkeypatch.setenv("XAGENT_TASK_LEASE_TTL_SECONDS", "not-a-number")
+    assert max_command_defers() == 120


### PR DESCRIPTION
Follow-up to #1973, fixing three defects found in the review of xorbitsai/xagent-saas#952 (findings B2, B3, M3 there).

## Summary

- **Terminal rejections of external-scope MESSAGE commands now broadcast.** `execute_durable_task_command`'s `TaskCommandRejected` arm neither bound a terminal draft nor called `_broadcast_terminal_command_error` — the seam executor is the one MESSAGE handler with no notification channel of its own, so a deferred external answer that was later terminally rejected (revoked principal, stale request, spent id, quota) vanished silently while its task stayed parked. External-scope MESSAGE rejections broadcast the client-safe terminal error; most first-party rejections keep their handler-owned enqueue-time notifications and are deliberately not re-broadcast (#952 B2; the `finish_existing_delivery` sub-cases below are a known pre-existing exception).
- **The live broadcast mirrors the persisted disclosure rule.** `_broadcast_terminal_command_error` now withholds `command_id`/`command_kind` for every external-scope command, not just cancels, matching `include_command_identity=scope != EXTERNAL_COMMAND_SCOPE`; external MESSAGE terminals carry a purpose-built sentence (`EXTERNAL_INPUT_NOT_APPLIED_MESSAGE`) that asserts the refusal and instructs neither retry nor abandonment — an identical resubmission legitimately reopens a spent budget, while a revoked principal makes any retry futile (review round 2, findings 1–2).
- **An executor-bound terminal draft now survives the rejection disposition.** The transport's rejection closure hardcoded a neutral `TerminalTaskEventDraft`, silently discarding the draft the executor bound (the seam's documented contract) — `include_command_identity=False` never persisted. Bound draft wins; the literal stays as the fallback (#952 M3). Proven through the real dispatch path, not by reading back the attribute.
- **The defer budget is coupled to the lease TTL.** `MAX_COMMAND_DEFERS = 60` with a one-second re-arm was uncoupled from `XAGENT_TASK_LEASE_TTL_SECONDS` (default 60, env-overridable): a lease held for real wall-clock time — the parked-task retention window, or any raised TTL — exhausted an already-accepted command into a terminal failure. The effective budget is now `max_command_defers() = max(60, 2 * TTL)`, 100% headroom at every setting, with the historical constant as the floor (#952 B3). **Note: this doubles the default deployment's budget from 60 to 120**, documented in `example.env`. This is a mitigation, not a structural closure — a RUNNING row's lease is heartbeat-refreshed for the whole turn, so a turn longer than the budget can still exhaust an accepted command; the wall-clock deadline is #1995.

## Verification

- Three new/extended tests: `test_rejected_external_input_broadcasts_and_keeps_the_bound_draft` (real `dispatch_one_task_command` end to end: broadcast emitted with the purpose-built sentence and no identity fields, terminal event persists the bound draft with identity withheld), `test_exhausted_external_deferral_withholds_command_identity` (now also pins the live broadcast payload), and `test_defer_budget_is_coupled_to_the_lease_ttl`.
- Existing exhaustion tests moved from the constant to the effective budget (`max_command_defers()`); the constant remains exported for its floor role. The payload-literal census moves 50 → 51 for the new identity-free literal.
- Suites green: `test_external_input_command_seam` (14), `test_durable_message_resume_contention`, `test_task_command_transport` (74), `test_external_task_cancel`, `test_websocket_owner_actor`, `test_websocket_client_safe_errors`, `test_a2a_api`, `test_task_command_terminal_events` — PostgreSQL-parametrized cases skipped locally.
- Ruff and mypy clean on touched files.

## Out of scope (tracked)

- Restore-to-parked on provably pre-dispatch cancellation of a preacquired-lease resume: #1977.
- CANCEL overtaking a deferring MESSAGE in the per-task FIFO: #1978.
- Inconsistent terminal-draft binding across `execute_durable_task_command`'s exception arms (bind-only-if-unbound helper): #1994.
- Defer budget as a wall-clock deadline against `created_at` (structural closure of the exhaustion during long turns): #1995.
- Terminal command error broadcasts fire before the disposition persists and carry no dedupe, so a reclaim can duplicate a client-facing `agent_error` (pre-existing shape): #1996.
- Remaining coverage from review round 2 finding 8 (first-party non-broadcast, external CANCEL routing, default/invalid TTL budget): #1997.
- External CANCEL rejections are terminal without a live frame by design (`external_task_cancel.py` module docstring); whether any rejection reason (notably `stale_run` against a still-live successor run) should gain a live frame is a per-reason policy question: #2009. The same unguarded-broadcast shape fixed here for the rejection arm pre-exists in the deferral-exhaustion and generic-failure arms (from #857): #2013.
- Persisted `message_code` for external MESSAGE terminals still uses the generic codes while the live sentence is purpose-built: #2010. Consolidating the four independent identity-withholding sites into one classifier: #2011. The client-safe AST guard trusts, rather than verifies, blessed constructor bodies: #2012.
- First-party rejections surfacing during durable re-execution (as opposed to enqueue time) currently get no notification through any channel (`suppress_delivery_ack` path, pre-existing and unmodified here). The same holds for `finish_existing_delivery`'s stale-payload-conflict and already-failed-delivery sub-cases, which set `_durable_ack_sent` unconditionally and never broadcast (#1979 round 5, NEW-5).



