### PR TITLE
fix(agent): ground tool-call arguments, not just answer text

### DIFF
--- a/src/xagent/core/agent/grounding.py
+++ b/src/xagent/core/agent/grounding.py
@@ -1,8 +1,17 @@
-"""Shared anti-fabrication rules for prompts that emit user-facing answers.
+"""Shared anti-fabrication rules for prompts that emit answers or tool calls.
 
 Every prompt that produces a final user-facing answer should carry this rule.
 That is a design goal, not an enforced invariant: nothing walks the prompt
 builders to verify it, and ReAct's no-tool branch still lacks it.
+
+A prompt whose LLM call may invoke work tools additionally receives the
+tool-argument clause, which holds fact-carrying argument values to the same
+sourcing standard as answer text: a fabricated value is more harmful as a tool
+argument than as answer text, because it is invisible to the user and lands in
+an external system. That clause is selected by ``can_call_tools`` and is absent
+from the forced-answer sites, which emit no work-tool call to constrain. Its
+remedy -- ask the user, or finish reporting the gap -- belongs to the calling
+pattern, which owns the user-interaction policy this module cannot see.
 
 This is the proposal-A mitigation from issue #1235. It reduces how often
 unsourced figures are emitted and makes disclosure the instructed default, but
@@ -15,19 +24,23 @@ from __future__ import annotations
 
 
 def grounding_rule(*, can_call_tools: bool = True) -> str:
-    """Return the grounding rule for user-facing answer generation.
+    """Return the grounding rule for answer text and, optionally, tool arguments.
 
     Args:
         can_call_tools: Whether the receiving LLM call may invoke work tools.
             ``False`` at the three forced-answer sites -- ReAct's forced final
             answer, the DAG completion assessment, and the Auto routing
             decision -- where the rule must tell the model to state the gap
-            instead of suggesting a tool call it cannot make.
+            instead of suggesting a tool call it cannot make, and where the
+            tool-argument clause is omitted because no work-tool call is
+            possible.
 
     Returns:
         A prompt fragment forbidding unsupported claims and unsourced
         quantitative data, and requiring up-front disclosure of any
-        illustrative figures.
+        illustrative figures. When ``can_call_tools`` is true it also forbids
+        supplying a fact-carrying tool-call argument that no source provides,
+        while leaving arguments the model is expected to compose untouched.
     """
     insufficient_context_rule = (
         "If available context is insufficient, say so or use an appropriate "
@@ -37,6 +50,24 @@ def grounding_rule(*, can_call_tools: bool = True) -> str:
             "If available context is insufficient, say so instead of filling "
             "the gap with invented values. "
         )
+    )
+    tool_argument_rule = (
+        " The same standard applies to tool-call arguments that assert facts "
+        "rather than wording you compose: record field values, identifiers, "
+        "reference numbers, dates, quantities, amounts, statuses, and "
+        "account or target references. Take such a value from the user's "
+        "messages, the retrieved context, or a value an earlier tool result "
+        "actually returned; never guess one, never substitute a "
+        "plausible-looking placeholder for one the user has not given, and "
+        "never carry one over from a different record. This does not restrict "
+        "values you are expected to compose yourself, such as a search query, "
+        "code or a command you write to do the work, a message or answer you "
+        "write to the user, or document text you were asked to produce. Treat "
+        "a fact-carrying value you cannot source as "
+        "missing information rather than inventing it, and omit it when the "
+        "tool allows it to be omitted."
+        if can_call_tools
+        else ""
     )
     return (
         "Do not introduce specific entities, incidents, dates, sources, "
@@ -51,4 +82,5 @@ def grounding_rule(*, can_call_tools: bool = True) -> str:
         "tool result or provided context supports, whether or not the user asked "
         "for one, say so up front, before presenting it, and state that those "
         "figures are illustrative placeholders not drawn from any data source."
+        f"{tool_argument_rule}"
     )

--- a/src/xagent/core/agent/grounding.py
+++ b/src/xagent/core/agent/grounding.py
@@ -40,7 +40,9 @@ def grounding_rule(*, can_call_tools: bool = True) -> str:
         quantitative data, and requiring up-front disclosure of any
         illustrative figures. When ``can_call_tools`` is true it also forbids
         supplying a fact-carrying tool-call argument that no source provides,
-        while leaving arguments the model is expected to compose untouched.
+        while leaving arguments the model is expected to compose untouched --
+        except for a fact value written literally inside composed code or
+        document text, which the sourcing requirement still covers.
     """
     insufficient_context_rule = (
         "If available context is insufficient, say so or use an appropriate "
@@ -62,7 +64,11 @@ def grounding_rule(*, can_call_tools: bool = True) -> str:
         "never carry one over from a different record. This does not restrict "
         "values you are expected to compose yourself, such as a search query, "
         "code or a command you write to do the work, a message or answer you "
-        "write to the user, or document text you were asked to produce. Treat "
+        "write to the user, or document text you were asked to produce. A fact "
+        "value written literally inside such composed code or text is still "
+        "subject to the sourcing rule above. The rule also does not reach a "
+        "default or inferred parameter value such as a page size or result "
+        "limit, which you are expected to decide yourself. Treat "
         "a fact-carrying value you cannot source as "
         "missing information rather than inventing it, and omit it when the "
         "tool allows it to be omitted."

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1119,12 +1119,14 @@ class ReActPattern(AgentPattern):
             clock_zone_label = clock_zone.key if clock_zone is not None else "UTC"
             missing_information_instruction = (
                 "If a tool needs missing information from the user, including a "
-                "fact-carrying argument value the user has not provided, call "
+                "fact-carrying argument value (one that asserts a real-world "
+                "fact) the user has not provided, call "
                 "ask_user_question; do not ask the question as plain assistant "
                 "text and do not fill the value in yourself. "
                 if self.user_interaction_enabled
                 else "If missing user information prevents completion, including a "
-                "fact-carrying argument value the user has not provided, do not ask "
+                "fact-carrying argument value (one that asserts a real-world fact) "
+                "the user has not provided, do not ask "
                 "the user or attempt an unavailable interaction tool; finish with "
                 "outcome=blocked and explain what is missing. "
             )
@@ -2163,8 +2165,8 @@ class ReActPattern(AgentPattern):
                         "the user responds. Use this only when execution cannot "
                         "continue without missing user-provided information, such "
                         "as a required file, URL, account, target object, permission, "
-                        "a fact-carrying value for a tool argument that the user has "
-                        "not provided, "
+                        "a fact-carrying value (one that asserts a real-world fact) "
+                        "for a tool argument that the user has not provided, "
                         "or a choice between mutually exclusive actions with "
                         "different side effects. Do not use it to confirm execution "
                         "strategy, whether to search, whether to use memory, whether "

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -1118,11 +1118,13 @@ class ReActPattern(AgentPattern):
             )
             clock_zone_label = clock_zone.key if clock_zone is not None else "UTC"
             missing_information_instruction = (
-                "If a tool needs missing information from the user, call "
+                "If a tool needs missing information from the user, including a "
+                "fact-carrying argument value the user has not provided, call "
                 "ask_user_question; do not ask the question as plain assistant "
-                "text. "
+                "text and do not fill the value in yourself. "
                 if self.user_interaction_enabled
-                else "If missing user information prevents completion, do not ask "
+                else "If missing user information prevents completion, including a "
+                "fact-carrying argument value the user has not provided, do not ask "
                 "the user or attempt an unavailable interaction tool; finish with "
                 "outcome=blocked and explain what is missing. "
             )
@@ -2161,11 +2163,16 @@ class ReActPattern(AgentPattern):
                         "the user responds. Use this only when execution cannot "
                         "continue without missing user-provided information, such "
                         "as a required file, URL, account, target object, permission, "
+                        "a fact-carrying value for a tool argument that the user has "
+                        "not provided, "
                         "or a choice between mutually exclusive actions with "
                         "different side effects. Do not use it to confirm execution "
                         "strategy, whether to search, whether to use memory, whether "
                         "to apply formatting preferences, or whether to proceed with "
-                        "a sufficiently specified task; decide those yourself."
+                        "a sufficiently specified task; decide those yourself. A task "
+                        "is not sufficiently specified if carrying it out would "
+                        "require inventing a fact-carrying argument value the user "
+                        "has not provided."
                     ),
                     "parameters": {
                         "type": "object",

--- a/tests/core/agent/test_grounding.py
+++ b/tests/core/agent/test_grounding.py
@@ -38,6 +38,59 @@ def test_grounding_rule_without_tools_omits_tool_verification() -> None:
     assert "invented values. Never invent figures" in rule
 
 
+def test_grounding_rule_covers_fact_carrying_tool_arguments() -> None:
+    """A fabricated value is worse as a tool argument than as answer text.
+
+    An invented figure in an answer is visible to the user; the same value
+    passed to a connector's write tool is invisible, persistent, and lands in
+    an external system.
+    """
+    rule = grounding_rule()
+
+    for phrase in (
+        "tool-call arguments that assert facts",
+        "identifiers",
+        "reference numbers",
+        "a value an earlier tool result actually returned",
+        "never guess one",
+        "never carry one over from a different record",
+        "missing information rather than inventing it",
+        "omit it when the tool allows",
+    ):
+        assert phrase in rule
+    # Pin the concatenation onto the answer rules that precede it.
+    assert "illustrative placeholders not drawn from any data source. The same" in rule
+
+
+def test_grounding_rule_exempts_values_the_model_must_compose() -> None:
+    """The prohibition must not reach arguments the model is meant to author.
+
+    ReAct runs with ``tool_choice="required"``, and the answer it writes is
+    itself a tool argument. Without this exemption the rule would be violated
+    on every turn, which would drain the authority of the answer rules sharing
+    the same prompt.
+    """
+    rule = grounding_rule()
+
+    assert "This does not restrict values you are expected to compose yourself" in rule
+    for example in (
+        "a search query",
+        "code or a command you write to do the work",
+        "a message or answer you write to the user",
+        "document text you were asked to produce",
+    ):
+        assert example in rule
+
+
+def test_grounding_rule_without_tools_omits_tool_argument_clause() -> None:
+    """The three forced-answer sites emit no work-tool call to constrain."""
+    rule = grounding_rule(can_call_tools=False)
+
+    assert "tool-call arguments that assert facts" not in rule
+    assert "never guess one" not in rule
+    assert "compose yourself" not in rule
+
+
 def test_grounding_rule_requires_labeling_regardless_of_request() -> None:
     """Disclosure must not be conditional on the user asking for a template.
 

--- a/tests/core/agent/test_grounding.py
+++ b/tests/core/agent/test_grounding.py
@@ -80,6 +80,29 @@ def test_grounding_rule_exempts_values_the_model_must_compose() -> None:
         "document text you were asked to produce",
     ):
         assert example in rule
+    # A page size the model picks is not a claim about the world, so pausing
+    # for it would be the over-asking failure the exemption exists to prevent.
+    assert (
+        "does not reach a default or inferred parameter value such as a page "
+        "size or result limit" in rule
+    )
+
+
+def test_grounding_rule_keeps_literal_facts_inside_composed_text_sourced() -> None:
+    """The compose exemption is per value, not per argument.
+
+    ``python_executor`` takes one free-form ``code`` argument and
+    ``write_file`` one ``content`` argument. Read at whole-argument
+    granularity, the exemption would clear an invented identifier for
+    delivery into an external system as long as it rode inside composed code
+    or document text -- the same outcome the rule exists to prevent.
+    """
+    rule = grounding_rule()
+
+    assert (
+        "A fact value written literally inside such composed code or text is "
+        "still subject to the sourcing rule above." in rule
+    )
 
 
 def test_grounding_rule_without_tools_omits_tool_argument_clause() -> None:
@@ -89,6 +112,8 @@ def test_grounding_rule_without_tools_omits_tool_argument_clause() -> None:
     assert "tool-call arguments that assert facts" not in rule
     assert "never guess one" not in rule
     assert "compose yourself" not in rule
+    assert "still subject to the sourcing rule above" not in rule
+    assert "a default or inferred parameter value" not in rule
 
 
 def test_grounding_rule_requires_labeling_regardless_of_request() -> None:

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -1549,19 +1549,22 @@ def test_react_missing_argument_value_instruction_matches_interaction_policy(
     present.
     """
     ask_instruction = (
-        "including a fact-carrying argument value the user has not "
-        "provided, call ask_user_question"
+        "including a fact-carrying argument value (one that asserts a "
+        "real-world fact) the user has not provided, call ask_user_question"
     )
     blocked_instruction = (
-        "including a fact-carrying argument value the user has not "
-        "provided, do not ask the user"
+        "including a fact-carrying argument value (one that asserts a "
+        "real-world fact) the user has not provided, do not ask the user"
     )
     pattern = ReActPattern(user_interaction_enabled=user_interaction_enabled)
     context = ExecutionContext(system_prompt="You are helpful.")
     context.add_user_message("update Jane Doe")
 
-    # Mirror the schema filter: with interaction disabled the interaction
-    # control tools never reach the tool name list.
+    # tool_names is derived per branch only to keep the input shaped like
+    # production, where the interaction control tools are filtered out of the
+    # schema when interaction is disabled. It drives nothing here:
+    # missing_information_instruction never reads tool_names, so every
+    # assertion below is driven solely by user_interaction_enabled.
     tool_names = ["update_record"]
     if user_interaction_enabled:
         tool_names.append("ask_user_question")
@@ -1577,6 +1580,68 @@ def test_react_missing_argument_value_instruction_matches_interaction_policy(
         assert blocked_instruction in prompt
         assert ask_instruction not in prompt
         assert "finish with outcome=blocked and explain what is missing" in prompt
+
+
+@pytest.mark.asyncio
+async def test_react_tool_argument_rule_tracks_ask_user_question_availability() -> None:
+    """The prohibition and its remedy must reach the model on the same call.
+
+    The grounding rule tells the model to treat an unsourceable fact-carrying
+    argument as missing information; ask_user_question is the tool that acts on
+    that classification. Telling the model not to invent a value on a turn
+    where it cannot ask for one would leave it with no legal move. Both are
+    gated by ``force_final_answer`` today, so the coupling holds only
+    incidentally; this pins both directions of it against a later change that
+    narrows one gate without the other.
+    """
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Need calculation.",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "function": {
+                            "name": "calculator",
+                            "arguments": '{"expression":"2+2"}',
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "final_call",
+                        "function": {
+                            "name": "final_answer",
+                            "arguments": '{"answer":"The result is 4."}',
+                        },
+                    }
+                ],
+                "done": False,
+            },
+        ]
+    )
+    pattern = ReActPattern(max_iterations=3, finalize_after_tool_result=True)
+    context = ExecutionContext(system_prompt="You are helpful.")
+    context.add_user_message("Calculate 2+2")
+
+    result = await pattern.run(context=context, tools=[FakeTool()], llm=llm)
+
+    assert result["success"] is True
+    coupling = [
+        (
+            "ask_user_question"
+            in [schema["function"]["name"] for schema in call["tools"]],
+            "tool-call arguments that assert facts" in call["messages"][0]["content"],
+        )
+        for call in llm.calls
+    ]
+    # One run covers both cells: the open turn offers ask_user_question and
+    # carries the rule, the forced final turn offers neither.
+    assert coupling == [(True, True), (False, False)]
 
 
 @pytest.mark.asyncio
@@ -4081,8 +4146,9 @@ async def test_react_pattern_reserves_control_tool_names_in_schema() -> None:
     )
     assert "Do not use it to confirm execution strategy" in ask_user_description
     assert "whether to use memory" in ask_user_description
-    assert "a fact-carrying value for a tool argument that the user has not" in (
-        ask_user_description
+    assert (
+        "a fact-carrying value (one that asserts a real-world fact) for a tool "
+        "argument that the user has not provided" in ask_user_description
     )
     # The qualifier must match the grounding rule's scope: without it the
     # description would invite pausing for a search query the model composes.

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -1518,6 +1518,14 @@ def test_react_grounding_rule_present_in_both_answer_paths() -> None:
         assert "illustrative placeholders" in prompt
     assert "use an appropriate tool to verify" in tool_prompt
     assert "use an appropriate tool" not in forced_prompt
+    for prompt in (tool_prompt, lookup_tool_prompt):
+        assert "tool-call arguments that assert facts" in prompt
+        assert "never guess one" in prompt
+        assert (
+            "This does not restrict values you are expected to compose yourself"
+            in prompt
+        )
+    assert "tool-call arguments that assert facts" not in forced_prompt
     assert "## FINAL DELIVERABLE FILE REFERENCES" not in tool_prompt
     assert "exact markdown_link" in tool_prompt
     assert "lookup is unavailable" in tool_prompt
@@ -1527,6 +1535,48 @@ def test_react_grounding_rule_present_in_both_answer_paths() -> None:
     )
     assert forced_prompt.count("## FINAL DELIVERABLE FILE REFERENCES") == 1
     assert "call get_workspace_output_files once before finalizing" not in forced_prompt
+
+
+@pytest.mark.parametrize("user_interaction_enabled", [True, False])
+def test_react_missing_argument_value_instruction_matches_interaction_policy(
+    user_interaction_enabled: bool,
+) -> None:
+    """A missing argument value routes to whichever remedy the run allows.
+
+    The grounding rule tells the model to classify an unsourced fact-carrying
+    argument as missing information; this instruction is what turns that
+    classification into an action, and the two branches must never both be
+    present.
+    """
+    ask_instruction = (
+        "including a fact-carrying argument value the user has not "
+        "provided, call ask_user_question"
+    )
+    blocked_instruction = (
+        "including a fact-carrying argument value the user has not "
+        "provided, do not ask the user"
+    )
+    pattern = ReActPattern(user_interaction_enabled=user_interaction_enabled)
+    context = ExecutionContext(system_prompt="You are helpful.")
+    context.add_user_message("update Jane Doe")
+
+    # Mirror the schema filter: with interaction disabled the interaction
+    # control tools never reach the tool name list.
+    tool_names = ["update_record"]
+    if user_interaction_enabled:
+        tool_names.append("ask_user_question")
+    prompt = pattern._messages_for_llm(context, has_tools=True, tool_names=tool_names)[
+        0
+    ]["content"]
+
+    if user_interaction_enabled:
+        assert ask_instruction in prompt
+        assert blocked_instruction not in prompt
+        assert "do not fill the value in yourself" in prompt
+    else:
+        assert blocked_instruction in prompt
+        assert ask_instruction not in prompt
+        assert "finish with outcome=blocked and explain what is missing" in prompt
 
 
 @pytest.mark.asyncio
@@ -4031,6 +4081,12 @@ async def test_react_pattern_reserves_control_tool_names_in_schema() -> None:
     )
     assert "Do not use it to confirm execution strategy" in ask_user_description
     assert "whether to use memory" in ask_user_description
+    assert "a fact-carrying value for a tool argument that the user has not" in (
+        ask_user_description
+    )
+    # The qualifier must match the grounding rule's scope: without it the
+    # description would invite pausing for a search query the model composes.
+    assert "require inventing a fact-carrying argument value" in ask_user_description
     system_prompt = llm.calls[0]["messages"][0]["content"]
     assert "Only call tools that are present in the current tool schema" in (
         system_prompt


### PR DESCRIPTION
The anti-fabrication rule applied to user-facing answer text only. A
fabricated value was therefore forbidden in an answer but permitted as a
tool-call argument, where it is invisible to the user, persistent, and
written into an external system. Given a vague write request naming a
target record but no field values, the agent would invent argument values
and execute the write.

## Behavior changes

- The shared grounding rule now covers fact-carrying tool-call arguments:
  record field values, identifiers, reference numbers, dates, quantities,
  amounts, statuses, and account or target references. Such a value must
  come from the user's messages, the retrieved context, or a value an
  earlier tool result actually returned.
- Values the model is expected to compose are explicitly exempt: a search
  query, code or a command it writes to do the work, a message or answer
  it sends, and document text it was asked to produce. Without this the
  rule would collide with `final_answer(answer=...)` and with the output
  language policy, which instructs the model about tool arguments that
  carry user-facing prose.
- The clause is emitted only when the receiving LLM call may invoke work
  tools. The three forced-answer sites -- the forced final answer, the DAG
  completion assessment, and the routing decision -- produce byte-identical
  prompts to before.
- The remedy stays with ReAct, which owns the user-interaction policy: ask
  through `ask_user_question` when interaction is enabled, otherwise finish
  with `outcome=blocked` and say what is missing. Both branches now name a
  missing argument value explicitly.
- `ask_user_question`'s description lists a fact-carrying value the user
  has not provided among the valid reasons to ask, and states that a task
  is not sufficiently specified when carrying it out would require
  inventing one.

Both halves ship together. The prohibition alone would leave the model
told not to invent a value and, by the tool's own description, not to ask
for it either.

## Verification

- `pytest tests/core/agent` (the agent pattern and prompt suites): 1026
  passed.
- `pytest tests/core` (the whole core suite) on this branch: 7377 passed,
  18 failed, 22 skipped. The same command on the same base with these four
  files reverted: 7372 passed, 18 failed, 22 skipped. Comparing the sorted
  `FAILED` lines from the two runs gives an empty set difference in both
  directions, so the branch adds five tests and no failures. The 18 are
  pre-existing local-environment failures that reproduce identically
  without this change: 15 pptx tool tests whose npm dependency is not
  installed, one RAG ingestion test with no local embedding model, and two
  command-executor tests.
- `pre-commit run` over the four changed files: ruff check, ruff format,
  mypy, isort, codespell and the whitespace hooks all pass.
- New pins assert the clause is present for tool-calling prompts, absent
  for forced-answer prompts, and that each user-interaction branch carries
  only its own remedy. Each assertion was mutation-verified by breaking the
  corresponding prompt text and confirming the intended test fails: making
  the clause unconditional reddens the three forced-answer prompt tests
  plus the negative grounding pin, removing the `ask_user_question`
  qualifier reddens the tool-schema pin, and reverting the non-interactive
  remedy reddens that branch's parameter case.

Closes #1986
