### PR TITLE
fix(connectors): lock the MCP server definition row on edit

### DIFF
--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -62,6 +62,7 @@ on:
       - 'src/xagent/web/models/custom_api.py'
       - 'tests/web/api/test_mcp_server_edit_lock_postgresql.py'
       - 'src/xagent/web/api/mcp.py'
+      - 'src/xagent/core/tools/core/mcp/model.py'
   pull_request:
     branches: [main]
   # Required by the merge queue: without this the two required contexts below
@@ -160,6 +161,7 @@ jobs:
             src/xagent/web/models/custom_api.py
             tests/web/api/test_mcp_server_edit_lock_postgresql.py
             src/xagent/web/api/mcp.py
+            src/xagent/core/tools/core/mcp/model.py
           )
 
           case "$EVENT_NAME" in

--- a/.github/workflows/test-migrations.yml
+++ b/.github/workflows/test-migrations.yml
@@ -56,6 +56,9 @@ on:
       - 'tests/web/test_trusted_actor_oauth_postgresql.py'
       - 'tests/shared/postgres_disposable.py'
       - 'tests/web/services/checkpoint_anchor_shared.py'
+      - 'tests/web/api/test_mcp_server_edit_lock_postgresql.py'
+      - 'src/xagent/web/api/mcp.py'
+      - 'src/xagent/web/services/connector_team_scope.py'
   pull_request:
     branches: [main]
   # Required by the merge queue: without this the two required contexts below
@@ -148,6 +151,9 @@ jobs:
             tests/web/test_trusted_actor_oauth_postgresql.py
             tests/shared/postgres_disposable.py
             tests/web/services/checkpoint_anchor_shared.py
+            tests/web/api/test_mcp_server_edit_lock_postgresql.py
+            src/xagent/web/api/mcp.py
+            src/xagent/web/services/connector_team_scope.py
           )
 
           case "$EVENT_NAME" in
@@ -490,6 +496,13 @@ jobs:
         if: needs.detect-migration-changes.outputs.should-test == 'true'
         run: |
           pytest tests/web/services/test_supersede_savepoint_postgresql.py -m postgresql -q
+        env:
+          XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
+
+      - name: Test MCP server edit row lock (Postgres-only)
+        if: needs.detect-migration-changes.outputs.should-test == 'true'
+        run: |
+          pytest tests/web/api/test_mcp_server_edit_lock_postgresql.py -m postgresql -q
         env:
           XAGENT_TEST_POSTGRES_URL: postgresql://xagent:xagent@localhost:5432/xagent_test
 

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -3386,6 +3386,19 @@ def update_mcp_server(
         # lock is taken in a few cases that did not need it, and skipped in
         # none whose fields target that row.
         #
+        # One flag, three decisions, and they are the same decision on
+        # purpose: whether to take the row lock (the ``with_for_update``
+        # below), whether to re-derive the caller's write authority after
+        # that wait (the block right after the lock), and whether to
+        # rebuild, validate and write the definition row (the block
+        # further down). Moving a field into the exclusion set above
+        # therefore also drops that payload's post-lock re-authorization --
+        # the hazard ``custom_api.py``'s equivalent comment warns about --
+        # and drops its runtime-config validation with it. Change that set
+        # only with all three in view;
+        # ``tests/web/api/test_mcp_update_lock_partition.py`` fails on a
+        # field added to ``MCPServerUpdate`` without that decision.
+        #
         # This set is also exactly the set of payloads the block below
         # rebuilds and writes the definition row for: the whole rebuild --
         # building ``update_data``, validating it, and writing every
@@ -3433,6 +3446,13 @@ def update_mcp_server(
         # ``FOR UPDATE``. On MySQL, which has no such distinction,
         # ``key_share`` is accepted and ignored: SQLAlchemy renders plain
         # ``FOR UPDATE`` there either way.
+        #
+        # The weaker mode is not what leaves the residual window the
+        # re-reads after the lock cover: neither deleting a
+        # ``UserMCPServer`` row nor clearing a ``User.is_admin`` flag takes
+        # any lock on this row in either mode, so plain ``FOR UPDATE``
+        # would leave exactly the same window open. See the re-read block
+        # below for how it is handled instead.
         definition_query = (
             db.query(MCPServer).filter(MCPServer.id == server_id).populate_existing()
         )
@@ -3527,10 +3547,15 @@ def update_mcp_server(
                 db.query(User).filter(User.id == user_id).populate_existing().first()
             )
             if current_admin_user is None:
+                # Distinct wording from the two 404s above on purpose: the
+                # definition row and the caller's link to it were both still
+                # there when this branch is reached, and what vanished inside
+                # the lock wait is the caller's own account. Answering "MCP
+                # server not found" here would name the wrong missing object.
                 db.rollback()
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
-                    detail="MCP server not found",
+                    detail="Requesting user account no longer exists",
                 )
             can_edit_global = _check_mcp_permission(
                 user_mcp, bool(current_admin_user.is_admin), require="edit"

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -3363,10 +3363,19 @@ def update_mcp_server(
         # definition row for a payload that carries only those two made an
         # activate/deactivate queue behind an unrelated edit of the same
         # connector -- and, under PostgreSQL REPEATABLE READ, made it fail
-        # outright: the lock statement follows the snapshot the joined read
-        # above already established, so a definition edit committed in between
-        # raises SQLSTATE 40001 and the route's generic handler answers 500
-        # with the requested activation state unwritten.
+        # outright: the lock statement follows the snapshot this session's
+        # first read in the request already established. In a real request
+        # that first read is ``get_current_user``'s own lookup of the caller
+        # (``_resolve_access_token_user``, ``auth_dependencies.py``), which
+        # FastAPI's dependency injection runs on this same session before
+        # this route body executes at all -- the join immediately below is
+        # not what pins the snapshot in production. It is what pins it in
+        # the PostgreSQL lock suite's tests, though: those call this
+        # function directly and skip the dependency chain, so for them the
+        # join below is the session's first statement. Either way, a
+        # definition edit committed in between raises SQLSTATE 40001 and the
+        # route's generic handler answers 500 with the requested activation
+        # state unwritten.
         #
         # ``model_fields_set`` decides this, not the values, because that is
         # what decides the writes themselves: an explicitly-null
@@ -3377,13 +3386,18 @@ def update_mcp_server(
         # lock is taken in a few cases that did not need it, and skipped in
         # none whose fields target that row.
         #
-        # One caveat: this set is not a superset of the writes that follow.
-        # ``_update_server_from_config`` below
-        # re-encrypts a global ``env`` or ``auth`` on every call and Fernet
-        # ciphertext differs each time, so on a server carrying one of those
-        # the rebuild still writes the definition row on this lock-free path.
-        # That write is the pre-existing behavior of this route, unchanged
-        # here; the isolation-level contract governing it is tracked in #1945.
+        # This set is also exactly the set of payloads the block below
+        # rebuilds and writes the definition row for: the whole rebuild --
+        # building ``update_data``, validating it, and writing every
+        # resulting field back onto ``server`` -- runs only when
+        # ``writes_definition_row`` is true. A lock-free payload therefore
+        # cannot produce a definition-row write: there is no code path left
+        # that would build one. (An earlier version of this route rebuilt
+        # the config unconditionally regardless of which row the lock
+        # covered, so a server carrying a global ``env`` or ``auth`` still
+        # got its value re-encrypted and written back with no lock held --
+        # this is why the two now share one flag instead of the write
+        # having its own, independently-derived guard.)
         fields_set = server_data.model_fields_set
         writes_definition_row = bool(fields_set - {"is_active", "user_env"})
 
@@ -3406,13 +3420,35 @@ def update_mcp_server(
         # dual-dialect fence ``acquire_runtime_key_transition_fence``
         # (services/api_keys.py) uses -- a no-op ``UPDATE`` that takes SQLite's
         # writer lock -- and is left to a change of its own.
+        #
+        # ``key_share=True`` asks PostgreSQL for ``FOR NO KEY UPDATE`` instead
+        # of plain ``FOR UPDATE``: this route never changes ``MCPServer.id``
+        # (the column any referencing foreign key cares about), only the
+        # other columns, so the weaker lock covers everything it writes.
+        # Plain ``FOR UPDATE`` would also block a concurrent connect or
+        # disconnect on the same server -- ``UserMCPServer`` inserts and
+        # deletes take a ``FOR KEY SHARE`` lock on the ``MCPServer`` row they
+        # reference, to verify that row still exists -- and ``FOR KEY SHARE``
+        # is compatible with ``FOR NO KEY UPDATE`` but not with plain
+        # ``FOR UPDATE``. On MySQL, which has no such distinction,
+        # ``key_share`` is accepted and ignored: SQLAlchemy renders plain
+        # ``FOR UPDATE`` there either way.
         definition_query = (
             db.query(MCPServer).filter(MCPServer.id == server_id).populate_existing()
         )
         if writes_definition_row:
-            definition_query = definition_query.with_for_update()
+            definition_query = definition_query.with_for_update(key_share=True)
         current_server = definition_query.first()
         if current_server is None:
+            # This statement holds a row lock on ``writes_definition_row``
+            # (see the comment on the query above), so it opened a
+            # transaction the outer ``except HTTPException: raise`` will not
+            # close: that handler re-raises without rolling back, unlike its
+            # ``except Exception`` sibling further down. Roll back explicitly
+            # -- matching the same-shaped 404 below and the two later
+            # branches that raise after a write -- so this 404 does not
+            # leave a transaction (and any lock it took) open.
+            db.rollback()
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND, detail="MCP server not found"
             )
@@ -3420,29 +3456,35 @@ def update_mcp_server(
 
         if writes_definition_row:
             # The join gate above ran before the lock statement, and the
-            # lock statement waits. Both things that read established --
+            # lock statement waits. Both inputs to ``can_edit_global`` --
             # that the caller still has a ``UserMCPServer`` link to this
-            # server, and whether that link owns it (``can_edit_global``)
-            # -- were fixed before a wait of unbounded length. A supported
-            # admin user deletion removes association rows and leaves
-            # every definition row standing, and an MCP disconnect removes
-            # the caller's own link while another user's link keeps the
-            # definition alive; either can commit inside the wait. The
-            # request would then write and commit the shared definition
-            # row on a revoked authority, and fail only afterwards, in
-            # ``db.refresh(user_mcp)`` below -- which runs after the
-            # commit, so the generic handler's rollback cannot take the
-            # shared write back and the caller sees a 500 over a durable
-            # change.
+            # server (link ownership), and whether the caller is a platform
+            # admin -- were read from that pre-wait state: the gate's join
+            # for the link, ``current_user`` (built once by the auth
+            # dependency before this route even started) for admin status.
+            # A supported admin user deletion removes association rows and
+            # leaves every definition row standing; a platform admin's own
+            # admin flag can itself be revoked by another admin; an MCP
+            # disconnect removes the caller's own link while another user's
+            # link keeps the definition alive. Any of these can commit
+            # inside the wait. The request would then write and commit the
+            # shared definition row on a revoked authority, and fail only
+            # afterwards, in ``db.refresh(user_mcp)`` below -- which runs
+            # after the commit, so the generic handler's rollback cannot
+            # take the shared write back and the caller sees a 500 over a
+            # durable change.
             #
             # ``populate_existing()`` on the definition query above
-            # refreshes that statement's row and nothing else, so the link
-            # row needs its own statement. This is a single-table read of
-            # it -- the gate above is a two-table join and cannot address
-            # this table alone -- and the row it returns replaces
-            # ``user_mcp`` and re-derives ``can_edit_global`` for the rest
-            # of the route: the per-user env write, the activation write,
-            # the refresh and the response all read it.
+            # refreshes that statement's row and nothing else, so both
+            # inputs need their own fresh single-table reads here -- the
+            # gate above is a two-table join and cannot address either
+            # table alone. The link read below replaces ``user_mcp``; the
+            # admin read further below replaces the value passed into
+            # ``_check_mcp_permission``. Together they re-derive
+            # ``can_edit_global`` for the rest of the route: the per-user
+            # env write, the activation write, the refresh and the response
+            # all read ``user_mcp``, and the owner-only guard below reads
+            # ``can_edit_global``.
             #
             # A gone link is this route's existing 404, matching the gate.
             # A link that is still there but no longer owns the server is
@@ -3461,13 +3503,37 @@ def update_mcp_server(
                 .first()
             )
             if current_user_mcp is None:
+                # Same reasoning as the definition-row 404 above: this read
+                # ran inside the transaction that held the lock, so an
+                # explicit rollback keeps this 404 from leaving that
+                # transaction open for the outer ``except HTTPException``
+                # handler to skip past.
+                db.rollback()
                 raise HTTPException(
                     status_code=status.HTTP_404_NOT_FOUND,
                     detail="MCP server not found",
                 )
             user_mcp = current_user_mcp
+            # ``current_user.is_admin`` is the value the auth dependency's
+            # own read fixed before this route's wait for the lock, same as
+            # ``user_mcp``'s pre-lock read above -- and admin status is
+            # exactly as revocable during that wait as link ownership is
+            # (a supported admin action can strip it from another user
+            # mid-request). The link re-read above already guards its half
+            # of this permission check; this is the other half, re-read the
+            # same way: a fresh single-table lookup of the caller's own row,
+            # not the pre-wait object.
+            current_admin_user = (
+                db.query(User).filter(User.id == user_id).populate_existing().first()
+            )
+            if current_admin_user is None:
+                db.rollback()
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="MCP server not found",
+                )
             can_edit_global = _check_mcp_permission(
-                user_mcp, getattr(current_user, "is_admin", False), require="edit"
+                user_mcp, bool(current_admin_user.is_admin), require="edit"
             )
 
         # Read from the fresh definition-row read above, not the pre-lock
@@ -3520,68 +3586,71 @@ def update_mcp_server(
                     detail=f"MCP server '{server_data.name}' already exists",
                 )
 
-        # Build update config - only include provided fields. Non-owners keep the
-        # existing global config untouched.
-        update_data = MCPServerCreate(
-            name=(server_data.name if can_edit_global else None) or server.name,
-            transport=(server_data.transport if can_edit_global else None)
-            or server.transport,
-            description=server_data.description
-            if can_edit_global and server_data.description is not None
-            else server.description,
-            config=incoming_config,
-            is_active=server_data.is_active
-            if server_data.is_active is not None
-            else user_mcp.is_active,
-        )
-
-        # Build and validate config
-        try:
-            config = _build_server_config(update_data, server)
-            runtime_input_schema = (
-                server_data.runtime_input_schema
-                if can_edit_global and "runtime_input_schema" in fields_set
-                else server.runtime_input_schema
-            )
-            runtime_bindings = (
-                server_data.runtime_bindings
-                if can_edit_global and "runtime_bindings" in fields_set
-                else server.runtime_bindings
-            )
-            allow_delegated_authorization = (
-                bool(server_data.allow_delegated_authorization)
-                if can_edit_global and "allow_delegated_authorization" in fields_set
-                else bool(server.allow_delegated_authorization)
-            )
-            _validate_mcp_runtime_config(
-                runtime_input_schema=runtime_input_schema,
-                runtime_bindings=runtime_bindings,
-                allow_delegated_authorization=allow_delegated_authorization,
-                static_headers=config.headers,
-            )
-        except ValueError as e:
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Invalid configuration: {str(e)}",
+        if writes_definition_row:
+            # Build update config - only include provided fields. Non-owners keep the
+            # existing global config untouched.
+            update_data = MCPServerCreate(
+                name=(server_data.name if can_edit_global else None) or server.name,
+                transport=(server_data.transport if can_edit_global else None)
+                or server.transport,
+                description=server_data.description
+                if can_edit_global and server_data.description is not None
+                else server.description,
+                config=incoming_config,
+                is_active=server_data.is_active
+                if server_data.is_active is not None
+                else user_mcp.is_active,
             )
 
-        # Update server fields (global config; no-op values for non-owners)
-        try:
-            _update_server_from_config(server, config)
-        except ValueError as exc:
-            db.rollback()
-            raise HTTPException(
-                status_code=status.HTTP_400_BAD_REQUEST,
-                detail=f"Invalid environment variables: {exc}",
-            ) from exc
-        if can_edit_global:
-            orm_server = cast(Any, server)
-            if "runtime_input_schema" in fields_set:
-                orm_server.runtime_input_schema = runtime_input_schema
-            if "runtime_bindings" in fields_set:
-                orm_server.runtime_bindings = runtime_bindings
-            if "allow_delegated_authorization" in fields_set:
-                orm_server.allow_delegated_authorization = allow_delegated_authorization
+            # Build and validate config
+            try:
+                config = _build_server_config(update_data, server)
+                runtime_input_schema = (
+                    server_data.runtime_input_schema
+                    if can_edit_global and "runtime_input_schema" in fields_set
+                    else server.runtime_input_schema
+                )
+                runtime_bindings = (
+                    server_data.runtime_bindings
+                    if can_edit_global and "runtime_bindings" in fields_set
+                    else server.runtime_bindings
+                )
+                allow_delegated_authorization = (
+                    bool(server_data.allow_delegated_authorization)
+                    if can_edit_global and "allow_delegated_authorization" in fields_set
+                    else bool(server.allow_delegated_authorization)
+                )
+                _validate_mcp_runtime_config(
+                    runtime_input_schema=runtime_input_schema,
+                    runtime_bindings=runtime_bindings,
+                    allow_delegated_authorization=allow_delegated_authorization,
+                    static_headers=config.headers,
+                )
+            except ValueError as e:
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Invalid configuration: {str(e)}",
+                )
+
+            # Update server fields (global config; no-op values for non-owners)
+            try:
+                _update_server_from_config(server, config)
+            except ValueError as exc:
+                db.rollback()
+                raise HTTPException(
+                    status_code=status.HTTP_400_BAD_REQUEST,
+                    detail=f"Invalid environment variables: {exc}",
+                ) from exc
+            if can_edit_global:
+                orm_server = cast(Any, server)
+                if "runtime_input_schema" in fields_set:
+                    orm_server.runtime_input_schema = runtime_input_schema
+                if "runtime_bindings" in fields_set:
+                    orm_server.runtime_bindings = runtime_bindings
+                if "allow_delegated_authorization" in fields_set:
+                    orm_server.allow_delegated_authorization = (
+                        allow_delegated_authorization
+                    )
 
         # Store this user's per-user env override (masked values keep stored secrets)
         if server_data.user_env is not None:

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -3352,10 +3352,137 @@ def update_mcp_server(
             )
 
         user_mcp, server = result
-        old_name = str(server.name)
         can_edit_global = _check_mcp_permission(
             user_mcp, getattr(current_user, "is_admin", False), require="edit"
         )
+
+        # Which row a request writes decides which row it locks. Seven of the
+        # nine fields of ``MCPServerUpdate`` target the shared ``MCPServer``
+        # definition row; ``is_active`` and ``user_env`` write this caller's
+        # own ``UserMCPServer`` link row and nothing else. Locking the
+        # definition row for a payload that carries only those two made an
+        # activate/deactivate queue behind an unrelated edit of the same
+        # connector -- and, under PostgreSQL REPEATABLE READ, made it fail
+        # outright: the lock statement follows the snapshot the joined read
+        # above already established, so a definition edit committed in between
+        # raises SQLSTATE 40001 and the route's generic handler answers 500
+        # with the requested activation state unwritten.
+        #
+        # ``model_fields_set`` decides this, not the values, because that is
+        # what decides the writes themselves: an explicitly-null
+        # ``runtime_input_schema`` is written to the definition row below even
+        # though its value is ``None``, while an absent field is not written at
+        # all. So a payload carrying ``description=None`` is counted here and
+        # then skipped by the write at its own ``is not None`` guard -- the
+        # lock is taken in a few cases that did not need it, and skipped in
+        # none whose fields target that row.
+        #
+        # One caveat: this set is not a superset of the writes that follow.
+        # ``_update_server_from_config`` below
+        # re-encrypts a global ``env`` or ``auth`` on every call and Fernet
+        # ciphertext differs each time, so on a server carrying one of those
+        # the rebuild still writes the definition row on this lock-free path.
+        # That write is the pre-existing behavior of this route, unchanged
+        # here; the isolation-level contract governing it is tracked in #1945.
+        fields_set = server_data.model_fields_set
+        writes_definition_row = bool(fields_set - {"is_active", "user_env"})
+
+        # A fresh single-table read of the definition row, on both paths. The
+        # read above is a two-table join and cannot itself address just this
+        # table; this is a separate statement, so a row deleted between the two
+        # still yields None here (handled as the same 404) rather than
+        # surfacing as an unrelated error out of the write path below.
+        # ``populate_existing()`` makes this statement's row the one the rest
+        # of this route reads: without it the already-identity-mapped instance
+        # from the join above would be returned unrefreshed, and every field
+        # below would still be that earlier snapshot.
+        #
+        # ``FOR UPDATE`` is added only on the path that writes this row, so a
+        # request that writes it still waits for another request holding it.
+        # That clause is a PostgreSQL/MySQL row lock only: SQLAlchemy renders
+        # no locking clause at all on SQLite, so on a SQLite deployment the
+        # read-modify-write below is not serialized and two concurrent edits of
+        # one server can still interleave. Closing that window needs the
+        # dual-dialect fence ``acquire_runtime_key_transition_fence``
+        # (services/api_keys.py) uses -- a no-op ``UPDATE`` that takes SQLite's
+        # writer lock -- and is left to a change of its own.
+        definition_query = (
+            db.query(MCPServer).filter(MCPServer.id == server_id).populate_existing()
+        )
+        if writes_definition_row:
+            definition_query = definition_query.with_for_update()
+        current_server = definition_query.first()
+        if current_server is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND, detail="MCP server not found"
+            )
+        server = current_server
+
+        if writes_definition_row:
+            # The join gate above ran before the lock statement, and the
+            # lock statement waits. Both things that read established --
+            # that the caller still has a ``UserMCPServer`` link to this
+            # server, and whether that link owns it (``can_edit_global``)
+            # -- were fixed before a wait of unbounded length. A supported
+            # admin user deletion removes association rows and leaves
+            # every definition row standing, and an MCP disconnect removes
+            # the caller's own link while another user's link keeps the
+            # definition alive; either can commit inside the wait. The
+            # request would then write and commit the shared definition
+            # row on a revoked authority, and fail only afterwards, in
+            # ``db.refresh(user_mcp)`` below -- which runs after the
+            # commit, so the generic handler's rollback cannot take the
+            # shared write back and the caller sees a 500 over a durable
+            # change.
+            #
+            # ``populate_existing()`` on the definition query above
+            # refreshes that statement's row and nothing else, so the link
+            # row needs its own statement. This is a single-table read of
+            # it -- the gate above is a two-table join and cannot address
+            # this table alone -- and the row it returns replaces
+            # ``user_mcp`` and re-derives ``can_edit_global`` for the rest
+            # of the route: the per-user env write, the activation write,
+            # the refresh and the response all read it.
+            #
+            # A gone link is this route's existing 404, matching the gate.
+            # A link that is still there but no longer owns the server is
+            # not an error by itself here -- the gate does not refuse a
+            # non-owner either -- so it is answered exactly as the gate
+            # would have answered it: the owner-only guard below rejects a
+            # payload that changes the shared configuration and drops one
+            # that does not.
+            current_user_mcp = (
+                db.query(UserMCPServer)
+                .filter(
+                    UserMCPServer.user_id == user_id,
+                    UserMCPServer.mcpserver_id == server_id,
+                )
+                .populate_existing()
+                .first()
+            )
+            if current_user_mcp is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="MCP server not found",
+                )
+            user_mcp = current_user_mcp
+            can_edit_global = _check_mcp_permission(
+                user_mcp, getattr(current_user, "is_admin", False), require="edit"
+            )
+
+        # Read from the fresh definition-row read above, not the pre-lock
+        # read further up: rename_team_connector's "old" argument must be
+        # the name that read actually returned. On the path that writes
+        # this row, that read is also the locked one, so this is the name
+        # this transaction holds locked -- a concurrent committed rename in
+        # between would otherwise make this stale, and the rewrite below
+        # would then look for a name that no longer exists anywhere,
+        # leaving the previous renamer's selectors dangling with no error.
+        # On the lock-free path this concern does not arise: a payload that
+        # skips the lock never carries ``name`` in ``fields_set``, so
+        # ``old_name`` and the name written back below are always the same
+        # string, and the rename hook below never fires for it.
+        old_name = str(server.name)
 
         # Non-owners may not touch the shared global config (env, command, etc.);
         # they only get to set their own per-user env override below. Reject a
@@ -3411,7 +3538,6 @@ def update_mcp_server(
         # Build and validate config
         try:
             config = _build_server_config(update_data, server)
-            fields_set = server_data.model_fields_set
             runtime_input_schema = (
                 server_data.runtime_input_schema
                 if can_edit_global and "runtime_input_schema" in fields_set

--- a/tests/web/api/test_mcp_server_edit_lock_postgresql.py
+++ b/tests/web/api/test_mcp_server_edit_lock_postgresql.py
@@ -21,9 +21,12 @@ helper the other ``*_postgresql.py`` suites in this repo use, rather than
 opening a hand-rolled connection. That helper reads
 ``XAGENT_TEST_POSTGRES_URL`` and skips the whole module when it is unset.
 
-Also covers the caller's own ``UserMCPServer`` link row being revoked --
-deleted, or stripped of ownership -- by a second connection while the
-route holds the definition row locked.
+Also covers the caller's own permission inputs being revoked by a second
+connection while the route holds the definition row locked: the
+``UserMCPServer`` link row deleted or stripped of ownership, and the
+caller's ``User.is_admin`` flag cleared. Those two values are what
+``_check_mcp_permission`` reads, and the route re-derives both after the
+lock rather than answering from what it read before the wait.
 """
 
 from __future__ import annotations
@@ -576,8 +579,10 @@ def test_a_user_env_only_edit_on_a_server_with_a_global_env_does_not_take_the_lo
     db = rr_factory()
     real_query = db.query
     committed = threading.Event()
+    queried_entities: list[tuple] = []
 
     def commit_a_definition_edit_when_the_definition_query_starts(*entities, **kwargs):
+        queried_entities.append(entities)
         if entities == (MCPServer,) and not committed.is_set():
             committed.set()
             with default_factory() as other:
@@ -601,6 +606,12 @@ def test_a_user_env_only_edit_on_a_server_with_a_global_env_does_not_take_the_lo
         db.close()
 
     assert committed.is_set(), "the concurrent definition edit never ran"
+    assert queried_entities[:2] == [(UserMCPServer, MCPServer), (MCPServer,)], (
+        "the concurrent commit must land after the access read's own read and "
+        "before this route's definition read; otherwise this test is not "
+        "exercising the window it claims to -- saw "
+        f"{queried_entities!r}"
+    )
     assert response is not None
 
     with default_factory() as fresh:
@@ -714,8 +725,10 @@ def test_an_is_active_only_edit_on_a_server_with_concurrent_tools_null_does_not_
     db = rr_factory()
     real_query = db.query
     committed = threading.Event()
+    queried_entities: list[tuple] = []
 
     def commit_a_definition_edit_when_the_definition_query_starts(*entities, **kwargs):
+        queried_entities.append(entities)
         if entities == (MCPServer,) and not committed.is_set():
             committed.set()
             with default_factory() as other:
@@ -739,6 +752,12 @@ def test_an_is_active_only_edit_on_a_server_with_concurrent_tools_null_does_not_
         db.close()
 
     assert committed.is_set(), "the concurrent definition edit never ran"
+    assert queried_entities[:2] == [(UserMCPServer, MCPServer), (MCPServer,)], (
+        "the concurrent commit must land after the access read's own read and "
+        "before this route's definition read; otherwise this test is not "
+        "exercising the window it claims to -- saw "
+        f"{queried_entities!r}"
+    )
     assert response.is_active is False
 
     with default_factory() as fresh:
@@ -833,8 +852,10 @@ def test_a_user_env_only_edit_on_a_server_with_restart_policy_always_does_not_ta
     db = rr_factory()
     real_query = db.query
     committed = threading.Event()
+    queried_entities: list[tuple] = []
 
     def commit_a_definition_edit_when_the_definition_query_starts(*entities, **kwargs):
+        queried_entities.append(entities)
         if entities == (MCPServer,) and not committed.is_set():
             committed.set()
             with default_factory() as other:
@@ -858,6 +879,12 @@ def test_a_user_env_only_edit_on_a_server_with_restart_policy_always_does_not_ta
         db.close()
 
     assert committed.is_set(), "the concurrent definition edit never ran"
+    assert queried_entities[:2] == [(UserMCPServer, MCPServer), (MCPServer,)], (
+        "the concurrent commit must land after the access read's own read and "
+        "before this route's definition read; otherwise this test is not "
+        "exercising the window it claims to -- saw "
+        f"{queried_entities!r}"
+    )
     assert response is not None
 
     with default_factory() as fresh:
@@ -1079,5 +1106,144 @@ def test_a_put_whose_association_is_revoked_after_the_lock_is_refused_with_no_sh
     with session_factory() as fresh:
         row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
         assert row.name == "edit-lock-target", (
+            "the shared definition row must be untouched by a refused edit"
+        )
+
+
+def test_a_put_whose_admin_flag_is_revoked_after_the_lock_is_refused_with_no_shared_write(
+    session_factory,
+) -> None:
+    """The other half of the post-lock permission re-derivation. A caller
+    who is an admin but not the server's owner passes the gate on admin
+    status alone; a second connection can strip that status and commit
+    while this route is still waiting on, or already holding, the
+    definition-row lock. ``_check_mcp_permission`` reads exactly two
+    things -- the link row's ``is_owner`` and the caller's ``is_admin`` --
+    so re-reading only the link row after the lock leaves this half
+    answering from the pre-wait value the auth dependency fixed.
+
+    Both inputs are re-read now, and this pins the second one: a rename
+    from a caller whose admin flag was revoked during the wait must be
+    refused by the route's existing owner-only guard, commit nothing, and
+    leave the shared row's name alone.
+
+    The revocation fires on the route's ``User`` read, which exists only
+    after the lock -- this suite calls the route function directly, so no
+    auth dependency has read a ``User`` on this session beforehand. The
+    recorded sequence is filtered to the four statements under test
+    (``DatabaseMCPServerManager`` may issue queries of its own).
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    with session_factory() as db:
+        owner = User(
+            username="mcp-admin-revoke-owner", password_hash="x", is_admin=False
+        )
+        admin = User(
+            username="mcp-admin-revoke-admin", password_hash="x", is_admin=True
+        )
+        db.add_all([owner, admin])
+        db.flush()
+        server = MCPServer(
+            name="admin-revoke-target",
+            transport="stdio",
+            managed="external",
+            command="true",
+            concurrent_tools=[],
+        )
+        db.add(server)
+        db.flush()
+        db.add_all(
+            [
+                UserMCPServer(
+                    user_id=int(owner.id),
+                    mcpserver_id=int(server.id),
+                    is_owner=True,
+                    is_active=True,
+                ),
+                # The admin's own link row: not the owner. Before the
+                # revocation their edit rights come from ``is_admin``
+                # alone, which is exactly the value under test.
+                UserMCPServer(
+                    user_id=int(admin.id),
+                    mcpserver_id=int(server.id),
+                    is_owner=False,
+                    is_active=True,
+                ),
+            ]
+        )
+        db.commit()
+        admin_id, server_id = int(admin.id), int(server.id)
+
+    current_user = SimpleNamespace(id=admin_id, is_admin=True)
+
+    db = session_factory()
+    real_query = db.query
+    real_commit = db.commit
+    revoked_already = threading.Event()
+    queried_entities: list[tuple] = []
+    tracked_keys = {
+        (UserMCPServer, MCPServer),
+        (MCPServer,),
+        (UserMCPServer,),
+        (User,),
+    }
+    commits: list[str] = []
+
+    def revoke_admin_when_the_admin_read_starts(*entities, **kwargs):
+        if entities in tracked_keys:
+            queried_entities.append(entities)
+        if entities == (User,) and not revoked_already.is_set():
+            revoked_already.set()
+            with session_factory() as other:
+                other.execute(
+                    sa.update(User).where(User.id == admin_id).values(is_admin=False)
+                )
+                other.commit()
+        return real_query(*entities, **kwargs)
+
+    def record_commit():
+        commits.append("commit")
+        return real_commit()
+
+    db.query = revoke_admin_when_the_admin_read_starts
+    db.commit = record_commit
+    try:
+        with pytest.raises(HTTPException) as exc:
+            mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(name="renamed-after-admin-revocation"),
+                current_user=current_user,
+                db=db,
+            )
+        assert exc.value.status_code == 403
+        assert revoked_already.is_set(), "the concurrent revocation never ran"
+        assert queried_entities[:4] == [
+            (UserMCPServer, MCPServer),
+            (MCPServer,),
+            (UserMCPServer,),
+            (User,),
+        ], (
+            "the concurrent revocation must land after the gate's own read, "
+            "after the lock statement and after the link re-read, and be "
+            "caught by the admin re-read that follows them -- otherwise the "
+            "403 under test could be the gate's rather than the re-read's -- "
+            f"saw {queried_entities!r}"
+        )
+        assert (
+            exc.value.detail
+            == "Only the server owner can change the shared configuration"
+        ), (
+            "the refusal must come from the route's existing owner-only "
+            f"guard, not a new error shape -- saw {exc.value.detail!r}"
+        )
+        assert commits == [], "the refused edit must commit nothing"
+    finally:
+        db.close()
+
+    with session_factory() as fresh:
+        row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+        assert row.name == "admin-revoke-target", (
             "the shared definition row must be untouched by a refused edit"
         )

--- a/tests/web/api/test_mcp_server_edit_lock_postgresql.py
+++ b/tests/web/api/test_mcp_server_edit_lock_postgresql.py
@@ -23,14 +23,21 @@ opening a hand-rolled connection. That helper reads
 
 Also covers the caller's own permission inputs being revoked by a second
 connection while the route holds the definition row locked: the
-``UserMCPServer`` link row deleted or stripped of ownership, and the
-caller's ``User.is_admin`` flag cleared. Those two values are what
-``_check_mcp_permission`` reads, and the route re-derives both after the
-lock rather than answering from what it read before the wait.
+``UserMCPServer`` link row deleted or stripped of ownership, the caller's
+``User`` row deleted outright, and the caller's ``User.is_admin`` flag
+cleared. Those values are what ``_check_mcp_permission`` reads, and the
+route re-derives them after the lock rather than answering from what it
+read before the wait.
+
+Finally, it reads back the SQL the engine actually executed, so the lock
+statement's rendered strength (``FOR NO KEY UPDATE``, not plain ``FOR
+UPDATE``) is pinned as text rather than inferred from the keyword argument
+that asks for it.
 """
 
 from __future__ import annotations
 
+import contextlib
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
@@ -225,12 +232,17 @@ def test_a_second_editor_blocks_until_the_first_editors_transaction_finishes(
             # on the database at this point. If the lock were not real (or
             # a no-op, as on SQLite), the second call would sail through
             # almost immediately and this would flip to True.
-            assert not second_finished.wait(timeout=1.0), (
-                "the second editor finished before the first one released "
-                "the row -- the lock did not actually block it"
-            )
-
-            release_lock.set()
+            try:
+                assert not second_finished.wait(timeout=1.0), (
+                    "the second editor finished before the first one released "
+                    "the row -- the lock did not actually block it"
+                )
+            finally:
+                # Released even when the assertion above fails: the first
+                # editor is parked on ``release_lock.wait(timeout=10)``, so
+                # a bare ``set()`` after the assert would make every failure
+                # of this test also spend that full timeout before reporting.
+                release_lock.set()
             first.result(timeout=10)
             second.result(timeout=10)
 
@@ -341,11 +353,15 @@ def test_the_second_editors_rename_reports_the_first_editors_committed_name_as_o
             )
 
             second = executor.submit(run_second)
-            assert not second_finished.wait(timeout=1.0), (
-                "the second editor finished before the first one released the row"
-            )
-
-            release_lock.set()
+            try:
+                assert not second_finished.wait(timeout=1.0), (
+                    "the second editor finished before the first one released the row"
+                )
+            finally:
+                # Same reason as the test above: release the parked first
+                # editor even on an assertion failure, so a failure reports
+                # immediately instead of after its 10-second wait.
+                release_lock.set()
             first.result(timeout=10)
             second.result(timeout=10)
 
@@ -1247,3 +1263,392 @@ def test_a_put_whose_admin_flag_is_revoked_after_the_lock_is_refused_with_no_sha
         assert row.name == "admin-revoke-target", (
             "the shared definition row must be untouched by a refused edit"
         )
+
+
+@contextlib.contextmanager
+def _captured_sql(session_factory):
+    """Every SQL statement the engine behind ``session_factory`` sends to
+    the server while this context is open, as the raw strings the driver
+    received.
+
+    The lock this suite exists for is one clause on one SELECT. Every
+    other test here infers it from behavior (a second writer blocks, a
+    serialization failure does or does not happen); this reads the clause
+    itself, which is the only way to tell ``FOR NO KEY UPDATE`` from the
+    plain ``FOR UPDATE`` that would block a concurrent connect.
+    """
+    engine = session_factory.kw["bind"]
+    statements: list[str] = []
+
+    def record(_conn, _cursor, statement, _parameters, _context, _executemany):
+        statements.append(statement)
+
+    sa.event.listen(engine, "before_cursor_execute", record)
+    try:
+        yield statements
+    finally:
+        sa.event.remove(engine, "before_cursor_execute", record)
+
+
+def _locking_reads(statements: list[str]) -> tuple[list[str], list[str]]:
+    """The captured statements that take a weak row lock, and those that
+    take the strong one -- ``FOR NO KEY UPDATE`` does not contain the
+    substring ``FOR UPDATE``, so the two lists never overlap."""
+    weak = [text for text in statements if "FOR NO KEY UPDATE" in text]
+    strong = [text for text in statements if "FOR UPDATE" in text]
+    return weak, strong
+
+
+def test_the_definition_row_read_renders_for_no_key_update(
+    session_factory, seeded
+) -> None:
+    """``with_for_update(key_share=True)`` must reach PostgreSQL as ``FOR NO
+    KEY UPDATE``.
+
+    That strength is load-bearing, not cosmetic: ``FOR KEY SHARE`` -- the
+    lock a concurrent ``UserMCPServer`` insert takes on the ``MCPServer``
+    row it references -- is compatible with ``FOR NO KEY UPDATE`` and not
+    with plain ``FOR UPDATE``, so rendering the stronger clause would make
+    an unrelated connect queue behind an edit. Dropping ``key_share=True``
+    turns this red.
+
+    The lock-free half of the same assertion is here too: a payload that
+    writes only the caller's own link row must send no locking clause at
+    all.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    owner_id, server_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    with _captured_sql(session_factory) as statements:
+        with session_factory() as db:
+            mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(description="edited-under-a-captured-lock"),
+                current_user=current_user,
+                db=db,
+            )
+    weak, strong = _locking_reads(statements)
+    assert len(weak) == 1, (
+        "a definition-row edit must send exactly one FOR NO KEY UPDATE read "
+        f"-- saw {weak!r}"
+    )
+    assert "mcp_servers" in weak[0], (
+        f"the locking read must be the definition-row read -- saw {weak[0]!r}"
+    )
+    assert strong == [], (
+        "plain FOR UPDATE would block a concurrent connect or disconnect on "
+        f"this server -- saw {strong!r}"
+    )
+
+    with _captured_sql(session_factory) as statements:
+        with session_factory() as db:
+            mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(is_active=False),
+                current_user=current_user,
+                db=db,
+            )
+    weak, strong = _locking_reads(statements)
+    assert weak == [] and strong == [], (
+        "a payload that writes only the caller's own link row must take no "
+        f"lock on the shared definition row -- saw {weak!r} {strong!r}"
+    )
+
+
+def test_a_non_owner_edit_naming_a_definition_field_locks_and_drops_it(
+    session_factory, seeded
+) -> None:
+    """A non-owner PUT that names a definition-row field takes the lock and
+    is answered by value: identical to what is stored, it is dropped and
+    the request succeeds; different, it is refused with 403. Either way the
+    shared row's own values are what they were.
+
+    The identical-value half is the path with no other coverage: it is the
+    only way to reach the full config rebuild as a caller who is not
+    allowed to change anything, because ``_global_config_tampered``
+    compares values and finds nothing changed. Removing the 403 raise turns
+    the second half red.
+
+    "The shared row's values are unchanged" is the claim here, not "no
+    UPDATE was emitted" -- the rebuild still runs on this path, and the
+    ``to_config_dict()`` flattening it goes through (#2088) remains
+    reachable for row shapes this seed does not carry.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    _owner_id, server_id = seeded
+    with session_factory() as db:
+        db.execute(
+            sa.update(MCPServer)
+            .where(MCPServer.id == server_id)
+            .values(concurrent_tools=[])
+        )
+        guest = User(username="mcp-edit-lock-guest", password_hash="x", is_admin=False)
+        db.add(guest)
+        db.flush()
+        db.add(
+            UserMCPServer(
+                user_id=int(guest.id),
+                mcpserver_id=server_id,
+                is_owner=False,
+                is_active=True,
+            )
+        )
+        db.commit()
+        guest_id = int(guest.id)
+        stored = db.query(MCPServer).filter(MCPServer.id == server_id).one()
+        stored_values = (
+            stored.name,
+            stored.transport,
+            stored.description,
+            stored.command,
+            stored.env,
+        )
+    guest_user = SimpleNamespace(id=guest_id, is_admin=False)
+
+    def read_back_shared_values():
+        with session_factory() as fresh:
+            row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+            return (row.name, row.transport, row.description, row.command, row.env)
+
+    with _captured_sql(session_factory) as statements:
+        with session_factory() as db:
+            response = mcp_api.update_mcp_server(
+                server_id,
+                # Exactly what the row already stores, so nothing counts as
+                # tampered and the payload is dropped rather than refused.
+                MCPServerUpdate(config={"command": "true"}),
+                current_user=guest_user,
+                db=db,
+            )
+    assert response.can_edit_global is False
+    weak, strong = _locking_reads(statements)
+    assert len(weak) == 1 and strong == [], (
+        "naming a definition-row field puts the request on the locking path "
+        f"whatever its values are -- saw {weak!r} {strong!r}"
+    )
+    assert read_back_shared_values() == stored_values, (
+        "a non-owner's value-identical payload must leave the shared row as it was"
+    )
+
+    with session_factory() as db:
+        with pytest.raises(HTTPException) as raised:
+            mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(config={"command": "hijacked"}),
+                current_user=guest_user,
+                db=db,
+            )
+    assert raised.value.status_code == 403
+    assert read_back_shared_values() == stored_values, (
+        "a refused non-owner payload must leave the shared row as it was"
+    )
+
+
+def test_a_put_whose_caller_account_is_deleted_after_the_lock_is_refused(
+    session_factory, seeded
+) -> None:
+    """The caller's own ``User`` row deleted inside the lock wait.
+
+    Reachable exactly here and nowhere earlier: deleting the user cascades
+    to that user's ``UserMCPServer`` rows, so the link re-read has to have
+    already run for this branch to see a link and no user. This test
+    commits the delete from a second connection at the moment the route
+    issues its admin re-read, which is the one statement between the two.
+
+    The answer must name the object that actually went missing -- the
+    caller's account, not the server, which is still there. Deleting the
+    ``current_admin_user is None`` branch turns this red: the next line
+    reads ``.is_admin`` off ``None`` and the route answers 500.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    owner_id, server_id = seeded
+    db = session_factory()
+    real_query = db.query
+    deleted = threading.Event()
+
+    def delete_the_caller_when_the_admin_read_starts(*entities, **kwargs):
+        if entities == (User,) and not deleted.is_set():
+            deleted.set()
+            with session_factory() as other:
+                other.execute(sa.delete(User).where(User.id == owner_id))
+                other.commit()
+        return real_query(*entities, **kwargs)
+
+    db.query = delete_the_caller_when_the_admin_read_starts
+    try:
+        with pytest.raises(HTTPException) as raised:
+            mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(description="written-by-a-deleted-account"),
+                current_user=SimpleNamespace(id=owner_id, is_admin=False),
+                db=db,
+            )
+    finally:
+        db.close()
+
+    assert deleted.is_set(), "the caller's account was never deleted"
+    assert raised.value.status_code == 404
+    assert raised.value.detail == "Requesting user account no longer exists", (
+        "this 404 must name the caller's account, not the server -- the "
+        f"server row is still there; saw {raised.value.detail!r}"
+    )
+
+    with session_factory() as fresh:
+        row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+        assert row.description is None, (
+            "a request refused after the lock must leave the shared row unwritten"
+        )
+
+
+def test_a_link_row_only_edit_is_not_refused_over_invalid_stored_shared_config(
+    session_factory, seeded
+) -> None:
+    """Runtime-config validation belongs to the definition-row write, not to
+    every PUT.
+
+    A stored ``runtime_bindings`` value can be invalid against the row's
+    own ``runtime_input_schema`` -- an earlier schema edit, an import, a
+    validator that has since grown a rule. While the route validated that
+    stored value on every payload, such a row could be neither used nor
+    switched off: activating or deactivating it, which writes only the
+    caller's own link row, was refused over shared configuration the
+    request does not touch. Both directions are pinned here, because the
+    fix is to move the validation, not to drop it: a payload that does
+    write the definition row is still refused.
+
+    Moving the validation call back outside ``if writes_definition_row:``
+    turns the first half red.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    owner_id, server_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+    # Declared nowhere in runtime_input_schema (which stays NULL), so the
+    # validator rejects it as an undeclared binding source.
+    invalid_bindings = [
+        {
+            "source": {"input_type": "context", "key": "undeclared"},
+            "target": {"target_type": "header", "key": "X-Undeclared"},
+        }
+    ]
+    with session_factory() as db:
+        db.execute(
+            sa.update(MCPServer)
+            .where(MCPServer.id == server_id)
+            .values(concurrent_tools=[], runtime_bindings=invalid_bindings)
+        )
+        db.commit()
+
+    with session_factory() as db:
+        response = mcp_api.update_mcp_server(
+            server_id,
+            MCPServerUpdate(is_active=False),
+            current_user=current_user,
+            db=db,
+        )
+    assert response.is_active is False, (
+        "deactivating a connector writes the caller's own link row; stored "
+        "shared configuration it does not touch must not refuse it"
+    )
+
+    with session_factory() as db:
+        with pytest.raises(HTTPException) as raised:
+            mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(description="edited-over-invalid-stored-config"),
+                current_user=current_user,
+                db=db,
+            )
+    assert raised.value.status_code == 400
+    assert "not declared" in str(raised.value.detail), (
+        "a payload that does write the definition row must still be "
+        f"validated -- saw {raised.value.detail!r}"
+    )
+
+    with session_factory() as fresh:
+        row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+        assert row.description is None
+        assert (
+            fresh.query(UserMCPServer)
+            .filter(
+                UserMCPServer.mcpserver_id == server_id,
+                UserMCPServer.user_id == owner_id,
+            )
+            .one()
+            .is_active
+            is False
+        )
+
+
+def test_a_link_row_only_edit_reports_the_stored_restart_policy_of_an_internal_row(
+    session_factory,
+) -> None:
+    """The response body on the lock-free path reports the row as stored.
+
+    A ``managed="internal"`` row is the shape that makes this visible in
+    the response at all: ``to_config_dict()`` emits ``restart_policy`` only
+    for those rows, so an ``external`` row's overwritten value shows up in
+    the database and not in the JSON. Running the rebuild here rewrites
+    ``managed`` to ``"external"`` -- ``_build_server_config`` hardcodes that
+    value -- and ``to_config_dict()`` then stops emitting ``restart_policy``
+    at all, so the field disappears from the response entirely rather than
+    coming back with the config default. Removing the
+    ``if writes_definition_row:`` guard on the rebuild turns this red with
+    exactly that ``KeyError``.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    with session_factory() as db:
+        owner = User(
+            username="mcp-internal-restart-owner", password_hash="x", is_admin=False
+        )
+        db.add(owner)
+        db.flush()
+        server = MCPServer(
+            name="internal-restart-target",
+            transport="stdio",
+            managed="internal",
+            command="true",
+            concurrent_tools=[],
+            restart_policy="always",
+        )
+        db.add(server)
+        db.flush()
+        db.add(
+            UserMCPServer(
+                user_id=int(owner.id),
+                mcpserver_id=int(server.id),
+                is_owner=True,
+                is_active=True,
+            )
+        )
+        db.commit()
+        owner_id, server_id = int(owner.id), int(server.id)
+
+    with session_factory() as db:
+        response = mcp_api.update_mcp_server(
+            server_id,
+            MCPServerUpdate(user_env={"MINE": "x"}),
+            current_user=SimpleNamespace(id=owner_id, is_admin=False),
+            db=db,
+        )
+
+    assert response.config["restart_policy"] == "always", (
+        "the response must report the stored restart_policy, not the config "
+        f"default the rebuild would substitute -- saw {response.config!r}"
+    )
+    assert response.config["managed"] == "internal"
+
+    with session_factory() as fresh:
+        row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+        assert row.restart_policy == "always"
+        assert row.managed == "internal"

--- a/tests/web/api/test_mcp_server_edit_lock_postgresql.py
+++ b/tests/web/api/test_mcp_server_edit_lock_postgresql.py
@@ -1,14 +1,12 @@
 """Real-PostgreSQL coverage for the row lock ``update_mcp_server`` takes on
 the ``MCPServer`` definition row before building the new config -- and, for
 the payloads that must *not* take it: a PUT that sets only ``is_active``
-and/or ``user_env`` writes the caller's own ``UserMCPServer`` link row. On
-a server carrying no global ``env`` or ``auth`` the rebuild writes nothing
-back to the definition row, so it reads that row without locking it (a
-server with a global ``env`` or ``auth`` still gets its re-encrypted
-secret written back on this path -- pre-existing behavior, tracked in
-#1945). Under PostgreSQL REPEATABLE READ that distinction is the
-difference between HTTP 200 and a serialization failure surfacing as
-HTTP 500.
+and/or ``user_env`` writes the caller's own ``UserMCPServer`` link row and
+never runs the config rebuild at all, regardless of what the row it reads
+carries -- a server with a global ``env`` or ``auth`` gets no re-encrypted
+secret written back on this path either. Under PostgreSQL REPEATABLE READ,
+locking a row this payload never writes is the difference between HTTP 200
+and a serialization failure surfacing as HTTP 500.
 
 ``FOR UPDATE`` is a no-op on SQLite -- every other suite in this repo runs
 against SQLite, so nothing there can tell a genuine second-writer block
@@ -404,8 +402,10 @@ def test_a_row_that_vanishes_after_the_gate_but_before_the_lock_is_a_404_not_a_5
     db = session_factory()
     real_query = db.query
     deleted_already = threading.Event()
+    queried_entities: list[tuple] = []
 
     def delete_the_row_when_the_lock_query_starts(*entities, **kwargs):
+        queried_entities.append(entities)
         if entities == (MCPServer,) and not deleted_already.is_set():
             deleted_already.set()
             with session_factory() as other:
@@ -429,6 +429,12 @@ def test_a_row_that_vanishes_after_the_gate_but_before_the_lock_is_a_404_not_a_5
             )
         assert deleted_already.is_set(), "the concurrent delete never ran"
         assert exc.value.status_code == 404
+        assert queried_entities[:2] == [(UserMCPServer, MCPServer), (MCPServer,)], (
+            "the concurrent delete must land after the access read's own "
+            "read and before this route's definition read; otherwise this "
+            "404 could be the gate's rather than the lock query's own "
+            f"empty result -- saw {queried_entities!r}"
+        )
     finally:
         db.close()
 
@@ -508,6 +514,398 @@ def test_an_activation_only_edit_survives_a_concurrent_definition_commit_under_r
         assert (
             fresh.query(MCPServer).filter(MCPServer.id == server_id).one().description
             == "edited-by-the-concurrent-definition-editor"
+        )
+
+
+def test_a_user_env_only_edit_on_a_server_with_a_global_env_does_not_take_the_lock(
+    repeatable_read_sessions,
+) -> None:
+    """A payload that sets only ``user_env`` writes this caller's own
+    ``UserMCPServer`` link row, even when the shared server it targets
+    carries a global ``env``. Before the fix this route rebuilds, this row
+    shape is exactly the one the reviewer's finding was about: the config
+    rebuild decrypts the definition row's ``env``, then encrypts it again
+    on the way back out, and Fernet ciphertext differs on every call even
+    when the plaintext does not -- so the lock-free path still wrote this
+    row, unlocked. After the fix the rebuild does not run at all on this
+    path, so the stored ciphertext must come back byte-for-byte identical.
+
+    Proves the lock is not taken the same way the activation-only test
+    above does: a concurrent definition-row commit lands strictly between
+    this route's access read and its definition-row read, and under
+    REPEATABLE READ that commit is invisible to a plain read but forces a
+    locking read (``FOR ... UPDATE``) to fail with SQLSTATE 40001. This
+    request surviving with HTTP 200 is what shows no locking read ran --
+    the concurrent commit is itself a real definition-row write (to
+    ``description``, a column this test does not otherwise touch), so it
+    is expected to move the row's own ``updated_at``; the companion test
+    below covers that assertion for a request with no concurrent editor
+    to confuse it.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.core.utils.encryption import encrypt_env_dict
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    default_factory, rr_factory = repeatable_read_sessions
+    stored_env = encrypt_env_dict({"K": "v"})
+    with default_factory() as db:
+        owner = User(username="mcp-env-only-owner", password_hash="x", is_admin=False)
+        db.add(owner)
+        db.flush()
+        server = MCPServer(
+            name="env-only-target",
+            transport="stdio",
+            managed="external",
+            command="true",
+            concurrent_tools=[],
+            env=stored_env,
+        )
+        db.add(server)
+        db.flush()
+        db.add(
+            UserMCPServer(
+                user_id=int(owner.id),
+                mcpserver_id=int(server.id),
+                is_owner=True,
+                is_active=True,
+            )
+        )
+        db.commit()
+        owner_id, server_id = int(owner.id), int(server.id)
+
+    db = rr_factory()
+    real_query = db.query
+    committed = threading.Event()
+
+    def commit_a_definition_edit_when_the_definition_query_starts(*entities, **kwargs):
+        if entities == (MCPServer,) and not committed.is_set():
+            committed.set()
+            with default_factory() as other:
+                other.execute(
+                    sa.update(MCPServer)
+                    .where(MCPServer.id == server_id)
+                    .values(description="edited-by-the-concurrent-definition-editor")
+                )
+                other.commit()
+        return real_query(*entities, **kwargs)
+
+    db.query = commit_a_definition_edit_when_the_definition_query_starts
+    try:
+        response = mcp_api.update_mcp_server(
+            server_id,
+            MCPServerUpdate(user_env={"MINE": "x"}),
+            current_user=SimpleNamespace(id=owner_id, is_admin=False),
+            db=db,
+        )
+    finally:
+        db.close()
+
+    assert committed.is_set(), "the concurrent definition edit never ran"
+    assert response is not None
+
+    with default_factory() as fresh:
+        row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+        assert row.env == stored_env, (
+            "the shared definition row's env must be untouched byte-for-byte "
+            "by a request that only sets user_env -- a changed value here "
+            "means the config rebuild ran (and re-encrypted it) on a path "
+            "that must not run it at all"
+        )
+        assert row.description == "edited-by-the-concurrent-definition-editor", (
+            "the concurrent definition edit must have actually landed, or "
+            "this test proves nothing about interleaving"
+        )
+
+
+def test_a_user_env_only_edit_on_a_server_with_a_global_env_leaves_it_and_updated_at_untouched(
+    session_factory, seeded
+) -> None:
+    """The single-request counterpart to the concurrency test above, with
+    no concurrent editor to also move ``updated_at``: a payload that sets
+    only ``user_env`` on a server carrying a global ``env`` must leave that
+    ``env`` value AND the row's ``updated_at`` exactly as they were --
+    nothing in this request has any business touching either.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.core.utils.encryption import encrypt_env_dict
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    owner_id, server_id = seeded
+    stored_env = encrypt_env_dict({"K": "v"})
+    with session_factory() as db:
+        db.execute(
+            sa.update(MCPServer)
+            .where(MCPServer.id == server_id)
+            .values(env=stored_env, concurrent_tools=[])
+        )
+        db.commit()
+        original_updated_at = (
+            db.query(MCPServer).filter(MCPServer.id == server_id).one().updated_at
+        )
+
+    with session_factory() as db:
+        response = mcp_api.update_mcp_server(
+            server_id,
+            MCPServerUpdate(user_env={"MINE": "x"}),
+            current_user=SimpleNamespace(id=owner_id, is_admin=False),
+            db=db,
+        )
+    assert response is not None
+
+    with session_factory() as fresh:
+        row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+        assert row.env == stored_env, (
+            "env must be untouched byte-for-byte by a user_env-only request"
+        )
+        assert row.updated_at == original_updated_at, (
+            "a request that writes only the caller's own link row must not "
+            "move the shared definition row's updated_at"
+        )
+
+
+def test_an_is_active_only_edit_on_a_server_with_concurrent_tools_null_does_not_take_the_lock(
+    repeatable_read_sessions,
+) -> None:
+    """Same shape as the global-``env`` case above, for the other row shape
+    the reviewer's finding covers: a pre-migration row whose
+    ``concurrent_tools`` column is still ``NULL`` (the
+    ``20260624_add_mcp_concurrency_config`` migration added the column with
+    no ``server_default`` and no backfill). Before the fix, the config
+    rebuild normalizes a ``NULL`` ``concurrent_tools`` to ``[]`` and writes
+    it back even on the lock-free path; after the fix the rebuild does not
+    run, so the column must still read ``NULL``. See the companion test
+    below for the ``updated_at``-unchanged assertion this test's concurrent
+    editor (a real definition-row write of its own) would otherwise
+    confuse.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    default_factory, rr_factory = repeatable_read_sessions
+    with default_factory() as db:
+        owner = User(
+            username="mcp-ctnull-only-owner", password_hash="x", is_admin=False
+        )
+        db.add(owner)
+        db.flush()
+        server = MCPServer(
+            name="ctnull-only-target",
+            transport="stdio",
+            managed="external",
+            command="true",
+        )
+        db.add(server)
+        db.flush()
+        assert server.concurrent_tools is None, (
+            "this test depends on a hand-built row leaving concurrent_tools "
+            "NULL, the way a pre-migration row does"
+        )
+        db.add(
+            UserMCPServer(
+                user_id=int(owner.id),
+                mcpserver_id=int(server.id),
+                is_owner=True,
+                is_active=True,
+            )
+        )
+        db.commit()
+        owner_id, server_id = int(owner.id), int(server.id)
+
+    db = rr_factory()
+    real_query = db.query
+    committed = threading.Event()
+
+    def commit_a_definition_edit_when_the_definition_query_starts(*entities, **kwargs):
+        if entities == (MCPServer,) and not committed.is_set():
+            committed.set()
+            with default_factory() as other:
+                other.execute(
+                    sa.update(MCPServer)
+                    .where(MCPServer.id == server_id)
+                    .values(description="edited-by-the-concurrent-definition-editor")
+                )
+                other.commit()
+        return real_query(*entities, **kwargs)
+
+    db.query = commit_a_definition_edit_when_the_definition_query_starts
+    try:
+        response = mcp_api.update_mcp_server(
+            server_id,
+            MCPServerUpdate(is_active=False),
+            current_user=SimpleNamespace(id=owner_id, is_admin=False),
+            db=db,
+        )
+    finally:
+        db.close()
+
+    assert committed.is_set(), "the concurrent definition edit never ran"
+    assert response.is_active is False
+
+    with default_factory() as fresh:
+        row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+        assert row.concurrent_tools is None, (
+            "an is_active-only request must not normalize this row's NULL "
+            "concurrent_tools to [] -- that write means the config rebuild "
+            "ran on a path that must not run it at all"
+        )
+        assert row.description == "edited-by-the-concurrent-definition-editor", (
+            "the concurrent definition edit must have actually landed, or "
+            "this test proves nothing about interleaving"
+        )
+
+
+def test_an_is_active_only_edit_on_a_server_with_concurrent_tools_null_stays_null(
+    session_factory, seeded
+) -> None:
+    """The single-request counterpart to the concurrency test above: an
+    ``is_active``-only payload against a row whose ``concurrent_tools`` is
+    still ``NULL`` must leave it ``NULL``, not normalize it to ``[]``."""
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    owner_id, server_id = seeded
+    with session_factory() as db:
+        assert (
+            db.query(MCPServer).filter(MCPServer.id == server_id).one().concurrent_tools
+            is None
+        ), "the seeded fixture's row must leave concurrent_tools NULL"
+
+    with session_factory() as db:
+        response = mcp_api.update_mcp_server(
+            server_id,
+            MCPServerUpdate(is_active=False),
+            current_user=SimpleNamespace(id=owner_id, is_admin=False),
+            db=db,
+        )
+    assert response.is_active is False
+
+    with session_factory() as fresh:
+        row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+        assert row.concurrent_tools is None, (
+            "an is_active-only request must not normalize a NULL concurrent_tools to []"
+        )
+
+
+def test_a_user_env_only_edit_on_a_server_with_restart_policy_always_does_not_take_the_lock(
+    repeatable_read_sessions,
+) -> None:
+    """Same shape again, for the third row form the reviewer's finding
+    covers: a ``restart_policy`` other than the config default. Before the
+    fix, ``_build_server_config``'s round trip through ``to_config_dict()``
+    only emits ``restart_policy`` for a ``managed="internal"`` row, so an
+    ``external`` row's real ``"always"`` reads back as the config default
+    ``"no"`` and gets written onto the row on the lock-free path -- silently
+    turning off a connector's configured auto-restart on an unrelated
+    per-user env edit. After the fix the rebuild does not run, so the
+    column must still read ``"always"``.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    default_factory, rr_factory = repeatable_read_sessions
+    with default_factory() as db:
+        owner = User(
+            username="mcp-restart-only-owner", password_hash="x", is_admin=False
+        )
+        db.add(owner)
+        db.flush()
+        server = MCPServer(
+            name="restart-only-target",
+            transport="stdio",
+            managed="external",
+            command="true",
+            concurrent_tools=[],
+            restart_policy="always",
+        )
+        db.add(server)
+        db.flush()
+        db.add(
+            UserMCPServer(
+                user_id=int(owner.id),
+                mcpserver_id=int(server.id),
+                is_owner=True,
+                is_active=True,
+            )
+        )
+        db.commit()
+        owner_id, server_id = int(owner.id), int(server.id)
+
+    db = rr_factory()
+    real_query = db.query
+    committed = threading.Event()
+
+    def commit_a_definition_edit_when_the_definition_query_starts(*entities, **kwargs):
+        if entities == (MCPServer,) and not committed.is_set():
+            committed.set()
+            with default_factory() as other:
+                other.execute(
+                    sa.update(MCPServer)
+                    .where(MCPServer.id == server_id)
+                    .values(description="edited-by-the-concurrent-definition-editor")
+                )
+                other.commit()
+        return real_query(*entities, **kwargs)
+
+    db.query = commit_a_definition_edit_when_the_definition_query_starts
+    try:
+        response = mcp_api.update_mcp_server(
+            server_id,
+            MCPServerUpdate(user_env={"MINE": "x"}),
+            current_user=SimpleNamespace(id=owner_id, is_admin=False),
+            db=db,
+        )
+    finally:
+        db.close()
+
+    assert committed.is_set(), "the concurrent definition edit never ran"
+    assert response is not None
+
+    with default_factory() as fresh:
+        row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+        assert row.restart_policy == "always", (
+            "a user_env-only request must not overwrite this row's "
+            "restart_policy with the config default -- that write means "
+            "the config rebuild ran on a path that must not run it at all"
+        )
+        assert row.description == "edited-by-the-concurrent-definition-editor", (
+            "the concurrent definition edit must have actually landed, or "
+            "this test proves nothing about interleaving"
+        )
+
+
+def test_a_user_env_only_edit_on_a_server_with_restart_policy_always_leaves_it_untouched(
+    session_factory, seeded
+) -> None:
+    """The single-request counterpart to the concurrency test above: a
+    ``user_env``-only payload against a row with ``restart_policy="always"``
+    must leave that value alone, not overwrite it with the config
+    default (``"no"``)."""
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    owner_id, server_id = seeded
+    with session_factory() as db:
+        db.execute(
+            sa.update(MCPServer)
+            .where(MCPServer.id == server_id)
+            .values(restart_policy="always", concurrent_tools=[])
+        )
+        db.commit()
+
+    with session_factory() as db:
+        response = mcp_api.update_mcp_server(
+            server_id,
+            MCPServerUpdate(user_env={"MINE": "x"}),
+            current_user=SimpleNamespace(id=owner_id, is_admin=False),
+            db=db,
+        )
+    assert response is not None
+
+    with session_factory() as fresh:
+        row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+        assert row.restart_policy == "always", (
+            "a user_env-only request must not overwrite restart_policy "
+            "with the config default"
         )
 
 

--- a/tests/web/api/test_mcp_server_edit_lock_postgresql.py
+++ b/tests/web/api/test_mcp_server_edit_lock_postgresql.py
@@ -1,0 +1,685 @@
+"""Real-PostgreSQL coverage for the row lock ``update_mcp_server`` takes on
+the ``MCPServer`` definition row before building the new config -- and, for
+the payloads that must *not* take it: a PUT that sets only ``is_active``
+and/or ``user_env`` writes the caller's own ``UserMCPServer`` link row. On
+a server carrying no global ``env`` or ``auth`` the rebuild writes nothing
+back to the definition row, so it reads that row without locking it (a
+server with a global ``env`` or ``auth`` still gets its re-encrypted
+secret written back on this path -- pre-existing behavior, tracked in
+#1945). Under PostgreSQL REPEATABLE READ that distinction is the
+difference between HTTP 200 and a serialization failure surfacing as
+HTTP 500.
+
+``FOR UPDATE`` is a no-op on SQLite -- every other suite in this repo runs
+against SQLite, so nothing there can tell a genuine second-writer block
+from a lock statement that silently does nothing. This file is the one
+place that runs the real statement against a real server and proves it
+actually blocks a second writer, plus the companion path where the row
+vanishes between the route's first read and this lock.
+
+Obtains its database through ``tests/shared/postgres_disposable.py``
+(``disposable_database_factory``), the same disposable-CREATE-DATABASE
+helper the other ``*_postgresql.py`` suites in this repo use, rather than
+opening a hand-rolled connection. That helper reads
+``XAGENT_TEST_POSTGRES_URL`` and skips the whole module when it is unset.
+
+Also covers the caller's own ``UserMCPServer`` link row being revoked --
+deleted, or stripped of ownership -- by a second connection while the
+route holds the definition row locked.
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+import pytest
+import sqlalchemy as sa
+from fastapi import HTTPException
+from sqlalchemy.orm import sessionmaker
+
+from tests.shared.postgres_disposable import disposable_database_factory
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.user import User
+from xagent.web.services.connector_team_scope import set_connector_team_hooks
+
+pytestmark = pytest.mark.postgresql
+
+
+@pytest.fixture()
+def session_factory():
+    with disposable_database_factory("xagent_mcp_edit_lock") as make_database:
+        engine = make_database("edit_lock")
+        Base.metadata.create_all(bind=engine)
+        yield sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture()
+def seeded(session_factory):
+    """One owner, one owned MCP server, in their own committed rows."""
+    with session_factory() as db:
+        owner = User(username="mcp-edit-lock-owner", password_hash="x", is_admin=False)
+        db.add(owner)
+        db.flush()
+        server = MCPServer(
+            name="edit-lock-target",
+            transport="stdio",
+            managed="external",
+            command="true",
+        )
+        db.add(server)
+        db.flush()
+        db.add(
+            UserMCPServer(
+                user_id=int(owner.id),
+                mcpserver_id=int(server.id),
+                is_owner=True,
+                is_active=True,
+            )
+        )
+        db.commit()
+        return int(owner.id), int(server.id)
+
+
+def _seed_by_the_create_route(session_factory) -> tuple[int, int]:
+    """One owner and one server created the way the API actually creates
+    one -- through ``create_mcp_server`` itself, not hand-built rows.
+
+    The shape matters for the activation-only tests below. ``MCPServer``
+    rows the create route makes store ``concurrent_tools`` as an empty
+    list (``MCPServerConfig`` declares it ``default_factory=list`` and
+    ``MCPServer.from_config`` normalizes it), while a hand-built row
+    leaves the column NULL. An update rebuilds the shared config on every
+    payload and assigns ``[]`` back, which is a no-op against ``[]`` and a
+    real ``UPDATE`` against NULL -- so a hand-built row would make the
+    activation-only request write the definition row for a reason that
+    exists nowhere in production, and the tests below would be measuring
+    that instead of what they claim to measure.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerCreate
+
+    with session_factory() as db:
+        owner = User(username="mcp-activation-owner", password_hash="x", is_admin=False)
+        db.add(owner)
+        db.commit()
+        owner_id = int(owner.id)
+
+        mcp_api.create_mcp_server(
+            MCPServerCreate(
+                name="activation-target",
+                transport="stdio",
+                config={"command": "true"},
+            ),
+            current_user=SimpleNamespace(id=owner_id, is_admin=False),
+            db=db,
+        )
+
+    with session_factory() as db:
+        server = db.query(MCPServer).filter(MCPServer.name == "activation-target").one()
+        # The anchor for the docstring above: if the create route ever stops
+        # storing an empty list here, these tests must be re-derived rather
+        # than silently start measuring a different row shape.
+        assert server.concurrent_tools == [], (
+            "the create route no longer stores concurrent_tools as an empty "
+            f"list (saw {server.concurrent_tools!r}); the activation-only "
+            "tests below depend on that shape"
+        )
+        return owner_id, int(server.id)
+
+
+@pytest.fixture()
+def repeatable_read_sessions():
+    """Two session factories on one disposable database: the first at the
+    server's default isolation level (used to seed and to read back what
+    committed), the second at REPEATABLE READ -- the level the route runs
+    at on a deployment configured that way, and the one under which the
+    interleaving below used to fail.
+    """
+    with disposable_database_factory("xagent_mcp_activation_rr") as make_database:
+        engine = make_database("rr")
+        Base.metadata.create_all(bind=engine)
+        yield (
+            sessionmaker(autocommit=False, autoflush=False, bind=engine),
+            sessionmaker(
+                autocommit=False,
+                autoflush=False,
+                bind=engine.execution_options(isolation_level="REPEATABLE READ"),
+            ),
+        )
+
+
+def test_a_second_editor_blocks_until_the_first_editors_transaction_finishes(
+    session_factory, seeded
+) -> None:
+    """Two real connections, barrier-synchronised: the second call's own
+    lock statement must not return until the first call's transaction
+    commits or rolls back -- the actual behavior ``FOR UPDATE`` exists to
+    provide, and the one thing no SQLite-backed test can demonstrate.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    owner_id, server_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    lock_acquired = threading.Event()
+    release_lock = threading.Event()
+    second_finished = threading.Event()
+    first_call_claimed = threading.Event()
+    first_call_lock = threading.Lock()
+
+    real_build_server_config = mcp_api._build_server_config
+
+    def paced_build_server_config(update_data, server):
+        # Both threads run through this same patched function once each
+        # gets past its own lock statement. Only the call that gets here
+        # *first* pauses: that is the first editor, holding its row lock
+        # open via this still-uncommitted transaction. A second call that
+        # reaches this point too (rather than staying blocked earlier,
+        # inside its own lock statement) is not made to wait a second
+        # time here -- pausing it too would prove nothing about the
+        # database lock, only about this Python-level barrier.
+        with first_call_lock:
+            is_first_call = not first_call_claimed.is_set()
+            first_call_claimed.set()
+        if is_first_call:
+            lock_acquired.set()
+            assert release_lock.wait(timeout=10), "the first editor was never released"
+        return real_build_server_config(update_data, server)
+
+    mcp_api._build_server_config = paced_build_server_config
+    session_a = session_factory()
+    session_b = session_factory()
+    try:
+
+        def run_first():
+            return mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(name="renamed-by-first-editor"),
+                current_user=current_user,
+                db=session_a,
+            )
+
+        def run_second():
+            result = mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(description="edited-by-second-editor"),
+                current_user=current_user,
+                db=session_b,
+            )
+            second_finished.set()
+            return result
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(run_first)
+            assert lock_acquired.wait(timeout=5), (
+                "the first editor never reached the lock"
+            )
+
+            second = executor.submit(run_second)
+            # The second call's own lock statement should still be blocked
+            # on the database at this point. If the lock were not real (or
+            # a no-op, as on SQLite), the second call would sail through
+            # almost immediately and this would flip to True.
+            assert not second_finished.wait(timeout=1.0), (
+                "the second editor finished before the first one released "
+                "the row -- the lock did not actually block it"
+            )
+
+            release_lock.set()
+            first.result(timeout=10)
+            second.result(timeout=10)
+
+        assert second_finished.is_set()
+    finally:
+        mcp_api._build_server_config = real_build_server_config
+        session_a.close()
+        session_b.close()
+
+    # Both writer sessions are closed above, so this reads what actually
+    # committed rather than either session's own uncommitted view. The
+    # block above proves the second editor waited; without this it would
+    # still pass if neither editor's write survived.
+    with session_factory() as fresh:
+        row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+        assert row.name == "renamed-by-first-editor"
+        assert row.description == "edited-by-second-editor"
+        assert row.transport == "stdio"
+        assert row.command == "true"
+        assert row.managed == "external"
+        assert (
+            fresh.query(UserMCPServer)
+            .filter(
+                UserMCPServer.mcpserver_id == server_id,
+                UserMCPServer.user_id == owner_id,
+            )
+            .one()
+            .is_active
+            is True
+        )
+
+
+def test_the_second_editors_rename_reports_the_first_editors_committed_name_as_old(
+    session_factory, seeded
+) -> None:
+    """``rename_team_connector``'s ``old`` argument must be the name this
+    transaction's own lock actually holds once acquired, not whatever the
+    pre-lock read saw.
+
+    Interleaving under test: the first editor renames the connector and
+    commits while the second editor is blocked on the lock. The second
+    editor then acquires the lock, refreshed to the first editor's
+    committed name, and renames again. If the second editor's ``old``
+    argument were captured before its own lock instead, it would report
+    the connector's *original* name -- not the name every team agent's
+    selector was already rewritten to by the first editor's own call --
+    and the second rewrite would search for a name nothing holds anymore,
+    leaving the first rewrite's result permanently dangling with no error.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    owner_id, server_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    lock_acquired = threading.Event()
+    release_lock = threading.Event()
+    second_finished = threading.Event()
+    first_call_claimed = threading.Event()
+    first_call_lock = threading.Lock()
+
+    renamed_calls: list[tuple[str, str]] = []
+    renamed_calls_lock = threading.Lock()
+
+    def spy_renamed_hook(_db, _user_id, _connector_type, _connector_id, old, new):
+        with renamed_calls_lock:
+            renamed_calls.append((old, new))
+
+    real_build_server_config = mcp_api._build_server_config
+
+    def paced_build_server_config(update_data, server):
+        with first_call_lock:
+            is_first_call = not first_call_claimed.is_set()
+            first_call_claimed.set()
+        if is_first_call:
+            lock_acquired.set()
+            assert release_lock.wait(timeout=10), "the first editor was never released"
+        return real_build_server_config(update_data, server)
+
+    mcp_api._build_server_config = paced_build_server_config
+    session_a = session_factory()
+    session_b = session_factory()
+    set_connector_team_hooks(renamed=spy_renamed_hook)
+    try:
+
+        def run_first():
+            return mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(name="renamed-by-first-editor"),
+                current_user=current_user,
+                db=session_a,
+            )
+
+        def run_second():
+            result = mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(name="renamed-by-second-editor"),
+                current_user=current_user,
+                db=session_b,
+            )
+            second_finished.set()
+            return result
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            first = executor.submit(run_first)
+            assert lock_acquired.wait(timeout=5), (
+                "the first editor never reached the lock"
+            )
+
+            second = executor.submit(run_second)
+            assert not second_finished.wait(timeout=1.0), (
+                "the second editor finished before the first one released the row"
+            )
+
+            release_lock.set()
+            first.result(timeout=10)
+            second.result(timeout=10)
+
+        assert renamed_calls == [
+            ("edit-lock-target", "renamed-by-first-editor"),
+            ("renamed-by-first-editor", "renamed-by-second-editor"),
+        ]
+    finally:
+        set_connector_team_hooks()
+        mcp_api._build_server_config = real_build_server_config
+        session_a.close()
+        session_b.close()
+
+    # The hook tuples above are in-process call records; this reads what
+    # actually committed, so a rename that reported the right pair of names
+    # and then failed to persist cannot pass.
+    with session_factory() as fresh:
+        row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+        assert row.name == "renamed-by-second-editor"
+        assert row.transport == "stdio"
+        assert row.command == "true"
+        assert row.managed == "external"
+        assert (
+            fresh.query(UserMCPServer)
+            .filter(
+                UserMCPServer.mcpserver_id == server_id,
+                UserMCPServer.user_id == owner_id,
+            )
+            .one()
+            .is_active
+            is True
+        )
+
+
+def test_a_row_that_vanishes_after_the_gate_but_before_the_lock_is_a_404_not_a_500(
+    session_factory, seeded
+) -> None:
+    """The route's own access read can find the row and still lose a race
+    to a concurrent delete that commits before the lock statement runs. The
+    lock statement must see that as an ordinary "row not found" (``None``)
+    and let the route's existing 404 handle it, rather than leaving the
+    write path below to fail on a row that is no longer there.
+
+    The concurrent delete is fired from a wrapper around this session's own
+    ``query``, which lands it strictly between the two reads: the lock is
+    the only statement in this route that asks for ``MCPServer`` as its
+    sole entity (the access read above asks for ``UserMCPServer`` joined to
+    it, passing ``MCPServer`` as a second entity), so the wrapper can
+    recognise the lock query and nothing else.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    owner_id, server_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    db = session_factory()
+    real_query = db.query
+    deleted_already = threading.Event()
+
+    def delete_the_row_when_the_lock_query_starts(*entities, **kwargs):
+        if entities == (MCPServer,) and not deleted_already.is_set():
+            deleted_already.set()
+            with session_factory() as other:
+                other.execute(
+                    sa.delete(UserMCPServer).where(
+                        UserMCPServer.mcpserver_id == server_id
+                    )
+                )
+                other.execute(sa.delete(MCPServer).where(MCPServer.id == server_id))
+                other.commit()
+        return real_query(*entities, **kwargs)
+
+    db.query = delete_the_row_when_the_lock_query_starts
+    try:
+        with pytest.raises(HTTPException) as exc:
+            mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(name="renamed-after-vanish"),
+                current_user=current_user,
+                db=db,
+            )
+        assert deleted_already.is_set(), "the concurrent delete never ran"
+        assert exc.value.status_code == 404
+    finally:
+        db.close()
+
+
+def test_an_activation_only_edit_survives_a_concurrent_definition_commit_under_repeatable_read(
+    repeatable_read_sessions,
+) -> None:
+    """A payload that sets only ``is_active`` writes this caller's own
+    ``UserMCPServer`` link row. Under PostgreSQL REPEATABLE READ the
+    route's own snapshot is fixed by its first read, so a definition edit
+    another request commits after that read is invisible to this one --
+    which is harmless for a request that does not write the definition
+    row, and fatal for one that asks the database to lock it: the lock
+    statement raises SQLSTATE 40001 and this route's generic handler turns
+    that into HTTP 500 with the requested activation state unwritten.
+
+    The concurrent commit is fired from a wrapper around this session's
+    own ``query``, which lands it strictly between the access read (which
+    asks for ``UserMCPServer`` joined to ``MCPServer``) and this route's
+    first single-entity ``MCPServer`` read.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    default_factory, rr_factory = repeatable_read_sessions
+    owner_id, server_id = _seed_by_the_create_route(default_factory)
+
+    db = rr_factory()
+    real_query = db.query
+    committed = threading.Event()
+    queried_entities: list[tuple] = []
+
+    def commit_a_definition_edit_when_the_definition_query_starts(*entities, **kwargs):
+        queried_entities.append(entities)
+        if entities == (MCPServer,) and not committed.is_set():
+            committed.set()
+            with default_factory() as other:
+                other.execute(
+                    sa.update(MCPServer)
+                    .where(MCPServer.id == server_id)
+                    .values(description="edited-by-the-concurrent-definition-editor")
+                )
+                other.commit()
+        return real_query(*entities, **kwargs)
+
+    db.query = commit_a_definition_edit_when_the_definition_query_starts
+    try:
+        response = mcp_api.update_mcp_server(
+            server_id,
+            MCPServerUpdate(is_active=False),
+            current_user=SimpleNamespace(id=owner_id, is_admin=False),
+            db=db,
+        )
+    finally:
+        db.close()
+
+    assert committed.is_set(), "the concurrent definition edit never ran"
+    assert queried_entities[:2] == [(UserMCPServer, MCPServer), (MCPServer,)], (
+        "the concurrent commit must land after the access read's own read and "
+        "before this route's definition read; otherwise this test is not "
+        "exercising the window it claims to -- saw "
+        f"{queried_entities!r}"
+    )
+    assert response.is_active is False
+
+    with default_factory() as fresh:
+        assert (
+            fresh.query(UserMCPServer)
+            .filter(
+                UserMCPServer.mcpserver_id == server_id,
+                UserMCPServer.user_id == owner_id,
+            )
+            .one()
+            .is_active
+            is False
+        )
+        assert (
+            fresh.query(MCPServer).filter(MCPServer.id == server_id).one().description
+            == "edited-by-the-concurrent-definition-editor"
+        )
+
+
+def test_an_activation_only_edit_whose_row_vanishes_before_its_read_is_a_404(
+    session_factory, seeded
+) -> None:
+    """The activation-only path skips the lock but keeps the same
+    vanished-definition handling: its own fresh read of ``MCPServer`` must
+    return ``None`` and raise the route's 404, rather than leaving the
+    write path below to fail on a row that is no longer there.
+
+    Uses the plain hand-built ``seeded`` fixture rather than the
+    create-route seeding helper: this request 404s before any write is
+    attempted, so the row's shape (NULL vs. ``[]`` ``concurrent_tools``)
+    plays no part in what this test measures.
+
+    Same wrapper shape as
+    ``test_a_row_that_vanishes_after_the_gate_but_before_the_lock_is_a_404_not_a_500``
+    above: the concurrent delete fires from this session's own ``query``,
+    which lands it strictly between the access read (which asks for
+    ``UserMCPServer`` joined to ``MCPServer``) and this route's first
+    single-entity ``MCPServer`` read.
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    owner_id, server_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    db = session_factory()
+    real_query = db.query
+    deleted_already = threading.Event()
+    queried_entities: list[tuple] = []
+
+    def delete_the_row_when_the_definition_query_starts(*entities, **kwargs):
+        queried_entities.append(entities)
+        if entities == (MCPServer,) and not deleted_already.is_set():
+            deleted_already.set()
+            with session_factory() as other:
+                other.execute(
+                    sa.delete(UserMCPServer).where(
+                        UserMCPServer.mcpserver_id == server_id
+                    )
+                )
+                other.execute(sa.delete(MCPServer).where(MCPServer.id == server_id))
+                other.commit()
+        return real_query(*entities, **kwargs)
+
+    db.query = delete_the_row_when_the_definition_query_starts
+    try:
+        with pytest.raises(HTTPException) as exc:
+            mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(is_active=False),
+                current_user=current_user,
+                db=db,
+            )
+        assert exc.value.status_code == 404
+        assert deleted_already.is_set(), "the concurrent delete never ran"
+        assert queried_entities[:2] == [(UserMCPServer, MCPServer), (MCPServer,)], (
+            "the concurrent delete must land after the access read's own "
+            "read and before this route's definition read; otherwise the "
+            "404 under test could be the access read's -- saw "
+            f"{queried_entities!r}"
+        )
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize(
+    ("revocation", "expected_status"),
+    [("link-deleted", 404), ("ownership-cleared", 403)],
+)
+def test_a_put_whose_association_is_revoked_after_the_lock_is_refused_with_no_shared_write(
+    session_factory, seeded, revocation, expected_status
+) -> None:
+    """A second connection can revoke the caller's own link -- delete it,
+    or clear ``is_owner`` -- and commit while this route still holds the
+    definition row locked, after the gate already let the request through.
+    The re-read added after the lock, which re-derives ``can_edit_global``,
+    must catch that: a gone link is the gate's own 404. A link that no
+    longer owns the server is not an error by itself -- the gate does not
+    refuse a non-owner either -- so a payload that changes the shared
+    configuration is refused by the existing owner-only guard instead.
+
+    The revocation fires on this route's first single-entity
+    ``UserMCPServer`` read -- the gate's own read joins it to ``MCPServer``,
+    so a bare ``(UserMCPServer,)`` can only be the re-read after the lock.
+    The recorded sequence is filtered to the three statements under test
+    (``DatabaseMCPServerManager`` may issue queries of its own).
+    """
+    import xagent.web.api.mcp as mcp_api
+    from xagent.web.api.mcp import MCPServerUpdate
+
+    owner_id, server_id = seeded
+    current_user = SimpleNamespace(id=owner_id, is_admin=False)
+
+    db = session_factory()
+    real_query = db.query
+    real_commit = db.commit
+    revoked_already = threading.Event()
+    queried_entities: list[tuple] = []
+    tracked_keys = {(UserMCPServer, MCPServer), (MCPServer,), (UserMCPServer,)}
+    commits: list[str] = []
+
+    def revoke_when_the_recheck_query_starts(*entities, **kwargs):
+        if entities in tracked_keys:
+            queried_entities.append(entities)
+        if entities == (UserMCPServer,) and not revoked_already.is_set():
+            revoked_already.set()
+            with session_factory() as other:
+                if revocation == "link-deleted":
+                    other.execute(
+                        sa.delete(UserMCPServer).where(
+                            UserMCPServer.user_id == owner_id,
+                            UserMCPServer.mcpserver_id == server_id,
+                        )
+                    )
+                else:
+                    other.execute(
+                        sa.update(UserMCPServer)
+                        .where(
+                            UserMCPServer.user_id == owner_id,
+                            UserMCPServer.mcpserver_id == server_id,
+                        )
+                        .values(is_owner=False)
+                    )
+                other.commit()
+        return real_query(*entities, **kwargs)
+
+    def record_commit():
+        commits.append("commit")
+        return real_commit()
+
+    db.query = revoke_when_the_recheck_query_starts
+    db.commit = record_commit
+    try:
+        with pytest.raises(HTTPException) as exc:
+            mcp_api.update_mcp_server(
+                server_id,
+                MCPServerUpdate(name="renamed-after-revocation"),
+                current_user=current_user,
+                db=db,
+            )
+        assert exc.value.status_code == expected_status
+        assert revoked_already.is_set(), "the concurrent revocation never ran"
+        assert queried_entities[:3] == [
+            (UserMCPServer, MCPServer),
+            (MCPServer,),
+            (UserMCPServer,),
+        ], (
+            "the concurrent revocation must land after the gate's own read "
+            "and after the lock statement, and be caught by the re-read "
+            "added after the lock -- otherwise the status under test could "
+            f"be the gate's rather than the re-read's -- saw "
+            f"{queried_entities!r}"
+        )
+        if revocation == "ownership-cleared":
+            assert (
+                exc.value.detail
+                == "Only the server owner can change the shared configuration"
+            ), (
+                "the 403 for a link that no longer owns the server must come "
+                "from the route's existing owner-only guard, not a new error "
+                f"shape -- saw {exc.value.detail!r}"
+            )
+        assert commits == [], "the refused edit must commit nothing"
+    finally:
+        db.close()
+
+    with session_factory() as fresh:
+        row = fresh.query(MCPServer).filter(MCPServer.id == server_id).one()
+        assert row.name == "edit-lock-target", (
+            "the shared definition row must be untouched by a refused edit"
+        )

--- a/tests/web/api/test_mcp_update_lock_partition.py
+++ b/tests/web/api/test_mcp_update_lock_partition.py
@@ -1,0 +1,113 @@
+"""Guards the partition ``update_mcp_server`` uses to decide which row a
+``PUT /api/mcp/servers/{id}`` request writes -- and therefore which row it
+locks (see the ``writes_definition_row`` comment in
+``xagent/web/api/mcp.py``).
+
+That decision is ``bool(server_data.model_fields_set - {"is_active",
+"user_env"})``: those two fields write only the caller's own
+``UserMCPServer`` link row, and every other field on ``MCPServerUpdate``
+writes the shared ``MCPServer`` definition row. This module has no access
+to that expression directly -- it lives as a local variable inside the
+route function, not a standalone helper -- so it re-derives the partition
+against the model's own declared field set instead, and fails loudly if
+that set ever drifts out from under it: a new field added to
+``MCPServerUpdate`` with no corresponding decision about which row it
+writes would otherwise silently join the "writes the definition row"
+side by default (any field not in the two-item exclusion set does), and
+nothing else in this repo would notice.
+"""
+
+from __future__ import annotations
+
+from xagent.web.api.mcp import MCPServerUpdate
+
+# The complete, literal field set as of this test's writing. Kept as a
+# literal (not derived from the model) so a field added to the model without
+# a matching update here fails this assertion instead of silently passing.
+_EXPECTED_FIELDS = {
+    "name",
+    "transport",
+    "description",
+    "config",
+    "is_active",
+    "user_env",
+    "runtime_input_schema",
+    "runtime_bindings",
+    "allow_delegated_authorization",
+}
+
+# The two fields that write only the caller's own UserMCPServer link row.
+# Mirrors the literal set in the ``writes_definition_row`` expression in
+# ``xagent/web/api/mcp.py`` -- kept as a second literal, not imported from
+# there, for the same reason: this test exists to catch that expression and
+# this docstring's picture of it drifting apart un-noticed.
+_LINK_ROW_ONLY_FIELDS = {"is_active", "user_env"}
+
+
+def _writes_definition_row(payload: MCPServerUpdate) -> bool:
+    """The exact expression ``update_mcp_server`` evaluates, reproduced here
+    so this module can exercise it without a live request/session/route
+    call -- see the module docstring for why this can't just import it."""
+    return bool(payload.model_fields_set - _LINK_ROW_ONLY_FIELDS)
+
+
+def test_mcp_server_update_field_set_matches_the_lock_partition() -> None:
+    """If this fails, ``MCPServerUpdate`` gained or lost a field and the
+    partition above (and the matching literals in
+    ``xagent/web/api/mcp.py``'s ``writes_definition_row`` comment and this
+    module's ``_LINK_ROW_ONLY_FIELDS``) needs a deliberate decision about
+    which row the new field belongs to -- not a silent default."""
+    assert set(MCPServerUpdate.model_fields) == _EXPECTED_FIELDS, (
+        "MCPServerUpdate's fields no longer match the set this test and "
+        "the route's writes_definition_row comment were written against "
+        f"(saw {set(MCPServerUpdate.model_fields)!r}); decide which row "
+        "the new/removed field belongs to before updating this literal"
+    )
+    assert _LINK_ROW_ONLY_FIELDS <= _EXPECTED_FIELDS, (
+        "the link-row-only fields must themselves be a subset of the "
+        "model's fields -- this failing means the two literals in this "
+        "file have already drifted apart"
+    )
+
+
+def test_an_is_active_only_payload_does_not_write_the_definition_row() -> None:
+    assert _writes_definition_row(MCPServerUpdate(is_active=True)) is False
+
+
+def test_a_user_env_only_payload_does_not_write_the_definition_row() -> None:
+    assert _writes_definition_row(MCPServerUpdate(user_env={"K": "v"})) is False
+
+
+def test_a_combined_is_active_and_user_env_payload_does_not_write_the_definition_row() -> (
+    None
+):
+    assert (
+        _writes_definition_row(MCPServerUpdate(is_active=True, user_env={"K": "v"}))
+        is False
+    )
+
+
+def test_a_description_only_payload_writes_the_definition_row() -> None:
+    assert _writes_definition_row(MCPServerUpdate(description="new")) is True
+
+
+def test_a_mixed_is_active_and_description_payload_writes_the_definition_row() -> None:
+    """A payload naming one link-row field and one definition-row field
+    must fall on the definition-row (locking) side -- the partition is
+    "only the two link-row fields, and nothing else" skips the lock, not
+    "the two link-row fields, even alongside other fields"."""
+    assert (
+        _writes_definition_row(MCPServerUpdate(is_active=True, description="new"))
+        is True
+    )
+
+
+def test_an_explicitly_null_definition_row_field_still_writes_the_definition_row() -> (
+    None
+):
+    """``model_fields_set`` tracks which fields were named in the payload,
+    not which ones carry a non-``None`` value: an explicit
+    ``runtime_input_schema: null`` is still a decision to write that field
+    (clearing it), distinct from omitting it (leave it alone) -- so it
+    must still land on the locking side even though its value is falsy."""
+    assert _writes_definition_row(MCPServerUpdate(runtime_input_schema=None)) is True


### PR DESCRIPTION
## What

`PUT /api/mcp/servers/{id}` reads the shared `MCPServer` definition row and then
writes it, with no lock in between. The route now takes a `SELECT ... FOR UPDATE`
on that row ahead of anything that reads or mutates it, and re-establishes the
caller's authority once the lock is held.

The route reads the definition row through a two-table join with the caller's
link row. A join reads that row without locking it, so two requests can hold the
same snapshot at the same time.

## Why

**Two concurrent edits lose one of them.** Alice sends
`PUT {"description": "billing lookup"}` and Bob sends `PUT {"url": ".../v2"}` at
the same moment against MCP server 7, which starts as
`{url: ".../v1", description: "old"}`.

```
   Alice                                  Bob
   read row -> {url: v1, desc: old}
                                          read row -> {url: v1, desc: old}
   set desc = "billing lookup"
                                          set url = ".../v2"
   COMMIT -> {url: v1, desc: billing}
                                          COMMIT -> {url: v2, desc: old}
```

Final row: `{url: ".../v2", description: "old"}`. Alice got HTTP 200 and her
description is gone. With the lock, Bob's transaction blocks on Alice's until she
commits, re-reads `{url: v1, desc: billing}`, and the final row is
`{url: ".../v2", description: "billing lookup"}` — both edits kept.

**A rename tells the connector team hook a name that is already stale.** The
route calls `rename_team_connector(db, ..., old, new)` so an installing
application can rewrite agent selectors that refer to the connector by name. The
`old` argument used to be read before the write, off an unlocked row.

```
   first renamer                          second renamer
   read name -> "billing"
                                          read name -> "billing"
   rename to "billing-api", COMMIT
   hook called with ("billing" -> "billing-api")
                                          rename to "billing-v2", COMMIT
                                          hook called with ("billing" -> "billing-v2")
```

The second call asks the application to rewrite selectors that say `"billing"`.
Nothing says `"billing"` any more — the first renamer already rewrote them all to
`"billing-api"`. The second rewrite matches nothing, reports no error, and every
selector the first rename produced is left pointing at a name the row no longer
has. With the lock, the second renamer reads its `old` off the row it holds
locked, gets `"billing-api"`, and the hook is called with
`("billing-api" -> "billing-v2")`.

**A row that vanishes mid-request produces a confusing 500.** The access read can
find the row and still lose a race to a concurrent delete. Without a branch for
that, the write path runs against a row that is gone and surfaces as:

```
500 Failed to update MCP server: UPDATE statement on table 'mcp_servers'
    expected to update 1 row(s); 0 were matched.
```

## How

### Taking the lock

The locking path issues a fresh single-table read of the definition row. That
read is a separate statement from the two-table join above it, which cannot
address just this table, so a row deleted between the two returns `None` here and
the route answers with the 404 it already has for a missing server, rather than
letting the write path fail on a row that is gone.

The query uses `populate_existing()`, which forces the read row to replace the one
already in the session's identity map. Without it the query would return the
unrefreshed instance from the join above, and every field below would still be
that earlier snapshot.

The lock is taken after the access and permission gates that precede it in the
route, so a request refused by those gates never acquires it. Refusals that need
data read under the lock necessarily come after it: the route validates the
payload once locked, including the 403 when a non-owner submits a changed shared
configuration.

`old_name` for the rename hook is read from this fresh read rather than from the
pre-lock join. On the path that writes the definition row that read is also the
locked one, so `old_name` is the name this transaction holds locked. On the
lock-free path the concern does not arise: a payload that skips the lock never
carries `name`, so `old_name` and the name written back are always the same
string and the rename hook never fires.

`DELETE /api/mcp/servers/{id}` takes no definition-row lock and is not changed
here. Bringing it under the same lock ordering would require the delete hook to be
called with the definition row already held, which is a change to that route's
hook interaction rather than to the edit path this change is about.

### Which requests take the lock

The payload decides which row the request writes. Seven of the nine fields of
`MCPServerUpdate` target the shared `MCPServer` definition row; `is_active` and
`user_env` write the caller's own `UserMCPServer` link row and nothing else. A
payload carrying only those two has no write on the definition row to serialize.

Locking the definition row for such a payload made an activate/deactivate request
queue behind an unrelated edit of the same connector — and, under PostgreSQL
REPEATABLE READ, made it fail outright: the lock statement follows the snapshot
the joined read above already established, so a definition edit committed in
between raises SQLSTATE 40001 and the route's generic handler answers 500 with the
requested activation state unwritten.

The route decides from `server_data.model_fields_set`: any field other than
`is_active` and `user_env` takes the lock. The set is used rather than the values
because that is what decides the writes themselves — an explicitly-null
`runtime_input_schema` is written to the definition row even though its value is
`None`, while an absent field is not written at all. So a payload carrying
`description=None` is counted and then skipped by the write at its own
`is not None` guard: the lock is taken in a few cases that did not need it, and
skipped in none whose fields target that row.

The field set is also exactly the set of payloads that rebuild and write the
definition row. The whole rebuild — building `update_data`, validating it, and
writing every resulting field back onto the row — runs only when that expression is
true. A lock-free payload therefore cannot produce a definition-row write: there is
no code path left that would build one.

An earlier version of this route rebuilt the configuration unconditionally,
regardless of which row the lock covered. That was not only a re-encryption: the
rebuild round-trips the row through `to_config_dict()`, which does not emit
`restart_policy`, `auto_start`, `docker_url`, `volumes` or `bind_ports` for an
`external` row, so those columns came back as config defaults and were written over
the stored values. Driving the route against ten stored row shapes, a payload naming
only `is_active` and/or `user_env` wrote the definition row in six distinct shapes:
`concurrent_tools` (`NULL` normalized to `[]`), `env` and `auth` (re-encrypted),
`restart_policy` (`'always'` overwritten with `'no'`), `docker_url`, and `volumes`
with `bind_ports`. Against the same ten shapes after this change: zero
definition-row writes and zero locking statements.

Three consequences follow, and none of them are incidental. A row with
`managed="internal"` can now be activated and deactivated. Previously the rebuild
rewrote `managed` to `external`: a row carrying `docker_image` was then rejected
with `400 Invalid configuration: external managed servers should not have docker
configuration`, and a row without one was accepted with its `managed` value
silently flipped. Editing such a row's shared configuration still returns the same
400, since that path still rebuilds. A row whose stored configuration is already
invalid can likewise now be activated and deactivated: a request that changes only
the caller's own association row is not refused over shared configuration it is not
touching. And the response body on this path now reports the row as stored rather
than as rebuilt — `to_config_dict()` emits `restart_policy` only while `managed` is
still `internal`, so rebuilding made that field vanish from the response of an
internal row; for an `external` row the overwritten value shows up in the stored
column rather than in the JSON, which never carried the key either way.

The second of those three has a name worth stating outright, because it is a fix
rather than a side effect. `_validate_mcp_runtime_config` used to run on every PUT;
it now runs inside the definition-row block, with the rest of the rebuild. A row
whose stored `runtime_bindings` no longer validate against its own
`runtime_input_schema` — an earlier schema edit, an import, a validator rule added
since — could until now be neither used nor switched off: activating or
deactivating it writes only the caller's own link row, and that request was refused
with 400 over shared configuration it does not touch. A payload that does write the
definition row is still validated and still refused. Both directions are pinned by
`test_a_link_row_only_edit_is_not_refused_over_invalid_stored_shared_config`.

Both paths run the same fresh single-table read with `populate_existing()`; only
the `FOR UPDATE` clause is conditional. The vanished-definition 404 and the
response snapshot are therefore identical on both, and cannot drift apart.

### Authority after the wait

`FOR UPDATE` waits, and the gates above it ran before that wait. Everything the
route decided from the caller's link row — that the link exists at all, and
whether it owns the server — was therefore established before a wait with no bound
on its length, and nothing re-established it afterwards. Two supported operations
can commit inside that wait: an administrator deleting a user removes that user's
link rows and leaves every definition row standing, and a disconnect removes the
caller's own link while another user's link keeps the definition alive. A request
that resumes after either one would write the shared definition row on an
authority it no longer has, commit it, and fail only later — in the refresh of the
link row, which runs after the commit, so the generic handler's rollback cannot
take the shared write back and the caller sees a 500 over a durable change.

The locking path now re-reads the caller's link row once it holds the definition
row, before it calls a connector-team hook and before it writes anything shared,
and re-derives its authority from that read. A link that is gone is this route's
existing 404, matching the gate. A link that is still there but no longer owns the
server is not an error by itself — the gate does not refuse a non-owner either —
so it is answered exactly as the gate would have answered it: what the re-read
changes is `can_edit_global`, which the route's existing owner-only guard already
consumes. A non-owner's payload that actually changes the shared configuration
still gets that guard's 403, while a non-owner's payload that changes nothing gets
200 with the shared configuration silently dropped, exactly as a request from a
non-owner always did. The row that read returns replaces the pre-lock one for the
rest of the route, so the per-user env write, the activation write, the refresh
and the response all read the row the transaction actually verified.
`populate_existing()` on the definition query covers the definition row and only
it, which is why the link row needs a statement of its own.

Two boundaries this does not move. The window between that re-read and the commit
is the window this route had before it took any lock — in process, with no wait in
it — and closing that one belongs with the team-authorization work, not here. The
path that skips the definition lock adds no wait, so it adds no exposure and is
left alone.

The route is already a plain `def` and needs no change on that count: a blocking
`FOR UPDATE` wait on an `async def` route would occupy the event loop thread and
stall every request the process is serving, not just its own.

## Known limitations tracked separately

These are known and deliberately not addressed here. Each is either repo-wide work
or a contract question wider than this route.

- **`FOR UPDATE` is a no-op on SQLite (#1944).** It is a PostgreSQL/MySQL row
  lock; SQLAlchemy renders no locking clause at all on SQLite — the statement
  emitted there is byte-for-byte the one emitted without the call — so on a SQLite
  deployment this read-modify-write sequence is not serialized and the
  interleavings above remain possible. The lock site says so in a comment, so a
  reader is not left believing otherwise. Closing the gap needs a dual-dialect
  fence (a no-op write that takes SQLite's writer lock before the read), which
  this repository already has in two places, applied at every `with_for_update()`
  call site in the repository. That is repo-wide work rather than a change to this
  route.
- **The PostgreSQL isolation level is never checked (#1945).** The engine does not
  verify the isolation level the server hands it. Under REPEATABLE READ a lock
  statement follows the snapshot an earlier read in the same transaction already
  fixed, so an edit committed in between raises SQLSTATE 40001 and the route's
  generic handler answers 500. Skipping the lock for association-only payloads
  removes that failure for those payloads outright, on every stored row shape. That
  is an engine-wide contract, not something this route can settle.
- **Lock waits are unbounded (#1946).** No lock site here bounds how long a waiter
  may wait, and the same issue records that connector definition-row locks are
  held across application hooks. Bounding the wait is a decision about every lock
  site in the repository.
- **The hook contract does not state what lock the caller holds (#1932).** An
  installing application implementing `rename_team_connector` is not told that this
  route calls it while holding the definition row, so it cannot reason about the
  order in which to take locks of its own. Writing that contract down is a change
  to the hook interface, not to this route.
- **A test-quality gap in the suite added here (#1816).** The negative timing
  assertions (`not event.wait(timeout=1.0)`, meaning "the second writer is still
  blocked") have no upper bound, so a genuinely broken lock that resolves in more
  than a second still satisfies them. It is tracked with the other test-quality
  items in that issue rather than fixed piecemeal here.
- **The configuration rebuild still flattens columns on the path that writes the
  row.** `_build_server_config` round-trips a row through `to_config_dict()`, which
  emits `restart_policy`, `auto_start` and the docker fields only for a
  `managed="internal"` row. On an `external` row those come back as config defaults
  and are written over the stored values, so an edit to an unrelated field flattens
  them:

  ```
  BEFORE: restart_policy='always'  auto_start=True
  PUT   : {"description": "a new description"}
  AFTER : restart_policy='no'      auto_start=None
  ```

  This is present on the base commit and is not changed here; this pull request
  removes it from the lock-free path only. Fixing the round-trip is a change to
  `_build_server_config` and `to_config_dict`, not to this route.

## Relationship to #1913

This is the MCP half of #1913, which covered both connector route families in one
change. It is split by route family so each half can be reviewed on its own. The
Custom API half is #2059; the two touch disjoint production
files and disjoint test files, depend on neither each other's code nor each
other's merge order, and can land in either order.

The only file both halves touch is `.github/workflows/test-migrations.yml`, where
each adds its own suite's path entries and its own test step. One shared entry —
`src/xagent/web/services/connector_team_scope.py`, which both suites import —
appears in both, so whichever half lands second will need a trivial conflict
resolution there.

#1913 in turn was split out of #1661. The lock is independent of the
team-ownership work on that branch: it fixes concurrency defects that exist today,
on a route that has no team overlay, so it stands on its own.

## Tests

`FOR UPDATE` is a no-op on SQLite, so nothing in the ordinary suite can tell a
real lock from a statement that silently does nothing. A Postgres-only suite runs
the real statement against a real server:

- `tests/web/api/test_mcp_server_edit_lock_postgresql.py`

It covers, on two real connections with a barrier between them: a second editor
blocking until the first commits; the second editor's rename reporting the first
editor's committed name; an `is_active`-only edit completing while a concurrent
definition edit holds the row, including under REPEATABLE READ, where it asserts
the outcome — 200, a persisted `is_active=false`, and the concurrent editor's
`description` intact — rather than only that no error was raised; and the
vanished-row 404 for both the locking and the association-only path.

It also covers revocation on the other side of the lock: the caller's link row
deleted, and the link's ownership withdrawn, each committed by a second connection
while the route holds the definition row locked — asserting the 404 for the first
and the owner-only guard's 403 for the second, that no shared row was written, and
that nothing was committed.

Each timing test reopens an independent session once both writer sessions have
closed and asserts the committed definition, association and configuration fields.
Without that, a route that produced the right hook calls and the right timing but
wrote nothing durable would still pass.

It reads back the SQL the engine actually sent, so the lock's rendered strength is
pinned as text: a definition-row edit sends exactly one `FOR NO KEY UPDATE` read
and no plain `FOR UPDATE`, and a link-row-only payload sends neither. And it covers
three paths that had none — a non-owner payload naming a definition-row field whose
value matches what is stored (dropped, 200, shared row unchanged) alongside its
refused sibling (403); the caller's own `User` row deleted between the link re-read
and the admin re-read; and both directions of the validation partition described
above.

The suite is wired into the existing Postgres job in `test-migrations.yml`. That
workflow's two hand-maintained path lists also gain the production modules this
suite depends on beyond the route file — `connector_team_scope.py` and
`core/tools/core/mcp/model.py`, where `to_config_dict()` and its
`managed == "internal"` branch live; `models/mcp.py` is already listed — so a change
confined to one of them can no longer leave the Postgres jobs skipped while CI
reports success.

Run locally against PostgreSQL 17.11:

| Suite | Result |
|---|---|
| `test_mcp_server_edit_lock_postgresql.py -m postgresql` | 19 passed, 0 skipped |
| `test_mcp_api.py`, `test_mcp_oauth_flow.py`, `test_mcp_apps_connect.py`, `test_mcp_apps_attachability.py`, `test_mcp_admin_visibility.py`, `test_mcp_apps_team_visibility.py`, `test_public_mcp_connector_visibility.py`, `test_mcp_apps_catalog_dedupe.py`, `test_connector_team_scope.py` | 381 passed |


