### PR TITLE
feat(web-crawler): record why a crawl stopped so blocked crawls stop reporting success

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/web_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/web_ingestion_tool.py
@@ -193,6 +193,21 @@ async def _create_knowledge_base_from_url_impl(
             ).model_dump()
         await kb_service.refresh_collection_metadata(collection_name)
 
+        if result.crawl_blocked_by_site:
+            # Narrower than status == "partial" on purpose: a partial caused by
+            # individual pages failing to parse keeps reporting success, which
+            # is the existing policy. This is the other kind - nothing failed,
+            # the site simply refused everything past the start page. The pages
+            # that did land stay published (re-importing would re-crawl them),
+            # but calling it success would let an agent build on a knowledge
+            # base holding one page.
+            return CreateKnowledgeBaseFromUrlResult(
+                success=False,
+                collection_name=collection_name,
+                message=result.message,
+                pages_crawled=result.pages_crawled,
+            ).model_dump()
+
         return CreateKnowledgeBaseFromUrlResult(
             success=True,
             collection_name=collection_name,

--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -2271,6 +2271,15 @@ class WebIngestionResult(BaseModel):
         ...,
         description="Overall status: success|error|partial",
     )
+    crawl_blocked_by_site: bool = Field(
+        default=False,
+        description=(
+            "The crawl ended because the site refused every link past the "
+            "start page. Callers need this to tell such a partial from one "
+            "caused by individual pages failing to parse, which is not the "
+            "site's doing and keeps its existing success policy."
+        ),
+    )
     collection: str = Field(..., description="Target collection name")
 
     # Crawl statistics

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -33,6 +33,7 @@ from ..utils.config_utils import coerce_ingestion_config
 from ..utils.string_utils import sanitize_for_doc_id
 from ..utils.user_scope import resolve_user_scope
 from ..web_crawler import WebCrawler
+from ..web_crawler.crawler import STOPPED_NO_ELIGIBLE_LINKS
 from .document_ingestion import run_document_ingestion
 
 if TYPE_CHECKING:
@@ -857,6 +858,18 @@ async def _run_web_ingestion_impl(
     if rollback_failed_urls:
         status = "error"
 
+    # A crawl can end with zero failures and still not be what the user asked
+    # for: every link the start page offered was refused by the site. Configured
+    # stops (page cap, depth, deliberate filtering) are not this case, which is
+    # why the reason comes from the crawler rather than from link counts.
+    crawl_stats = crawler.get_statistics()
+    blocked_stop = (
+        status == "success"
+        and crawl_stats.get("stop_reason") == STOPPED_NO_ELIGIBLE_LINKS
+    )
+    if blocked_stop:
+        status = "partial"
+
     crawled_urls_list = [r.url for r in crawl_results if r.status == "success"]
 
     # Build a status-aware message. Previously this was unconditionally
@@ -901,6 +914,16 @@ async def _run_web_ingestion_impl(
                     f"{pages_crawled} pages, {len(failed_urls)} failed "
                     f"(first: {first_url} returned {first_err})"
                 )
+    elif blocked_stop:
+        refused = ", ".join(
+            f"{count} {reason}"
+            for reason, count in sorted(crawl_stats.get("link_rejections", {}).items())
+        )
+        message = (
+            f"Web ingestion incomplete: {documents_created} documents from "
+            f"{pages_crawled} page(s). No further pages could be crawled - "
+            f"every link found was refused ({refused})."
+        )
     else:
         message = (
             f"Web ingestion completed: {documents_created} documents, "

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -34,12 +34,28 @@ from ..utils.string_utils import sanitize_for_doc_id
 from ..utils.user_scope import resolve_user_scope
 from ..web_crawler import WebCrawler
 from ..web_crawler.crawler import STOPPED_NO_ELIGIBLE_LINKS
+from ..web_crawler.url_filter import (
+    REJECTED_EXCLUDED,
+    REJECTED_NOT_INCLUDED,
+    REJECTED_OFF_DOMAIN,
+    REJECTED_ROBOTS,
+    REJECTED_UNPARSABLE,
+)
 from .document_ingestion import run_document_ingestion
 
 if TYPE_CHECKING:
     from ..kb import KBPipelineCompatibilityFacade
 
 logger = logging.getLogger(__name__)
+
+# Reason keys are internal identifiers; this message reaches an end user.
+_REJECTION_LABELS = {
+    REJECTED_OFF_DOMAIN: "blocked by the same-domain rule",
+    REJECTED_EXCLUDED: "blocked by an exclude pattern",
+    REJECTED_NOT_INCLUDED: "outside the include patterns",
+    REJECTED_ROBOTS: "blocked by robots.txt rules",
+    REJECTED_UNPARSABLE: "not a crawlable http(s) link",
+}
 
 FileHandlerCallback = Callable[..., Any]
 
@@ -916,7 +932,7 @@ async def _run_web_ingestion_impl(
                 )
     elif blocked_stop:
         refused = ", ".join(
-            f"{count} {reason}"
+            f"{count} {_REJECTION_LABELS.get(reason, reason)}"
             for reason, count in sorted(crawl_stats.get("link_rejections", {}).items())
         )
         message = (
@@ -932,6 +948,7 @@ async def _run_web_ingestion_impl(
 
     result = WebIngestionResult(
         status=status,
+        crawl_blocked_by_site=blocked_stop,
         collection=collection,
         total_urls_found=crawler.total_urls_found,
         pages_crawled=pages_crawled,

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
@@ -5,7 +5,7 @@ import importlib
 import importlib.util
 import logging
 import time
-from collections import deque
+from collections import Counter, deque
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -16,7 +16,7 @@ import httpx
 from ..core.schemas import CrawlResult, WebCrawlConfig
 from .content_cleaner import ContentCleaner
 from .link_extractor import LinkExtractor
-from .url_filter import URLFilter
+from .url_filter import CONFIGURED_REJECTIONS, URLFilter
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +73,16 @@ _WEAK_CHALLENGE_PAGE_MARKERS: Tuple[str, ...] = (
     "just a moment",
     "needs to review the security",
 )
+
+# Why the crawl loop ended. NO_LINKS and PAGE_CAP are the crawl doing what it
+# was configured to do; NO_ELIGIBLE_LINKS means links existed but the site
+# refused them, which is the case worth surfacing to the user. UNKNOWN is the
+# fail-loud default: the loop assigns a real reason in its epilogue, so this
+# value surviving means it never got there.
+STOPPED_UNKNOWN = "unknown"
+STOPPED_NO_LINKS = "no_more_links"
+STOPPED_PAGE_CAP = "page_cap_reached"
+STOPPED_NO_ELIGIBLE_LINKS = "no_eligible_links"
 
 _MIN_MARKDOWN_TEXT_LENGTH = 10
 _SHORT_TEXT_LENGTH = 200
@@ -517,8 +527,13 @@ class WebCrawler:
         self.crawl_results: List[CrawlResult] = []
         self.failed_urls: Dict[str, str] = {}
 
-        # Statistics
+        # Statistics. total_urls_found counts raw extractor output; the two
+        # below count what survived URLFilter and why the rest did not, which
+        # is what tells a configured stop from an unexpected one.
         self.total_urls_found = 0
+        self.total_links_eligible = 0
+        self.link_rejections: Counter = Counter()
+        self.stop_reason: str = STOPPED_UNKNOWN
         self.start_time: Optional[float] = None
 
     async def crawl(self) -> List[CrawlResult]:
@@ -849,6 +864,31 @@ class WebCrawler:
                         self.config.max_pages,
                     )
 
+        if len(self.visited_urls) >= self.config.max_pages:
+            self.stop_reason = STOPPED_PAGE_CAP
+        elif self.total_links_eligible == 0 and self._refusals_dominate():
+            self.stop_reason = STOPPED_NO_ELIGIBLE_LINKS
+        else:
+            self.stop_reason = STOPPED_NO_LINKS
+
+    def _refusals_dominate(self) -> bool:
+        """Whether the site, rather than this crawl's own configuration, is
+        what kept every link out.
+
+        Presence is not enough: a scoped crawl that rejects fifty off-domain
+        links and happens to meet one robots-disallowed link was still doing
+        what it was configured to do.
+        """
+        total = sum(self.link_rejections.values())
+        if not total:
+            return False
+        refused = sum(
+            count
+            for reason, count in self.link_rejections.items()
+            if reason not in CONFIGURED_REJECTIONS
+        )
+        return refused * 2 > total
+
     async def _crawl_page(
         self,
         sessions: Dict[Optional[str], Any],
@@ -981,10 +1021,16 @@ class WebCrawler:
                 # consistent with what the WAF actually sees.
                 valid_links = set()
                 for link in links:
-                    if self.url_filter.should_crawl(link, self._policy_user_agent):
+                    reason = self.url_filter.rejection_reason(
+                        link, self._policy_user_agent
+                    )
+                    if reason is None:
                         valid_links.add(link)
+                    else:
+                        self.link_rejections[reason] += 1
 
                 self.total_urls_found += len(links)
+                self.total_links_eligible += len(valid_links)
 
                 # Create result
                 result = CrawlResult(
@@ -1045,6 +1091,9 @@ class WebCrawler:
         """
         return {
             "total_urls_found": self.total_urls_found,
+            "total_links_eligible": self.total_links_eligible,
+            "link_rejections": dict(self.link_rejections),
+            "stop_reason": self.stop_reason,
             "visited_urls": len(self.visited_urls),
             "successful_pages": len(self.crawl_results),
             "failed_pages": len(self.failed_urls),

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
@@ -16,7 +16,7 @@ import httpx
 from ..core.schemas import CrawlResult, WebCrawlConfig
 from .content_cleaner import ContentCleaner
 from .link_extractor import LinkExtractor
-from .url_filter import CONFIGURED_REJECTIONS, URLFilter
+from .url_filter import REJECTED_ROBOTS, URLFilter
 
 logger = logging.getLogger(__name__)
 
@@ -527,11 +527,14 @@ class WebCrawler:
         self.crawl_results: List[CrawlResult] = []
         self.failed_urls: Dict[str, str] = {}
 
-        # Statistics. total_urls_found counts raw extractor output; the two
-        # below count what survived URLFilter and why the rest did not, which
-        # is what tells a configured stop from an unexpected one.
+        # Statistics. total_urls_found counts raw extractor output and
+        # total_links_eligible what survived URLFilter; both are diagnostic.
+        # Only total_links_queued tracks actual frontier progress - a link can
+        # survive every filter and still queue nothing, having been seen
+        # already or sitting past max_depth.
         self.total_urls_found = 0
         self.total_links_eligible = 0
+        self.total_links_queued = 0
         self.link_rejections: Counter = Counter()
         self.stop_reason: str = STOPPED_UNKNOWN
         self.start_time: Optional[float] = None
@@ -866,28 +869,22 @@ class WebCrawler:
 
         if len(self.visited_urls) >= self.config.max_pages:
             self.stop_reason = STOPPED_PAGE_CAP
-        elif self.total_links_eligible == 0 and self._refusals_dominate():
+        elif self._site_refused_the_frontier():
             self.stop_reason = STOPPED_NO_ELIGIBLE_LINKS
         else:
             self.stop_reason = STOPPED_NO_LINKS
 
-    def _refusals_dominate(self) -> bool:
-        """Whether the site, rather than this crawl's own configuration, is
-        what kept every link out.
+    def _site_refused_the_frontier(self) -> bool:
+        """Whether the site's own policy is why there was nothing left to crawl.
 
-        Presence is not enough: a scoped crawl that rejects fifty off-domain
-        links and happens to meet one robots-disallowed link was still doing
-        what it was configured to do.
+        Asks about the frontier, not about rejection counts: a crawl that
+        queued a page was making progress whatever else it turned away. Depth
+        needs no separate guard - max_depth is at least 1, so a page dropped
+        for depth is always behind one that was queued.
         """
-        total = sum(self.link_rejections.values())
-        if not total:
+        if self.total_links_queued:
             return False
-        refused = sum(
-            count
-            for reason, count in self.link_rejections.items()
-            if reason not in CONFIGURED_REJECTIONS
-        )
-        return refused * 2 > total
+        return self.link_rejections[REJECTED_ROBOTS] > 0
 
     async def _crawl_page(
         self,
@@ -1082,6 +1079,7 @@ class WebCrawler:
             # Only add if not visited and not already pending
             if link not in self.visited_urls and link not in pending_urls_set:
                 self.pending_urls.append((link, next_depth))
+                self.total_links_queued += 1
 
     def get_statistics(self) -> dict:
         """Get crawl statistics.
@@ -1092,6 +1090,7 @@ class WebCrawler:
         return {
             "total_urls_found": self.total_urls_found,
             "total_links_eligible": self.total_links_eligible,
+            "total_links_queued": self.total_links_queued,
             "link_rejections": dict(self.link_rejections),
             "stop_reason": self.stop_reason,
             "visited_urls": len(self.visited_urls),

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/url_filter.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/url_filter.py
@@ -13,6 +13,20 @@ from ..core.web_url_utils import normalize_web_url
 
 logger = logging.getLogger(__name__)
 
+# Why a discovered link was not queued. The first three are the operator's own
+# configuration doing its job; the last two mean the site pushed back.
+REJECTED_OFF_DOMAIN = "off_domain"
+REJECTED_EXCLUDED = "excluded_pattern"
+REJECTED_NOT_INCLUDED = "not_included_pattern"
+REJECTED_ROBOTS = "robots_txt"
+REJECTED_UNPARSABLE = "unparsable"
+
+# Rejections that reflect how the crawl was configured, so a crawl that ends
+# with only these is doing what it was asked to do.
+CONFIGURED_REJECTIONS = frozenset(
+    {REJECTED_OFF_DOMAIN, REJECTED_EXCLUDED, REJECTED_NOT_INCLUDED}
+)
+
 
 class URLFilter:
     """URL filtering and validation.
@@ -185,6 +199,38 @@ class URLFilter:
         """
         return any(pattern.search(url) for pattern in self.exclude_patterns)
 
+    def rejection_reason(self, url: str, user_agent: str = "*") -> Optional[str]:
+        """Return why this URL will not be crawled, or None if it will be.
+
+        Callers aggregate these to tell a crawl that stopped because the
+        operator configured it that way from one that stopped unexpectedly.
+        Every configured rule is therefore checked before robots.txt: a link
+        that is both out of scope and robots-disallowed was never going to be
+        crawled regardless of what the site said, so attributing it to the site
+        would blame it for the operator's own filtering.
+        """
+        normalized = self.normalize_url(url)
+        if not normalized:
+            return REJECTED_UNPARSABLE
+
+        if self.same_domain_only and not self.is_same_domain(normalized):
+            logger.debug("Skipping %s: different domain", normalized)
+            return REJECTED_OFF_DOMAIN
+
+        if self.is_excluded(normalized):
+            logger.debug("Skipping %s: matches exclusion pattern", normalized)
+            return REJECTED_EXCLUDED
+
+        if not self.matches_patterns(normalized):
+            logger.debug("Skipping %s: does not match inclusion pattern", normalized)
+            return REJECTED_NOT_INCLUDED
+
+        if self.respect_robots_txt and not self.is_allowed(normalized, user_agent):
+            logger.debug("Skipping %s: disallowed by robots.txt", normalized)
+            return REJECTED_ROBOTS
+
+        return None
+
     def should_crawl(self, url: str, user_agent: str = "*") -> bool:
         """Check if URL should be crawled based on all rules.
 
@@ -195,32 +241,7 @@ class URLFilter:
         Returns:
             True if URL should be crawled, False otherwise
         """
-        # Normalize URL
-        normalized = self.normalize_url(url)
-        if not normalized:
-            return False
-
-        # Check domain
-        if self.same_domain_only and not self.is_same_domain(normalized):
-            logger.debug("Skipping %s: different domain", normalized)
-            return False
-
-        # Check robots.txt
-        if self.respect_robots_txt and not self.is_allowed(normalized, user_agent):
-            logger.debug("Skipping %s: disallowed by robots.txt", normalized)
-            return False
-
-        # Check exclusion patterns
-        if self.is_excluded(normalized):
-            logger.debug("Skipping %s: matches exclusion pattern", normalized)
-            return False
-
-        # Check inclusion patterns
-        if not self.matches_patterns(normalized):
-            logger.debug("Skipping %s: does not match inclusion pattern", normalized)
-            return False
-
-        return True
+        return self.rejection_reason(url, user_agent) is None
 
     def normalize_url(self, url: str, base_url: Optional[str] = None) -> Optional[str]:
         """Normalize URL by handling relative URLs and removing fragments.

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/url_filter.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/url_filter.py
@@ -13,19 +13,19 @@ from ..core.web_url_utils import normalize_web_url
 
 logger = logging.getLogger(__name__)
 
-# Why a discovered link was not queued. The first three are the operator's own
-# configuration doing its job; the last two mean the site pushed back.
+# Why a discovered link was not queued.
 REJECTED_OFF_DOMAIN = "off_domain"
 REJECTED_EXCLUDED = "excluded_pattern"
 REJECTED_NOT_INCLUDED = "not_included_pattern"
 REJECTED_ROBOTS = "robots_txt"
 REJECTED_UNPARSABLE = "unparsable"
 
-# Rejections that reflect how the crawl was configured, so a crawl that ends
-# with only these is doing what it was asked to do.
-CONFIGURED_REJECTIONS = frozenset(
-    {REJECTED_OFF_DOMAIN, REJECTED_EXCLUDED, REJECTED_NOT_INCLUDED}
-)
+# Only robots.txt speaks for the site. Scope rules belong to the operator and
+# an unsupported scheme (ftp:, data:, intent:) is this crawler's own limit, so
+# neither may make the site look responsible for a crawl that went nowhere.
+# Membership, never the complement: a reason added later is not a refusal
+# until someone says it is.
+SITE_REJECTIONS = frozenset({REJECTED_ROBOTS})
 
 
 class URLFilter:

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -354,6 +354,64 @@ async def test_create_kb_from_url_empty_crawl_publishes_nothing(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_create_kb_from_url_partial_crawl_is_not_reported_as_success(monkeypatch):
+    """A site that refused every link past the start page yields documents and
+    no failures. Reporting success there lets an agent build on a knowledge
+    base holding one page, which is what this status exists to prevent."""
+    monkeypatch.setenv(WEB_CRAWL_TLS_IMPERSONATE, "auto")
+
+    ingest_result = WebIngestionResult(
+        status="partial",
+        crawl_blocked_by_site=True,
+        collection="agent_url_kb",
+        total_urls_found=5,
+        pages_crawled=1,
+        pages_failed=0,
+        documents_created=1,
+        chunks_created=6,
+        embeddings_created=6,
+        crawled_urls=["https://example.com"],
+        failed_urls={},
+        message=(
+            "Web ingestion incomplete: 1 documents from 1 page(s). No further "
+            "pages could be crawled - every link found was refused "
+            "(5 blocked by robots.txt rules)."
+        ),
+        warnings=[],
+        elapsed_time_ms=1,
+    )
+    service = MagicMock()
+    service.prepare_collection = AsyncMock(return_value="agent_url_kb")
+    service.publish_collection = AsyncMock()
+    service.collection_exists = AsyncMock(return_value=False)
+    service.cleanup_failed_collection = AsyncMock()
+    service.refresh_collection_metadata = AsyncMock()
+
+    with (
+        patch(
+            "xagent.core.tools.adapters.vibe.agent_kb_service.AgentKnowledgeBaseService",
+            return_value=service,
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion.run_web_ingestion",
+            new=AsyncMock(return_value=ingest_result),
+        ),
+    ):
+        tool = CreateKnowledgeBaseFromUrlTool(user_id=71, is_admin=False)
+        result = await tool.run_json_async(
+            {"url": "https://example.com", "collection_name": "agent_url_kb"}
+        )
+
+    assert result["success"] is False
+    assert "blocked by robots.txt rules" in result["message"]
+    assert result["pages_crawled"] == 1
+    # The one page that did land is kept: re-importing would re-crawl it, and
+    # discarding it helps nobody.
+    service.publish_collection.assert_awaited_once()
+    service.cleanup_failed_collection.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_create_kb_from_url_uses_shared_service(monkeypatch):
     monkeypatch.setenv(WEB_CRAWL_TLS_IMPERSONATE, "auto")
 

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -27,6 +27,7 @@ from xagent.core.tools.core.RAG_tools.kb.models import (
     RollbackFailedIngestionRequest,
     RollbackFailedIngestionResult,
 )
+from xagent.core.tools.core.RAG_tools.web_crawler.crawler import STOPPED_NO_LINKS
 
 
 class _FakeMetadataStore:
@@ -554,6 +555,9 @@ class _SinglePageCrawler:
     ) -> None:
         self.total_urls_found = 1
         self.failed_urls: dict[str, str] = {}
+
+    def get_statistics(self) -> dict:
+        return {"stop_reason": STOPPED_NO_LINKS, "link_rejections": {}}
 
     async def crawl(self) -> list[CrawlResult]:
         return [

--- a/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
@@ -1433,7 +1433,8 @@ class TestCrawlStopReasonDrivesStatus:
 
         assert result.status == "partial"
         assert "every link found was refused" in result.message
-        assert "5 robots_txt" in result.message
+        assert "5 blocked by robots.txt rules" in result.message
+        assert "robots_txt" not in result.message
 
     @pytest.mark.asyncio
     async def test_page_cap_is_a_success(self, crawl_config, ingestion_config):

--- a/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
@@ -18,6 +18,11 @@ from xagent.core.tools.core.RAG_tools.pipelines.web_ingestion import (
 )
 from xagent.core.tools.core.RAG_tools.utils.string_utils import sanitize_for_doc_id
 from xagent.core.tools.core.RAG_tools.utils.user_scope import user_scope_context
+from xagent.core.tools.core.RAG_tools.web_crawler.crawler import (
+    STOPPED_NO_ELIGIBLE_LINKS,
+    STOPPED_NO_LINKS,
+    STOPPED_PAGE_CAP,
+)
 
 
 class TestWebIngestionPipeline:
@@ -1345,3 +1350,125 @@ class TestWebIngestionFileHandler:
 
         assert result.status == "success"
         assert events == [("commit", successful_ingestion)]
+
+
+class TestCrawlStopReasonDrivesStatus:
+    """A crawl that ends because the site refused every link is not a success,
+    but one that ends because the operator capped or filtered it is.
+
+    Predicates here read the crawler's stop reason rather than link counts:
+    `total_urls_found` is raw extractor output taken before URLFilter, so it
+    cannot tell a page cap or a deliberate filter from a site that blocked us.
+    """
+
+    @pytest.fixture
+    def crawl_config(self):
+        return WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=3,
+            max_depth=1,
+            concurrent_requests=1,
+            request_delay=0,
+        )
+
+    @pytest.fixture
+    def ingestion_config(self):
+        return IngestionConfig(chunk_size=500, chunk_overlap=100)
+
+    async def _run(self, crawl_config, ingestion_config, *, stop_reason, rejections):
+        ingestion_result = IngestionResult(
+            status="success",
+            doc_id="d",
+            parse_hash="h",
+            chunk_count=6,
+            embedding_count=6,
+            vector_count=6,
+            completed_steps=[],
+            failed_step=None,
+            message="Success",
+            warnings=[],
+        )
+        page = MagicMock(
+            url="https://example.com/",
+            title="Home",
+            content_markdown="# Home",
+            status="success",
+            depth=0,
+            timestamp=datetime(2025, 1, 1, 12, 0, 0),
+            content_length=50,
+        )
+        with patch(
+            "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion.WebCrawler"
+        ) as mock_crawler_class:
+            crawler = MagicMock()
+            crawler.crawl = AsyncMock(return_value=[page])
+            crawler.total_urls_found = sum(rejections.values())
+            crawler.failed_urls = {}
+            crawler.get_statistics.return_value = {
+                "stop_reason": stop_reason,
+                "link_rejections": rejections,
+                "total_links_eligible": 0,
+            }
+            mock_crawler_class.return_value = crawler
+            with patch(
+                "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion.run_document_ingestion",
+                return_value=ingestion_result,
+            ):
+                return await run_web_ingestion(
+                    collection="test_collection",
+                    crawl_config=crawl_config,
+                    ingestion_config=ingestion_config,
+                )
+
+    @pytest.mark.asyncio
+    async def test_every_link_refused_by_the_site_is_partial(
+        self, crawl_config, ingestion_config
+    ):
+        result = await self._run(
+            crawl_config,
+            ingestion_config,
+            stop_reason=STOPPED_NO_ELIGIBLE_LINKS,
+            rejections={"robots_txt": 5},
+        )
+
+        assert result.status == "partial"
+        assert "every link found was refused" in result.message
+        assert "5 robots_txt" in result.message
+
+    @pytest.mark.asyncio
+    async def test_page_cap_is_a_success(self, crawl_config, ingestion_config):
+        result = await self._run(
+            crawl_config,
+            ingestion_config,
+            stop_reason=STOPPED_PAGE_CAP,
+            rejections={},
+        )
+
+        assert result.status == "success"
+        assert "Web ingestion completed" in result.message
+
+    @pytest.mark.asyncio
+    async def test_deliberate_filtering_is_a_success(
+        self, crawl_config, ingestion_config
+    ):
+        """Every outgoing link was off-domain: the filter did its job."""
+        result = await self._run(
+            crawl_config,
+            ingestion_config,
+            stop_reason=STOPPED_NO_LINKS,
+            rejections={"off_domain": 7},
+        )
+
+        assert result.status == "success"
+        assert "Web ingestion completed" in result.message
+
+    @pytest.mark.asyncio
+    async def test_single_page_site_is_a_success(self, crawl_config, ingestion_config):
+        result = await self._run(
+            crawl_config,
+            ingestion_config,
+            stop_reason=STOPPED_NO_LINKS,
+            rejections={},
+        )
+
+        assert result.status == "success"

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
@@ -11,6 +11,10 @@ import pytest
 
 from xagent.core.tools.core.RAG_tools.core.schemas import WebCrawlConfig
 from xagent.core.tools.core.RAG_tools.web_crawler.crawler import (
+    STOPPED_NO_ELIGIBLE_LINKS,
+    STOPPED_NO_LINKS,
+    STOPPED_PAGE_CAP,
+    STOPPED_UNKNOWN,
     WebCrawler,
     _get_httpx_accept_encoding,
 )
@@ -1032,3 +1036,142 @@ class TestRobotsAtCrawlLevel:
             results = await WebCrawler(config).crawl()
 
         assert len(results) == 1
+
+
+class TestStopReason:
+    """The crawl loop records why it ended, so ingestion can tell a configured
+    stop from a site that refused every link."""
+
+    @staticmethod
+    def _mock_client(html: str):
+        response = MagicMock()
+        response.status_code = 200
+        response.text = html
+        client = AsyncMock()
+        client.get.return_value = response
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock()
+        return client
+
+    HTML_WITH_LINKS = """
+        <html><body><h1>Docs</h1>
+        <p>Enough body text here to pass the content length check.</p>
+        <a href="/a">A</a><a href="/b">B</a>
+        </body></html>
+    """
+
+    HTML_NO_LINKS = """
+        <html><body><h1>Only page</h1>
+        <p>Enough body text here to pass the content length check.</p>
+        </body></html>
+    """
+
+    @pytest.mark.asyncio
+    async def test_robots_refusing_every_link_is_flagged(self):
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+        with patch(
+            "httpx.AsyncClient", return_value=self._mock_client(self.HTML_WITH_LINKS)
+        ):
+            crawler = WebCrawler(config)
+            # Site allows the start page but refuses everything it links to.
+            crawler.url_filter.rejection_reason = lambda url, ua="*": "robots_txt"
+            await crawler.crawl()
+
+        assert crawler.stop_reason == STOPPED_NO_ELIGIBLE_LINKS
+        assert crawler.total_links_eligible == 0
+        assert crawler.link_rejections["robots_txt"] == 2
+
+    @pytest.mark.asyncio
+    async def test_off_domain_links_only_is_not_flagged(self):
+        """Deliberate filtering is the crawl doing what it was told."""
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+        with patch(
+            "httpx.AsyncClient", return_value=self._mock_client(self.HTML_WITH_LINKS)
+        ):
+            crawler = WebCrawler(config)
+            crawler.url_filter.rejection_reason = lambda url, ua="*": "off_domain"
+            await crawler.crawl()
+
+        assert crawler.stop_reason == STOPPED_NO_LINKS
+
+    @pytest.mark.asyncio
+    async def test_page_cap_is_recorded(self):
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=1,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+        with patch(
+            "httpx.AsyncClient", return_value=self._mock_client(self.HTML_WITH_LINKS)
+        ):
+            crawler = WebCrawler(config)
+            await crawler.crawl()
+
+        assert crawler.stop_reason == STOPPED_PAGE_CAP
+
+    @pytest.mark.asyncio
+    async def test_one_refused_link_among_many_configured_ones_is_not_flagged(self):
+        """Presence is not dominance: a scoped crawl that rejects many
+        off-domain links and meets one robots-disallowed link was doing what it
+        was configured to do."""
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+        with patch(
+            "httpx.AsyncClient", return_value=self._mock_client(self.HTML_WITH_LINKS)
+        ):
+            crawler = WebCrawler(config)
+            reasons = iter(["off_domain", "robots_txt"])
+            crawler.url_filter.rejection_reason = lambda url, ua="*": next(
+                reasons, "off_domain"
+            )
+            await crawler.crawl()
+
+        assert crawler.link_rejections["off_domain"] == 1
+        assert crawler.link_rejections["robots_txt"] == 1
+        # 1 of 2 is not a majority, so the site is not held responsible.
+        assert crawler.stop_reason == STOPPED_NO_LINKS
+
+    def test_stop_reason_defaults_to_unknown_before_the_loop_runs(self):
+        """A success-implying default would misreport a crawl that raised
+        before the loop epilogue assigned a real reason."""
+        config = WebCrawlConfig(
+            start_url="https://example.com", request_delay=0, tls_impersonate=None
+        )
+        assert WebCrawler(config).stop_reason == STOPPED_UNKNOWN
+
+    @pytest.mark.asyncio
+    async def test_site_with_no_links_is_not_flagged(self):
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+        with patch(
+            "httpx.AsyncClient", return_value=self._mock_client(self.HTML_NO_LINKS)
+        ):
+            crawler = WebCrawler(config)
+            await crawler.crawl()
+
+        assert crawler.stop_reason == STOPPED_NO_LINKS
+        assert crawler.link_rejections == {}

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
@@ -1107,6 +1107,111 @@ class TestStopReason:
         assert crawler.stop_reason == STOPPED_NO_LINKS
 
     @pytest.mark.asyncio
+    async def test_one_in_scope_refusal_outweighs_many_out_of_scope_links(self):
+        """Links that were never in scope cannot vouch for the site. A ratio
+        over all rejections lets fifty off-domain links bury the one refusal
+        that actually closed the crawl."""
+        html = (
+            "<html><body><h1>Docs</h1><p>Enough body text to pass the check.</p>"
+            + "".join(f'<a href="https://other{i}.com/x">O</a>' for i in range(50))
+            + '<a href="/blocked">B</a></body></html>'
+        )
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+        with patch("httpx.AsyncClient", return_value=self._mock_client(html)):
+            crawler = WebCrawler(config)
+            crawler.url_filter.rejection_reason = (
+                lambda url, ua="*": "robots_txt"
+                if url.startswith("https://example.com/")
+                else "off_domain"
+            )
+            await crawler.crawl()
+
+        assert crawler.stop_reason == STOPPED_NO_ELIGIBLE_LINKS
+
+    @pytest.mark.asyncio
+    async def test_unsupported_schemes_alone_are_not_a_refusal(self):
+        """ftp:/data:/intent: anchors are this crawler's own limit. No site
+        policy was consulted, so a one-page import stays a success."""
+        html = """
+            <html><body><h1>Only page</h1>
+            <p>Enough body text here to pass the content length check.</p>
+            <a href="ftp://example.com/f">F</a><a href="data:text/plain,x">D</a>
+            </body></html>
+        """
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+            respect_robots_txt=False,
+        )
+        with patch("httpx.AsyncClient", return_value=self._mock_client(html)):
+            crawler = WebCrawler(config)
+            crawler.url_filter.rejection_reason = lambda url, ua="*": "unparsable"
+            await crawler.crawl()
+
+        assert crawler.stop_reason == STOPPED_NO_LINKS
+
+    @pytest.mark.asyncio
+    async def test_an_already_seen_link_is_not_frontier_progress(self):
+        """A self link survives every filter and queues nothing. Counting it as
+        progress hides that the only forward page was refused."""
+        html = """
+            <html><body><h1>Docs</h1>
+            <p>Enough body text here to pass the content length check.</p>
+            <a href="https://example.com">home</a><a href="/child">C</a>
+            </body></html>
+        """
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+        with patch("httpx.AsyncClient", return_value=self._mock_client(html)):
+            crawler = WebCrawler(config)
+            crawler.url_filter.rejection_reason = (
+                lambda url, ua="*": "robots_txt" if url.endswith("/child") else None
+            )
+            await crawler.crawl()
+
+        assert crawler.total_links_eligible == 1
+        assert crawler.total_links_queued == 0
+        assert crawler.stop_reason == STOPPED_NO_ELIGIBLE_LINKS
+
+    @pytest.mark.asyncio
+    async def test_a_refusal_alongside_real_progress_is_not_a_blocked_crawl(self):
+        """The common shape: robots forbids /private and the rest crawls fine.
+        A refusal only closed the door if nothing was queued behind it."""
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+        with patch(
+            "httpx.AsyncClient", return_value=self._mock_client(self.HTML_WITH_LINKS)
+        ):
+            crawler = WebCrawler(config)
+            crawler.url_filter.rejection_reason = (
+                lambda url, ua="*": "robots_txt" if url.endswith("/b") else None
+            )
+            await crawler.crawl()
+
+        assert crawler.link_rejections["robots_txt"] > 0
+        assert crawler.total_links_queued > 0
+        assert crawler.stop_reason == STOPPED_NO_LINKS
+
+    @pytest.mark.asyncio
     async def test_page_cap_is_recorded(self):
         config = WebCrawlConfig(
             start_url="https://example.com",
@@ -1124,7 +1229,7 @@ class TestStopReason:
         assert crawler.stop_reason == STOPPED_PAGE_CAP
 
     @pytest.mark.asyncio
-    async def test_one_refused_link_among_many_configured_ones_is_not_flagged(self):
+    async def test_an_out_of_scope_link_does_not_excuse_a_refusal(self):
         """Presence is not dominance: a scoped crawl that rejects many
         off-domain links and meets one robots-disallowed link was doing what it
         was configured to do."""
@@ -1147,8 +1252,9 @@ class TestStopReason:
 
         assert crawler.link_rejections["off_domain"] == 1
         assert crawler.link_rejections["robots_txt"] == 1
-        # 1 of 2 is not a majority, so the site is not held responsible.
-        assert crawler.stop_reason == STOPPED_NO_LINKS
+        # The off-domain link was never a candidate, so it cannot vouch for a
+        # site that refused the only one that was.
+        assert crawler.stop_reason == STOPPED_NO_ELIGIBLE_LINKS
 
     def test_stop_reason_defaults_to_unknown_before_the_loop_runs(self):
         """A success-implying default would misreport a crawl that raised

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_url_filter.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_url_filter.py
@@ -9,11 +9,12 @@ from pydantic import ValidationError
 
 from xagent.core.tools.core.RAG_tools.core.schemas import WebCrawlConfig
 from xagent.core.tools.core.RAG_tools.web_crawler.url_filter import (
-    CONFIGURED_REJECTIONS,
     REJECTED_EXCLUDED,
     REJECTED_NOT_INCLUDED,
     REJECTED_OFF_DOMAIN,
     REJECTED_ROBOTS,
+    REJECTED_UNPARSABLE,
+    SITE_REJECTIONS,
     URLFilter,
 )
 
@@ -183,6 +184,14 @@ def test_web_crawl_config_rejects_invalid_start_urls():
         WebCrawlConfig(start_url="http://@")
 
 
+def _patch_client_with_handler(monkeypatch, handler):
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        partial(httpx.Client, transport=httpx.MockTransport(handler)),
+    )
+
+
 class _FakeResponse:
     def __init__(self, status_code: int, text: str = "") -> None:
         self.status_code = status_code
@@ -275,7 +284,7 @@ class TestRobotsTxtAvailability:
         """The kwarg assertion above cannot show the sixth hop is refused.
         s2.3.1.2 permits treating an over-long chain as unavailable (allow);
         this takes the stricter reading, so it needs a behavioural anchor."""
-        self._patch_client_with_handler(
+        _patch_client_with_handler(
             monkeypatch,
             lambda request: httpx.Response(
                 301, headers={"Location": f"{request.url}/again"}
@@ -284,13 +293,6 @@ class TestRobotsTxtAvailability:
         f = URLFilter("https://example.com", respect_robots_txt=True)
 
         assert f.should_crawl("https://example.com/docs/intro") is False
-
-    def _patch_client_with_handler(self, monkeypatch, handler):
-        monkeypatch.setattr(
-            httpx,
-            "Client",
-            partial(httpx.Client, transport=httpx.MockTransport(handler)),
-        )
 
     def test_disallow_rules_behind_a_redirect_are_honoured(self, monkeypatch):
         """http->https and www canonicalisation redirect /robots.txt routinely.
@@ -304,7 +306,7 @@ class TestRobotsTxtAvailability:
                 )
             return httpx.Response(200, text="User-agent: *\nDisallow: /private\n")
 
-        self._patch_client_with_handler(monkeypatch, handler)
+        _patch_client_with_handler(monkeypatch, handler)
         f = URLFilter("https://example.com", respect_robots_txt=True)
 
         assert f.should_crawl("https://example.com/private/secret") is False
@@ -349,7 +351,7 @@ class TestRejectionReason:
             "https://example.com", same_domain_only=True, respect_robots_txt=False
         )
         assert f.rejection_reason("https://other.com/x") == REJECTED_OFF_DOMAIN
-        assert REJECTED_OFF_DOMAIN in CONFIGURED_REJECTIONS
+        assert REJECTED_OFF_DOMAIN not in SITE_REJECTIONS
 
     def test_exclusion_is_reported_as_configuration(self):
         f = URLFilter(
@@ -358,31 +360,37 @@ class TestRejectionReason:
             respect_robots_txt=False,
         )
         assert f.rejection_reason("https://example.com/private/x") == REJECTED_EXCLUDED
-        assert REJECTED_EXCLUDED in CONFIGURED_REJECTIONS
+        assert REJECTED_EXCLUDED not in SITE_REJECTIONS
 
     def test_robots_is_not_configuration(self, monkeypatch):
         """The site refusing us is not the operator configuring us."""
-        import httpx
-
-        monkeypatch.setattr(
-            httpx,
-            "get",
-            lambda url, **kw: _FakeResponse(200, "User-agent: *\nDisallow: /private\n"),
+        _patch_client_with_handler(
+            monkeypatch,
+            lambda request: httpx.Response(
+                200, text="User-agent: *\nDisallow: /private\n"
+            ),
         )
         f = URLFilter("https://example.com", respect_robots_txt=True)
         assert f.rejection_reason("https://example.com/private/x") == REJECTED_ROBOTS
-        assert REJECTED_ROBOTS not in CONFIGURED_REJECTIONS
+        assert REJECTED_ROBOTS in SITE_REJECTIONS
+
+    def test_an_unsupported_scheme_is_not_the_site_refusing(self):
+        """ftp:/data:/intent: anchors are this crawler's own limit, so they
+        must not make the site look responsible for a crawl going nowhere."""
+        f = URLFilter("https://example.com", respect_robots_txt=False)
+
+        assert f.rejection_reason("ftp://example.com/file") == REJECTED_UNPARSABLE
+        assert REJECTED_UNPARSABLE not in SITE_REJECTIONS
 
     def test_configured_rules_win_over_robots(self, monkeypatch):
         """A link that is both out of scope and robots-disallowed was never
         going to be crawled regardless of what the site said, so blaming the
         site would report the operator's own filtering as a refusal."""
-        import httpx
-
-        monkeypatch.setattr(
-            httpx,
-            "get",
-            lambda url, **kw: _FakeResponse(200, "User-agent: *\nDisallow: /blog\n"),
+        _patch_client_with_handler(
+            monkeypatch,
+            lambda request: httpx.Response(
+                200, text="User-agent: *\nDisallow: /blog\n"
+            ),
         )
         f = URLFilter(
             "https://example.com", url_patterns=[r"/docs"], respect_robots_txt=True
@@ -391,15 +399,14 @@ class TestRejectionReason:
         assert f.rejection_reason("https://example.com/blog/post") == (
             REJECTED_NOT_INCLUDED
         )
-        assert REJECTED_NOT_INCLUDED in CONFIGURED_REJECTIONS
+        assert REJECTED_NOT_INCLUDED not in SITE_REJECTIONS
 
     def test_excluded_wins_over_robots(self, monkeypatch):
-        import httpx
-
-        monkeypatch.setattr(
-            httpx,
-            "get",
-            lambda url, **kw: _FakeResponse(200, "User-agent: *\nDisallow: /blog\n"),
+        _patch_client_with_handler(
+            monkeypatch,
+            lambda request: httpx.Response(
+                200, text="User-agent: *\nDisallow: /blog\n"
+            ),
         )
         f = URLFilter(
             "https://example.com", exclude_patterns=[r"/blog"], respect_robots_txt=True
@@ -408,12 +415,11 @@ class TestRejectionReason:
         assert f.rejection_reason("https://example.com/blog/post") == REJECTED_EXCLUDED
 
     def test_robots_still_reported_when_no_configured_rule_applies(self, monkeypatch):
-        import httpx
-
-        monkeypatch.setattr(
-            httpx,
-            "get",
-            lambda url, **kw: _FakeResponse(200, "User-agent: *\nDisallow: /blog\n"),
+        _patch_client_with_handler(
+            monkeypatch,
+            lambda request: httpx.Response(
+                200, text="User-agent: *\nDisallow: /blog\n"
+            ),
         )
         f = URLFilter("https://example.com", respect_robots_txt=True)
 

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_url_filter.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_url_filter.py
@@ -8,7 +8,14 @@ import pytest
 from pydantic import ValidationError
 
 from xagent.core.tools.core.RAG_tools.core.schemas import WebCrawlConfig
-from xagent.core.tools.core.RAG_tools.web_crawler.url_filter import URLFilter
+from xagent.core.tools.core.RAG_tools.web_crawler.url_filter import (
+    CONFIGURED_REJECTIONS,
+    REJECTED_EXCLUDED,
+    REJECTED_NOT_INCLUDED,
+    REJECTED_OFF_DOMAIN,
+    REJECTED_ROBOTS,
+    URLFilter,
+)
 
 
 class TestURLFilter:
@@ -328,3 +335,93 @@ class TestRobotsTxtAvailability:
         )
         assert f.should_crawl("https://example.com/private/secret") is False
         assert f.should_crawl("https://example.com/public/page") is True
+
+
+class TestRejectionReason:
+    """should_crawl only says no; callers need to know which rule said it."""
+
+    def test_reason_is_none_when_crawlable(self):
+        f = URLFilter("https://example.com", respect_robots_txt=False)
+        assert f.rejection_reason("https://example.com/docs") is None
+
+    def test_off_domain_is_reported_as_configuration(self):
+        f = URLFilter(
+            "https://example.com", same_domain_only=True, respect_robots_txt=False
+        )
+        assert f.rejection_reason("https://other.com/x") == REJECTED_OFF_DOMAIN
+        assert REJECTED_OFF_DOMAIN in CONFIGURED_REJECTIONS
+
+    def test_exclusion_is_reported_as_configuration(self):
+        f = URLFilter(
+            "https://example.com",
+            exclude_patterns=[r"/private"],
+            respect_robots_txt=False,
+        )
+        assert f.rejection_reason("https://example.com/private/x") == REJECTED_EXCLUDED
+        assert REJECTED_EXCLUDED in CONFIGURED_REJECTIONS
+
+    def test_robots_is_not_configuration(self, monkeypatch):
+        """The site refusing us is not the operator configuring us."""
+        import httpx
+
+        monkeypatch.setattr(
+            httpx,
+            "get",
+            lambda url, **kw: _FakeResponse(200, "User-agent: *\nDisallow: /private\n"),
+        )
+        f = URLFilter("https://example.com", respect_robots_txt=True)
+        assert f.rejection_reason("https://example.com/private/x") == REJECTED_ROBOTS
+        assert REJECTED_ROBOTS not in CONFIGURED_REJECTIONS
+
+    def test_configured_rules_win_over_robots(self, monkeypatch):
+        """A link that is both out of scope and robots-disallowed was never
+        going to be crawled regardless of what the site said, so blaming the
+        site would report the operator's own filtering as a refusal."""
+        import httpx
+
+        monkeypatch.setattr(
+            httpx,
+            "get",
+            lambda url, **kw: _FakeResponse(200, "User-agent: *\nDisallow: /blog\n"),
+        )
+        f = URLFilter(
+            "https://example.com", url_patterns=[r"/docs"], respect_robots_txt=True
+        )
+
+        assert f.rejection_reason("https://example.com/blog/post") == (
+            REJECTED_NOT_INCLUDED
+        )
+        assert REJECTED_NOT_INCLUDED in CONFIGURED_REJECTIONS
+
+    def test_excluded_wins_over_robots(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(
+            httpx,
+            "get",
+            lambda url, **kw: _FakeResponse(200, "User-agent: *\nDisallow: /blog\n"),
+        )
+        f = URLFilter(
+            "https://example.com", exclude_patterns=[r"/blog"], respect_robots_txt=True
+        )
+
+        assert f.rejection_reason("https://example.com/blog/post") == REJECTED_EXCLUDED
+
+    def test_robots_still_reported_when_no_configured_rule_applies(self, monkeypatch):
+        import httpx
+
+        monkeypatch.setattr(
+            httpx,
+            "get",
+            lambda url, **kw: _FakeResponse(200, "User-agent: *\nDisallow: /blog\n"),
+        )
+        f = URLFilter("https://example.com", respect_robots_txt=True)
+
+        assert f.rejection_reason("https://example.com/blog/post") == REJECTED_ROBOTS
+
+    def test_should_crawl_still_agrees_with_the_reason(self):
+        f = URLFilter(
+            "https://example.com", same_domain_only=True, respect_robots_txt=False
+        )
+        for url in ("https://example.com/ok", "https://other.com/no"):
+            assert f.should_crawl(url) is (f.rejection_reason(url) is None)


### PR DESCRIPTION
Fixes #2052. #2043 has merged; this branch is rebased onto it, so its diff is
this feature alone.

## Invariant

A crawl that stops because it was **configured** to (page cap, depth cap,
deliberate filtering) is a success. A crawl that stops because the **site
refused every link** is not, and it has to say why.

## Problem

A crawl with zero failures can still produce an unusable knowledge base, and
all the user sees is:

```
status = succeeded
pages_crawled = 1
pages_failed = 0
message = "Web ingestion completed: 1 documents, 6 chunks, 6 embeddings"
```

Every field reads as good news, so there is nothing to act on.

## Why link counts cannot decide this

#2043 originally used `pages_crawled <= 1 && total_urls_found > 1`. Review
showed why that is wrong: `crawler.py` does `total_urls_found += len(links)` on
the **raw** `LinkExtractor` output, before `URLFilter` runs. A legitimate
`max_pages=1` crawl, or one where same-domain / include / exclude rules reject
every outgoing link, would be mislabelled.

## Changes

1. **`URLFilter.rejection_reason()`** returns *which rule* rejected a link
   (`off_domain`, `excluded_pattern`, `not_included_pattern`, `robots_txt`,
   `unparsable`); `should_crawl()` is now implemented in terms of it and
   behaves identically. The first three are `CONFIGURED_REJECTIONS` — the
   operator's own settings doing their job. The rest mean the site pushed back.

   Every configured rule is checked **before** robots.txt. A link that is out
   of scope was never going to be crawled regardless of what the site said, so
   attributing the overlap to robots would report the operator's own filtering
   as a refusal.

2. **`WebCrawler`** tracks `total_links_eligible` (survived filtering, as
   opposed to raw `total_urls_found`), `link_rejections` (counted by reason),
   and `stop_reason` (`page_cap_reached` / `no_more_links` /
   `no_eligible_links`). All three are exposed through `get_statistics()`.

3. **`run_web_ingestion`** reads `crawler.get_statistics()` and downgrades to
   `partial` only for `no_eligible_links`, naming the rejection reasons and
   counts in the message.

   `no_eligible_links` requires **dominance**, not presence: non-configured
   rejections have to be a strict majority before the site is held
   responsible. A scoped crawl that rejects fifty off-domain links and meets
   one robots-disallowed link was doing what it was configured to do.

## Entry points

`URLFilter.rejection_reason` · `WebCrawler._crawl_loop` · `run_web_ingestion`

## Non-goals

- Does not use `IngestionResult.embedding_count` to judge searchability. It
  counts embeddings generated *this run*, and an unchanged re-import takes the
  `pending_count == 0` early return in `document_ingestion.py`, returning
  `embedding_count=0` while its persisted vectors stay searchable. Deciding
  "this KB really has no vectors" needs the persisted total, which is out of
  scope here.
- No change to crawl behaviour itself — only to what is counted and reported.
- No change to cross-subdomain rules, content extraction, chunking, or
  retrieval scoring.

## Blocking criteria

- Page cap, deliberate filtering, and a genuinely single-page site all still
  report success (one test each)
- A site refusing every link reports `partial` and names the reason (test)
- `should_crawl()` and `rejection_reason()` never disagree (test)

## Verification

Both shapes exercised against a Docusaurus documentation site that serves no
robots.txt:

| scenario | pages | stop_reason | status |
|---|---|---|---|
| normal crawl | 42 | `no_more_links` (1099 eligible links) | success |
| every link refused (robots simulated) | 1 | `no_eligible_links` (5 rejected) | partial + reason |

18 new tests, including the rule-overlap cases (a link both out of scope and
robots-disallowed reports the configured reason), the dominance boundary (one
refusal among two rejections is not a majority), and the fail-loud
`stop_reason` default.

Six mutations — counting every rejection as a site refusal, reading
`total_links_eligible` instead of the queued count, dropping the queue
increment, removing the Vibe partial branch, bypassing the label map, and
dropping the `partial` downgrade — are each killed by a test.
`tests/core/tools/core/RAG_tools` and `tests/core/tools/adapters/vibe` pass;
pre-commit (incl. mypy) passes.

### Review round 2

Four blocking findings. The first three shared one root, so they are fixed by
replacing the predicate rather than by patching it three times.

**A ratio over all rejections cannot say who closed the crawl.** The previous
`_refusals_dominate` put configured rejections in the denominator, so 50
off-domain links buried the one in-scope link the site actually refused. And
because it asked `reason not in CONFIGURED_REJECTIONS`, every reason not
explicitly listed counted as a refusal — which is how `unparsable` came to mean
"the site refused us", turning a one-page site whose only anchors are `ftp:` or
`data:` into a `partial` blaming a site policy that was never consulted.
Meanwhile `total_links_eligible` was incremented before the depth and
visited/pending checks, so a link back to the start page counted as forward
progress while the only real candidate was refused.

All three go away with one question asked correctly:

```python
def _site_refused_the_frontier(self) -> bool:
    if self.total_links_queued:
        return False
    return self.link_rejections[REJECTED_ROBOTS] > 0
```

`CONFIGURED_REJECTIONS` is deleted in favour of
`SITE_REJECTIONS = frozenset({REJECTED_ROBOTS})` — membership, never the
complement, so a reason added later is not a site refusal until someone says it
is. `total_links_queued` is incremented where a URL actually enters the queue.
A link that was never a candidate now neither accuses the site nor vouches for
it.

**The public Vibe entry converted the new `partial` back to success.** It
treats only `status == "error"` as failure, so a refused crawl published its
one page and returned `success=True` with fixed text, discarding the message.
Fixed narrowly on purpose: an existing test pins that a partial caused by
individual pages failing to parse still reports success, and widening the
branch to all partials would have reversed that policy silently.
`WebIngestionResult` therefore gains `crawl_blocked_by_site`, set from the
`blocked_stop` the pipeline already computes, and the Vibe caller branches on
that alone. The pages that landed stay published — re-importing would re-crawl
them — but the result no longer claims the import was complete.

Two minor findings fixed: reason keys are mapped to prose, so the message reads
`5 blocked by robots.txt rules` rather than `5 robots_txt`; and the "crawling
nothing" warning is corrected by the rebase onto #2043.

One minor finding left open and not claimed as fixed: the policy-user-agent
seam has its wiring pinned in #2043 (`test_robots_fetch_inherits_the_crawl_user_agent`),
but there is still no end-to-end crawl over a non-wildcard `User-agent` group.

Also fixed while rebasing: four of this PR's `TestRejectionReason` tests still
patched `httpx.get`, which #2043 replaced with `httpx.Client`, so they were
issuing real network requests to `example.com/robots.txt` instead of reaching
the stub.

