### PR TITLE
fix(agent): close every final_answer stream a ReAct batch opens

### DIFF
--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -2814,6 +2814,33 @@ class ReActPattern(AgentPattern):
             if record is not None:
                 self.tool_ledger[tool_id] = record
 
+    def _disabled_control_tool_index(
+        self,
+        tool_calls: list[dict[str, Any]],
+        *,
+        user_interaction_enabled: bool,
+    ) -> int | None:
+        """Index of the first disabled user-interaction control tool, if any.
+
+        Shared by ``_execute_pending_tool_calls`` (which cancels every call
+        ahead of that index) and ``_close_streamed_answer`` (which must treat
+        a batch the same way whether or not its first call has already run).
+        Both callers pass their own ``user_interaction_enabled`` state rather
+        than this reading ``self`` directly, so the two call sites cannot
+        silently drift onto different predicates.
+        """
+
+        if user_interaction_enabled:
+            return None
+        return next(
+            (
+                index
+                for index, pending in enumerate(tool_calls)
+                if pending.get("name") in USER_INTERACTION_CONTROL_TOOL_NAMES
+            ),
+            None,
+        )
+
     async def _execute_pending_tool_calls(
         self,
         *,
@@ -2823,13 +2850,9 @@ class ReActPattern(AgentPattern):
         runtime: PatternRuntime,
     ) -> dict[str, Any] | None:
         if not self.user_interaction_enabled:
-            disabled_index = next(
-                (
-                    index
-                    for index, pending in enumerate(self.pending_tool_calls)
-                    if pending.get("name") in USER_INTERACTION_CONTROL_TOOL_NAMES
-                ),
-                None,
+            disabled_index = self._disabled_control_tool_index(
+                self.pending_tool_calls,
+                user_interaction_enabled=self.user_interaction_enabled,
             )
             if disabled_index is not None:
                 preceding = self.pending_tool_calls[:disabled_index]

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -95,6 +95,7 @@ from ...runtime import (
     INVALID_TOOL_PROTOCOL_AFTER_RETRY_REASON,
     INVALID_TOOL_PROTOCOL_RETRYING_REASON,
     NO_DELIVERABLE_FINAL_ANSWER_REASON,
+    UNAVAILABLE_TOOL_CALL_RESTORING_TOOLS_REASON,
     ExecutionInterrupted,
     LLMCallInterrupted,
     PatternRuntime,
@@ -728,7 +729,7 @@ class ReActPattern(AgentPattern):
                 unavailable_tool_call = exc.code == "unavailable_tool_call"
                 if answer_streamer is not None:
                     await answer_streamer.fail(
-                        "unavailable tool call, restoring available tools"
+                        UNAVAILABLE_TOOL_CALL_RESTORING_TOOLS_REASON
                         if unavailable_tool_call
                         else f"invalid {exc.code} tool protocol, retrying"
                     )
@@ -1022,36 +1023,28 @@ class ReActPattern(AgentPattern):
     ) -> None:
         """Ensure a started answer stream reaches exactly one terminal event.
 
-        If ``answer_streamer`` never streamed any content, this is a no-op
-        (R0) - there is nothing to close. Otherwise exactly one of the
-        following fires:
+        The branches below are R0 (nothing streamed - no-op), R1
+        (``tool_calls[0]`` is a ``final_answer`` with a non-blank answer and
+        no disabled user-interaction control tool in the batch, per
+        ``_disabled_control_tool_index`` - ``finish`` with that answer's
+        exact, unstripped text, the same text ``_handle_control_tool``
+        delivers), R2 (no tool calls, plain assistant text - ``finish`` with
+        that text) and R3 (anything else - ``fail`` with a fixed reason;
+        ``fail`` is a no-op for a stream already closed earlier in this
+        response).
 
-        - R1: ``tool_calls[0]`` is a ``final_answer`` call with a non-blank
-          answer, and no disabled user-interaction control tool preempts it
-          (``_disabled_control_tool_index``) -> ``finish`` with that answer's
-          exact text, unstripped. The batch's first call is the only one
-          ``_execute_pending_tool_calls`` can ever actually deliver (its
-          ``final_answer`` branch finalizes the run immediately and discards
-          whatever follows), so the streamed content must match it exactly -
-          not a later or "nicer-looking" candidate elsewhere in the batch,
-          and not the same text with whitespace trimmed off.
-        - R2: the batch has no tool calls at all and the model produced
-          plain text -> ``finish`` with that text.
-        - R3: neither of the above -> ``fail`` with a fixed reason. This
-          covers a stream left open by a batch whose first call is not a
-          deliverable final_answer (including one already closed earlier in
-          this same response, e.g. by the bundled-final_answer strip - see
-          ``FinalAnswerStreamSession``, whose ``fail`` is a no-op once
-          already closed) as well as shapes with no known production
-          trigger, kept as an explicit fallback rather than an unhandled
-          state.
-
-        Do not relax R1 to "a final_answer anywhere in the batch" - only the
-        batch's first call is ever delivered, and treating a later one as
-        authoritative would stream text the run does not actually produce as
-        its answer. Do not turn R3 into a ``finish`` to avoid the error
-        event it produces - that would report an undelivered candidate as
-        the completed answer.
+        Do not relax R1's first-position condition. A later ``final_answer``
+        in a mixed batch can still be delivered
+        (``_execute_pending_tool_calls`` keeps walking past e.g. a
+        ``send_message`` that expects no response), but such a batch never
+        leaves an open stream to close: ``ReActFinalAnswerStreamer``
+        permanently disables itself as soon as a non-``final_answer`` tool
+        name appears in the response, before any answer content for a
+        non-first ``final_answer`` has accumulated, so R0 applies. Relaxing
+        the condition would finish streams with candidates whose delivery
+        this method has not checked. Do not turn R3 into a ``finish`` to
+        avoid the error event it produces - that would report an undelivered
+        candidate as the completed answer.
         """
 
         if not answer_streamer.started:

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -89,6 +89,12 @@ from ...result import (
     unwrap_final_answer_content,
 )
 from ...runtime import (
+    DISCARDED_BUNDLED_FINAL_ANSWER_REASON,
+    INTERRUPTED_DURING_LLM_STREAM_REASON,
+    INVALID_TOOL_PROTOCOL_AFTER_RECOVERY_REASON,
+    INVALID_TOOL_PROTOCOL_AFTER_RETRY_REASON,
+    INVALID_TOOL_PROTOCOL_RETRYING_REASON,
+    NO_DELIVERABLE_FINAL_ANSWER_REASON,
     ExecutionInterrupted,
     LLMCallInterrupted,
     PatternRuntime,
@@ -709,7 +715,7 @@ class ReActPattern(AgentPattern):
                     response = await runtime.stream_final_answer(call_llm, **llm_kwargs)
             except LLMCallInterrupted:
                 if answer_streamer is not None:
-                    await answer_streamer.fail("interrupted during LLM stream")
+                    await answer_streamer.fail(INTERRUPTED_DURING_LLM_STREAM_REASON)
                 interrupted = await self._interrupt_if_requested(
                     runtime=runtime,
                     context=context,
@@ -795,13 +801,13 @@ class ReActPattern(AgentPattern):
                         context=context,
                         iteration=iteration,
                         answer_streamer=answer_streamer,
-                        stream_failure_message=("invalid tool protocol after recovery"),
+                        stream_failure_message=INVALID_TOOL_PROTOCOL_AFTER_RECOVERY_REASON,
                         empty_final_answer=(
                             self._empty_final_answer_call(normalized) is not None
                         ),
                     )
                 if answer_streamer is not None:
-                    await answer_streamer.fail("invalid tool protocol, retrying")
+                    await answer_streamer.fail(INVALID_TOOL_PROTOCOL_RETRYING_REASON)
                 # Rejecting the whole response drops any assistant preamble it
                 # carried: the response is discarded before ``add_assistant_message``,
                 # so the retry rebuilds from context without it. Deliberate - the
@@ -868,7 +874,7 @@ class ReActPattern(AgentPattern):
                         context=context,
                         iteration=iteration,
                         answer_streamer=answer_streamer,
-                        stream_failure_message="invalid tool protocol after retry",
+                        stream_failure_message=INVALID_TOOL_PROTOCOL_AFTER_RETRY_REASON,
                         empty_final_answer=(
                             self._empty_final_answer_call(normalized) is not None
                         ),
@@ -893,10 +899,7 @@ class ReActPattern(AgentPattern):
                     # The discarded text may already be streaming to the UI.
                     # Nothing downstream closes that stream once the batch no
                     # longer carries a final_answer, so close it here.
-                    await answer_streamer.fail(
-                        "discarded an answer that arrived together with tool "
-                        "calls; answering again once the tools have run"
-                    )
+                    await answer_streamer.fail(DISCARDED_BUNDLED_FINAL_ANSWER_REASON)
             if force_final_answer_now and not normalized.get("tool_calls"):
                 normalized["done"] = True
 
@@ -1067,7 +1070,7 @@ class ReActPattern(AgentPattern):
         if not tool_calls and assistant_content is not None:
             await answer_streamer.finish(str(assistant_content))
             return
-        await answer_streamer.fail("no deliverable final_answer in this batch")
+        await answer_streamer.fail(NO_DELIVERABLE_FINAL_ANSWER_REASON)
 
     def _messages_for_llm(
         self,
@@ -1285,7 +1288,7 @@ class ReActPattern(AgentPattern):
                 on_chunk=answer_streamer.handle_chunk,
             )
         except LLMCallInterrupted:
-            await answer_streamer.fail("interrupted during LLM stream")
+            await answer_streamer.fail(INTERRUPTED_DURING_LLM_STREAM_REASON)
             raise
         except Exception as exc:
             await answer_streamer.fail(str(exc))

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -920,7 +920,7 @@ class ReActPattern(AgentPattern):
                 )
 
             if answer_streamer is not None:
-                await self._finish_streamed_answer_if_final(
+                await self._close_streamed_answer(
                     answer_streamer=answer_streamer,
                     assistant_content=assistant_content,
                     tool_calls=tool_calls,
@@ -1010,33 +1010,64 @@ class ReActPattern(AgentPattern):
             },
         ).to_dict()
 
-    async def _finish_streamed_answer_if_final(
+    async def _close_streamed_answer(
         self,
         *,
         answer_streamer: ReActFinalAnswerStreamer,
         assistant_content: Any,
         tool_calls: list[dict[str, Any]],
     ) -> None:
+        """Ensure a started answer stream reaches exactly one terminal event.
+
+        If ``answer_streamer`` never streamed any content, this is a no-op
+        (R0) - there is nothing to close. Otherwise exactly one of the
+        following fires:
+
+        - R1: ``tool_calls[0]`` is a ``final_answer`` call with a non-blank
+          answer, and no disabled user-interaction control tool preempts it
+          (``_disabled_control_tool_index``) -> ``finish`` with that answer's
+          exact text, unstripped. The batch's first call is the only one
+          ``_execute_pending_tool_calls`` can ever actually deliver (its
+          ``final_answer`` branch finalizes the run immediately and discards
+          whatever follows), so the streamed content must match it exactly -
+          not a later or "nicer-looking" candidate elsewhere in the batch,
+          and not the same text with whitespace trimmed off.
+        - R2: the batch has no tool calls at all and the model produced
+          plain text -> ``finish`` with that text.
+        - R3: neither of the above -> ``fail`` with a fixed reason. This
+          covers a stream left open by a batch whose first call is not a
+          deliverable final_answer (including one already closed earlier in
+          this same response, e.g. by the bundled-final_answer strip - see
+          ``FinalAnswerStreamSession``, whose ``fail`` is a no-op once
+          already closed) as well as shapes with no known production
+          trigger, kept as an explicit fallback rather than an unhandled
+          state.
+
+        Do not relax R1 to "a final_answer anywhere in the batch" - only the
+        batch's first call is ever delivered, and treating a later one as
+        authoritative would stream text the run does not actually produce as
+        its answer. Do not turn R3 into a ``finish`` to avoid the error
+        event it produces - that would report an undelivered candidate as
+        the completed answer.
+        """
+
         if not answer_streamer.started:
             return
-        final_answer = self._final_answer_tool_content(tool_calls)
-        if final_answer is not None and len(tool_calls) == 1:
-            await answer_streamer.finish(final_answer)
-            return
+        if tool_calls and tool_calls[0].get("name") == "final_answer":
+            answer = self._final_answer_text(tool_calls[0].get("args"))
+            if answer.strip() and (
+                self._disabled_control_tool_index(
+                    tool_calls,
+                    user_interaction_enabled=self.user_interaction_enabled,
+                )
+                is None
+            ):
+                await answer_streamer.finish(answer)
+                return
         if not tool_calls and assistant_content is not None:
             await answer_streamer.finish(str(assistant_content))
-
-    def _final_answer_tool_content(
-        self,
-        tool_calls: list[dict[str, Any]],
-    ) -> str | None:
-        for tool_call in tool_calls:
-            if tool_call.get("name") != "final_answer":
-                continue
-            args = tool_call.get("args")
-            if isinstance(args, dict):
-                return self._final_answer_text(args)
-        return None
+            return
+        await answer_streamer.fail("no deliverable final_answer in this batch")
 
     def _messages_for_llm(
         self,

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -642,19 +642,19 @@ class PatternRuntime:
             return None
         message_id = f"final_answer_{uuid4().hex}"
         self.last_final_answer_stream_message_id = None
-        logger.info(
-            "final_answer stream opened. task_id=%s step=%s turn=%s message_id=%s",
-            self.execution_id,
-            self.active_react_step_id,
-            self.active_turn_id,
-            message_id,
-        )
         await self._emit_outbound(
             {
                 "type": "final_answer_start",
                 "message_id": message_id,
                 "task_id": self.execution_id,
             }
+        )
+        logger.info(
+            "final_answer stream opened. task_id=%s step=%s turn=%s message_id=%s",
+            self.execution_id,
+            self.active_react_step_id,
+            self.active_turn_id,
+            message_id,
         )
         return message_id
 
@@ -672,6 +672,14 @@ class PatternRuntime:
 
     async def end_final_answer_stream(self, message_id: str, content: str) -> None:
         self.last_final_answer_stream_message_id = message_id
+        await self._emit_outbound(
+            {
+                "type": "final_answer_end",
+                "message_id": message_id,
+                "task_id": self.execution_id,
+                "content": content,
+            }
+        )
         logger.info(
             "final_answer stream closed. task_id=%s step=%s turn=%s "
             "message_id=%s content_chars=%d",
@@ -681,18 +689,18 @@ class PatternRuntime:
             message_id,
             len(content),
         )
-        await self._emit_outbound(
-            {
-                "type": "final_answer_end",
-                "message_id": message_id,
-                "task_id": self.execution_id,
-                "content": content,
-            }
-        )
 
     async def fail_final_answer_stream(self, message_id: str, error: str) -> None:
         if self.last_final_answer_stream_message_id == message_id:
             self.last_final_answer_stream_message_id = None
+        await self._emit_outbound(
+            {
+                "type": "final_answer_error",
+                "message_id": message_id,
+                "task_id": self.execution_id,
+                "error": error,
+            }
+        )
         logger.warning(
             "final_answer stream failed. task_id=%s step=%s turn=%s "
             "message_id=%s reason=%s",
@@ -701,14 +709,6 @@ class PatternRuntime:
             self.active_turn_id,
             message_id,
             _normalize_stream_close_reason(error),
-        )
-        await self._emit_outbound(
-            {
-                "type": "final_answer_error",
-                "message_id": message_id,
-                "task_id": self.execution_id,
-                "error": error,
-            }
         )
 
     def _has_native_stream_chat(self, llm: Any) -> bool:

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -38,6 +38,86 @@ from .streaming import merge_streamed_tool_call_arguments
 
 logger = logging.getLogger(__name__)
 
+# Fixed final_answer stream close reasons. ReAct's fail() call sites import
+# these names directly (react.py already imports this module at module
+# scope, so that adds no new dependency edge) instead of writing their own
+# copies of the literal text, so there is exactly one place that spells each
+# reason and exactly one place that recognizes it for logging.
+INTERRUPTED_DURING_LLM_STREAM_REASON = "interrupted during LLM stream"
+UNAVAILABLE_TOOL_CALL_RESTORING_TOOLS_REASON = (
+    "unavailable tool call, restoring available tools"
+)
+INVALID_TOOL_PROTOCOL_RETRYING_REASON = "invalid tool protocol, retrying"
+DISCARDED_BUNDLED_FINAL_ANSWER_REASON = (
+    "discarded an answer that arrived together with tool "
+    "calls; answering again once the tools have run"
+)
+INVALID_TOOL_PROTOCOL_AFTER_RECOVERY_REASON = "invalid tool protocol after recovery"
+INVALID_TOOL_PROTOCOL_AFTER_RETRY_REASON = "invalid tool protocol after retry"
+NO_DELIVERABLE_FINAL_ANSWER_REASON = "no deliverable final_answer in this batch"
+
+_KNOWN_STREAM_CLOSE_REASONS = frozenset(
+    {
+        INTERRUPTED_DURING_LLM_STREAM_REASON,
+        UNAVAILABLE_TOOL_CALL_RESTORING_TOOLS_REASON,
+        INVALID_TOOL_PROTOCOL_RETRYING_REASON,
+        DISCARDED_BUNDLED_FINAL_ANSWER_REASON,
+        INVALID_TOOL_PROTOCOL_AFTER_RECOVERY_REASON,
+        INVALID_TOOL_PROTOCOL_AFTER_RETRY_REASON,
+        NO_DELIVERABLE_FINAL_ANSWER_REASON,
+    }
+)
+
+# react.py's LLMToolProtocolError handler builds this reason as
+# f"invalid {exc.code} tool protocol, retrying", where exc.code comes
+# straight from the provider's error payload. _normalize_stream_close_reason
+# folds it to a fixed shape that keeps exc.code's length, never its text.
+_TOOL_PROTOCOL_RETRY_PREFIX = "invalid "
+_TOOL_PROTOCOL_RETRY_SUFFIX = " tool protocol, retrying"
+_TOOL_PROTOCOL_RETRY_TEMPLATE_MIN_LENGTH = len(_TOOL_PROTOCOL_RETRY_PREFIX) + len(
+    _TOOL_PROTOCOL_RETRY_SUFFIX
+)
+
+
+def _normalize_stream_close_reason(reason: str) -> str:
+    """Classify a final_answer stream close reason for logging.
+
+    ``reason`` is whatever ``FinalAnswerStreamSession.fail`` was called with:
+    a fixed string this codebase wrote, a provider-error-code-derived
+    template, or an arbitrary provider exception's ``str(exc)``. It still
+    reaches the frontend unchanged either way - this function only decides
+    what gets logged - and the classification works from the string's
+    content alone; there is no side channel telling it where a reason came
+    from.
+
+    - An exact match against a known fixed string is logged verbatim.
+    - A match against the "invalid <code> tool protocol, retrying" template
+      is folded to a fixed shape that keeps the length of the
+      provider-controlled ``code`` value but not its text. The exact-match
+      check above runs first, so the one known literal that could otherwise
+      overlap this template ("invalid tool protocol, retrying", with a
+      single space doing double duty as both the prefix's and the suffix's
+      space) is already resolved by the time this check runs; the length
+      guard here is a second, independent reason it cannot match anyway,
+      since a real templated reason is always longer.
+    - Anything else - including a raw provider exception message - is
+      reduced to its length. Never guess a class name or any other
+      structure out of unrecognized text: that would smuggle part of it
+      into the logs, which is the one thing this function exists to
+      prevent.
+    """
+
+    if reason in _KNOWN_STREAM_CLOSE_REASONS:
+        return reason
+    if (
+        len(reason) > _TOOL_PROTOCOL_RETRY_TEMPLATE_MIN_LENGTH
+        and reason.startswith(_TOOL_PROTOCOL_RETRY_PREFIX)
+        and reason.endswith(_TOOL_PROTOCOL_RETRY_SUFFIX)
+    ):
+        code_chars = len(reason) - _TOOL_PROTOCOL_RETRY_TEMPLATE_MIN_LENGTH
+        return f"invalid tool protocol (code:{code_chars} chars), retrying"
+    return f"<unparsed>:{len(reason)}"
+
 
 class ExecutionInterrupted(Exception):
     """Base signal for an execution interrupted at an active I/O boundary."""
@@ -562,6 +642,13 @@ class PatternRuntime:
             return None
         message_id = f"final_answer_{uuid4().hex}"
         self.last_final_answer_stream_message_id = None
+        logger.info(
+            "final_answer stream opened. task_id=%s step=%s turn=%s message_id=%s",
+            self.execution_id,
+            self.active_react_step_id,
+            self.active_turn_id,
+            message_id,
+        )
         await self._emit_outbound(
             {
                 "type": "final_answer_start",
@@ -585,6 +672,15 @@ class PatternRuntime:
 
     async def end_final_answer_stream(self, message_id: str, content: str) -> None:
         self.last_final_answer_stream_message_id = message_id
+        logger.info(
+            "final_answer stream closed. task_id=%s step=%s turn=%s "
+            "message_id=%s content_chars=%d",
+            self.execution_id,
+            self.active_react_step_id,
+            self.active_turn_id,
+            message_id,
+            len(content),
+        )
         await self._emit_outbound(
             {
                 "type": "final_answer_end",
@@ -597,6 +693,15 @@ class PatternRuntime:
     async def fail_final_answer_stream(self, message_id: str, error: str) -> None:
         if self.last_final_answer_stream_message_id == message_id:
             self.last_final_answer_stream_message_id = None
+        logger.warning(
+            "final_answer stream failed. task_id=%s step=%s turn=%s "
+            "message_id=%s reason=%s",
+            self.execution_id,
+            self.active_react_step_id,
+            self.active_turn_id,
+            message_id,
+            _normalize_stream_close_reason(error),
+        )
         await self._emit_outbound(
             {
                 "type": "final_answer_error",

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -29,6 +29,7 @@ from xagent.core.agent.pattern.react.react import (
     _normalize_ask_user_interactions,
 )
 from xagent.core.agent.result import tool_result_succeeded
+from xagent.core.agent.runtime import NO_DELIVERABLE_FINAL_ANSWER_REASON
 from xagent.core.file_ref import WORKSPACE_OUTPUT_FILES_TOOL_NAME
 from xagent.core.model.chat.basic.router import RouterLLM
 from xagent.core.model.chat.exceptions import LLMToolProtocolError
@@ -8191,7 +8192,10 @@ async def test_react_control_tool_before_final_answer_opens_no_answer_stream(
     """I-4: a control tool ahead of final_answer in the same batch disables
     the answer streamer before any answer bytes are emitted (the streamer
     self-disables on the first non-final_answer tool name it sees), so no
-    final_answer_* event of any kind is ever produced for that response."""
+    final_answer_* event of any kind is ever produced for that response.
+    The run's delivered outcome is pinned too: the later final_answer is
+    still executed and delivered unless a response-expecting control tool
+    pauses the run before reaching it."""
 
     llm = ScriptedStreamLLM([[control_call, _fa("Answer one.")], _FALLBACK_BATCH])
     pattern = ReActPattern(max_iterations=3)
@@ -8200,9 +8204,15 @@ async def test_react_control_tool_before_final_answer_opens_no_answer_stream(
     outbound = OutboundCollector()
     runtime = PatternRuntime(execution_id="task-1", outbound_message_handler=outbound)
 
-    await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
 
     assert not any(e["type"].startswith("final_answer_") for e in outbound.events)
+    control_name, control_args = control_call
+    if control_name == "ask_user_question" or control_args.get("expect_response"):
+        assert result["status"] == "waiting_for_user"
+    else:
+        assert result["success"] is True
+        assert result["response"] == "Answer one."
 
 
 @pytest.mark.asyncio
@@ -8457,4 +8467,4 @@ async def test_react_close_streamed_answer_fails_open_stream_without_deliverable
     )
 
     assert streamer.finish_calls == []
-    assert len(streamer.fail_calls) == 1
+    assert streamer.fail_calls == [NO_DELIVERABLE_FINAL_ANSWER_REASON]

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -8271,11 +8271,9 @@ async def test_react_work_tool_batch_still_fails_stream_before_close(
 
     by_id = _terminal_events_by_message_id(outbound.events)
     assert len(by_id) == 2
-    sequences = list(by_id.values())
-    assert sequences[0] == ["final_answer_start", "final_answer_error"]
-    assert sequences[1] == ["final_answer_start", "final_answer_error"] or sequences[
-        1
-    ] == ["final_answer_start", "final_answer_end"]
+    first_id, second_id = by_id.keys()
+    assert by_id[first_id] == ["final_answer_start", "final_answer_error"]
+    assert by_id[second_id] == ["final_answer_start", "final_answer_end"]
     first_stream_error = next(
         e for e in outbound.events if e["type"] == "final_answer_error"
     )
@@ -8283,6 +8281,13 @@ async def test_react_work_tool_batch_still_fails_stream_before_close(
         "discarded an answer that arrived together with tool "
         "calls; answering again once the tools have run"
     )
+    second_stream_end = next(
+        e
+        for e in outbound.events
+        if e["type"] == "final_answer_end" and e["message_id"] == second_id
+    )
+    assert second_stream_end["content"] == _FALLBACK_ANSWER
+    assert runtime.last_final_answer_stream_message_id == second_id
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -23,6 +23,7 @@ from xagent.core.agent import (
     ToolCallRecord,
 )
 from xagent.core.agent.context.execution import CLOCK_TIMEZONE_METADATA_KEY
+from xagent.core.agent.pattern.final_answer_stream import ReActFinalAnswerStreamer
 from xagent.core.agent.pattern.react.react import (
     _INTERACTION_TRIM_CHARS,
     _normalize_ask_user_interactions,
@@ -891,6 +892,44 @@ class StreamingRepeatedGuardFinalAnswerLLM:
                     }
                 ],
             )
+        yield StreamChunk(type=ChunkType.END)
+
+
+class ScriptedStreamLLM:
+    """Streams one scripted tool-call batch per ``stream_chat`` call.
+
+    Each batch is a list of ``(tool_name, args_dict)`` pairs. Every call's
+    arguments are streamed in two fragments (a truncated prefix, then the
+    full JSON) so the answer streamer sees a partial candidate before the
+    complete one, matching the production streaming shape. This is the one
+    general-purpose fake model for the #486 batch-shape matrix - covering a
+    new shape means adding a batch here, not a new fake model class.
+    """
+
+    def __init__(self, batches: list[list[tuple[str, dict[str, Any]]]]) -> None:
+        self.batches = batches
+        self.stream_calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> Any:
+        raise AssertionError("ScriptedStreamLLM should not fall back to chat()")
+
+    async def stream_chat(self, **kwargs: Any) -> Any:
+        self.stream_calls.append(kwargs)
+        index = min(len(self.stream_calls) - 1, len(self.batches) - 1)
+        for position, (name, args) in enumerate(self.batches[index]):
+            serialized = json.dumps(args)
+            cut = max(1, len(serialized) // 2)
+            for fragment in (serialized[:cut], serialized):
+                yield StreamChunk(
+                    type=ChunkType.TOOL_CALL,
+                    tool_calls=[
+                        {
+                            "index": position,
+                            "id": f"call_{position}",
+                            "function": {"name": name, "arguments": fragment},
+                        }
+                    ],
+                )
         yield StreamChunk(type=ChunkType.END)
 
 
@@ -7712,3 +7751,710 @@ def test_tool_call_date_line_uses_the_caller_timezone() -> None:
 
 def test_tool_call_date_line_degrades_to_utc_for_an_unusable_timezone() -> None:
     assert _date_instruction(_react_clock_prompt("Not/AZone")) == UTC_DATE_INSTRUCTION
+
+
+# ---------------------------------------------------------------------------
+# xagent#486: every final_answer stream that gets opened must be closed with
+# exactly one terminal event, regardless of how the batch that opened it
+# resolves. See _close_streamed_answer's docstring in react.py for the R0-R3
+# contract these tests pin down.
+# ---------------------------------------------------------------------------
+
+
+def _fa(answer: str) -> tuple[str, dict[str, Any]]:
+    return ("final_answer", {"answer": answer})
+
+
+def _send_message_call(*, expect_response: bool) -> tuple[str, dict[str, Any]]:
+    return (
+        "send_message",
+        {
+            "message": "Side note",
+            "message_type": "question" if expect_response else "progress",
+            "expect_response": expect_response,
+        },
+    )
+
+
+def _ask_user_question_call() -> tuple[str, dict[str, Any]]:
+    return (
+        "ask_user_question",
+        {
+            "message": "Which one?",
+            "interactions": [
+                {"type": "select_one", "field": "choice", "label": "Choice"}
+            ],
+        },
+    )
+
+
+def _work_tool_call() -> tuple[str, dict[str, Any]]:
+    return ("calculator", {"expression": "2+2"})
+
+
+_FALLBACK_ANSWER = "Fallback answer."
+_FALLBACK_BATCH: list[tuple[str, dict[str, Any]]] = [_fa(_FALLBACK_ANSWER)]
+
+
+def _terminal_events_by_message_id(
+    events: list[dict[str, Any]],
+) -> dict[str, list[str]]:
+    """Group final_answer_start/end/error events by message_id.
+
+    Used to check that every started message_id gets exactly one terminal
+    event (end or error), never zero and never two.
+    """
+
+    by_id: dict[str, list[str]] = {}
+    for event in events:
+        event_type = event.get("type")
+        if event_type not in (
+            "final_answer_start",
+            "final_answer_end",
+            "final_answer_error",
+        ):
+            continue
+        by_id.setdefault(event["message_id"], []).append(event_type)
+    return by_id
+
+
+_I1_RUN_CASES: list[dict[str, Any]] = [
+    {
+        "label": "C1_single_final_answer",
+        "batches": [[_fa("Answer one.")]],
+        "needs_tool": False,
+        "user_interaction_enabled": True,
+        "max_iterations": 1,
+        "expected_sequences": [["final_answer_start", "final_answer_end"]],
+    },
+    {
+        "label": "C2_identical_final_answers",
+        "batches": [[_fa("Same answer."), _fa("Same answer.")]],
+        "needs_tool": False,
+        "user_interaction_enabled": True,
+        "max_iterations": 1,
+        "expected_sequences": [["final_answer_start", "final_answer_end"]],
+    },
+    {
+        "label": "C3_distinct_final_answers",
+        "batches": [[_fa("First."), _fa("Second."), _fa("Third.")]],
+        "needs_tool": False,
+        "user_interaction_enabled": True,
+        "max_iterations": 1,
+        "expected_sequences": [["final_answer_start", "final_answer_end"]],
+    },
+    {
+        "label": "C4_final_answer_before_send_message",
+        "batches": [[_fa("Answer one."), _send_message_call(expect_response=False)]],
+        "needs_tool": False,
+        "user_interaction_enabled": True,
+        "max_iterations": 1,
+        "expected_sequences": [["final_answer_start", "final_answer_end"]],
+    },
+    {
+        "label": "C5_final_answer_before_ask_user_question",
+        "batches": [[_fa("Answer one."), _ask_user_question_call()]],
+        "needs_tool": False,
+        "user_interaction_enabled": True,
+        "max_iterations": 1,
+        "expected_sequences": [["final_answer_start", "final_answer_end"]],
+    },
+    {
+        "label": "C6_send_message_before_final_answer",
+        "batches": [[_send_message_call(expect_response=False), _fa("Answer one.")]],
+        "needs_tool": False,
+        "user_interaction_enabled": True,
+        "max_iterations": 1,
+        "expected_sequences": [],
+    },
+    {
+        "label": "C7_send_message_expect_response_before_final_answer",
+        "batches": [[_send_message_call(expect_response=True), _fa("Answer one.")]],
+        "needs_tool": False,
+        "user_interaction_enabled": True,
+        "max_iterations": 1,
+        "expected_sequences": [],
+    },
+    {
+        "label": "C8_ask_user_question_before_final_answer",
+        "batches": [[_ask_user_question_call(), _fa("Answer one.")]],
+        "needs_tool": False,
+        "user_interaction_enabled": True,
+        "max_iterations": 1,
+        "expected_sequences": [],
+    },
+    {
+        "label": "C9a_final_answer_before_work_tool",
+        "batches": [[_fa("Candidate."), _work_tool_call()], _FALLBACK_BATCH],
+        "needs_tool": True,
+        "user_interaction_enabled": True,
+        "max_iterations": 3,
+        "expected_sequences": [
+            ["final_answer_start", "final_answer_error"],
+            ["final_answer_start", "final_answer_end"],
+        ],
+    },
+    {
+        "label": "C9b_work_tool_before_final_answer",
+        "batches": [[_work_tool_call(), _fa("Candidate.")], _FALLBACK_BATCH],
+        "needs_tool": True,
+        "user_interaction_enabled": True,
+        "max_iterations": 3,
+        # The work tool's name arrives before any final_answer bytes, so the
+        # streamer disables itself immediately - only the fallback batch's
+        # stream ever opens.
+        "expected_sequences": [["final_answer_start", "final_answer_end"]],
+    },
+    {
+        "label": "C10_empty_final_answer_in_control_only_batch",
+        "batches": [[_fa("Valid answer."), _fa("")], _FALLBACK_BATCH],
+        "needs_tool": False,
+        "user_interaction_enabled": True,
+        "max_iterations": 3,
+        "expected_sequences": [
+            ["final_answer_start", "final_answer_error"],
+            ["final_answer_start", "final_answer_end"],
+        ],
+    },
+    {
+        "label": "C14_disabled_control_tool_cancels_first_final_answer",
+        "batches": [
+            [_fa("Answer one."), _send_message_call(expect_response=False)],
+            _FALLBACK_BATCH,
+        ],
+        "needs_tool": False,
+        "user_interaction_enabled": False,
+        "max_iterations": 3,
+        "expected_sequences": [
+            ["final_answer_start", "final_answer_error"],
+            ["final_answer_start", "final_answer_end"],
+        ],
+    },
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "case", _I1_RUN_CASES, ids=[case["label"] for case in _I1_RUN_CASES]
+)
+async def test_react_every_started_answer_stream_gets_exactly_one_terminal_event(
+    case: dict[str, Any],
+) -> None:
+    """I-1: for every batch shape that can occur through a real ReAct run,
+    each final_answer_start's message_id gets exactly one terminal event
+    (final_answer_end or final_answer_error) - never zero, never two. A
+    shape whose stream never opens (R0) produces no started ids at all."""
+
+    llm = ScriptedStreamLLM(case["batches"])
+    pattern = ReActPattern(
+        max_iterations=case["max_iterations"],
+        user_interaction_enabled=case["user_interaction_enabled"],
+    )
+    tools = [FakeTool()] if case["needs_tool"] else []
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Question")
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(execution_id="task-1", outbound_message_handler=outbound)
+
+    await pattern.run(context=context, tools=tools, llm=llm, runtime=runtime)
+
+    by_id = _terminal_events_by_message_id(outbound.events)
+    actual_sequences = list(by_id.values())
+    assert actual_sequences == case["expected_sequences"]
+    for sequence in actual_sequences:
+        assert sequence[0] == "final_answer_start"
+        assert len(sequence) == 2
+        assert sequence[1] in ("final_answer_end", "final_answer_error")
+
+
+@pytest.mark.asyncio
+async def test_react_every_started_answer_stream_gets_exactly_one_terminal_event_without_outbound_handler() -> (
+    None
+):
+    """I-1, front condition (no outbound handler): start_final_answer_stream
+    returns None with no handler to send to, so the answer streamer never
+    accumulates content and never starts - the run still delivers the
+    correct answer through the non-streaming path, and there is nothing to
+    close."""
+
+    llm = ScriptedStreamLLM([[_fa("Answer one.")]])
+    pattern = ReActPattern(max_iterations=1)
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Question")
+    runtime = PatternRuntime(execution_id="task-1", outbound_message_handler=None)
+
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert result["success"] is True
+    assert result["response"] == "Answer one."
+    assert runtime.last_final_answer_stream_message_id is None
+
+
+@pytest.mark.asyncio
+async def test_react_every_started_answer_stream_gets_exactly_one_terminal_event_without_native_streaming() -> (
+    None
+):
+    """I-1, front condition (no native streaming): a model without
+    stream_chat falls back to the non-streaming call path, so on_chunk is
+    never invoked and the answer streamer never starts - zero final_answer_*
+    events, even though tool_schemas were offered and a final_answer call
+    was made."""
+
+    llm = FakeLLM(
+        responses=[
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_final",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"Answer one."}',
+                        },
+                    }
+                ]
+            }
+        ]
+    )
+    pattern = ReActPattern(max_iterations=1)
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Question")
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(execution_id="task-1", outbound_message_handler=outbound)
+
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert result["success"] is True
+    assert result["response"] == "Answer one."
+    assert outbound.events == []
+
+
+@pytest.mark.asyncio
+async def test_react_every_started_answer_stream_gets_exactly_one_terminal_event_c12_manual() -> (
+    None
+):
+    """I-1, C12 (no tool_calls, plain assistant content, stream already
+    open): there is no known way for a real model response to leave the
+    stream open while producing zero tool_calls - reaching R1 or R3 both
+    require at least one tool call, and the only way tool_calls empties out
+    after the stream opens (the bundled-final_answer strip) always keeps a
+    work-tool entry behind. This case drives the stream open through the
+    real streaming primitive directly, then calls the close function with a
+    tool_calls=[] batch, so the R2 branch is exercised the same way I-11
+    exercises R3's otherwise-untriggerable shapes."""
+
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(execution_id="task-1", outbound_message_handler=outbound)
+    streamer = ReActFinalAnswerStreamer(runtime)
+    await streamer.handle_chunk(
+        StreamChunk(
+            type=ChunkType.TOOL_CALL,
+            tool_calls=[
+                {
+                    "id": "call_final",
+                    "function": {
+                        "name": "final_answer",
+                        "arguments": '{"answer":"Partial"}',
+                    },
+                }
+            ],
+        )
+    )
+    assert streamer.started
+    pattern = ReActPattern(max_iterations=1)
+
+    await pattern._close_streamed_answer(
+        answer_streamer=streamer,
+        assistant_content="Some plain content.",
+        tool_calls=[],
+    )
+
+    by_id = _terminal_events_by_message_id(outbound.events)
+    assert len(by_id) == 1
+    (sequence,) = by_id.values()
+    assert sequence == ["final_answer_start", "final_answer_end"]
+    end_event = next(e for e in outbound.events if e["type"] == "final_answer_end")
+    assert end_event["content"] == "Some plain content."
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "label,batch,force_final_answer",
+    [
+        ("identical", [_fa("  Same answer.\n"), _fa("  Same answer.\n")], False),
+        (
+            "distinct_increasing",
+            [_fa("  First.\n"), _fa("  Second, longer.\n"), _fa("  Third, longest.\n")],
+            False,
+        ),
+        (
+            "distinct_decreasing",
+            [_fa("  First, longest.\n"), _fa("  Second.\n"), _fa("  Third.\n")],
+            False,
+        ),
+        (
+            "two_distinct_forced",
+            [_fa("  First.\n"), _fa("  Second, different.\n")],
+            True,
+        ),
+    ],
+)
+async def test_react_multi_final_answer_closes_stream_with_first_payload(
+    label: str,
+    batch: list[tuple[str, dict[str, Any]]],
+    force_final_answer: bool,
+) -> None:
+    """I-2: a batch with more than one final_answer call closes the stream on
+    the batch's first payload, verbatim (no stripping) - matching the text
+    _handle_control_tool actually delivers, whatever the later payloads say.
+
+    Every payload carries leading/trailing whitespace so this is only green
+    if the close path uses the raw text and never adds a ``.strip()``.
+    ``two_distinct_forced`` runs with ``force_final_answer_next`` set: when
+    the model is forced to answer through a single-tool ``final_answer``
+    schema, more than one call in the same batch is the shape that actually
+    reaches production, not an edge case.
+    """
+
+    llm = ScriptedStreamLLM([batch])
+    pattern = ReActPattern(max_iterations=1)
+    if force_final_answer:
+        pattern.force_final_answer_next = True
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Question")
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(execution_id="task-1", outbound_message_handler=outbound)
+
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    first_payload = batch[0][1]["answer"]
+    assert result["success"] is True
+    assert result["response"] == first_payload
+    end_events = [e for e in outbound.events if e["type"] == "final_answer_end"]
+    assert len(end_events) == 1
+    assert end_events[0]["content"] == first_payload
+    assert not any(e["type"] == "final_answer_error" for e in outbound.events)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "control_call",
+    [
+        _send_message_call(expect_response=False),
+        _ask_user_question_call(),
+    ],
+    ids=["send_message", "ask_user_question"],
+)
+async def test_react_final_answer_before_control_tool_ends_stream(
+    control_call: tuple[str, dict[str, Any]],
+) -> None:
+    """I-3: final_answer first in the batch always ends the stream with its
+    own answer, even when a control tool follows it in the same batch - that
+    trailing call never actually runs (_handle_control_tool's final_answer
+    branch finalizes the run before it is reached)."""
+
+    llm = ScriptedStreamLLM([[_fa("Answer one."), control_call]])
+    pattern = ReActPattern(max_iterations=1)
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Question")
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(execution_id="task-1", outbound_message_handler=outbound)
+
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert result["success"] is True
+    assert result["response"] == "Answer one."
+    assert [e["type"] for e in outbound.events] == [
+        "final_answer_start",
+        "final_answer_delta",
+        "final_answer_end",
+    ]
+    assert outbound.events[-1]["content"] == "Answer one."
+    # The trailing control tool never ran: it would have produced an
+    # agent_message event (send_message) or paused the run.
+    assert not any(e["type"] == "agent_message" for e in outbound.events)
+    assert result.get("status") != "waiting_for_user"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "control_call",
+    [
+        _send_message_call(expect_response=False),
+        _send_message_call(expect_response=True),
+        _ask_user_question_call(),
+    ],
+    ids=["send_message", "send_message_expect_response", "ask_user_question"],
+)
+async def test_react_control_tool_before_final_answer_opens_no_answer_stream(
+    control_call: tuple[str, dict[str, Any]],
+) -> None:
+    """I-4: a control tool ahead of final_answer in the same batch disables
+    the answer streamer before any answer bytes are emitted (the streamer
+    self-disables on the first non-final_answer tool name it sees), so no
+    final_answer_* event of any kind is ever produced for that response."""
+
+    llm = ScriptedStreamLLM([[control_call, _fa("Answer one.")], _FALLBACK_BATCH])
+    pattern = ReActPattern(max_iterations=3)
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Question")
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(execution_id="task-1", outbound_message_handler=outbound)
+
+    await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert not any(e["type"].startswith("final_answer_") for e in outbound.events)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ordering", ["final_answer_first", "work_tool_first"])
+async def test_react_work_tool_batch_still_fails_stream_before_close(
+    ordering: str,
+) -> None:
+    """I-5: a final_answer bundled with a work tool keeps going through the
+    existing strip-and-fail path (the batch is stripped of its final_answer
+    call and the open stream is failed there), not through the close
+    function's own R3 fallback, and the stream this closes never ends as
+    though the stripped text were the delivered answer.
+
+    Streaming a work-tool name before any final_answer bytes disables the
+    answer streamer immediately (final_answer_stream.py's guard checks tool
+    names as soon as they appear, before reading any field), so
+    ``work_tool_first`` never opens a stream at all; ``final_answer_first``
+    is the only ordering that can leave a stream open for the strip point to
+    close.
+    """
+
+    if ordering == "final_answer_first":
+        batch = [_fa("Candidate."), _work_tool_call()]
+    else:
+        batch = [_work_tool_call(), _fa("Candidate.")]
+    llm = ScriptedStreamLLM([batch, _FALLBACK_BATCH])
+    pattern = ReActPattern(max_iterations=3)
+    tool = FakeTool()
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Question")
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(execution_id="task-1", outbound_message_handler=outbound)
+
+    result = await pattern.run(context=context, tools=[tool], llm=llm, runtime=runtime)
+
+    assert result["success"] is True
+    assert result["response"] == _FALLBACK_ANSWER
+    # Deltas may echo the discarded candidate while the model is still
+    # streaming - that is pre-existing emit_prefix behavior, unrelated to
+    # this invariant. What must never happen is the discarded text being
+    # delivered as a completed answer.
+    assert not any(
+        e["type"] == "final_answer_end" and e.get("content") == "Candidate."
+        for e in outbound.events
+    )
+
+    if ordering == "work_tool_first":
+        # The work tool's name arrives before any final_answer bytes, so the
+        # streamer disables itself immediately: no stream is ever opened for
+        # this batch, and only the fallback batch's stream produces events.
+        by_id = _terminal_events_by_message_id(outbound.events)
+        assert len(by_id) == 1
+        (only_sequence,) = by_id.values()
+        assert only_sequence == ["final_answer_start", "final_answer_end"]
+        return
+
+    by_id = _terminal_events_by_message_id(outbound.events)
+    assert len(by_id) == 2
+    sequences = list(by_id.values())
+    assert sequences[0] == ["final_answer_start", "final_answer_error"]
+    assert sequences[1] == ["final_answer_start", "final_answer_error"] or sequences[
+        1
+    ] == ["final_answer_start", "final_answer_end"]
+    first_stream_error = next(
+        e for e in outbound.events if e["type"] == "final_answer_error"
+    )
+    assert first_stream_error["error"] == (
+        "discarded an answer that arrived together with tool "
+        "calls; answering again once the tools have run"
+    )
+
+
+@pytest.mark.asyncio
+async def test_react_disabled_control_tool_fails_cancelled_answer_stream() -> None:
+    """I-6: when a disabled user-interaction control tool shares the batch
+    with the first final_answer, _disabled_control_tool_index means R1 does
+    not fire - the stream is failed, not ended, and the run recovers on the
+    next forced turn. The failed stream's id is never mistaken for the
+    delivered one."""
+
+    llm = ScriptedStreamLLM(
+        [
+            [_fa("Answer one."), _send_message_call(expect_response=False)],
+            _FALLBACK_BATCH,
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3, user_interaction_enabled=False)
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Question")
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(execution_id="task-1", outbound_message_handler=outbound)
+
+    result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert result["success"] is True
+    assert result["response"] == _FALLBACK_ANSWER
+    by_id = _terminal_events_by_message_id(outbound.events)
+    assert len(by_id) == 2
+    first_id, second_id = by_id.keys()
+    assert by_id[first_id] == ["final_answer_start", "final_answer_error"]
+    assert by_id[second_id] == ["final_answer_start", "final_answer_end"]
+    assert runtime.last_final_answer_stream_message_id == second_id
+    assert runtime.last_final_answer_stream_message_id != first_id
+
+
+@pytest.mark.asyncio
+async def test_react_close_streamed_answer_zero_side_effect_when_discarded_stream_is_last() -> (
+    None
+):
+    """A discarded stream's id must never leave itself behind in
+    runtime.last_final_answer_stream_message_id. max_iterations=1 forces the
+    discarded stream to be the run's only stream, which is the only
+    construction where this assertion has any discriminating power - with a
+    later round, start_final_answer_stream unconditionally clears the field
+    before a new id could be confused with the old one, so the assertion
+    would pass even if the close function wrongly called finish() instead of
+    fail() here."""
+
+    llm = ScriptedStreamLLM(
+        [[_fa("Answer one."), _send_message_call(expect_response=False)]]
+    )
+    pattern = ReActPattern(max_iterations=1, user_interaction_enabled=False)
+    context = ExecutionContext(system_prompt="You are helpful.", execution_id="task-1")
+    context.add_user_message("Question")
+    outbound = OutboundCollector()
+    runtime = PatternRuntime(execution_id="task-1", outbound_message_handler=outbound)
+
+    await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert runtime.last_final_answer_stream_message_id is None
+
+
+@pytest.mark.asyncio
+async def test_react_disabled_control_tool_index_is_the_single_predicate(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """I-7: _close_streamed_answer and _execute_pending_tool_calls must share
+    one _disabled_control_tool_index implementation. Patching it to always
+    return None flips both call sites' observable behavior together: the
+    execution side stops canceling the first final_answer, and the streaming
+    side switches from failing to ending that same stream. A collusion where
+    the close function reimplemented the check inline would not move under
+    this patch."""
+
+    def make_pattern() -> tuple[
+        ReActPattern,
+        ScriptedStreamLLM,
+        OutboundCollector,
+        PatternRuntime,
+        ExecutionContext,
+    ]:
+        llm = ScriptedStreamLLM(
+            [
+                [_fa("Answer one."), _send_message_call(expect_response=False)],
+                _FALLBACK_BATCH,
+            ]
+        )
+        pattern = ReActPattern(max_iterations=3, user_interaction_enabled=False)
+        context = ExecutionContext(
+            system_prompt="You are helpful.", execution_id="task-1"
+        )
+        context.add_user_message("Question")
+        outbound = OutboundCollector()
+        runtime = PatternRuntime(
+            execution_id="task-1", outbound_message_handler=outbound
+        )
+        return pattern, llm, outbound, runtime, context
+
+    real_pattern, real_llm, real_outbound, real_runtime, real_context = make_pattern()
+    real_result = await real_pattern.run(
+        context=real_context, tools=[], llm=real_llm, runtime=real_runtime
+    )
+
+    assert real_result["response"] == _FALLBACK_ANSWER
+    assert any(e["type"] == "final_answer_error" for e in real_outbound.events)
+
+    (
+        mutant_pattern,
+        mutant_llm,
+        mutant_outbound,
+        mutant_runtime,
+        mutant_context,
+    ) = make_pattern()
+    monkeypatch.setattr(
+        mutant_pattern,
+        "_disabled_control_tool_index",
+        lambda tool_calls, *, user_interaction_enabled: None,
+    )
+    mutant_result = await mutant_pattern.run(
+        context=mutant_context, tools=[], llm=mutant_llm, runtime=mutant_runtime
+    )
+
+    assert mutant_result["response"] == "Answer one."
+    assert not any(e["type"] == "final_answer_error" for e in mutant_outbound.events)
+    assert any(
+        e["type"] == "final_answer_end" and e["content"] == "Answer one."
+        for e in mutant_outbound.events
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "label,tool_calls,assistant_content",
+    [
+        (
+            "C11_work_tool_only",
+            [{"name": "calculator", "args": {"expression": "2+2"}}],
+            None,
+        ),
+        ("C13_no_calls_no_content", [], None),
+        (
+            "C15_final_answer_not_first",
+            [
+                {"name": "send_message", "args": {"message": "hi"}},
+                {"name": "final_answer", "args": {"answer": "x"}},
+            ],
+            None,
+        ),
+    ],
+)
+async def test_react_close_streamed_answer_fails_open_stream_without_deliverable_final_answer(
+    label: str,
+    tool_calls: list[dict[str, Any]],
+    assistant_content: Any,
+) -> None:
+    """I-11: these three tool_calls shapes have no known way to occur through
+    a real model response, so they are pinned at the function level instead
+    of being forced into an end-to-end fake-model shape that would not occur
+    in production. Whenever the stream is open and neither R1 nor R2 applies,
+    _close_streamed_answer
+    must fail it exactly once and must never call finish."""
+
+    class RecordingStreamer:
+        def __init__(self) -> None:
+            self.started = True
+            self.finish_calls: list[str] = []
+            self.fail_calls: list[str] = []
+
+        async def finish(self, content: str) -> None:
+            self.finish_calls.append(content)
+
+        async def fail(self, error: str) -> None:
+            self.fail_calls.append(error)
+
+    pattern = ReActPattern(max_iterations=1)
+    streamer = RecordingStreamer()
+
+    await pattern._close_streamed_answer(
+        answer_streamer=streamer,
+        assistant_content=assistant_content,
+        tool_calls=tool_calls,
+    )
+
+    assert streamer.finish_calls == []
+    assert len(streamer.fail_calls) == 1

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -730,6 +730,8 @@ async def test_runtime_stream_events_are_logged_once_each(
     logged_end = recording_logger.info_calls[1][0] % recording_logger.info_calls[1][1]
     assert message_id in logged_end
     assert "content_chars=11" in logged_end
+    # The answer text itself must never reach the log - only its length.
+    assert "answer text" not in logged_end
 
     second_message_id = await runtime.start_final_answer_stream()
     assert second_message_id is not None

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 from xagent.core.agent import ExecutionContext, PatternRuntime
+from xagent.core.agent import runtime as runtime_module
 from xagent.core.agent.pattern.final_answer_stream import (
     ToolCallStringFieldStreamer,
     _JsonStringFieldReader,
@@ -616,6 +617,133 @@ async def test_runtime_stream_final_answer_emits_error_terminal_event() -> None:
     assert outbound.events[2]["error"] == "provider disconnected"
     assert len({event["message_id"] for event in outbound.events}) == 1
     assert runtime.last_final_answer_stream_message_id is None
+
+
+class RecordingLogger:
+    """Records info/warning calls without depending on the logging module's
+    own configuration - per the project rule against log assertions that
+    depend on caplog or other global logging state, this replaces the
+    module-level ``logger`` binding directly."""
+
+    def __init__(self) -> None:
+        self.info_calls: list[tuple[str, tuple[Any, ...]]] = []
+        self.warning_calls: list[tuple[str, tuple[Any, ...]]] = []
+
+    def info(self, msg: str, *args: Any) -> None:
+        self.info_calls.append((msg, args))
+
+    def warning(self, msg: str, *args: Any) -> None:
+        self.warning_calls.append((msg, args))
+
+
+_NEWLINE_AND_QUOTE_EXCEPTION_TEXT = (
+    "Traceback (most recent call last):\n"
+    '  File "provider.py", line 42, in call\n'
+    "    raise ValueError(\"bad 'quoted' response\")\n"
+    "ValueError: bad 'quoted' response"
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "label,reason,expected_reason",
+    [
+        (
+            "known_literal",
+            "interrupted during LLM stream",
+            "interrupted during LLM stream",
+        ),
+        (
+            "tool_protocol_retry_template",
+            "invalid some_provider_code tool protocol, retrying",
+            "invalid tool protocol (code:18 chars), retrying",
+        ),
+        ("unparsed_provider_exception", "x" * 5000, "<unparsed>:5000"),
+        (
+            "unparsed_exception_with_newlines_and_quotes",
+            _NEWLINE_AND_QUOTE_EXCEPTION_TEXT,
+            f"<unparsed>:{len(_NEWLINE_AND_QUOTE_EXCEPTION_TEXT)}",
+        ),
+    ],
+)
+async def test_runtime_stream_close_log_records_reason_in_one_of_three_shapes(
+    monkeypatch: pytest.MonkeyPatch,
+    label: str,
+    reason: str,
+    expected_reason: str,
+) -> None:
+    """I-8: fail_final_answer_stream logs a normalized reason that is always
+    one of three shapes - a known fixed string verbatim, the
+    tool-protocol-retry template folded to a fixed shape that keeps only the
+    provider error code's length, or <unparsed>:<length> for anything else -
+    never the raw external text itself."""
+
+    recording_logger = RecordingLogger()
+    monkeypatch.setattr(runtime_module, "logger", recording_logger)
+    runtime = PatternRuntime(execution_id="task-1")
+    runtime.last_final_answer_stream_message_id = "final_answer_abc"
+
+    await runtime.fail_final_answer_stream("final_answer_abc", reason)
+
+    assert len(recording_logger.warning_calls) == 1
+    msg, args = recording_logger.warning_calls[0]
+    logged = msg % args
+    assert f"reason={expected_reason}" in logged
+    if reason != expected_reason:
+        assert reason[:40] not in logged
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "has_handler", [True, False], ids=["with_handler", "without_handler"]
+)
+async def test_runtime_stream_events_are_logged_once_each(
+    monkeypatch: pytest.MonkeyPatch,
+    has_handler: bool,
+) -> None:
+    """I-9: each of the three final_answer stream events logs exactly once
+    per call, with the acting message_id present in the logged line - except
+    start_final_answer_stream, which logs nothing at all (and returns None)
+    when there is no outbound handler, because no stream was actually
+    opened."""
+
+    recording_logger = RecordingLogger()
+    monkeypatch.setattr(runtime_module, "logger", recording_logger)
+    outbound = OutboundCollector() if has_handler else None
+    runtime = PatternRuntime(execution_id="task-1", outbound_message_handler=outbound)
+
+    message_id = await runtime.start_final_answer_stream()
+
+    if not has_handler:
+        assert message_id is None
+        assert recording_logger.info_calls == []
+        assert recording_logger.warning_calls == []
+        return
+
+    assert message_id is not None
+    assert len(recording_logger.info_calls) == 1
+    logged_start = recording_logger.info_calls[0][0] % recording_logger.info_calls[0][1]
+    assert message_id in logged_start
+
+    await runtime.end_final_answer_stream(message_id, "answer text")
+    assert len(recording_logger.info_calls) == 2
+    logged_end = recording_logger.info_calls[1][0] % recording_logger.info_calls[1][1]
+    assert message_id in logged_end
+    assert "content_chars=11" in logged_end
+
+    second_message_id = await runtime.start_final_answer_stream()
+    assert second_message_id is not None
+    assert len(recording_logger.info_calls) == 3
+
+    await runtime.fail_final_answer_stream(
+        second_message_id, "interrupted during LLM stream"
+    )
+    assert len(recording_logger.warning_calls) == 1
+    logged_fail = (
+        recording_logger.warning_calls[0][0] % recording_logger.warning_calls[0][1]
+    )
+    assert second_message_id in logged_fail
+    assert "reason=interrupted during LLM stream" in logged_fail
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -749,6 +749,38 @@ async def test_runtime_stream_events_are_logged_once_each(
 
 
 @pytest.mark.asyncio
+async def test_runtime_stream_log_suppressed_when_outbound_handler_raises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The opened/closed/failed log lines sit after the outbound emit call in
+    all three stream methods, not before it - so when the outbound handler
+    itself raises, the exception propagates to the caller and the
+    corresponding log line is never written, because the emit it was meant
+    to describe never actually succeeded."""
+
+    async def raising_handler(payload: dict[str, Any]) -> None:
+        raise RuntimeError("outbound send failed")
+
+    recording_logger = RecordingLogger()
+    monkeypatch.setattr(runtime_module, "logger", recording_logger)
+    runtime = PatternRuntime(
+        execution_id="task-1", outbound_message_handler=raising_handler
+    )
+
+    with pytest.raises(RuntimeError, match="outbound send failed"):
+        await runtime.start_final_answer_stream()
+    assert recording_logger.info_calls == []
+
+    with pytest.raises(RuntimeError, match="outbound send failed"):
+        await runtime.end_final_answer_stream("final_answer_abc", "answer text")
+    assert recording_logger.info_calls == []
+
+    with pytest.raises(RuntimeError, match="outbound send failed"):
+        await runtime.fail_final_answer_stream("final_answer_abc", "some reason")
+    assert recording_logger.warning_calls == []
+
+
+@pytest.mark.asyncio
 async def test_runtime_streaming_llm_call_merges_tool_call_argument_deltas() -> None:
     runtime = PatternRuntime()
 


### PR DESCRIPTION
Part of #486.

## What

`ReActPattern` only closed a started final-answer stream when the batch held exactly one
tool call (or no calls at all). Several other batch shapes that had already streamed a
candidate left the stream open with no terminal event: `PatternRuntime.last_final_answer_stream_message_id` stayed
unset, the persisted answer therefore carried no `stream_message_id`, and the client had
nothing to merge the streamed bubble onto - the duplicate-answer rendering described in
 #486 (a stranded streaming bubble plus a second, unmerged answer bubble).

This makes the close path total: every started stream now reaches exactly one terminal
event on every normally-returning batch shape.

 #486 also covers the Auto decision path and the DAG completion path. Those are separate
stream lifecycles with their own admission rules - Auto's turns on what happens to a
candidate after `_normalize_decision` rewrites the routing decision, DAG's on a streamed
`status` prefix disagreeing with the parsed assessment - and they share no code with the
ReAct close. They are not touched here, so the issue stays open.

## Why this shape

**The close has to agree with delivery, so it keys off the batch's first call.**
`_execute_pending_tool_calls` walks the batch in order; its `final_answer` branch finalizes
the run and clears the rest, so the first `final_answer` in the batch is the only one that
can ever be delivered. The close therefore finishes with that call's answer text, verbatim
and unstripped, matching what `_handle_control_tool` hands to `add_assistant_message`. A
later or longer candidate elsewhere in the batch is never the run's answer, and trimming
whitespace here would desynchronize the two channels this change exists to keep in sync.

**Only the first position needs a delivery predicate.** Everything that can preempt a call
is "an earlier call in the batch", which by definition cannot exist for position 0. The one
exception is the disabled-user-interaction pre-scan, which looks ahead and cancels
everything before the first disabled control tool - so that lookup is now a shared helper
rather than a second copy of the same rule.

**`finish` is preferred over `fail`.** `final_answer_error` is a terminal failure signal:
the chat UI renders it as a failed bubble (#1723), and a downstream embedder projecting
these events onto a public API maps it to a task-level error. Reporting a candidate that
the run does in fact deliver as a failure would trade one inconsistency for another, so
`fail` is reserved for candidates that provably will not be delivered.

**The fallback lives at the streamer's own lifetime end.** A `ReActFinalAnswerStreamer` is
constructed per LLM response and is last referenced at the close call, so "open on entry,
closed on exit" enforced there covers the whole response. No streamer has to be threaded
into `_execute_pending_tool_calls` or `_finalize_outcome`.

## How

Three commits, each independently green:

1. `refactor(react)` - extract `_disabled_control_tool_index` from the inline lookup in
   `_execute_pending_tool_calls`. Pure move: the enclosing
   `if not self.user_interaction_enabled:` guard stays, and the gate is passed as a
   parameter so the original call site keeps identical behavior; the second caller added
   in the next commit inherits the same predicate.
2. `fix(react)` - `_finish_streamed_answer_if_final` becomes `_close_streamed_answer` with a
   total contract: no-op when nothing streamed; finish with the first call's answer when it
   is a deliverable `final_answer`; finish with the assistant text when the batch has no
   calls; otherwise fail with a fixed reason. `_final_answer_tool_content` is deleted - its
   only caller was the rewritten branch, and scanning `final_answer` calls anywhere in the
   batch is exactly the lookup the new contract must not do.
3. `feat(runtime)` - `start` / `end` / `fail` of a final-answer stream each log once, with
   task, step, turn and message id. Close reasons pass through one normalizer with three
   shapes: an allowlisted constant verbatim; a provider-templated reason folded to its
   fixed prefix plus the interpolated fragment's length; anything else as
   `<unparsed>:<length>`. Answer text never reaches the log - completion records only a
   character count.

## Behavior changes

Sixteen batch shapes (a shape that never opens a stream is a no-op in both the old and the
new code):

| Batch shape | Before | After |
|---|---|---|
| Two or three `final_answer` calls, identical or differing payloads | stream abandoned, duplicate answer | finished with the first call's answer |
| `final_answer` first, then `send_message` or `ask_user_question` | stream abandoned, duplicate answer | finished with that answer |
| Exactly one `final_answer` | finished | unchanged |
| A control tool before `final_answer` (three variants) | no stream opened | unchanged |
| `final_answer` bundled with a work tool (either order) | closed by the strip, or no stream opened | unchanged |
| Control-only batch containing an empty answer | discarded and retried, stream failed first | unchanged |
| No tool calls, plain assistant text | finished | unchanged |

Four shapes improve and are user-visible; eight are byte-identical.

The remaining four shapes take the new fallback: a batch whose first call is not a
deliverable `final_answer` while a stream is open. Three have no known production trigger,
and the fourth requires a control tool that is filtered out of the schema in the
configuration that would reach it. Combined with the fact that the bundled-`final_answer`
strip has already closed its stream by the time the fallback runs (`fail` is a no-op once
closed), **this change emits no new `final_answer_error` on any reachable production path**,
and therefore no new task-level error for downstream consumers.

Two consequences worth stating plainly:

- Outbound-handler exceptions now propagate from more places. The close path has always
  let them through - swallowing a failed close is the defect being fixed - but the number
  of batch shapes that reach a `finish` grows from two to six.
- Between the close and the actual delivery there is an interrupt check, so an interrupt
  landing in that window can leave a completed bubble whose answer was never persisted.
  That window predates this change and applies to the same six shapes.

## Testing

`tests/core/agent/`: 948 -> 986. `pre-commit` clean on all changed files.

New invariants:

| Invariant | Test |
|---|---|
| Every started stream gets exactly one terminal event, over all end-to-end reachable shapes | `test_react_every_started_answer_stream_gets_exactly_one_terminal_event` (+ no-outbound-handler and no-native-streaming variants) |
| Repeated `final_answer` closes with the first payload, and it equals what the run returns | `test_react_multi_final_answer_closes_stream_with_first_payload` |
| `final_answer` ahead of a control tool ends rather than errors | `test_react_final_answer_before_control_tool_ends_stream` |
| A control tool ahead of `final_answer` opens no stream at all | `test_react_control_tool_before_final_answer_opens_no_answer_stream` |
| The bundled-work-tool strip still owns its close | `test_react_work_tool_batch_still_fails_stream_before_close` |
| A cancelled first `final_answer` fails rather than completes | `test_react_disabled_control_tool_fails_cancelled_answer_stream` |
| A discarded stream never becomes the merge target | `test_react_close_streamed_answer_zero_side_effect_when_discarded_stream_is_last` |
| The disabled-control-tool lookup has one implementation | `test_react_disabled_control_tool_index_is_the_single_predicate` |
| The fallback fires for shapes with no end-to-end trigger | `test_react_close_streamed_answer_fails_open_stream_without_deliverable_final_answer` |
| Close reasons take one of three shapes; answer text never logged | `test_runtime_stream_close_log_records_reason_in_one_of_three_shapes` |
| Each stream event logs exactly once, and not at all without an outbound handler | `test_runtime_stream_events_are_logged_once_each` |

Four shapes are unreachable end to end without fabricating a response no provider emits, so
they are pinned by calling the close directly with a constructed streamer rather than by
building a fake model around them.

Each of the six load-bearing decisions was mutation-checked and goes red when reverted:
keying the close off the batch's first position; restoring the single-tool-call condition;
turning the fallback into a `finish`; bypassing the reason normalizer; removing the
plain-text branch; and dropping the log-reason shape constraint.

## Size

Three-dot diff against the merge base: 4 files, +1070 / -34. Production `+196 / -34`
(`react.py`, `runtime.py`); tests `+874` (`test_react.py`, `test_runtime.py`).
