### PR TITLE
fix(frontend): tolerate transient poll failures while waiting on a background job

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,7 @@
     "test:kb-components": "vitest run --config vitest.config.ts src/components/kb",
     "test:ci-manifest": "vitest run --config vitest.config.ts src/ci/frontend-test-manifest.test.ts",
     "test:app-pages": "vitest run --config vitest.config.ts src/app",
-    "test:home-build-contracts": "vitest run --config vitest.config.ts src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts src/lib/team-sharing-sanitizers.test.ts",
+    "test:home-build-contracts": "vitest run --config vitest.config.ts src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts src/lib/background-jobs.test.ts src/lib/team-sharing-sanitizers.test.ts",
     "test:widget": "vitest run --config vitest.widget.config.ts",
     "test:widget:coverage": "vitest run --config vitest.widget.config.ts --coverage"
   },

--- a/frontend/src/ci/frontend-test-manifest.test.ts
+++ b/frontend/src/ci/frontend-test-manifest.test.ts
@@ -23,7 +23,7 @@ const pagesCommand =
 const kbComponentsCommand = "vitest run --config vitest.config.ts src/components/kb"
 const appPagesCommand = "vitest run --config vitest.config.ts src/app"
 const homeBuildContractsCommand =
-  "vitest run --config vitest.config.ts src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts src/lib/team-sharing-sanitizers.test.ts"
+  "vitest run --config vitest.config.ts src/lib/models.test.ts src/lib/task-create.test.ts src/i18n/translations.test.ts src/lib/utils.test.ts src/lib/time-utils.test.ts src/lib/background-jobs.test.ts src/lib/team-sharing-sanitizers.test.ts"
 const ciSummaryCondition =
   "always() && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)"
 const frontendSummaryCheckCommand =

--- a/frontend/src/lib/background-jobs.test.ts
+++ b/frontend/src/lib/background-jobs.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
 
@@ -40,6 +40,10 @@ beforeEach(() => {
   const realSetTimeout = window.setTimeout
   vi.spyOn(window, "setTimeout").mockImplementation(((fn: () => void) =>
     realSetTimeout(fn, 0)) as unknown as typeof window.setTimeout)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 describe("waitForBackgroundJob", () => {

--- a/frontend/src/lib/background-jobs.test.ts
+++ b/frontend/src/lib/background-jobs.test.ts
@@ -1,0 +1,88 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+
+const apiRequestMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@/lib/api-wrapper", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api-wrapper")>(
+    "@/lib/api-wrapper",
+  )
+  return { ...actual, apiRequest: apiRequestMock }
+})
+
+import {
+  waitForBackgroundJob,
+  type BackgroundJobResponse,
+} from "@/lib/background-jobs"
+
+function job(status: string): BackgroundJobResponse {
+  return {
+    id: "job-1",
+    user_id: 1,
+    job_type: "kb_ingest_web",
+    queue: "default",
+    status,
+    attempts: 1,
+    max_attempts: 3,
+  }
+}
+
+function ok(status: string) {
+  return { ok: true, json: async () => job(status) } as unknown as Response
+}
+
+const badGateway = { ok: false, status: 502, json: async () => ({}) } as unknown as Response
+
+beforeEach(() => {
+  apiRequestMock.mockReset()
+  // Every poll sleeps 1s; collapse it to a macrotask so the loop advances without
+  // wall time while still yielding, or a non-terminating regression hangs the worker
+  // instead of failing the test.
+  const realSetTimeout = window.setTimeout
+  vi.spyOn(window, "setTimeout").mockImplementation(((fn: () => void) =>
+    realSetTimeout(fn, 0)) as unknown as typeof window.setTimeout)
+})
+
+describe("waitForBackgroundJob", () => {
+  it("survives transient poll failures and returns the terminal job", async () => {
+    apiRequestMock
+      .mockResolvedValueOnce(badGateway)
+      .mockRejectedValueOnce(new Error("network down"))
+      .mockResolvedValueOnce(ok("running"))
+      .mockResolvedValueOnce(badGateway)
+      .mockResolvedValueOnce(ok("succeeded"))
+
+    await expect(waitForBackgroundJob("http://api.local", job("running"))).resolves.toMatchObject({
+      status: "succeeded",
+    })
+  })
+
+  it("gives up once failures are consecutive enough to be real", async () => {
+    apiRequestMock.mockResolvedValue(badGateway)
+
+    await expect(waitForBackgroundJob("http://api.local", job("running"))).rejects.toThrow(
+      "Failed to fetch background job job-1",
+    )
+    expect(apiRequestMock).toHaveBeenCalledTimes(10)
+  })
+
+  it("counts failures consecutively, not cumulatively", async () => {
+    for (let i = 0; i < 9; i++) apiRequestMock.mockResolvedValueOnce(badGateway)
+    apiRequestMock.mockResolvedValueOnce(ok("running"))
+    for (let i = 0; i < 9; i++) apiRequestMock.mockResolvedValueOnce(badGateway)
+    apiRequestMock.mockResolvedValueOnce(ok("succeeded"))
+
+    await expect(waitForBackgroundJob("http://api.local", job("running"))).resolves.toMatchObject({
+      status: "succeeded",
+    })
+    expect(apiRequestMock).toHaveBeenCalledTimes(20)
+  })
+
+  it("keeps rejecting a malformed payload immediately", async () => {
+    apiRequestMock.mockResolvedValue({ ok: true, json: async () => ({ nope: true }) })
+
+    await expect(waitForBackgroundJob("http://api.local", job("running"))).rejects.toThrow(
+      "Invalid background job response",
+    )
+    expect(apiRequestMock).toHaveBeenCalledTimes(1)
+  })
+})

--- a/frontend/src/lib/background-jobs.test.ts
+++ b/frontend/src/lib/background-jobs.test.ts
@@ -9,10 +9,7 @@ vi.mock("@/lib/api-wrapper", async () => {
   return { ...actual, apiRequest: apiRequestMock }
 })
 
-import {
-  waitForBackgroundJob,
-  type BackgroundJobResponse,
-} from "@/lib/background-jobs"
+import { waitForBackgroundJob, type BackgroundJobResponse } from "@/lib/background-jobs"
 
 function job(status: string): BackgroundJobResponse {
   return {
@@ -32,14 +29,22 @@ function ok(status: string) {
 
 const badGateway = { ok: false, status: 502, json: async () => ({}) } as unknown as Response
 
+// The loop's own pacing and a poll's duration both spend the same budget, so the clock
+// only advances where the code under test would really wait.
+let clock = 0
+function elapsedSeconds() {
+  return clock / 1000
+}
+
 beforeEach(() => {
   apiRequestMock.mockReset()
-  // Every poll sleeps 1s; collapse it to a macrotask so the loop advances without
-  // wall time while still yielding, or a non-terminating regression hangs the worker
-  // instead of failing the test.
+  clock = 0
+  vi.spyOn(Date, "now").mockImplementation(() => clock)
   const realSetTimeout = window.setTimeout
-  vi.spyOn(window, "setTimeout").mockImplementation(((fn: () => void) =>
-    realSetTimeout(fn, 0)) as unknown as typeof window.setTimeout)
+  vi.spyOn(window, "setTimeout").mockImplementation(((fn: () => void, ms?: number) => {
+    clock += ms ?? 0
+    return realSetTimeout(fn, 0)
+  }) as unknown as typeof window.setTimeout)
 })
 
 afterEach(() => {
@@ -47,29 +52,40 @@ afterEach(() => {
 })
 
 describe("waitForBackgroundJob", () => {
-  it("survives transient poll failures and returns the terminal job", async () => {
-    apiRequestMock
-      .mockResolvedValueOnce(badGateway)
-      .mockRejectedValueOnce(new Error("network down"))
-      .mockResolvedValueOnce(ok("running"))
-      .mockResolvedValueOnce(badGateway)
-      .mockResolvedValueOnce(ok("succeeded"))
+  it("rides out a burst of instant failures and returns the terminal job", async () => {
+    for (let i = 0; i < 9; i++) apiRequestMock.mockResolvedValueOnce(badGateway)
+    apiRequestMock.mockResolvedValueOnce(ok("succeeded"))
 
     await expect(waitForBackgroundJob("http://api.local", job("running"))).resolves.toMatchObject({
       status: "succeeded",
     })
   })
 
-  it("gives up once failures are consecutive enough to be real", async () => {
+  it("rejects once instant failures outlast the window, not before", async () => {
     apiRequestMock.mockResolvedValue(badGateway)
 
     await expect(waitForBackgroundJob("http://api.local", job("running"))).rejects.toThrow(
       "Failed to fetch background job job-1",
     )
-    expect(apiRequestMock).toHaveBeenCalledTimes(10)
+    // First failure at 1s opens a window closing at 11s; nothing may reject earlier.
+    expect(elapsedSeconds()).toBeGreaterThanOrEqual(11)
   })
 
-  it("counts failures consecutively, not cumulatively", async () => {
+  it("rejects a slow auth-refresh failure without waiting for ten of them", async () => {
+    // A 401 whose refresh times out burns AUTH_REFRESH_TIMEOUT_MS before returning.
+    apiRequestMock.mockImplementation(async () => {
+      clock += 15_000
+      return { ok: false, status: 401, json: async () => ({}) } as unknown as Response
+    })
+
+    await expect(waitForBackgroundJob("http://api.local", job("running"))).rejects.toThrow(
+      "Failed to fetch background job job-1",
+    )
+    expect(apiRequestMock).toHaveBeenCalledTimes(2)
+    expect(elapsedSeconds()).toBeLessThan(60)
+  })
+
+  it("reopens the full window after any successful poll", async () => {
     for (let i = 0; i < 9; i++) apiRequestMock.mockResolvedValueOnce(badGateway)
     apiRequestMock.mockResolvedValueOnce(ok("running"))
     for (let i = 0; i < 9; i++) apiRequestMock.mockResolvedValueOnce(badGateway)

--- a/frontend/src/lib/background-jobs.test.ts
+++ b/frontend/src/lib/background-jobs.test.ts
@@ -67,8 +67,9 @@ describe("waitForBackgroundJob", () => {
     await expect(waitForBackgroundJob("http://api.local", job("running"))).rejects.toThrow(
       "Failed to fetch background job job-1",
     )
-    // First failure at 1s opens a window closing at 11s; nothing may reject earlier.
-    expect(elapsedSeconds()).toBeGreaterThanOrEqual(11)
+    // First failure at 1s opens a window closing at 11s: the rejection lands on that
+    // boundary exactly, so pin it from both sides.
+    expect(elapsedSeconds()).toBe(11)
   })
 
   it("rejects a slow auth-refresh failure without waiting for ten of them", async () => {

--- a/frontend/src/lib/background-jobs.ts
+++ b/frontend/src/lib/background-jobs.ts
@@ -79,11 +79,13 @@ export function getBackgroundJobFailureMessage(
   return job.error_message || fallbackMessage
 }
 
-// An ingest polls for minutes while the worker runs independently of this loop,
-// so a gap the proxy can close on its own must not fail the job. At one poll per
-// second this covers the proxy's 10s DNS re-resolve window; a backend that stays
-// down longer than that is a real failure and still surfaces as one.
-const MAX_CONSECUTIVE_POLL_FAILURES = 10
+// An ingest polls for minutes while the worker runs independently of this loop, so a
+// gap the proxy can close on its own must not fail the job. The budget is wall-clock
+// rather than a poll count because a failing poll takes anywhere from no time at all
+// to the api-wrapper's 15s auth-refresh timeout. It bounds when the streak may end,
+// not when the rejection lands: a single failure that outlasts the window is only
+// seen once it returns.
+const TRANSIENT_POLL_FAILURE_WINDOW_MS = 10_000
 
 export async function waitForBackgroundJob(
   apiUrl: string,
@@ -91,7 +93,7 @@ export async function waitForBackgroundJob(
   onUpdate?: (job: BackgroundJobResponse) => void
 ): Promise<BackgroundJobResponse> {
   let job = initialJob
-  let consecutiveFailures = 0
+  let failureWindowExpiresAt: number | null = null
   onUpdate?.(job)
 
   while (!isBackgroundJobTerminal(job)) {
@@ -104,14 +106,18 @@ export async function waitForBackgroundJob(
       }
       data = await response.json()
     } catch (error) {
-      consecutiveFailures += 1
-      if (consecutiveFailures >= MAX_CONSECUTIVE_POLL_FAILURES) throw error
+      const now = Date.now()
+      if (failureWindowExpiresAt === null) {
+        failureWindowExpiresAt = now + TRANSIENT_POLL_FAILURE_WINDOW_MS
+      } else if (now >= failureWindowExpiresAt) {
+        throw error
+      }
       continue
     }
     if (!isBackgroundJobResponse(data)) {
       throw new Error(`Invalid background job response for ${job.id}`)
     }
-    consecutiveFailures = 0
+    failureWindowExpiresAt = null
     job = data
     onUpdate?.(job)
   }

--- a/frontend/src/lib/background-jobs.ts
+++ b/frontend/src/lib/background-jobs.ts
@@ -79,24 +79,39 @@ export function getBackgroundJobFailureMessage(
   return job.error_message || fallbackMessage
 }
 
+// An ingest polls for minutes while the worker runs independently of this loop,
+// so a gap the proxy can close on its own must not fail the job. At one poll per
+// second this covers the proxy's 10s DNS re-resolve window; a backend that stays
+// down longer than that is a real failure and still surfaces as one.
+const MAX_CONSECUTIVE_POLL_FAILURES = 10
+
 export async function waitForBackgroundJob(
   apiUrl: string,
   initialJob: BackgroundJobResponse,
   onUpdate?: (job: BackgroundJobResponse) => void
 ): Promise<BackgroundJobResponse> {
   let job = initialJob
+  let consecutiveFailures = 0
   onUpdate?.(job)
 
   while (!isBackgroundJobTerminal(job)) {
     await new Promise(resolve => window.setTimeout(resolve, 1000))
-    const response = await apiRequest(`${apiUrl}/api/jobs/${job.id}`)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch background job ${job.id}`)
+    let data: unknown
+    try {
+      const response = await apiRequest(`${apiUrl}/api/jobs/${job.id}`)
+      if (!response.ok) {
+        throw new Error(`Failed to fetch background job ${job.id}`)
+      }
+      data = await response.json()
+    } catch (error) {
+      consecutiveFailures += 1
+      if (consecutiveFailures >= MAX_CONSECUTIVE_POLL_FAILURES) throw error
+      continue
     }
-    const data = await response.json()
     if (!isBackgroundJobResponse(data)) {
       throw new Error(`Invalid background job response for ${job.id}`)
     }
+    consecutiveFailures = 0
     job = data
     onUpdate?.(job)
   }


### PR DESCRIPTION
## Invariant

A background job that is still running on the worker must not be reported to the user as failed because one status poll did not come back.

## The bug

`waitForBackgroundJob` polls `GET /api/jobs/{id}` once a second until the job reaches a terminal state. A web ingest runs for minutes, so this is hundreds of polls, and **any single non-2xx response** aborted the whole wait:

```ts
const response = await apiRequest(`${apiUrl}/api/jobs/${job.id}`)
if (!response.ok) {
  throw new Error(`Failed to fetch background job ${job.id}`)
}
```

The user gets `Website import failed: Failed to fetch background job <id>` while the Celery worker keeps crawling and the knowledge base is created normally. Nothing on the failure path cancels the job — `GET /api/jobs/{id}` is a pure read and there is no cancel route at all.

Network-level errors were already retried three times inside `fetchWithRetry`, so the gap was specifically an HTTP response the proxy or backend returned: a 502 while the backend address is being re-resolved, or a 401 whose refresh attempt hit the same window.

## The fix

Give a failure streak a 10-second wall-clock budget instead of aborting on the first failure. Any successful poll clears the streak, so intermittent gaps spread across a long ingest never accumulate into a spurious failure. A backend that is genuinely down past the window still surfaces as an error, with the same message and error object as before.

The budget is elapsed time rather than an attempt count because a failing poll's duration is not bounded: an instant 502 and a 401 that burns the api-wrapper's 15s `AUTH_REFRESH_TIMEOUT_MS` are both single failures. A count of ten would mean nine seconds of tolerance in the first case and roughly 150 in the second. The window bounds when the streak may end, not when the rejection lands — a single failure that outlasts the window is only observed once it returns.

## Entry points

`waitForBackgroundJob` is shared by all six callers, so one change covers all of them:

- `knowledge-base-creation-dialog.tsx:594,752` — file upload and web import during KB creation
- `knowledge-base-detail.tsx:470,662` — the same two flows on an existing KB
- `knowledge-base.tsx:205` and `agent-builder.tsx:1411` — KB ownership transfer, where the wait is an ordering barrier before the agent is promoted; a single 502 there reported a failure for a transfer that had actually succeeded

None of the callers depend on fail-fast semantics; each one only feeds the result to a progress bar or an error toast.

## Tests

New `background-jobs.test.ts`, 5 cases under a controlled clock. Roughly 80% of the diff is test code.

`Date.now` is stubbed and advanced by the loop's own pacing and by each poll's simulated duration, so the tests assert elapsed time rather than attempt counts. Two of them are timing-specific: instant 502s must not reject before the window closes, and a 401 that burns the 15s refresh timeout must reject after two attempts rather than ten.

Verified by mutation — each mutation below fails the suite, and the unmutated suite passes:

| Mutation | Result |
|---|---|
| drop the streak reset (per-streak becomes cumulative) | 1 failed |
| window 10s → 3s | 3 failed |
| never give up (remove the `throw`) | 4 failed |
| open the window at `now` (collapse it to zero) | 3 failed |
| window → effectively unbounded (degenerates to a count) | 2 failed |

The 1s sleep is collapsed to a macrotask rather than run synchronously, so a non-terminating regression fails on the test timeout instead of hanging the worker.

## Non-goals

Deliberately not in this PR:

- **No job history UI.** `GET /api/jobs` exists on the backend but no frontend code calls it. Once a poll loop ends — or the user reloads the page — the job id is gone and there is no way back to it. That is the reason a user cannot tell whether an import succeeded, and retrying polls does not address it.
- **No status on the KB card.** The `Active` badge is a hardcoded string unrelated to ingest or index state, so a knowledge base with zero documents looks identical to a healthy one.
- **No overall deadline for the wait.** A job stuck in `running` forever loops forever — true both before and after this change.
- **No special handling for 4xx.** A 401 whose refresh already redirected to login, or a 404, is now delayed by up to the window instead of being immediate. Distinguishing those would mean carving out 429, which is exactly the retryable case.
