### PR TITLE
feat(memory): add trusted service policy overrides (toby)

### DIFF
--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 import os
 from collections import deque
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Mapping, Optional, TypeVar, Union, cast
 
@@ -28,8 +27,6 @@ from ...core.execution_scope import (
     resolve_execution_scope_off_turn,
     scope_fingerprint,
 )
-from ...core.memory.base import MemoryStore
-from ...core.memory.in_memory import InMemoryMemoryStore
 from ...core.model.chat.basic.base import BaseLLM
 from ...core.model.chat.basic.deepseek import DeepSeekLLM
 from ...core.model.chat.basic.openai import OpenAILLM
@@ -56,7 +53,6 @@ from ...core.tools.adapters.vibe.selection_spec import (
 from ...core.tools.core.knowledge_base_scope import KnowledgeBaseScopeError
 from ...sandbox import SandboxMountIntent
 from ..auth_dependencies import get_current_user
-from ..dynamic_memory_store import get_memory_store
 from ..models.agent import Agent, AgentStatus, is_workforce_generated_manager_agent
 from ..models.chat_message import TaskChatMessage
 from ..models.database import (
@@ -107,6 +103,10 @@ from ..services.hot_path_cache import (
 )
 from ..services.llm_utils import resolve_llms_from_names
 from ..services.managed_file_ref import ensure_uploaded_file_local_path
+from ..services.memory_policy import (
+    AgentServiceMemoryPolicy,
+    resolve_agent_service_memory_policy,
+)
 from ..services.mcp_runtime import (
     MCPBuiltinOAuthActorPolicy,
     MCPBuiltinOAuthActorPolicyMismatchError,
@@ -306,32 +306,6 @@ def _get_task_activity_ids(db: Session, task_id: int) -> tuple[int, int]:
         or 0
     )
     return int(max_trace_event_id), int(max_chat_message_id)
-
-
-@dataclass(frozen=True)
-class AgentServiceMemoryPolicy:
-    memory: MemoryStore
-    memory_enabled: bool
-
-
-def resolve_agent_service_memory_policy(
-    *,
-    task: Optional[Any] = None,
-    agent_config: Optional[Mapping[str, Any]] = None,
-) -> AgentServiceMemoryPolicy:
-    """Resolve the memory store and enablement for an AgentService runtime."""
-    config = agent_config
-    if config is None:
-        task_config = getattr(task, "agent_config", None)
-        config = task_config if isinstance(task_config, Mapping) else {}
-
-    if config.get("is_preview") is True:
-        return AgentServiceMemoryPolicy(InMemoryMemoryStore(), False)
-
-    if task is not None and task.agent_id:
-        return AgentServiceMemoryPolicy(get_memory_store(), False)
-
-    return AgentServiceMemoryPolicy(get_memory_store(), True)
 
 
 async def resolve_agent_service_memory_policy_async(

--- a/src/xagent/web/services/memory_policy.py
+++ b/src/xagent/web/services/memory_policy.py
@@ -1,0 +1,187 @@
+"""Trusted host overrides for task memory eligibility."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Mapping
+
+from ...core.memory.base import MemoryStore
+from ...core.memory.in_memory import InMemoryMemoryStore
+from ..dynamic_memory_store import get_memory_store
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class TrustedMemoryPolicyRequest:
+    """Primitive task context exposed to an embedding application's resolver."""
+
+    task_id: int | None
+    user_id: int | None
+    agent_id: int | None
+    source: str | None
+    is_preview: bool
+
+
+@dataclass(frozen=True)
+class TrustedMemoryPolicyDecision:
+    """A trusted host's explicit memory policy decision."""
+
+    enabled: bool
+    available: bool
+    reason: str
+
+
+TrustedMemoryPolicyResolver = Callable[
+    [TrustedMemoryPolicyRequest], TrustedMemoryPolicyDecision
+]
+
+
+@dataclass(frozen=True)
+class AgentServiceMemoryPolicy:
+    """Resolved memory store and eligibility for an agent runtime."""
+
+    memory: MemoryStore
+    memory_enabled: bool
+    memory_available: bool
+    reason: str | None = None
+
+
+_trusted_memory_policy_resolver: TrustedMemoryPolicyResolver | None = None
+
+
+def set_trusted_memory_policy_resolver(
+    resolver: TrustedMemoryPolicyResolver | None,
+) -> None:
+    """Install or clear the process-wide trusted memory policy resolver.
+
+    The embedding application is responsible for authenticating and validating
+    requests before they reach this hook. XAgent only exposes primitive task
+    metadata and validates the resolver's decision before applying it.
+    """
+
+    global _trusted_memory_policy_resolver
+    if resolver is not None and not callable(resolver):
+        raise TypeError("resolver must be callable or None")
+    _trusted_memory_policy_resolver = resolver
+
+
+def _optional_exact_int(value: object) -> int | None:
+    return value if type(value) is int else None
+
+
+def _optional_str(value: object) -> str | None:
+    return value if isinstance(value, str) else None
+
+
+def _default_memory_policy(
+    *,
+    task: Any | None,
+    config: Mapping[str, Any],
+) -> AgentServiceMemoryPolicy:
+    if config.get("is_preview") is True:
+        return AgentServiceMemoryPolicy(
+            memory=InMemoryMemoryStore(),
+            memory_enabled=False,
+            memory_available=False,
+            reason="preview_memory_disabled",
+        )
+
+    if task is not None and getattr(task, "agent_id", None):
+        return AgentServiceMemoryPolicy(
+            memory=get_memory_store(),
+            memory_enabled=False,
+            memory_available=False,
+            reason="published_agent_memory_disabled",
+        )
+
+    return AgentServiceMemoryPolicy(
+        memory=get_memory_store(),
+        memory_enabled=True,
+        memory_available=True,
+    )
+
+
+def _resolver_request(
+    *,
+    task: Any | None,
+    config: Mapping[str, Any],
+) -> TrustedMemoryPolicyRequest:
+    return TrustedMemoryPolicyRequest(
+        task_id=_optional_exact_int(getattr(task, "id", None)),
+        user_id=_optional_exact_int(getattr(task, "user_id", None)),
+        agent_id=_optional_exact_int(getattr(task, "agent_id", None)),
+        source=_optional_str(getattr(task, "source", None)),
+        is_preview=config.get("is_preview") is True,
+    )
+
+
+def _fail_closed(
+    default: AgentServiceMemoryPolicy,
+    *,
+    reason: str,
+) -> AgentServiceMemoryPolicy:
+    return AgentServiceMemoryPolicy(
+        memory=default.memory,
+        memory_enabled=False,
+        memory_available=False,
+        reason=reason,
+    )
+
+
+def _validated_decision(
+    decision: object,
+) -> tuple[bool, bool, str] | None:
+    if not isinstance(decision, TrustedMemoryPolicyDecision):
+        return None
+    if type(decision.enabled) is not bool or type(decision.available) is not bool:
+        return None
+    if not isinstance(decision.reason, str) or not decision.reason.strip():
+        return None
+    if decision.enabled and not decision.available:
+        return None
+    return decision.enabled, decision.available, decision.reason.strip()
+
+
+def resolve_agent_service_memory_policy(
+    *,
+    task: Any | None = None,
+    agent_config: Mapping[str, Any] | None = None,
+) -> AgentServiceMemoryPolicy:
+    """Resolve the default policy, then apply a trusted host override if set."""
+
+    config = agent_config
+    if config is None:
+        task_config = getattr(task, "agent_config", None)
+        config = task_config if isinstance(task_config, Mapping) else {}
+
+    default = _default_memory_policy(task=task, config=config)
+    resolver = _trusted_memory_policy_resolver
+    if resolver is None:
+        return default
+
+    try:
+        decision = resolver(_resolver_request(task=task, config=config))
+    except Exception as exc:
+        logger.warning(
+            "Trusted memory policy resolver failed (%s)",
+            type(exc).__name__,
+        )
+        return _fail_closed(default, reason="trusted_resolver_failed")
+
+    validated = _validated_decision(decision)
+    if validated is None:
+        logger.warning("Trusted memory policy resolver returned an invalid decision")
+        return _fail_closed(default, reason="invalid_trusted_resolver_decision")
+
+    enabled, available, reason = validated
+    memory = default.memory
+    if enabled and isinstance(memory, InMemoryMemoryStore):
+        memory = get_memory_store()
+    return AgentServiceMemoryPolicy(
+        memory=memory,
+        memory_enabled=enabled,
+        memory_available=available,
+        reason=reason,
+    )

--- a/tests/web/api/test_websocket_preview.py
+++ b/tests/web/api/test_websocket_preview.py
@@ -20,6 +20,7 @@ from xagent.web.api.websocket import (
     handle_build_preview_execution,
 )
 from xagent.web.dynamic_memory_store import DynamicMemoryStoreManager
+from xagent.web.services import memory_policy as memory_policy_module
 from xagent.web.models.database import Base
 from xagent.web.models.task import Task
 from xagent.web.models.uploaded_file import UploadedFile
@@ -333,7 +334,11 @@ async def test_memory_policy_pool_timeout_does_not_block_loop_or_fallback(
 
     monkeypatch.setattr(dynamic_memory_store_module, "get_db", get_test_db)
     memory_manager = DynamicMemoryStoreManager()
-    monkeypatch.setattr(chat_api, "get_memory_store", memory_manager.get_memory_store)
+    monkeypatch.setattr(
+        memory_policy_module,
+        "get_memory_store",
+        memory_manager.get_memory_store,
+    )
 
     held_connection = engine.connect()
     stop_ticker = asyncio.Event()

--- a/tests/web/services/test_memory_policy.py
+++ b/tests/web/services/test_memory_policy.py
@@ -1,0 +1,190 @@
+from types import SimpleNamespace
+
+import pytest
+
+from xagent.core.memory.in_memory import InMemoryMemoryStore
+from xagent.web.services import memory_policy as policy_module
+from xagent.web.services.memory_policy import (
+    TrustedMemoryPolicyDecision,
+    TrustedMemoryPolicyRequest,
+    resolve_agent_service_memory_policy,
+    set_trusted_memory_policy_resolver,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_trusted_resolver():
+    set_trusted_memory_policy_resolver(None)
+    yield
+    set_trusted_memory_policy_resolver(None)
+
+
+def _task(
+    *,
+    agent_id: int | None = None,
+    agent_config: dict | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=41,
+        user_id=7,
+        agent_id=agent_id,
+        source="internal",
+        agent_config=agent_config,
+    )
+
+
+def test_default_preview_policy_stays_disabled_and_in_memory(monkeypatch):
+    def unexpected_store_lookup():
+        raise AssertionError("preview defaults must not load the persistent store")
+
+    monkeypatch.setattr(policy_module, "get_memory_store", unexpected_store_lookup)
+
+    policy = resolve_agent_service_memory_policy(
+        task=_task(agent_config={"is_preview": True}),
+    )
+
+    assert isinstance(policy.memory, InMemoryMemoryStore)
+    assert policy.memory_enabled is False
+    assert policy.memory_available is False
+    assert policy.reason == "preview_memory_disabled"
+
+
+def test_default_published_agent_policy_stays_disabled(monkeypatch):
+    memory_store = object()
+    monkeypatch.setattr(policy_module, "get_memory_store", lambda: memory_store)
+
+    policy = resolve_agent_service_memory_policy(task=_task(agent_id=19))
+
+    assert policy.memory is memory_store
+    assert policy.memory_enabled is False
+    assert policy.memory_available is False
+    assert policy.reason == "published_agent_memory_disabled"
+
+
+def test_default_unpublished_task_policy_stays_enabled(monkeypatch):
+    memory_store = object()
+    monkeypatch.setattr(policy_module, "get_memory_store", lambda: memory_store)
+
+    policy = resolve_agent_service_memory_policy(task=_task())
+
+    assert policy.memory is memory_store
+    assert policy.memory_enabled is True
+    assert policy.memory_available is True
+    assert policy.reason is None
+
+
+def test_trusted_resolver_can_enable_memory_and_receives_primitive_context(
+    monkeypatch,
+):
+    memory_store = object()
+    requests: list[TrustedMemoryPolicyRequest] = []
+    monkeypatch.setattr(policy_module, "get_memory_store", lambda: memory_store)
+
+    def resolve(request: TrustedMemoryPolicyRequest) -> TrustedMemoryPolicyDecision:
+        requests.append(request)
+        return TrustedMemoryPolicyDecision(
+            enabled=True,
+            available=True,
+            reason="trusted_request_enabled",
+        )
+
+    set_trusted_memory_policy_resolver(resolve)
+
+    policy = resolve_agent_service_memory_policy(task=_task(agent_id=19))
+
+    assert policy.memory is memory_store
+    assert policy.memory_enabled is True
+    assert policy.memory_available is True
+    assert policy.reason == "trusted_request_enabled"
+    assert requests == [
+        TrustedMemoryPolicyRequest(
+            task_id=41,
+            user_id=7,
+            agent_id=19,
+            source="internal",
+            is_preview=False,
+        )
+    ]
+
+
+def test_trusted_resolver_can_explicitly_disable_default_enabled_memory(monkeypatch):
+    memory_store = object()
+    monkeypatch.setattr(policy_module, "get_memory_store", lambda: memory_store)
+    set_trusted_memory_policy_resolver(
+        lambda request: TrustedMemoryPolicyDecision(
+            enabled=False,
+            available=True,
+            reason="disabled_by_host_policy",
+        )
+    )
+
+    policy = resolve_agent_service_memory_policy(task=_task())
+
+    assert policy.memory is memory_store
+    assert policy.memory_enabled is False
+    assert policy.memory_available is True
+    assert policy.reason == "disabled_by_host_policy"
+
+
+@pytest.mark.parametrize(
+    "decision",
+    [
+        None,
+        TrustedMemoryPolicyDecision(
+            enabled=1,  # type: ignore[arg-type]
+            available=True,
+            reason="wrong_enabled_type",
+        ),
+        TrustedMemoryPolicyDecision(
+            enabled=True,
+            available=False,
+            reason="contradictory_availability",
+        ),
+        TrustedMemoryPolicyDecision(
+            enabled=False,
+            available=False,
+            reason="  ",
+        ),
+    ],
+)
+def test_invalid_trusted_resolver_decisions_fail_closed(monkeypatch, decision):
+    memory_store = object()
+    monkeypatch.setattr(policy_module, "get_memory_store", lambda: memory_store)
+    set_trusted_memory_policy_resolver(lambda request: decision)  # type: ignore[arg-type]
+
+    policy = resolve_agent_service_memory_policy(task=_task())
+
+    assert policy.memory is memory_store
+    assert policy.memory_enabled is False
+    assert policy.memory_available is False
+    assert policy.reason == "invalid_trusted_resolver_decision"
+
+
+def test_trusted_resolver_exception_fails_closed_without_logging_details(
+    monkeypatch,
+    caplog,
+):
+    memory_store = object()
+    monkeypatch.setattr(policy_module, "get_memory_store", lambda: memory_store)
+
+    class ResolverFailure(RuntimeError):
+        pass
+
+    def fail(request: TrustedMemoryPolicyRequest) -> TrustedMemoryPolicyDecision:
+        raise ResolverFailure("host-private-detail")
+
+    set_trusted_memory_policy_resolver(fail)
+
+    policy = resolve_agent_service_memory_policy(task=_task())
+
+    assert policy.memory is memory_store
+    assert policy.memory_enabled is False
+    assert policy.memory_available is False
+    assert policy.reason == "trusted_resolver_failed"
+    assert "ResolverFailure" in caplog.text
+    assert "host-private-detail" not in caplog.text
+
+
+def test_resolver_registration_rejects_non_callable():
+    with pytest.raises(TypeError, match="resolver must be callable or None"):
+        set_trusted_memory_policy_resolver(object())  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

- add a process-wide trusted resolver for agent memory eligibility
- preserve preview and published-agent defaults when no resolver is installed
- validate explicit enabled, availability, and reason fields and fail closed on invalid decisions or resolver failures

## Testing

- focused memory policy tests
- existing preview memory policy and pool-timeout tests
- Ruff and py_compile checks
- mutation check by bypassing installed overrides

Closes #2037