### PR TITLE
fix: broadcast validation-rejected external cancels and withhold identity for every external-scope terminal

### DIFF
--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -9604,10 +9604,16 @@ async def _execute_durable_task_command(
                     target_state_version,
                     int,
                 ):
+                    # ``invalid_target``, not ``stale_run``: nothing about
+                    # the run moved — the command payload itself carries no
+                    # usable version. Labelling it stale told the A2A error
+                    # renderer to advise a retry that can never succeed, and
+                    # let the broadcast gate below mistake a malformed stop
+                    # for a target-gone case whose silence is by design.
                     raise TaskCommandRejected(
                         f"Cancel command {command.command_id} has no exact "
                         "state-version target",
-                        reason="stale_run",
+                        reason="invalid_target",
                     )
                 # The A2A execution core loads its target as an A2A task, so
                 # a cancel for any other task source needs its own core. The
@@ -9846,22 +9852,34 @@ async def execute_durable_task_command(
         # Rejections come from handlers that already expose their durable
         # domain-level outcome. The dispatcher makes them terminal immediately.
         _command_origins.discard_command(command.command_id, command.task_id)
-        if (
+        _rejected_scope = _command_scope(command)
+        # Rejection reasons whose silence external_task_cancel.py's module
+        # docstring owns: the stop's target no longer exists as addressed
+        # (the run rotated, settled, or the task is gone), and that target's
+        # own settlement owns the transcript and the terminal event. A
+        # validation-class rejection is the opposite case — the target may
+        # be perfectly alive and the stop simply did not apply — and staying
+        # silent there strands an anonymous visitor with a stop button that
+        # did nothing (#1979 review, prior blocking finding).
+        _cancel_target_gone = exc.reason in {"stale_run", "task_not_found"}
+        if _rejected_scope == EXTERNAL_COMMAND_SCOPE and (
             command.kind == TaskCommandKind.MESSAGE
-            and _command_scope(command) == EXTERNAL_COMMAND_SCOPE
+            or (command.kind == TaskCommandKind.CANCEL and not _cancel_target_gone)
         ):
-            # The one command whose handler has no channel of its own: the
+            # The commands whose handlers have no channel of their own: the
             # external audience's answer travels through the seam executor,
-            # which reports outcomes only as these exceptions. Without a
-            # broadcast, a deferred answer that is later terminally rejected
-            # (revoked principal, stale request, spent id, quota) vanishes
-            # silently — the task stays parked and nobody is told
-            # (xorbitsai/xagent-saas#952 B2). First-party rejections keep
-            # their handler-owned notifications and are deliberately not
-            # re-broadcast here. An executor-bound presentation draft is
-            # preserved; the standard one is derived only when none was
-            # bound, so the persisted terminal event is classified either
-            # way.
+            # and its stop through the external cancel core — both report
+            # outcomes only as these exceptions. Without a broadcast, a
+            # deferred answer that is later terminally rejected (revoked
+            # principal, stale request, spent id, quota), or a stop whose
+            # command payload failed validation, vanishes silently — the
+            # task stays parked or running and nobody is told
+            # (xorbitsai/xagent-saas#952 B2; #1979 review round 3).
+            # First-party rejections keep their handler-owned notifications
+            # and are deliberately not re-broadcast here. An executor-bound
+            # presentation draft is preserved; the standard one is derived
+            # only when none was bound, so the persisted terminal event is
+            # classified either way.
             if terminal_event_draft_for_error(exc) is None:
                 bind_terminal_event_draft(
                     exc,
@@ -9872,8 +9890,11 @@ async def execute_durable_task_command(
             except Exception:
                 # The rejection is already classified and its draft is
                 # bound; a failed notification must not supersede the
-                # terminal rejection into a retried failure (the finalize
-                # broadcast in external_task_cancel.py keeps the same rule).
+                # terminal rejection into a retried failure. Unlike
+                # external_task_cancel.py's finalize, which commits its
+                # terminal row before broadcasting, this broadcast runs
+                # before the transport persists the disposition — the
+                # persist-then-notify ordering here is #1996's follow-up.
                 # Exception, never BaseException: cancellation propagates.
                 logger.warning(
                     "task %s external input rejection is terminal but its "

--- a/src/xagent/web/services/external_task_input.py
+++ b/src/xagent/web/services/external_task_input.py
@@ -19,6 +19,14 @@ terminal domain refusal. Any other exception consumes the failure budget.
 An executor may attach a ``TerminalTaskEventDraft`` to the exceptions it
 raises (``bind_terminal_event_draft``) to control the durable terminal
 outcome's client-safe presentation.
+
+Contract note on ``TaskCommandRejected``: raise it only when the refusal
+also *establishes non-application* -- the answer verifiably never reached
+the downstream operation. ``external_input_terminal_message`` renders every
+rejection with the categorical not-applied sentence on the strength of this
+contract; an executor that cannot prove non-application (for example, a
+spent delivery id whose original attempt may have landed) must raise a
+plain failure instead, whose wording asserts only uncertainty.
 """
 
 from __future__ import annotations

--- a/src/xagent/web/services/task_command_terminal_events.py
+++ b/src/xagent/web/services/task_command_terminal_events.py
@@ -147,9 +147,15 @@ def stage_terminal_event(
         outcome=outcome,
         message_code=(draft.message_code.value if draft.message_code else None),
         resend_safe=bool(draft.resend_safe),
+        # Any external-scope command, not only the cancel: the audience is
+        # anonymous, cannot act on durable command identity, and must not be
+        # shown it. Enforced here — the single persistence chokepoint —
+        # rather than at each draft-building call site, so a caller that
+        # forgets (or a defaulted draft on the success path, which carries
+        # include_command_identity=True) cannot leak the identity for an
+        # external MESSAGE terminal (#1979 review NEW-1).
         include_command_identity=bool(
-            draft.include_command_identity
-            and not is_external_cancel_command(kind=str(command.kind), scope=scope)
+            draft.include_command_identity and scope != _EXTERNAL_COMMAND_SCOPE
         ),
     )
     try:

--- a/tests/web/api/test_external_input_command_seam.py
+++ b/tests/web/api/test_external_input_command_seam.py
@@ -13,6 +13,7 @@ scoped command at the WebSocket enqueue boundary.
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -469,8 +470,6 @@ async def test_exhausted_external_deferral_withholds_command_identity(
     same chokepoint.
     """
 
-    from unittest.mock import AsyncMock, MagicMock
-
     agent_id, owner_user_id = _create_agent()
     task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
 
@@ -559,8 +558,6 @@ async def test_defer_exhaustion_boundary_uses_the_effective_budget(
     handoff, the broadcast must assert only uncertainty, never
     non-application.
     """
-
-    from unittest.mock import AsyncMock, MagicMock
 
     monkeypatch.setenv("XAGENT_TASK_LEASE_TTL_SECONDS", "300")
     budget = max_command_defers()
@@ -689,8 +686,6 @@ async def test_exhausted_generic_failure_reports_an_unconfirmed_outcome(
     non-application.
     """
 
-    from unittest.mock import AsyncMock, MagicMock
-
     agent_id, owner_user_id = _create_agent()
     task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
 
@@ -773,8 +768,6 @@ async def test_rejected_external_input_broadcasts_and_keeps_the_bound_draft(
     ``TerminalTaskEventDraft`` accepts but the fallback never produces, so
     only the bound draft winning can explain the assertion below.
     """
-
-    from unittest.mock import AsyncMock, MagicMock
 
     from xagent.web.services.task_command_terminal_events import (
         TerminalTaskEventDraft,
@@ -869,8 +862,6 @@ async def test_rejected_external_input_without_a_bound_draft_gets_the_fallback(
     -- the other half of the precedence contract pinned above.
     """
 
-    from unittest.mock import AsyncMock, MagicMock
-
     agent_id, owner_user_id = _create_agent()
     task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
 
@@ -947,8 +938,6 @@ async def test_rejection_broadcast_failure_does_not_supersede_the_disposition(
     draft persisted.
     """
 
-    from unittest.mock import AsyncMock, MagicMock
-
     from xagent.web.services.task_command_terminal_events import (
         TerminalTaskEventDraft,
         bind_terminal_event_draft,
@@ -1014,6 +1003,232 @@ async def test_rejection_broadcast_failure_does_not_supersede_the_disposition(
         )
         assert event.outcome == "failed"
         assert event.message_code is None
+        assert event.include_command_identity is False
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_rejected_external_cancel_validation_broadcasts(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stop whose payload fails validation must not vanish silently.
+
+    The target may be perfectly alive; only the command was malformed. The
+    visitor pressed a button that did nothing, and the cancel core's own
+    success-path broadcast is never reached — the wrapper owns this
+    notification (#1979 review, prior blocking finding). The broadcast uses
+    the external-cancel wording branch and never carries durable command
+    identity.
+    """
+
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
+
+    broadcast_manager = MagicMock()
+    broadcast_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", broadcast_manager)
+
+    db = _direct_db_session()
+    try:
+        enqueued = enqueue_task_command(
+            db,
+            task_id=task_id,
+            actor_user_id=None,
+            command_id="ext-cancel-invalid",
+            kind=TaskCommandKind.CANCEL,
+            payload={
+                "agent_id": agent_id,
+                "scope": "external",
+                # No target_state_version: the validation-class rejection.
+            },
+        )
+        assert enqueued.created
+    finally:
+        db.close()
+
+    processed = await dispatch_one_task_command(
+        websocket_api.execute_durable_task_command
+    )
+    assert processed is True
+
+    payloads = [
+        call.args[0] for call in broadcast_manager.broadcast_to_task.await_args_list
+    ]
+    assert [payload["type"] for payload in payloads] == ["agent_error"]
+    assert "command_id" not in payloads[0]
+    assert "command_kind" not in payloads[0]
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.command_id == "ext-cancel-invalid")
+            .one()
+        )
+        assert row.status == COMMAND_FAILED
+        assert row.result == {"rejection_reason": "invalid_target"}
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_rejected_external_cancel_stale_target_stays_silent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A stop whose target moved on keeps its documented silence.
+
+    ``external_task_cancel``'s module contract: a rejected command is
+    terminal without a client-visible error frame when the stop no longer
+    has a target — that run's own settlement owns the transcript and the
+    event. The broadcast gate must not widen into this family.
+    """
+
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
+
+    broadcast_manager = MagicMock()
+    broadcast_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", broadcast_manager)
+
+    db = _direct_db_session()
+    try:
+        enqueued = enqueue_task_command(
+            db,
+            task_id=task_id,
+            actor_user_id=None,
+            command_id="ext-cancel-stale",
+            kind=TaskCommandKind.CANCEL,
+            payload={
+                "agent_id": agent_id,
+                "scope": "external",
+                # Valid shape, wrong version: the run moved on.
+                "target_state_version": 999,
+            },
+        )
+        assert enqueued.created
+    finally:
+        db.close()
+
+    processed = await dispatch_one_task_command(
+        websocket_api.execute_durable_task_command
+    )
+    assert processed is True
+
+    broadcast_manager.broadcast_to_task.assert_not_awaited()
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.command_id == "ext-cancel-stale")
+            .one()
+        )
+        assert row.status == COMMAND_FAILED
+        assert row.result == {"rejection_reason": "stale_run"}
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_first_party_message_rejection_does_not_broadcast(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """First-party rejections keep their handler-owned notifications.
+
+    The broadcast gate exists for audiences with no channel of their own;
+    a scopeless MESSAGE whose delivery is already FAILED must reject
+    without adding a task-wide agent_error on top of the handler's
+    personal reply (#1979 review NEW-7).
+    """
+
+    async def quiet_chat(_ws: Any, _task_id: int, _data: dict[str, Any]) -> None:
+        return None
+
+    monkeypatch.setattr(websocket_api, "_handle_chat_message_unserialized", quiet_chat)
+    monkeypatch.setattr(
+        websocket_api,
+        "_load_command_actor",
+        lambda _actor_id: SimpleNamespace(id=7, is_admin=False),
+    )
+    monkeypatch.setattr(
+        websocket_api,
+        "_load_command_message_delivery_status",
+        lambda _task_id, _turn_id: "failed",
+    )
+    broadcast_manager = MagicMock()
+    broadcast_manager.broadcast_to_task = AsyncMock()
+    monkeypatch.setattr(websocket_api, "manager", broadcast_manager)
+
+    command = ClaimedTaskCommand(
+        id=1,
+        task_id=55,
+        actor_user_id=7,
+        command_id="chat-rejected",
+        kind=TaskCommandKind.MESSAGE,
+        payload={"message": "hello"},
+        target_run_id=None,
+        attempt_count=1,
+    )
+
+    with pytest.raises(TaskCommandRejected, match="could not be applied"):
+        await websocket_api.execute_durable_task_command(command)
+
+    broadcast_manager.broadcast_to_task.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_successful_external_message_terminal_event_withholds_identity() -> None:
+    """The disclosure rule holds on the success path too.
+
+    ``finish_task_command`` stages its terminal event with a defaulted
+    draft whose ``include_command_identity`` is True; the persistence
+    chokepoint must strip it for any external-scope command, or a
+    successful answer leaks the durable command identity the failure paths
+    withhold (#1979 review NEW-1).
+    """
+
+    agent_id, owner_user_id = _create_agent()
+    task_id = _create_waiting_task(agent_id=agent_id, owner_user_id=owner_user_id)
+
+    async def executor(_command: ClaimedTaskCommand) -> dict[str, Any]:
+        return {"admitted": "dispatched"}
+
+    register_external_task_input_executor(executor)
+
+    db = _direct_db_session()
+    try:
+        enqueued = enqueue_task_command(
+            db,
+            task_id=task_id,
+            actor_user_id=None,
+            command_id="ext-input-success",
+            kind=TaskCommandKind.MESSAGE,
+            payload={"scope": "external", "message": "the answer"},
+        )
+        assert enqueued.created
+    finally:
+        db.close()
+
+    processed = await dispatch_one_task_command(
+        websocket_api.execute_durable_task_command
+    )
+    assert processed is True
+
+    db = _direct_db_session()
+    try:
+        row = (
+            db.query(TaskExecutionCommand)
+            .filter(TaskExecutionCommand.command_id == "ext-input-success")
+            .one()
+        )
+        assert row.status == COMMAND_COMPLETED
+        event = (
+            db.query(TaskCommandTerminalEvent)
+            .filter(TaskCommandTerminalEvent.task_command_id == int(row.id))
+            .one()
+        )
+        assert event.outcome == "completed"
         assert event.include_command_identity is False
     finally:
         db.close()

--- a/tests/web/services/test_task_command_terminal_events.py
+++ b/tests/web/services/test_task_command_terminal_events.py
@@ -271,7 +271,11 @@ def test_external_cancel_suppresses_command_identity_projection(
             TaskCommandKind.PAUSE,
             {"scope": "external"},
             True,
-            True,
+            # The disclosure rule is scope-based, not kind-based: any
+            # external-scope command withholds durable command identity,
+            # because the audience is anonymous whatever the kind
+            # (#1979 review NEW-1 widened this from cancel-only).
+            False,
             id="external-scope-on-non-cancel",
         ),
         pytest.param(


### PR DESCRIPTION
Recovers the round-3 response to #1979's review, which missed that PR's squash window by minutes: the squash was prepared from the round-2 head (`341e5bcd`) at 12:36Z while the round-3 commit (`3b3330aa`, 13:15Z) landed on the branch just before the 13:18Z merge — so merged `main` carries rounds 1–2 but not the round's sole blocker fix. This PR is that commit, cherry-picked verbatim onto current `main` (no new content beyond what the round-3 reply on #1979 already describes).

## Summary

- **External-scope CANCEL rejections now broadcast** ([prior] blocking finding, #1979 review rounds 3–4) — except the target-gone family (`stale_run`, `task_not_found`), whose client-visible silence `external_task_cancel.py`'s module contract explicitly owns (that run's own settlement carries the transcript and the event). A visitor's stop whose command payload failed validation no longer vanishes silently.
- The malformed-payload rejection (missing/invalid `target_state_version`) was mislabelled `reason=stale_run`, making it indistinguishable from a genuinely stale target and steering the A2A renderer toward an impossible retry — now `reason=invalid_target`.
- `stage_terminal_event` withholds durable command identity for **every** external-scope command at the single persistence chokepoint (#1979 review NEW-1), covering the success path's defaulted draft; previously only the external cancel was stripped.
- Ride-alongs from the same round: the rejection-broadcast ordering comment no longer mischaracterizes the cited precedent (NEW-3; persist-then-notify stays #1996); the seam docstring states the `TaskCommandRejected` non-application contract (NEW-2); first-party-MESSAGE-no-broadcast and external-CANCEL both-directions regressions added (NEW-7); the six inline `unittest.mock` imports hoisted (review simplification).

## Verification

- Four new dispatch-path tests: validation-rejected external CANCEL broadcasts (identity withheld, `invalid_target` persisted); stale-target CANCEL stays silent; first-party MESSAGE rejection does not broadcast; successful external MESSAGE terminal event withholds identity.
- Suites green on this head: seam (26), `test_task_command_terminal_events`, `test_external_task_cancel`, `test_a2a_api`, plus the transport/owner-actor/client-safe suites — 500+ locally; ruff/isort/mypy clean on touched files.

## Out of scope

Unchanged from #1979's declarations: defer-budget ceiling (review NEW-4), `finish_existing_delivery` first-party sub-cases (NEW-5, pre-existing), persist-then-notify ordering (#1996), restore-to-parked on pre-dispatch cancellation (#1977), CANCEL FIFO overtaking (#1978).