### PR TITLE
feat(memory): add trusted service policy overrides (toby)

### DIFF
--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -112,6 +112,10 @@ from ..services.mcp_runtime import (
     MCPBuiltinOAuthActorPolicyMismatchError,
     MCPBuiltinOAuthActorPolicyRequiredError,
 )
+from ..services.memory_policy import (
+    MemoryPolicyRequest,
+    resolve_trusted_memory_policy,
+)
 from ..services.model_service import _get_visible_user_ids
 from ..services.task_deletion import purge_task_rows
 from ..services.task_execution_context_service import (
@@ -312,6 +316,13 @@ def _get_task_activity_ids(db: Session, task_id: int) -> tuple[int, int]:
 class AgentServiceMemoryPolicy:
     memory: MemoryStore
     memory_enabled: bool
+    memory_available: bool = True
+    memory_availability_reason: str | None = None
+
+
+def _optional_task_int(task: Any, field: str) -> int | None:
+    value = getattr(task, field, None)
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
 
 
 def resolve_agent_service_memory_policy(
@@ -325,13 +336,31 @@ def resolve_agent_service_memory_policy(
         task_config = getattr(task, "agent_config", None)
         config = task_config if isinstance(task_config, Mapping) else {}
 
-    if config.get("is_preview") is True:
-        return AgentServiceMemoryPolicy(InMemoryMemoryStore(), False)
-
-    if task is not None and task.agent_id:
-        return AgentServiceMemoryPolicy(get_memory_store(), False)
-
-    return AgentServiceMemoryPolicy(get_memory_store(), True)
+    is_preview = config.get("is_preview") is True
+    default_enabled = not is_preview and not (
+        task is not None and getattr(task, "agent_id", None)
+    )
+    source = getattr(task, "source", None)
+    override = resolve_trusted_memory_policy(
+        MemoryPolicyRequest(
+            task_id=_optional_task_int(task, "id"),
+            user_id=_optional_task_int(task, "user_id"),
+            agent_id=_optional_task_int(task, "agent_id"),
+            source=source if isinstance(source, str) else None,
+            is_preview=is_preview,
+        )
+    )
+    enabled = default_enabled if override is None else override.enabled
+    use_in_memory = (is_preview and not enabled) or (
+        override is not None and not override.available
+    )
+    memory = InMemoryMemoryStore() if use_in_memory else get_memory_store()
+    return AgentServiceMemoryPolicy(
+        memory=memory,
+        memory_enabled=enabled,
+        memory_available=True if override is None else override.available,
+        memory_availability_reason=None if override is None else override.reason,
+    )
 
 
 async def resolve_agent_service_memory_policy_async(

--- a/src/xagent/web/services/memory_policy.py
+++ b/src/xagent/web/services/memory_policy.py
@@ -1,0 +1,84 @@
+"""Trusted host overrides for task memory eligibility."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+MEMORY_POLICY_RESOLVER_FAILURE_REASON = "resolver_failed"
+
+
+@dataclass(frozen=True)
+class MemoryPolicyRequest:
+    """Stable task fields supplied to the trusted host resolver."""
+
+    task_id: int | None
+    user_id: int | None
+    agent_id: int | None
+    source: str | None
+    is_preview: bool
+
+
+@dataclass(frozen=True)
+class MemoryPolicyDecision:
+    """Explicit memory eligibility and availability decision."""
+
+    enabled: bool
+    available: bool
+    reason: str | None = None
+
+
+MemoryPolicyResolver = Callable[[MemoryPolicyRequest], MemoryPolicyDecision]
+
+_trusted_memory_policy_resolver: MemoryPolicyResolver | None = None
+
+
+def set_trusted_memory_policy_resolver(
+    resolver: MemoryPolicyResolver | None,
+) -> None:
+    """Install or clear the process-wide resolver owned by the trusted host."""
+
+    if resolver is not None and not callable(resolver):
+        raise TypeError("memory policy resolver must be callable")
+    global _trusted_memory_policy_resolver
+    _trusted_memory_policy_resolver = resolver
+
+
+def resolve_trusted_memory_policy(
+    request: MemoryPolicyRequest,
+) -> MemoryPolicyDecision | None:
+    """Resolve a host override, failing closed on errors or invalid decisions."""
+
+    resolver = _trusted_memory_policy_resolver
+    if resolver is None:
+        return None
+
+    try:
+        decision = resolver(request)
+        _validate_decision(decision)
+        return decision
+    except Exception:
+        logger.exception("Trusted memory policy resolver failed")
+        return MemoryPolicyDecision(
+            enabled=False,
+            available=False,
+            reason=MEMORY_POLICY_RESOLVER_FAILURE_REASON,
+        )
+
+
+def _validate_decision(decision: object) -> None:
+    if not isinstance(decision, MemoryPolicyDecision):
+        raise TypeError("memory policy resolver returned an invalid decision type")
+    if type(decision.enabled) is not bool or type(decision.available) is not bool:
+        raise TypeError("memory policy decision flags must be bool")
+    if decision.enabled and not decision.available:
+        raise ValueError("unavailable memory cannot be enabled")
+    if decision.reason is not None and (
+        not isinstance(decision.reason, str) or not decision.reason.strip()
+    ):
+        raise TypeError("memory policy decision reason must be a non-empty string")
+    if not decision.available and decision.reason is None:
+        raise ValueError("unavailable memory requires a reason")

--- a/tests/web/services/test_memory_policy.py
+++ b/tests/web/services/test_memory_policy.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from collections.abc import Iterator
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from xagent.core.memory.in_memory import InMemoryMemoryStore
+from xagent.web.api import chat as chat_api
+from xagent.web.services.memory_policy import (
+    MEMORY_POLICY_RESOLVER_FAILURE_REASON,
+    MemoryPolicyDecision,
+    MemoryPolicyRequest,
+    set_trusted_memory_policy_resolver,
+)
+
+
+@pytest.fixture(autouse=True)
+def clear_memory_policy_resolver() -> Iterator[None]:
+    set_trusted_memory_policy_resolver(None)
+    yield
+    set_trusted_memory_policy_resolver(None)
+
+
+def _task(*, agent_id: int | None = None, source: str | None = None) -> Any:
+    return SimpleNamespace(
+        id=17,
+        user_id=23,
+        agent_id=agent_id,
+        source=source,
+        agent_config={},
+    )
+
+
+@pytest.mark.parametrize(
+    ("agent_config", "agent_id", "expected_enabled", "uses_in_memory"),
+    [
+        ({"is_preview": True}, None, False, True),
+        ({}, 41, False, False),
+        ({}, None, True, False),
+    ],
+    ids=("preview", "published-agent", "ordinary-task"),
+)
+def test_default_memory_policy_is_unchanged_without_resolver(
+    monkeypatch: pytest.MonkeyPatch,
+    agent_config: dict[str, Any],
+    agent_id: int | None,
+    expected_enabled: bool,
+    uses_in_memory: bool,
+) -> None:
+    dynamic_store = Mock(name="dynamic-memory-store")
+    get_memory_store = Mock(return_value=dynamic_store)
+    monkeypatch.setattr(chat_api, "get_memory_store", get_memory_store)
+
+    policy = chat_api.resolve_agent_service_memory_policy(
+        task=_task(agent_id=agent_id),
+        agent_config=agent_config,
+    )
+
+    assert policy.memory_enabled is expected_enabled
+    assert policy.memory_available is True
+    assert policy.memory_availability_reason is None
+    if uses_in_memory:
+        assert isinstance(policy.memory, InMemoryMemoryStore)
+        get_memory_store.assert_not_called()
+    else:
+        assert policy.memory is dynamic_store
+        get_memory_store.assert_called_once_with()
+
+
+def test_trusted_resolver_can_enable_preview_memory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dynamic_store = Mock(name="dynamic-memory-store")
+    monkeypatch.setattr(chat_api, "get_memory_store", Mock(return_value=dynamic_store))
+    resolver = Mock(
+        return_value=MemoryPolicyDecision(
+            enabled=True,
+            available=True,
+            reason=None,
+        )
+    )
+    set_trusted_memory_policy_resolver(resolver)
+
+    policy = chat_api.resolve_agent_service_memory_policy(
+        task=_task(source="trusted-ingress"),
+        agent_config={"is_preview": True},
+    )
+
+    assert policy.memory is dynamic_store
+    assert policy.memory_enabled is True
+    assert policy.memory_available is True
+    assert policy.memory_availability_reason is None
+    resolver.assert_called_once_with(
+        MemoryPolicyRequest(
+            task_id=17,
+            user_id=23,
+            agent_id=None,
+            source="trusted-ingress",
+            is_preview=True,
+        )
+    )
+
+
+def test_trusted_resolver_can_disable_otherwise_enabled_memory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    dynamic_store = Mock(name="dynamic-memory-store")
+    monkeypatch.setattr(chat_api, "get_memory_store", Mock(return_value=dynamic_store))
+    set_trusted_memory_policy_resolver(
+        lambda _request: MemoryPolicyDecision(
+            enabled=False,
+            available=True,
+            reason="disabled_by_host_policy",
+        )
+    )
+
+    policy = chat_api.resolve_agent_service_memory_policy(task=_task())
+
+    assert policy.memory is dynamic_store
+    assert policy.memory_enabled is False
+    assert policy.memory_available is True
+    assert policy.memory_availability_reason == "disabled_by_host_policy"
+
+
+def test_trusted_resolver_can_report_unavailable_memory(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    get_memory_store = Mock(name="get-memory-store")
+    monkeypatch.setattr(chat_api, "get_memory_store", get_memory_store)
+    set_trusted_memory_policy_resolver(
+        lambda _request: MemoryPolicyDecision(
+            enabled=False,
+            available=False,
+            reason="memory_service_unavailable",
+        )
+    )
+
+    policy = chat_api.resolve_agent_service_memory_policy(task=_task())
+
+    assert isinstance(policy.memory, InMemoryMemoryStore)
+    assert policy.memory_enabled is False
+    assert policy.memory_available is False
+    assert policy.memory_availability_reason == "memory_service_unavailable"
+    get_memory_store.assert_not_called()
+
+
+def test_resolver_exception_fails_closed_for_preview() -> None:
+    def fail(_request: MemoryPolicyRequest) -> MemoryPolicyDecision:
+        raise RuntimeError("resolver is unavailable")
+
+    set_trusted_memory_policy_resolver(fail)
+
+    policy = chat_api.resolve_agent_service_memory_policy(
+        task=_task(),
+        agent_config={"is_preview": True},
+    )
+
+    assert isinstance(policy.memory, InMemoryMemoryStore)
+    assert policy.memory_enabled is False
+    assert policy.memory_available is False
+    assert policy.memory_availability_reason == MEMORY_POLICY_RESOLVER_FAILURE_REASON
+
+
+@pytest.mark.parametrize(
+    "decision",
+    [
+        None,
+        MemoryPolicyDecision(enabled=True, available=False, reason="unavailable"),
+        MemoryPolicyDecision(enabled=False, available=False),
+        MemoryPolicyDecision(enabled=True, available=True, reason=""),
+        MemoryPolicyDecision(enabled=1, available=True),  # type: ignore[arg-type]
+    ],
+    ids=(
+        "wrong-type",
+        "enabled-while-unavailable",
+        "unavailable-without-reason",
+        "empty-reason",
+        "non-bool-flag",
+    ),
+)
+def test_invalid_resolver_decision_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    decision: object,
+) -> None:
+    get_memory_store = Mock(name="get-memory-store")
+    monkeypatch.setattr(chat_api, "get_memory_store", get_memory_store)
+    set_trusted_memory_policy_resolver(lambda _request: decision)  # type: ignore[arg-type,return-value]
+
+    policy = chat_api.resolve_agent_service_memory_policy(task=_task())
+
+    assert isinstance(policy.memory, InMemoryMemoryStore)
+    assert policy.memory_enabled is False
+    assert policy.memory_available is False
+    assert policy.memory_availability_reason == MEMORY_POLICY_RESOLVER_FAILURE_REASON
+    get_memory_store.assert_not_called()
+
+
+def test_resolver_receives_none_for_missing_or_nonprimitive_task_fields() -> None:
+    resolver = Mock(
+        return_value=MemoryPolicyDecision(
+            enabled=False,
+            available=True,
+            reason="disabled_by_host_policy",
+        )
+    )
+    set_trusted_memory_policy_resolver(resolver)
+
+    chat_api.resolve_agent_service_memory_policy(task=None, agent_config={})
+
+    resolver.assert_called_once_with(
+        MemoryPolicyRequest(
+            task_id=None,
+            user_id=None,
+            agent_id=None,
+            source=None,
+            is_preview=False,
+        )
+    )


### PR DESCRIPTION
## Summary

- add a process-wide trusted resolver for memory eligibility decisions
- preserve preview, published-agent, and ordinary-task defaults when no resolver is installed
- fail closed to disabled in-memory behavior for invalid decisions, unavailable memory, or resolver exceptions
- expose stable availability and reason metadata on the resolved policy

## Tests

- `PYTHONPATH=src /opt/anaconda3/envs/xagent/bin/python -m pytest -q tests/web/services/test_memory_policy.py tests/web/api/test_websocket_preview.py`
- `ruff check src/xagent/web/services/memory_policy.py src/xagent/web/api/chat.py tests/web/services/test_memory_policy.py`
- `ruff format --check src/xagent/web/services/memory_policy.py src/xagent/web/api/chat.py tests/web/services/test_memory_policy.py`
- `PYTHONPATH=src /opt/anaconda3/envs/xagent/bin/python -m py_compile src/xagent/web/services/memory_policy.py src/xagent/web/api/chat.py tests/web/services/test_memory_policy.py`

Closes #2037