### PR TITLE
fix(mcp): fence OAuth persistence by lifecycle generation (toby)

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -17,6 +17,9 @@ on:
       - 'src/xagent/web/models/generation.py'
       - 'src/xagent/web/models/mcp.py'
       - 'src/xagent/web/models/public_mcp.py'
+      - 'src/xagent/web/models/mcp_oauth.py'
+      - 'src/xagent/web/api/mcp.py'
+      - 'tests/web/api/test_mcp_oauth_lifecycle_postgresql.py'
       - 'src/xagent/web/services/gmail_provisioning.py'
       - 'tests/web/services/test_gmail_provisioning.py'
       - 'src/xagent/web/services/agent_management.py'
@@ -116,6 +119,9 @@ jobs:
             src/xagent/web/models/generation.py
             src/xagent/web/models/mcp.py
             src/xagent/web/models/public_mcp.py
+            src/xagent/web/models/mcp_oauth.py
+            src/xagent/web/api/mcp.py
+            tests/web/api/test_mcp_oauth_lifecycle_postgresql.py
             src/xagent/web/services/gmail_provisioning.py
             tests/web/services/test_gmail_provisioning.py
             src/xagent/web/services/agent_management.py
@@ -365,6 +371,13 @@ jobs:
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
           pytest tests/migrations/test_20260902_add_mcp_lifecycle_generations.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
+      - name: Test MCP OAuth lifecycle fencing (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/web/api/test_mcp_oauth_lifecycle_postgresql.py -m postgresql -q
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 

--- a/src/xagent/migrations/versions/20260902_add_mcp_oauth_flow_generation.py
+++ b/src/xagent/migrations/versions/20260902_add_mcp_oauth_flow_generation.py
@@ -1,0 +1,54 @@
+"""bind MCP OAuth flows to an association lifecycle generation
+
+Revision ID: 20260902_oauth_flow_generation
+Revises: 20260902_mcp_generations
+Create Date: 2026-09-02
+
+Existing authorization flows cannot be attributed safely to a specific
+``UserMCPServer`` lifecycle, so their new snapshot remains NULL and callbacks
+fail closed. Newly-created flows always persist the exact generation captured
+before provider I/O.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260902_oauth_flow_generation"
+down_revision: Union[str, None] = "20260902_mcp_generations"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE_NAME = "mcp_oauth_flow_states"
+COLUMN_NAME = "association_lifecycle_generation"
+
+
+def _table_exists() -> bool:
+    return TABLE_NAME in sa.inspect(op.get_bind()).get_table_names()
+
+
+def upgrade() -> None:
+    if not _table_exists():
+        return
+    columns = {
+        column["name"] for column in sa.inspect(op.get_bind()).get_columns(TABLE_NAME)
+    }
+    if COLUMN_NAME not in columns:
+        op.add_column(
+            TABLE_NAME,
+            sa.Column(COLUMN_NAME, sa.Uuid(as_uuid=True), nullable=True),
+        )
+
+
+def downgrade() -> None:
+    if not _table_exists():
+        return
+    columns = {
+        column["name"] for column in sa.inspect(op.get_bind()).get_columns(TABLE_NAME)
+    }
+    if COLUMN_NAME in columns:
+        with op.batch_alter_table(TABLE_NAME) as batch_op:
+            batch_op.drop_column(COLUMN_NAME)

--- a/src/xagent/migrations/versions/20260902_add_mcp_oauth_flow_generation.py
+++ b/src/xagent/migrations/versions/20260902_add_mcp_oauth_flow_generation.py
@@ -1,7 +1,7 @@
 """bind MCP OAuth flows to an association lifecycle generation
 
 Revision ID: 20260902_oauth_flow_generation
-Revises: 20260903_model_management
+Revises: 20260826_seed_employment_hero_mcp_app
 Create Date: 2026-09-02
 
 Existing authorization flows cannot be attributed safely to a specific
@@ -18,7 +18,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260902_oauth_flow_generation"
-down_revision: Union[str, None] = "20260903_model_management"
+down_revision: Union[str, None] = "20260826_seed_employment_hero_mcp_app"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260902_add_mcp_oauth_flow_generation.py
+++ b/src/xagent/migrations/versions/20260902_add_mcp_oauth_flow_generation.py
@@ -18,7 +18,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260902_oauth_flow_generation"
-down_revision: Union[str, None] = "20260902_mcp_generations"
+down_revision: Union[str, None] = "20260901_seed_chartmogul_mcp_app"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260902_add_mcp_oauth_flow_generation.py
+++ b/src/xagent/migrations/versions/20260902_add_mcp_oauth_flow_generation.py
@@ -1,7 +1,7 @@
 """bind MCP OAuth flows to an association lifecycle generation
 
 Revision ID: 20260902_oauth_flow_generation
-Revises: 20260902_mcp_generations
+Revises: 20260903_model_management
 Create Date: 2026-09-02
 
 Existing authorization flows cannot be attributed safely to a specific
@@ -18,7 +18,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260902_oauth_flow_generation"
-down_revision: Union[str, None] = "20260901_seed_chartmogul_mcp_app"
+down_revision: Union[str, None] = "20260903_model_management"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -857,7 +857,7 @@ def _lock_active_mcp_oauth_lifecycle(
     flow_identity: _MCPOAuthFlowIdentity | None = None,
     association_must_be_active: bool = True,
 ) -> tuple[MCPServer, UserMCPServer, MCPOAuthFlowState | None] | None:
-    """Lock the exact association lifecycle before final OAuth persistence."""
+    """Lock server, exact association generation, then exact flow if supplied."""
     if db.get_bind().dialect.name == "sqlite":
         _begin_sqlite_oauth_persistence(db)
     db.expire_all()
@@ -909,6 +909,35 @@ def _lock_active_mcp_oauth_lifecycle(
     return server, association, flow_state
 
 
+def _sweep_expired_mcp_oauth_flow_states(db: Session) -> None:
+    """Delete one bounded batch of dead flow states outside lifecycle locks."""
+    # Sweep this table's dead rows before adding another, mirroring the Slack
+    # OAuth flow-state ledger in channel.py. Every abandoned, denied or
+    # double-submitted authorization leaves a row that is permanently unusable
+    # once it expires (the claim query requires consumed_at IS NULL and
+    # expires_at > now), but nothing else removes it until a disconnect or a
+    # server cascade. Deliberately global so users who never reconnect do not
+    # retain rows forever, and bounded so one user-facing request does not drain
+    # an unbounded historical backlog.
+    try:
+        stale_flow_state_ids = (
+            db.query(MCPOAuthFlowState.id)
+            .filter(
+                MCPOAuthFlowState.expires_at
+                < _utc_now() - MCP_OAUTH_FLOW_STATE_RETENTION
+            )
+            .limit(MCP_OAUTH_FLOW_STATE_SWEEP_BATCH)
+            .scalar_subquery()
+        )
+        db.query(MCPOAuthFlowState).filter(
+            MCPOAuthFlowState.id.in_(stale_flow_state_ids)
+        ).delete(synchronize_session=False)
+        db.commit()
+    except Exception:
+        db.rollback()
+        raise
+
+
 def _persist_mcp_oauth_connect_flow(
     db: Session,
     *,
@@ -926,6 +955,10 @@ def _persist_mcp_oauth_connect_flow(
     redirect_after: str | None,
 ) -> tuple[str, str, str] | None:
     """Persist a client and flow only for the preflight association generation."""
+    # This global maintenance write is independent of the new flow. Commit it
+    # before taking per-lifecycle row locks so unrelated expired rows cannot
+    # widen the server -> association critical section.
+    _sweep_expired_mcp_oauth_flow_states(db)
     lifecycle = _lock_active_mcp_oauth_lifecycle(
         db,
         association_identity=association_identity,
@@ -945,19 +978,6 @@ def _persist_mcp_oauth_connect_flow(
             redirect_uri=redirect_uri,
             registration_lookup_hash=registration_lookup_hash,
         )
-
-        stale_flow_state_ids = (
-            db.query(MCPOAuthFlowState.id)
-            .filter(
-                MCPOAuthFlowState.expires_at
-                < _utc_now() - MCP_OAUTH_FLOW_STATE_RETENTION
-            )
-            .limit(MCP_OAUTH_FLOW_STATE_SWEEP_BATCH)
-            .scalar_subquery()
-        )
-        db.query(MCPOAuthFlowState).filter(
-            MCPOAuthFlowState.id.in_(stale_flow_state_ids)
-        ).delete(synchronize_session=False)
 
         state_value = secrets.token_urlsafe(32)
         code_verifier = secrets.token_urlsafe(64)
@@ -4167,7 +4187,6 @@ async def delete_mcp_server(
 ) -> None:
     """Delete an MCP server."""
     try:
-        manager = DatabaseMCPServerManager(db)
         user_id = current_user.id
 
         # Check user has access to this server
@@ -4189,15 +4208,13 @@ async def delete_mcp_server(
             user_id=int(user_id),
             lifecycle_generation=user_mcp.lifecycle_generation,
         )
-        association_was_active = bool(user_mcp.is_active)
-
         # Serialize teardown with OAuth producers before enumerating artifacts.
         # The exact generation prevents a stale DELETE from touching a replacement
         # association created for the same user and shared server.
         lifecycle = _lock_active_mcp_oauth_lifecycle(
             db,
             association_identity=association_identity,
-            association_must_be_active=association_was_active,
+            association_must_be_active=False,
         )
         if lifecycle is None:
             db.rollback()
@@ -4341,36 +4358,43 @@ async def delete_mcp_server(
 
         # Remove user-server association
         db.delete(user_mcp)
-        db.commit()
+        db.flush()
 
-        for snapshot in grant_revocations:
-            await _revoke_mcp_oauth_grant_snapshot_externally(snapshot)
-
-        # Check if any other users are using this server
+        # Decide shared-row retention while the server lifecycle lock is still
+        # held. A post-commit check followed by a second delete transaction can
+        # erase a replacement association committed between those operations.
         other_users = (
             db.query(UserMCPServer)
             .filter(UserMCPServer.mcpserver_id == server_id)
             .first()
         )
-
-        # Only remove from manager and delete if no other users
+        server_deleted = False
+        retained_team_server = False
+        retained_platform_server = False
         if not other_users:
-            if team_delete.team_owned and not team_delete.delete_definition:
-                logger.info(
-                    f"Kept shared MCP server '{server_name}' after team disconnect"
-                )
-                return
-            if _catalog_server_has_platform_key(db, server):
-                # Keep the shared catalog row: it holds the admin's platform
-                # fallback key and is reused by future connects. Deleting it would
-                # silently wipe the platform key with no signal to the admin.
-                logger.info(
-                    f"Kept shared catalog server '{server_name}' after last user "
-                    "disconnect (preserves platform fallback key)"
-                )
-            else:
-                manager.remove_server(server_name)
-                logger.info(f"Deleted MCP server '{server_name}'")
+            retained_team_server = bool(
+                team_delete.team_owned and not team_delete.delete_definition
+            )
+            if not retained_team_server:
+                retained_platform_server = _catalog_server_has_platform_key(db, server)
+            if not retained_team_server and not retained_platform_server:
+                db.delete(server)
+                server_deleted = True
+
+        db.commit()
+
+        for snapshot in grant_revocations:
+            await _revoke_mcp_oauth_grant_snapshot_externally(snapshot)
+
+        if retained_team_server:
+            logger.info(f"Kept shared MCP server '{server_name}' after team disconnect")
+        elif retained_platform_server:
+            logger.info(
+                f"Kept shared catalog server '{server_name}' after last user "
+                "disconnect (preserves platform fallback key)"
+            )
+        elif server_deleted:
+            logger.info(f"Deleted MCP server '{server_name}'")
         else:
             logger.info(f"Removed user {user_id} access to MCP server '{server_name}'")
 
@@ -4793,8 +4817,8 @@ async def mcp_oauth_callback(
     state_error = _mcp_oauth_flow_state_error(db, flow_state)
     if state_error is not None:
         error_code, message = state_error
-        return _mcp_oauth_callback_error_redirect(
-            flow_state,
+        return _mcp_oauth_callback_error_redirect_for_path(
+            callback_redirect_after,
             error_code=error_code,
             message=message,
         )
@@ -4852,22 +4876,22 @@ async def mcp_oauth_callback(
     claim_error = _claim_mcp_oauth_flow_state(db, flow_state)
     if claim_error is not None:
         error_code, message = claim_error
-        return _mcp_oauth_callback_error_redirect(
-            flow_state,
+        return _mcp_oauth_callback_error_redirect_for_path(
+            callback_redirect_after,
             error_code=error_code,
             message=message,
         )
     if error:
-        return _mcp_oauth_callback_error_redirect(
-            flow_state,
+        return _mcp_oauth_callback_error_redirect_for_path(
+            callback_redirect_after,
             error_code="token_exchange_failed",
             message=oauth_error_message(
                 {"error": error}, "MCP OAuth authorization failed"
             ),
         )
     if not code:
-        return _mcp_oauth_callback_error_redirect(
-            flow_state,
+        return _mcp_oauth_callback_error_redirect_for_path(
+            callback_redirect_after,
             error_code="invalid_state",
             message="Missing authorization code",
         )

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -1208,7 +1208,9 @@ def _mcp_oauth_issued_token_snapshot(
     flow_id: int,
     token_data: dict[str, Any],
 ) -> _MCPOAuthIssuedTokenSnapshot:
-    metadata = client.metadata_json if isinstance(client.metadata_json, dict) else {}
+    metadata: dict[str, Any] = (
+        client.metadata_json if isinstance(client.metadata_json, dict) else {}
+    )
     revocation_endpoint = metadata.get("revocation_endpoint")
     refresh_token = token_data.get("refresh_token")
     return _MCPOAuthIssuedTokenSnapshot(

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -855,6 +855,7 @@ def _lock_active_mcp_oauth_lifecycle(
     *,
     association_identity: _MCPOAuthAssociationIdentity,
     flow_identity: _MCPOAuthFlowIdentity | None = None,
+    association_must_be_active: bool = True,
 ) -> tuple[MCPServer, UserMCPServer, MCPOAuthFlowState | None] | None:
     """Lock the exact association lifecycle before final OAuth persistence."""
     if db.get_bind().dialect.name == "sqlite":
@@ -869,18 +870,14 @@ def _lock_active_mcp_oauth_lifecycle(
     )
     if server is None:
         return None
-    association = (
-        db.query(UserMCPServer)
-        .filter(
-            UserMCPServer.user_id == association_identity.user_id,
-            UserMCPServer.mcpserver_id == association_identity.server_id,
-            UserMCPServer.lifecycle_generation
-            == association_identity.lifecycle_generation,
-            UserMCPServer.is_active.is_(True),
-        )
-        .with_for_update()
-        .one_or_none()
+    association_query = db.query(UserMCPServer).filter(
+        UserMCPServer.user_id == association_identity.user_id,
+        UserMCPServer.mcpserver_id == association_identity.server_id,
+        UserMCPServer.lifecycle_generation == association_identity.lifecycle_generation,
     )
+    if association_must_be_active:
+        association_query = association_query.filter(UserMCPServer.is_active.is_(True))
+    association = association_query.with_for_update().one_or_none()
     if association is None:
         return None
 
@@ -1322,94 +1319,149 @@ async def _rollback_and_revoke_mcp_oauth_issued_token(
     await _revoke_mcp_oauth_issued_token_externally(snapshot)
 
 
+@dataclass(frozen=True)
+class _MCPOAuthGrantRevocationSnapshot:
+    grant_id: int
+    revocation_endpoint: str | None
+    client_id: str
+    encrypted_client_secret: str | None
+    token_endpoint_auth_method: str
+    encrypted_access_token: str | None
+    encrypted_refresh_token: str | None
+
+
+def _mcp_oauth_grant_revocation_snapshot(
+    *, client: MCPOAuthClient, grant: MCPOAuthGrant
+) -> _MCPOAuthGrantRevocationSnapshot:
+    metadata: dict[str, Any] = (
+        client.metadata_json if isinstance(client.metadata_json, dict) else {}
+    )
+    revocation_endpoint = metadata.get("revocation_endpoint")
+    return _MCPOAuthGrantRevocationSnapshot(
+        grant_id=int(grant.id),
+        revocation_endpoint=(
+            revocation_endpoint
+            if isinstance(revocation_endpoint, str) and revocation_endpoint
+            else None
+        ),
+        client_id=str(client.client_id),
+        encrypted_client_secret=(
+            str(client.client_secret) if client.client_secret else None
+        ),
+        token_endpoint_auth_method=str(client.token_endpoint_auth_method or "none"),
+        encrypted_access_token=(
+            str(grant.access_token) if grant.access_token else None
+        ),
+        encrypted_refresh_token=(
+            str(grant.refresh_token) if grant.refresh_token else None
+        ),
+    )
+
+
+async def _revoke_mcp_oauth_grant_snapshot_externally(
+    snapshot: _MCPOAuthGrantRevocationSnapshot,
+) -> None:
+    """Best-effort revoke a detached grant snapshot without ORM access."""
+    if snapshot.revocation_endpoint is None:
+        return
+
+    try:
+        client_secret = (
+            decrypt_value(snapshot.encrypted_client_secret)
+            if snapshot.encrypted_client_secret
+            else ""
+        )
+    except Exception as exc:
+        logger.warning(
+            "Skipping MCP OAuth token revocation for grant %s "
+            "(stage=decrypt_client_secret, exception_type=%s)",
+            snapshot.grant_id,
+            type(exc).__name__,
+        )
+        return
+    auth_method = snapshot.token_endpoint_auth_method
+    auth: httpx.Auth | None = None
+    base_data: dict[str, str] = {"client_id": snapshot.client_id}
+    if auth_method == "client_secret_post" and client_secret:
+        base_data["client_secret"] = client_secret
+    elif auth_method == "client_secret_basic" and client_secret:
+        auth = httpx.BasicAuth(snapshot.client_id, client_secret)
+    elif auth_method not in {"none", "client_secret_post", "client_secret_basic"}:
+        logger.warning(
+            "Skipping MCP OAuth token revocation for grant %s "
+            "(stage=validate_auth_method)",
+            snapshot.grant_id,
+        )
+        return
+
+    try:
+        async with create_mcp_oauth_http_client(
+            timeout=MCP_OAUTH_HTTP_TIMEOUT_SECONDS,
+        ) as http_client:
+            for encrypted_token, token_type_hint in (
+                (snapshot.encrypted_access_token, "access_token"),
+                (snapshot.encrypted_refresh_token, "refresh_token"),
+            ):
+                if not encrypted_token:
+                    continue
+                try:
+                    decrypted_token = decrypt_value(encrypted_token)
+                except Exception as exc:
+                    logger.warning(
+                        "Skipping MCP OAuth token revocation for grant %s "
+                        "(stage=decrypt_%s, exception_type=%s)",
+                        snapshot.grant_id,
+                        token_type_hint,
+                        type(exc).__name__,
+                    )
+                    continue
+                request_kwargs: dict[str, Any] = {
+                    "data": {
+                        **base_data,
+                        "token": decrypted_token,
+                        "token_type_hint": token_type_hint,
+                    },
+                    "headers": {"Content-Type": "application/x-www-form-urlencoded"},
+                }
+                if auth is not None:
+                    request_kwargs["auth"] = auth
+                try:
+                    response = await oauth_post(
+                        snapshot.revocation_endpoint,
+                        client=http_client,
+                        **request_kwargs,
+                    )
+                    if response.status_code >= 400:
+                        logger.warning(
+                            "MCP OAuth token revocation returned HTTP %s for grant %s",
+                            response.status_code,
+                            snapshot.grant_id,
+                        )
+                except Exception as exc:
+                    logger.warning(
+                        "MCP OAuth token revocation failed for grant %s "
+                        "(stage=revoke_%s, exception_type=%s)",
+                        snapshot.grant_id,
+                        token_type_hint,
+                        type(exc).__name__,
+                    )
+    except Exception as exc:
+        logger.warning(
+            "MCP OAuth token revocation could not start for grant %s "
+            "(stage=create_client, exception_type=%s)",
+            snapshot.grant_id,
+            type(exc).__name__,
+        )
+
+
 async def _revoke_mcp_oauth_grant_externally(
     *,
     client: MCPOAuthClient,
     grant: MCPOAuthGrant,
 ) -> None:
-    metadata: dict[str, Any] = (
-        client.metadata_json if isinstance(client.metadata_json, dict) else {}
+    await _revoke_mcp_oauth_grant_snapshot_externally(
+        _mcp_oauth_grant_revocation_snapshot(client=client, grant=grant)
     )
-    revocation_endpoint = metadata.get("revocation_endpoint")
-    if not isinstance(revocation_endpoint, str) or not revocation_endpoint:
-        return
-
-    try:
-        client_secret = (
-            decrypt_value(str(client.client_secret)) if client.client_secret else ""
-        )
-    except Exception as exc:
-        logger.warning(
-            "Skipping MCP OAuth token revocation for grant %s because client secret "
-            "could not be decrypted: %s",
-            grant.id,
-            exc,
-        )
-        return
-    auth_method = str(client.token_endpoint_auth_method or "none")
-    auth: httpx.Auth | None = None
-    base_data: dict[str, str] = {"client_id": str(client.client_id)}
-    if auth_method == "client_secret_post" and client_secret:
-        base_data["client_secret"] = client_secret
-    elif auth_method == "client_secret_basic" and client_secret:
-        auth = httpx.BasicAuth(str(client.client_id), client_secret)
-    elif auth_method not in {"none", "client_secret_post", "client_secret_basic"}:
-        logger.warning(
-            "Skipping MCP OAuth token revocation for unsupported auth method %s",
-            auth_method,
-        )
-        return
-
-    encrypted_tokens = (
-        (grant.access_token, "access_token"),
-        (grant.refresh_token, "refresh_token"),
-    )
-    async with create_mcp_oauth_http_client(
-        timeout=MCP_OAUTH_HTTP_TIMEOUT_SECONDS,
-    ) as http_client:
-        for encrypted_token, token_type_hint in encrypted_tokens:
-            if not encrypted_token:
-                continue
-            try:
-                decrypted_token = decrypt_value(str(encrypted_token))
-            except Exception as exc:
-                logger.warning(
-                    "Skipping MCP OAuth %s revocation for grant %s because token "
-                    "could not be decrypted: %s",
-                    token_type_hint,
-                    grant.id,
-                    exc,
-                )
-                continue
-            data = {
-                **base_data,
-                "token": decrypted_token,
-                "token_type_hint": token_type_hint,
-            }
-            request_kwargs: dict[str, Any] = {
-                "data": data,
-                "headers": {"Content-Type": "application/x-www-form-urlencoded"},
-            }
-            if auth is not None:
-                request_kwargs["auth"] = auth
-            try:
-                response = await oauth_post(
-                    revocation_endpoint,
-                    client=http_client,
-                    **request_kwargs,
-                )
-                if response.status_code >= 400:
-                    logger.warning(
-                        "MCP OAuth token revocation returned HTTP %s for grant %s",
-                        response.status_code,
-                        grant.id,
-                    )
-            except (MCPOAuthDiscoveryError, httpx.HTTPError) as exc:
-                logger.warning(
-                    "MCP OAuth token revocation failed for grant %s: %s",
-                    grant.id,
-                    exc,
-                )
 
 
 def _upsert_mcp_oauth_grant(
@@ -4132,6 +4184,27 @@ async def delete_mcp_server(
             )
 
         user_mcp, server = result
+        association_identity = _MCPOAuthAssociationIdentity(
+            server_id=int(server.id),
+            user_id=int(user_id),
+            lifecycle_generation=user_mcp.lifecycle_generation,
+        )
+        association_was_active = bool(user_mcp.is_active)
+
+        # Serialize teardown with OAuth producers before enumerating artifacts.
+        # The exact generation prevents a stale DELETE from touching a replacement
+        # association created for the same user and shared server.
+        lifecycle = _lock_active_mcp_oauth_lifecycle(
+            db,
+            association_identity=association_identity,
+            association_must_be_active=association_was_active,
+        )
+        if lifecycle is None:
+            db.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="MCP server not found"
+            )
+        server, user_mcp, _ = lifecycle
 
         # Deleting cascades to the shared config once no associations remain;
         # gate it on ownership, consistent with the update handler.
@@ -4143,7 +4216,7 @@ async def delete_mcp_server(
                 detail="You do not have permission to delete this MCP server",
             )
 
-        server_name = server.name
+        server_name = str(server.name)
 
         from ..services.connector_team_scope import delete_team_connector
 
@@ -4230,15 +4303,16 @@ async def delete_mcp_server(
                             providers=[provider],
                         )
 
-        # Revoke and purge this user's MCP OAuth grants for the server. On a
+        # Snapshot and purge this user's MCP OAuth grants for the server. On a
         # shared (multi-user) row the server outlives this disconnect, so
         # without this the grant's refresh token would stay usable — and its
         # row would stay stored — until the LAST user disconnects and the
-        # cascade finally removes it. Best-effort external revocation first
-        # (now awaitable, unlike the previous local-only status flip), then a
-        # hard delete rather than a "revoked" status flip: a revoked grant
+        # cascade finally removes it. The provider-facing revocation happens
+        # only after the local commit releases lifecycle locks. Use a hard
+        # delete rather than a "revoked" status flip: a revoked grant
         # row is otherwise never swept, accumulating indefinitely as an
         # inert but secret-bearing row (F10).
+        grant_revocations: list[_MCPOAuthGrantRevocationSnapshot] = []
         for grant in (
             db.query(MCPOAuthGrant)
             .filter(
@@ -4249,8 +4323,10 @@ async def delete_mcp_server(
             .all()
         ):
             if isinstance(grant.oauth_client, MCPOAuthClient):
-                await _revoke_mcp_oauth_grant_externally(
-                    client=grant.oauth_client, grant=grant
+                grant_revocations.append(
+                    _mcp_oauth_grant_revocation_snapshot(
+                        client=grant.oauth_client, grant=grant
+                    )
                 )
             db.delete(grant)
 
@@ -4266,6 +4342,9 @@ async def delete_mcp_server(
         # Remove user-server association
         db.delete(user_mcp)
         db.commit()
+
+        for snapshot in grant_revocations:
+            await _revoke_mcp_oauth_grant_snapshot_externally(snapshot)
 
         # Check if any other users are using this server
         other_users = (
@@ -4296,10 +4375,13 @@ async def delete_mcp_server(
             logger.info(f"Removed user {user_id} access to MCP server '{server_name}'")
 
     except HTTPException:
-        raise
-    except Exception as e:
         db.rollback()
-        logger.error(f"Failed to delete MCP server: {e}")
+        raise
+    except Exception as exc:
+        db.rollback()
+        logger.error(
+            "Failed to delete MCP server (exception_type=%s)", type(exc).__name__
+        )
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to delete MCP server",
@@ -4790,6 +4872,7 @@ async def mcp_oauth_callback(
             message="Missing authorization code",
         )
     issued_token: _MCPOAuthIssuedTokenSnapshot | None = None
+    failure_stage = "token_exchange"
     try:
         token_data = await _exchange_mcp_oauth_code(
             client=client,
@@ -4797,11 +4880,13 @@ async def mcp_oauth_callback(
             code_verifier=code_verifier,
             resource=resource,
         )
+        failure_stage = "snapshot_issued_token"
         issued_token = _mcp_oauth_issued_token_snapshot(
             client=client,
             flow_id=flow_identity.id,
             token_data=token_data,
         )
+        failure_stage = "lock_lifecycle"
         lifecycle = _lock_active_mcp_oauth_lifecycle(
             db,
             association_identity=association_identity,
@@ -4817,11 +4902,13 @@ async def mcp_oauth_callback(
         locked_flow_state = lifecycle[2]
         if locked_flow_state is None:
             raise RuntimeError("MCP OAuth lifecycle lock did not return the flow")
+        failure_stage = "persist_grant"
         _upsert_mcp_oauth_grant(
             db,
             flow_state=locked_flow_state,
             token_data=token_data,
         )
+        failure_stage = "commit_grant"
         db.commit()
     except HTTPException as exc:
         if issued_token is not None:
@@ -4836,12 +4923,16 @@ async def mcp_oauth_callback(
             error_code=error_code,
             message=message,
         )
-    except Exception:
+    except Exception as exc:
         if issued_token is not None:
             await _rollback_and_revoke_mcp_oauth_issued_token(db, issued_token)
         else:
             db.rollback()
-        logger.error("MCP OAuth callback failed after state claim")
+        logger.error(
+            "MCP OAuth callback failed after state claim (stage=%s, exception_type=%s)",
+            failure_stage,
+            type(exc).__name__,
+        )
         return _mcp_oauth_callback_error_redirect_for_path(
             callback_redirect_after,
             error_code="token_exchange_failed",

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -17,6 +17,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from typing import Annotated, Any, Callable, Dict, List, Literal, Optional, Union, cast
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
+from uuid import UUID
 
 import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
@@ -492,6 +493,19 @@ def _mcp_oauth_callback_error_redirect(
     raw_redirect_after = (
         str(flow_state.redirect_after) if flow_state.redirect_after else None
     )
+    return _mcp_oauth_callback_error_redirect_for_path(
+        raw_redirect_after,
+        error_code=error_code,
+        message=message,
+    )
+
+
+def _mcp_oauth_callback_error_redirect_for_path(
+    raw_redirect_after: str | None,
+    *,
+    error_code: str,
+    message: str,
+) -> RedirectResponse:
     redirect_path = _redirect_after_with_params(
         raw_redirect_after,
         (
@@ -776,6 +790,206 @@ def _upsert_mcp_oauth_client(
         return client
 
 
+class _SQLiteOAuthPersistenceTransactionError(RuntimeError):
+    """The caller has SQLite writes that the persistence fence cannot reset."""
+
+
+def _begin_sqlite_oauth_persistence(db: Session) -> None:
+    """Acquire SQLite write intent before lifecycle identity is re-read."""
+    if db.new or db.dirty or db.deleted:
+        raise _SQLiteOAuthPersistenceTransactionError(
+            "SQLite OAuth persistence requires a read-only preflight"
+        )
+
+    connection = db.connection()
+    driver_connection = connection.connection.driver_connection
+    if bool(getattr(driver_connection, "in_transaction", False)):
+        raise _SQLiteOAuthPersistenceTransactionError(
+            "SQLite OAuth persistence requires an owned transaction"
+        )
+
+    # SQLAlchemy has logically autobegun for the read-only preflight even
+    # though pysqlite has not emitted BEGIN. End that logical transaction,
+    # then reserve SQLite's single writer before the identity reads.
+    db.rollback()
+    connection = db.connection()
+    driver_connection = connection.connection.driver_connection
+    if bool(getattr(driver_connection, "in_transaction", False)):
+        raise RuntimeError("SQLite OAuth persistence could not reset preflight")
+    connection.exec_driver_sql("BEGIN IMMEDIATE")
+
+
+@dataclass(frozen=True)
+class _MCPOAuthAssociationIdentity:
+    server_id: int
+    user_id: int
+    lifecycle_generation: UUID
+
+
+@dataclass(frozen=True)
+class _MCPOAuthFlowIdentity:
+    id: int
+    state: str
+    server_id: int
+    user_id: int
+    client_id: int
+    association_lifecycle_generation: UUID
+
+
+def _mcp_oauth_flow_identity(flow_state: MCPOAuthFlowState) -> _MCPOAuthFlowIdentity:
+    generation = flow_state.association_lifecycle_generation
+    if not isinstance(generation, UUID):
+        raise RuntimeError("MCP OAuth flow has no association lifecycle generation")
+    return _MCPOAuthFlowIdentity(
+        id=int(flow_state.id),
+        state=str(flow_state.state),
+        server_id=int(flow_state.mcp_server_id),
+        user_id=int(flow_state.user_id),
+        client_id=int(flow_state.mcp_oauth_client_id),
+        association_lifecycle_generation=generation,
+    )
+
+
+def _lock_active_mcp_oauth_lifecycle(
+    db: Session,
+    *,
+    association_identity: _MCPOAuthAssociationIdentity,
+    flow_identity: _MCPOAuthFlowIdentity | None = None,
+) -> tuple[MCPServer, UserMCPServer, MCPOAuthFlowState | None] | None:
+    """Lock the exact association lifecycle before final OAuth persistence."""
+    if db.get_bind().dialect.name == "sqlite":
+        _begin_sqlite_oauth_persistence(db)
+    db.expire_all()
+
+    server = (
+        db.query(MCPServer)
+        .filter(MCPServer.id == association_identity.server_id)
+        .with_for_update()
+        .one_or_none()
+    )
+    if server is None:
+        return None
+    association = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == association_identity.user_id,
+            UserMCPServer.mcpserver_id == association_identity.server_id,
+            UserMCPServer.lifecycle_generation
+            == association_identity.lifecycle_generation,
+            UserMCPServer.is_active.is_(True),
+        )
+        .with_for_update()
+        .one_or_none()
+    )
+    if association is None:
+        return None
+
+    flow_state: MCPOAuthFlowState | None = None
+    if flow_identity is not None:
+        if (
+            flow_identity.server_id != association_identity.server_id
+            or flow_identity.user_id != association_identity.user_id
+            or flow_identity.association_lifecycle_generation
+            != association_identity.lifecycle_generation
+        ):
+            return None
+        flow_state = (
+            db.query(MCPOAuthFlowState)
+            .filter(
+                MCPOAuthFlowState.id == flow_identity.id,
+                MCPOAuthFlowState.state == flow_identity.state,
+                MCPOAuthFlowState.mcp_server_id == flow_identity.server_id,
+                MCPOAuthFlowState.user_id == flow_identity.user_id,
+                MCPOAuthFlowState.mcp_oauth_client_id == flow_identity.client_id,
+                MCPOAuthFlowState.association_lifecycle_generation
+                == flow_identity.association_lifecycle_generation,
+            )
+            .with_for_update()
+            .one_or_none()
+        )
+        if flow_state is None:
+            return None
+    return server, association, flow_state
+
+
+def _persist_mcp_oauth_connect_flow(
+    db: Session,
+    *,
+    association_identity: _MCPOAuthAssociationIdentity,
+    discovery: Any,
+    client_id: str,
+    client_secret: str | None,
+    token_endpoint_auth_method: str,
+    redirect_uri: str,
+    registration_lookup_hash: str | None,
+    resource_owner_key: str,
+    selected_issuer: str,
+    selected_resource: str,
+    selected_scope: str,
+    redirect_after: str | None,
+) -> tuple[str, str, str] | None:
+    """Persist a client and flow only for the preflight association generation."""
+    lifecycle = _lock_active_mcp_oauth_lifecycle(
+        db,
+        association_identity=association_identity,
+    )
+    if lifecycle is None:
+        db.rollback()
+        return None
+
+    try:
+        oauth_client = _upsert_mcp_oauth_client(
+            db,
+            server_id=association_identity.server_id,
+            discovery=discovery,
+            client_id=client_id,
+            client_secret=client_secret,
+            token_endpoint_auth_method=token_endpoint_auth_method,
+            redirect_uri=redirect_uri,
+            registration_lookup_hash=registration_lookup_hash,
+        )
+
+        stale_flow_state_ids = (
+            db.query(MCPOAuthFlowState.id)
+            .filter(
+                MCPOAuthFlowState.expires_at
+                < _utc_now() - MCP_OAUTH_FLOW_STATE_RETENTION
+            )
+            .limit(MCP_OAUTH_FLOW_STATE_SWEEP_BATCH)
+            .scalar_subquery()
+        )
+        db.query(MCPOAuthFlowState).filter(
+            MCPOAuthFlowState.id.in_(stale_flow_state_ids)
+        ).delete(synchronize_session=False)
+
+        state_value = secrets.token_urlsafe(32)
+        code_verifier = secrets.token_urlsafe(64)
+        db.add(
+            MCPOAuthFlowState(
+                state=state_value,
+                mcp_server_id=association_identity.server_id,
+                user_id=association_identity.user_id,
+                association_lifecycle_generation=(
+                    association_identity.lifecycle_generation
+                ),
+                mcp_oauth_client_id=oauth_client.id,
+                resource_owner_key=resource_owner_key,
+                issuer=selected_issuer,
+                resource=selected_resource,
+                scope=selected_scope,
+                code_verifier=encrypt_value(code_verifier),
+                redirect_after=_safe_mcp_oauth_redirect_after(redirect_after),
+                expires_at=_utc_now() + MCP_OAUTH_STATE_TTL,
+            )
+        )
+        persisted_client_id = str(oauth_client.client_id)
+        db.commit()
+        return persisted_client_id, state_value, code_verifier
+    except Exception:
+        db.rollback()
+        raise
+
+
 def _mcp_oauth_grant_response(grant: MCPOAuthGrant) -> MCPOAuthGrantResponse:
     return MCPOAuthGrantResponse(
         id=cast(int, grant.id),
@@ -835,12 +1049,19 @@ def _mcp_oauth_flow_state_error(
         return "state_already_consumed", "OAuth state consumed"
     if _as_aware_utc(flow_state.expires_at) <= _utc_now():
         return "expired_state", "OAuth state expired"
+    association_generation = flow_state.association_lifecycle_generation
+    if association_generation is None:
+        return (
+            "invalid_state",
+            "OAuth state is not bound to an MCP server connection lifecycle",
+        )
     if (
         db.query(UserMCPServer)
         .filter(
             UserMCPServer.user_id == flow_state.user_id,
             UserMCPServer.mcpserver_id == flow_state.mcp_server_id,
-            UserMCPServer.is_active,
+            UserMCPServer.lifecycle_generation == association_generation,
+            UserMCPServer.is_active.is_(True),
         )
         .first()
         is None
@@ -860,6 +1081,12 @@ def _claim_mcp_oauth_flow_state(
         db.query(MCPOAuthFlowState)
         .filter(
             MCPOAuthFlowState.id == flow_state.id,
+            MCPOAuthFlowState.state == flow_state.state,
+            MCPOAuthFlowState.mcp_server_id == flow_state.mcp_server_id,
+            MCPOAuthFlowState.user_id == flow_state.user_id,
+            MCPOAuthFlowState.mcp_oauth_client_id == flow_state.mcp_oauth_client_id,
+            MCPOAuthFlowState.association_lifecycle_generation
+            == flow_state.association_lifecycle_generation,
             MCPOAuthFlowState.consumed_at.is_(None),
             MCPOAuthFlowState.expires_at > claimed_at,
         )
@@ -872,7 +1099,6 @@ def _claim_mcp_oauth_flow_state(
         db.rollback()
         return "state_already_consumed", "OAuth state consumed"
     db.commit()
-    db.refresh(flow_state)
     return None
 
 
@@ -963,6 +1189,135 @@ async def _exchange_mcp_oauth_code(
             },
         )
     return payload
+
+
+@dataclass(frozen=True)
+class _MCPOAuthIssuedTokenSnapshot:
+    flow_id: int
+    revocation_endpoint: str | None
+    client_id: str
+    encrypted_client_secret: str | None
+    token_endpoint_auth_method: str
+    access_token: str
+    refresh_token: str | None
+
+
+def _mcp_oauth_issued_token_snapshot(
+    *,
+    client: MCPOAuthClient,
+    flow_id: int,
+    token_data: dict[str, Any],
+) -> _MCPOAuthIssuedTokenSnapshot:
+    metadata = client.metadata_json if isinstance(client.metadata_json, dict) else {}
+    revocation_endpoint = metadata.get("revocation_endpoint")
+    refresh_token = token_data.get("refresh_token")
+    return _MCPOAuthIssuedTokenSnapshot(
+        flow_id=flow_id,
+        revocation_endpoint=(
+            revocation_endpoint
+            if isinstance(revocation_endpoint, str) and revocation_endpoint
+            else None
+        ),
+        client_id=str(client.client_id),
+        encrypted_client_secret=(
+            str(client.client_secret) if client.client_secret else None
+        ),
+        token_endpoint_auth_method=str(client.token_endpoint_auth_method or "none"),
+        access_token=str(token_data["access_token"]),
+        refresh_token=str(refresh_token) if refresh_token else None,
+    )
+
+
+async def _revoke_mcp_oauth_issued_token_externally(
+    snapshot: _MCPOAuthIssuedTokenSnapshot,
+) -> None:
+    """Best-effort revoke a token whose final local persistence failed."""
+    if snapshot.revocation_endpoint is None:
+        return
+    try:
+        client_secret = (
+            decrypt_value(snapshot.encrypted_client_secret)
+            if snapshot.encrypted_client_secret
+            else ""
+        )
+    except Exception:
+        logger.warning(
+            "Skipping issued MCP OAuth token revocation for flow %s because "
+            "client credentials are unavailable",
+            snapshot.flow_id,
+        )
+        return
+
+    auth: httpx.Auth | None = None
+    data_base: dict[str, str] = {"client_id": snapshot.client_id}
+    if snapshot.token_endpoint_auth_method == "client_secret_post" and client_secret:
+        data_base["client_secret"] = client_secret
+    elif snapshot.token_endpoint_auth_method == "client_secret_basic" and client_secret:
+        auth = httpx.BasicAuth(snapshot.client_id, client_secret)
+    elif snapshot.token_endpoint_auth_method not in {
+        "none",
+        "client_secret_post",
+        "client_secret_basic",
+    }:
+        logger.warning(
+            "Skipping issued MCP OAuth token revocation for flow %s because "
+            "the client authentication method is unsupported",
+            snapshot.flow_id,
+        )
+        return
+
+    try:
+        async with create_mcp_oauth_http_client(
+            timeout=MCP_OAUTH_HTTP_TIMEOUT_SECONDS,
+        ) as http_client:
+            for token, token_type_hint in (
+                (snapshot.access_token, "access_token"),
+                (snapshot.refresh_token, "refresh_token"),
+            ):
+                if token is None:
+                    continue
+                request_kwargs: dict[str, Any] = {
+                    "data": {
+                        **data_base,
+                        "token": token,
+                        "token_type_hint": token_type_hint,
+                    },
+                    "headers": {"Content-Type": "application/x-www-form-urlencoded"},
+                }
+                if auth is not None:
+                    request_kwargs["auth"] = auth
+                try:
+                    response = await oauth_post(
+                        snapshot.revocation_endpoint,
+                        client=http_client,
+                        **request_kwargs,
+                    )
+                    if response.status_code >= 400:
+                        logger.warning(
+                            "Issued MCP OAuth token revocation returned HTTP %s "
+                            "for flow %s",
+                            response.status_code,
+                            snapshot.flow_id,
+                        )
+                except Exception:
+                    logger.warning(
+                        "Issued MCP OAuth token revocation failed for flow %s",
+                        snapshot.flow_id,
+                    )
+    except Exception:
+        logger.warning(
+            "Issued MCP OAuth token revocation could not start for flow %s",
+            snapshot.flow_id,
+        )
+
+
+async def _rollback_and_revoke_mcp_oauth_issued_token(
+    db: Session,
+    snapshot: _MCPOAuthIssuedTokenSnapshot,
+) -> None:
+    """Release database locks before any compensating provider request."""
+    db.rollback()
+    await _revoke_mcp_oauth_issued_token_externally(snapshot)
 
 
 async def _revoke_mcp_oauth_grant_externally(
@@ -4334,6 +4689,9 @@ async def mcp_oauth_callback(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={"code": "invalid_state", "message": "Invalid OAuth state"},
         )
+    callback_redirect_after = (
+        str(flow_state.redirect_after) if flow_state.redirect_after else None
+    )
     try:
         _validate_mcp_oauth_state_cookie(request, state_value)
     except HTTPException as exc:
@@ -4370,6 +4728,20 @@ async def mcp_oauth_callback(
         )
 
     try:
+        flow_identity = _mcp_oauth_flow_identity(flow_state)
+    except RuntimeError:
+        return _mcp_oauth_callback_error_redirect_for_path(
+            callback_redirect_after,
+            error_code="invalid_state",
+            message="OAuth state is not bound to an MCP server connection lifecycle",
+        )
+    association_identity = _MCPOAuthAssociationIdentity(
+        server_id=flow_identity.server_id,
+        user_id=flow_identity.user_id,
+        lifecycle_generation=flow_identity.association_lifecycle_generation,
+    )
+
+    try:
         _validate_mcp_oauth_callback_issuer(
             request=request,
             client=client,
@@ -4387,6 +4759,12 @@ async def mcp_oauth_callback(
                 or "Authorization response issuer did not match flow state"
             ),
         )
+    code_verifier = decrypt_value(str(flow_state.code_verifier))
+    resource = str(flow_state.resource)
+    # The claim commit expires ORM instances. Keep the provider-facing client
+    # snapshot detached so a concurrent server deletion cannot make token
+    # exchange or compensation reload stale ORM state.
+    db.expunge(client)
     claim_error = _claim_mcp_oauth_flow_state(db, flow_state)
     if claim_error is not None:
         error_code, message = claim_error
@@ -4409,30 +4787,61 @@ async def mcp_oauth_callback(
             error_code="invalid_state",
             message="Missing authorization code",
         )
+    issued_token: _MCPOAuthIssuedTokenSnapshot | None = None
     try:
         token_data = await _exchange_mcp_oauth_code(
             client=client,
             code=code,
-            code_verifier=decrypt_value(str(flow_state.code_verifier)),
-            resource=str(flow_state.resource),
+            code_verifier=code_verifier,
+            resource=resource,
         )
-        _upsert_mcp_oauth_grant(db, flow_state=flow_state, token_data=token_data)
+        issued_token = _mcp_oauth_issued_token_snapshot(
+            client=client,
+            flow_id=flow_identity.id,
+            token_data=token_data,
+        )
+        lifecycle = _lock_active_mcp_oauth_lifecycle(
+            db,
+            association_identity=association_identity,
+            flow_identity=flow_identity,
+        )
+        if lifecycle is None:
+            await _rollback_and_revoke_mcp_oauth_issued_token(db, issued_token)
+            return _mcp_oauth_callback_error_redirect_for_path(
+                callback_redirect_after,
+                error_code="invalid_state",
+                message="MCP server connection changed during OAuth authorization",
+            )
+        locked_flow_state = lifecycle[2]
+        if locked_flow_state is None:
+            raise RuntimeError("MCP OAuth lifecycle lock did not return the flow")
+        _upsert_mcp_oauth_grant(
+            db,
+            flow_state=locked_flow_state,
+            token_data=token_data,
+        )
         db.commit()
     except HTTPException as exc:
-        db.rollback()
+        if issued_token is not None:
+            await _rollback_and_revoke_mcp_oauth_issued_token(db, issued_token)
+        else:
+            db.rollback()
         detail: dict[str, Any] = exc.detail if isinstance(exc.detail, dict) else {}
         error_code = str(detail.get("code") or "token_exchange_failed")
         message = str(detail.get("message") or "MCP OAuth authorization failed")
-        return _mcp_oauth_callback_error_redirect(
-            flow_state,
+        return _mcp_oauth_callback_error_redirect_for_path(
+            callback_redirect_after,
             error_code=error_code,
             message=message,
         )
     except Exception:
-        db.rollback()
-        logger.exception("MCP OAuth callback failed after state claim")
-        return _mcp_oauth_callback_error_redirect(
-            flow_state,
+        if issued_token is not None:
+            await _rollback_and_revoke_mcp_oauth_issued_token(db, issued_token)
+        else:
+            db.rollback()
+        logger.error("MCP OAuth callback failed after state claim")
+        return _mcp_oauth_callback_error_redirect_for_path(
+            callback_redirect_after,
             error_code="token_exchange_failed",
             message="MCP OAuth authorization failed",
         )
@@ -4444,7 +4853,7 @@ async def mcp_oauth_callback(
     response = RedirectResponse(
         _mcp_oauth_redirect_after_url(
             _redirect_after_with_params(
-                str(flow_state.redirect_after) if flow_state.redirect_after else None,
+                callback_redirect_after,
                 (("mcp_oauth_success", "1"),),
             )
         )
@@ -4482,8 +4891,22 @@ async def connect_mcp_oauth(
 ) -> RedirectResponse | JSONResponse:
     """Start MCP OAuth Authorization Code + PKCE for the current user."""
     user_id = cast(int, current_user.id)
-    _, server = _get_user_mcp_server_or_404(
+    association, server = _get_user_mcp_server_or_404(
         db, user_id=user_id, server_id=server_id, require_active=True
+    )
+    association_generation = association.lifecycle_generation
+    if not isinstance(association_generation, UUID):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "oauth_lifecycle_changed",
+                "message": "MCP server connection lifecycle is unavailable",
+            },
+        )
+    association_identity = _MCPOAuthAssociationIdentity(
+        server_id=server_id,
+        user_id=user_id,
+        lifecycle_generation=association_generation,
     )
     auth_config = _get_mcp_oauth_config(server)
     discovery = await _discover_mcp_oauth_for_server(server, auth_config)
@@ -4540,6 +4963,9 @@ async def connect_mcp_oauth(
                 registered_client.token_endpoint_auth_method
             )
         else:
+            # Dynamic registration is provider I/O too; release the client
+            # lookup transaction before awaiting it.
+            db.rollback()
             try:
                 registration = await register_mcp_oauth_public_client(
                     discovery.authorization_server,
@@ -4563,70 +4989,34 @@ async def connect_mcp_oauth(
         str(discovery.resource), field_name="resource"
     )
 
-    oauth_client = _upsert_mcp_oauth_client(
+    persisted = _persist_mcp_oauth_connect_flow(
         db,
-        server_id=server_id,
+        association_identity=association_identity,
         discovery=discovery,
         client_id=client_id,
         client_secret=client_secret,
         token_endpoint_auth_method=token_endpoint_auth_method,
         redirect_uri=redirect_uri,
         registration_lookup_hash=registration_lookup_hash,
-    )
-
-    # Sweep this table's dead rows before adding another, mirroring the Slack
-    # OAuth flow-state ledger in channel.py. Every abandoned, denied or
-    # double-submitted authorization leaves a row that is permanently unusable
-    # once it expires (the claim query requires consumed_at IS NULL and
-    # expires_at > now), but nothing deleted it: the only other deletes are the
-    # per-user purge on disconnect and the FK cascade on server deletion, so
-    # the table grew without bound. Deliberately global rather than scoped to
-    # this user/server — a user who never reconnects would otherwise keep their
-    # rows forever, which is the leak this is meant to close. Filtering on
-    # expires_at alone (an indexed column) also covers consumed rows, since
-    # every row expires within MCP_OAUTH_STATE_TTL of being created.
-    #
-    # Bounded per request. The index narrows the scan but does not cap the work,
-    # and this table is precisely the one that has never been swept — the first
-    # connect after this ships meets whatever backlog has accumulated, inside a
-    # user-facing transaction. Draining a fixed batch per connect keeps that
-    # transaction short; the remainder is already dead, so later connects
-    # clearing it costs nothing. Deleting by a bounded id subquery rather than
-    # an IN list of fetched ids keeps it to one statement and clear of any
-    # bound-parameter limit.
-    stale_flow_state_ids = (
-        db.query(MCPOAuthFlowState.id)
-        .filter(
-            MCPOAuthFlowState.expires_at < _utc_now() - MCP_OAUTH_FLOW_STATE_RETENTION
-        )
-        .limit(MCP_OAUTH_FLOW_STATE_SWEEP_BATCH)
-        .scalar_subquery()
-    )
-    db.query(MCPOAuthFlowState).filter(
-        MCPOAuthFlowState.id.in_(stale_flow_state_ids)
-    ).delete(synchronize_session=False)
-
-    state_value = secrets.token_urlsafe(32)
-    code_verifier = secrets.token_urlsafe(64)
-    flow_state = MCPOAuthFlowState(
-        state=state_value,
-        mcp_server_id=server_id,
-        user_id=user_id,
-        mcp_oauth_client_id=oauth_client.id,
         resource_owner_key=resource_owner_key,
-        issuer=selected_issuer,
-        resource=selected_resource,
-        scope=selected_scope,
-        code_verifier=encrypt_value(code_verifier),
-        redirect_after=_safe_mcp_oauth_redirect_after(request_data.redirect_after),
-        expires_at=_utc_now() + MCP_OAUTH_STATE_TTL,
+        selected_issuer=selected_issuer,
+        selected_resource=selected_resource,
+        selected_scope=selected_scope,
+        redirect_after=request_data.redirect_after,
     )
-    db.add(flow_state)
-    db.commit()
+    if persisted is None:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail={
+                "code": "oauth_lifecycle_changed",
+                "message": "MCP server connection changed during OAuth setup",
+            },
+        )
+    persisted_client_id, state_value, code_verifier = persisted
 
     params = {
         "response_type": "code",
-        "client_id": str(oauth_client.client_id),
+        "client_id": persisted_client_id,
         "redirect_uri": redirect_uri,
         "state": state_value,
         "code_challenge": _pkce_code_challenge(code_verifier),

--- a/src/xagent/web/models/mcp_oauth.py
+++ b/src/xagent/web/models/mcp_oauth.py
@@ -3,7 +3,17 @@ from __future__ import annotations
 import hashlib
 from typing import Any
 
-from sqlalchemy import JSON, Column, DateTime, ForeignKey, Integer, String, Text, event
+from sqlalchemy import (
+    JSON,
+    Column,
+    DateTime,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    Uuid,
+    event,
+)
 from sqlalchemy.orm import relationship
 from sqlalchemy.schema import Index, UniqueConstraint
 from sqlalchemy.sql import func
@@ -224,6 +234,11 @@ class MCPOAuthFlowState(Base):  # type: ignore
     user_id = Column(
         Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
     )
+    # Snapshot of the exact UserMCPServer lifecycle that created this flow.
+    # NULL is reserved for flows created before the lifecycle fence migration;
+    # callbacks for those rows fail closed because their association identity
+    # cannot be proven after a delete-and-recreate race.
+    association_lifecycle_generation = Column(Uuid, nullable=True)
     mcp_oauth_client_id = Column(
         Integer,
         ForeignKey("mcp_oauth_clients.id", ondelete="CASCADE"),

--- a/tests/migrations/test_migration_workflow_contract.py
+++ b/tests/migrations/test_migration_workflow_contract.py
@@ -13,6 +13,11 @@ GENERATION_MODEL_PATHS = (
     "src/xagent/web/models/mcp.py",
     "src/xagent/web/models/public_mcp.py",
 )
+OAUTH_LIFECYCLE_PATHS = (
+    "src/xagent/web/models/mcp_oauth.py",
+    "src/xagent/web/api/mcp.py",
+    "tests/web/api/test_mcp_oauth_lifecycle_postgresql.py",
+)
 
 
 def _workflow_text() -> str:
@@ -56,4 +61,26 @@ def test_generation_model_changes_run_real_postgresql_migration_step(
     assert (
         "pytest tests/migrations/test_20260902_add_mcp_lifecycle_generations.py "
         "-m postgresql -q"
+    ) in regression["run"]
+
+
+@pytest.mark.parametrize("source_path", OAUTH_LIFECYCLE_PATHS)
+def test_oauth_lifecycle_changes_run_real_postgresql_fence_tests(
+    source_path: str,
+) -> None:
+    text = _workflow_text()
+    assert source_path in _push_paths(text)
+    assert source_path in _detector_paths(text)
+
+    workflow = yaml.safe_load(text)
+    job = workflow["jobs"]["test-postgresql-migrations"]
+    regression = next(
+        step
+        for step in job["steps"]
+        if step["name"] == "Test MCP OAuth lifecycle fencing (Postgres-only)"
+    )
+    output = "needs.detect-migration-changes.outputs.should-test"
+    assert regression["if"] == f"{output} == 'true'"
+    assert (
+        "pytest tests/web/api/test_mcp_oauth_lifecycle_postgresql.py -m postgresql -q"
     ) in regression["run"]

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -7,6 +7,7 @@ import time
 from datetime import timedelta
 from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
+from uuid import uuid4
 
 import httpx
 import pytest
@@ -255,6 +256,19 @@ def _set_user_mcp_active(db, user: User, server: MCPServer, is_active: bool) -> 
     )
     user_mcp.is_active = is_active
     db.commit()
+
+
+def _allow_standalone_connector_delete(monkeypatch) -> None:
+    monkeypatch.setattr(
+        connector_team_scope,
+        "delete_team_connector",
+        lambda *args: SimpleNamespace(
+            blocked_reason=None,
+            team_owned=False,
+            authorized=False,
+            delete_definition=False,
+        ),
+    )
 
 
 @pytest.mark.asyncio
@@ -1158,6 +1172,183 @@ async def test_stale_real_disconnect_cannot_delete_replacement_association(
 
 
 @pytest.mark.asyncio
+async def test_real_disconnect_uses_generation_when_active_state_changes_before_lock(
+    db_session, monkeypatch
+):
+    db, user, other_user = db_session
+    server = _add_mcp_oauth_server(db, user)
+    db.add(
+        UserMCPServer(
+            user_id=other_user.id,
+            mcpserver_id=server.id,
+            is_owner=False,
+            is_active=True,
+        )
+    )
+    db.commit()
+    server_id = int(server.id)
+    user_id = int(user.id)
+    SessionLocal = sessionmaker(bind=db.get_bind(), autoflush=False, autocommit=False)
+    original_lock = mcp_api._lock_active_mcp_oauth_lifecycle
+    toggled = False
+
+    def deactivate_before_lock(*args, **kwargs):
+        nonlocal toggled
+        if not toggled:
+            toggled = True
+            with SessionLocal() as toggle_db:
+                toggle_db.query(UserMCPServer).filter(
+                    UserMCPServer.user_id == user_id,
+                    UserMCPServer.mcpserver_id == server_id,
+                ).update(
+                    {UserMCPServer.is_active: False},
+                    synchronize_session=False,
+                )
+                toggle_db.commit()
+        return original_lock(*args, **kwargs)
+
+    monkeypatch.setattr(
+        mcp_api, "_lock_active_mcp_oauth_lifecycle", deactivate_before_lock
+    )
+    _allow_standalone_connector_delete(monkeypatch)
+
+    await delete_mcp_server(server_id, current_user=user, db=db)
+
+    assert toggled is True
+    db.expire_all()
+    assert (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user_id,
+            UserMCPServer.mcpserver_id == server_id,
+        )
+        .one_or_none()
+        is None
+    )
+    assert (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == other_user.id,
+            UserMCPServer.mcpserver_id == server_id,
+        )
+        .one()
+        is not None
+    )
+
+
+@pytest.mark.asyncio
+async def test_last_user_disconnect_deletes_server_before_post_commit_reconnect(
+    db_session, monkeypatch
+):
+    db, user, _ = db_session
+    server = _add_mcp_oauth_server(db, user)
+    server_id = int(server.id)
+    user_id = int(user.id)
+    client = _add_oauth_client(
+        db,
+        server,
+        metadata_json={"revocation_endpoint": "https://auth.example.com/revoke"},
+    )
+    generation = _association_generation(db, user, server)
+    db.add_all(
+        [
+            MCPOAuthFlowState(
+                state="last-user-flow",
+                mcp_server_id=server_id,
+                user_id=user_id,
+                association_lifecycle_generation=generation,
+                mcp_oauth_client_id=client.id,
+                resource_owner_key=f"xagent:user:{user_id}",
+                issuer="https://auth.example.com",
+                resource="https://mcp.example.com/mcp",
+                scope="records.read",
+                code_verifier=encrypt_value("last-user-verifier"),
+                expires_at=mcp_api._utc_now() + timedelta(minutes=10),
+            ),
+            MCPOAuthGrant(
+                mcp_server_id=server_id,
+                user_id=user_id,
+                mcp_oauth_client_id=client.id,
+                resource_owner_key=f"xagent:user:{user_id}",
+                issuer="https://auth.example.com",
+                resource="https://mcp.example.com/mcp",
+                scope="records.read",
+                access_token=encrypt_value("last-user-token"),
+                status="active",
+            ),
+        ]
+    )
+    db.commit()
+    engine = db.get_bind()
+
+    @event.listens_for(engine, "connect")
+    def enable_foreign_keys(dbapi_connection, _connection_record):
+        cursor = dbapi_connection.cursor()
+        try:
+            cursor.execute("PRAGMA foreign_keys=ON")
+        finally:
+            cursor.close()
+
+    db.connection().exec_driver_sql("PRAGMA foreign_keys=ON")
+    assert db.connection().exec_driver_sql("PRAGMA foreign_keys").scalar() == 1
+    db.rollback()
+    SessionLocal = sessionmaker(bind=db.get_bind(), autoflush=False, autocommit=False)
+    replacement_committed: list[bool] = []
+    main_commits: list[None] = []
+
+    @event.listens_for(db, "after_commit")
+    def record_main_commit(session):
+        main_commits.append(None)
+
+    async def reconnect_after_local_commit(snapshot):
+        assert not db.in_transaction()
+        with SessionLocal() as reconnect_db:
+            reconnect_db.add(
+                UserMCPServer(
+                    user_id=user_id,
+                    mcpserver_id=server_id,
+                    is_owner=False,
+                    is_active=True,
+                )
+            )
+            try:
+                reconnect_db.commit()
+            except IntegrityError:
+                reconnect_db.rollback()
+                replacement_committed.append(False)
+            else:  # pragma: no cover - the assertion below reports the regression
+                replacement_committed.append(True)
+
+    monkeypatch.setattr(
+        mcp_api,
+        "_revoke_mcp_oauth_grant_snapshot_externally",
+        reconnect_after_local_commit,
+    )
+    _allow_standalone_connector_delete(monkeypatch)
+
+    await delete_mcp_server(server_id, current_user=user, db=db)
+
+    assert replacement_committed == [False]
+    assert len(main_commits) == 1
+    db.expire_all()
+    assert db.query(MCPServer).filter(MCPServer.id == server_id).count() == 0
+    assert (
+        db.query(UserMCPServer).filter(UserMCPServer.mcpserver_id == server_id).count()
+        == 0
+    )
+    assert (
+        db.query(MCPOAuthGrant).filter(MCPOAuthGrant.mcp_server_id == server_id).count()
+        == 0
+    )
+    assert (
+        db.query(MCPOAuthFlowState)
+        .filter(MCPOAuthFlowState.mcp_server_id == server_id)
+        .count()
+        == 0
+    )
+
+
+@pytest.mark.asyncio
 async def test_connect_sweeps_flow_states_expired_past_the_retention_window(
     db_session, monkeypatch
 ):
@@ -1248,6 +1439,20 @@ async def test_connect_sweeps_flow_states_expired_past_the_retention_window(
         return _discovery()
 
     monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+    ordering: list[str] = []
+    original_sweep = mcp_api._sweep_expired_mcp_oauth_flow_states
+    original_lock = mcp_api._lock_active_mcp_oauth_lifecycle
+
+    def record_sweep(*args, **kwargs):
+        ordering.append("sweep")
+        return original_sweep(*args, **kwargs)
+
+    def record_lock(*args, **kwargs):
+        ordering.append("lifecycle_lock")
+        return original_lock(*args, **kwargs)
+
+    monkeypatch.setattr(mcp_api, "_sweep_expired_mcp_oauth_flow_states", record_sweep)
+    monkeypatch.setattr(mcp_api, "_lock_active_mcp_oauth_lifecycle", record_lock)
 
     response = await connect_mcp_oauth(
         server.id,
@@ -1262,8 +1467,9 @@ async def test_connect_sweeps_flow_states_expired_past_the_retention_window(
         {"stale-other-user", "stale-other-server", "stale-consumed"} & surviving
     )
     assert {"expired-inside-window", "in-flight"} <= surviving
-    # The sweep runs in the same transaction as the insert, so the new row must
-    # still be there once it commits.
+    assert ordering[:2] == ["sweep", "lifecycle_lock"]
+    # The independent maintenance commit cannot consume the new flow because
+    # lifecycle persistence starts only after the sweep has completed.
     assert _redirect_query(response)["state"][0] in surviving
 
 
@@ -1271,11 +1477,9 @@ async def test_connect_sweeps_flow_states_expired_past_the_retention_window(
 async def test_connect_sweep_is_bounded_and_drains_across_requests(
     db_session, monkeypatch
 ):
-    # The sweep runs inside a user-facing request, and this table is the one
-    # that has never been swept — so the first connect after this ships meets
-    # whatever backlog accumulated. The batch cap is what keeps that from
-    # becoming one long transaction; the leftovers are already dead, so later
-    # connects draining them costs nothing.
+    # The sweep runs as a short maintenance transaction in a user-facing
+    # request. The batch cap keeps the first connect after an accumulated
+    # backlog from draining it all at once; later connects drain the remainder.
     db, user, _ = db_session
     server = _add_mcp_oauth_server(db, user)
     client = _add_oauth_client(db, server)
@@ -2777,6 +2981,218 @@ async def test_callback_exchanges_code_and_stores_encrypted_grant(
     assert decrypt_value(grant.access_token) == "plain-access-token"
     assert decrypt_value(grant.refresh_token) == "plain-refresh-token"
     assert db.query(MCPOAuthFlowState).one().consumed_at is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("callback_query", "lose_claim", "expected_error"),
+    [
+        ("code=auth-code", True, "state_already_consumed"),
+        ("error=access_denied", False, "token_exchange_failed"),
+        ("", False, "invalid_state"),
+    ],
+    ids=("claim-lost", "provider-error", "missing-code"),
+)
+async def test_callback_uses_cached_redirect_when_real_delete_removes_claimed_flow(
+    db_session,
+    monkeypatch,
+    callback_query,
+    lose_claim,
+    expected_error,
+):
+    db, user, _ = db_session
+    server, _, flow = _add_callback_client_and_state(
+        db,
+        user,
+        state=f"deleted-after-claim-{expected_error}",
+        redirect_after="/mcp/cached",
+    )
+    server_id = int(server.id)
+    user_id = int(user.id)
+    flow_id = int(flow.id)
+    state_value = str(flow.state)
+    SessionLocal = sessionmaker(bind=db.get_bind(), autoflush=False, autocommit=False)
+    _allow_standalone_connector_delete(monkeypatch)
+    original_claim = mcp_api._claim_mcp_oauth_flow_state
+
+    def claim_then_delete(claim_db, claim_flow):
+        if lose_claim:
+            with SessionLocal() as competing_claim_db:
+                competing_claim_db.query(MCPOAuthFlowState).filter(
+                    MCPOAuthFlowState.id == flow_id
+                ).update(
+                    {MCPOAuthFlowState.consumed_at: mcp_api._utc_now()},
+                    synchronize_session=False,
+                )
+                competing_claim_db.commit()
+
+        claim_result = original_claim(claim_db, claim_flow)
+        delete_errors: list[BaseException] = []
+
+        def delete() -> None:
+            try:
+                with SessionLocal() as delete_db:
+                    asyncio.run(
+                        delete_mcp_server(
+                            server_id,
+                            current_user=delete_db.get(User, user_id),
+                            db=delete_db,
+                        )
+                    )
+            except BaseException as exc:  # pragma: no cover - assertion reports it
+                delete_errors.append(exc)
+
+        delete_thread = threading.Thread(target=delete)
+        delete_thread.start()
+        delete_thread.join(timeout=5)
+        assert not delete_thread.is_alive()
+        assert delete_errors == []
+        return claim_result
+
+    monkeypatch.setattr(mcp_api, "_claim_mcp_oauth_flow_state", claim_then_delete)
+    separator = "&" if callback_query else ""
+    response = await mcp_oauth_callback(
+        _request(
+            f"/api/mcp/oauth/callback?{callback_query}{separator}state={state_value}"
+        ),
+        db,
+    )
+
+    assert response.status_code == 307
+    assert _redirect_query(response)["mcp_oauth_error"] == [expected_error]
+    assert urlparse(response.headers["location"]).path == "/mcp/cached"
+    db.expire_all()
+    assert db.query(MCPOAuthFlowState).count() == 0
+    assert db.query(MCPServer).filter(MCPServer.id == server_id).count() == 0
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_preserved_flow_after_association_generation_changes(
+    db_session, monkeypatch
+):
+    db, user, _ = db_session
+    server, _, original_flow = _add_callback_client_and_state(
+        db,
+        user,
+        state="preserved-flow-replaced-association",
+        metadata_json={"revocation_endpoint": "https://auth.example.com/revoke"},
+    )
+    server_id = int(server.id)
+    user_id = int(user.id)
+    original_flow_id = int(original_flow.id)
+    original_generation = original_flow.association_lifecycle_generation
+    SessionLocal = sessionmaker(bind=db.get_bind(), autoflush=False, autocommit=False)
+
+    async def replace_association_only(**kwargs):
+        with SessionLocal() as replacement_db:
+            replacement_db.query(UserMCPServer).filter(
+                UserMCPServer.user_id == user_id,
+                UserMCPServer.mcpserver_id == server_id,
+            ).delete(synchronize_session=False)
+            replacement = UserMCPServer(
+                user_id=user_id,
+                mcpserver_id=server_id,
+                is_owner=False,
+                is_active=True,
+            )
+            replacement_db.add(replacement)
+            replacement_db.commit()
+            assert replacement.lifecycle_generation != original_generation
+        return {
+            "access_token": "issued-access-token",
+            "token_type": "Bearer",
+            "scope": "records.read",
+        }
+
+    revoked: list[mcp_api._MCPOAuthIssuedTokenSnapshot] = []
+
+    async def record_revoke(snapshot):
+        revoked.append(snapshot)
+
+    monkeypatch.setattr(mcp_api, "_exchange_mcp_oauth_code", replace_association_only)
+    monkeypatch.setattr(
+        mcp_api, "_revoke_mcp_oauth_issued_token_externally", record_revoke
+    )
+
+    response = await mcp_oauth_callback(
+        _request(
+            "/api/mcp/oauth/callback?code=auth-code&state="
+            "preserved-flow-replaced-association"
+        ),
+        db,
+    )
+
+    assert _redirect_query(response)["mcp_oauth_error"] == ["invalid_state"]
+    assert len(revoked) == 1
+    db.expire_all()
+    assert db.query(MCPOAuthGrant).count() == 0
+    assert db.query(MCPOAuthFlowState).one().id == original_flow_id
+    assert _association_generation(db, user, server) != original_generation
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_same_flow_id_when_its_generation_changes(
+    db_session, monkeypatch
+):
+    db, user, _ = db_session
+    server, _, original_flow = _add_callback_client_and_state(
+        db,
+        user,
+        state="same-flow-id-new-generation",
+        metadata_json={"revocation_endpoint": "https://auth.example.com/revoke"},
+    )
+    flow_id = int(original_flow.id)
+    original_generation = original_flow.association_lifecycle_generation
+    changed_generation = uuid4()
+    SessionLocal = sessionmaker(bind=db.get_bind(), autoflush=False, autocommit=False)
+
+    async def change_flow_generation_only(**kwargs):
+        with SessionLocal() as replacement_db:
+            replacement_db.query(MCPOAuthFlowState).filter(
+                MCPOAuthFlowState.id == flow_id
+            ).update(
+                {
+                    MCPOAuthFlowState.association_lifecycle_generation: (
+                        changed_generation
+                    )
+                },
+                synchronize_session=False,
+            )
+            replacement_db.commit()
+        return {
+            "access_token": "issued-access-token",
+            "token_type": "Bearer",
+            "scope": "records.read",
+        }
+
+    revoked: list[mcp_api._MCPOAuthIssuedTokenSnapshot] = []
+
+    async def record_revoke(snapshot):
+        revoked.append(snapshot)
+
+    monkeypatch.setattr(
+        mcp_api, "_exchange_mcp_oauth_code", change_flow_generation_only
+    )
+    monkeypatch.setattr(
+        mcp_api, "_revoke_mcp_oauth_issued_token_externally", record_revoke
+    )
+
+    response = await mcp_oauth_callback(
+        _request(
+            "/api/mcp/oauth/callback?code=auth-code&state=same-flow-id-new-generation"
+        ),
+        db,
+    )
+
+    assert _redirect_query(response)["mcp_oauth_error"] == ["invalid_state"]
+    assert len(revoked) == 1
+    db.expire_all()
+    assert db.query(MCPOAuthGrant).count() == 0
+    persisted_flow = db.query(MCPOAuthFlowState).one()
+    assert persisted_flow.id == flow_id
+    assert persisted_flow.association_lifecycle_generation == changed_generation
+    assert persisted_flow.association_lifecycle_generation != original_generation
+    assert _association_generation(db, user, server) == original_generation
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
 import time
@@ -10,8 +11,7 @@ from urllib.parse import parse_qs, urlparse
 import httpx
 import pytest
 from fastapi import HTTPException
-from sqlalchemy import create_engine
-from sqlalchemy import event
+from sqlalchemy import create_engine, event
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 from starlette.requests import Request
@@ -46,6 +46,7 @@ from xagent.web.models.mcp_oauth import mcp_oauth_client_registration_lookup_has
 from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
 from xagent.web.services import mcp_oauth as mcp_oauth_service
+from xagent.web.services import connector_team_scope
 from xagent.web.services.mcp_oauth import (
     MCP_OAUTH_PERSISTED_VALUE_MAX_LENGTH,
     MCP_OAUTH_RESOURCE_OWNER_KEY_MAX_LENGTH,
@@ -769,15 +770,13 @@ def test_connect_producer_first_blocks_disconnect_until_flow_commit(
         other_db = SessionLocal()
         try:
             disconnect_started.set()
-            other_db.query(MCPOAuthFlowState).filter(
-                MCPOAuthFlowState.mcp_server_id == server.id,
-                MCPOAuthFlowState.user_id == user.id,
-            ).delete(synchronize_session=False)
-            other_db.query(UserMCPServer).filter(
-                UserMCPServer.mcpserver_id == server.id,
-                UserMCPServer.user_id == user.id,
-            ).delete(synchronize_session=False)
-            other_db.commit()
+            asyncio.run(
+                delete_mcp_server(
+                    server.id,
+                    current_user=other_db.get(User, user.id),
+                    db=other_db,
+                )
+            )
         except BaseException as exc:  # pragma: no cover - assertion reports it
             disconnect_errors.append(exc)
         finally:
@@ -797,6 +796,16 @@ def test_connect_producer_first_blocks_disconnect_until_flow_commit(
         return original_upsert(*args, **kwargs)
 
     monkeypatch.setattr(mcp_api, "_upsert_mcp_oauth_client", gated_upsert)
+    monkeypatch.setattr(
+        connector_team_scope,
+        "delete_team_connector",
+        lambda *args: SimpleNamespace(
+            blocked_reason=None,
+            team_owned=False,
+            authorized=False,
+            delete_definition=False,
+        ),
+    )
     persisted = mcp_api._persist_mcp_oauth_connect_flow(
         db,
         association_identity=association_identity,
@@ -837,6 +846,314 @@ def test_connect_producer_first_blocks_disconnect_until_flow_commit(
         )
         .one()
         is not None
+    )
+
+
+def test_callback_producer_first_blocks_real_disconnect_until_grant_commit(
+    db_session, monkeypatch
+):
+    db, user, other_user = db_session
+    server = _add_mcp_oauth_server(db, user)
+    db.add(
+        UserMCPServer(
+            user_id=other_user.id,
+            mcpserver_id=server.id,
+            is_owner=False,
+            is_active=True,
+        )
+    )
+    client = _add_oauth_client(db, server)
+    generation = _association_generation(db, user, server)
+    flow = MCPOAuthFlowState(
+        state="sqlite-producer-first",
+        mcp_server_id=server.id,
+        user_id=user.id,
+        association_lifecycle_generation=generation,
+        mcp_oauth_client_id=client.id,
+        resource_owner_key=f"xagent:user:{user.id}",
+        issuer="https://auth.example.com",
+        resource="https://mcp.example.com/mcp",
+        scope="records.read",
+        code_verifier=encrypt_value("sqlite-verifier"),
+        expires_at=mcp_api._utc_now() + timedelta(minutes=10),
+        consumed_at=mcp_api._utc_now(),
+    )
+    db.add(flow)
+    db.commit()
+    association_identity = mcp_api._MCPOAuthAssociationIdentity(
+        server_id=server.id,
+        user_id=user.id,
+        lifecycle_generation=generation,
+    )
+    flow_identity = mcp_api._mcp_oauth_flow_identity(flow)
+    lifecycle = mcp_api._lock_active_mcp_oauth_lifecycle(
+        db,
+        association_identity=association_identity,
+        flow_identity=flow_identity,
+    )
+    assert lifecycle is not None and lifecycle[2] is not None
+
+    monkeypatch.setattr(
+        connector_team_scope,
+        "delete_team_connector",
+        lambda *args: SimpleNamespace(
+            blocked_reason=None,
+            team_owned=False,
+            authorized=False,
+            delete_definition=False,
+        ),
+    )
+    SessionLocal = sessionmaker(bind=db.get_bind(), autoflush=False, autocommit=False)
+    disconnect_started = threading.Event()
+    disconnect_lock_attempted = threading.Event()
+    disconnect_finished = threading.Event()
+    disconnect_errors: list[BaseException] = []
+
+    def disconnect() -> None:
+        with SessionLocal() as disconnect_db:
+            try:
+                disconnect_started.set()
+                asyncio.run(
+                    delete_mcp_server(
+                        server.id,
+                        current_user=disconnect_db.get(User, user.id),
+                        db=disconnect_db,
+                    )
+                )
+            except BaseException as exc:  # pragma: no cover - assertion reports it
+                disconnect_errors.append(exc)
+            finally:
+                disconnect_finished.set()
+
+    disconnect_thread = threading.Thread(target=disconnect)
+    original_lock = mcp_api._lock_active_mcp_oauth_lifecycle
+
+    def record_disconnect_lock_attempt(*args, **kwargs):
+        disconnect_lock_attempted.set()
+        return original_lock(*args, **kwargs)
+
+    monkeypatch.setattr(
+        mcp_api,
+        "_lock_active_mcp_oauth_lifecycle",
+        record_disconnect_lock_attempt,
+    )
+    disconnect_thread.start()
+    assert disconnect_started.wait(timeout=2)
+    assert disconnect_lock_attempted.wait(timeout=2)
+    assert not disconnect_finished.wait(timeout=0.2)
+    mcp_api._upsert_mcp_oauth_grant(
+        db,
+        flow_state=lifecycle[2],
+        token_data={
+            "access_token": "sqlite-issued-token",
+            "token_type": "Bearer",
+            "scope": "records.read",
+        },
+    )
+    db.commit()
+
+    disconnect_thread.join(timeout=5)
+    assert disconnect_finished.is_set()
+    assert disconnect_errors == []
+    db.expire_all()
+    assert db.query(MCPOAuthGrant).count() == 0
+    assert db.query(MCPOAuthFlowState).count() == 0
+    assert (
+        db.query(UserMCPServer).filter(UserMCPServer.mcpserver_id == server.id).count()
+        == 1
+    )
+
+
+def test_real_disconnect_first_rejects_stale_callback_and_preserves_replacement(
+    db_session, monkeypatch
+):
+    db, user, other_user = db_session
+    server = _add_mcp_oauth_server(db, user)
+    db.add(
+        UserMCPServer(
+            user_id=other_user.id,
+            mcpserver_id=server.id,
+            is_owner=False,
+            is_active=True,
+        )
+    )
+    client = _add_oauth_client(db, server)
+    original_generation = _association_generation(db, user, server)
+    flow = MCPOAuthFlowState(
+        state="sqlite-teardown-first",
+        mcp_server_id=server.id,
+        user_id=user.id,
+        association_lifecycle_generation=original_generation,
+        mcp_oauth_client_id=client.id,
+        resource_owner_key=f"xagent:user:{user.id}",
+        issuer="https://auth.example.com",
+        resource="https://mcp.example.com/mcp",
+        scope="records.read",
+        code_verifier=encrypt_value("sqlite-verifier"),
+        expires_at=mcp_api._utc_now() + timedelta(minutes=10),
+        consumed_at=mcp_api._utc_now(),
+    )
+    db.add(flow)
+    db.commit()
+    association_identity = mcp_api._MCPOAuthAssociationIdentity(
+        server_id=server.id,
+        user_id=user.id,
+        lifecycle_generation=original_generation,
+    )
+    flow_identity = mcp_api._mcp_oauth_flow_identity(flow)
+    SessionLocal = sessionmaker(bind=db.get_bind(), autoflush=False, autocommit=False)
+    teardown_locked = threading.Event()
+    allow_teardown = threading.Event()
+    producer_started = threading.Event()
+    producer_finished = threading.Event()
+    producer_results: list[object] = []
+    errors: list[BaseException] = []
+
+    def gated_team_delete(*args):
+        teardown_locked.set()
+        assert allow_teardown.wait(timeout=5)
+        return SimpleNamespace(
+            blocked_reason=None,
+            team_owned=False,
+            authorized=False,
+            delete_definition=False,
+        )
+
+    monkeypatch.setattr(
+        connector_team_scope, "delete_team_connector", gated_team_delete
+    )
+
+    def disconnect() -> None:
+        with SessionLocal() as disconnect_db:
+            try:
+                asyncio.run(
+                    delete_mcp_server(
+                        server.id,
+                        current_user=disconnect_db.get(User, user.id),
+                        db=disconnect_db,
+                    )
+                )
+            except BaseException as exc:  # pragma: no cover - assertion reports it
+                errors.append(exc)
+
+    def producer() -> None:
+        with SessionLocal() as producer_db:
+            try:
+                producer_started.set()
+                producer_results.append(
+                    mcp_api._lock_active_mcp_oauth_lifecycle(
+                        producer_db,
+                        association_identity=association_identity,
+                        flow_identity=flow_identity,
+                    )
+                )
+                producer_db.rollback()
+            except BaseException as exc:  # pragma: no cover - assertion reports it
+                errors.append(exc)
+            finally:
+                producer_finished.set()
+
+    disconnect_thread = threading.Thread(target=disconnect)
+    disconnect_thread.start()
+    assert teardown_locked.wait(timeout=2)
+    producer_thread = threading.Thread(target=producer)
+    producer_thread.start()
+    assert producer_started.wait(timeout=2)
+    assert not producer_finished.wait(timeout=0.2)
+    allow_teardown.set()
+    disconnect_thread.join(timeout=5)
+    producer_thread.join(timeout=5)
+    assert errors == []
+    assert producer_finished.is_set()
+    assert producer_results == [None]
+
+    db.expire_all()
+    replacement = UserMCPServer(
+        user_id=user.id,
+        mcpserver_id=server.id,
+        is_owner=False,
+        is_active=True,
+    )
+    db.add(replacement)
+    db.commit()
+    assert replacement.lifecycle_generation != original_generation
+    assert (
+        mcp_api._lock_active_mcp_oauth_lifecycle(
+            db,
+            association_identity=association_identity,
+            flow_identity=flow_identity,
+        )
+        is None
+    )
+    db.rollback()
+    assert db.query(MCPOAuthGrant).count() == 0
+    assert db.query(MCPOAuthFlowState).count() == 0
+    assert (
+        db.query(UserMCPServer).filter(UserMCPServer.mcpserver_id == server.id).count()
+        == 2
+    )
+
+
+@pytest.mark.asyncio
+async def test_stale_real_disconnect_cannot_delete_replacement_association(
+    db_session, monkeypatch
+):
+    db, user, other_user = db_session
+    server = _add_mcp_oauth_server(db, user)
+    db.add(
+        UserMCPServer(
+            user_id=other_user.id,
+            mcpserver_id=server.id,
+            is_owner=False,
+            is_active=True,
+        )
+    )
+    db.commit()
+    original_generation = _association_generation(db, user, server)
+    SessionLocal = sessionmaker(bind=db.get_bind(), autoflush=False, autocommit=False)
+    original_lock = mcp_api._lock_active_mcp_oauth_lifecycle
+    replacement_generation: list[object] = []
+
+    def replace_before_lock(*args, **kwargs):
+        with SessionLocal() as replacement_db:
+            replacement_db.query(UserMCPServer).filter(
+                UserMCPServer.user_id == user.id,
+                UserMCPServer.mcpserver_id == server.id,
+                UserMCPServer.lifecycle_generation == original_generation,
+            ).delete(synchronize_session=False)
+            replacement = UserMCPServer(
+                user_id=user.id,
+                mcpserver_id=server.id,
+                is_owner=True,
+                is_active=True,
+            )
+            replacement_db.add(replacement)
+            replacement_db.commit()
+            replacement_generation.append(replacement.lifecycle_generation)
+        return original_lock(*args, **kwargs)
+
+    monkeypatch.setattr(
+        mcp_api, "_lock_active_mcp_oauth_lifecycle", replace_before_lock
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await delete_mcp_server(server.id, current_user=user, db=db)
+
+    assert exc_info.value.status_code == 404
+    assert replacement_generation[0] != original_generation
+    db.expire_all()
+    replacement = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .one()
+    )
+    assert replacement.lifecycle_generation == replacement_generation[0]
+    assert (
+        db.query(UserMCPServer).filter(UserMCPServer.mcpserver_id == server.id).count()
+        == 2
     )
 
 
@@ -2714,6 +3031,8 @@ async def test_callback_rolls_back_before_revoke_and_sanitizes_failure_log(
     assert "issued-secret-access-token" not in caplog.text
     assert "issued-secret-refresh-token" not in caplog.text
     assert "raw persistence detail" not in caplog.text
+    assert "stage=persist_grant" in caplog.text
+    assert "exception_type=RuntimeError" in caplog.text
     assert db.query(MCPOAuthGrant).count() == 0
 
 
@@ -3547,6 +3866,7 @@ async def test_delete_mcp_server_revokes_external_tokens_when_endpoint_is_advert
     real_async_client = httpx.AsyncClient
 
     def handler(request: httpx.Request) -> httpx.Response:
+        assert not db.in_transaction()
         requests.append(parse_qs(request.content.decode()))
         return httpx.Response(200)
 
@@ -3603,8 +3923,53 @@ async def test_delete_mcp_server_purges_the_users_own_flow_state_rows(db_session
 
 
 @pytest.mark.asyncio
+async def test_delete_mcp_server_preserves_inactive_association_semantics(db_session):
+    db, user, other_user = db_session
+    server = _add_mcp_oauth_server(db, user)
+    association = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .one()
+    )
+    association.is_active = False
+    db.add(
+        UserMCPServer(
+            user_id=other_user.id,
+            mcpserver_id=server.id,
+            is_owner=False,
+            is_active=True,
+        )
+    )
+    db.commit()
+
+    await delete_mcp_server(server.id, current_user=user, db=db)
+
+    assert (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .one_or_none()
+        is None
+    )
+    assert (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == other_user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .one()
+        is not None
+    )
+
+
+@pytest.mark.asyncio
 async def test_delete_grant_continues_local_revoke_when_token_decryption_fails(
-    db_session, monkeypatch
+    db_session, monkeypatch, caplog
 ):
     db, user, _ = db_session
     server = _add_mcp_oauth_server(db, user)
@@ -3632,7 +3997,7 @@ async def test_delete_grant_continues_local_revoke_when_token_decryption_fails(
 
     def fail_target_token_decrypt(value: str) -> str:
         if value == "not-encrypted-token":
-            raise ValueError("cannot decrypt token")
+            raise ValueError("cannot decrypt raw-sensitive-provider-detail")
         return real_decrypt_value(value)
 
     def handler(request: httpx.Request) -> httpx.Response:
@@ -3649,6 +4014,9 @@ async def test_delete_grant_continues_local_revoke_when_token_decryption_fails(
     db.refresh(grant)
     assert grant.status == "revoked"
     assert grant.revoked_at is not None
+    assert "raw-sensitive-provider-detail" not in caplog.text
+    assert "stage=decrypt_access_token" in caplog.text
+    assert "exception_type=ValueError" in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import threading
+import time
 from datetime import timedelta
 from types import SimpleNamespace
 from urllib.parse import parse_qs, urlparse
@@ -9,6 +11,7 @@ import httpx
 import pytest
 from fastapi import HTTPException
 from sqlalchemy import create_engine
+from sqlalchemy import event
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
 from starlette.requests import Request
@@ -58,6 +61,8 @@ def db_session(tmp_path):
     engine = create_engine(
         f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
     )
+    with engine.connect() as connection:
+        assert connection.exec_driver_sql("PRAGMA journal_mode=WAL").scalar() == "wal"
     Base.metadata.create_all(engine)
     SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
     db = SessionLocal()
@@ -197,6 +202,17 @@ def _add_oauth_client(
     return client
 
 
+def _association_generation(db, user: User, server: MCPServer):
+    return (
+        db.query(UserMCPServer.lifecycle_generation)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .scalar()
+    )
+
+
 def _add_callback_client_and_state(
     db,
     user: User,
@@ -207,10 +223,12 @@ def _add_callback_client_and_state(
 ) -> tuple[MCPServer, MCPOAuthClient, MCPOAuthFlowState]:
     server = _add_mcp_oauth_server(db, user)
     client = _add_oauth_client(db, server, metadata_json=metadata_json)
+    association_generation = _association_generation(db, user, server)
     flow_state = MCPOAuthFlowState(
         state=state,
         mcp_server_id=server.id,
         user_id=user.id,
+        association_lifecycle_generation=association_generation,
         mcp_oauth_client_id=client.id,
         resource_owner_key="resource-owner-a",
         issuer="https://auth.example.com",
@@ -654,6 +672,172 @@ async def test_connect_creates_pkce_state_and_redirects(db_session, monkeypatch)
     assert client.client_secret != "client-secret"
     assert decrypt_value(client.client_secret) == "client-secret"
     assert flow_state.mcp_oauth_client_id == client.id
+    assert flow_state.association_lifecycle_generation == _association_generation(
+        db, user, server
+    )
+
+
+@pytest.mark.asyncio
+async def test_connect_rejects_delete_and_recreate_during_provider_io(
+    db_session, monkeypatch
+):
+    db, user, other_user = db_session
+    server = _add_mcp_oauth_server(db, user)
+    db.add(
+        UserMCPServer(
+            user_id=other_user.id,
+            mcpserver_id=server.id,
+            is_owner=False,
+            is_active=True,
+        )
+    )
+    db.commit()
+    original_generation = _association_generation(db, user, server)
+    SessionLocal = sessionmaker(bind=db.get_bind(), autoflush=False, autocommit=False)
+
+    async def replace_association_during_discovery(*args, **kwargs):
+        other_db = SessionLocal()
+        try:
+            other_db.query(UserMCPServer).filter(
+                UserMCPServer.user_id == user.id,
+                UserMCPServer.mcpserver_id == server.id,
+            ).delete(synchronize_session=False)
+            other_db.commit()
+            other_db.add(
+                UserMCPServer(
+                    user_id=user.id,
+                    mcpserver_id=server.id,
+                    is_owner=False,
+                    is_active=True,
+                )
+            )
+            other_db.commit()
+        finally:
+            other_db.close()
+        return _discovery()
+
+    monkeypatch.setattr(
+        mcp_api, "discover_mcp_oauth_metadata", replace_association_during_discovery
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await connect_mcp_oauth(
+            server.id,
+            MCPOAuthConnectRequest(redirect_after="/mcp"),
+            user,
+            db,
+        )
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail["code"] == "oauth_lifecycle_changed"
+    db.expire_all()
+    replacement_generation = _association_generation(db, user, server)
+    assert replacement_generation != original_generation
+    assert db.query(MCPOAuthClient).count() == 0
+    assert db.query(MCPOAuthFlowState).count() == 0
+    assert (
+        db.query(UserMCPServer).filter(UserMCPServer.mcpserver_id == server.id).count()
+        == 2
+    )
+
+
+def test_connect_producer_first_blocks_disconnect_until_flow_commit(
+    db_session, monkeypatch
+):
+    db, user, other_user = db_session
+    server = _add_mcp_oauth_server(db, user)
+    db.add(
+        UserMCPServer(
+            user_id=other_user.id,
+            mcpserver_id=server.id,
+            is_owner=False,
+            is_active=True,
+        )
+    )
+    db.commit()
+    association_identity = mcp_api._MCPOAuthAssociationIdentity(
+        server_id=server.id,
+        user_id=user.id,
+        lifecycle_generation=_association_generation(db, user, server),
+    )
+    SessionLocal = sessionmaker(bind=db.get_bind(), autoflush=False, autocommit=False)
+    disconnect_started = threading.Event()
+    disconnect_finished = threading.Event()
+    disconnect_errors: list[BaseException] = []
+
+    def disconnect() -> None:
+        other_db = SessionLocal()
+        try:
+            disconnect_started.set()
+            other_db.query(MCPOAuthFlowState).filter(
+                MCPOAuthFlowState.mcp_server_id == server.id,
+                MCPOAuthFlowState.user_id == user.id,
+            ).delete(synchronize_session=False)
+            other_db.query(UserMCPServer).filter(
+                UserMCPServer.mcpserver_id == server.id,
+                UserMCPServer.user_id == user.id,
+            ).delete(synchronize_session=False)
+            other_db.commit()
+        except BaseException as exc:  # pragma: no cover - assertion reports it
+            disconnect_errors.append(exc)
+        finally:
+            other_db.close()
+            disconnect_finished.set()
+
+    original_upsert = mcp_api._upsert_mcp_oauth_client
+    disconnect_thread: threading.Thread | None = None
+
+    def gated_upsert(*args, **kwargs):
+        nonlocal disconnect_thread
+        disconnect_thread = threading.Thread(target=disconnect)
+        disconnect_thread.start()
+        assert disconnect_started.wait(timeout=2)
+        time.sleep(0.1)
+        assert not disconnect_finished.is_set()
+        return original_upsert(*args, **kwargs)
+
+    monkeypatch.setattr(mcp_api, "_upsert_mcp_oauth_client", gated_upsert)
+    persisted = mcp_api._persist_mcp_oauth_connect_flow(
+        db,
+        association_identity=association_identity,
+        discovery=_discovery(),
+        client_id="client-123",
+        client_secret=None,
+        token_endpoint_auth_method="none",
+        redirect_uri="https://xagent.example.com/api/mcp/oauth/callback",
+        registration_lookup_hash=None,
+        resource_owner_key=f"xagent:user:{user.id}",
+        selected_issuer="https://auth.example.com",
+        selected_resource="https://mcp.example.com/mcp",
+        selected_scope="records.read",
+        redirect_after="/mcp",
+    )
+    assert persisted is not None
+    assert disconnect_thread is not None
+    disconnect_thread.join(timeout=2)
+
+    assert disconnect_finished.is_set()
+    assert disconnect_errors == []
+    db.expire_all()
+    assert (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .one_or_none()
+        is None
+    )
+    assert db.query(MCPOAuthFlowState).count() == 0
+    assert (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == other_user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .one()
+        is not None
+    )
 
 
 @pytest.mark.asyncio
@@ -2207,10 +2391,19 @@ async def test_callback_exchanges_code_and_stores_encrypted_grant(
         client_secret=mcp_api.encrypt_value("client-secret"),
         token_endpoint_auth_method="client_secret_post",
     )
+    association_generation = (
+        db.query(UserMCPServer.lifecycle_generation)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .scalar()
+    )
     flow_state = MCPOAuthFlowState(
         state="state-123",
         mcp_server_id=server.id,
         user_id=user.id,
+        association_lifecycle_generation=association_generation,
         mcp_oauth_client_id=client.id,
         resource_owner_key="resource-owner-a",
         issuer="https://auth.example.com",
@@ -2267,6 +2460,296 @@ async def test_callback_exchanges_code_and_stores_encrypted_grant(
     assert decrypt_value(grant.access_token) == "plain-access-token"
     assert decrypt_value(grant.refresh_token) == "plain-refresh-token"
     assert db.query(MCPOAuthFlowState).one().consumed_at is not None
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_replacement_lifecycle_and_flow_after_token_issue(
+    db_session, monkeypatch
+):
+    db, user, other_user = db_session
+    server, client, original_flow = _add_callback_client_and_state(
+        db,
+        user,
+        state="replacement-lifecycle-state",
+        metadata_json={"revocation_endpoint": "https://auth.example.com/revoke"},
+    )
+    db.add(
+        UserMCPServer(
+            user_id=other_user.id,
+            mcpserver_id=server.id,
+            is_owner=False,
+            is_active=True,
+        )
+    )
+    db.commit()
+    server_id = int(server.id)
+    user_id = int(user.id)
+    client_id = int(client.id)
+    original_generation = original_flow.association_lifecycle_generation
+    SessionLocal = sessionmaker(bind=db.get_bind(), autoflush=False, autocommit=False)
+    replacement: dict[str, object] = {}
+
+    async def replace_lifecycle_during_exchange(**kwargs):
+        other_db = SessionLocal()
+        try:
+            other_db.query(MCPOAuthFlowState).filter(
+                MCPOAuthFlowState.id == original_flow.id
+            ).delete(synchronize_session=False)
+            other_db.query(UserMCPServer).filter(
+                UserMCPServer.user_id == user_id,
+                UserMCPServer.mcpserver_id == server_id,
+            ).delete(synchronize_session=False)
+            other_db.commit()
+            replacement_association = UserMCPServer(
+                user_id=user_id,
+                mcpserver_id=server_id,
+                is_owner=False,
+                is_active=True,
+            )
+            other_db.add(replacement_association)
+            other_db.flush()
+            replacement_flow = MCPOAuthFlowState(
+                state="replacement-lifecycle-state",
+                mcp_server_id=server_id,
+                user_id=user_id,
+                association_lifecycle_generation=(
+                    replacement_association.lifecycle_generation
+                ),
+                mcp_oauth_client_id=client_id,
+                resource_owner_key="replacement-owner",
+                issuer="https://auth.example.com",
+                resource="https://mcp.example.com/mcp",
+                scope="records.read",
+                code_verifier=encrypt_value("replacement-verifier"),
+                redirect_after="/replacement",
+                expires_at=mcp_api._utc_now() + timedelta(minutes=10),
+            )
+            other_db.add(replacement_flow)
+            other_db.commit()
+            replacement["generation"] = replacement_association.lifecycle_generation
+            replacement["flow_id"] = replacement_flow.id
+        finally:
+            other_db.close()
+        return {
+            "access_token": "issued-access-token",
+            "refresh_token": "issued-refresh-token",
+            "token_type": "Bearer",
+            "scope": "records.read",
+        }
+
+    revoked: list[mcp_api._MCPOAuthIssuedTokenSnapshot] = []
+
+    async def record_revoke(snapshot):
+        revoked.append(snapshot)
+
+    monkeypatch.setattr(
+        mcp_api, "_exchange_mcp_oauth_code", replace_lifecycle_during_exchange
+    )
+    monkeypatch.setattr(
+        mcp_api, "_revoke_mcp_oauth_issued_token_externally", record_revoke
+    )
+
+    response = await mcp_oauth_callback(
+        _request(
+            "/api/mcp/oauth/callback?code=auth-code&state=replacement-lifecycle-state"
+        ),
+        db,
+    )
+
+    assert _redirect_query(response)["mcp_oauth_error"] == ["invalid_state"]
+    assert replacement["generation"] != original_generation
+    assert len(revoked) == 1
+    assert revoked[0].access_token == "issued-access-token"
+    db.expire_all()
+    assert db.query(MCPOAuthGrant).count() == 0
+    replacement_flow = db.query(MCPOAuthFlowState).one()
+    assert replacement_flow.id == replacement["flow_id"]
+    assert replacement_flow.redirect_after == "/replacement"
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_replacement_flow_in_same_lifecycle(
+    db_session, monkeypatch
+):
+    db, user, _ = db_session
+    server, client, original_flow = _add_callback_client_and_state(
+        db,
+        user,
+        state="replacement-flow-state",
+        metadata_json={"revocation_endpoint": "https://auth.example.com/revoke"},
+    )
+    sentinel = MCPOAuthFlowState(
+        state="replacement-flow-sentinel",
+        mcp_server_id=server.id,
+        user_id=user.id,
+        association_lifecycle_generation=original_flow.association_lifecycle_generation,
+        mcp_oauth_client_id=client.id,
+        resource_owner_key="sentinel-owner",
+        issuer="https://auth.example.com",
+        resource="https://mcp.example.com/mcp",
+        scope="records.read",
+        code_verifier=encrypt_value("sentinel-verifier"),
+        expires_at=mcp_api._utc_now() + timedelta(minutes=10),
+    )
+    db.add(sentinel)
+    db.commit()
+    original_flow_id = int(original_flow.id)
+    server_id = int(server.id)
+    user_id = int(user.id)
+    client_id = int(client.id)
+    lifecycle_generation = original_flow.association_lifecycle_generation
+    SessionLocal = sessionmaker(bind=db.get_bind(), autoflush=False, autocommit=False)
+    replacement_flow_id: list[int] = []
+
+    async def replace_flow_during_exchange(**kwargs):
+        other_db = SessionLocal()
+        try:
+            other_db.query(MCPOAuthFlowState).filter(
+                MCPOAuthFlowState.id == original_flow_id
+            ).delete(synchronize_session=False)
+            other_db.commit()
+            replacement_flow = MCPOAuthFlowState(
+                state="replacement-flow-state",
+                mcp_server_id=server_id,
+                user_id=user_id,
+                association_lifecycle_generation=lifecycle_generation,
+                mcp_oauth_client_id=client_id,
+                resource_owner_key="replacement-owner",
+                issuer="https://auth.example.com",
+                resource="https://mcp.example.com/mcp",
+                scope="records.read",
+                code_verifier=encrypt_value("replacement-verifier"),
+                redirect_after="/replacement",
+                expires_at=mcp_api._utc_now() + timedelta(minutes=10),
+            )
+            other_db.add(replacement_flow)
+            other_db.commit()
+            replacement_flow_id.append(int(replacement_flow.id))
+        finally:
+            other_db.close()
+        return {
+            "access_token": "issued-access-token",
+            "token_type": "Bearer",
+            "scope": "records.read",
+        }
+
+    revoked: list[mcp_api._MCPOAuthIssuedTokenSnapshot] = []
+
+    async def record_revoke(snapshot):
+        revoked.append(snapshot)
+
+    monkeypatch.setattr(
+        mcp_api, "_exchange_mcp_oauth_code", replace_flow_during_exchange
+    )
+    monkeypatch.setattr(
+        mcp_api, "_revoke_mcp_oauth_issued_token_externally", record_revoke
+    )
+
+    response = await mcp_oauth_callback(
+        _request("/api/mcp/oauth/callback?code=auth-code&state=replacement-flow-state"),
+        db,
+    )
+
+    assert _redirect_query(response)["mcp_oauth_error"] == ["invalid_state"]
+    assert replacement_flow_id[0] != original_flow_id
+    assert len(revoked) == 1
+    db.expire_all()
+    assert db.query(MCPOAuthGrant).count() == 0
+    replacement_flow = (
+        db.query(MCPOAuthFlowState)
+        .filter(MCPOAuthFlowState.state == "replacement-flow-state")
+        .one()
+    )
+    assert replacement_flow.id == replacement_flow_id[0]
+    assert replacement_flow.consumed_at is None
+
+
+@pytest.mark.asyncio
+async def test_callback_rolls_back_before_revoke_and_sanitizes_failure_log(
+    db_session, monkeypatch, caplog
+):
+    db, user, _ = db_session
+    _add_callback_client_and_state(
+        db,
+        user,
+        state="persistence-failure-state",
+        metadata_json={"revocation_endpoint": "https://auth.example.com/revoke"},
+    )
+    ordering: list[str] = []
+
+    @event.listens_for(db, "after_rollback")
+    def record_rollback(session):
+        ordering.append("rollback")
+
+    async def fake_exchange(**kwargs):
+        return {
+            "access_token": "issued-secret-access-token",
+            "refresh_token": "issued-secret-refresh-token",
+            "token_type": "Bearer",
+            "scope": "records.read",
+        }
+
+    def fail_persistence(*args, **kwargs):
+        raise RuntimeError("raw persistence detail issued-secret-access-token")
+
+    async def record_revoke(snapshot):
+        assert not db.in_transaction()
+        ordering.append("revoke")
+
+    monkeypatch.setattr(mcp_api, "_exchange_mcp_oauth_code", fake_exchange)
+    monkeypatch.setattr(mcp_api, "_upsert_mcp_oauth_grant", fail_persistence)
+    monkeypatch.setattr(
+        mcp_api, "_revoke_mcp_oauth_issued_token_externally", record_revoke
+    )
+
+    response = await mcp_oauth_callback(
+        _request(
+            "/api/mcp/oauth/callback?code=auth-code&state=persistence-failure-state"
+        ),
+        db,
+    )
+
+    assert _redirect_query(response)["mcp_oauth_error"] == ["token_exchange_failed"]
+    assert ordering[-2:] == ["rollback", "revoke"]
+    assert "issued-secret-access-token" not in caplog.text
+    assert "issued-secret-refresh-token" not in caplog.text
+    assert "raw persistence detail" not in caplog.text
+    assert db.query(MCPOAuthGrant).count() == 0
+
+
+@pytest.mark.asyncio
+async def test_issued_token_compensation_revokes_access_and_refresh(monkeypatch):
+    requests: list[dict[str, list[str]]] = []
+    real_async_client = httpx.AsyncClient
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(parse_qs(request.content.decode()))
+        return httpx.Response(200)
+
+    def async_client_factory(*args, **kwargs):
+        return real_async_client(transport=httpx.MockTransport(handler))
+
+    monkeypatch.setattr(mcp_api, "create_mcp_oauth_http_client", async_client_factory)
+    await mcp_api._revoke_mcp_oauth_issued_token_externally(
+        mcp_api._MCPOAuthIssuedTokenSnapshot(
+            flow_id=7,
+            revocation_endpoint="https://auth.example.com/revoke",
+            client_id="public-client",
+            encrypted_client_secret=None,
+            token_endpoint_auth_method="none",
+            access_token="issued-access-token",
+            refresh_token="issued-refresh-token",
+        )
+    )
+
+    assert [request["token"] for request in requests] == [
+        ["issued-access-token"],
+        ["issued-refresh-token"],
+    ]
+    assert [request["token_type_hint"] for request in requests] == [
+        ["access_token"],
+        ["refresh_token"],
+    ]
 
 
 @pytest.mark.asyncio
@@ -2393,6 +2876,30 @@ async def test_callback_rejects_state_without_browser_session_cookie(
 
 
 @pytest.mark.asyncio
+async def test_callback_rejects_legacy_state_without_lifecycle_generation(
+    db_session, monkeypatch
+):
+    db, user, _ = db_session
+    _, _, flow_state = _add_callback_client_and_state(
+        db, user, state="legacy-unbound-state"
+    )
+    flow_state.association_lifecycle_generation = None
+    db.commit()
+
+    async def fail_exchange(**kwargs):
+        pytest.fail("an unbound pre-migration flow must fail before token exchange")
+
+    monkeypatch.setattr(mcp_api, "_exchange_mcp_oauth_code", fail_exchange)
+    response = await mcp_oauth_callback(
+        _request("/api/mcp/oauth/callback?code=auth-code&state=legacy-unbound-state"),
+        db,
+    )
+
+    assert _redirect_query(response)["mcp_oauth_error"] == ["invalid_state"]
+    assert db.query(MCPOAuthGrant).count() == 0
+
+
+@pytest.mark.asyncio
 async def test_callback_uses_flow_bound_client_when_same_issuer_has_multiple_clients(
     db_session, monkeypatch
 ):
@@ -2400,10 +2907,19 @@ async def test_callback_uses_flow_bound_client_when_same_issuer_has_multiple_cli
     server = _add_mcp_oauth_server(db, user)
     _add_oauth_client(db, server, client_id="stale-client")
     bound_client = _add_oauth_client(db, server, client_id="bound-client")
+    association_generation = (
+        db.query(UserMCPServer.lifecycle_generation)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .scalar()
+    )
     flow_state = MCPOAuthFlowState(
         state="client-bound-state",
         mcp_server_id=server.id,
         user_id=user.id,
+        association_lifecycle_generation=association_generation,
         mcp_oauth_client_id=bound_client.id,
         resource_owner_key="resource-owner-a",
         issuer="https://auth.example.com",
@@ -2834,6 +3350,7 @@ async def test_callback_reports_token_exchange_failure(db_session, monkeypatch):
             state="bad-token-state",
             mcp_server_id=server.id,
             user_id=user.id,
+            association_lifecycle_generation=_association_generation(db, user, server),
             mcp_oauth_client_id=client.id,
             resource_owner_key="resource-owner-a",
             issuer="https://auth.example.com",

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -45,8 +45,8 @@ from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.mcp_oauth import mcp_oauth_client_registration_lookup_hash
 from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
-from xagent.web.services import mcp_oauth as mcp_oauth_service
 from xagent.web.services import connector_team_scope
+from xagent.web.services import mcp_oauth as mcp_oauth_service
 from xagent.web.services.mcp_oauth import (
     MCP_OAUTH_PERSISTED_VALUE_MAX_LENGTH,
     MCP_OAUTH_RESOURCE_OWNER_KEY_MAX_LENGTH,

--- a/tests/web/api/test_mcp_oauth_lifecycle_postgresql.py
+++ b/tests/web/api/test_mcp_oauth_lifecycle_postgresql.py
@@ -1,0 +1,253 @@
+"""PostgreSQL release gate for MCP OAuth producer lifecycle fencing."""
+
+from __future__ import annotations
+
+import threading
+from datetime import timedelta
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+from tests.shared.postgres_disposable import disposable_database_factory
+from xagent.core.utils.encryption import encrypt_value
+from xagent.web.api import mcp as mcp_api
+from xagent.web.models import MCPOAuthClient, MCPOAuthFlowState, MCPOAuthGrant
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.user import User
+
+pytestmark = pytest.mark.postgresql
+
+
+@pytest.fixture()
+def postgresql_engine():
+    with disposable_database_factory("xagent_mcp_oauth_lifecycle") as make:
+        engine = make("producer_fence")
+        Base.metadata.create_all(
+            engine,
+            tables=[
+                User.__table__,
+                MCPServer.__table__,
+                UserMCPServer.__table__,
+                MCPOAuthClient.__table__,
+                MCPOAuthGrant.__table__,
+                MCPOAuthFlowState.__table__,
+            ],
+        )
+        yield engine
+
+
+def _seed_lifecycle(factory):
+    with factory() as db:
+        user = User(username="postgres-oauth-alice", password_hash="x")
+        other_user = User(username="postgres-oauth-bob", password_hash="x")
+        server = MCPServer.from_config(
+            {
+                "name": "postgres-oauth-records",
+                "managed": "external",
+                "transport": "streamable_http",
+                "url": "https://mcp.example.com/mcp",
+                "auth": {"type": "mcp_oauth"},
+            }
+        )
+        db.add_all([user, other_user, server])
+        db.flush()
+        association = UserMCPServer(
+            user_id=user.id,
+            mcpserver_id=server.id,
+            is_owner=True,
+            is_active=True,
+        )
+        other_association = UserMCPServer(
+            user_id=other_user.id,
+            mcpserver_id=server.id,
+            is_owner=False,
+            is_active=True,
+        )
+        client = MCPOAuthClient(
+            mcp_server_id=server.id,
+            issuer="https://auth.example.com",
+            authorization_endpoint="https://auth.example.com/authorize",
+            token_endpoint="https://auth.example.com/token",
+            client_id="postgres-client",
+            token_endpoint_auth_method="none",
+            redirect_uri="https://xagent.example.com/api/mcp/oauth/callback",
+        )
+        db.add_all([association, other_association, client])
+        db.flush()
+        flow = MCPOAuthFlowState(
+            state="postgres-flow-state",
+            mcp_server_id=server.id,
+            user_id=user.id,
+            association_lifecycle_generation=association.lifecycle_generation,
+            mcp_oauth_client_id=client.id,
+            resource_owner_key=f"xagent:user:{user.id}",
+            issuer="https://auth.example.com",
+            resource="https://mcp.example.com/mcp",
+            scope="records.read",
+            code_verifier=encrypt_value("postgres-verifier"),
+            expires_at=mcp_api._utc_now() + timedelta(minutes=10),
+            consumed_at=mcp_api._utc_now(),
+        )
+        db.add(flow)
+        db.commit()
+        return {
+            "user_id": int(user.id),
+            "other_user_id": int(other_user.id),
+            "server_id": int(server.id),
+            "client_id": int(client.id),
+            "flow_id": int(flow.id),
+            "generation": association.lifecycle_generation,
+        }
+
+
+def _identities(seed):
+    association_identity = mcp_api._MCPOAuthAssociationIdentity(
+        server_id=seed["server_id"],
+        user_id=seed["user_id"],
+        lifecycle_generation=seed["generation"],
+    )
+    flow_identity = mcp_api._MCPOAuthFlowIdentity(
+        id=seed["flow_id"],
+        state="postgres-flow-state",
+        server_id=seed["server_id"],
+        user_id=seed["user_id"],
+        client_id=seed["client_id"],
+        association_lifecycle_generation=seed["generation"],
+    )
+    return association_identity, flow_identity
+
+
+def test_disconnect_first_replacement_cannot_receive_stale_callback_grant(
+    postgresql_engine,
+) -> None:
+    factory = sessionmaker(bind=postgresql_engine, autoflush=False, autocommit=False)
+    seed = _seed_lifecycle(factory)
+    association_identity, flow_identity = _identities(seed)
+
+    with factory() as disconnect_db:
+        disconnect_db.query(MCPOAuthFlowState).filter(
+            MCPOAuthFlowState.id == seed["flow_id"]
+        ).delete(synchronize_session=False)
+        disconnect_db.query(UserMCPServer).filter(
+            UserMCPServer.user_id == seed["user_id"],
+            UserMCPServer.mcpserver_id == seed["server_id"],
+        ).delete(synchronize_session=False)
+        disconnect_db.commit()
+        replacement_association = UserMCPServer(
+            user_id=seed["user_id"],
+            mcpserver_id=seed["server_id"],
+            is_owner=False,
+            is_active=True,
+        )
+        disconnect_db.add(replacement_association)
+        disconnect_db.flush()
+        replacement_flow = MCPOAuthFlowState(
+            state="postgres-flow-state",
+            mcp_server_id=seed["server_id"],
+            user_id=seed["user_id"],
+            association_lifecycle_generation=(
+                replacement_association.lifecycle_generation
+            ),
+            mcp_oauth_client_id=seed["client_id"],
+            resource_owner_key="replacement-owner",
+            issuer="https://auth.example.com",
+            resource="https://mcp.example.com/mcp",
+            scope="records.read",
+            code_verifier=encrypt_value("replacement-verifier"),
+            expires_at=mcp_api._utc_now() + timedelta(minutes=10),
+        )
+        disconnect_db.add(replacement_flow)
+        disconnect_db.commit()
+        replacement_flow_id = int(replacement_flow.id)
+        assert replacement_association.lifecycle_generation != seed["generation"]
+
+    with factory() as producer_db:
+        assert (
+            mcp_api._lock_active_mcp_oauth_lifecycle(
+                producer_db,
+                association_identity=association_identity,
+                flow_identity=flow_identity,
+            )
+            is None
+        )
+        producer_db.rollback()
+
+    with factory() as verify_db:
+        assert verify_db.query(MCPOAuthGrant).count() == 0
+        assert verify_db.query(MCPOAuthFlowState).one().id == replacement_flow_id
+        assert (
+            verify_db.query(UserMCPServer)
+            .filter(UserMCPServer.mcpserver_id == seed["server_id"])
+            .count()
+            == 2
+        )
+
+
+def test_producer_first_holds_lifecycle_locks_until_grant_commit(
+    postgresql_engine,
+) -> None:
+    factory = sessionmaker(bind=postgresql_engine, autoflush=False, autocommit=False)
+    seed = _seed_lifecycle(factory)
+    association_identity, flow_identity = _identities(seed)
+    disconnect_started = threading.Event()
+    disconnect_finished = threading.Event()
+    disconnect_errors: list[BaseException] = []
+
+    def disconnect() -> None:
+        try:
+            with factory() as disconnect_db:
+                disconnect_started.set()
+                disconnect_db.query(MCPOAuthGrant).filter(
+                    MCPOAuthGrant.mcp_server_id == seed["server_id"],
+                    MCPOAuthGrant.user_id == seed["user_id"],
+                ).delete(synchronize_session=False)
+                disconnect_db.query(MCPOAuthFlowState).filter(
+                    MCPOAuthFlowState.id == seed["flow_id"]
+                ).delete(synchronize_session=False)
+                disconnect_db.query(UserMCPServer).filter(
+                    UserMCPServer.user_id == seed["user_id"],
+                    UserMCPServer.mcpserver_id == seed["server_id"],
+                ).delete(synchronize_session=False)
+                disconnect_db.commit()
+        except BaseException as exc:  # pragma: no cover - assertion reports it
+            disconnect_errors.append(exc)
+        finally:
+            disconnect_finished.set()
+
+    with factory() as producer_db:
+        lifecycle = mcp_api._lock_active_mcp_oauth_lifecycle(
+            producer_db,
+            association_identity=association_identity,
+            flow_identity=flow_identity,
+        )
+        assert lifecycle is not None
+        locked_flow = lifecycle[2]
+        assert locked_flow is not None
+        disconnect_thread = threading.Thread(target=disconnect)
+        disconnect_thread.start()
+        assert disconnect_started.wait(timeout=2)
+        assert not disconnect_finished.wait(timeout=0.2)
+        mcp_api._upsert_mcp_oauth_grant(
+            producer_db,
+            flow_state=locked_flow,
+            token_data={
+                "access_token": "postgres-issued-token",
+                "token_type": "Bearer",
+                "scope": "records.read",
+            },
+        )
+        producer_db.commit()
+
+    disconnect_thread.join(timeout=5)
+    assert disconnect_finished.is_set()
+    assert disconnect_errors == []
+    with factory() as verify_db:
+        assert verify_db.query(MCPOAuthGrant).count() == 0
+        assert verify_db.query(MCPOAuthFlowState).count() == 0
+        assert (
+            verify_db.query(UserMCPServer)
+            .filter(UserMCPServer.mcpserver_id == seed["server_id"])
+            .count()
+            == 1
+        )

--- a/tests/web/api/test_mcp_oauth_lifecycle_postgresql.py
+++ b/tests/web/api/test_mcp_oauth_lifecycle_postgresql.py
@@ -6,9 +6,12 @@ import asyncio
 import threading
 from datetime import timedelta
 from types import SimpleNamespace
+from typing import Any
+from urllib.parse import urlparse
 
 import pytest
 from sqlalchemy.orm import sessionmaker
+from starlette.requests import Request
 
 from tests.shared.postgres_disposable import disposable_database_factory
 from xagent.core.utils.encryption import encrypt_value
@@ -40,7 +43,7 @@ def postgresql_engine():
         yield engine
 
 
-def _seed_lifecycle(factory):
+def _seed_lifecycle(factory, *, flow_consumed: bool = True):
     with factory() as db:
         user = User(username="postgres-oauth-alice", password_hash="x")
         other_user = User(username="postgres-oauth-bob", password_hash="x")
@@ -90,7 +93,7 @@ def _seed_lifecycle(factory):
             scope="records.read",
             code_verifier=encrypt_value("postgres-verifier"),
             expires_at=mcp_api._utc_now() + timedelta(minutes=10),
-            consumed_at=mcp_api._utc_now(),
+            consumed_at=mcp_api._utc_now() if flow_consumed else None,
         )
         db.add(flow)
         db.commit()
@@ -102,6 +105,24 @@ def _seed_lifecycle(factory):
             "flow_id": int(flow.id),
             "generation": association.lifecycle_generation,
         }
+
+
+def _callback_request(state: str) -> Request:
+    path = f"/api/mcp/oauth/callback?code=auth-code&state={state}"
+    parsed = urlparse(path)
+    cookie = (
+        f"{mcp_api.MCP_OAUTH_STATE_COOKIE}="
+        f"{mcp_api._mcp_oauth_state_cookie_value(state)}"
+    )
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": parsed.path,
+            "query_string": parsed.query.encode(),
+            "headers": [(b"cookie", cookie.encode())],
+        }
+    )
 
 
 def _identities(seed):
@@ -317,6 +338,116 @@ def test_producer_first_holds_lifecycle_locks_until_grant_commit(
     disconnect_thread.join(timeout=5)
     assert disconnect_finished.is_set()
     assert disconnect_errors == []
+    with factory() as verify_db:
+        assert verify_db.query(MCPOAuthGrant).count() == 0
+        assert verify_db.query(MCPOAuthFlowState).count() == 0
+        assert (
+            verify_db.query(UserMCPServer)
+            .filter(UserMCPServer.mcpserver_id == seed["server_id"])
+            .count()
+            == 1
+        )
+
+
+def test_real_callback_producer_blocks_disconnect_until_grant_commit(
+    postgresql_engine, monkeypatch
+) -> None:
+    factory = sessionmaker(bind=postgresql_engine, autoflush=False, autocommit=False)
+    seed = _seed_lifecycle(factory, flow_consumed=False)
+    producer_at_upsert = threading.Event()
+    allow_producer_commit = threading.Event()
+    disconnect_lock_attempted = threading.Event()
+    disconnect_finished = threading.Event()
+    callback_results: list[Any] = []
+    callback_errors: list[BaseException] = []
+    disconnect_errors: list[BaseException] = []
+
+    async def exchange_code(**kwargs):
+        return {
+            "access_token": "postgres-callback-token",
+            "token_type": "Bearer",
+            "scope": "records.read",
+        }
+
+    original_upsert = mcp_api._upsert_mcp_oauth_grant
+
+    def gated_upsert(*args, **kwargs):
+        producer_at_upsert.set()
+        assert allow_producer_commit.wait(timeout=5)
+        return original_upsert(*args, **kwargs)
+
+    original_lock = mcp_api._lock_active_mcp_oauth_lifecycle
+
+    def record_disconnect_lock_attempt(*args, **kwargs):
+        if threading.current_thread().name == "postgres-real-disconnect":
+            disconnect_lock_attempted.set()
+        return original_lock(*args, **kwargs)
+
+    monkeypatch.setattr(mcp_api, "_exchange_mcp_oauth_code", exchange_code)
+    monkeypatch.setattr(mcp_api, "_upsert_mcp_oauth_grant", gated_upsert)
+    monkeypatch.setattr(
+        mcp_api,
+        "_lock_active_mcp_oauth_lifecycle",
+        record_disconnect_lock_attempt,
+    )
+    monkeypatch.setattr(
+        connector_team_scope,
+        "delete_team_connector",
+        lambda *args: SimpleNamespace(
+            blocked_reason=None,
+            team_owned=False,
+            authorized=False,
+            delete_definition=False,
+        ),
+    )
+
+    def callback() -> None:
+        try:
+            with factory() as callback_db:
+                callback_results.append(
+                    asyncio.run(
+                        mcp_api.mcp_oauth_callback(
+                            _callback_request("postgres-flow-state"), callback_db
+                        )
+                    )
+                )
+        except BaseException as exc:  # pragma: no cover - assertion reports it
+            callback_errors.append(exc)
+
+    def disconnect() -> None:
+        try:
+            with factory() as disconnect_db:
+                asyncio.run(
+                    mcp_api.delete_mcp_server(
+                        seed["server_id"],
+                        current_user=disconnect_db.get(User, seed["user_id"]),
+                        db=disconnect_db,
+                    )
+                )
+        except BaseException as exc:  # pragma: no cover - assertion reports it
+            disconnect_errors.append(exc)
+        finally:
+            disconnect_finished.set()
+
+    callback_thread = threading.Thread(target=callback, name="postgres-real-callback")
+    callback_thread.start()
+    assert producer_at_upsert.wait(timeout=5)
+    disconnect_thread = threading.Thread(
+        target=disconnect, name="postgres-real-disconnect"
+    )
+    disconnect_thread.start()
+    assert disconnect_lock_attempted.wait(timeout=5)
+    assert not disconnect_finished.wait(timeout=0.2)
+    allow_producer_commit.set()
+    callback_thread.join(timeout=5)
+    disconnect_thread.join(timeout=5)
+
+    assert not callback_thread.is_alive()
+    assert not disconnect_thread.is_alive()
+    assert callback_errors == []
+    assert disconnect_errors == []
+    assert len(callback_results) == 1
+    assert callback_results[0].status_code == 307
     with factory() as verify_db:
         assert verify_db.query(MCPOAuthGrant).count() == 0
         assert verify_db.query(MCPOAuthFlowState).count() == 0

--- a/tests/web/api/test_mcp_oauth_lifecycle_postgresql.py
+++ b/tests/web/api/test_mcp_oauth_lifecycle_postgresql.py
@@ -198,6 +198,12 @@ def test_producer_first_holds_lifecycle_locks_until_grant_commit(
         try:
             with factory() as disconnect_db:
                 disconnect_started.set()
+                # The teardown consumer specified by #2033 follows the same
+                # global lock order as the producer fence. Model that contract
+                # here without changing the generic DELETE route in this PR.
+                disconnect_db.query(MCPServer).filter(
+                    MCPServer.id == seed["server_id"]
+                ).with_for_update().one()
                 disconnect_db.query(MCPOAuthGrant).filter(
                     MCPOAuthGrant.mcp_server_id == seed["server_id"],
                     MCPOAuthGrant.user_id == seed["user_id"],

--- a/tests/web/api/test_mcp_oauth_lifecycle_postgresql.py
+++ b/tests/web/api/test_mcp_oauth_lifecycle_postgresql.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 import threading
 from datetime import timedelta
+from types import SimpleNamespace
 
 import pytest
 from sqlalchemy.orm import sessionmaker
@@ -15,6 +17,7 @@ from xagent.web.models import MCPOAuthClient, MCPOAuthFlowState, MCPOAuthGrant
 from xagent.web.models.database import Base
 from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.user import User
+from xagent.web.services import connector_team_scope
 
 pytestmark = pytest.mark.postgresql
 
@@ -119,21 +122,74 @@ def _identities(seed):
 
 
 def test_disconnect_first_replacement_cannot_receive_stale_callback_grant(
-    postgresql_engine,
+    postgresql_engine, monkeypatch
 ) -> None:
     factory = sessionmaker(bind=postgresql_engine, autoflush=False, autocommit=False)
     seed = _seed_lifecycle(factory)
     association_identity, flow_identity = _identities(seed)
 
+    teardown_locked = threading.Event()
+    allow_teardown = threading.Event()
+    producer_started = threading.Event()
+    producer_finished = threading.Event()
+    disconnect_errors: list[BaseException] = []
+    producer_results: list[object] = []
+
+    def gated_team_delete(*args):
+        teardown_locked.set()
+        assert allow_teardown.wait(timeout=5)
+        return SimpleNamespace(
+            blocked_reason=None,
+            team_owned=False,
+            authorized=False,
+            delete_definition=False,
+        )
+
+    monkeypatch.setattr(
+        connector_team_scope, "delete_team_connector", gated_team_delete
+    )
+
+    def disconnect() -> None:
+        try:
+            with factory() as disconnect_db:
+                asyncio.run(
+                    mcp_api.delete_mcp_server(
+                        seed["server_id"],
+                        current_user=disconnect_db.get(User, seed["user_id"]),
+                        db=disconnect_db,
+                    )
+                )
+        except BaseException as exc:  # pragma: no cover - assertion reports it
+            disconnect_errors.append(exc)
+
+    def producer() -> None:
+        with factory() as producer_db:
+            producer_started.set()
+            producer_results.append(
+                mcp_api._lock_active_mcp_oauth_lifecycle(
+                    producer_db,
+                    association_identity=association_identity,
+                    flow_identity=flow_identity,
+                )
+            )
+            producer_db.rollback()
+        producer_finished.set()
+
+    disconnect_thread = threading.Thread(target=disconnect)
+    disconnect_thread.start()
+    assert teardown_locked.wait(timeout=5)
+    producer_thread = threading.Thread(target=producer)
+    producer_thread.start()
+    assert producer_started.wait(timeout=2)
+    assert not producer_finished.wait(timeout=0.2)
+    allow_teardown.set()
+    disconnect_thread.join(timeout=5)
+    producer_thread.join(timeout=5)
+    assert disconnect_errors == []
+    assert producer_finished.is_set()
+    assert producer_results == [None]
+
     with factory() as disconnect_db:
-        disconnect_db.query(MCPOAuthFlowState).filter(
-            MCPOAuthFlowState.id == seed["flow_id"]
-        ).delete(synchronize_session=False)
-        disconnect_db.query(UserMCPServer).filter(
-            UserMCPServer.user_id == seed["user_id"],
-            UserMCPServer.mcpserver_id == seed["server_id"],
-        ).delete(synchronize_session=False)
-        disconnect_db.commit()
         replacement_association = UserMCPServer(
             user_id=seed["user_id"],
             mcpserver_id=seed["server_id"],
@@ -185,37 +241,38 @@ def test_disconnect_first_replacement_cannot_receive_stale_callback_grant(
 
 
 def test_producer_first_holds_lifecycle_locks_until_grant_commit(
-    postgresql_engine,
+    postgresql_engine, monkeypatch
 ) -> None:
     factory = sessionmaker(bind=postgresql_engine, autoflush=False, autocommit=False)
     seed = _seed_lifecycle(factory)
     association_identity, flow_identity = _identities(seed)
     disconnect_started = threading.Event()
+    disconnect_lock_attempted = threading.Event()
     disconnect_finished = threading.Event()
     disconnect_errors: list[BaseException] = []
+
+    monkeypatch.setattr(
+        connector_team_scope,
+        "delete_team_connector",
+        lambda *args: SimpleNamespace(
+            blocked_reason=None,
+            team_owned=False,
+            authorized=False,
+            delete_definition=False,
+        ),
+    )
 
     def disconnect() -> None:
         try:
             with factory() as disconnect_db:
                 disconnect_started.set()
-                # The teardown consumer specified by #2033 follows the same
-                # global lock order as the producer fence. Model that contract
-                # here without changing the generic DELETE route in this PR.
-                disconnect_db.query(MCPServer).filter(
-                    MCPServer.id == seed["server_id"]
-                ).with_for_update().one()
-                disconnect_db.query(MCPOAuthGrant).filter(
-                    MCPOAuthGrant.mcp_server_id == seed["server_id"],
-                    MCPOAuthGrant.user_id == seed["user_id"],
-                ).delete(synchronize_session=False)
-                disconnect_db.query(MCPOAuthFlowState).filter(
-                    MCPOAuthFlowState.id == seed["flow_id"]
-                ).delete(synchronize_session=False)
-                disconnect_db.query(UserMCPServer).filter(
-                    UserMCPServer.user_id == seed["user_id"],
-                    UserMCPServer.mcpserver_id == seed["server_id"],
-                ).delete(synchronize_session=False)
-                disconnect_db.commit()
+                asyncio.run(
+                    mcp_api.delete_mcp_server(
+                        seed["server_id"],
+                        current_user=disconnect_db.get(User, seed["user_id"]),
+                        db=disconnect_db,
+                    )
+                )
         except BaseException as exc:  # pragma: no cover - assertion reports it
             disconnect_errors.append(exc)
         finally:
@@ -230,9 +287,21 @@ def test_producer_first_holds_lifecycle_locks_until_grant_commit(
         assert lifecycle is not None
         locked_flow = lifecycle[2]
         assert locked_flow is not None
+        original_lock = mcp_api._lock_active_mcp_oauth_lifecycle
+
+        def record_disconnect_lock_attempt(*args, **kwargs):
+            disconnect_lock_attempted.set()
+            return original_lock(*args, **kwargs)
+
+        monkeypatch.setattr(
+            mcp_api,
+            "_lock_active_mcp_oauth_lifecycle",
+            record_disconnect_lock_attempt,
+        )
         disconnect_thread = threading.Thread(target=disconnect)
         disconnect_thread.start()
         assert disconnect_started.wait(timeout=2)
+        assert disconnect_lock_attempted.wait(timeout=2)
         assert not disconnect_finished.wait(timeout=0.2)
         mcp_api._upsert_mcp_oauth_grant(
             producer_db,


### PR DESCRIPTION
## Summary

- bind OAuth connect and callback producers to the exact user-server lifecycle generation captured before provider I/O
- re-read and lock the server, exact active association generation, and exact original flow before final persistence
- roll back and release database locks before best-effort revocation when issued tokens cannot be persisted
- add SQLite WAL and PostgreSQL two-session race coverage for delete-and-recreate and producer-first ordering

## Validation

- `pytest tests/web/api/test_mcp_oauth_flow.py -q`
- `pytest tests/migrations/test_migration_workflow_contract.py -q`
- `python tests/migrations/test_migration_integration.py --db sqlite incremental`
- `ruff check` on all changed Python files
- mutation checks for the generation predicate, exact-flow predicate, and rollback-before-revoke ordering
- PostgreSQL release-gate tests are wired into the migration workflow

Closes #2032
