### PR TITLE
chore: bump docker/* actions and actions/github-script

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -55,10 +55,10 @@ jobs:
           rmz_version: "3.1.1"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Log in to Docker Hub
         if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.push_to_dockerhub == 'true' }}
@@ -77,7 +77,7 @@ jobs:
 
       - name: Extract metadata for backend
         id: meta-backend
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.BACKEND_IMAGE }}
           tags: |
@@ -86,7 +86,7 @@ jobs:
 
       - name: Extract metadata for frontend
         id: meta-frontend
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.FRONTEND_IMAGE }}
           tags: |
@@ -111,7 +111,7 @@ jobs:
           echo "build_time=$BUILD_TIME" >> "$GITHUB_OUTPUT"
 
       - name: Build and push backend image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.backend
@@ -128,7 +128,7 @@ jobs:
           cache-to: ${{ (github.event_name != 'workflow_dispatch' || github.event.inputs.push_to_dockerhub == 'true') && format('type=registry,ref={0}:buildcache,mode=max', env.BACKEND_IMAGE) || '' }}
 
       - name: Build and push frontend image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./frontend
           file: docker/Dockerfile.frontend
@@ -142,7 +142,7 @@ jobs:
       - name: Extract metadata for backend GHCR
         id: meta-backend-ghcr
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_ghcr == 'true' }}
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/xagent-backend
           tags: |
@@ -152,7 +152,7 @@ jobs:
       - name: Extract metadata for frontend GHCR
         id: meta-frontend-ghcr
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_ghcr == 'true' }}
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/xagent-frontend
           tags: |
@@ -161,7 +161,7 @@ jobs:
 
       - name: Build and push backend image to GHCR
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_ghcr == 'true' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.backend
@@ -177,7 +177,7 @@ jobs:
 
       - name: Build and push frontend image to GHCR
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_ghcr == 'true' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./frontend
           file: docker/Dockerfile.frontend

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -58,10 +58,10 @@ jobs:
           rmz_version: "3.1.1"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Log in to Docker Hub
         if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.push_to_dockerhub == 'true' }}
@@ -91,7 +91,7 @@ jobs:
           echo "build_time=$BUILD_TIME" >> "$GITHUB_OUTPUT"
 
       - name: Build and push backend nightly image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.backend
@@ -115,7 +115,7 @@ jobs:
           cache-to: ${{ (github.event_name != 'workflow_dispatch' || github.event.inputs.push_to_dockerhub == 'true') && format('type=registry,ref={0}:buildcache,mode=max', env.BACKEND_IMAGE) || '' }}
 
       - name: Build and push frontend nightly image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./frontend
           file: docker/Dockerfile.frontend
@@ -145,7 +145,7 @@ jobs:
       - name: Extract metadata for backend GHCR
         id: meta-backend-ghcr
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_ghcr == 'true' }}
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/xagent-backend
           tags: |
@@ -155,7 +155,7 @@ jobs:
       - name: Extract metadata for frontend GHCR
         id: meta-frontend-ghcr
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_ghcr == 'true' }}
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ghcr.io/${{ github.repository_owner }}/xagent-frontend
           tags: |
@@ -164,7 +164,7 @@ jobs:
 
       - name: Build and push backend nightly image to GHCR
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_ghcr == 'true' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.backend
@@ -180,7 +180,7 @@ jobs:
 
       - name: Build and push frontend nightly image to GHCR
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.push_to_ghcr == 'true' }}
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./frontend
           file: docker/Dockerfile.frontend
@@ -191,7 +191,7 @@ jobs:
 
       - name: Notify on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             github.rest.issues.create({

--- a/.github/workflows/sandbox-publish.yml
+++ b/.github/workflows/sandbox-publish.yml
@@ -50,10 +50,10 @@ jobs:
           rmz_version: "3.1.1"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@v4
 
       - name: Log in to Docker Hub
         if: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.push_to_dockerhub == 'true' }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Extract metadata for sandbox
         id: meta-sandbox
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.SANDBOX_IMAGE }}
           tags: |
@@ -73,7 +73,7 @@ jobs:
             type=raw,value=${{ github.event.inputs.tag || 'latest' }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
       - name: Build and push sandbox image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: docker/Dockerfile.sandbox


### PR DESCRIPTION
## Why

Final follow-up to #1971, which bumped `actions/checkout` and deferred the rest of the node24 migration. #1983 took the setup actions and #1984 took the cache/artifact pipeline; this PR takes what is left.

These five are grouped for one reason: **none of the three workflows they live in has a `pull_request` trigger.** `docker-publish.yml` and `sandbox-publish.yml` run on tag pushes, `nightly-build.yml` on a schedule. CI cannot prove any of this change, so they all share the same `workflow_dispatch` smoke-test story and belong in one PR rather than scattered across the others.

All five actions are currently `node20`, i.e. the "forced to run on Node.js 24" annotation from #1971.

## Breaking-change review

Rather than reading release notes, I diffed the `action.yml` input/output surface between each current and target version — names, defaults, and deprecation markers.

| action | input diff | output diff |
| --- | --- | --- |
| `build-push-action` v6 → v7 | **byte-identical** (33 inputs, same defaults) | none |
| `metadata-action` v5 → v6 | **byte-identical** (11 inputs, same defaults) | none |
| `setup-buildx-action` v3 → v4 | `−config`, `−config-inline`, `−install` (all three already carried a `deprecationMessage` in v3) | none |
| `setup-qemu-action` v3 → v4 | `+reset` (default `'false'`) | none |
| `github-script` v7 → v9 | **byte-identical** (9 inputs, same defaults) | none |

Nothing we pass was removed, and no shared input changed its default:

- **`setup-buildx-action` is the only one that drops inputs, and all six `docker/setup-*` steps in this repo pass no inputs at all** — they are bare `uses:` lines. Worth recording for later: if anyone needs BuildKit config in future, v4 exposes it as `buildkitd-config` / `buildkitd-config-inline`.
- **`setup-qemu-action`'s new `reset` defaults to `false`**, which is the v3 behaviour.
- **`build-push-action@v7` removes the `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs.** `grep -rn` finds neither anywhere under `.github/`. Every input we pass — `context`, `file`, `platforms`, `push`, `tags`, `labels`, `build-args`, `cache-from`, `cache-to` — survives v7 unchanged.
- **`metadata-action@v6` changes `#` handling in list inputs**: a `#` inside a value is now preserved rather than treated as the start of a comment, while a full-line `#` is still a comment. Every `tags:` value in this repo is a `type=semver` or `type=raw` expression and every `labels:` value is an OCI annotation; none contains a `#`. The outputs the workflows read (`steps.meta-*.outputs.tags` and `.labels`) are unchanged.
- **`github-script@v9` drops `require('@actions/github')`** and injects `getOctokit` as a script parameter, so a script declaring `const getOctokit = …` would now be a `SyntaxError`. The one script we have — the nightly failure notifier at [`nightly-build.yml`](.github/workflows/nightly-build.yml) — uses only `github.rest.issues.create`, `context`, and `Date`. No `require`, no `getOctokit`.

Every target major requires Actions Runner >= 2.327.1. All three workflows are `runs-on: ubuntu-latest`; there are no self-hosted runners and no `container:` jobs.

## What changed

The version string, nothing else — 23 occurrences across 3 workflow files. No inputs, step names, or surrounding logic touched.

## Verification

- `actionlint` reports no new issues. It still flags the two `actions/setup-python@v4` `node16` errors in `test-migrations.yml`; those are #1983's fix and are untouched here by design.
- `pytest tests/test_ci_summary_contract.py tests/test_docker_workflow_versions.py` — 67 passed. `test_docker_workflow_versions.py` reads these workflows but pins only `peter-evans/dockerhub-description`'s SHA, which is unchanged (and already node24).
### Smoke test: all three workflows dispatched and green

**CI cannot reach any of this**, so I dispatched all three workflows with the push gates off (`push_to_dockerhub: false`, `push_to_ghcr: false`). All three completed `success`, building the real Dockerfiles for `linux/amd64,linux/arm64`:

| workflow | result |
| --- | --- |
| Publish Docker Images | success |
| Nightly Build | success |
| Publish Sandbox Image | success |

That exercises `setup-buildx-action@v4`, `setup-qemu-action@v4`, `metadata-action@v6`, and `build-push-action@v7` against real multi-arch builds. Every step that did not run was one of the intentionally gated ones — the login steps, the GHCR steps, and `Update Docker Hub repository description`.

Nothing was published: the logs show `push: false` on every Docker Hub build step, the GHCR build steps were skipped outright, and both login steps were skipped so no registry credentials were ever loaded.

### Two things this does *not* cover

- **The GHCR-gated steps were skipped**, so 4 of the 9 `build-push-action@v7` uses and 4 of the 7 `metadata-action@v6` uses went unexercised. Enabling `push_to_ghcr` would have published real images, which is not something a smoke test should do. Those steps use the same action versions as the ones that did run and differ only in their inputs, all of which are unchanged in v7/v6 per the table above.
- **The `github-script` step is `if: failure()`** and is skipped in a green run (confirmed: it shows as `skipped` in the Nightly Build dispatch). Its correctness rests on the source review above — the script uses only `github.rest.issues.create`, `context`, and `Date`, with no `require` and no `getOctokit` declaration. It fires for real on the next nightly failure.

## Not in scope

`pypa/gh-action-pypi-publish@release/v1` remains on a floating branch ref. It is a Docker action, so it carries no Node runtime and is unaffected by this migration — pinning it is a separate supply-chain question, not part of the node24 work.

With this merged, every action in `.github/workflows/` is on a node24 runtime. Already current and untouched across all three PRs: `docker/login-action@v4`, `dorny/paths-filter` and `peter-evans/dockerhub-description` (both SHA-pinned at their current latest tags), and `endersonmenezes/free-disk-space` (a composite action).
