### PR TITLE
fix(db): fail startup when the live taskstatus enum has drifted

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -26,6 +26,7 @@ on:
       - 'src/xagent/web/models/task.py'
       - 'tests/web/services/task_status_storage_shared.py'
       - 'tests/web/services/test_task_status_storage_postgresql.py'
+      - 'tests/web/services/test_task_status_enum_drift.py'
       - 'src/xagent/web/api/monitor.py'
       - 'tests/web/api/test_monitor_postgresql.py'
       - 'tests/web/api/monitor_daily_window_shared.py'
@@ -114,6 +115,7 @@ jobs:
             src/xagent/web/models/task.py
             tests/web/services/task_status_storage_shared.py
             tests/web/services/test_task_status_storage_postgresql.py
+            tests/web/services/test_task_status_enum_drift.py
             src/xagent/web/api/monitor.py
             tests/web/api/test_monitor_postgresql.py
             tests/web/api/monitor_daily_window_shared.py
@@ -378,6 +380,20 @@ jobs:
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
           pytest tests/web/services/test_task_status_storage_postgresql.py -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
+      # -m postgresql because this file is mixed: the PostgreSQL cells need a
+      # live server, and the non-PostgreSQL cells pin the check being skipped
+      # outright and already run in the ordinary suite. Each PostgreSQL cell
+      # creates and drops its own disposable database, so this step has no
+      # ordering dependency on the others -- and dropping/recreating the
+      # taskstatus type, which several of the cells do, never reaches the
+      # base database this URL names.
+      - name: Test taskstatus enum drift startup guard (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/web/services/test_task_status_enum_drift.py -m postgresql -q
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -397,6 +397,13 @@ jobs:
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 
+      - name: Test taskstatus enum repair migration (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/migrations/test_20260901_add_task_status_waiting_for_user_enum_label.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
       - name: Test task_interaction_requests migration (Postgres-only)
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |

--- a/src/xagent/migrations/versions/20260901_add_task_status_waiting_for_user_enum_label.py
+++ b/src/xagent/migrations/versions/20260901_add_task_status_waiting_for_user_enum_label.py
@@ -1,0 +1,121 @@
+"""add WAITING_FOR_USER to the native enum backing tasks.status
+
+Revision ID: 20260901_taskstatus_waiting_for_user
+Revises: 20260828_terminal_cmd_events
+Create Date: 2026-09-01 00:00:00.000000
+
+``TaskStatus.WAITING_FOR_USER`` entered the application enum on 2026-05-14.
+On PostgreSQL ``tasks.status`` is a native enum type whose labels are fixed
+when the type is created, and ``Base.metadata.create_all`` does not add
+labels to a type that already exists -- so a database initialized before
+that date still carries the five-label type, and every write of the new
+label fails at the write. This revision adds the label to the type
+``tasks.status`` is actually declared with.
+
+It resolves that type the way ``check_task_status_enum_drift``
+(``web/models/task.py``) resolves it -- through the column, not through
+whichever type happens to be named ``taskstatus`` -- because the two must
+agree: an asymmetric ``search_path`` can otherwise point the repair at one
+type and the check at another.
+
+Only this one label, deliberately. A revision runs once and is then recorded
+in ``alembic_version``, so a "add whatever TaskStatus has that the database
+lacks" body would still not add a member introduced after this revision had
+already run. Each new ``TaskStatus`` member needs its own revision.
+
+Non-PostgreSQL backends store the column as a plain string and have no
+native type to repair, so this revision is a no-op there.
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260901_taskstatus_waiting_for_user"
+down_revision: Union[str, None] = "20260828_terminal_cmd_events"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "tasks"
+COLUMN = "status"
+LABEL = "WAITING_FOR_USER"
+# Offline (``--sql``) rendering cannot reflect anything, so it emits the
+# unqualified name -- the one an operator's own psql session resolves the
+# same way the application does.
+OFFLINE_TYPE_NAME = "taskstatus"
+
+# ``regtype`` renders the OID as a name that resolves back to the same type
+# under the current ``search_path``, schema-qualifying it exactly when an
+# unqualified name would resolve somewhere else. That makes the rendering
+# safe to put straight back into ``ALTER TYPE``, and it comes from the system
+# catalog rather than from any caller. ``typtype = 'e'`` keeps a ``status``
+# column that is not an enum out of the result entirely.
+_COLUMN_ENUM_TYPE_SQL = sa.text(
+    "SELECT a.atttypid::regtype::text "
+    "FROM pg_catalog.pg_attribute a "
+    "JOIN pg_catalog.pg_type t ON t.oid = a.atttypid "
+    "WHERE a.attrelid = pg_catalog.to_regclass(:table_name) "
+    "AND a.attname = :column_name "
+    "AND t.typtype = 'e'"
+)
+
+_LABEL_PRESENT_SQL = sa.text(
+    "SELECT 1 "
+    "FROM pg_catalog.pg_attribute a "
+    "JOIN pg_catalog.pg_enum e ON e.enumtypid = a.atttypid "
+    "WHERE a.attrelid = pg_catalog.to_regclass(:table_name) "
+    "AND a.attname = :column_name "
+    "AND e.enumlabel = :label"
+)
+
+
+def _add_value_sql(type_name: str) -> str:
+    return f"ALTER TYPE {type_name} ADD VALUE IF NOT EXISTS '{LABEL}'"
+
+
+def upgrade() -> None:
+    context = op.get_context()
+    if context.dialect.name != "postgresql":
+        return
+
+    if context.as_sql:
+        with context.autocommit_block():
+            op.execute(_add_value_sql(OFFLINE_TYPE_NAME))
+        return
+
+    bind = op.get_bind()
+    params = {"table_name": TABLE, "column_name": COLUMN}
+    type_name = bind.execute(_COLUMN_ENUM_TYPE_SQL, params).scalar_one_or_none()
+    if type_name is None:
+        # Either there is no tasks table yet -- a brand-new database, where
+        # create_all builds the type with every current label right after the
+        # migrations run -- or status is not a native enum. ALTER TYPE
+        # repairs neither, and check_task_status_enum_drift is the place that
+        # reports the second one.
+        return
+
+    if bind.execute(_LABEL_PRESENT_SQL, {**params, "label": LABEL}).first() is not None:
+        return
+
+    # An autocommit block rather than the surrounding per-migration
+    # transaction. database_startup_lock holds a *session*-level advisory lock
+    # and commits before yielding precisely so Alembic can do this
+    # (db/migration.py), so the intermediate commit does not release it. What
+    # it buys: PostgreSQL rejects a write of a label added earlier in the same
+    # transaction ("unsafe use of new value"), and that error aborts the
+    # transaction, taking the ALTER TYPE down with it. Committing the label on
+    # its own puts that failure mode out of reach instead of leaving it to
+    # whatever a later edit adds below this line.
+    with context.autocommit_block():
+        op.execute(_add_value_sql(type_name))
+
+
+def downgrade() -> None:
+    # One-way by construction: PostgreSQL has no ALTER TYPE ... DROP VALUE.
+    # Removing one label means building a replacement type, rewriting every
+    # tasks.status value and the column default onto it under an exclusive
+    # lock, and dropping the old type -- to reach a state whose only property
+    # is that it cannot store WAITING_FOR_USER. A label no process writes
+    # costs nothing to leave in place.
+    pass

--- a/src/xagent/web/models/database.py
+++ b/src/xagent/web/models/database.py
@@ -217,7 +217,9 @@ def configure_db(
 
 
 def _initialize_database_schema(engine: Engine) -> list[dict[str, Any]]:
-    """Migrate, create, and seed the schema under one startup ownership lock."""
+    """Migrate, create, and seed the schema under one startup ownership lock,
+    and refuse to serve if the live ``taskstatus`` enum has drifted from
+    ``TaskStatus`` (``check_task_status_enum_drift``, ``models/task.py``)."""
 
     from ...db.migration import (
         database_startup_lock,
@@ -228,6 +230,7 @@ def _initialize_database_schema(engine: Engine) -> list[dict[str, Any]]:
         seed_builtin_oauth_and_public_mcp_apps,
         validate_builtin_public_mcp_apps,
     )
+    from .task import check_task_status_enum_drift
 
     with database_startup_lock(engine) as locked_connection:
         startup_bind: Engine | Connection = (
@@ -240,12 +243,21 @@ def _initialize_database_schema(engine: Engine) -> list[dict[str, Any]]:
         )
         Base.metadata.create_all(bind=startup_bind)
 
+        # Checked on both branches rather than only where locked_connection is
+        # set: database_startup_lock yields None outright on any non-PostgreSQL
+        # backend (see that function's own docstring), so PostgreSQL always
+        # takes the locked branch and the other branch's check is a no-op there
+        # -- but tying the check to "schema is ready" rather than to "which
+        # branch we're on" means a future change to the lock's backend behavior
+        # can't silently drop it.
         if locked_connection is not None:
+            check_task_status_enum_drift(locked_connection)
             if should_seed_builtin_mcp_registry:
                 seed_builtin_oauth_and_public_mcp_apps(locked_connection)
             return validate_builtin_public_mcp_apps(locked_connection)
 
         with engine.begin() as connection:
+            check_task_status_enum_drift(connection)
             if should_seed_builtin_mcp_registry:
                 seed_builtin_oauth_and_public_mcp_apps(connection)
             return validate_builtin_public_mcp_apps(connection)

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -60,6 +60,24 @@ class TaskStatusEnumDriftError(RuntimeError):
     """
 
 
+#: The Alembic revision that adds ``WAITING_FOR_USER`` to a native
+#: ``taskstatus`` enum created before that member existed. Named in the
+#: remediation text below so an operator reading a startup failure has an
+#: exact revision rather than a description; pinned against the revision file
+#: itself by
+#: tests/migrations/test_20260901_add_task_status_waiting_for_user_enum_label.py.
+TASKSTATUS_ENUM_REPAIR_REVISION = "20260901_taskstatus_waiting_for_user"
+
+_MISSING_LABEL_REMEDY = (
+    "Upgrade this database to the Alembic head: revision "
+    f"{TASKSTATUS_ENUM_REPAIR_REVISION} adds WAITING_FOR_USER to the type "
+    "backing tasks.status. A label no revision adds needs one written; to "
+    "repair a database by hand instead, run ALTER TYPE <the type tasks.status "
+    "is declared with> ADD VALUE IF NOT EXISTS '<label>' for each missing "
+    "label, then restart this process."
+)
+
+
 def check_task_status_enum_drift(bind: Connection) -> None:
     """Refuse to serve when the live ``taskstatus`` enum's labels disagree
     with ``TaskStatus``'s own members.
@@ -75,7 +93,9 @@ def check_task_status_enum_drift(bind: Connection) -> None:
     follow from that placement and are the reason for it. A migration that
     adds a ``TaskStatus`` label via ``ALTER TYPE ... ADD VALUE`` has already
     run by the time this check reads the catalog, so shipping one cannot
-    trip this check into a crash loop. The connection is the startup lock's
+    trip this check into a crash loop -- revision
+    ``20260901_taskstatus_waiting_for_user`` is that migration for
+    ``WAITING_FOR_USER``. The connection is the startup lock's
     own, so this check adds no failure mode of its own beyond the ones
     schema initialization already has. And no second backend worker can
     observe a half-initialized database while it runs.
@@ -140,16 +160,12 @@ def check_task_status_enum_drift(bind: Connection) -> None:
     extra = sorted(live_labels - expected_labels)
     if missing and extra:
         remedy = (
-            "Run the pending migration that adds the missing label(s); the "
-            "unexpected label(s) indicate this process is older than the "
-            "database and cannot be reconciled by a migration, since "
-            "PostgreSQL has no ALTER TYPE ... DROP VALUE."
+            f"{_MISSING_LABEL_REMEDY} The unexpected label(s) indicate this "
+            "process is older than the database and cannot be reconciled by "
+            "a migration, since PostgreSQL has no ALTER TYPE ... DROP VALUE."
         )
     elif missing:
-        remedy = (
-            "Run the pending migration that adds the missing label(s) before "
-            "starting this process."
-        )
+        remedy = _MISSING_LABEL_REMEDY
     else:
         remedy = (
             "No migration can remove them -- PostgreSQL has no ALTER TYPE ... "

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -16,7 +16,12 @@ from sqlalchemy import (
     Text,
     UniqueConstraint,
 )
+from sqlalchemy import inspect as sa_inspect
+from sqlalchemy import (
+    text,
+)
 from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.engine import Connection
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
@@ -44,6 +49,106 @@ class TaskStatus(enum.Enum):
     WAITING_FOR_USER = "waiting_for_user"
     COMPLETED = "completed"
     FAILED = "failed"
+
+
+class TaskStatusEnumDriftError(RuntimeError):
+    """The live database's ``taskstatus`` enum does not carry the same labels
+    as ``TaskStatus``. Raised during database startup, before the process
+    begins serving, because a mismatch here has no runtime remedy: writing a
+    label the database does not have fails at the write, in request context,
+    after the caller already believes the transition happened.
+    """
+
+
+def check_task_status_enum_drift(bind: Connection) -> None:
+    """Refuse to serve when the live ``taskstatus`` enum's labels disagree
+    with ``TaskStatus``'s own members.
+
+    A no-op on every backend other than PostgreSQL: ``pg_enum`` is a
+    PostgreSQL system catalog, and the other backends this repo supports
+    store the ``Enum`` column as a plain string, checked at the ORM layer
+    instead.
+
+    Takes the caller's connection rather than opening its own, and runs from
+    ``_initialize_database_schema`` (``models/database.py``) after
+    ``try_upgrade_db`` and inside ``database_startup_lock``. Three properties
+    follow from that placement and are the reason for it. A migration that
+    adds a ``TaskStatus`` label via ``ALTER TYPE ... ADD VALUE`` has already
+    run by the time this check reads the catalog, so shipping one cannot
+    trip this check into a crash loop. The connection is the startup lock's
+    own, so this check adds no failure mode of its own beyond the ones
+    schema initialization already has. And no second backend worker can
+    observe a half-initialized database while it runs.
+
+    Unlike ``validate_builtin_public_mcp_apps`` (``builtin_mcp_registry.py``),
+    which runs from the same place and only reports drift, this one raises.
+    Catalog drift there is configuration that an operator can reconcile while
+    the process serves; a missing enum label is a write that will fail after
+    a caller already believes a status transition succeeded, so the process
+    must not begin serving at all.
+
+    Keyed on the ``tasks`` table's existence rather than on an empty live
+    label set: ``taskstatus`` is the type of ``tasks.status``, so "``tasks``
+    is present but ``taskstatus`` is not" produces the same empty set as
+    "nothing has been created yet" while being exactly the drift this check
+    exists to catch. Callers that run schema creation first (the startup path
+    does) always find ``tasks`` present; the guard covers a caller that
+    passes a bind whose schema has not been created.
+
+    Resolves ``taskstatus`` the way an unqualified name resolves at runtime:
+    ``pg_type_is_visible`` narrows the label set to the single type the
+    connection's ``search_path`` picks, the same schema the
+    ``has_table("tasks")`` call above already resolves against. Without that
+    narrowing every same-named enum in the database joins the result -- extra
+    labels on a copy in another schema would reject a correct deployment, and
+    a complete copy there would hide a label genuinely missing here.
+    """
+
+    if bind.dialect.name != "postgresql":
+        return
+
+    if not sa_inspect(bind).has_table("tasks"):
+        return  # schema not created yet -- nothing to compare
+
+    live_labels = set(
+        bind.scalars(
+            text(
+                "SELECT e.enumlabel FROM pg_catalog.pg_type t "
+                "JOIN pg_catalog.pg_enum e ON t.oid = e.enumtypid "
+                "WHERE t.typname = 'taskstatus' "
+                "AND pg_catalog.pg_type_is_visible(t.oid)"
+            )
+        )
+    )
+
+    expected_labels = {member.name for member in TaskStatus}
+    if live_labels == expected_labels:
+        return
+
+    missing = sorted(expected_labels - live_labels)
+    extra = sorted(live_labels - expected_labels)
+    if missing and extra:
+        remedy = (
+            "Run the pending migration that adds the missing label(s); the "
+            "unexpected label(s) indicate this process is older than the "
+            "database and cannot be reconciled by a migration, since "
+            "PostgreSQL has no ALTER TYPE ... DROP VALUE."
+        )
+    elif missing:
+        remedy = (
+            "Run the pending migration that adds the missing label(s) before "
+            "starting this process."
+        )
+    else:
+        remedy = (
+            "No migration can remove them -- PostgreSQL has no ALTER TYPE ... "
+            "DROP VALUE -- so this process is older than the database it is "
+            "pointed at."
+        )
+    raise TaskStatusEnumDriftError(
+        "PostgreSQL 'taskstatus' enum type has drifted from TaskStatus: "
+        f"missing labels {missing}, unexpected labels {extra}. {remedy}"
+    )
 
 
 class DAGExecutionPhase(enum.Enum):

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -66,6 +66,11 @@ class TaskStatusEnumDriftError(RuntimeError):
 #: exact revision rather than a description; pinned against the revision file
 #: itself by
 #: tests/migrations/test_20260901_add_task_status_waiting_for_user_enum_label.py.
+#: This revision only backfills the ``WAITING_FOR_USER`` label. Each future
+#: ``TaskStatus`` member needs its own ``ALTER TYPE ... ADD VALUE``
+#: migration, and this constant needs updating to name it, or the
+#: remediation text above keeps pointing an operator at a revision that
+#: does not add the label they are missing.
 TASKSTATUS_ENUM_REPAIR_REVISION = "20260901_taskstatus_waiting_for_user"
 
 _MISSING_LABEL_REMEDY = (
@@ -80,7 +85,7 @@ _MISSING_LABEL_REMEDY = (
 
 def check_task_status_enum_drift(bind: Connection) -> None:
     """Refuse to serve when the live ``taskstatus`` enum's labels disagree
-    with ``TaskStatus``'s own members.
+    with the labels ``Task.status`` is declared with.
 
     A no-op on every backend other than PostgreSQL: ``pg_enum`` is a
     PostgreSQL system catalog, and the other backends this repo supports
@@ -132,6 +137,15 @@ def check_task_status_enum_drift(bind: Connection) -> None:
     A complete copy in ``shadow`` would then hide a label genuinely missing
     from the type the column uses, and an extra label on that copy would
     reject a correct deployment.
+
+    Expected labels come from ``Task.__table__.c.status.type.enums`` --
+    the ``Enum`` column's own declared labels -- rather than from
+    ``{member.name for member in TaskStatus}``. Today the two sets are
+    equal, because the column has no ``values_callable`` and SQLAlchemy's
+    default is to persist member names. If the column is ever given a
+    ``values_callable`` that persists something else (member values, for
+    instance), the column's declared labels stop matching the member-name
+    set, and only the column is still the live database's contract.
     """
 
     if bind.dialect.name != "postgresql":
@@ -152,7 +166,7 @@ def check_task_status_enum_drift(bind: Connection) -> None:
         )
     )
 
-    expected_labels = {member.name for member in TaskStatus}
+    expected_labels = set(Task.__table__.c.status.type.enums)
     if live_labels == expected_labels:
         return
 

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -88,20 +88,30 @@ def check_task_status_enum_drift(bind: Connection) -> None:
     must not begin serving at all.
 
     Keyed on the ``tasks`` table's existence rather than on an empty live
-    label set: ``taskstatus`` is the type of ``tasks.status``, so "``tasks``
-    is present but ``taskstatus`` is not" produces the same empty set as
-    "nothing has been created yet" while being exactly the drift this check
-    exists to catch. Callers that run schema creation first (the startup path
-    does) always find ``tasks`` present; the guard covers a caller that
-    passes a bind whose schema has not been created.
+    label set, because two different situations produce that same empty
+    set and only one of them is drift. "Nothing has been created yet" is
+    not; "``tasks`` is present and its ``status`` column yields no enum
+    labels" is, and it stays caught: the column is gone (``DROP TYPE ...
+    CASCADE`` takes the column with the type), or ``status`` is not an
+    enum column at all. Both of those report every ``TaskStatus`` member
+    as missing and refuse to serve, which is the direction to fail in.
+    Callers that run schema creation first (the startup path does) always
+    find ``tasks`` present; the guard covers a caller that passes a bind
+    whose schema has not been created.
 
-    Resolves ``taskstatus`` the way an unqualified name resolves at runtime:
-    ``pg_type_is_visible`` narrows the label set to the single type the
-    connection's ``search_path`` picks, the same schema the
-    ``has_table("tasks")`` call above already resolves against. Without that
-    narrowing every same-named enum in the database joins the result -- extra
-    labels on a copy in another schema would reject a correct deployment, and
-    a complete copy there would hide a label genuinely missing here.
+    Reads the labels off ``tasks.status``'s own type rather than off
+    whichever type happens to be named ``taskstatus``. ``to_regclass``
+    resolves the unqualified ``tasks`` exactly as the ``has_table("tasks")``
+    guard above does, ``pg_attribute`` names the column, and ``atttypid``
+    is the type that column is declared with -- one resolution, not two
+    that can disagree. Matching on the type name would be the second,
+    independent one: PostgreSQL resolves relation names and type names
+    against ``search_path`` separately, so with ``search_path = shadow,
+    public``, a ``shadow.taskstatus`` and a ``public.tasks`` whose column
+    uses ``public.taskstatus`` send the two lookups to different schemas.
+    A complete copy in ``shadow`` would then hide a label genuinely missing
+    from the type the column uses, and an extra label on that copy would
+    reject a correct deployment.
     """
 
     if bind.dialect.name != "postgresql":
@@ -113,10 +123,11 @@ def check_task_status_enum_drift(bind: Connection) -> None:
     live_labels = set(
         bind.scalars(
             text(
-                "SELECT e.enumlabel FROM pg_catalog.pg_type t "
-                "JOIN pg_catalog.pg_enum e ON t.oid = e.enumtypid "
-                "WHERE t.typname = 'taskstatus' "
-                "AND pg_catalog.pg_type_is_visible(t.oid)"
+                "SELECT e.enumlabel "
+                "FROM pg_catalog.pg_attribute a "
+                "JOIN pg_catalog.pg_enum e ON e.enumtypid = a.atttypid "
+                "WHERE a.attrelid = pg_catalog.to_regclass('tasks') "
+                "AND a.attname = 'status'"
             )
         )
     )

--- a/tests/migrations/test_20260901_add_task_status_waiting_for_user_enum_label.py
+++ b/tests/migrations/test_20260901_add_task_status_waiting_for_user_enum_label.py
@@ -1,0 +1,332 @@
+"""The taskstatus enum repair (20260901_taskstatus_waiting_for_user).
+
+``TaskStatus.WAITING_FOR_USER`` was added to the application enum after this
+project had already been deployed, and PostgreSQL fixes a native enum's
+labels at creation time. This file covers the revision that repairs such a
+database, including the end-to-end shape the check exists for: a database
+whose enum predates the label starts, migrates, and passes
+``check_task_status_enum_drift`` -- rather than aborting startup with no
+shipped repair.
+
+The PostgreSQL cells mint their own disposable databases (the plumbing this
+repository already centralizes in tests/shared/postgres_disposable.py), so
+nothing here touches the base database XAGENT_TEST_POSTGRES_URL names.
+"""
+
+from __future__ import annotations
+
+from contextlib import nullcontext
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import text
+
+from tests.shared.postgres_disposable import (
+    disposable_database_factory,
+    load_migration_module,
+)
+from xagent.web.models.database import Base, _initialize_database_schema
+from xagent.web.models.task import (
+    TASKSTATUS_ENUM_REPAIR_REVISION,
+    TaskStatus,
+    TaskStatusEnumDriftError,
+    check_task_status_enum_drift,
+)
+
+MIGRATION_PATH = (
+    Path(__file__).parent.parent.parent
+    / "src/xagent/migrations/versions"
+    / "20260901_add_task_status_waiting_for_user_enum_label.py"
+)
+LABEL = "WAITING_FOR_USER"
+ALL_LABELS = [member.name for member in TaskStatus]
+LEGACY_LABELS = [name for name in ALL_LABELS if name != LABEL]
+
+_COLUMN_LABELS_SQL = text(
+    "SELECT e.enumlabel "
+    "FROM pg_catalog.pg_attribute a "
+    "JOIN pg_catalog.pg_enum e ON e.enumtypid = a.atttypid "
+    "WHERE a.attrelid = pg_catalog.to_regclass('tasks') "
+    "AND a.attname = 'status'"
+)
+
+
+def _column_labels(connectable) -> list[str]:
+    with connectable.connect() as connection:
+        return sorted(connection.scalars(_COLUMN_LABELS_SQL))
+
+
+def _create_legacy_enum(connectable, labels: list[str] = LEGACY_LABELS) -> None:
+    """A ``taskstatus`` type carrying exactly ``labels`` -- the shape a
+    database initialized before the label existed still has."""
+    body = ", ".join(f"'{label}'" for label in labels)
+    with connectable.begin() as connection:
+        connection.execute(text(f"CREATE TYPE taskstatus AS ENUM ({body})"))
+
+
+def _create_legacy_tasks_table(connectable) -> None:
+    """Migration-only schema: the one column this revision resolves."""
+    with connectable.begin() as connection:
+        connection.execute(
+            text(
+                "CREATE TABLE tasks (id SERIAL PRIMARY KEY, "
+                "status taskstatus NOT NULL DEFAULT 'PENDING')"
+            )
+        )
+
+
+def _stamp(connectable, revision: str) -> None:
+    with connectable.begin() as connection:
+        connection.execute(
+            text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)")
+        )
+        connection.execute(
+            text("INSERT INTO alembic_version (version_num) VALUES (:revision)"),
+            {"revision": revision},
+        )
+
+
+def _run_module_upgrade(connectable) -> None:
+    """Drive the revision module directly.
+
+    ``autocommit_block`` asserts that the migration context owns a
+    transaction, which only holds when Alembic itself is driving; the same
+    substitution tests/alembic/test_20260725_add_task_lease_recovery_index.py
+    makes. The end-to-end cell below runs the real runner, so the autocommit
+    path is not left untested by this substitution.
+    """
+    migration = load_migration_module(MIGRATION_PATH)
+    with connectable.connect() as connection:
+        context = MigrationContext.configure(connection)
+        with patch.object(context, "autocommit_block", nullcontext):
+            with patch.object(migration, "op", Operations(context)):
+                with Operations.context(context):
+                    migration.upgrade()
+        connection.commit()
+
+
+def _offline_sql(dialect_name: str, operation: str = "upgrade") -> str:
+    migration = load_migration_module(MIGRATION_PATH)
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name=dialect_name,
+        opts={"as_sql": True, "output_buffer": output},
+    )
+    with Operations.context(context):
+        with patch.object(migration, "op", Operations(context)):
+            getattr(migration, operation)()
+    return output.getvalue()
+
+
+@pytest.fixture()
+def postgresql_engine_factory():
+    with disposable_database_factory("xagent_taskstatus_enum_repair") as make:
+        yield make
+
+
+# ---- the revision's identity ----
+
+
+def test_the_startup_remedy_names_this_revision() -> None:
+    """``check_task_status_enum_drift`` tells the operator which revision
+    adds the label. Renaming this file or its revision id without updating
+    that constant would leave the startup failure pointing at nothing --
+    which is the exact defect this revision exists to remove."""
+    migration = load_migration_module(MIGRATION_PATH)
+
+    assert migration.revision == TASKSTATUS_ENUM_REPAIR_REVISION
+
+
+# ---- end-to-end: an old database starts ----
+
+
+@pytest.mark.postgresql
+def test_a_pre_waiting_for_user_database_starts_after_upgrading_to_head(
+    postgresql_engine_factory,
+) -> None:
+    """The shape this revision exists for, driven through the production
+    startup path rather than through the revision module: a database whose
+    native enum predates ``WAITING_FOR_USER`` runs
+    ``_initialize_database_schema`` -- startup lock, migrations, create_all,
+    drift check -- and comes out able to serve.
+    """
+    engine = postgresql_engine_factory("upgrade_from_old_schema")
+    migration = load_migration_module(MIGRATION_PATH)
+
+    _create_legacy_enum(engine)
+    Base.metadata.create_all(bind=engine)
+    _stamp(engine, migration.down_revision)
+
+    assert _column_labels(engine) == sorted(LEGACY_LABELS)
+    with engine.connect() as connection:
+        with pytest.raises(TaskStatusEnumDriftError):
+            check_task_status_enum_drift(connection)
+
+    _initialize_database_schema(engine)
+
+    assert _column_labels(engine) == sorted(ALL_LABELS)
+    with engine.connect() as connection:
+        check_task_status_enum_drift(connection)  # must not raise
+    with engine.begin() as connection:
+        version = connection.execute(
+            text("SELECT version_num FROM alembic_version")
+        ).scalar_one()
+        user_id = connection.execute(
+            text(
+                "INSERT INTO users (username, password_hash, is_admin) "
+                "VALUES ('taskstatus_enum_repair', 'x', false) RETURNING id"
+            )
+        ).scalar_one()
+        connection.execute(
+            text(
+                "INSERT INTO tasks (user_id, title, status) "
+                "VALUES (:user_id, 'taskstatus enum repair smoke row', :label)"
+            ),
+            {"user_id": user_id, "label": LABEL},
+        )
+    assert version == migration.revision
+
+
+# ---- the revision's own branches ----
+
+
+@pytest.mark.postgresql
+def test_online_upgrade_adds_the_label_idempotently(postgresql_engine_factory) -> None:
+    engine = postgresql_engine_factory("legacy_enum")
+    _create_legacy_enum(engine)
+    _create_legacy_tasks_table(engine)
+
+    _run_module_upgrade(engine)
+    _run_module_upgrade(engine)
+
+    assert _column_labels(engine) == sorted(ALL_LABELS)
+
+
+@pytest.mark.postgresql
+def test_online_upgrade_leaves_a_complete_enum_untouched(
+    postgresql_engine_factory,
+) -> None:
+    engine = postgresql_engine_factory("complete_enum")
+    _create_legacy_enum(engine, ALL_LABELS)
+    _create_legacy_tasks_table(engine)
+
+    _run_module_upgrade(engine)
+
+    assert _column_labels(engine) == sorted(ALL_LABELS)
+
+
+@pytest.mark.postgresql
+@pytest.mark.parametrize(
+    ("tag", "schema_sql"),
+    [
+        ("no_tasks_table", None),
+        (
+            "status_is_not_an_enum",
+            "CREATE TABLE tasks (id SERIAL PRIMARY KEY, status VARCHAR(32))",
+        ),
+    ],
+)
+def test_online_upgrade_is_a_noop_without_a_native_enum_column(
+    postgresql_engine_factory, tag: str, schema_sql: str | None
+) -> None:
+    """Neither shape is something ALTER TYPE can repair. A fresh database is
+    the first one: create_all builds the type with every current label right
+    after the migrations run."""
+    engine = postgresql_engine_factory(tag)
+    if schema_sql is not None:
+        with engine.begin() as connection:
+            connection.execute(text(schema_sql))
+
+    _run_module_upgrade(engine)  # must not raise
+
+    assert _column_labels(engine) == []
+
+
+@pytest.mark.postgresql
+def test_online_upgrade_repairs_the_columns_own_type_under_a_shadowing_search_path(
+    postgresql_engine_factory,
+) -> None:
+    """``search_path`` resolves relation names and type names separately, so
+    a complete ``taskstatus`` sitting ahead of the real one can hide a
+    genuinely missing label from a lookup that matches on the name. This
+    revision resolves the type through ``tasks.status`` -- the same
+    resolution ``check_task_status_enum_drift`` makes -- so the repair lands
+    on the type the column actually uses and the shadow copy is untouched.
+    """
+    engine = postgresql_engine_factory("shadow_search_path")
+    complete = ", ".join(f"'{label}'" for label in ALL_LABELS)
+    legacy = ", ".join(f"'{label}'" for label in LEGACY_LABELS)
+    with engine.begin() as connection:
+        connection.execute(text("CREATE SCHEMA shadow"))
+        connection.execute(text("CREATE SCHEMA app"))
+        connection.execute(text(f"CREATE TYPE shadow.taskstatus AS ENUM ({complete})"))
+        connection.execute(text(f"CREATE TYPE app.taskstatus AS ENUM ({legacy})"))
+        connection.execute(
+            text(
+                "CREATE TABLE app.tasks (id SERIAL PRIMARY KEY, "
+                "status app.taskstatus NOT NULL DEFAULT 'PENDING')"
+            )
+        )
+
+    migration = load_migration_module(MIGRATION_PATH)
+    with engine.connect() as connection:
+        connection.execute(text("SET search_path TO shadow, app"))
+        connection.commit()
+        context = MigrationContext.configure(connection)
+        with patch.object(context, "autocommit_block", nullcontext):
+            with patch.object(migration, "op", Operations(context)):
+                with Operations.context(context):
+                    migration.upgrade()
+        connection.commit()
+
+    with engine.connect() as connection:
+        connection.execute(text("SET search_path TO shadow, app"))
+        assert sorted(connection.scalars(_COLUMN_LABELS_SQL)) == sorted(ALL_LABELS)
+
+
+# ---- non-PostgreSQL and offline ----
+
+
+def test_sqlite_upgrade_and_downgrade_are_noops() -> None:
+    """SQLite stores the Enum column as a plain string: there is no native
+    type to repair, and the whole migration integration suite runs this
+    revision on SQLite."""
+    migration = load_migration_module(MIGRATION_PATH)
+    engine = sa.create_engine("sqlite:///:memory:")
+
+    with engine.begin() as connection:
+        connection.execute(
+            text("CREATE TABLE tasks (id INTEGER PRIMARY KEY, status VARCHAR(32))")
+        )
+        context = MigrationContext.configure(connection)
+        with patch.object(migration, "op", Operations(context)):
+            with Operations.context(context):
+                migration.upgrade()
+                migration.downgrade()
+
+        columns = {c["name"] for c in sa.inspect(connection).get_columns("tasks")}
+    assert columns == {"id", "status"}
+
+
+def test_offline_postgresql_upgrade_emits_an_idempotent_add_value() -> None:
+    sql = _offline_sql("postgresql")
+
+    assert f"ALTER TYPE taskstatus ADD VALUE IF NOT EXISTS '{LABEL}'" in sql
+    assert "%(" not in sql and ":table_name" not in sql
+
+
+def test_offline_sqlite_upgrade_emits_nothing() -> None:
+    assert _offline_sql("sqlite").strip() == ""
+
+
+def test_offline_downgrade_emits_nothing_on_either_dialect() -> None:
+    """PostgreSQL has no ALTER TYPE ... DROP VALUE; the downgrade is a no-op
+    on purpose, and the migration integration suite downgrades the whole
+    chain."""
+    assert _offline_sql("postgresql", "downgrade").strip() == ""
+    assert _offline_sql("sqlite", "downgrade").strip() == ""

--- a/tests/web/services/test_task_status_enum_drift.py
+++ b/tests/web/services/test_task_status_enum_drift.py
@@ -1,0 +1,245 @@
+"""``check_task_status_enum_drift`` (``models/task.py``).
+
+Companion to test_task_status_storage_postgresql.py's
+``test_pg_enum_reflects_exactly_the_taskstatus_members``, which pins that a
+*fresh* ``create_all`` schema has no drift -- it cannot observe a deployed
+database whose enum type predates a later addition to ``TaskStatus``. This
+file is that missing half: it builds the ``taskstatus`` type by hand, with a
+label set the test controls directly, so it can put the check in front of a
+type that has actually drifted rather than one ``create_all`` always gets
+right.
+
+Disposable-database plumbing is the one this repository already centralizes
+for this exact need (``tests/shared/postgres_disposable.py``, extracted from
+two near-identical fixtures for the same reason this file would otherwise
+duplicate a third).
+"""
+
+from __future__ import annotations
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import text
+
+from tests.shared.postgres_disposable import disposable_database_factory
+from xagent.web.models.database import Base
+from xagent.web.models.task import (
+    TaskStatus,
+    TaskStatusEnumDriftError,
+    check_task_status_enum_drift,
+)
+
+_ALL_LABELS = [member.name for member in TaskStatus]
+
+
+def _label_list_sql(labels: list[str]) -> str:
+    return ", ".join(f"'{label}'" for label in labels)
+
+
+def _create_taskstatus_type_and_table(conn: sa.Connection, labels: list[str]) -> None:
+    """Minimal ``taskstatus`` enum plus a ``tasks`` table using it -- enough
+    for ``check_task_status_enum_drift`` to see (it only queries
+    ``pg_catalog`` for a type literally named ``taskstatus`` and calls
+    ``has_table("tasks")``), without going through the full ``Task`` ORM
+    schema this check has no other dependency on."""
+    conn.execute(text(f"CREATE TYPE taskstatus AS ENUM ({_label_list_sql(labels)})"))
+    conn.execute(
+        text(
+            "CREATE TABLE tasks (id SERIAL PRIMARY KEY, "
+            f"status taskstatus NOT NULL DEFAULT '{labels[0]}')"
+        )
+    )
+
+
+@pytest.fixture()
+def postgresql_engine_factory():
+    with disposable_database_factory("xagent_taskstatus_drift") as make:
+        yield make
+
+
+@pytest.mark.postgresql
+def test_pg_enum_labels_match_passes(postgresql_engine_factory) -> None:
+    """A correct schema must pass. Both label sets here come from the same
+    ``TaskStatus`` class (the live one via ``create_all``, expected via
+    iterating the enum), so this cell cannot fail on a genuine label
+    mismatch -- that direction is covered by the failure cells below. What
+    it does pin is the opposite direction: the check must not reject a
+    deployment whose enum is correct, which is the regression a stricter
+    query (an unqualified type name, a missing visibility predicate) would
+    introduce.
+    """
+    engine = postgresql_engine_factory("correct")
+    Base.metadata.create_all(bind=engine)
+    with engine.connect() as conn:
+        check_task_status_enum_drift(conn)
+
+
+@pytest.mark.postgresql
+def test_pg_enum_missing_label_raises(postgresql_engine_factory) -> None:
+    engine = postgresql_engine_factory("missing")
+    missing_label = _ALL_LABELS[-1]
+    present_labels = _ALL_LABELS[:-1]
+    with engine.begin() as conn:
+        _create_taskstatus_type_and_table(conn, present_labels)
+
+    with engine.connect() as conn:
+        with pytest.raises(TaskStatusEnumDriftError) as exc_info:
+            check_task_status_enum_drift(conn)
+
+    message = str(exc_info.value)
+    assert missing_label in message
+    assert "pending migration" in message
+    assert "unexpected" not in message.split("missing labels")[0]
+
+
+@pytest.mark.postgresql
+def test_pg_enum_extra_label_raises(postgresql_engine_factory) -> None:
+    engine = postgresql_engine_factory("extra")
+    extra_label = "ARCHIVED_LEGACY"
+    with engine.begin() as conn:
+        _create_taskstatus_type_and_table(conn, [*_ALL_LABELS, extra_label])
+
+    with engine.connect() as conn:
+        with pytest.raises(TaskStatusEnumDriftError) as exc_info:
+            check_task_status_enum_drift(conn)
+
+    message = str(exc_info.value)
+    assert extra_label in message
+    assert "ALTER TYPE" in message
+    assert "DROP VALUE" in message
+
+
+@pytest.mark.postgresql
+def test_pg_enum_missing_and_extra_labels_name_both_in_the_message(
+    postgresql_engine_factory,
+) -> None:
+    """Both directions can be true at once -- a process older than the
+    database (unexpected labels present) that is also missing a label a
+    newer process added (a concurrent-deployment window, not just a stale
+    one). The remediation sentence has to say both things are true rather
+    than picking one, since only one of them has a migration that fixes it.
+    """
+    engine = postgresql_engine_factory("both")
+    extra_label = "ARCHIVED_LEGACY"
+    with engine.begin() as conn:
+        _create_taskstatus_type_and_table(conn, [*_ALL_LABELS[:-1], extra_label])
+
+    with engine.connect() as conn:
+        with pytest.raises(TaskStatusEnumDriftError) as exc_info:
+            check_task_status_enum_drift(conn)
+
+    message = str(exc_info.value)
+    assert _ALL_LABELS[-1] in message
+    assert extra_label in message
+    assert "cannot be reconciled by a migration" in message
+
+
+@pytest.mark.postgresql
+def test_missing_tasks_table_is_a_noop(postgresql_engine_factory) -> None:
+    """A bind whose schema has not been created yet -- ``has_table("tasks")``
+    is false, so the check has nothing to compare and must not raise. The
+    startup path itself never reaches this: it runs after schema creation.
+    This covers a caller that doesn't.
+    """
+    engine = postgresql_engine_factory("empty")
+    with engine.connect() as conn:
+        check_task_status_enum_drift(conn)  # must not raise
+
+
+def test_sqlite_backend_is_a_noop() -> None:
+    """Any non-PostgreSQL backend is a no-op before the check ever touches
+    ``pg_catalog`` -- which doesn't exist on SQLite, so if the dialect guard
+    didn't fire, this would raise ``OperationalError`` rather than pass
+    silently.
+
+    Builds the real schema first (``tasks`` present) rather than using an
+    empty database: an empty database returns early through the
+    schema-not-created-yet guard regardless of dialect, which would let a
+    missing or deleted dialect guard pass this test by accident. With
+    ``tasks`` present, the dialect guard is the only thing standing between
+    this call and a query ``pg_catalog`` doesn't have.
+    """
+    engine = sa.create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    with engine.connect() as conn:
+        check_task_status_enum_drift(conn)  # must not raise, must not query
+
+
+def test_sqlite_backend_never_reaches_the_catalog_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same claim as above, proven the other way: replace ``text`` in
+    ``models/task.py`` with a spy that raises if called, so a failure to
+    short-circuit on ``bind.dialect.name`` shows up as an assertion failure
+    naming the exact reason, not a generic ``OperationalError`` fifteen
+    frames down in the sqlite3 driver. Same schema requirement as the cell
+    above, for the same reason: an empty database would pass this test
+    whether or not the dialect guard exists.
+    """
+    import xagent.web.models.task as task_module
+
+    def _spy(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError(
+            "check_task_status_enum_drift queried the catalog on a "
+            "non-PostgreSQL bind instead of returning early"
+        )
+
+    monkeypatch.setattr(task_module, "text", _spy)
+    engine = sa.create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    with engine.connect() as conn:
+        check_task_status_enum_drift(conn)
+
+
+@pytest.mark.postgresql
+def test_search_path_schema_with_extra_labels_does_not_reject_correct_deployment(
+    postgresql_engine_factory,
+) -> None:
+    """A same-named ``taskstatus`` type in a schema later on the search path,
+    carrying labels this database's real type does not have, must not make
+    a correct deployment look drifted. Without the ``pg_type_is_visible``
+    narrowing, the raw label join across both schemas would surface the
+    other schema's extra label as if it belonged to the resolved type.
+    """
+    engine = postgresql_engine_factory("visible_extra")
+    with engine.begin() as conn:
+        conn.execute(text("CREATE SCHEMA other_app"))
+        conn.execute(text("SET search_path TO other_app"))
+        conn.execute(
+            text(
+                "CREATE TYPE taskstatus AS ENUM "
+                f"({_label_list_sql([*_ALL_LABELS, 'SHADOWED_EXTRA'])})"
+            )
+        )
+        conn.execute(text("SET search_path TO public"))
+        _create_taskstatus_type_and_table(conn, _ALL_LABELS)
+
+    with engine.connect() as conn:
+        conn.execute(text("SET search_path TO public"))
+        check_task_status_enum_drift(conn)  # must not raise
+
+
+@pytest.mark.postgresql
+def test_search_path_schema_with_complete_copy_does_not_mask_missing_label_here(
+    postgresql_engine_factory,
+) -> None:
+    """The inverse: a complete, correct copy of the type sitting in a schema
+    that is *not* first on the search path must not hide a genuinely
+    incomplete type in the schema that is. Without the visibility
+    narrowing, the join across both schemas would produce the full label
+    set and mask the drift this check exists to catch.
+    """
+    engine = postgresql_engine_factory("visible_masked")
+    with engine.begin() as conn:
+        conn.execute(text("CREATE SCHEMA complete_copy"))
+        conn.execute(text("SET search_path TO complete_copy"))
+        _create_taskstatus_type_and_table(conn, _ALL_LABELS)
+        conn.execute(text("SET search_path TO public"))
+        _create_taskstatus_type_and_table(conn, _ALL_LABELS[:-1])
+
+    with engine.connect() as conn:
+        conn.execute(text("SET search_path TO public"))
+        with pytest.raises(TaskStatusEnumDriftError) as exc_info:
+            check_task_status_enum_drift(conn)
+
+    assert _ALL_LABELS[-1] in str(exc_info.value)

--- a/tests/web/services/test_task_status_enum_drift.py
+++ b/tests/web/services/test_task_status_enum_drift.py
@@ -17,12 +17,16 @@ duplicate a third).
 
 from __future__ import annotations
 
+import ast
+import inspect
+import textwrap
+
 import pytest
 import sqlalchemy as sa
 from sqlalchemy import text
 
 from tests.shared.postgres_disposable import disposable_database_factory
-from xagent.web.models.database import Base
+from xagent.web.models.database import Base, _initialize_database_schema
 from xagent.web.models.task import (
     TaskStatus,
     TaskStatusEnumDriftError,
@@ -36,17 +40,30 @@ def _label_list_sql(labels: list[str]) -> str:
     return ", ".join(f"'{label}'" for label in labels)
 
 
-def _create_taskstatus_type_and_table(conn: sa.Connection, labels: list[str]) -> None:
-    """Minimal ``taskstatus`` enum plus a ``tasks`` table using it -- enough
-    for ``check_task_status_enum_drift`` to see (it only queries
-    ``pg_catalog`` for a type literally named ``taskstatus`` and calls
-    ``has_table("tasks")``), without going through the full ``Task`` ORM
-    schema this check has no other dependency on."""
-    conn.execute(text(f"CREATE TYPE taskstatus AS ENUM ({_label_list_sql(labels)})"))
+def _create_taskstatus_type(
+    conn: sa.Connection, labels: list[str], schema: str | None = None
+) -> None:
+    """A ``taskstatus`` enum carrying exactly ``labels``, in ``schema`` when
+    one is named and in whatever ``search_path`` picks otherwise."""
+    qualified = f"{schema}.taskstatus" if schema else "taskstatus"
+    conn.execute(text(f"CREATE TYPE {qualified} AS ENUM ({_label_list_sql(labels)})"))
+
+
+def _create_taskstatus_type_and_table(
+    conn: sa.Connection, labels: list[str], schema: str | None = None
+) -> None:
+    """Minimal ``taskstatus`` enum plus a ``tasks`` table whose ``status``
+    column is declared with it -- enough for ``check_task_status_enum_drift``
+    to see (it resolves ``tasks``, reads the type of that table's ``status``
+    column, and lists that type's labels), without going through the full
+    ``Task`` ORM schema this check has no other dependency on."""
+    _create_taskstatus_type(conn, labels, schema)
+    prefix = f"{schema}." if schema else ""
+    type_name = f"{schema}.taskstatus" if schema else "taskstatus"
     conn.execute(
         text(
-            "CREATE TABLE tasks (id SERIAL PRIMARY KEY, "
-            f"status taskstatus NOT NULL DEFAULT '{labels[0]}')"
+            f"CREATE TABLE {prefix}tasks (id SERIAL PRIMARY KEY, "
+            f"status {type_name} NOT NULL DEFAULT '{labels[0]}')"
         )
     )
 
@@ -89,7 +106,10 @@ def test_pg_enum_missing_label_raises(postgresql_engine_factory) -> None:
     message = str(exc_info.value)
     assert missing_label in message
     assert "pending migration" in message
-    assert "unexpected" not in message.split("missing labels")[0]
+    # Exclusive, not merely present: the combined branch also says "pending
+    # migration", so only the absence of its own wording distinguishes them.
+    assert "unexpected label(s) indicate" not in message
+    assert "DROP VALUE" not in message
 
 
 @pytest.mark.postgresql
@@ -105,8 +125,13 @@ def test_pg_enum_extra_label_raises(postgresql_engine_factory) -> None:
 
     message = str(exc_info.value)
     assert extra_label in message
+    assert "No migration can remove them" in message
     assert "ALTER TYPE" in message
     assert "DROP VALUE" in message
+    # The combined branch carries ALTER TYPE and DROP VALUE too, so those
+    # alone cannot tell the two apart; these two exclusions can.
+    assert "pending migration" not in message
+    assert "unexpected label(s) indicate" not in message
 
 
 @pytest.mark.postgresql
@@ -192,54 +217,209 @@ def test_sqlite_backend_never_reaches_the_catalog_query(
 
 
 @pytest.mark.postgresql
-def test_search_path_schema_with_extra_labels_does_not_reject_correct_deployment(
+def test_shadow_type_first_on_search_path_does_not_mask_a_missing_label(
     postgresql_engine_factory,
 ) -> None:
-    """A same-named ``taskstatus`` type in a schema later on the search path,
-    carrying labels this database's real type does not have, must not make
-    a correct deployment look drifted. Without the ``pg_type_is_visible``
-    narrowing, the raw label join across both schemas would surface the
-    other schema's extra label as if it belonged to the resolved type.
+    """``search_path = shadow, app``: ``shadow`` holds a complete
+    ``taskstatus`` and no ``tasks`` at all, while the ``tasks`` that does
+    resolve lives in ``app`` and its ``status`` column is missing a label.
+    Relation visibility and type visibility are separate resolutions in
+    PostgreSQL, so a check that finds the type by name reads ``shadow``'s
+    complete copy, sees no drift, and lets the process start against a
+    database whose next write of that label will fail.
+
+    The assertion names the missing label exactly rather than merely
+    looking for it in the message: with the application schema deliberately
+    somewhere other than ``public``, hard-coding a schema onto the
+    ``to_regclass`` argument would resolve nothing, report every member as
+    missing, and still contain this label.
     """
-    engine = postgresql_engine_factory("visible_extra")
+    engine = postgresql_engine_factory("shadow_masks")
+    missing_label = _ALL_LABELS[-1]
     with engine.begin() as conn:
-        conn.execute(text("CREATE SCHEMA other_app"))
-        conn.execute(text("SET search_path TO other_app"))
-        conn.execute(
-            text(
-                "CREATE TYPE taskstatus AS ENUM "
-                f"({_label_list_sql([*_ALL_LABELS, 'SHADOWED_EXTRA'])})"
-            )
-        )
-        conn.execute(text("SET search_path TO public"))
-        _create_taskstatus_type_and_table(conn, _ALL_LABELS)
+        conn.execute(text("CREATE SCHEMA shadow"))
+        conn.execute(text("CREATE SCHEMA app"))
+        _create_taskstatus_type(conn, _ALL_LABELS, schema="shadow")
+        _create_taskstatus_type_and_table(conn, _ALL_LABELS[:-1], schema="app")
 
     with engine.connect() as conn:
-        conn.execute(text("SET search_path TO public"))
-        check_task_status_enum_drift(conn)  # must not raise
-
-
-@pytest.mark.postgresql
-def test_search_path_schema_with_complete_copy_does_not_mask_missing_label_here(
-    postgresql_engine_factory,
-) -> None:
-    """The inverse: a complete, correct copy of the type sitting in a schema
-    that is *not* first on the search path must not hide a genuinely
-    incomplete type in the schema that is. Without the visibility
-    narrowing, the join across both schemas would produce the full label
-    set and mask the drift this check exists to catch.
-    """
-    engine = postgresql_engine_factory("visible_masked")
-    with engine.begin() as conn:
-        conn.execute(text("CREATE SCHEMA complete_copy"))
-        conn.execute(text("SET search_path TO complete_copy"))
-        _create_taskstatus_type_and_table(conn, _ALL_LABELS)
-        conn.execute(text("SET search_path TO public"))
-        _create_taskstatus_type_and_table(conn, _ALL_LABELS[:-1])
-
-    with engine.connect() as conn:
-        conn.execute(text("SET search_path TO public"))
+        conn.execute(text("SET search_path TO shadow, app"))
         with pytest.raises(TaskStatusEnumDriftError) as exc_info:
             check_task_status_enum_drift(conn)
 
-    assert _ALL_LABELS[-1] in str(exc_info.value)
+    message = str(exc_info.value)
+    assert f"missing labels ['{missing_label}']" in message
+    assert "unexpected labels []" in message
+
+
+@pytest.mark.postgresql
+def test_shadow_type_first_on_search_path_does_not_reject_a_correct_column(
+    postgresql_engine_factory,
+) -> None:
+    """The other direction of the same asymmetry: ``shadow`` is first on
+    the search path and holds a ``taskstatus`` carrying a label this
+    application does not know, but no ``tasks``; the ``tasks`` that
+    resolves is in ``app`` and its ``status`` column's type is exactly
+    right. Finding the type by name would read ``shadow``'s copy and
+    refuse to start a correct deployment.
+    """
+    engine = postgresql_engine_factory("shadow_rejects")
+    with engine.begin() as conn:
+        conn.execute(text("CREATE SCHEMA shadow"))
+        conn.execute(text("CREATE SCHEMA app"))
+        _create_taskstatus_type(conn, [*_ALL_LABELS, "SHADOWED_EXTRA"], schema="shadow")
+        _create_taskstatus_type_and_table(conn, _ALL_LABELS, schema="app")
+
+    with engine.connect() as conn:
+        conn.execute(text("SET search_path TO shadow, app"))
+        check_task_status_enum_drift(conn)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Startup wiring. Every cell above calls check_task_status_enum_drift
+# directly, so none of them can observe whether startup still calls it.
+# ---------------------------------------------------------------------------
+
+_CHECK_NAME = "check_task_status_enum_drift"
+
+
+def _calls_named(node: ast.AST, name: str) -> list[ast.Call]:
+    """Every call to ``name`` anywhere under ``node``, matching a bare name
+    (``check_task_status_enum_drift(...)``) and an attribute tail
+    (``Base.metadata.create_all(...)``) alike."""
+    found: list[ast.Call] = []
+    for child in ast.walk(node):
+        if not isinstance(child, ast.Call):
+            continue
+        func = child.func
+        if isinstance(func, ast.Name) and func.id == name:
+            found.append(child)
+        elif isinstance(func, ast.Attribute) and func.attr == name:
+            found.append(child)
+    return found
+
+
+def _statement_blocks(tree: ast.AST) -> list[list[ast.stmt]]:
+    """Every statement list in ``tree`` -- one per suite, so a statement's
+    position relative to its own block's other statements can be read."""
+    blocks: list[list[ast.stmt]] = []
+    for node in ast.walk(tree):
+        for field in ("body", "orelse", "finalbody"):
+            block = getattr(node, field, None)
+            if isinstance(block, list) and block and isinstance(block[0], ast.stmt):
+                blocks.append(block)
+    return blocks
+
+
+def _calls_in_own_scope(statement: ast.stmt, name: str) -> list[ast.Call]:
+    """Calls to ``name`` reachable from ``statement`` without descending into
+    any suite it owns (``body``/``orelse``/``finalbody``) -- so a bare
+    ``try_upgrade_db(...)`` line matches, but a ``with`` or ``if`` that
+    merely contains such a call somewhere inside it does not.
+
+    ``_statement_blocks`` returns every suite in the function, including the
+    function's own top-level suite, which contains the ``with
+    database_startup_lock(...)`` statement as a single statement. A loose,
+    fully recursive call search (``_calls_named``) matches that one
+    statement for both ``try_upgrade_db`` and ``check_task_status_enum_drift``
+    at once -- they are both nested somewhere inside its body -- which
+    collapses the two calls to the same index and can never show one after
+    the other. Selecting the ``with`` statement's own suite (the block whose
+    statements make the calls directly) needs this narrower match.
+    """
+    found: list[ast.Call] = []
+
+    def visit(node: ast.AST) -> None:
+        if isinstance(node, ast.Call):
+            func = node.func
+            if (isinstance(func, ast.Name) and func.id == name) or (
+                isinstance(func, ast.Attribute) and func.attr == name
+            ):
+                found.append(node)
+        for field, value in ast.iter_fields(node):
+            if field in ("body", "orelse", "finalbody"):
+                continue
+            if isinstance(value, ast.AST):
+                visit(value)
+            elif isinstance(value, list):
+                for item in value:
+                    if isinstance(item, ast.AST):
+                        visit(item)
+
+    visit(statement)
+    return found
+
+
+def test_startup_initializer_still_runs_the_drift_check() -> None:
+    """``_initialize_database_schema`` (``models/database.py``) is this
+    check's only production caller, and nothing else in the test suite can
+    see it: every cell above calls the checker directly, the initializer
+    test in tests/migration/test_migration.py drives a ``MagicMock`` engine
+    whose dialect is not PostgreSQL (so the checker returns before reading
+    anything), and the startup tests monkeypatch ``init_db`` and never
+    enter the initializer at all. Deleting the call, moving it ahead of the
+    migrations it depends on, dropping it from one of the two return
+    paths, or wrapping it in a ``try``/``except`` would leave all of those
+    green while the process stopped refusing to serve on a drifted enum.
+
+    Read off the source rather than by driving the initializer: all four of
+    those are properties of the call site's shape, which the syntax tree
+    answers directly, and standing up a PostgreSQL-shaped engine, a startup
+    lock, a migration runner and a seed path just to watch one call would
+    make this test more fragile than the four lines it protects.
+    """
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(_initialize_database_schema)))
+
+    # (1) Called, and on every path that returns.
+    assert _calls_named(tree, _CHECK_NAME), (
+        f"_initialize_database_schema no longer calls {_CHECK_NAME}: startup "
+        "would begin serving against a database whose taskstatus enum has "
+        "drifted from TaskStatus"
+    )
+    for block in _statement_blocks(tree):
+        for index, statement in enumerate(block):
+            if not any(isinstance(n, ast.Return) for n in ast.walk(statement)):
+                continue
+            assert any(
+                _calls_named(earlier, _CHECK_NAME) for earlier in block[: index + 1]
+            ), (
+                "_initialize_database_schema returns without having run "
+                f"{_CHECK_NAME} on that path (source line "
+                f"{statement.lineno} of the function)"
+            )
+
+    # (2) Not inside a try block, where a handler could swallow the refusal.
+    for try_node in (n for n in ast.walk(tree) if isinstance(n, ast.Try)):
+        assert not [
+            call
+            for statement in try_node.body
+            for call in _calls_named(statement, _CHECK_NAME)
+        ], (
+            f"{_CHECK_NAME} sits inside a try block: a handler there can "
+            "swallow TaskStatusEnumDriftError and let startup continue"
+        )
+
+    # (3) After the migrations and the schema creation it reads the result of.
+    lock_body = next(
+        block
+        for block in _statement_blocks(tree)
+        if any(_calls_in_own_scope(statement, "try_upgrade_db") for statement in block)
+    )
+
+    def first_index(name: str) -> int:
+        for index, statement in enumerate(lock_body):
+            if _calls_named(statement, name):
+                return index
+        raise AssertionError(f"{name} is no longer called under the startup lock")
+
+    check_index = first_index(_CHECK_NAME)
+    assert check_index > first_index("try_upgrade_db"), (
+        f"{_CHECK_NAME} runs before try_upgrade_db: a migration that adds a "
+        "TaskStatus label with ALTER TYPE ... ADD VALUE would then trip this "
+        "check into a startup crash loop"
+    )
+    assert check_index > first_index("create_all"), (
+        f"{_CHECK_NAME} runs before Base.metadata.create_all: a fresh "
+        "database would have no taskstatus type yet"
+    )

--- a/tests/web/services/test_task_status_enum_drift.py
+++ b/tests/web/services/test_task_status_enum_drift.py
@@ -365,8 +365,17 @@ def test_startup_initializer_still_runs_the_drift_check() -> None:
     anything), and the startup tests monkeypatch ``init_db`` and never
     enter the initializer at all. Deleting the call, moving it ahead of the
     migrations it depends on, dropping it from one of the two return
-    paths, or wrapping it in a ``try``/``except`` would leave all of those
-    green while the process stopped refusing to serve on a drifted enum.
+    paths, wrapping it in a ``try``/``except``, or nesting it under a
+    condition the return does not share -- ``if
+    should_seed_builtin_mcp_registry``, which is false on every database
+    that already has tables -- would leave all of those green while the
+    process stopped refusing to serve on a drifted enum.
+
+    The return-path assertion below is what closes that last one, and it is
+    why it matches only a ``return`` that is a statement of the block being
+    scanned and only a checker call made directly by that same block: a
+    recursive match finds the checker "before" a return that a nested
+    condition can skip.
 
     Read off the source rather than by driving the initializer: all four of
     those are properties of the call site's shape, which the syntax tree
@@ -377,7 +386,8 @@ def test_startup_initializer_still_runs_the_drift_check() -> None:
 
     tree = ast.parse(textwrap.dedent(inspect.getsource(_initialize_database_schema)))
 
-    # (1) Called, and on every path that returns.
+    # (1) Called, and directly on every block that returns -- not merely
+    # somewhere inside a statement that block happens to contain.
     assert _calls_named(tree, _CHECK_NAME), (
         f"_initialize_database_schema no longer calls {_CHECK_NAME}: startup "
         "would begin serving against a database whose taskstatus enum has "
@@ -385,10 +395,11 @@ def test_startup_initializer_still_runs_the_drift_check() -> None:
     )
     for block in _statement_blocks(tree):
         for index, statement in enumerate(block):
-            if not any(isinstance(n, ast.Return) for n in ast.walk(statement)):
+            if not isinstance(statement, ast.Return):
                 continue
             assert any(
-                _calls_named(earlier, _CHECK_NAME) for earlier in block[: index + 1]
+                _calls_in_own_scope(earlier, _CHECK_NAME)
+                for earlier in block[: index + 1]
             ), (
                 "_initialize_database_schema returns without having run "
                 f"{_CHECK_NAME} on that path (source line "
@@ -429,3 +440,51 @@ def test_startup_initializer_still_runs_the_drift_check() -> None:
         f"{_CHECK_NAME} runs before Base.metadata.create_all: a fresh "
         "database would have no taskstatus type yet"
     )
+
+
+@pytest.mark.postgresql
+def test_startup_refuses_to_serve_a_database_with_an_unrepairable_extra_label(
+    postgresql_engine_factory,
+) -> None:
+    """The static test above pins the call site's shape; this one drives
+    the real ``_initialize_database_schema`` path and pins the outcome a
+    caller actually observes, on the one drift shape no migration can heal.
+
+    An extra, unrecognized label is deliberately not the missing-label shape
+    the taskstatus-repair migration (``20260901_taskstatus_waiting_for_user``)
+    exists for: ``ALTER TYPE ... ADD VALUE`` only ever adds labels, so
+    ``try_upgrade_db`` running ahead of this check cannot make an extra label
+    disappear the way it makes a missing one appear. That is what makes this
+    fixture load-bearing for startup wiring specifically, where the
+    missing-label fixture the migration's own test drives is not: on a
+    database that is already complete except for one label the application
+    does not expect, ``check_task_status_enum_drift`` is the *only* thing
+    standing between a drifted enum and a serving process, so nesting its
+    call under a condition that is false on any already-populated database
+    (``should_seed_builtin_mcp_registry``, via ``is_database_empty`` -- this
+    fixture creates the full schema before startup runs, so it is never
+    empty) removes the only thing that would have refused to serve.
+    """
+    engine = postgresql_engine_factory("unrepairable_extra_label")
+    extra_label = "LEGACY_EXTRA"
+
+    Base.metadata.create_all(bind=engine)
+    with engine.begin() as connection:
+        connection.execute(
+            text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)")
+        )
+        connection.execute(
+            text("INSERT INTO alembic_version (version_num) VALUES (:revision)"),
+            {"revision": TASKSTATUS_ENUM_REPAIR_REVISION},
+        )
+        connection.execute(text(f"ALTER TYPE taskstatus ADD VALUE '{extra_label}'"))
+
+    with pytest.raises(TaskStatusEnumDriftError) as exc_info:
+        _initialize_database_schema(engine)
+
+    message = str(exc_info.value)
+    assert extra_label in message
+    # The extra-only branch's own wording (see check_task_status_enum_drift):
+    # exclusive to this branch is exactly the point, since it is what a
+    # nested-under-seed-condition mutation removes.
+    assert "No migration can remove them" in message

--- a/tests/web/services/test_task_status_enum_drift.py
+++ b/tests/web/services/test_task_status_enum_drift.py
@@ -29,12 +29,19 @@ from tests.shared.postgres_disposable import disposable_database_factory
 from xagent.web.models.database import Base, _initialize_database_schema
 from xagent.web.models.task import (
     TASKSTATUS_ENUM_REPAIR_REVISION,
+    Task,
     TaskStatus,
     TaskStatusEnumDriftError,
     check_task_status_enum_drift,
 )
 
-_ALL_LABELS = [member.name for member in TaskStatus]
+# Same source as check_task_status_enum_drift's own expected_labels: the
+# status column's declared enum labels, not TaskStatus's member names. The
+# two happen to agree today (see test_expected_labels_match_taskstatus_members
+# below for why, and what it means when they stop), but building the
+# fixture labels from the member names directly would let this file drift
+# out of sync with what the guard actually compares against.
+_ALL_LABELS = list(Task.__table__.c.status.type.enums)
 
 
 def _label_list_sql(labels: list[str]) -> str:
@@ -75,16 +82,45 @@ def postgresql_engine_factory():
         yield make
 
 
+def test_expected_labels_match_taskstatus_members() -> None:
+    """Sentinel, not a functional test of the guard itself.
+
+    check_task_status_enum_drift's expected_labels comes from
+    Task.__table__.c.status.type.enums (the status column's own declared
+    labels), not from iterating TaskStatus's member names. The two sets are
+    equal only because the column has no values_callable, so SQLAlchemy's
+    default -- persist the member name -- is in effect. Nothing keeps that
+    true: give Task.status a values_callable that persists something else
+    (member values, for instance) and this equality breaks.
+
+    test_pg_enum_reflects_exactly_the_taskstatus_members
+    (test_task_status_storage_postgresql.py) pins the same equality, but
+    its db_session fixture skips whenever XAGENT_TEST_POSTGRES_URL is
+    unset, and the ordinary test matrix never sets it -- so that cell is
+    green-by-skip in exactly the runs where a values_callable change would
+    first appear. It also compares a different pair of sources (a real
+    create_all schema vs. TaskStatus's member names), so its failure
+    message blames create_all rather than the column declaration. This
+    test opens no database, so it actually executes in the ordinary
+    matrix. A red run here means the column's storage format is changing
+    and needs a data migration for every existing row, not just a code
+    change.
+    """
+    assert {member.name for member in TaskStatus} == set(
+        Task.__table__.c.status.type.enums
+    )
+
+
 @pytest.mark.postgresql
 def test_pg_enum_labels_match_passes(postgresql_engine_factory) -> None:
     """A correct schema must pass. Both label sets here come from the same
-    ``TaskStatus`` class (the live one via ``create_all``, expected via
-    iterating the enum), so this cell cannot fail on a genuine label
-    mismatch -- that direction is covered by the failure cells below. What
-    it does pin is the opposite direction: the check must not reject a
-    deployment whose enum is correct, which is the regression a stricter
-    query (an unqualified type name, a missing visibility predicate) would
-    introduce.
+    ``TaskStatus`` class (the live one via ``create_all``, expected from
+    the status column's declared labels), so this cell cannot fail on a
+    genuine label mismatch -- that direction is covered by the failure
+    cells below. What it does pin is the opposite direction: the check
+    must not reject a deployment whose enum is correct, which is the
+    regression a stricter query (an unqualified type name, a missing
+    visibility predicate) would introduce.
     """
     engine = postgresql_engine_factory("correct")
     Base.metadata.create_all(bind=engine)

--- a/tests/web/services/test_task_status_enum_drift.py
+++ b/tests/web/services/test_task_status_enum_drift.py
@@ -28,6 +28,7 @@ from sqlalchemy import text
 from tests.shared.postgres_disposable import disposable_database_factory
 from xagent.web.models.database import Base, _initialize_database_schema
 from xagent.web.models.task import (
+    TASKSTATUS_ENUM_REPAIR_REVISION,
     TaskStatus,
     TaskStatusEnumDriftError,
     check_task_status_enum_drift,
@@ -105,9 +106,11 @@ def test_pg_enum_missing_label_raises(postgresql_engine_factory) -> None:
 
     message = str(exc_info.value)
     assert missing_label in message
-    assert "pending migration" in message
-    # Exclusive, not merely present: the combined branch also says "pending
-    # migration", so only the absence of its own wording distinguishes them.
+    assert "Upgrade this database to the Alembic head" in message
+    assert TASKSTATUS_ENUM_REPAIR_REVISION in message
+    # Exclusive, not merely present: the combined branch carries the same
+    # upgrade instruction, so only the absence of its own wording
+    # distinguishes them.
     assert "unexpected label(s) indicate" not in message
     assert "DROP VALUE" not in message
 
@@ -129,8 +132,10 @@ def test_pg_enum_extra_label_raises(postgresql_engine_factory) -> None:
     assert "ALTER TYPE" in message
     assert "DROP VALUE" in message
     # The combined branch carries ALTER TYPE and DROP VALUE too, so those
-    # alone cannot tell the two apart; these two exclusions can.
-    assert "pending migration" not in message
+    # alone cannot tell the two apart; these two exclusions can. No migration
+    # repairs an unexpected label, so the upgrade instruction must not appear
+    # on this branch.
+    assert "Upgrade this database to the Alembic head" not in message
     assert "unexpected label(s) indicate" not in message
 
 
@@ -156,6 +161,7 @@ def test_pg_enum_missing_and_extra_labels_name_both_in_the_message(
     message = str(exc_info.value)
     assert _ALL_LABELS[-1] in message
     assert extra_label in message
+    assert "Upgrade this database to the Alembic head" in message
     assert "cannot be reconciled by a migration" in message
 
 


### PR DESCRIPTION
A database migrated before a `TaskStatus` member was added has no way to
surface that gap until the first write of the new label fails at runtime, in
request context — after the caller already believes the status transition
happened. This adds a startup check that compares the live PostgreSQL
`taskstatus` enum's labels against `TaskStatus`'s own members and refuses to
serve when they disagree.

**Where it runs, and why there.**

`check_task_status_enum_drift` lives beside `TaskStatus` in
`web/models/task.py`, and runs from `_initialize_database_schema`
(`web/models/database.py`) after `try_upgrade_db` and inside
`database_startup_lock`, taking that section's own connection. That is the
same placement and the same `bind: Connection` shape
`validate_builtin_public_mcp_apps` already uses from the same call site.

Three properties follow from running there rather than earlier:

- A migration that adds a `TaskStatus` label via `ALTER TYPE ... ADD VALUE`
  has already run by the time this check reads the catalog, so shipping one
  cannot trip the check and abort startup before its own migration applies.
- The check opens no connection and no engine of its own, so it adds no
  failure mode beyond the ones schema initialization already has.
- No second backend worker can observe a half-initialized database while it
  runs.

**Why it raises where the sibling validator only reports.**

`validate_builtin_public_mcp_apps` returns drift summaries that the caller
logs. Catalog drift there is configuration an operator can reconcile while
the process keeps serving. A missing enum label is different in kind: the
write that needs it fails after a caller already believes a status
transition succeeded, so the process must not begin serving at all.

**Scope of the check.**

It is a no-op on any backend other than PostgreSQL: `pg_enum` is a
PostgreSQL system catalog, and the other backends store the `Enum` column as
a plain string checked at the ORM layer instead.

It is keyed on the `tasks` table's existence rather than on an empty live
label set: `taskstatus` is the type of `tasks.status`, so "`tasks` present,
`taskstatus` missing" produces the same empty set as "nothing created yet"
while being exactly the drift this check exists to catch.

The catalog query resolves the type through the column rather than through
its name: `to_regclass('tasks')` resolves the table, `pg_attribute` finds
its `status` column, and `atttypid` is the type that column is declared
with — the same relation-name resolution `has_table("tasks")` already
makes, read through to the one type the column actually uses.

Resolving by name instead would be a second, independent lookup: PostgreSQL
resolves relation names and type names against `search_path` separately, so
`search_path = shadow, public` can point a bare `taskstatus` at `shadow`'s
copy while `tasks` still resolves in `public`. A complete copy in `shadow`
would then hide a label genuinely missing from the type `tasks.status`
actually uses, and an extra label on that copy would reject a correct
deployment. Both directions have a test cell.

The remediation sentence branches on which of missing/extra is populated.
PostgreSQL has no `ALTER TYPE ... DROP VALUE`, so telling an operator to run
a migration is wrong when only unexpected labels are present — that state
means the process is older than the database it is pointed at.

**Migration: repairing databases that predate the label.**

This check exists precisely for the databases it would otherwise strand:
any PostgreSQL database initialized before `WAITING_FOR_USER` was added to
`TaskStatus` (2026-05-14) still carries the five-label native enum
`create_all` built at the time, because `create_all` never adds a label to
a type that already exists. Before this PR, no revision in the migrations
graph ever ran `ALTER TYPE` on `taskstatus` — so shipping the check alone
would turn a silent write failure into a startup failure with no way out.

`20260901_taskstatus_waiting_for_user` adds the one label,
`ALTER TYPE ... ADD VALUE IF NOT EXISTS`, resolving the type through
`tasks.status`'s own column the same way the check does — an asymmetric
`search_path` cannot make the migration repair one type while the check
reads another. It runs inside an autocommit block: `database_startup_lock`
holds a *session*-level advisory lock and commits before yielding for
exactly this reason (see that function's docstring), and PostgreSQL rejects
a write of a label added earlier in the same transaction, aborting the
transaction and taking the `ALTER TYPE` down with it.

The migration adds only this one label, deliberately, rather than diffing
`TaskStatus` against the live enum and adding whatever is missing: a
revision runs once and is then recorded in `alembic_version`, so a "catch
up to whatever TaskStatus has today" body would still miss a member added
after this revision ships. Each new `TaskStatus` member needs its own
revision.

`downgrade()` is a no-op: PostgreSQL has no `ALTER TYPE ... DROP VALUE`.
Removing a label means building a replacement type, rewriting every
`tasks.status` value and the column default onto it, and dropping the old
type — to reach a state whose only distinguishing property is that it
cannot store `WAITING_FOR_USER`. A label nothing writes costs nothing to
leave in place.

`tests/migrations/test_20260901_add_task_status_waiting_for_user_enum_label.py`
covers it end to end: a database whose native enum still has five labels
runs the real startup path (`_initialize_database_schema` — lock, migrate,
create_all, drift check) and comes out able to serve and write the new
label. The other cells cover idempotence, a complete enum left untouched,
the no-op shapes (no `tasks` table yet, `status` not a native enum), the
same `search_path`-shadowing case the check itself guards against, SQLite
(no native type to repair), and offline (`--sql`) rendering on both
dialects. It runs as its own PostgreSQL-only CI step, registered per this
workflow's existing convention for new migration test files.

**Verification** — `uv run pytest`, both test files passing against a real
PostgreSQL 17 server:

- `test_task_status_enum_drift.py` — 11 cells (8 PostgreSQL: correct-schema,
  missing-label, extra-label, missing+extra, no-tables-yet, both
  `search_path`-visibility directions, and a database complete except for
  one label the migration cannot heal; 3 non-PostgreSQL/static: the SQLite
  no-op and the startup-wiring shape).
- `test_20260901_add_task_status_waiting_for_user_enum_label.py` — 11 cells
  (6 PostgreSQL: the end-to-end old-database upgrade, idempotence, a
  complete enum left untouched, the two no-op shapes, and the
  `search_path`-shadowing repair; 5 non-PostgreSQL/offline: SQLite and
  `--sql` rendering on both dialects).

The full migration chain (`test_migration_integration.py`
upgrade/idempotence/incremental/downgrade) passes on both PostgreSQL and
SQLite. Thirteen targeted mutations — across the check, the migration, and
the startup-wiring assertion — each flip exactly the cell(s) they should and
leave the rest passing, including a database carrying every `TaskStatus`
label plus one unrecognized one: the one drift shape no migration can fix,
which is what makes it load-bearing for catching the check being skipped
rather than the migration silently doing the work instead.
