### PR TITLE
feat: add Xero MCP connector

### DIFF
--- a/src/xagent/migrations/versions/20260903_seed_xero_mcp_app.py
+++ b/src/xagent/migrations/versions/20260903_seed_xero_mcp_app.py
@@ -1,0 +1,178 @@
+"""seed built-in Xero (OAuth) MCP connector
+
+Revision ID: 20260903_seed_xero_mcp_app
+Revises: 20260901_seed_chartmogul_mcp_app
+Create Date: 2026-09-03 00:00:00.000000
+
+"""
+
+import os
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260903_seed_xero_mcp_app"
+down_revision: Union[str, None] = "20260901_seed_chartmogul_mcp_app"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+FULL_OAUTH_PROVIDERS_TABLE = sa.table(
+    "oauth_providers",
+    sa.column("provider_name", sa.String),
+    sa.column("name", sa.String),
+    sa.column("client_id", sa.String),
+    sa.column("client_secret", sa.String),
+    sa.column("auth_url", sa.String),
+    sa.column("token_url", sa.String),
+    sa.column("redirect_uri", sa.String),
+    sa.column("userinfo_url", sa.String),
+    sa.column("user_id_path", sa.String),
+    sa.column("email_path", sa.String),
+    sa.column("default_scopes", sa.JSON),
+)
+
+OAUTH_PROVIDERS_TABLE = sa.table(
+    "oauth_providers",
+    sa.column("provider_name", sa.String),
+)
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+
+APP_ID = "xero"
+
+XERO_SCOPES = [
+    "offline_access",
+    "accounting.contacts",
+    "accounting.transactions",
+    "accounting.settings",
+]
+
+XERO_PROVIDER_DEFAULT_SCOPES = ["openid", "profile", "email"]
+
+
+def _filter_row(row: dict[str, object], allowed_columns: set[str]) -> dict[str, object]:
+    return {key: value for key, value in row.items() if key in allowed_columns}
+
+
+def _xero_provider_row() -> dict[str, object]:
+    return {
+        "provider_name": "xero",
+        "name": "Xero",
+        "client_id": os.environ.get("XERO_CLIENT_ID", ""),
+        "client_secret": os.environ.get("XERO_CLIENT_SECRET", ""),
+        "auth_url": "https://login.xero.com/identity/connect/authorize",
+        "token_url": "https://identity.xero.com/connect/token",
+        "redirect_uri": os.environ.get("XERO_REDIRECT_URI", ""),
+        "userinfo_url": "https://identity.xero.com/connect/userinfo",
+        "user_id_path": "sub",
+        "email_path": "email",
+        "default_scopes": XERO_PROVIDER_DEFAULT_SCOPES,
+    }
+
+
+def _xero_app_row() -> dict[str, object]:
+    return {
+        "app_id": APP_ID,
+        "name": "Xero",
+        "description": "Connect to Xero to look up organisations, manage contacts and invoices, and browse the chart of accounts and payments.",
+        "icon": "https://www.google.com/s2/favicons?domain=xero.com&sz=128",
+        "transport": "oauth",
+        "provider_name": "xero",
+        "category": "Accounting",
+        "oauth_scopes": XERO_SCOPES,
+        "is_visible_in_connector": False,
+        "launch_config": {
+            "command": "python",
+            "args": ["-m", "xagent.web.tools.mcp.xero"],
+            "env_mapping": {"XERO_ACCESS_TOKEN": "access_token"},
+        },
+    }
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "oauth_providers" in existing_tables:
+        oauth_columns = {
+            column["name"] for column in inspector.get_columns("oauth_providers")
+        }
+        existing_provider_names = set(
+            bind.execute(sa.select(OAUTH_PROVIDERS_TABLE.c.provider_name)).scalars()
+        )
+        if "xero" not in existing_provider_names:
+            bind.execute(
+                sa.insert(FULL_OAUTH_PROVIDERS_TABLE),
+                [_filter_row(_xero_provider_row(), oauth_columns)],
+            )
+
+    if "public_mcp_apps" in existing_tables:
+        app_columns = {
+            column["name"] for column in inspector.get_columns("public_mcp_apps")
+        }
+        existing_app_ids = set(
+            bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars()
+        )
+        if APP_ID not in existing_app_ids:
+            bind.execute(
+                sa.insert(PUBLIC_MCP_APPS_TABLE),
+                [_filter_row(_xero_app_row(), app_columns)],
+            )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "public_mcp_apps" in existing_tables:
+        # Only the catalog entry is removed. Any user OAuth connections created
+        # against this app are not owned by this migration and are cleaned up
+        # through the normal disconnect path.
+        bind.execute(
+            sa.delete(PUBLIC_MCP_APPS_TABLE).where(
+                PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID
+            )
+        )
+
+    if "oauth_providers" not in existing_tables:
+        return
+
+    if "public_mcp_apps" in existing_tables:
+        remaining_xero_apps = bind.execute(
+            sa.select(sa.func.count())
+            .select_from(PUBLIC_MCP_APPS_TABLE)
+            .where(PUBLIC_MCP_APPS_TABLE.c.provider_name == "xero")
+        ).scalar()
+        if remaining_xero_apps:
+            return
+
+    # Only delete the provider row when it still matches the static shape this
+    # migration seeded, so an admin-created "xero" provider (via
+    # POST /admin/mcp/providers) is preserved. client_id/client_secret are
+    # env-dependent and intentionally not part of the guard. name/auth_url/
+    # token_url are NOT NULL core columns present since the table's creation,
+    # so they can be matched unconditionally.
+    seeded_provider = _xero_provider_row()
+    bind.execute(
+        sa.delete(FULL_OAUTH_PROVIDERS_TABLE)
+        .where(FULL_OAUTH_PROVIDERS_TABLE.c.provider_name == "xero")
+        .where(FULL_OAUTH_PROVIDERS_TABLE.c.name == seeded_provider["name"])
+        .where(FULL_OAUTH_PROVIDERS_TABLE.c.auth_url == seeded_provider["auth_url"])
+        .where(FULL_OAUTH_PROVIDERS_TABLE.c.token_url == seeded_provider["token_url"])
+    )

--- a/src/xagent/migrations/versions/20260903_seed_xero_mcp_app.py
+++ b/src/xagent/migrations/versions/20260903_seed_xero_mcp_app.py
@@ -57,7 +57,8 @@ APP_ID = "xero"
 XERO_SCOPES = [
     "offline_access",
     "accounting.contacts",
-    "accounting.transactions",
+    "accounting.invoices",
+    "accounting.payments.read",
     "accounting.settings",
 ]
 

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -2634,9 +2634,13 @@ def generic_oauth_callback(
         if requires_json_accept_header(provider):
             headers["Accept"] = "application/json"
         auth: tuple[str, str] | None = None
-        if provider.lower() == "zoom":
-            # Zoom's token endpoint requires HTTP Basic Auth for client
-            # credentials (client_id:client_secret, base64).
+        if provider.lower() in ("zoom", "xero"):
+            # Zoom's and Xero's token endpoints both require HTTP Basic Auth
+            # for client credentials (client_id:client_secret, base64) --
+            # confirmed for Xero directly against its official SDK
+            # (XeroAPI/xero-node's tokenRequest()), which authenticates the
+            # same authorization_code/refresh_token exchange this way rather
+            # than posting client_id/client_secret in the body.
             auth = (client_id, client_secret)
         else:
             data["client_id"] = client_id

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -167,6 +167,23 @@ def get_builtin_oauth_provider_rows() -> list[dict[str, Any]]:
             "default_scopes": ["user:read:user"],
         },
         {
+            "provider_name": "xero",
+            "name": "Xero",
+            "client_id": os.environ.get("XERO_CLIENT_ID", ""),
+            "client_secret": os.environ.get("XERO_CLIENT_SECRET", ""),
+            "auth_url": "https://login.xero.com/identity/connect/authorize",
+            "token_url": "https://identity.xero.com/connect/token",
+            "redirect_uri": os.environ.get("XERO_REDIRECT_URI", ""),
+            "userinfo_url": "https://identity.xero.com/connect/userinfo",
+            "user_id_path": "sub",
+            "email_path": "email",
+            # Identity-only (openid/profile/email), matching zoom/google —
+            # the functional accounting.* scopes this connector actually
+            # calls live on the app row's oauth_scopes below and are merged
+            # in at authorize time, so they aren't duplicated here.
+            "default_scopes": ["openid", "profile", "email"],
+        },
+        {
             "provider_name": "github",
             "name": "GitHub",
             "client_id": os.environ.get("GITHUB_CLIENT_ID", ""),
@@ -704,6 +721,47 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
                 "command": "python",
                 "args": ["-m", "xagent.web.tools.mcp.zoom"],
                 "env_mapping": {"ZOOM_ACCESS_TOKEN": "access_token"},
+            },
+        },
+        {
+            "app_id": "xero",
+            "name": "Xero",
+            "description": "Connect to Xero to look up organisations, manage contacts and invoices, and browse the chart of accounts and payments.",
+            "icon": "https://www.google.com/s2/favicons?domain=xero.com&sz=128",
+            "transport": "oauth",
+            "provider_name": "xero",
+            # "Accounting" is not one of the connect dialog's fixed sidebar
+            # category filters (connect-mcp-dialog.tsx only has CRM/Support/
+            # Marketing/Payments/Analytics/etc.), so this connector won't
+            # get a dedicated filter button yet -- still findable via the
+            # catalog's "All" view/search. "Payments" would be misleading:
+            # Xero is bookkeeping/invoicing, not a payments processor.
+            "category": "Accounting",
+            # Granular scopes -- Xero deprecated the broad accounting.*
+            # scopes (accounting.transactions/accounting.contacts covering
+            # everything) for apps created on or after 2 March 2026 in
+            # favor of per-resource read/write scopes; any app registered
+            # today only ever gets the granular set. offline_access is
+            # required for a refresh token (a 30-minute access token with
+            # no refresh would otherwise force re-consent every session).
+            "oauth_scopes": [
+                "offline_access",
+                "accounting.contacts",
+                "accounting.transactions",
+                "accounting.settings",
+            ],
+            # Hidden until manually verified against a live organisation,
+            # same precedent as the intercom/zendesk rows: it ships
+            # customer/supplier-facing write tools (create/update contact,
+            # create invoice, change invoice status) not yet verified live,
+            # and Xero's own auth model changed twice in the last 18 months
+            # (see the oauth_scopes comment) so the exact request/response
+            # shapes are worth a live check before general availability.
+            "is_visible_in_connector": False,
+            "launch_config": {
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.xero"],
+                "env_mapping": {"XERO_ACCESS_TOKEN": "access_token"},
             },
         },
         {

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -737,17 +737,25 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             # catalog's "All" view/search. "Payments" would be misleading:
             # Xero is bookkeeping/invoicing, not a payments processor.
             "category": "Accounting",
-            # Granular scopes -- Xero deprecated the broad accounting.*
-            # scopes (accounting.transactions/accounting.contacts covering
-            # everything) for apps created on or after 2 March 2026 in
-            # favor of per-resource read/write scopes; any app registered
-            # today only ever gets the granular set. offline_access is
-            # required for a refresh token (a 30-minute access token with
-            # no refresh would otherwise force re-consent every session).
+            # Granular scopes -- Xero deprecated the broad accounting.
+            # transactions scope (bank transactions/credit notes/invoices/
+            # repeating invoices, all under one scope) for apps created on
+            # or after 2 March 2026, replacing it with per-resource scopes;
+            # requesting the old broad scope on a new app fails the
+            # authorize redirect outright with "invalid_scope" (confirmed
+            # live). accounting.contacts and accounting.settings were NOT
+            # part of that split and are unchanged. accounting.invoices
+            # (not just its .read variant) is needed because this connector
+            # both reads and writes invoices; accounting.payments.read
+            # (not the full accounting.payments) because its one payments
+            # tool is read-only. offline_access is required for a refresh
+            # token (a 30-minute access token with no refresh would
+            # otherwise force re-consent every session).
             "oauth_scopes": [
                 "offline_access",
                 "accounting.contacts",
-                "accounting.transactions",
+                "accounting.invoices",
+                "accounting.payments.read",
                 "accounting.settings",
             ],
             # Hidden until manually verified against a live organisation,

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -930,12 +930,16 @@ async def refresh_oauth_token_if_needed(
         }
         post_kwargs: dict[str, Any] = {}
         # Matches the code-exchange branch in api/auth.py: an admin-created
-        # provider named "Zoom" would otherwise connect fine but silently
-        # fail every refresh an hour later.
-        if normalized_provider == "zoom":
-            # Zoom's token endpoint requires HTTP Basic Auth for client
-            # credentials (client_id:client_secret, base64) on every refresh,
-            # same as the initial code exchange.
+        # provider named "Zoom" or "Xero" would otherwise connect fine but
+        # silently fail every refresh (Xero's access token lives only 30
+        # minutes, so this would surface fast).
+        if normalized_provider in ("zoom", "xero"):
+            # Zoom's and Xero's token endpoints both require HTTP Basic Auth
+            # for client credentials (client_id:client_secret, base64) on
+            # every refresh, same as the initial code exchange -- confirmed
+            # for Xero directly against its official SDK (XeroAPI/xero-node's
+            # tokenRequest(), shared by both the code-exchange and
+            # refresh_token grants).
             post_kwargs["auth"] = httpx.BasicAuth(client_id, client_secret)
         else:
             data["client_id"] = client_id

--- a/src/xagent/web/tools/mcp/xero.py
+++ b/src/xagent/web/tools/mcp/xero.py
@@ -1,0 +1,638 @@
+import json
+import logging
+import os
+import re
+from typing import Any
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+from ...utils.graphql_errors import truncate_error_text
+from .utils import setup_proxy_env, success_with_capped_dict, url_path_id
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("xero-mcp")
+
+# Ensure standard proxy environment variables are set to prevent hanging requests
+setup_proxy_env()
+
+mcp = FastMCP("xero-mcp")
+
+# The Connections API (which organisations this token can access) and the
+# Accounting API live on different hosts -- confirmed against Xero's own
+# published OpenAPI spec (github.com/XeroAPI/Xero-OpenAPI/xero_accounting.yaml).
+XERO_CONNECTIONS_URL = "https://api.xero.com/connections"
+XERO_ACCOUNTING_BASE_URL = "https://api.xero.com/api.xro/2.0"
+DEFAULT_TIMEOUT_SECONDS = 30
+
+_INVOICE_TYPES = frozenset({"ACCREC", "ACCPAY"})  # sales invoice / purchase bill
+_INVOICE_STATUSES = frozenset(
+    {"DRAFT", "SUBMITTED", "AUTHORISED", "PAID", "VOIDED", "DELETED"}
+)
+_GUID_PATTERN = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+def _success(**payload: Any) -> str:
+    return json.dumps({"status": "success", **payload}, ensure_ascii=False)
+
+
+def _error(message: str) -> str:
+    return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
+
+
+def _headers(tenant_id: str = "") -> dict[str, str]:
+    access_token = os.environ.get("XERO_ACCESS_TOKEN")
+    if not access_token:
+        raise ValueError("XERO_ACCESS_TOKEN environment variable is missing")
+    headers = {
+        "Authorization": f"Bearer {access_token}",
+        "Accept": "application/json",
+        "Content-Type": "application/json",
+    }
+    if tenant_id:
+        # One Xero OAuth connection can be authorized against several
+        # organisations ("tenants") at once -- every Accounting API call
+        # (everything except listing the connections themselves) must say
+        # which one it means via this header. There is no "current"/default
+        # tenant the way posthog.py's "@current" project sentinel works:
+        # Xero has no such concept, so every tool below requires tenant_id
+        # explicitly rather than defaulting it.
+        headers["Xero-tenant-id"] = tenant_id
+    return headers
+
+
+def _require_non_blank(value: str, field_name: str) -> str:
+    if not value or not value.strip():
+        raise ValueError(f"{field_name} must not be blank")
+    return value
+
+
+def _validate_guid(value: str, field_name: str) -> str:
+    """Validate a Xero id is a well-formed GUID before it goes into a
+    hand-built `where=` filter expression (e.g. `Guid("...")`)  -- a GUID
+    can never contain a `"` or otherwise break out of that literal, so this
+    closes the filter-injection risk a raw f-string interpolation would
+    otherwise have, while also rejecting a malformed id with a clear local
+    error instead of an opaque Xero 400."""
+    if not _GUID_PATTERN.match(value):
+        raise ValueError(f"{field_name} must be a UUID, got {value!r}")
+    return value
+
+
+def _reject_quote(value: str, field_name: str) -> str:
+    """Reject a value containing '"' before it's interpolated into a Xero
+    `where=` string literal -- none of the values this is applied to
+    (a status keyword, an account type keyword) should ever legitimately
+    contain one, so rejecting outright is simpler and safer than attempting
+    to escape Xero's filter-expression quoting rules."""
+    if '"' in value:
+        raise ValueError(f"{field_name} must not contain a '\"' character")
+    return value
+
+
+def _extract_error_detail(response: requests.Response) -> str | None:
+    """Pull the human-readable message out of a Xero error body.
+
+    Xero's Error schema is {"ErrorNumber", "Type", "Message", "Elements":
+    [{"ValidationErrors": [{"Message": ...}]}]} -- Message alone is often
+    generic ("A validation exception occurred"), so per-field validation
+    messages nested under Elements are folded in when present. Returns
+    None so the caller falls back to the raw response text when the body
+    isn't in this shape at all.
+    """
+    try:
+        payload = response.json()
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    message = payload.get("Message")
+    if not isinstance(message, str):
+        message = None
+    validation_messages = []
+    for element in payload.get("Elements") or []:
+        if not isinstance(element, dict):
+            continue
+        for validation_error in element.get("ValidationErrors") or []:
+            if isinstance(validation_error, dict):
+                detail = validation_error.get("Message")
+                if isinstance(detail, str) and detail:
+                    validation_messages.append(detail)
+    if validation_messages:
+        joined = "; ".join(validation_messages)
+        return f"{message}: {joined}" if message else joined
+    return message
+
+
+def _request(
+    method: str,
+    url: str,
+    *,
+    tenant_id: str = "",
+    params: dict[str, Any] | None = None,
+    json_data: dict[str, Any] | None = None,
+) -> Any:
+    try:
+        response = requests.request(
+            method=method,
+            url=url,
+            headers=_headers(tenant_id),
+            params=params,
+            json=json_data,
+            timeout=DEFAULT_TIMEOUT_SECONDS,
+        )
+    except requests.RequestException as exc:
+        raise RuntimeError(str(exc)) from exc
+
+    try:
+        response.raise_for_status()
+    except requests.HTTPError as exc:
+        message = str(exc)
+        detail = _extract_error_detail(response)
+        if detail is None:
+            detail = truncate_error_text(response.text.strip())
+        if detail:
+            message = f"{message} - {detail}"
+        raise RuntimeError(message) from exc
+
+    if response.status_code == 204 or not response.content:
+        return {}
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise RuntimeError(
+            f"Xero returned a 2xx response with a non-JSON body: {exc}"
+        ) from exc
+
+
+def _accounting_request(
+    method: str,
+    tenant_id: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    json_data: dict[str, Any] | None = None,
+) -> Any:
+    _require_non_blank(tenant_id, "tenant_id")
+    return _request(
+        method,
+        f"{XERO_ACCOUNTING_BASE_URL}{path}",
+        tenant_id=tenant_id,
+        params=params,
+        json_data=json_data,
+    )
+
+
+def _list_items(result: Any, key: str) -> list[Any]:
+    return result.get(key) or [] if isinstance(result, dict) else []
+
+
+def _first_item(result: Any, key: str, not_found_message: str) -> dict[str, Any]:
+    """Unwrap Xero's plural response envelope ({"Contacts": [...]},
+    {"Invoices": [...]}, ...) and return its first element -- shared by
+    every single-object get/create/update tool below, which all hit this
+    same "envelope with exactly one element" shape."""
+    items = _list_items(result, key)
+    if not items:
+        raise ValueError(not_found_message)
+    first: dict[str, Any] = items[0]
+    return first
+
+
+def _contact_summary(contact: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "contact_id": contact.get("ContactID"),
+        "name": contact.get("Name"),
+        "first_name": contact.get("FirstName"),
+        "last_name": contact.get("LastName"),
+        "email": contact.get("EmailAddress"),
+        "status": contact.get("ContactStatus"),
+        "is_customer": contact.get("IsCustomer"),
+        "is_supplier": contact.get("IsSupplier"),
+        "updated_date_utc": contact.get("UpdatedDateUTC"),
+    }
+
+
+def _invoice_summary(invoice: dict[str, Any]) -> dict[str, Any]:
+    contact = invoice.get("Contact") or {}
+    return {
+        "invoice_id": invoice.get("InvoiceID"),
+        "invoice_number": invoice.get("InvoiceNumber"),
+        "type": invoice.get("Type"),
+        "status": invoice.get("Status"),
+        "contact_id": contact.get("ContactID"),
+        "contact_name": contact.get("Name"),
+        "date": invoice.get("DateString") or invoice.get("Date"),
+        "due_date": invoice.get("DueDateString") or invoice.get("DueDate"),
+        "sub_total": invoice.get("SubTotal"),
+        "total_tax": invoice.get("TotalTax"),
+        "total": invoice.get("Total"),
+        "amount_due": invoice.get("AmountDue"),
+        "amount_paid": invoice.get("AmountPaid"),
+        "currency_code": invoice.get("CurrencyCode"),
+    }
+
+
+def _account_summary(account: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "account_id": account.get("AccountID"),
+        "code": account.get("Code"),
+        "name": account.get("Name"),
+        "type": account.get("Type"),
+        "tax_type": account.get("TaxType"),
+        "status": account.get("Status"),
+        "class": account.get("Class"),
+    }
+
+
+def _payment_summary(payment: dict[str, Any]) -> dict[str, Any]:
+    invoice = payment.get("Invoice") or {}
+    account = payment.get("Account") or {}
+    return {
+        "payment_id": payment.get("PaymentID"),
+        "amount": payment.get("Amount"),
+        "date": payment.get("Date"),
+        "status": payment.get("Status"),
+        "invoice_id": invoice.get("InvoiceID"),
+        "invoice_number": invoice.get("InvoiceNumber"),
+        "account_name": account.get("Name"),
+    }
+
+
+def _build_line_items(line_items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Translate caller-supplied line items (snake_case keys: description,
+    quantity, unit_amount, account_code) into Xero's PascalCase LineItem
+    shape. A line item with only a description is valid per Xero's own
+    docs (used for a text-only line with no amount), so quantity/
+    unit_amount/account_code are all optional here."""
+    built = []
+    for index, item in enumerate(line_items):
+        if not isinstance(item, dict):
+            raise ValueError(f"line_items[{index}] must be an object")
+        description = item.get("description")
+        if not description or not str(description).strip():
+            raise ValueError(f"line_items[{index}].description must not be blank")
+        xero_item: dict[str, Any] = {"Description": description}
+        quantity = item.get("quantity")
+        if quantity is not None:
+            if not isinstance(quantity, (int, float)):
+                raise ValueError(f"line_items[{index}].quantity must be a number")
+            xero_item["Quantity"] = quantity
+        unit_amount = item.get("unit_amount")
+        if unit_amount is not None:
+            if not isinstance(unit_amount, (int, float)):
+                raise ValueError(f"line_items[{index}].unit_amount must be a number")
+            xero_item["UnitAmount"] = unit_amount
+        if item.get("account_code"):
+            xero_item["AccountCode"] = item["account_code"]
+        built.append(xero_item)
+    return built
+
+
+@mcp.tool()
+def xero_list_organisations() -> str:
+    """
+    List the Xero organisations ("tenants") this connection is authorized
+    for -- tenant_id and name. Use the returned tenant_id with every other
+    tool here; Xero has no default organisation, so it must always be
+    passed explicitly.
+    """
+    try:
+        result = _request("GET", XERO_CONNECTIONS_URL)
+        connections = result if isinstance(result, list) else []
+        organisations = [
+            {
+                "tenant_id": c.get("tenantId"),
+                "tenant_name": c.get("tenantName"),
+                "tenant_type": c.get("tenantType"),
+            }
+            for c in connections
+            if isinstance(c, dict)
+        ]
+        return _success(organisations=organisations)
+    except Exception as e:
+        logger.error(f"Error listing Xero organisations: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def xero_get_organisation(tenant_id: str) -> str:
+    """
+    Get basic details (name, legal name, base currency, timezone) about one
+    Xero organisation.
+    tenant_id: from xero_list_organisations.
+    """
+    try:
+        result = _accounting_request("GET", tenant_id, "/Organisation")
+        organisation = _first_item(
+            result, "Organisations", "Xero returned no organisation data"
+        )
+        return _success(organisation=organisation)
+    except Exception as e:
+        logger.error(f"Error fetching Xero organisation {tenant_id}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def xero_list_contacts(tenant_id: str, search_term: str = "", page: int = 1) -> str:
+    """
+    Search/list contacts (customers and suppliers), most recently updated
+    first is not guaranteed -- pass search_term to filter.
+    search_term: optional case-insensitive substring matched against name,
+    first/last name, contact number, and email.
+    page: 1-based page number; Xero returns up to 100 contacts per page.
+    """
+    try:
+        params: dict[str, Any] = {"page": max(1, page)}
+        if search_term:
+            params["searchTerm"] = search_term
+        result = _accounting_request("GET", tenant_id, "/Contacts", params=params)
+        contacts = _list_items(result, "Contacts")
+        pagination = result.get("pagination") or {} if isinstance(result, dict) else {}
+        return success_with_capped_dict(
+            "contacts",
+            {
+                "contacts": [_contact_summary(c) for c in contacts],
+                "page": pagination.get("page"),
+                "page_count": pagination.get("pageCount"),
+                "item_count": pagination.get("itemCount"),
+            },
+        )
+    except Exception as e:
+        logger.error(f"Error listing Xero contacts: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def xero_get_contact(tenant_id: str, contact_id: str) -> str:
+    """
+    Get a Xero contact by id.
+    """
+    try:
+        encoded_id = url_path_id(contact_id, "contact_id")
+        result = _accounting_request("GET", tenant_id, f"/Contacts/{encoded_id}")
+        contact = _first_item(result, "Contacts", f"Contact '{contact_id}' not found")
+        return _success(contact=_contact_summary(contact))
+    except Exception as e:
+        logger.error(f"Error fetching Xero contact {contact_id}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def xero_create_contact(
+    tenant_id: str, name: str, email: str = "", phone: str = ""
+) -> str:
+    """
+    Create a new contact.
+    name: the contact's display name (required, must be unique in the org).
+    email: optional email address.
+    phone: optional default phone number.
+    """
+    try:
+        _require_non_blank(name, "name")
+        contact: dict[str, Any] = {"Name": name}
+        if email:
+            contact["EmailAddress"] = email
+        if phone:
+            contact["Phones"] = [{"PhoneType": "DEFAULT", "PhoneNumber": phone}]
+        result = _accounting_request(
+            "POST", tenant_id, "/Contacts", json_data={"Contacts": [contact]}
+        )
+        created = _first_item(
+            result, "Contacts", "Xero did not return the created contact"
+        )
+        return _success(contact=_contact_summary(created))
+    except Exception as e:
+        logger.error(f"Error creating Xero contact: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def xero_update_contact(
+    tenant_id: str,
+    contact_id: str,
+    name: str | None = None,
+    email: str | None = None,
+    phone: str | None = None,
+) -> str:
+    """
+    Update an existing contact. Only the fields explicitly provided (not
+    None) are changed. phone replaces the contact's *entire* phone number
+    list with this single default number (Xero has no per-type patch) --
+    pass phone="" to remove all phone numbers, or leave phone unset to
+    leave the existing numbers untouched.
+    """
+    try:
+        encoded_id = url_path_id(contact_id, "contact_id")
+        contact: dict[str, Any] = {}
+        if name is not None:
+            _require_non_blank(name, "name")
+            contact["Name"] = name
+        if email is not None:
+            contact["EmailAddress"] = email
+        if phone is not None:
+            contact["Phones"] = (
+                [{"PhoneType": "DEFAULT", "PhoneNumber": phone}] if phone else []
+            )
+        if not contact:
+            return _error("at least one field to update must be provided")
+
+        result = _accounting_request(
+            "POST",
+            tenant_id,
+            f"/Contacts/{encoded_id}",
+            json_data={"Contacts": [contact]},
+        )
+        updated = _first_item(
+            result, "Contacts", "Xero did not return the updated contact"
+        )
+        return _success(contact=_contact_summary(updated))
+    except Exception as e:
+        logger.error(f"Error updating Xero contact {contact_id}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def xero_list_invoices(
+    tenant_id: str, status: str = "", contact_id: str = "", page: int = 1
+) -> str:
+    """
+    Search/list invoices (sales invoices and purchase bills).
+    status: optional filter, one of "DRAFT", "SUBMITTED", "AUTHORISED",
+    "PAID", "VOIDED", "DELETED".
+    contact_id: optional contact id (a UUID) to filter by, from
+    xero_list_contacts.
+    page: 1-based page number; Xero returns up to 100 invoices per page.
+    """
+    try:
+        max_page = max(1, page)
+        params: dict[str, Any] = {"page": max_page}
+        where_clauses = []
+        if status:
+            if status not in _INVOICE_STATUSES:
+                return _error(
+                    f"status must be one of {sorted(_INVOICE_STATUSES)}, got {status!r}"
+                )
+            where_clauses.append(f'Status=="{status}"')
+        if contact_id:
+            _validate_guid(contact_id, "contact_id")
+            where_clauses.append(f'Contact.ContactID==Guid("{contact_id}")')
+        if where_clauses:
+            params["where"] = " AND ".join(where_clauses)
+        result = _accounting_request("GET", tenant_id, "/Invoices", params=params)
+        invoices = _list_items(result, "Invoices")
+        return success_with_capped_dict(
+            "invoices", {"invoices": [_invoice_summary(i) for i in invoices]}
+        )
+    except Exception as e:
+        logger.error(f"Error listing Xero invoices: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def xero_get_invoice(tenant_id: str, invoice_id: str) -> str:
+    """
+    Get a Xero invoice by id, including its line items.
+    """
+    try:
+        encoded_id = url_path_id(invoice_id, "invoice_id")
+        result = _accounting_request("GET", tenant_id, f"/Invoices/{encoded_id}")
+        invoice = _first_item(result, "Invoices", f"Invoice '{invoice_id}' not found")
+        summary = _invoice_summary(invoice)
+        summary["line_items"] = invoice.get("LineItems") or []
+        return success_with_capped_dict("invoice", summary)
+    except Exception as e:
+        logger.error(f"Error fetching Xero invoice {invoice_id}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def xero_create_invoice(
+    tenant_id: str,
+    contact_id: str,
+    line_items: list[dict[str, Any]],
+    invoice_type: str = "ACCREC",
+    date: str = "",
+    due_date: str = "",
+    status: str = "DRAFT",
+) -> str:
+    """
+    Create a new invoice.
+    contact_id: the customer's (or, for a bill, the supplier's) contact id,
+    from xero_list_contacts.
+    line_items: a list of objects, each with "description" (required),
+    and optionally "quantity", "unit_amount", and "account_code" (from
+    xero_list_accounts) -- e.g.
+    [{"description": "Consulting", "quantity": 2, "unit_amount": 150.0,
+    "account_code": "200"}].
+    invoice_type: "ACCREC" (sales invoice, default) or "ACCPAY" (bill you
+    owe a supplier).
+    date, due_date: optional "YYYY-MM-DD" dates; Xero defaults both to
+    today if omitted.
+    status: "DRAFT" (default), "SUBMITTED", or "AUTHORISED" (AUTHORISED
+    makes the invoice final and visible to the customer/supplier).
+    """
+    try:
+        _require_non_blank(contact_id, "contact_id")
+        if invoice_type not in _INVOICE_TYPES:
+            return _error(f"invoice_type must be one of {sorted(_INVOICE_TYPES)}")
+        if status not in _INVOICE_STATUSES:
+            return _error(f"status must be one of {sorted(_INVOICE_STATUSES)}")
+        if not line_items:
+            return _error("line_items must contain at least one item")
+        invoice: dict[str, Any] = {
+            "Type": invoice_type,
+            "Contact": {"ContactID": contact_id},
+            "LineItems": _build_line_items(line_items),
+            "Status": status,
+        }
+        if date:
+            invoice["Date"] = date
+        if due_date:
+            invoice["DueDate"] = due_date
+        result = _accounting_request(
+            "POST", tenant_id, "/Invoices", json_data={"Invoices": [invoice]}
+        )
+        created = _first_item(
+            result, "Invoices", "Xero did not return the created invoice"
+        )
+        return _success(invoice=_invoice_summary(created))
+    except Exception as e:
+        logger.error(f"Error creating Xero invoice: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def xero_update_invoice_status(tenant_id: str, invoice_id: str, status: str) -> str:
+    """
+    Change an invoice's status -- e.g. move a DRAFT to AUTHORISED, or VOID
+    an invoice that shouldn't have been raised.
+    status: one of "AUTHORISED", "DELETED" (DRAFT/SUBMITTED invoices only),
+    "VOIDED" (AUTHORISED invoices only), "SUBMITTED".
+    """
+    try:
+        if status not in _INVOICE_STATUSES:
+            return _error(f"status must be one of {sorted(_INVOICE_STATUSES)}")
+        encoded_id = url_path_id(invoice_id, "invoice_id")
+        result = _accounting_request(
+            "POST",
+            tenant_id,
+            f"/Invoices/{encoded_id}",
+            json_data={"Invoices": [{"Status": status}]},
+        )
+        updated = _first_item(
+            result, "Invoices", "Xero did not return the updated invoice"
+        )
+        return _success(invoice=_invoice_summary(updated))
+    except Exception as e:
+        logger.error(f"Error updating Xero invoice {invoice_id}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def xero_list_accounts(tenant_id: str, account_type: str = "") -> str:
+    """
+    List the chart of accounts. Xero does not paginate this endpoint, so a
+    very large chart of accounts may be truncated in the response (see the
+    truncated flag) -- narrow with account_type if you hit that.
+    account_type: optional filter, e.g. "BANK", "REVENUE", "EXPENSE",
+    "CURRENT", "FIXED".
+    """
+    try:
+        params: dict[str, Any] = {}
+        if account_type:
+            _reject_quote(account_type, "account_type")
+            params["where"] = f'Type=="{account_type}"'
+        result = _accounting_request("GET", tenant_id, "/Accounts", params=params)
+        accounts = _list_items(result, "Accounts")
+        return success_with_capped_dict(
+            "accounts", {"accounts": [_account_summary(a) for a in accounts]}
+        )
+    except Exception as e:
+        logger.error(f"Error listing Xero accounts: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def xero_list_payments(tenant_id: str, page: int = 1) -> str:
+    """
+    List payments applied to invoices, most recently updated first.
+    page: 1-based page number; Xero returns up to 100 payments per page.
+    """
+    try:
+        result = _accounting_request(
+            "GET", tenant_id, "/Payments", params={"page": max(1, page)}
+        )
+        payments = _list_items(result, "Payments")
+        return success_with_capped_dict(
+            "payments", {"payments": [_payment_summary(p) for p in payments]}
+        )
+    except Exception as e:
+        logger.error(f"Error listing Xero payments: {e}")
+        return _error(str(e))
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/src/xagent/web/tools/mcp/xero.py
+++ b/src/xagent/web/tools/mcp/xero.py
@@ -82,13 +82,17 @@ def _validate_guid(value: str, field_name: str) -> str:
 
 
 def _reject_quote(value: str, field_name: str) -> str:
-    """Reject a value containing '"' before it's interpolated into a Xero
-    `where=` string literal -- none of the values this is applied to
+    """Reject a value containing '"' or '\\' before it's interpolated into a
+    Xero `where=` string literal -- none of the values this is applied to
     (a status keyword, an account type keyword) should ever legitimately
     contain one, so rejecting outright is simpler and safer than attempting
-    to escape Xero's filter-expression quoting rules."""
-    if '"' in value:
-        raise ValueError(f"{field_name} must not contain a '\"' character")
+    to escape Xero's filter-expression quoting rules. '\\' is rejected too
+    since Xero's where-clause strings support backslash-escaping a quote --
+    without this, a trailing backslash could consume the literal's own
+    closing quote from the template rather than the caller's value.
+    """
+    if '"' in value or "\\" in value:
+        raise ValueError(f"{field_name} must not contain a '\"' or '\\' character")
     return value
 
 
@@ -112,14 +116,19 @@ def _extract_error_detail(response: requests.Response) -> str | None:
     if not isinstance(message, str):
         message = None
     validation_messages = []
-    for element in payload.get("Elements") or []:
-        if not isinstance(element, dict):
-            continue
-        for validation_error in element.get("ValidationErrors") or []:
-            if isinstance(validation_error, dict):
-                detail = validation_error.get("Message")
-                if isinstance(detail, str) and detail:
-                    validation_messages.append(detail)
+    elements = payload.get("Elements")
+    if isinstance(elements, list):
+        for element in elements:
+            if not isinstance(element, dict):
+                continue
+            validation_errors = element.get("ValidationErrors")
+            if not isinstance(validation_errors, list):
+                continue
+            for validation_error in validation_errors:
+                if isinstance(validation_error, dict):
+                    detail = validation_error.get("Message")
+                    if isinstance(detail, str) and detail:
+                        validation_messages.append(detail)
     if validation_messages:
         joined = "; ".join(validation_messages)
         return f"{message}: {joined}" if message else joined
@@ -185,8 +194,12 @@ def _accounting_request(
     )
 
 
-def _list_items(result: Any, key: str) -> list[Any]:
-    return result.get(key) or [] if isinstance(result, dict) else []
+def _list_items(result: Any, key: str) -> list[dict[str, Any]]:
+    if isinstance(result, dict):
+        items = result.get(key)
+        if isinstance(items, list):
+            return [item for item in items if isinstance(item, dict)]
+    return []
 
 
 def _first_item(result: Any, key: str, not_found_message: str) -> dict[str, Any]:
@@ -216,7 +229,9 @@ def _contact_summary(contact: dict[str, Any]) -> dict[str, Any]:
 
 
 def _invoice_summary(invoice: dict[str, Any]) -> dict[str, Any]:
-    contact = invoice.get("Contact") or {}
+    contact = invoice.get("Contact")
+    if not isinstance(contact, dict):
+        contact = {}
     return {
         "invoice_id": invoice.get("InvoiceID"),
         "invoice_number": invoice.get("InvoiceNumber"),
@@ -248,8 +263,12 @@ def _account_summary(account: dict[str, Any]) -> dict[str, Any]:
 
 
 def _payment_summary(payment: dict[str, Any]) -> dict[str, Any]:
-    invoice = payment.get("Invoice") or {}
-    account = payment.get("Account") or {}
+    invoice = payment.get("Invoice")
+    if not isinstance(invoice, dict):
+        invoice = {}
+    account = payment.get("Account")
+    if not isinstance(account, dict):
+        account = {}
     return {
         "payment_id": payment.get("PaymentID"),
         "amount": payment.get("Amount"),
@@ -350,7 +369,9 @@ def xero_list_contacts(tenant_id: str, search_term: str = "", page: int = 1) -> 
             params["searchTerm"] = search_term
         result = _accounting_request("GET", tenant_id, "/Contacts", params=params)
         contacts = _list_items(result, "Contacts")
-        pagination = result.get("pagination") or {} if isinstance(result, dict) else {}
+        pagination = result.get("pagination") if isinstance(result, dict) else None
+        if not isinstance(pagination, dict):
+            pagination = {}
         return success_with_capped_dict(
             "contacts",
             {
@@ -501,7 +522,8 @@ def xero_get_invoice(tenant_id: str, invoice_id: str) -> str:
         result = _accounting_request("GET", tenant_id, f"/Invoices/{encoded_id}")
         invoice = _first_item(result, "Invoices", f"Invoice '{invoice_id}' not found")
         summary = _invoice_summary(invoice)
-        summary["line_items"] = invoice.get("LineItems") or []
+        line_items = invoice.get("LineItems")
+        summary["line_items"] = line_items if isinstance(line_items, list) else []
         return success_with_capped_dict("invoice", summary)
     except Exception as e:
         logger.error(f"Error fetching Xero invoice {invoice_id}: {e}")

--- a/tests/alembic/test_20260903_seed_xero_mcp_app.py
+++ b/tests/alembic/test_20260903_seed_xero_mcp_app.py
@@ -1,0 +1,208 @@
+"""Tests for the Xero MCP connector seed migration."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260903_seed_xero_mcp_app.py"
+    )
+    spec = importlib.util.spec_from_file_location("seed_xero_migration", migration_file)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_tables(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE oauth_providers (
+                id INTEGER PRIMARY KEY,
+                provider_name VARCHAR(50) NOT NULL UNIQUE,
+                name VARCHAR(100) NOT NULL,
+                client_id VARCHAR(500) NOT NULL,
+                client_secret VARCHAR(500) NOT NULL,
+                auth_url VARCHAR(500) NOT NULL,
+                token_url VARCHAR(500) NOT NULL,
+                redirect_uri VARCHAR(500),
+                userinfo_url VARCHAR(500),
+                user_id_path VARCHAR(100),
+                email_path VARCHAR(100),
+                default_scopes JSON
+            )
+            """
+        )
+    )
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                name VARCHAR(200) NOT NULL,
+                description TEXT,
+                icon VARCHAR(1000),
+                transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                provider_name VARCHAR(50),
+                category VARCHAR(100),
+                oauth_scopes JSON,
+                is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                launch_config JSON
+            )
+            """
+        )
+    )
+
+
+def _app_ids(connection):
+    return set(connection.execute(text("SELECT app_id FROM public_mcp_apps")).scalars())
+
+
+def _provider_names(connection):
+    return set(
+        connection.execute(text("SELECT provider_name FROM oauth_providers")).scalars()
+    )
+
+
+def test_upgrade_inserts_provider_and_app(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        assert "xero" in _provider_names(connection)
+        assert "xero" in _app_ids(connection)
+
+        row = connection.execute(
+            text(
+                "SELECT transport, provider_name, launch_config FROM public_mcp_apps"
+                " WHERE app_id='xero'"
+            )
+        ).first()
+        assert row[0] == "oauth"
+        assert row[1] == "xero"
+        assert "xagent.web.tools.mcp.xero" in str(row[2])
+        assert "XERO_ACCESS_TOKEN" in str(row[2])
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()  # second run must not raise or duplicate
+        app_count = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='xero'")
+        ).scalar()
+        assert app_count == 1
+        provider_count = connection.execute(
+            text("SELECT COUNT(*) FROM oauth_providers WHERE provider_name='xero'")
+        ).scalar()
+        assert provider_count == 1
+
+
+def test_seed_rows_match_registry(tmp_path):
+    """The migration snapshot and the runtime registry must define the same
+    xero rows (the migration is a frozen copy; this catches drift)."""
+    from xagent.web.builtin_mcp_registry import (
+        get_builtin_oauth_provider_rows,
+        get_builtin_public_mcp_app_rows,
+    )
+
+    migration = _load_migration_module()
+
+    registry_app = next(
+        row for row in get_builtin_public_mcp_app_rows() if row["app_id"] == "xero"
+    )
+    assert migration._xero_app_row() == registry_app
+
+    registry_provider = next(
+        row
+        for row in get_builtin_oauth_provider_rows()
+        if row["provider_name"] == "xero"
+    )
+    assert migration._xero_provider_row() == registry_provider
+
+
+def test_downgrade_removes_provider_and_app(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "xero" not in _app_ids(connection)
+        assert "xero" not in _provider_names(connection)
+
+
+def test_downgrade_keeps_provider_when_custom_xero_app_exists(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            connection.execute(
+                text(
+                    "INSERT INTO public_mcp_apps (app_id, name, transport, provider_name)"
+                    " VALUES ('custom-xero', 'Custom Xero', 'oauth', 'xero')"
+                )
+            )
+            migration.downgrade()
+        assert "xero" in _provider_names(connection)
+
+
+def test_downgrade_preserves_admin_created_xero_provider(tmp_path):
+    """A pre-existing admin-created "xero" provider (different shape than the
+    seeded row) must survive downgrade even when no xero apps remain."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        connection.execute(
+            text(
+                "INSERT INTO oauth_providers"
+                " (provider_name, name, client_id, client_secret, auth_url, token_url)"
+                " VALUES ('xero', 'Custom Xero', 'cid', 'secret',"
+                " 'https://custom.example.com/authorize',"
+                " 'https://custom.example.com/token')"
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "xero" not in _app_ids(connection)
+        assert "xero" in _provider_names(connection)
+
+
+def test_upgrade_and_downgrade_no_op_without_tables(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        table_names = set(
+            connection.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table'")
+            ).scalars()
+        )
+        assert "oauth_providers" not in table_names
+        assert "public_mcp_apps" not in table_names

--- a/tests/web/test_xero_oauth.py
+++ b/tests/web/test_xero_oauth.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import base64
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.core.utils.encryption import encrypt_value
+from xagent.web.api import auth as auth_api
+from xagent.web.api.auth import create_access_token, generic_oauth_callback
+from xagent.web.models.database import Base
+from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.oauth_provider import OAuthProvider
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.models.user_oauth import UserOAuth
+from xagent.web.tools import config as tool_config
+
+
+class MockResponse:
+    def __init__(self, json_data=None, status_code: int = 200, text: str = ""):
+        self._json_data = json_data or {}
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    user = User(username="alice", password_hash="x", is_admin=False)
+    db.add(user)
+    db.add(
+        PublicMCPApp(
+            app_id="xero",
+            name="Xero",
+            description="Xero connector",
+            transport="oauth",
+            provider_name="xero",
+            category="Accounting",
+            oauth_scopes=["offline_access", "accounting.contacts"],
+            # True here regardless of the real catalog row's current value
+            # (which ships hidden as a release gate, see
+            # builtin_mcp_registry.py's own comment on it): a hidden app's
+            # OAuth callback 404s unconditionally (auth.py's
+            # _reject_hidden_catalog_app, enforced server-side on all three
+            # connect paths) -- this fixture exists to isolate and verify
+            # the Basic-Auth token-exchange mechanics below, which is a
+            # separate concern from that visibility gate and shouldn't be
+            # coupled to whichever value the real row happens to have.
+            is_visible_in_connector=True,
+            launch_config={
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.xero"],
+                "env_mapping": {"XERO_ACCESS_TOKEN": "access_token"},
+            },
+        )
+    )
+    db.commit()
+    db.refresh(user)
+
+    yield db, user
+    db.close()
+    engine.dispose()
+
+
+def _xero_provider() -> SimpleNamespace:
+    return SimpleNamespace(
+        provider_name="xero",
+        client_id=encrypt_value("xero-client-id"),
+        client_secret=encrypt_value("xero-client-secret"),
+        token_url="https://identity.xero.com/connect/token",
+        redirect_uri="https://app.example.com/api/auth/xero/callback",
+        userinfo_url="https://identity.xero.com/connect/userinfo",
+        user_id_path="sub",
+        email_path="email",
+        default_scopes=["openid", "profile", "email"],
+    )
+
+
+def test_xero_callback_exchanges_code_with_http_basic_auth(db_session, monkeypatch):
+    """Xero's token endpoint (per its own official SDK, XeroAPI/xero-node's
+    tokenRequest()) authenticates via HTTP Basic Auth, not a client_secret in
+    the POST body -- assert the exchange sends Basic auth and omits the
+    secret (and client_id) from the form body, not just that the call
+    "worked"."""
+    db, user = db_session
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": "xero",
+            "app_id": "xero",
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    request = SimpleNamespace(query_params={"code": "xero-code", "state": state})
+
+    post = Mock(
+        return_value=MockResponse(
+            {
+                "access_token": "xero-token",
+                "refresh_token": "xero-refresh",
+                "token_type": "bearer",
+                "expires_in": 1800,
+                "scope": "openid profile email offline_access accounting.contacts",
+            }
+        )
+    )
+    monkeypatch.setattr(auth_api.requests, "post", post)
+    monkeypatch.setattr(
+        auth_api.requests,
+        "get",
+        Mock(
+            return_value=MockResponse({"sub": "xero-user-1", "email": "alice@xero.com"})
+        ),
+    )
+
+    response = generic_oauth_callback("xero", request, db, _xero_provider())
+
+    assert response.status_code == 200
+    assert post.call_args.kwargs["auth"] == ("xero-client-id", "xero-client-secret")
+    assert "client_id" not in post.call_args.kwargs["data"]
+    assert "client_secret" not in post.call_args.kwargs["data"]
+    assert post.call_args.kwargs["data"]["grant_type"] == "authorization_code"
+
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "xero")
+        .one()
+    )
+    assert oauth_account.access_token == "xero-token"
+    assert oauth_account.refresh_token == "xero-refresh"
+    assert oauth_account.provider_user_id == "xero-user-1"
+    assert oauth_account.email == "alice@xero.com"
+
+    server = db.query(MCPServer).filter(MCPServer.name == "Xero").one()
+    assert server.transport == "oauth"
+    user_mcp = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .one()
+    )
+    assert user_mcp.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_xero_expired_token_refresh_uses_http_basic_auth(db_session, monkeypatch):
+    """Xero access tokens last only 30 minutes, so a missed Basic-Auth branch
+    on the refresh leg would surface as a broken connection within the hour
+    even if the initial code exchange happened to work."""
+    db, user = db_session
+    db.add(
+        OAuthProvider(
+            provider_name="xero",
+            name="Xero",
+            client_id=encrypt_value("xero-client-id"),
+            client_secret=encrypt_value("xero-client-secret"),
+            auth_url="https://login.xero.com/identity/connect/authorize",
+            token_url="https://identity.xero.com/connect/token",
+            redirect_uri="https://app.example.com/api/auth/xero/callback",
+            userinfo_url="https://identity.xero.com/connect/userinfo",
+            user_id_path="sub",
+            email_path="email",
+            default_scopes=["openid", "profile", "email"],
+        )
+    )
+    oauth_account = UserOAuth(
+        user_id=user.id,
+        provider="xero",
+        access_token="old-token",
+        refresh_token="old-refresh",
+        expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        provider_user_id="xero-user-1",
+    )
+    db.add(oauth_account)
+    db.commit()
+
+    captured_requests = []
+
+    class FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            captured_requests.append((url, kwargs))
+            return MockResponse(
+                {
+                    "access_token": "new-token",
+                    "refresh_token": "new-refresh",
+                    "token_type": "bearer",
+                    "expires_in": 1800,
+                },
+                status_code=200,
+            )
+
+    monkeypatch.setattr(tool_config.httpx, "AsyncClient", FakeAsyncClient)
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "xero")
+        is True
+    )
+
+    assert oauth_account.access_token == "new-token"
+    assert oauth_account.refresh_token == "new-refresh"
+    assert len(captured_requests) == 1
+    url, kwargs = captured_requests[0]
+    assert url == "https://identity.xero.com/connect/token"
+    assert kwargs["data"] == {
+        "grant_type": "refresh_token",
+        "refresh_token": "old-refresh",
+    }
+    auth = kwargs["auth"]
+    assert isinstance(auth, tool_config.httpx.BasicAuth)
+    expected_credential = base64.b64encode(b"xero-client-id:xero-client-secret").decode(
+        "ascii"
+    )
+    assert auth._auth_header == f"Basic {expected_credential}"

--- a/tests/web/test_xero_oauth.py
+++ b/tests/web/test_xero_oauth.py
@@ -51,7 +51,13 @@ def db_session(tmp_path):
             transport="oauth",
             provider_name="xero",
             category="Accounting",
-            oauth_scopes=["offline_access", "accounting.contacts"],
+            oauth_scopes=[
+                "offline_access",
+                "accounting.contacts",
+                "accounting.invoices",
+                "accounting.payments.read",
+                "accounting.settings",
+            ],
             # True here regardless of the real catalog row's current value
             # (which ships hidden as a release gate, see
             # builtin_mcp_registry.py's own comment on it): a hidden app's

--- a/tests/web/tools/test_xero_mcp.py
+++ b/tests/web/tools/test_xero_mcp.py
@@ -1,0 +1,595 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+import requests
+
+from xagent.web.tools.mcp import xero
+
+
+class MockResponse:
+    def __init__(
+        self,
+        json_data=None,
+        text: str = "",
+        status_code: int = 200,
+        url: str = "",
+        json_raises: bool = False,
+    ):
+        self._json_data = json_data if json_data is not None else {}
+        self._json_raises = json_raises
+        self.text = text or (json.dumps(self._json_data) if json_data else "")
+        self.status_code = status_code
+        self.content = self.text.encode()
+        self.url = url
+
+    def json(self):
+        if self._json_raises:
+            raise json.JSONDecodeError("Expecting value", self.text, 0)
+        return self._json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise requests.HTTPError(
+                f"{self.status_code} Client Error for url: {self.url}", response=self
+            )
+
+
+_GUID = "12345678-1234-1234-1234-123456789012"
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("XERO_ACCESS_TOKEN", "access-token")
+
+
+def test_headers_require_access_token(monkeypatch):
+    monkeypatch.delenv("XERO_ACCESS_TOKEN")
+
+    with pytest.raises(ValueError, match="XERO_ACCESS_TOKEN"):
+        xero._headers()
+
+
+def test_headers_include_bearer_token_without_tenant():
+    headers = xero._headers()
+
+    assert headers["Authorization"] == "Bearer access-token"
+    assert "Xero-tenant-id" not in headers
+
+
+def test_headers_include_tenant_id_when_provided():
+    headers = xero._headers("tenant-123")
+
+    assert headers["Xero-tenant-id"] == "tenant-123"
+
+
+@pytest.mark.parametrize("value", ["", "   ", None])
+def test_require_non_blank_rejects_empty_values(value):
+    with pytest.raises(ValueError, match="field"):
+        xero._require_non_blank(value, "field")
+
+
+def test_validate_guid_accepts_well_formed_guid():
+    assert xero._validate_guid(_GUID, "contact_id") == _GUID
+
+
+@pytest.mark.parametrize("value", ["not-a-guid", "c1", _GUID + "x", '"; DROP TABLE'])
+def test_validate_guid_rejects_malformed_values(value):
+    with pytest.raises(ValueError, match="contact_id"):
+        xero._validate_guid(value, "contact_id")
+
+
+def test_reject_quote_passes_through_clean_value():
+    assert xero._reject_quote("BANK", "account_type") == "BANK"
+
+
+def test_reject_quote_rejects_embedded_quote():
+    with pytest.raises(ValueError, match="account_type"):
+        xero._reject_quote('BANK" || Type!="', "account_type")
+
+
+def test_extract_error_detail_returns_plain_message():
+    response = MockResponse(json_data={"Message": "Invalid contact"})
+
+    assert xero._extract_error_detail(response) == "Invalid contact"
+
+
+def test_extract_error_detail_folds_in_validation_errors():
+    response = MockResponse(
+        json_data={
+            "Message": "A validation exception occurred",
+            "Elements": [{"ValidationErrors": [{"Message": "Name must not be blank"}]}],
+        }
+    )
+
+    assert (
+        xero._extract_error_detail(response)
+        == "A validation exception occurred: Name must not be blank"
+    )
+
+
+def test_extract_error_detail_returns_none_for_non_json_body():
+    response = MockResponse(status_code=500, text="not json", json_raises=True)
+
+    assert xero._extract_error_detail(response) is None
+
+
+def test_build_line_items_requires_description():
+    with pytest.raises(ValueError, match="description"):
+        xero._build_line_items([{"quantity": 1}])
+
+
+def test_build_line_items_translates_snake_case_to_pascal_case():
+    result = xero._build_line_items(
+        [
+            {
+                "description": "Consulting",
+                "quantity": 2,
+                "unit_amount": 150.0,
+                "account_code": "200",
+            }
+        ]
+    )
+
+    assert result == [
+        {
+            "Description": "Consulting",
+            "Quantity": 2,
+            "UnitAmount": 150.0,
+            "AccountCode": "200",
+        }
+    ]
+
+
+def test_build_line_items_allows_description_only():
+    result = xero._build_line_items([{"description": "Note line"}])
+
+    assert result == [{"Description": "Note line"}]
+
+
+def test_build_line_items_allows_zero_quantity_and_amount():
+    result = xero._build_line_items(
+        [{"description": "Free sample", "quantity": 0, "unit_amount": 0}]
+    )
+
+    assert result == [{"Description": "Free sample", "Quantity": 0, "UnitAmount": 0}]
+
+
+def test_build_line_items_rejects_non_numeric_quantity():
+    with pytest.raises(ValueError, match="quantity"):
+        xero._build_line_items([{"description": "x", "quantity": "two"}])
+
+
+def test_build_line_items_rejects_non_numeric_unit_amount():
+    with pytest.raises(ValueError, match="unit_amount"):
+        xero._build_line_items([{"description": "x", "unit_amount": "ten"}])
+
+
+def test_request_uses_bearer_and_tenant_headers(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"ok": True}))
+    monkeypatch.setattr(xero.requests, "request", mock_request)
+
+    result = xero._request("GET", "https://api.xero.com/x", tenant_id="tenant-123")
+
+    assert result == {"ok": True}
+    assert (
+        mock_request.call_args.kwargs["headers"]["Authorization"]
+        == "Bearer access-token"
+    )
+    assert mock_request.call_args.kwargs["headers"]["Xero-tenant-id"] == "tenant-123"
+
+
+def test_request_returns_empty_dict_for_204(monkeypatch):
+    monkeypatch.setattr(
+        xero.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=204, text="")),
+    )
+
+    assert xero._request("DELETE", "https://api.xero.com/x") == {}
+
+
+def test_request_raises_with_structured_error_detail(monkeypatch):
+    monkeypatch.setattr(
+        xero.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=400, json_data={"Message": "Bad request"}
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="Bad request"):
+        xero._request("GET", "https://api.xero.com/x")
+
+
+def test_request_raises_clear_error_for_non_json_2xx_body(monkeypatch):
+    monkeypatch.setattr(
+        xero.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=200, text="<html>not json</html>", json_raises=True
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="non-JSON"):
+        xero._request("GET", "https://api.xero.com/x")
+
+
+def test_accounting_request_requires_tenant_id():
+    with pytest.raises(ValueError, match="tenant_id"):
+        xero._accounting_request("GET", "  ", "/Contacts")
+
+
+def test_accounting_request_builds_accounting_url(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"ok": True}))
+    monkeypatch.setattr(xero.requests, "request", mock_request)
+
+    xero._accounting_request("GET", "tenant-1", "/Contacts")
+
+    assert (
+        mock_request.call_args.kwargs["url"]
+        == "https://api.xero.com/api.xro/2.0/Contacts"
+    )
+
+
+def test_first_item_raises_when_empty():
+    with pytest.raises(ValueError, match="nope"):
+        xero._first_item({"Contacts": []}, "Contacts", "nope")
+
+
+def test_first_item_returns_first_element():
+    assert xero._first_item({"Contacts": [{"a": 1}, {"a": 2}]}, "Contacts", "x") == {
+        "a": 1
+    }
+
+
+def test_list_organisations_returns_summaries(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data=[
+                {"tenantId": "t1", "tenantName": "Acme", "tenantType": "ORGANISATION"}
+            ]
+        )
+    )
+    monkeypatch.setattr(xero.requests, "request", mock_request)
+
+    result = json.loads(xero.xero_list_organisations())
+
+    assert result["status"] == "success"
+    assert result["organisations"] == [
+        {"tenant_id": "t1", "tenant_name": "Acme", "tenant_type": "ORGANISATION"}
+    ]
+    assert mock_request.call_args.kwargs["url"] == xero.XERO_CONNECTIONS_URL
+    assert "Xero-tenant-id" not in mock_request.call_args.kwargs["headers"]
+
+
+def test_get_organisation_returns_first_entry(monkeypatch):
+    monkeypatch.setattr(
+        xero.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(json_data={"Organisations": [{"Name": "Acme"}]})
+        ),
+    )
+
+    result = json.loads(xero.xero_get_organisation("tenant-1"))
+
+    assert result["status"] == "success"
+    assert result["organisation"]["Name"] == "Acme"
+
+
+def test_list_contacts_sends_search_term_and_page(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={
+                "Contacts": [{"ContactID": "c1", "Name": "Jane"}],
+                "pagination": {"page": 2, "pageCount": 3, "itemCount": 250},
+            }
+        )
+    )
+    monkeypatch.setattr(xero.requests, "request", mock_request)
+
+    result = json.loads(xero.xero_list_contacts("tenant-1", search_term="jane", page=2))
+
+    assert result["status"] == "success"
+    assert result["contacts"]["contacts"][0]["name"] == "Jane"
+    assert result["contacts"]["page_count"] == 3
+    params = mock_request.call_args.kwargs["params"]
+    assert params == {"page": 2, "searchTerm": "jane"}
+
+
+def test_get_contact_returns_error_when_not_found(monkeypatch):
+    monkeypatch.setattr(
+        xero.requests,
+        "request",
+        Mock(return_value=MockResponse(json_data={"Contacts": []})),
+    )
+
+    result = json.loads(xero.xero_get_contact("tenant-1", "missing"))
+
+    assert result["status"] == "error"
+
+
+def test_create_contact_requires_name():
+    result = json.loads(xero.xero_create_contact("tenant-1", ""))
+
+    assert result["status"] == "error"
+
+
+def test_create_contact_sends_expected_body(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"Contacts": [{"ContactID": "c1", "Name": "Jane"}]}
+        )
+    )
+    monkeypatch.setattr(xero.requests, "request", mock_request)
+
+    result = json.loads(
+        xero.xero_create_contact(
+            "tenant-1", "Jane", email="jane@example.com", phone="555"
+        )
+    )
+
+    assert result["status"] == "success"
+    body = mock_request.call_args.kwargs["json"]["Contacts"][0]
+    assert body["Name"] == "Jane"
+    assert body["EmailAddress"] == "jane@example.com"
+    assert body["Phones"] == [{"PhoneType": "DEFAULT", "PhoneNumber": "555"}]
+    assert mock_request.call_args.kwargs["method"] == "POST"
+
+
+def test_update_contact_requires_at_least_one_field():
+    result = json.loads(xero.xero_update_contact("tenant-1", "c1"))
+
+    assert result["status"] == "error"
+
+
+def test_update_contact_sends_only_provided_fields(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"Contacts": [{"ContactID": "c1"}]})
+    )
+    monkeypatch.setattr(xero.requests, "request", mock_request)
+
+    xero.xero_update_contact("tenant-1", "c1", email="new@example.com")
+
+    body = mock_request.call_args.kwargs["json"]["Contacts"][0]
+    assert body == {"EmailAddress": "new@example.com"}
+    assert mock_request.call_args.kwargs["url"].endswith("/Contacts/c1")
+
+
+def test_update_contact_clears_phone_with_empty_string(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"Contacts": [{"ContactID": "c1"}]})
+    )
+    monkeypatch.setattr(xero.requests, "request", mock_request)
+
+    xero.xero_update_contact("tenant-1", "c1", phone="")
+
+    body = mock_request.call_args.kwargs["json"]["Contacts"][0]
+    assert body == {"Phones": []}
+
+
+def test_update_contact_sets_single_default_phone(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"Contacts": [{"ContactID": "c1"}]})
+    )
+    monkeypatch.setattr(xero.requests, "request", mock_request)
+
+    xero.xero_update_contact("tenant-1", "c1", phone="555-1234")
+
+    body = mock_request.call_args.kwargs["json"]["Contacts"][0]
+    assert body == {"Phones": [{"PhoneType": "DEFAULT", "PhoneNumber": "555-1234"}]}
+
+
+def test_list_invoices_builds_where_clause_from_status_and_contact(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"Invoices": []}))
+    monkeypatch.setattr(xero.requests, "request", mock_request)
+
+    xero.xero_list_invoices("tenant-1", status="DRAFT", contact_id=_GUID)
+
+    params = mock_request.call_args.kwargs["params"]
+    assert params["where"] == f'Status=="DRAFT" AND Contact.ContactID==Guid("{_GUID}")'
+
+
+def test_list_invoices_rejects_invalid_status():
+    result = json.loads(xero.xero_list_invoices("tenant-1", status="BOGUS"))
+
+    assert result["status"] == "error"
+
+
+def test_list_invoices_rejects_non_guid_contact_id():
+    result = json.loads(xero.xero_list_invoices("tenant-1", contact_id="not-a-guid"))
+
+    assert result["status"] == "error"
+
+
+def test_list_invoices_omits_where_when_no_filters(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"Invoices": []}))
+    monkeypatch.setattr(xero.requests, "request", mock_request)
+
+    xero.xero_list_invoices("tenant-1")
+
+    assert "where" not in mock_request.call_args.kwargs["params"]
+
+
+def test_get_invoice_includes_line_items(monkeypatch):
+    monkeypatch.setattr(
+        xero.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "Invoices": [
+                        {
+                            "InvoiceID": "i1",
+                            "LineItems": [{"Description": "Consulting"}],
+                        }
+                    ]
+                }
+            )
+        ),
+    )
+
+    result = json.loads(xero.xero_get_invoice("tenant-1", "i1"))
+
+    assert result["status"] == "success"
+    assert result["invoice"]["line_items"] == [{"Description": "Consulting"}]
+
+
+def test_create_invoice_requires_line_items():
+    result = json.loads(xero.xero_create_invoice("tenant-1", "c1", []))
+
+    assert result["status"] == "error"
+
+
+def test_create_invoice_rejects_invalid_type():
+    result = json.loads(
+        xero.xero_create_invoice(
+            "tenant-1", "c1", [{"description": "x"}], invoice_type="BOGUS"
+        )
+    )
+
+    assert result["status"] == "error"
+
+
+def test_create_invoice_rejects_invalid_status():
+    result = json.loads(
+        xero.xero_create_invoice(
+            "tenant-1", "c1", [{"description": "x"}], status="BOGUS"
+        )
+    )
+
+    assert result["status"] == "error"
+
+
+def test_create_invoice_sends_expected_body(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"Invoices": [{"InvoiceID": "i1"}]})
+    )
+    monkeypatch.setattr(xero.requests, "request", mock_request)
+
+    result = json.loads(
+        xero.xero_create_invoice(
+            "tenant-1",
+            "c1",
+            [{"description": "Consulting", "quantity": 1, "unit_amount": 100.0}],
+            date="2026-01-01",
+            due_date="2026-01-15",
+        )
+    )
+
+    assert result["status"] == "success"
+    body = mock_request.call_args.kwargs["json"]["Invoices"][0]
+    assert body["Type"] == "ACCREC"
+    assert body["Contact"] == {"ContactID": "c1"}
+    assert body["Status"] == "DRAFT"
+    assert body["Date"] == "2026-01-01"
+    assert body["DueDate"] == "2026-01-15"
+    assert body["LineItems"] == [
+        {"Description": "Consulting", "Quantity": 1, "UnitAmount": 100.0}
+    ]
+
+
+def test_update_invoice_status_sends_status_only(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"Invoices": [{"InvoiceID": "i1", "Status": "AUTHORISED"}]}
+        )
+    )
+    monkeypatch.setattr(xero.requests, "request", mock_request)
+
+    result = json.loads(xero.xero_update_invoice_status("tenant-1", "i1", "AUTHORISED"))
+
+    assert result["status"] == "success"
+    body = mock_request.call_args.kwargs["json"]["Invoices"][0]
+    assert body == {"Status": "AUTHORISED"}
+    assert mock_request.call_args.kwargs["url"].endswith("/Invoices/i1")
+
+
+def test_update_invoice_status_rejects_invalid_status():
+    result = json.loads(xero.xero_update_invoice_status("tenant-1", "i1", "BOGUS"))
+
+    assert result["status"] == "error"
+
+
+def test_list_accounts_sends_type_filter(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"Accounts": []}))
+    monkeypatch.setattr(xero.requests, "request", mock_request)
+
+    xero.xero_list_accounts("tenant-1", account_type="BANK")
+
+    assert mock_request.call_args.kwargs["params"]["where"] == 'Type=="BANK"'
+
+
+def test_list_accounts_rejects_account_type_with_embedded_quote():
+    result = json.loads(
+        xero.xero_list_accounts("tenant-1", account_type='BANK" || Type!="')
+    )
+
+    assert result["status"] == "error"
+
+
+def test_list_accounts_omits_where_when_no_type(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"Accounts": []}))
+    monkeypatch.setattr(xero.requests, "request", mock_request)
+
+    xero.xero_list_accounts("tenant-1")
+
+    assert "where" not in mock_request.call_args.kwargs["params"]
+
+
+def test_list_payments_returns_summaries(monkeypatch):
+    monkeypatch.setattr(
+        xero.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                json_data={
+                    "Payments": [
+                        {
+                            "PaymentID": "p1",
+                            "Amount": 10.0,
+                            "Invoice": {"InvoiceID": "i1", "InvoiceNumber": "INV-1"},
+                        }
+                    ]
+                }
+            )
+        ),
+    )
+
+    result = json.loads(xero.xero_list_payments("tenant-1"))
+
+    assert result["status"] == "success"
+    assert result["payments"]["payments"][0]["invoice_number"] == "INV-1"
+
+
+def test_xero_app_registry_uses_oauth_transport_and_provider():
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    xero_app = next(
+        row for row in get_builtin_public_mcp_app_rows() if row["app_id"] == "xero"
+    )
+    assert xero_app["transport"] == "oauth"
+    assert xero_app["provider_name"] == "xero"
+    assert xero_app["category"] == "Accounting"
+    assert xero_app["launch_config"]["env_mapping"] == {
+        "XERO_ACCESS_TOKEN": "access_token"
+    }
+
+
+def test_xero_oauth_provider_registry_has_expected_endpoints():
+    from xagent.web.builtin_mcp_registry import get_builtin_oauth_provider_rows
+
+    xero_provider = next(
+        row
+        for row in get_builtin_oauth_provider_rows()
+        if row["provider_name"] == "xero"
+    )
+    assert (
+        xero_provider["auth_url"] == "https://login.xero.com/identity/connect/authorize"
+    )
+    assert xero_provider["token_url"] == "https://identity.xero.com/connect/token"


### PR DESCRIPTION
## Summary
- Adds an OAuth2 Xero connector at `src/xagent/web/tools/mcp/xero.py`, using the Accounting API (`api.xro/2.0`): organisation listing, contact search/get/create/update, invoice search/get/create/status-change, chart of accounts, and payments
- Registers **both** an `oauth_providers` row and a `public_mcp_apps` row in `builtin_mcp_registry.py`, and seeds them via an Alembic migration — mirroring `zoom.py`'s existing pattern exactly (this is the first connector added since zoom that needs a brand-new OAuth provider, not just an app row)
- Xero app registration is self-serve (developer.xero.com), no review required for private use — same bar as the existing OAuth connectors in this registry
- Every tool except `xero_list_organisations` requires an explicit `tenant_id` (from that first call) and sends it as the `Xero-tenant-id` header — one OAuth connection can be authorized against multiple organisations with no server-side "current" concept, and (confirmed against this runtime's own MCP session lifecycle) a per-process cache wouldn't help anyway since each tool call is a fresh subprocess
- Uses the newer granular `accounting.*` scopes required for any Xero app registered on or after March 2, 2026 — Xero deprecated the old broad `accounting.transactions`/`accounting.contacts`-covers-everything scopes for new apps

## Test plan
- [x] `pytest tests/web/tools/test_xero_mcp.py tests/alembic/test_20260903_seed_xero_mcp_app.py` — 66 passing
- [x] `pytest tests/web/api/test_public_mcp_connector_visibility.py` (registry/drift/connect-flow integration) — 51 passing
- [x] `ruff check` / `ruff format --check` / `mypy` clean on the new module
- [x] Alembic revision graph: single head, chains cleanly off `20260901_seed_chartmogul_mcp_app`
- [x] Endpoint paths, header name, response envelope shape, and field names cross-checked against Xero's official published OpenAPI spec (github.com/XeroAPI/Xero-OpenAPI) after a self-review pass; fixed a `where`-clause filter-injection gap (unescaped `status`/`contact_id`/`account_type` interpolation — now GUID-validated / quote-rejected), a contact-update bug where `phone=""` couldn't actually clear a phone number, missing output-size caps on list tools, and 11x duplicated response-envelope-unwrapping logic before commit