### PR TITLE
feat: add ChartMogul MCP connector

### DIFF
--- a/src/xagent/core/utils/security.py
+++ b/src/xagent/core/utils/security.py
@@ -32,6 +32,7 @@ ASSIGNMENT_SECRET_PATTERN = re.compile(
     r"(?i)\b(api[_-]?key|access[_-]?token|token|password|secret|key)=([^&\s]+)"
 )
 BEARER_PATTERN = re.compile(r"(?i)(authorization\s*[:=]\s*bearer\s+)([^\s,;]+)")
+BASIC_AUTH_PATTERN = re.compile(r"(?i)(authorization\s*[:=]\s*basic\s+)([^\s,;]+)")
 HEADER_KEY_PATTERNS = [
     re.compile(r"(?i)(x-goog-api-key\s*[:=]\s*)([^\s,;]+)"),
     re.compile(r"(?i)(x-api-key\s*[:=]\s*)([^\s,;]+)"),
@@ -318,6 +319,10 @@ def redact_sensitive_text(text: str) -> str:
         redacted,
     )
     redacted = BEARER_PATTERN.sub(
+        lambda match: f"{match.group(1)}{_mask_secret(match.group(2))}",
+        redacted,
+    )
+    redacted = BASIC_AUTH_PATTERN.sub(
         lambda match: f"{match.group(1)}{_mask_secret(match.group(2))}",
         redacted,
     )

--- a/src/xagent/core/utils/security.py
+++ b/src/xagent/core/utils/security.py
@@ -31,8 +31,9 @@ URL_PATTERN = re.compile(r"https?://[^\s\"'>]+")
 ASSIGNMENT_SECRET_PATTERN = re.compile(
     r"(?i)\b(api[_-]?key|access[_-]?token|token|password|secret|key)=([^&\s]+)"
 )
-BEARER_PATTERN = re.compile(r"(?i)(authorization\s*[:=]\s*bearer\s+)([^\s,;]+)")
-BASIC_AUTH_PATTERN = re.compile(r"(?i)(authorization\s*[:=]\s*basic\s+)([^\s,;]+)")
+AUTH_HEADER_PATTERN = re.compile(
+    r"(?i)(authorization\s*[:=]\s*(?:bearer|basic)\s+)([^\s,;]+)"
+)
 HEADER_KEY_PATTERNS = [
     re.compile(r"(?i)(x-goog-api-key\s*[:=]\s*)([^\s,;]+)"),
     re.compile(r"(?i)(x-api-key\s*[:=]\s*)([^\s,;]+)"),
@@ -318,11 +319,7 @@ def redact_sensitive_text(text: str) -> str:
         lambda match: f"{match.group(1)}={_mask_secret(match.group(2))}",
         redacted,
     )
-    redacted = BEARER_PATTERN.sub(
-        lambda match: f"{match.group(1)}{_mask_secret(match.group(2))}",
-        redacted,
-    )
-    redacted = BASIC_AUTH_PATTERN.sub(
+    redacted = AUTH_HEADER_PATTERN.sub(
         lambda match: f"{match.group(1)}{_mask_secret(match.group(2))}",
         redacted,
     )

--- a/src/xagent/migrations/versions/20260901_seed_chartmogul_mcp_app.py
+++ b/src/xagent/migrations/versions/20260901_seed_chartmogul_mcp_app.py
@@ -1,7 +1,7 @@
 """seed built-in ChartMogul (key-based) MCP connector
 
 Revision ID: 20260901_seed_chartmogul_mcp_app
-Revises: 20260901_taskstatus_waiting_for_user
+Revises: 20260901_seed_mixpanel_mcp_app
 Create Date: 2026-09-01 00:00:00.000000
 
 """
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 # revision identifiers, used by Alembic.
 revision: str = "20260901_seed_chartmogul_mcp_app"
-down_revision: Union[str, None] = "20260901_taskstatus_waiting_for_user"
+down_revision: Union[str, None] = "20260901_seed_mixpanel_mcp_app"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260901_seed_chartmogul_mcp_app.py
+++ b/src/xagent/migrations/versions/20260901_seed_chartmogul_mcp_app.py
@@ -1,0 +1,99 @@
+"""seed built-in ChartMogul (key-based) MCP connector
+
+Revision ID: 20260901_seed_chartmogul_mcp_app
+Revises: 20260828_terminal_cmd_events
+Create Date: 2026-09-01 00:00:00.000000
+
+"""
+
+import logging
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+logger = logging.getLogger(__name__)
+
+# revision identifiers, used by Alembic.
+revision: str = "20260901_seed_chartmogul_mcp_app"
+down_revision: Union[str, None] = "20260828_terminal_cmd_events"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+
+APP_ID = "chartmogul"
+
+ROW = {
+    "app_id": APP_ID,
+    "name": "ChartMogul",
+    "description": "Connect your ChartMogul account (with a per-user API key from Profile -> API keys) to look up and manage customers, contacts, and sales opportunities.",
+    "icon": "https://www.google.com/s2/favicons?domain=chartmogul.com&sz=128",
+    "transport": "stdio",
+    "provider_name": None,
+    "category": "Analytics",
+    "oauth_scopes": None,
+    "is_visible_in_connector": True,
+    "launch_config": {
+        "command": "python",
+        "args": ["-m", "xagent.web.tools.mcp.chartmogul"],
+        "required_env": ["CHARTMOGUL_API_KEY"],
+    },
+}
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+
+    columns = {c["name"] for c in inspector.get_columns("public_mcp_apps")}
+    existing = set(bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars())
+    if APP_ID in existing:
+        return
+
+    # Silently degrades rather than failing outright (this table is never
+    # expected to be missing a column that predates this migration by
+    # months), but the app_id-exists guard above means a row seeded here
+    # while a column was missing can never self-heal on a later re-run --
+    # so at least surface which keys were dropped instead of leaving no
+    # trace at all.
+    dropped_keys = sorted(set(ROW) - columns)
+    if dropped_keys:
+        logger.warning(
+            "public_mcp_apps is missing columns %s; seeding %r without "
+            "them -- this row will not self-heal on a later re-run",
+            dropped_keys,
+            APP_ID,
+        )
+    row = {k: v for k, v in ROW.items() if k in columns}
+    bind.execute(sa.insert(PUBLIC_MCP_APPS_TABLE), [row])
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if "public_mcp_apps" not in set(inspector.get_table_names()):
+        return
+    # Only the catalog entry is removed. ChartMogul has no oauth_providers row
+    # (it is key-based). Any MCPServer/UserMCPServer rows created by users who
+    # already connected are intentionally left in place -- connect-driven
+    # rows are not owned by this migration and are cleaned up through the
+    # normal disconnect path. Matches stripe's/posthog's identical downgrade
+    # for the same reason.
+    bind.execute(
+        sa.delete(PUBLIC_MCP_APPS_TABLE).where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+    )

--- a/src/xagent/migrations/versions/20260901_seed_chartmogul_mcp_app.py
+++ b/src/xagent/migrations/versions/20260901_seed_chartmogul_mcp_app.py
@@ -43,7 +43,7 @@ ROW = {
     "icon": "https://www.google.com/s2/favicons?domain=chartmogul.com&sz=128",
     "transport": "stdio",
     "provider_name": None,
-    "category": "Analytics",
+    "category": "CRM",
     "oauth_scopes": None,
     "is_visible_in_connector": True,
     "launch_config": {

--- a/src/xagent/migrations/versions/20260901_seed_chartmogul_mcp_app.py
+++ b/src/xagent/migrations/versions/20260901_seed_chartmogul_mcp_app.py
@@ -1,7 +1,7 @@
 """seed built-in ChartMogul (key-based) MCP connector
 
 Revision ID: 20260901_seed_chartmogul_mcp_app
-Revises: 20260828_terminal_cmd_events
+Revises: 20260901_taskstatus_waiting_for_user
 Create Date: 2026-09-01 00:00:00.000000
 
 """
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 # revision identifiers, used by Alembic.
 revision: str = "20260901_seed_chartmogul_mcp_app"
-down_revision: Union[str, None] = "20260828_terminal_cmd_events"
+down_revision: Union[str, None] = "20260901_taskstatus_waiting_for_user"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -1170,6 +1170,28 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
                 "required_env": ["STRIPE_API_KEY"],
             },
         },
+        {
+            "app_id": "chartmogul",
+            "name": "ChartMogul",
+            "description": "Connect your ChartMogul account (with a per-user API key from Profile -> API keys) to look up and manage customers, contacts, and sales opportunities.",
+            "icon": "https://www.google.com/s2/favicons?domain=chartmogul.com&sz=128",
+            "transport": "stdio",
+            "provider_name": None,
+            "category": "Analytics",
+            "oauth_scopes": None,
+            "is_visible_in_connector": True,
+            # Key-based (non-oauth), like aws/google-maps/posthog/stripe:
+            # ChartMogul has no OAuth flow at all, only a per-user API key
+            # generated from Profile -> API keys in their own account --
+            # sent as HTTP Basic Auth username (confirmed against
+            # chartmogul-python's Config class), same no-review self-serve
+            # bar as an OAuth App.
+            "launch_config": {
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.chartmogul"],
+                "required_env": ["CHARTMOGUL_API_KEY"],
+            },
+        },
     ]
 
 

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -1177,7 +1177,11 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "icon": "https://www.google.com/s2/favicons?domain=chartmogul.com&sz=128",
             "transport": "stdio",
             "provider_name": None,
-            "category": "Analytics",
+            # CRM, not Analytics: the 15 tools this connector exposes are
+            # exclusively customer/contact/opportunity CRUD -- no metrics,
+            # subscription, MRR, or churn endpoints, despite ChartMogul the
+            # product being analytics-branded.
+            "category": "CRM",
             "oauth_scopes": None,
             "is_visible_in_connector": True,
             # Key-based (non-oauth), like aws/google-maps/posthog/stripe:

--- a/src/xagent/web/tools/mcp/chartmogul.py
+++ b/src/xagent/web/tools/mcp/chartmogul.py
@@ -410,10 +410,13 @@ def chartmogul_create_contact(customer_uuid: str, data: dict[str, Any]) -> str:
         result = _request(
             "POST", f"/customers/{safe_customer_uuid}/contacts", json_data=data
         )
-        result = _validated_dict(result, "/contacts")
+        result = _validated_dict(result, f"/customers/{safe_customer_uuid}/contacts")
         return success_with_capped_dict("contact", result)
     except Exception as e:
-        logger.error(f"Error creating ChartMogul contact: {e}", exc_info=True)
+        logger.error(
+            f"Error creating ChartMogul contact for customer {customer_uuid}: {e}",
+            exc_info=True,
+        )
         return _error(str(e))
 
 

--- a/src/xagent/web/tools/mcp/chartmogul.py
+++ b/src/xagent/web/tools/mcp/chartmogul.py
@@ -110,7 +110,9 @@ def _extract_error_detail(response: requests.Response) -> str | None:
         detail = payload.get(key)
         if isinstance(detail, str) and detail:
             return detail
-        if isinstance(detail, dict) and detail:
+        # "errors" in particular can be a list of per-field messages (e.g.
+        # {"errors": ["external_id can't be blank"]}), not just a dict.
+        if isinstance(detail, (dict, list)) and detail:
             return json.dumps(detail, ensure_ascii=False)
     return None
 

--- a/src/xagent/web/tools/mcp/chartmogul.py
+++ b/src/xagent/web/tools/mcp/chartmogul.py
@@ -9,7 +9,7 @@ from mcp.server.fastmcp import FastMCP
 from ....config import get_tool_max_output_length
 from ....core.utils.security import redact_sensitive_text
 from ...utils.graphql_errors import truncate_error_text
-from .utils import setup_proxy_env, success_with_capped_dict, url_path_id
+from .utils import clamp_limit, setup_proxy_env, success_with_capped_dict, url_path_id
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("chartmogul-mcp")
@@ -79,6 +79,12 @@ def _success_with_capped_list(list_field: str, payload: dict[str, Any]) -> str:
         items = items[: len(items) // 2]
         halved = True
         response = _build(items, True, halved)
+    if halved and len(response) > max_output_length:
+        # Even an empty item list didn't buy back enough room (an unusually
+        # large cursor/other payload field, or a very small configured
+        # limit) -- drop the added "message" text itself as a last resort,
+        # matching deputy.py's identical fallback.
+        response = _build(items, True, False)
     return response
 
 
@@ -129,7 +135,13 @@ def _request(
             method=method,
             url=f"{API_BASE_URL}{path}",
             auth=(_api_key(), ""),
-            params={k: v for k, v in (params or {}).items() if v is not None},
+            # Drop "" as well as None: every list filter below is optional,
+            # and an LLM tool-call passing e.g. email="" to mean "no filter"
+            # would otherwise become a real `?email=` query param instead of
+            # being omitted.
+            params={
+                k: v for k, v in (params or {}).items() if v is not None and v != ""
+            },
             json=json_data,
             timeout=DEFAULT_TIMEOUT_SECONDS,
         )
@@ -163,7 +175,35 @@ def _request(
 
 
 def _clamp_per_page(per_page: int) -> int:
-    return max(1, min(int(per_page), MAX_PER_PAGE))
+    return clamp_limit(per_page, max_limit=MAX_PER_PAGE)
+
+
+def _validated_dict(result: Any, endpoint: str) -> dict[str, Any] | str:
+    """Return ``result`` if it's a dict, else an ``_error()`` JSON string."""
+    if not isinstance(result, dict):
+        return _error(f"ChartMogul returned an unexpected response for {endpoint}")
+    return result
+
+
+def _validated_list_result(result: Any, endpoint: str) -> dict[str, Any] | str:
+    """Return ``result`` with ``entries`` normalized to a list, else an
+    ``_error()`` JSON string.
+
+    A present-but-``null`` ``entries`` field is treated the same as an
+    empty list rather than a connector-level error, in case ChartMogul
+    ever returns ``null`` instead of ``[]`` for a zero-result page. A
+    *missing* ``entries`` key is still rejected as an unexpected shape --
+    unlike an explicit ``null``, its absence isn't evidence of "empty",
+    just of a response that isn't a page of this resource at all.
+    """
+    if not isinstance(result, dict) or "entries" not in result:
+        return _error(f"ChartMogul returned an unexpected response for {endpoint}")
+    entries = result["entries"]
+    if entries is None:
+        entries = []
+    elif not isinstance(entries, list):
+        return _error(f"ChartMogul returned an unexpected response for {endpoint}")
+    return {**result, "entries": entries}
 
 
 # ---------------------------------------------------------------------------
@@ -212,8 +252,9 @@ def chartmogul_list_customers(
                 "per_page": _clamp_per_page(per_page),
             },
         )
-        if not isinstance(result, dict) or not isinstance(result.get("entries"), list):
-            return _error("ChartMogul returned an unexpected response for /customers")
+        result = _validated_list_result(result, "/customers")
+        if isinstance(result, str):
+            return result
         return _success_with_capped_list("entries", result)
     except Exception as e:
         logger.error(f"Error listing ChartMogul customers: {e}", exc_info=True)
@@ -231,8 +272,9 @@ def chartmogul_create_customer(data: dict[str, Any]) -> str:
     """
     try:
         result = _request("POST", "/customers", json_data=data)
-        if not isinstance(result, dict):
-            return _error("ChartMogul returned an unexpected response for /customers")
+        result = _validated_dict(result, "/customers")
+        if isinstance(result, str):
+            return result
         return success_with_capped_dict("customer", result)
     except Exception as e:
         logger.error(f"Error creating ChartMogul customer: {e}", exc_info=True)
@@ -249,8 +291,9 @@ def chartmogul_get_customer(uuid: str) -> str:
     try:
         safe_uuid = url_path_id(uuid, "uuid")
         result = _request("GET", f"/customers/{safe_uuid}")
-        if not isinstance(result, dict):
-            return _error("ChartMogul returned an unexpected response for /customers")
+        result = _validated_dict(result, "/customers")
+        if isinstance(result, str):
+            return result
         return success_with_capped_dict("customer", result)
     except Exception as e:
         logger.error(f"Error fetching ChartMogul customer {uuid}: {e}", exc_info=True)
@@ -268,8 +311,9 @@ def chartmogul_update_customer(uuid: str, data: dict[str, Any]) -> str:
     try:
         safe_uuid = url_path_id(uuid, "uuid")
         result = _request("PATCH", f"/customers/{safe_uuid}", json_data=data)
-        if not isinstance(result, dict):
-            return _error("ChartMogul returned an unexpected response for /customers")
+        result = _validated_dict(result, "/customers")
+        if isinstance(result, str):
+            return result
         return success_with_capped_dict("customer", result)
     except Exception as e:
         logger.error(f"Error updating ChartMogul customer {uuid}: {e}", exc_info=True)
@@ -335,8 +379,9 @@ def chartmogul_list_contacts(
                 "per_page": _clamp_per_page(per_page),
             },
         )
-        if not isinstance(result, dict) or not isinstance(result.get("entries"), list):
-            return _error("ChartMogul returned an unexpected response for /contacts")
+        result = _validated_list_result(result, "/contacts")
+        if isinstance(result, str):
+            return result
         return _success_with_capped_list("entries", result)
     except Exception as e:
         logger.error(f"Error listing ChartMogul contacts: {e}", exc_info=True)
@@ -355,8 +400,9 @@ def chartmogul_create_contact(data: dict[str, Any]) -> str:
     """
     try:
         result = _request("POST", "/contacts", json_data=data)
-        if not isinstance(result, dict):
-            return _error("ChartMogul returned an unexpected response for /contacts")
+        result = _validated_dict(result, "/contacts")
+        if isinstance(result, str):
+            return result
         return success_with_capped_dict("contact", result)
     except Exception as e:
         logger.error(f"Error creating ChartMogul contact: {e}", exc_info=True)
@@ -373,8 +419,9 @@ def chartmogul_get_contact(uuid: str) -> str:
     try:
         safe_uuid = url_path_id(uuid, "uuid")
         result = _request("GET", f"/contacts/{safe_uuid}")
-        if not isinstance(result, dict):
-            return _error("ChartMogul returned an unexpected response for /contacts")
+        result = _validated_dict(result, "/contacts")
+        if isinstance(result, str):
+            return result
         return success_with_capped_dict("contact", result)
     except Exception as e:
         logger.error(f"Error fetching ChartMogul contact {uuid}: {e}", exc_info=True)
@@ -392,8 +439,9 @@ def chartmogul_update_contact(uuid: str, data: dict[str, Any]) -> str:
     try:
         safe_uuid = url_path_id(uuid, "uuid")
         result = _request("PATCH", f"/contacts/{safe_uuid}", json_data=data)
-        if not isinstance(result, dict):
-            return _error("ChartMogul returned an unexpected response for /contacts")
+        result = _validated_dict(result, "/contacts")
+        if isinstance(result, str):
+            return result
         return success_with_capped_dict("contact", result)
     except Exception as e:
         logger.error(f"Error updating ChartMogul contact {uuid}: {e}", exc_info=True)
@@ -465,10 +513,9 @@ def chartmogul_list_opportunities(
                 "per_page": _clamp_per_page(per_page),
             },
         )
-        if not isinstance(result, dict) or not isinstance(result.get("entries"), list):
-            return _error(
-                "ChartMogul returned an unexpected response for /opportunities"
-            )
+        result = _validated_list_result(result, "/opportunities")
+        if isinstance(result, str):
+            return result
         return _success_with_capped_list("entries", result)
     except Exception as e:
         logger.error(f"Error listing ChartMogul opportunities: {e}", exc_info=True)
@@ -487,10 +534,9 @@ def chartmogul_create_opportunity(data: dict[str, Any]) -> str:
     """
     try:
         result = _request("POST", "/opportunities", json_data=data)
-        if not isinstance(result, dict):
-            return _error(
-                "ChartMogul returned an unexpected response for /opportunities"
-            )
+        result = _validated_dict(result, "/opportunities")
+        if isinstance(result, str):
+            return result
         return success_with_capped_dict("opportunity", result)
     except Exception as e:
         logger.error(f"Error creating ChartMogul opportunity: {e}", exc_info=True)
@@ -507,10 +553,9 @@ def chartmogul_get_opportunity(uuid: str) -> str:
     try:
         safe_uuid = url_path_id(uuid, "uuid")
         result = _request("GET", f"/opportunities/{safe_uuid}")
-        if not isinstance(result, dict):
-            return _error(
-                "ChartMogul returned an unexpected response for /opportunities"
-            )
+        result = _validated_dict(result, "/opportunities")
+        if isinstance(result, str):
+            return result
         return success_with_capped_dict("opportunity", result)
     except Exception as e:
         logger.error(
@@ -530,10 +575,9 @@ def chartmogul_update_opportunity(uuid: str, data: dict[str, Any]) -> str:
     try:
         safe_uuid = url_path_id(uuid, "uuid")
         result = _request("PATCH", f"/opportunities/{safe_uuid}", json_data=data)
-        if not isinstance(result, dict):
-            return _error(
-                "ChartMogul returned an unexpected response for /opportunities"
-            )
+        result = _validated_dict(result, "/opportunities")
+        if isinstance(result, str):
+            return result
         return success_with_capped_dict("opportunity", result)
     except Exception as e:
         logger.error(

--- a/src/xagent/web/tools/mcp/chartmogul.py
+++ b/src/xagent/web/tools/mcp/chartmogul.py
@@ -171,38 +171,48 @@ def _request(
         )
     if response.status_code == 204 or not response.content:
         return {}
-    return response.json()
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise RuntimeError(
+            f"ChartMogul returned a 2xx response with a non-JSON body: {exc}"
+        ) from exc
 
 
 def _clamp_per_page(per_page: int) -> int:
     return clamp_limit(per_page, max_limit=MAX_PER_PAGE)
 
 
-def _validated_dict(result: Any, endpoint: str) -> dict[str, Any] | str:
-    """Return ``result`` if it's a dict, else an ``_error()`` JSON string."""
+def _validated_dict(result: Any, endpoint: str) -> dict[str, Any]:
+    """Return ``result`` if it's a dict, else raise.
+
+    Every caller is inside a ``try/except Exception -> _error(str(e))``
+    block, so raising here (rather than returning a ``dict | str`` union
+    every call site would have to narrow) reaches the caller's own error
+    envelope unchanged.
+    """
     if not isinstance(result, dict):
-        return _error(f"ChartMogul returned an unexpected response for {endpoint}")
+        raise RuntimeError(f"ChartMogul returned an unexpected response for {endpoint}")
     return result
 
 
-def _validated_list_result(result: Any, endpoint: str) -> dict[str, Any] | str:
-    """Return ``result`` with ``entries`` normalized to a list, else an
-    ``_error()`` JSON string.
+def _validated_list_result(result: Any, endpoint: str) -> dict[str, Any]:
+    """Return ``result`` with ``entries`` normalized to a list, else raise.
 
     A present-but-``null`` ``entries`` field is treated the same as an
-    empty list rather than a connector-level error, in case ChartMogul
-    ever returns ``null`` instead of ``[]`` for a zero-result page. A
-    *missing* ``entries`` key is still rejected as an unexpected shape --
-    unlike an explicit ``null``, its absence isn't evidence of "empty",
-    just of a response that isn't a page of this resource at all.
+    empty list rather than an error, in case ChartMogul ever returns
+    ``null`` instead of ``[]`` for a zero-result page. A *missing*
+    ``entries`` key is still rejected as an unexpected shape -- unlike an
+    explicit ``null``, its absence isn't evidence of "empty", just of a
+    response that isn't a page of this resource at all.
     """
     if not isinstance(result, dict) or "entries" not in result:
-        return _error(f"ChartMogul returned an unexpected response for {endpoint}")
+        raise RuntimeError(f"ChartMogul returned an unexpected response for {endpoint}")
     entries = result["entries"]
     if entries is None:
         entries = []
     elif not isinstance(entries, list):
-        return _error(f"ChartMogul returned an unexpected response for {endpoint}")
+        raise RuntimeError(f"ChartMogul returned an unexpected response for {endpoint}")
     return {**result, "entries": entries}
 
 
@@ -253,8 +263,6 @@ def chartmogul_list_customers(
             },
         )
         result = _validated_list_result(result, "/customers")
-        if isinstance(result, str):
-            return result
         return _success_with_capped_list("entries", result)
     except Exception as e:
         logger.error(f"Error listing ChartMogul customers: {e}", exc_info=True)
@@ -273,8 +281,6 @@ def chartmogul_create_customer(data: dict[str, Any]) -> str:
     try:
         result = _request("POST", "/customers", json_data=data)
         result = _validated_dict(result, "/customers")
-        if isinstance(result, str):
-            return result
         return success_with_capped_dict("customer", result)
     except Exception as e:
         logger.error(f"Error creating ChartMogul customer: {e}", exc_info=True)
@@ -292,8 +298,6 @@ def chartmogul_get_customer(uuid: str) -> str:
         safe_uuid = url_path_id(uuid, "uuid")
         result = _request("GET", f"/customers/{safe_uuid}")
         result = _validated_dict(result, "/customers")
-        if isinstance(result, str):
-            return result
         return success_with_capped_dict("customer", result)
     except Exception as e:
         logger.error(f"Error fetching ChartMogul customer {uuid}: {e}", exc_info=True)
@@ -312,8 +316,6 @@ def chartmogul_update_customer(uuid: str, data: dict[str, Any]) -> str:
         safe_uuid = url_path_id(uuid, "uuid")
         result = _request("PATCH", f"/customers/{safe_uuid}", json_data=data)
         result = _validated_dict(result, "/customers")
-        if isinstance(result, str):
-            return result
         return success_with_capped_dict("customer", result)
     except Exception as e:
         logger.error(f"Error updating ChartMogul customer {uuid}: {e}", exc_info=True)
@@ -380,8 +382,6 @@ def chartmogul_list_contacts(
             },
         )
         result = _validated_list_result(result, "/contacts")
-        if isinstance(result, str):
-            return result
         return _success_with_capped_list("entries", result)
     except Exception as e:
         logger.error(f"Error listing ChartMogul contacts: {e}", exc_info=True)
@@ -389,20 +389,28 @@ def chartmogul_list_contacts(
 
 
 @mcp.tool()
-def chartmogul_create_contact(data: dict[str, Any]) -> str:
+def chartmogul_create_contact(customer_uuid: str, data: dict[str, Any]) -> str:
     """
-    Create a contact (POST /contacts).
+    Create a contact under a customer (POST /customers/{customer_uuid}/contacts).
 
-    data: a ChartMogul contact object. Should include "customer_uuid" (or
-    "customer_external_id" together with "data_source_uuid") to associate
-    it with a customer; commonly also "first_name", "last_name", "email",
-    "title", "phone".
+    Unlike customers and opportunities, contact creation is nested under its
+    customer -- confirmed against ChartMogul's official docs
+    (dev.chartmogul.com/reference/customers/add-contact): "customer_uuid" is
+    a path parameter, not a body field.
+
+    customer_uuid: the ChartMogul customer this contact belongs to.
+    data: a ChartMogul contact object. Must include "data_source_uuid" (the
+    customer's data source; an error is returned if the customer isn't
+    associated with it); optionally "first_name", "last_name", "email",
+    "title", "phone", "position", "external_id", "linked_in", "twitter",
+    "notes", "custom".
     """
     try:
-        result = _request("POST", "/contacts", json_data=data)
+        safe_customer_uuid = url_path_id(customer_uuid, "customer_uuid")
+        result = _request(
+            "POST", f"/customers/{safe_customer_uuid}/contacts", json_data=data
+        )
         result = _validated_dict(result, "/contacts")
-        if isinstance(result, str):
-            return result
         return success_with_capped_dict("contact", result)
     except Exception as e:
         logger.error(f"Error creating ChartMogul contact: {e}", exc_info=True)
@@ -420,8 +428,6 @@ def chartmogul_get_contact(uuid: str) -> str:
         safe_uuid = url_path_id(uuid, "uuid")
         result = _request("GET", f"/contacts/{safe_uuid}")
         result = _validated_dict(result, "/contacts")
-        if isinstance(result, str):
-            return result
         return success_with_capped_dict("contact", result)
     except Exception as e:
         logger.error(f"Error fetching ChartMogul contact {uuid}: {e}", exc_info=True)
@@ -440,8 +446,6 @@ def chartmogul_update_contact(uuid: str, data: dict[str, Any]) -> str:
         safe_uuid = url_path_id(uuid, "uuid")
         result = _request("PATCH", f"/contacts/{safe_uuid}", json_data=data)
         result = _validated_dict(result, "/contacts")
-        if isinstance(result, str):
-            return result
         return success_with_capped_dict("contact", result)
     except Exception as e:
         logger.error(f"Error updating ChartMogul contact {uuid}: {e}", exc_info=True)
@@ -514,8 +518,6 @@ def chartmogul_list_opportunities(
             },
         )
         result = _validated_list_result(result, "/opportunities")
-        if isinstance(result, str):
-            return result
         return _success_with_capped_list("entries", result)
     except Exception as e:
         logger.error(f"Error listing ChartMogul opportunities: {e}", exc_info=True)
@@ -535,8 +537,6 @@ def chartmogul_create_opportunity(data: dict[str, Any]) -> str:
     try:
         result = _request("POST", "/opportunities", json_data=data)
         result = _validated_dict(result, "/opportunities")
-        if isinstance(result, str):
-            return result
         return success_with_capped_dict("opportunity", result)
     except Exception as e:
         logger.error(f"Error creating ChartMogul opportunity: {e}", exc_info=True)
@@ -554,8 +554,6 @@ def chartmogul_get_opportunity(uuid: str) -> str:
         safe_uuid = url_path_id(uuid, "uuid")
         result = _request("GET", f"/opportunities/{safe_uuid}")
         result = _validated_dict(result, "/opportunities")
-        if isinstance(result, str):
-            return result
         return success_with_capped_dict("opportunity", result)
     except Exception as e:
         logger.error(
@@ -576,8 +574,6 @@ def chartmogul_update_opportunity(uuid: str, data: dict[str, Any]) -> str:
         safe_uuid = url_path_id(uuid, "uuid")
         result = _request("PATCH", f"/opportunities/{safe_uuid}", json_data=data)
         result = _validated_dict(result, "/opportunities")
-        if isinstance(result, str):
-            return result
         return success_with_capped_dict("opportunity", result)
     except Exception as e:
         logger.error(

--- a/src/xagent/web/tools/mcp/chartmogul.py
+++ b/src/xagent/web/tools/mcp/chartmogul.py
@@ -1,0 +1,563 @@
+import json
+import logging
+import os
+from typing import Any
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+from ....config import get_tool_max_output_length
+from ....core.utils.security import redact_sensitive_text
+from ...utils.graphql_errors import truncate_error_text
+from .utils import setup_proxy_env, success_with_capped_dict, url_path_id
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("chartmogul-mcp")
+
+# Ensure standard proxy environment variables are set to prevent hanging requests
+setup_proxy_env()
+
+mcp = FastMCP("chartmogul-mcp")
+
+# ChartMogul's REST API (dev.chartmogul.com) authenticates every request with
+# HTTP Basic Auth: the account's API key as the username, empty password --
+# confirmed against the official chartmogul-python SDK's Config class
+# (chartmogul/api/config.py: `self.auth = (api_key, "")`), not guessed. There
+# is no OAuth flow; the key is generated per-user from
+# Profile -> API keys in their own ChartMogul account, same self-serve bar
+# as an OAuth app. Unlike Stripe, ChartMogul's docs describe only this one
+# key type per account -- no separate restricted/scoped key tier to enforce
+# the way stripe.py checks for an "rk_"-prefixed key.
+API_BASE_URL = "https://api.chartmogul.com/v1"
+DEFAULT_TIMEOUT_SECONDS = 30
+# ChartMogul's own page-size cap (dev.chartmogul.com/reference/list-customers:
+# per_page defaults to, and maxes out at, 200); passing a larger value is
+# rejected server-side rather than clamped.
+MAX_PER_PAGE = 200
+DEFAULT_PER_PAGE = 20
+
+
+def _success(**payload: Any) -> str:
+    return json.dumps({"status": "success", **payload}, ensure_ascii=False)
+
+
+def _error(message: str) -> str:
+    return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
+
+
+def _success_with_capped_list(list_field: str, payload: dict[str, Any]) -> str:
+    """Build a success payload from a ChartMogul cursor-paginated list
+    response, halving ``payload[list_field]`` until it fits the platform's
+    output limit.
+
+    Mirrors deputy.py's ``_success_with_capped_list``, including its
+    explicit "data lost" message when halving actually ran: ChartMogul's
+    ``cursor``/``has_more`` describe the *already-fetched* page from the one
+    API call this made, so a halved-away item is gone for this call, not
+    recoverable by resuming from that same cursor (which fetches the *next*
+    page, not the rest of this one) -- there's no cursor a caller could
+    retry with to get the dropped items back.
+    """
+    max_output_length = get_tool_max_output_length()
+    items = payload.get(list_field) or []
+
+    def _build(items: list[Any], truncated: bool, halved: bool) -> str:
+        extra: dict[str, Any] = {}
+        if halved:
+            extra["message"] = (
+                f"Returned {len(items)} {list_field} out of the full page; the "
+                "rest did not fit the output size limit and cannot be recovered "
+                "via this tool call (a smaller per_page avoids this)."
+            )
+        return _success(
+            **{**payload, list_field: items, "truncated": truncated, **extra}
+        )
+
+    halved = False
+    response = _build(items, False, halved)
+    while len(response) > max_output_length and items:
+        items = items[: len(items) // 2]
+        halved = True
+        response = _build(items, True, halved)
+    return response
+
+
+def _api_key() -> str:
+    # Stripped, not just a bare os.environ.get(): a stray leading/trailing
+    # newline or space in the injected key (e.g. from a copy-pasted env
+    # value in a manual launch_config override) would otherwise silently
+    # produce a malformed Basic Auth header rather than the clear "missing"
+    # error below.
+    api_key = (os.environ.get("CHARTMOGUL_API_KEY") or "").strip()
+    if not api_key:
+        raise ValueError("CHARTMOGUL_API_KEY environment variable is missing or empty")
+    return api_key
+
+
+def _extract_error_detail(response: requests.Response) -> str | None:
+    """Pull a human-readable message out of a ChartMogul error body, trying
+    a few plausible key names rather than assuming one fixed shape. Returns
+    None if the body isn't in any of the expected shapes, so the caller
+    falls back to the raw response text.
+    """
+    try:
+        payload = response.json()
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    for key in ("message", "error", "errors"):
+        detail = payload.get(key)
+        if isinstance(detail, str) and detail:
+            return detail
+        if isinstance(detail, dict) and detail:
+            return json.dumps(detail, ensure_ascii=False)
+    return None
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    json_data: Any = None,
+) -> Any:
+    try:
+        response = requests.request(
+            method=method,
+            url=f"{API_BASE_URL}{path}",
+            auth=(_api_key(), ""),
+            params={k: v for k, v in (params or {}).items() if v is not None},
+            json=json_data,
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+        )
+    except requests.RequestException as exc:
+        # A connection/timeout/proxy failure's message can itself embed
+        # sensitive data -- e.g. a ProxyError echoing the ambient
+        # HTTPS_PROXY URL, which may carry embedded user:pass@ credentials
+        # (setup_proxy_env() exports whatever the OS has configured) --
+        # matches stripe.py's/posthog.py's identical fix for the same
+        # shared proxy-env exposure surface.
+        raise RuntimeError(
+            f"ChartMogul request failed: {truncate_error_text(redact_sensitive_text(str(exc)))}"
+        ) from exc
+    if response.status_code >= 400:
+        detail = _extract_error_detail(response)
+        if detail is None:
+            detail = response.text.strip()
+        # The response body is host-controlled content, not something this
+        # module wrote -- if it happens to echo request headers (e.g. a
+        # misconfigured proxy/WAF/gateway error page), redact the Basic
+        # Auth credential before it reaches logs or the LLM's context,
+        # matching stripe.py's/posthog.py's identical treatment.
+        detail = truncate_error_text(redact_sensitive_text(detail))
+        raise RuntimeError(
+            f"ChartMogul API error (status {response.status_code})"
+            + (f": {detail}" if detail else "")
+        )
+    if response.status_code == 204 or not response.content:
+        return {}
+    return response.json()
+
+
+def _clamp_per_page(per_page: int) -> int:
+    return max(1, min(int(per_page), MAX_PER_PAGE))
+
+
+# ---------------------------------------------------------------------------
+# Customers
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def chartmogul_list_customers(
+    data_source_uuid: str | None = None,
+    external_id: str | None = None,
+    email: str | None = None,
+    status: str | None = None,
+    system: str | None = None,
+    cursor: str | None = None,
+    per_page: int = DEFAULT_PER_PAGE,
+) -> str:
+    """
+    List customers (GET /customers). Returns a page of entries plus a
+    ``cursor``/``has_more`` pair -- pass the returned ``cursor`` back in to
+    fetch the next page.
+
+    data_source_uuid: optional, restrict to one connected data source.
+    external_id: optional, the customer's id in the connected billing
+    system (e.g. a Stripe customer id).
+    email: optional, filter by the customer's email address.
+    status: optional, one of "New_Lead", "Working_Lead", "Qualified_Lead",
+    "Unqualified_Lead", "Active", "Past_Due", "Cancelled".
+    system: optional, filter by billing system name (e.g. "Stripe",
+    "Recurly", "Custom") -- case-sensitive.
+    cursor: optional, from a previous call's response, to fetch the next
+    page.
+    per_page: page size, 1-200 (ChartMogul's own server-side cap).
+    """
+    try:
+        result = _request(
+            "GET",
+            "/customers",
+            params={
+                "data_source_uuid": data_source_uuid,
+                "external_id": external_id,
+                "email": email,
+                "status": status,
+                "system": system,
+                "cursor": cursor,
+                "per_page": _clamp_per_page(per_page),
+            },
+        )
+        if not isinstance(result, dict) or not isinstance(result.get("entries"), list):
+            return _error("ChartMogul returned an unexpected response for /customers")
+        return _success_with_capped_list("entries", result)
+    except Exception as e:
+        logger.error(f"Error listing ChartMogul customers: {e}", exc_info=True)
+        return _error(str(e))
+
+
+@mcp.tool()
+def chartmogul_create_customer(data: dict[str, Any]) -> str:
+    """
+    Create a customer (POST /customers).
+
+    data: a ChartMogul customer object. Must include "data_source_uuid" and
+    "external_id" (the id from your billing/CRM system) at minimum; commonly
+    also "name", "email", "company", "country", "city", "state", "zip".
+    """
+    try:
+        result = _request("POST", "/customers", json_data=data)
+        if not isinstance(result, dict):
+            return _error("ChartMogul returned an unexpected response for /customers")
+        return success_with_capped_dict("customer", result)
+    except Exception as e:
+        logger.error(f"Error creating ChartMogul customer: {e}", exc_info=True)
+        return _error(str(e))
+
+
+@mcp.tool()
+def chartmogul_get_customer(uuid: str) -> str:
+    """
+    Get one customer by uuid (GET /customers/{uuid}).
+
+    uuid: the customer's ChartMogul uuid (e.g. "cus_00000000-0000-0000-0000-000000000000").
+    """
+    try:
+        safe_uuid = url_path_id(uuid, "uuid")
+        result = _request("GET", f"/customers/{safe_uuid}")
+        if not isinstance(result, dict):
+            return _error("ChartMogul returned an unexpected response for /customers")
+        return success_with_capped_dict("customer", result)
+    except Exception as e:
+        logger.error(f"Error fetching ChartMogul customer {uuid}: {e}", exc_info=True)
+        return _error(str(e))
+
+
+@mcp.tool()
+def chartmogul_update_customer(uuid: str, data: dict[str, Any]) -> str:
+    """
+    Update a customer (PATCH /customers/{uuid}).
+
+    uuid: the customer's ChartMogul uuid.
+    data: fields to change, e.g. {"company": "Acme Inc.", "country": "US"}.
+    """
+    try:
+        safe_uuid = url_path_id(uuid, "uuid")
+        result = _request("PATCH", f"/customers/{safe_uuid}", json_data=data)
+        if not isinstance(result, dict):
+            return _error("ChartMogul returned an unexpected response for /customers")
+        return success_with_capped_dict("customer", result)
+    except Exception as e:
+        logger.error(f"Error updating ChartMogul customer {uuid}: {e}", exc_info=True)
+        return _error(str(e))
+
+
+@mcp.tool()
+def chartmogul_delete_customer(uuid: str) -> str:
+    """
+    Permanently delete a customer, including all its associated data
+    (subscriptions, invoices, activities) (DELETE /customers/{uuid}). This
+    cannot be undone -- confirm with the user before calling this.
+
+    uuid: the customer's ChartMogul uuid.
+    """
+    try:
+        safe_uuid = url_path_id(uuid, "uuid")
+        _request("DELETE", f"/customers/{safe_uuid}")
+        return _success(uuid=uuid)
+    except Exception as e:
+        logger.error(f"Error deleting ChartMogul customer {uuid}: {e}", exc_info=True)
+        return _error(str(e))
+
+
+# ---------------------------------------------------------------------------
+# Contacts
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def chartmogul_list_contacts(
+    email: str | None = None,
+    customer_uuid: str | None = None,
+    customer_external_id: str | None = None,
+    data_source_uuid: str | None = None,
+    cursor: str | None = None,
+    per_page: int = DEFAULT_PER_PAGE,
+) -> str:
+    """
+    List contacts (GET /contacts). Returns a page of entries plus a
+    ``cursor``/``has_more`` pair -- pass the returned ``cursor`` back in to
+    fetch the next page.
+
+    email: optional, filter by exact email address.
+    customer_uuid: optional, restrict to one customer's contacts.
+    customer_external_id: optional, restrict by the customer's external id
+    instead of its ChartMogul uuid.
+    data_source_uuid: optional, restrict to one connected data source.
+    cursor: optional, from a previous call's response, to fetch the next
+    page.
+    per_page: page size, 1-200 (ChartMogul's own server-side cap).
+    """
+    try:
+        result = _request(
+            "GET",
+            "/contacts",
+            params={
+                "email": email,
+                "customer_uuid": customer_uuid,
+                "customer_external_id": customer_external_id,
+                "data_source_uuid": data_source_uuid,
+                "cursor": cursor,
+                "per_page": _clamp_per_page(per_page),
+            },
+        )
+        if not isinstance(result, dict) or not isinstance(result.get("entries"), list):
+            return _error("ChartMogul returned an unexpected response for /contacts")
+        return _success_with_capped_list("entries", result)
+    except Exception as e:
+        logger.error(f"Error listing ChartMogul contacts: {e}", exc_info=True)
+        return _error(str(e))
+
+
+@mcp.tool()
+def chartmogul_create_contact(data: dict[str, Any]) -> str:
+    """
+    Create a contact (POST /contacts).
+
+    data: a ChartMogul contact object. Should include "customer_uuid" (or
+    "customer_external_id" together with "data_source_uuid") to associate
+    it with a customer; commonly also "first_name", "last_name", "email",
+    "title", "phone".
+    """
+    try:
+        result = _request("POST", "/contacts", json_data=data)
+        if not isinstance(result, dict):
+            return _error("ChartMogul returned an unexpected response for /contacts")
+        return success_with_capped_dict("contact", result)
+    except Exception as e:
+        logger.error(f"Error creating ChartMogul contact: {e}", exc_info=True)
+        return _error(str(e))
+
+
+@mcp.tool()
+def chartmogul_get_contact(uuid: str) -> str:
+    """
+    Get one contact by uuid (GET /contacts/{uuid}).
+
+    uuid: the contact's ChartMogul uuid.
+    """
+    try:
+        safe_uuid = url_path_id(uuid, "uuid")
+        result = _request("GET", f"/contacts/{safe_uuid}")
+        if not isinstance(result, dict):
+            return _error("ChartMogul returned an unexpected response for /contacts")
+        return success_with_capped_dict("contact", result)
+    except Exception as e:
+        logger.error(f"Error fetching ChartMogul contact {uuid}: {e}", exc_info=True)
+        return _error(str(e))
+
+
+@mcp.tool()
+def chartmogul_update_contact(uuid: str, data: dict[str, Any]) -> str:
+    """
+    Update a contact (PATCH /contacts/{uuid}).
+
+    uuid: the contact's ChartMogul uuid.
+    data: fields to change, e.g. {"title": "VP Engineering", "phone": "+1..."}.
+    """
+    try:
+        safe_uuid = url_path_id(uuid, "uuid")
+        result = _request("PATCH", f"/contacts/{safe_uuid}", json_data=data)
+        if not isinstance(result, dict):
+            return _error("ChartMogul returned an unexpected response for /contacts")
+        return success_with_capped_dict("contact", result)
+    except Exception as e:
+        logger.error(f"Error updating ChartMogul contact {uuid}: {e}", exc_info=True)
+        return _error(str(e))
+
+
+@mcp.tool()
+def chartmogul_delete_contact(uuid: str) -> str:
+    """
+    Permanently delete a contact (DELETE /contacts/{uuid}). This cannot be
+    undone -- confirm with the user before calling this.
+
+    uuid: the contact's ChartMogul uuid.
+    """
+    try:
+        safe_uuid = url_path_id(uuid, "uuid")
+        _request("DELETE", f"/contacts/{safe_uuid}")
+        return _success(uuid=uuid)
+    except Exception as e:
+        logger.error(f"Error deleting ChartMogul contact {uuid}: {e}", exc_info=True)
+        return _error(str(e))
+
+
+# ---------------------------------------------------------------------------
+# Opportunities
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+def chartmogul_list_opportunities(
+    customer_uuid: str | None = None,
+    owner: str | None = None,
+    pipeline: str | None = None,
+    pipeline_stage: str | None = None,
+    estimated_close_date_on_or_after: str | None = None,
+    estimated_close_date_on_or_before: str | None = None,
+    cursor: str | None = None,
+    per_page: int = DEFAULT_PER_PAGE,
+) -> str:
+    """
+    List sales opportunities (GET /opportunities). Returns a page of
+    entries plus a ``cursor``/``has_more`` pair -- pass the returned
+    ``cursor`` back in to fetch the next page.
+
+    customer_uuid: optional, restrict to one customer's opportunities.
+    owner: optional, filter by the owner's email address.
+    pipeline: optional, filter by pipeline name.
+    pipeline_stage: optional, filter by pipeline stage name.
+    estimated_close_date_on_or_after: optional, ISO 8601 date, only
+    opportunities closing on or after this date.
+    estimated_close_date_on_or_before: optional, ISO 8601 date, only
+    opportunities closing on or before this date.
+    cursor: optional, from a previous call's response, to fetch the next
+    page.
+    per_page: page size, 1-200 (ChartMogul's own server-side cap).
+    """
+    try:
+        result = _request(
+            "GET",
+            "/opportunities",
+            params={
+                "customer_uuid": customer_uuid,
+                "owner": owner,
+                "pipeline": pipeline,
+                "pipeline_stage": pipeline_stage,
+                "estimated_close_date_on_or_after": estimated_close_date_on_or_after,
+                "estimated_close_date_on_or_before": estimated_close_date_on_or_before,
+                "cursor": cursor,
+                "per_page": _clamp_per_page(per_page),
+            },
+        )
+        if not isinstance(result, dict) or not isinstance(result.get("entries"), list):
+            return _error(
+                "ChartMogul returned an unexpected response for /opportunities"
+            )
+        return _success_with_capped_list("entries", result)
+    except Exception as e:
+        logger.error(f"Error listing ChartMogul opportunities: {e}", exc_info=True)
+        return _error(str(e))
+
+
+@mcp.tool()
+def chartmogul_create_opportunity(data: dict[str, Any]) -> str:
+    """
+    Create a sales opportunity (POST /opportunities).
+
+    data: a ChartMogul opportunity object. Must include "customer_uuid",
+    "owner", "pipeline", "pipeline_stage", "estimated_close_date",
+    "currency", and "amount_in_cents"; optionally "type",
+    "forecast_category", "win_likelihood".
+    """
+    try:
+        result = _request("POST", "/opportunities", json_data=data)
+        if not isinstance(result, dict):
+            return _error(
+                "ChartMogul returned an unexpected response for /opportunities"
+            )
+        return success_with_capped_dict("opportunity", result)
+    except Exception as e:
+        logger.error(f"Error creating ChartMogul opportunity: {e}", exc_info=True)
+        return _error(str(e))
+
+
+@mcp.tool()
+def chartmogul_get_opportunity(uuid: str) -> str:
+    """
+    Get one sales opportunity by uuid (GET /opportunities/{uuid}).
+
+    uuid: the opportunity's ChartMogul uuid.
+    """
+    try:
+        safe_uuid = url_path_id(uuid, "uuid")
+        result = _request("GET", f"/opportunities/{safe_uuid}")
+        if not isinstance(result, dict):
+            return _error(
+                "ChartMogul returned an unexpected response for /opportunities"
+            )
+        return success_with_capped_dict("opportunity", result)
+    except Exception as e:
+        logger.error(
+            f"Error fetching ChartMogul opportunity {uuid}: {e}", exc_info=True
+        )
+        return _error(str(e))
+
+
+@mcp.tool()
+def chartmogul_update_opportunity(uuid: str, data: dict[str, Any]) -> str:
+    """
+    Update a sales opportunity (PATCH /opportunities/{uuid}).
+
+    uuid: the opportunity's ChartMogul uuid.
+    data: fields to change, e.g. {"pipeline_stage": "Won", "win_likelihood": 100}.
+    """
+    try:
+        safe_uuid = url_path_id(uuid, "uuid")
+        result = _request("PATCH", f"/opportunities/{safe_uuid}", json_data=data)
+        if not isinstance(result, dict):
+            return _error(
+                "ChartMogul returned an unexpected response for /opportunities"
+            )
+        return success_with_capped_dict("opportunity", result)
+    except Exception as e:
+        logger.error(
+            f"Error updating ChartMogul opportunity {uuid}: {e}", exc_info=True
+        )
+        return _error(str(e))
+
+
+@mcp.tool()
+def chartmogul_delete_opportunity(uuid: str) -> str:
+    """
+    Permanently delete a sales opportunity (DELETE /opportunities/{uuid}).
+    This cannot be undone -- confirm with the user before calling this.
+
+    uuid: the opportunity's ChartMogul uuid.
+    """
+    try:
+        safe_uuid = url_path_id(uuid, "uuid")
+        _request("DELETE", f"/opportunities/{safe_uuid}")
+        return _success(uuid=uuid)
+    except Exception as e:
+        logger.error(
+            f"Error deleting ChartMogul opportunity {uuid}: {e}", exc_info=True
+        )
+        return _error(str(e))
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tests/alembic/test_20260901_seed_chartmogul_mcp_app.py
+++ b/tests/alembic/test_20260901_seed_chartmogul_mcp_app.py
@@ -1,0 +1,177 @@
+"""Tests for the ChartMogul MCP connector seed migration."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260901_seed_chartmogul_mcp_app.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "seed_chartmogul_migration", migration_file
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_table(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                name VARCHAR(200) NOT NULL,
+                description TEXT,
+                icon VARCHAR(1000),
+                transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                provider_name VARCHAR(50),
+                category VARCHAR(100),
+                oauth_scopes JSON,
+                is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                launch_config JSON
+            )
+            """
+        )
+    )
+
+
+def _app_ids(connection):
+    return set(connection.execute(text("SELECT app_id FROM public_mcp_apps")).scalars())
+
+
+def test_upgrade_inserts_chartmogul(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        assert "chartmogul" in _app_ids(connection)
+        row = connection.execute(
+            text(
+                "SELECT transport, provider_name, is_visible_in_connector, "
+                "launch_config FROM public_mcp_apps WHERE app_id='chartmogul'"
+            )
+        ).first()
+        assert row[0] == "stdio"
+        assert row[1] is None
+        assert row[2] == 1
+        assert "xagent.web.tools.mcp.chartmogul" in str(row[3])
+        assert "CHARTMOGUL_API_KEY" in str(row[3])
+
+
+def test_upgrade_warns_and_still_inserts_when_column_missing(tmp_path, caplog):
+    """If a table predates one of ROW's keys (shouldn't happen here, but the
+    column-filter exists defensively), the row must still be inserted, and
+    the drop must be logged rather than silent -- app_id then already
+    exists, so a later run can never self-heal the missing column."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE public_mcp_apps (
+                    id INTEGER PRIMARY KEY,
+                    app_id VARCHAR(100) NOT NULL UNIQUE,
+                    name VARCHAR(200) NOT NULL,
+                    icon VARCHAR(1000),
+                    transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                    provider_name VARCHAR(50),
+                    category VARCHAR(100),
+                    oauth_scopes JSON,
+                    is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                    launch_config JSON
+                )
+                """
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            with caplog.at_level("WARNING"):
+                migration.upgrade()
+        assert "chartmogul" in _app_ids(connection)
+
+    messages = [record.getMessage() for record in caplog.records]
+    assert any(
+        "description" in message and "missing columns" in message
+        for message in messages
+    )
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()  # second run must not raise or duplicate
+        rows = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='chartmogul'")
+        ).scalar()
+        assert rows == 1
+
+
+def test_seed_row_matches_registry():
+    """The migration snapshot and the runtime registry must define the same
+    chartmogul row (the migration is a frozen copy; this catches drift)."""
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    migration = _load_migration_module()
+    registry_row = next(
+        r for r in get_builtin_public_mcp_app_rows() if r["app_id"] == "chartmogul"
+    )
+    assert migration.ROW == registry_row
+
+
+def test_seed_row_classifies_api_key():
+    """The ChartMogul entry must classify as "api_key" -- an
+    "unconnectable" classification would make the catalog entry dead on
+    arrival in the connector UI."""
+    from xagent.web.mcp_apps import classify_app_auth
+
+    migration = _load_migration_module()
+    assert (
+        classify_app_auth(migration.ROW["transport"], migration.ROW["launch_config"])
+        == "api_key"
+    )
+
+
+def test_downgrade_removes_chartmogul(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "chartmogul" not in _app_ids(connection)
+
+
+def test_upgrade_and_downgrade_no_op_without_table(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        table_names = set(
+            connection.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table'")
+            ).scalars()
+        )
+        assert "public_mcp_apps" not in table_names

--- a/tests/core/model/test_security.py
+++ b/tests/core/model/test_security.py
@@ -282,6 +282,13 @@ def test_redact_sensitive_text_masks_bearer_and_header_keys() -> None:
     assert "my_api_key" not in redacted
 
 
+def test_redact_sensitive_text_masks_basic_auth_credential() -> None:
+    text = "Authorization: Basic dXNlcjpzdXBlci1zZWNyZXQtdG9rZW4="
+    redacted = redact_sensitive_text(text)
+
+    assert "dXNlcjpzdXBlci1zZWNyZXQtdG9rZW4=" not in redacted
+
+
 def test_redact_sensitive_text_masks_assignment_style_secrets() -> None:
     text = "api_key=sk-super-secret timeout=30"
     redacted = redact_sensitive_text(text)

--- a/tests/core/model/test_security.py
+++ b/tests/core/model/test_security.py
@@ -287,6 +287,9 @@ def test_redact_sensitive_text_masks_basic_auth_credential() -> None:
     redacted = redact_sensitive_text(text)
 
     assert "dXNlcjpzdXBlci1zZWNyZXQtdG9rZW4=" not in redacted
+    # Not just "the secret is gone" -- confirm it was actually masked in
+    # place rather than the whole header being silently dropped.
+    assert "Authorization: Basic ***" in redacted
 
 
 def test_redact_sensitive_text_masks_assignment_style_secrets() -> None:

--- a/tests/web/tools/test_chartmogul_mcp.py
+++ b/tests/web/tools/test_chartmogul_mcp.py
@@ -72,6 +72,15 @@ def test_extract_error_detail_prefers_message_key():
     assert chartmogul._extract_error_detail(response) == "Invalid API key"
 
 
+def test_extract_error_detail_handles_a_list_of_field_errors():
+    response = MockResponse(json_data={"errors": ["external_id can't be blank"]})
+
+    detail = chartmogul._extract_error_detail(response)
+
+    assert detail is not None
+    assert "external_id can't be blank" in detail
+
+
 def test_extract_error_detail_returns_none_for_non_json():
     response = MockResponse(text="<html>gateway error</html>")
 

--- a/tests/web/tools/test_chartmogul_mcp.py
+++ b/tests/web/tools/test_chartmogul_mcp.py
@@ -113,6 +113,15 @@ def test_request_drops_none_valued_params(monkeypatch):
     assert mock_request.call_args.kwargs["params"] == {"cursor": "abc"}
 
 
+def test_request_drops_empty_string_valued_params(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"ok": True}))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    chartmogul._request("GET", "/customers", params={"email": "", "cursor": "abc"})
+
+    assert mock_request.call_args.kwargs["params"] == {"cursor": "abc"}
+
+
 def test_request_raises_with_error_detail_on_failure(monkeypatch):
     monkeypatch.setattr(
         chartmogul.requests,
@@ -176,6 +185,23 @@ def test_list_customers_rejects_unexpected_shape(monkeypatch):
     result = json.loads(chartmogul.chartmogul_list_customers())
 
     assert result["status"] == "error"
+
+
+def test_list_customers_treats_null_entries_as_empty_page(monkeypatch):
+    monkeypatch.setattr(
+        chartmogul.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={"entries": None, "has_more": False, "cursor": None}
+            )
+        ),
+    )
+
+    result = json.loads(chartmogul.chartmogul_list_customers())
+
+    assert result["status"] == "success"
+    assert result["entries"] == []
 
 
 def test_list_customers_clamps_per_page(monkeypatch):
@@ -516,3 +542,25 @@ def test_success_with_capped_list_message_warns_data_is_not_recoverable(monkeypa
     # cursor/has_more still describe the original fetched page, unchanged
     assert result["cursor"] == "abc"
     assert result["has_more"] is True
+
+
+def test_success_with_capped_list_drops_message_as_last_resort(monkeypatch):
+    # Small enough that even an empty item list plus the added "message"
+    # text doesn't fit -- forces the post-loop fallback that drops the
+    # message itself rather than returning an over-limit response.
+    monkeypatch.setattr(chartmogul, "get_tool_max_output_length", lambda: 40)
+
+    result = json.loads(
+        chartmogul._success_with_capped_list(
+            "entries",
+            {
+                "entries": [{"uuid": "cus_1"}, {"uuid": "cus_2"}],
+                "has_more": True,
+                "cursor": "abc",
+            },
+        )
+    )
+
+    assert result["entries"] == []
+    assert result["truncated"] is True
+    assert "message" not in result

--- a/tests/web/tools/test_chartmogul_mcp.py
+++ b/tests/web/tools/test_chartmogul_mcp.py
@@ -308,13 +308,17 @@ def test_create_contact_sends_post(monkeypatch):
     monkeypatch.setattr(chartmogul.requests, "request", mock_request)
 
     chartmogul.chartmogul_create_contact(
-        {"customer_uuid": "cus_1", "email": "a@example.com"}
+        "cus_1", {"data_source_uuid": "ds_1", "email": "a@example.com"}
     )
 
     assert mock_request.call_args.kwargs["method"] == "POST"
     assert mock_request.call_args.kwargs["url"] == (
-        "https://api.chartmogul.com/v1/contacts"
+        "https://api.chartmogul.com/v1/customers/cus_1/contacts"
     )
+    assert mock_request.call_args.kwargs["json"] == {
+        "data_source_uuid": "ds_1",
+        "email": "a@example.com",
+    }
 
 
 def test_get_contact_returns_record(monkeypatch):
@@ -564,3 +568,30 @@ def test_success_with_capped_list_drops_message_as_last_resort(monkeypatch):
     assert result["entries"] == []
     assert result["truncated"] is True
     assert "message" not in result
+
+
+async def test_mcp_registers_all_fifteen_tools():
+    """Direct-call unit tests above exercise each tool's Python body, but
+    none of them go through FastMCP's own registration/schema layer -- a
+    tool whose @mcp.tool() decorator was dropped, or whose name was
+    typo'd, would still pass every test above while being unreachable to
+    an agent."""
+    tools = await chartmogul.mcp.list_tools()
+
+    assert {tool.name for tool in tools} == {
+        "chartmogul_list_customers",
+        "chartmogul_create_customer",
+        "chartmogul_get_customer",
+        "chartmogul_update_customer",
+        "chartmogul_delete_customer",
+        "chartmogul_list_contacts",
+        "chartmogul_create_contact",
+        "chartmogul_get_contact",
+        "chartmogul_update_contact",
+        "chartmogul_delete_contact",
+        "chartmogul_list_opportunities",
+        "chartmogul_create_opportunity",
+        "chartmogul_get_opportunity",
+        "chartmogul_update_opportunity",
+        "chartmogul_delete_opportunity",
+    }

--- a/tests/web/tools/test_chartmogul_mcp.py
+++ b/tests/web/tools/test_chartmogul_mcp.py
@@ -1,0 +1,502 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from xagent.web.tools.mcp import chartmogul
+
+
+class MockResponse:
+    def __init__(self, json_data=None, status_code: int = 200, text: str = ""):
+        self._json_data = json_data if json_data is not None else {}
+        self.status_code = status_code
+        # `json_data is not None`, not truthiness: an explicit `{}` must
+        # still serialize to the text "{}" rather than falling through to
+        # the empty-string default, or a test constructing MockResponse({})
+        # to check error-detail-extraction-on-empty-body would silently
+        # exercise the wrong code path.
+        self.text = text or (
+            json.dumps(self._json_data) if json_data is not None else ""
+        )
+        self.content = self.text.encode()
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("CHARTMOGUL_API_KEY", "test-api-key")
+
+
+# ---------------------------------------------------------------------------
+# _api_key
+# ---------------------------------------------------------------------------
+
+
+def test_api_key_requires_env_var(monkeypatch):
+    monkeypatch.delenv("CHARTMOGUL_API_KEY")
+
+    with pytest.raises(ValueError, match="CHARTMOGUL_API_KEY"):
+        chartmogul._api_key()
+
+
+def test_api_key_rejects_whitespace_only(monkeypatch):
+    monkeypatch.setenv("CHARTMOGUL_API_KEY", "   ")
+
+    with pytest.raises(ValueError, match="CHARTMOGUL_API_KEY"):
+        chartmogul._api_key()
+
+
+def test_api_key_strips_surrounding_whitespace(monkeypatch):
+    monkeypatch.setenv("CHARTMOGUL_API_KEY", "  test-api-key\n")
+
+    assert chartmogul._api_key() == "test-api-key"
+
+
+# ---------------------------------------------------------------------------
+# _extract_error_detail
+# ---------------------------------------------------------------------------
+
+
+def test_extract_error_detail_prefers_message_key():
+    response = MockResponse(json_data={"message": "Invalid API key", "error": "auth"})
+
+    assert chartmogul._extract_error_detail(response) == "Invalid API key"
+
+
+def test_extract_error_detail_returns_none_for_non_json():
+    response = MockResponse(text="<html>gateway error</html>")
+
+    assert chartmogul._extract_error_detail(response) is None
+
+
+# ---------------------------------------------------------------------------
+# _request
+# ---------------------------------------------------------------------------
+
+
+def test_request_uses_basic_auth_with_empty_password(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"ok": True}))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    chartmogul._request("GET", "/customers")
+
+    assert mock_request.call_args.kwargs["auth"] == ("test-api-key", "")
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://api.chartmogul.com/v1/customers"
+    )
+
+
+def test_request_drops_none_valued_params(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"ok": True}))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    chartmogul._request("GET", "/customers", params={"status": None, "cursor": "abc"})
+
+    assert mock_request.call_args.kwargs["params"] == {"cursor": "abc"}
+
+
+def test_request_raises_with_error_detail_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        chartmogul.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=401, json_data={"message": "Invalid API key"}
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Invalid API key"):
+        chartmogul._request("GET", "/customers")
+
+
+def test_request_returns_empty_dict_on_204(monkeypatch):
+    monkeypatch.setattr(
+        chartmogul.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=204, text="")),
+    )
+
+    assert chartmogul._request("PATCH", "/customers/uuid-1") == {}
+
+
+# ---------------------------------------------------------------------------
+# chartmogul_list_customers
+# ---------------------------------------------------------------------------
+
+
+def test_list_customers_returns_entries(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "entries": [{"uuid": "cus_1", "name": "Acme"}],
+                "has_more": False,
+                "cursor": None,
+            }
+        )
+    )
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    result = json.loads(chartmogul.chartmogul_list_customers())
+
+    assert result["status"] == "success"
+    assert result["entries"][0]["name"] == "Acme"
+    assert result["has_more"] is False
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://api.chartmogul.com/v1/customers"
+    )
+    assert mock_request.call_args.kwargs["method"] == "GET"
+
+
+def test_list_customers_rejects_unexpected_shape(monkeypatch):
+    monkeypatch.setattr(
+        chartmogul.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data={"unexpected": True})),
+    )
+
+    result = json.loads(chartmogul.chartmogul_list_customers())
+
+    assert result["status"] == "error"
+
+
+def test_list_customers_clamps_per_page(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"entries": [], "has_more": False})
+    )
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    chartmogul.chartmogul_list_customers(per_page=10000)
+
+    assert (
+        mock_request.call_args.kwargs["params"]["per_page"] == chartmogul.MAX_PER_PAGE
+    )
+
+
+# ---------------------------------------------------------------------------
+# chartmogul_create_customer / chartmogul_get_customer / chartmogul_update_customer
+# ---------------------------------------------------------------------------
+
+
+def test_create_customer_returns_created_record(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"uuid": "cus_1", "name": "Acme"})
+    )
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    result = json.loads(
+        chartmogul.chartmogul_create_customer(
+            {"data_source_uuid": "ds_1", "external_id": "acme-1", "name": "Acme"}
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["customer"]["uuid"] == "cus_1"
+    assert mock_request.call_args.kwargs["method"] == "POST"
+    assert mock_request.call_args.kwargs["json"]["name"] == "Acme"
+
+
+def test_get_customer_percent_encodes_uuid(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"uuid": "cus_1"}))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    chartmogul.chartmogul_get_customer("cus/1")
+
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://api.chartmogul.com/v1/customers/cus%2F1"
+    )
+
+
+def test_update_customer_sends_patch(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"uuid": "cus_1"}))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    chartmogul.chartmogul_update_customer("cus_1", {"company": "Acme Inc."})
+
+    assert mock_request.call_args.kwargs["method"] == "PATCH"
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://api.chartmogul.com/v1/customers/cus_1"
+    )
+
+
+def test_get_customer_returns_error_payload_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        chartmogul.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=404, json_data={"message": "Customer not found"}
+            )
+        ),
+    )
+
+    result = json.loads(chartmogul.chartmogul_get_customer("cus_missing"))
+
+    assert result["status"] == "error"
+    assert "Customer not found" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# chartmogul_list_contacts / chartmogul_create_contact / chartmogul_get_contact /
+# chartmogul_update_contact
+# ---------------------------------------------------------------------------
+
+
+def test_list_contacts_returns_entries(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"entries": [{"uuid": "con_1", "email": "a@example.com"}]}
+        )
+    )
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    result = json.loads(chartmogul.chartmogul_list_contacts(email="a@example.com"))
+
+    assert result["status"] == "success"
+    assert result["entries"][0]["email"] == "a@example.com"
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://api.chartmogul.com/v1/contacts"
+    )
+
+
+def test_create_contact_sends_post(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"uuid": "con_1"}))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    chartmogul.chartmogul_create_contact(
+        {"customer_uuid": "cus_1", "email": "a@example.com"}
+    )
+
+    assert mock_request.call_args.kwargs["method"] == "POST"
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://api.chartmogul.com/v1/contacts"
+    )
+
+
+def test_get_contact_returns_record(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"uuid": "con_1"}))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    result = json.loads(chartmogul.chartmogul_get_contact("con_1"))
+
+    assert result["status"] == "success"
+    assert result["contact"]["uuid"] == "con_1"
+
+
+def test_update_contact_sends_patch(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"uuid": "con_1"}))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    chartmogul.chartmogul_update_contact("con_1", {"title": "VP"})
+
+    assert mock_request.call_args.kwargs["method"] == "PATCH"
+    assert mock_request.call_args.kwargs["json"] == {"title": "VP"}
+
+
+# ---------------------------------------------------------------------------
+# chartmogul_list_opportunities / chartmogul_create_opportunity /
+# chartmogul_get_opportunity / chartmogul_update_opportunity
+# ---------------------------------------------------------------------------
+
+
+def test_list_opportunities_returns_entries(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"entries": [{"uuid": "opp_1"}]})
+    )
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    result = json.loads(chartmogul.chartmogul_list_opportunities(customer_uuid="cus_1"))
+
+    assert result["status"] == "success"
+    assert result["entries"][0]["uuid"] == "opp_1"
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://api.chartmogul.com/v1/opportunities"
+    )
+
+
+def test_create_opportunity_sends_post(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"uuid": "opp_1"}))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    chartmogul.chartmogul_create_opportunity(
+        {
+            "customer_uuid": "cus_1",
+            "owner": "sales@example.com",
+            "pipeline": "Default",
+            "pipeline_stage": "Discovery",
+            "estimated_close_date": "2026-12-31",
+            "currency": "USD",
+            "amount_in_cents": 100000,
+        }
+    )
+
+    assert mock_request.call_args.kwargs["method"] == "POST"
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://api.chartmogul.com/v1/opportunities"
+    )
+
+
+def test_get_opportunity_returns_record(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"uuid": "opp_1"}))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    result = json.loads(chartmogul.chartmogul_get_opportunity("opp_1"))
+
+    assert result["status"] == "success"
+    assert result["opportunity"]["uuid"] == "opp_1"
+
+
+def test_update_opportunity_sends_patch(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"uuid": "opp_1"}))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    chartmogul.chartmogul_update_opportunity("opp_1", {"pipeline_stage": "Won"})
+
+    assert mock_request.call_args.kwargs["method"] == "PATCH"
+    assert mock_request.call_args.kwargs["json"] == {"pipeline_stage": "Won"}
+
+
+def test_list_opportunities_rejects_unexpected_shape(monkeypatch):
+    monkeypatch.setattr(
+        chartmogul.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data={"unexpected": True})),
+    )
+
+    result = json.loads(chartmogul.chartmogul_list_opportunities())
+
+    assert result["status"] == "error"
+
+
+def test_list_opportunities_passes_estimated_close_date_filters(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"entries": []}))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    chartmogul.chartmogul_list_opportunities(
+        estimated_close_date_on_or_after="2026-01-01",
+        estimated_close_date_on_or_before="2026-12-31",
+    )
+
+    params = mock_request.call_args.kwargs["params"]
+    assert params["estimated_close_date_on_or_after"] == "2026-01-01"
+    assert params["estimated_close_date_on_or_before"] == "2026-12-31"
+
+
+def test_list_customers_passes_email_and_system_filters(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"entries": []}))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    chartmogul.chartmogul_list_customers(email="a@example.com", system="Stripe")
+
+    params = mock_request.call_args.kwargs["params"]
+    assert params["email"] == "a@example.com"
+    assert params["system"] == "Stripe"
+
+
+def test_list_contacts_passes_data_source_uuid_filter(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"entries": []}))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    chartmogul.chartmogul_list_contacts(data_source_uuid="ds_1")
+
+    assert mock_request.call_args.kwargs["params"]["data_source_uuid"] == "ds_1"
+
+
+# ---------------------------------------------------------------------------
+# Delete tools
+# ---------------------------------------------------------------------------
+
+
+def test_delete_customer_sends_delete(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(status_code=204, text=""))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    result = json.loads(chartmogul.chartmogul_delete_customer("cus_1"))
+
+    assert result["status"] == "success"
+    assert mock_request.call_args.kwargs["method"] == "DELETE"
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://api.chartmogul.com/v1/customers/cus_1"
+    )
+
+
+def test_delete_contact_sends_delete(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(status_code=204, text=""))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    result = json.loads(chartmogul.chartmogul_delete_contact("con_1"))
+
+    assert result["status"] == "success"
+    assert mock_request.call_args.kwargs["method"] == "DELETE"
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://api.chartmogul.com/v1/contacts/con_1"
+    )
+
+
+def test_delete_opportunity_sends_delete(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(status_code=204, text=""))
+    monkeypatch.setattr(chartmogul.requests, "request", mock_request)
+
+    result = json.loads(chartmogul.chartmogul_delete_opportunity("opp_1"))
+
+    assert result["status"] == "success"
+    assert mock_request.call_args.kwargs["method"] == "DELETE"
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://api.chartmogul.com/v1/opportunities/opp_1"
+    )
+
+
+def test_delete_customer_returns_error_payload_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        chartmogul.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=404, json_data={"message": "Customer not found"}
+            )
+        ),
+    )
+
+    result = json.loads(chartmogul.chartmogul_delete_customer("cus_missing"))
+
+    assert result["status"] == "error"
+    assert "Customer not found" in result["message"]
+
+
+# ---------------------------------------------------------------------------
+# Proxy/connection failure redaction and truncated-list messaging
+# ---------------------------------------------------------------------------
+
+
+def test_request_redacts_credentials_from_connection_failure(monkeypatch):
+    def _raise(*args, **kwargs):
+        raise chartmogul.requests.exceptions.ProxyError(
+            "Unable to connect to proxy: https://user:sup3rsecret@proxy.example.com"
+        )
+
+    monkeypatch.setattr(chartmogul.requests, "request", _raise)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        chartmogul._request("GET", "/customers")
+
+    assert "sup3rsecret" not in str(exc_info.value)
+
+
+def test_success_with_capped_list_message_warns_data_is_not_recoverable(monkeypatch):
+    big_item = {"uuid": "cus_1", "blob": "x" * 100000}
+    monkeypatch.setattr(chartmogul, "get_tool_max_output_length", lambda: 5000)
+
+    result = json.loads(
+        chartmogul._success_with_capped_list(
+            "entries",
+            {"entries": [big_item, big_item], "has_more": True, "cursor": "abc"},
+        )
+    )
+
+    assert result["truncated"] is True
+    assert "cannot be recovered" in result["message"]
+    # cursor/has_more still describe the original fetched page, unchanged
+    assert result["cursor"] == "abc"
+    assert result["has_more"] is True

--- a/tests/web/tools/test_chartmogul_mcp.py
+++ b/tests/web/tools/test_chartmogul_mcp.py
@@ -8,20 +8,27 @@ from xagent.web.tools.mcp import chartmogul
 
 class MockResponse:
     def __init__(self, json_data=None, status_code: int = 200, text: str = ""):
-        self._json_data = json_data if json_data is not None else {}
         self.status_code = status_code
         # `json_data is not None`, not truthiness: an explicit `{}` must
         # still serialize to the text "{}" rather than falling through to
         # the empty-string default, or a test constructing MockResponse({})
         # to check error-detail-extraction-on-empty-body would silently
         # exercise the wrong code path.
-        self.text = text or (
-            json.dumps(self._json_data) if json_data is not None else ""
-        )
+        self.text = text or (json.dumps(json_data) if json_data is not None else "")
         self.content = self.text.encode()
 
     def json(self):
-        return self._json_data
+        # Parses ``self.text`` for real, rather than returning a
+        # precomputed dict unconditionally -- otherwise a test constructing
+        # MockResponse(text="<html>...</html>") to exercise
+        # _extract_error_detail's `except ValueError` branch would pass
+        # without ever actually reaching it, since .json() would never
+        # raise. Matches real requests.Response.json()'s contract: invalid
+        # JSON raises, it doesn't silently return something else.
+        try:
+            return json.loads(self.text)
+        except json.JSONDecodeError as e:
+            raise ValueError("No JSON object could be decoded") from e
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary

Adds a built-in, key-based ChartMogul MCP connector, implemented as a first-party Python wrapper module (`src/xagent/web/tools/mcp/chartmogul.py`) that calls ChartMogul's REST API directly with `requests`, following the same pattern as the existing `deputy.py`/`stripe.py`/`posthog.py` connectors.

This replaces the design explored in #1804, which vendored the third-party `chartmogul-mcp-server` repo into the Docker image. That approach accumulated several downstream problems during review (the vendored server's own error handling swallows API failures into silent empty results; its `uv`-based launch bypasses MCP sandbox routing; a configurable vendor path could desync from what's actually persisted for already-connected users) that are all structural to vendoring untrusted third-party code, not fixable with a small patch. A first-party wrapper avoids all of them by construction -- it's ordinary in-repo Python calling a REST API, like every other key-based connector already does.

## What's covered

12 read/write tools + 3 delete tools, covering full CRUD for the three entities requested:
- **Customers**: list, create, get, update, delete
- **Contacts**: list, create, get, update, delete
- **Opportunities**: list, create, get, update, delete

Endpoints, parameters, and the HTTP Basic Auth mechanism (API key as username, empty password) were verified against ChartMogul's official REST API docs (dev.chartmogul.com) and the official `chartmogul-python` SDK source, not guessed.

Ships `is_visible_in_connector: True` (unlike the vendored version, there's no Docker-image coupling or untrusted upstream code to gate behind a hidden flag).

## Test plan

- [x] `pytest tests/alembic/test_20260901_seed_chartmogul_mcp_app.py tests/web/tools/test_chartmogul_mcp.py` -- 41 passed
- [x] `alembic heads` -- single head
- [x] `ruff check` / `ruff format --check` / `mypy` -- clean
- [x] Two rounds of self-review (5 independent angles: correctness, cross-file consistency, precedent/regression comparison against `deputy.py`/`stripe.py`, and a fact-check of every documented API param/field against ChartMogul's official docs and SDK)