### PR TITLE
chore: bump actions/setup-python and actions/setup-node

### DIFF
--- a/.github/workflows/ci-real-rag.yml
+++ b/.github/workflows/ci-real-rag.yml
@@ -116,7 +116,7 @@ jobs:
 
       - name: Setup Node.js
         if: steps.eligibility.outputs.run_tests == 'true' && steps.provider.outputs.configured == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -298,7 +298,7 @@ jobs:
           python3 -m uv sync --group dev
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
           cache: 'npm'
@@ -380,7 +380,7 @@ jobs:
 
       - name: Setup Node.js
         if: needs.changes.outputs.code == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
 
@@ -550,7 +550,7 @@ jobs:
 
       - name: Setup Node.js
         if: needs.changes.outputs.code == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
 
@@ -698,7 +698,7 @@ jobs:
 
       - name: Setup Node.js
         if: needs.changes.outputs.code == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '20'
 
@@ -796,7 +796,7 @@ jobs:
 
       - name: Setup Node.js
         if: needs.changes.outputs.frontend == 'true'
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
           cache: 'npm'
@@ -804,7 +804,7 @@ jobs:
 
       - name: Setup Python
         if: needs.changes.outputs.frontend == 'true'
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 

--- a/.github/workflows/install-script.yml
+++ b/.github/workflows/install-script.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22" # node --test needs >=18; AbortSignal.timeout needs >=17.3
       - name: ShellCheck

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -19,11 +19,11 @@ jobs:
         with:
           fetch-depth: 0  # full history + tags so hatch-vcs can derive the version
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: "22"
 

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -181,7 +181,7 @@ jobs:
 
       - name: Set up Python
         if: needs.detect-migration-changes.outputs.should-test == 'true'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 
@@ -266,7 +266,7 @@ jobs:
 
       - name: Set up Python
         if: needs.detect-migration-changes.outputs.should-test == 'true'
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: "3.11"
 


### PR DESCRIPTION
## Why

Follow-up to #1971, which bumped `actions/checkout` and deferred the rest of the node24 migration.

`actions/setup-python@v4` is not just a deprecation annotation — it declares `runs.using: node16`, and `actionlint` reports it as a hard error. These two lines are the **only** action-level errors `actionlint` finds in the repo today:

```
.github/workflows/test-migrations.yml:184:15: the runner of "actions/setup-python@v4" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
.github/workflows/test-migrations.yml:269:15: the runner of "actions/setup-python@v4" action is too old to run on GitHub Actions. update the action's version to fix this issue [action]
```

(Everything else `actionlint` prints is pre-existing `shellcheck` SC2086 info noise, untouched here.)

`actions/setup-node@v4` and `actions/setup-python@v5` are both `node20`, i.e. the "forced to run on Node.js 24" annotation from #1971.

## Breaking-change review

Rather than reading release notes, I diffed the `action.yml` input/output surface between each current and target version — names, defaults, and deprecation markers.

| action | input diff | output diff |
| --- | --- | --- |
| `setup-python` v4 → v7 | `+freethreaded` (default `false`), `+pip-version` (default unset) | none |
| `setup-python` v5 → v7 | `+pip-version` | none |
| `setup-node` v4 → v7 | `−always-auth` (already marked `deprecationMessage` in v4), `+package-manager-cache` (default `true`) | `+cache-primary-key`, `+cache-matched-key` |

Nothing we pass was removed, and no shared input changed its default. Our call sites pass only `python-version` (`"3.11"`), `node-version` (`20`/`22`), and — on two of the eight node steps — `cache: 'npm'` with `cache-dependency-path: frontend/package-lock.json`.

Two notes on things that look like they might bite but do not:

- **`setup-node`'s new `package-manager-cache` defaults to `true`, but it is inert in this repo.** Per [v7's `src/main.ts`](https://github.com/actions/setup-node/blob/v7/src/main.ts), auto-detection runs only when the `cache` input is empty, and `getNameFromPackageManagerField()` reads `$GITHUB_WORKSPACE/package.json` — the repository root, regardless of the step's `working-directory`. There is no root `package.json` (only `frontend/` and `scripts/get.xagent.co/`), and `grep -rn '"packageManager"'` across every `package.json` finds nothing, so the read throws, is caught, and returns `undefined`. No caching is enabled that was not enabled before. I deliberately did not add `package-manager-cache: false` — it would be noise guarding against a path that cannot be reached.
- **The v7 release notes mention removing the `pip-install` input.** That input was *added* in v6; it does not exist in v4 or v5, so it was never available to us and is not a migration concern.

`setup-python` v6 / `setup-node` v5 both require Actions Runner >= 2.327.1. Every job here is `runs-on: ubuntu-latest` or a hosted `matrix.os`; there are no self-hosted runners and no `container:` jobs.

## What changed

The version string, nothing else — 12 occurrences across 5 workflow files. No inputs, step names, or surrounding logic touched.

Expected benign side effect: `setup-node@v7` bumps its internal `@actions/cache` to 5.1.0, which can shift the npm cache key salt. Worst case is one cold `npm ci` on the two frontend jobs that cache.

## Verification

- `actionlint` is now clean of action-level errors — the two `node16` errors above are gone, and no new ones appeared.
- `pytest tests/test_ci_summary_contract.py tests/test_docker_workflow_versions.py` — 67 passed. Neither file pins these actions (`test_ci_summary_contract.py` pins only `dorny/paths-filter`'s SHA, `test_docker_workflow_versions.py` only `peter-evans/dockerhub-description`'s SHA), and `grep` finds no reference to `setup-python`/`setup-node` outside `.github/workflows/`.
- The real check is this PR's own CI: `ci.yml`, `ci-real-rag.yml`, `install-script.yml`, and `test-migrations.yml` all run on `pull_request` and each lists its own file in its path filter, so editing them self-triggers. The Node 20 annotation should be absent from those runs.

## Not in scope

The remaining deferred actions from #1971 — `actions/cache`, the artifact actions, `actions/github-script`, and the `docker/*` family — follow in two separate PRs, split by how each group can be verified.
