### PR TITLE
fix(onboarding): remove the visible focus outline on step headings

### DIFF
--- a/frontend/src/app/onboarding/onboarding.css
+++ b/frontend/src/app/onboarding/onboarding.css
@@ -324,6 +324,16 @@
   font-weight: 760;
   letter-spacing: -0.036em;
   color: hsl(var(--foreground));
+  /* This heading gets tabIndex={-1} and a programmatic .focus() call on
+     every step change (page.tsx's stepHeadingRef effect) purely so screen
+     readers announce the new step - tabIndex={-1} already keeps it out of
+     the normal Tab order entirely, so no keyboard user ever reaches it by
+     tabbing. Without this, the browser's native focus ring (visible right
+     after a step change, until the next pointer interaction anywhere on
+     the page flips :focus-visible's heuristic) showed up as an unrelated,
+     confusing blue box around the heading text for sighted mouse users -
+     a user-reported bug, reproduced in both Chrome and Safari. */
+  outline: none;
 }
 .ob-step h1 em {
   font-style: normal;


### PR DESCRIPTION
## Summary
- Each onboarding step's `<h1>` gets `tabIndex={-1}` and a programmatic `.focus()` call on every step change, purely so screen readers announce the new step.
- `tabIndex={-1}` already keeps it out of the normal Tab order, so no keyboard user ever reaches it by tabbing - the visible focus ring has no accessibility purpose here.
- With no outline suppression, the browser's native focus ring showed up as an unrelated blue box around the heading text right after each step change, until the next pointer interaction anywhere on the page. Reported by a user, reproduced in both Chrome and Safari.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean
- [x] Confirmed the root cause via `document.activeElement`/computed style inspection on a live `/onboarding` session (outline/box-shadow/border were unset for this element before the fix)
- [x] Manually reproduced in Chrome and Safari before the fix; visual-only CSS change, no logic touched