### PR TITLE
fix(memory): separate recall input from execution context (toby)

### DIFF
--- a/src/xagent/core/agent/context/enrichment.py
+++ b/src/xagent/core/agent/context/enrichment.py
@@ -265,56 +265,6 @@ def latest_user_text(context: Any, *, prefer_display: bool = False) -> str:
     return str(task or "")
 
 
-def memory_input_text(context: Any, *, execution_text: str | None = None) -> str:
-    """Return clean user-facing text for memory recall and provenance.
-
-    Runtime user messages may contain execution-only augmentation such as file
-    references. Their ``display_message`` metadata carries the corresponding
-    user-facing text. DAG child contexts also append internal user-role step
-    messages, so those are excluded when locating the root request.
-
-    ``execution_text`` lets a resumed ReAct run keep memory provenance attached
-    to its original task rather than a later clarification response. Legacy
-    contexts without display metadata retain their previous content fallback.
-    """
-
-    messages = list(getattr(context, "messages", []) or [])
-    dag_step_id = (
-        context.metadata.get("dag_step_id")
-        if isinstance(getattr(context, "metadata", None), dict)
-        else None
-    )
-    candidates: list[Any] = []
-    for message in reversed(messages):
-        if getattr(message, "role", None) != "user":
-            continue
-        metadata = getattr(message, "metadata", None)
-        metadata = metadata if isinstance(metadata, dict) else {}
-        if dag_step_id and metadata.get("dag_step_id"):
-            continue
-        content = str(getattr(message, "content", "") or "")
-        if execution_text is not None and not dag_step_id and content != execution_text:
-            continue
-        candidates.append(message)
-
-    if not candidates and execution_text is not None:
-        return memory_input_text(context)
-    if candidates:
-        message = candidates[0]
-        metadata = getattr(message, "metadata", None)
-        display = (
-            metadata.get("display_message") if isinstance(metadata, dict) else None
-        )
-        if isinstance(display, str) and display.strip():
-            return display
-        if dag_step_id and execution_text is not None:
-            return execution_text
-        return str(getattr(message, "content", "") or "")
-
-    task = context.metadata.get("task") if hasattr(context, "metadata") else None
-    return str(task or "")
-
-
 def _runtime_attr(runtime: Any | None, name: str) -> Any | None:
     if runtime is None:
         return None
@@ -376,7 +326,10 @@ def _lookup_relevant_memories_with_context(
             similarity_threshold=similarity_threshold,
         )
     except Exception:
-        logger.exception("Failed to retrieve memories")
+        logger.exception(
+            "Failed to retrieve memories%s",
+            " with user context" if user_id is not None else "",
+        )
         return []
 
 

--- a/src/xagent/core/agent/context/enrichment.py
+++ b/src/xagent/core/agent/context/enrichment.py
@@ -183,10 +183,24 @@ def display_message_override(metadata: Any) -> str | None:
     return display.strip()
 
 
-def top_level_user_request(context: Any) -> TopLevelUserRequest:
-    """Return and persist the latest independent top-level user request."""
+def top_level_user_request(
+    context: Any,
+    *,
+    user_message_limit: int | None = None,
+) -> TopLevelUserRequest:
+    """Return and persist the latest independent top-level user request.
+
+    ``user_message_limit`` freezes selection to a checkpointed prefix when a
+    later waiting response has already been appended to the root context.
+    """
     has_pending_response = False
-    for message in reversed(getattr(context, "messages", []) or []):
+    messages = list(getattr(context, "messages", []) or [])
+    if user_message_limit is not None:
+        user_messages = [
+            message for message in messages if getattr(message, "role", None) == "user"
+        ]
+        messages = user_messages[: max(0, user_message_limit)]
+    for message in reversed(messages):
         if getattr(message, "role", None) != "user" or getattr(
             message, "hidden", False
         ):

--- a/src/xagent/core/agent/context/enrichment.py
+++ b/src/xagent/core/agent/context/enrichment.py
@@ -352,8 +352,8 @@ def _lookup_relevant_memories_with_context(
     similarity_threshold: float | None,
     user_id: Any | None,
 ) -> list[dict[str, Any]]:
-    if user_id is not None:
-        try:
+    try:
+        if user_id is not None:
             token = current_user_id.set(user_id)
             try:
                 return lookup_relevant_memories(
@@ -366,18 +366,18 @@ def _lookup_relevant_memories_with_context(
                 )
             finally:
                 current_user_id.reset(token)
-        except Exception:
-            logger.exception("Failed to retrieve memories with user context")
-            return []
 
-    return lookup_relevant_memories(
-        memory_store,
-        query,
-        category,
-        include_general=include_general,
-        limit=limit,
-        similarity_threshold=similarity_threshold,
-    )
+        return lookup_relevant_memories(
+            memory_store,
+            query,
+            category,
+            include_general=include_general,
+            limit=limit,
+            similarity_threshold=similarity_threshold,
+        )
+    except Exception:
+        logger.exception("Failed to retrieve memories")
+        return []
 
 
 def _current_user_id() -> Any | None:

--- a/src/xagent/core/agent/context/enrichment.py
+++ b/src/xagent/core/agent/context/enrichment.py
@@ -265,6 +265,56 @@ def latest_user_text(context: Any, *, prefer_display: bool = False) -> str:
     return str(task or "")
 
 
+def memory_input_text(context: Any, *, execution_text: str | None = None) -> str:
+    """Return clean user-facing text for memory recall and provenance.
+
+    Runtime user messages may contain execution-only augmentation such as file
+    references. Their ``display_message`` metadata carries the corresponding
+    user-facing text. DAG child contexts also append internal user-role step
+    messages, so those are excluded when locating the root request.
+
+    ``execution_text`` lets a resumed ReAct run keep memory provenance attached
+    to its original task rather than a later clarification response. Legacy
+    contexts without display metadata retain their previous content fallback.
+    """
+
+    messages = list(getattr(context, "messages", []) or [])
+    dag_step_id = (
+        context.metadata.get("dag_step_id")
+        if isinstance(getattr(context, "metadata", None), dict)
+        else None
+    )
+    candidates: list[Any] = []
+    for message in reversed(messages):
+        if getattr(message, "role", None) != "user":
+            continue
+        metadata = getattr(message, "metadata", None)
+        metadata = metadata if isinstance(metadata, dict) else {}
+        if dag_step_id and metadata.get("dag_step_id"):
+            continue
+        content = str(getattr(message, "content", "") or "")
+        if execution_text is not None and not dag_step_id and content != execution_text:
+            continue
+        candidates.append(message)
+
+    if not candidates and execution_text is not None:
+        return memory_input_text(context)
+    if candidates:
+        message = candidates[0]
+        metadata = getattr(message, "metadata", None)
+        display = (
+            metadata.get("display_message") if isinstance(metadata, dict) else None
+        )
+        if isinstance(display, str) and display.strip():
+            return display
+        if dag_step_id and execution_text is not None:
+            return execution_text
+        return str(getattr(message, "content", "") or "")
+
+    task = context.metadata.get("task") if hasattr(context, "metadata") else None
+    return str(task or "")
+
+
 def _runtime_attr(runtime: Any | None, name: str) -> Any | None:
     if runtime is None:
         return None

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -539,14 +539,25 @@ class ExecutionContext:
             "instead of computing from this value."
         )
 
-    def _current_user_request_text(self, *, prefer_display: bool = False) -> str:
+    def current_user_request_text(
+        self,
+        *,
+        prefer_display: bool = False,
+        user_message_limit: int | None = None,
+    ) -> str:
         """Return the current request text.
 
         ``prefer_display`` yields the user-typed message instead of the
         execution prompt, whose appended file-reference block is fixed English
         and would otherwise decide the language of a short foreign request.
+        ``user_message_limit`` restricts selection to a previously checkpointed
+        user-message window so later waiting responses cannot become the task.
         """
-        for message in reversed(self.messages):
+        messages = self.messages
+        if user_message_limit is not None:
+            user_messages = [message for message in messages if message.role == "user"]
+            messages = user_messages[: max(0, user_message_limit)]
+        for message in reversed(messages):
             if message.hidden or message.role != "user":
                 continue
             if message.metadata.get("response_to_waiting_for_user"):
@@ -556,9 +567,9 @@ class ExecutionContext:
             if message.metadata.get("dag_step_id"):
                 continue
             if prefer_display:
-                display = str(message.metadata.get("display_message") or "").strip()
-                if display:
-                    return display
+                display = message.metadata.get("display_message")
+                if isinstance(display, str) and display.strip():
+                    return display.strip()
             content = str(message.content or "").strip()
             if content:
                 return content
@@ -567,7 +578,7 @@ class ExecutionContext:
     def _system_context(self) -> str:
         parts = [self._current_time_context(), FILE_REF_MODEL_INSTRUCTIONS]
         dag_step_id = self.metadata.get("dag_step_id")
-        current_task = self._current_user_request_text()
+        current_task = self.current_user_request_text()
         output_language = effective_output_language(self)
         if current_task and not dag_step_id:
             language_directives = output_language_directives(
@@ -649,7 +660,7 @@ class ExecutionContext:
             request_anchor = output_language_directives(
                 output_language,
                 section="dag_step_request_anchor",
-                request=self._current_user_request_text(prefer_display=True),
+                request=self.current_user_request_text(prefer_display=True),
             )
             if request_anchor:
                 parts.append(request_anchor)

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -553,27 +553,13 @@ class ExecutionContext:
         ``user_message_limit`` restricts selection to a previously checkpointed
         user-message window so later waiting responses cannot become the task.
         """
-        messages = self.messages
-        if user_message_limit is not None:
-            user_messages = [message for message in messages if message.role == "user"]
-            messages = user_messages[: max(0, user_message_limit)]
-        for message in reversed(messages):
-            if message.hidden or message.role != "user":
-                continue
-            if message.metadata.get("response_to_waiting_for_user"):
-                continue
-            # A DAG child context copies the root messages and then appends step
-            # scaffolding; only the root request may anchor the response language.
-            if message.metadata.get("dag_step_id"):
-                continue
-            if prefer_display:
-                display = message.metadata.get("display_message")
-                if isinstance(display, str) and display.strip():
-                    return display.strip()
-            content = str(message.content or "").strip()
-            if content:
-                return content
-        return str(self.metadata.get("task") or "").strip()
+        request = top_level_user_request(
+            self,
+            user_message_limit=user_message_limit,
+        )
+        if prefer_display and request.display_state == "text":
+            return request.language_text
+        return request.execution_text
 
     def _system_context(self) -> str:
         parts = [self._current_time_context(), FILE_REF_MODEL_INSTRUCTIONS]

--- a/src/xagent/core/agent/context/memory_tool.py
+++ b/src/xagent/core/agent/context/memory_tool.py
@@ -267,24 +267,13 @@ class SearchMemoryTool:
                 data={"query": query[:200], "source": SEARCH_MEMORY_TOOL_NAME},
             )
 
+        error: str | None = None
         try:
             memories = await asyncio.to_thread(self._search, query, limit)
         except Exception:
             logger.exception("search_memory failed")
-            if tracer is not None and task_id:
-                await trace_memory_retrieve_end(
-                    tracer,
-                    task_id=task_id,
-                    step_id=step_id,
-                    data={
-                        "query": query[:200],
-                        "memories_count": 0,
-                        "found": False,
-                        "success": False,
-                        "source": SEARCH_MEMORY_TOOL_NAME,
-                    },
-                )
-            return {"success": False, "error": "Failed to search memories."}
+            memories = []
+            error = "Failed to search memories."
 
         if tracer is not None and task_id:
             await trace_memory_retrieve_end(
@@ -295,10 +284,13 @@ class SearchMemoryTool:
                     "query": query[:200],
                     "memories_count": len(memories),
                     "found": bool(memories),
+                    "success": error is None,
                     "source": SEARCH_MEMORY_TOOL_NAME,
                 },
             )
 
+        if error is not None:
+            return {"success": False, "error": error}
         return {"success": True, "memories": memories, "count": len(memories)}
 
     def _search(self, query: str, limit: int) -> list[dict[str, Any]]:

--- a/src/xagent/core/agent/context/memory_tool.py
+++ b/src/xagent/core/agent/context/memory_tool.py
@@ -267,7 +267,24 @@ class SearchMemoryTool:
                 data={"query": query[:200], "source": SEARCH_MEMORY_TOOL_NAME},
             )
 
-        memories = await asyncio.to_thread(self._search, query, limit)
+        try:
+            memories = await asyncio.to_thread(self._search, query, limit)
+        except Exception:
+            logger.exception("search_memory failed")
+            if tracer is not None and task_id:
+                await trace_memory_retrieve_end(
+                    tracer,
+                    task_id=task_id,
+                    step_id=step_id,
+                    data={
+                        "query": query[:200],
+                        "memories_count": 0,
+                        "found": False,
+                        "success": False,
+                        "source": SEARCH_MEMORY_TOOL_NAME,
+                    },
+                )
+            return {"success": False, "error": "Failed to search memories."}
 
         if tracer is not None and task_id:
             await trace_memory_retrieve_end(
@@ -285,11 +302,7 @@ class SearchMemoryTool:
         return {"success": True, "memories": memories, "count": len(memories)}
 
     def _search(self, query: str, limit: int) -> list[dict[str, Any]]:
-        try:
-            results = self.memory_store.search(query=query, k=limit)
-        except Exception:
-            logger.exception("search_memory failed")
-            return []
+        results = self.memory_store.search(query=query, k=limit)
         memories = []
         for note in results or []:
             memories.append(

--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -17,7 +17,7 @@ from ...context.enrichment import (
     SELECTED_SKILL_METADATA_KEY,
     SKILL_CONTEXT_METADATA_KEY,
     enrich_context_with_memory,
-    latest_user_text,
+    memory_input_text,
 )
 from ...context.skill_tool import (
     LOAD_SKILL_TOOL_NAME,
@@ -490,7 +490,7 @@ class AutoPattern(AgentPattern):
         final_answer_stream: FinalAnswerStreamSession | None = None
         if self.decision is None:
             self.status = "deciding"
-            task_text = latest_user_text(context)
+            task_text = memory_input_text(context)
             await enrich_context_with_memory(
                 context=context,
                 query=task_text,

--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -17,7 +17,6 @@ from ...context.enrichment import (
     SELECTED_SKILL_METADATA_KEY,
     SKILL_CONTEXT_METADATA_KEY,
     enrich_context_with_memory,
-    memory_input_text,
 )
 from ...context.skill_tool import (
     LOAD_SKILL_TOOL_NAME,
@@ -490,10 +489,10 @@ class AutoPattern(AgentPattern):
         final_answer_stream: FinalAnswerStreamSession | None = None
         if self.decision is None:
             self.status = "deciding"
-            task_text = memory_input_text(context)
+            memory_text = context.current_user_request_text(prefer_display=True)
             await enrich_context_with_memory(
                 context=context,
-                query=task_text,
+                query=memory_text,
                 category="react_memory",
                 memory_store=memory_store,
                 runtime=runtime,

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -16,6 +16,7 @@ from ...context.enrichment import (
     enrich_context_with_memory,
     hydrate_top_level_user_request,
     latest_user_text,
+    memory_input_text,
 )
 from ...frame import ExecutionFrame, ExecutionSnapshot, ExecutionStatus
 from ...grounding import grounding_rule
@@ -466,7 +467,7 @@ class DAGPattern(AgentPattern):
             self.status = "planning"
         try:
             if self.plan is None:
-                task_text = latest_user_text(context)
+                task_text = memory_input_text(context)
                 await enrich_context_with_memory(
                     context=context,
                     query=task_text,

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -1000,6 +1000,7 @@ class DAGPattern(AgentPattern):
             finalize_after_tool_result=False,
             user_interaction_enabled=self.user_interaction_enabled,
         )
+        react_pattern.memory_input_text = memory_input_text(root_context)
         active_pattern_state = self.active_step_pattern_states.get(step.id)
         if active_pattern_state is not None:
             react_pattern.load_state(active_pattern_state)

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -15,8 +15,6 @@ from ....task_runtime import (
 from ...context.enrichment import (
     enrich_context_with_memory,
     hydrate_top_level_user_request,
-    latest_user_text,
-    memory_input_text,
 )
 from ...frame import ExecutionFrame, ExecutionSnapshot, ExecutionStatus
 from ...grounding import grounding_rule
@@ -388,6 +386,7 @@ class DAGPattern(AgentPattern):
         self.active_step_contexts: dict[str, dict[str, Any]] = {}
         self.step_results: dict[str, Any] = {}
         self.planned_user_message_count = 0
+        self.memory_input_text: str | None = None
         self.completion_feedback: str | None = None
         self.completion_replan_count = 0
         # Live concurrent step tasks for the in-progress batch, maintained by
@@ -467,10 +466,10 @@ class DAGPattern(AgentPattern):
             self.status = "planning"
         try:
             if self.plan is None:
-                task_text = memory_input_text(context)
+                memory_text = self._memory_text(context)
                 await enrich_context_with_memory(
                     context=context,
-                    query=task_text,
+                    query=memory_text,
                     category="dag_plan_execute_memory",
                     memory_store=memory_store,
                     runtime=runtime,
@@ -1000,7 +999,7 @@ class DAGPattern(AgentPattern):
             finalize_after_tool_result=False,
             user_interaction_enabled=self.user_interaction_enabled,
         )
-        react_pattern.memory_input_text = memory_input_text(root_context)
+        react_pattern.seed_memory_input(self._memory_text(root_context))
         active_pattern_state = self.active_step_pattern_states.get(step.id)
         if active_pattern_state is not None:
             react_pattern.load_state(active_pattern_state)
@@ -1166,6 +1165,7 @@ class DAGPattern(AgentPattern):
             "active_step_contexts": dict(self.active_step_contexts),
             "step_results": dict(self.step_results),
             "planned_user_message_count": self.planned_user_message_count,
+            "memory_input_text": self.memory_input_text,
             "max_concurrency": self.max_concurrency,
             "completion_feedback": self.completion_feedback,
             "completion_replan_count": self.completion_replan_count,
@@ -1257,6 +1257,15 @@ class DAGPattern(AgentPattern):
         self.planned_user_message_count = int(
             state.get("planned_user_message_count", 0)
         )
+        stored_memory_input = state.get("memory_input_text")
+        if stored_memory_input:
+            self.memory_input_text = str(stored_memory_input)
+        elif self.memory_input_text is None:
+            for child_state in self.active_step_pattern_states.values():
+                child_memory_input = child_state.get("memory_input_text")
+                if child_memory_input:
+                    self.memory_input_text = str(child_memory_input)
+                    break
         self.max_concurrency = max(1, int(state.get("max_concurrency", 4)))
         feedback = state.get("completion_feedback")
         self.completion_feedback = str(feedback) if feedback else None
@@ -1265,6 +1274,16 @@ class DAGPattern(AgentPattern):
             0,
             int(state.get("max_completion_replans", self.max_completion_replans)),
         )
+
+    def _memory_text(self, context: Any) -> str:
+        if self.memory_input_text is None:
+            self.memory_input_text = context.current_user_request_text(
+                prefer_display=True,
+                user_message_limit=(
+                    self.planned_user_message_count if self.plan is not None else None
+                ),
+            )
+        return self.memory_input_text
 
     async def _fail(
         self,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -78,7 +78,6 @@ from ...context.enrichment import (
     IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
     enrich_context_with_memory,
     latest_user_text,
-    memory_input_text,
 )
 from ...context.memory_tool import build_memory_tools
 from ...context.skill_tool import build_load_skill_tool
@@ -1735,11 +1734,15 @@ class ReActPattern(AgentPattern):
     def _memory_text(self, context: Any, *, execution_text: str) -> str:
         if self.memory_input_text:
             return self.memory_input_text
-        self.memory_input_text = memory_input_text(
-            context,
-            execution_text=execution_text,
+        self.memory_input_text = (
+            context.current_user_request_text(prefer_display=True) or execution_text
         )
         return self.memory_input_text
+
+    def seed_memory_input(self, memory_text: str) -> None:
+        """Provide DAG-owned provenance without replacing restored state."""
+        if self.memory_input_text is None:
+            self.memory_input_text = str(memory_text or "") or None
 
     def _mark_latest_user_message_as_waiting_response(
         self,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -448,6 +448,7 @@ class ReActPattern(AgentPattern):
         self.waiting_for_user_request: dict[str, Any] | None = None
         self.pending_tool_interaction_responses: list[dict[str, str]] = []
         self.task_text: str | None = None
+        self.memory_input_text: str | None = None
         self._memory_store: Any | None = None
         self._tool_decision_groups_by_name: dict[str, str] = {}
 
@@ -507,7 +508,7 @@ class ReActPattern(AgentPattern):
 
         try:
             task_text = self._task_text(context)
-            memory_text = memory_input_text(context, execution_text=task_text)
+            memory_text = self._memory_text(context, execution_text=task_text)
             self._memory_store = kwargs.get("memory_store")
             # DAG steps skip the automatic retrieval: the root run already
             # retrieved for the whole task, and steps can search_memory on
@@ -1585,6 +1586,7 @@ class ReActPattern(AgentPattern):
                 self.pending_tool_interaction_responses
             ),
             "task_text": self.task_text,
+            "memory_input_text": self.memory_input_text,
             "last_response": self.last_response,
             "pending_tool_calls": self.pending_tool_calls,
             "pending_tool_call_content": self.pending_tool_call_content,
@@ -1654,6 +1656,9 @@ class ReActPattern(AgentPattern):
         ]
         stored_task_text = state.get("task_text")
         self.task_text = str(stored_task_text) if stored_task_text else None
+        stored_memory_input = state.get("memory_input_text")
+        if stored_memory_input:
+            self.memory_input_text = str(stored_memory_input)
         self.last_response = state.get("last_response")
         self.pending_tool_calls = list(state.get("pending_tool_calls", []))
         self.pending_tool_call_content = dict(
@@ -1726,6 +1731,15 @@ class ReActPattern(AgentPattern):
             return self.task_text
         self.task_text = latest_user_text(context)
         return self.task_text
+
+    def _memory_text(self, context: Any, *, execution_text: str) -> str:
+        if self.memory_input_text:
+            return self.memory_input_text
+        self.memory_input_text = memory_input_text(
+            context,
+            execution_text=execution_text,
+        )
+        return self.memory_input_text
 
     def _mark_latest_user_message_as_waiting_response(
         self,

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -78,6 +78,7 @@ from ...context.enrichment import (
     IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
     enrich_context_with_memory,
     latest_user_text,
+    memory_input_text,
 )
 from ...context.memory_tool import build_memory_tools
 from ...context.skill_tool import build_load_skill_tool
@@ -506,6 +507,7 @@ class ReActPattern(AgentPattern):
 
         try:
             task_text = self._task_text(context)
+            memory_text = memory_input_text(context, execution_text=task_text)
             self._memory_store = kwargs.get("memory_store")
             # DAG steps skip the automatic retrieval: the root run already
             # retrieved for the whole task, and steps can search_memory on
@@ -513,7 +515,7 @@ class ReActPattern(AgentPattern):
             if not context.metadata.get("dag_step_id"):
                 await enrich_context_with_memory(
                     context=context,
-                    query=task_text,
+                    query=memory_text,
                     category="react_memory",
                     memory_store=self._memory_store,
                     runtime=runtime,
@@ -522,7 +524,7 @@ class ReActPattern(AgentPattern):
             context_tools = await self._with_context_tools(
                 tools=tools,
                 context=context,
-                task_text=task_text,
+                task_text=memory_text,
                 runtime=runtime,
                 skill_manager=kwargs.get("skill_manager"),
                 allowed_skills=kwargs.get("allowed_skills"),

--- a/src/xagent/core/memory/base.py
+++ b/src/xagent/core/memory/base.py
@@ -110,6 +110,10 @@ class MemoryStore(ABC):
 
         Returns:
             List[MemoryNote]: List of matching memory notes.
+
+        Raises:
+            Exception: If the backend cannot complete the search. An empty list
+                is reserved for a successful search with no matching notes.
         """
         pass
 
@@ -130,6 +134,10 @@ class MemoryStore(ABC):
 
         Returns:
             List[MemoryNote]: List of memory notes matching the filters.
+
+        Raises:
+            Exception: If the backend cannot complete the listing. An empty list
+                is reserved for a successful listing of an empty store.
         """
         pass
 

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -875,9 +875,6 @@ class LanceDBMemoryStore(MemoryStore):
 
             return results[:k]
 
-        except Exception:
-            logger.exception("Failed to search memories for query %r", query[:50])
-            raise
         finally:
             _safe_close_table(table)
 
@@ -897,14 +894,10 @@ class LanceDBMemoryStore(MemoryStore):
         so list_all and search cannot diverge (#909). Results are sorted
         newest-first to match InMemoryStore.list_all.
         """
-        try:
-            notes = self.search(query="", k=10000, filters=filters or None)
-            # Mirror InMemoryStore: newest first.
-            notes.sort(key=lambda n: n.timestamp, reverse=True)
-            return notes
-        except Exception as e:
-            logger.error(f"Failed to list all memories: {e}")
-            return []
+        notes = self.search(query="", k=10000, filters=filters or None)
+        # Mirror InMemoryStore: newest first.
+        notes.sort(key=lambda n: n.timestamp, reverse=True)
+        return notes
 
     def get_stats(self) -> dict[str, Any]:
         """Get statistics about the memory store."""

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -875,9 +875,9 @@ class LanceDBMemoryStore(MemoryStore):
 
             return results[:k]
 
-        except Exception as e:
-            logger.error(f"Failed to search memories with query '{query[:50]}...': {e}")
-            return []
+        except Exception:
+            logger.exception("Failed to search memories for query %r", query[:50])
+            raise
         finally:
             _safe_close_table(table)
 

--- a/src/xagent/web/api/memory.py
+++ b/src/xagent/web/api/memory.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime
 from typing import Any, Callable, Optional
 
@@ -13,6 +14,9 @@ from ..auth_dependencies import get_current_user
 from ..dynamic_memory_store import get_memory_store_manager
 from ..models.user import User
 from ..user_isolated_memory import UserContext
+
+logger = logging.getLogger(__name__)
+MEMORY_READ_UNAVAILABLE_DETAIL = "Memory storage is temporarily unavailable."
 
 
 class MemoryListRequest(BaseModel):
@@ -139,19 +143,22 @@ class MemoryManagementRouter:
                     if date_to:
                         filters["date_to"] = date_to
 
-                    # Get memories
-                    if search:
-                        # Use search functionality if search query is provided
-                        search_results = self.memory_store.search(
-                            query=search,
-                            k=1000,
-                            filters=filters if filters else None,
-                            similarity_threshold=similarity_threshold,
-                        )
-                        memories = search_results
-                    else:
-                        # Use regular list_all if no search query
-                        memories = self.memory_store.list_all(filters)
+                    try:
+                        if search:
+                            memories = self.memory_store.search(
+                                query=search,
+                                k=1000,
+                                filters=filters if filters else None,
+                                similarity_threshold=similarity_threshold,
+                            )
+                        else:
+                            memories = self.memory_store.list_all(filters)
+                    except Exception:
+                        logger.exception("Memory list read failed")
+                        raise HTTPException(
+                            status_code=503,
+                            detail=MEMORY_READ_UNAVAILABLE_DETAIL,
+                        ) from None
 
                     # Apply pagination
                     total_count = len(memories)
@@ -177,10 +184,13 @@ class MemoryManagementRouter:
                         total_count=total_count,
                         filters_used=filters,
                     )
-            except Exception as e:
+            except HTTPException:
+                raise
+            except Exception:
+                logger.exception("Failed to build memory list response")
                 raise HTTPException(
-                    status_code=500, detail=f"Failed to list memories: {str(e)}"
-                )
+                    status_code=500, detail="Failed to list memories."
+                ) from None
 
         @self.router.delete("/{memory_id}")
         async def delete_memory(

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -447,7 +447,10 @@ async def test_auto_decision_sees_memory_context() -> None:
         ]
     )
     context = ExecutionContext(execution_id="auto-context")
-    context.add_user_message("Answer from context")
+    context.add_user_message(
+        "Answer from context\n\nAttached file: /private/runtime/input.txt",
+        metadata={"display_message": "Answer from context"},
+    )
     memory_store = FakeMemoryStore()
 
     result = await AutoPattern().run(
@@ -462,6 +465,10 @@ async def test_auto_decision_sees_memory_context() -> None:
     assert [search["filters"]["category"] for search in memory_store.searches] == [
         "react_memory",
         "general",
+    ]
+    assert [search["query"] for search in memory_store.searches] == [
+        "Answer from context",
+        "Answer from context",
     ]
     decision_messages = llm.calls[0]["messages"]
     system_context = next(

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -503,6 +503,32 @@ def test_memory_enrichment_uses_web_user_context(
     assert current_user_id.get() is None
 
 
+def test_memory_enrichment_without_user_context_fails_open(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_lookup(*_: object, **__: object) -> list[dict[str, str]]:
+        raise RuntimeError("memory backend unavailable")
+
+    monkeypatch.setattr(
+        enrichment_module,
+        "lookup_relevant_memories",
+        fail_lookup,
+    )
+
+    memories = _lookup_relevant_memories_with_context(
+        memory_store=object(),
+        query="query",
+        category="general",
+        include_general=True,
+        limit=5,
+        similarity_threshold=None,
+        user_id=None,
+    )
+
+    assert memories == []
+    assert current_user_id.get() is None
+
+
 @pytest.mark.asyncio
 async def test_enrich_context_with_memory_caches_and_builds_context(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -20,6 +20,7 @@ from xagent.core.agent.context.enrichment import (
     _current_user_id,
     _lookup_relevant_memories_with_context,
     enrich_context_with_memory,
+    memory_input_text,
 )
 from xagent.core.agent.context.execution import CLOCK_TIMEZONE_METADATA_KEY
 from xagent.core.agent.language import (
@@ -60,6 +61,87 @@ def test_create_context() -> None:
     assert ctx.workspace_state["files"] == 2
     assert ctx.memory_session_id == "mem-1"
     assert ctx.memory_snapshot == {"summary": "hello"}
+
+
+def test_memory_input_prefers_display_message_after_context_rebuild() -> None:
+    typed = "Summarize the attachment"
+    augmented = f"{typed}\n\nAttached file: /private/runtime/input.txt"
+    context = ExecutionContext(execution_id="memory-input")
+    context.add_user_message(
+        augmented,
+        metadata={"display_message": typed},
+    )
+
+    rebuilt = ExecutionContext.from_dict(context.to_dict())
+
+    assert memory_input_text(rebuilt) == typed
+    assert memory_input_text(rebuilt, execution_text=augmented) == typed
+
+
+def test_memory_input_preserves_legacy_content_fallback() -> None:
+    context = ExecutionContext(execution_id="legacy-memory-input")
+    context.add_user_message("Legacy execution text")
+
+    assert memory_input_text(context) == "Legacy execution text"
+    assert (
+        memory_input_text(context, execution_text="Legacy execution text")
+        == "Legacy execution text"
+    )
+
+
+def test_memory_input_uses_original_display_for_frozen_react_task() -> None:
+    original = "Inspect the report"
+    augmented = f"{original}\n\nAttached file: /private/runtime/report.pdf"
+    context = ExecutionContext(execution_id="resumed-memory-input")
+    context.add_user_message(augmented, metadata={"display_message": original})
+    context.add_user_message("Continue with the second option")
+
+    assert memory_input_text(context) == "Continue with the second option"
+    assert memory_input_text(context, execution_text=augmented) == original
+
+
+@pytest.mark.parametrize("display_message", [None, "", 42, {"text": "visible"}])
+def test_memory_input_ignores_unusable_display_metadata(
+    display_message: object,
+) -> None:
+    context = ExecutionContext(execution_id="invalid-display-memory-input")
+    context.add_user_message(
+        "Execution text fallback",
+        metadata={"display_message": display_message},
+    )
+
+    assert memory_input_text(context) == "Execution text fallback"
+
+
+def test_dag_memory_input_ignores_internal_step_messages() -> None:
+    typed = "Plan the release"
+    augmented = f"{typed}\n\nAttached file: /private/runtime/input.txt"
+    root = ExecutionContext(execution_id="dag-memory-input")
+    root.add_user_message(augmented, metadata={"display_message": typed})
+    child = root.create_child_context(metadata={"dag_step_id": "draft"})
+    child.add_user_message(
+        "Only execute this internal step.",
+        metadata={"dag_step_id": "draft", "kind": "dag_step_instruction"},
+    )
+
+    assert memory_input_text(child) == typed
+    assert (
+        memory_input_text(child, execution_text="Only execute this internal step.")
+        == typed
+    )
+
+
+def test_dag_memory_input_preserves_legacy_step_fallback() -> None:
+    root = ExecutionContext(execution_id="legacy-dag-memory-input")
+    root.add_user_message("Legacy root execution text")
+    child = root.create_child_context(metadata={"dag_step_id": "draft"})
+    step_instruction = "Only execute this legacy internal step."
+    child.add_user_message(
+        step_instruction,
+        metadata={"dag_step_id": "draft", "kind": "dag_step_instruction"},
+    )
+
+    assert memory_input_text(child, execution_text=step_instruction) == step_instruction
 
 
 def test_sanitize_tool_result_for_context_hides_image_path_when_artifact_exists() -> (

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -20,7 +20,6 @@ from xagent.core.agent.context.enrichment import (
     _current_user_id,
     _lookup_relevant_memories_with_context,
     enrich_context_with_memory,
-    memory_input_text,
 )
 from xagent.core.agent.context.execution import CLOCK_TIMEZONE_METADATA_KEY
 from xagent.core.agent.language import (
@@ -74,30 +73,42 @@ def test_memory_input_prefers_display_message_after_context_rebuild() -> None:
 
     rebuilt = ExecutionContext.from_dict(context.to_dict())
 
-    assert memory_input_text(rebuilt) == typed
-    assert memory_input_text(rebuilt, execution_text=augmented) == typed
+    assert rebuilt.current_user_request_text(prefer_display=True) == typed
 
 
 def test_memory_input_preserves_legacy_content_fallback() -> None:
     context = ExecutionContext(execution_id="legacy-memory-input")
     context.add_user_message("Legacy execution text")
 
-    assert memory_input_text(context) == "Legacy execution text"
-    assert (
-        memory_input_text(context, execution_text="Legacy execution text")
-        == "Legacy execution text"
+    assert context.current_user_request_text(prefer_display=True) == (
+        "Legacy execution text"
     )
 
 
-def test_memory_input_uses_original_display_for_frozen_react_task() -> None:
+def test_memory_input_ignores_waiting_response() -> None:
     original = "Inspect the report"
     augmented = f"{original}\n\nAttached file: /private/runtime/report.pdf"
     context = ExecutionContext(execution_id="resumed-memory-input")
     context.add_user_message(augmented, metadata={"display_message": original})
-    context.add_user_message("Continue with the second option")
+    context.add_user_message(
+        "Continue with the second option",
+        metadata={"response_to_waiting_for_user": {"question": "Which option?"}},
+    )
 
-    assert memory_input_text(context) == "Continue with the second option"
-    assert memory_input_text(context, execution_text=augmented) == original
+    assert context.current_user_request_text(prefer_display=True) == original
+
+
+def test_memory_input_can_freeze_a_prior_user_message_window() -> None:
+    context = ExecutionContext(execution_id="frozen-memory-input")
+    context.add_user_message(
+        "Original execution text", metadata={"display_message": "Original request"}
+    )
+    context.add_user_message("Later clarification")
+
+    assert (
+        context.current_user_request_text(prefer_display=True, user_message_limit=1)
+        == "Original request"
+    )
 
 
 @pytest.mark.parametrize("display_message", [None, "", 42, {"text": "visible"}])
@@ -110,7 +121,9 @@ def test_memory_input_ignores_unusable_display_metadata(
         metadata={"display_message": display_message},
     )
 
-    assert memory_input_text(context) == "Execution text fallback"
+    assert context.current_user_request_text(prefer_display=True) == (
+        "Execution text fallback"
+    )
 
 
 def test_dag_memory_input_ignores_internal_step_messages() -> None:
@@ -124,24 +137,7 @@ def test_dag_memory_input_ignores_internal_step_messages() -> None:
         metadata={"dag_step_id": "draft", "kind": "dag_step_instruction"},
     )
 
-    assert memory_input_text(child) == typed
-    assert (
-        memory_input_text(child, execution_text="Only execute this internal step.")
-        == typed
-    )
-
-
-def test_dag_memory_input_preserves_legacy_step_fallback() -> None:
-    root = ExecutionContext(execution_id="legacy-dag-memory-input")
-    root.add_user_message("Legacy root execution text")
-    child = root.create_child_context(metadata={"dag_step_id": "draft"})
-    step_instruction = "Only execute this legacy internal step."
-    child.add_user_message(
-        step_instruction,
-        metadata={"dag_step_id": "draft", "kind": "dag_step_instruction"},
-    )
-
-    assert memory_input_text(child, execution_text=step_instruction) == step_instruction
+    assert child.current_user_request_text(prefer_display=True) == typed
 
 
 def test_sanitize_tool_result_for_context_hides_image_path_when_artifact_exists() -> (

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -240,10 +241,17 @@ class MemoryNote:
 class FakeMemoryStore:
     def __init__(self) -> None:
         self.searches: list[dict[str, Any]] = []
+        self.added: list[Any] = []
 
     def search(self, **kwargs: Any) -> list[MemoryNote]:
         self.searches.append(kwargs)
+        if kwargs.get("query") == "User prefers concise summaries.":
+            return []
         return [MemoryNote()]
+
+    def add(self, note: Any) -> Any:
+        self.added.append(note)
+        return SimpleNamespace(success=True, memory_id=f"mem-{len(self.added)}")
 
 
 class FakeSkillManager:
@@ -4059,12 +4067,33 @@ async def test_dag_pattern_enriches_plan_prompt_with_memory() -> None:
     generator = LLMPlanGenerator()
     pattern = DAGPattern(generator)
     context = ExecutionContext(execution_id="dag-enriched")
-    context.add_user_message("Plan this")
+    context.add_user_message(
+        "Plan this\n\nAttached file: /private/runtime/input.txt",
+        metadata={"display_message": "Plan this"},
+    )
     memory_store = FakeMemoryStore()
     skill_manager = FakeSkillManager()
     llm = SequenceLLM(
         [
             plan_tool_response([{"id": "only", "task": "Only step"}]),
+            {
+                "content": "Remembering a reusable preference.",
+                "tool_calls": [
+                    {
+                        "id": "call_store_memory",
+                        "function": {
+                            "name": "store_memory",
+                            "arguments": json.dumps(
+                                {
+                                    "content": "User prefers concise summaries.",
+                                    "kind": "user_preference",
+                                }
+                            ),
+                        },
+                    }
+                ],
+                "done": False,
+            },
             {"content": "step done", "done": True},
         ]
     )
@@ -4082,7 +4111,15 @@ async def test_dag_pattern_enriches_plan_prompt_with_memory() -> None:
     assert [search["filters"]["category"] for search in memory_store.searches] == [
         "dag_plan_execute_memory",
         "general",
+        "react_memory",
     ]
+    assert [search["query"] for search in memory_store.searches] == [
+        "Plan this",
+        "Plan this",
+        "User prefers concise summaries.",
+    ]
+    assert memory_store.added[0].metadata["task"] == "Plan this"
+    assert "/private/runtime/input.txt" not in memory_store.added[0].metadata["task"]
     prompt_payload = json.loads(llm.call_kwargs[0]["messages"][1]["content"])
     assert (
         "Split this project using the historical DAG pattern."

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -40,8 +40,9 @@ from xagent.core.agent.pattern.dag.plan_generator import (
     PLAN_GENERATION_REQUIRED_TOOL_MESSAGE,
     PlanLanguageMismatchError,
 )
+from xagent.core.memory.core import MemoryNote as StoredMemoryNote
+from xagent.core.memory.core import MemoryResponse
 from xagent.core.model.chat.types import ChunkType, StreamChunk
-from xagent.core.memory.core import MemoryNote as StoredMemoryNote, MemoryResponse
 from xagent.core.task_runtime import PREFERRED_INPUT_MODALITIES_METADATA_KEY
 
 DAG_COMPLETION_TOOL_NAME = "assess_dag_completion"

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -41,6 +41,7 @@ from xagent.core.agent.pattern.dag.plan_generator import (
     PlanLanguageMismatchError,
 )
 from xagent.core.model.chat.types import ChunkType, StreamChunk
+from xagent.core.memory.core import MemoryNote as StoredMemoryNote, MemoryResponse
 from xagent.core.task_runtime import PREFERRED_INPUT_MODALITIES_METADATA_KEY
 
 DAG_COMPLETION_TOOL_NAME = "assess_dag_completion"
@@ -995,6 +996,125 @@ async def test_dag_pattern_passes_compact_llm_to_step_react_compaction() -> None
         "compacted dag step context" in message["content"]
         for message in llm.seen_messages[0]
     )
+
+
+@pytest.mark.asyncio
+async def test_dag_compaction_resume_preserves_clean_memory_metadata() -> None:
+    class CrudMemoryStore:
+        def __init__(self) -> None:
+            self.notes = {
+                "existing": StoredMemoryNote(
+                    id="existing",
+                    content="Old preference",
+                    metadata={},
+                )
+            }
+            self.added: list[StoredMemoryNote] = []
+            self.updated: list[StoredMemoryNote] = []
+
+        def search(self, **_: Any) -> list[StoredMemoryNote]:
+            return []
+
+        def add(self, note: StoredMemoryNote) -> MemoryResponse:
+            self.added.append(note)
+            return MemoryResponse(success=True, memory_id="added")
+
+        def get(self, note_id: str) -> MemoryResponse:
+            return MemoryResponse(success=True, content=self.notes[note_id])
+
+        def update(self, note: StoredMemoryNote) -> MemoryResponse:
+            self.updated.append(note)
+            return MemoryResponse(success=True, memory_id=note.id)
+
+    typed = "Prepare the report"
+    augmented = f"{typed}\n\nAttached file: /private/runtime/input.txt"
+    context = ExecutionContext(execution_id="dag-memory-provenance")
+    context.metadata["task"] = augmented
+    context.compact_config.threshold = 1
+    context.add_user_message(augmented, metadata={"display_message": typed})
+    runtime = PatternRuntime(execution_id=context.execution_id)
+    runtime.interrupt_checker = lambda: any(
+        checkpoint["label"] == "dag_after_llm" for checkpoint in runtime.checkpoints
+    )
+    pattern = DAGPattern(
+        lambda **_: build_plan(PlanStep(id="answer", task="Draft the report"))
+    )
+    first_llm = SequenceLLM(
+        [
+            {
+                "content": "Persist memory changes.",
+                "tool_calls": [
+                    {
+                        "id": "store",
+                        "function": {
+                            "name": "store_memory",
+                            "arguments": json.dumps(
+                                {
+                                    "content": "User prefers brief reports.",
+                                    "kind": "user_preference",
+                                }
+                            ),
+                        },
+                    },
+                    {
+                        "id": "update",
+                        "function": {
+                            "name": "update_memory",
+                            "arguments": json.dumps(
+                                {
+                                    "memory_id": "existing",
+                                    "content": "User prefers concise reports.",
+                                }
+                            ),
+                        },
+                    },
+                ],
+                "done": False,
+            }
+        ]
+    )
+    compact_llm = SequenceLLM([{"content": "Compacted DAG child"}])
+    memory_store = CrudMemoryStore()
+
+    interrupted = await pattern.run(
+        context=context,
+        tools=[],
+        llm=first_llm,
+        compact_llm=compact_llm,
+        memory_store=memory_store,
+        runtime=runtime,
+    )
+    checkpoint = runtime.last_checkpoint
+
+    assert interrupted["status"] == "interrupted"
+    assert checkpoint is not None
+    step_state = checkpoint["pattern_state"]["active_step_pattern_states"]["answer"]
+    assert step_state["memory_input_text"] == typed
+
+    restored_context = ExecutionContext.from_dict(checkpoint["context"])
+    restored_context.add_user_message(
+        "Internal resumed step",
+        metadata={"dag_step_id": "answer"},
+    )
+    restored_context.compact_with_llm_response({"content": "Rebuilt root"})
+    restored = DAGPattern(
+        lambda **_: build_plan(PlanStep(id="answer", task="Draft the report"))
+    )
+    restored.load_state(checkpoint["pattern_state"])
+
+    result = await restored.run(
+        context=restored_context,
+        tools=[],
+        llm=SequenceLLM([{"content": "Done.", "done": True}]),
+        compact_llm=SequenceLLM([{"content": "Compacted resumed child"}]),
+        memory_store=memory_store,
+    )
+
+    assert result["success"] is True, result
+    assert memory_store.added[0].metadata["task"] == typed
+    assert memory_store.updated[0].metadata["updated_by_task"] == typed
+    assert augmented not in memory_store.added[0].metadata.values()
+    assert augmented not in memory_store.updated[0].metadata.values()
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -495,6 +495,101 @@ async def test_dag_forwards_disabled_interaction_policy_to_each_step(
     assert observed_policies == [False]
 
 
+@pytest.mark.asyncio
+async def test_dag_waiting_resume_keeps_memory_input_for_later_child() -> None:
+    class EmptyMemoryStore(FakeMemoryStore):
+        def search(self, **kwargs: Any) -> list[MemoryNote]:
+            self.searches.append(kwargs)
+            return []
+
+    typed = "Compare the attached options"
+    augmented = f"{typed}\n\nAttached file: /private/runtime/options.pdf"
+    context = ExecutionContext(execution_id="dag-waiting-memory")
+    context.metadata["task"] = augmented
+    context.add_user_message(augmented, metadata={"display_message": typed})
+    plan = build_plan(
+        PlanStep(id="confirm", task="Ask which option to use"),
+        PlanStep(id="save", task="Save the choice", dependencies=["confirm"]),
+    )
+    pattern = DAGPattern(lambda **_: plan)
+    memory_store = EmptyMemoryStore()
+    first = await pattern.run(
+        context=context,
+        tools=[],
+        llm=SequenceLLM(
+            [
+                {
+                    "tool_calls": [
+                        {
+                            "id": "ask-choice",
+                            "function": {
+                                "name": "send_message",
+                                "arguments": json.dumps(
+                                    {
+                                        "message": "Choose A or B",
+                                        "message_type": "question",
+                                        "expect_response": True,
+                                    }
+                                ),
+                            },
+                        }
+                    ],
+                    "done": False,
+                }
+            ]
+        ),
+        memory_store=memory_store,
+    )
+
+    assert first["status"] == "waiting_for_user"
+    legacy_state = pattern.get_state()
+    legacy_state.pop("memory_input_text")
+    rebuilt = ExecutionContext.from_dict(context.to_dict())
+    rebuilt.add_user_message("B")
+    restored = DAGPattern(lambda **_: plan)
+    restored.load_state(legacy_state)
+
+    resume_llm = SequenceLLM(
+        [
+            {"content": "Choice confirmed.", "done": True},
+            {
+                "content": "Remembering the choice.",
+                "tool_calls": [
+                    {
+                        "id": "store-choice",
+                        "function": {
+                            "name": "store_memory",
+                            "arguments": json.dumps(
+                                {
+                                    "content": "User chose option B.",
+                                    "kind": "user_preference",
+                                }
+                            ),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {"content": "Choice saved.", "done": True},
+        ]
+    )
+    result = await restored.run(
+        context=rebuilt,
+        tools=[],
+        llm=resume_llm,
+        memory_store=memory_store,
+    )
+
+    assert result["success"] is True, result
+    assert restored.memory_input_text == typed
+    assert memory_store.added
+    assert memory_store.added[-1].metadata["task"] == typed
+    assert {call["query"] for call in memory_store.searches} == {
+        typed,
+        "User chose option B.",
+    }
+
+
 async def run_invalid_plan(plan: ExecutionPlan) -> dict[str, Any]:
     pattern = DAGPattern(lambda **_: plan)
     return await pattern.run(
@@ -1089,6 +1184,7 @@ async def test_dag_compaction_resume_preserves_clean_memory_metadata() -> None:
 
     assert interrupted["status"] == "interrupted"
     assert checkpoint is not None
+    assert checkpoint["pattern_state"]["memory_input_text"] == typed
     step_state = checkpoint["pattern_state"]["active_step_pattern_states"]["answer"]
     assert step_state["memory_input_text"] == typed
 
@@ -1114,8 +1210,6 @@ async def test_dag_compaction_resume_preserves_clean_memory_metadata() -> None:
     assert result["success"] is True, result
     assert memory_store.added[0].metadata["task"] == typed
     assert memory_store.updated[0].metadata["updated_by_task"] == typed
-    assert augmented not in memory_store.added[0].metadata.values()
-    assert augmented not in memory_store.updated[0].metadata.values()
 
 
 @pytest.mark.asyncio
@@ -5422,6 +5516,9 @@ async def test_restored_dag_step_instruction_drops_stale_language_policy(
     class CapturingReActPattern:
         def __init__(self, **kwargs: Any) -> None:
             del kwargs
+
+        def seed_memory_input(self, memory_text: str) -> None:
+            del memory_text
 
         async def run(self, *, context: Any, **kwargs: Any) -> dict[str, Any]:
             del kwargs

--- a/tests/core/agent/test_memory_tool.py
+++ b/tests/core/agent/test_memory_tool.py
@@ -14,6 +14,8 @@ from xagent.core.agent.context.memory_tool import (
     build_store_memory_tool,
 )
 from xagent.core.memory.core import MemoryNote, MemoryResponse
+from xagent.core.memory.lancedb import LanceDBMemoryStore
+from xagent.web.user_isolated_memory import UserIsolatedMemoryStore
 
 
 class RecordingMemoryStore:
@@ -295,6 +297,33 @@ async def test_search_memory_reports_backend_failure() -> None:
     assert result == {"success": False, "error": "Failed to search memories."}
     assert tracer.events[-1]["data"]["success"] is False
     assert tracer.events[-1]["data"]["found"] is False
+
+
+@pytest.mark.asyncio
+async def test_search_memory_reports_terminal_lancedb_failure(
+    tmp_path: Any,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class BrokenConnection:
+        def open_table(self, _: str) -> Any:
+            raise RuntimeError("memory table unavailable")
+
+    base_store = LanceDBMemoryStore(
+        db_dir=str(tmp_path),
+        collection_name="terminal_failure",
+    )
+    monkeypatch.setattr(
+        base_store._vector_store,
+        "get_raw_connection",
+        lambda: BrokenConnection(),
+    )
+    tool = SearchMemoryTool(
+        memory_store=UserIsolatedMemoryStore(base_store),
+    )
+
+    result = await tool.execute(query="preferences")
+
+    assert result == {"success": False, "error": "Failed to search memories."}
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_memory_tool.py
+++ b/tests/core/agent/test_memory_tool.py
@@ -279,6 +279,7 @@ async def test_search_memory_rejects_empty_query_and_emits_trace() -> None:
         "task_start_memory_retrieve",
         "task_end_memory_retrieve",
     ]
+    assert tracer.events[-1]["data"]["success"] is True
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_memory_tool.py
+++ b/tests/core/agent/test_memory_tool.py
@@ -280,6 +280,24 @@ async def test_search_memory_rejects_empty_query_and_emits_trace() -> None:
 
 
 @pytest.mark.asyncio
+async def test_search_memory_reports_backend_failure() -> None:
+    class BrokenSearchStore(CrudMemoryStore):
+        def search(self, **kwargs: Any) -> list[Any]:
+            raise RuntimeError("backend unavailable")
+
+    tracer = TraceEventRecorder()
+    tool = SearchMemoryTool(
+        memory_store=BrokenSearchStore(), runtime=FakeRuntime(tracer=tracer)
+    )
+
+    result = await tool.execute(query="preferences")
+
+    assert result == {"success": False, "error": "Failed to search memories."}
+    assert tracer.events[-1]["data"]["success"] is False
+    assert tracer.events[-1]["data"]["found"] is False
+
+
+@pytest.mark.asyncio
 async def test_update_memory_replaces_content() -> None:
     store = CrudMemoryStore({"mem-1": _note("mem-1", "Old fact.")})
     tool = UpdateMemoryTool(memory_store=store, task="current task")

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -6055,6 +6055,7 @@ def test_react_pattern_state_roundtrip() -> None:
     pattern.status = "acting"
     pattern.current_iteration = 2
     pattern.task_text = "Original task"
+    pattern.memory_input_text = "Clean original task"
     pattern.pending_tool_calls = [{"id": "call_1", "name": "calculator", "args": {}}]
     pattern._record_tool_call(
         {"id": "call_1", "name": "calculator", "args": {"expression": "1+1"}},
@@ -6070,8 +6071,19 @@ def test_react_pattern_state_roundtrip() -> None:
     assert restored.max_iterations == 5
     assert restored.repeated_tool_decision_after_consecutive_work_tool_calls == 7
     assert restored.task_text == "Original task"
+    assert restored.memory_input_text == "Clean original task"
     assert restored.reasoning_mode == ReActReasoningMode.TOOL_CALLING
     assert restored.tool_ledger["call_1"].result == {"result": 2}
+
+
+def test_react_pattern_loads_legacy_state_without_overwriting_memory_input() -> None:
+    restored = ReActPattern()
+    restored.memory_input_text = "Clean task from the rebuilt root context"
+
+    restored.load_state({"task_text": "Augmented execution task"})
+
+    assert restored.task_text == "Augmented execution task"
+    assert restored.memory_input_text == "Clean task from the rebuilt root context"
 
 
 def test_react_pattern_state_roundtrip_preserves_disabled_decision_thresholds() -> None:

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -5362,7 +5362,9 @@ async def test_react_pattern_resume_binds_original_task_to_store_memory() -> Non
     rebuilt_context = ExecutionContext.from_dict(context.to_dict())
     rebuilt_context.add_user_message("B")
     resumed_pattern = ReActPattern(max_iterations=3)
-    resumed_pattern.load_state(pattern.get_state())
+    legacy_state = pattern.get_state()
+    legacy_state.pop("memory_input_text")
+    resumed_pattern.load_state(legacy_state)
     resumed_llm = FakeLLM(
         responses=[
             {

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -4000,7 +4000,10 @@ async def test_react_pattern_injects_memory_context_and_skill_index() -> None:
     skill_manager = FakeSkillManager()
     pattern = ReActPattern(max_iterations=3)
     context = ExecutionContext(system_prompt="You are helpful.")
-    context.add_user_message("Do the thing")
+    context.add_user_message(
+        "Do the thing\n\nAttached file: /private/runtime/input.txt",
+        metadata={"display_message": "Do the thing"},
+    )
 
     result = await pattern.run(
         context=context,
@@ -4015,6 +4018,10 @@ async def test_react_pattern_injects_memory_context_and_skill_index() -> None:
     assert [search["filters"]["category"] for search in memory_store.searches] == [
         "react_memory",
         "general",
+    ]
+    assert [search["query"] for search in memory_store.searches] == [
+        "Do the thing",
+        "Do the thing",
     ]
     first_system_prompt = llm.calls[0]["messages"][0]["content"]
     assert "Use the stored project preference." in first_system_prompt
@@ -5344,12 +5351,16 @@ async def test_react_pattern_resume_binds_original_task_to_store_memory() -> Non
     )
     pattern = ReActPattern(max_iterations=3)
     context = ExecutionContext()
-    context.add_user_message("Ask, then calculate")
+    context.add_user_message(
+        "Ask, then calculate\n\nAttached file: /private/runtime/input.txt",
+        metadata={"display_message": "Ask, then calculate"},
+    )
 
     first = await pattern.run(context=context, tools=[], llm=llm)
 
     assert first["status"] == "waiting_for_user"
-    context.add_user_message("B")
+    rebuilt_context = ExecutionContext.from_dict(context.to_dict())
+    rebuilt_context.add_user_message("B")
     resumed_pattern = ReActPattern(max_iterations=3)
     resumed_pattern.load_state(pattern.get_state())
     resumed_llm = FakeLLM(
@@ -5376,7 +5387,7 @@ async def test_react_pattern_resume_binds_original_task_to_store_memory() -> Non
     memory_store = MemoryToolStore()
 
     resumed = await resumed_pattern.run(
-        context=context,
+        context=rebuilt_context,
         tools=[],
         llm=resumed_llm,
         memory_store=memory_store,
@@ -6176,6 +6187,8 @@ class MemoryToolStore:
     def __init__(self) -> None:
         self.searches: list[dict[str, Any]] = []
         self.added: list[Any] = []
+        self.notes: dict[str, Any] = {}
+        self.updated: list[Any] = []
 
     def search(self, **kwargs: Any) -> list[Any]:
         self.searches.append(kwargs)
@@ -6184,6 +6197,17 @@ class MemoryToolStore:
     def add(self, note: Any) -> Any:
         self.added.append(note)
         return SimpleNamespace(success=True, memory_id=f"mem-{len(self.added)}")
+
+    def get(self, memory_id: str) -> Any:
+        note = self.notes.get(memory_id)
+        if note is None:
+            return SimpleNamespace(success=False, content=None)
+        return SimpleNamespace(success=True, content=note)
+
+    def update(self, note: Any) -> Any:
+        self.updated.append(note)
+        self.notes[note.id] = note
+        return SimpleNamespace(success=True, memory_id=note.id)
 
 
 def _tool_names_from_llm_call(call: dict[str, Any]) -> list[str]:
@@ -6252,6 +6276,56 @@ async def test_react_pattern_exposes_store_memory_tool_with_memory_store() -> No
     # consumed by the ReAct loop itself.
     assert llm.responses == []
     assert len(llm.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_react_update_memory_uses_clean_task_metadata() -> None:
+    llm = FakeLLM(
+        responses=[
+            {
+                "content": "Correcting stale memory.",
+                "tool_calls": [
+                    {
+                        "id": "call_update_memory",
+                        "function": {
+                            "name": "update_memory",
+                            "arguments": json.dumps(
+                                {
+                                    "memory_id": "mem-existing",
+                                    "content": "Use the current release channel.",
+                                }
+                            ),
+                        },
+                    }
+                ],
+                "done": False,
+            },
+            {"content": "Done.", "done": True},
+        ]
+    )
+    memory_store = MemoryToolStore()
+    memory_store.notes["mem-existing"] = SimpleNamespace(
+        id="mem-existing",
+        content="Use the legacy release channel.",
+        metadata={"source": "test"},
+    )
+    pattern = ReActPattern(max_iterations=3)
+    typed = "Update the release notes"
+    augmented = f"{typed}\n\nAttached file: /private/runtime/input.txt"
+    context = ExecutionContext()
+    context.add_user_message(augmented, metadata={"display_message": typed})
+
+    result = await pattern.run(
+        context=context,
+        tools=[],
+        llm=llm,
+        memory_store=memory_store,
+    )
+
+    assert result["success"] is True
+    assert len(memory_store.updated) == 1
+    assert memory_store.updated[0].metadata["updated_by_task"] == typed
+    assert augmented not in memory_store.updated[0].metadata.values()
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -19,6 +19,7 @@ from xagent.core.agent.checkpoint import (
     CheckpointCorruptError,
     CheckpointUnavailableError,
 )
+from xagent.core.agent.context.enrichment import memory_input_text
 from xagent.core.agent.language import (
     OUTPUT_LANGUAGE_METADATA_KEY,
     OUTPUT_LANGUAGE_SOURCE_METADATA_KEY,
@@ -1636,6 +1637,7 @@ async def test_runner_initial_user_message_preserves_display_metadata(
     assert first_user.content == execution_message
     assert first_user.metadata["display_message"] == "Read file"
     assert first_user.metadata["files"] == files
+    assert memory_input_text(result["context"]) == "Read file"
     turn_id = first_user.metadata.get("turn_id")
     assert isinstance(turn_id, str) and turn_id
     user_event = next(

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -19,7 +19,6 @@ from xagent.core.agent.checkpoint import (
     CheckpointCorruptError,
     CheckpointUnavailableError,
 )
-from xagent.core.agent.context.enrichment import memory_input_text
 from xagent.core.agent.language import (
     OUTPUT_LANGUAGE_METADATA_KEY,
     OUTPUT_LANGUAGE_SOURCE_METADATA_KEY,
@@ -1637,7 +1636,9 @@ async def test_runner_initial_user_message_preserves_display_metadata(
     assert first_user.content == execution_message
     assert first_user.metadata["display_message"] == "Read file"
     assert first_user.metadata["files"] == files
-    assert memory_input_text(result["context"]) == "Read file"
+    assert result["context"].current_user_request_text(prefer_display=True) == (
+        "Read file"
+    )
     turn_id = first_user.metadata.get("turn_id")
     assert isinstance(turn_id, str) and turn_id
     user_event = next(

--- a/tests/core/memory/test_lancedb.py
+++ b/tests/core/memory/test_lancedb.py
@@ -431,9 +431,27 @@ def test_embedding_fallback(memory_store):
         results = fallback_store.search("Test content", k=5)
         assert len(results) >= 1
         assert results[0].content == "Test content for fallback"
-
     finally:
         shutil.rmtree(temp_dir, ignore_errors=True)
+
+
+def test_list_all_propagates_terminal_search_failure(temp_db_dir, monkeypatch):
+    class BrokenConnection:
+        def open_table(self, _: str):
+            raise RuntimeError("memory table unavailable")
+
+    store = LanceDBMemoryStore(
+        db_dir=temp_db_dir,
+        collection_name="terminal_list_failure",
+    )
+    monkeypatch.setattr(
+        store._vector_store,
+        "get_raw_connection",
+        lambda: BrokenConnection(),
+    )
+
+    with pytest.raises(RuntimeError, match="memory table unavailable"):
+        store.list_all()
 
 
 def test_large_content_handling(memory_store):

--- a/tests/web/test_memory_api.py
+++ b/tests/web/test_memory_api.py
@@ -279,8 +279,35 @@ class TestMemoryListEndpoint:
 
         response = client.get("/api/memory/list", headers=auth_headers)
 
-        assert response.status_code == 500
-        assert "Failed to list memories" in response.json()["detail"]
+        assert response.status_code == 503
+        assert response.json()["detail"] == "Memory storage is temporarily unavailable."
+        assert "Database error" not in response.text
+
+    def test_search_memories_returns_empty_success_for_no_match(
+        self, client, mock_memory_store, auth_headers
+    ):
+        mock_memory_store.search.return_value = []
+
+        response = client.get("/api/memory/list?search=missing", headers=auth_headers)
+
+        assert response.status_code == 200
+        assert response.json()["memories"] == []
+        assert response.json()["total_count"] == 0
+
+    def test_search_memories_sanitizes_backend_failure(
+        self, client, mock_memory_store, auth_headers
+    ):
+        mock_memory_store.search.side_effect = RuntimeError(
+            "lancedb://internal-host/private-table"
+        )
+
+        response = client.get(
+            "/api/memory/list?search=preferences", headers=auth_headers
+        )
+
+        assert response.status_code == 503
+        assert response.json()["detail"] == "Memory storage is temporarily unavailable."
+        assert "internal-host" not in response.text
 
 
 class TestMemoryGetEndpoint:


### PR DESCRIPTION
## Summary

- select user-facing display text for Auto, ReAct, and DAG memory recall while preserving legacy execution-text fallback
- keep augmented execution prompts out of stored and updated memory provenance metadata
- return an explicit unsuccessful result when the memory search backend fails

## Validation

- `ruff check` on all changed Python files
- `python -m py_compile` on changed production modules
- 139 focused tests covering context selection, memory tools, runner creation, Auto, ReAct, DAG, checkpoint rebuild, and metadata sanitation
- mutation verification: restoring execution-context query/provenance selection caused all 5 targeted regression tests to fail

Closes #2036