### PR TITLE
feat(memory): require persistent vector backends (toby)

### DIFF
--- a/src/xagent/core/memory/base.py
+++ b/src/xagent/core/memory/base.py
@@ -12,6 +12,10 @@ from .scope_columns import (
 )
 
 
+class MemoryBackendUnavailableError(RuntimeError):
+    """A caller-required memory backend capability is unavailable."""
+
+
 def comparable_timestamp(value: Any) -> Any:
     """Normalize a datetime for cross-comparison in date-range filters.
 

--- a/src/xagent/core/memory/base.py
+++ b/src/xagent/core/memory/base.py
@@ -11,6 +11,8 @@ from .scope_columns import (
     scope_dim_element,
 )
 
+MEMORY_BACKEND_UNAVAILABLE_REASON = "required_memory_backend_unavailable"
+
 
 class MemoryBackendUnavailableError(RuntimeError):
     """A caller-required memory backend capability is unavailable."""
@@ -43,6 +45,37 @@ class MemoryStore(ABC):
     Any concrete implementation (e.g., in-memory store, ChromaDB, Redis, etc.)
     should implement all the following methods to manage MemoryNote objects.
     """
+
+    def ensure_persistence(self) -> None:
+        """Verify durable storage without changing backend state."""
+
+        raise MemoryBackendUnavailableError(MEMORY_BACKEND_UNAVAILABLE_REASON)
+
+    def ensure_required_vector_search(self) -> None:
+        """Verify strict vector operations without network calls or mutation."""
+
+        raise MemoryBackendUnavailableError(MEMORY_BACKEND_UNAVAILABLE_REASON)
+
+    def add_required_vector(self, note: "MemoryNote") -> "MemoryResponse":
+        """Add a note only when a valid vector can be persisted."""
+
+        raise MemoryBackendUnavailableError(MEMORY_BACKEND_UNAVAILABLE_REASON)
+
+    def update_required_vector(self, note: "MemoryNote") -> "MemoryResponse":
+        """Atomically replace a note only after producing a valid vector."""
+
+        raise MemoryBackendUnavailableError(MEMORY_BACKEND_UNAVAILABLE_REASON)
+
+    def search_required_vector(
+        self,
+        query: str,
+        k: int = 5,
+        filters: Optional[dict[str, Any]] = None,
+        similarity_threshold: Optional[float] = None,
+    ) -> list["MemoryNote"]:
+        """Search only through a compatible vector index."""
+
+        raise MemoryBackendUnavailableError(MEMORY_BACKEND_UNAVAILABLE_REASON)
 
     @abstractmethod
     def add(self, note: "MemoryNote") -> "MemoryResponse":

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -16,7 +16,7 @@ from ..model.embedding import BaseEmbedding, DashScopeEmbedding
 from ..model.embedding.adapter import create_embedding_adapter
 from ..model.model import EmbeddingModelConfig
 from ..tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
-from .base import MemoryStore
+from .base import MemoryBackendUnavailableError, MemoryStore
 from .core import MemoryNote, MemoryResponse
 from .schema_migration import (
     MemoryMismatchKind,
@@ -35,6 +35,8 @@ from .scope_columns import (
 
 logger = logging.getLogger(__name__)
 
+_VECTOR_SPACE_METADATA_KEY = b"xagent.memory.vector_space"
+
 
 class LanceDBMemoryStore(MemoryStore):
     """LanceDB-based memory store implementation with vector search capabilities."""
@@ -46,6 +48,7 @@ class LanceDBMemoryStore(MemoryStore):
         db_dir: str,
         collection_name: str = "memories",
         embedding_model: Optional[Union[BaseEmbedding, EmbeddingModelConfig]] = None,
+        vector_space_identity: Optional[str] = None,
         similarity_threshold: float = 1.0,
         **embedding_kwargs: Any,
     ):
@@ -60,6 +63,7 @@ class LanceDBMemoryStore(MemoryStore):
             **embedding_kwargs: Additional arguments for embedding model
         """
         self._collection_name = collection_name
+        self._vector_space_identity = vector_space_identity
 
         # Handle different types of embedding_model input
         if embedding_model is None:
@@ -197,6 +201,24 @@ class LanceDBMemoryStore(MemoryStore):
             logger.error(f"Failed to generate embedding for text '{text[:50]}...': {e}")
             return None
 
+    def _get_required_embedding(self, text: str) -> list[float]:
+        """Encode text or report that required vector search is unavailable."""
+        if not self._embedding_model or not text.strip():
+            raise MemoryBackendUnavailableError("required_memory_backend_unavailable")
+        try:
+            result = self._embedding_model.encode(text)
+            if isinstance(result, list) and result:
+                vector = result[0] if isinstance(result[0], list) else result
+                if vector and all(isinstance(value, (int, float)) for value in vector):
+                    return [float(value) for value in vector]
+        except MemoryBackendUnavailableError:
+            raise
+        except Exception as exc:
+            raise MemoryBackendUnavailableError(
+                "required_memory_backend_unavailable"
+            ) from exc
+        raise MemoryBackendUnavailableError("required_memory_backend_unavailable")
+
     def _current_embedding_dim(self) -> Optional[int]:
         """Return the vector dimension the store currently produces, or None.
 
@@ -281,7 +303,13 @@ class LanceDBMemoryStore(MemoryStore):
         columns[USER_ID_COLUMN] = user_ids
         columns[SCOPE_DIMS_COLUMN] = scope_dims
 
-        return pa.table(columns)
+        migrated = pa.table(columns)
+        metadata = dict(existing.schema.metadata or {})
+        if target_dim is None or self._vector_space_identity is None:
+            metadata.pop(_VECTOR_SPACE_METADATA_KEY, None)
+        else:
+            metadata[_VECTOR_SPACE_METADATA_KEY] = self._vector_space_identity.encode()
+        return migrated.replace_schema_metadata(metadata)
 
     def _derive_scope_arrays(self, metadata_column: Any) -> tuple[Any, Any]:
         """Derive the (user_id, scope_dims) Arrow columns from a metadata column.
@@ -317,7 +345,74 @@ class LanceDBMemoryStore(MemoryStore):
         user_ids, scope_dims = self._derive_scope_arrays(metadata_column)
         columns[USER_ID_COLUMN] = user_ids
         columns[SCOPE_DIMS_COLUMN] = scope_dims
-        return pa.table(columns)
+        return pa.table(columns).replace_schema_metadata(existing.schema.metadata)
+
+    def ensure_text_persistence(self) -> None:
+        """Remove stale vector state while retaining every persistent row."""
+        conn = self._vector_store.get_raw_connection()
+        table = conn.open_table(self._collection_name)
+        try:
+            schema = table.schema
+        finally:
+            _safe_close_table(table)
+        if "vector" in schema.names or _VECTOR_SPACE_METADATA_KEY in (
+            schema.metadata or {}
+        ):
+            migrate_table_swap(
+                conn,
+                self._collection_name,
+                lambda existing: self._build_migrated_table(existing, None),
+            )
+
+    def ensure_required_vector_search(self) -> None:
+        """Establish and verify the configured persistent vector space."""
+        if self._vector_space_identity is None:
+            raise MemoryBackendUnavailableError("required_memory_backend_unavailable")
+        target_dim = len(self._get_required_embedding("sample"))
+        try:
+            declared_dim = self._embedding_model.get_dimension()  # type: ignore[union-attr]
+        except Exception as exc:
+            raise MemoryBackendUnavailableError(
+                "required_memory_backend_unavailable"
+            ) from exc
+        if declared_dim and int(declared_dim) != target_dim:
+            raise MemoryBackendUnavailableError("required_memory_backend_unavailable")
+        conn = self._vector_store.get_raw_connection()
+        try:
+            table = conn.open_table(self._collection_name)
+            try:
+                schema = table.schema
+            finally:
+                _safe_close_table(table)
+            stored_identity = (schema.metadata or {}).get(_VECTOR_SPACE_METADATA_KEY)
+            mismatch = classify_memory_schema_mismatch(schema, target_dim)
+            if (
+                mismatch.kind is not MemoryMismatchKind.NONE
+                or stored_identity != self._vector_space_identity.encode()
+            ):
+                migrate_table_swap(
+                    conn,
+                    self._collection_name,
+                    lambda existing: self._build_migrated_table(existing, target_dim),
+                )
+            table = conn.open_table(self._collection_name)
+            try:
+                schema = table.schema
+                if (
+                    classify_memory_schema_mismatch(schema, target_dim).kind
+                    is not MemoryMismatchKind.NONE
+                    or (schema.metadata or {}).get(_VECTOR_SPACE_METADATA_KEY)
+                    != self._vector_space_identity.encode()
+                ):
+                    raise RuntimeError("vector schema verification failed")
+            finally:
+                _safe_close_table(table)
+        except MemoryBackendUnavailableError:
+            raise
+        except Exception as exc:
+            raise MemoryBackendUnavailableError(
+                "required_memory_backend_unavailable"
+            ) from exc
 
     def _ensure_scope_columns(self, conn: Any) -> None:
         """Promote user_id + scope_dims to real columns on an existing table (#822).
@@ -411,13 +506,19 @@ class LanceDBMemoryStore(MemoryStore):
             record = {k: v for k, v in record.items() if k != "vector"}
         table.add([record])
 
-    def _memory_note_to_dict(self, note: MemoryNote) -> dict[str, Any]:
+    def _memory_note_to_dict(
+        self, note: MemoryNote, *, require_vector_search: bool = False
+    ) -> dict[str, Any]:
         """Convert MemoryNote to dictionary for storage."""
         # Get embedding for the content
         content_text = (
             note.content.decode() if isinstance(note.content, bytes) else note.content
         )
-        embedding = self._get_embedding(content_text)
+        embedding = (
+            self._get_required_embedding(content_text)
+            if require_vector_search
+            else self._get_embedding(content_text)
+        )
 
         # Prepare metadata
         metadata = {
@@ -480,13 +581,22 @@ class LanceDBMemoryStore(MemoryStore):
 
     def add(self, note: MemoryNote) -> MemoryResponse:
         """Add a memory note to the store."""
+        return self._add(note, require_vector_search=False)
+
+    def add_required_vector(self, note: MemoryNote) -> MemoryResponse:
+        """Add a note without permitting embedding or storage fallback."""
+        return self._add(note, require_vector_search=True)
+
+    def _add(self, note: MemoryNote, *, require_vector_search: bool) -> MemoryResponse:
         try:
             # Generate ID if not provided
             if not note.id:
                 note.id = str(uuid4())
 
             # Convert to storage format
-            data = self._memory_note_to_dict(note)
+            data = self._memory_note_to_dict(
+                note, require_vector_search=require_vector_search
+            )
 
             # Add to vector store - use a consistent approach
             conn = self._vector_store.get_raw_connection()
@@ -506,6 +616,10 @@ class LanceDBMemoryStore(MemoryStore):
                 # Add vector if available
                 if data["vector"]:
                     record["vector"] = data["vector"]
+                elif require_vector_search:
+                    raise MemoryBackendUnavailableError(
+                        "required_memory_backend_unavailable"
+                    )
 
                 # Try to add the record. On a schema mismatch, migrate the
                 # existing table in place (preserving all rows) instead of
@@ -528,6 +642,10 @@ class LanceDBMemoryStore(MemoryStore):
                             "Safe schema migration failed; table left intact: %s",
                             migrate_error,
                         )
+                        if require_vector_search:
+                            raise MemoryBackendUnavailableError(
+                                "required_memory_backend_unavailable"
+                            ) from migrate_error
                         return MemoryResponse(
                             success=False,
                             error=f"Failed to add memory: {migrate_error}",
@@ -541,8 +659,14 @@ class LanceDBMemoryStore(MemoryStore):
 
             return MemoryResponse(success=True, memory_id=data["id"])
 
+        except MemoryBackendUnavailableError:
+            raise
         except Exception as e:
             logger.error(f"Failed to add memory note {note.id}: {e}")
+            if require_vector_search:
+                raise MemoryBackendUnavailableError(
+                    "required_memory_backend_unavailable"
+                ) from e
             return MemoryResponse(
                 success=False,
                 error=f"Failed to add memory: {str(e)}",
@@ -701,6 +825,8 @@ class LanceDBMemoryStore(MemoryStore):
         k: int = 5,
         filters: Optional[dict[str, Any]] = None,
         similarity_threshold: Optional[float] = None,
+        *,
+        _require_vector_search: bool = False,
     ) -> list[MemoryNote]:
         """Search memory notes by query text with optional filters.
 
@@ -735,11 +861,14 @@ class LanceDBMemoryStore(MemoryStore):
 
             # Try vector search first
             try:
-                query_embedding = self._get_embedding(query)
+                query_embedding = (
+                    self._get_required_embedding(query)
+                    if _require_vector_search
+                    else self._get_embedding(query)
+                )
                 if query_embedding:
                     # Check if vector column exists and has the right dimension
-                    sample_df = table.search().limit(1).to_pandas()
-                    if not sample_df.empty and "vector" in sample_df.columns:
+                    if "vector" in table.schema.names:
                         # Try vector search
                         try:
                             vector_query = table.search(
@@ -803,6 +932,10 @@ class LanceDBMemoryStore(MemoryStore):
 
                                 results.append(note)
                         except Exception as vector_error:
+                            if _require_vector_search:
+                                raise MemoryBackendUnavailableError(
+                                    "required_memory_backend_unavailable"
+                                ) from vector_error
                             if where_sql:
                                 # Distinguish a pushdown-specific failure: the
                                 # text fallback re-applies the full filters in
@@ -823,13 +956,23 @@ class LanceDBMemoryStore(MemoryStore):
                                     "search: %s",
                                     vector_error,
                                 )
+                    elif _require_vector_search:
+                        raise MemoryBackendUnavailableError(
+                            "required_memory_backend_unavailable"
+                        )
+            except MemoryBackendUnavailableError:
+                raise
             except Exception as embedding_error:
+                if _require_vector_search:
+                    raise MemoryBackendUnavailableError(
+                        "required_memory_backend_unavailable"
+                    ) from embedding_error
                 logger.warning(
                     f"Embedding generation failed, using text search: {embedding_error}"
                 )
 
             # Fallback to text search if no vector results or vector search failed
-            if not results:
+            if not results and not _require_vector_search:
                 # Text search
                 df = table.search().to_pandas()
                 other_filters = self._flat_other_filters(filters)
@@ -875,11 +1018,33 @@ class LanceDBMemoryStore(MemoryStore):
 
             return results[:k]
 
+        except MemoryBackendUnavailableError:
+            raise
         except Exception as e:
             logger.error(f"Failed to search memories with query '{query[:50]}...': {e}")
+            if _require_vector_search:
+                raise MemoryBackendUnavailableError(
+                    "required_memory_backend_unavailable"
+                ) from e
             return []
         finally:
             _safe_close_table(table)
+
+    def search_required_vector(
+        self,
+        query: str,
+        k: int = 5,
+        filters: Optional[dict[str, Any]] = None,
+        similarity_threshold: Optional[float] = None,
+    ) -> list[MemoryNote]:
+        """Search without permitting embedding, schema, or ANN fallback."""
+        return self.search(
+            query,
+            k=k,
+            filters=filters,
+            similarity_threshold=similarity_threshold,
+            _require_vector_search=True,
+        )
 
     def clear(self) -> None:
         """Clear all memory notes from the store."""

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional, Union, cast
 from uuid import uuid4
 
 import pyarrow as pa  # type: ignore
@@ -210,7 +210,7 @@ class LanceDBMemoryStore(MemoryStore):
             if isinstance(result, list) and result:
                 vector = result[0] if isinstance(result[0], list) else result
                 if vector and all(isinstance(value, (int, float)) for value in vector):
-                    return [float(value) for value in vector]
+                    return [float(value) for value in cast(list[float], vector)]
         except MemoryBackendUnavailableError:
             raise
         except Exception as exc:

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any, List, Optional, Union, cast
+from typing import Any, List, Optional, Union
 from uuid import uuid4
 
 import pyarrow as pa  # type: ignore
@@ -16,7 +16,11 @@ from ..model.embedding import BaseEmbedding, DashScopeEmbedding
 from ..model.embedding.adapter import create_embedding_adapter
 from ..model.model import EmbeddingModelConfig
 from ..tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
-from .base import MemoryBackendUnavailableError, MemoryStore
+from .base import (
+    MEMORY_BACKEND_UNAVAILABLE_REASON,
+    MemoryBackendUnavailableError,
+    MemoryStore,
+)
 from .core import MemoryNote, MemoryResponse
 from .schema_migration import (
     MemoryMismatchKind,
@@ -48,8 +52,9 @@ class LanceDBMemoryStore(MemoryStore):
         db_dir: str,
         collection_name: str = "memories",
         embedding_model: Optional[Union[BaseEmbedding, EmbeddingModelConfig]] = None,
-        vector_space_identity: Optional[str] = None,
         similarity_threshold: float = 1.0,
+        vector_space_identity: Optional[dict[str, Any]] = None,
+        allow_schema_migration: bool = True,
         **embedding_kwargs: Any,
     ):
         """
@@ -64,6 +69,7 @@ class LanceDBMemoryStore(MemoryStore):
         """
         self._collection_name = collection_name
         self._vector_space_identity = vector_space_identity
+        self._allow_schema_migration = allow_schema_migration
 
         # Handle different types of embedding_model input
         if embedding_model is None:
@@ -91,9 +97,48 @@ class LanceDBMemoryStore(MemoryStore):
                 f"Unsupported embedding model type: {type(embedding_model)}"
             )
         self._similarity_threshold = similarity_threshold
-        self._vector_store = LanceDBVectorStore(db_dir, collection_name)
         self._conn_manager = LanceDBConnectionManager()
+        self._vector_store = LanceDBVectorStore(
+            db_dir,
+            collection_name,
+            connection_manager=self._conn_manager,
+            initial_data=self._initial_table_data(),
+        )
         self._ensure_table_schema()
+
+    def _configured_embedding_dimension(self) -> Optional[int]:
+        if self._vector_space_identity is not None:
+            dimension = self._vector_space_identity.get("dimension")
+            return int(dimension) if dimension else None
+        if not self._embedding_model:
+            return None
+        try:
+            dimension = self._embedding_model.get_dimension()
+        except Exception:
+            return None
+        return int(dimension) if dimension else None
+
+    def _initial_table_data(self) -> Any:
+        base: dict[str, Any] = {
+            "id": ["sample"],
+            "text": ["sample"],
+            "metadata": ["{}"],
+            USER_ID_COLUMN: pa.array([0], pa.int64()),
+            SCOPE_DIMS_COLUMN: pa.array([["sample"]], pa.list_(pa.string())),
+        }
+        dimension = self._configured_embedding_dimension()
+        if dimension is not None:
+            base["vector"] = pa.array(
+                [[0.0] * dimension], pa.list_(pa.float32(), dimension)
+            )
+        data = pa.table(base)
+        if self._vector_space_identity is not None:
+            metadata = dict(data.schema.metadata or {})
+            metadata[_VECTOR_SPACE_METADATA_KEY] = json.dumps(
+                self._vector_space_identity, sort_keys=True, separators=(",", ":")
+            ).encode()
+            data = data.replace_schema_metadata(metadata)
+        return data
 
     def _ensure_table_schema(self) -> None:
         """Ensure the table has the correct schema for memory storage.
@@ -107,6 +152,11 @@ class LanceDBMemoryStore(MemoryStore):
         a table is both missing a base column and vector-mismatched.
         """
         conn = self._vector_store.get_raw_connection()
+
+        if not self._allow_schema_migration:
+            # Request-time manager stores use read-only admission. Existing
+            # shared tables are never scanned, rebuilt, or re-embedded here.
+            return
 
         # Determine whether the table already exists and read its columns.
         table = None
@@ -180,9 +230,90 @@ class LanceDBMemoryStore(MemoryStore):
         # Remove sample data
         table.delete("id = 'sample'")
 
+    def _table_schema(self) -> Any:
+        table = self._vector_store.get_raw_connection().open_table(
+            self._collection_name
+        )
+        try:
+            return table.schema
+        finally:
+            _safe_close_table(table)
+
+    @staticmethod
+    def _vector_dimension(schema: Any) -> Optional[int]:
+        if "vector" not in schema.names:
+            return None
+        vector_type = schema.field("vector").type
+        return (
+            int(vector_type.list_size)
+            if pa.types.is_fixed_size_list(vector_type)
+            else None
+        )
+
+    def _stored_vector_space_identity(self, schema: Any) -> Optional[dict[str, Any]]:
+        encoded = (schema.metadata or {}).get(_VECTOR_SPACE_METADATA_KEY)
+        if encoded is None:
+            return None
+        try:
+            value = json.loads(encoded.decode())
+        except (UnicodeDecodeError, json.JSONDecodeError, TypeError):
+            return None
+        return value if isinstance(value, dict) else None
+
+    def _has_compatible_vector_space(self) -> bool:
+        try:
+            schema = self._table_schema()
+        except Exception:
+            return False
+        dimension = self._configured_embedding_dimension()
+        if dimension is None or self._vector_dimension(schema) != dimension:
+            return False
+        if self._vector_space_identity is None:
+            # Preserve direct/legacy callers that predate persisted identity.
+            return self._embedding_model is not None
+        return self._stored_vector_space_identity(schema) == self._vector_space_identity
+
+    def ensure_persistence(self) -> None:
+        """Verify the persistent table is readable without mutating it."""
+
+        try:
+            schema = self._table_schema()
+            if not {
+                "id",
+                "text",
+                "metadata",
+                USER_ID_COLUMN,
+                SCOPE_DIMS_COLUMN,
+            } <= set(schema.names):
+                raise RuntimeError("memory table requires an offline schema migration")
+        except Exception as exc:
+            raise MemoryBackendUnavailableError(
+                MEMORY_BACKEND_UNAVAILABLE_REASON
+            ) from exc
+
+    def ensure_required_vector_search(self) -> None:
+        """Read-only strict admission; it performs no embedding call."""
+
+        self.ensure_persistence()
+        if (
+            self._embedding_model is None
+            or self._vector_space_identity is None
+            or not self._has_compatible_vector_space()
+        ):
+            raise MemoryBackendUnavailableError(MEMORY_BACKEND_UNAVAILABLE_REASON)
+
     def _get_embedding(self, text: str) -> Optional[list[float]]:
         """Get embedding for text using the configured embedding model."""
         if not self._embedding_model or not text.strip():
+            return None
+        if (
+            self._vector_space_identity is not None
+            and not self._has_compatible_vector_space()
+        ):
+            logger.warning(
+                "Configured embedding identity does not match the persisted "
+                "vector space; using text-only fallback"
+            )
             return None
 
         try:
@@ -202,22 +333,16 @@ class LanceDBMemoryStore(MemoryStore):
             return None
 
     def _get_required_embedding(self, text: str) -> list[float]:
-        """Encode text or report that required vector search is unavailable."""
-        if not self._embedding_model or not text.strip():
-            raise MemoryBackendUnavailableError("required_memory_backend_unavailable")
-        try:
-            result = self._embedding_model.encode(text)
-            if isinstance(result, list) and result:
-                vector = result[0] if isinstance(result[0], list) else result
-                if vector and all(isinstance(value, (int, float)) for value in vector):
-                    return [float(value) for value in cast(list[float], vector)]
-        except MemoryBackendUnavailableError:
-            raise
-        except Exception as exc:
-            raise MemoryBackendUnavailableError(
-                "required_memory_backend_unavailable"
-            ) from exc
-        raise MemoryBackendUnavailableError("required_memory_backend_unavailable")
+        self.ensure_required_vector_search()
+        embedding = self._get_embedding(text)
+        expected_dimension = self._configured_embedding_dimension()
+        if (
+            embedding is None
+            or expected_dimension is None
+            or len(embedding) != expected_dimension
+        ):
+            raise MemoryBackendUnavailableError(MEMORY_BACKEND_UNAVAILABLE_REASON)
+        return [float(value) for value in embedding]
 
     def _current_embedding_dim(self) -> Optional[int]:
         """Return the vector dimension the store currently produces, or None.
@@ -225,6 +350,9 @@ class LanceDBMemoryStore(MemoryStore):
         None means no embedding model is available and the store operates in
         vector-less (text-search) mode.
         """
+        configured = self._configured_embedding_dimension()
+        if configured is not None:
+            return configured
         if not self._embedding_model:
             return None
         try:
@@ -303,13 +431,7 @@ class LanceDBMemoryStore(MemoryStore):
         columns[USER_ID_COLUMN] = user_ids
         columns[SCOPE_DIMS_COLUMN] = scope_dims
 
-        migrated = pa.table(columns)
-        metadata = dict(existing.schema.metadata or {})
-        if target_dim is None or self._vector_space_identity is None:
-            metadata.pop(_VECTOR_SPACE_METADATA_KEY, None)
-        else:
-            metadata[_VECTOR_SPACE_METADATA_KEY] = self._vector_space_identity.encode()
-        return migrated.replace_schema_metadata(metadata)
+        return pa.table(columns)
 
     def _derive_scope_arrays(self, metadata_column: Any) -> tuple[Any, Any]:
         """Derive the (user_id, scope_dims) Arrow columns from a metadata column.
@@ -345,74 +467,7 @@ class LanceDBMemoryStore(MemoryStore):
         user_ids, scope_dims = self._derive_scope_arrays(metadata_column)
         columns[USER_ID_COLUMN] = user_ids
         columns[SCOPE_DIMS_COLUMN] = scope_dims
-        return pa.table(columns).replace_schema_metadata(existing.schema.metadata)
-
-    def ensure_text_persistence(self) -> None:
-        """Remove stale vector state while retaining every persistent row."""
-        conn = self._vector_store.get_raw_connection()
-        table = conn.open_table(self._collection_name)
-        try:
-            schema = table.schema
-        finally:
-            _safe_close_table(table)
-        if "vector" in schema.names or _VECTOR_SPACE_METADATA_KEY in (
-            schema.metadata or {}
-        ):
-            migrate_table_swap(
-                conn,
-                self._collection_name,
-                lambda existing: self._build_migrated_table(existing, None),
-            )
-
-    def ensure_required_vector_search(self) -> None:
-        """Establish and verify the configured persistent vector space."""
-        if self._vector_space_identity is None:
-            raise MemoryBackendUnavailableError("required_memory_backend_unavailable")
-        target_dim = len(self._get_required_embedding("sample"))
-        try:
-            declared_dim = self._embedding_model.get_dimension()  # type: ignore[union-attr]
-        except Exception as exc:
-            raise MemoryBackendUnavailableError(
-                "required_memory_backend_unavailable"
-            ) from exc
-        if declared_dim and int(declared_dim) != target_dim:
-            raise MemoryBackendUnavailableError("required_memory_backend_unavailable")
-        conn = self._vector_store.get_raw_connection()
-        try:
-            table = conn.open_table(self._collection_name)
-            try:
-                schema = table.schema
-            finally:
-                _safe_close_table(table)
-            stored_identity = (schema.metadata or {}).get(_VECTOR_SPACE_METADATA_KEY)
-            mismatch = classify_memory_schema_mismatch(schema, target_dim)
-            if (
-                mismatch.kind is not MemoryMismatchKind.NONE
-                or stored_identity != self._vector_space_identity.encode()
-            ):
-                migrate_table_swap(
-                    conn,
-                    self._collection_name,
-                    lambda existing: self._build_migrated_table(existing, target_dim),
-                )
-            table = conn.open_table(self._collection_name)
-            try:
-                schema = table.schema
-                if (
-                    classify_memory_schema_mismatch(schema, target_dim).kind
-                    is not MemoryMismatchKind.NONE
-                    or (schema.metadata or {}).get(_VECTOR_SPACE_METADATA_KEY)
-                    != self._vector_space_identity.encode()
-                ):
-                    raise RuntimeError("vector schema verification failed")
-            finally:
-                _safe_close_table(table)
-        except MemoryBackendUnavailableError:
-            raise
-        except Exception as exc:
-            raise MemoryBackendUnavailableError(
-                "required_memory_backend_unavailable"
-            ) from exc
+        return pa.table(columns)
 
     def _ensure_scope_columns(self, conn: Any) -> None:
         """Promote user_id + scope_dims to real columns on an existing table (#822).
@@ -507,7 +562,7 @@ class LanceDBMemoryStore(MemoryStore):
         table.add([record])
 
     def _memory_note_to_dict(
-        self, note: MemoryNote, *, require_vector_search: bool = False
+        self, note: MemoryNote, *, require_vector: bool = False
     ) -> dict[str, Any]:
         """Convert MemoryNote to dictionary for storage."""
         # Get embedding for the content
@@ -516,7 +571,7 @@ class LanceDBMemoryStore(MemoryStore):
         )
         embedding = (
             self._get_required_embedding(content_text)
-            if require_vector_search
+            if require_vector
             else self._get_embedding(content_text)
         )
 
@@ -581,22 +636,21 @@ class LanceDBMemoryStore(MemoryStore):
 
     def add(self, note: MemoryNote) -> MemoryResponse:
         """Add a memory note to the store."""
-        return self._add(note, require_vector_search=False)
+        return self._add(note, require_vector=False)
 
     def add_required_vector(self, note: MemoryNote) -> MemoryResponse:
-        """Add a note without permitting embedding or storage fallback."""
-        return self._add(note, require_vector_search=True)
+        """Add only after a compatible embedding has been produced."""
 
-    def _add(self, note: MemoryNote, *, require_vector_search: bool) -> MemoryResponse:
+        return self._add(note, require_vector=True)
+
+    def _add(self, note: MemoryNote, *, require_vector: bool) -> MemoryResponse:
         try:
             # Generate ID if not provided
             if not note.id:
                 note.id = str(uuid4())
 
             # Convert to storage format
-            data = self._memory_note_to_dict(
-                note, require_vector_search=require_vector_search
-            )
+            data = self._memory_note_to_dict(note, require_vector=require_vector)
 
             # Add to vector store - use a consistent approach
             conn = self._vector_store.get_raw_connection()
@@ -616,10 +670,6 @@ class LanceDBMemoryStore(MemoryStore):
                 # Add vector if available
                 if data["vector"]:
                     record["vector"] = data["vector"]
-                elif require_vector_search:
-                    raise MemoryBackendUnavailableError(
-                        "required_memory_backend_unavailable"
-                    )
 
                 # Try to add the record. On a schema mismatch, migrate the
                 # existing table in place (preserving all rows) instead of
@@ -627,6 +677,8 @@ class LanceDBMemoryStore(MemoryStore):
                 try:
                     table.add([record])
                 except Exception as add_error:
+                    if require_vector or not self._allow_schema_migration:
+                        raise add_error
                     logger.warning(
                         f"add() failed on possible schema mismatch: {add_error}; "
                         "attempting safe in-place migration"
@@ -642,10 +694,6 @@ class LanceDBMemoryStore(MemoryStore):
                             "Safe schema migration failed; table left intact: %s",
                             migrate_error,
                         )
-                        if require_vector_search:
-                            raise MemoryBackendUnavailableError(
-                                "required_memory_backend_unavailable"
-                            ) from migrate_error
                         return MemoryResponse(
                             success=False,
                             error=f"Failed to add memory: {migrate_error}",
@@ -663,9 +711,9 @@ class LanceDBMemoryStore(MemoryStore):
             raise
         except Exception as e:
             logger.error(f"Failed to add memory note {note.id}: {e}")
-            if require_vector_search:
+            if require_vector:
                 raise MemoryBackendUnavailableError(
-                    "required_memory_backend_unavailable"
+                    MEMORY_BACKEND_UNAVAILABLE_REASON
                 ) from e
             return MemoryResponse(
                 success=False,
@@ -736,6 +784,42 @@ class LanceDBMemoryStore(MemoryStore):
                 error=f"Failed to update memory: {str(e)}",
                 memory_id=note.id,
             )
+
+    def update_required_vector(self, note: MemoryNote) -> MemoryResponse:
+        """Atomically replace a row after obtaining a valid embedding."""
+
+        get_response = self.get(note.id)
+        if not get_response.success:
+            if get_response.error != "Memory not found":
+                raise MemoryBackendUnavailableError(MEMORY_BACKEND_UNAVAILABLE_REASON)
+            return MemoryResponse(
+                success=False, error="Memory not found", memory_id=note.id
+            )
+
+        try:
+            data = self._memory_note_to_dict(note, require_vector=True)
+            record = {
+                "id": data["id"],
+                "text": data["text"],
+                "metadata": data["metadata"],
+                "vector": data["vector"],
+                USER_ID_COLUMN: data[USER_ID_COLUMN],
+                SCOPE_DIMS_COLUMN: data[SCOPE_DIMS_COLUMN],
+            }
+            table = self._vector_store.get_raw_connection().open_table(
+                self._collection_name
+            )
+            try:
+                (table.merge_insert("id").when_matched_update_all().execute([record]))
+            finally:
+                _safe_close_table(table)
+            return MemoryResponse(success=True, memory_id=note.id)
+        except MemoryBackendUnavailableError:
+            raise
+        except Exception as exc:
+            raise MemoryBackendUnavailableError(
+                MEMORY_BACKEND_UNAVAILABLE_REASON
+            ) from exc
 
     def delete(self, note_id: str) -> MemoryResponse:
         """Delete a memory note by its ID."""
@@ -825,8 +909,6 @@ class LanceDBMemoryStore(MemoryStore):
         k: int = 5,
         filters: Optional[dict[str, Any]] = None,
         similarity_threshold: Optional[float] = None,
-        *,
-        _require_vector_search: bool = False,
     ) -> list[MemoryNote]:
         """Search memory notes by query text with optional filters.
 
@@ -861,14 +943,11 @@ class LanceDBMemoryStore(MemoryStore):
 
             # Try vector search first
             try:
-                query_embedding = (
-                    self._get_required_embedding(query)
-                    if _require_vector_search
-                    else self._get_embedding(query)
-                )
+                query_embedding = self._get_embedding(query)
                 if query_embedding:
                     # Check if vector column exists and has the right dimension
-                    if "vector" in table.schema.names:
+                    sample_df = table.search().limit(1).to_pandas()
+                    if not sample_df.empty and "vector" in sample_df.columns:
                         # Try vector search
                         try:
                             vector_query = table.search(
@@ -932,10 +1011,6 @@ class LanceDBMemoryStore(MemoryStore):
 
                                 results.append(note)
                         except Exception as vector_error:
-                            if _require_vector_search:
-                                raise MemoryBackendUnavailableError(
-                                    "required_memory_backend_unavailable"
-                                ) from vector_error
                             if where_sql:
                                 # Distinguish a pushdown-specific failure: the
                                 # text fallback re-applies the full filters in
@@ -956,23 +1031,13 @@ class LanceDBMemoryStore(MemoryStore):
                                     "search: %s",
                                     vector_error,
                                 )
-                    elif _require_vector_search:
-                        raise MemoryBackendUnavailableError(
-                            "required_memory_backend_unavailable"
-                        )
-            except MemoryBackendUnavailableError:
-                raise
             except Exception as embedding_error:
-                if _require_vector_search:
-                    raise MemoryBackendUnavailableError(
-                        "required_memory_backend_unavailable"
-                    ) from embedding_error
                 logger.warning(
                     f"Embedding generation failed, using text search: {embedding_error}"
                 )
 
             # Fallback to text search if no vector results or vector search failed
-            if not results and not _require_vector_search:
+            if not results:
                 # Text search
                 df = table.search().to_pandas()
                 other_filters = self._flat_other_filters(filters)
@@ -1018,14 +1083,8 @@ class LanceDBMemoryStore(MemoryStore):
 
             return results[:k]
 
-        except MemoryBackendUnavailableError:
-            raise
         except Exception as e:
             logger.error(f"Failed to search memories with query '{query[:50]}...': {e}")
-            if _require_vector_search:
-                raise MemoryBackendUnavailableError(
-                    "required_memory_backend_unavailable"
-                ) from e
             return []
         finally:
             _safe_close_table(table)
@@ -1037,14 +1096,52 @@ class LanceDBMemoryStore(MemoryStore):
         filters: Optional[dict[str, Any]] = None,
         similarity_threshold: Optional[float] = None,
     ) -> list[MemoryNote]:
-        """Search without permitting embedding, schema, or ANN fallback."""
-        return self.search(
-            query,
-            k=k,
-            filters=filters,
-            similarity_threshold=similarity_threshold,
-            _require_vector_search=True,
-        )
+        """Search through the compatible vector column without text fallback."""
+
+        table = None
+        try:
+            query_embedding = self._get_required_embedding(query)
+            table = self._vector_store.get_raw_connection().open_table(
+                self._collection_name
+            )
+            if "vector" not in table.schema.names:
+                raise RuntimeError("memory table has no vector column")
+            where_sql, residual_filters = build_scope_where(filters)
+            residual_other_filters = self._flat_other_filters(residual_filters)
+            vector_query = table.search(query_embedding, vector_column_name="vector")
+            if where_sql:
+                vector_query = vector_query.where(where_sql, prefilter=True)
+            rows = vector_query.limit(k).to_pandas()
+            threshold = (
+                similarity_threshold
+                if similarity_threshold is not None
+                else self._similarity_threshold
+            )
+            results: list[MemoryNote] = []
+            for _, row in rows.iterrows():
+                if row.get("_distance", float("inf")) > threshold:
+                    continue
+                note = self._dict_to_memory_note(
+                    {
+                        "id": row.get("id", ""),
+                        "text": row.get("text", ""),
+                        "metadata": row.get("metadata", "{}"),
+                    }
+                )
+                if residual_filters and not self._matches_filters(
+                    note, residual_filters, residual_other_filters
+                ):
+                    continue
+                results.append(note)
+            return results
+        except MemoryBackendUnavailableError:
+            raise
+        except Exception as exc:
+            raise MemoryBackendUnavailableError(
+                MEMORY_BACKEND_UNAVAILABLE_REASON
+            ) from exc
+        finally:
+            _safe_close_table(table)
 
     def clear(self) -> None:
         """Clear all memory notes from the store."""

--- a/src/xagent/core/model/embedding/dashscope.py
+++ b/src/xagent/core/model/embedding/dashscope.py
@@ -101,8 +101,12 @@ class DashScopeEmbedding(BaseEmbedding):
                 "model": self.model,
                 "input": {"texts": batch_texts},
                 "output_type": "dense",
-                "parameters": {"dimension": dimension or self.dimension},
+                "parameters": {},
             }
+
+            final_dimension = dimension or self.dimension
+            if final_dimension is not None:
+                payload["parameters"]["dimension"] = final_dimension
 
             # Add instruction if provided
             final_instruct = instruct or self.instruct
@@ -134,7 +138,7 @@ class DashScopeEmbedding(BaseEmbedding):
 
     def get_dimension(self) -> Optional[int]:
         """Get the embedding dimension."""
-        return self.dimension
+        return self.dimension or 1024
 
     @property
     def abilities(self) -> List[str]:

--- a/src/xagent/providers/vector_store/lancedb.py
+++ b/src/xagent/providers/vector_store/lancedb.py
@@ -230,6 +230,7 @@ class LanceDBVectorStore(VectorStore):
         db_dir: str,
         collection_name: str = "vectors",
         connection_manager: Optional[LanceDBConnectionManager] = None,
+        initial_data: Optional[Any] = None,
     ):
         """
         Initialize LanceDB vector store.
@@ -243,9 +244,9 @@ class LanceDBVectorStore(VectorStore):
         self._collection_name = collection_name
         self._conn_manager = connection_manager or LanceDBConnectionManager()
         self._conn = self._conn_manager.get_connection(db_dir)
-        self._ensure_table()
+        self._ensure_table(initial_data)
 
-    def _ensure_table(self) -> None:
+    def _ensure_table(self, initial_data: Optional[Any] = None) -> None:
         """Ensure the vector table exists."""
         table = None
         try:
@@ -258,7 +259,7 @@ class LanceDBVectorStore(VectorStore):
             )
             # Table doesn't exist, create it with sample data
             # LanceDB needs actual data to properly infer vector column type
-            sample_data = [
+            sample_data = initial_data or [
                 {
                     "id": "sample",
                     "vector": [0.0, 0.0, 0.0],  # Sample vector
@@ -266,7 +267,12 @@ class LanceDBVectorStore(VectorStore):
                     "metadata": "{}",
                 }
             ]
-            table = self._conn.create_table(self._collection_name, data=sample_data)
+            try:
+                table = self._conn.create_table(self._collection_name, data=sample_data)
+            except Exception:
+                # Another constructor may have created the shared table after
+                # open_table() failed. Never overwrite that winner.
+                table = self._conn.open_table(self._collection_name)
             # Remove sample data
             table.delete("id = 'sample'")
         finally:

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -28,7 +28,7 @@ from ...core.execution_scope import (
     resolve_execution_scope_off_turn,
     scope_fingerprint,
 )
-from ...core.memory.base import MemoryStore
+from ...core.memory.base import MemoryBackendUnavailableError, MemoryStore
 from ...core.memory.in_memory import InMemoryMemoryStore
 from ...core.model.chat.basic.base import BaseLLM
 from ...core.model.chat.basic.deepseek import DeepSeekLLM
@@ -56,11 +56,7 @@ from ...core.tools.adapters.vibe.selection_spec import (
 from ...core.tools.core.knowledge_base_scope import KnowledgeBaseScopeError
 from ...sandbox import SandboxMountIntent
 from ..auth_dependencies import get_current_user
-from ..dynamic_memory_store import (
-    MEMORY_BACKEND_UNAVAILABLE_REASON,
-    MemoryBackendUnavailableError,
-    get_memory_store,
-)
+from ..dynamic_memory_store import get_memory_store
 from ..models.agent import Agent, AgentStatus, is_workforce_generated_manager_agent
 from ..models.chat_message import TaskChatMessage
 from ..models.database import (
@@ -358,7 +354,6 @@ def resolve_agent_service_memory_policy(
     use_in_memory = (is_preview and not enabled) or (
         override is not None and not override.available
     )
-    backend_unavailable = False
     memory: MemoryStore
     if use_in_memory:
         memory = InMemoryMemoryStore()
@@ -372,17 +367,9 @@ def resolve_agent_service_memory_policy(
             and (override.require_persistence or override.require_vector_search)
             else {}
         )
-        try:
-            memory = get_memory_store(**requirements)
-        except MemoryBackendUnavailableError:
-            memory = InMemoryMemoryStore()
-            enabled = False
-            backend_unavailable = True
+        memory = get_memory_store(**requirements)
     available = True if override is None else override.available
     availability_reason = None if override is None else override.reason
-    if backend_unavailable:
-        available = False
-        availability_reason = MEMORY_BACKEND_UNAVAILABLE_REASON
     return AgentServiceMemoryPolicy(
         memory=memory,
         memory_enabled=enabled,
@@ -2639,6 +2626,7 @@ class AgentServiceManager:
                             return self._agents[task_id]
                     except (
                         HTTPException,
+                        MemoryBackendUnavailableError,
                         TaskOwnerMismatchError,
                         _AgentRuntimeSessionBoundaryError,
                     ):
@@ -4034,10 +4022,11 @@ class AgentServiceManager:
                 if agent_config
                 else None
             )
-            memory_policy = await resolve_agent_service_memory_policy_async(
-                task=task,
-                agent_config=agent_config,
-            )
+            with UserContext(user_id):
+                memory_policy = await resolve_agent_service_memory_policy_async(
+                    task=task,
+                    agent_config=agent_config,
+                )
             allowed_external_dirs = _build_allowed_external_dirs(
                 user_id,
                 scope=scope,

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -358,15 +358,14 @@ def resolve_agent_service_memory_policy(
     if use_in_memory:
         memory = InMemoryMemoryStore()
     else:
-        requirements = (
-            {
-                "require_persistence": override.require_persistence,
-                "require_vector_search": override.require_vector_search,
-            }
-            if override is not None
-            and (override.require_persistence or override.require_vector_search)
-            else {}
-        )
+        requirements = {
+            "require_persistence": bool(
+                override is not None and override.require_persistence
+            ),
+            "require_vector_search": bool(
+                override is not None and override.require_vector_search
+            ),
+        }
         memory = get_memory_store(**requirements)
     available = True if override is None else override.available
     availability_reason = None if override is None else override.reason

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -56,7 +56,11 @@ from ...core.tools.adapters.vibe.selection_spec import (
 from ...core.tools.core.knowledge_base_scope import KnowledgeBaseScopeError
 from ...sandbox import SandboxMountIntent
 from ..auth_dependencies import get_current_user
-from ..dynamic_memory_store import get_memory_store
+from ..dynamic_memory_store import (
+    MEMORY_BACKEND_UNAVAILABLE_REASON,
+    MemoryBackendUnavailableError,
+    get_memory_store,
+)
 from ..models.agent import Agent, AgentStatus, is_workforce_generated_manager_agent
 from ..models.chat_message import TaskChatMessage
 from ..models.database import (
@@ -354,12 +358,35 @@ def resolve_agent_service_memory_policy(
     use_in_memory = (is_preview and not enabled) or (
         override is not None and not override.available
     )
-    memory = InMemoryMemoryStore() if use_in_memory else get_memory_store()
+    backend_unavailable = False
+    if use_in_memory:
+        memory = InMemoryMemoryStore()
+    else:
+        requirements = (
+            {
+                "require_persistence": override.require_persistence,
+                "require_vector_search": override.require_vector_search,
+            }
+            if override is not None
+            and (override.require_persistence or override.require_vector_search)
+            else {}
+        )
+        try:
+            memory = get_memory_store(**requirements)
+        except MemoryBackendUnavailableError:
+            memory = InMemoryMemoryStore()
+            enabled = False
+            backend_unavailable = True
+    available = True if override is None else override.available
+    availability_reason = None if override is None else override.reason
+    if backend_unavailable:
+        available = False
+        availability_reason = MEMORY_BACKEND_UNAVAILABLE_REASON
     return AgentServiceMemoryPolicy(
         memory=memory,
         memory_enabled=enabled,
-        memory_available=True if override is None else override.available,
-        memory_availability_reason=None if override is None else override.reason,
+        memory_available=available,
+        memory_availability_reason=availability_reason,
     )
 
 

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -359,6 +359,7 @@ def resolve_agent_service_memory_policy(
         override is not None and not override.available
     )
     backend_unavailable = False
+    memory: MemoryStore
     if use_in_memory:
         memory = InMemoryMemoryStore()
     else:

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -335,10 +335,12 @@ def _task_error_payload(
 def create_terminal_task_error_event(
     task_id: int,
     message: str,
+    *,
+    error_code: str | None = None,
 ) -> dict[str, Any]:
     """Shape an error event after the exact lease owner commits FAILED."""
 
-    return {
+    payload = {
         "type": "task_error",
         "message": message,
         "task_id": task_id,
@@ -349,6 +351,9 @@ def create_terminal_task_error_event(
         "error": message,
         "timestamp": datetime.now(timezone.utc).timestamp(),
     }
+    if error_code is not None:
+        payload["error_code"] = error_code
+    return payload
 
 
 def _client_message_id(value: Any) -> str | None:

--- a/src/xagent/web/dynamic_memory_store.py
+++ b/src/xagent/web/dynamic_memory_store.py
@@ -1,12 +1,16 @@
 """Dynamic memory store manager for web application."""
 
-import json
 import logging
 import os
 import threading
+from dataclasses import dataclass
+from enum import Enum, auto
 from typing import Optional, Union, cast
 
-from ..core.memory.base import MemoryBackendUnavailableError
+from ..core.memory.base import (
+    MEMORY_BACKEND_UNAVAILABLE_REASON,
+    MemoryBackendUnavailableError,
+)
 from ..core.memory.in_memory import InMemoryMemoryStore
 from ..core.memory.lancedb import LanceDBMemoryStore
 from ..core.model import EmbeddingModelConfig
@@ -15,13 +19,9 @@ from ..core.storage.manager import get_storage_root
 from .models.database import get_db
 from .models.model import Model as DBModel
 from .models.user import UserDefaultModel
-from .services.db_runtime import is_database_pool_timeout
 from .user_isolated_memory import UserIsolatedMemoryStore, current_user_id
 
 logger = logging.getLogger(__name__)
-
-MEMORY_BACKEND_UNAVAILABLE_REASON = "required_memory_backend_unavailable"
-
 
 # Type alias for our memory store types that includes user isolation
 MemoryStoreType = Union[
@@ -38,22 +38,27 @@ def _embedding_model_fingerprint(model: Optional[DBModel]) -> Optional[tuple]:
     """
     if model is None:
         return None
-    return (model.id, str(model.updated_at))
-
-
-def _embedding_vector_space_identity(model: DBModel) -> str:
-    """Stable identity of the vector space produced by a database model."""
-
-    return json.dumps(
-        {
-            "base_url": model.base_url,
-            "dimension": model.dimension,
-            "model": model.model_name,
-            "provider": str(model.model_provider).strip().lower(),
-        },
-        sort_keys=True,
-        separators=(",", ":"),
+    return (
+        model.id,
+        str(model.updated_at),
+        model.model_provider,
+        model.model_name,
+        model.base_url,
+        model.dimension,
     )
+
+
+class _ModelLookupStatus(Enum):
+    FOUND = auto()
+    NONE = auto()
+    FAILED = auto()
+
+
+@dataclass(frozen=True)
+class _ModelLookupResult:
+    status: _ModelLookupStatus
+    model: Optional[DBModel] = None
+    error: Optional[BaseException] = None
 
 
 class DynamicMemoryStoreManager:
@@ -69,13 +74,13 @@ class DynamicMemoryStoreManager:
         self._similarity_threshold = similarity_threshold
         self._memory_store: Optional[MemoryStoreType] = None
         self._lock = threading.RLock()
+        self._lookup_lock = threading.Lock()
         self._last_embedding_model_id: Optional[int] = None
         # (id, updated_at) of the embedding model the store was built with.
         # Comparing the full fingerprint (not just the id) makes API key or
         # endpoint rotation on the same model take effect without a restart.
         self._last_embedding_model_fingerprint: Optional[tuple] = None
         self._is_lancedb: bool = False
-        self._model_lookup_failed = False
 
         # Initialize with in-memory store (will be replaced with LanceDB when embedding model is configured)
         self._initialize_in_memory_store()
@@ -92,84 +97,66 @@ class DynamicMemoryStoreManager:
 
     def _get_embedding_model_from_db(self) -> Optional[DBModel]:
         """Get the current embedding model from database."""
+        db = next(get_db())
         try:
-            db = next(get_db())
-            try:
-                # Get current user ID from context
-                user_id = current_user_id.get()
+            user_id = current_user_id.get()
+            from .services.model_service import _is_model_visible_to_user
 
-                from .services.model_service import _is_model_visible_to_user
-
-                if user_id:
-                    # First, try to get user's default embedding model
-                    user_default = (
-                        db.query(UserDefaultModel)
+            if user_id:
+                user_default = (
+                    db.query(UserDefaultModel)
+                    .filter(
+                        UserDefaultModel.user_id == user_id,
+                        UserDefaultModel.config_type == "embedding",
+                    )
+                    .first()
+                )
+                if user_default:
+                    embedding_model = (
+                        db.query(DBModel)
                         .filter(
-                            UserDefaultModel.user_id == user_id,
-                            UserDefaultModel.config_type == "embedding",
+                            DBModel.id == user_default.model_id,
+                            DBModel.category == "embedding",
+                            DBModel.is_active,
                         )
                         .first()
                     )
-
-                    if user_default:
-                        # Get the actual model
-                        embedding_model = (
-                            db.query(DBModel)
-                            .filter(
-                                DBModel.id == user_default.model_id,
-                                DBModel.category == "embedding",
-                                DBModel.is_active,
-                            )
-                            .first()
-                        )
-                        if embedding_model:
-                            if not _is_model_visible_to_user(
-                                db, embedding_model.id, user_id
-                            ):
-                                logger.warning(
-                                    f"User default embedding model {user_default.model_id} is no longer visible"
-                                )
-                                # fall through to system fallback
-                            else:
-                                logger.info(
-                                    f"Found user's default embedding model: {embedding_model.model_id}"
-                                )
-                                return embedding_model
-                        else:
-                            logger.warning(
-                                f"User default embedding model {user_default.model_id} not found or inactive"
-                            )
-
-                # Fallback: look for first active embedding model visible to user
-                all_active_embeddings = (
-                    db.query(DBModel)
-                    .filter(
-                        DBModel.category == "embedding",
-                        DBModel.is_active,
-                    )
-                    .all()
-                )
-
-                for embedding_model in all_active_embeddings:
-                    if _is_model_visible_to_user(db, embedding_model.id, user_id):
-                        logger.info(
-                            f"Using visible active embedding model: {embedding_model.model_id}"
-                        )
+                    if embedding_model and _is_model_visible_to_user(
+                        db, embedding_model.id, user_id
+                    ):
                         return embedding_model
+                    logger.warning(
+                        "User default embedding model %s is unavailable",
+                        user_default.model_id,
+                    )
 
-                logger.info("No visible active embedding model found")
-                return None
-            finally:
-                db.close()
-        except Exception as e:
-            if is_database_pool_timeout(e):
-                raise
-            self._model_lookup_failed = True
-            logger.error(f"Error checking for embedding model: {e}")
+            all_active_embeddings = (
+                db.query(DBModel)
+                .filter(DBModel.category == "embedding", DBModel.is_active)
+                .all()
+            )
+            for embedding_model in all_active_embeddings:
+                if _is_model_visible_to_user(db, embedding_model.id, user_id):
+                    return embedding_model
             return None
+        finally:
+            db.close()
+
+    def _lookup_embedding_model(self) -> _ModelLookupResult:
+        try:
+            model = self._get_embedding_model_from_db()
+        except Exception as exc:
+            logger.error("Error checking for embedding model: %s", exc)
+            return _ModelLookupResult(_ModelLookupStatus.FAILED, error=exc)
+        if model is None:
+            return _ModelLookupResult(_ModelLookupStatus.NONE)
+        return _ModelLookupResult(_ModelLookupStatus.FOUND, model=model)
 
     def _create_lancedb_store(
-        self, embedding_model: Optional[DBModel]
+        self,
+        embedding_model: Optional[DBModel],
+        *,
+        allow_schema_migration: bool = False,
     ) -> UserIsolatedMemoryStore:
         """Create LanceDB store with the given embedding model."""
         # Check legacy location (project root) first for backward compatibility
@@ -188,7 +175,14 @@ class DynamicMemoryStoreManager:
             db_dir = str(new_dir)
 
         embedding_adapter = None
+        vector_space_identity = None
         if embedding_model is not None:
+            dimension = embedding_model.dimension
+            if (
+                dimension is None
+                and str(embedding_model.model_provider).lower().strip() == "dashscope"
+            ):
+                dimension = 1024
             embedding_adapter = create_embedding_adapter(
                 EmbeddingModelConfig(
                     id=str(embedding_model.model_id),
@@ -196,18 +190,21 @@ class DynamicMemoryStoreManager:
                     model_provider=embedding_model.model_provider,
                     api_key=str(embedding_model.api_key),
                     base_url=embedding_model.base_url,
-                    dimension=embedding_model.dimension,
+                    dimension=dimension,
                 )
             )
+            vector_space_identity = {
+                "provider": str(embedding_model.model_provider).lower().strip(),
+                "model": embedding_model.model_name,
+                "endpoint": embedding_model.base_url,
+                "dimension": dimension,
+            }
         lancedb_store = LanceDBMemoryStore(
             db_dir=db_dir,
             embedding_model=embedding_adapter,
-            vector_space_identity=(
-                _embedding_vector_space_identity(embedding_model)
-                if embedding_model is not None
-                else None
-            ),
             similarity_threshold=self._similarity_threshold or 1.5,
+            vector_space_identity=vector_space_identity,
+            allow_schema_migration=allow_schema_migration,
         )
         logger.info("Created LanceDB memory store")
         return UserIsolatedMemoryStore(lancedb_store)
@@ -217,108 +214,120 @@ class DynamicMemoryStoreManager:
         *,
         require_persistence: bool = False,
         require_vector_search: bool = False,
-    ) -> None:
+    ) -> MemoryStoreType:
         """Check if embedding model configuration has changed and update store accordingly."""
+        with self._lookup_lock:
+            return self._check_and_update_store_once(
+                require_persistence=require_persistence,
+                require_vector_search=require_vector_search,
+            )
+
+    def _check_and_update_store_once(
+        self,
+        *,
+        require_persistence: bool,
+        require_vector_search: bool,
+    ) -> MemoryStoreType:
+        lookup = self._lookup_embedding_model()
+
         with self._lock:
-            self._model_lookup_failed = False
-            try:
-                embedding_model = self._get_embedding_model_from_db()
-            except Exception as exc:
+            strict = require_persistence or require_vector_search
+            if lookup.status is _ModelLookupStatus.FAILED:
                 if require_vector_search:
                     raise MemoryBackendUnavailableError(
                         MEMORY_BACKEND_UNAVAILABLE_REASON
-                    ) from exc
-                if not require_persistence:
-                    raise
-                embedding_model = None
-            if require_vector_search and self._model_lookup_failed:
-                raise MemoryBackendUnavailableError(MEMORY_BACKEND_UNAVAILABLE_REASON)
-            current_model_id = (
-                cast(int, embedding_model.id) if embedding_model else None
-            )
+                    ) from lookup.error
+                if require_persistence and not self._is_lancedb:
+                    try:
+                        self._install_lancedb_store(None, None)
+                    except Exception as exc:
+                        raise MemoryBackendUnavailableError(
+                            MEMORY_BACKEND_UNAVAILABLE_REASON
+                        ) from exc
+                if require_persistence:
+                    self._require_persistence()
+                assert self._memory_store is not None
+                return self._memory_store
+
+            embedding_model = lookup.model
             current_fingerprint = _embedding_model_fingerprint(embedding_model)
-
-            # Check if we need to update the store
-            should_update = False
-
-            if embedding_model and (
-                not self._is_lancedb or self._last_embedding_model_fingerprint is None
-            ):
-                # We have an embedding model but using in-memory store
-                should_update = True
-                logger.info("Embedding model detected, upgrading to LanceDB store")
-            elif (
+            should_install = bool(
                 embedding_model
-                and self._is_lancedb
-                and current_fingerprint != self._last_embedding_model_fingerprint
-            ):
-                # Embedding model changed, or the same model was reconfigured
-                # (e.g. API key rotation) — rebuild so the new config is used.
-                should_update = True
-                logger.info(
-                    "Embedding model configuration changed, updating LanceDB store"
-                )
-            elif not embedding_model and self._is_lancedb and not require_persistence:
-                # No embedding model available but using LanceDB (shouldn't happen normally)
-                should_update = True
-                logger.info(
-                    "No embedding model available, falling back to in-memory store"
-                )
-
-            elif (
-                not embedding_model
-                and require_persistence
                 and (
                     not self._is_lancedb
-                    or self._last_embedding_model_fingerprint is not None
+                    or current_fingerprint != self._last_embedding_model_fingerprint
                 )
-            ):
-                should_update = True
-
-            if require_vector_search and embedding_model is None:
-                raise MemoryBackendUnavailableError(MEMORY_BACKEND_UNAVAILABLE_REASON)
-
-            if should_update:
-                if embedding_model or require_persistence:
-                    try:
-                        memory_store = self._create_lancedb_store(embedding_model)
-                    except Exception as exc:
-                        logger.exception("Error creating LanceDB memory store")
-                        if require_persistence or require_vector_search:
-                            raise MemoryBackendUnavailableError(
-                                MEMORY_BACKEND_UNAVAILABLE_REASON
-                            ) from exc
-                        self._initialize_in_memory_store()
-                        return
-                    self._memory_store = memory_store
-                    self._is_lancedb = True
-                    self._last_embedding_model_id = current_model_id
-                    self._last_embedding_model_fingerprint = current_fingerprint
-                    logger.info("Switched to LanceDB memory store")
-                else:
-                    self._initialize_in_memory_store()
-                    logger.info("Switched to in-memory memory store")
-
-            base_store = (
-                self._memory_store._base_store
-                if isinstance(self._memory_store, UserIsolatedMemoryStore)
-                else self._memory_store
             )
-            try:
-                if require_vector_search:
-                    if not isinstance(base_store, LanceDBMemoryStore):
-                        raise RuntimeError("LanceDB store is not available")
-                    base_store.ensure_required_vector_search()
-                elif require_persistence and embedding_model is None:
-                    if not isinstance(base_store, LanceDBMemoryStore):
-                        raise RuntimeError("LanceDB store is not available")
-                    base_store.ensure_text_persistence()
-            except MemoryBackendUnavailableError:
-                raise
-            except Exception as exc:
-                raise MemoryBackendUnavailableError(
-                    MEMORY_BACKEND_UNAVAILABLE_REASON
-                ) from exc
+            # An authoritative NONE clears a stale adapter while preserving a
+            # durable handle and all shared-table data.
+            should_clear_adapter = bool(
+                embedding_model is None
+                and self._is_lancedb
+                and self._last_embedding_model_fingerprint is not None
+            )
+            should_create_text_store = bool(
+                embedding_model is None and require_persistence and not self._is_lancedb
+            )
+
+            if should_install or should_clear_adapter or should_create_text_store:
+                try:
+                    self._install_lancedb_store(embedding_model, current_fingerprint)
+                except Exception as exc:
+                    logger.exception("Error creating LanceDB memory store")
+                    if strict:
+                        raise MemoryBackendUnavailableError(
+                            MEMORY_BACKEND_UNAVAILABLE_REASON
+                        ) from exc
+                    assert self._memory_store is not None
+                    return self._memory_store
+
+            if require_persistence:
+                self._require_persistence()
+            if require_vector_search:
+                if embedding_model is None:
+                    raise MemoryBackendUnavailableError(
+                        MEMORY_BACKEND_UNAVAILABLE_REASON
+                    )
+                self._require_vector_search()
+            assert self._memory_store is not None
+            return self._memory_store
+
+    def _install_lancedb_store(
+        self, embedding_model: Optional[DBModel], fingerprint: Optional[tuple]
+    ) -> None:
+        memory_store = self._create_lancedb_store(
+            embedding_model, allow_schema_migration=False
+        )
+        self._memory_store = memory_store
+        self._is_lancedb = True
+        self._last_embedding_model_id = (
+            cast(int, embedding_model.id) if embedding_model else None
+        )
+        self._last_embedding_model_fingerprint = fingerprint
+
+    def _require_persistence(self) -> None:
+        if self._memory_store is None:
+            raise MemoryBackendUnavailableError(MEMORY_BACKEND_UNAVAILABLE_REASON)
+        try:
+            self._memory_store.ensure_persistence()
+        except MemoryBackendUnavailableError:
+            raise
+        except Exception as exc:
+            raise MemoryBackendUnavailableError(
+                MEMORY_BACKEND_UNAVAILABLE_REASON
+            ) from exc
+
+    def _require_vector_search(self) -> None:
+        if self._memory_store is None:
+            raise MemoryBackendUnavailableError(MEMORY_BACKEND_UNAVAILABLE_REASON)
+        try:
+            self._memory_store.ensure_required_vector_search()
+        except MemoryBackendUnavailableError:
+            raise
+        except Exception as exc:
+            raise MemoryBackendUnavailableError(
+                MEMORY_BACKEND_UNAVAILABLE_REASON
+            ) from exc
 
     def get_memory_store(
         self,
@@ -332,26 +341,21 @@ class DynamicMemoryStoreManager:
         Returns:
             Current memory store instance
         """
-        with self._lock:
-            self._check_and_update_store(
-                require_persistence=require_persistence,
-                require_vector_search=require_vector_search,
+        store = self._check_and_update_store(
+            require_persistence=require_persistence,
+            require_vector_search=require_vector_search,
+        )
+        if require_vector_search and isinstance(store, UserIsolatedMemoryStore):
+            return UserIsolatedMemoryStore(
+                store._base_store, require_vector_search=True
             )
-            if require_vector_search:
-                base_store = (
-                    self._memory_store._base_store
-                    if isinstance(self._memory_store, UserIsolatedMemoryStore)
-                    else cast(MemoryStoreType, self._memory_store)
-                )
-                return UserIsolatedMemoryStore(base_store, require_vector_search=True)
-            return self._memory_store  # type: ignore[return-value]
+        return store  # type: ignore[return-value]
 
     def force_reinitialize(self) -> None:
         """Force reinitialization of the memory store."""
-        with self._lock:
-            self._initialize_in_memory_store()
-            self._check_and_update_store()
-            logger.info("Force reinitialized memory store")
+        self._initialize_in_memory_store()
+        self._check_and_update_store()
+        logger.info("Force reinitialized memory store")
 
     def check_embedding_model_change(self) -> bool:
         """Check if embedding model configuration has changed and update if necessary.
@@ -363,9 +367,9 @@ class DynamicMemoryStoreManager:
             old_is_lancedb = self._is_lancedb
             old_fingerprint = self._last_embedding_model_fingerprint
 
-            self._check_and_update_store()
+        self._check_and_update_store()
 
-            # Return true if anything changed
+        with self._lock:
             return (
                 old_is_lancedb != self._is_lancedb
                 or old_fingerprint != self._last_embedding_model_fingerprint
@@ -385,15 +389,21 @@ class DynamicMemoryStoreManager:
                 else self._memory_store
             )
 
+            supports_vector_search = False
+            if self._is_lancedb and base_store is not None:
+                try:
+                    base_store.ensure_required_vector_search()
+                except MemoryBackendUnavailableError:
+                    pass
+                else:
+                    supports_vector_search = True
+
             return {
                 "store_type": type(base_store).__name__,
                 "is_lancedb": self._is_lancedb,
                 "embedding_model_id": self._last_embedding_model_id,
                 "similarity_threshold": self._similarity_threshold,
-                "supports_vector_search": (
-                    self._is_lancedb
-                    and self._last_embedding_model_fingerprint is not None
-                ),
+                "supports_vector_search": supports_vector_search,
             }
 
 

--- a/src/xagent/web/dynamic_memory_store.py
+++ b/src/xagent/web/dynamic_memory_store.py
@@ -3,7 +3,7 @@
 import logging
 import os
 import threading
-from typing import Optional, Union
+from typing import Optional, Union, cast
 
 from ..core.memory.in_memory import InMemoryMemoryStore
 from ..core.memory.lancedb import LanceDBMemoryStore
@@ -214,7 +214,9 @@ class DynamicMemoryStoreManager:
                 raise
             if strict and self._model_lookup_failed:
                 raise MemoryBackendUnavailableError(MEMORY_BACKEND_UNAVAILABLE_REASON)
-            current_model_id = embedding_model.id if embedding_model else None
+            current_model_id = (
+                cast(int, embedding_model.id) if embedding_model else None
+            )
             current_fingerprint = _embedding_model_fingerprint(embedding_model)
 
             # Check if we need to update the store

--- a/src/xagent/web/dynamic_memory_store.py
+++ b/src/xagent/web/dynamic_memory_store.py
@@ -349,7 +349,7 @@ class DynamicMemoryStoreManager:
             return UserIsolatedMemoryStore(
                 store._base_store, require_vector_search=True
             )
-        return store  # type: ignore[return-value]
+        return store
 
     def force_reinitialize(self) -> None:
         """Force reinitialization of the memory store."""

--- a/src/xagent/web/dynamic_memory_store.py
+++ b/src/xagent/web/dynamic_memory_store.py
@@ -7,7 +7,8 @@ from typing import Optional, Union
 
 from ..core.memory.in_memory import InMemoryMemoryStore
 from ..core.memory.lancedb import LanceDBMemoryStore
-from ..core.model.embedding import DashScopeEmbedding
+from ..core.model import EmbeddingModelConfig
+from ..core.model.embedding import create_embedding_adapter
 from ..core.storage.manager import get_storage_root
 from .models.database import get_db
 from .models.model import Model as DBModel
@@ -16,6 +17,13 @@ from .services.db_runtime import is_database_pool_timeout
 from .user_isolated_memory import UserIsolatedMemoryStore, current_user_id
 
 logger = logging.getLogger(__name__)
+
+MEMORY_BACKEND_UNAVAILABLE_REASON = "required_memory_backend_unavailable"
+
+
+class MemoryBackendUnavailableError(RuntimeError):
+    """Raised when an opt-in memory backend capability cannot be provided."""
+
 
 # Type alias for our memory store types that includes user isolation
 MemoryStoreType = Union[
@@ -54,6 +62,7 @@ class DynamicMemoryStoreManager:
         # endpoint rotation on the same model take effect without a restart.
         self._last_embedding_model_fingerprint: Optional[tuple] = None
         self._is_lancedb: bool = False
+        self._model_lookup_failed = False
 
         # Initialize with in-memory store (will be replaced with LanceDB when embedding model is configured)
         self._initialize_in_memory_store()
@@ -142,65 +151,78 @@ class DynamicMemoryStoreManager:
         except Exception as e:
             if is_database_pool_timeout(e):
                 raise
+            self._model_lookup_failed = True
             logger.error(f"Error checking for embedding model: {e}")
             return None
 
     def _create_lancedb_store(
-        self, embedding_model: DBModel
+        self, embedding_model: Optional[DBModel]
     ) -> UserIsolatedMemoryStore:
         """Create LanceDB store with the given embedding model."""
-        try:
-            # Check legacy location (project root) first for backward compatibility
-            legacy_dir = os.path.join(
-                os.path.dirname(
-                    os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-                ),
-                "memory_store",
+        # Check legacy location (project root) first for backward compatibility
+        legacy_dir = os.path.join(
+            os.path.dirname(
+                os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+            ),
+            "memory_store",
+        )
+        if os.path.exists(legacy_dir) and os.listdir(legacy_dir):
+            logger.info(f"Using legacy memory store location: {legacy_dir}")
+            db_dir = legacy_dir
+        else:
+            new_dir = get_storage_root() / "memory_store"
+            os.makedirs(new_dir, exist_ok=True)
+            db_dir = str(new_dir)
+
+        embedding_adapter = None
+        if embedding_model is not None:
+            embedding_adapter = create_embedding_adapter(
+                EmbeddingModelConfig(
+                    id=str(embedding_model.model_id),
+                    model_name=embedding_model.model_name,
+                    model_provider=embedding_model.model_provider,
+                    api_key=str(embedding_model.api_key),
+                    base_url=embedding_model.base_url,
+                    dimension=embedding_model.dimension,
+                )
             )
-            if os.path.exists(legacy_dir) and os.listdir(legacy_dir):
-                logger.info(f"Using legacy memory store location: {legacy_dir}")
-                db_dir = legacy_dir
-            else:
-                # Use new default location
-                new_dir = get_storage_root() / "memory_store"
-                os.makedirs(new_dir, exist_ok=True)
-                db_dir = str(new_dir)
+        lancedb_store = LanceDBMemoryStore(
+            db_dir=db_dir,
+            embedding_model=embedding_adapter,
+            similarity_threshold=self._similarity_threshold or 1.5,
+        )
+        logger.info("Created LanceDB memory store")
+        return UserIsolatedMemoryStore(lancedb_store)
 
-            if embedding_model.model_provider == "dashscope":
-                lancedb_store = LanceDBMemoryStore(
-                    db_dir=db_dir,
-                    embedding_model=DashScopeEmbedding(
-                        api_key=str(embedding_model.api_key),
-                        dimension=int(embedding_model.dimension or 1024),
-                    ),
-                    similarity_threshold=self._similarity_threshold or 1.5,
-                )
-                logger.info("Created LanceDB store with DashScope embedding model")
-                return UserIsolatedMemoryStore(lancedb_store)
-            else:
-                # Fallback to in-memory if embedding type not supported
-                logger.warning(
-                    f"Unsupported embedding model type: {embedding_model.model_provider}"
-                )
-                self._initialize_in_memory_store()
-                return self._memory_store  # type: ignore[return-value]
-        except Exception as e:
-            logger.error(f"Error creating LanceDB store: {e}")
-            # Fallback to in-memory store
-            self._initialize_in_memory_store()
-            return self._memory_store  # type: ignore[return-value]
-
-    def _check_and_update_store(self) -> None:
+    def _check_and_update_store(
+        self,
+        *,
+        require_persistence: bool = False,
+        require_vector_search: bool = False,
+    ) -> None:
         """Check if embedding model configuration has changed and update store accordingly."""
         with self._lock:
-            embedding_model = self._get_embedding_model_from_db()
+            strict = require_persistence or require_vector_search
+            self._model_lookup_failed = False
+            try:
+                embedding_model = self._get_embedding_model_from_db()
+            except Exception as exc:
+                if strict:
+                    raise MemoryBackendUnavailableError(
+                        MEMORY_BACKEND_UNAVAILABLE_REASON
+                    ) from exc
+                raise
+            if strict and self._model_lookup_failed:
+                raise MemoryBackendUnavailableError(MEMORY_BACKEND_UNAVAILABLE_REASON)
             current_model_id = embedding_model.id if embedding_model else None
             current_fingerprint = _embedding_model_fingerprint(embedding_model)
 
             # Check if we need to update the store
             should_update = False
 
-            if embedding_model and not self._is_lancedb:
+            if embedding_model and (
+                not self._is_lancedb or self._last_embedding_model_fingerprint is None
+            ):
                 # We have an embedding model but using in-memory store
                 should_update = True
                 logger.info("Embedding model detected, upgrading to LanceDB store")
@@ -215,32 +237,56 @@ class DynamicMemoryStoreManager:
                 logger.info(
                     "Embedding model configuration changed, updating LanceDB store"
                 )
-            elif not embedding_model and self._is_lancedb:
+            elif not embedding_model and self._is_lancedb and not require_persistence:
                 # No embedding model available but using LanceDB (shouldn't happen normally)
                 should_update = True
                 logger.info(
                     "No embedding model available, falling back to in-memory store"
                 )
 
+            elif not embedding_model and require_persistence and not self._is_lancedb:
+                should_update = True
+
+            if require_vector_search and embedding_model is None:
+                raise MemoryBackendUnavailableError(MEMORY_BACKEND_UNAVAILABLE_REASON)
+
             if should_update:
-                if embedding_model:
-                    self._memory_store = self._create_lancedb_store(embedding_model)
+                if embedding_model or require_persistence:
+                    try:
+                        memory_store = self._create_lancedb_store(embedding_model)
+                    except Exception as exc:
+                        logger.exception("Error creating LanceDB memory store")
+                        self._initialize_in_memory_store()
+                        if strict:
+                            raise MemoryBackendUnavailableError(
+                                MEMORY_BACKEND_UNAVAILABLE_REASON
+                            ) from exc
+                        return
+                    self._memory_store = memory_store
                     self._is_lancedb = True
-                    self._last_embedding_model_id = current_model_id  # type: ignore[assignment]
+                    self._last_embedding_model_id = current_model_id
                     self._last_embedding_model_fingerprint = current_fingerprint
                     logger.info("Switched to LanceDB memory store")
                 else:
                     self._initialize_in_memory_store()
                     logger.info("Switched to in-memory memory store")
 
-    def get_memory_store(self) -> MemoryStoreType:
+    def get_memory_store(
+        self,
+        *,
+        require_persistence: bool = False,
+        require_vector_search: bool = False,
+    ) -> MemoryStoreType:
         """
         Get the current memory store, initializing or updating as necessary.
 
         Returns:
             Current memory store instance
         """
-        self._check_and_update_store()
+        self._check_and_update_store(
+            require_persistence=require_persistence,
+            require_vector_search=require_vector_search,
+        )
         return self._memory_store  # type: ignore[return-value]
 
     def force_reinitialize(self) -> None:
@@ -287,7 +333,10 @@ class DynamicMemoryStoreManager:
                 "is_lancedb": self._is_lancedb,
                 "embedding_model_id": self._last_embedding_model_id,
                 "similarity_threshold": self._similarity_threshold,
-                "supports_vector_search": self._is_lancedb,
+                "supports_vector_search": (
+                    self._is_lancedb
+                    and self._last_embedding_model_fingerprint is not None
+                ),
             }
 
 
@@ -310,10 +359,17 @@ def get_memory_store_manager(
     return _dynamic_manager
 
 
-def get_memory_store() -> MemoryStoreType:
+def get_memory_store(
+    *,
+    require_persistence: bool = False,
+    require_vector_search: bool = False,
+) -> MemoryStoreType:
     """Get the current memory store (for backward compatibility)."""
     manager = get_memory_store_manager()
-    return manager.get_memory_store()
+    return manager.get_memory_store(
+        require_persistence=require_persistence,
+        require_vector_search=require_vector_search,
+    )
 
 
 def force_reinitialize_memory_store() -> None:

--- a/src/xagent/web/dynamic_memory_store.py
+++ b/src/xagent/web/dynamic_memory_store.py
@@ -19,6 +19,7 @@ from ..core.storage.manager import get_storage_root
 from .models.database import get_db
 from .models.model import Model as DBModel
 from .models.user import UserDefaultModel
+from .services.db_runtime import is_database_pool_timeout
 from .user_isolated_memory import UserIsolatedMemoryStore, current_user_id
 
 logger = logging.getLogger(__name__)
@@ -146,6 +147,8 @@ class DynamicMemoryStoreManager:
         try:
             model = self._get_embedding_model_from_db()
         except Exception as exc:
+            if is_database_pool_timeout(exc):
+                raise
             logger.error("Error checking for embedding model: %s", exc)
             return _ModelLookupResult(_ModelLookupStatus.FAILED, error=exc)
         if model is None:

--- a/src/xagent/web/dynamic_memory_store.py
+++ b/src/xagent/web/dynamic_memory_store.py
@@ -1,10 +1,12 @@
 """Dynamic memory store manager for web application."""
 
+import json
 import logging
 import os
 import threading
 from typing import Optional, Union, cast
 
+from ..core.memory.base import MemoryBackendUnavailableError
 from ..core.memory.in_memory import InMemoryMemoryStore
 from ..core.memory.lancedb import LanceDBMemoryStore
 from ..core.model import EmbeddingModelConfig
@@ -19,10 +21,6 @@ from .user_isolated_memory import UserIsolatedMemoryStore, current_user_id
 logger = logging.getLogger(__name__)
 
 MEMORY_BACKEND_UNAVAILABLE_REASON = "required_memory_backend_unavailable"
-
-
-class MemoryBackendUnavailableError(RuntimeError):
-    """Raised when an opt-in memory backend capability cannot be provided."""
 
 
 # Type alias for our memory store types that includes user isolation
@@ -41,6 +39,21 @@ def _embedding_model_fingerprint(model: Optional[DBModel]) -> Optional[tuple]:
     if model is None:
         return None
     return (model.id, str(model.updated_at))
+
+
+def _embedding_vector_space_identity(model: DBModel) -> str:
+    """Stable identity of the vector space produced by a database model."""
+
+    return json.dumps(
+        {
+            "base_url": model.base_url,
+            "dimension": model.dimension,
+            "model": model.model_name,
+            "provider": str(model.model_provider).strip().lower(),
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
 
 
 class DynamicMemoryStoreManager:
@@ -189,6 +202,11 @@ class DynamicMemoryStoreManager:
         lancedb_store = LanceDBMemoryStore(
             db_dir=db_dir,
             embedding_model=embedding_adapter,
+            vector_space_identity=(
+                _embedding_vector_space_identity(embedding_model)
+                if embedding_model is not None
+                else None
+            ),
             similarity_threshold=self._similarity_threshold or 1.5,
         )
         logger.info("Created LanceDB memory store")
@@ -202,17 +220,18 @@ class DynamicMemoryStoreManager:
     ) -> None:
         """Check if embedding model configuration has changed and update store accordingly."""
         with self._lock:
-            strict = require_persistence or require_vector_search
             self._model_lookup_failed = False
             try:
                 embedding_model = self._get_embedding_model_from_db()
             except Exception as exc:
-                if strict:
+                if require_vector_search:
                     raise MemoryBackendUnavailableError(
                         MEMORY_BACKEND_UNAVAILABLE_REASON
                     ) from exc
-                raise
-            if strict and self._model_lookup_failed:
+                if not require_persistence:
+                    raise
+                embedding_model = None
+            if require_vector_search and self._model_lookup_failed:
                 raise MemoryBackendUnavailableError(MEMORY_BACKEND_UNAVAILABLE_REASON)
             current_model_id = (
                 cast(int, embedding_model.id) if embedding_model else None
@@ -246,7 +265,14 @@ class DynamicMemoryStoreManager:
                     "No embedding model available, falling back to in-memory store"
                 )
 
-            elif not embedding_model and require_persistence and not self._is_lancedb:
+            elif (
+                not embedding_model
+                and require_persistence
+                and (
+                    not self._is_lancedb
+                    or self._last_embedding_model_fingerprint is not None
+                )
+            ):
                 should_update = True
 
             if require_vector_search and embedding_model is None:
@@ -258,11 +284,11 @@ class DynamicMemoryStoreManager:
                         memory_store = self._create_lancedb_store(embedding_model)
                     except Exception as exc:
                         logger.exception("Error creating LanceDB memory store")
-                        self._initialize_in_memory_store()
-                        if strict:
+                        if require_persistence or require_vector_search:
                             raise MemoryBackendUnavailableError(
                                 MEMORY_BACKEND_UNAVAILABLE_REASON
                             ) from exc
+                        self._initialize_in_memory_store()
                         return
                     self._memory_store = memory_store
                     self._is_lancedb = True
@@ -272,6 +298,27 @@ class DynamicMemoryStoreManager:
                 else:
                     self._initialize_in_memory_store()
                     logger.info("Switched to in-memory memory store")
+
+            base_store = (
+                self._memory_store._base_store
+                if isinstance(self._memory_store, UserIsolatedMemoryStore)
+                else self._memory_store
+            )
+            try:
+                if require_vector_search:
+                    if not isinstance(base_store, LanceDBMemoryStore):
+                        raise RuntimeError("LanceDB store is not available")
+                    base_store.ensure_required_vector_search()
+                elif require_persistence and embedding_model is None:
+                    if not isinstance(base_store, LanceDBMemoryStore):
+                        raise RuntimeError("LanceDB store is not available")
+                    base_store.ensure_text_persistence()
+            except MemoryBackendUnavailableError:
+                raise
+            except Exception as exc:
+                raise MemoryBackendUnavailableError(
+                    MEMORY_BACKEND_UNAVAILABLE_REASON
+                ) from exc
 
     def get_memory_store(
         self,
@@ -285,11 +332,19 @@ class DynamicMemoryStoreManager:
         Returns:
             Current memory store instance
         """
-        self._check_and_update_store(
-            require_persistence=require_persistence,
-            require_vector_search=require_vector_search,
-        )
-        return self._memory_store  # type: ignore[return-value]
+        with self._lock:
+            self._check_and_update_store(
+                require_persistence=require_persistence,
+                require_vector_search=require_vector_search,
+            )
+            if require_vector_search:
+                base_store = (
+                    self._memory_store._base_store
+                    if isinstance(self._memory_store, UserIsolatedMemoryStore)
+                    else cast(MemoryStoreType, self._memory_store)
+                )
+                return UserIsolatedMemoryStore(base_store, require_vector_search=True)
+            return self._memory_store  # type: ignore[return-value]
 
     def force_reinitialize(self) -> None:
         """Force reinitialization of the memory store."""

--- a/src/xagent/web/services/client_error_messages.py
+++ b/src/xagent/web/services/client_error_messages.py
@@ -2,6 +2,7 @@
 
 from enum import StrEnum
 
+from ...core.memory.base import MemoryBackendUnavailableError
 from ...core.tools.adapters.vibe.config import RequiredMCPUnavailableError
 
 CLIENT_SAFE_VALIDATION_ERROR = "The message could not be processed. Please try again."
@@ -9,6 +10,9 @@ CLIENT_SAFE_VALIDATION_ERROR = "The message could not be processed. Please try a
 # Task audiences did not necessarily initiate the failing operation, so a
 # task-level failure uses neutral wording instead of the validation fallback.
 CLIENT_SAFE_TASK_FAILURE = "Task execution failed."
+CLIENT_SAFE_MEMORY_BACKEND_UNAVAILABLE = (
+    "Required memory is temporarily unavailable. Please try again later."
+)
 CLIENT_SAFE_GUIDANCE_IN_PROGRESS = (
     "A previous guidance message is still being applied. Please wait for it to finish."
 )
@@ -36,6 +40,7 @@ class ClientErrorCode(StrEnum):
     AUTHENTICATION_REQUIRED = "authentication_required"
     TASK_ACCESS_DENIED = "task_access_denied"
     INVALID_MESSAGE = "invalid_message"
+    MEMORY_BACKEND_UNAVAILABLE = "memory_backend_unavailable"
 
 
 def client_error_message(code: ClientErrorCode) -> str:
@@ -91,6 +96,9 @@ def client_error_message(code: ClientErrorCode) -> str:
         ),
         ClientErrorCode.TASK_ACCESS_DENIED: "You do not have access to this task.",
         ClientErrorCode.INVALID_MESSAGE: "The message format is invalid.",
+        ClientErrorCode.MEMORY_BACKEND_UNAVAILABLE: (
+            CLIENT_SAFE_MEMORY_BACKEND_UNAVAILABLE
+        ),
     }[code]
 
 
@@ -111,3 +119,11 @@ def required_mcp_unavailable_client_message(
     if message.strip():
         return message
     return fallback
+
+
+def memory_backend_unavailable_client_message(error: BaseException) -> str:
+    """Return only the fixed message for the typed capability failure."""
+
+    if not isinstance(error, MemoryBackendUnavailableError):
+        return CLIENT_SAFE_TASK_FAILURE
+    return CLIENT_SAFE_MEMORY_BACKEND_UNAVAILABLE

--- a/src/xagent/web/services/memory_policy.py
+++ b/src/xagent/web/services/memory_policy.py
@@ -29,6 +29,8 @@ class MemoryPolicyDecision:
     enabled: bool
     available: bool
     reason: str | None = None
+    require_persistence: bool = False
+    require_vector_search: bool = False
 
 
 MemoryPolicyResolver = Callable[[MemoryPolicyRequest], MemoryPolicyDecision]
@@ -74,6 +76,11 @@ def _validate_decision(decision: object) -> None:
         raise TypeError("memory policy resolver returned an invalid decision type")
     if type(decision.enabled) is not bool or type(decision.available) is not bool:
         raise TypeError("memory policy decision flags must be bool")
+    if (
+        type(decision.require_persistence) is not bool
+        or type(decision.require_vector_search) is not bool
+    ):
+        raise TypeError("memory backend requirement flags must be bool")
     if decision.enabled and not decision.available:
         raise ValueError("unavailable memory cannot be enabled")
     if decision.reason is not None and (

--- a/src/xagent/web/services/memory_policy.py
+++ b/src/xagent/web/services/memory_policy.py
@@ -83,6 +83,10 @@ def _validate_decision(decision: object) -> None:
         raise TypeError("memory backend requirement flags must be bool")
     if decision.enabled and not decision.available:
         raise ValueError("unavailable memory cannot be enabled")
+    if (decision.require_persistence or decision.require_vector_search) and not (
+        decision.enabled and decision.available
+    ):
+        raise ValueError("memory backend requirements need enabled, available memory")
     if decision.reason is not None and (
         not isinstance(decision.reason, str) or not decision.reason.strip()
     ):

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -58,6 +58,7 @@ from sqlalchemy.orm import Session
 
 from ...core.agent.context.execution import CLOCK_TIMEZONE_METADATA_KEY
 from ...core.execution_scope import resolve_execution_scope
+from ...core.memory.base import MemoryBackendUnavailableError
 from ...core.tools.adapters.vibe.config import RequiredMCPUnavailableError
 from ..models.task import Task, TaskStatus
 from .assistant_history_safety import (
@@ -73,6 +74,8 @@ from .chat_history_service import (
 )
 from .client_error_messages import (
     CLIENT_SAFE_TASK_FAILURE,
+    ClientErrorCode,
+    memory_backend_unavailable_client_message,
     required_mcp_unavailable_client_message,
 )
 from .db_runtime import (
@@ -1793,6 +1796,7 @@ def _schedule_bg(
         client_history_error_message: str | None = None
         client_history_message_type = TASK_FAILURE_MESSAGE_TYPE
         broadcast_error_message: str | None = None
+        broadcast_error_code: str | None = None
         defer_settlement_to_ttl_recovery = False
         skip_delivery_reconciliation = False
         # Positive evidence for finalize's delivery target: once
@@ -1943,10 +1947,24 @@ def _schedule_bg(
                         exc_info=True,
                     )
                 else:
+                    is_memory_backend_error = isinstance(
+                        setup_or_run_err, MemoryBackendUnavailableError
+                    )
                     is_public_safe_mcp_error = isinstance(
                         setup_or_run_err, RequiredMCPUnavailableError
                     )
-                    if is_public_safe_mcp_error:
+                    if is_memory_backend_error:
+                        settlement_error = (
+                            "setup/run error: MemoryBackendUnavailableError"
+                        )
+                        client_history_message_type = CLIENT_SAFE_FAILURE_MESSAGE_TYPE
+                        broadcast_error_message = (
+                            memory_backend_unavailable_client_message(setup_or_run_err)
+                        )
+                        broadcast_error_code = (
+                            ClientErrorCode.MEMORY_BACKEND_UNAVAILABLE.value
+                        )
+                    elif is_public_safe_mcp_error:
                         # This exception's string contract is deliberately
                         # public-safe. Preserve it exactly in the durable task
                         # and TriggerRun projections; adding the exception type
@@ -2033,6 +2051,7 @@ def _schedule_bg(
                                     create_terminal_task_error_event(
                                         task_id,
                                         broadcast_error_message,
+                                        error_code=broadcast_error_code,
                                     ),
                                     task_id,
                                 )

--- a/src/xagent/web/user_isolated_memory.py
+++ b/src/xagent/web/user_isolated_memory.py
@@ -1,7 +1,7 @@
 """User-isolated memory store for web application."""
 
 import contextvars
-from typing import Any, List, Optional
+from typing import Any, Callable, List, Optional, cast
 
 from xagent.core.execution_scope import (
     ExecutionScope,
@@ -167,7 +167,11 @@ class UserIsolatedMemoryStore(MemoryStore):
         note.metadata.update(memory_dimension_metadata(get_execution_scope()))
 
         if self._require_vector_search:
-            return self._base_store.add_required_vector(note)  # type: ignore[attr-defined]
+            strict_add = cast(
+                Callable[[MemoryNote], MemoryResponse],
+                getattr(self._base_store, "add_required_vector"),
+            )
+            return strict_add(note)
         return self._base_store.add(note)
 
     def get(self, note_id: str) -> MemoryResponse:

--- a/src/xagent/web/user_isolated_memory.py
+++ b/src/xagent/web/user_isolated_memory.py
@@ -1,7 +1,7 @@
 """User-isolated memory store for web application."""
 
 import contextvars
-from typing import Any, Callable, List, Optional, cast
+from typing import Any, List, Optional
 
 from xagent.core.execution_scope import (
     ExecutionScope,
@@ -9,7 +9,11 @@ from xagent.core.execution_scope import (
     memory_dimension_metadata,
     metadata_carries_scope_dimensions,
 )
-from xagent.core.memory.base import MemoryStore
+from xagent.core.memory.base import (
+    MEMORY_BACKEND_UNAVAILABLE_REASON,
+    MemoryBackendUnavailableError,
+    MemoryStore,
+)
 from xagent.core.memory.core import MemoryNote, MemoryResponse
 from xagent.core.memory.scope_columns import SCOPE_EXCLUSIVE_FILTER_KEY
 from xagent.core.user_context import current_user_id
@@ -167,12 +171,21 @@ class UserIsolatedMemoryStore(MemoryStore):
         note.metadata.update(memory_dimension_metadata(get_execution_scope()))
 
         if self._require_vector_search:
-            strict_add = cast(
-                Callable[[MemoryNote], MemoryResponse],
-                getattr(self._base_store, "add_required_vector"),
-            )
-            return strict_add(note)
+            return self._base_store.add_required_vector(note)
         return self._base_store.add(note)
+
+    def ensure_persistence(self) -> None:
+        self._base_store.ensure_persistence()
+
+    def ensure_required_vector_search(self) -> None:
+        self._base_store.ensure_required_vector_search()
+
+    def add_required_vector(self, note: MemoryNote) -> MemoryResponse:
+        user_id = self._get_current_user_id()
+        if user_id is not None:
+            note.metadata["user_id"] = user_id
+        note.metadata.update(memory_dimension_metadata(get_execution_scope()))
+        return self._base_store.add_required_vector(note)
 
     def get(self, note_id: str) -> MemoryResponse:
         """
@@ -215,13 +228,40 @@ class UserIsolatedMemoryStore(MemoryStore):
         if note.id and (user_id is not None or self._scope_gates_by_id_access()):
             existing_response = self.get(note.id)
             if not existing_response.success:
+                if self._require_vector_search and existing_response.error not in {
+                    "Memory not found",
+                    "Memory note not found or access denied",
+                }:
+                    raise MemoryBackendUnavailableError(
+                        MEMORY_BACKEND_UNAVAILABLE_REASON
+                    )
                 return existing_response
 
         # Add user ID to metadata if not present
         if user_id is not None and "user_id" not in note.metadata:
             note.metadata["user_id"] = user_id
 
+        if self._require_vector_search:
+            return self._base_store.update_required_vector(note)
         return self._base_store.update(note)
+
+    def update_required_vector(self, note: MemoryNote) -> MemoryResponse:
+        user_id = self._get_current_user_id()
+        if note.id and (user_id is not None or self._scope_gates_by_id_access()):
+            existing_response = self.get(note.id)
+            if not existing_response.success:
+                if existing_response.error not in {
+                    "Memory not found",
+                    "Memory note not found or access denied",
+                }:
+                    raise MemoryBackendUnavailableError(
+                        MEMORY_BACKEND_UNAVAILABLE_REASON
+                    )
+                return existing_response
+        if user_id is not None and "user_id" not in note.metadata:
+            note.metadata["user_id"] = user_id
+        note.metadata.update(memory_dimension_metadata(get_execution_scope()))
+        return self._base_store.update_required_vector(note)
 
     def delete(self, note_id: str) -> MemoryResponse:
         """
@@ -292,15 +332,29 @@ class UserIsolatedMemoryStore(MemoryStore):
         # the store (prefilter on the vector path), not post-filtered here.
         filtered_filters = self._add_user_filter(filters)
 
-        method = (
-            self._base_store.search_required_vector  # type: ignore[attr-defined]
+        search = (
+            self._base_store.search_required_vector
             if self._require_vector_search
             else self._base_store.search
         )
-        return method(
+        return search(
             query=query,
             k=k,
             filters=filtered_filters,
+            similarity_threshold=similarity_threshold,
+        )
+
+    def search_required_vector(
+        self,
+        query: str,
+        k: int = 5,
+        filters: Optional[dict[str, Any]] = None,
+        similarity_threshold: Optional[float] = None,
+    ) -> List[MemoryNote]:
+        return self._base_store.search_required_vector(
+            query=query,
+            k=k,
+            filters=self._add_user_filter(filters),
             similarity_threshold=similarity_threshold,
         )
 

--- a/src/xagent/web/user_isolated_memory.py
+++ b/src/xagent/web/user_isolated_memory.py
@@ -42,7 +42,9 @@ class UserIsolatedMemoryStore(MemoryStore):
     remains the only access-control key.
     """
 
-    def __init__(self, base_store: MemoryStore) -> None:
+    def __init__(
+        self, base_store: MemoryStore, *, require_vector_search: bool = False
+    ) -> None:
         """
         Initialize with a base memory store for actual storage.
 
@@ -50,6 +52,7 @@ class UserIsolatedMemoryStore(MemoryStore):
             base_store: The underlying memory store for storage operations
         """
         self._base_store = base_store
+        self._require_vector_search = require_vector_search
 
     def _get_current_user_id(self) -> Optional[int]:
         """Get the current user ID from context."""
@@ -163,6 +166,8 @@ class UserIsolatedMemoryStore(MemoryStore):
         # filter on them (no-op when unscoped or dimension-less).
         note.metadata.update(memory_dimension_metadata(get_execution_scope()))
 
+        if self._require_vector_search:
+            return self._base_store.add_required_vector(note)  # type: ignore[attr-defined]
         return self._base_store.add(note)
 
     def get(self, note_id: str) -> MemoryResponse:
@@ -283,7 +288,12 @@ class UserIsolatedMemoryStore(MemoryStore):
         # the store (prefilter on the vector path), not post-filtered here.
         filtered_filters = self._add_user_filter(filters)
 
-        return self._base_store.search(
+        method = (
+            self._base_store.search_required_vector  # type: ignore[attr-defined]
+            if self._require_vector_search
+            else self._base_store.search
+        )
+        return method(
             query=query,
             k=k,
             filters=filtered_filters,

--- a/tests/core/memory/test_required_vector_backend.py
+++ b/tests/core/memory/test_required_vector_backend.py
@@ -1,129 +1,235 @@
-from unittest.mock import Mock
+from __future__ import annotations
 
-import pandas as pd
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
 import pytest
 
 from xagent.core.memory.base import MemoryBackendUnavailableError
 from xagent.core.memory.core import MemoryNote
-from xagent.core.memory.lancedb import _VECTOR_SPACE_METADATA_KEY, LanceDBMemoryStore
-from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
+from xagent.core.memory.lancedb import LanceDBMemoryStore
+from xagent.core.model.embedding import BaseEmbedding
+from xagent.web.user_isolated_memory import UserContext, UserIsolatedMemoryStore
 
-from .conftest import ConstantEmbedding
 
+class RecordingEmbedding(BaseEmbedding):
+    def __init__(self, dimension: int = 8, *, fail: bool = False) -> None:
+        self.dimension = dimension
+        self.fail = fail
+        self.inputs: list[Any] = []
 
-class FailingEmbedding(ConstantEmbedding):
     def encode(self, text, dimension=None, instruct=None):
-        raise RuntimeError("embedding unavailable")
+        self.inputs.append(text)
+        if self.fail:
+            raise RuntimeError("embedding unavailable")
+        if isinstance(text, str):
+            return [0.1] * self.dimension
+        return [[0.1] * self.dimension for _ in text]
+
+    def get_dimension(self):
+        return self.dimension
+
+    @property
+    def abilities(self):
+        return ["embed"]
 
 
-def _store(tmp_path, embedding, identity):
+def _identity(
+    model: str = "embedding-a", dimension: int = 8, endpoint: str = "https://a"
+) -> dict[str, Any]:
+    return {
+        "provider": "test",
+        "model": model,
+        "endpoint": endpoint,
+        "dimension": dimension,
+    }
+
+
+def _store(tmp_path, embedding, identity=None):
     return LanceDBMemoryStore(
         db_dir=str(tmp_path),
-        collection_name="required",
+        collection_name="memories",
         embedding_model=embedding,
         vector_space_identity=identity,
+        allow_schema_migration=False,
     )
 
 
-def _schema(store):
-    table = store._vector_store.get_raw_connection().open_table("required")
-    try:
-        return table.schema
-    finally:
-        _safe_close_table(table)
-
-
-def test_strict_initialization_add_and_search_succeed(tmp_path) -> None:
-    store = _store(tmp_path, ConstantEmbedding(8), "provider/model/a")
+def test_strict_vector_success_uses_real_store(tmp_path) -> None:
+    embedding = RecordingEmbedding()
+    store = _store(tmp_path, embedding, _identity())
 
     store.ensure_required_vector_search()
-    added = store.add_required_vector(MemoryNote(content="alpha"))
+    added = store.add_required_vector(MemoryNote(id="one", content="alpha"))
+    results = store.search_required_vector("alpha")
 
     assert added.success
-    assert [note.content for note in store.search_required_vector("alpha")] == ["alpha"]
-    assert _schema(store).metadata[_VECTOR_SPACE_METADATA_KEY] == b"provider/model/a"
+    assert [note.id for note in results] == ["one"]
+    assert embedding.inputs == ["alpha", "alpha"]
 
 
-def test_strict_embedding_failure_does_not_use_text_fallback(tmp_path) -> None:
-    store = _store(tmp_path, FailingEmbedding(8), "provider/model/a")
-
-    with pytest.raises(MemoryBackendUnavailableError):
-        store.ensure_required_vector_search()
-    with pytest.raises(MemoryBackendUnavailableError):
-        store.add_required_vector(MemoryNote(content="alpha"))
-
-    assert store.add(MemoryNote(content="alpha")).success
-    assert [note.content for note in store.search("alpha")] == ["alpha"]
-
-
-def test_strict_search_rejects_missing_vector_column(tmp_path) -> None:
-    store = _store(tmp_path, ConstantEmbedding(8), "provider/model/a")
-    store.ensure_required_vector_search()
-    store.ensure_text_persistence()
-
-    with pytest.raises(MemoryBackendUnavailableError):
-        store.search_required_vector("alpha")
-
-
-def test_strict_ann_failure_raises_while_default_falls_back(tmp_path) -> None:
-    store = _store(tmp_path, ConstantEmbedding(8), "provider/model/a")
-    store.ensure_required_vector_search()
-    metadata = '{"content":"alpha","timestamp":"2026-01-01T00:00:00Z"}'
-    table = Mock()
-    table.schema = _schema(store)
-    vector_query = Mock()
-    vector_query.limit.return_value.to_pandas.side_effect = RuntimeError("ANN failed")
-    text_query = Mock()
-    text_query.to_pandas.return_value = pd.DataFrame(
-        [{"id": "a", "text": "alpha", "metadata": metadata}]
-    )
-    table.search.side_effect = lambda vector=None, **_kwargs: (
-        vector_query if vector is not None else text_query
-    )
-    connection = Mock()
-    connection.open_table.return_value = table
-    store._vector_store.get_raw_connection = Mock(return_value=connection)
-
-    with pytest.raises(MemoryBackendUnavailableError):
-        store.search_required_vector("alpha")
-    assert [note.content for note in store.search("alpha")] == ["alpha"]
-
-
-@pytest.mark.parametrize(
-    ("old_dim", "new_dim"),
-    [(8, 8), (8, 12)],
-    ids=("same-dimension-model-switch", "dimension-change"),
-)
-def test_vector_identity_change_reembeds_existing_rows_before_write(
-    tmp_path, old_dim, new_dim
+def test_admission_is_read_only_and_operation_embedding_failure_is_typed(
+    tmp_path,
 ) -> None:
-    first = _store(tmp_path, ConstantEmbedding(old_dim, 0.1), "provider/model/a")
-    first.ensure_required_vector_search()
-    added = first.add_required_vector(MemoryNote(content="alpha"))
-    assert added.success
+    initial = _store(tmp_path, RecordingEmbedding(), _identity())
+    assert initial.add_required_vector(MemoryNote(id="one", content="alpha")).success
+    failing = RecordingEmbedding(fail=True)
+    strict = _store(tmp_path, failing, _identity())
 
-    restarted = _store(tmp_path, ConstantEmbedding(new_dim, 0.9), "provider/model/b")
+    strict.ensure_required_vector_search()
+    assert failing.inputs == []
+    with pytest.raises(MemoryBackendUnavailableError):
+        strict.add_required_vector(MemoryNote(id="two", content="beta"))
+    with pytest.raises(MemoryBackendUnavailableError):
+        strict.search_required_vector("alpha")
+    assert strict.get("one").success
+
+
+def test_identity_mismatch_is_unavailable_but_ordinary_add_is_text_only(
+    tmp_path,
+) -> None:
+    first = _store(tmp_path, RecordingEmbedding(), _identity("model-a"))
+    assert first.add_required_vector(MemoryNote(id="old", content="old")).success
+    replacement_embedding = RecordingEmbedding()
+    replacement = _store(tmp_path, replacement_embedding, _identity("model-b"))
+
+    with pytest.raises(MemoryBackendUnavailableError):
+        replacement.ensure_required_vector_search()
+    assert replacement.add(MemoryNote(id="new", content="new")).success
+    assert replacement_embedding.inputs == []
+
+    table = replacement._vector_store.get_raw_connection().open_table("memories")
+    rows = {row["id"]: row["vector"] for row in table.to_arrow().to_pylist()}
+    assert rows["old"] is not None
+    assert rows["new"] is None
+    assert first.ensure_required_vector_search() is None
+
+
+def test_missing_vector_column_is_strictly_unavailable_but_text_still_works(
+    tmp_path,
+) -> None:
+    text_store = _store(tmp_path, None)
+    assert text_store.add(MemoryNote(id="old", content="old text")).success
+    strict = _store(tmp_path, RecordingEmbedding(), _identity())
+
+    with pytest.raises(MemoryBackendUnavailableError):
+        strict.ensure_required_vector_search()
+    with pytest.raises(MemoryBackendUnavailableError):
+        strict.search_required_vector("old")
+    assert [note.id for note in strict.search("old")] == ["old"]
+
+
+def test_strict_search_converts_terminal_ann_failure_to_typed_unavailable(
+    monkeypatch, tmp_path
+) -> None:
+    store = _store(tmp_path, RecordingEmbedding(), _identity())
+    assert store.add_required_vector(MemoryNote(id="one", content="old")).success
+    connection = store._vector_store.get_raw_connection()
+    table = connection.open_table("memories")
+    monkeypatch.setattr(connection, "open_table", lambda _name: table)
+    monkeypatch.setattr(
+        table,
+        "search",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RuntimeError("ANN failed")),
+    )
+
+    with pytest.raises(MemoryBackendUnavailableError):
+        store.search_required_vector("old")
+
+
+def test_dimension_change_before_first_new_write_is_read_only(tmp_path) -> None:
+    first = _store(tmp_path, RecordingEmbedding(8), _identity(dimension=8))
+    assert first.add_required_vector(MemoryNote(id="old", content="old")).success
+    changed = _store(
+        tmp_path,
+        RecordingEmbedding(16),
+        _identity(dimension=16),
+    )
+
+    with pytest.raises(MemoryBackendUnavailableError):
+        changed.ensure_required_vector_search()
+
+    table = first._vector_store.get_raw_connection().open_table("memories")
+    arrow = table.to_arrow()
+    assert arrow.column("id").to_pylist() == ["old"]
+    assert arrow.schema.field("vector").type.list_size == 8
+
+
+def test_populated_shared_table_admission_never_scans_or_migrates_tenants(
+    monkeypatch, tmp_path
+) -> None:
+    store = UserIsolatedMemoryStore(_store(tmp_path, RecordingEmbedding(), _identity()))
+    with UserContext(1):
+        assert store.add_required_vector(
+            MemoryNote(id="one", content="secret-a")
+        ).success
+    with UserContext(2):
+        assert store.add_required_vector(
+            MemoryNote(id="two", content="secret-b")
+        ).success
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("strict admission must not migrate or re-embed")
+
+    monkeypatch.setattr("xagent.core.memory.lancedb.migrate_table_swap", forbidden)
+    restarted_embedding = RecordingEmbedding()
+    restarted = _store(tmp_path, restarted_embedding, _identity())
     restarted.ensure_required_vector_search()
 
-    table = restarted._vector_store.get_raw_connection().open_table("required")
-    try:
-        arrow = table.to_arrow()
-    finally:
-        _safe_close_table(table)
-    assert arrow.num_rows == 1
-    assert arrow.column("vector").to_pylist() == [[pytest.approx(0.9)] * new_dim]
-    assert arrow.schema.metadata[_VECTOR_SPACE_METADATA_KEY] == b"provider/model/b"
-    assert restarted.get(added.memory_id).success
+    assert restarted_embedding.inputs == []
+    assert {note.id for note in restarted.list_all()} == {"one", "two"}
 
 
-def test_failed_identity_migration_preserves_old_rows_and_identity(tmp_path) -> None:
-    first = _store(tmp_path, ConstantEmbedding(8), "provider/model/a")
-    first.ensure_required_vector_search()
-    added = first.add_required_vector(MemoryNote(content="alpha"))
+def test_strict_update_failure_preserves_old_row(tmp_path) -> None:
+    initial = _store(tmp_path, RecordingEmbedding(), _identity())
+    assert initial.add_required_vector(MemoryNote(id="one", content="old")).success
+    failing = _store(tmp_path, RecordingEmbedding(fail=True), _identity())
 
-    failed = _store(tmp_path, FailingEmbedding(12), "provider/model/b")
     with pytest.raises(MemoryBackendUnavailableError):
-        failed.ensure_required_vector_search()
+        failing.update_required_vector(MemoryNote(id="one", content="new"))
 
-    assert first.get(added.memory_id).success
-    assert _schema(first).metadata[_VECTOR_SPACE_METADATA_KEY] == b"provider/model/a"
+    existing = initial.get("one")
+    assert existing.success
+    assert existing.content.content == "old"
+
+
+def test_strict_update_replaces_row_after_embedding_succeeds(tmp_path) -> None:
+    store = _store(tmp_path, RecordingEmbedding(), _identity())
+    assert store.add_required_vector(MemoryNote(id="one", content="old")).success
+
+    updated = store.update_required_vector(MemoryNote(id="one", content="new"))
+
+    assert updated.success
+    assert store.get("one").content.content == "new"
+
+
+def test_concurrent_read_only_admission_does_not_lose_writer(tmp_path) -> None:
+    store = _store(tmp_path, RecordingEmbedding(), _identity())
+
+    def admit() -> None:
+        for _ in range(20):
+            store.ensure_required_vector_search()
+
+    def write() -> None:
+        for index in range(20):
+            result = store.add_required_vector(
+                MemoryNote(id=f"row-{index}", content=f"text-{index}")
+            )
+            assert result.success
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        list(pool.map(lambda fn: fn(), (admit, write)))
+
+    assert {note.id for note in store.list_all()} == {
+        f"row-{index}" for index in range(20)
+    }
+
+
+def test_strict_wrapper_routes_add_search_and_update(tmp_path) -> None:
+    base = _store(tmp_path, RecordingEmbedding(), _identity())
+    strict = UserIsolatedMemoryStore(base, require_vector_search=True)
+
+    assert strict.add(MemoryNote(id="one", content="old")).success
+    assert strict.search("old")[0].id == "one"
+    assert strict.update(MemoryNote(id="one", content="new")).success
+    assert strict.get("one").content.content == "new"

--- a/tests/core/memory/test_required_vector_backend.py
+++ b/tests/core/memory/test_required_vector_backend.py
@@ -5,10 +5,7 @@ import pytest
 
 from xagent.core.memory.base import MemoryBackendUnavailableError
 from xagent.core.memory.core import MemoryNote
-from xagent.core.memory.lancedb import (
-    LanceDBMemoryStore,
-    _VECTOR_SPACE_METADATA_KEY,
-)
+from xagent.core.memory.lancedb import _VECTOR_SPACE_METADATA_KEY, LanceDBMemoryStore
 from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
 
 from .conftest import ConstantEmbedding

--- a/tests/core/memory/test_required_vector_backend.py
+++ b/tests/core/memory/test_required_vector_backend.py
@@ -1,0 +1,132 @@
+from unittest.mock import Mock
+
+import pandas as pd
+import pytest
+
+from xagent.core.memory.base import MemoryBackendUnavailableError
+from xagent.core.memory.core import MemoryNote
+from xagent.core.memory.lancedb import (
+    LanceDBMemoryStore,
+    _VECTOR_SPACE_METADATA_KEY,
+)
+from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
+
+from .conftest import ConstantEmbedding
+
+
+class FailingEmbedding(ConstantEmbedding):
+    def encode(self, text, dimension=None, instruct=None):
+        raise RuntimeError("embedding unavailable")
+
+
+def _store(tmp_path, embedding, identity):
+    return LanceDBMemoryStore(
+        db_dir=str(tmp_path),
+        collection_name="required",
+        embedding_model=embedding,
+        vector_space_identity=identity,
+    )
+
+
+def _schema(store):
+    table = store._vector_store.get_raw_connection().open_table("required")
+    try:
+        return table.schema
+    finally:
+        _safe_close_table(table)
+
+
+def test_strict_initialization_add_and_search_succeed(tmp_path) -> None:
+    store = _store(tmp_path, ConstantEmbedding(8), "provider/model/a")
+
+    store.ensure_required_vector_search()
+    added = store.add_required_vector(MemoryNote(content="alpha"))
+
+    assert added.success
+    assert [note.content for note in store.search_required_vector("alpha")] == ["alpha"]
+    assert _schema(store).metadata[_VECTOR_SPACE_METADATA_KEY] == b"provider/model/a"
+
+
+def test_strict_embedding_failure_does_not_use_text_fallback(tmp_path) -> None:
+    store = _store(tmp_path, FailingEmbedding(8), "provider/model/a")
+
+    with pytest.raises(MemoryBackendUnavailableError):
+        store.ensure_required_vector_search()
+    with pytest.raises(MemoryBackendUnavailableError):
+        store.add_required_vector(MemoryNote(content="alpha"))
+
+    assert store.add(MemoryNote(content="alpha")).success
+    assert [note.content for note in store.search("alpha")] == ["alpha"]
+
+
+def test_strict_search_rejects_missing_vector_column(tmp_path) -> None:
+    store = _store(tmp_path, ConstantEmbedding(8), "provider/model/a")
+    store.ensure_required_vector_search()
+    store.ensure_text_persistence()
+
+    with pytest.raises(MemoryBackendUnavailableError):
+        store.search_required_vector("alpha")
+
+
+def test_strict_ann_failure_raises_while_default_falls_back(tmp_path) -> None:
+    store = _store(tmp_path, ConstantEmbedding(8), "provider/model/a")
+    store.ensure_required_vector_search()
+    metadata = '{"content":"alpha","timestamp":"2026-01-01T00:00:00Z"}'
+    table = Mock()
+    table.schema = _schema(store)
+    vector_query = Mock()
+    vector_query.limit.return_value.to_pandas.side_effect = RuntimeError("ANN failed")
+    text_query = Mock()
+    text_query.to_pandas.return_value = pd.DataFrame(
+        [{"id": "a", "text": "alpha", "metadata": metadata}]
+    )
+    table.search.side_effect = lambda vector=None, **_kwargs: (
+        vector_query if vector is not None else text_query
+    )
+    connection = Mock()
+    connection.open_table.return_value = table
+    store._vector_store.get_raw_connection = Mock(return_value=connection)
+
+    with pytest.raises(MemoryBackendUnavailableError):
+        store.search_required_vector("alpha")
+    assert [note.content for note in store.search("alpha")] == ["alpha"]
+
+
+@pytest.mark.parametrize(
+    ("old_dim", "new_dim"),
+    [(8, 8), (8, 12)],
+    ids=("same-dimension-model-switch", "dimension-change"),
+)
+def test_vector_identity_change_reembeds_existing_rows_before_write(
+    tmp_path, old_dim, new_dim
+) -> None:
+    first = _store(tmp_path, ConstantEmbedding(old_dim, 0.1), "provider/model/a")
+    first.ensure_required_vector_search()
+    added = first.add_required_vector(MemoryNote(content="alpha"))
+    assert added.success
+
+    restarted = _store(tmp_path, ConstantEmbedding(new_dim, 0.9), "provider/model/b")
+    restarted.ensure_required_vector_search()
+
+    table = restarted._vector_store.get_raw_connection().open_table("required")
+    try:
+        arrow = table.to_arrow()
+    finally:
+        _safe_close_table(table)
+    assert arrow.num_rows == 1
+    assert arrow.column("vector").to_pylist() == [[pytest.approx(0.9)] * new_dim]
+    assert arrow.schema.metadata[_VECTOR_SPACE_METADATA_KEY] == b"provider/model/b"
+    assert restarted.get(added.memory_id).success
+
+
+def test_failed_identity_migration_preserves_old_rows_and_identity(tmp_path) -> None:
+    first = _store(tmp_path, ConstantEmbedding(8), "provider/model/a")
+    first.ensure_required_vector_search()
+    added = first.add_required_vector(MemoryNote(content="alpha"))
+
+    failed = _store(tmp_path, FailingEmbedding(12), "provider/model/b")
+    with pytest.raises(MemoryBackendUnavailableError):
+        failed.ensure_required_vector_search()
+
+    assert first.get(added.memory_id).success
+    assert _schema(first).metadata[_VECTOR_SPACE_METADATA_KEY] == b"provider/model/a"

--- a/tests/core/model/embedding/test_dashscope.py
+++ b/tests/core/model/embedding/test_dashscope.py
@@ -83,6 +83,21 @@ class TestDashScopeEmbedding(BaseEmbeddingTest):
                 call_args[1]["json"]["parameters"]["instruct"] == "Override instruction"
             )
 
+    def test_omitted_dimension_uses_service_default(self):
+        from unittest.mock import Mock, patch
+
+        with patch("requests.Session.post") as mock_post:
+            response = Mock()
+            response.raise_for_status.return_value = None
+            response.json.return_value = self.get_mock_response([[0.1] * 1024])
+            mock_post.return_value = response
+
+            client = DashScopeEmbedding(api_key="test_key")
+            client.encode("Hello")
+
+        assert "dimension" not in mock_post.call_args.kwargs["json"]["parameters"]
+        assert client.get_dimension() == 1024
+
 
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/web/api/test_get_agent_for_task_reconstruct_precheck.py
+++ b/tests/web/api/test_get_agent_for_task_reconstruct_precheck.py
@@ -41,6 +41,7 @@ from xagent.core.tools.adapters.vibe.config import (
     RequiredMCPUnavailableError,
 )
 from xagent.web.api.chat import AgentServiceManager
+from xagent.web.dynamic_memory_store import MemoryBackendUnavailableError
 from xagent.web.models.agent import Agent, AgentStatus
 from xagent.web.models.task import DAGExecution, Task, TaskStatus, TraceEvent
 from xagent.web.models.user import User
@@ -51,6 +52,7 @@ from xagent.web.services.task_setup_snapshot import (
     TaskSetupSnapshot,
     _TaskFields,
 )
+from xagent.web.user_isolated_memory import current_user_id
 
 
 def _make_user() -> User:
@@ -148,6 +150,45 @@ def _build_snapshot(
 
 class _Fake:
     """Sentinel used to select trace- or DAG-backed snapshot history."""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("owner_id", [1, 2])
+async def test_reconstruction_resolves_required_memory_as_owner(owner_id) -> None:
+    manager = AgentServiceManager()
+    user = _make_user()
+    user.id = owner_id
+    task = _make_task(TaskStatus.RUNNING)
+    task.user_id = owner_id
+    snapshot = _build_snapshot(task, user, trace_event=_Fake())
+
+    async def required_memory(*_args, **_kwargs):
+        assert current_user_id.get() == owner_id
+        raise MemoryBackendUnavailableError("required_memory_backend_unavailable")
+
+    with (
+        patch.object(
+            manager, "_build_tools_for_task", new=AsyncMock(return_value=([], {}))
+        ),
+        patch("xagent.web.api.chat.create_task_tracer", return_value=MagicMock()),
+        patch("xagent.web.api.chat._build_workforce_system_prompt", return_value=None),
+        patch("xagent.web.api.agents.enhance_system_prompt_with_kb", return_value=None),
+        patch("xagent.web.api.agents.apply_user_voice", return_value=None),
+        patch("xagent.web.api.agents.voice_from_runtime_user", return_value=None),
+        patch(
+            "xagent.web.api.chat.resolve_agent_service_memory_policy_async",
+            side_effect=required_memory,
+        ),
+        patch("xagent.web.api.chat.AgentService") as agent_service,
+    ):
+        with pytest.raises(MemoryBackendUnavailableError):
+            await manager._reconstruct_agent_from_history(
+                task_id=42,
+                db=None,
+                task_setup_snapshot=snapshot,
+            )
+
+    agent_service.assert_not_called()
 
 
 def _build_db(
@@ -339,6 +380,32 @@ async def test_running_with_prior_trace_event_runs_reconstruct() -> None:
         mcp_runtime_authorization_policy=None,
     )
     snapshot_loader.assert_called_once_with(42, None)
+
+
+@pytest.mark.asyncio
+async def test_reconstruction_required_memory_failure_does_not_fallback() -> None:
+    manager = AgentServiceManager()
+    user = _make_user()
+    task = _make_task(TaskStatus.RUNNING, agent_id=7)
+    snapshot = _build_snapshot(task, user, trace_event=_Fake())
+    reconstruct = AsyncMock(
+        side_effect=MemoryBackendUnavailableError("required_memory_backend_unavailable")
+    )
+
+    with (
+        patch.object(manager, "_reconstruct_agent_from_history", reconstruct),
+        patch(
+            "xagent.web.api.chat.load_task_setup_snapshot_sync", return_value=snapshot
+        ),
+    ):
+        with pytest.raises(MemoryBackendUnavailableError):
+            await manager.get_agent_for_task(
+                task_id=42,
+                db=_build_db(task, user=user),
+                user=user,
+            )
+
+    reconstruct.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_memory_policy.py
+++ b/tests/web/services/test_memory_policy.py
@@ -68,7 +68,10 @@ def test_default_memory_policy_is_unchanged_without_resolver(
         get_memory_store.assert_not_called()
     else:
         assert policy.memory is dynamic_store
-        get_memory_store.assert_called_once_with()
+        get_memory_store.assert_called_once_with(
+            require_persistence=False,
+            require_vector_search=False,
+        )
 
 
 def test_trusted_resolver_can_enable_preview_memory(
@@ -137,7 +140,7 @@ def test_trusted_resolver_forwards_backend_requirements_independently(
     )
 
 
-def test_required_backend_failure_propagates_to_task_setup(
+def test_required_backend_failure_propagates_to_setup_failure_channel(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -155,27 +158,6 @@ def test_required_backend_failure_propagates_to_task_setup(
 
     with pytest.raises(MemoryBackendUnavailableError):
         chat_api.resolve_agent_service_memory_policy(task=_task())
-
-
-@pytest.mark.asyncio
-async def test_required_backend_failure_propagates_through_async_setup(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(
-        chat_api,
-        "get_memory_store",
-        Mock(side_effect=MemoryBackendUnavailableError("unavailable")),
-    )
-    set_trusted_memory_policy_resolver(
-        lambda _request: MemoryPolicyDecision(
-            enabled=True,
-            available=True,
-            require_vector_search=True,
-        )
-    )
-
-    with pytest.raises(MemoryBackendUnavailableError):
-        await chat_api.resolve_agent_service_memory_policy_async(task=_task())
 
 
 def test_trusted_resolver_can_disable_otherwise_enabled_memory(
@@ -251,6 +233,17 @@ def test_resolver_exception_fails_closed_for_preview() -> None:
             available=True,
             require_persistence=1,  # type: ignore[arg-type]
         ),
+        MemoryPolicyDecision(
+            enabled=False,
+            available=True,
+            require_persistence=True,
+        ),
+        MemoryPolicyDecision(
+            enabled=False,
+            available=False,
+            reason="unavailable",
+            require_vector_search=True,
+        ),
     ],
     ids=(
         "wrong-type",
@@ -259,6 +252,8 @@ def test_resolver_exception_fails_closed_for_preview() -> None:
         "empty-reason",
         "non-bool-flag",
         "non-bool-requirement",
+        "disabled-with-requirement",
+        "unavailable-with-requirement",
     ),
 )
 def test_invalid_resolver_decision_fails_closed(

--- a/tests/web/services/test_memory_policy.py
+++ b/tests/web/services/test_memory_policy.py
@@ -9,10 +9,7 @@ import pytest
 
 from xagent.core.memory.in_memory import InMemoryMemoryStore
 from xagent.web.api import chat as chat_api
-from xagent.web.dynamic_memory_store import (
-    MEMORY_BACKEND_UNAVAILABLE_REASON,
-    MemoryBackendUnavailableError,
-)
+from xagent.web.dynamic_memory_store import MemoryBackendUnavailableError
 from xagent.web.services.memory_policy import (
     MEMORY_POLICY_RESOLVER_FAILURE_REASON,
     MemoryPolicyDecision,
@@ -140,7 +137,7 @@ def test_trusted_resolver_forwards_backend_requirements_independently(
     )
 
 
-def test_required_backend_failure_is_reported_and_fails_closed(
+def test_required_backend_failure_propagates_to_task_setup(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
@@ -156,12 +153,29 @@ def test_required_backend_failure_is_reported_and_fails_closed(
         )
     )
 
-    policy = chat_api.resolve_agent_service_memory_policy(task=_task())
+    with pytest.raises(MemoryBackendUnavailableError):
+        chat_api.resolve_agent_service_memory_policy(task=_task())
 
-    assert isinstance(policy.memory, InMemoryMemoryStore)
-    assert policy.memory_enabled is False
-    assert policy.memory_available is False
-    assert policy.memory_availability_reason == MEMORY_BACKEND_UNAVAILABLE_REASON
+
+@pytest.mark.asyncio
+async def test_required_backend_failure_propagates_through_async_setup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        chat_api,
+        "get_memory_store",
+        Mock(side_effect=MemoryBackendUnavailableError("unavailable")),
+    )
+    set_trusted_memory_policy_resolver(
+        lambda _request: MemoryPolicyDecision(
+            enabled=True,
+            available=True,
+            require_vector_search=True,
+        )
+    )
+
+    with pytest.raises(MemoryBackendUnavailableError):
+        await chat_api.resolve_agent_service_memory_policy_async(task=_task())
 
 
 def test_trusted_resolver_can_disable_otherwise_enabled_memory(

--- a/tests/web/services/test_memory_policy.py
+++ b/tests/web/services/test_memory_policy.py
@@ -9,6 +9,10 @@ import pytest
 
 from xagent.core.memory.in_memory import InMemoryMemoryStore
 from xagent.web.api import chat as chat_api
+from xagent.web.dynamic_memory_store import (
+    MEMORY_BACKEND_UNAVAILABLE_REASON,
+    MemoryBackendUnavailableError,
+)
 from xagent.web.services.memory_policy import (
     MEMORY_POLICY_RESOLVER_FAILURE_REASON,
     MemoryPolicyDecision,
@@ -104,6 +108,62 @@ def test_trusted_resolver_can_enable_preview_memory(
     )
 
 
+@pytest.mark.parametrize(
+    ("require_persistence", "require_vector_search"),
+    [(True, False), (False, True), (True, True)],
+    ids=("persistence", "vector-search", "both"),
+)
+def test_trusted_resolver_forwards_backend_requirements_independently(
+    monkeypatch: pytest.MonkeyPatch,
+    require_persistence: bool,
+    require_vector_search: bool,
+) -> None:
+    dynamic_store = Mock(name="dynamic-memory-store")
+    get_memory_store = Mock(return_value=dynamic_store)
+    monkeypatch.setattr(chat_api, "get_memory_store", get_memory_store)
+    set_trusted_memory_policy_resolver(
+        lambda _request: MemoryPolicyDecision(
+            enabled=True,
+            available=True,
+            require_persistence=require_persistence,
+            require_vector_search=require_vector_search,
+        )
+    )
+
+    policy = chat_api.resolve_agent_service_memory_policy(task=_task())
+
+    assert policy.memory is dynamic_store
+    assert policy.memory_enabled is True
+    get_memory_store.assert_called_once_with(
+        require_persistence=require_persistence,
+        require_vector_search=require_vector_search,
+    )
+
+
+def test_required_backend_failure_is_reported_and_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        chat_api,
+        "get_memory_store",
+        Mock(side_effect=MemoryBackendUnavailableError("unavailable")),
+    )
+    set_trusted_memory_policy_resolver(
+        lambda _request: MemoryPolicyDecision(
+            enabled=True,
+            available=True,
+            require_persistence=True,
+        )
+    )
+
+    policy = chat_api.resolve_agent_service_memory_policy(task=_task())
+
+    assert isinstance(policy.memory, InMemoryMemoryStore)
+    assert policy.memory_enabled is False
+    assert policy.memory_available is False
+    assert policy.memory_availability_reason == MEMORY_BACKEND_UNAVAILABLE_REASON
+
+
 def test_trusted_resolver_can_disable_otherwise_enabled_memory(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -172,6 +232,11 @@ def test_resolver_exception_fails_closed_for_preview() -> None:
         MemoryPolicyDecision(enabled=False, available=False),
         MemoryPolicyDecision(enabled=True, available=True, reason=""),
         MemoryPolicyDecision(enabled=1, available=True),  # type: ignore[arg-type]
+        MemoryPolicyDecision(
+            enabled=True,
+            available=True,
+            require_persistence=1,  # type: ignore[arg-type]
+        ),
     ],
     ids=(
         "wrong-type",
@@ -179,6 +244,7 @@ def test_resolver_exception_fails_closed_for_preview() -> None:
         "unavailable-without-reason",
         "empty-reason",
         "non-bool-flag",
+        "non-bool-requirement",
     ),
 )
 def test_invalid_resolver_decision_fails_closed(

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -38,6 +38,7 @@ from tests.web.pool_contention_shared import (
     wait_for_ticks,
 )
 from xagent.core.agent.checkpoint import CHECKPOINT_TYPE
+from xagent.core.memory.base import MemoryBackendUnavailableError
 from xagent.core.tools.adapters.vibe.config import RequiredMCPUnavailableError
 from xagent.core.tools.adapters.vibe.connector_runtime import ConnectorRef
 from xagent.web.models import database as database_module
@@ -3086,6 +3087,68 @@ async def test_schedule_bg_preserves_public_safe_required_mcp_failure(
     event = broadcast.await_args.args[0]
     assert event["message"] == public_message
     assert event["error"] == public_message
+
+
+@pytest.mark.asyncio
+async def test_schedule_bg_sanitizes_memory_backend_failure(db_session) -> None:
+    from xagent.web.api.websocket import background_task_manager
+    from xagent.web.api.websocket import manager as ws_manager
+
+    user = _create_user(db_session)
+    task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
+    task.runner_id = "test-runner"
+    task.run_id = "run-a"
+    db_session.commit()
+    lease = TaskLease(task_id=int(task.id), runner_id="test-runner", run_id="run-a")
+
+    with (
+        patch(
+            "xagent.web.services.task_orchestrator.acquire_task_lease_isolated",
+            return_value=lease,
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.run_task_lease_heartbeat",
+            new=AsyncMock(),
+        ),
+        patch(
+            "xagent.web.services.task_orchestrator.load_task_setup_snapshot_sync",
+            side_effect=MemoryBackendUnavailableError("provider token=secret"),
+        ),
+        patch.object(background_task_manager, "register_task"),
+        patch.object(ws_manager, "broadcast_to_task", new=AsyncMock()) as broadcast,
+        patch(
+            "xagent.web.services.task_orchestrator._get_agent_manager",
+            return_value=MagicMock(),
+        ),
+    ):
+        await _schedule_bg(
+            task_id=int(task.id),
+            task_owner_user_id=int(user.id),
+            task_source=task.source,
+            payload=TaskTurnPayload("hello"),
+            force_fresh=False,
+            context=None,
+        )
+
+    db_session.expire_all()
+    persisted = db_session.get(Task, int(task.id))
+    assert persisted is not None
+    assert persisted.error_message == "setup/run error: MemoryBackendUnavailableError"
+    assert "secret" not in persisted.error_message
+    assistant = (
+        db_session.query(TaskChatMessage)
+        .filter(
+            TaskChatMessage.task_id == task.id,
+            TaskChatMessage.role == "assistant",
+        )
+        .one()
+    )
+    safe_message = "Required memory is temporarily unavailable. Please try again later."
+    assert assistant.content == safe_message
+    event = broadcast.await_args.args[0]
+    assert event["message"] == safe_message
+    assert event["error_code"] == "memory_backend_unavailable"
+    assert "secret" not in repr(event)
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_agent_manager_reconstruction.py
+++ b/tests/web/test_agent_manager_reconstruction.py
@@ -8,6 +8,7 @@ import pytest
 
 from xagent.core.tools.adapters.vibe.config import MCPFailurePolicy
 from xagent.web.api.chat import AgentServiceManager
+from xagent.web.user_isolated_memory import current_user_id
 from xagent.web.models.task import (
     DAGExecution,
     DAGExecutionPhase,
@@ -832,6 +833,55 @@ class TestAgentServiceManagerReconstruction:
         _, agent_kwargs = mock_agent_service_class.call_args
         assert agent_kwargs["tools"] == ["tool"]
         assert agent_kwargs["tool_config"] == "tool_config"
+
+    @pytest.mark.asyncio
+    async def test_reconstruction_resolves_memory_as_authoritative_owner(
+        self,
+        agent_manager,
+        mock_user,
+        sample_task,
+        sample_trace_events,
+        sample_dag_execution,
+    ):
+        runtime_llm = MagicMock(model_name="task-qwen")
+        snapshot = _build_reconstruction_snapshot(
+            sample_task,
+            mock_user,
+            trace_events=sample_trace_events,
+            dag_execution=sample_dag_execution,
+            task_llm=runtime_llm,
+        )
+        seen_users = []
+
+        async def resolve_memory(**_kwargs):
+            seen_users.append(current_user_id.get())
+            return MagicMock(
+                memory=MagicMock(),
+                memory_enabled=True,
+                memory_available=True,
+                memory_availability_reason=None,
+            )
+
+        with (
+            patch(
+                "xagent.web.api.chat.create_default_tools",
+                new=AsyncMock(return_value=([], {})),
+            ),
+            patch(
+                "xagent.web.api.chat.resolve_agent_service_memory_policy_async",
+                new=resolve_memory,
+            ),
+            patch("xagent.web.sandbox_manager.get_sandbox_manager", return_value=None),
+            patch("xagent.web.api.chat.AgentService") as agent_service,
+        ):
+            agent_service.return_value.reconstruct_from_history = AsyncMock()
+            await agent_manager._reconstruct_agent_from_history(
+                int(sample_task.id),
+                None,
+                task_setup_snapshot=snapshot,
+            )
+
+        assert seen_users == [int(sample_task.user_id)]
 
     @pytest.mark.asyncio
     async def test_reconstruct_agent_from_history_uses_shared_runtime_config(

--- a/tests/web/test_agent_manager_reconstruction.py
+++ b/tests/web/test_agent_manager_reconstruction.py
@@ -8,7 +8,6 @@ import pytest
 
 from xagent.core.tools.adapters.vibe.config import MCPFailurePolicy
 from xagent.web.api.chat import AgentServiceManager
-from xagent.web.user_isolated_memory import current_user_id
 from xagent.web.models.task import (
     DAGExecution,
     DAGExecutionPhase,
@@ -23,6 +22,7 @@ from xagent.web.services.task_setup_snapshot import (
     TaskSetupSnapshot,
     _TaskFields,
 )
+from xagent.web.user_isolated_memory import current_user_id
 
 
 def _build_reconstruction_snapshot(

--- a/tests/web/test_client_error_messages.py
+++ b/tests/web/test_client_error_messages.py
@@ -1,10 +1,13 @@
+from xagent.core.memory.base import MemoryBackendUnavailableError
 from xagent.core.tools.adapters.vibe.config import RequiredMCPUnavailableError
 from xagent.web.services.client_error_messages import (
     CLIENT_SAFE_GUIDANCE_IN_PROGRESS,
+    CLIENT_SAFE_MEMORY_BACKEND_UNAVAILABLE,
     CLIENT_SAFE_TASK_FAILURE,
     CLIENT_SAFE_VALIDATION_ERROR,
     ClientErrorCode,
     client_error_message,
+    memory_backend_unavailable_client_message,
     required_mcp_unavailable_client_message,
 )
 
@@ -71,6 +74,9 @@ def test_client_error_codes_have_fixed_safe_fallbacks() -> None:
         "authentication_required": "Authentication is required to send this message.",
         "task_access_denied": "You do not have access to this task.",
         "invalid_message": "The message format is invalid.",
+        "memory_backend_unavailable": (
+            "Required memory is temporarily unavailable. Please try again later."
+        ),
     }
 
 
@@ -88,5 +94,25 @@ def test_required_mcp_adapter_rejects_incidental_exceptions() -> None:
             error,
             fallback=CLIENT_SAFE_TASK_FAILURE,
         )
+        == CLIENT_SAFE_TASK_FAILURE
+    )
+
+
+def test_memory_backend_error_uses_stable_sanitized_message() -> None:
+    error = MemoryBackendUnavailableError("provider token=secret")
+
+    assert (
+        memory_backend_unavailable_client_message(error)
+        == CLIENT_SAFE_MEMORY_BACKEND_UNAVAILABLE
+    )
+    assert (
+        client_error_message(ClientErrorCode.MEMORY_BACKEND_UNAVAILABLE)
+        == CLIENT_SAFE_MEMORY_BACKEND_UNAVAILABLE
+    )
+
+
+def test_memory_backend_adapter_rejects_incidental_exception() -> None:
+    assert (
+        memory_backend_unavailable_client_message(RuntimeError("secret"))
         == CLIENT_SAFE_TASK_FAILURE
     )

--- a/tests/web/test_dynamic_memory_store.py
+++ b/tests/web/test_dynamic_memory_store.py
@@ -12,8 +12,11 @@ from xagent.web.dynamic_memory_store import (
     DynamicMemoryStoreManager,
     MemoryBackendUnavailableError,
 )
-from xagent.web.user_isolated_memory import UserIsolatedMemoryStore
-from xagent.web.user_isolated_memory import UserContext, current_user_id
+from xagent.web.user_isolated_memory import (
+    UserContext,
+    UserIsolatedMemoryStore,
+    current_user_id,
+)
 
 
 class FakeLanceStore:

--- a/tests/web/test_dynamic_memory_store.py
+++ b/tests/web/test_dynamic_memory_store.py
@@ -18,6 +18,14 @@ from xagent.web.user_isolated_memory import UserIsolatedMemoryStore
 class FakeLanceStore:
     def __init__(self, model: Any) -> None:
         self.model = model
+        self.vector_checks = 0
+        self.text_checks = 0
+
+    def ensure_required_vector_search(self) -> None:
+        self.vector_checks += 1
+
+    def ensure_text_persistence(self) -> None:
+        self.text_checks += 1
 
 
 def _manager_with_fake_db(monkeypatch, model_holder: dict) -> DynamicMemoryStoreManager:
@@ -30,6 +38,7 @@ def _manager_with_fake_db(monkeypatch, model_holder: dict) -> DynamicMemoryStore
         "_create_lancedb_store",
         lambda model: FakeLanceStore(model),
     )
+    monkeypatch.setattr(memory_store_module, "LanceDBMemoryStore", FakeLanceStore)
     return manager
 
 
@@ -91,6 +100,7 @@ def test_persistence_can_be_required_without_vector_search(monkeypatch) -> None:
     persistent_store = FakeLanceStore(None)
     create_store = Mock(return_value=persistent_store)
     monkeypatch.setattr(manager, "_create_lancedb_store", create_store)
+    monkeypatch.setattr(memory_store_module, "LanceDBMemoryStore", FakeLanceStore)
 
     assert manager.get_memory_store(require_persistence=True) is persistent_store
     create_store.assert_called_once_with(None)
@@ -114,8 +124,9 @@ def test_vector_search_requirement_succeeds_with_embedding_model(monkeypatch) ->
 
     store = manager.get_memory_store(require_vector_search=True)
 
-    assert isinstance(store, FakeLanceStore)
-    assert store.model is model
+    assert isinstance(store, UserIsolatedMemoryStore)
+    assert store._base_store.model is model
+    assert store._base_store.vector_checks == 1
     assert manager.get_store_info()["supports_vector_search"] is True
 
 
@@ -140,7 +151,7 @@ def test_strict_creation_failure_is_reported_but_default_falls_back(
     assert isinstance(store._base_store, InMemoryMemoryStore)
 
 
-def test_strict_model_lookup_exception_fails_closed(monkeypatch) -> None:
+def test_persistence_ignores_optional_model_lookup_failure(monkeypatch) -> None:
     manager = DynamicMemoryStoreManager()
     monkeypatch.setattr(
         manager,
@@ -148,12 +159,17 @@ def test_strict_model_lookup_exception_fails_closed(monkeypatch) -> None:
         Mock(side_effect=RuntimeError("model store down")),
     )
 
-    with pytest.raises(MemoryBackendUnavailableError) as exc_info:
-        manager.get_memory_store(require_persistence=True)
-    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    persistent_store = FakeLanceStore(None)
+    monkeypatch.setattr(
+        manager, "_create_lancedb_store", lambda _model: persistent_store
+    )
+    monkeypatch.setattr(memory_store_module, "LanceDBMemoryStore", FakeLanceStore)
+
+    assert manager.get_memory_store(require_persistence=True) is persistent_store
+    assert persistent_store.text_checks == 1
 
 
-def test_swallowed_model_database_failure_still_fails_closed_in_strict_mode(
+def test_swallowed_model_database_failure_allows_persistence_only(
     monkeypatch,
 ) -> None:
     manager = DynamicMemoryStoreManager()
@@ -164,8 +180,53 @@ def test_swallowed_model_database_failure_still_fails_closed_in_strict_mode(
 
     monkeypatch.setattr(memory_store_module, "get_db", broken_db)
 
-    with pytest.raises(MemoryBackendUnavailableError):
-        manager.get_memory_store(require_persistence=True)
+    persistent_store = FakeLanceStore(None)
+    monkeypatch.setattr(
+        manager, "_create_lancedb_store", lambda _model: persistent_store
+    )
+    monkeypatch.setattr(memory_store_module, "LanceDBMemoryStore", FakeLanceStore)
+
+    assert manager.get_memory_store(require_persistence=True) is persistent_store
+
+
+def test_persistence_clears_stale_model_after_same_user_removal(monkeypatch) -> None:
+    holder = {"model": _model(2, "2026-07-17 10:00:00", "key")}
+    manager = _manager_with_fake_db(monkeypatch, holder)
+    first = manager.get_memory_store(require_vector_search=True)._base_store
+
+    holder["model"] = None
+    second = manager.get_memory_store(require_persistence=True)
+
+    assert second is not first
+    assert second.model is None
+    assert second.text_checks == 1
+    assert manager.get_store_info()["supports_vector_search"] is False
+
+
+def test_persistence_clears_stale_model_across_users(monkeypatch) -> None:
+    models = {1: _model(2, "2026-07-17 10:00:00", "key"), 2: None}
+    manager = DynamicMemoryStoreManager()
+    monkeypatch.setattr(
+        manager,
+        "_get_embedding_model_from_db",
+        lambda: models[memory_store_module.current_user_id.get()],
+    )
+    monkeypatch.setattr(manager, "_create_lancedb_store", FakeLanceStore)
+    monkeypatch.setattr(memory_store_module, "LanceDBMemoryStore", FakeLanceStore)
+
+    token = memory_store_module.current_user_id.set(1)
+    try:
+        first = manager.get_memory_store(require_vector_search=True)._base_store
+    finally:
+        memory_store_module.current_user_id.reset(token)
+    token = memory_store_module.current_user_id.set(2)
+    try:
+        second = manager.get_memory_store(require_persistence=True)
+    finally:
+        memory_store_module.current_user_id.reset(token)
+
+    assert second is not first
+    assert second.model is None
 
 
 def test_database_embedding_configuration_is_propagated(monkeypatch, tmp_path) -> None:
@@ -187,5 +248,10 @@ def test_database_embedding_configuration_is_propagated(monkeypatch, tmp_path) -
     assert config.api_key == "secret"
     assert config.base_url == "https://embedding.example/v1"
     assert config.dimension == 1024
+    identity = lancedb_store.call_args.kwargs["vector_space_identity"]
+    assert '"base_url":"https://embedding.example/v1"' in identity
+    assert '"dimension":1024' in identity
+    assert '"model":"text-embedding-v4"' in identity
+    assert '"provider":"dashscope"' in identity
     assert isinstance(wrapped, UserIsolatedMemoryStore)
     assert wrapped._base_store is lancedb_store.return_value

--- a/tests/web/test_dynamic_memory_store.py
+++ b/tests/web/test_dynamic_memory_store.py
@@ -13,19 +13,19 @@ from xagent.web.dynamic_memory_store import (
     MemoryBackendUnavailableError,
 )
 from xagent.web.user_isolated_memory import UserIsolatedMemoryStore
+from xagent.web.user_isolated_memory import UserContext, current_user_id
 
 
 class FakeLanceStore:
     def __init__(self, model: Any) -> None:
         self.model = model
-        self.vector_checks = 0
-        self.text_checks = 0
+
+    def ensure_persistence(self) -> None:
+        return None
 
     def ensure_required_vector_search(self) -> None:
-        self.vector_checks += 1
-
-    def ensure_text_persistence(self) -> None:
-        self.text_checks += 1
+        if self.model is None:
+            raise MemoryBackendUnavailableError("missing vector model")
 
 
 def _manager_with_fake_db(monkeypatch, model_holder: dict) -> DynamicMemoryStoreManager:
@@ -36,9 +36,8 @@ def _manager_with_fake_db(monkeypatch, model_holder: dict) -> DynamicMemoryStore
     monkeypatch.setattr(
         manager,
         "_create_lancedb_store",
-        lambda model: FakeLanceStore(model),
+        lambda model, **_kwargs: FakeLanceStore(model),
     )
-    monkeypatch.setattr(memory_store_module, "LanceDBMemoryStore", FakeLanceStore)
     return manager
 
 
@@ -81,15 +80,15 @@ def test_unchanged_model_keeps_store_instance(monkeypatch) -> None:
     assert manager.get_memory_store() is first
 
 
-def test_embedding_configuration_read_happens_under_lock(monkeypatch) -> None:
+def test_embedding_configuration_read_happens_outside_lock(monkeypatch) -> None:
     holder = {"model": _model(2, "2026-07-17 10:00:00", "key")}
     manager = _manager_with_fake_db(monkeypatch, holder)
 
-    def get_model_under_lock() -> Any:
-        assert manager._lock._is_owned()  # type: ignore[attr-defined]
+    def get_model_without_lock() -> Any:
+        assert not manager._lock._is_owned()  # type: ignore[attr-defined]
         return holder["model"]
 
-    monkeypatch.setattr(manager, "_get_embedding_model_from_db", get_model_under_lock)
+    monkeypatch.setattr(manager, "_get_embedding_model_from_db", get_model_without_lock)
 
     assert isinstance(manager.get_memory_store(), FakeLanceStore)
 
@@ -100,10 +99,9 @@ def test_persistence_can_be_required_without_vector_search(monkeypatch) -> None:
     persistent_store = FakeLanceStore(None)
     create_store = Mock(return_value=persistent_store)
     monkeypatch.setattr(manager, "_create_lancedb_store", create_store)
-    monkeypatch.setattr(memory_store_module, "LanceDBMemoryStore", FakeLanceStore)
 
     assert manager.get_memory_store(require_persistence=True) is persistent_store
-    create_store.assert_called_once_with(None)
+    create_store.assert_called_once_with(None, allow_schema_migration=False)
     assert manager.get_store_info()["supports_vector_search"] is False
 
 
@@ -124,9 +122,8 @@ def test_vector_search_requirement_succeeds_with_embedding_model(monkeypatch) ->
 
     store = manager.get_memory_store(require_vector_search=True)
 
-    assert isinstance(store, UserIsolatedMemoryStore)
-    assert store._base_store.model is model
-    assert store._base_store.vector_checks == 1
+    assert isinstance(store, FakeLanceStore)
+    assert store.model is model
     assert manager.get_store_info()["supports_vector_search"] is True
 
 
@@ -151,7 +148,9 @@ def test_strict_creation_failure_is_reported_but_default_falls_back(
     assert isinstance(store._base_store, InMemoryMemoryStore)
 
 
-def test_persistence_ignores_optional_model_lookup_failure(monkeypatch) -> None:
+def test_persistence_requirement_is_independent_of_model_lookup_failure(
+    monkeypatch,
+) -> None:
     manager = DynamicMemoryStoreManager()
     monkeypatch.setattr(
         manager,
@@ -159,17 +158,13 @@ def test_persistence_ignores_optional_model_lookup_failure(monkeypatch) -> None:
         Mock(side_effect=RuntimeError("model store down")),
     )
 
-    persistent_store = FakeLanceStore(None)
-    monkeypatch.setattr(
-        manager, "_create_lancedb_store", lambda _model: persistent_store
-    )
-    monkeypatch.setattr(memory_store_module, "LanceDBMemoryStore", FakeLanceStore)
+    persistent = FakeLanceStore(None)
+    monkeypatch.setattr(manager, "_create_lancedb_store", Mock(return_value=persistent))
 
-    assert manager.get_memory_store(require_persistence=True) is persistent_store
-    assert persistent_store.text_checks == 1
+    assert manager.get_memory_store(require_persistence=True) is persistent
 
 
-def test_swallowed_model_database_failure_allows_persistence_only(
+def test_model_database_failure_fails_closed_for_vector_requirement(
     monkeypatch,
 ) -> None:
     manager = DynamicMemoryStoreManager()
@@ -180,53 +175,78 @@ def test_swallowed_model_database_failure_allows_persistence_only(
 
     monkeypatch.setattr(memory_store_module, "get_db", broken_db)
 
-    persistent_store = FakeLanceStore(None)
-    monkeypatch.setattr(
-        manager, "_create_lancedb_store", lambda _model: persistent_store
-    )
-    monkeypatch.setattr(memory_store_module, "LanceDBMemoryStore", FakeLanceStore)
-
-    assert manager.get_memory_store(require_persistence=True) is persistent_store
+    with pytest.raises(MemoryBackendUnavailableError):
+        manager.get_memory_store(require_vector_search=True)
 
 
-def test_persistence_clears_stale_model_after_same_user_removal(monkeypatch) -> None:
+def test_lookup_failure_preserves_existing_persistent_store(monkeypatch) -> None:
     holder = {"model": _model(2, "2026-07-17 10:00:00", "key")}
     manager = _manager_with_fake_db(monkeypatch, holder)
-    first = manager.get_memory_store(require_vector_search=True)._base_store
+    existing = manager.get_memory_store()
+    monkeypatch.setattr(
+        manager,
+        "_get_embedding_model_from_db",
+        Mock(side_effect=RuntimeError("temporary lookup failure")),
+    )
 
+    assert manager.get_memory_store() is existing
+    assert manager.get_memory_store(require_persistence=True) is existing
+
+
+def test_authoritative_model_removal_clears_adapter_without_store_thrash(
+    monkeypatch,
+) -> None:
+    holder = {"model": _model(2, "2026-07-17 10:00:00", "key")}
+    manager = _manager_with_fake_db(monkeypatch, holder)
+    first = manager.get_memory_store()
     holder["model"] = None
-    second = manager.get_memory_store(require_persistence=True)
 
-    assert second is not first
-    assert second.model is None
-    assert second.text_checks == 1
-    assert manager.get_store_info()["supports_vector_search"] is False
+    text_store = manager.get_memory_store()
+
+    assert text_store is not first
+    assert text_store.model is None
+    assert manager.get_memory_store() is text_store
 
 
-def test_persistence_clears_stale_model_across_users(monkeypatch) -> None:
-    models = {1: _model(2, "2026-07-17 10:00:00", "key"), 2: None}
+def test_cross_user_transition_never_reuses_other_users_model(monkeypatch) -> None:
+    user_one_model = _model(1, "2026-07-17 10:00:00", "one")
     manager = DynamicMemoryStoreManager()
     monkeypatch.setattr(
         manager,
         "_get_embedding_model_from_db",
-        lambda: models[memory_store_module.current_user_id.get()],
+        lambda: user_one_model if current_user_id.get() == 1 else None,
     )
-    monkeypatch.setattr(manager, "_create_lancedb_store", FakeLanceStore)
-    monkeypatch.setattr(memory_store_module, "LanceDBMemoryStore", FakeLanceStore)
+    monkeypatch.setattr(
+        manager,
+        "_create_lancedb_store",
+        lambda model, **_kwargs: FakeLanceStore(model),
+    )
 
-    token = memory_store_module.current_user_id.set(1)
-    try:
-        first = manager.get_memory_store(require_vector_search=True)._base_store
-    finally:
-        memory_store_module.current_user_id.reset(token)
-    token = memory_store_module.current_user_id.set(2)
-    try:
+    with UserContext(1):
+        first = manager.get_memory_store()
+        assert first.model is user_one_model
+    with UserContext(2):
         second = manager.get_memory_store(require_persistence=True)
-    finally:
-        memory_store_module.current_user_id.reset(token)
+        assert second.model is None
+        with pytest.raises(MemoryBackendUnavailableError):
+            manager.get_memory_store(require_vector_search=True)
 
-    assert second is not first
-    assert second.model is None
+
+def test_strict_view_does_not_replace_persistent_store_handle(monkeypatch) -> None:
+    model = _model(2, "2026-07-17 10:00:00", "key")
+    manager = DynamicMemoryStoreManager()
+    base = FakeLanceStore(model)
+    persistent = UserIsolatedMemoryStore(base)
+    monkeypatch.setattr(manager, "_get_embedding_model_from_db", lambda: model)
+    monkeypatch.setattr(manager, "_create_lancedb_store", Mock(return_value=persistent))
+
+    ordinary = manager.get_memory_store()
+    strict = manager.get_memory_store(require_vector_search=True)
+
+    assert ordinary is persistent
+    assert strict is not persistent
+    assert strict._base_store is base
+    assert manager.get_memory_store() is persistent
 
 
 def test_database_embedding_configuration_is_propagated(monkeypatch, tmp_path) -> None:
@@ -248,10 +268,30 @@ def test_database_embedding_configuration_is_propagated(monkeypatch, tmp_path) -
     assert config.api_key == "secret"
     assert config.base_url == "https://embedding.example/v1"
     assert config.dimension == 1024
-    identity = lancedb_store.call_args.kwargs["vector_space_identity"]
-    assert '"base_url":"https://embedding.example/v1"' in identity
-    assert '"dimension":1024' in identity
-    assert '"model":"text-embedding-v4"' in identity
-    assert '"provider":"dashscope"' in identity
+    kwargs = lancedb_store.call_args.kwargs
+    assert kwargs["vector_space_identity"] == {
+        "provider": "dashscope",
+        "model": "text-embedding-v4",
+        "endpoint": "https://embedding.example/v1",
+        "dimension": 1024,
+    }
     assert isinstance(wrapped, UserIsolatedMemoryStore)
     assert wrapped._base_store is lancedb_store.return_value
+
+
+def test_dashscope_omitted_dimension_uses_compatible_default(
+    monkeypatch, tmp_path
+) -> None:
+    manager = DynamicMemoryStoreManager()
+    model = _model(7, "2026-07-17 10:00:00", "secret")
+    model.dimension = None
+    create_adapter = Mock(return_value=Mock())
+    lancedb_store = Mock()
+    monkeypatch.setattr(memory_store_module, "create_embedding_adapter", create_adapter)
+    monkeypatch.setattr(memory_store_module, "LanceDBMemoryStore", lancedb_store)
+    monkeypatch.setattr(memory_store_module, "get_storage_root", lambda: tmp_path)
+
+    manager._create_lancedb_store(model)
+
+    assert create_adapter.call_args.args[0].dimension == 1024
+    assert lancedb_store.call_args.kwargs["vector_space_identity"]["dimension"] == 1024

--- a/tests/web/test_dynamic_memory_store.py
+++ b/tests/web/test_dynamic_memory_store.py
@@ -2,8 +2,17 @@
 
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import Mock
 
-from xagent.web.dynamic_memory_store import DynamicMemoryStoreManager
+import pytest
+
+from xagent.core.memory.in_memory import InMemoryMemoryStore
+from xagent.web import dynamic_memory_store as memory_store_module
+from xagent.web.dynamic_memory_store import (
+    DynamicMemoryStoreManager,
+    MemoryBackendUnavailableError,
+)
+from xagent.web.user_isolated_memory import UserIsolatedMemoryStore
 
 
 class FakeLanceStore:
@@ -30,6 +39,9 @@ def _model(model_id: int, updated_at: str, api_key: str) -> Any:
         updated_at=updated_at,
         api_key=api_key,
         model_provider="dashscope",
+        model_id="configured-embedding",
+        model_name="text-embedding-v4",
+        base_url="https://embedding.example/v1",
         dimension=1024,
     )
 
@@ -71,3 +83,109 @@ def test_embedding_configuration_read_happens_under_lock(monkeypatch) -> None:
     monkeypatch.setattr(manager, "_get_embedding_model_from_db", get_model_under_lock)
 
     assert isinstance(manager.get_memory_store(), FakeLanceStore)
+
+
+def test_persistence_can_be_required_without_vector_search(monkeypatch) -> None:
+    manager = DynamicMemoryStoreManager()
+    monkeypatch.setattr(manager, "_get_embedding_model_from_db", lambda: None)
+    persistent_store = FakeLanceStore(None)
+    create_store = Mock(return_value=persistent_store)
+    monkeypatch.setattr(manager, "_create_lancedb_store", create_store)
+
+    assert manager.get_memory_store(require_persistence=True) is persistent_store
+    create_store.assert_called_once_with(None)
+    assert manager.get_store_info()["supports_vector_search"] is False
+
+
+def test_vector_search_requirement_fails_without_embedding_model(monkeypatch) -> None:
+    manager = DynamicMemoryStoreManager()
+    monkeypatch.setattr(manager, "_get_embedding_model_from_db", lambda: None)
+
+    with pytest.raises(MemoryBackendUnavailableError):
+        manager.get_memory_store(require_vector_search=True)
+
+    assert isinstance(manager.get_memory_store(), UserIsolatedMemoryStore)
+    assert isinstance(manager.get_memory_store()._base_store, InMemoryMemoryStore)
+
+
+def test_vector_search_requirement_succeeds_with_embedding_model(monkeypatch) -> None:
+    model = _model(2, "2026-07-17 10:00:00", "key")
+    manager = _manager_with_fake_db(monkeypatch, {"model": model})
+
+    store = manager.get_memory_store(require_vector_search=True)
+
+    assert isinstance(store, FakeLanceStore)
+    assert store.model is model
+    assert manager.get_store_info()["supports_vector_search"] is True
+
+
+def test_strict_creation_failure_is_reported_but_default_falls_back(
+    monkeypatch,
+) -> None:
+    manager = DynamicMemoryStoreManager()
+    model = _model(2, "2026-07-17 10:00:00", "key")
+    monkeypatch.setattr(manager, "_get_embedding_model_from_db", lambda: model)
+    monkeypatch.setattr(
+        manager,
+        "_create_lancedb_store",
+        Mock(side_effect=RuntimeError("backend down")),
+    )
+
+    with pytest.raises(MemoryBackendUnavailableError) as exc_info:
+        manager.get_memory_store(require_vector_search=True)
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+    store = manager.get_memory_store()
+    assert isinstance(store, UserIsolatedMemoryStore)
+    assert isinstance(store._base_store, InMemoryMemoryStore)
+
+
+def test_strict_model_lookup_exception_fails_closed(monkeypatch) -> None:
+    manager = DynamicMemoryStoreManager()
+    monkeypatch.setattr(
+        manager,
+        "_get_embedding_model_from_db",
+        Mock(side_effect=RuntimeError("model store down")),
+    )
+
+    with pytest.raises(MemoryBackendUnavailableError) as exc_info:
+        manager.get_memory_store(require_persistence=True)
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+
+
+def test_swallowed_model_database_failure_still_fails_closed_in_strict_mode(
+    monkeypatch,
+) -> None:
+    manager = DynamicMemoryStoreManager()
+
+    def broken_db():
+        raise RuntimeError("database unavailable")
+        yield
+
+    monkeypatch.setattr(memory_store_module, "get_db", broken_db)
+
+    with pytest.raises(MemoryBackendUnavailableError):
+        manager.get_memory_store(require_persistence=True)
+
+
+def test_database_embedding_configuration_is_propagated(monkeypatch, tmp_path) -> None:
+    manager = DynamicMemoryStoreManager()
+    model = _model(7, "2026-07-17 10:00:00", "secret")
+    adapter = Mock(name="embedding-adapter")
+    create_adapter = Mock(return_value=adapter)
+    lancedb_store = Mock(name="lancedb-store")
+    monkeypatch.setattr(memory_store_module, "create_embedding_adapter", create_adapter)
+    monkeypatch.setattr(memory_store_module, "LanceDBMemoryStore", lancedb_store)
+    monkeypatch.setattr(memory_store_module, "get_storage_root", lambda: tmp_path)
+
+    wrapped = manager._create_lancedb_store(model)
+
+    config = create_adapter.call_args.args[0]
+    assert config.id == "configured-embedding"
+    assert config.model_name == "text-embedding-v4"
+    assert config.model_provider == "dashscope"
+    assert config.api_key == "secret"
+    assert config.base_url == "https://embedding.example/v1"
+    assert config.dimension == 1024
+    assert isinstance(wrapped, UserIsolatedMemoryStore)
+    assert wrapped._base_store is lancedb_store.return_value


### PR DESCRIPTION
## Summary

- add independent opt-in persistence and vector-search requirements to trusted memory policy decisions
- report required backend unavailability instead of silently degrading to in-memory or text-only storage
- construct embedding clients from the selected database model configuration, including provider, model, endpoint, and dimension
- preserve existing fallback behavior when no strict requirement is requested

## Validation

- Ruff checks on the changed production and test files
- 40 focused tests covering dynamic backend selection, trusted memory policy compatibility, and preview behavior
- mutation checks for vector rejection, persistence-only selection, embedding endpoint/dimension propagation, and policy forwarding/fail-closed behavior

Closes #2038