### PR TITLE
feat: add stable MCP lifecycle generations (toby)

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -341,6 +341,13 @@ jobs:
         env:
           DATABASE_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 
+      - name: Test MCP lifecycle generation migration (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/migrations/test_20260902_add_mcp_lifecycle_generations.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
       - name: Test trusted actor OAuth concurrency (Postgres-only)
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -14,6 +14,9 @@ on:
       - 'tests/alembic/**'
       - '.github/workflows/test-migrations.yml'
       - 'src/xagent/db/**'
+      - 'src/xagent/web/models/generation.py'
+      - 'src/xagent/web/models/mcp.py'
+      - 'src/xagent/web/models/public_mcp.py'
       - 'src/xagent/web/services/gmail_provisioning.py'
       - 'tests/web/services/test_gmail_provisioning.py'
       - 'src/xagent/web/services/agent_management.py'
@@ -103,6 +106,9 @@ jobs:
             tests/alembic
             .github/workflows/test-migrations.yml
             src/xagent/db
+            src/xagent/web/models/generation.py
+            src/xagent/web/models/mcp.py
+            src/xagent/web/models/public_mcp.py
             src/xagent/web/services/gmail_provisioning.py
             tests/web/services/test_gmail_provisioning.py
             src/xagent/web/services/agent_management.py

--- a/src/xagent/migrations/versions/20260902_add_mcp_lifecycle_generations.py
+++ b/src/xagent/migrations/versions/20260902_add_mcp_lifecycle_generations.py
@@ -32,6 +32,13 @@ ASSOCIATION_TABLE = "user_mcpservers"
 ASSOCIATION_COLUMN = "lifecycle_generation"
 ASSOCIATION_UNIQUE = "uq_user_mcpservers_lifecycle_generation"
 ASSOCIATION_NONEMPTY = "ck_user_mcpservers_lifecycle_generation_nonempty"
+SQLITE_UUID_V4_DEFAULT = sa.text(
+    "(lower(hex(randomblob(4))) || lower(hex(randomblob(2))) || "
+    "'4' || substr(lower(hex(randomblob(2))), 2) || "
+    "substr('89ab', (random() & 3) + 1, 1) || "
+    "substr(lower(hex(randomblob(2))), 2) || lower(hex(randomblob(6))))"
+)
+POSTGRESQL_UUID_V4_DEFAULT = sa.text("gen_random_uuid()")
 
 
 def _table_exists(table_name: str) -> bool:
@@ -45,18 +52,48 @@ def _add_and_backfill(
     nonempty_name: str,
 ) -> None:
     generation_type = sa.Uuid(as_uuid=True)
-    op.add_column(
-        table_name,
-        sa.Column(column_name, generation_type, nullable=True),
-    )
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+    if dialect == "postgresql":
+        server_default = POSTGRESQL_UUID_V4_DEFAULT
+    elif dialect == "sqlite":
+        server_default = SQLITE_UUID_V4_DEFAULT
+    else:
+        raise RuntimeError(f"unsupported MCP generation dialect: {dialect}")
+
+    inspector = sa.inspect(bind)
+    columns = {item["name"]: item for item in inspector.get_columns(table_name)}
+    unique_names = {
+        item["name"] for item in inspector.get_unique_constraints(table_name)
+    }
+    check_names = {item["name"] for item in inspector.get_check_constraints(table_name)}
+    if column_name in columns:
+        column = columns[column_name]
+        if (
+            column["nullable"] is False
+            and column["default"] is not None
+            and unique_name in unique_names
+            and nonempty_name in check_names
+        ):
+            return
+    else:
+        op.add_column(
+            table_name,
+            sa.Column(
+                column_name,
+                generation_type,
+                nullable=True,
+            ),
+        )
 
     table = sa.table(
         table_name,
         sa.column("id", sa.Integer()),
         sa.column(column_name, generation_type),
     )
-    bind = op.get_bind()
-    row_ids = list(bind.scalars(sa.select(table.c.id)))
+    row_ids = list(
+        bind.scalars(sa.select(table.c.id).where(table.c[column_name].is_(None)))
+    )
     generated: set[uuid.UUID] = set()
     backfill_rows: list[dict[str, object]] = []
     for row_id in row_ids:
@@ -79,12 +116,15 @@ def _add_and_backfill(
             column_name,
             existing_type=generation_type,
             nullable=False,
+            server_default=server_default,
         )
-        batch_op.create_unique_constraint(unique_name, [column_name])
-        batch_op.create_check_constraint(
-            nonempty_name,
-            f"CAST({column_name} AS VARCHAR) <> ''",
-        )
+        if unique_name not in unique_names:
+            batch_op.create_unique_constraint(unique_name, [column_name])
+        if nonempty_name not in check_names:
+            batch_op.create_check_constraint(
+                nonempty_name,
+                f"CAST({column_name} AS VARCHAR) <> ''",
+            )
 
 
 def upgrade() -> None:

--- a/src/xagent/migrations/versions/20260902_add_mcp_lifecycle_generations.py
+++ b/src/xagent/migrations/versions/20260902_add_mcp_lifecycle_generations.py
@@ -13,7 +13,6 @@ later lifecycle fences distinguish each replacement from its predecessor.
 
 from __future__ import annotations
 
-import uuid
 from typing import Sequence, Union
 
 import sqlalchemy as sa
@@ -88,28 +87,13 @@ def _add_and_backfill(
 
     table = sa.table(
         table_name,
-        sa.column("id", sa.Integer()),
         sa.column(column_name, generation_type),
     )
-    row_ids = list(
-        bind.scalars(sa.select(table.c.id).where(table.c[column_name].is_(None)))
+    bind.execute(
+        sa.update(table)
+        .where(table.c[column_name].is_(None))
+        .values({column_name: server_default})
     )
-    generated: set[uuid.UUID] = set()
-    backfill_rows: list[dict[str, object]] = []
-    for row_id in row_ids:
-        generation = uuid.uuid4()
-        while generation in generated:
-            generation = uuid.uuid4()
-        generated.add(generation)
-        backfill_rows.append({"_row_id": row_id, "_generation": generation})
-
-    if backfill_rows:
-        bind.execute(
-            sa.update(table)
-            .where(table.c.id == sa.bindparam("_row_id"))
-            .values({column_name: sa.bindparam("_generation")}),
-            backfill_rows,
-        )
 
     with op.batch_alter_table(table_name) as batch_op:
         batch_op.alter_column(

--- a/src/xagent/migrations/versions/20260902_add_mcp_lifecycle_generations.py
+++ b/src/xagent/migrations/versions/20260902_add_mcp_lifecycle_generations.py
@@ -1,0 +1,136 @@
+"""add stable MCP catalog and association generations
+
+Revision ID: 20260902_mcp_generations
+Revises: 20260901_taskstatus_waiting_for_user
+Create Date: 2026-09-02
+
+The integer primary keys on ``public_mcp_apps`` and ``user_mcpservers`` are
+storage identities, not lifecycle identities. In particular, SQLite can reuse
+the maximum ROWID after deletion, and the association's logical unique key can
+be recreated after its original row is deleted. Random UUID generations let
+later lifecycle fences distinguish each replacement from its predecessor.
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260902_mcp_generations"
+down_revision: Union[str, None] = "20260901_taskstatus_waiting_for_user"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+CATALOG_TABLE = "public_mcp_apps"
+CATALOG_COLUMN = "generation"
+CATALOG_UNIQUE = "uq_public_mcp_apps_generation"
+CATALOG_NONEMPTY = "ck_public_mcp_apps_generation_nonempty"
+ASSOCIATION_TABLE = "user_mcpservers"
+ASSOCIATION_COLUMN = "lifecycle_generation"
+ASSOCIATION_UNIQUE = "uq_user_mcpservers_lifecycle_generation"
+ASSOCIATION_NONEMPTY = "ck_user_mcpservers_lifecycle_generation_nonempty"
+
+
+def _table_exists(table_name: str) -> bool:
+    return table_name in sa.inspect(op.get_bind()).get_table_names()
+
+
+def _add_and_backfill(
+    table_name: str,
+    column_name: str,
+    unique_name: str,
+    nonempty_name: str,
+) -> None:
+    generation_type = sa.Uuid(as_uuid=True)
+    op.add_column(
+        table_name,
+        sa.Column(column_name, generation_type, nullable=True),
+    )
+
+    table = sa.table(
+        table_name,
+        sa.column("id", sa.Integer()),
+        sa.column(column_name, generation_type),
+    )
+    bind = op.get_bind()
+    row_ids = list(bind.scalars(sa.select(table.c.id)))
+    generated: set[uuid.UUID] = set()
+    backfill_rows: list[dict[str, object]] = []
+    for row_id in row_ids:
+        generation = uuid.uuid4()
+        while generation in generated:
+            generation = uuid.uuid4()
+        generated.add(generation)
+        backfill_rows.append({"_row_id": row_id, "_generation": generation})
+
+    if backfill_rows:
+        bind.execute(
+            sa.update(table)
+            .where(table.c.id == sa.bindparam("_row_id"))
+            .values({column_name: sa.bindparam("_generation")}),
+            backfill_rows,
+        )
+
+    with op.batch_alter_table(table_name) as batch_op:
+        batch_op.alter_column(
+            column_name,
+            existing_type=generation_type,
+            nullable=False,
+        )
+        batch_op.create_unique_constraint(unique_name, [column_name])
+        batch_op.create_check_constraint(
+            nonempty_name,
+            f"CAST({column_name} AS VARCHAR) <> ''",
+        )
+
+
+def upgrade() -> None:
+    if _table_exists(CATALOG_TABLE):
+        _add_and_backfill(
+            CATALOG_TABLE,
+            CATALOG_COLUMN,
+            CATALOG_UNIQUE,
+            CATALOG_NONEMPTY,
+        )
+    if _table_exists(ASSOCIATION_TABLE):
+        _add_and_backfill(
+            ASSOCIATION_TABLE,
+            ASSOCIATION_COLUMN,
+            ASSOCIATION_UNIQUE,
+            ASSOCIATION_NONEMPTY,
+        )
+
+
+def _drop_generation(
+    table_name: str,
+    column_name: str,
+    unique_name: str,
+    nonempty_name: str,
+) -> None:
+    with op.batch_alter_table(table_name) as batch_op:
+        batch_op.drop_constraint(nonempty_name, type_="check")
+        batch_op.drop_constraint(unique_name, type_="unique")
+        batch_op.drop_column(column_name)
+
+
+def downgrade() -> None:
+    # Older application versions do not read these internal lifecycle tokens.
+    # Dropping them is therefore schema-compatible, but a later re-upgrade
+    # intentionally generates new UUIDs instead of resurrecting old lifecycles.
+    if _table_exists(ASSOCIATION_TABLE):
+        _drop_generation(
+            ASSOCIATION_TABLE,
+            ASSOCIATION_COLUMN,
+            ASSOCIATION_UNIQUE,
+            ASSOCIATION_NONEMPTY,
+        )
+    if _table_exists(CATALOG_TABLE):
+        _drop_generation(
+            CATALOG_TABLE,
+            CATALOG_COLUMN,
+            CATALOG_UNIQUE,
+            CATALOG_NONEMPTY,
+        )

--- a/src/xagent/web/models/generation.py
+++ b/src/xagent/web/models/generation.py
@@ -1,0 +1,38 @@
+"""Cross-dialect database defaults for durable UUID generations."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from sqlalchemy import Uuid
+from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.sql.functions import FunctionElement
+
+
+class RandomUUID(FunctionElement[UUID]):
+    """A database-generated random UUID on every supported dialect."""
+
+    type = Uuid(as_uuid=True)
+    inherit_cache = True
+
+
+@compiles(RandomUUID, "postgresql")
+def _compile_postgresql_random_uuid(
+    _element: RandomUUID, _compiler: object, **_kwargs: object
+) -> str:
+    return "gen_random_uuid()"
+
+
+@compiles(RandomUUID, "sqlite")
+def _compile_sqlite_random_uuid(
+    _element: RandomUUID, _compiler: object, **_kwargs: object
+) -> str:
+    # SQLite has no UUID function. Assemble 32 hexadecimal digits while
+    # pinning RFC 4122 version/variant bits so SQLAlchemy's emulated Uuid type
+    # reads the database-generated value with the same semantics as uuid4().
+    return (
+        "(lower(hex(randomblob(4))) || lower(hex(randomblob(2))) || "
+        "'4' || substr(lower(hex(randomblob(2))), 2) || "
+        "substr('89ab', (random() & 3) + 1, 1) || "
+        "substr(lower(hex(randomblob(2))), 2) || lower(hex(randomblob(6))))"
+    )

--- a/src/xagent/web/models/mcp.py
+++ b/src/xagent/web/models/mcp.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 
 from ...core.tools.core.mcp.model import create_mcp_server_table
+from .generation import RandomUUID
 
 if TYPE_CHECKING:
     from sqlalchemy import JSON, Boolean, Column, DateTime, Integer, String, Text
@@ -109,6 +110,7 @@ class UserMCPServer(Base):  # type: ignore
     lifecycle_generation = Column(
         Uuid,
         default=uuid.uuid4,
+        server_default=RandomUUID(),
         nullable=False,
     )
     user_id = Column(

--- a/src/xagent/web/models/mcp.py
+++ b/src/xagent/web/models/mcp.py
@@ -1,16 +1,21 @@
 from __future__ import annotations
 
+import uuid
 from typing import TYPE_CHECKING, Any, Type
 
 from sqlalchemy import (
     JSON,
     Boolean,
+    CheckConstraint,
     Column,
     DateTime,
     ForeignKey,
     Integer,
     String,
     UniqueConstraint,
+    Uuid,
+    event,
+    inspect,
 )
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
@@ -90,9 +95,22 @@ class UserMCPServer(Base):  # type: ignore
     __tablename__ = "user_mcpservers"
     __table_args__ = (
         UniqueConstraint("user_id", "mcpserver_id", name="uq_user_mcpservers"),
+        UniqueConstraint(
+            "lifecycle_generation",
+            name="uq_user_mcpservers_lifecycle_generation",
+        ),
+        CheckConstraint(
+            "CAST(lifecycle_generation AS VARCHAR) <> ''",
+            name="ck_user_mcpservers_lifecycle_generation_nonempty",
+        ),
     )
 
     id = Column(Integer, primary_key=True, index=True)
+    lifecycle_generation = Column(
+        Uuid,
+        default=uuid.uuid4,
+        nullable=False,
+    )
     user_id = Column(
         Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False
     )
@@ -129,3 +147,12 @@ class UserMCPServer(Base):  # type: ignore
 
     def __repr__(self) -> str:
         return f"<UserMCPServer(user_id={self.user_id}, mcpserver_id={self.mcpserver_id}, is_owner={self.is_owner})>"
+
+
+@event.listens_for(UserMCPServer, "before_update")
+def _prevent_user_mcpserver_generation_update(
+    _mapper: Any, _connection: Any, target: UserMCPServer
+) -> None:
+    """Keep an association generation tied to exactly one row lifecycle."""
+    if inspect(target).attrs.lifecycle_generation.history.has_changes():
+        raise ValueError("UserMCPServer.lifecycle_generation is immutable")

--- a/src/xagent/web/models/public_mcp.py
+++ b/src/xagent/web/models/public_mcp.py
@@ -1,14 +1,20 @@
 from datetime import datetime
 from typing import Any
+from uuid import UUID, uuid4
 
 from sqlalchemy import (
     JSON,
     Boolean,
+    CheckConstraint,
     DateTime,
     ForeignKey,
     Integer,
     String,
     Text,
+    UniqueConstraint,
+    Uuid,
+    event,
+    inspect,
     true,
 )
 from sqlalchemy.orm import Mapped, mapped_column
@@ -21,8 +27,20 @@ class PublicMCPApp(Base):  # type: ignore[no-any-unimported]
     """Registry of official MCP apps available for users to connect to."""
 
     __tablename__ = "public_mcp_apps"
+    __table_args__ = (
+        UniqueConstraint("generation", name="uq_public_mcp_apps_generation"),
+        CheckConstraint(
+            "CAST(generation AS VARCHAR) <> ''",
+            name="ck_public_mcp_apps_generation_nonempty",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, index=True)
+    generation: Mapped[UUID] = mapped_column(
+        Uuid,
+        default=uuid4,
+        nullable=False,
+    )
     app_id: Mapped[str] = mapped_column(
         String(100), unique=True, nullable=False, index=True
     )
@@ -40,6 +58,15 @@ class PublicMCPApp(Base):  # type: ignore[no-any-unimported]
         Boolean, default=True, server_default=true(), nullable=False
     )
     launch_config: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+
+
+@event.listens_for(PublicMCPApp, "before_update")
+def _prevent_public_mcp_app_generation_update(
+    _mapper: Any, _connection: Any, target: PublicMCPApp
+) -> None:
+    """Keep a catalog generation tied to exactly one row lifecycle."""
+    if inspect(target).attrs.generation.history.has_changes():
+        raise ValueError("PublicMCPApp.generation is immutable")
 
 
 class PublicMCPAppAudit(Base):  # type: ignore[no-any-unimported]

--- a/src/xagent/web/models/public_mcp.py
+++ b/src/xagent/web/models/public_mcp.py
@@ -21,6 +21,7 @@ from sqlalchemy.orm import Mapped, mapped_column
 from sqlalchemy.sql import func
 
 from .database import Base
+from .generation import RandomUUID
 
 
 class PublicMCPApp(Base):  # type: ignore[no-any-unimported]
@@ -39,6 +40,7 @@ class PublicMCPApp(Base):  # type: ignore[no-any-unimported]
     generation: Mapped[UUID] = mapped_column(
         Uuid,
         default=uuid4,
+        server_default=RandomUUID(),
         nullable=False,
     )
     app_id: Mapped[str] = mapped_column(

--- a/tests/migrations/test_20260901_add_task_status_waiting_for_user_enum_label.py
+++ b/tests/migrations/test_20260901_add_task_status_waiting_for_user_enum_label.py
@@ -24,12 +24,14 @@ import pytest
 import sqlalchemy as sa
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
+from alembic.script import ScriptDirectory
 from sqlalchemy import text
 
 from tests.shared.postgres_disposable import (
     disposable_database_factory,
     load_migration_module,
 )
+from xagent.db.config import create_alembic_config
 from xagent.web.models.database import Base, _initialize_database_schema
 from xagent.web.models.task import (
     TASKSTATUS_ENUM_REPAIR_REVISION,
@@ -189,7 +191,8 @@ def test_a_pre_waiting_for_user_database_starts_after_upgrading_to_head(
             ),
             {"user_id": user_id, "label": LABEL},
         )
-    assert version == migration.revision
+    script = ScriptDirectory.from_config(create_alembic_config(engine))
+    assert version == script.get_current_head()
 
 
 # ---- the revision's own branches ----

--- a/tests/migrations/test_20260902_add_mcp_lifecycle_generations.py
+++ b/tests/migrations/test_20260902_add_mcp_lifecycle_generations.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 
 import pytest
@@ -18,6 +19,7 @@ from xagent.web.models.user import User
 REVISION = "20260902_mcp_generations"
 DOWN_REVISION = "20260901_taskstatus_waiting_for_user"
 MIGRATIONS_DIR = Path(__file__).parents[2] / "src" / "xagent" / "migrations"
+BACKFILL_TABLES = ("public_mcp_apps", "user_mcpservers")
 
 
 def _create_legacy_schema(connection: sa.Connection) -> None:
@@ -81,6 +83,7 @@ def _assert_generation_schema(connection: sa.Connection) -> None:
         assert uniques[unique_name]["column_names"] == [column]
         values = _generations(connection, table, column)
         assert len(values) == len(set(values)) == 2
+        assert all(value.version == 4 for value in values)
 
 
 def _assert_database_defaults(connection: sa.Connection) -> None:
@@ -136,6 +139,109 @@ def _assert_constraints(connection: sa.Connection) -> None:
         connection.rollback()
 
 
+def _add_partial_generation_columns(
+    connection: sa.Connection,
+) -> tuple[uuid.UUID, uuid.UUID]:
+    generation_type = "UUID" if connection.dialect.name == "postgresql" else "CHAR(32)"
+    connection.execute(
+        sa.text(
+            f"ALTER TABLE public_mcp_apps ADD COLUMN generation {generation_type}"  # noqa: S608
+        )
+    )
+    connection.execute(
+        sa.text(
+            "ALTER TABLE user_mcpservers ADD COLUMN "
+            f"lifecycle_generation {generation_type}"  # noqa: S608
+        )
+    )
+    catalog_generation = uuid.uuid4()
+    association_generation = uuid.uuid4()
+    connection.execute(
+        sa.text("UPDATE public_mcp_apps SET generation = :generation WHERE id = 1"),
+        {"generation": str(catalog_generation)},
+    )
+    connection.execute(
+        sa.text(
+            "UPDATE user_mcpservers SET lifecycle_generation = :generation WHERE id = 1"
+        ),
+        {"generation": str(association_generation)},
+    )
+    return catalog_generation, association_generation
+
+
+def _capture_backfill_updates(
+    engine: sa.Engine,
+) -> tuple[list[tuple[str, bool]], Callable[[], None]]:
+    updates: list[tuple[str, bool]] = []
+
+    def capture(
+        _connection,
+        _cursor,
+        statement: str,
+        _parameters,
+        _context,
+        executemany: bool,
+    ) -> None:
+        normalized = " ".join(statement.lower().split())
+        if any(normalized.startswith(f"update {table}") for table in BACKFILL_TABLES):
+            updates.append((normalized, executemany))
+
+    sa.event.listen(engine, "before_cursor_execute", capture)
+
+    def cleanup() -> None:
+        sa.event.remove(engine, "before_cursor_execute", capture)
+
+    return updates, cleanup
+
+
+def _assert_set_based_partial_backfill(engine: sa.Engine) -> None:
+    config = create_alembic_config(engine)
+    config.set_main_option("script_location", str(MIGRATIONS_DIR))
+    with engine.connect() as connection:
+        _create_legacy_schema(connection)
+        catalog_generation, association_generation = _add_partial_generation_columns(
+            connection
+        )
+        updates, cleanup = _capture_backfill_updates(engine)
+        try:
+            config.attributes["connection"] = connection
+            command.upgrade(config, REVISION)
+        finally:
+            cleanup()
+
+        _assert_generation_schema(connection)
+        assert (
+            uuid.UUID(
+                str(
+                    connection.scalar(
+                        sa.text("SELECT generation FROM public_mcp_apps WHERE id = 1")
+                    )
+                )
+            )
+            == catalog_generation
+        )
+        assert (
+            uuid.UUID(
+                str(
+                    connection.scalar(
+                        sa.text(
+                            "SELECT lifecycle_generation FROM user_mcpservers WHERE id = 1"
+                        )
+                    )
+                )
+            )
+            == association_generation
+        )
+
+    assert len(updates) == len(BACKFILL_TABLES)
+    for table in BACKFILL_TABLES:
+        matching = [item for item in updates if item[0].startswith(f"update {table}")]
+        assert len(matching) == 1
+        statement, executemany = matching[0]
+        assert " is null" in statement
+        assert executemany is False
+
+
 def _upgrade_cycle(engine: sa.Engine) -> None:
     config = create_alembic_config(engine)
     config.set_main_option("script_location", str(MIGRATIONS_DIR))
@@ -178,6 +284,10 @@ def test_sqlite_upgrade_backfills_constraints_and_round_trips() -> None:
     _upgrade_cycle(sa.create_engine("sqlite:///:memory:"))
 
 
+def test_sqlite_partial_backfill_is_set_based_and_preserves_existing_values() -> None:
+    _assert_set_based_partial_backfill(sa.create_engine("sqlite:///:memory:"))
+
+
 @pytest.fixture()
 def postgresql_engine_factory():
     with disposable_database_factory("xagent_mcp_generations") as make:
@@ -212,3 +322,10 @@ def test_postgresql_upgrade_backfills_constraints_and_round_trips(
 
         assert isinstance(app.generation, uuid.UUID)
         assert isinstance(association.lifecycle_generation, uuid.UUID)
+
+
+@pytest.mark.postgresql
+def test_postgresql_partial_backfill_is_set_based_and_preserves_existing_values(
+    postgresql_engine_factory,
+) -> None:
+    _assert_set_based_partial_backfill(postgresql_engine_factory("partial_backfill"))

--- a/tests/migrations/test_20260902_add_mcp_lifecycle_generations.py
+++ b/tests/migrations/test_20260902_add_mcp_lifecycle_generations.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from tests.shared.postgres_disposable import disposable_database_factory
+from xagent.db.config import create_alembic_config
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+
+REVISION = "20260902_mcp_generations"
+DOWN_REVISION = "20260901_taskstatus_waiting_for_user"
+MIGRATIONS_DIR = Path(__file__).parents[2] / "src" / "xagent" / "migrations"
+
+
+def _create_legacy_schema(connection: sa.Connection) -> None:
+    connection.execute(
+        sa.text(
+            "CREATE TABLE public_mcp_apps ("
+            "id INTEGER PRIMARY KEY, app_id VARCHAR(100) NOT NULL UNIQUE)"
+        )
+    )
+    connection.execute(
+        sa.text(
+            "CREATE TABLE user_mcpservers ("
+            "id INTEGER PRIMARY KEY, user_id INTEGER NOT NULL, "
+            "mcpserver_id INTEGER NOT NULL, "
+            "CONSTRAINT uq_user_mcpservers UNIQUE (user_id, mcpserver_id))"
+        )
+    )
+    connection.execute(
+        sa.text(
+            "INSERT INTO public_mcp_apps (id, app_id) VALUES (1, 'one'), (2, 'two')"
+        )
+    )
+    connection.execute(
+        sa.text(
+            "INSERT INTO user_mcpservers (id, user_id, mcpserver_id) "
+            "VALUES (1, 10, 20), (2, 11, 20)"
+        )
+    )
+    connection.execute(
+        sa.text("CREATE TABLE alembic_version (version_num VARCHAR(255) NOT NULL)")
+    )
+    connection.execute(
+        sa.text("INSERT INTO alembic_version VALUES (:revision)"),
+        {"revision": DOWN_REVISION},
+    )
+
+
+def _generations(connection: sa.Connection, table: str, column: str) -> list[uuid.UUID]:
+    values = connection.scalars(
+        sa.text(f"SELECT {column} FROM {table} ORDER BY id")  # noqa: S608
+    )
+    return [uuid.UUID(str(value)) for value in values]
+
+
+def _assert_generation_schema(connection: sa.Connection) -> None:
+    inspector = sa.inspect(connection)
+    for table, column, unique_name in (
+        ("public_mcp_apps", "generation", "uq_public_mcp_apps_generation"),
+        (
+            "user_mcpservers",
+            "lifecycle_generation",
+            "uq_user_mcpservers_lifecycle_generation",
+        ),
+    ):
+        columns = {item["name"]: item for item in inspector.get_columns(table)}
+        assert columns[column]["nullable"] is False
+        uniques = {
+            item["name"]: item for item in inspector.get_unique_constraints(table)
+        }
+        assert uniques[unique_name]["column_names"] == [column]
+        values = _generations(connection, table, column)
+        assert len(values) == len(set(values)) == 2
+
+
+def _assert_constraints(connection: sa.Connection) -> None:
+    for table, column in (
+        ("public_mcp_apps", "generation"),
+        ("user_mcpservers", "lifecycle_generation"),
+    ):
+        generation = connection.scalar(
+            sa.text(f"SELECT {column} FROM {table} WHERE id = 1")  # noqa: S608
+        )
+        with pytest.raises(IntegrityError):
+            connection.execute(
+                sa.text(
+                    f"UPDATE {table} SET {column} = :generation WHERE id = 2"  # noqa: S608
+                ),
+                {"generation": generation},
+            )
+        connection.rollback()
+
+        with pytest.raises((IntegrityError, sa.exc.StatementError, sa.exc.DataError)):
+            connection.execute(
+                sa.text(
+                    f"UPDATE {table} SET {column} = '' WHERE id = 1"  # noqa: S608
+                )
+            )
+        connection.rollback()
+
+
+def _upgrade_cycle(engine: sa.Engine) -> None:
+    config = create_alembic_config(engine)
+    config.set_main_option("script_location", str(MIGRATIONS_DIR))
+    with engine.begin() as connection:
+        _create_legacy_schema(connection)
+        config.attributes["connection"] = connection
+        command.upgrade(config, REVISION)
+        _assert_generation_schema(connection)
+        first_catalog = set(_generations(connection, "public_mcp_apps", "generation"))
+        first_associations = set(
+            _generations(connection, "user_mcpservers", "lifecycle_generation")
+        )
+
+        command.downgrade(config, DOWN_REVISION)
+        assert "generation" not in {
+            item["name"]
+            for item in sa.inspect(connection).get_columns("public_mcp_apps")
+        }
+        assert "lifecycle_generation" not in {
+            item["name"]
+            for item in sa.inspect(connection).get_columns("user_mcpservers")
+        }
+
+        command.upgrade(config, REVISION)
+        _assert_generation_schema(connection)
+        assert first_catalog.isdisjoint(
+            _generations(connection, "public_mcp_apps", "generation")
+        )
+        assert first_associations.isdisjoint(
+            _generations(connection, "user_mcpservers", "lifecycle_generation")
+        )
+
+    with engine.connect() as connection:
+        _assert_constraints(connection)
+
+
+def test_sqlite_upgrade_backfills_constraints_and_round_trips() -> None:
+    _upgrade_cycle(sa.create_engine("sqlite:///:memory:"))
+
+
+@pytest.fixture()
+def postgresql_engine_factory():
+    with disposable_database_factory("xagent_mcp_generations") as make:
+        yield make
+
+
+@pytest.mark.postgresql
+def test_postgresql_upgrade_backfills_constraints_and_round_trips(
+    postgresql_engine_factory,
+) -> None:
+    _upgrade_cycle(postgresql_engine_factory("upgrade"))
+
+    fresh_engine = postgresql_engine_factory("fresh_models")
+    User.__table__.create(fresh_engine)
+    MCPServer.__table__.create(fresh_engine)
+    PublicMCPApp.__table__.create(fresh_engine)
+    UserMCPServer.__table__.create(fresh_engine)
+    with Session(fresh_engine) as db:
+        user = User(username="postgres-generation", password_hash="x")
+        server = MCPServer(
+            name="postgres-generation",
+            managed="external",
+            transport="streamable_http",
+            restart_policy="no",
+        )
+        app = PublicMCPApp(app_id="postgres-generation", name="Postgres generation")
+        db.add_all([user, server, app])
+        db.flush()
+        association = UserMCPServer(user_id=user.id, mcpserver_id=server.id)
+        db.add(association)
+        db.commit()
+
+        assert isinstance(app.generation, uuid.UUID)
+        assert isinstance(association.lifecycle_generation, uuid.UUID)

--- a/tests/migrations/test_20260902_add_mcp_lifecycle_generations.py
+++ b/tests/migrations/test_20260902_add_mcp_lifecycle_generations.py
@@ -74,12 +74,40 @@ def _assert_generation_schema(connection: sa.Connection) -> None:
     ):
         columns = {item["name"]: item for item in inspector.get_columns(table)}
         assert columns[column]["nullable"] is False
+        assert columns[column]["default"] is not None
         uniques = {
             item["name"]: item for item in inspector.get_unique_constraints(table)
         }
         assert uniques[unique_name]["column_names"] == [column]
         values = _generations(connection, table, column)
         assert len(values) == len(set(values)) == 2
+
+
+def _assert_database_defaults(connection: sa.Connection) -> None:
+    connection.execute(
+        sa.text(
+            "INSERT INTO public_mcp_apps (id, app_id) VALUES (3, 'database-default')"
+        )
+    )
+    connection.execute(
+        sa.text(
+            "INSERT INTO user_mcpservers (id, user_id, mcpserver_id) VALUES (3, 12, 20)"
+        )
+    )
+    for table, column in (
+        ("public_mcp_apps", "generation"),
+        ("user_mcpservers", "lifecycle_generation"),
+    ):
+        generated = uuid.UUID(
+            str(
+                connection.scalar(
+                    sa.text(
+                        f"SELECT {column} FROM {table} WHERE id = 3"  # noqa: S608
+                    )
+                )
+            )
+        )
+        assert generated.version == 4
 
 
 def _assert_constraints(connection: sa.Connection) -> None:
@@ -139,6 +167,7 @@ def _upgrade_cycle(engine: sa.Engine) -> None:
         assert first_associations.isdisjoint(
             _generations(connection, "user_mcpservers", "lifecycle_generation")
         )
+        _assert_database_defaults(connection)
 
     with engine.connect() as connection:
         _assert_constraints(connection)

--- a/tests/migrations/test_20260902_add_mcp_lifecycle_generations.py
+++ b/tests/migrations/test_20260902_add_mcp_lifecycle_generations.py
@@ -139,7 +139,7 @@ def _assert_constraints(connection: sa.Connection) -> None:
 def _upgrade_cycle(engine: sa.Engine) -> None:
     config = create_alembic_config(engine)
     config.set_main_option("script_location", str(MIGRATIONS_DIR))
-    with engine.begin() as connection:
+    with engine.connect() as connection:
         _create_legacy_schema(connection)
         config.attributes["connection"] = connection
         command.upgrade(config, REVISION)
@@ -168,6 +168,7 @@ def _upgrade_cycle(engine: sa.Engine) -> None:
             _generations(connection, "user_mcpservers", "lifecycle_generation")
         )
         _assert_database_defaults(connection)
+        connection.commit()
 
     with engine.connect() as connection:
         _assert_constraints(connection)

--- a/tests/migrations/test_migration_workflow_contract.py
+++ b/tests/migrations/test_migration_workflow_contract.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "test-migrations.yml"
+GENERATION_MODEL_PATHS = (
+    "src/xagent/web/models/generation.py",
+    "src/xagent/web/models/mcp.py",
+    "src/xagent/web/models/public_mcp.py",
+)
+
+
+def _workflow_text() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def _push_paths(text: str) -> set[str]:
+    block = re.search(r"(?ms)^  push:\n.*?^  pull_request:", text)
+    assert block is not None
+    return set(re.findall(r"^      - '([^']+)'$", block.group(0), re.MULTILINE))
+
+
+def _detector_paths(text: str) -> set[str]:
+    block = re.search(r"(?ms)^          RELEVANT_PATHS=\(\n(.*?)^          \)", text)
+    assert block is not None
+    return set(re.findall(r"^            (\S+)$", block.group(1), re.MULTILINE))
+
+
+@pytest.mark.parametrize("model_path", GENERATION_MODEL_PATHS)
+def test_generation_model_changes_run_real_postgresql_migration_step(
+    model_path: str,
+) -> None:
+    text = _workflow_text()
+    assert re.search(r"(?m)^  pull_request:\n    branches: \[main\]$", text)
+    assert model_path in _push_paths(text)
+    assert model_path in _detector_paths(text)
+
+    workflow = yaml.safe_load(text)
+    job = workflow["jobs"]["test-postgresql-migrations"]
+    assert job["needs"] == "detect-migration-changes"
+    steps = job["steps"]
+    sentinel = next(step for step in steps if step["name"] == "Skip migration tests")
+    regression = next(
+        step
+        for step in steps
+        if step["name"] == "Test MCP lifecycle generation migration (Postgres-only)"
+    )
+    output = "needs.detect-migration-changes.outputs.should-test"
+    assert sentinel["if"] == f"{output} != 'true'"
+    assert regression["if"] == f"{output} == 'true'"
+    assert (
+        "pytest tests/migrations/test_20260902_add_mcp_lifecycle_generations.py "
+        "-m postgresql -q"
+    ) in regression["run"]

--- a/tests/web/test_mcp_lifecycle_generation_models.py
+++ b/tests/web/test_mcp_lifecycle_generation_models.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import ast
+import uuid
+from pathlib import Path
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+
+
+def _session() -> Session:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return Session(engine)
+
+
+def _catalog_app() -> PublicMCPApp:
+    return PublicMCPApp(app_id="generation-test", name="Generation test")
+
+
+def _user_and_server(db: Session) -> tuple[User, object]:
+    user = User(username="generation-test", password_hash="x")
+    server = MCPServer(
+        name="generation-test-server",
+        managed="external",
+        transport="streamable_http",
+        restart_policy="no",
+    )
+    db.add_all([user, server])
+    db.flush()
+    return user, server
+
+
+def test_catalog_generation_is_random_unique_and_not_reused_with_sqlite_rowid() -> None:
+    with _session() as db:
+        original = _catalog_app()
+        db.add(original)
+        db.commit()
+        original_id = original.id
+        original_generation = original.generation
+
+        db.delete(original)
+        db.commit()
+
+        replacement = _catalog_app()
+        db.add(replacement)
+        db.commit()
+
+        assert replacement.id == original_id
+        assert isinstance(replacement.generation, uuid.UUID)
+        assert replacement.generation != original_generation
+
+
+def test_association_generation_is_random_unique_and_not_reused() -> None:
+    with _session() as db:
+        user, server = _user_and_server(db)
+        original = UserMCPServer(user_id=user.id, mcpserver_id=server.id)
+        db.add(original)
+        db.commit()
+        original_generation = original.lifecycle_generation
+
+        db.delete(original)
+        db.commit()
+
+        replacement = UserMCPServer(user_id=user.id, mcpserver_id=server.id)
+        db.add(replacement)
+        db.commit()
+
+        assert isinstance(replacement.lifecycle_generation, uuid.UUID)
+        assert replacement.lifecycle_generation != original_generation
+
+
+@pytest.mark.parametrize(
+    ("factory", "attribute"),
+    [
+        (_catalog_app, "generation"),
+        (lambda: UserMCPServer(user_id=1, mcpserver_id=1), "lifecycle_generation"),
+    ],
+)
+def test_generation_is_immutable_after_insert(factory, attribute: str) -> None:
+    with _session() as db:
+        if attribute == "lifecycle_generation":
+            user, server = _user_and_server(db)
+            row = UserMCPServer(user_id=user.id, mcpserver_id=server.id)
+        else:
+            row = factory()
+        db.add(row)
+        db.commit()
+        original = getattr(row, attribute)
+
+        setattr(row, attribute, uuid.uuid4())
+        with pytest.raises(ValueError, match="immutable"):
+            db.commit()
+        db.rollback()
+
+        assert getattr(row, attribute) == original
+
+
+def test_generation_unique_constraints_reject_duplicate_values() -> None:
+    with _session() as db:
+        generation = uuid.uuid4()
+        db.add_all(
+            [
+                PublicMCPApp(
+                    app_id="generation-one",
+                    name="Generation one",
+                    generation=generation,
+                ),
+                PublicMCPApp(
+                    app_id="generation-two",
+                    name="Generation two",
+                    generation=generation,
+                ),
+            ]
+        )
+        with pytest.raises(IntegrityError):
+            db.commit()
+
+
+def test_regular_updates_preserve_generations() -> None:
+    with _session() as db:
+        user, server = _user_and_server(db)
+        app = _catalog_app()
+        association = UserMCPServer(user_id=user.id, mcpserver_id=server.id)
+        db.add_all([app, association])
+        db.commit()
+        catalog_generation = app.generation
+        association_generation = association.lifecycle_generation
+
+        app.name = "Updated generation test"
+        association.is_active = False
+        db.commit()
+
+        assert app.generation == catalog_generation
+        assert association.lifecycle_generation == association_generation
+
+
+def test_production_association_creation_paths_share_the_model_default() -> None:
+    """Pin every production constructor that inherits the generation default."""
+    repository_root = Path(__file__).parents[2]
+    source_root = repository_root / "src" / "xagent"
+    constructors: dict[str, set[str]] = {
+        "PublicMCPApp": set(),
+        "UserMCPServer": set(),
+    }
+    for path in source_root.rglob("*.py"):
+        if "migrations" in path.parts:
+            continue
+        tree = ast.parse(path.read_text())
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            function = node.func
+            if isinstance(function, ast.Name) and function.id in constructors:
+                generation_field = (
+                    "generation"
+                    if function.id == "PublicMCPApp"
+                    else "lifecycle_generation"
+                )
+                assert all(keyword.arg != generation_field for keyword in node.keywords)
+                constructors[function.id].add(str(path.relative_to(repository_root)))
+
+    assert constructors == {
+        "PublicMCPApp": {"src/xagent/web/api/admin_mcp.py"},
+        "UserMCPServer": {
+            "src/xagent/web/api/auth.py",
+            "src/xagent/web/api/mcp.py",
+            "src/xagent/web/mcp_apps.py",
+        },
+    }

--- a/tests/web/test_mcp_lifecycle_generation_models.py
+++ b/tests/web/test_mcp_lifecycle_generation_models.py
@@ -5,9 +5,12 @@ import uuid
 from pathlib import Path
 
 import pytest
+import sqlalchemy as sa
 from sqlalchemy import create_engine
+from sqlalchemy.dialects import postgresql
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+from sqlalchemy.schema import CreateColumn
 
 from xagent.web.models.database import Base
 from xagent.web.models.mcp import MCPServer, UserMCPServer
@@ -140,6 +143,67 @@ def test_regular_updates_preserve_generations() -> None:
 
         assert app.generation == catalog_generation
         assert association.lifecycle_generation == association_generation
+
+
+def test_fresh_schema_raw_inserts_receive_database_generations() -> None:
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as db:
+        user, server = _user_and_server(db)
+        db.commit()
+        user_id = user.id
+        server_id = server.id
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.text(
+                "INSERT INTO public_mcp_apps (app_id, name, transport) "
+                "VALUES ('raw-catalog', 'Raw catalog', 'oauth')"
+            )
+        )
+        connection.execute(
+            sa.text(
+                "INSERT INTO user_mcpservers "
+                "(user_id, mcpserver_id, is_owner, can_edit, can_delete, "
+                "is_shared, is_active, is_default) "
+                "VALUES (:user_id, :server_id, 0, 0, 0, 0, 1, 0)"
+            ),
+            {"user_id": user_id, "server_id": server_id},
+        )
+        catalog_generation = uuid.UUID(
+            str(
+                connection.scalar(
+                    sa.text(
+                        "SELECT generation FROM public_mcp_apps "
+                        "WHERE app_id = 'raw-catalog'"
+                    )
+                )
+            )
+        )
+        association_generation = uuid.UUID(
+            str(
+                connection.scalar(
+                    sa.text(
+                        "SELECT lifecycle_generation FROM user_mcpservers "
+                        "WHERE user_id = :user_id AND mcpserver_id = :server_id"
+                    ),
+                    {"user_id": user_id, "server_id": server_id},
+                )
+            )
+        )
+
+    assert catalog_generation.version == 4
+    assert association_generation.version == 4
+    assert catalog_generation != association_generation
+
+
+@pytest.mark.parametrize(
+    "column",
+    [PublicMCPApp.generation, UserMCPServer.lifecycle_generation],
+)
+def test_postgresql_fresh_schema_uses_database_uuid_default(column) -> None:
+    ddl = str(CreateColumn(column).compile(dialect=postgresql.dialect()))
+    assert "DEFAULT gen_random_uuid()" in ddl
 
 
 def test_production_association_creation_paths_share_the_model_default() -> None:


### PR DESCRIPTION
## Summary

- add immutable random UUID generations to `PublicMCPApp` and `UserMCPServer`
- backfill every existing catalog and association row before enforcing non-null, unique, and non-empty constraints on SQLite and PostgreSQL
- preserve current API responses while covering every production ORM creation path through model defaults
- route the PostgreSQL migration regression through the migration workflow

## Validation

- `pytest -q tests/web/test_mcp_lifecycle_generation_models.py tests/migrations/test_20260902_add_mcp_lifecycle_generations.py -m 'not postgresql'`
- `python tests/migrations/test_migration_integration.py --db sqlite upgrade`
- `python tests/migrations/test_migration_integration.py --db sqlite downgrade`
- Ruff checks and `py_compile` on all changed Python files
- mutation checks confirmed failures when either model generation assignment or migration backfill was removed, and when catalog generation reuse was permitted

The PostgreSQL regression is included in the dedicated migration workflow. It was collected locally but skipped because no local PostgreSQL test URL was configured.

Closes #2031
