### PR TITLE
fix: define agent message display contract

### DIFF
--- a/frontend/src/components/build/agent-builder-chat.test.tsx
+++ b/frontend/src/components/build/agent-builder-chat.test.tsx
@@ -277,8 +277,24 @@ describe("AgentBuilderChat", () => {
     await waitFor(() => {
       expect(screen.getByText("Ordinary visible update")).toBeInTheDocument()
     })
-    const messages = screen.getAllByTestId("chat-message")
-    expect(messages[messages.length - 1]).toHaveAttribute("data-trace-count", "1")
+    let messages = screen.getAllByTestId("chat-message")
+    expect(messages[messages.length - 2]).toHaveAttribute("data-trace-count", "1")
+
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: "trace_event",
+        event_type: "ai_message",
+        data: { content: "Final builder answer", display: "chat" },
+      }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("Ordinary visible update")).toBeInTheDocument()
+      expect(screen.getByText("Final builder answer")).toBeInTheDocument()
+    })
+    messages = screen.getAllByTestId("chat-message")
+    expect(messages[messages.length - 2]).toHaveTextContent("Ordinary visible update")
+    expect(messages[messages.length - 1]).toHaveTextContent("Final builder answer")
   })
 
   it("keeps timeline agent messages out of builder chat content", async () => {
@@ -300,6 +316,30 @@ describe("AgentBuilderChat", () => {
       expect(messages[messages.length - 1]).toHaveAttribute("data-trace-count", "1")
     })
     expect(screen.queryByText("Timeline only")).not.toBeInTheDocument()
+  })
+
+  it("renders waiting questions in builder chat", async () => {
+    renderBuilderChat()
+    fireEvent.click(screen.getByText("send-chat-input"))
+
+    const ws = MockWebSocket.instances[0]
+    ws.open()
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: "trace_event",
+        event_type: "agent_message",
+        data: {
+          message: "Choose an option",
+          message_type: "question",
+          expect_response: true,
+          display: "chat",
+        },
+      }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("Choose an option")).toBeInTheDocument()
+    })
   })
 
   it("shows backend upload error details when file upload is unavailable", async () => {

--- a/frontend/src/components/build/agent-builder-chat.test.tsx
+++ b/frontend/src/components/build/agent-builder-chat.test.tsx
@@ -127,6 +127,7 @@ vi.mock("@/components/chat/ChatMessage", () => ({
         data-process-status={processStatus || ""}
         data-trace-count={traceEvents?.length ?? 0}
       >
+        <span data-testid="chat-content">{content}</span>
         <button
           type="button"
           onClick={async () => {
@@ -252,6 +253,53 @@ describe("AgentBuilderChat", () => {
   afterEach(() => {
     cleanup()
     globalThis.WebSocket = originalWebSocket
+  })
+
+  it("renders ordinary agent messages in chat without requiring a response", async () => {
+    renderBuilderChat()
+    fireEvent.click(screen.getByText("send-chat-input"))
+
+    const ws = MockWebSocket.instances[0]
+    ws.open()
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: "trace_event",
+        event_type: "agent_message",
+        data: {
+          message: "Ordinary visible update",
+          message_type: "info",
+          expect_response: false,
+          display: "chat",
+        },
+      }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("Ordinary visible update")).toBeInTheDocument()
+    })
+    const messages = screen.getAllByTestId("chat-message")
+    expect(messages[messages.length - 1]).toHaveAttribute("data-trace-count", "1")
+  })
+
+  it("keeps timeline agent messages out of builder chat content", async () => {
+    renderBuilderChat()
+    fireEvent.click(screen.getByText("send-chat-input"))
+
+    const ws = MockWebSocket.instances[0]
+    ws.open()
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: "trace_event",
+        event_type: "agent_message",
+        data: { message: "Timeline only", display: "timeline" },
+      }),
+    })
+
+    await waitFor(() => {
+      const messages = screen.getAllByTestId("chat-message")
+      expect(messages[messages.length - 1]).toHaveAttribute("data-trace-count", "1")
+    })
+    expect(screen.queryByText("Timeline only")).not.toBeInTheDocument()
   })
 
   it("shows backend upload error details when file upload is unavailable", async () => {

--- a/frontend/src/components/build/agent-builder-chat.test.tsx
+++ b/frontend/src/components/build/agent-builder-chat.test.tsx
@@ -297,6 +297,139 @@ describe("AgentBuilderChat", () => {
     expect(messages[messages.length - 1]).toHaveTextContent("Final builder answer")
   })
 
+  it("preserves a final answer when a non-waiting message arrives afterwards", async () => {
+    renderBuilderChat()
+    fireEvent.click(screen.getByText("send-chat-input"))
+
+    const ws = MockWebSocket.instances[0]
+    ws.open()
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: "trace_event",
+        event_type: "ai_message",
+        data: { content: "Final answer first", display: "chat" },
+      }),
+    })
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: "trace_event",
+        event_type: "agent_message",
+        data: {
+          message: "Late durable note",
+          expect_response: false,
+          display: "chat",
+        },
+      }),
+    })
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: "task_completed",
+        status: "completed",
+        result: { content: "Final answer first" },
+      }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("Final answer first")).toBeInTheDocument()
+      expect(screen.getByText("Late durable note")).toBeInTheDocument()
+    })
+    expect(screen.getAllByText("Final answer first")).toHaveLength(1)
+  })
+
+  it("renders native final-answer stream events from the builder bridge", async () => {
+    renderBuilderChat()
+    fireEvent.click(screen.getByText("send-chat-input"))
+
+    const ws = MockWebSocket.instances[0]
+    ws.open()
+    for (const event of [
+      { type: "final_answer_start", message_id: "answer-1" },
+      { type: "final_answer_delta", message_id: "answer-1", delta: "Streamed " },
+      { type: "final_answer_delta", message_id: "answer-1", delta: "answer" },
+      { type: "final_answer_end", message_id: "answer-1", content: "Streamed answer" },
+    ]) {
+      ws.onmessage?.({ data: JSON.stringify(event) })
+    }
+
+    await waitFor(() => {
+      expect(screen.getByText("Streamed answer")).toBeInTheDocument()
+    })
+    expect(screen.getAllByText("Streamed answer")).toHaveLength(1)
+  })
+
+  it("keeps each streamed final answer inside its own user turn", async () => {
+    renderBuilderChat()
+    fireEvent.click(screen.getByText("send-chat-input"))
+
+    const ws = MockWebSocket.instances[0]
+    ws.open()
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: "trace_event",
+        event_type: "ai_message",
+        data: { content: "First answer", display: "chat" },
+      }),
+    })
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: "task_completed",
+        status: "completed",
+        result: { content: "First answer" },
+      }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("First answer")).toBeInTheDocument()
+    })
+    fireEvent.click(screen.getByText("send-chat-input"))
+    for (const event of [
+      { type: "final_answer_start", message_id: "answer-2" },
+      { type: "final_answer_delta", message_id: "answer-2", delta: "Second answer" },
+      { type: "final_answer_end", message_id: "answer-2", content: "Second answer" },
+    ]) {
+      ws.onmessage?.({ data: JSON.stringify(event) })
+    }
+
+    await waitFor(() => {
+      expect(screen.getByText("First answer")).toBeInTheDocument()
+      expect(screen.getByText("Second answer")).toBeInTheDocument()
+    })
+  })
+
+  it("removes an empty completion placeholder after a durable message", async () => {
+    renderBuilderChat()
+    fireEvent.click(screen.getByText("send-chat-input"))
+
+    const ws = MockWebSocket.instances[0]
+    ws.open()
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: "trace_event",
+        event_type: "agent_message",
+        data: {
+          message: "Only durable update",
+          expect_response: false,
+          display: "chat",
+        },
+      }),
+    })
+    ws.onmessage?.({
+      data: JSON.stringify({
+        type: "task_completed",
+        status: "completed",
+        result: "",
+      }),
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("Only durable update")).toBeInTheDocument()
+      expect(screen.getAllByTestId("chat-message")).toHaveLength(3)
+    })
+    expect(
+      screen.queryByText("builds.configForm.chat.defaultReply"),
+    ).not.toBeInTheDocument()
+  })
+
   it("keeps timeline agent messages out of builder chat content", async () => {
     renderBuilderChat()
     fireEvent.click(screen.getByText("send-chat-input"))

--- a/frontend/src/components/build/agent-builder-chat.tsx
+++ b/frontend/src/components/build/agent-builder-chat.tsx
@@ -15,6 +15,7 @@ import { useI18n } from "@/contexts/i18n-context"
 import { toast } from "@/components/ui/sonner"
 import { getBrandingFromEnv } from "@/lib/branding"
 import { normalizeUploadFileIds } from "@/lib/upload-file-ids"
+import { expectsUserResponse, getMessageSurface, isMessageDisplayEventType } from "@/lib/message-surface"
 
 import { Interaction } from "@/contexts/app-context-chat"
 
@@ -282,6 +283,12 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
             const data = JSON.parse(event.data)
 
             if (data.type === "trace_event") {
+              const messageSurface = isMessageDisplayEventType(data.event_type)
+                ? getMessageSurface(data.event_type, data.data)
+                : null
+              if (messageSurface === "ignore") {
+                return
+              }
               // Update the last message (assistant) with the new trace event
               setMessages(prev => {
                 return updateLastAssistantMessage(prev, lastMsg => ({
@@ -290,7 +297,7 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
                 }))
               })
 
-              if (data.event_type === "ai_message") {
+              if (data.event_type === "ai_message" && messageSurface === "chat") {
                 if (data.data?.message_type === "reasoning") {
                   // Do not update the main message content for reasoning.
                   // TraceEventRenderer will handle displaying it in the execution logs.
@@ -342,13 +349,12 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
                     return updated
                   })
                 }
-              } else if (data.event_type === "agent_message") {
-                const displayReply = data.data?.message || ""
+              } else if (isMessageDisplayEventType(data.event_type) && messageSurface === "chat") {
+                const displayReply = data.data?.message || data.data?.content || ""
                 const interactions = data.data?.metadata?.interactions
-                if (!data.data?.expect_response && data.data?.message_type !== "question") {
-                  return
+                if (expectsUserResponse(data.event_type, data.data)) {
+                  setIsLoading(false)
                 }
-                setIsLoading(false)
                 setMessages(prev => {
                   const updated = [...prev]
                   const lastMsg = updated[updated.length - 1]

--- a/frontend/src/components/build/agent-builder-chat.tsx
+++ b/frontend/src/components/build/agent-builder-chat.tsx
@@ -16,6 +16,7 @@ import { toast } from "@/components/ui/sonner"
 import { getBrandingFromEnv } from "@/lib/branding"
 import { normalizeUploadFileIds } from "@/lib/upload-file-ids"
 import { expectsUserResponse, getMessageSurface, isMessageDisplayEventType } from "@/lib/message-surface"
+import { isFinalAnswerStreamEventType } from "@/lib/streaming-final-answer"
 
 import { Interaction } from "@/contexts/app-context-chat"
 
@@ -28,18 +29,38 @@ interface Message {
   timestamp?: number
   interactions?: Interaction[]
   processStatus?: TraceProcessStatus
+  isPending?: boolean
+  isFinalAnswer?: boolean
+}
+
+const findLastAssistantIndex = (
+  messages: Message[],
+  predicate: (message: Message) => boolean = () => true,
+  afterIndex = -1,
+): number => {
+  for (let i = messages.length - 1; i > afterIndex; i--) {
+    if (messages[i].role === "assistant" && predicate(messages[i])) return i
+  }
+  return -1
+}
+
+const findLastUserIndex = (messages: Message[]): number => {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "user") return i
+  }
+  return -1
 }
 
 const updateLastAssistantMessage = (
   messages: Message[],
   update: (message: Message) => Message
 ): Message[] => {
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if (messages[i].role === "assistant") {
-      const updated = [...messages]
-      updated[i] = update(messages[i])
-      return updated
-    }
+  const pendingIndex = findLastAssistantIndex(messages, message => message.isPending === true)
+  const index = pendingIndex >= 0 ? pendingIndex : findLastAssistantIndex(messages)
+  if (index >= 0) {
+    const updated = [...messages]
+    updated[index] = update(messages[index])
+    return updated
   }
   return messages
 }
@@ -164,7 +185,13 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
     setIsLoading(true)
 
     // Add empty assistant message for streaming
-    setMessages(prev => [...prev, { role: "assistant", content: "", traceEvents: [], timestamp: Date.now() }])
+    setMessages(prev => [...prev, {
+      role: "assistant",
+      content: "",
+      traceEvents: [],
+      timestamp: Date.now(),
+      isPending: true,
+    }])
 
     let currentReply = ""
     let finalMessage = text;
@@ -282,20 +309,79 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
           try {
             const data = JSON.parse(event.data)
 
-            if (data.type === "trace_event") {
+            if (isFinalAnswerStreamEventType(data.type)) {
+              if (data.type === "final_answer_error") {
+                setIsLoading(false)
+                setMessages(prev => updateLastAssistantMessage(prev, message => ({
+                  ...message,
+                  isPending: false,
+                  processStatus: "failed",
+                })))
+                return
+              }
+
+              if (data.type === "final_answer_start") {
+                currentReply = ""
+                return
+              }
+              if (data.type === "final_answer_delta") {
+                currentReply += typeof data.delta === "string" ? data.delta : ""
+              } else if (data.type === "final_answer_end") {
+                currentReply = typeof data.content === "string" ? data.content : currentReply
+              }
+
+              if (currentReply) {
+                setMessages(prev => {
+                  const updated = [...prev]
+                  const lastUserIndex = findLastUserIndex(updated)
+                  let index = findLastAssistantIndex(
+                    updated,
+                    message => message.isPending === true,
+                    lastUserIndex,
+                  )
+                  if (index < 0) {
+                    index = findLastAssistantIndex(
+                      updated,
+                      message => message.isFinalAnswer === true,
+                      lastUserIndex,
+                    )
+                  }
+                  if (index < 0) {
+                    updated.push({
+                      role: "assistant",
+                      content: "",
+                      traceEvents: [],
+                      timestamp: Date.now(),
+                      isPending: true,
+                    })
+                    index = updated.length - 1
+                  }
+                  updated[index] = {
+                    ...updated[index],
+                    content: currentReply,
+                    isFinalAnswer: true,
+                    isPending: data.type !== "final_answer_end",
+                  }
+                  return updated
+                })
+              }
+            } else if (data.type === "trace_event") {
               const messageSurface = isMessageDisplayEventType(data.event_type)
                 ? getMessageSurface(data.event_type, data.data)
                 : null
               if (messageSurface === "ignore") {
                 return
               }
-              // Update the last message (assistant) with the new trace event
-              setMessages(prev => {
-                return updateLastAssistantMessage(prev, lastMsg => ({
-                  ...lastMsg,
+              // Chat-surface events are attached to the bubble they create
+              // below. Other events stay on the active execution bubble.
+              if (messageSurface !== "chat") {
+                setMessages(prev => {
+                  return updateLastAssistantMessage(prev, lastMsg => ({
+                    ...lastMsg,
                     traceEvents: [...(lastMsg.traceEvents || []), data]
-                }))
-              })
+                  }))
+                })
+              }
 
               if (data.event_type === "ai_message" && messageSurface === "chat") {
                 if (data.data?.message_type === "reasoning") {
@@ -342,9 +428,27 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
 
                   setMessages(prev => {
                     const updated = [...prev]
-                    updated[updated.length - 1].content = displayReply
-                    if (interactions) {
-                      updated[updated.length - 1].interactions = interactions;
+                    let index = findLastAssistantIndex(
+                      updated,
+                      message => message.isPending === true,
+                    )
+                    if (index < 0) {
+                      updated.push({
+                        role: "assistant",
+                        content: "",
+                        traceEvents: [],
+                        timestamp: Date.now(),
+                        isPending: true,
+                      })
+                      index = updated.length - 1
+                    }
+                    updated[index] = {
+                      ...updated[index],
+                      content: displayReply,
+                      interactions: interactions || updated[index].interactions,
+                      traceEvents: [...(updated[index].traceEvents || []), data],
+                      isPending: false,
+                      isFinalAnswer: true,
                     }
                     return updated
                   })
@@ -361,14 +465,28 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
                 }
                 setMessages(prev => {
                   const updated = [...prev]
-                  const lastMsg = updated[updated.length - 1]
-                  if (!lastMsg || lastMsg.role !== 'assistant') {
-                    return updated
+                  let index = findLastAssistantIndex(
+                    updated,
+                    message => message.isPending === true,
+                  )
+                  if (index < 0) {
+                    updated.push({
+                      role: "assistant",
+                      content: "",
+                      traceEvents: [],
+                      timestamp: Date.now(),
+                      isPending: true,
+                    })
+                    index = updated.length - 1
                   }
-                  updated[updated.length - 1] = {
-                    ...lastMsg,
+                  const target = updated[index]
+                  updated[index] = {
+                    ...target,
                     content: displayReply,
-                    interactions: Array.isArray(interactions) ? interactions : lastMsg.interactions
+                    interactions: Array.isArray(interactions) ? interactions : target.interactions,
+                    traceEvents: [...(target.traceEvents || []), data],
+                    isPending: false,
+                    isFinalAnswer: false,
                   }
                   if (!waitsForUser) {
                     updated.push({
@@ -376,6 +494,7 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
                       content: "",
                       traceEvents: [],
                       timestamp: Date.now(),
+                      isPending: true,
                     })
                   }
                   return updated
@@ -488,11 +607,65 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
               }
 
               setMessages(prev => {
-                return updateLastAssistantMessage(prev, message => ({
+                const updated = [...prev]
+                const hasFinalContent = typeof cleanReply === "string" && cleanReply.length > 0
+                const lastUserIndex = findLastUserIndex(updated)
+                const finalIndex = findLastAssistantIndex(
+                  updated,
+                  message => message.isFinalAnswer === true,
+                  lastUserIndex,
+                )
+                if (finalIndex >= 0) {
+                  updated[finalIndex] = {
+                    ...updated[finalIndex],
+                    content: hasFinalContent ? cleanReply : updated[finalIndex].content,
+                    interactions: interactions || updated[finalIndex].interactions,
+                    processStatus: taskCompletion.status,
+                    isPending: false,
+                  }
+                  return updated.filter(message => !(
+                    message.role === "assistant" &&
+                    message.isPending === true &&
+                    message.content === ""
+                  ))
+                }
+
+                if (hasFinalContent) {
+                  return updateLastAssistantMessage(updated, message => ({
+                    ...message,
+                    content: cleanReply,
+                    interactions: interactions || message.interactions,
+                    processStatus: taskCompletion.status,
+                    isPending: false,
+                    isFinalAnswer: true,
+                  }))
+                }
+
+                let meaningfulIndex = -1
+                for (let i = updated.length - 1; i > lastUserIndex; i--) {
+                  if (updated[i].role === "assistant" && updated[i].content !== "") {
+                    meaningfulIndex = i
+                    break
+                  }
+                }
+                if (meaningfulIndex >= 0) {
+                  updated[meaningfulIndex] = {
+                    ...updated[meaningfulIndex],
+                    processStatus: taskCompletion.status,
+                  }
+                  return updated.filter(message => !(
+                    message.role === "assistant" &&
+                    message.isPending === true &&
+                    message.content === ""
+                  ))
+                }
+
+                return updateLastAssistantMessage(updated, message => ({
                   ...message,
-                  content: cleanReply || t("builds.configForm.chat.defaultReply") || "I have updated the configuration based on your request.",
+                  content: t("builds.configForm.chat.defaultReply") || "I have updated the configuration based on your request.",
                   interactions: interactions || message.interactions,
                   processStatus: taskCompletion.status,
+                  isPending: false,
                 }))
               })
 

--- a/frontend/src/components/build/agent-builder-chat.tsx
+++ b/frontend/src/components/build/agent-builder-chat.tsx
@@ -352,7 +352,11 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
               } else if (isMessageDisplayEventType(data.event_type) && messageSurface === "chat") {
                 const displayReply = data.data?.message || data.data?.content || ""
                 const interactions = data.data?.metadata?.interactions
-                if (expectsUserResponse(data.event_type, data.data)) {
+                if (!displayReply) {
+                  return
+                }
+                const waitsForUser = expectsUserResponse(data.event_type, data.data)
+                if (waitsForUser) {
                   setIsLoading(false)
                 }
                 setMessages(prev => {
@@ -365,6 +369,14 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
                     ...lastMsg,
                     content: displayReply,
                     interactions: Array.isArray(interactions) ? interactions : lastMsg.interactions
+                  }
+                  if (!waitsForUser) {
+                    updated.push({
+                      role: "assistant",
+                      content: "",
+                      traceEvents: [],
+                      timestamp: Date.now(),
+                    })
                   }
                   return updated
                 })

--- a/frontend/src/components/chat/TraceEventRenderer.test.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.test.tsx
@@ -64,9 +64,20 @@ vi.mock("@/components/file/pptx-preview-renderer", () => ({
   }) => <div data-testid="pptx-preview">{base64Content ?? fileId ?? ""}</div>,
 }))
 
-import { TraceEventRenderer } from "./TraceEventRenderer"
+import { isAgentProgressEvent, TraceEventRenderer } from "./TraceEventRenderer"
 
 describe("TraceEventRenderer", () => {
+  it("does not classify an ordinary non-waiting agent message as progress", () => {
+    expect(isAgentProgressEvent({
+      event_type: "agent_message",
+      data: { message_type: "info", expect_response: false },
+    })).toBe(false)
+    expect(isAgentProgressEvent({
+      event_type: "agent_message",
+      data: { message_type: "info", display: "timeline" },
+    })).toBe(true)
+  })
+
   it("ignores null, primitive, and malformed trace event entries", () => {
     expect(() => render(
       <TraceEventRenderer

--- a/frontend/src/components/chat/TraceEventRenderer.tsx
+++ b/frontend/src/components/chat/TraceEventRenderer.tsx
@@ -35,6 +35,7 @@ import {
   isStoppedTraceProcessStatus,
   resolveTraceProcessStatus,
 } from '@/lib/trace-process-status';
+import { expectsUserResponse, getMessageSurface } from '@/lib/message-surface';
 
 // Types
 interface ToolArgs {
@@ -244,7 +245,7 @@ const getWaitingQuestionFromEvents = (events: TraceEvent[]): string | null => {
   for (let i = events.length - 1; i >= 0; i--) {
     const event = events[i];
     if (event.event_type === 'agent_message') {
-      const expectsResponse = event.data?.expect_response === true || event.data?.message_type === 'question';
+      const expectsResponse = expectsUserResponse(event.event_type || '', event.data);
       if (!expectsResponse) {
         continue;
       }
@@ -316,11 +317,10 @@ export function getRawToolName(event: TraceEvent): string {
 }
 
 export const isAgentProgressEvent = (event: TraceEvent): boolean => (
-  event.event_type === 'agent_progress' ||
+  event.event_type === 'agent_progress' || event.event_type === 'agent_status' ||
   (
     event.event_type === 'agent_message' &&
-    event.data?.expect_response !== true &&
-    event.data?.message_type !== 'question'
+    getMessageSurface(event.event_type, event.data) === 'timeline'
   )
 );
 

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -19,6 +19,7 @@ import { useApp } from "@/contexts/app-context-chat"
 import { useFileAccess } from "@/contexts/file-access-context"
 import { useI18n } from "@/contexts/i18n-context"
 import { isStreamingFinalAnswerMessage } from "@/lib/streaming-final-answer"
+import { expectsUserResponse } from "@/lib/message-surface"
 import { getProcessGroupIndex, getUserTimelineAnchors } from "@/lib/task-timeline"
 import { resolveTraceProcessStatus } from "@/lib/trace-process-status"
 import { cn } from "@/lib/utils"
@@ -134,7 +135,7 @@ const findWaitingPrompt = (currentTask: any, traceEvents: any[]) => {
   for (let i = traceEvents.length - 1; i >= 0; i--) {
     const event = traceEvents[i]
     if (event.event_type === "agent_message") {
-      const expectsResponse = event.data?.expect_response === true
+      const expectsResponse = expectsUserResponse(event.event_type || "", event.data)
       const message = event.data?.message || event.data?.content
       if (expectsResponse && typeof message === "string" && message.trim()) {
         return message
@@ -167,7 +168,7 @@ const findWaitingInteractions = (currentTask: any, traceEvents: any[]) => {
   for (let i = traceEvents.length - 1; i >= 0; i--) {
     const event = traceEvents[i]
     if (event.event_type === "agent_message") {
-      const expectsResponse = event.data?.expect_response === true
+      const expectsResponse = expectsUserResponse(event.event_type || "", event.data)
       const interactions = event.data?.metadata?.interactions
       if (expectsResponse && Array.isArray(interactions) && interactions.length > 0) {
         return interactions

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -462,6 +462,27 @@ function SeedRunningTask() {
   return null
 }
 
+function SeedCompletedTask() {
+  const { dispatch } = useApp()
+
+  React.useEffect(() => {
+    dispatch({ type: "SET_TASK_ID", payload: 1 })
+    dispatch({
+      type: "SET_CURRENT_TASK",
+      payload: {
+        id: "1",
+        title: "Completed task",
+        status: "completed",
+        description: "Completed task",
+        createdAt: "2026-05-27T05:00:00Z",
+        updatedAt: "2026-05-27T05:01:00Z",
+      },
+    })
+  }, [dispatch])
+
+  return null
+}
+
 function SeedExistingTask() {
   const { dispatch } = useApp()
 
@@ -617,6 +638,44 @@ describe("AppProvider websocket message routing", () => {
       )
     })
     expect(screen.getByTestId("messages").textContent).not.toContain("Searching")
+  })
+
+  it("does not turn a completed task into waiting from question metadata alone", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedCompletedTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("completed")
+    })
+
+    act(() => {
+      webSocketOptions.current?.onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:00Z",
+        task_id: 1,
+        data: {
+          event_id: "stray-question-row",
+          event_type: "agent_message",
+          data: {
+            message: "A question-shaped note",
+            message_type: "question",
+            expect_response: false,
+            display: "chat",
+          },
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("messages").textContent).toContain(
+        "A question-shaped note",
+      )
+    })
+    expect(screen.getByTestId("task-status").textContent).toBe("completed")
   })
 
   it("preserves workforce delegation event types for agent execution links", async () => {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -6,6 +6,7 @@ import { FileText, Target, Zap, CheckCircle, XCircle, Wrench, Activity, Search, 
 import { JsonRenderer, MarkdownRenderer } from "../components/ui/markdown-renderer"
 import { UserMessageContent } from "@/components/chat/user-message-content"
 import { ReplayScheduler } from '@/lib/replay-scheduler'
+import { expectsUserResponse, getMessageSurface, isMessageDisplayEventType } from '@/lib/message-surface'
 import { CollapsibleSection } from "@/components/collapsible-section"
 import { Badge } from "@/components/ui/badge"
 import { ClarificationForm } from "@/components/chat/clarification-form"
@@ -3013,7 +3014,10 @@ export function AppProvider({
           }
 
           // Agent progress messages belong in the execution timeline, not the chat transcript.
-          else if (eventType === "agent_progress") {
+          else if (
+            isMessageDisplayEventType(eventType) &&
+            ["timeline", "status"].includes(getMessageSurface(eventType, eventData))
+          ) {
             dispatch({
               type: "ADD_TRACE_EVENT",
               payload: {
@@ -3047,7 +3051,7 @@ export function AppProvider({
           }
 
           // Agent-to-user messages, including ask_user_question prompts.
-          else if (eventType === "agent_message" || eventType === "ai_message") {
+          else if (isMessageDisplayEventType(eventType) && getMessageSurface(eventType, eventData) === "chat") {
             // Child Agent output belongs exclusively to the on-demand Agent
             // inspector. Rendering it as parent chat content makes live state
             // disagree with historical replay and can expose child clarifiers
@@ -3070,35 +3074,8 @@ export function AppProvider({
               : undefined
             const isAgentMessage = eventType === "agent_message"
             const isAiMessage = eventType === "ai_message"
-            const expectsUserResponse =
-              isAgentMessage &&
-              eventData.expect_response === true
-            const agentMessageDisplay = eventData.display || eventData.metadata?.display
-            const isExplicitTranscriptMessage =
-              agentMessageDisplay === "chat" ||
-              eventData.source === "chat_history" ||
-              eventData.role === "assistant"
-            const isTimelineAgentMessage =
-              eventType === "agent_message" &&
-              !isExplicitTranscriptMessage &&
-              agentMessageDisplay === "timeline"
-            if (isTimelineAgentMessage) {
-              dispatch({
-                type: "ADD_TRACE_EVENT",
-                payload: {
-                  event_id: message.event_id || eventData.event_id || generateMessageId("trace-agent-progress"),
-                  event_type: "agent_progress",
-                  step_id: message.step_id || eventData.step_id,
-                  timestamp: message.timestamp?.toString() || Date.now().toString(),
-                  data: eventData,
-                }
-              })
-              return
-            }
-            const shouldHideAgentMessage =
-              isAgentMessage &&
-              eventData.visible === false
-            if (expectsUserResponse) {
+            const expectsResponse = expectsUserResponse(eventType, eventData)
+            if (expectsResponse) {
               dispatch({
                 type: "UPDATE_TASK_STATUS",
                 payload: {
@@ -3113,9 +3090,6 @@ export function AppProvider({
               isAiMessage
                 ? getFinalAnswerStreamMessageId(eventData)
                 : undefined
-            if (shouldHideAgentMessage) {
-              return
-            }
             if (!streamMessageId && isDuplicateMessageForViewedTask(
               messageContent,
               'agent-message',

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -3013,6 +3013,16 @@ export function AppProvider({
             dispatch({ type: "UPSERT_STREAMING_FINAL_ANSWER", payload })
           }
 
+          // These surfaces are handled outside the ordinary message router.
+          // Keeping an explicit guard prevents malformed/direct frames from
+          // falling through into the generic trace-event fallback.
+          else if (
+            isMessageDisplayEventType(eventType) &&
+            ["ignore", "stream"].includes(getMessageSurface(eventType, eventData))
+          ) {
+            return
+          }
+
           // Agent progress messages belong in the execution timeline, not the chat transcript.
           else if (
             isMessageDisplayEventType(eventType) &&

--- a/frontend/src/lib/message-surface.test.ts
+++ b/frontend/src/lib/message-surface.test.ts
@@ -25,18 +25,40 @@ describe("message surface contract", () => {
     expect(getMessageSurface("final_answer_delta", {})).toBe("stream");
   });
 
-  it("keeps questions visible but waits only when explicitly requested", () => {
+  it("keeps questions visible and preserves legacy question waiting", () => {
     const legacyQuestion = { message_type: "question", expect_response: false };
     const waitingQuestion = { message_type: "question", expect_response: true };
 
     expect(getMessageSurface("agent_message", legacyQuestion)).toBe("chat");
-    expect(expectsUserResponse("agent_message", legacyQuestion)).toBe(false);
+    expect(expectsUserResponse("agent_message", legacyQuestion)).toBe(true);
     expect(expectsUserResponse("agent_message", waitingQuestion)).toBe(true);
+    expect(
+      getMessageSurface("agent_message", {
+        expect_response: true,
+        visible: false,
+      }),
+    ).toBe("chat");
   });
 
   it("honors hidden messages before any display hint", () => {
     expect(
       getMessageSurface("agent_message", { visible: false, display: "chat" }),
     ).toBe("ignore");
+  });
+
+  it("uses metadata display and ignores invalid display values", () => {
+    expect(
+      getMessageSurface("agent_message", {
+        metadata: { display: "timeline" },
+      }),
+    ).toBe("timeline");
+    expect(getMessageSurface("agent_message", { display: "unsupported" })).toBe(
+      "chat",
+    );
+  });
+
+  it("keeps transcript event types chat-visible by default", () => {
+    expect(getMessageSurface("ai_message", {})).toBe("chat");
+    expect(getMessageSurface("chat_message", {})).toBe("chat");
   });
 });

--- a/frontend/src/lib/message-surface.test.ts
+++ b/frontend/src/lib/message-surface.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, it } from "vitest";
 
+import contractCases from "../../../tests/fixtures/message_surface_contract.json";
 import { expectsUserResponse, getMessageSurface } from "./message-surface";
+
+describe("shared backend/frontend message surface fixtures", () => {
+  it.each(contractCases)("$name", testCase => {
+    expect(getMessageSurface(testCase.event_type, testCase.data)).toBe(
+      testCase.surface,
+    );
+    expect(expectsUserResponse(testCase.event_type, testCase.data)).toBe(
+      testCase.expects_response,
+    );
+  });
+});
 
 describe("message surface contract", () => {
   it("keeps ordinary agent messages in chat without waiting", () => {
@@ -25,12 +37,12 @@ describe("message surface contract", () => {
     expect(getMessageSurface("final_answer_delta", {})).toBe("stream");
   });
 
-  it("keeps questions visible and preserves legacy question waiting", () => {
-    const legacyQuestion = { message_type: "question", expect_response: false };
+  it("keeps questions visible but waits only on the explicit flag", () => {
+    const nonWaitingQuestion = { message_type: "question", expect_response: false };
     const waitingQuestion = { message_type: "question", expect_response: true };
 
-    expect(getMessageSurface("agent_message", legacyQuestion)).toBe("chat");
-    expect(expectsUserResponse("agent_message", legacyQuestion)).toBe(true);
+    expect(getMessageSurface("agent_message", nonWaitingQuestion)).toBe("chat");
+    expect(expectsUserResponse("agent_message", nonWaitingQuestion)).toBe(false);
     expect(expectsUserResponse("agent_message", waitingQuestion)).toBe(true);
     expect(
       getMessageSurface("agent_message", {
@@ -43,6 +55,13 @@ describe("message surface contract", () => {
   it("honors hidden messages before any display hint", () => {
     expect(
       getMessageSurface("agent_message", { visible: false, display: "chat" }),
+    ).toBe("ignore");
+    expect(
+      getMessageSurface("agent_message", {
+        message_type: "question",
+        expect_response: false,
+        visible: false,
+      }),
     ).toBe("ignore");
   });
 
@@ -60,5 +79,15 @@ describe("message surface contract", () => {
   it("keeps transcript event types chat-visible by default", () => {
     expect(getMessageSurface("ai_message", {})).toBe("chat");
     expect(getMessageSurface("chat_message", {})).toBe("chat");
+    expect(getMessageSurface("user_message", {})).toBe("chat");
+  });
+
+  it("does not apply agent waiting precedence to other event types", () => {
+    expect(
+      getMessageSurface("ai_message", {
+        display: "timeline",
+        expect_response: true,
+      }),
+    ).toBe("timeline");
   });
 });

--- a/frontend/src/lib/message-surface.test.ts
+++ b/frontend/src/lib/message-surface.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+
+import { expectsUserResponse, getMessageSurface } from "./message-surface";
+
+describe("message surface contract", () => {
+  it("keeps ordinary agent messages in chat without waiting", () => {
+    const data = { message_type: "info", expect_response: false };
+
+    expect(getMessageSurface("agent_message", data)).toBe("chat");
+    expect(expectsUserResponse("agent_message", data)).toBe(false);
+  });
+
+  it("routes progress and explicit timeline messages to the timeline", () => {
+    expect(getMessageSurface("agent_progress", {})).toBe("timeline");
+    expect(
+      getMessageSurface("agent_message", { message_type: "progress" }),
+    ).toBe("timeline");
+    expect(getMessageSurface("agent_message", { display: "timeline" })).toBe(
+      "timeline",
+    );
+  });
+
+  it("preserves status and final-answer stream surfaces", () => {
+    expect(getMessageSurface("agent_status", {})).toBe("status");
+    expect(getMessageSurface("final_answer_delta", {})).toBe("stream");
+  });
+
+  it("keeps questions visible but waits only when explicitly requested", () => {
+    const legacyQuestion = { message_type: "question", expect_response: false };
+    const waitingQuestion = { message_type: "question", expect_response: true };
+
+    expect(getMessageSurface("agent_message", legacyQuestion)).toBe("chat");
+    expect(expectsUserResponse("agent_message", legacyQuestion)).toBe(false);
+    expect(expectsUserResponse("agent_message", waitingQuestion)).toBe(true);
+  });
+
+  it("honors hidden messages before any display hint", () => {
+    expect(
+      getMessageSurface("agent_message", { visible: false, display: "chat" }),
+    ).toBe("ignore");
+  });
+});

--- a/frontend/src/lib/message-surface.ts
+++ b/frontend/src/lib/message-surface.ts
@@ -31,6 +31,7 @@ export const isMessageDisplayEventType = (eventType: string): boolean =>
     "agent_status",
     "ai_message",
     "chat_message",
+    "user_message",
   ].includes(eventType);
 
 export const expectsUserResponse = (
@@ -41,8 +42,7 @@ export const expectsUserResponse = (
     data && typeof data === "object" ? (data as MessageSurfaceData) : undefined;
   return (
     eventType === "agent_message" &&
-    (messageData?.expect_response === true ||
-      messageData?.message_type === "question")
+    messageData?.expect_response === true
   );
 };
 
@@ -68,6 +68,12 @@ export const getMessageSurface = (
     messageData?.message_type === "progress"
   ) {
     return "timeline";
+  }
+  if (
+    eventType === "agent_message" &&
+    messageData?.message_type === "question"
+  ) {
+    return "chat";
   }
   if (
     ["agent_message", "ai_message", "chat_message", "user_message"].includes(

--- a/frontend/src/lib/message-surface.ts
+++ b/frontend/src/lib/message-surface.ts
@@ -1,0 +1,78 @@
+export type MessageSurface =
+  "chat" | "timeline" | "status" | "stream" | "ignore";
+
+type MessageSurfaceData = {
+  display?: unknown;
+  expect_response?: unknown;
+  message_type?: unknown;
+  metadata?: { display?: unknown };
+  visible?: unknown;
+};
+
+const MESSAGE_SURFACES = new Set<MessageSurface>([
+  "chat",
+  "timeline",
+  "status",
+  "stream",
+  "ignore",
+]);
+
+const FINAL_ANSWER_EVENT_TYPES = new Set([
+  "final_answer_start",
+  "final_answer_delta",
+  "final_answer_end",
+  "final_answer_error",
+]);
+
+export const isMessageDisplayEventType = (eventType: string): boolean =>
+  [
+    "agent_message",
+    "agent_progress",
+    "agent_status",
+    "ai_message",
+    "chat_message",
+  ].includes(eventType);
+
+export const expectsUserResponse = (
+  eventType: string,
+  data: unknown,
+): boolean => {
+  const messageData = data && typeof data === "object"
+    ? data as MessageSurfaceData
+    : undefined;
+  return eventType === "agent_message" && messageData?.expect_response === true;
+};
+
+export const getMessageSurface = (
+  eventType: string,
+  data: unknown,
+): MessageSurface => {
+  const messageData = data && typeof data === "object"
+    ? data as MessageSurfaceData
+    : undefined;
+  if (
+    expectsUserResponse(eventType, messageData) ||
+    messageData?.message_type === "question"
+  ) {
+    return "chat";
+  }
+  if (messageData?.visible === false) return "ignore";
+
+  const configured = messageData?.display ?? messageData?.metadata?.display;
+  if (MESSAGE_SURFACES.has(configured as MessageSurface)) {
+    return configured as MessageSurface;
+  }
+  if (FINAL_ANSWER_EVENT_TYPES.has(eventType)) return "stream";
+  if (eventType === "agent_status") return "status";
+  if (eventType === "agent_progress" || messageData?.message_type === "progress") {
+    return "timeline";
+  }
+  if (
+    ["agent_message", "ai_message", "chat_message", "user_message"].includes(
+      eventType,
+    )
+  ) {
+    return "chat";
+  }
+  return "timeline";
+};

--- a/frontend/src/lib/message-surface.ts
+++ b/frontend/src/lib/message-surface.ts
@@ -37,23 +37,22 @@ export const expectsUserResponse = (
   eventType: string,
   data: unknown,
 ): boolean => {
-  const messageData = data && typeof data === "object"
-    ? data as MessageSurfaceData
-    : undefined;
-  return eventType === "agent_message" && messageData?.expect_response === true;
+  const messageData =
+    data && typeof data === "object" ? (data as MessageSurfaceData) : undefined;
+  return (
+    eventType === "agent_message" &&
+    (messageData?.expect_response === true ||
+      messageData?.message_type === "question")
+  );
 };
 
 export const getMessageSurface = (
   eventType: string,
   data: unknown,
 ): MessageSurface => {
-  const messageData = data && typeof data === "object"
-    ? data as MessageSurfaceData
-    : undefined;
-  if (
-    expectsUserResponse(eventType, messageData) ||
-    messageData?.message_type === "question"
-  ) {
+  const messageData =
+    data && typeof data === "object" ? (data as MessageSurfaceData) : undefined;
+  if (expectsUserResponse(eventType, messageData)) {
     return "chat";
   }
   if (messageData?.visible === false) return "ignore";
@@ -64,7 +63,10 @@ export const getMessageSurface = (
   }
   if (FINAL_ANSWER_EVENT_TYPES.has(eventType)) return "stream";
   if (eventType === "agent_status") return "status";
-  if (eventType === "agent_progress" || messageData?.message_type === "progress") {
+  if (
+    eventType === "agent_progress" ||
+    messageData?.message_type === "progress"
+  ) {
     return "timeline";
   }
   if (

--- a/src/xagent/core/agent/message_display.py
+++ b/src/xagent/core/agent/message_display.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import Literal, cast
+
+MessageDisplay = Literal["chat", "timeline", "status", "stream", "ignore"]
+
+MESSAGE_DISPLAYS = frozenset({"chat", "timeline", "status", "stream", "ignore"})
+FINAL_ANSWER_EVENT_TYPES = frozenset(
+    {
+        "final_answer_start",
+        "final_answer_delta",
+        "final_answer_end",
+        "final_answer_error",
+    }
+)
+
+
+def resolve_message_display(
+    *,
+    display: str | None = None,
+    event_type: str | None = None,
+    message_type: str | None = None,
+    expect_response: bool = False,
+    visible: bool = True,
+) -> MessageDisplay:
+    """Resolve where an outbound message is rendered.
+
+    Visibility and response waiting are deliberately separate concerns. A
+    response-bearing message is always chat-visible, while legacy messages
+    without an explicit display retain their established semantic defaults.
+    """
+
+    if expect_response or message_type == "question":
+        return "chat"
+    if not visible:
+        return "ignore"
+    if display in MESSAGE_DISPLAYS:
+        return cast(MessageDisplay, display)
+    if event_type in FINAL_ANSWER_EVENT_TYPES:
+        return "stream"
+    if event_type == "agent_status":
+        return "status"
+    if event_type == "agent_progress" or message_type == "progress":
+        return "timeline"
+    if event_type in {
+        "agent_message",
+        "ai_message",
+        "chat_message",
+        "user_message",
+    }:
+        return "chat"
+    return "timeline"

--- a/src/xagent/core/agent/message_display.py
+++ b/src/xagent/core/agent/message_display.py
@@ -34,7 +34,7 @@ def resolve_message_display(
         return "chat"
     if not visible:
         return "ignore"
-    if display in MESSAGE_DISPLAYS:
+    if isinstance(display, str) and display in MESSAGE_DISPLAYS:
         return cast(MessageDisplay, display)
     if event_type in FINAL_ANSWER_EVENT_TYPES:
         return "stream"

--- a/src/xagent/core/agent/message_display.py
+++ b/src/xagent/core/agent/message_display.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import logging
 from typing import Literal, cast
+
+logger = logging.getLogger(__name__)
 
 MessageDisplay = Literal["chat", "timeline", "status", "stream", "ignore"]
 
@@ -30,18 +33,25 @@ def resolve_message_display(
     without an explicit display retain their established semantic defaults.
     """
 
-    if expect_response or message_type == "question":
+    # A real waiting prompt must stay actionable even when a producer also
+    # supplied a contradictory visibility hint. ``message_type`` is only
+    # presentation metadata; ReAct suspends exclusively on expect_response.
+    if event_type == "agent_message" and expect_response:
         return "chat"
     if not visible:
         return "ignore"
     if isinstance(display, str) and display in MESSAGE_DISPLAYS:
         return cast(MessageDisplay, display)
+    if display is not None:
+        logger.warning("Ignoring unsupported message display value: %r", display)
     if event_type in FINAL_ANSWER_EVENT_TYPES:
         return "stream"
     if event_type == "agent_status":
         return "status"
     if event_type == "agent_progress" or message_type == "progress":
         return "timeline"
+    if event_type == "agent_message" and message_type == "question":
+        return "chat"
     if event_type in {
         "agent_message",
         "ai_message",

--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -229,6 +229,7 @@ class _AutoChildRuntime:
         message_type: str = "info",
         expect_response: bool = False,
         visible: bool = True,
+        display: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         return await self.parent.send_message(
@@ -236,6 +237,7 @@ class _AutoChildRuntime:
             message_type=message_type,
             expect_response=expect_response,
             visible=visible,
+            display=display,
             metadata=metadata,
         )
 

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -150,6 +150,7 @@ class _DAGStepRuntime:
         message_type: str = "info",
         expect_response: bool = False,
         visible: bool = True,
+        display: str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         outbound_metadata = dict(metadata or {})
@@ -160,6 +161,7 @@ class _DAGStepRuntime:
             message_type=message_type,
             expect_response=expect_response,
             visible=visible,
+            display=display,
             metadata=outbound_metadata,
         )
 

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -2154,6 +2154,11 @@ class ReActPattern(AgentPattern):
                             "display": {
                                 "type": "string",
                                 "enum": ["chat", "timeline"],
+                                "description": (
+                                    "Where to render this message. Use chat for "
+                                    "durable user-facing information and timeline "
+                                    "for transient execution progress."
+                                ),
                             },
                         },
                         "required": ["message"],
@@ -2345,13 +2350,24 @@ class ReActPattern(AgentPattern):
             expect_response = bool(args.get("expect_response", False))
             message_type = str(args.get("message_type", "info"))
             visible = bool(args.get("visible", True))
-            display = args.get("display")
+            requested_display = args.get("display")
+            display = (
+                requested_display
+                if isinstance(requested_display, str)
+                and requested_display in {"chat", "timeline"}
+                else None
+            )
+            if requested_display is not None and display is None:
+                logger.warning(
+                    "Ignoring unsupported send_message display value: %r",
+                    requested_display,
+                )
             outbound_message = await runtime.send_message(
                 message=message,
                 message_type=message_type,
                 expect_response=expect_response,
                 visible=visible,
-                display=str(display) if display is not None else None,
+                display=display,
             )
             self._record_tool_call(
                 tool_call,
@@ -2360,6 +2376,7 @@ class ReActPattern(AgentPattern):
                     "message": message,
                     "expect_response": expect_response,
                     "visible": visible,
+                    "display": outbound_message["display"],
                 },
             )
             if expect_response:
@@ -2396,7 +2413,11 @@ class ReActPattern(AgentPattern):
                 }
             context.add_tool_result(
                 tool_name=name,
-                result={"message": message, "status": "sent"},
+                result={
+                    "message": message,
+                    "status": "sent",
+                    "display": outbound_message["display"],
+                },
                 tool_call_id=tool_call.get("id"),
             )
             return {

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -2151,6 +2151,10 @@ class ReActPattern(AgentPattern):
                             },
                             "expect_response": {"type": "boolean"},
                             "visible": {"type": "boolean"},
+                            "display": {
+                                "type": "string",
+                                "enum": ["chat", "timeline"],
+                            },
                         },
                         "required": ["message"],
                     },
@@ -2341,11 +2345,13 @@ class ReActPattern(AgentPattern):
             expect_response = bool(args.get("expect_response", False))
             message_type = str(args.get("message_type", "info"))
             visible = bool(args.get("visible", True))
+            display = args.get("display")
             outbound_message = await runtime.send_message(
                 message=message,
                 message_type=message_type,
                 expect_response=expect_response,
                 visible=visible,
+                display=str(display) if display is not None else None,
             )
             self._record_tool_call(
                 tool_call,
@@ -2431,6 +2437,7 @@ class ReActPattern(AgentPattern):
                 message_type="question",
                 expect_response=True,
                 visible=True,
+                display="chat",
                 metadata={"interactions": interactions},
             )
             self._record_tool_call(
@@ -2752,6 +2759,7 @@ class ReActPattern(AgentPattern):
             message_type=message_type,
             expect_response=True,
             visible=True,
+            display="chat",
             metadata={"interactions": interactions},
         )
         self.status = "waiting_for_user"

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -753,7 +753,9 @@ class PatternRuntime:
 
         outbound_metadata = dict(metadata or {})
         resolved_display = resolve_message_display(
-            display=display or outbound_metadata.get("display"),
+            display=(
+                display if display is not None else outbound_metadata.get("display")
+            ),
             event_type="agent_message",
             message_type=message_type,
             expect_response=expect_response,

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -35,6 +35,7 @@ from ..tools.user_interaction import (
     tool_result_waits_for_user,
 )
 from .context.execution import COMPACT_SUMMARY_FALLBACK_BUDGETS
+from .message_display import MessageDisplay, resolve_message_display
 from .result import normalize_tool_failure_code, tool_result_succeeded
 from .streaming import merge_streamed_tool_call_arguments
 
@@ -745,11 +746,20 @@ class PatternRuntime:
         message_type: str = "info",
         expect_response: bool = False,
         visible: bool = True,
+        display: MessageDisplay | str | None = None,
         metadata: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         """Emit an agent-to-user message through the runtime boundary."""
 
         outbound_metadata = dict(metadata or {})
+        resolved_display = resolve_message_display(
+            display=display or outbound_metadata.get("display"),
+            event_type="agent_message",
+            message_type=message_type,
+            expect_response=expect_response,
+            visible=visible,
+        )
+        outbound_metadata["display"] = resolved_display
         step_id = (
             outbound_metadata.get("step_id")
             or outbound_metadata.get("dag_step_id")
@@ -765,6 +775,7 @@ class PatternRuntime:
             "message_type": message_type,
             "expect_response": expect_response,
             "visible": visible,
+            "display": resolved_display,
             "metadata": outbound_metadata,
         }
         if expect_response or message_type == "question":

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -53,6 +53,7 @@ from ...core.agent.checkpoint import (
     CheckpointReadError,
     CheckpointUnavailableError,
 )
+from ...core.agent.message_display import resolve_message_display
 from ...core.agent.runner import UserMessageInjectionOutcome
 from ...core.agent.trace import TraceEvent, TraceHandler
 from ...core.execution_scope import (
@@ -1049,10 +1050,51 @@ def _persist_agent_outbound_event(task_id: int, event: Dict[str, Any]) -> None:
 
 
 def _agent_outbound_event_type(payload: Dict[str, Any]) -> str:
-    message_type = str(payload.get("message_type") or "info")
-    if bool(payload.get("expect_response")) or message_type == "question":
-        return "agent_message"
-    return "agent_progress"
+    display = _agent_outbound_display(payload)
+    if display == "timeline":
+        return "agent_progress"
+    if display == "status":
+        return "agent_status"
+    return "agent_message"
+
+
+def _agent_outbound_display(payload: Dict[str, Any]) -> str:
+    metadata = payload.get("metadata")
+    metadata_display = metadata.get("display") if isinstance(metadata, dict) else None
+    return resolve_message_display(
+        display=payload.get("display") or metadata_display,
+        event_type="agent_message",
+        message_type=str(payload.get("message_type") or "info"),
+        expect_response=bool(payload.get("expect_response")),
+        visible=payload.get("visible") is not False,
+    )
+
+
+def create_agent_outbound_stream_event(
+    task_id: int, payload: Dict[str, Any]
+) -> Dict[str, Any] | None:
+    """Build one normalized UI event for a runtime outbound message."""
+
+    display = _agent_outbound_display(payload)
+    if display in {"ignore", "stream"}:
+        return None
+    event_type = _agent_outbound_event_type(payload)
+    return create_stream_event(
+        event_type,
+        task_id,
+        {
+            "event_id": payload.get("event_id"),
+            "step_id": payload.get("step_id"),
+            "execution_id": payload.get("execution_id"),
+            "message": payload.get("message"),
+            "message_type": payload.get("message_type", "info"),
+            "expect_response": bool(payload.get("expect_response", False)),
+            "display": display,
+            "visible": bool(payload.get("visible", True)),
+            "metadata": payload.get("metadata") or {},
+        },
+        event_id=payload.get("event_id"),
+    )
 
 
 def _reconcile_streamed_final_answer(task_id: int, content: str) -> str:
@@ -1102,26 +1144,9 @@ def make_agent_outbound_handler(task_id: int) -> Any:
             )
             return
 
-        if payload.get("visible") is False:
+        event = create_agent_outbound_stream_event(task_id, payload)
+        if event is None:
             return
-
-        event_type = _agent_outbound_event_type(payload)
-        event = create_stream_event(
-            event_type,
-            task_id,
-            {
-                "event_id": payload.get("event_id"),
-                "step_id": payload.get("step_id"),
-                "execution_id": payload.get("execution_id"),
-                "message": payload.get("message"),
-                "message_type": payload.get("message_type", "info"),
-                "expect_response": bool(payload.get("expect_response", False)),
-                "display": "chat" if event_type == "agent_message" else "timeline",
-                "visible": bool(payload.get("visible", True)),
-                "metadata": payload.get("metadata") or {},
-            },
-            event_id=payload.get("event_id"),
-        )
         await asyncio.to_thread(_persist_agent_outbound_event, task_id, event)
         await manager.broadcast_to_task(event, task_id)
 

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -10166,27 +10166,10 @@ clarification questions as plain assistant text.
 
         async def send_builder_outbound_message(payload: Dict[str, Any]) -> None:
             """Bridge agent agent-to-user messages to the builder chat socket."""
-            await websocket.send_text(
-                json.dumps(
-                    create_stream_event(
-                        _agent_outbound_event_type(payload),
-                        builder_task_id,
-                        {
-                            "event_id": payload.get("event_id"),
-                            "step_id": payload.get("step_id"),
-                            "execution_id": payload.get("execution_id"),
-                            "message": payload.get("message"),
-                            "message_type": payload.get("message_type", "info"),
-                            "expect_response": bool(
-                                payload.get("expect_response", False)
-                            ),
-                            "visible": bool(payload.get("visible", True)),
-                            "metadata": payload.get("metadata") or {},
-                        },
-                        event_id=payload.get("event_id"),
-                    )
-                )
-            )
+            event = create_agent_outbound_stream_event(builder_task_id, payload)
+            if event is None:
+                return
+            await websocket.send_text(json.dumps(event))
 
         llm = runtime_inputs.llm
         compact_llm = runtime_inputs.compact_llm

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -1018,7 +1018,7 @@ def _persist_agent_outbound_event(task_id: int, event: Dict[str, Any]) -> None:
         )
         db.add(trace_event)
 
-        if bool(data.get("expect_response")):
+        if bool(data.get("expect_response")) or data.get("message_type") == "question":
             task = db.query(DatabaseTask).filter(DatabaseTask.id == task_id).first()
             message = str(data.get("message") or "")
             task_user_id = _task_user_id(task) if task else None
@@ -1063,7 +1063,7 @@ def _agent_outbound_display(payload: Dict[str, Any]) -> str:
     metadata_display = metadata.get("display") if isinstance(metadata, dict) else None
     return resolve_message_display(
         display=payload.get("display") or metadata_display,
-        event_type="agent_message",
+        event_type=str(payload.get("type") or "agent_message"),
         message_type=str(payload.get("message_type") or "info"),
         expect_response=bool(payload.get("expect_response")),
         visible=payload.get("visible") is not False,

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -53,7 +53,10 @@ from ...core.agent.checkpoint import (
     CheckpointReadError,
     CheckpointUnavailableError,
 )
-from ...core.agent.message_display import resolve_message_display
+from ...core.agent.message_display import (
+    FINAL_ANSWER_EVENT_TYPES,
+    resolve_message_display,
+)
 from ...core.agent.runner import UserMessageInjectionOutcome
 from ...core.agent.trace import TraceEvent, TraceHandler
 from ...core.execution_scope import (
@@ -1018,7 +1021,7 @@ def _persist_agent_outbound_event(task_id: int, event: Dict[str, Any]) -> None:
         )
         db.add(trace_event)
 
-        if bool(data.get("expect_response")) or data.get("message_type") == "question":
+        if bool(data.get("expect_response")):
             task = db.query(DatabaseTask).filter(DatabaseTask.id == task_id).first()
             message = str(data.get("message") or "")
             task_user_id = _task_user_id(task) if task else None
@@ -1062,7 +1065,11 @@ def _agent_outbound_display(payload: Dict[str, Any]) -> str:
     metadata = payload.get("metadata")
     metadata_display = metadata.get("display") if isinstance(metadata, dict) else None
     return resolve_message_display(
-        display=payload.get("display") or metadata_display,
+        display=(
+            payload.get("display")
+            if payload.get("display") is not None
+            else metadata_display
+        ),
         event_type=str(payload.get("type") or "agent_message"),
         message_type=str(payload.get("message_type") or "info"),
         expect_response=bool(payload.get("expect_response")),
@@ -1118,37 +1125,56 @@ def _reconcile_streamed_final_answer(task_id: int, content: str) -> str:
         db.close()
 
 
+async def deliver_agent_outbound_message(
+    *,
+    task_id: int,
+    payload: Dict[str, Any],
+    send_event: Any,
+    persist_event: bool,
+    reconcile_final_answer: bool,
+) -> Dict[str, Any] | None:
+    """Normalize and deliver one runtime outbound payload to a UI transport."""
+
+    payload_type = str(payload.get("type") or "")
+    event: Dict[str, Any] | None
+    if payload_type in FINAL_ANSWER_EVENT_TYPES:
+        if (
+            reconcile_final_answer
+            and payload_type == "final_answer_end"
+            and isinstance(payload.get("content"), str)
+        ):
+            payload = dict(payload)
+            payload["content"] = await asyncio.to_thread(
+                _reconcile_streamed_final_answer,
+                task_id,
+                str(payload["content"]),
+            )
+        event = create_final_answer_stream_event(payload_type, task_id, dict(payload))
+    else:
+        event = create_agent_outbound_stream_event(task_id, payload)
+    if event is None:
+        return None
+    if persist_event and payload_type not in FINAL_ANSWER_EVENT_TYPES:
+        await asyncio.to_thread(_persist_agent_outbound_event, task_id, event)
+
+    await send_event(event)
+    return event
+
+
 def make_agent_outbound_handler(task_id: int) -> Any:
     """Create a web bridge for agent agent-to-user messages."""
 
     async def handle_outbound_message(payload: Dict[str, Any]) -> None:
-        payload_type = str(payload.get("type") or "")
-        if payload_type in {
-            "final_answer_start",
-            "final_answer_delta",
-            "final_answer_end",
-            "final_answer_error",
-        }:
-            if payload_type == "final_answer_end" and isinstance(
-                payload.get("content"), str
-            ):
-                payload = dict(payload)
-                payload["content"] = await asyncio.to_thread(
-                    _reconcile_streamed_final_answer,
-                    task_id,
-                    str(payload["content"]),
-                )
-            await manager.broadcast_to_task(
-                create_final_answer_stream_event(payload_type, task_id, dict(payload)),
-                task_id,
-            )
-            return
+        async def send_event(event: Dict[str, Any]) -> None:
+            await manager.broadcast_to_task(event, task_id)
 
-        event = create_agent_outbound_stream_event(task_id, payload)
-        if event is None:
-            return
-        await asyncio.to_thread(_persist_agent_outbound_event, task_id, event)
-        await manager.broadcast_to_task(event, task_id)
+        await deliver_agent_outbound_message(
+            task_id=task_id,
+            payload=payload,
+            send_event=send_event,
+            persist_event=True,
+            reconcile_final_answer=True,
+        )
 
     return handle_outbound_message
 
@@ -7898,7 +7924,13 @@ def _load_historical_stream_snapshot_sync(
                                 ("user", content.strip(), attachment_key)
                             )
                     elif (
-                        trace_event.event_type in {"agent_message", "ai_message"}
+                        (
+                            trace_event.event_type == "ai_message"
+                            or (
+                                trace_event.event_type == "agent_message"
+                                and normalized_event_data.get("expect_response") is True
+                            )
+                        )
                         and isinstance(content, str)
                         and content.strip()
                     ):
@@ -10166,10 +10198,17 @@ clarification questions as plain assistant text.
 
         async def send_builder_outbound_message(payload: Dict[str, Any]) -> None:
             """Bridge agent agent-to-user messages to the builder chat socket."""
-            event = create_agent_outbound_stream_event(builder_task_id, payload)
-            if event is None:
-                return
-            await websocket.send_text(json.dumps(event))
+
+            async def send_event(event: Dict[str, Any]) -> None:
+                await websocket.send_text(json.dumps(event))
+
+            await deliver_agent_outbound_message(
+                task_id=builder_task_id,
+                payload=payload,
+                send_event=send_event,
+                persist_event=False,
+                reconcile_final_answer=False,
+            )
 
         llm = runtime_inputs.llm
         compact_llm = runtime_inputs.compact_llm

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -39,6 +39,25 @@ from xagent.core.model.chat.types import ChunkType, StreamChunk
 DAG_COMPLETION_TOOL_NAME = "assess_dag_completion"
 
 
+@pytest.mark.asyncio
+async def test_auto_child_runtime_forwards_message_display() -> None:
+    parent = PatternRuntime(execution_id="auto-display")
+    child = _AutoChildRuntime(
+        parent=parent,
+        auto_pattern=object(),  # type: ignore[arg-type]
+        root_context=object(),
+    )
+
+    payload = await child.send_message(
+        message="Planning update",
+        message_type="info",
+        display="timeline",
+    )
+
+    assert payload["display"] == "timeline"
+    assert payload["metadata"]["display"] == "timeline"
+
+
 class SearchArgs(BaseModel):
     query: str
     count: int = 10

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -45,6 +45,27 @@ from xagent.core.task_runtime import PREFERRED_INPUT_MODALITIES_METADATA_KEY
 DAG_COMPLETION_TOOL_NAME = "assess_dag_completion"
 
 
+@pytest.mark.asyncio
+async def test_dag_step_runtime_forwards_display_and_step_metadata() -> None:
+    parent = PatternRuntime(execution_id="dag-display")
+    child = _DAGStepRuntime(
+        parent=parent,
+        dag_pattern=object(),  # type: ignore[arg-type]
+        root_context=object(),
+        step_id="step-1",
+    )
+
+    payload = await child.send_message(
+        message="Step update",
+        message_type="info",
+        display="timeline",
+    )
+
+    assert payload["display"] == "timeline"
+    assert payload["step_id"] == "step-1"
+    assert payload["metadata"]["dag_step_id"] == "step-1"
+
+
 @pytest.fixture(autouse=True)
 def reset_context_manager() -> None:
     manager = ContextManager()

--- a/tests/core/agent/test_message_display.py
+++ b/tests/core/agent/test_message_display.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from xagent.core.agent.message_display import resolve_message_display
+
+
+CONTRACT_CASES: list[dict[str, Any]] = json.loads(
+    (
+        Path(__file__).parents[2] / "fixtures" / "message_surface_contract.json"
+    ).read_text(encoding="utf-8")
+)
+
+
+@pytest.mark.parametrize("case", CONTRACT_CASES, ids=lambda case: case["name"])
+def test_message_surface_contract(case: dict[str, Any]) -> None:
+    data = case["data"]
+    metadata = data.get("metadata")
+    metadata_display = metadata.get("display") if isinstance(metadata, dict) else None
+    display = (
+        data.get("display") if data.get("display") is not None else metadata_display
+    )
+
+    assert (
+        resolve_message_display(
+            display=display,
+            event_type=case["event_type"],
+            message_type=data.get("message_type"),
+            expect_response=data.get("expect_response") is True,
+            visible=data.get("visible") is not False,
+        )
+        == case["surface"]
+    )

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -4530,6 +4530,47 @@ async def test_react_pattern_send_message_without_response_continues() -> None:
 
 
 @pytest.mark.asyncio
+async def test_react_pattern_send_message_rejects_internal_display_values(
+    caplog,
+) -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "tool_calls": [
+                    {
+                        "id": "call_message",
+                        "function": {
+                            "name": "send_message",
+                            "arguments": '{"message":"Still working","display":"ignore"}',
+                        },
+                    }
+                ],
+            },
+            {"content": "All done."},
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3)
+    runtime = PatternRuntime()
+    context = ExecutionContext()
+    context.add_user_message("Work")
+
+    with caplog.at_level(
+        logging.WARNING, logger="xagent.core.agent.pattern.react.react"
+    ):
+        result = await pattern.run(context=context, tools=[], llm=llm, runtime=runtime)
+
+    assert result["success"] is True
+    assert len(runtime.outbound_messages) == 1
+    assert runtime.outbound_messages[0]["message"] == "Still working"
+    assert runtime.outbound_messages[0]["display"] == "chat"
+    assert "unsupported send_message display value" in caplog.text
+
+    tool_messages = context.get_messages_by_role("tool")
+    assert len(tool_messages) == 1
+    assert tool_messages[0].metadata["raw_result"]["display"] == "chat"
+
+
+@pytest.mark.asyncio
 async def test_react_pattern_send_message_with_response_waits() -> None:
     llm = FakeLLM(
         responses=[

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -4516,6 +4516,7 @@ async def test_react_pattern_send_message_without_response_continues() -> None:
     assert outbound_message["message_type"] == "progress"
     assert outbound_message["expect_response"] is False
     assert outbound_message["visible"] is True
+    assert outbound_message["display"] == "timeline"
     assert outbound_message["step_id"] == outbound_message["metadata"]["step_id"]
     tool_messages = context.get_messages_by_role("tool")
     assert len(tool_messages) == 1
@@ -4560,6 +4561,7 @@ async def test_react_pattern_send_message_with_response_waits() -> None:
     assert sent_messages == runtime.outbound_messages
     assert sent_messages[0]["message"] == "Choose A or B"
     assert sent_messages[0]["expect_response"] is True
+    assert sent_messages[0]["display"] == "chat"
     assert pattern.status == "waiting_for_user"
     tool_messages = context.get_messages_by_role("tool")
     assert tool_messages[0].tool_call_id == "call_question"
@@ -4605,6 +4607,7 @@ async def test_react_pattern_ask_user_question_pauses_with_structured_payload() 
     assert outbound_message["message_type"] == "question"
     assert outbound_message["expect_response"] is True
     assert outbound_message["visible"] is True
+    assert outbound_message["display"] == "chat"
     assert outbound_message["step_id"] == outbound_message["metadata"]["step_id"]
     assert outbound_message["metadata"]["interactions"] == [
         {

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -553,7 +553,31 @@ async def test_runtime_send_message_includes_active_step_id() -> None:
 
     assert payload["step_id"] == "react-step-1"
     assert payload["metadata"]["step_id"] == "react-step-1"
+    assert payload["display"] == "timeline"
     assert outbound.events[0]["step_id"] == "react-step-1"
+
+
+@pytest.mark.asyncio
+async def test_runtime_send_message_resolves_display_independently_from_waiting() -> (
+    None
+):
+    runtime = PatternRuntime(execution_id="task-123")
+
+    info = await runtime.send_message(message="An ordinary update")
+    question = await runtime.send_message(
+        message="Need input", message_type="question", expect_response=False
+    )
+    explicit_timeline = await runtime.send_message(
+        message="A compact update", display="timeline"
+    )
+    hidden = await runtime.send_message(message="Internal", visible=False)
+
+    assert info["display"] == "chat"
+    assert info["expect_response"] is False
+    assert question["display"] == "chat"
+    assert question["expect_response"] is False
+    assert explicit_timeline["display"] == "timeline"
+    assert hidden["display"] == "ignore"
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -571,6 +571,13 @@ async def test_runtime_send_message_resolves_display_independently_from_waiting(
         message="A compact update", display="timeline"
     )
     hidden = await runtime.send_message(message="Internal", visible=False)
+    hidden_question = await runtime.send_message(
+        message="Required input", expect_response=True, visible=False
+    )
+    invalid_display = await runtime.send_message(
+        message="Fallback message",
+        display={"surface": "timeline"},  # type: ignore[arg-type]
+    )
 
     assert info["display"] == "chat"
     assert info["expect_response"] is False
@@ -578,6 +585,8 @@ async def test_runtime_send_message_resolves_display_independently_from_waiting(
     assert question["expect_response"] is False
     assert explicit_timeline["display"] == "timeline"
     assert hidden["display"] == "ignore"
+    assert hidden_question["display"] == "chat"
+    assert invalid_display["display"] == "chat"
 
 
 @pytest.mark.asyncio

--- a/tests/fixtures/message_surface_contract.json
+++ b/tests/fixtures/message_surface_contract.json
@@ -1,0 +1,72 @@
+[
+  {
+    "name": "ordinary info is durable chat without waiting",
+    "event_type": "agent_message",
+    "data": {"message_type": "info", "expect_response": false},
+    "surface": "chat",
+    "expects_response": false
+  },
+  {
+    "name": "progress stays in the timeline",
+    "event_type": "agent_message",
+    "data": {"message_type": "progress", "expect_response": false},
+    "surface": "timeline",
+    "expects_response": false
+  },
+  {
+    "name": "waiting prompt remains actionable",
+    "event_type": "agent_message",
+    "data": {"expect_response": true, "visible": false},
+    "surface": "chat",
+    "expects_response": true
+  },
+  {
+    "name": "question metadata does not imply waiting",
+    "event_type": "agent_message",
+    "data": {"message_type": "question", "expect_response": false},
+    "surface": "chat",
+    "expects_response": false
+  },
+  {
+    "name": "hidden non-waiting question stays hidden",
+    "event_type": "agent_message",
+    "data": {"message_type": "question", "expect_response": false, "visible": false},
+    "surface": "ignore",
+    "expects_response": false
+  },
+  {
+    "name": "waiting precedence is agent-message only",
+    "event_type": "ai_message",
+    "data": {"display": "timeline", "expect_response": true},
+    "surface": "timeline",
+    "expects_response": false
+  },
+  {
+    "name": "empty top-level display does not use metadata fallback",
+    "event_type": "agent_message",
+    "data": {"display": "", "metadata": {"display": "timeline"}},
+    "surface": "chat",
+    "expects_response": false
+  },
+  {
+    "name": "malformed display falls back safely",
+    "event_type": "agent_message",
+    "data": {"display": ["timeline"]},
+    "surface": "chat",
+    "expects_response": false
+  },
+  {
+    "name": "user transcript events are chat-visible",
+    "event_type": "user_message",
+    "data": {},
+    "surface": "chat",
+    "expects_response": false
+  },
+  {
+    "name": "final answer deltas use the stream",
+    "event_type": "final_answer_delta",
+    "data": {},
+    "surface": "stream",
+    "expects_response": false
+  }
+]

--- a/tests/web/api/client_safe_ast_guard.py
+++ b/tests/web/api/client_safe_ast_guard.py
@@ -77,6 +77,7 @@ SENSITIVE_PAYLOAD_FIELDS = {"type", "message", "error"}
 NON_ERROR_STREAM_EVENT_BUILDERS = {
     "_agent_outbound_event_type": None,
     "_waiting_or_paused_event_fields": 0,
+    "create_agent_outbound_stream_event": None,
 }
 DICT_ERROR_PAYLOAD_BUILDERS = {
     "_read_task_error_payload_offloop": "error",

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -201,8 +201,11 @@ def test_no_delivery_producer_can_bypass_the_client_safe_message() -> None:
     # ``_broadcast_terminal_command_error`` gained a third payload literal for
     # external-scope non-cancel commands, mirroring the persisted-event
     # identity rule for the live frame too, bringing the census to 51.
-    assert result.error_payloads == 51, (
-        f"expected exactly 51 error payloads, matched {result.error_payloads}; "
+    # Agent outbound delivery now goes through one transport callback shared by
+    # main chat and Builder. The callback forwarding site is a 52nd recognized
+    # shape; its event factory is explicitly proven non-error by the guard.
+    assert result.error_payloads == 52, (
+        f"expected exactly 52 error payloads, matched {result.error_payloads}; "
         "review the changed sites and bump deliberately"
     )
     # Every allowlist entry must be earned by a live call site: a stale entry

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -37,6 +37,7 @@ from xagent.web.api.websocket import (
     _is_agent_checkpoint_data,
     _is_duplicate_user_message_turn,
     _persist_agent_outbound_event,
+    create_agent_outbound_stream_event,
     create_final_answer_stream_event,
     create_stream_event,
     make_agent_outbound_handler,
@@ -210,6 +211,16 @@ def test_agent_outbound_event_type_separates_progress_from_questions() -> None:
     assert (
         _agent_outbound_event_type(
             {
+                "message": "An ordinary update",
+                "message_type": "info",
+                "expect_response": False,
+            }
+        )
+        == "agent_message"
+    )
+    assert (
+        _agent_outbound_event_type(
+            {
                 "message": "Still working",
                 "message_type": "progress",
                 "expect_response": False,
@@ -226,6 +237,36 @@ def test_agent_outbound_event_type_separates_progress_from_questions() -> None:
             }
         )
         == "agent_message"
+    )
+    assert (
+        _agent_outbound_event_type(
+            {
+                "message": "Timeline narration",
+                "message_type": "info",
+                "display": "timeline",
+            }
+        )
+        == "agent_progress"
+    )
+
+
+def test_agent_outbound_stream_event_carries_resolved_display() -> None:
+    chat_event = create_agent_outbound_stream_event(
+        365, {"message": "Visible update", "message_type": "info"}
+    )
+    timeline_event = create_agent_outbound_stream_event(
+        365, {"message": "Progress", "message_type": "progress"}
+    )
+
+    assert chat_event is not None
+    assert chat_event["event_type"] == "agent_message"
+    assert chat_event["data"]["display"] == "chat"
+    assert timeline_event is not None
+    assert timeline_event["event_type"] == "agent_progress"
+    assert timeline_event["data"]["display"] == "timeline"
+    assert (
+        create_agent_outbound_stream_event(365, {"message": "Hidden", "visible": False})
+        is None
     )
     assert (
         _agent_outbound_event_type(

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -248,6 +248,16 @@ def test_agent_outbound_event_type_separates_progress_from_questions() -> None:
         )
         == "agent_progress"
     )
+    assert (
+        _agent_outbound_event_type(
+            {
+                "message": "Need input",
+                "message_type": "info",
+                "expect_response": True,
+            }
+        )
+        == "agent_message"
+    )
 
 
 def test_agent_outbound_stream_event_carries_resolved_display() -> None:
@@ -264,19 +274,25 @@ def test_agent_outbound_stream_event_carries_resolved_display() -> None:
     assert timeline_event is not None
     assert timeline_event["event_type"] == "agent_progress"
     assert timeline_event["data"]["display"] == "timeline"
+    metadata_timeline_event = create_agent_outbound_stream_event(
+        365,
+        {
+            "message": "Metadata progress",
+            "metadata": {"display": "timeline"},
+        },
+    )
+    assert metadata_timeline_event is not None
+    assert metadata_timeline_event["event_type"] == "agent_progress"
+    assert metadata_timeline_event["data"]["display"] == "timeline"
     assert (
         create_agent_outbound_stream_event(365, {"message": "Hidden", "visible": False})
         is None
     )
     assert (
-        _agent_outbound_event_type(
-            {
-                "message": "Need input",
-                "message_type": "info",
-                "expect_response": True,
-            }
+        create_agent_outbound_stream_event(
+            365, {"message": "Ignored", "display": "ignore"}
         )
-        == "agent_message"
+        is None
     )
 
 

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -294,6 +294,22 @@ def test_agent_outbound_stream_event_carries_resolved_display() -> None:
         )
         is None
     )
+    invalid_display_event = create_agent_outbound_stream_event(
+        365, {"message": "Fallback", "display": ["timeline"]}
+    )
+    assert invalid_display_event is not None
+    assert invalid_display_event["event_type"] == "agent_message"
+    assert invalid_display_event["data"]["display"] == "chat"
+    assert (
+        create_agent_outbound_stream_event(
+            365,
+            {
+                "type": "final_answer_start",
+                "message_id": "final-answer-1",
+            },
+        )
+        is None
+    )
 
 
 @pytest.mark.asyncio
@@ -420,13 +436,31 @@ def test_persist_agent_outbound_event_uses_payload_ids(monkeypatch) -> None:
     )
 
     _persist_agent_outbound_event(int(task.id), event)
+    legacy_question = create_stream_event(
+        "agent_message",
+        int(task.id),
+        {
+            "event_id": "agent-question-1",
+            "message": "Which option?",
+            "message_type": "question",
+            "expect_response": False,
+        },
+    )
+    _persist_agent_outbound_event(int(task.id), legacy_question)
 
     db = SessionLocal()
     try:
-        trace_event = db.query(DatabaseTraceEvent).filter_by(task_id=int(task.id)).one()
+        trace_event = (
+            db.query(DatabaseTraceEvent)
+            .filter_by(task_id=int(task.id), event_id="agent-event-1")
+            .one()
+        )
         assert trace_event.event_id == "agent-event-1"
         assert trace_event.event_type == "agent_progress"
         assert trace_event.step_id == "react-step-1"
+        chat_message = db.query(TaskChatMessage).filter_by(task_id=int(task.id)).one()
+        assert chat_message.content == "Which option?"
+        assert chat_message.message_type == "question"
     finally:
         db.close()
 

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -40,6 +40,7 @@ from xagent.web.api.websocket import (
     create_agent_outbound_stream_event,
     create_final_answer_stream_event,
     create_stream_event,
+    deliver_agent_outbound_message,
     make_agent_outbound_handler,
     send_historical_data_as_stream,
 )
@@ -205,6 +206,42 @@ def test_final_answer_stream_event_is_not_trace_event() -> None:
     assert event["delta"] == "hello"
     assert "event_type" not in event
     assert "data" not in event
+
+
+@pytest.mark.asyncio
+async def test_shared_outbound_delivery_keeps_builder_final_answer_streams() -> None:
+    sent_events: list[dict[str, object]] = []
+
+    async def send_event(event: dict[str, object]) -> None:
+        sent_events.append(event)
+
+    for payload in (
+        {"type": "final_answer_start", "message_id": "answer-1"},
+        {
+            "type": "final_answer_delta",
+            "message_id": "answer-1",
+            "delta": "Hello",
+        },
+        {
+            "type": "final_answer_end",
+            "message_id": "answer-1",
+            "content": "Hello",
+        },
+    ):
+        await deliver_agent_outbound_message(
+            task_id=-1,
+            payload=payload,
+            send_event=send_event,
+            persist_event=False,
+            reconcile_final_answer=False,
+        )
+
+    assert [event["type"] for event in sent_events] == [
+        "final_answer_start",
+        "final_answer_delta",
+        "final_answer_end",
+    ]
+    assert sent_events[-1]["content"] == "Hello"
 
 
 def test_agent_outbound_event_type_separates_progress_from_questions() -> None:
@@ -436,17 +473,28 @@ def test_persist_agent_outbound_event_uses_payload_ids(monkeypatch) -> None:
     )
 
     _persist_agent_outbound_event(int(task.id), event)
-    legacy_question = create_stream_event(
+    non_waiting_question = create_stream_event(
         "agent_message",
         int(task.id),
         {
             "event_id": "agent-question-1",
-            "message": "Which option?",
+            "message": "Here is a question-shaped note",
             "message_type": "question",
             "expect_response": False,
         },
     )
-    _persist_agent_outbound_event(int(task.id), legacy_question)
+    waiting_question = create_stream_event(
+        "agent_message",
+        int(task.id),
+        {
+            "event_id": "agent-question-2",
+            "message": "Which option?",
+            "message_type": "question",
+            "expect_response": True,
+        },
+    )
+    _persist_agent_outbound_event(int(task.id), non_waiting_question)
+    _persist_agent_outbound_event(int(task.id), waiting_question)
 
     db = SessionLocal()
     try:
@@ -3068,6 +3116,85 @@ async def test_historical_replay_marks_assistant_chat_history_for_chat_display(
     assert assistant_data["expect_response"] is False
     assert assistant_data["source"] == "chat_history"
     assert assistant_data["display"] == "chat"
+
+
+@pytest.mark.asyncio
+async def test_historical_replay_keeps_equal_progress_and_final_answer_text(
+    monkeypatch,
+) -> None:
+    SessionLocal, db, task = _create_trace_handler_test_task("chat-history-collision")
+    try:
+        task_id = int(task.id)
+        user_id = int(task.user_id)
+        base_time = datetime(2026, 5, 27, tzinfo=timezone.utc)
+        db.add_all(
+            [
+                DatabaseTraceEvent(
+                    task_id=task_id,
+                    event_id="ordinary-agent-message",
+                    event_type="agent_message",
+                    timestamp=base_time,
+                    data={
+                        "message": "Done.",
+                        "message_type": "info",
+                        "expect_response": False,
+                        "display": "chat",
+                    },
+                ),
+                TaskChatMessage(
+                    task_id=task_id,
+                    user_id=user_id,
+                    role="assistant",
+                    content="Done.",
+                    message_type="assistant",
+                    created_at=base_time + timedelta(seconds=1),
+                ),
+            ]
+        )
+        db.commit()
+    finally:
+        db.close()
+
+    def get_test_db() -> Iterator[Session]:
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    sent_events: list[dict] = []
+
+    async def send_personal_message(event: dict, websocket: object) -> None:
+        sent_events.append(event)
+
+    monkeypatch.setattr("xagent.web.models.database.get_db", get_test_db)
+    monkeypatch.setattr("xagent.web.api.websocket.cache_get", lambda *args: None)
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.cache_set", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(
+        "xagent.web.api.websocket.manager.send_personal_message",
+        send_personal_message,
+    )
+
+    await send_historical_data_as_stream(
+        websocket=object(),
+        task_id=task_id,
+        user=SimpleNamespace(id=user_id, is_admin=False),
+    )
+
+    matching_events = [
+        event
+        for event in sent_events
+        if event.get("type") == "trace_event"
+        and event.get("event_type") == "agent_message"
+        and event.get("data", {}).get("message") == "Done."
+    ]
+    assert len(matching_events) == 2
+    assert {event["data"].get("source") for event in matching_events} == {
+        None,
+        "chat_history",
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- introduce a shared `chat | timeline | status | stream | ignore` display contract at the runtime boundary
- decouple message visibility from `expect_response`, while preserving legacy `message_type=question` waiting behavior
- preserve the contract through Auto, DAG, ReAct, WebSocket live delivery, persistence, and historical replay
- use the same routing rules in main chat, trace rendering, waiting prompts, task conversation, and Agent Builder
- keep non-waiting Builder messages as durable transcript bubbles so later final answers cannot overwrite them
- safely fall back for malformed display values and keep final-answer stream events out of ordinary message routing

## Validation

- `518 passed`: backend runtime, Auto, DAG, ReAct, WebSocket delivery/persistence/replay tests
- `2821 passed, 1 failed`: full frontend suite; the single pre-existing failure is the unrelated missing Salesforce entry in `PROVIDER_DISPLAY_NAMES`, and neither affected file is changed by this PR
- `npm run type-check`
- `npm run build` (production build and static export completed; existing ESLint CLI option warning remains non-fatal)
- Ruff check and format check for all changed Python source files
- Python compileall and `git diff --check`
- local full-stack smoke test on the rebased head: backend and frontend return HTTP 200, first-run `/login` redirects to `/setup`, `/setup-admin` creates the first administrator, and `/login` returns access and refresh tokens

Closes #554