### PR TITLE
fix(web-crawler): treat a missing robots.txt as no restrictions

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
@@ -469,30 +469,6 @@ class WebCrawler:
         self.config = config
         self.progress_callback = progress_callback
 
-        # Initialize components
-        self.url_filter = URLFilter(
-            base_url=config.start_url,
-            same_domain_only=config.same_domain_only,
-            url_patterns=config.url_patterns,
-            exclude_patterns=config.exclude_patterns,
-            respect_robots_txt=config.respect_robots_txt,
-        )
-        self.content_cleaner = ContentCleaner(
-            content_selector=config.content_selector,
-            remove_selectors=config.remove_selectors,
-        )
-        self.link_extractor = LinkExtractor(config.start_url)
-
-        # Crawl state
-        self.visited_urls: Set[str] = set()
-        self.pending_urls: deque = deque()
-        self.crawl_results: List[CrawlResult] = []
-        self.failed_urls: Dict[str, str] = {}
-
-        # Statistics
-        self.total_urls_found = 0
-        self.start_time: Optional[float] = None
-
         # Resolve the TLS-fingerprint sequence to use for fetches.
         # Element type is Optional[str]: None means "use httpx, no impersonation".
         if config.tls_impersonate is None:
@@ -519,6 +495,31 @@ class WebCrawler:
             self._policy_user_agent = (
                 _IMPERSONATE_TO_UA.get(first_fp, "*") if first_fp else "*"
             )
+
+        # Initialize components
+        self.url_filter = URLFilter(
+            base_url=config.start_url,
+            same_domain_only=config.same_domain_only,
+            url_patterns=config.url_patterns,
+            exclude_patterns=config.exclude_patterns,
+            respect_robots_txt=config.respect_robots_txt,
+            user_agent=self._policy_user_agent,
+        )
+        self.content_cleaner = ContentCleaner(
+            content_selector=config.content_selector,
+            remove_selectors=config.remove_selectors,
+        )
+        self.link_extractor = LinkExtractor(config.start_url)
+
+        # Crawl state
+        self.visited_urls: Set[str] = set()
+        self.pending_urls: deque = deque()
+        self.crawl_results: List[CrawlResult] = []
+        self.failed_urls: Dict[str, str] = {}
+
+        # Statistics
+        self.total_urls_found = 0
+        self.start_time: Optional[float] = None
 
     async def crawl(self) -> List[CrawlResult]:
         """Start crawling from the configured start URL.

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/url_filter.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/url_filter.py
@@ -59,7 +59,10 @@ class URLFilter:
                 self.robots_parser = None
 
     def _fetch_robots_txt(self) -> None:
-        """Fetch and parse robots.txt."""
+        """Fetch robots.txt and apply the three-way RFC 9309 s2.3 policy: parse
+        it on a 2xx, drop the parser on a 4xx (unavailable means unrestricted),
+        and leave it unread on a 5xx or transport error (undefined means
+        complete disallow)."""
         import httpx
 
         if not self.robots_parser or not self.robots_url:
@@ -68,9 +71,15 @@ class URLFilter:
         try:
             # follow_redirects is required, not incidental: httpx defaults to
             # False, and an unfollowed 3xx would land in the branch below and
-            # discard the Disallow rules waiting at the redirect target.
-            response = httpx.get(self.robots_url, timeout=10, follow_redirects=True)
-            if response.status_code == 200:
+            # discard the Disallow rules waiting at the redirect target. Client
+            # rather than httpx.get because only Client takes max_redirects, and
+            # timeout is per-request: 20 default hops stretch the ceiling to
+            # ~200s. Five is the threshold RFC 9309 s2.3.1.2 suggests.
+            with httpx.Client(
+                timeout=10, follow_redirects=True, max_redirects=5
+            ) as client:
+                response = client.get(self.robots_url)
+            if 200 <= response.status_code < 300:
                 self.robots_parser.parse(response.text.splitlines())
                 logger.info("Loaded robots.txt from %s", self.robots_url)
             elif 400 <= response.status_code < 500:
@@ -80,7 +89,8 @@ class URLFilter:
                 # which silently reduces a site with no robots.txt to its start
                 # page alone. 5xx and transport errors deliberately fall through
                 # to that deny-all state instead: s2.3.1.4 makes an undefined
-                # robots.txt a complete disallow.
+                # robots.txt a complete disallow. 429 is knowingly grouped here:
+                # s2.3.1.3 draws the line at the status class, not at intent.
                 self.robots_parser = None
                 logger.info(
                     "No robots.txt restrictions from %s (HTTP %s)",
@@ -89,15 +99,23 @@ class URLFilter:
                 )
             else:
                 logger.warning(
-                    "robots.txt undefined at %s (HTTP %s); crawling nothing",
+                    "robots.txt undefined at %s (HTTP %s); only the start URL "
+                    "will be fetched, discovered links will be skipped",
                     self.robots_url,
                     response.status_code,
                 )
         except Exception as e:
+            # Deliberately broad: narrowing to transport errors would let a bug
+            # in here escape to __init__, which clears the parser and so fails
+            # open on the whole site instead of closed.
             logger.warning("Could not fetch robots.txt from %s: %s", self.robots_url, e)
 
     def is_allowed(self, url: str, user_agent: str = "*") -> bool:
         """Check if URL is allowed by robots.txt.
+
+        A parser of None is the upstream decision that the site has no rules
+        (see _fetch_robots_txt), not a defensive fallback: returning True there
+        is what makes a site without robots.txt crawlable.
 
         Args:
             url: URL to check

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/url_filter.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/url_filter.py
@@ -66,12 +66,35 @@ class URLFilter:
             return
 
         try:
-            response = httpx.get(self.robots_url, timeout=10)
+            # follow_redirects is required, not incidental: httpx defaults to
+            # False, and an unfollowed 3xx would land in the branch below and
+            # discard the Disallow rules waiting at the redirect target.
+            response = httpx.get(self.robots_url, timeout=10, follow_redirects=True)
             if response.status_code == 200:
                 self.robots_parser.parse(response.text.splitlines())
                 logger.info("Loaded robots.txt from %s", self.robots_url)
+            elif 400 <= response.status_code < 500:
+                # RFC 9309 s2.3.1.3: unavailable means the crawler may access
+                # anything. Dropping the parser is what expresses that - keeping
+                # an unread RobotFileParser makes can_fetch() deny every URL,
+                # which silently reduces a site with no robots.txt to its start
+                # page alone. 5xx and transport errors deliberately fall through
+                # to that deny-all state instead: s2.3.1.4 makes an undefined
+                # robots.txt a complete disallow.
+                self.robots_parser = None
+                logger.info(
+                    "No robots.txt restrictions from %s (HTTP %s)",
+                    self.robots_url,
+                    response.status_code,
+                )
+            else:
+                logger.warning(
+                    "robots.txt undefined at %s (HTTP %s); crawling nothing",
+                    self.robots_url,
+                    response.status_code,
+                )
         except Exception as e:
-            logger.warning("Failed to fetch robots.txt: %s", e)
+            logger.warning("Could not fetch robots.txt from %s: %s", self.robots_url, e)
 
     def is_allowed(self, url: str, user_agent: str = "*") -> bool:
         """Check if URL is allowed by robots.txt.

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/url_filter.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/url_filter.py
@@ -28,6 +28,7 @@ class URLFilter:
         url_patterns: Optional[list[str]] = None,
         exclude_patterns: Optional[list[str]] = None,
         respect_robots_txt: bool = True,
+        user_agent: Optional[str] = None,
     ):
         """Initialize URL filter.
 
@@ -37,6 +38,9 @@ class URLFilter:
             url_patterns: Regex patterns for allowed URLs
             exclude_patterns: Regex patterns for excluded URLs
             respect_robots_txt: Whether to check robots.txt
+            user_agent: UA to send when fetching robots.txt. Must be the one
+                the crawl itself sends: a WAF that 403s an unrecognised UA
+                would otherwise be read as "this site has no rules".
         """
         normalized_base_url = normalize_web_url(base_url)
         self.base_domain = urlparse(normalized_base_url or base_url).netloc.lower()
@@ -44,6 +48,7 @@ class URLFilter:
         self.url_patterns = [re.compile(p) for p in (url_patterns or [])]
         self.exclude_patterns = [re.compile(p) for p in (exclude_patterns or [])]
         self.respect_robots_txt = respect_robots_txt
+        self.user_agent = user_agent
 
         # Initialize robots.txt parser
         self.robots_parser: Optional[RobotFileParser] = None
@@ -70,27 +75,31 @@ class URLFilter:
 
         try:
             # follow_redirects is required, not incidental: httpx defaults to
-            # False, and an unfollowed 3xx would land in the branch below and
-            # discard the Disallow rules waiting at the redirect target. Client
-            # rather than httpx.get because only Client takes max_redirects, and
-            # timeout is per-request: 20 default hops stretch the ceiling to
-            # ~200s. Five is the threshold RFC 9309 s2.3.1.2 suggests.
+            # False, so a 3xx would reach the final branch below and deny the
+            # whole site, with the Disallow rules left unread at the redirect
+            # target. Client rather than httpx.get because only Client takes
+            # max_redirects, and timeout is per-request: 20 default hops
+            # stretch the ceiling to ~200s. Five is the floor RFC 9309
+            # s2.3.1.2 asks crawlers to follow.
+            headers = {"User-Agent": self.user_agent} if self.user_agent else None
             with httpx.Client(
                 timeout=10, follow_redirects=True, max_redirects=5
             ) as client:
-                response = client.get(self.robots_url)
+                response = client.get(self.robots_url, headers=headers)
             if 200 <= response.status_code < 300:
                 self.robots_parser.parse(response.text.splitlines())
                 logger.info("Loaded robots.txt from %s", self.robots_url)
-            elif 400 <= response.status_code < 500:
+            elif 400 <= response.status_code < 500 and response.status_code != 429:
                 # RFC 9309 s2.3.1.3: unavailable means the crawler may access
                 # anything. Dropping the parser is what expresses that - keeping
                 # an unread RobotFileParser makes can_fetch() deny every URL,
                 # which silently reduces a site with no robots.txt to its start
                 # page alone. 5xx and transport errors deliberately fall through
                 # to that deny-all state instead: s2.3.1.4 makes an undefined
-                # robots.txt a complete disallow. 429 is knowingly grouped here:
-                # s2.3.1.3 draws the line at the status class, not at intent.
+                # robots.txt a complete disallow. s2.3.1.3 judges by meaning
+                # ("the resource is unavailable") and only cites 400-499 as an
+                # example, so 429 is excluded: a server asking us to slow down
+                # has not said it has no rules.
                 self.robots_parser = None
                 logger.info(
                     "No robots.txt restrictions from %s (HTTP %s)",

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
@@ -957,3 +957,67 @@ class TestWebCrawler:
         assert "All TLS fingerprints failed" in caplog.text
         assert "chrome116:TimeoutError" in caplog.text
         assert "https://example.com" in crawler.failed_urls
+
+
+class TestRobotsAtCrawlLevel:
+    """The url_filter unit tests cannot catch this on their own: the start URL
+    never passes through should_crawl, so a deny-all filter still yields one
+    page and a non-zero total_urls_found. Only page count across a real crawl
+    distinguishes "robots absent" from "robots denied everything"."""
+
+    HTML = """
+        <html><body><h1>Docs</h1>
+        <p>Enough body text here to pass the content length check.</p>
+        <a href="/a">A</a><a href="/b">B</a>
+        </body></html>
+    """
+
+    def _client(self):
+        response = MagicMock()
+        response.status_code = 200
+        response.text = self.HTML
+        client = AsyncMock()
+        client.get.return_value = response
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock()
+        return client
+
+    @pytest.mark.asyncio
+    async def test_absent_robots_txt_does_not_stop_at_the_start_page(self, monkeypatch):
+        monkeypatch.setattr(
+            httpx, "get", lambda url, **kw: MagicMock(status_code=404, text="")
+        )
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+            respect_robots_txt=True,
+        )
+        with patch("httpx.AsyncClient", return_value=self._client()):
+            results = await WebCrawler(config).crawl()
+
+        assert len(results) > 1
+
+    @pytest.mark.asyncio
+    async def test_real_disallow_still_stops_the_crawl(self, monkeypatch):
+        monkeypatch.setattr(
+            httpx,
+            "get",
+            lambda url, **kw: MagicMock(
+                status_code=200, text="User-agent: *\nDisallow: /\n"
+            ),
+        )
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+            respect_robots_txt=True,
+        )
+        with patch("httpx.AsyncClient", return_value=self._client()):
+            results = await WebCrawler(config).crawl()
+
+        assert len(results) == 1

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
@@ -982,11 +982,16 @@ class TestRobotsAtCrawlLevel:
         client.__aexit__ = AsyncMock()
         return client
 
+    def _robots(self, monkeypatch, status, text=""):
+        client = MagicMock()
+        client.return_value.__enter__.return_value.get.return_value = MagicMock(
+            status_code=status, text=text
+        )
+        monkeypatch.setattr(httpx, "Client", client)
+
     @pytest.mark.asyncio
     async def test_absent_robots_txt_does_not_stop_at_the_start_page(self, monkeypatch):
-        monkeypatch.setattr(
-            httpx, "get", lambda url, **kw: MagicMock(status_code=404, text="")
-        )
+        self._robots(monkeypatch, 404)
         config = WebCrawlConfig(
             start_url="https://example.com",
             max_pages=10,
@@ -1002,13 +1007,7 @@ class TestRobotsAtCrawlLevel:
 
     @pytest.mark.asyncio
     async def test_real_disallow_still_stops_the_crawl(self, monkeypatch):
-        monkeypatch.setattr(
-            httpx,
-            "get",
-            lambda url, **kw: MagicMock(
-                status_code=200, text="User-agent: *\nDisallow: /\n"
-            ),
-        )
+        self._robots(monkeypatch, 200, "User-agent: *\nDisallow: /\n")
         config = WebCrawlConfig(
             start_url="https://example.com",
             max_pages=10,

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
@@ -989,6 +989,18 @@ class TestRobotsAtCrawlLevel:
         )
         monkeypatch.setattr(httpx, "Client", client)
 
+    def test_robots_fetch_inherits_the_crawl_user_agent(self):
+        """Probing robots.txt as python-httpx while crawling as a browser lets
+        a WAF 403 read as "this site has no rules"."""
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            user_agent="XagentBot/1.0",
+            tls_impersonate=None,
+            respect_robots_txt=False,
+        )
+
+        assert WebCrawler(config).url_filter.user_agent == "XagentBot/1.0"
+
     @pytest.mark.asyncio
     async def test_absent_robots_txt_does_not_stop_at_the_start_page(self, monkeypatch):
         self._robots(monkeypatch, 404)

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_url_filter.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_url_filter.py
@@ -1,5 +1,9 @@
 """Unit tests for URL filter."""
 
+from functools import partial
+from unittest.mock import MagicMock
+
+import httpx
 import pytest
 from pydantic import ValidationError
 
@@ -187,21 +191,12 @@ class TestRobotsTxtAvailability:
     """
 
     def _filter_with_robots_response(
-        self, monkeypatch, response, *, raises=False
+        self, monkeypatch, response=None, *, error=None
     ) -> URLFilter:
-        import httpx
-
-        self.requested: list[str] = []
-        self.request_kwargs: dict = {}
-
-        def fake_get(url, **kwargs):
-            self.requested.append(url)
-            self.request_kwargs = kwargs
-            if raises:
-                raise OSError("connection refused")
-            return response
-
-        monkeypatch.setattr(httpx, "get", fake_get)
+        self.client = MagicMock()
+        self.get = self.client.return_value.__enter__.return_value.get
+        self.get.side_effect = error or (lambda url: response)
+        monkeypatch.setattr(httpx, "Client", self.client)
         return URLFilter("https://example.com", respect_robots_txt=True)
 
     @pytest.mark.parametrize("status", [404, 403, 410])
@@ -212,6 +207,14 @@ class TestRobotsTxtAvailability:
         assert f.is_allowed("https://example.com/docs/intro") is True
         assert f.should_crawl("https://example.com/docs/intro") is True
 
+    @pytest.mark.parametrize("status", [200, 204, 206])
+    def test_any_2xx_robots_is_parsed(self, monkeypatch, status):
+        """A CDN answering /robots.txt with 204 No Content has said the site
+        has no rules; an exact match on 200 would drop it into the deny-all
+        branch and invert that."""
+        f = self._filter_with_robots_response(monkeypatch, _FakeResponse(status))
+        assert f.should_crawl("https://example.com/docs/intro") is True
+
     @pytest.mark.parametrize("status", [500, 503])
     def test_5xx_robots_blocks_the_crawl(self, monkeypatch, status):
         """RFC 9309 s2.3.1.4: an unreachable robots.txt is undefined, and an
@@ -220,22 +223,50 @@ class TestRobotsTxtAvailability:
         f = self._filter_with_robots_response(monkeypatch, _FakeResponse(status))
         assert f.should_crawl("https://example.com/docs/intro") is False
 
-    def test_unreachable_robots_blocks_the_crawl(self, monkeypatch):
-        f = self._filter_with_robots_response(
-            monkeypatch, _FakeResponse(200), raises=True
-        )
+    @pytest.mark.parametrize(
+        "error",
+        [
+            OSError("connection refused"),
+            httpx.ConnectTimeout("timed out"),
+            httpx.ConnectError("name resolution failed"),
+            httpx.TooManyRedirects("redirect loop"),
+        ],
+    )
+    def test_unreachable_robots_blocks_the_crawl(self, monkeypatch, error):
+        """TooManyRedirects is included on purpose: s2.3.1.2 permits treating a
+        too-long chain as unavailable (allow), and this takes the stricter of
+        the two readings."""
+        f = self._filter_with_robots_response(monkeypatch, error=error)
         assert f.should_crawl("https://example.com/docs/intro") is False
 
-    def test_fetch_opts_into_following_redirects(self, monkeypatch):
-        """A kwarg-contract assertion, not a behavioural one: the fetch calls
-        module-level httpx.get, so a stub cannot exercise httpx's own redirect
-        machinery. httpx defaults follow_redirects to False, and an unfollowed
-        3xx would land in neither the 200 nor the 4xx branch, discarding the
-        Disallow rules waiting at the redirect target -- http->https and www
-        canonicalisation redirect /robots.txt routinely."""
+    def test_redirect_chain_is_bounded(self, monkeypatch):
+        """timeout is per-request, so the redirect limit is what bounds the
+        total wait."""
         self._filter_with_robots_response(monkeypatch, _FakeResponse(404))
 
-        assert self.request_kwargs.get("follow_redirects") is True
+        assert self.client.call_args.kwargs["max_redirects"] == 5
+
+    def test_disallow_rules_behind_a_redirect_are_honoured(self, monkeypatch):
+        """http->https and www canonicalisation redirect /robots.txt routinely.
+        httpx defaults follow_redirects to False, which would land the 3xx in
+        the deny-all branch and discard the rules at the redirect target."""
+
+        def handler(request):
+            if request.url.host == "example.com":
+                return httpx.Response(
+                    301, headers={"Location": "https://www.example.com/robots.txt"}
+                )
+            return httpx.Response(200, text="User-agent: *\nDisallow: /private\n")
+
+        monkeypatch.setattr(
+            httpx,
+            "Client",
+            partial(httpx.Client, transport=httpx.MockTransport(handler)),
+        )
+        f = URLFilter("https://example.com", respect_robots_txt=True)
+
+        assert f.should_crawl("https://example.com/private/secret") is False
+        assert f.should_crawl("https://example.com/public/page") is True
 
     def test_soft_404_html_body_still_allows_the_crawl(self, monkeypatch):
         """Static hosts often answer /robots.txt with HTTP 200 and an HTML
@@ -251,7 +282,9 @@ class TestRobotsTxtAvailability:
     def test_robots_is_fetched_from_the_site_root(self, monkeypatch):
         self._filter_with_robots_response(monkeypatch, _FakeResponse(404))
 
-        assert self.requested == ["https://example.com/robots.txt"]
+        assert [c.args[0] for c in self.get.call_args_list] == [
+            "https://example.com/robots.txt"
+        ]
 
     def test_real_robots_rules_are_still_enforced(self, monkeypatch):
         f = self._filter_with_robots_response(

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_url_filter.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_url_filter.py
@@ -170,3 +170,93 @@ def test_web_crawl_config_rejects_invalid_start_urls():
         match="Invalid start_url: URL must include a hostname",
     ):
         WebCrawlConfig(start_url="http://@")
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, text: str = "") -> None:
+        self.status_code = status_code
+        self.text = text
+
+
+class TestRobotsTxtAvailability:
+    """A missing robots.txt must not lock the crawler out of the whole site.
+
+    RobotFileParser denies everything until it has been read, so any branch
+    that leaves the parser untouched silently reduces a crawl to its start
+    page: on a real documentation site this turned 42 reachable pages into 1.
+    """
+
+    def _filter_with_robots_response(
+        self, monkeypatch, response, *, raises=False
+    ) -> URLFilter:
+        import httpx
+
+        self.requested: list[str] = []
+        self.request_kwargs: dict = {}
+
+        def fake_get(url, **kwargs):
+            self.requested.append(url)
+            self.request_kwargs = kwargs
+            if raises:
+                raise OSError("connection refused")
+            return response
+
+        monkeypatch.setattr(httpx, "get", fake_get)
+        return URLFilter("https://example.com", respect_robots_txt=True)
+
+    @pytest.mark.parametrize("status", [404, 403, 410])
+    def test_4xx_robots_allows_every_path(self, monkeypatch, status):
+        f = self._filter_with_robots_response(
+            monkeypatch, _FakeResponse(status, "<html>Page Not Found</html>")
+        )
+        assert f.is_allowed("https://example.com/docs/intro") is True
+        assert f.should_crawl("https://example.com/docs/intro") is True
+
+    @pytest.mark.parametrize("status", [500, 503])
+    def test_5xx_robots_blocks_the_crawl(self, monkeypatch, status):
+        """RFC 9309 s2.3.1.4: an unreachable robots.txt is undefined, and an
+        undefined robots.txt is a complete disallow. Unlike 4xx, a server error
+        says nothing about whether rules exist."""
+        f = self._filter_with_robots_response(monkeypatch, _FakeResponse(status))
+        assert f.should_crawl("https://example.com/docs/intro") is False
+
+    def test_unreachable_robots_blocks_the_crawl(self, monkeypatch):
+        f = self._filter_with_robots_response(
+            monkeypatch, _FakeResponse(200), raises=True
+        )
+        assert f.should_crawl("https://example.com/docs/intro") is False
+
+    def test_fetch_opts_into_following_redirects(self, monkeypatch):
+        """A kwarg-contract assertion, not a behavioural one: the fetch calls
+        module-level httpx.get, so a stub cannot exercise httpx's own redirect
+        machinery. httpx defaults follow_redirects to False, and an unfollowed
+        3xx would land in neither the 200 nor the 4xx branch, discarding the
+        Disallow rules waiting at the redirect target -- http->https and www
+        canonicalisation redirect /robots.txt routinely."""
+        self._filter_with_robots_response(monkeypatch, _FakeResponse(404))
+
+        assert self.request_kwargs.get("follow_redirects") is True
+
+    def test_soft_404_html_body_still_allows_the_crawl(self, monkeypatch):
+        """Static hosts often answer /robots.txt with HTTP 200 and an HTML
+        404 page. Parsing that yields no rules, which must read as "no
+        restrictions" rather than deny-all."""
+        f = self._filter_with_robots_response(
+            monkeypatch,
+            _FakeResponse(200, "<html><body>Page Not Found</body></html>"),
+        )
+
+        assert f.should_crawl("https://example.com/docs/intro") is True
+
+    def test_robots_is_fetched_from_the_site_root(self, monkeypatch):
+        self._filter_with_robots_response(monkeypatch, _FakeResponse(404))
+
+        assert self.requested == ["https://example.com/robots.txt"]
+
+    def test_real_robots_rules_are_still_enforced(self, monkeypatch):
+        f = self._filter_with_robots_response(
+            monkeypatch,
+            _FakeResponse(200, "User-agent: *\nDisallow: /private\n"),
+        )
+        assert f.should_crawl("https://example.com/private/secret") is False
+        assert f.should_crawl("https://example.com/public/page") is True

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_url_filter.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_url_filter.py
@@ -195,9 +195,20 @@ class TestRobotsTxtAvailability:
     ) -> URLFilter:
         self.client = MagicMock()
         self.get = self.client.return_value.__enter__.return_value.get
-        self.get.side_effect = error or (lambda url: response)
+        self.get.side_effect = error or (lambda url, headers=None: response)
         monkeypatch.setattr(httpx, "Client", self.client)
         return URLFilter("https://example.com", respect_robots_txt=True)
+
+    def test_robots_is_fetched_with_the_crawl_user_agent(self, monkeypatch):
+        """A WAF that 403s an unrecognised UA would otherwise be read as "no
+        rules" while the crawl itself proceeds under a browser UA."""
+        self.client = MagicMock()
+        self.get = self.client.return_value.__enter__.return_value.get
+        self.get.side_effect = lambda url, headers=None: _FakeResponse(404)
+        monkeypatch.setattr(httpx, "Client", self.client)
+        URLFilter("https://example.com", user_agent="XagentBot/1.0")
+
+        assert self.get.call_args.kwargs["headers"] == {"User-Agent": "XagentBot/1.0"}
 
     @pytest.mark.parametrize("status", [404, 403, 410])
     def test_4xx_robots_allows_every_path(self, monkeypatch, status):
@@ -239,17 +250,45 @@ class TestRobotsTxtAvailability:
         f = self._filter_with_robots_response(monkeypatch, error=error)
         assert f.should_crawl("https://example.com/docs/intro") is False
 
-    def test_redirect_chain_is_bounded(self, monkeypatch):
-        """timeout is per-request, so the redirect limit is what bounds the
-        total wait."""
+    def test_429_blocks_the_crawl(self, monkeypatch):
+        """s2.3.1.3 judges by meaning, not by status class: a server asking us
+        to slow down has not said it has no rules."""
+        f = self._filter_with_robots_response(monkeypatch, _FakeResponse(429))
+        assert f.should_crawl("https://example.com/docs/intro") is False
+
+    def test_fetch_is_bounded_in_time(self, monkeypatch):
+        """timeout is per-request, so it and the redirect limit together are
+        what bound the total wait."""
         self._filter_with_robots_response(monkeypatch, _FakeResponse(404))
 
+        assert self.client.call_args.kwargs["timeout"] == 10
         assert self.client.call_args.kwargs["max_redirects"] == 5
+
+    def test_endless_redirects_block_the_crawl(self, monkeypatch):
+        """The kwarg assertion above cannot show the sixth hop is refused.
+        s2.3.1.2 permits treating an over-long chain as unavailable (allow);
+        this takes the stricter reading, so it needs a behavioural anchor."""
+        self._patch_client_with_handler(
+            monkeypatch,
+            lambda request: httpx.Response(
+                301, headers={"Location": f"{request.url}/again"}
+            ),
+        )
+        f = URLFilter("https://example.com", respect_robots_txt=True)
+
+        assert f.should_crawl("https://example.com/docs/intro") is False
+
+    def _patch_client_with_handler(self, monkeypatch, handler):
+        monkeypatch.setattr(
+            httpx,
+            "Client",
+            partial(httpx.Client, transport=httpx.MockTransport(handler)),
+        )
 
     def test_disallow_rules_behind_a_redirect_are_honoured(self, monkeypatch):
         """http->https and www canonicalisation redirect /robots.txt routinely.
-        httpx defaults follow_redirects to False, which would land the 3xx in
-        the deny-all branch and discard the rules at the redirect target."""
+        httpx defaults follow_redirects to False, which would leave the rules
+        unread at the redirect target and deny the whole site."""
 
         def handler(request):
             if request.url.host == "example.com":
@@ -258,11 +297,7 @@ class TestRobotsTxtAvailability:
                 )
             return httpx.Response(200, text="User-agent: *\nDisallow: /private\n")
 
-        monkeypatch.setattr(
-            httpx,
-            "Client",
-            partial(httpx.Client, transport=httpx.MockTransport(handler)),
-        )
+        self._patch_client_with_handler(monkeypatch, handler)
         f = URLFilter("https://example.com", respect_robots_txt=True)
 
         assert f.should_crawl("https://example.com/private/secret") is False


### PR DESCRIPTION
## Invariant

With `respect_robots_txt=True`, only a `Disallow` rule that actually exists in a
fetched robots.txt may stop a fetch. A robots.txt that is absent or unreachable
must not block any path.

## Problem

`RobotFileParser.can_fetch()` returns `False` for every URL until the parser has
been read — the stdlib says so outright: *"Until the robots.txt file has been
read or found not to exist, we must assume that no url is allowable."*

`_fetch_robots_txt()` only calls `parse()` on HTTP 200 and does nothing
otherwise, leaving the parser in exactly that unread state. The result: **any
site without a robots.txt is crawled down to its start page alone.** The start
page is queued directly and never passes through `should_crawl()`, so it is
fetched; every link extracted from it is then rejected as "disallowed by
robots.txt" and never queued.

The `except` branch had the same hole — a timeout or DNS failure while fetching
robots.txt also disallowed the entire site.

Sites like this are common: the default templates for Docusaurus, VitePress,
GitBook and Mintlify ship no robots.txt, and documentation sites are the primary
use case for web ingestion.

## Change

A **4xx** response now clears `robots_parser`, and `is_allowed()` already
returns `True` when there is no parser. Real `Disallow` rules are unaffected.

### 4xx and 5xx are opposites, and only 4xx changes here

RFC 9309 splits these deliberately:

- **§2.3.1.3 (4xx)** — "If a server status code indicates that the robots.txt
  file is unavailable to the crawler, then the crawler **MAY access any
  resources** on the server." A site that serves no robots.txt has no rules,
  and this is the case the reported bug runs into.
- **§2.3.1.4 (5xx / transport errors)** — "If the robots.txt file is
  unreachable due to server or network errors, this means the robots.txt file
  is undefined and the crawler **MUST assume complete disallow**." A server
  error says nothing about whether rules exist.

The unread-parser state the class already had happens to be exactly the
"complete disallow" §2.3.1.4 asks for, so 5xx and the `except` branch keep it
untouched. Only the 4xx branch clears the parser. An earlier revision of this
PR cleared it for every non-200 status, which fixed the reported bug but broke
§2.3.1.4 on the way; that is corrected here and pinned by tests.

## Entry points

`URLFilter._fetch_robots_txt` · `URLFilter.is_allowed`

## Non-goals

- No change to cross-subdomain crawling (`is_same_domain` stays an exact
  hostname comparison)
- No change to content extraction, chunking, or retrieval scoring
- No backfill of existing knowledge bases — affected ones need re-importing
- **No ingestion-status changes.** An earlier revision also downgraded
  "one page crawled" and "zero embeddings" from `success` to `partial`, so a
  degraded crawl would stop reporting as a clean success. Review showed both
  predicates read signals that do not carry that meaning: `total_urls_found`
  counts raw extracted links before `URLFilter`, so a legitimate `max_pages=1`
  or fully-filtered crawl would be mislabelled; and `IngestionResult.embedding_count`
  counts embeddings generated *this run*, so an idempotent re-import that reuses
  persisted vectors would be wrongly reported as unsearchable. Doing this
  correctly needs signals that do not exist yet (eligible/followed link count,
  persisted vector total, or an explicit crawl termination reason), so it is
  split out rather than shipped on the wrong inputs.

## Blocking criteria

- Real `Disallow` rules are still honoured (covered by a test)

## Verification

Against a Docusaurus documentation site that serves no robots.txt, with default
settings (`respect_robots_txt=True`, `max_depth=3`):

| | before | after |
|---|---|---|
| pages crawled | 1 | 42 |

Tests cover the robots.txt outcomes (any 2xx parses, 4xx allows, 5xx and
transport errors disallow, real rules honoured, HTTP 200 with an HTML soft-404
body, `Disallow` behind a 301, redirect bound, fetch URL) plus two
crawler-level tests. The crawler-level pair matters because the `url_filter`
unit tests cannot catch this bug on their own: the start URL never passes
through `should_crawl`, so a deny-all filter still yields one page and a
non-zero `total_urls_found` — only the page count across a real crawl separates
"robots absent" from "robots denied everything".

Five mutations (drop `follow_redirects`, narrow 2xx back to an exact `200`,
drop `max_redirects`, widen the 4xx parser clear to 5xx, clear on transport
error) are each killed by a test — the last two are the guards against
regressing §2.3.1.4. `tests/core/tools/core/RAG_tools` passes; pre-commit
(incl. mypy) passes.

### Review round 2

Ten non-blocking comments, all addressed. Three changed behaviour:

- The status check was an exact match on `200`, so a `204 No Content`
  robots.txt — a real CDN response meaning "no rules" — fell into the deny-all
  branch. Now `200 <= status < 300`.
- `follow_redirects=True` (added in round 1) raised the worst-case wait from
  ~10s to ~200s, because `timeout` bounds one request and httpx allows 20 hops.
  `max_redirects=5` bounds it, at the threshold §2.3.1.2 suggests. That kwarg
  only exists on `httpx.Client`, not `httpx.get` — mypy caught it, so the fetch
  moved to a `Client`.
- The 301 case now has a behavioural test using `httpx.MockTransport`, running
  httpx's real redirect machinery rather than asserting a kwarg. Round 1 waived
  this on an incorrect premise; the reviewer was right that the stub was already
  the injection point.

The rest are comments and wording: the broad `except Exception` is kept
deliberately (narrowing it would let a bug reach `__init__`, which clears the
parser and so fails *open* on the whole site), and the deny-all log line no
longer says "crawling nothing" when the start URL is in fact fetched.

### Self-review round 3

Three independent falsification passes over the whole diff (production logic,
test honesty, comment accuracy) found two defects that the reviewer's rounds
and my own earlier replies had missed.

**The robots.txt probe used a different User-Agent than the crawl itself.**
`URLFilter` never received one, so the probe went out as `python-httpx/0.28.1`
while pages are fetched under `config.user_agent` or an impersonated browser UA.
A WAF that 403s an unrecognised client is common, and this PR is what makes that
dangerous: before it, a 403 left the parser unread (deny-all, conservative);
after it, a 403 lands in the 4xx branch and clears the parser, so the crawler
concludes the site has no rules and proceeds to crawl all of it under a browser
UA — while the site does have a robots.txt with real `Disallow` rules. "We
probed wrong, therefore you have no rules" is the worst available reading.
`_policy_user_agent` now moves above the `URLFilter` construction in
`WebCrawler.__init__` (a pure relocation — it depends only on `config`) and is
passed in.

This was raised in round 2 and I declined it, citing the cost of a new
constructor parameter plus reordering initialisation. The reordering half of
that was wrong: the two blocks depend on nothing but `config`.

**429 was treated as "no restrictions".** Now excluded from the 4xx branch and
handled as undefined. §2.3.1.3 defines unavailability by meaning — "status codes
indicating that the resource in question is unavailable" — and cites 400-499
only as an example, so grouping 429 there was our approximation, not the RFC's
line. A server asking us to slow down has not said it has no rules. The comment
claiming otherwise is corrected.

Also corrected: "Five is the threshold s2.3.1.2 suggests" (the RFC says
crawlers SHOULD follow *at least* five, a floor rather than a suggested
ceiling), and a comment describing an unfollowed 3xx as "discarding" the rules
when it in fact denies the whole site.

Two coverage gaps closed: `timeout=10` had no assertion (deleting it left the
suite green), and `max_redirects` was pinned only as a kwarg — an over-long
chain now has a behavioural test driving httpx's real redirect machinery
through `MockTransport`. Five further mutations (429 back into 4xx, drop the
probe headers, drop the crawler's `user_agent` argument, `max_redirects` to
500, 4xx no longer clearing the parser) are each killed by a test.

Two known limits, both out of scope here: with five hops at `timeout=10` the
worst-case synchronous fetch is ~60s on the calling loop (it was ~10s before
this PR, ~200s at httpx's default), and 21 existing tests construct crawlers
without `respect_robots_txt=False`, so they issue a real request to
`example.com/robots.txt` — pre-existing, unaffected by CI, and a separate
cleanup.


