### PR TITLE
feat: allow excluding xrouter candidate models

### DIFF
--- a/example.env
+++ b/example.env
@@ -301,6 +301,10 @@ INFERENCE_API_KEY="your-inference-api-key"
 # OpenRouter fallback behavior. Set to true to route official model families
 # (OpenAI, Anthropic, Google, DeepSeek, MiniMax, Z.AI) only to official endpoints.
 # XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY="false"
+# Comma-separated exact, case-sensitive OpenRouter model slugs to omit from
+# xrouter candidate sets. This does not disable profile lookup, explicit model
+# selection, or XAGENT_ROUTER_FALLBACK_MODEL.
+# XAGENT_XROUTER_EXCLUDED_MODELS="z-ai/glm-5.3-flash"
 
 # ===========================================
 # Embedding API Keys (for vector memory)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,7 +99,7 @@ command-path-guard = ["bashlex>=0.18"]
 # does not declare its bundled predictor runtime deps, so keep them explicit
 # here until upstream does.
 router = [
-  "xrouter-llm>=0.1.2",
+  "xrouter-llm>=0.3.3",
   "sentence-transformers>=3.0.0",
   # xrouter-llm's embedding model is a Qwen3-architecture checkpoint; transformers
   # only registered the `qwen3` model type in 4.51.
@@ -158,7 +158,7 @@ all = [
   "curl_cffi>=0.14.0",
   "chromadb",
   "pymilvus>=2.6.9,<3.0.0",
-  "xrouter-llm>=0.1.2",
+  "xrouter-llm>=0.3.3",
   "sentence-transformers>=3.0.0",
 ]
 
@@ -196,7 +196,7 @@ backend-image = [
   "pymilvus>=2.6.9,<3.0.0",
   "torch",
   "torchvision",
-  "xrouter-llm>=0.1.2",
+  "xrouter-llm>=0.3.3",
   "sentence-transformers>=3.0.0",
 ]
 

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -212,6 +212,7 @@ OIDC_LOGIN_TTL_SECONDS = "XAGENT_OIDC_LOGIN_TTL_SECONDS"
 OIDC_EXCHANGE_TTL_SECONDS = "XAGENT_OIDC_EXCHANGE_TTL_SECONDS"
 SESSION_SECRET = "XAGENT_SESSION_SECRET"
 OPENROUTER_OFFICIAL_PROVIDERS_ONLY = "XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY"
+XROUTER_EXCLUDED_MODELS = "XAGENT_XROUTER_EXCLUDED_MODELS"
 MCP_OAUTH_ALLOW_PRIVATE_HOSTS = "XAGENT_MCP_OAUTH_ALLOW_PRIVATE_HOSTS"
 MCP_OAUTH_PROXY_URL = "XAGENT_MCP_OAUTH_PROXY_URL"
 TRUSTED_EGRESS_PROXY = "XAGENT_TRUSTED_EGRESS_PROXY"
@@ -606,6 +607,18 @@ def get_smtp_from_name(default: str) -> str:
 def get_openrouter_official_providers_only() -> bool:
     """Return whether OpenRouter requests should pin official provider endpoints."""
     return _get_bool_env(OPENROUTER_OFFICIAL_PROVIDERS_ONLY, False)
+
+
+def get_xrouter_excluded_models() -> tuple[str, ...]:
+    """Return model slugs excluded from xrouter candidate sets.
+
+    The environment value is a comma-separated list. Empty entries are ignored,
+    and duplicates are removed while preserving the configured order.
+    """
+    value = os.getenv(XROUTER_EXCLUDED_MODELS, "")
+    return tuple(
+        dict.fromkeys(item.strip() for item in value.split(",") if item.strip())
+    )
 
 
 def get_mcp_oauth_allow_private_hosts() -> bool:

--- a/src/xagent/core/model/chat/basic/router.py
+++ b/src/xagent/core/model/chat/basic/router.py
@@ -22,6 +22,7 @@ Env overrides (all optional; default to the bundled package data):
   XAGENT_XROUTER_MODELS_DIR     model-profile registry dir/file
   XAGENT_XROUTER_ROUTERS_DIR    router configs dir/file
   XAGENT_XROUTER_DB             routing-decision SQLite history path
+  XAGENT_XROUTER_EXCLUDED_MODELS comma-separated candidate model slugs to omit
   XAGENT_ROUTER_FALLBACK_MODEL  slug to use if routing fails
 """
 
@@ -34,6 +35,7 @@ import os
 import threading
 from typing import Any, AsyncIterator, Callable, List, Optional
 
+from .....config import get_xrouter_excluded_models
 from ....context_ref import CONTEXT_REFS_KEY, normalize_context_references
 from ....model import ChatModelConfig
 from ....task_runtime import normalize_input_modalities
@@ -482,12 +484,13 @@ class RouterLLM(BaseLLM):
             route_parameters = dict(inspect.signature(service.route).parameters)
         except (TypeError, ValueError):
             route_parameters = {}
+        supports_keyword_arguments = any(
+            parameter.kind is inspect.Parameter.VAR_KEYWORD
+            for parameter in route_parameters.values()
+        )
         supports_modality_preferences = (
             "preferred_input_modalities" in route_parameters
-            or any(
-                parameter.kind is inspect.Parameter.VAR_KEYWORD
-                for parameter in route_parameters.values()
-            )
+            or supports_keyword_arguments
         )
         requested_modalities = tuple(
             dict.fromkeys((*advisory_input_modalities, *preferred_input_modalities))
@@ -511,6 +514,26 @@ class RouterLLM(BaseLLM):
                 "modality preferences (%s); routing without them.",
                 ", ".join(advisory_input_modalities),
             )
+
+        excluded_models = frozenset(get_xrouter_excluded_models())
+        configs = getattr(service, "configs", None) or {}
+        config = configs.get(self._config_name)
+        configured_models = tuple(getattr(config, "models", ()) or ())
+        eligible_models = [
+            model for model in configured_models if model not in excluded_models
+        ]
+        if excluded_models and len(eligible_models) != len(configured_models):
+            if not eligible_models:
+                raise RuntimeError(
+                    f"{self._config_name!r} has no candidates after applying "
+                    "XAGENT_XROUTER_EXCLUDED_MODELS"
+                )
+            if "models" not in route_parameters and not supports_keyword_arguments:
+                raise RuntimeError(
+                    "The installed xrouter-llm RoutingService cannot apply "
+                    "XAGENT_XROUTER_EXCLUDED_MODELS; upgrade xrouter-llm."
+                )
+            route_kwargs["models"] = eligible_models
         result = service.route(prompt, **route_kwargs)
         return list(result.get("selected") or [])
 

--- a/tests/core/model/chat/basic/test_router.py
+++ b/tests/core/model/chat/basic/test_router.py
@@ -303,6 +303,155 @@ def test_route_sync_forwards_advisory_modalities_when_supported(monkeypatch) -> 
     assert calls == [("image", "audio")]
 
 
+def test_route_sync_excludes_configured_models(monkeypatch) -> None:
+    calls: list[dict[str, Any]] = []
+
+    class Service:
+        configs = {
+            "auto": SimpleNamespace(
+                models=("z-ai/glm-5.3-flash", "openai/gpt-5.6-luna")
+            )
+        }
+
+        def route(
+            self,
+            prompt: str,
+            *,
+            config_name: str,
+            models: list[str] | None = None,
+        ) -> dict[str, Any]:
+            calls.append(
+                {"prompt": prompt, "config_name": config_name, "models": models}
+            )
+            return {"selected": [models[0]] if models else []}
+
+    monkeypatch.setenv("XAGENT_XROUTER_EXCLUDED_MODELS", "z-ai/glm-5.3-flash")
+    monkeypatch.setattr(
+        "xagent.core.model.chat.basic.router._get_service",
+        lambda: Service(),
+    )
+
+    selected = RouterLLM()._route_sync("inspect")
+
+    assert selected == ["openai/gpt-5.6-luna"]
+    assert calls == [
+        {
+            "prompt": "inspect",
+            "config_name": "auto",
+            "models": ["openai/gpt-5.6-luna"],
+        }
+    ]
+
+
+@pytest.mark.parametrize("excluded_models", ["", "unknown/model"])
+def test_route_sync_leaves_models_unset_without_matching_exclusions(
+    monkeypatch,
+    excluded_models: str,
+) -> None:
+    calls: list[list[str] | None] = []
+
+    class Service:
+        configs = {
+            "auto": SimpleNamespace(
+                models=("z-ai/glm-5.3-flash", "openai/gpt-5.6-luna")
+            )
+        }
+
+        def route(
+            self,
+            prompt: str,
+            *,
+            config_name: str,
+            models: list[str] | None = None,
+        ) -> dict[str, Any]:
+            del prompt, config_name
+            calls.append(models)
+            return {"selected": ["z-ai/glm-5.3-flash"]}
+
+    monkeypatch.setenv("XAGENT_XROUTER_EXCLUDED_MODELS", excluded_models)
+    monkeypatch.setattr(
+        "xagent.core.model.chat.basic.router._get_service",
+        lambda: Service(),
+    )
+
+    selected = RouterLLM()._route_sync("inspect")
+
+    assert selected == ["z-ai/glm-5.3-flash"]
+    assert calls == [None]
+
+
+def test_route_sync_rejects_excluding_every_candidate(monkeypatch) -> None:
+    class Service:
+        configs = {
+            "auto": SimpleNamespace(models=("z-ai/glm-5.3-flash",)),
+        }
+
+        def route(
+            self,
+            prompt: str,
+            *,
+            config_name: str,
+            models: list[str] | None = None,
+        ) -> dict[str, Any]:
+            raise AssertionError("route must not run without an eligible candidate")
+
+    monkeypatch.setenv("XAGENT_XROUTER_EXCLUDED_MODELS", "z-ai/glm-5.3-flash")
+    monkeypatch.setattr(
+        "xagent.core.model.chat.basic.router._get_service",
+        lambda: Service(),
+    )
+
+    with pytest.raises(RuntimeError, match="no candidates"):
+        RouterLLM()._route_sync("inspect")
+
+
+@pytest.mark.asyncio
+async def test_exclusion_failure_uses_explicit_fallback(monkeypatch) -> None:
+    class Service:
+        configs = {
+            "auto": SimpleNamespace(models=("z-ai/glm-5.3-flash",)),
+        }
+
+        def route(
+            self,
+            prompt: str,
+            *,
+            config_name: str,
+            models: list[str] | None = None,
+        ) -> dict[str, Any]:
+            raise AssertionError("route must not run without an eligible candidate")
+
+    monkeypatch.setenv("XAGENT_XROUTER_EXCLUDED_MODELS", "z-ai/glm-5.3-flash")
+    monkeypatch.setenv("XAGENT_ROUTER_FALLBACK_MODEL", "fallback/model")
+    monkeypatch.setattr(
+        "xagent.core.model.chat.basic.router._get_service",
+        lambda: Service(),
+    )
+
+    assert await RouterLLM()._select_model("inspect") == "fallback/model"
+
+
+def test_route_sync_rejects_older_router_api_for_exclusions(monkeypatch) -> None:
+    class Service:
+        configs = {
+            "auto": SimpleNamespace(
+                models=("z-ai/glm-5.3-flash", "openai/gpt-5.6-luna")
+            )
+        }
+
+        def route(self, prompt: str, *, config_name: str) -> dict[str, Any]:
+            return {"selected": ["z-ai/glm-5.3-flash"]}
+
+    monkeypatch.setenv("XAGENT_XROUTER_EXCLUDED_MODELS", "z-ai/glm-5.3-flash")
+    monkeypatch.setattr(
+        "xagent.core.model.chat.basic.router._get_service",
+        lambda: Service(),
+    )
+
+    with pytest.raises(RuntimeError, match="upgrade xrouter-llm"):
+        RouterLLM()._route_sync("inspect")
+
+
 def test_route_sync_rejects_older_router_api_for_modality_requests(
     monkeypatch,
 ) -> None:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -115,6 +115,7 @@ from xagent.config import (
     WEB_CRAWL_TLS_IMPERSONATE,
     WEB_DIR,
     WEB_SEARCH_PROVIDER,
+    XROUTER_EXCLUDED_MODELS,
     ExternalUploadsDirConfigurationError,
     format_file_size,
     get_agent_pattern_for_execution_mode,
@@ -222,6 +223,7 @@ from xagent.config import (
     get_web_crawl_tls_impersonate,
     get_web_dir,
     get_web_search_provider,
+    get_xrouter_excluded_models,
     in_sandbox_tool_runner,
     validate_sandbox_namespace,
 )
@@ -356,6 +358,9 @@ class TestEnvironmentVariableConstants:
             OPENROUTER_OFFICIAL_PROVIDERS_ONLY
             == "XAGENT_OPENROUTER_OFFICIAL_PROVIDERS_ONLY"
         )
+
+    def test_xrouter_excluded_models_constant(self):
+        assert XROUTER_EXCLUDED_MODELS == "XAGENT_XROUTER_EXCLUDED_MODELS"
 
     def test_mcp_oauth_allow_private_hosts_constant(self):
         assert MCP_OAUTH_ALLOW_PRIVATE_HOSTS == "XAGENT_MCP_OAUTH_ALLOW_PRIVATE_HOSTS"
@@ -567,6 +572,21 @@ class TestOpenRouterConfig:
     def test_official_providers_only_false_values(self, monkeypatch, value):
         monkeypatch.setenv(OPENROUTER_OFFICIAL_PROVIDERS_ONLY, value)
         assert get_openrouter_official_providers_only() is False
+
+    def test_xrouter_excluded_models_defaults_empty(self, monkeypatch):
+        monkeypatch.delenv(XROUTER_EXCLUDED_MODELS, raising=False)
+        assert get_xrouter_excluded_models() == ()
+
+    def test_xrouter_excluded_models_parses_and_deduplicates(self, monkeypatch):
+        monkeypatch.setenv(
+            XROUTER_EXCLUDED_MODELS,
+            " z-ai/glm-5.3-flash, openai/gpt-5.6-luna, z-ai/glm-5.3-flash,, ",
+        )
+
+        assert get_xrouter_excluded_models() == (
+            "z-ai/glm-5.3-flash",
+            "openai/gpt-5.6-luna",
+        )
 
 
 class TestMCPOAuthConfig:

--- a/uv.lock
+++ b/uv.lock
@@ -8090,8 +8090,8 @@ requires-dist = [
     { name = "volcengine-python-sdk", extras = ["ark"], specifier = ">=5.0.37" },
     { name = "websockets", specifier = ">=15.0.1" },
     { name = "xinference-client", specifier = ">=2.3.0" },
-    { name = "xrouter-llm", marker = "extra == 'all'", specifier = ">=0.1.2" },
-    { name = "xrouter-llm", marker = "extra == 'router'", specifier = ">=0.1.2" },
+    { name = "xrouter-llm", marker = "extra == 'all'", specifier = ">=0.3.3" },
+    { name = "xrouter-llm", marker = "extra == 'router'", specifier = ">=0.3.3" },
     { name = "zai-sdk", specifier = ">=0.0.3.2" },
 ]
 provides-extras = ["ai-document", "all", "browser", "chromadb", "command-path-guard", "document-processing", "duckdb", "milvus", "postgresql", "router", "waf-crawl"]
@@ -8115,7 +8115,7 @@ backend-image = [
     { name = "torchvision", index = "https://download.pytorch.org/whl/cpu" },
     { name = "typer", specifier = ">=0.9.0" },
     { name = "unstructured", specifier = ">=0.15.0" },
-    { name = "xrouter-llm", specifier = ">=0.1.2" },
+    { name = "xrouter-llm", specifier = ">=0.3.3" },
 ]
 dev = [
     { name = "asyncssh", specifier = ">=2.14.0" },
@@ -8239,9 +8239,11 @@ wheels = [
 
 [[package]]
 name = "xrouter-llm"
-version = "0.1.2"
+version = "0.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "alembic" },
+    { name = "fastapi" },
     { name = "huggingface-hub" },
     { name = "joblib" },
     { name = "numpy" },
@@ -8249,10 +8251,12 @@ dependencies = [
     { name = "pyyaml" },
     { name = "scikit-learn" },
     { name = "scipy" },
+    { name = "sqlalchemy" },
+    { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/36/63ccf8f0db5c0bdb8bcd04eae05e07ec7d013c2ec9854dd0e3c720cf74df/xrouter_llm-0.1.2.tar.gz", hash = "sha256:0d3b184f749505fc80b0049ee9a466d7472171145dad98977a778e4effd3d7c9", size = 1506669, upload-time = "2026-06-23T13:41:34.143Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/12/87e13894b94035576d3c3efd717f87f3dabb1938d3a0685ae5bd2dc28daf/xrouter_llm-0.3.3.tar.gz", hash = "sha256:468cbba01b9122111fdf50e18d53254b117d83ec87c98feb579bee3b3d7f571e", size = 1469842, upload-time = "2026-09-02T07:40:38.239Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3f/77/f4082e25dad8d123bd85173735e66dd547c34a43c39aa87e43713fbe83bd/xrouter_llm-0.1.2-py3-none-any.whl", hash = "sha256:df1b5c2f36c091b27f3e97355ba154c2bb0c5cfecac52b6ca3ec5e867041ada8", size = 116349, upload-time = "2026-06-23T13:41:32.776Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b0/6c5149e55c1f6598b02203c08efc4aa29bdde7ed8fac99fa77e828dc92f1/xrouter_llm-0.3.3-py3-none-any.whl", hash = "sha256:709b04c5ac189984d1cd9ea2d8763b7b83787367f030c9fd7869a058b84f4779", size = 150405, upload-time = "2026-09-02T07:40:36.453Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- add `XAGENT_XROUTER_EXCLUDED_MODELS` as a comma-separated runtime candidate denylist
- filter named xrouter configs per call and fail safely if no eligible candidate remains
- require and lock `xrouter-llm` 0.3.3, document the switch, and cover parsing and routing edge cases

## Testing

- `PYTHONPATH=src /Users/xuyeqin/Workspace/xagent/.venv/bin/python -m pytest -q tests/core/test_config.py tests/core/model/chat/basic/test_router.py` (499 passed)
- commit hooks: ruff, format, mypy, isort, codespell
- `uv lock --check`
- published `xrouter-llm==0.3.3` wheel smoke check for the `models` route parameter and the GLM 5.3 Flash candidate