### PR TITLE
fix(ci): de-flake the tracker pool-pressure loop-responsiveness tests

### DIFF
--- a/tests/web/tracking/test_task_tracker.py
+++ b/tests/web/tracking/test_task_tracker.py
@@ -153,6 +153,15 @@ def _run_tracker_ownership_race(
     return result["owned"], persisted
 
 
+# Loop progress is waited for, not counted inside a fixed window: an
+# oversubscribed CI runner can starve the loop for longer than the window, so a
+# rate assertion fails on scheduling rather than on the property under test
+# (#1993). The window stays under the pool's 1s timeout, which keeps the worker
+# parked while the assertions run.
+_REQUIRED_LOOP_TICKS = 3
+_LOOP_PROGRESS_WINDOW_SECONDS = 0.5
+
+
 def _create_tracker_pool_db(tmp_path, filename):
     engine = create_engine(
         f"sqlite:///{tmp_path / filename}",
@@ -215,7 +224,7 @@ async def _assert_tracker_operation_keeps_loop_responsive_under_pool_pressure(
     def traced_helper(*args, **kwargs):
         nonlocal window_timer, worker_thread_id
         worker_thread_id = threading.get_ident()
-        window_timer = threading.Timer(0.1, end_window)
+        window_timer = threading.Timer(_LOOP_PROGRESS_WINDOW_SECONDS, end_window)
         if timer_created is not None:
             timer_created(window_timer)
         window_timer.start()
@@ -227,6 +236,10 @@ async def _assert_tracker_operation_keeps_loop_responsive_under_pool_pressure(
         while not ticker_stop.is_set():
             await asyncio.sleep(0.01)
             ticker_ticks += 1
+            if ticker_ticks >= _REQUIRED_LOOP_TICKS:
+                # The timer is only the safety net; enough loop progress closes
+                # the window on its own.
+                end_window()
 
     def end_window():
         ticker_stop.set()
@@ -246,9 +259,10 @@ async def _assert_tracker_operation_keeps_loop_responsive_under_pool_pressure(
         )
 
         assert await asyncio.wait_for(
-            asyncio.to_thread(window_elapsed.wait, 0.2), timeout=0.3
+            asyncio.to_thread(window_elapsed.wait, _LOOP_PROGRESS_WINDOW_SECONDS + 0.1),
+            timeout=_LOOP_PROGRESS_WINDOW_SECONDS + 0.2,
         )
-        assert ticker_ticks >= 3
+        assert ticker_ticks >= _REQUIRED_LOOP_TICKS
         assert not operation_task.done()
         assert worker_thread_id is not None
         assert worker_thread_id != event_loop_thread_id


### PR DESCRIPTION
Closes #1993.

## Problem

`Pytest Fast (web)` intermittently fails with:

```
FAILED tests/web/tracking/test_task_tracker.py::TestTaskTracker::test_periodic_update_does_not_block_event_loop_when_pool_is_full - assert 1 >= 3
```

The assertion lives in the shared helper `_assert_tracker_operation_keeps_loop_responsive_under_pool_pressure`, used by three tests. It is a **rate** assertion, not a condition: a ticker coroutine loops on `await asyncio.sleep(0.01)`, a `threading.Timer(0.1, end_window)` closes the window, and then `assert ticker_ticks >= 3` demands the event loop complete three 10 ms sleep cycles inside a fixed 100 ms wall-clock window — i.e. a reschedule latency of ≲33 ms.

That job runs on a 4-vCPU `ubuntu-latest` runner with `pytest -n 4`, and `tests/web` also drives a real Docker daemon (`test_sandbox_reconcile_e2e.py`, which is why the job has a sandbox pre-pull step). The host is heavily oversubscribed and loop wake-up latency can exceed the whole window. `ticker_ticks == 1` means the loop was scheduled exactly once inside it — the property under test was never violated, only the arbitrary rate threshold.

## Fix

Wait for the ticks instead of counting them inside a fixed window. The timer becomes a safety net and the ticker closes the window itself as soon as it has produced `_REQUIRED_LOOP_TICKS`.

The net is **0.5 s**, deliberately under the pool's existing `pool_timeout=1`, so the worker is still parked when the assertions run and `_create_tracker_pool_db` needs no change. On an idle machine the window now closes after ~30 ms instead of a fixed 100 ms, so the tests get slightly *faster*; under CI load the loop gets 5x longer to produce the same 3 ticks.

`assert not operation_task.done()` and the `worker_thread_id != event_loop_thread_id` check are untouched — with the worker still parked they remain the load-independent teeth of the test.

One test file, 17 insertions. No production code, no workflow change, no other test touched.

## Blast radius

- Three tests share the helper and all get the fix: `test_start_tracking_...`, `test_periodic_update_...`, `test_complete_tracking_does_not_block_event_loop_when_pool_is_full`.
- `test_tracker_pool_helper_joins_timer_created_by_delayed_worker` (both params) needs no edit — keeping the `threading.Timer` and the `timer_created` hook is why. It cancels the helper before the worker starts, cleanup still does `window_timer.cancel(); window_timer.join()`, and a 0.5 s timer is even less likely than a 0.1 s one to have fired by cancel time, so `assert not recorded_timers[0].is_alive()` still holds.

## Verification

- `pytest tests/web/tracking/test_task_tracker.py -q` — 43/43 green.
- **Reproduces the CI condition:** 24 CPU-burner processes saturating the machine, then 8 consecutive runs of the file — green every time. (For reference, an instrumented run on `main` under the same load measured `ticks=8..9` in a `0.103 s` window against an ideal of 10 — only ~3x headroom over the threshold of 3, and macOS scheduling of a foreground process is far kinder than a saturated CI runner.)
- **Regression check — the teeth still bite:** temporarily made `run_db_io_cancellation_safe` call the operation inline (no `to_thread`) so the pool wait runs on the event loop; all three tests failed as expected, then reverted.
- `pytest tests/web tests/architecture -m "not slow and not postgresql" -n 4 --dist=loadscope` — 0 tracking failures. The 11 failures in that run (`test_gmail_oidc_real_signature.py`, `test_svg_preview_cache.py`, `test_file_upload.py::TestSvgPreviewSecurity`) reproduce identically on a clean checkout of `main` — a local optional-dependency gap, not this change.
- `ruff format --check` and `ruff check` clean.

## Out of scope

Noted while investigating, deliberately parked (also recorded in #1993): the pool's `pool_timeout=1` is an escape hatch that, if the test ever failed to release `held_connection` in time, would let `periodic_update` swallow the QueuePool timeout by design and make the operation task complete early — surfacing as a misleading assertion failure. The same applies to the remaining wall-clock budgets (`worker_entered.wait(2)`, `wait_for(operation_task, timeout=1)`). This change stays under that 1 s ceiling by construction and does not make it any more likely than today.
