### PR TITLE
fix: jitter the trigger dispatcher's first tick after startup

### DIFF
--- a/example.env
+++ b/example.env
@@ -132,9 +132,12 @@ PORT="80"
 # XAGENT_TRIGGER_DISPATCHER_ENABLED="true"
 # XAGENT_TRIGGER_DISPATCHER_INTERVAL_SECONDS="5"
 # XAGENT_TRIGGER_DISPATCHER_BATCH_SIZE="20"
-# Random delay (0-N seconds) before the dispatcher's first tick after startup,
-# so a container restart's backlog of due triggers doesn't fire all at once
-# while egress networking may still be warming up. 0 disables the delay.
+# Random delay (0-N seconds) before this backend's dispatcher first tick,
+# pushing it past the likely egress-network warm-up window after a container
+# restart and staggering first ticks across replicas. Does NOT limit or pace
+# one backend's first-tick backlog -- that backlog (still governed by the
+# scan/batch settings above) fires in full once the delay elapses. 0 disables
+# the delay.
 # XAGENT_TRIGGER_DISPATCHER_STARTUP_JITTER_SECONDS="30"
 # Rate limits for the public trigger callback endpoint (keyed by callback id +
 # caller IP) and trigger create/update/delete APIs (keyed by user). Uses Redis

--- a/example.env
+++ b/example.env
@@ -132,6 +132,10 @@ PORT="80"
 # XAGENT_TRIGGER_DISPATCHER_ENABLED="true"
 # XAGENT_TRIGGER_DISPATCHER_INTERVAL_SECONDS="5"
 # XAGENT_TRIGGER_DISPATCHER_BATCH_SIZE="20"
+# Random delay (0-N seconds) before the dispatcher's first tick after startup,
+# so a container restart's backlog of due triggers doesn't fire all at once
+# while egress networking may still be warming up. 0 disables the delay.
+# XAGENT_TRIGGER_DISPATCHER_STARTUP_JITTER_SECONDS="30"
 # Rate limits for the public trigger callback endpoint (keyed by callback id +
 # caller IP) and trigger create/update/delete APIs (keyed by user). Uses Redis
 # when XAGENT_REDIS_URL is set; otherwise limits are per backend process.

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -1086,10 +1086,13 @@ def get_trigger_dispatcher_startup_jitter_seconds() -> int:
     A container restart brings every trigger that fell due while it was
     down (Gmail watch renewals, scheduled triggers) up for processing all
     at once, and the dispatcher's first tick runs immediately on startup --
-    before egress networking may be fully warmed up, and, on a
-    multi-replica rolling restart, at the same moment as every other
-    replica's first tick. Spreading that first tick across a random window
-    keeps the resulting burst smaller. 0 disables the delay.
+    before egress networking may be fully warmed up. This delay pushes that
+    first tick past the likely warm-up window; it does not shrink how much
+    that tick processes (still gated by the dispatcher's own batch-size and
+    scan-limit settings), only when it starts. On a multi-replica rolling
+    restart it also desyncs every replica's first tick from firing at the
+    same instant, spreading their combined load across the window instead
+    of concentrating it in a single moment. 0 disables the delay.
     """
     return _get_positive_int_env(
         TRIGGER_DISPATCHER_STARTUP_JITTER_SECONDS,

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -149,6 +149,9 @@ WORKFORCE_PREVIEW_RUN_STALE_SECONDS = "XAGENT_WORKFORCE_PREVIEW_RUN_STALE_SECOND
 TRIGGER_DISPATCHER_ENABLED = "XAGENT_TRIGGER_DISPATCHER_ENABLED"
 TRIGGER_DISPATCHER_INTERVAL_SECONDS = "XAGENT_TRIGGER_DISPATCHER_INTERVAL_SECONDS"
 TRIGGER_DISPATCHER_BATCH_SIZE = "XAGENT_TRIGGER_DISPATCHER_BATCH_SIZE"
+TRIGGER_DISPATCHER_STARTUP_JITTER_SECONDS = (
+    "XAGENT_TRIGGER_DISPATCHER_STARTUP_JITTER_SECONDS"
+)
 TRIGGER_CALLBACK_RATE_LIMIT = "XAGENT_TRIGGER_CALLBACK_RATE_LIMIT"
 TRIGGER_CALLBACK_IP_RATE_LIMIT = "XAGENT_TRIGGER_CALLBACK_IP_RATE_LIMIT"
 TRIGGER_CRUD_RATE_LIMIT = "XAGENT_TRIGGER_CRUD_RATE_LIMIT"
@@ -1069,6 +1072,29 @@ def get_trigger_dispatcher_batch_size() -> int:
         TRIGGER_DISPATCHER_BATCH_SIZE,
         20,
         minimum=1,
+    )
+
+
+def get_trigger_dispatcher_startup_jitter_seconds() -> int:
+    """Return the max random delay before the dispatcher's first tick.
+
+    Priority:
+        1. XAGENT_TRIGGER_DISPATCHER_STARTUP_JITTER_SECONDS environment
+           variable
+        2. Default 30
+
+    A container restart brings every trigger that fell due while it was
+    down (Gmail watch renewals, scheduled triggers) up for processing all
+    at once, and the dispatcher's first tick runs immediately on startup --
+    before egress networking may be fully warmed up, and, on a
+    multi-replica rolling restart, at the same moment as every other
+    replica's first tick. Spreading that first tick across a random window
+    keeps the resulting burst smaller. 0 disables the delay.
+    """
+    return _get_positive_int_env(
+        TRIGGER_DISPATCHER_STARTUP_JITTER_SECONDS,
+        30,
+        minimum=0,
     )
 
 

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -2,6 +2,7 @@ import asyncio
 import json
 import logging
 import os
+import random
 import threading
 import time
 from collections.abc import Iterator
@@ -32,6 +33,7 @@ from ..config import (
     get_trigger_dispatcher_batch_size,
     get_trigger_dispatcher_enabled,
     get_trigger_dispatcher_interval_seconds,
+    get_trigger_dispatcher_startup_jitter_seconds,
     get_uploaded_file_recovery_batch_size,
     get_uploaded_file_recovery_interval_seconds,
     get_uploaded_file_recovery_stale_seconds,
@@ -271,7 +273,21 @@ async def _run_trigger_dispatcher(
     *,
     poll_interval_seconds: int,
     batch_size: int,
+    startup_jitter_seconds: int = 0,
 ) -> None:
+    if startup_jitter_seconds > 0:
+        # Runs before the loop below's first tick, which otherwise fires
+        # immediately on startup -- see
+        # get_trigger_dispatcher_startup_jitter_seconds for why that's a
+        # problem right after a container restart.
+        delay = random.uniform(0, startup_jitter_seconds)
+        logger.info(
+            "Trigger dispatcher delaying first tick by %.1fs to spread out "
+            "a restart-time burst",
+            delay,
+        )
+        await asyncio.sleep(delay)
+
     from .models.database import get_session_local
     from .services.gmail_triggers import scan_due_gmail_watch_renewals
     from .services.triggers import (
@@ -418,18 +434,22 @@ def start_trigger_dispatcher_task(app_instance: FastAPI) -> asyncio.Task[Any] | 
 
     poll_interval_seconds = get_trigger_dispatcher_interval_seconds()
     batch_size = get_trigger_dispatcher_batch_size()
+    startup_jitter_seconds = get_trigger_dispatcher_startup_jitter_seconds()
     task = asyncio.create_task(
         _run_trigger_dispatcher(
             poll_interval_seconds=poll_interval_seconds,
             batch_size=batch_size,
+            startup_jitter_seconds=startup_jitter_seconds,
         )
     )
     _trigger_dispatcher_task = task
     app_instance.state.trigger_dispatcher_task = task
     logger.info(
-        "Started trigger dispatcher task (interval=%ss, batch_size=%s)",
+        "Started trigger dispatcher task (interval=%ss, batch_size=%s, "
+        "startup_jitter=%ss)",
         poll_interval_seconds,
         batch_size,
+        startup_jitter_seconds,
     )
     return task
 

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -282,8 +282,7 @@ async def _run_trigger_dispatcher(
         # problem right after a container restart.
         delay = random.uniform(0, startup_jitter_seconds)
         logger.info(
-            "Trigger dispatcher delaying first tick by %.1fs to spread out "
-            "a restart-time burst",
+            "Trigger dispatcher delaying first tick by %.1fs past startup",
             delay,
         )
         await asyncio.sleep(delay)

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -106,6 +106,7 @@ from xagent.config import (
     TRIGGER_DISPATCHER_BATCH_SIZE,
     TRIGGER_DISPATCHER_ENABLED,
     TRIGGER_DISPATCHER_INTERVAL_SECONDS,
+    TRIGGER_DISPATCHER_STARTUP_JITTER_SECONDS,
     TRUSTED_EGRESS_PROXY,
     UPLOADED_FILE_RECOVERY_BATCH_SIZE,
     UPLOADED_FILE_RECOVERY_INTERVAL_SECONDS,
@@ -212,6 +213,7 @@ from xagent.config import (
     get_trigger_dispatcher_batch_size,
     get_trigger_dispatcher_enabled,
     get_trigger_dispatcher_interval_seconds,
+    get_trigger_dispatcher_startup_jitter_seconds,
     get_trusted_egress_proxy_enabled,
     get_uploaded_file_recovery_batch_size,
     get_uploaded_file_recovery_interval_seconds,
@@ -694,16 +696,20 @@ class TestCeleryBackgroundJobConfig:
         monkeypatch.delenv(TRIGGER_DISPATCHER_ENABLED, raising=False)
         monkeypatch.delenv(TRIGGER_DISPATCHER_INTERVAL_SECONDS, raising=False)
         monkeypatch.delenv(TRIGGER_DISPATCHER_BATCH_SIZE, raising=False)
+        monkeypatch.delenv(TRIGGER_DISPATCHER_STARTUP_JITTER_SECONDS, raising=False)
         assert get_trigger_dispatcher_enabled() is True
         assert get_trigger_dispatcher_interval_seconds() == 5
         assert get_trigger_dispatcher_batch_size() == 20
+        assert get_trigger_dispatcher_startup_jitter_seconds() == 30
 
         monkeypatch.setenv(TRIGGER_DISPATCHER_ENABLED, "false")
         monkeypatch.setenv(TRIGGER_DISPATCHER_INTERVAL_SECONDS, "9")
         monkeypatch.setenv(TRIGGER_DISPATCHER_BATCH_SIZE, "3")
+        monkeypatch.setenv(TRIGGER_DISPATCHER_STARTUP_JITTER_SECONDS, "0")
         assert get_trigger_dispatcher_enabled() is False
         assert get_trigger_dispatcher_interval_seconds() == 9
         assert get_trigger_dispatcher_batch_size() == 3
+        assert get_trigger_dispatcher_startup_jitter_seconds() == 0
 
     def test_task_lease_recovery_tuning(self, monkeypatch):
         monkeypatch.setenv(TASK_LEASE_TTL_SECONDS, "60")

--- a/tests/web/test_trigger_dispatcher_startup_jitter.py
+++ b/tests/web/test_trigger_dispatcher_startup_jitter.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from xagent.web import app as app_module
+
+
+@pytest.mark.asyncio
+async def test_trigger_dispatcher_delays_first_tick_by_startup_jitter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A container restart brings every backlogged trigger due at once, and
+    the dispatcher's first tick otherwise fires immediately on startup. The
+    startup jitter must delay that first tick -- before touching the DB or
+    scanning anything -- so a restart-time burst gets spread out instead."""
+
+    order: list[str] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        order.append(f"sleep:{seconds}")
+
+    def fake_uniform(a: float, b: float) -> float:
+        assert (a, b) == (0, 30)
+        return 12.5
+
+    class FakeSession:
+        def close(self) -> None:
+            return None
+
+    def fake_scan_due_scheduled_triggers(_db):
+        order.append("scan")
+        return []
+
+    def fake_reap_stale_preview_workforce_runs(_db):
+        order.append("reap")
+        return []
+
+    async def fake_dispatch(_db, *, limit: int) -> int:
+        order.append("dispatch")
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(app_module.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(app_module.random, "uniform", fake_uniform)
+    monkeypatch.setattr(
+        app_module, "get_gmail_watch_enabled", lambda: False, raising=False
+    )
+    monkeypatch.setattr(
+        "xagent.web.models.database.get_session_local",
+        lambda: FakeSession,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.triggers.scan_due_scheduled_triggers",
+        fake_scan_due_scheduled_triggers,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.workforce_runtime.reap_stale_preview_workforce_runs",
+        fake_reap_stale_preview_workforce_runs,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.triggers.dispatch_pending_trigger_runs",
+        fake_dispatch,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await app_module._run_trigger_dispatcher(
+            poll_interval_seconds=60,
+            batch_size=25,
+            startup_jitter_seconds=30,
+        )
+
+    assert order[0] == "sleep:12.5"
+    assert order.index("sleep:12.5") < order.index("scan")
+    assert order.index("sleep:12.5") < order.index("dispatch")
+
+
+@pytest.mark.asyncio
+async def test_trigger_dispatcher_skips_startup_delay_when_jitter_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sleep_calls: list[float] = []
+
+    async def fake_sleep(seconds: float) -> None:
+        sleep_calls.append(seconds)
+
+    class FakeSession:
+        def close(self) -> None:
+            return None
+
+    async def fake_dispatch(_db, *, limit: int) -> int:
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(app_module.asyncio, "sleep", fake_sleep)
+    monkeypatch.setattr(
+        app_module, "get_gmail_watch_enabled", lambda: False, raising=False
+    )
+    monkeypatch.setattr(
+        "xagent.web.models.database.get_session_local",
+        lambda: FakeSession,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.triggers.scan_due_scheduled_triggers",
+        lambda _db: [],
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.workforce_runtime.reap_stale_preview_workforce_runs",
+        lambda _db: [],
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.triggers.dispatch_pending_trigger_runs",
+        fake_dispatch,
+    )
+
+    with pytest.raises(asyncio.CancelledError):
+        await app_module._run_trigger_dispatcher(
+            poll_interval_seconds=60,
+            batch_size=25,
+            startup_jitter_seconds=0,
+        )
+
+    assert sleep_calls == []
+
+
+@pytest.mark.asyncio
+async def test_start_trigger_dispatcher_task_passes_configured_jitter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run_trigger_dispatcher(**kwargs):
+        captured.update(kwargs)
+
+        async def _noop() -> None:
+            return None
+
+        return _noop()
+
+    monkeypatch.setattr(app_module, "get_trigger_dispatcher_enabled", lambda: True)
+    monkeypatch.setattr(
+        app_module, "get_trigger_dispatcher_interval_seconds", lambda: 5
+    )
+    monkeypatch.setattr(app_module, "get_trigger_dispatcher_batch_size", lambda: 20)
+    monkeypatch.setattr(
+        app_module, "get_trigger_dispatcher_startup_jitter_seconds", lambda: 45
+    )
+    monkeypatch.setattr(
+        app_module, "_run_trigger_dispatcher", fake_run_trigger_dispatcher
+    )
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+
+    class FakeAppState:
+        trigger_dispatcher_task = None
+
+    class FakeApp:
+        state = FakeAppState()
+
+    task = app_module.start_trigger_dispatcher_task(FakeApp())
+    try:
+        assert captured["startup_jitter_seconds"] == 45
+    finally:
+        if task is not None:
+            task.cancel()

--- a/tests/web/test_trigger_dispatcher_startup_jitter.py
+++ b/tests/web/test_trigger_dispatcher_startup_jitter.py
@@ -14,7 +14,11 @@ async def test_trigger_dispatcher_delays_first_tick_by_startup_jitter(
     """A container restart brings every backlogged trigger due at once, and
     the dispatcher's first tick otherwise fires immediately on startup. The
     startup jitter must delay that first tick -- before touching the DB or
-    scanning anything -- so a restart-time burst gets spread out instead."""
+    scanning anything, including the Gmail watch-renewal/provisioning-sweep
+    branch when Gmail is enabled -- so a restart-time burst gets spread out
+    instead. Gmail is enabled here (unlike the disabled-jitter test below)
+    specifically so a later reorder that puts those calls ahead of the sleep
+    would fail this test."""
 
     order: list[str] = []
 
@@ -28,6 +32,14 @@ async def test_trigger_dispatcher_delays_first_tick_by_startup_jitter(
     class FakeSession:
         def close(self) -> None:
             return None
+
+    def fake_scan_due_gmail_watch_renewals(_db):
+        order.append("gmail_watch_renewal")
+        return 0
+
+    def fake_sweep_gmail_provisioning(_db):
+        order.append("gmail_provisioning_sweep")
+        return 0
 
     def fake_scan_due_scheduled_triggers(_db):
         order.append("scan")
@@ -44,11 +56,22 @@ async def test_trigger_dispatcher_delays_first_tick_by_startup_jitter(
     monkeypatch.setattr(app_module.asyncio, "sleep", fake_sleep)
     monkeypatch.setattr(app_module.random, "uniform", fake_uniform)
     monkeypatch.setattr(
-        app_module, "get_gmail_watch_enabled", lambda: False, raising=False
+        app_module, "get_gmail_watch_enabled", lambda: True, raising=False
+    )
+    monkeypatch.setattr(
+        "xagent.config.get_gmail_pubsub_project_id", lambda: "test-project"
     )
     monkeypatch.setattr(
         "xagent.web.models.database.get_session_local",
         lambda: FakeSession,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.gmail_triggers.scan_due_gmail_watch_renewals",
+        fake_scan_due_gmail_watch_renewals,
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.gmail_provisioning.sweep_gmail_provisioning",
+        fake_sweep_gmail_provisioning,
     )
     monkeypatch.setattr(
         "xagent.web.services.triggers.scan_due_scheduled_triggers",
@@ -71,6 +94,8 @@ async def test_trigger_dispatcher_delays_first_tick_by_startup_jitter(
         )
 
     assert order[0] == "sleep:12.5"
+    assert order.index("sleep:12.5") < order.index("gmail_watch_renewal")
+    assert order.index("sleep:12.5") < order.index("gmail_provisioning_sweep")
     assert order.index("sleep:12.5") < order.index("scan")
     assert order.index("sleep:12.5") < order.index("dispatch")
 


### PR DESCRIPTION
## Summary
- The in-process trigger dispatcher's loop body runs immediately on startup, before its first `asyncio.sleep`. A container restart leaves a backlog of due triggers (Gmail watch renewals, scheduled triggers), so that first tick processes all of them at once, right as egress networking may still be warming up.
- Adds a random startup delay (`XAGENT_TRIGGER_DISPATCHER_STARTUP_JITTER_SECONDS`, default 30s, 0 disables it) before the dispatcher's first tick.
- Follows this repo's config convention (`src/xagent/config.py`, env var override, documented in `example.env`).

**Scope note:** this delays *when* the first tick fires; it does not reduce *how much* that tick processes once it does. `scan_due_gmail_watch_renewals`/`scan_due_scheduled_triggers` still drain their entire due backlog in one shot (up to 500/100 respectively), unbounded per tick -- so on a single instance the burst is the same size, just shifted later, ideally past the cold-start network warm-up window. The genuinely size-reducing benefit is on a multi-replica rolling restart, where staggering each replica's first tick spreads their combined load instead of all replicas bursting at the same instant. Bounding the per-tick backlog itself (matching `orphan_upload_gc.py`'s cursor/`max_pages_per_tick` pattern) would be a further, separate improvement, out of scope here.

Related to (independent of, mergeable in any order): #1988, #1989.

## Test plan
- [x] `pytest tests/web/test_trigger_dispatcher_gmail_gate.py tests/web/test_trigger_dispatcher_startup_jitter.py tests/web/api/test_agent_triggers.py -k dispatcher tests/core/test_config.py -k trigger_dispatcher`
- [x] `ruff check` / `ruff format --check` / `mypy` on changed files
- [x] New tests cover: the jitter delay runs before any DB/scan work, jitter=0 skips the delay entirely, and `start_trigger_dispatcher_task` wires the configured value through