### PR TITLE
feat(mcp): add actor-scoped OAuth grants

### DIFF
--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -1862,9 +1862,14 @@ def _actor_oauth_cookie_name(nonce: str) -> str:
 
 
 def is_actor_oauth_cookie_header(value: str) -> bool:
-    """Accept only a Set-Cookie header for an actor OAuth flow."""
-    name, separator, _rest = value.partition("=")
-    return separator == "=" and name.strip().startswith(_ACTOR_OAUTH_COOKIE_PREFIX)
+    """Accept only a non-empty Set-Cookie header for an actor OAuth flow."""
+    name, separator, rest = value.partition("=")
+    cookie_value = rest.partition(";")[0].strip()
+    return (
+        separator == "="
+        and name.strip().startswith(_ACTOR_OAUTH_COOKIE_PREFIX)
+        and bool(cookie_value)
+    )
 
 
 def _actor_oauth_cookie_scope(provider: str, db_provider: Any) -> tuple[bool, str]:

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -3258,6 +3258,8 @@ async def connect_mcp_oauth_app(
         app_id=app_id,
         user_id=user_id,
     )
+    # Release catalog and association writes before OAuth network I/O.
+    db.commit()
     logger.info(
         "User %s starting OAuth connect for MCP app %r",
         user_id,

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -566,6 +566,7 @@ def _has_actor_owned_mcp_oauth_state(
             MCPOAuthGrant.mcp_server_id == server_id,
             MCPOAuthGrant.user_id == user_id,
             MCPOAuthGrant.resource_owner_key != default_owner,
+            MCPOAuthGrant.status == "active",
         )
         .first()
     )
@@ -578,6 +579,7 @@ def _has_actor_owned_mcp_oauth_state(
             MCPOAuthFlowState.mcp_server_id == server_id,
             MCPOAuthFlowState.user_id == user_id,
             MCPOAuthFlowState.resource_owner_key != default_owner,
+            MCPOAuthFlowState.expires_at > _utc_now(),
         )
         .first()
         is not None
@@ -3645,11 +3647,12 @@ async def delete_mcp_server(
         manager = DatabaseMCPServerManager(db)
         user_id = current_user.id
 
-        # Check user has access to this server
+        # Serialize deletion against OAuth flow creation for this association.
         result = (
             db.query(UserMCPServer, MCPServer)
             .join(MCPServer, UserMCPServer.mcpserver_id == MCPServer.id)
             .filter(UserMCPServer.user_id == user_id, MCPServer.id == server_id)
+            .with_for_update()
             .first()
         )
 
@@ -4501,6 +4504,22 @@ async def _connect_mcp_oauth_for_owner(
         str(discovery.resource), field_name="resource"
     )
 
+    association = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user_id,
+            UserMCPServer.mcpserver_id == server_id,
+            UserMCPServer.is_active,
+        )
+        .with_for_update()
+        .first()
+    )
+    if association is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="MCP server not found",
+        )
+
     oauth_client = _upsert_mcp_oauth_client(
         db,
         server_id=server_id,
@@ -4605,6 +4624,7 @@ async def get_mcp_oauth_status(
         server_id=server_id,
         user_id=user_id,
         auth_config=auth_config if isinstance(auth_config, dict) else {},
+        resource_owner_key=_default_resource_owner_key(user_id),
     )
     return MCPOAuthStatusResponse(
         server_id=server_id,
@@ -4686,6 +4706,7 @@ async def delete_mcp_oauth_grant(
             MCPOAuthGrant.id == grant_id,
             MCPOAuthGrant.mcp_server_id == server_id,
             MCPOAuthGrant.user_id == user_id,
+            MCPOAuthGrant.resource_owner_key == _default_resource_owner_key(user_id),
         )
         .first()
     )

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -483,15 +483,12 @@ def _redirect_after_with_params(
     return urlunsplit((parts.scheme, parts.netloc, parts.path, urlencode(query), ""))
 
 
-def _mcp_oauth_callback_error_redirect(
-    flow_state: MCPOAuthFlowState,
+def _mcp_oauth_callback_error_redirect_after(
+    raw_redirect_after: str | None,
     *,
     error_code: str,
     message: str,
 ) -> RedirectResponse:
-    raw_redirect_after = (
-        str(flow_state.redirect_after) if flow_state.redirect_after else None
-    )
     redirect_path = _redirect_after_with_params(
         raw_redirect_after,
         (
@@ -505,6 +502,19 @@ def _mcp_oauth_callback_error_redirect(
     response = RedirectResponse(_mcp_oauth_redirect_after_url(redirect_path))
     _clear_mcp_oauth_state_cookie(response)
     return response
+
+
+def _mcp_oauth_callback_error_redirect(
+    flow_state: MCPOAuthFlowState,
+    *,
+    error_code: str,
+    message: str,
+) -> RedirectResponse:
+    return _mcp_oauth_callback_error_redirect_after(
+        str(flow_state.redirect_after) if flow_state.redirect_after else None,
+        error_code=error_code,
+        message=message,
+    )
 
 
 def _validate_mcp_oauth_state_cookie(request: Request, state_value: str) -> None:
@@ -3013,6 +3023,8 @@ def _ensure_catalog_mcp_oauth_server(
                     status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                     detail=f"Failed to create catalog server: {str(exc)}",
                 ) from exc
+            # Apply the same catalog and ownership checks to the concurrent winner.
+            return _ensure_catalog_mcp_oauth_server(db, app_id)
     return server, app_info
 
 
@@ -4248,30 +4260,51 @@ async def mcp_oauth_callback(
             error_code="invalid_state",
             message="Missing authorization code",
         )
+    flow_id = int(flow_state.id)
+    code_verifier = decrypt_value(str(flow_state.code_verifier))
+    resource = str(flow_state.resource)
+    redirect_after = (
+        str(flow_state.redirect_after) if flow_state.redirect_after else None
+    )
     try:
         token_data = await _exchange_mcp_oauth_code(
             client=client,
             code=code,
-            code_verifier=decrypt_value(str(flow_state.code_verifier)),
-            resource=str(flow_state.resource),
+            code_verifier=code_verifier,
+            resource=resource,
         )
-        _upsert_mcp_oauth_grant(db, flow_state=flow_state, token_data=token_data)
+        locked_flow = (
+            db.query(MCPOAuthFlowState)
+            .filter(MCPOAuthFlowState.id == flow_id)
+            .with_for_update()
+            .populate_existing()
+            .one_or_none()
+        )
+        if locked_flow is None:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail={
+                    "code": "invalid_state",
+                    "message": "OAuth flow was revoked before completion",
+                },
+            )
+        _upsert_mcp_oauth_grant(db, flow_state=locked_flow, token_data=token_data)
         db.commit()
     except HTTPException as exc:
         db.rollback()
         detail: dict[str, Any] = exc.detail if isinstance(exc.detail, dict) else {}
         error_code = str(detail.get("code") or "token_exchange_failed")
         message = str(detail.get("message") or "MCP OAuth authorization failed")
-        return _mcp_oauth_callback_error_redirect(
-            flow_state,
+        return _mcp_oauth_callback_error_redirect_after(
+            redirect_after,
             error_code=error_code,
             message=message,
         )
     except Exception:
         db.rollback()
         logger.exception("MCP OAuth callback failed after state claim")
-        return _mcp_oauth_callback_error_redirect(
-            flow_state,
+        return _mcp_oauth_callback_error_redirect_after(
+            redirect_after,
             error_code="token_exchange_failed",
             message="MCP OAuth authorization failed",
         )
@@ -4283,7 +4316,7 @@ async def mcp_oauth_callback(
     response = RedirectResponse(
         _mcp_oauth_redirect_after_url(
             _redirect_after_with_params(
-                str(flow_state.redirect_after) if flow_state.redirect_after else None,
+                redirect_after,
                 (("mcp_oauth_success", "1"),),
             )
         )
@@ -4555,7 +4588,7 @@ async def revoke_mcp_oauth_grants_for_owner(
         db,
         user_id=user_id,
         server_id=server_id,
-        require_active=True,
+        require_active=False,
     )
     owner_key = _bounded_mcp_oauth_value(
         resource_owner_key,
@@ -4566,7 +4599,6 @@ async def revoke_mcp_oauth_grants_for_owner(
         MCPOAuthFlowState.mcp_server_id == server_id,
         MCPOAuthFlowState.user_id == user_id,
         MCPOAuthFlowState.resource_owner_key == owner_key,
-        MCPOAuthFlowState.consumed_at.is_(None),
     ).delete(synchronize_session=False)
     grants = (
         db.query(MCPOAuthGrant)

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -4587,7 +4587,7 @@ async def revoke_mcp_oauth_grants_for_owner(
             )
         setattr(grant, "status", "revoked")
         setattr(grant, "revoked_at", now)
-    db.commit()
+    db.flush()
     return len(grants)
 
 

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -552,6 +552,38 @@ def _default_resource_owner_key(user_id: int) -> str:
     return f"xagent:user:{user_id}"
 
 
+def _has_actor_owned_mcp_oauth_state(
+    db: Session,
+    *,
+    server_id: int,
+    user_id: int,
+) -> bool:
+    """Whether generic deletion would cross an actor ownership boundary."""
+    default_owner = _default_resource_owner_key(user_id)
+    actor_grant = (
+        db.query(MCPOAuthGrant.id)
+        .filter(
+            MCPOAuthGrant.mcp_server_id == server_id,
+            MCPOAuthGrant.user_id == user_id,
+            MCPOAuthGrant.resource_owner_key != default_owner,
+        )
+        .first()
+    )
+    if actor_grant is not None:
+        return True
+
+    return (
+        db.query(MCPOAuthFlowState.id)
+        .filter(
+            MCPOAuthFlowState.mcp_server_id == server_id,
+            MCPOAuthFlowState.user_id == user_id,
+            MCPOAuthFlowState.resource_owner_key != default_owner,
+        )
+        .first()
+        is not None
+    )
+
+
 def _oauth_authorization_url(endpoint: str, params: dict[str, str]) -> str:
     parts = urlsplit(endpoint)
     query = dict(parse_qsl(parts.query, keep_blank_values=True))
@@ -3634,6 +3666,16 @@ async def delete_mcp_server(
             raise HTTPException(
                 status_code=status.HTTP_403_FORBIDDEN,
                 detail="You do not have permission to delete this MCP server",
+            )
+
+        if _has_actor_owned_mcp_oauth_state(
+            db,
+            server_id=server_id,
+            user_id=int(user_id),
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="MCP server has actor-owned OAuth connections",
             )
 
         server_name = server.name

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -882,7 +882,6 @@ def _claim_mcp_oauth_flow_state(
         db.rollback()
         return "state_already_consumed", "OAuth state consumed"
     db.commit()
-    db.refresh(flow_state)
     return None
 
 
@@ -3724,6 +3723,14 @@ async def delete_mcp_server(
                             providers=[provider],
                         )
 
+        # Invalidate flows before scanning grants. A callback that already
+        # locked its flow must commit first; this scan then sees and removes
+        # the grant it created.
+        db.query(MCPOAuthFlowState).filter(
+            MCPOAuthFlowState.mcp_server_id == server_id,
+            MCPOAuthFlowState.user_id == user_id,
+        ).delete(synchronize_session=False)
+
         # Revoke and purge this user's MCP OAuth grants for the server. On a
         # shared (multi-user) row the server outlives this disconnect, so
         # without this the grant's refresh token would stay usable — and its
@@ -3747,15 +3754,6 @@ async def delete_mcp_server(
                     client=grant.oauth_client, grant=grant
                 )
             db.delete(grant)
-
-        # This user's own flow-state rows (code_verifier etc.) are per-user,
-        # unlike MCPOAuthClient which a shared server's other users may still
-        # reference — safe to purge outright rather than only on server
-        # deletion's cascade.
-        db.query(MCPOAuthFlowState).filter(
-            MCPOAuthFlowState.mcp_server_id == server_id,
-            MCPOAuthFlowState.user_id == user_id,
-        ).delete(synchronize_session=False)
 
         # Remove user-server association
         db.delete(user_mcp)
@@ -4238,39 +4236,39 @@ async def mcp_oauth_callback(
                 or "Authorization response issuer did not match flow state"
             ),
         )
+    flow_id = int(flow_state.id)
+    encrypted_code_verifier = str(flow_state.code_verifier)
+    resource = str(flow_state.resource)
+    redirect_after = (
+        str(flow_state.redirect_after) if flow_state.redirect_after else None
+    )
     claim_error = _claim_mcp_oauth_flow_state(db, flow_state)
     if claim_error is not None:
         error_code, message = claim_error
-        return _mcp_oauth_callback_error_redirect(
-            flow_state,
+        return _mcp_oauth_callback_error_redirect_after(
+            redirect_after,
             error_code=error_code,
             message=message,
         )
     if error:
-        return _mcp_oauth_callback_error_redirect(
-            flow_state,
+        return _mcp_oauth_callback_error_redirect_after(
+            redirect_after,
             error_code="token_exchange_failed",
             message=oauth_error_message(
                 {"error": error}, "MCP OAuth authorization failed"
             ),
         )
     if not code:
-        return _mcp_oauth_callback_error_redirect(
-            flow_state,
+        return _mcp_oauth_callback_error_redirect_after(
+            redirect_after,
             error_code="invalid_state",
             message="Missing authorization code",
         )
-    flow_id = int(flow_state.id)
-    code_verifier = decrypt_value(str(flow_state.code_verifier))
-    resource = str(flow_state.resource)
-    redirect_after = (
-        str(flow_state.redirect_after) if flow_state.redirect_after else None
-    )
     try:
         token_data = await _exchange_mcp_oauth_code(
             client=client,
             code=code,
-            code_verifier=code_verifier,
+            code_verifier=decrypt_value(encrypted_code_verifier),
             resource=resource,
         )
         locked_flow = (

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -2983,7 +2983,7 @@ def _ensure_catalog_mcp_oauth_server(
                 if value and isinstance(value, str):
                     encrypted_auth[key] = encrypt_value(value)
             cast(Any, server).auth = encrypted_auth
-            db.commit()
+            db.flush()
     if not server:
         try:
             config = _build_server_config(
@@ -2999,7 +2999,20 @@ def _ensure_catalog_mcp_oauth_server(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Invalid app configuration: {str(e)}",
             )
-        server = _add_catalog_server_with_race_recovery(db, config, server_name)
+
+        candidate = MCPServer.from_config(config.model_dump())
+        try:
+            with db.begin_nested():
+                db.add(candidate)
+                db.flush()
+            server = candidate
+        except IntegrityError as exc:
+            server = db.query(MCPServer).filter(MCPServer.name == server_name).first()
+            if server is None:
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail=f"Failed to create catalog server: {str(exc)}",
+                ) from exc
     return server, app_info
 
 
@@ -3156,7 +3169,7 @@ def _ensure_mcp_oauth_app_user(
         .first()
     )
     if assoc is None:
-        assoc = UserMCPServer(
+        candidate = UserMCPServer(
             user_id=user_id,
             mcpserver_id=server.id,
             is_active=True,
@@ -3164,11 +3177,12 @@ def _ensure_mcp_oauth_app_user(
             can_edit=False,
             can_delete=True,
         )
-        db.add(assoc)
         try:
-            db.commit()
+            with db.begin_nested():
+                db.add(candidate)
+                db.flush()
+            assoc = candidate
         except IntegrityError:
-            db.rollback()
             assoc = (
                 db.query(UserMCPServer)
                 .filter(
@@ -3181,7 +3195,7 @@ def _ensure_mcp_oauth_app_user(
                 raise
     elif not assoc.is_active:
         assoc.is_active = True
-        db.commit()
+        db.flush()
     return server, app_info
 
 
@@ -3220,8 +3234,14 @@ async def connect_mcp_oauth_app_for_owner(
     resource_owner_key: str,
     accept: str | None = None,
 ) -> RedirectResponse | JSONResponse:
-    """Start catalog MCP OAuth for a trusted server-owned resource owner."""
+    """Start catalog MCP OAuth for a trusted server-owned resource owner.
 
+    The caller commits or rolls back the returned flow and catalog visibility.
+    """
+
+    # Keep nested race-recovery savepoints inside one caller-owned transaction,
+    # including on SQLite where releasing a top-level savepoint commits it.
+    db.begin_nested()
     user_id = cast(int, current_user.id)
     server, app_info = _ensure_mcp_oauth_app_user(
         db,
@@ -4301,7 +4321,7 @@ async def connect_mcp_oauth(
 ) -> RedirectResponse | JSONResponse:
     """Start MCP OAuth Authorization Code + PKCE for the current user."""
 
-    return await _connect_mcp_oauth_for_owner(
+    response = await _connect_mcp_oauth_for_owner(
         server_id,
         request_data,
         current_user,
@@ -4309,6 +4329,8 @@ async def connect_mcp_oauth(
         resource_owner_key=_default_resource_owner_key(cast(int, current_user.id)),
         accept=accept,
     )
+    db.commit()
+    return response
 
 
 async def _connect_mcp_oauth_for_owner(
@@ -4463,7 +4485,7 @@ async def _connect_mcp_oauth_for_owner(
         expires_at=_utc_now() + MCP_OAUTH_STATE_TTL,
     )
     db.add(flow_state)
-    db.commit()
+    db.flush()
 
     params = {
         "response_type": "code",

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -3138,35 +3138,26 @@ def connect_mcp_app(
     )
 
 
-@mcp_router.post("/apps/{app_id}/oauth/connect", response_model=None)
-async def connect_mcp_oauth_app(
+def _ensure_mcp_oauth_app_user(
+    db: Session,
+    *,
     app_id: str,
-    request_data: MCPOAuthConnectRequest,
-    current_user: User = Depends(get_current_user),
-    db: Session = Depends(get_db),
-    accept: Annotated[str | None, Header()] = None,
-) -> RedirectResponse | JSONResponse:
-    """Connect a remote-MCP OAuth (DCR-capable) catalog app for the current user.
+    user_id: int,
+) -> tuple[MCPServer, dict]:
+    """Ensure one catalog server and active non-owning user link."""
 
-    Ensures the shared server row and this user's association exist, then
-    delegates to connect_mcp_oauth's Authorization Code + PKCE flow — the
-    per-user DCR/token machinery is identical to a self-added custom MCP
-    server; only the server row's origin (catalog vs. a user-typed URL)
-    differs.
-    """
     server, app_info = _ensure_catalog_mcp_oauth_server(db, app_id)
-
     assoc: Any = (
         db.query(UserMCPServer)
         .filter(
-            UserMCPServer.user_id == current_user.id,
+            UserMCPServer.user_id == user_id,
             UserMCPServer.mcpserver_id == server.id,
         )
         .first()
     )
     if assoc is None:
         assoc = UserMCPServer(
-            user_id=current_user.id,
+            user_id=user_id,
             mcpserver_id=server.id,
             is_active=True,
             is_owner=False,
@@ -3177,13 +3168,11 @@ async def connect_mcp_oauth_app(
         try:
             db.commit()
         except IntegrityError:
-            # Concurrent same-user connect (double-click/client retry): another
-            # request already inserted the (user_id, mcpserver_id) association.
             db.rollback()
             assoc = (
                 db.query(UserMCPServer)
                 .filter(
-                    UserMCPServer.user_id == current_user.id,
+                    UserMCPServer.user_id == user_id,
                     UserMCPServer.mcpserver_id == server.id,
                 )
                 .first()
@@ -3191,16 +3180,66 @@ async def connect_mcp_oauth_app(
             if assoc is None:
                 raise
     elif not assoc.is_active:
-        # A reconnect after the user previously disconnected their own
-        # association — re-activate it rather than leaving it dormant.
         assoc.is_active = True
         db.commit()
+    return server, app_info
 
+
+@mcp_router.post("/apps/{app_id}/oauth/connect", response_model=None)
+async def connect_mcp_oauth_app(
+    app_id: str,
+    request_data: MCPOAuthConnectRequest,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db),
+    accept: Annotated[str | None, Header()] = None,
+) -> RedirectResponse | JSONResponse:
+    """Connect a remote-MCP OAuth catalog app for the current user."""
+
+    user_id = cast(int, current_user.id)
+    server, app_info = _ensure_mcp_oauth_app_user(
+        db,
+        app_id=app_id,
+        user_id=user_id,
+    )
     logger.info(
-        f"User {current_user.id} starting OAuth connect for MCP app '{app_info['id']}'"
+        "User %s starting OAuth connect for MCP app %r",
+        user_id,
+        app_info["id"],
     )
     return await connect_mcp_oauth(
         cast(int, server.id), request_data, current_user, db, accept
+    )
+
+
+async def connect_mcp_oauth_app_for_owner(
+    app_id: str,
+    request_data: MCPOAuthConnectRequest,
+    current_user: User,
+    db: Session,
+    *,
+    resource_owner_key: str,
+    accept: str | None = None,
+) -> RedirectResponse | JSONResponse:
+    """Start catalog MCP OAuth for a trusted server-owned resource owner."""
+
+    user_id = cast(int, current_user.id)
+    server, app_info = _ensure_mcp_oauth_app_user(
+        db,
+        app_id=app_id,
+        user_id=user_id,
+    )
+    logger.info(
+        "User %s starting trusted OAuth connect for MCP app %r",
+        user_id,
+        app_info["id"],
+    )
+    return await _connect_mcp_oauth_for_owner(
+        cast(int, server.id),
+        request_data,
+        current_user,
+        db,
+        resource_owner_key=resource_owner_key,
+        accept=accept,
     )
 
 
@@ -4261,6 +4300,28 @@ async def connect_mcp_oauth(
     accept: Annotated[str | None, Header()] = None,
 ) -> RedirectResponse | JSONResponse:
     """Start MCP OAuth Authorization Code + PKCE for the current user."""
+
+    return await _connect_mcp_oauth_for_owner(
+        server_id,
+        request_data,
+        current_user,
+        db,
+        resource_owner_key=_default_resource_owner_key(cast(int, current_user.id)),
+        accept=accept,
+    )
+
+
+async def _connect_mcp_oauth_for_owner(
+    server_id: int,
+    request_data: MCPOAuthConnectRequest,
+    current_user: User,
+    db: Session,
+    *,
+    resource_owner_key: str,
+    accept: str | None,
+) -> RedirectResponse | JSONResponse:
+    """Start one OAuth flow in an exact trusted resource-owner namespace."""
+
     user_id = cast(int, current_user.id)
     _, server = _get_user_mcp_server_or_404(
         db, user_id=user_id, server_id=server_id, require_active=True
@@ -4335,7 +4396,7 @@ async def connect_mcp_oauth(
             token_endpoint_auth_method = registration.token_endpoint_auth_method
     selected_scope = _scope_string(auth_config.get("scope") or discovery.scopes)
     resource_owner_key = _bounded_mcp_oauth_value(
-        _default_resource_owner_key(user_id),
+        resource_owner_key,
         field_name="resource_owner_key",
         max_length=MCP_OAUTH_RESOURCE_OWNER_KEY_MAX_LENGTH,
     )
@@ -4456,6 +4517,56 @@ async def get_mcp_oauth_status(
         scope=auth_config.get("scope") if isinstance(auth_config, dict) else None,
         grants=[_mcp_oauth_grant_response(grant) for grant in grants],
     )
+
+
+async def revoke_mcp_oauth_grants_for_owner(
+    server_id: int,
+    current_user: User,
+    db: Session,
+    *,
+    resource_owner_key: str,
+) -> int:
+    """Revoke active grants for one trusted resource-owner namespace."""
+
+    user_id = cast(int, current_user.id)
+    _get_user_mcp_server_or_404(
+        db,
+        user_id=user_id,
+        server_id=server_id,
+        require_active=True,
+    )
+    owner_key = _bounded_mcp_oauth_value(
+        resource_owner_key,
+        field_name="resource_owner_key",
+        max_length=MCP_OAUTH_RESOURCE_OWNER_KEY_MAX_LENGTH,
+    )
+    db.query(MCPOAuthFlowState).filter(
+        MCPOAuthFlowState.mcp_server_id == server_id,
+        MCPOAuthFlowState.user_id == user_id,
+        MCPOAuthFlowState.resource_owner_key == owner_key,
+        MCPOAuthFlowState.consumed_at.is_(None),
+    ).delete(synchronize_session=False)
+    grants = (
+        db.query(MCPOAuthGrant)
+        .filter(
+            MCPOAuthGrant.mcp_server_id == server_id,
+            MCPOAuthGrant.user_id == user_id,
+            MCPOAuthGrant.resource_owner_key == owner_key,
+            MCPOAuthGrant.status == "active",
+        )
+        .all()
+    )
+    now = _utc_now()
+    for grant in grants:
+        if isinstance(grant.oauth_client, MCPOAuthClient):
+            await _revoke_mcp_oauth_grant_externally(
+                client=grant.oauth_client,
+                grant=grant,
+            )
+        setattr(grant, "status", "revoked")
+        setattr(grant, "revoked_at", now)
+    db.commit()
+    return len(grants)
 
 
 @mcp_router.delete(

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -799,15 +799,10 @@ def classify_actor_remote_oauth_server(
 
     app_id = str(app_info["id"])
     app_name = str(app_info["name"])
-    candidates: list[Any] = []
-    for candidate in db.query(MCPServer).all():
-        auth: Mapping[str, Any] = (
-            candidate.auth if isinstance(candidate.auth, Mapping) else {}
-        )
-        if auth.get("app_id") == app_id or (
-            "app_id" not in auth and candidate.name in {app_id, app_name}
-        ):
-            candidates.append(candidate)
+    # Remote catalog identity is the reserved server name, not mutable auth.
+    candidates = (
+        db.query(MCPServer).filter(MCPServer.name.in_((app_id, app_name))).all()
+    )
     if len(candidates) != 1 or int(candidates[0].id) != int(server.id):
         raise RemoteOAuthServerDefinitionError(
             "remote OAuth app must have exactly one server definition"
@@ -815,7 +810,10 @@ def classify_actor_remote_oauth_server(
 
     launch = app_info.get("launch_config") or {}
     expected_auth = launch.get("auth") or {}
-    actual_auth = dict(server._decrypt_auth_config(server.auth))
+    decrypted_auth = server._decrypt_auth_config(server.auth)
+    if not isinstance(decrypted_auth, Mapping):
+        raise RemoteOAuthServerDefinitionError("remote OAuth auth is invalid")
+    actual_auth = dict(decrypted_auth)
     actual_auth.pop("app_id", None)
     failures = []
     if str(server.managed or "") != "external":

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -790,9 +790,31 @@ def classify_actor_remote_oauth_server(
     """Require one non-owned server that exactly matches remote catalog data."""
 
     from .models.mcp import MCPServer, UserMCPServer
+    from .services.mcp_runtime import HTTP_MCP_TRANSPORTS
 
+    auth = getattr(server, "auth", None)
+    is_remote_oauth = (
+        str(getattr(server, "transport", "") or "").lower() in HTTP_MCP_TRANSPORTS
+        and isinstance(auth, Mapping)
+        and auth.get("type") == "mcp_oauth"
+    )
     app_info = get_app_for_mcp_server(db, server)
     if app_info is None or app_info.get("auth_type") != "mcp_oauth":
+        if is_remote_oauth:
+            # Native OAuth servers have an owner. Catalog rows do not.
+            has_owner = (
+                db.query(UserMCPServer.id)
+                .filter(
+                    UserMCPServer.mcpserver_id == int(server.id),
+                    UserMCPServer.is_owner,
+                )
+                .first()
+                is not None
+            )
+            if not has_owner:
+                raise RemoteOAuthServerDefinitionError(
+                    "remote OAuth catalog identity is unavailable"
+                )
         return None
     if not app_info.get("is_visible_in_connector", True):
         raise RemoteOAuthServerDefinitionError("remote OAuth app is hidden")

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -226,6 +226,10 @@ class BuiltinOAuthServerDefinitionError(ValueError):
     """Raised when trusted builtin OAuth identity is absent or ambiguous."""
 
 
+class RemoteOAuthServerDefinitionError(ValueError):
+    """Raised when a remote catalog OAuth server is not canonical."""
+
+
 def _normalized_catalog_key(value: object) -> str | None:
     """Normalize only for collision detection, never for persisted identity."""
     if value is None:
@@ -778,3 +782,66 @@ def get_app_for_mcp_server(db: Session, server: Any) -> Dict[str, Any] | None:
     if len(owners) != 1:
         return None
     return _app_to_dict(candidates[0])
+
+
+def classify_actor_remote_oauth_server(
+    db: Session, server: Any
+) -> Dict[str, Any] | None:
+    """Require one non-owned server that exactly matches remote catalog data."""
+
+    from .models.mcp import MCPServer, UserMCPServer
+
+    app_info = get_app_for_mcp_server(db, server)
+    if app_info is None or app_info.get("auth_type") != "mcp_oauth":
+        return None
+    if not app_info.get("is_visible_in_connector", True):
+        raise RemoteOAuthServerDefinitionError("remote OAuth app is hidden")
+
+    app_id = str(app_info["id"])
+    app_name = str(app_info["name"])
+    candidates: list[Any] = []
+    for candidate in db.query(MCPServer).all():
+        auth: Mapping[str, Any] = (
+            candidate.auth if isinstance(candidate.auth, Mapping) else {}
+        )
+        if auth.get("app_id") == app_id or (
+            "app_id" not in auth and candidate.name in {app_id, app_name}
+        ):
+            candidates.append(candidate)
+    if len(candidates) != 1 or int(candidates[0].id) != int(server.id):
+        raise RemoteOAuthServerDefinitionError(
+            "remote OAuth app must have exactly one server definition"
+        )
+
+    launch = app_info.get("launch_config") or {}
+    expected_auth = launch.get("auth") or {}
+    actual_auth = dict(server._decrypt_auth_config(server.auth))
+    actual_auth.pop("app_id", None)
+    failures = []
+    if str(server.managed or "") != "external":
+        failures.append("managed")
+    if (
+        str(server.transport or "").lower()
+        != str(app_info.get("transport") or "").lower()
+    ):
+        failures.append("transport")
+    if server.url != launch.get("url"):
+        failures.append("url")
+    if actual_auth != expected_auth:
+        failures.append("auth")
+    if (
+        db.query(UserMCPServer.id)
+        .filter(
+            UserMCPServer.mcpserver_id == int(server.id),
+            UserMCPServer.is_owner,
+        )
+        .first()
+        is not None
+    ):
+        failures.append("ownership")
+    if failures:
+        raise RemoteOAuthServerDefinitionError(
+            f"remote OAuth app {app_id!r} has non-canonical fields: "
+            f"{', '.join(sorted(failures))}"
+        )
+    return app_info

--- a/src/xagent/web/services/mcp_oauth.py
+++ b/src/xagent/web/services/mcp_oauth.py
@@ -819,6 +819,30 @@ async def _refresh_runtime_grant_in_dedicated_session(  # noqa: PLR0913
         refresh_db.close()
 
 
+def select_mcp_oauth_owner(
+    db: Any,
+    *,
+    server_id: int,
+    user_id: int,
+    actor_owner_key: str,
+) -> str:
+    """Prefer an active exact actor grant, otherwise use the workspace owner."""
+
+    from ..models.mcp_oauth import MCPOAuthGrant
+
+    actor_grant = (
+        db.query(MCPOAuthGrant.id)
+        .filter(
+            MCPOAuthGrant.mcp_server_id == server_id,
+            MCPOAuthGrant.user_id == user_id,
+            MCPOAuthGrant.resource_owner_key == actor_owner_key,
+            MCPOAuthGrant.status == "active",
+        )
+        .first()
+    )
+    return actor_owner_key if actor_grant is not None else f"xagent:user:{user_id}"
+
+
 def select_mcp_oauth_grants(  # noqa: PLR0913
     db: Any,
     *,

--- a/src/xagent/web/services/mcp_oauth.py
+++ b/src/xagent/web/services/mcp_oauth.py
@@ -825,22 +825,22 @@ def select_mcp_oauth_owner(
     server_id: int,
     user_id: int,
     actor_owner_key: str,
+    auth_config: dict[str, Any],
 ) -> str:
-    """Prefer an active exact actor grant, otherwise use the workspace owner."""
+    """Prefer one usable exact actor grant, otherwise use the workspace owner."""
 
-    from ..models.mcp_oauth import MCPOAuthGrant
-
-    actor_grant = (
-        db.query(MCPOAuthGrant.id)
-        .filter(
-            MCPOAuthGrant.mcp_server_id == server_id,
-            MCPOAuthGrant.user_id == user_id,
-            MCPOAuthGrant.resource_owner_key == actor_owner_key,
-            MCPOAuthGrant.status == "active",
-        )
-        .first()
+    actor_grants = select_mcp_oauth_grants(
+        db,
+        server_id=server_id,
+        user_id=user_id,
+        auth_config=auth_config,
+        resource_owner_key=actor_owner_key,
     )
-    return actor_owner_key if actor_grant is not None else f"xagent:user:{user_id}"
+    try:
+        _select_runtime_grant(actor_grants, set())
+    except MCPOAuthRuntimeError:
+        return f"xagent:user:{user_id}"
+    return actor_owner_key
 
 
 def select_mcp_oauth_grants(  # noqa: PLR0913

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -26,10 +26,11 @@ class MCPBuiltinOAuthActorPolicyMismatchError(RuntimeError):
 
 @dataclass(frozen=True)
 class MCPBuiltinOAuthActorPolicy:
-    """Trusted actor owner namespace for builtin OAuth MCP execution.
+    """Trusted actor owner namespace for catalog OAuth MCP execution.
 
-    Server visibility and builtin classification remain xagent runtime
-    decisions. The caller supplies only the immutable credential owner.
+    Server visibility and catalog classification remain xagent runtime
+    decisions. The caller supplies only the immutable credential owner. The
+    owner governs both builtin-provider and remote MCP OAuth credentials.
     """
 
     resource_owner_key: str = dataclass_field(repr=False)

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3912,9 +3912,15 @@ class WebToolConfig(BaseToolConfig):
                 effective_mcp_oauth_resource,
             )
 
-            app_info = get_app_for_mcp_server(self.db, server)
+            resolver, registration_generation = _get_oauth_token_resolver_hook()
+            policy = self._mcp_runtime_authorization_policy
+            app_info = (
+                get_app_for_mcp_server(self.db, server)
+                if policy is not None or resolver is not None
+                else None
+            )
             actor_remote_oauth = bool(
-                self._mcp_runtime_authorization_policy is not None
+                policy is not None
                 and app_info is not None
                 and app_info.get("auth_type") == "mcp_oauth"
             )
@@ -3955,7 +3961,6 @@ class WebToolConfig(BaseToolConfig):
                     }
                 }
 
-            resolver, registration_generation = _get_oauth_token_resolver_hook()
             remote_providers_to_resolve: list[str] = []
             remote_configured_resource: str | None = None
             remote_hook_token: _ResolvedHookToken | None = None

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3924,6 +3924,17 @@ class WebToolConfig(BaseToolConfig):
                 and app_info is not None
                 and app_info.get("auth_type") == "mcp_oauth"
             )
+            if actor_remote_oauth:
+                runtime_bindings = None
+                allow_delegated_authorization = False
+                runtime_values = None
+                for key in (
+                    "runtime_input_schema",
+                    "runtime_bindings",
+                    "allow_delegated_authorization",
+                    "connector_runtime",
+                ):
+                    config.pop(key, None)
             if actor_remote_oauth and (self._mcp_auth_context or {}).get(
                 str(server.id)
             ):
@@ -3964,7 +3975,7 @@ class WebToolConfig(BaseToolConfig):
             remote_providers_to_resolve: list[str] = []
             remote_configured_resource: str | None = None
             remote_hook_token: _ResolvedHookToken | None = None
-            if resolver is not None:
+            if resolver is not None and not actor_remote_oauth:
                 remote_providers_to_resolve = (
                     _oauth_token_provider_candidates(app_info)
                     if app_info

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3950,6 +3950,7 @@ class WebToolConfig(BaseToolConfig):
                             server_id=int(server.id),
                             user_id=int(cast(int, self._user_id)),
                             actor_owner_key=policy.resource_owner_key,
+                            auth_config=server._decrypt_auth_config(server.auth),
                         )
                     }
                 }
@@ -4201,18 +4202,26 @@ class WebToolConfig(BaseToolConfig):
             if self._mcp_runtime_authorization_policy is not None:
                 from ...web.mcp_apps import (
                     BuiltinOAuthServerDefinitionError,
+                    RemoteOAuthServerDefinitionError,
                     classify_actor_builtin_oauth_server,
+                    classify_actor_remote_oauth_server,
                 )
 
                 for visible_server in servers:
                     try:
+                        builtin_app = classify_actor_builtin_oauth_server(
+                            self.db, visible_server
+                        )
+                        if builtin_app is None:
+                            classify_actor_remote_oauth_server(self.db, visible_server)
                         actor_classifications[int(visible_server.id)] = (
-                            classify_actor_builtin_oauth_server(
-                                self.db, visible_server
-                            ),
+                            builtin_app,
                             False,
                         )
-                    except BuiltinOAuthServerDefinitionError:
+                    except (
+                        BuiltinOAuthServerDefinitionError,
+                        RemoteOAuthServerDefinitionError,
+                    ):
                         actor_classifications[int(visible_server.id)] = (None, True)
 
             # Prefetch shared runtime state once before entering the isolated

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3905,22 +3905,60 @@ class WebToolConfig(BaseToolConfig):
 
         elif server.transport in ["sse", "websocket", "streamable_http"]:
             from ...web.mcp_apps import get_app_for_mcp_server
+            from ...web.services.mcp_oauth import select_mcp_oauth_owner
             from ...web.services.mcp_runtime import (
                 build_mcp_runtime_connection,
                 connection_to_transport_config,
                 effective_mcp_oauth_resource,
             )
 
+            app_info = get_app_for_mcp_server(self.db, server)
+            actor_remote_oauth = bool(
+                self._mcp_runtime_authorization_policy is not None
+                and app_info is not None
+                and app_info.get("auth_type") == "mcp_oauth"
+            )
+            if actor_remote_oauth and (self._mcp_auth_context or {}).get(
+                str(server.id)
+            ):
+                policy_diagnostic = {
+                    "code": "config_load_failed",
+                    "message": "Task-supplied MCP authorization is not accepted",
+                    "server_id": int(server.id),
+                    "server_name": server.name,
+                }
+                self._mcp_oauth_diagnostics.append(policy_diagnostic)
+                return self._build_unavailable_mcp_config(
+                    server=server,
+                    reason="config_load_failed",
+                    diagnostic=policy_diagnostic,
+                )
+
             auth_context = self._mcp_auth_context_for_server(
                 server_id=int(server.id),
                 runtime_values=runtime_values,
             )
+            if actor_remote_oauth:
+                policy = cast(
+                    Any,
+                    self._mcp_runtime_authorization_policy,
+                )
+                auth_context = {
+                    str(server.id): {
+                        "resource_owner_key": select_mcp_oauth_owner(
+                            self.db,
+                            server_id=int(server.id),
+                            user_id=int(cast(int, self._user_id)),
+                            actor_owner_key=policy.resource_owner_key,
+                        )
+                    }
+                }
+
             resolver, registration_generation = _get_oauth_token_resolver_hook()
             remote_providers_to_resolve: list[str] = []
             remote_configured_resource: str | None = None
             remote_hook_token: _ResolvedHookToken | None = None
             if resolver is not None:
-                app_info = get_app_for_mcp_server(self.db, server)
                 remote_providers_to_resolve = (
                     _oauth_token_provider_candidates(app_info)
                     if app_info

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -1538,6 +1538,44 @@ async def test_connect_app_creates_server_and_association_then_starts_dcr_flow(
 
 
 @pytest.mark.asyncio
+async def test_public_connect_commits_association_before_discovery(
+    db_session, monkeypatch
+):
+    db, user, _ = db_session
+    _add_remote_oauth_catalog_app(db)
+    commit_count = 0
+    real_commit = db.commit
+
+    def count_commit():
+        nonlocal commit_count
+        commit_count += 1
+        real_commit()
+
+    async def fake_discover(*args, **kwargs):
+        assert commit_count == 1
+        return _discovery()
+
+    async def register_client(*_args, **_kwargs):
+        return SimpleNamespace(
+            client_id="dynamic-client-123",
+            token_endpoint_auth_method="none",
+        )
+
+    monkeypatch.setattr(db, "commit", count_commit)
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+    monkeypatch.setattr(mcp_api, "register_mcp_oauth_public_client", register_client)
+
+    await connect_mcp_oauth_app(
+        "remote-notes",
+        MCPOAuthConnectRequest(redirect_after="/settings/mcp"),
+        user,
+        db,
+    )
+
+    assert commit_count == 2
+
+
+@pytest.mark.asyncio
 async def test_trusted_connect_app_stores_exact_resource_owner(db_session, monkeypatch):
     db, user, _ = db_session
     _add_remote_oauth_catalog_app(db)

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -3067,6 +3067,14 @@ async def test_trusted_revoke_removes_only_exact_resource_owner(db_session):
         "toby:slack:workspace:bob"
     ]
 
+    db.rollback()
+    db.expire_all()
+    assert [grant.status for grant in grants] == ["active", "active", "active"]
+    assert [row.resource_owner_key for row in db.query(MCPOAuthFlowState).all()] == [
+        "toby:slack:workspace:alice",
+        "toby:slack:workspace:bob",
+    ]
+
 
 @pytest.mark.asyncio
 async def test_delete_grant_revokes_external_tokens_when_endpoint_is_advertised(

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -1530,6 +1530,41 @@ async def test_trusted_connect_app_stores_exact_resource_owner(db_session, monke
 
 
 @pytest.mark.asyncio
+async def test_trusted_connect_app_can_roll_back_all_local_state(
+    db_session, monkeypatch
+):
+    db, user, _ = db_session
+    _add_remote_oauth_catalog_app(db)
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    async def register_client(*_args, **_kwargs):
+        return SimpleNamespace(
+            client_id="dynamic-client-123",
+            token_endpoint_auth_method="none",
+        )
+
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+    monkeypatch.setattr(mcp_api, "register_mcp_oauth_public_client", register_client)
+
+    await mcp_api.connect_mcp_oauth_app_for_owner(
+        "remote-notes",
+        MCPOAuthConnectRequest(redirect_after="/settings/mcp"),
+        user,
+        db,
+        resource_owner_key="toby:slack:workspace:alice",
+        accept="application/json",
+    )
+    db.rollback()
+
+    assert db.query(MCPServer).filter(MCPServer.name == "remote-notes").count() == 0
+    assert db.query(UserMCPServer).filter(UserMCPServer.user_id == user.id).count() == 0
+    assert db.query(MCPOAuthClient).count() == 0
+    assert db.query(MCPOAuthFlowState).count() == 0
+
+
+@pytest.mark.asyncio
 async def test_connect_app_is_idempotent_across_repeated_connects(
     db_session, monkeypatch
 ):

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -2204,6 +2204,76 @@ async def test_local_mcp_oauth_listing_omits_auth_type_when_deactivated(db_sessi
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("actor_state", ["grant", "flow"])
+async def test_delete_mcp_server_rejects_actor_owned_oauth_state(
+    db_session, actor_state
+):
+    db, user, _ = db_session
+    server = _add_mcp_oauth_server(db, user)
+    client = _add_oauth_client(db, server)
+    default_owner = mcp_api._default_resource_owner_key(user.id)
+    actor_owner = "toby:slack:workspace:alice"
+    state_rows: list[MCPOAuthGrant | MCPOAuthFlowState] = [
+        MCPOAuthGrant(
+            mcp_server_id=server.id,
+            user_id=user.id,
+            mcp_oauth_client_id=client.id,
+            resource_owner_key=default_owner,
+            issuer="https://auth.example.com",
+            resource="https://mcp.example.com/mcp",
+            scope="records.read",
+            access_token=encrypt_value("default-access-token"),
+        )
+    ]
+    if actor_state == "grant":
+        state_rows.append(
+            MCPOAuthGrant(
+                mcp_server_id=server.id,
+                user_id=user.id,
+                mcp_oauth_client_id=client.id,
+                resource_owner_key=actor_owner,
+                issuer="https://auth.example.com",
+                resource="https://mcp.example.com/mcp",
+                scope="records.read",
+                access_token=encrypt_value("actor-access-token"),
+            )
+        )
+    else:
+        state_rows.append(
+            MCPOAuthFlowState(
+                state="actor-flow",
+                mcp_server_id=server.id,
+                user_id=user.id,
+                mcp_oauth_client_id=client.id,
+                resource_owner_key=actor_owner,
+                issuer="https://auth.example.com",
+                resource="https://mcp.example.com/mcp",
+                scope="records.read",
+                code_verifier=encrypt_value("verifier"),
+                expires_at=mcp_api._utc_now() + timedelta(minutes=10),
+            )
+        )
+    db.add_all(state_rows)
+    db.commit()
+
+    with pytest.raises(HTTPException) as exc:
+        await delete_mcp_server(server.id, current_user=user, db=db)
+
+    assert exc.value.status_code == 409
+    assert db.query(MCPOAuthGrant).count() == (2 if actor_state == "grant" else 1)
+    assert db.query(MCPOAuthFlowState).count() == (1 if actor_state == "flow" else 0)
+    assert (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .one_or_none()
+        is not None
+    )
+
+
+@pytest.mark.asyncio
 async def test_delete_mcp_server_revokes_only_the_disconnecting_users_grant(
     db_session, monkeypatch
 ):
@@ -3415,10 +3485,16 @@ async def test_delete_mcp_server_invalidates_flows_before_scanning_grants(db_ses
         for index, statement in enumerate(statements)
         if statement.startswith("delete from mcp_oauth_flow_states")
     )
+    # Ownership preflight can read actor grants. Cleanup must still wait until
+    # flow invalidation before it scans active grants for revocation.
     grant_scan = next(
         index
         for index, statement in enumerate(statements)
-        if statement.startswith("select") and "from mcp_oauth_grants" in statement
+        if (
+            statement.startswith("select")
+            and "from mcp_oauth_grants" in statement
+            and "mcp_oauth_grants.status" in statement
+        )
     )
     assert flow_delete < grant_scan
 

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -1498,6 +1498,38 @@ async def test_connect_app_creates_server_and_association_then_starts_dcr_flow(
 
 
 @pytest.mark.asyncio
+async def test_trusted_connect_app_stores_exact_resource_owner(db_session, monkeypatch):
+    db, user, _ = db_session
+    _add_remote_oauth_catalog_app(db)
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+
+    async def register_client(*_args, **_kwargs):
+        return SimpleNamespace(
+            client_id="dynamic-client-123",
+            token_endpoint_auth_method="none",
+        )
+
+    monkeypatch.setattr(mcp_api, "register_mcp_oauth_public_client", register_client)
+
+    response = await mcp_api.connect_mcp_oauth_app_for_owner(
+        "remote-notes",
+        MCPOAuthConnectRequest(redirect_after="/settings/mcp"),
+        user,
+        db,
+        resource_owner_key="toby:slack:workspace:alice",
+        accept="application/json",
+    )
+
+    assert response.status_code == 200
+    flow_state = db.query(MCPOAuthFlowState).one()
+    assert flow_state.resource_owner_key == "toby:slack:workspace:alice"
+
+
+@pytest.mark.asyncio
 async def test_connect_app_is_idempotent_across_repeated_connects(
     db_session, monkeypatch
 ):
@@ -2938,6 +2970,67 @@ async def test_status_and_delete_are_scoped_to_current_user(db_session):
 
     status_response = await get_mcp_oauth_status(server.id, user, db)
     assert status_response.grants == []
+
+
+@pytest.mark.asyncio
+async def test_trusted_revoke_removes_only_exact_resource_owner(db_session):
+    db, user, _ = db_session
+    server = _add_mcp_oauth_server(db, user)
+    client = _add_oauth_client(db, server)
+    grants = [
+        MCPOAuthGrant(
+            mcp_server_id=server.id,
+            user_id=user.id,
+            mcp_oauth_client_id=client.id,
+            resource_owner_key=owner,
+            issuer="https://auth.example.com",
+            resource="https://mcp.example.com/mcp",
+            scope="records.read",
+            access_token=encrypt_value(f"{owner}-token"),
+        )
+        for owner in (
+            f"xagent:user:{user.id}",
+            "toby:slack:workspace:alice",
+            "toby:slack:workspace:bob",
+        )
+    ]
+    db.add_all(grants)
+    db.flush()
+    db.add_all(
+        [
+            MCPOAuthFlowState(
+                state=f"pending-{owner.rsplit(':', 1)[-1]}",
+                mcp_server_id=server.id,
+                user_id=user.id,
+                mcp_oauth_client_id=client.id,
+                resource_owner_key=owner,
+                issuer="https://auth.example.com",
+                resource="https://mcp.example.com/mcp",
+                scope="records.read",
+                code_verifier=encrypt_value("verifier"),
+                expires_at=mcp_api._utc_now() + timedelta(minutes=10),
+            )
+            for owner in (
+                "toby:slack:workspace:alice",
+                "toby:slack:workspace:bob",
+            )
+        ]
+    )
+    db.commit()
+
+    revoked = await mcp_api.revoke_mcp_oauth_grants_for_owner(
+        server.id,
+        user,
+        db,
+        resource_owner_key="toby:slack:workspace:alice",
+    )
+
+    assert revoked == 1
+    db.expire_all()
+    assert [grant.status for grant in grants] == ["active", "revoked", "active"]
+    assert [row.resource_owner_key for row in db.query(MCPOAuthFlowState).all()] == [
+        "toby:slack:workspace:bob"
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -8,7 +8,7 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 import pytest
 from fastapi import HTTPException
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 from starlette.requests import Request
@@ -2377,6 +2377,58 @@ async def test_callback_exchanges_code_and_stores_encrypted_grant(
 
 
 @pytest.mark.asyncio
+async def test_callback_handles_flow_deleted_after_claim_commit(
+    db_session, monkeypatch
+):
+    db, user, _ = db_session
+    _server, _client, _flow = _add_callback_client_and_state(
+        db,
+        user,
+        state="deleted-after-claim",
+        redirect_after="/mcp",
+    )
+    session_factory = sessionmaker(
+        bind=db.get_bind(), autoflush=False, autocommit=False
+    )
+    real_commit = db.commit
+    deleted = False
+
+    def commit_then_delete_flow():
+        nonlocal deleted
+        real_commit()
+        if deleted:
+            return
+        deleted = True
+        disconnect_db = session_factory()
+        try:
+            disconnect_db.query(MCPOAuthFlowState).filter(
+                MCPOAuthFlowState.state == "deleted-after-claim"
+            ).delete(synchronize_session=False)
+            disconnect_db.commit()
+        finally:
+            disconnect_db.close()
+
+    async def fake_exchange(**kwargs):
+        return {
+            "access_token": "must-not-persist",
+            "token_type": "Bearer",
+            "scope": "records.read",
+        }
+
+    monkeypatch.setattr(db, "commit", commit_then_delete_flow)
+    monkeypatch.setattr(mcp_api, "_exchange_mcp_oauth_code", fake_exchange)
+
+    response = await mcp_oauth_callback(
+        _request("/api/mcp/oauth/callback?code=auth-code&state=deleted-after-claim"),
+        db,
+    )
+
+    assert response.status_code == 307
+    assert _redirect_query(response)["mcp_oauth_error"] == ["invalid_state"]
+    assert db.query(MCPOAuthGrant).count() == 0
+
+
+@pytest.mark.asyncio
 async def test_callback_discards_token_when_disconnect_removes_claimed_flow(
     db_session, monkeypatch
 ):
@@ -3312,6 +3364,63 @@ async def test_delete_mcp_server_purges_the_users_own_flow_state_rows(db_session
         .one_or_none()
         is None
     )
+
+
+@pytest.mark.asyncio
+async def test_delete_mcp_server_invalidates_flows_before_scanning_grants(db_session):
+    db, user, _ = db_session
+    server = _add_mcp_oauth_server(db, user)
+    client = _add_oauth_client(db, server)
+    db.add_all(
+        [
+            MCPOAuthGrant(
+                mcp_server_id=server.id,
+                user_id=user.id,
+                mcp_oauth_client_id=client.id,
+                resource_owner_key=f"xagent:user:{user.id}",
+                issuer="https://auth.example.com",
+                resource="https://mcp.example.com/mcp",
+                scope="records.read",
+                access_token=encrypt_value("access-token"),
+            ),
+            MCPOAuthFlowState(
+                state="disconnect-order",
+                mcp_server_id=server.id,
+                user_id=user.id,
+                mcp_oauth_client_id=client.id,
+                resource_owner_key=f"xagent:user:{user.id}",
+                issuer="https://auth.example.com",
+                resource="https://mcp.example.com/mcp",
+                scope="records.read",
+                code_verifier=encrypt_value("verifier"),
+                expires_at=mcp_api._utc_now() + timedelta(minutes=10),
+            ),
+        ]
+    )
+    db.commit()
+    statements: list[str] = []
+
+    def record_statement(_conn, _cursor, statement, _parameters, _context, _many):
+        statements.append(statement.lower())
+
+    engine = db.get_bind()
+    event.listen(engine, "before_cursor_execute", record_statement)
+    try:
+        await delete_mcp_server(server.id, current_user=user, db=db)
+    finally:
+        event.remove(engine, "before_cursor_execute", record_statement)
+
+    flow_delete = next(
+        index
+        for index, statement in enumerate(statements)
+        if statement.startswith("delete from mcp_oauth_flow_states")
+    )
+    grant_scan = next(
+        index
+        for index, statement in enumerate(statements)
+        if statement.startswith("select") and "from mcp_oauth_grants" in statement
+    )
+    assert flow_delete < grant_scan
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -1436,6 +1436,46 @@ def _add_remote_oauth_catalog_app(db, *, app_id: str = "remote-notes") -> None:
     db.commit()
 
 
+def test_catalog_oauth_server_revalidates_concurrent_winner(db_session, monkeypatch):
+    db, _user, _ = db_session
+    _add_remote_oauth_catalog_app(db)
+    session_factory = sessionmaker(
+        bind=db.get_bind(), autoflush=False, autocommit=False
+    )
+    real_flush = db.flush
+    inserted = False
+
+    def insert_drifted_winner(*args, **kwargs):
+        nonlocal inserted
+        if not inserted and any(isinstance(row, MCPServer) for row in db.new):
+            inserted = True
+            concurrent_db = session_factory()
+            try:
+                concurrent_db.add(
+                    MCPServer.from_config(
+                        {
+                            "name": "remote-notes",
+                            "managed": "external",
+                            "transport": "streamable_http",
+                            "url": "https://attacker.example/mcp",
+                            "auth": {"type": "mcp_oauth"},
+                        }
+                    )
+                )
+                concurrent_db.commit()
+            finally:
+                concurrent_db.close()
+            raise IntegrityError("insert", {}, Exception("duplicate server"))
+        return real_flush(*args, **kwargs)
+
+    monkeypatch.setattr(db, "flush", insert_drifted_winner)
+
+    with pytest.raises(HTTPException) as exc_info:
+        mcp_api._ensure_catalog_mcp_oauth_server(db, "remote-notes")
+
+    assert exc_info.value.status_code == 409
+
+
 @pytest.mark.asyncio
 async def test_connect_app_creates_server_and_association_then_starts_dcr_flow(
     db_session, monkeypatch
@@ -2337,6 +2377,50 @@ async def test_callback_exchanges_code_and_stores_encrypted_grant(
 
 
 @pytest.mark.asyncio
+async def test_callback_discards_token_when_disconnect_removes_claimed_flow(
+    db_session, monkeypatch
+):
+    db, user, _ = db_session
+    _server, _client, _flow = _add_callback_client_and_state(
+        db,
+        user,
+        state="disconnected-during-exchange",
+        redirect_after="/mcp",
+    )
+    session_factory = sessionmaker(
+        bind=db.get_bind(), autoflush=False, autocommit=False
+    )
+
+    async def fake_exchange(**kwargs):
+        disconnect_db = session_factory()
+        try:
+            disconnect_db.query(MCPOAuthFlowState).filter(
+                MCPOAuthFlowState.state == "disconnected-during-exchange"
+            ).delete(synchronize_session=False)
+            disconnect_db.commit()
+        finally:
+            disconnect_db.close()
+        return {
+            "access_token": "must-not-persist",
+            "token_type": "Bearer",
+            "scope": "records.read",
+        }
+
+    monkeypatch.setattr(mcp_api, "_exchange_mcp_oauth_code", fake_exchange)
+
+    response = await mcp_oauth_callback(
+        _request(
+            "/api/mcp/oauth/callback?code=auth-code&state=disconnected-during-exchange"
+        ),
+        db,
+    )
+
+    assert response.status_code == 307
+    assert _redirect_query(response)["mcp_oauth_error"] == ["invalid_state"]
+    assert db.query(MCPOAuthGrant).count() == 0
+
+
+@pytest.mark.asyncio
 async def test_exchange_code_sanitizes_transport_exception(db_session, monkeypatch):
     db, user, _ = db_session
     _, client, _ = _add_callback_client_and_state(
@@ -3031,26 +3115,35 @@ async def test_trusted_revoke_removes_only_exact_resource_owner(db_session):
     ]
     db.add_all(grants)
     db.flush()
-    db.add_all(
-        [
-            MCPOAuthFlowState(
-                state=f"pending-{owner.rsplit(':', 1)[-1]}",
-                mcp_server_id=server.id,
-                user_id=user.id,
-                mcp_oauth_client_id=client.id,
-                resource_owner_key=owner,
-                issuer="https://auth.example.com",
-                resource="https://mcp.example.com/mcp",
-                scope="records.read",
-                code_verifier=encrypt_value("verifier"),
-                expires_at=mcp_api._utc_now() + timedelta(minutes=10),
-            )
-            for owner in (
-                "toby:slack:workspace:alice",
-                "toby:slack:workspace:bob",
-            )
-        ]
+    flows = [
+        MCPOAuthFlowState(
+            state=f"pending-{owner.rsplit(':', 1)[-1]}",
+            mcp_server_id=server.id,
+            user_id=user.id,
+            mcp_oauth_client_id=client.id,
+            resource_owner_key=owner,
+            issuer="https://auth.example.com",
+            resource="https://mcp.example.com/mcp",
+            scope="records.read",
+            code_verifier=encrypt_value("verifier"),
+            expires_at=mcp_api._utc_now() + timedelta(minutes=10),
+        )
+        for owner in (
+            "toby:slack:workspace:alice",
+            "toby:slack:workspace:bob",
+        )
+    ]
+    flows[0].consumed_at = mcp_api._utc_now()
+    db.add_all(flows)
+    association = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .one()
     )
+    association.is_active = False
     db.commit()
 
     revoked = await mcp_api.revoke_mcp_oauth_grants_for_owner(

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -1538,6 +1538,39 @@ async def test_connect_app_creates_server_and_association_then_starts_dcr_flow(
 
 
 @pytest.mark.asyncio
+async def test_public_connect_revalidates_association_after_discovery(
+    db_session, monkeypatch
+):
+    db, user, _ = db_session
+    _add_remote_oauth_catalog_app(db)
+
+    async def fake_discover(*args, **kwargs):
+        db.query(UserMCPServer).filter(UserMCPServer.user_id == user.id).delete()
+        db.commit()
+        return _discovery()
+
+    async def register_client(*_args, **_kwargs):
+        return SimpleNamespace(
+            client_id="dynamic-client-123",
+            token_endpoint_auth_method="none",
+        )
+
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+    monkeypatch.setattr(mcp_api, "register_mcp_oauth_public_client", register_client)
+
+    with pytest.raises(HTTPException) as exc:
+        await connect_mcp_oauth_app(
+            "remote-notes",
+            MCPOAuthConnectRequest(redirect_after="/settings/mcp"),
+            user,
+            db,
+        )
+
+    assert exc.value.status_code == 404
+    assert db.query(MCPOAuthFlowState).count() == 0
+
+
+@pytest.mark.asyncio
 async def test_public_connect_commits_association_before_discovery(
     db_session, monkeypatch
 ):
@@ -2308,6 +2341,55 @@ async def test_delete_mcp_server_rejects_actor_owned_oauth_state(
         )
         .one_or_none()
         is not None
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_mcp_server_ignores_terminal_actor_oauth_state(db_session):
+    db, user, _ = db_session
+    server = _add_mcp_oauth_server(db, user)
+    client = _add_oauth_client(db, server)
+    actor_owner = "toby:slack:workspace:alice"
+    db.add_all(
+        [
+            MCPOAuthGrant(
+                mcp_server_id=server.id,
+                user_id=user.id,
+                mcp_oauth_client_id=client.id,
+                resource_owner_key=actor_owner,
+                issuer="https://auth.example.com",
+                resource="https://mcp.example.com/mcp",
+                scope="records.read",
+                access_token=encrypt_value("actor-access-token"),
+                status="revoked",
+            ),
+            MCPOAuthFlowState(
+                state="expired-actor-flow",
+                mcp_server_id=server.id,
+                user_id=user.id,
+                mcp_oauth_client_id=client.id,
+                resource_owner_key=actor_owner,
+                issuer="https://auth.example.com",
+                resource="https://mcp.example.com/mcp",
+                scope="records.read",
+                code_verifier=encrypt_value("verifier"),
+                expires_at=mcp_api._utc_now() - timedelta(minutes=1),
+            ),
+        ]
+    )
+    db.commit()
+    server_id = int(server.id)
+
+    await delete_mcp_server(server_id, current_user=user, db=db)
+
+    assert (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server_id,
+        )
+        .one_or_none()
+        is None
     )
 
 
@@ -3204,7 +3286,7 @@ async def test_callback_reports_token_exchange_failure(db_session, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_status_and_delete_are_scoped_to_current_user(db_session):
+async def test_status_and_delete_are_scoped_to_default_owner(db_session):
     db, user, other_user = db_session
     server = _add_mcp_oauth_server(db, user)
     client = _add_oauth_client(db, server)
@@ -3212,25 +3294,36 @@ async def test_status_and_delete_are_scoped_to_current_user(db_session):
         mcp_server_id=server.id,
         user_id=user.id,
         mcp_oauth_client_id=client.id,
-        resource_owner_key="resource-owner-a",
+        resource_owner_key=mcp_api._default_resource_owner_key(user.id),
         issuer="https://auth.example.com",
         resource="https://mcp.example.com/mcp",
         scope="records.read",
         access_token=mcp_api.encrypt_value("own-access-token"),
     )
+    actor_grant = MCPOAuthGrant(
+        mcp_server_id=server.id,
+        user_id=user.id,
+        mcp_oauth_client_id=client.id,
+        resource_owner_key="toby:slack:workspace:alice",
+        issuer="https://auth.example.com",
+        resource="https://mcp.example.com/mcp",
+        scope="records.read",
+        access_token=mcp_api.encrypt_value("actor-access-token"),
+    )
     other_grant = MCPOAuthGrant(
         mcp_server_id=server.id,
         user_id=other_user.id,
         mcp_oauth_client_id=client.id,
-        resource_owner_key="resource-owner-b",
+        resource_owner_key=mcp_api._default_resource_owner_key(other_user.id),
         issuer="https://auth.example.com",
         resource="https://mcp.example.com/mcp",
         scope="records.read",
         access_token=mcp_api.encrypt_value("other-access-token"),
     )
-    db.add_all([own_grant, other_grant])
+    db.add_all([own_grant, actor_grant, other_grant])
     db.commit()
     db.refresh(own_grant)
+    db.refresh(actor_grant)
     db.refresh(other_grant)
 
     status_response = await get_mcp_oauth_status(server.id, user, db)
@@ -3238,9 +3331,10 @@ async def test_status_and_delete_are_scoped_to_current_user(db_session):
     assert isinstance(status_response, MCPOAuthStatusResponse)
     assert [grant.id for grant in status_response.grants] == [own_grant.id]
 
-    with pytest.raises(mcp_api.HTTPException) as exc:
-        await delete_mcp_oauth_grant(server.id, other_grant.id, user, db)
-    assert exc.value.status_code == 404
+    for foreign_grant in (actor_grant, other_grant):
+        with pytest.raises(mcp_api.HTTPException) as exc:
+            await delete_mcp_oauth_grant(server.id, foreign_grant.id, user, db)
+        assert exc.value.status_code == 404
 
     await delete_mcp_oauth_grant(server.id, own_grant.id, user, db)
     db.refresh(own_grant)
@@ -3527,7 +3621,9 @@ async def test_delete_mcp_server_invalidates_flows_before_scanning_grants(db_ses
     # flow invalidation before it scans active grants for revocation.
     grant_scan = next(
         index
-        for index, statement in enumerate(statements)
+        for index, statement in enumerate(
+            statements[flow_delete + 1 :], flow_delete + 1
+        )
         if (
             statement.startswith("select")
             and "from mcp_oauth_grants" in statement
@@ -3596,7 +3692,7 @@ async def test_status_only_reports_grants_matching_current_oauth_config(db_sessi
         mcp_server_id=server.id,
         user_id=user.id,
         mcp_oauth_client_id=stale_client.id,
-        resource_owner_key="resource-owner-a",
+        resource_owner_key=mcp_api._default_resource_owner_key(user.id),
         issuer="https://auth.example.com",
         resource="https://mcp.example.com/mcp",
         scope="records.read",
@@ -3606,7 +3702,7 @@ async def test_status_only_reports_grants_matching_current_oauth_config(db_sessi
         mcp_server_id=server.id,
         user_id=user.id,
         mcp_oauth_client_id=current_client.id,
-        resource_owner_key="resource-owner-b",
+        resource_owner_key=mcp_api._default_resource_owner_key(user.id),
         issuer="https://auth.example.com",
         resource="https://mcp.example.com/mcp",
         scope="records.write records.read",

--- a/tests/web/test_trusted_actor_oauth.py
+++ b/tests/web/test_trusted_actor_oauth.py
@@ -260,6 +260,9 @@ def test_actor_cookie_header_check() -> None:
 
     assert auth_api.is_actor_oauth_cookie_header(actor_cookie)
     assert not auth_api.is_actor_oauth_cookie_header("session=proof; HttpOnly; Secure")
+    assert not auth_api.is_actor_oauth_cookie_header(
+        f"xagent_actor_oauth_{'a' * 24}=; Max-Age=0"
+    )
 
 
 def test_actor_start_leaves_commit_to_caller(oauth_db) -> None:

--- a/tests/web/tools/test_mcp_actor_owner_runtime.py
+++ b/tests/web/tools/test_mcp_actor_owner_runtime.py
@@ -415,6 +415,54 @@ async def test_actor_remote_ignores_foreign_auth_app_id(db_session) -> None:
 
 
 @pytest.mark.asyncio
+async def test_actor_remote_rejects_unverifiable_catalog_identity(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    server.name = "renamed-remote"
+    db_session.db.commit()
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=f"xagent:user:{db_session.user.id}",
+        token="workspace-token",
+    )
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert configs[0]["config"]["reason"] == "config_load_failed"
+    assert "workspace-token" not in str(configs)
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_rejects_catalog_auth_reclassification(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    app = (
+        db_session.db.query(PublicMCPApp)
+        .filter(PublicMCPApp.app_id == REMOTE_APP_ID)
+        .one()
+    )
+    app.launch_config = {
+        **app.launch_config,
+        "auth": {"type": "api_key"},
+    }
+    db_session.db.commit()
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=f"xagent:user:{db_session.user.id}",
+        token="workspace-token",
+    )
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert configs[0]["config"]["reason"] == "config_load_failed"
+    assert "workspace-token" not in str(configs)
+
+
+@pytest.mark.asyncio
 async def test_actor_remote_never_uses_another_actor_grant(db_session) -> None:
     server = _add_remote_server(db_session.db, db_session.user)
     _add_remote_grant(

--- a/tests/web/tools/test_mcp_actor_owner_runtime.py
+++ b/tests/web/tools/test_mcp_actor_owner_runtime.py
@@ -21,7 +21,11 @@ from xagent.web.models.user_oauth import UserOAuth
 from xagent.web.services import connector_team_scope
 from xagent.web.services.mcp_runtime import MCPBuiltinOAuthActorPolicy
 from xagent.web.tools import config as web_tools_config
-from xagent.web.tools.config import WebToolConfig
+from xagent.web.tools.config import (
+    ResolvedToken,
+    WebToolConfig,
+    set_oauth_token_resolver_hook,
+)
 
 OWNER_A = "toby:slack:team:actor-a"
 OWNER_B = "toby:slack:team:actor-b"
@@ -422,6 +426,72 @@ async def test_actor_remote_rejects_task_supplied_owner(db_session) -> None:
     assert configs[0]["transport"] == "unavailable"
     assert configs[0]["config"]["reason"] == "config_load_failed"
     assert "other-actor-token" not in str(configs)
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_ignores_delegated_authorization(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_A,
+        token="actor-token",
+    )
+    server.runtime_bindings = [
+        {
+            "source": {"input_type": "secrets", "key": "authorization"},
+            "target": {
+                "target_type": "transport_headers",
+                "key": "Authorization",
+            },
+        }
+    ]
+    server.allow_delegated_authorization = True
+    db_session.db.commit()
+    tool_config = _config(db_session, policy=_policy())
+    tool_config._connector_runtime_view = {
+        f"mcp:{server.id}": {
+            "context": {"account": "task-context"},
+            "secrets": {"authorization": "Bearer task-token"},
+            "auth_selector": {},
+        }
+    }
+
+    configs = await tool_config.get_mcp_server_configs()
+
+    assert configs[0]["config"]["headers"]["Authorization"] == "Bearer actor-token"
+    assert "task-token" not in str(configs)
+    assert "connector_runtime" not in configs[0]
+    assert "runtime_bindings" not in configs[0]
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_ignores_resolver_hook(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_A,
+        token="actor-token",
+    )
+    calls = 0
+
+    async def resolver(_request) -> ResolvedToken:
+        nonlocal calls
+        calls += 1
+        return ResolvedToken(access_token="resolver-token")
+
+    set_oauth_token_resolver_hook(resolver)
+    try:
+        configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+    finally:
+        set_oauth_token_resolver_hook(None)
+
+    assert calls == 0
+    assert configs[0]["config"]["headers"]["Authorization"] == "Bearer actor-token"
+    assert "resolver-token" not in str(configs)
 
 
 @pytest.mark.asyncio

--- a/tests/web/tools/test_mcp_actor_owner_runtime.py
+++ b/tests/web/tools/test_mcp_actor_owner_runtime.py
@@ -298,6 +298,86 @@ async def test_actor_remote_falls_back_to_workspace_grant(db_session) -> None:
     assert configs[0]["config"]["headers"]["Authorization"] == "Bearer workspace-token"
 
 
+@pytest.mark.parametrize("stale_kind", ["expired", "scope"])
+@pytest.mark.asyncio
+async def test_actor_remote_falls_back_from_unusable_actor_grant(
+    db_session, stale_kind
+) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=f"xagent:user:{db_session.user.id}",
+        token="workspace-token",
+    )
+    actor_grant = _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_A,
+        token="stale-actor-token",
+    )
+    if stale_kind == "expired":
+        actor_grant.expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    else:
+        actor_grant.scope = "old.read"
+    db_session.db.commit()
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["config"]["headers"]["Authorization"] == "Bearer workspace-token"
+    assert "stale-actor-token" not in str(configs)
+
+
+@pytest.mark.parametrize(
+    "drift", ["url", "transport", "auth", "managed", "ownership", "duplicate"]
+)
+@pytest.mark.asyncio
+async def test_actor_remote_rejects_drifted_catalog_server(db_session, drift) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_A,
+        token="actor-token",
+    )
+    if drift == "url":
+        server.url = "https://attacker.example/mcp"
+    elif drift == "transport":
+        server.transport = "sse"
+    elif drift == "auth":
+        server.auth = {**server.auth, "scope": "records.write"}
+    elif drift == "managed":
+        server.managed = "internal"
+    elif drift == "ownership":
+        association = db_session.db.query(UserMCPServer).one()
+        association.is_owner = True
+    else:
+        duplicate = MCPServer.from_config(
+            {
+                "name": "duplicate-actor-remote",
+                "managed": "external",
+                "transport": "streamable_http",
+                "url": "https://mcp.example.com/mcp",
+                "auth": {
+                    **mcp_apps.get_app_by_id(db_session.db, REMOTE_APP_ID)[
+                        "launch_config"
+                    ]["auth"],
+                    "app_id": REMOTE_APP_ID,
+                },
+            }
+        )
+        db_session.db.add(duplicate)
+    db_session.db.commit()
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert "actor-token" not in str(configs)
+
+
 @pytest.mark.asyncio
 async def test_actor_remote_never_uses_another_actor_grant(db_session) -> None:
     server = _add_remote_server(db_session.db, db_session.user)

--- a/tests/web/tools/test_mcp_actor_owner_runtime.py
+++ b/tests/web/tools/test_mcp_actor_owner_runtime.py
@@ -26,6 +26,7 @@ from xagent.web.tools.config import WebToolConfig
 OWNER_A = "toby:slack:team:actor-a"
 OWNER_B = "toby:slack:team:actor-b"
 APP_ID = "actor-drive"
+REMOTE_APP_ID = "actor-remote"
 APP_EXECUTION = {
     "name": "Actor Drive",
     "transport": "oauth",
@@ -116,6 +117,87 @@ def _add_builtin_server(
     return server
 
 
+def _add_remote_server(db: Session, user: User) -> MCPServer:
+    app = PublicMCPApp(
+        app_id=REMOTE_APP_ID,
+        name="Actor Remote",
+        transport="streamable_http",
+        launch_config={
+            "url": "https://mcp.example.com/mcp",
+            "auth": {
+                "type": "mcp_oauth",
+                "resource": "https://mcp.example.com/mcp",
+                "issuer": "https://auth.example.com",
+                "scope": "records.read",
+                "client_id": "actor-client",
+            },
+        },
+        is_visible_in_connector=True,
+    )
+    server = MCPServer.from_config(
+        {
+            "name": REMOTE_APP_ID,
+            "managed": "external",
+            "transport": "streamable_http",
+            "url": "https://mcp.example.com/mcp",
+            "auth": dict(app.launch_config["auth"]),
+        }
+    )
+    db.add_all([app, server])
+    db.flush()
+    db.add(
+        UserMCPServer(
+            user_id=int(user.id),
+            mcpserver_id=int(server.id),
+            is_owner=False,
+            is_active=True,
+        )
+    )
+    db.commit()
+    return server
+
+
+def _add_remote_grant(
+    db: Session,
+    user: User,
+    server: MCPServer,
+    *,
+    owner: str,
+    token: str,
+) -> MCPOAuthGrant:
+    client = (
+        db.query(MCPOAuthClient)
+        .filter(MCPOAuthClient.mcp_server_id == int(server.id))
+        .one_or_none()
+    )
+    if client is None:
+        client = MCPOAuthClient(
+            mcp_server_id=int(server.id),
+            issuer="https://auth.example.com",
+            authorization_endpoint="https://auth.example.com/authorize",
+            token_endpoint="https://auth.example.com/token",
+            client_id="actor-client",
+            token_endpoint_auth_method="none",
+            redirect_uri="https://xagent.example.com/api/mcp/oauth/callback",
+        )
+        db.add(client)
+        db.flush()
+    grant = MCPOAuthGrant(
+        mcp_server_id=int(server.id),
+        user_id=int(user.id),
+        mcp_oauth_client_id=int(client.id),
+        resource_owner_key=owner,
+        issuer="https://auth.example.com",
+        resource="https://mcp.example.com/mcp",
+        scope="records.read",
+        access_token=encrypt_value(token),
+        status="active",
+    )
+    db.add(grant)
+    db.commit()
+    return grant
+
+
 def _add_actor_credential(
     db: Session,
     user: User,
@@ -173,6 +255,76 @@ def test_actor_policy_is_frozen_normalized_and_owner_only() -> None:
 def test_actor_policy_rejects_invalid_owner(value: object) -> None:
     with pytest.raises((TypeError, ValueError)):
         MCPBuiltinOAuthActorPolicy(resource_owner_key=value)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_prefers_exact_owner_over_workspace_grant(
+    db_session,
+) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=f"xagent:user:{db_session.user.id}",
+        token="workspace-token",
+    )
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_A,
+        token="actor-token",
+    )
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["config"]["headers"]["Authorization"] == "Bearer actor-token"
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_falls_back_to_workspace_grant(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=f"xagent:user:{db_session.user.id}",
+        token="workspace-token",
+    )
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["config"]["headers"]["Authorization"] == "Bearer workspace-token"
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_rejects_task_supplied_owner(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_A,
+        token="actor-token",
+    )
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_B,
+        token="other-actor-token",
+    )
+
+    configs = await _config(
+        db_session,
+        policy=_policy(),
+        mcp_auth_context={str(server.id): {"resource_owner_key": OWNER_B}},
+    ).get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert configs[0]["config"]["reason"] == "config_load_failed"
+    assert "other-actor-token" not in str(configs)
 
 
 @pytest.mark.asyncio

--- a/tests/web/tools/test_mcp_actor_owner_runtime.py
+++ b/tests/web/tools/test_mcp_actor_owner_runtime.py
@@ -299,6 +299,23 @@ async def test_actor_remote_falls_back_to_workspace_grant(db_session) -> None:
 
 
 @pytest.mark.asyncio
+async def test_actor_remote_never_uses_another_actor_grant(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_B,
+        token="other-actor-token",
+    )
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert "other-actor-token" not in str(configs)
+
+
+@pytest.mark.asyncio
 async def test_actor_remote_rejects_task_supplied_owner(db_session) -> None:
     server = _add_remote_server(db_session.db, db_session.user)
     _add_remote_grant(

--- a/tests/web/tools/test_mcp_actor_owner_runtime.py
+++ b/tests/web/tools/test_mcp_actor_owner_runtime.py
@@ -334,9 +334,7 @@ async def test_actor_remote_falls_back_from_unusable_actor_grant(
     assert "stale-actor-token" not in str(configs)
 
 
-@pytest.mark.parametrize(
-    "drift", ["url", "transport", "auth", "managed", "ownership", "duplicate"]
-)
+@pytest.mark.parametrize("drift", ["url", "transport", "auth", "managed", "ownership"])
 @pytest.mark.asyncio
 async def test_actor_remote_rejects_drifted_catalog_server(db_session, drift) -> None:
     server = _add_remote_server(db_session.db, db_session.user)
@@ -358,28 +356,62 @@ async def test_actor_remote_rejects_drifted_catalog_server(db_session, drift) ->
     elif drift == "ownership":
         association = db_session.db.query(UserMCPServer).one()
         association.is_owner = True
-    else:
-        duplicate = MCPServer.from_config(
-            {
-                "name": "duplicate-actor-remote",
-                "managed": "external",
-                "transport": "streamable_http",
-                "url": "https://mcp.example.com/mcp",
-                "auth": {
-                    **mcp_apps.get_app_by_id(db_session.db, REMOTE_APP_ID)[
-                        "launch_config"
-                    ]["auth"],
-                    "app_id": REMOTE_APP_ID,
-                },
-            }
-        )
-        db_session.db.add(duplicate)
     db_session.db.commit()
 
     configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
 
     assert configs[0]["transport"] == "unavailable"
     assert "actor-token" not in str(configs)
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_marks_missing_auth_unavailable(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    server.auth = None
+    db_session.db.commit()
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert configs[0]["config"]["reason"] == "config_load_failed"
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_ignores_foreign_auth_app_id(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_A,
+        token="actor-token",
+    )
+    attacker = User(username="foreign-user", password_hash="x", is_admin=False)
+    foreign_server = MCPServer.from_config(
+        {
+            "name": "foreign-server",
+            "managed": "external",
+            "transport": "streamable_http",
+            "url": "https://attacker.example/mcp",
+            "auth": {"app_id": REMOTE_APP_ID},
+        }
+    )
+    db_session.db.add_all([attacker, foreign_server])
+    db_session.db.flush()
+    db_session.db.add(
+        UserMCPServer(
+            user_id=int(attacker.id),
+            mcpserver_id=int(foreign_server.id),
+            is_active=True,
+            is_owner=True,
+        )
+    )
+    db_session.db.commit()
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert len(configs) == 1
+    assert configs[0]["config"]["headers"]["Authorization"] == "Bearer actor-token"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Intention

Add trusted actor-owned OAuth for remote catalog MCP apps. This lets a server-side caller bind an OAuth flow, stored grant, runtime lookup, refresh, and revocation to one exact resource-owner namespace.

## Boundary

- Add trusted connect and revoke helpers for catalog MCP OAuth.
- Prefer a usable exact actor grant, with the existing machine-user grant as fallback.
- Validate catalog URL, transport, auth configuration, uniqueness, and ownership before actor token use.
- Keep callback claims, disconnects, and grant persistence serialized.
- Preserve caller-owned transactions for trusted operations.

## Rejected behavior

- Public clients cannot choose `resource_owner_key`.
- Task-supplied MCP authorization cannot override actor policy.
- Another actor's grant is never selected.
- Drifted or ambiguous catalog servers become unavailable instead of receiving a bearer token.
- Disconnect does not revoke another owner or commit unrelated caller changes.

## Accepted errors and trade-offs

- Missing or unusable actor grants fall back to a usable machine-user grant.
- Invalid catalog definitions fail closed with an unavailable connector.
- OAuth discovery, DCR, token exchange, and provider revocation failures keep their existing typed failure paths.
- This does not add actor ownership to custom MCP servers or non-catalog OAuth flows.

## Verification

- 141 focused OAuth and runtime tests
- Ruff check and format
- Configured mypy hook
