### PR TITLE
fix: retry OAuth token refresh across connect-phase failures and 5xx

### DIFF
--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -642,12 +642,11 @@ async def _request_oauth_refresh_with_retries(
         is_last_attempt = attempt == OAUTH_REFRESH_MAX_ATTEMPTS - 1
         try:
             response = await request()
+            if response.status_code < 500 or is_last_attempt:
+                return response
         except _OAUTH_REFRESH_RETRYABLE_EXCEPTIONS:
             if is_last_attempt:
                 raise
-        else:
-            if response.status_code < 500 or is_last_attempt:
-                return response
 
         # Jittered so a burst of concurrent refreshes (the exact scenario
         # above) doesn't retry in lockstep and reproduce the same

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -634,6 +634,13 @@ _OAUTH_REFRESH_RETRYABLE_EXCEPTIONS = (
     # the actual token endpoint either -- same "never transmitted"
     # guarantee as ConnectError, just one hop earlier.
     httpx.ProxyError,
+    # Timing out waiting for a free connection from the client's own pool
+    # happens before a single byte is written to the wire -- same
+    # guarantee again, and the likeliest of the four to actually fire in
+    # this function's own motivating scenario: a burst of concurrent
+    # refreshes contending for a still-small connection pool right after
+    # a cold start.
+    httpx.PoolTimeout,
 )
 
 

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -10,6 +10,7 @@ import copy
 import inspect
 import logging
 import os
+import random
 import re
 import shlex
 from dataclasses import dataclass, field
@@ -608,6 +609,62 @@ def _oauth_launch_config_mapping(
     raise _OAuthLaunchConfigInvalid(field="type")
 
 
+OAUTH_REFRESH_MAX_ATTEMPTS = 2
+OAUTH_REFRESH_RETRY_BASE_DELAY_SECONDS = 0.5
+# Only failures that guarantee the request body was never transmitted are
+# safe to retry blindly. A grant_type=refresh_token POST is not idempotent
+# on providers that rotate refresh tokens: if the server processed the
+# grant and issued a new refresh_token but the response was lost to a
+# ReadTimeout/WriteTimeout (request already sent, outcome unknown), a
+# retry would resend the now-stale refresh_token and get back a genuine
+# invalid_grant -- which _raise_if_permanent_oauth_refresh_error correctly
+# treats as confirmed-dead and deletes the connection, silently
+# reproducing the exact bug this refresh path was fixed to avoid. A
+# connect-phase failure never got that far, and a 5xx is the provider's
+# own signal that it didn't process the request, so both are safe.
+_OAUTH_REFRESH_RETRYABLE_EXCEPTIONS = (httpx.ConnectError, httpx.ConnectTimeout)
+
+
+async def _request_oauth_refresh_with_retries(
+    request: Callable[[], Awaitable[httpx.Response]],
+    *,
+    provider_name: str,
+) -> httpx.Response:
+    """Retry a token-endpoint request across transient failures that are
+    safe to resend -- see _OAUTH_REFRESH_RETRYABLE_EXCEPTIONS. Useful for
+    the cold-start network blip right after a container restart, when a
+    backlog of triggers firing at once produces a burst of concurrent
+    refreshes just as egress is still warming up. A 4xx is the provider's
+    definitive answer about this specific token; retrying cannot change
+    it, so it's returned immediately without spending a retry on it.
+    """
+    for attempt in range(OAUTH_REFRESH_MAX_ATTEMPTS):
+        is_last_attempt = attempt == OAUTH_REFRESH_MAX_ATTEMPTS - 1
+        try:
+            response = await request()
+        except _OAUTH_REFRESH_RETRYABLE_EXCEPTIONS:
+            if is_last_attempt:
+                raise
+        else:
+            if response.status_code < 500 or is_last_attempt:
+                return response
+
+        # Jittered so a burst of concurrent refreshes (the exact scenario
+        # above) doesn't retry in lockstep and reproduce the same
+        # contention on the next attempt.
+        delay = OAUTH_REFRESH_RETRY_BASE_DELAY_SECONDS * (2**attempt)
+        delay += random.uniform(0, OAUTH_REFRESH_RETRY_BASE_DELAY_SECONDS)
+        logger.info(
+            "Retrying %s token refresh after a transient failure (attempt %s/%s)",
+            provider_name,
+            attempt + 2,
+            OAUTH_REFRESH_MAX_ATTEMPTS,
+        )
+        await asyncio.sleep(delay)
+
+    raise AssertionError("unreachable: the last attempt always returns or raises")
+
+
 async def refresh_oauth_token_if_needed(
     db: Any, oauth_account: Any, provider_name: str
 ) -> bool:
@@ -666,15 +723,18 @@ async def refresh_oauth_token_if_needed(
 
         if normalized_provider == "meta":
             async with httpx.AsyncClient() as client:
-                response = await client.get(
-                    provider_config.token_url,
-                    params={
-                        "grant_type": "fb_exchange_token",
-                        "client_id": client_id,
-                        "client_secret": client_secret,
-                        "fb_exchange_token": oauth_account.access_token,
-                    },
-                    timeout=10.0,
+                response = await _request_oauth_refresh_with_retries(
+                    lambda: client.get(
+                        provider_config.token_url,
+                        params={
+                            "grant_type": "fb_exchange_token",
+                            "client_id": client_id,
+                            "client_secret": client_secret,
+                            "fb_exchange_token": oauth_account.access_token,
+                        },
+                        timeout=10.0,
+                    ),
+                    provider_name=provider_name,
                 )
 
             if response.status_code == 200:
@@ -784,12 +844,15 @@ async def refresh_oauth_token_if_needed(
             body_kwarg = {"json": data}
 
         async with httpx.AsyncClient() as client:
-            response = await client.post(
-                refresh_token_url,
-                headers=headers,
-                timeout=10.0,
-                **body_kwarg,
-                **post_kwargs,
+            response = await _request_oauth_refresh_with_retries(
+                lambda: client.post(
+                    refresh_token_url,
+                    headers=headers,
+                    timeout=10.0,
+                    **body_kwarg,
+                    **post_kwargs,
+                ),
+                provider_name=provider_name,
             )
 
         if response.status_code == 200:

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -626,7 +626,15 @@ OAUTH_REFRESH_RETRY_BASE_DELAY_SECONDS = 0.5
 # behind retrying 5xx across virtually every HTTP client's default retry
 # policy, and a much narrower risk window than a timeout that could land
 # on either side of the provider actually persisting the grant.
-_OAUTH_REFRESH_RETRYABLE_EXCEPTIONS = (httpx.ConnectError, httpx.ConnectTimeout)
+_OAUTH_REFRESH_RETRYABLE_EXCEPTIONS = (
+    httpx.ConnectError,
+    httpx.ConnectTimeout,
+    # A proxy-handshake failure (e.g. an env-configured egress proxy,
+    # trust_env=True is httpx's default) means the request never reached
+    # the actual token endpoint either -- same "never transmitted"
+    # guarantee as ConnectError, just one hop earlier.
+    httpx.ProxyError,
+)
 
 
 async def _request_oauth_refresh_with_retries(

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -617,11 +617,15 @@ OAUTH_REFRESH_RETRY_BASE_DELAY_SECONDS = 0.5
 # grant and issued a new refresh_token but the response was lost to a
 # ReadTimeout/WriteTimeout (request already sent, outcome unknown), a
 # retry would resend the now-stale refresh_token and get back a genuine
-# invalid_grant -- which _raise_if_permanent_oauth_refresh_error correctly
-# treats as confirmed-dead and deletes the connection, silently
-# reproducing the exact bug this refresh path was fixed to avoid. A
-# connect-phase failure never got that far, and a 5xx is the provider's
-# own signal that it didn't process the request, so both are safe.
+# invalid_grant for a token that, moments ago, was perfectly valid --
+# indistinguishable from an actually-dead token and forcing an
+# unnecessary reconnect. A connect-phase failure never got that far, so
+# it's unconditionally safe to retry. A 5xx is conventionally treated the
+# same way (the provider's own signal that it didn't process the
+# request) -- not an absolute guarantee, but the standard assumption
+# behind retrying 5xx across virtually every HTTP client's default retry
+# policy, and a much narrower risk window than a timeout that could land
+# on either side of the provider actually persisting the grant.
 _OAUTH_REFRESH_RETRYABLE_EXCEPTIONS = (httpx.ConnectError, httpx.ConnectTimeout)
 
 

--- a/tests/web/tools/test_oauth_refresh_retry.py
+++ b/tests/web/tools/test_oauth_refresh_retry.py
@@ -78,6 +78,17 @@ def _github_oauth_account(user) -> UserOAuth:
     )
 
 
+def _meta_oauth_account(user) -> UserOAuth:
+    return UserOAuth(
+        user_id=user.id,
+        provider="facebook",
+        access_token="old-long-token",
+        refresh_token=None,
+        expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        provider_user_id="meta-user-1",
+    )
+
+
 @pytest.fixture(autouse=True)
 def _no_real_sleep(monkeypatch):
     """The retry backoff would otherwise add real wall-clock delay to
@@ -91,10 +102,12 @@ def _no_real_sleep(monkeypatch):
 
 class _FakeAsyncClient:
     """Minimal async-context-manager stand-in for httpx.AsyncClient whose
-    `post` is supplied by the test."""
+    `post` and/or `get` are supplied by the test. Meta's refresh path uses
+    `get` (fb_exchange_token); every other provider uses `post`."""
 
-    def __init__(self, post):
+    def __init__(self, post=None, get=None):
         self._post = post
+        self._get = get
 
     async def __aenter__(self):
         return self
@@ -103,7 +116,14 @@ class _FakeAsyncClient:
         return None
 
     async def post(self, *args, **kwargs):
+        if self._post is None:
+            raise NotImplementedError("post not mocked for this test")
         return await self._post(*args, **kwargs)
+
+    async def get(self, *args, **kwargs):
+        if self._get is None:
+            raise NotImplementedError("get not mocked for this test")
+        return await self._get(*args, **kwargs)
 
 
 @pytest.mark.asyncio
@@ -242,3 +262,50 @@ async def test_refresh_does_not_retry_on_ambiguous_read_timeout(
         is False
     )
     assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_retries_transient_network_error_for_meta_get_path(
+    db_session, monkeypatch
+):
+    """Meta's refresh path uses client.get (fb_exchange_token), not POST
+    like every other provider -- make sure the retry wrapper covers it too,
+    not just the POST path the other tests in this file exercise."""
+    db, user = db_session
+    db.add(
+        OAuthProvider(
+            provider_name="meta",
+            name="Meta",
+            client_id=encrypt_value("meta-client-id"),
+            client_secret=encrypt_value("meta-client-secret"),
+            auth_url="https://www.facebook.com/v25.0/dialog/oauth",
+            token_url="https://graph.facebook.com/v25.0/oauth/access_token",
+            redirect_uri="https://app.example.com/api/auth/meta/callback",
+            userinfo_url="https://graph.facebook.com/v25.0/me?fields=id,email",
+            user_id_path="id",
+            email_path="email",
+            default_scopes=["public_profile"],
+        )
+    )
+    oauth_account = _meta_oauth_account(user)
+    db.add(oauth_account)
+    db.commit()
+
+    calls: list[int] = []
+
+    async def get(*args, **kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            raise httpx.ConnectTimeout("connection timed out")
+        return MockResponse({"access_token": "new-long-token", "expires_in": 5184000})
+
+    monkeypatch.setattr(
+        tool_config.httpx, "AsyncClient", lambda: _FakeAsyncClient(get=get)
+    )
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "meta")
+        is True
+    )
+    assert len(calls) == 2
+    assert oauth_account.access_token == "new-long-token"

--- a/tests/web/tools/test_oauth_refresh_retry.py
+++ b/tests/web/tools/test_oauth_refresh_retry.py
@@ -227,6 +227,39 @@ async def test_refresh_retries_proxy_error_then_succeeds(db_session, monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_refresh_retries_pool_timeout_then_succeeds(db_session, monkeypatch):
+    """PoolTimeout (waiting for a free connection from the client's own
+    pool) fires before a single byte is written to the wire -- the same
+    "never transmitted" guarantee as the other retryable exceptions, and
+    the likeliest of them to actually fire in this function's own
+    motivating scenario: a burst of concurrent refreshes right after a
+    cold start contending for a still-small connection pool."""
+    db, user = db_session
+    oauth_account = _github_oauth_account(user)
+    db.add(oauth_account)
+    db.commit()
+
+    calls: list[int] = []
+
+    async def post(*args, **kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            raise httpx.PoolTimeout("timed out waiting for a connection")
+        return MockResponse({"access_token": "new-token", "expires_in": 3600})
+
+    monkeypatch.setattr(
+        tool_config.httpx, "AsyncClient", lambda: _FakeAsyncClient(post)
+    )
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "github")
+        is True
+    )
+    assert len(calls) == 2
+    assert oauth_account.access_token == "new-token"
+
+
+@pytest.mark.asyncio
 async def test_refresh_succeeds_on_first_try_without_retry(db_session, monkeypatch):
     """The plain happy path: no failure, no retry spent."""
     db, user = db_session

--- a/tests/web/tools/test_oauth_refresh_retry.py
+++ b/tests/web/tools/test_oauth_refresh_retry.py
@@ -158,9 +158,11 @@ async def test_refresh_retries_transient_network_error_then_succeeds(
     assert oauth_account.access_token == "new-token"
     # base delay (0.5s) plus up to a full base delay of jitter -- see
     # OAUTH_REFRESH_RETRY_BASE_DELAY_SECONDS and the backoff formula in
-    # _request_oauth_refresh_with_retries.
+    # _request_oauth_refresh_with_retries. Upper bound has a tiny epsilon:
+    # random.uniform(0, 0.5) can round to exactly 0.5 in rare floating-point
+    # cases, and a strict "< 1.0" would flake on that.
     assert len(sleep_delays) == 1
-    assert 0.5 <= sleep_delays[0] < 1.0
+    assert 0.5 <= sleep_delays[0] <= 1.0 + 1e-9
 
 
 @pytest.mark.asyncio
@@ -180,6 +182,36 @@ async def test_refresh_retries_connect_error_then_succeeds(db_session, monkeypat
         calls.append(1)
         if len(calls) == 1:
             raise httpx.ConnectError("connection refused")
+        return MockResponse({"access_token": "new-token", "expires_in": 3600})
+
+    monkeypatch.setattr(
+        tool_config.httpx, "AsyncClient", lambda: _FakeAsyncClient(post)
+    )
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "github")
+        is True
+    )
+    assert len(calls) == 2
+    assert oauth_account.access_token == "new-token"
+
+
+@pytest.mark.asyncio
+async def test_refresh_retries_proxy_error_then_succeeds(db_session, monkeypatch):
+    """ProxyError (a failed CONNECT/SOCKS handshake) also guarantees the
+    request never reached the token endpoint -- must be retried like
+    ConnectError/ConnectTimeout, not silently dropped from the tuple."""
+    db, user = db_session
+    oauth_account = _github_oauth_account(user)
+    db.add(oauth_account)
+    db.commit()
+
+    calls: list[int] = []
+
+    async def post(*args, **kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            raise httpx.ProxyError("proxy CONNECT failed")
         return MockResponse({"access_token": "new-token", "expires_in": 3600})
 
     monkeypatch.setattr(

--- a/tests/web/tools/test_oauth_refresh_retry.py
+++ b/tests/web/tools/test_oauth_refresh_retry.py
@@ -90,14 +90,17 @@ def _meta_oauth_account(user) -> UserOAuth:
 
 
 @pytest.fixture(autouse=True)
-def _no_real_sleep(monkeypatch):
-    """The retry backoff would otherwise add real wall-clock delay to
-    every test in this file."""
+def sleep_delays(monkeypatch):
+    """Replace the retry backoff's real wall-clock sleep with one that
+    records the delay it was asked for, so tests can assert on the
+    backoff/jitter formula instead of just the resulting call count."""
+    delays: list[float] = []
 
-    async def instant_sleep(_seconds: float) -> None:
-        return None
+    async def instant_sleep(seconds: float) -> None:
+        delays.append(seconds)
 
     monkeypatch.setattr(tool_config.asyncio, "sleep", instant_sleep)
+    return delays
 
 
 class _FakeAsyncClient:
@@ -128,7 +131,7 @@ class _FakeAsyncClient:
 
 @pytest.mark.asyncio
 async def test_refresh_retries_transient_network_error_then_succeeds(
-    db_session, monkeypatch
+    db_session, monkeypatch, sleep_delays
 ):
     db, user = db_session
     oauth_account = _github_oauth_account(user)
@@ -152,6 +155,68 @@ async def test_refresh_retries_transient_network_error_then_succeeds(
         is True
     )
     assert len(calls) == 2
+    assert oauth_account.access_token == "new-token"
+    # base delay (0.5s) plus up to a full base delay of jitter -- see
+    # OAUTH_REFRESH_RETRY_BASE_DELAY_SECONDS and the backoff formula in
+    # _request_oauth_refresh_with_retries.
+    assert len(sleep_delays) == 1
+    assert 0.5 <= sleep_delays[0] < 1.0
+
+
+@pytest.mark.asyncio
+async def test_refresh_retries_connect_error_then_succeeds(db_session, monkeypatch):
+    """ConnectError (e.g. connection refused, DNS failure) is a distinct
+    exception from ConnectTimeout but carries the same "request never
+    transmitted" guarantee -- make sure it's retried too, not just
+    ConnectTimeout."""
+    db, user = db_session
+    oauth_account = _github_oauth_account(user)
+    db.add(oauth_account)
+    db.commit()
+
+    calls: list[int] = []
+
+    async def post(*args, **kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            raise httpx.ConnectError("connection refused")
+        return MockResponse({"access_token": "new-token", "expires_in": 3600})
+
+    monkeypatch.setattr(
+        tool_config.httpx, "AsyncClient", lambda: _FakeAsyncClient(post)
+    )
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "github")
+        is True
+    )
+    assert len(calls) == 2
+    assert oauth_account.access_token == "new-token"
+
+
+@pytest.mark.asyncio
+async def test_refresh_succeeds_on_first_try_without_retry(db_session, monkeypatch):
+    """The plain happy path: no failure, no retry spent."""
+    db, user = db_session
+    oauth_account = _github_oauth_account(user)
+    db.add(oauth_account)
+    db.commit()
+
+    calls: list[int] = []
+
+    async def post(*args, **kwargs):
+        calls.append(1)
+        return MockResponse({"access_token": "new-token", "expires_in": 3600})
+
+    monkeypatch.setattr(
+        tool_config.httpx, "AsyncClient", lambda: _FakeAsyncClient(post)
+    )
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "github")
+        is True
+    )
+    assert len(calls) == 1
     assert oauth_account.access_token == "new-token"
 
 
@@ -230,7 +295,40 @@ async def test_refresh_gives_up_after_max_attempts_on_persistent_network_error(
         await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "github")
         is False
     )
-    assert len(calls) == tool_config.OAUTH_REFRESH_MAX_ATTEMPTS
+    # Asserts the literal attempt count (2), not tool_config.OAUTH_REFRESH_
+    # MAX_ATTEMPTS -- reading the same constant the code under test uses
+    # would make this self-referential and unable to catch a regression in
+    # the intended attempt count.
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_refresh_gives_up_after_max_attempts_on_persistent_5xx(
+    db_session, monkeypatch
+):
+    """The exception-exhaustion case above has a response-based sibling:
+    every attempt returning 5xx (never an exception) must also give up
+    after OAUTH_REFRESH_MAX_ATTEMPTS and return False, not retry forever."""
+    db, user = db_session
+    oauth_account = _github_oauth_account(user)
+    db.add(oauth_account)
+    db.commit()
+
+    calls: list[int] = []
+
+    async def post(*args, **kwargs):
+        calls.append(1)
+        return MockResponse({"error": "server_error"}, status_code=503)
+
+    monkeypatch.setattr(
+        tool_config.httpx, "AsyncClient", lambda: _FakeAsyncClient(post)
+    )
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "github")
+        is False
+    )
+    assert len(calls) == 2
 
 
 @pytest.mark.asyncio

--- a/tests/web/tools/test_oauth_refresh_retry.py
+++ b/tests/web/tools/test_oauth_refresh_retry.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import httpx
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+# refresh_oauth_token_if_needed lazily imports xagent.web.api.auth (which
+# pulls in authlib's httpx-subclassing OAuth2 client) on first call. Forcing
+# that import here, before any test monkeypatches httpx.AsyncClient, avoids
+# a metaclass conflict when this file is the first to trigger it in the
+# pytest session (harmless once xagent.web.api.auth is already imported
+# elsewhere, which every sibling *_oauth.py test file already does).
+import xagent.web.api.auth  # noqa: F401
+from xagent.core.utils.encryption import encrypt_value
+from xagent.web.models.database import Base
+from xagent.web.models.oauth_provider import OAuthProvider
+from xagent.web.models.user import User
+from xagent.web.models.user_oauth import UserOAuth
+from xagent.web.tools import config as tool_config
+
+
+class MockResponse:
+    def __init__(self, json_data=None, status_code: int = 200, text: str = ""):
+        self._json_data = json_data or {}
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    user = User(username="alice", password_hash="x", is_admin=False)
+    db.add(user)
+    db.add(
+        OAuthProvider(
+            provider_name="github",
+            name="GitHub",
+            client_id=encrypt_value("github-client-id"),
+            client_secret=encrypt_value("github-client-secret"),
+            auth_url="https://github.com/login/oauth/authorize",
+            token_url="https://github.com/login/oauth/access_token",
+            redirect_uri="https://app.example.com/api/auth/github/callback",
+            userinfo_url="https://api.github.com/user",
+            user_id_path="id",
+            email_path="email",
+            default_scopes=["repo"],
+        )
+    )
+    db.commit()
+    db.refresh(user)
+
+    yield db, user
+    db.close()
+    engine.dispose()
+
+
+def _github_oauth_account(user) -> UserOAuth:
+    return UserOAuth(
+        user_id=user.id,
+        provider="github",
+        access_token="old-token",
+        refresh_token="old-refresh",
+        expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        provider_user_id="42",
+    )
+
+
+@pytest.fixture(autouse=True)
+def _no_real_sleep(monkeypatch):
+    """The retry backoff would otherwise add real wall-clock delay to
+    every test in this file."""
+
+    async def instant_sleep(_seconds: float) -> None:
+        return None
+
+    monkeypatch.setattr(tool_config.asyncio, "sleep", instant_sleep)
+
+
+class _FakeAsyncClient:
+    """Minimal async-context-manager stand-in for httpx.AsyncClient whose
+    `post` is supplied by the test."""
+
+    def __init__(self, post):
+        self._post = post
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def post(self, *args, **kwargs):
+        return await self._post(*args, **kwargs)
+
+
+@pytest.mark.asyncio
+async def test_refresh_retries_transient_network_error_then_succeeds(
+    db_session, monkeypatch
+):
+    db, user = db_session
+    oauth_account = _github_oauth_account(user)
+    db.add(oauth_account)
+    db.commit()
+
+    calls: list[int] = []
+
+    async def post(*args, **kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            raise httpx.ConnectTimeout("connection timed out")
+        return MockResponse({"access_token": "new-token", "expires_in": 3600})
+
+    monkeypatch.setattr(
+        tool_config.httpx, "AsyncClient", lambda: _FakeAsyncClient(post)
+    )
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "github")
+        is True
+    )
+    assert len(calls) == 2
+    assert oauth_account.access_token == "new-token"
+
+
+@pytest.mark.asyncio
+async def test_refresh_retries_5xx_then_succeeds(db_session, monkeypatch):
+    db, user = db_session
+    oauth_account = _github_oauth_account(user)
+    db.add(oauth_account)
+    db.commit()
+
+    calls: list[int] = []
+
+    async def post(*args, **kwargs):
+        calls.append(1)
+        if len(calls) == 1:
+            return MockResponse({"error": "server_error"}, status_code=503)
+        return MockResponse({"access_token": "new-token", "expires_in": 3600})
+
+    monkeypatch.setattr(
+        tool_config.httpx, "AsyncClient", lambda: _FakeAsyncClient(post)
+    )
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "github")
+        is True
+    )
+    assert len(calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_retry_on_definitive_4xx(db_session, monkeypatch):
+    """A 4xx is the provider's definitive answer about this token -- a
+    retry can't change it, so it should not spend one."""
+    db, user = db_session
+    oauth_account = _github_oauth_account(user)
+    db.add(oauth_account)
+    db.commit()
+
+    calls: list[int] = []
+
+    async def post(*args, **kwargs):
+        calls.append(1)
+        return MockResponse({"error": "invalid_grant"}, status_code=400)
+
+    monkeypatch.setattr(
+        tool_config.httpx, "AsyncClient", lambda: _FakeAsyncClient(post)
+    )
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "github")
+        is False
+    )
+    assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_refresh_gives_up_after_max_attempts_on_persistent_network_error(
+    db_session, monkeypatch
+):
+    db, user = db_session
+    oauth_account = _github_oauth_account(user)
+    db.add(oauth_account)
+    db.commit()
+
+    calls: list[int] = []
+
+    async def post(*args, **kwargs):
+        calls.append(1)
+        raise httpx.ConnectTimeout("connection timed out")
+
+    monkeypatch.setattr(
+        tool_config.httpx, "AsyncClient", lambda: _FakeAsyncClient(post)
+    )
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "github")
+        is False
+    )
+    assert len(calls) == tool_config.OAUTH_REFRESH_MAX_ATTEMPTS
+
+
+@pytest.mark.asyncio
+async def test_refresh_does_not_retry_on_ambiguous_read_timeout(
+    db_session, monkeypatch
+):
+    """A ReadTimeout means the request was already sent -- the provider may
+    have processed the grant (and, for a rotating-refresh-token provider,
+    already issued a new refresh_token) before the response was lost.
+    Blindly resending the now-stale refresh_token isn't safe, so this must
+    fail without retrying, unlike a connect-phase failure."""
+    db, user = db_session
+    oauth_account = _github_oauth_account(user)
+    db.add(oauth_account)
+    db.commit()
+
+    calls: list[int] = []
+
+    async def post(*args, **kwargs):
+        calls.append(1)
+        raise httpx.ReadTimeout("timed out waiting for response")
+
+    monkeypatch.setattr(
+        tool_config.httpx, "AsyncClient", lambda: _FakeAsyncClient(post)
+    )
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "github")
+        is False
+    )
+    assert len(calls) == 1


### PR DESCRIPTION
## Summary
- A cold-start network blip (e.g. right after a container restart) can fail an OAuth token refresh on the first try even though the refresh token itself is perfectly valid.
- `refresh_oauth_token_if_needed` now retries the token-endpoint request up to 2 attempts with jittered backoff, but only for failures that are safe to resend: connect-phase errors (`ConnectError`/`ConnectTimeout`/`ProxyError`/`PoolTimeout` -- request never transmitted) and 5xx responses (provider signals it didn't process the request).
- A read/write timeout is deliberately **not** retried: the request may have already reached the provider, and resending a `grant_type=refresh_token` body on a provider that rotates refresh tokens could hand back an already-consumed token, producing a genuine `invalid_grant` and forcing an unnecessary reconnect.
- Jitter on the backoff avoids a burst of concurrent refreshes (e.g. many trigger runs waking up after a restart) retrying in lockstep.

**Scope note:** the retry adds a ~1-1.5s backoff between attempts, but each attempt also carries its own 10s timeout, so the actual worst-case wall-clock cost of a retried refresh is closer to ~20.5-21.5s, not ~1.5s -- corrected from an earlier, inaccurate version of this note. This only reduces how often a refresh fails outright; it does not change what happens once retries are exhausted -- that path still falls through to the existing delete-the-connection-on-any-failure behavior. #1988 is the PR that changes *that* behavior (only delete on a confirmed-permanent failure). The two are independent and safe to merge in either order, but merging #1989 alone does not by itself stop restart-time disconnects for outages longer than the retry+timeout window.

Related to (independent of, mergeable in any order): #1988.

## Test plan
- [x] `pytest tests/web/test_salesforce_oauth.py tests/web/test_deputy_oauth.py tests/web/test_jira_oauth.py tests/web/test_linear_oauth.py tests/web/test_zoom_oauth.py tests/web/test_github_oauth.py tests/web/test_meta_oauth.py tests/web/tools/test_oauth_token_resolver_hook.py tests/web/tools/test_mcp_actor_owner_runtime.py tests/web/tools/test_oauth_refresh_retry.py`
- [x] `ruff check` / `ruff format --check` / `mypy` on changed files
- [x] Tests cover: retry-then-succeed on connect timeout/connect error/proxy error/pool timeout/5xx, no retry on a definitive 4xx or an ambiguous read timeout, giving up after max attempts (both the exception and the persistent-5xx case), a plain first-try-success no-retry case, backoff delay bounds, and the Meta GET retry path