### PR TITLE
feat(ci): add a weekly Trivy scan of the published Docker images

### DIFF
--- a/.github/workflows/image-security-scan.yml
+++ b/.github/workflows/image-security-scan.yml
@@ -30,12 +30,8 @@ permissions:
 jobs:
   scan:
     name: Scan ${{ matrix.slug }}
-    # Upstream only. The targets are images that only this org publishes, so a
-    # fork that ran this on a schedule would spend its own minutes filling its
-    # own alert list with our CVEs. GitHub already disables scheduled workflows
-    # when a public repo is forked; this also covers a fork that re-enables
-    # them. `workflow_dispatch` is deliberately still allowed everywhere, so a
-    # fork can run it by hand to test changes to this file.
+    # Upstream only: the targets are images that only this org publishes.
+    # workflow_dispatch stays open so a fork can test changes by hand.
     if: github.event_name == 'workflow_dispatch' || github.repository_owner == 'xorbitsai'
     timeout-minutes: 60
     runs-on: ubuntu-latest

--- a/.github/workflows/image-security-scan.yml
+++ b/.github/workflows/image-security-scan.yml
@@ -1,7 +1,7 @@
 name: Image Security Scan
 
-# Weekly Trivy scan of the images we publish to Docker Hub. Results go to the
-# repository's Security -> Code scanning tab, which gives severity grouping and
+# Weekly Trivy scan of the images we publish to Docker Hub. Results go to
+# "Security and quality" -> "Code scanning", which gives severity grouping and
 # alert lifecycle (fixed alerts close themselves) for free on a public repo.
 #
 # Reporting only: every step keeps exit-code 0 so a standing pile of upstream
@@ -128,7 +128,7 @@ jobs:
 
       # Actionable subset, and the only thing that becomes a code scanning
       # alert. The backend image carries three dependency trees (Debian + pip +
-      # npm) and produces hundreds of findings, so the Security tab is kept to
+      # npm) and produces hundreds of findings, so the alert list is kept to
       # what someone can actually act on:
       #   - ignore-unfixed: only CVEs with a fixed version available
       #   - CRITICAL/HIGH/MEDIUM only

--- a/.github/workflows/image-security-scan.yml
+++ b/.github/workflows/image-security-scan.yml
@@ -21,7 +21,10 @@ on:
   workflow_dispatch:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # event_name is part of the key: for a schedule run and a workflow_dispatch
+  # against the default branch, github.ref is identical, so without it a manual
+  # re-run would cancel the weekly run and lose that week's upload.
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
@@ -89,7 +92,7 @@ jobs:
 
       # Authenticated pulls avoid Docker Hub's anonymous per-IP rate limit,
       # which shared Actions runner IPs hit easily. Forks have no DOCKERHUB_*
-      # secrets, so this is skipped there -- five weekly anonymous pulls stay
+      # secrets, so this is skipped there -- three weekly anonymous pulls stay
       # well inside the limit.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' }}
@@ -135,8 +138,8 @@ jobs:
       # what someone can actually act on:
       #   - ignore-unfixed: only CVEs with a fixed version available
       #   - CRITICAL/HIGH/MEDIUM only
-      #   - limit-severities-for-sarif is mandatory: without it the SARIF
-      #     writer emits every severity regardless of the `severity` input.
+      #   - limit-severities-for-sarif is mandatory: trivy-action's wrapper
+      #     unsets TRIVY_SEVERITY for SARIF output unless this is true.
       - name: Scan image (actionable findings for code scanning)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -150,9 +153,13 @@ jobs:
           exit-code: '0'
           timeout: 30m
           trivyignores: .trivyignore
-          cache: true
+          # The scan above already downloaded the DB and installed the binary,
+          # both of which outlive the step. Restoring the cache again can put an
+          # older day's DB back over the fresh one via the prefix restore-key.
+          cache: false
+          skip-setup-trivy: true
 
-      # A distinct category per image keeps the five scans as five independent
+      # A distinct category per image keeps the three scans as three independent
       # alert sets: without it each upload would resolve the previous image's
       # alerts as fixed.
       - name: Upload results to code scanning

--- a/.github/workflows/image-security-scan.yml
+++ b/.github/workflows/image-security-scan.yml
@@ -1,0 +1,159 @@
+name: Image Security Scan
+
+# Weekly Trivy scan of the images we publish to Docker Hub. Results go to the
+# repository's Security -> Code scanning tab, which gives severity grouping and
+# alert lifecycle (fixed alerts close themselves) for free on a public repo.
+#
+# Reporting only: every step keeps exit-code 0 so a standing pile of upstream
+# CVEs can never turn this into a permanently red workflow that people learn to
+# ignore. See docs/image-security-scanning.md.
+
+on:
+  schedule:
+    # Wednesday 03:10 UTC+8 == Tuesday 19:10 UTC.
+    #
+    # The minute is deliberately not :00. GitHub delays scheduled events under
+    # load and documents the top of every hour as a high-load window, so an
+    # off-hour minute is the one thing we can do about it. Expect the run to
+    # start late regardless -- delivery is best-effort, not punctual, and a
+    # weekly scan does not care.
+    - cron: '10 19 * * 2'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scan:
+    name: Scan ${{ matrix.slug }}
+    timeout-minutes: 60
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+
+    env:
+      # Hoisted so the login step can test for its presence: the `secrets`
+      # context is not available in a step-level `if`, but `env` is.
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+
+    strategy:
+      # One bad image must not hide the other two.
+      fail-fast: false
+      matrix:
+        include:
+          - slug: backend-latest
+            image: xprobe/xagent-backend
+            tag: latest
+            large: true
+          - slug: frontend-latest
+            image: xprobe/xagent-frontend
+            tag: latest
+            large: false
+          - slug: sandbox-latest
+            image: xprobe/xagent-sandbox
+            tag: latest
+            large: false
+          # Deliberately not scanned:
+          #   - `nightly`: it is rebuilt daily, so its findings churn without
+          #     telling you anything about what users are running.
+          #   - `buildcache`: buildx cache manifests (13+ GB for the backend),
+          #     not runnable images.
+
+    steps:
+      # Only needed for .trivyignore -- the scan target is the published image,
+      # not this checkout.
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      # The backend image unpacks to roughly 10 GB, which does not fit in the
+      # default runner's free space. Same action and pin as docker-publish.yml.
+      - name: Free GitHub-hosted runner disk space
+        if: matrix.large
+        uses: endersonmenezes/free-disk-space@e6ed9b02e683a3b55ed0252f1ee469ce3b39a885
+        with:
+          remove_android: true
+          remove_dotnet: true
+          remove_haskell: true
+          remove_tool_cache: true
+          rm_cmd: rmz
+          rmz_version: "3.1.1"
+
+      # Authenticated pulls avoid Docker Hub's anonymous per-IP rate limit,
+      # which shared Actions runner IPs hit easily. Forks have no DOCKERHUB_*
+      # secrets, so this is skipped there -- five weekly anonymous pulls stay
+      # well inside the limit.
+      - name: Log in to Docker Hub
+        if: ${{ env.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
+      # Pull once up front. Both Trivy steps below then read the image from the
+      # local daemon (Trivy's default source priority is docker first), so the
+      # backend's 3.6 GB is downloaded once instead of twice. The images are
+      # multi-arch; we scan amd64 only.
+      - name: Pull image
+        run: docker pull --platform linux/amd64 "${{ matrix.image }}:${{ matrix.tag }}"
+
+      # Full picture, kept as an artifact rather than uploaded as alerts:
+      # every severity including the unfixed ones. This is where you look when
+      # you want to know the real total, not just what is actionable.
+      - name: Scan image (full report)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ matrix.image }}:${{ matrix.tag }}
+          format: json
+          output: trivy-${{ matrix.slug }}.json
+          scanners: vuln
+          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+          ignore-unfixed: false
+          exit-code: '0'
+          timeout: 30m
+          trivyignores: .trivyignore
+          cache: true
+
+      - name: Upload full report artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: trivy-report-${{ matrix.slug }}
+          path: trivy-${{ matrix.slug }}.json
+          retention-days: 30
+
+      # Actionable subset, and the only thing that becomes a code scanning
+      # alert. The backend image carries three dependency trees (Debian + pip +
+      # npm) and produces hundreds of findings, so the Security tab is kept to
+      # what someone can actually act on:
+      #   - ignore-unfixed: only CVEs with a fixed version available
+      #   - CRITICAL/HIGH/MEDIUM only
+      #   - limit-severities-for-sarif is mandatory: without it the SARIF
+      #     writer emits every severity regardless of the `severity` input.
+      - name: Scan image (actionable findings for code scanning)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ matrix.image }}:${{ matrix.tag }}
+          format: sarif
+          output: trivy-${{ matrix.slug }}.sarif
+          scanners: vuln
+          severity: CRITICAL,HIGH,MEDIUM
+          limit-severities-for-sarif: true
+          ignore-unfixed: true
+          exit-code: '0'
+          timeout: 30m
+          trivyignores: .trivyignore
+          cache: true
+
+      # A distinct category per image keeps the five scans as five independent
+      # alert sets: without it each upload would resolve the previous image's
+      # alerts as fixed.
+      - name: Upload results to code scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: trivy-${{ matrix.slug }}.sarif
+          category: image-scan/${{ matrix.slug }}

--- a/.github/workflows/image-security-scan.yml
+++ b/.github/workflows/image-security-scan.yml
@@ -1,14 +1,13 @@
 name: Image Security Scan
 
 # Weekly Trivy scan of the images we publish to Docker Hub. Reporting only:
-# every step keeps exit-code 0, so a red run means the scan itself broke, never
-# that a CVE was found. See docs/image-security-scanning.md.
+# a red run means the scan broke, not that a CVE was found.
+# See docs/image-security-scanning.md.
 
 on:
   schedule:
     # Wednesday 03:10 UTC+8 == Tuesday 19:10 UTC.
-    # WHY: the minute avoids :00 because GitHub documents the top of the hour as
-    # a high-load window for scheduled events. Expect the run to start late.
+    # WHY: :00 is GitHub's documented high-load window for scheduled events.
     - cron: '10 19 * * 2'
   workflow_dispatch:
 
@@ -24,8 +23,8 @@ permissions:
 jobs:
   scan:
     name: Scan ${{ matrix.slug }}
-    # WHY: only this org publishes the target images. workflow_dispatch stays
-    # open so a fork can test changes to this workflow by hand.
+    # WHY: a fork running this on a schedule would only fill its own alert list
+    # with our CVEs.
     if: github.event_name == 'workflow_dispatch' || github.repository_owner == 'xorbitsai'
     timeout-minutes: 60
     runs-on: ubuntu-latest
@@ -40,7 +39,6 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
     strategy:
-      # WHY: one bad image must not hide the other two.
       fail-fast: false
       matrix:
         include:
@@ -56,17 +54,17 @@ jobs:
             image: xprobe/xagent-sandbox
             tag: latest
             large: false
-          # WHY: `nightly` is rebuilt daily so its findings churn, and the
-          # `buildcache` tags are buildx manifests rather than runnable images.
+          # WHY: `nightly` churns daily, and the `buildcache` tags are buildx
+          # manifests rather than runnable images.
 
     steps:
-      # WHY: needed for .trivyignore only -- the scan target is the published
-      # image, not this checkout.
+      # WHY: only .trivyignore is needed from the repo -- the scan target is the
+      # published image.
       - name: Checkout repository
         uses: actions/checkout@v7
 
       # WHY: the backend image unpacks to roughly 10 GB, more than a default
-      # runner has free. Same action and pin as docker-publish.yml.
+      # runner has free.
       - name: Free GitHub-hosted runner disk space
         if: matrix.large
         uses: endersonmenezes/free-disk-space@e6ed9b02e683a3b55ed0252f1ee469ce3b39a885
@@ -78,9 +76,6 @@ jobs:
           rm_cmd: rmz
           rmz_version: "3.1.1"
 
-      # WHY: shared Actions runner IPs hit Docker Hub's anonymous per-IP pull
-      # limit easily. Forks have no secrets, and three weekly anonymous pulls
-      # stay well inside it, so skipping the login there is fine.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@v4
@@ -88,8 +83,8 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      # WHY: both Trivy steps read the image from the local daemon, so pulling
-      # once here downloads the backend's 3.6 GB once instead of twice.
+      # WHY: both Trivy steps then read from the local daemon, so the backend's
+      # 3.6 GB is pulled once instead of twice.
       - name: Pull image
         run: docker pull --platform linux/amd64 "${{ matrix.image }}:${{ matrix.tag }}"
 
@@ -114,9 +109,8 @@ jobs:
           path: trivy-${{ matrix.slug }}.json
           retention-days: 30
 
-      # WARN: limit-severities-for-sarif must stay true -- trivy-action's
-      # wrapper unsets TRIVY_SEVERITY for SARIF output otherwise, which makes
-      # the severity filter below silently do nothing.
+      # WARN: limit-severities-for-sarif must stay true -- trivy-action unsets
+      # TRIVY_SEVERITY for SARIF output otherwise, silently ignoring `severity`.
       - name: Scan image (actionable findings for code scanning)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -130,14 +124,12 @@ jobs:
           exit-code: '0'
           timeout: 30m
           trivyignores: .trivyignore
-          # WHY: the scan above already installed the binary and downloaded the
-          # DB, both of which outlive the step. Restoring again can put an older
-          # day's DB back over the fresh one via the prefix restore-key.
+          # WHY: the scan above already installed the binary and fetched the DB,
+          # and a prefix restore-key here can overwrite it with an older day's.
           cache: false
           skip-setup-trivy: true
 
-      # WHY: a distinct category per image keeps the three scans as three
-      # independent alert sets -- otherwise each upload resolves the previous
+      # WHY: without a per-image category, each upload resolves the previous
       # image's alerts as fixed.
       - name: Upload results to code scanning
         uses: github/codeql-action/upload-sarif@v4

--- a/.github/workflows/image-security-scan.yml
+++ b/.github/workflows/image-security-scan.yml
@@ -1,29 +1,20 @@
 name: Image Security Scan
 
-# Weekly Trivy scan of the images we publish to Docker Hub. Results go to
-# "Security and quality" -> "Code scanning", which gives severity grouping and
-# alert lifecycle (fixed alerts close themselves) for free on a public repo.
-#
-# Reporting only: every step keeps exit-code 0 so a standing pile of upstream
-# CVEs can never turn this into a permanently red workflow that people learn to
-# ignore. See docs/image-security-scanning.md.
+# Weekly Trivy scan of the images we publish to Docker Hub. Reporting only:
+# every step keeps exit-code 0, so a red run means the scan itself broke, never
+# that a CVE was found. See docs/image-security-scanning.md.
 
 on:
   schedule:
     # Wednesday 03:10 UTC+8 == Tuesday 19:10 UTC.
-    #
-    # The minute is deliberately not :00. GitHub delays scheduled events under
-    # load and documents the top of every hour as a high-load window, so an
-    # off-hour minute is the one thing we can do about it. Expect the run to
-    # start late regardless -- delivery is best-effort, not punctual, and a
-    # weekly scan does not care.
+    # WHY: the minute avoids :00 because GitHub documents the top of the hour as
+    # a high-load window for scheduled events. Expect the run to start late.
     - cron: '10 19 * * 2'
   workflow_dispatch:
 
 concurrency:
-  # event_name is part of the key: for a schedule run and a workflow_dispatch
-  # against the default branch, github.ref is identical, so without it a manual
-  # re-run would cancel the weekly run and lose that week's upload.
+  # WHY: schedule and workflow_dispatch resolve github.ref identically on the
+  # default branch, so without event_name a manual run cancels the weekly one.
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
@@ -33,8 +24,8 @@ permissions:
 jobs:
   scan:
     name: Scan ${{ matrix.slug }}
-    # Upstream only: the targets are images that only this org publishes.
-    # workflow_dispatch stays open so a fork can test changes by hand.
+    # WHY: only this org publishes the target images. workflow_dispatch stays
+    # open so a fork can test changes to this workflow by hand.
     if: github.event_name == 'workflow_dispatch' || github.repository_owner == 'xorbitsai'
     timeout-minutes: 60
     runs-on: ubuntu-latest
@@ -44,12 +35,12 @@ jobs:
       actions: read
 
     env:
-      # Hoisted so the login step can test for its presence: the `secrets`
-      # context is not available in a step-level `if`, but `env` is.
+      # WHY: hoisted so the login step can test for its presence -- the secrets
+      # context is unavailable in a step-level `if`, env is not.
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
 
     strategy:
-      # One bad image must not hide the other two.
+      # WHY: one bad image must not hide the other two.
       fail-fast: false
       matrix:
         include:
@@ -65,20 +56,17 @@ jobs:
             image: xprobe/xagent-sandbox
             tag: latest
             large: false
-          # Deliberately not scanned:
-          #   - `nightly`: it is rebuilt daily, so its findings churn without
-          #     telling you anything about what users are running.
-          #   - `buildcache`: buildx cache manifests (13+ GB for the backend),
-          #     not runnable images.
+          # WHY: `nightly` is rebuilt daily so its findings churn, and the
+          # `buildcache` tags are buildx manifests rather than runnable images.
 
     steps:
-      # Only needed for .trivyignore -- the scan target is the published image,
-      # not this checkout.
+      # WHY: needed for .trivyignore only -- the scan target is the published
+      # image, not this checkout.
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      # The backend image unpacks to roughly 10 GB, which does not fit in the
-      # default runner's free space. Same action and pin as docker-publish.yml.
+      # WHY: the backend image unpacks to roughly 10 GB, more than a default
+      # runner has free. Same action and pin as docker-publish.yml.
       - name: Free GitHub-hosted runner disk space
         if: matrix.large
         uses: endersonmenezes/free-disk-space@e6ed9b02e683a3b55ed0252f1ee469ce3b39a885
@@ -90,10 +78,9 @@ jobs:
           rm_cmd: rmz
           rmz_version: "3.1.1"
 
-      # Authenticated pulls avoid Docker Hub's anonymous per-IP rate limit,
-      # which shared Actions runner IPs hit easily. Forks have no DOCKERHUB_*
-      # secrets, so this is skipped there -- three weekly anonymous pulls stay
-      # well inside the limit.
+      # WHY: shared Actions runner IPs hit Docker Hub's anonymous per-IP pull
+      # limit easily. Forks have no secrets, and three weekly anonymous pulls
+      # stay well inside it, so skipping the login there is fine.
       - name: Log in to Docker Hub
         if: ${{ env.DOCKERHUB_USERNAME != '' }}
         uses: docker/login-action@v4
@@ -101,16 +88,11 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_PASSWORD }}
 
-      # Pull once up front. Both Trivy steps below then read the image from the
-      # local daemon (Trivy's default source priority is docker first), so the
-      # backend's 3.6 GB is downloaded once instead of twice. The images are
-      # multi-arch; we scan amd64 only.
+      # WHY: both Trivy steps read the image from the local daemon, so pulling
+      # once here downloads the backend's 3.6 GB once instead of twice.
       - name: Pull image
         run: docker pull --platform linux/amd64 "${{ matrix.image }}:${{ matrix.tag }}"
 
-      # Full picture, kept as an artifact rather than uploaded as alerts:
-      # every severity including the unfixed ones. This is where you look when
-      # you want to know the real total, not just what is actionable.
       - name: Scan image (full report)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -132,14 +114,9 @@ jobs:
           path: trivy-${{ matrix.slug }}.json
           retention-days: 30
 
-      # Actionable subset, and the only thing that becomes a code scanning
-      # alert. The backend image carries three dependency trees (Debian + pip +
-      # npm) and produces hundreds of findings, so the alert list is kept to
-      # what someone can actually act on:
-      #   - ignore-unfixed: only CVEs with a fixed version available
-      #   - CRITICAL/HIGH/MEDIUM only
-      #   - limit-severities-for-sarif is mandatory: trivy-action's wrapper
-      #     unsets TRIVY_SEVERITY for SARIF output unless this is true.
+      # WARN: limit-severities-for-sarif must stay true -- trivy-action's
+      # wrapper unsets TRIVY_SEVERITY for SARIF output otherwise, which makes
+      # the severity filter below silently do nothing.
       - name: Scan image (actionable findings for code scanning)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -153,15 +130,15 @@ jobs:
           exit-code: '0'
           timeout: 30m
           trivyignores: .trivyignore
-          # The scan above already downloaded the DB and installed the binary,
-          # both of which outlive the step. Restoring the cache again can put an
-          # older day's DB back over the fresh one via the prefix restore-key.
+          # WHY: the scan above already installed the binary and downloaded the
+          # DB, both of which outlive the step. Restoring again can put an older
+          # day's DB back over the fresh one via the prefix restore-key.
           cache: false
           skip-setup-trivy: true
 
-      # A distinct category per image keeps the three scans as three independent
-      # alert sets: without it each upload would resolve the previous image's
-      # alerts as fixed.
+      # WHY: a distinct category per image keeps the three scans as three
+      # independent alert sets -- otherwise each upload resolves the previous
+      # image's alerts as fixed.
       - name: Upload results to code scanning
         uses: github/codeql-action/upload-sarif@v4
         with:

--- a/.github/workflows/image-security-scan.yml
+++ b/.github/workflows/image-security-scan.yml
@@ -30,6 +30,13 @@ permissions:
 jobs:
   scan:
     name: Scan ${{ matrix.slug }}
+    # Upstream only. The targets are images that only this org publishes, so a
+    # fork that ran this on a schedule would spend its own minutes filling its
+    # own alert list with our CVEs. GitHub already disables scheduled workflows
+    # when a public repo is forked; this also covers a fork that re-enables
+    # them. `workflow_dispatch` is deliberately still allowed everywhere, so a
+    # fork can run it by hand to test changes to this file.
+    if: github.event_name == 'workflow_dispatch' || github.repository_owner == 'xorbitsai'
     timeout-minutes: 60
     runs-on: ubuntu-latest
     permissions:

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,12 @@
+# Vulnerabilities excluded from the weekly image scan
+# (.github/workflows/image-security-scan.yml).
+#
+# One CVE id per line. Add an entry only for a risk that has been reviewed and
+# accepted -- not to quiet an alert nobody has looked at yet. Each entry needs a
+# comment saying why, plus the PR that decided it:
+#
+#   # Not reachable: the vulnerable codec is never fed untrusted input. xorbitsai/xagent#0000
+#   CVE-0000-00000
+#
+# Note that unfixed vulnerabilities are already excluded from the Security tab
+# by the workflow's ignore-unfixed, so they do not need an entry here.

--- a/.trivyignore
+++ b/.trivyignore
@@ -8,5 +8,5 @@
 #   # Not reachable: the vulnerable codec is never fed untrusted input. xorbitsai/xagent#0000
 #   CVE-0000-00000
 #
-# Note that unfixed vulnerabilities are already excluded from the Security tab
-# by the workflow's ignore-unfixed, so they do not need an entry here.
+# Note that unfixed vulnerabilities never become code scanning alerts in the
+# first place (the workflow's ignore-unfixed), so they need no entry here.

--- a/.trivyignore
+++ b/.trivyignore
@@ -10,3 +10,6 @@
 #
 # Note that unfixed vulnerabilities never become code scanning alerts in the
 # first place (the workflow's ignore-unfixed), so they need no entry here.
+#
+# An entry here also removes the finding from the run's full JSON artifact, not
+# just from the alerts -- Trivy reads this file by default on both scans.

--- a/docs/image-security-scanning.md
+++ b/docs/image-security-scanning.md
@@ -42,7 +42,7 @@ The page has dropdowns for the common cases, and the search box takes qualifiers
 
 Every image is uploaded under its own SARIF category (`image-scan/backend-latest`, `image-scan/frontend-latest`, `image-scan/sandbox-latest`). That is what keeps the three scans from resolving each other's alerts, but it is not a view you can filter by: [GitHub does not support filtering the alert list by category](https://github.com/orgs/community/discussions/70050).
 
-Worse, **an alert belongs to only one category even when the vulnerability is in several images.** GitHub deduplicates alerts by rule and location, so an identical finding at an identical path in two images becomes one alert, arbitrarily attributed to one of them. The frontend and sandbox images share a `node:22` base, and 17 of the frontend's npm findings sit at the same `usr/local/lib/node_modules/npm/...` paths as the sandbox's. The result: the frontend's own report lists 47 actionable findings, while the Code scanning page attributes 30 to it and the other 17 to the sandbox. Neither number is wrong, but neither is "the frontend's vulnerability count" either.
+Worse, **counting alerts by category does not give you per-image totals.** GitHub deduplicates alerts by rule and location, so an identical finding at an identical path in two images becomes a single alert. That alert can belong to more than one configuration, but a per-alert view surfaces only one category for it — `most_recent_instance.category`, which the query below reads, is by definition the most recent one — so a shared finding counts towards one image and disappears from the other's total. The frontend and sandbox images share a `node:22` base, and 17 of the frontend's npm findings sit at the same `usr/local/lib/node_modules/npm/...` paths as the sandbox's. Measured on a fork: the frontend's own report lists 47 actionable findings, while counting alerts by category gives the frontend 30 and the sandbox the other 17. Neither number is wrong, but neither is "the frontend's vulnerability count" either.
 
 So:
 
@@ -64,7 +64,7 @@ The alert list deliberately shows a filtered subset (next section). The **comple
 gh run download <run-id> --repo xorbitsai/xagent -n trivy-report-backend-latest
 ```
 
-Go there when you want the real total rather than the actionable subset.
+Go there when you want the real total rather than the actionable subset. One caveat: this artifact is unfiltered by severity and by fix availability, but not by [`.trivyignore`](../.trivyignore) — Trivy reads that file from the repository root by default, so an accepted-risk entry drops out of the artifact as well as out of the alert list.
 
 ## Why the alert list shows less than the artifact
 
@@ -72,7 +72,7 @@ The backend image carries Debian, pip and npm dependency trees plus Chrome, Play
 
 - `ignore-unfixed: true` — only CVEs that have a fixed version available. A vulnerability nobody can patch yet is not a to-do item. This is the filter that does the real work: on the first backend scan it cut 4,554 findings to 399, almost entirely because Debian marks the overwhelming majority of its CVEs as not-to-be-fixed (4,173 Debian findings became 30). What survives is nearly all application-level: pip, npm, and Go/Rust binaries vendored into `node_modules`.
 - `CRITICAL,HIGH,MEDIUM` only. LOW and UNKNOWN stay in the artifact.
-- `limit-severities-for-sarif: true` — required. Without it Trivy's SARIF writer emits every severity regardless of the `severity` input, and the filter above silently does nothing.
+- `limit-severities-for-sarif: true` — required, and this is `trivy-action`'s behaviour rather than Trivy's. The action's `entrypoint.sh` unsets `TRIVY_SEVERITY` before invoking Trivy whenever the format is SARIF and this input is not `true`, which makes the filter above silently do nothing. The Trivy CLI on its own honours `--severity` with `--format sarif`.
 
 Note that the severity shown on the alert is GitHub's own, derived from the CVSS score, so it will not always match Trivy's label — a Trivy MEDIUM can appear as `low`.
 
@@ -107,10 +107,10 @@ Two other scheduling facts worth knowing: the `schedule` event only fires for wo
 
 ## Operational notes
 
-- **Docker Hub rate limits.** The workflow authenticates with `DOCKERHUB_USERNAME` / `DOCKERHUB_PASSWORD` when those secrets exist, because shared Actions runner IPs hit the anonymous per-IP pull limit easily. On forks, which have no such secrets, the login step skips itself and five weekly anonymous pulls stay well inside the limit.
+- **Docker Hub rate limits.** The workflow authenticates with `DOCKERHUB_USERNAME` / `DOCKERHUB_PASSWORD` when those secrets exist, because shared Actions runner IPs hit the anonymous per-IP pull limit easily. On forks, which have no such secrets, the login step skips itself and three weekly anonymous pulls stay well inside the limit.
 - **Disk.** The backend image unpacks to roughly 10 GB, more than a default runner has free, so `free-disk-space` runs first for that image only.
 - **One pull, two scans.** The image is pulled once with `docker pull`; both Trivy steps then read it from the local daemon. Running Trivy twice against the registry would download the backend's 3.6 GB twice.
-- **Trivy DB.** Caching is on, which is what keeps the ghcr.io vulnerability-database pulls under their rate limit.
+- **Trivy DB.** Both scans in a job share one on-disk `TRIVY_CACHE_DIR`, so the vulnerability database is fetched at most once per image — that, not the Actions cache, is why the download shows up once per job. The Actions cache is enabled on the first scan as well, but its key is per-day and GitHub evicts entries unused for 7 days, so on a weekly schedule reuse across runs is plausible rather than reliable.
 - **Cost.** Zero. Code scanning and GitHub-hosted runner minutes are both free for public repositories.
 
 ## Not covered

--- a/docs/image-security-scanning.md
+++ b/docs/image-security-scanning.md
@@ -99,6 +99,12 @@ Weekly, `cron: '10 19 * * 2'` — Wednesday 03:10 UTC+8. You can also run it on 
 
 Two other scheduling facts worth knowing: the `schedule` event only fires for workflow files that exist on the **default branch**, and GitHub disables scheduled workflows in a public repository after 60 days with no activity.
 
+### Forks
+
+**The weekly run is upstream-only.** The job is guarded by `github.repository_owner == 'xorbitsai'`, because the scan targets images that only this org publishes — a fork running it on a schedule would spend its own Actions minutes filling its own alert list with our CVEs, which it can do nothing about. GitHub [already disables scheduled workflows when a public repository is forked](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/disable-and-enable-workflows); the guard also covers a fork that re-enables them.
+
+`workflow_dispatch` is exempt from the guard, so a fork can still run the scan by hand — which is how changes to this workflow get tested without pushing to upstream. A fork that genuinely wants the weekly run should change the `image` values in the matrix to its own images, at which point the guard is the thing to edit too.
+
 ## Operational notes
 
 - **Docker Hub rate limits.** The workflow authenticates with `DOCKERHUB_USERNAME` / `DOCKERHUB_PASSWORD` when those secrets exist, because shared Actions runner IPs hit the anonymous per-IP pull limit easily. On forks, which have no such secrets, the login step skips itself and five weekly anonymous pulls stay well inside the limit.

--- a/docs/image-security-scanning.md
+++ b/docs/image-security-scanning.md
@@ -16,7 +16,7 @@ Only `latest` is scanned — what users actually pull. `nightly` is deliberately
 
 ## Where to look
 
-Go to the repository's **Security** tab → **Code scanning** in the left sidebar:
+Go to the repository's **Security and quality** tab → **Code scanning** in the left sidebar (GitHub [renamed the tab from "Security" in April 2026](https://github.blog/changelog/2026-04-02-the-security-tab-is-now-security-quality/); the URL is unchanged):
 
 <https://github.com/xorbitsai/xagent/security/code-scanning>
 
@@ -38,11 +38,11 @@ The page has dropdowns for the common cases, and the search box takes qualifiers
 
 ### Viewing one image at a time
 
-**Not from the Security tab, and this is worth understanding before you trust any per-image number you see there.**
+**Not from the alert list, and this is worth understanding before you trust any per-image number you see there.**
 
 Every image is uploaded under its own SARIF category (`image-scan/backend-latest`, `image-scan/frontend-latest`, `image-scan/sandbox-latest`). That is what keeps the three scans from resolving each other's alerts, but it is not a view you can filter by: [GitHub does not support filtering the alert list by category](https://github.com/orgs/community/discussions/70050).
 
-Worse, **an alert belongs to only one category even when the vulnerability is in several images.** GitHub deduplicates alerts by rule and location, so an identical finding at an identical path in two images becomes one alert, arbitrarily attributed to one of them. The frontend and sandbox images share a `node:22` base, and 17 of the frontend's npm findings sit at the same `usr/local/lib/node_modules/npm/...` paths as the sandbox's. The result: the frontend's own report lists 47 actionable findings, while the Security tab attributes 30 to it and the other 17 to the sandbox. Neither number is wrong, but neither is "the frontend's vulnerability count" either.
+Worse, **an alert belongs to only one category even when the vulnerability is in several images.** GitHub deduplicates alerts by rule and location, so an identical finding at an identical path in two images becomes one alert, arbitrarily attributed to one of them. The frontend and sandbox images share a `node:22` base, and 17 of the frontend's npm findings sit at the same `usr/local/lib/node_modules/npm/...` paths as the sandbox's. The result: the frontend's own report lists 47 actionable findings, while the Code scanning page attributes 30 to it and the other 17 to the sandbox. Neither number is wrong, but neither is "the frontend's vulnerability count" either.
 
 So:
 
@@ -58,7 +58,7 @@ So:
 
 ### The full report
 
-The Security tab deliberately shows a filtered subset (next section). The **complete** report — every severity, including everything with no fix available — is attached to each workflow run as the `trivy-report-<slug>` artifact (JSON, kept 30 days):
+The alert list deliberately shows a filtered subset (next section). The **complete** report — every severity, including everything with no fix available — is attached to each workflow run as the `trivy-report-<slug>` artifact (JSON, kept 30 days):
 
 ```bash
 gh run download <run-id> --repo xorbitsai/xagent -n trivy-report-backend-latest
@@ -66,7 +66,7 @@ gh run download <run-id> --repo xorbitsai/xagent -n trivy-report-backend-latest
 
 Go there when you want the real total rather than the actionable subset.
 
-## Why the Security tab shows less than the artifact
+## Why the alert list shows less than the artifact
 
 The backend image carries Debian, pip and npm dependency trees plus Chrome, Playwright and LibreOffice, and an unfiltered scan of it reports **thousands** of vulnerabilities. An alert list that long gets ignored, which is worse than no alert list. So the code scanning upload is filtered down to what someone can act on:
 
@@ -74,20 +74,20 @@ The backend image carries Debian, pip and npm dependency trees plus Chrome, Play
 - `CRITICAL,HIGH,MEDIUM` only. LOW and UNKNOWN stay in the artifact.
 - `limit-severities-for-sarif: true` — required. Without it Trivy's SARIF writer emits every severity regardless of the `severity` input, and the filter above silently does nothing.
 
-Note that the severity shown in the Security tab is GitHub's own, derived from the CVSS score, so it will not always match Trivy's label — a Trivy MEDIUM can appear as `low`.
+Note that the severity shown on the alert is GitHub's own, derived from the CVSS score, so it will not always match Trivy's label — a Trivy MEDIUM can appear as `low`.
 
 ## Handling an alert
 
 1. Open the alert; it names the package, the installed version and the fixed version.
 2. Decide where the package comes from:
-   - **Debian package** — the base images use floating tags (`python:3.11-bookworm`, `node:22-slim`), so a rebuild usually picks the fix up on its own and the alert closes at the next scan. If it survives several scans, the base image tag itself needs bumping in the relevant `docker/Dockerfile.*`. Note that Debian marks most of its CVEs as not-to-be-fixed, and those never reach the Security tab at all — see the filtering section above.
+   - **Debian package** — the base images use floating tags (`python:3.11-bookworm`, `node:22-slim`), so a rebuild usually picks the fix up on its own and the alert closes at the next scan. If it survives several scans, the base image tag itself needs bumping in the relevant `docker/Dockerfile.*`. Note that Debian marks most of its CVEs as not-to-be-fixed, and those never become alerts at all — see the filtering section above.
    - **pip / npm package** — bump it in `pyproject.toml` or `frontend/package.json`.
    - **Go or Rust binary** — a compiled binary vendored into `node_modules` or `/usr/local/bin`, reported against the toolchain that built it rather than against a package you declare. Bump whatever npm/pip package ships the binary.
 3. If the fix is not viable, add the CVE to [`.trivyignore`](../.trivyignore) with a comment saying why and the PR that decided it. Do not add entries to quiet alerts nobody has reviewed.
 
 ## Failure policy
 
-The workflow never fails. `exit-code` is `0` on every scan step regardless of what is found. A weekly job that goes permanently red because of upstream CVEs stops being read within a month, which defeats the point. Notification is the Security tab's job.
+The workflow never fails. `exit-code` is `0` on every scan step regardless of what is found. A weekly job that goes permanently red because of upstream CVEs stops being read within a month, which defeats the point. Notification is the code scanning alerts' job.
 
 A red run therefore means the scan itself broke — a pull failure, a rate limit, disk exhaustion — not that a vulnerability was found.
 

--- a/docs/image-security-scanning.md
+++ b/docs/image-security-scanning.md
@@ -1,0 +1,114 @@
+# Image security scanning
+
+Weekly vulnerability scan of the images published to Docker Hub, run by [`.github/workflows/image-security-scan.yml`](../.github/workflows/image-security-scan.yml).
+
+## What is scanned
+
+| Image | Tag | Package ecosystems Trivy sees |
+| --- | --- | --- |
+| `xprobe/xagent-backend` | `latest` | Debian packages, pip/uv (the venv at `/opt/venv`), npm, and Go/Rust binaries vendored into `node_modules` |
+| `xprobe/xagent-frontend` | `latest` | Debian packages, npm |
+| `xprobe/xagent-sandbox` | `latest` | Debian packages, pip, npm |
+
+Three targets, `linux/amd64` only. The images are multi-arch, but CVE differences between architectures are marginal and scanning both would double runner time for little signal.
+
+Only `latest` is scanned — what users actually pull. `nightly` is deliberately excluded: it is rebuilt every day, so its findings churn constantly without telling you anything about what is deployed. The `buildcache` tags are excluded too; they are buildx cache manifests, not runnable images.
+
+## Where to look
+
+Go to the repository's **Security** tab → **Code scanning** in the left sidebar:
+
+<https://github.com/xorbitsai/xagent/security/code-scanning>
+
+Each alert names the CVE, the package, the installed version and the version that fixes it. Severity is shown per alert and the sidebar counts them by level, so "how many Critical do we have" is answered without filtering anything.
+
+Alerts have a lifecycle: an alert closes itself once the next scan no longer finds the CVE, and reopens if it comes back. You are reading a list of current problems, not a weekly pile of fresh reports.
+
+### Filtering
+
+The page has dropdowns for the common cases, and the search box takes qualifiers. The ones worth knowing:
+
+| Qualifier | Use |
+| --- | --- |
+| `is:open` / `is:closed` | Default view is open alerts |
+| `severity:critical` | Also `high`, `medium`, `low`. Combine them: `severity:critical severity:high` |
+| `tool:Trivy` | Separates image findings from any other scanner added later |
+| `path:opt/venv` | Restrict to a path inside the image — see below |
+| `branch:main` | Alerts as of a given branch |
+
+### Viewing one image at a time
+
+**Not from the Security tab, and this is worth understanding before you trust any per-image number you see there.**
+
+Every image is uploaded under its own SARIF category (`image-scan/backend-latest`, `image-scan/frontend-latest`, `image-scan/sandbox-latest`). That is what keeps the three scans from resolving each other's alerts, but it is not a view you can filter by: [GitHub does not support filtering the alert list by category](https://github.com/orgs/community/discussions/70050).
+
+Worse, **an alert belongs to only one category even when the vulnerability is in several images.** GitHub deduplicates alerts by rule and location, so an identical finding at an identical path in two images becomes one alert, arbitrarily attributed to one of them. The frontend and sandbox images share a `node:22` base, and 17 of the frontend's npm findings sit at the same `usr/local/lib/node_modules/npm/...` paths as the sandbox's. The result: the frontend's own report lists 47 actionable findings, while the Security tab attributes 30 to it and the other 17 to the sandbox. Neither number is wrong, but neither is "the frontend's vulnerability count" either.
+
+So:
+
+1. **For an authoritative per-image list, use the artifact.** One JSON report per image, per run, deduplicated against nothing. This is the only per-image view that means what it looks like. See below.
+2. **For a quick look in the UI, use the `path:` filter.** Findings carry the path they were found at *inside the image*: backend application dependencies under `path:opt/venv` (Python) and `path:opt/xagent` (npm and vendored binaries), frontend ones under `path:app/node_modules`. OS-package findings carry the image reference itself as their path, so `path:xagent-backend` isolates the backend's Debian findings. `usr/local` appears in all three images, which is exactly where the attribution above gets shared around.
+3. **Via the API**, if you want to see how alerts are currently attributed — remembering that this is attribution, not the image's real total:
+
+   ```bash
+   gh api "repos/xorbitsai/xagent/code-scanning/alerts?state=open&per_page=100" --paginate \
+     --jq '.[] | select(.most_recent_instance.category == "image-scan/backend-latest")
+                 | "\(.rule.security_severity_level)\t\(.rule.id)"'
+   ```
+
+### The full report
+
+The Security tab deliberately shows a filtered subset (next section). The **complete** report — every severity, including everything with no fix available — is attached to each workflow run as the `trivy-report-<slug>` artifact (JSON, kept 30 days):
+
+```bash
+gh run download <run-id> --repo xorbitsai/xagent -n trivy-report-backend-latest
+```
+
+Go there when you want the real total rather than the actionable subset.
+
+## Why the Security tab shows less than the artifact
+
+The backend image carries Debian, pip and npm dependency trees plus Chrome, Playwright and LibreOffice, and an unfiltered scan of it reports **thousands** of vulnerabilities. An alert list that long gets ignored, which is worse than no alert list. So the code scanning upload is filtered down to what someone can act on:
+
+- `ignore-unfixed: true` — only CVEs that have a fixed version available. A vulnerability nobody can patch yet is not a to-do item. This is the filter that does the real work: on the first backend scan it cut 4,554 findings to 399, almost entirely because Debian marks the overwhelming majority of its CVEs as not-to-be-fixed (4,173 Debian findings became 30). What survives is nearly all application-level: pip, npm, and Go/Rust binaries vendored into `node_modules`.
+- `CRITICAL,HIGH,MEDIUM` only. LOW and UNKNOWN stay in the artifact.
+- `limit-severities-for-sarif: true` — required. Without it Trivy's SARIF writer emits every severity regardless of the `severity` input, and the filter above silently does nothing.
+
+Note that the severity shown in the Security tab is GitHub's own, derived from the CVSS score, so it will not always match Trivy's label — a Trivy MEDIUM can appear as `low`.
+
+## Handling an alert
+
+1. Open the alert; it names the package, the installed version and the fixed version.
+2. Decide where the package comes from:
+   - **Debian package** — the base images use floating tags (`python:3.11-bookworm`, `node:22-slim`), so a rebuild usually picks the fix up on its own and the alert closes at the next scan. If it survives several scans, the base image tag itself needs bumping in the relevant `docker/Dockerfile.*`. Note that Debian marks most of its CVEs as not-to-be-fixed, and those never reach the Security tab at all — see the filtering section above.
+   - **pip / npm package** — bump it in `pyproject.toml` or `frontend/package.json`.
+   - **Go or Rust binary** — a compiled binary vendored into `node_modules` or `/usr/local/bin`, reported against the toolchain that built it rather than against a package you declare. Bump whatever npm/pip package ships the binary.
+3. If the fix is not viable, add the CVE to [`.trivyignore`](../.trivyignore) with a comment saying why and the PR that decided it. Do not add entries to quiet alerts nobody has reviewed.
+
+## Failure policy
+
+The workflow never fails. `exit-code` is `0` on every scan step regardless of what is found. A weekly job that goes permanently red because of upstream CVEs stops being read within a month, which defeats the point. Notification is the Security tab's job.
+
+A red run therefore means the scan itself broke — a pull failure, a rate limit, disk exhaustion — not that a vulnerability was found.
+
+## When it runs
+
+Weekly, `cron: '10 19 * * 2'` — Wednesday 03:10 UTC+8. You can also run it on demand from the Actions tab (`workflow_dispatch`).
+
+**Treat that time as "no earlier than", not "at".** GitHub delivers scheduled events on a best-effort basis and [documents the top of every hour as a high-load window](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows), which is why the minute is `:10` rather than `:00`. Delays of hours are normal on low-activity repositories. Nothing in this workflow depends on the exact time, so this is a non-issue — but do not debug a "missing" run until it is several hours late.
+
+Two other scheduling facts worth knowing: the `schedule` event only fires for workflow files that exist on the **default branch**, and GitHub disables scheduled workflows in a public repository after 60 days with no activity.
+
+## Operational notes
+
+- **Docker Hub rate limits.** The workflow authenticates with `DOCKERHUB_USERNAME` / `DOCKERHUB_PASSWORD` when those secrets exist, because shared Actions runner IPs hit the anonymous per-IP pull limit easily. On forks, which have no such secrets, the login step skips itself and five weekly anonymous pulls stay well inside the limit.
+- **Disk.** The backend image unpacks to roughly 10 GB, more than a default runner has free, so `free-disk-space` runs first for that image only.
+- **One pull, two scans.** The image is pulled once with `docker pull`; both Trivy steps then read it from the local daemon. Running Trivy twice against the registry would download the backend's 3.6 GB twice.
+- **Trivy DB.** Caching is on, which is what keeps the ghcr.io vulnerability-database pulls under their rate limit.
+- **Cost.** Zero. Code scanning and GitHub-hosted runner minutes are both free for public repositories.
+
+## Not covered
+
+Released tags such as `0.7.2` are not scanned. Unlike `latest` they are never rebuilt, so they are what users running a pinned version stay exposed to — worth adding once the alert volume from the current three targets is understood.
+
+Also out of scope: the `nightly` tags, the third-party images in `docker-compose.yml` (`nginx:latest`, `postgres:17-bookworm`, `redis:7-alpine`), arm64, and scanning on pull requests.


### PR DESCRIPTION
## What

Adds a weekly Trivy scan of the three images we publish to Docker Hub, reporting into the repository's **Security and quality → Code scanning** page.

Nothing in this repo scanned `xprobe/xagent-{backend,frontend,sandbox}` for known vulnerabilities — no trivy/grype/snyk/codeql, no `dependabot.yml`. The images are rebuilt daily and pulled by users, but nobody could answer "how many known CVEs are in what we ship, and which of them can we fix".

Pure addition: one new workflow, one `.trivyignore`, one doc. **No existing file is touched** — the publish workflows, Dockerfiles and compose files are all unchanged, so this is entirely revertible by deleting the workflow.

## Why code scanning rather than Docker Scout

This repo is public, which makes GitHub code scanning free — severity grouping, filtering, and real alert lifecycle (an alert closes itself when the next scan no longer finds the CVE) at no cost and with no new account, secret or vendor dependency. Docker Scout's base-image upgrade advice is genuinely better than Trivy's, but its free tier covers 1 repository and we have 3, so full coverage means a Docker Team plan. Not worth paying for before we know what the alert volume even looks like.

## Scope

Three targets, `:latest` only, `linux/amd64` only:

| Image | Why this tag |
| --- | --- |
| `xprobe/xagent-backend:latest` | Debian + pip/uv + npm + vendored Go/Rust binaries |
| `xprobe/xagent-frontend:latest` | Debian + npm |
| `xprobe/xagent-sandbox:latest` | Debian + pip + npm |

Deliberately excluded: `nightly` (rebuilt daily, findings churn without saying anything about what is deployed), `buildcache` (buildx cache manifests, 13+ GB for the backend, not runnable images), released tags such as `0.7.2`, arm64, and the third-party images in `docker-compose.yml`.

## Noise control is the actual design problem

An unfiltered scan of the backend image reports **4,554** vulnerabilities. An alert list that long is worse than no alert list, so the SARIF upload is filtered to what someone can act on — `ignore-unfixed`, and `CRITICAL/HIGH/MEDIUM` only. That takes 4,554 findings down to **399**.

Almost all of that reduction is Debian marking its CVEs as not-to-be-fixed: **4,173 Debian findings become 30**. What survives is nearly all application-level and genuinely actionable — pip, npm, and Go/Rust binaries vendored into `node_modules`. The 369 non-Debian ones concentrate in 85 packages, with the top 10 covering 58%; the single largest is 67 findings against Go 1.20's stdlib compiled into a vendored `esbuild` binary.

`limit-severities-for-sarif: true` is load-bearing, not decoration: without it Trivy's SARIF writer emits every severity regardless of the `severity` input and the filter silently does nothing.

## Reporting only

`exit-code` stays `0` on every scan step. A weekly job that goes permanently red over upstream CVEs stops being read within a month, and notification is the code scanning alerts' job. A red run therefore means the scan itself broke — a pull failure, a rate limit, disk exhaustion — not that a vulnerability was found.

## Implementation notes

- **One pull, two scans.** `docker pull` runs once and both Trivy steps read the image from the local daemon, so the backend's 3.6 GB is not downloaded twice. `trivy convert` cannot do this instead — it supports `--severity` but not `--ignore-unfixed`.
- **Disk.** The backend image unpacks to roughly 10 GB, more than a default runner has free, so `free-disk-space` runs for that image only, reusing the same pinned SHA as `docker-publish.yml`.
- **Upstream only.** The job is guarded by `github.repository_owner == 'xorbitsai'`, since the targets are images only this org publishes — a fork on a schedule would burn its own minutes filling its own alert list with our CVEs. GitHub already disables scheduled workflows on forking a public repo; the guard covers a fork that re-enables them. `workflow_dispatch` stays exempt so a fork can still run it by hand, which is how this PR was tested.
- **Docker Hub login is conditional** on `DOCKERHUB_USERNAME` existing, so a manual fork run works with no secrets. Note the `secrets` context is not available in a step-level `if`, hence the job-level `env` hoist.
- **Cron minute is `:10`, not `:00`** — GitHub documents the top of every hour as a high-load window for delayed scheduled events.
- **Action versions** follow the existing convention: official actions on floating major tags, third-party (`trivy-action`) pinned to a SHA.

## Verification

Ran on a fork (`qinrui777/xagent`) via `workflow_dispatch`, twice:

- Three jobs green; **zero** deprecation warnings.
- Three distinct code scanning categories, with stable result counts across runs (367 / 48 / 74).
- `free-disk-space` executed for the backend and skipped for the small images.
- Docker Hub login skipped cleanly with no secrets present; anonymous pulls did not hit a rate limit.
- Vulnerability DB downloaded once per job, not twice — confirming the second scan reads the local image.
- Hundreds of findings and every job still green, confirming the reporting-only policy.

### One behaviour worth knowing before reading per-image numbers

**An alert belongs to only one category even when the vulnerability is in several images.** GitHub deduplicates alerts by rule and location, so an identical finding at an identical path in two images becomes one alert, arbitrarily attributed to one of them.

Measured on the fork: the frontend and sandbox images share a `node:22` base, and 17 of the frontend's npm findings sit at the same `usr/local/lib/node_modules/npm/...` paths as the sandbox's. The frontend's own report lists 47 actionable findings, while the Code scanning page attributes 30 to it and the other 17 to the sandbox — exactly 47 − 17.

Neither number is wrong, but neither is "the frontend's vulnerability count". [GitHub does not support filtering alerts by category](https://github.com/orgs/community/discussions/70050) either, so the per-image JSON artifact is the only per-image view that means what it looks like. This is documented in `docs/image-security-scanning.md` along with the `path:` filter workaround for quick UI lookups.

## Follow-ups (not in this PR)

Scanning released tags (never rebuilt, so what pinned users stay exposed to), scanning on PRs that touch `docker/`, arm64 coverage, and a `SECURITY.md`. All worth doing once the alert volume from these three targets is understood.
