### PR TITLE
chore: bump actions/cache and the artifact actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
 
       - name: Check Deepdoc cache
         id: deepdoc-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: ${{ env.DEEPDOC_CACHE_PATH }}
           key: deepdoc-${{ runner.os }}-py312-modelscope-deepdoc-lib-0.2.2-v1
@@ -228,14 +228,14 @@ jobs:
 
       - name: Save Deepdoc cache
         if: steps.deepdoc-cache.outputs.cache-hit != 'true' && github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: ${{ env.DEEPDOC_CACHE_PATH }}
           key: deepdoc-${{ runner.os }}-py312-modelscope-deepdoc-lib-0.2.2-v1
 
       - name: Upload Deepdoc cache artifact
         if: steps.deepdoc-cache.outputs.cache-hit != 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: deepdoc-cache
           path: ${{ env.DEEPDOC_CACHE_PATH }}
@@ -476,14 +476,14 @@ jobs:
 
       - name: Restore Deepdoc cache
         if: needs.changes.outputs.code == 'true' && (needs.prepare-deepdoc-cache.outputs.cache-hit == 'true')
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: ${{ env.DEEPDOC_CACHE_PATH }}
           key: deepdoc-${{ runner.os }}-py312-modelscope-deepdoc-lib-0.2.2-v1
 
       - name: Download Deepdoc cache artifact
         if: needs.changes.outputs.code == 'true' && (needs.prepare-deepdoc-cache.outputs.cache-hit != 'true')
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: deepdoc-cache
           path: ${{ env.DEEPDOC_CACHE_PATH }}
@@ -624,14 +624,14 @@ jobs:
 
       - name: Restore Deepdoc cache
         if: needs.changes.outputs.code == 'true' && (needs.prepare-deepdoc-cache.outputs.cache-hit == 'true')
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: ${{ env.DEEPDOC_CACHE_PATH }}
           key: deepdoc-${{ runner.os }}-py312-modelscope-deepdoc-lib-0.2.2-v1
 
       - name: Download Deepdoc cache artifact
         if: needs.changes.outputs.code == 'true' && (needs.prepare-deepdoc-cache.outputs.cache-hit != 'true')
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: deepdoc-cache
           path: ${{ env.DEEPDOC_CACHE_PATH }}

--- a/.github/workflows/deepdoc-cache.yml
+++ b/.github/workflows/deepdoc-cache.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Restore Deepdoc cache
         id: deepdoc-cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@v6
         with:
           path: ${{ env.DEEPDOC_CACHE_PATH }}
           key: deepdoc-${{ runner.os }}-py312-modelscope-deepdoc-lib-0.2.2-v1
@@ -128,7 +128,7 @@ jobs:
 
       - name: Save Deepdoc cache
         if: steps.deepdoc-cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@v6
         with:
           path: ${{ env.DEEPDOC_CACHE_PATH }}
           key: deepdoc-${{ runner.os }}-py312-modelscope-deepdoc-lib-0.2.2-v1


### PR DESCRIPTION
## Why

Follow-up to #1971, which bumped `actions/checkout` and deferred the rest of the node24 migration. This PR takes the deepdoc-cache pipeline: `actions/cache` plus the two artifact actions. Every use here is part of that one pipeline, which is why they are grouped. They stay separate from the setup-action bumps in #1983 for two reasons that are specific to this group: it is the only one whose writer path (`cache/save`) first executes after merge rather than in CI, and the only one that introduces a new failure mode (`download-artifact`'s `digest-mismatch: error`). Keeping it on its own branch means either can be reverted without taking anything else with it.

All four actions are currently `node20`, i.e. the "forced to run on Node.js 24" annotation from #1971.

## Why these must move together

- The six `actions/cache` uses form one closed loop: [`deepdoc-cache.yml`](.github/workflows/deepdoc-cache.yml) writes the key `ci.yml` reads (`deepdoc-${{ runner.os }}-py312-modelscope-deepdoc-lib-0.2.2-v1`), and `ci.yml` both reads it (a `lookup-only` probe in `prepare-deepdoc-cache`, plus two restores in downstream jobs) and writes it as a main-branch fallback.
- Upload and download likewise: one job uploads the `deepdoc-cache` artifact, two jobs download it.

Splitting either pair across PRs would leave a writer and a reader on different majors for however long the second PR takes to land.

## Breaking-change review

Rather than reading release notes, I diffed the `action.yml` input/output surface between each current and target version — names, defaults, and deprecation markers.

| action | input diff | output diff |
| --- | --- | --- |
| `cache/restore` v4 → v6 | **byte-identical** (6 inputs, same defaults) | none |
| `cache/save` v4 → v6 | **byte-identical** (4 inputs, same defaults) | none |
| `upload-artifact` v4 → v7 | `+archive` (default `'true'`) | none |
| `download-artifact` v4 → v8 | `+skip-decompress` (default `'false'`), `+digest-mismatch` (default `'error'`) | none |

Nothing we pass was removed, and no shared input changed its default.

### `actions/cache` v6 reads v4's entries: verified, not assumed

The cache entries themselves — their bytes, their archive format, and the version hash that decides hit or miss — are unchanged. Per the [v6 README](https://github.com/actions/cache/blob/v6/README.md):

> Cache version is a hash generated for a combination of compression tool used (Gzip, Zstd, etc. based on the runner OS) and the `path` of directories being cached.

The action's own version is not an input to that hash. To confirm nothing feeding it moved, I diffed the bundled code that actually executes on the runner (`dist/save/index.js`, 2.75 MB at v4 vs 3.38 MB at v6):

```js
// byte-identical in actions/cache@v4 and @v6
function getCacheVersion(paths, compressionMethod, enableCrossOsArchive = false) {
    const components = paths.slice();
    if (compressionMethod) components.push(compressionMethod);
    if (process.platform === 'win32' && !enableCrossOsArchive) components.push('windows-only');
    // Add salt to cache version to support breaking changes in cache entry
    components.push(versionSalt);
    return crypto.createHash('sha256').update(components.join('|')).digest('hex');
}
```

The only textual difference between the two bundles here is the bundler's local name for the crypto module (`crypto` vs `external_crypto_namespaceObject`), an artifact of the ESM migration rather than a behaviour change.

| | v4 | v6 |
| --- | --- | --- |
| `versionSalt` | `'1.0'` | `'1.0'` |
| compression method | `zstd-without-long` | same |
| zstd invocation | `zstdmt --long=30` | same |
| archive filename | `cache.tzst` / `cache.tgz` | same |
| `tar.js` arguments | — | only `constants_1.X` → `X`, the CJS→ESM import form |

`versionSalt` is the decisive one. Its own source comment states it exists "to support breaking changes in cache entry" — it is the mechanism upstream uses to invalidate every existing cache when the entry format changes, and it was not bumped. [The toolkit's `RELEASES.md`](https://github.com/actions/toolkit/blob/main/packages/cache/RELEASES.md) agrees: `@actions/cache` 5.0.0 through 6.1.0 contain only dependency updates, error-handling fixes, and the ESM migration.

Two consequences: there will be no cold rebuild from a shifted key, and a revert to v4 is equally safe, since the compatibility holds in both directions.

Every new input except one defaults to the old behaviour:

- **`upload-artifact`'s `archive: false`** (single-file unzipped upload) is opt-in. We leave it at the default, so uploads stay zipped and `download-artifact@v8`'s new `Content-Type` check unzips them normally. Our `compression-level: 0` still produces a zip — stored rather than deflated, not un-archived.
- **`download-artifact`'s `skip-decompress: false`** is the v4 behaviour.
- **`download-artifact`'s `digest-mismatch` now defaults to `error` rather than warning.** This is the one real behaviour change in the PR, and it is the semantics we want: a hash mismatch means the deepdoc cache transferred corrupt, and that should fail the job rather than flow silently into the test run that consumes it. I deliberately did not set `digest-mismatch: warn` to preserve the old behaviour — if this ever fires, the artifact really was bad.

Also checked and not applicable: `download-artifact@v5`'s breaking change is about path handling for single artifacts fetched via `artifact-ids:`. Both of our downloads use `name: deepdoc-cache`, which that release explicitly leaves unchanged.

`cache` v5, `upload-artifact` v6, and `download-artifact` v7 each require Actions Runner >= 2.327.1. Every job here is `runs-on: ubuntu-latest`; there are no self-hosted runners and no `container:` jobs.

## What changed

The version string, nothing else — 9 occurrences across 2 workflow files. Untouched on purpose: the `-v1` key suffix, `restore-keys`, `lookup-only`, `if-no-files-found`, `include-hidden-files`, `compression-level`, and `retention-days`.

## Verification

- `actionlint` reports no new issues. It still flags the two `actions/setup-python@v4` `node16` errors in `test-migrations.yml`; those are #1983's fix and are untouched here by design.
- `pytest tests/test_ci_summary_contract.py tests/test_docker_workflow_versions.py` — 67 passed. Neither file pins these actions, and `grep` finds no reference to them outside `.github/workflows/`.
- The only step output any workflow reads from these actions is `steps.deepdoc-cache.outputs.cache-hit` (from `cache/restore`), which is unchanged in v6.
- This PR's own CI is the real check. Watch `Prepare Deepdoc Cache`: a `cache-hit == 'true'` proves `cache/restore@v6` reads the entry `cache/save@v4` wrote, and the downstream `Verify Deepdoc cache` step proves the upload/download round-trip end to end.
### Known limitation: `cache/save@v6` cannot be exercised before merge

Both `cache/save` sites are main-only by design — [`deepdoc-cache.yml`](.github/workflows/deepdoc-cache.yml)'s only job is guarded by `if: github.ref == 'refs/heads/main'`, and [`ci.yml`](.github/workflows/ci.yml)'s save step by `github.event_name != 'pull_request' && github.ref == 'refs/heads/main'`. A `workflow_dispatch` from this branch is skipped rather than run, so there is no pre-merge path to the writer side. I confirmed this by dispatching it (the run completed as `skipped`).

What this PR's CI *does* prove is the read side and the artifact round-trip: `cache/restore@v6` reading the entry `cache/save@v4` wrote, plus upload/download.

What is left unproven is narrow: that `cache/save@v6` runs to completion on main. What it *writes* is already settled by the bundle comparison above — same archive format, same compression, same version hash — so a v6-written entry is byte-compatible with what v4 wrote and with what `cache/restore@v6` will look for on the next run.

Still worth watching the first post-merge `main` run and the next scheduled `Warm Deepdoc Cache` (cron `17 3 */3 * *`), since that is the first execution of the writer path. If it did somehow fail, the failure mode is a cache miss: `ci.yml` rebuilds and re-saves, so it costs one slow `main` run and does not break PRs.

## Not in scope

The `docker/*` family and `actions/github-script` follow in a third PR — none of the workflows they live in run on `pull_request`, so they need a `workflow_dispatch` smoke test rather than CI, which is why they are grouped separately.


