### PR TITLE
feat(memory): add trusted service policy overrides (toby)

### DIFF
--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -107,6 +107,10 @@ from ..services.hot_path_cache import (
 )
 from ..services.llm_utils import resolve_llms_from_names
 from ..services.managed_file_ref import ensure_uploaded_file_local_path
+from ..services.memory_policy import (
+    TrustedMemoryPolicyRequest,
+    resolve_trusted_memory_policy,
+)
 from ..services.mcp_runtime import (
     MCPBuiltinOAuthActorPolicy,
     MCPBuiltinOAuthActorPolicyMismatchError,
@@ -312,6 +316,8 @@ def _get_task_activity_ids(db: Session, task_id: int) -> tuple[int, int]:
 class AgentServiceMemoryPolicy:
     memory: MemoryStore
     memory_enabled: bool
+    memory_available: bool = True
+    reason: str | None = None
 
 
 def resolve_agent_service_memory_policy(
@@ -325,13 +331,37 @@ def resolve_agent_service_memory_policy(
         task_config = getattr(task, "agent_config", None)
         config = task_config if isinstance(task_config, Mapping) else {}
 
-    if config.get("is_preview") is True:
-        return AgentServiceMemoryPolicy(InMemoryMemoryStore(), False)
+    is_preview = config.get("is_preview") is True
+    if is_preview:
+        default_policy = AgentServiceMemoryPolicy(InMemoryMemoryStore(), False)
+    elif task is not None and task.agent_id:
+        default_policy = AgentServiceMemoryPolicy(get_memory_store(), False)
+    else:
+        default_policy = AgentServiceMemoryPolicy(get_memory_store(), True)
 
-    if task is not None and task.agent_id:
-        return AgentServiceMemoryPolicy(get_memory_store(), False)
+    decision = resolve_trusted_memory_policy(
+        TrustedMemoryPolicyRequest(
+            task_id=_optional_task_id(task, "id"),
+            user_id=_optional_task_id(task, "user_id"),
+            agent_id=_optional_task_id(task, "agent_id"),
+            is_preview=is_preview,
+            default_enabled=default_policy.memory_enabled,
+        )
+    )
+    if decision is None:
+        return default_policy
 
-    return AgentServiceMemoryPolicy(get_memory_store(), True)
+    return AgentServiceMemoryPolicy(
+        memory=default_policy.memory,
+        memory_enabled=decision.enabled and decision.available,
+        memory_available=decision.available,
+        reason=decision.reason,
+    )
+
+
+def _optional_task_id(task: Optional[Any], attribute: str) -> int | None:
+    value = getattr(task, attribute, None)
+    return value if type(value) is int else None
 
 
 async def resolve_agent_service_memory_policy_async(

--- a/src/xagent/web/services/memory_policy.py
+++ b/src/xagent/web/services/memory_policy.py
@@ -1,0 +1,92 @@
+"""Trusted host overrides for AgentService memory eligibility."""
+
+import logging
+from dataclasses import dataclass
+from typing import Callable
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TrustedMemoryPolicyRequest:
+    """Stable request facts exposed to a trusted host policy resolver."""
+
+    task_id: int | None
+    user_id: int | None
+    agent_id: int | None
+    is_preview: bool
+    default_enabled: bool
+
+
+@dataclass(frozen=True)
+class TrustedMemoryPolicyDecision:
+    """A host's explicit memory eligibility and backend availability decision."""
+
+    enabled: bool
+    available: bool
+    reason: str | None = None
+
+
+TrustedMemoryPolicyResolver = Callable[
+    [TrustedMemoryPolicyRequest], TrustedMemoryPolicyDecision
+]
+
+_trusted_memory_policy_resolver: TrustedMemoryPolicyResolver | None = None
+
+
+def set_trusted_memory_policy_resolver(
+    resolver: TrustedMemoryPolicyResolver | None,
+) -> None:
+    """Install a process-level resolver owned by the trusted host service.
+
+    Passing ``None`` restores XAgent's default preview and published-agent
+    policy. The hook is intended for startup-time registration, before the
+    process begins serving requests.
+    """
+
+    global _trusted_memory_policy_resolver
+    if resolver is not None and not callable(resolver):
+        raise TypeError("resolver must be callable or None")
+    _trusted_memory_policy_resolver = resolver
+
+
+def resolve_trusted_memory_policy(
+    request: TrustedMemoryPolicyRequest,
+) -> TrustedMemoryPolicyDecision | None:
+    """Return a validated override, or ``None`` when no hook is installed.
+
+    A registered hook is authoritative. Resolver failures and malformed
+    decisions therefore become an unavailable, disabled decision instead of
+    falling back to the more permissive default policy.
+    """
+
+    resolver = _trusted_memory_policy_resolver
+    if resolver is None:
+        return None
+
+    try:
+        decision = resolver(request)
+    except Exception:
+        logger.exception("Trusted memory policy resolver failed")
+        return _failed_decision("resolver_error")
+
+    if not _is_valid_decision(decision):
+        logger.error("Trusted memory policy resolver returned an invalid decision")
+        return _failed_decision("invalid_decision")
+    return decision
+
+
+def _is_valid_decision(decision: object) -> bool:
+    if not isinstance(decision, TrustedMemoryPolicyDecision):
+        return False
+    if type(decision.enabled) is not bool or type(decision.available) is not bool:
+        return False
+    if decision.reason is not None and (
+        not isinstance(decision.reason, str) or not decision.reason.strip()
+    ):
+        return False
+    return decision.available or decision.reason is not None
+
+
+def _failed_decision(reason: str) -> TrustedMemoryPolicyDecision:
+    return TrustedMemoryPolicyDecision(enabled=False, available=False, reason=reason)

--- a/tests/web/api/test_websocket_preview.py
+++ b/tests/web/api/test_websocket_preview.py
@@ -25,6 +25,17 @@ from xagent.web.models.task import Task
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.models.user import User
 from xagent.web.schemas.chat import TaskCreateResponse
+from xagent.web.services.memory_policy import (
+    TrustedMemoryPolicyDecision,
+    set_trusted_memory_policy_resolver,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_trusted_memory_policy_resolver():
+    set_trusted_memory_policy_resolver(None)
+    yield
+    set_trusted_memory_policy_resolver(None)
 
 
 class _BlockingPreviewWebSocket:
@@ -305,6 +316,166 @@ def test_inline_preview_agent_config_uses_in_memory_disabled_policy():
 
     assert isinstance(policy.memory, InMemoryMemoryStore)
     assert policy.memory_enabled is False
+
+
+@pytest.mark.parametrize(
+    ("agent_id", "expected_enabled"),
+    [
+        (None, True),
+        (42, False),
+    ],
+)
+def test_default_memory_policy_for_regular_and_published_agents(
+    monkeypatch,
+    agent_id,
+    expected_enabled,
+):
+    memory = object()
+    monkeypatch.setattr(chat_api, "get_memory_store", lambda: memory)
+    task = SimpleNamespace(
+        id=7,
+        user_id=8,
+        agent_id=agent_id,
+        agent_config={},
+    )
+
+    policy = resolve_agent_service_memory_policy(task=task)
+
+    assert policy.memory is memory
+    assert policy.memory_enabled is expected_enabled
+    assert policy.memory_available is True
+    assert policy.reason is None
+
+
+def test_trusted_memory_policy_can_enable_published_agent(monkeypatch):
+    memory = object()
+    monkeypatch.setattr(chat_api, "get_memory_store", lambda: memory)
+    task = SimpleNamespace(
+        id=7,
+        user_id=8,
+        agent_id=42,
+        agent_config={},
+    )
+    requests = []
+
+    def resolve(request):
+        requests.append(request)
+        return TrustedMemoryPolicyDecision(
+            enabled=True,
+            available=True,
+            reason="service_memory_available",
+        )
+
+    set_trusted_memory_policy_resolver(resolve)
+
+    policy = resolve_agent_service_memory_policy(task=task)
+
+    assert policy.memory is memory
+    assert policy.memory_enabled is True
+    assert policy.memory_available is True
+    assert policy.reason == "service_memory_available"
+    assert requests == [
+        chat_api.TrustedMemoryPolicyRequest(
+            task_id=7,
+            user_id=8,
+            agent_id=42,
+            is_preview=False,
+            default_enabled=False,
+        )
+    ]
+
+
+def test_trusted_memory_policy_can_disable_default_memory(monkeypatch):
+    memory = object()
+    monkeypatch.setattr(chat_api, "get_memory_store", lambda: memory)
+    task = SimpleNamespace(
+        id=7,
+        user_id=8,
+        agent_id=None,
+        agent_config={},
+    )
+    set_trusted_memory_policy_resolver(
+        lambda request: TrustedMemoryPolicyDecision(
+            enabled=False,
+            available=True,
+            reason="disabled_by_service_policy",
+        )
+    )
+
+    policy = resolve_agent_service_memory_policy(task=task)
+
+    assert policy.memory is memory
+    assert policy.memory_enabled is False
+    assert policy.memory_available is True
+    assert policy.reason == "disabled_by_service_policy"
+
+
+@pytest.mark.parametrize(
+    ("resolver", "expected_reason"),
+    [
+        (lambda request: None, "invalid_decision"),
+        (
+            lambda request: TrustedMemoryPolicyDecision(
+                enabled=True,
+                available=False,
+            ),
+            "invalid_decision",
+        ),
+        (
+            lambda request: TrustedMemoryPolicyDecision(
+                enabled=1,
+                available=True,
+            ),
+            "invalid_decision",
+        ),
+    ],
+)
+def test_invalid_trusted_memory_policy_decision_fails_closed(
+    monkeypatch,
+    resolver,
+    expected_reason,
+):
+    memory = object()
+    monkeypatch.setattr(chat_api, "get_memory_store", lambda: memory)
+    set_trusted_memory_policy_resolver(resolver)
+
+    policy = resolve_agent_service_memory_policy(
+        task=SimpleNamespace(
+            id=7,
+            user_id=8,
+            agent_id=None,
+            agent_config={},
+        )
+    )
+
+    assert policy.memory is memory
+    assert policy.memory_enabled is False
+    assert policy.memory_available is False
+    assert policy.reason == expected_reason
+
+
+def test_trusted_memory_policy_resolver_failure_fails_closed(monkeypatch):
+    memory = object()
+    monkeypatch.setattr(chat_api, "get_memory_store", lambda: memory)
+
+    def fail(request):
+        raise RuntimeError("resolver unavailable")
+
+    set_trusted_memory_policy_resolver(fail)
+
+    policy = resolve_agent_service_memory_policy(
+        task=SimpleNamespace(
+            id=7,
+            user_id=8,
+            agent_id=None,
+            agent_config={},
+        )
+    )
+
+    assert policy.memory is memory
+    assert policy.memory_enabled is False
+    assert policy.memory_available is False
+    assert policy.reason == "resolver_error"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- add a process-level trusted resolver for AgentService memory eligibility
- expose explicit enabled, available, and reason fields while preserving default preview and published-agent behavior when no resolver is installed
- fail closed when a resolver raises or returns a malformed decision

## Validation

- `PYTHONPATH=src /opt/anaconda3/envs/xagent/bin/python -m pytest -q tests/web/api/test_websocket_preview.py` (20 passed)
- `ruff format --check src/xagent/web/api/chat.py src/xagent/web/services/memory_policy.py tests/web/api/test_websocket_preview.py`
- `ruff check src/xagent/web/api/chat.py src/xagent/web/services/memory_policy.py tests/web/api/test_websocket_preview.py`
- `PYTHONPATH=src /opt/anaconda3/envs/xagent/bin/python -m py_compile src/xagent/web/api/chat.py src/xagent/web/services/memory_policy.py tests/web/api/test_websocket_preview.py`
- mutation verification: bypassing the trusted override makes the valid-override integration assertion fail

Closes #2037
