### PR TITLE
refactor(compaction): demote message dropping from strategy to backstop

### DIFF
--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -106,9 +106,10 @@ class MergeStrategy(str, Enum):
 class CompactConfig:
     """Compaction policy for message history.
 
-    There is no strategy knob: compaction always tries to summarize, and
-    dropping the oldest messages is only the backstop for when it cannot.
-    ``max_messages`` sizes that backstop's retained tail.
+    There is no strategy knob. ``PatternRuntime`` is expected to summarize
+    first and to fall back to dropping messages only when it cannot; this
+    dataclass configures the threshold that triggers either, and
+    ``max_messages`` sizes the retained tail when messages are dropped.
     """
 
     enabled: bool = True
@@ -976,6 +977,12 @@ class ExecutionContext:
                 }
                 for call in self.llm_calls
             ],
+            # ``strategy`` used to be emitted here and is deliberately not
+            # replaced: an older reader defaults the missing key to
+            # ``"truncate"``, which is the only value this field was ever
+            # written with, so it rebuilds the identical config. That makes
+            # dropping it safe in both rolling-deploy directions, unlike the
+            # fields kept for compatibility just below.
             "compact_config": {
                 "enabled": self.compact_config.enabled,
                 "threshold": self.compact_config.threshold,
@@ -1074,10 +1081,11 @@ class ExecutionContext:
     def compact_if_needed(self) -> CompactResult:
         """Shrink the context by dropping old messages, if it is over budget.
 
-        This is the backstop, not a strategy the caller chooses: the runtime
-        summarizes first and only reaches here when summarization was
-        unavailable or produced nothing usable. Everything it removes is lost
-        outright, so a caller that can summarize should.
+        This is the backstop, not a strategy the caller chooses. It does not
+        summarize and does not check whether anything tried to: ``PatternRuntime``
+        is expected to have summarized first and to call this only when that
+        was unavailable or produced nothing usable. Everything removed here is
+        lost outright, so a caller that can summarize should.
         """
         if not self.compact_config.enabled:
             return CompactResult(
@@ -1126,9 +1134,15 @@ class ExecutionContext:
     def _drop_oldest_messages(self) -> CompactResult:
         """Keep a tail window and discard everything before it.
 
-        Lossy and unconditional -- the dropped turns are not summarized,
-        recorded, or recoverable from the context. ``strategy="truncate"`` on
-        the result is the trace label for that outcome, not a mode.
+        Lossy: the dropped turns are not summarized, recorded, or recoverable
+        from the context. ``strategy="truncate"`` on the result is the trace
+        label for that outcome, not a mode.
+
+        Note that ``compacted=True`` does not imply anything was removed. When
+        the context is over budget but holds no more than ``max_messages``
+        messages -- a handful of very large tool results, say -- the window
+        keeps all of them and ``removed_count`` is 0. Callers that need to know
+        whether the context actually shrank must read ``removed_count``.
         """
         original_count = len(self.messages)
         keep_count = min(max(0, self.compact_config.max_messages), original_count)

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -104,11 +104,15 @@ class MergeStrategy(str, Enum):
 
 @dataclass
 class CompactConfig:
-    """Compaction policy for message history."""
+    """Compaction policy for message history.
+
+    There is no strategy knob: compaction always tries to summarize, and
+    dropping the oldest messages is only the backstop for when it cannot.
+    ``max_messages`` sizes that backstop's retained tail.
+    """
 
     enabled: bool = True
     threshold: int = 32000
-    strategy: str = "truncate"
     max_messages: int = 20
 
 
@@ -975,7 +979,6 @@ class ExecutionContext:
             "compact_config": {
                 "enabled": self.compact_config.enabled,
                 "threshold": self.compact_config.threshold,
-                "strategy": self.compact_config.strategy,
                 "max_messages": self.compact_config.max_messages,
             },
             # Backward compatibility for older serialized payloads.
@@ -1019,7 +1022,6 @@ class ExecutionContext:
         compact_config = CompactConfig(
             enabled=compact.get("enabled", True),
             threshold=compact.get("threshold", CompactConfig().threshold),
-            strategy=compact.get("strategy", "truncate"),
             max_messages=compact.get("max_messages", 20),
         )
         created_at = (
@@ -1069,7 +1071,14 @@ class ExecutionContext:
 
         return context
 
-    def compact_if_needed(self, llm: Any = None) -> CompactResult:
+    def compact_if_needed(self) -> CompactResult:
+        """Shrink the context by dropping old messages, if it is over budget.
+
+        This is the backstop, not a strategy the caller chooses: the runtime
+        summarizes first and only reaches here when summarization was
+        unavailable or produced nothing usable. Everything it removes is lost
+        outright, so a caller that can summarize should.
+        """
         if not self.compact_config.enabled:
             return CompactResult(
                 compacted=False,
@@ -1080,7 +1089,7 @@ class ExecutionContext:
 
         total_tokens = self._get_total_tokens()
         if total_tokens > self.compact_config.threshold:
-            result = self._compact(llm)
+            result = self._drop_oldest_messages()
             return self._annotate_compact_result(result, total_tokens)
 
         return CompactResult(
@@ -1114,40 +1123,34 @@ class ExecutionContext:
             },
         }
 
-    def _compact(self, llm: Any = None) -> CompactResult:
-        original_count = len(self.messages)
-        if self.compact_config.strategy == "truncate":
-            keep_count = min(max(0, self.compact_config.max_messages), original_count)
-            retained = self._tail_window_preserving_tool_pairs(keep_count)
-            removed = max(0, original_count - len(retained))
-            # The window is a suffix minus any interior tool fragments sanitized
-            # out of it, so diff by object identity rather than slicing a prefix.
-            retained_ids = {id(message) for message in retained}
-            dropped_tool_counts = self._dropped_tool_result_counts(
-                [
-                    message
-                    for message in self.messages
-                    if id(message) not in retained_ids
-                ]
-            )
-            self.messages = retained
-            return CompactResult(
-                compacted=True,
-                original_count=original_count,
-                final_count=len(self.messages),
-                strategy="truncate",
-                metadata={
-                    "removed_count": removed,
-                    "dropped_tool_result_count": sum(dropped_tool_counts.values()),
-                    "dropped_tool_results_by_name": dropped_tool_counts,
-                },
-            )
+    def _drop_oldest_messages(self) -> CompactResult:
+        """Keep a tail window and discard everything before it.
 
+        Lossy and unconditional -- the dropped turns are not summarized,
+        recorded, or recoverable from the context. ``strategy="truncate"`` on
+        the result is the trace label for that outcome, not a mode.
+        """
+        original_count = len(self.messages)
+        keep_count = min(max(0, self.compact_config.max_messages), original_count)
+        retained = self._tail_window_preserving_tool_pairs(keep_count)
+        removed = max(0, original_count - len(retained))
+        # The window is a suffix minus any interior tool fragments sanitized
+        # out of it, so diff by object identity rather than slicing a prefix.
+        retained_ids = {id(message) for message in retained}
+        dropped_tool_counts = self._dropped_tool_result_counts(
+            [message for message in self.messages if id(message) not in retained_ids]
+        )
+        self.messages = retained
         return CompactResult(
-            compacted=False,
+            compacted=True,
             original_count=original_count,
             final_count=len(self.messages),
-            strategy="none",
+            strategy="truncate",
+            metadata={
+                "removed_count": removed,
+                "dropped_tool_result_count": sum(dropped_tool_counts.values()),
+                "dropped_tool_results_by_name": dropped_tool_counts,
+            },
         )
 
     def _annotate_compact_result(

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -1340,10 +1340,14 @@ class PatternRuntime:
         # is indistinguishable in the trace from compaction that never tried
         # to summarize at all.
         unusable_summary_metadata: dict[str, Any] | None = None
-        # Cleared once the summary path is entered. Reaching the fallback with
-        # this still set means no summary was ever attempted -- previously
-        # indistinguishable in the trace from a summary that was attempted and
-        # failed, since both just produced a "truncate" result.
+        # Cleared as soon as a usable summary path exists -- a model with a
+        # ``chat`` method plus a context that implements the compact protocol.
+        # It is deliberately NOT tied to a summary actually being attempted: a
+        # context that declines to build a request (nothing visible to
+        # summarize) had a summarizer available and must not be reported as
+        # lacking one. Reaching the fallback with this still set means no
+        # summarizer was reachable at all, which the trace previously could
+        # not distinguish from a summary that was attempted and failed.
         summary_unavailable_metadata: dict[str, Any] | None = {
             "llm_summary_unavailable": True,
         }
@@ -1422,14 +1426,22 @@ class PatternRuntime:
             result = compact_if_needed()
             if inspect.isawaitable(result):
                 result = await result
-            dropped_messages = getattr(result, "compacted", False)
+            # ``compacted`` is True even when the tail window already held
+            # every message and nothing was removed, so it cannot stand in for
+            # "messages were dropped" -- claiming a drop that did not happen
+            # would be the same kind of lie this marker exists to prevent.
+            removed_count = (getattr(result, "metadata", None) or {}).get(
+                "removed_count", 0
+            )
             fallback_metadata = unusable_summary_metadata
-            if fallback_metadata is None and dropped_messages:
+            if fallback_metadata is None and removed_count > 0:
                 fallback_metadata = summary_unavailable_metadata
                 if fallback_metadata is not None:
                     logger.warning(
-                        "Context compaction had no usable summary model; "
-                        "dropping messages instead. execution_id=%s",
+                        "Context compaction found no reachable summary path "
+                        "(no compact model, or a context that cannot build a "
+                        "compact request); dropping messages instead. "
+                        "execution_id=%s",
                         getattr(context, "execution_id", None),
                     )
             if result is not None and fallback_metadata is not None:

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -1340,6 +1340,13 @@ class PatternRuntime:
         # is indistinguishable in the trace from compaction that never tried
         # to summarize at all.
         unusable_summary_metadata: dict[str, Any] | None = None
+        # Cleared once the summary path is entered. Reaching the fallback with
+        # this still set means no summary was ever attempted -- previously
+        # indistinguishable in the trace from a summary that was attempted and
+        # failed, since both just produced a "truncate" result.
+        summary_unavailable_metadata: dict[str, Any] | None = {
+            "llm_summary_unavailable": True,
+        }
         # Written by ``_run_compact_llm_call`` when it had to lower the
         # budget, so the compact trace event can say so alongside the other
         # degrade markers.
@@ -1350,6 +1357,7 @@ class PatternRuntime:
             and callable(llm_compact_request_if_needed)
             and callable(compact_with_llm_response)
         ):
+            summary_unavailable_metadata = None
             request = llm_compact_request_if_needed()
             if request is not None:
                 request_metadata = request.get("metadata") or {}
@@ -1405,14 +1413,27 @@ class PatternRuntime:
                     result.metadata["fallback_strategy"] = result.strategy
                     result.metadata.update(request_metadata)
 
+        # Backstop. ``compact_if_needed`` drops the oldest messages outright,
+        # so it runs only after summarization was skipped, errored, or came
+        # back unusable -- never as an alternative worth choosing.
         if result is None or not getattr(result, "compacted", False):
             if not callable(compact_if_needed):
                 return result
-            result = compact_if_needed(llm)
+            result = compact_if_needed()
             if inspect.isawaitable(result):
                 result = await result
-            if result is not None and unusable_summary_metadata is not None:
-                result.metadata.update(unusable_summary_metadata)
+            dropped_messages = getattr(result, "compacted", False)
+            fallback_metadata = unusable_summary_metadata
+            if fallback_metadata is None and dropped_messages:
+                fallback_metadata = summary_unavailable_metadata
+                if fallback_metadata is not None:
+                    logger.warning(
+                        "Context compaction had no usable summary model; "
+                        "dropping messages instead. execution_id=%s",
+                        getattr(context, "execution_id", None),
+                    )
+            if result is not None and fallback_metadata is not None:
+                result.metadata.update(fallback_metadata)
                 result.metadata["fallback_strategy"] = result.strategy
 
         if result is None:

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -1966,13 +1966,20 @@ def test_compact_rejects_content_the_client_marked_as_a_reasoning_fallback() -> 
     assert ctx.messages == original
 
 
-def test_from_dict_ignores_the_retired_compact_strategy_key() -> None:
-    """Contexts persisted before the strategy knob was removed still carry
-    ``"strategy": "truncate"`` inside ``compact_config``, and those rows are
-    live -- every resumed execution reloads one. ``from_dict`` has to keep
-    accepting the key instead of choking on it.
+def test_compact_config_round_trip_drops_the_retired_strategy_key() -> None:
+    """Pins the rolling-deploy contract for the removed ``strategy`` knob.
+
+    ``to_dict`` must stop emitting the key, and a legacy payload that still
+    carries it -- every row persisted before the removal, reloaded by every
+    resumed execution -- must restore the surrounding fields unchanged. The
+    ``from_dict`` half cannot break as long as the reader uses per-key
+    ``get``; it is pinned because switching to ``CompactConfig(**compact)``
+    would turn those live rows into a crash. The ``hasattr`` check guards the
+    other direction: re-adding the field with a default would silently revive
+    the dispatch this change removed.
     """
     context = ExecutionContext()
+    context.compact_config.enabled = False
     context.compact_config.threshold = 1234
     context.compact_config.max_messages = 7
 
@@ -1982,6 +1989,7 @@ def test_from_dict_ignores_the_retired_compact_strategy_key() -> None:
 
     restored = ExecutionContext.from_dict(payload)
 
+    assert restored.compact_config.enabled is False
     assert restored.compact_config.threshold == 1234
     assert restored.compact_config.max_messages == 7
     assert not hasattr(restored.compact_config, "strategy")

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -1964,3 +1964,24 @@ def test_compact_rejects_content_the_client_marked_as_a_reasoning_fallback() -> 
     assert not result.compacted
     assert result.strategy == "none"
     assert ctx.messages == original
+
+
+def test_from_dict_ignores_the_retired_compact_strategy_key() -> None:
+    """Contexts persisted before the strategy knob was removed still carry
+    ``"strategy": "truncate"`` inside ``compact_config``, and those rows are
+    live -- every resumed execution reloads one. ``from_dict`` has to keep
+    accepting the key instead of choking on it.
+    """
+    context = ExecutionContext()
+    context.compact_config.threshold = 1234
+    context.compact_config.max_messages = 7
+
+    payload = context.to_dict()
+    assert "strategy" not in payload["compact_config"]
+    payload["compact_config"]["strategy"] = "truncate"
+
+    restored = ExecutionContext.from_dict(payload)
+
+    assert restored.compact_config.threshold == 1234
+    assert restored.compact_config.max_messages == 7
+    assert not hasattr(restored.compact_config, "strategy")

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -1612,19 +1612,19 @@ async def test_compaction_stops_descending_once_a_budget_is_accepted() -> None:
     assert llm.budgets == [8000]
     assert result.strategy == "truncate"
     assert result.metadata["llm_summary_unusable"] is True
-    # A summary was attempted here, so the "no summary model at all" marker
-    # must stay off: the two reach the same fallback and would otherwise be
-    # indistinguishable again, which is what the marker exists to prevent.
-    assert "llm_summary_unavailable" not in result.metadata
 
 
 @pytest.mark.asyncio
-async def test_compaction_marks_messages_dropped_for_want_of_a_summary_model() -> None:
+async def test_compaction_marks_messages_dropped_for_want_of_a_summary_model(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Dropping messages because no summary model was reachable used to look
     exactly like dropping them after a summary failed -- both produced a bare
     ``truncate`` result, and only the failure path left a marker behind. That
-    made "nobody gave compaction a model" invisible in the trace.
+    made "nothing could summarize" invisible in the trace.
     """
+    recording_logger = RecordingLogger()
+    monkeypatch.setattr(runtime_module, "logger", recording_logger)
     context = ExecutionContext(execution_id="no-compact-model")
     context.compact_config.threshold = 1
     context.compact_config.max_messages = 2
@@ -1637,5 +1637,73 @@ async def test_compaction_marks_messages_dropped_for_want_of_a_summary_model() -
 
     assert result.compacted is True
     assert result.strategy == "truncate"
+    # Without this the test cannot tell a real drop from the no-op window that
+    # keeps every message, which is exactly what the marker must not claim.
+    assert result.metadata["removed_count"] == 4
     assert result.metadata["llm_summary_unavailable"] is True
     assert result.metadata["fallback_strategy"] == "truncate"
+    assert len(recording_logger.warning_calls) == 1
+    msg, args = recording_logger.warning_calls[0]
+    assert "no reachable summary path" in msg % args
+
+
+@pytest.mark.asyncio
+async def test_compaction_does_not_claim_a_drop_when_the_window_kept_everything(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A context can be over budget while holding fewer messages than the tail
+    window keeps -- one huge tool result does it. ``_drop_oldest_messages``
+    still reports ``compacted=True`` there, so keying the marker off that flag
+    announced a drop that never happened, once per turn, forever.
+    """
+    recording_logger = RecordingLogger()
+    monkeypatch.setattr(runtime_module, "logger", recording_logger)
+    context = ExecutionContext(execution_id="nothing-to-drop")
+    context.compact_config.threshold = 1
+    context.compact_config.max_messages = 20
+    context.add_user_message("only message")
+
+    result = await PatternRuntime().compact_context_if_needed(
+        context=context, llm=None, metadata={"phase": "test"}
+    )
+
+    assert result.metadata["removed_count"] == 0
+    assert "llm_summary_unavailable" not in result.metadata
+    assert recording_logger.warning_calls == []
+
+
+@pytest.mark.asyncio
+async def test_compaction_does_not_blame_the_model_when_nothing_is_summarizable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A usable summary model plus a context that declines to build a request
+    (over budget, but every message hidden) is not the same failure as having
+    no summarizer at all, and must not be reported as one.
+
+    This is the only test that reaches the line clearing
+    ``summary_unavailable_metadata``: delete that line and the marker below
+    reappears.
+    """
+    recording_logger = RecordingLogger()
+    monkeypatch.setattr(runtime_module, "logger", recording_logger)
+
+    class UnusedCompactLLM:
+        model_name = "compact-test"
+
+        async def chat(self, **_: Any) -> Any:  # pragma: no cover - never called
+            raise AssertionError("no request should have been built")
+
+    context = ExecutionContext(execution_id="nothing-summarizable")
+    context.compact_config.threshold = 1
+    context.compact_config.max_messages = 2
+    for index in range(6):
+        context.add_user_message(f"m{index}", hidden=True)
+
+    result = await PatternRuntime().compact_context_if_needed(
+        context=context, llm=UnusedCompactLLM(), metadata={"phase": "test"}
+    )
+
+    assert result.compacted is True
+    assert result.metadata["removed_count"] == 4
+    assert "llm_summary_unavailable" not in result.metadata
+    assert recording_logger.warning_calls == []

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -1612,3 +1612,30 @@ async def test_compaction_stops_descending_once_a_budget_is_accepted() -> None:
     assert llm.budgets == [8000]
     assert result.strategy == "truncate"
     assert result.metadata["llm_summary_unusable"] is True
+    # A summary was attempted here, so the "no summary model at all" marker
+    # must stay off: the two reach the same fallback and would otherwise be
+    # indistinguishable again, which is what the marker exists to prevent.
+    assert "llm_summary_unavailable" not in result.metadata
+
+
+@pytest.mark.asyncio
+async def test_compaction_marks_messages_dropped_for_want_of_a_summary_model() -> None:
+    """Dropping messages because no summary model was reachable used to look
+    exactly like dropping them after a summary failed -- both produced a bare
+    ``truncate`` result, and only the failure path left a marker behind. That
+    made "nobody gave compaction a model" invisible in the trace.
+    """
+    context = ExecutionContext(execution_id="no-compact-model")
+    context.compact_config.threshold = 1
+    context.compact_config.max_messages = 2
+    for index in range(6):
+        context.add_user_message(f"m{index}")
+
+    result = await PatternRuntime().compact_context_if_needed(
+        context=context, llm=None, metadata={"phase": "test"}
+    )
+
+    assert result.compacted is True
+    assert result.strategy == "truncate"
+    assert result.metadata["llm_summary_unavailable"] is True
+    assert result.metadata["fallback_strategy"] == "truncate"


### PR DESCRIPTION
Follow-up to #1939. That PR made compaction keep the summary path when no
separate compact model is configured. With the summary path always having a
model to call, dropping messages is no longer one of two strategies — it is
only the backstop. This makes the code say so.

## The knob that only had one working position

`CompactConfig.strategy` was never set to anything. The only assignment in the
repo was `from_dict` defaulting it back to `"truncate"`, and `_compact`
dispatched on it:

```python
def _compact(self, llm: Any = None) -> CompactResult:
    if self.compact_config.strategy == "truncate":
        ...                      # does the work
    return CompactResult(
        compacted=False, ..., strategy="none",   # for an over-budget context
    )
```

Configuring any other value would have turned compaction into a silent no-op
while the context kept growing past its threshold — the second branch reports
"nothing to do" for a context that has already blown its budget. A knob with
one working position and one broken one is not a choice worth keeping.

## Changes

- Delete the `strategy` field, its two read sites, and its slot in the
  serialized payload. Older persisted contexts still carry the key; `from_dict`
  reads by `get` and ignores it. A test pins that, because every resumed
  execution reloads one of those rows.
- Collapse `_compact` into `_drop_oldest_messages` — one branch, no dead
  return — and drop the `llm` argument that `compact_if_needed` threaded into a
  method that never read it.
- `CompactResult.strategy` keeps its `"truncate"` / `"llm_summary"` labels.
  Those describe what happened and traces read them; only the *config*
  dimension goes away.

## One case the trace could not distinguish

Dropping messages because no summary model was reachable produced a bare
`truncate` result — identical to dropping them after a summary failed. Only the
failure paths left a marker (`llm_compact_error`, `llm_summary_unusable`), so
"compaction never even tried to summarize" was invisible.

The fallback now records `llm_summary_unavailable` and logs a warning. After
#1939 both production call sites substitute the main model, so this path should
be unreachable — which is exactly why it deserves a warning rather than silence
if it ever fires.

## What actually triggers the fallback marker

Worth stating precisely, because the marker's name (`llm_summary_unavailable`)
suggests a narrower cause than the code has. The summary path is guarded by
four conditions: `llm is not None`, `callable(llm.chat)`, and the context
implementing both `build_llm_compact_request_if_needed` and
`compact_with_llm_response`. Any of the four failing lands on the marker.

`llm=None` specifically is close to unreachable: `ReActPattern` returns an
error and `AutoPattern` raises before compaction runs, and both call sites
substitute the main model when no compact model is configured. Every shipped
chat model defines `chat`. So the realistic trigger is a duck-typed context
that does not implement the compact protocol — not a missing model.

That is also why this stays a warning rather than an assertion: the reachable
cause is a protocol mismatch in a `getattr`-based entry point, which should
degrade visibly rather than kill the turn. Turning it into a hard error would
need an audit of every derived-runtime construction path and belongs in its
own change.

## Verification

- `tests/core` (excluding `RAG_tools`): 0 failures.
- `pre-commit run --all-files`: all Python hooks pass. The two npm hooks exit
  127 (`eslint` / `tsc` not found) because frontend dependencies are not
  installed locally; this change touches no frontend files.
- `tests/core/tools/test_pptx_tool.py` fails locally with
  `Node.js execution failed (exit code 1)` for the same missing-dependency
  reason, unrelated to this diff.
- The new marker test was confirmed to fail (`KeyError:
  'llm_summary_unavailable'`) with the fallback logic reverted, so it is not a
  no-op assertion.
