### PR TITLE
fix(tools): parse JSON-encoded array strings in MCP tool-arg normalization

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -1123,6 +1123,14 @@ class MCPToolAdapter(AbstractBaseTool):
             if value is None:
                 continue
             if self._schema_is_array_only(field_schema) and not isinstance(value, list):
+                if isinstance(value, str):
+                    try:
+                        parsed_value = json.loads(value)
+                    except (ValueError, TypeError):
+                        parsed_value = None
+                    if isinstance(parsed_value, list):
+                        normalized_args[field_name] = parsed_value
+                        continue
                 normalized_args[field_name] = [value]
 
         return normalized_args

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -1124,12 +1124,22 @@ class MCPToolAdapter(AbstractBaseTool):
                 continue
             if self._schema_is_array_only(field_schema) and not isinstance(value, list):
                 if isinstance(value, str):
+                    # Tool-calling models sometimes double-encode an
+                    # array-only argument as a JSON string instead of a real
+                    # array — e.g. '["date"]', or even a lone item as
+                    # '"date"'. Recover the intended value before falling
+                    # back to the raw wrap below, which would otherwise
+                    # leak the string's own brackets/quotes into a garbled
+                    # single item.
                     try:
                         parsed_value = json.loads(value)
-                    except (ValueError, TypeError):
+                    except json.JSONDecodeError:
                         parsed_value = None
                     if isinstance(parsed_value, list):
                         normalized_args[field_name] = parsed_value
+                        continue
+                    if isinstance(parsed_value, str):
+                        normalized_args[field_name] = [parsed_value]
                         continue
                 normalized_args[field_name] = [value]
 

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -1135,6 +1135,12 @@ class MCPToolAdapter(AbstractBaseTool):
                         parsed_value = json.loads(value)
                     except json.JSONDecodeError:
                         parsed_value = None
+                    except RecursionError:
+                        # A pathologically deep/adversarial bracket string
+                        # (e.g. thousands of nested "[") blows the C parser's
+                        # recursion limit instead of raising JSONDecodeError.
+                        # Treat it the same as any other unparsable value.
+                        parsed_value = None
                     if isinstance(parsed_value, list):
                         normalized_args[field_name] = parsed_value
                         continue

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -1105,6 +1105,13 @@ class MCPToolAdapter(AbstractBaseTool):
             return all(item == "null" for item in schema_type)
         return False
 
+    # Caps the string this method will attempt to recover as a double-encoded
+    # array/scalar (see below). A real LLM double-encoding mistake is small —
+    # '["date"]', not a multi-KB blob — so anything past this length is out of
+    # scope for the recovery and just takes the raw-wrap fallback instead of
+    # being handed to json.loads at all.
+    _ARRAY_ARG_JSON_RECOVERY_MAX_CHARS = 4096
+
     def _normalize_args_by_schema(self, args: Mapping[str, Any]) -> Dict[str, Any]:
         """Normalize common LLM argument shape mistakes using the MCP input schema."""
         normalized_args = dict(args)
@@ -1123,23 +1130,24 @@ class MCPToolAdapter(AbstractBaseTool):
             if value is None:
                 continue
             if self._schema_is_array_only(field_schema) and not isinstance(value, list):
-                if isinstance(value, str):
+                if (
+                    isinstance(value, str)
+                    and len(value) <= self._ARRAY_ARG_JSON_RECOVERY_MAX_CHARS
+                ):
                     # Tool-calling models sometimes double-encode an
                     # array-only argument as a JSON string instead of a real
                     # array — e.g. '["date"]', or even a lone item as
                     # '"date"'. Recover the intended value before falling
                     # back to the raw wrap below, which would otherwise
                     # leak the string's own brackets/quotes into a garbled
-                    # single item.
+                    # single item. Both ValueError (json.JSONDecodeError,
+                    # and CPython's int-string-conversion digit-limit guard
+                    # for a long run of digits) and RecursionError (a
+                    # pathologically deep bracket string) mean the same
+                    # thing here: not recoverable, fall back below.
                     try:
                         parsed_value = json.loads(value)
-                    except json.JSONDecodeError:
-                        parsed_value = None
-                    except RecursionError:
-                        # A pathologically deep/adversarial bracket string
-                        # (e.g. thousands of nested "[") blows the C parser's
-                        # recursion limit instead of raising JSONDecodeError.
-                        # Treat it the same as any other unparsable value.
+                    except (ValueError, RecursionError):
                         parsed_value = None
                     if isinstance(parsed_value, list):
                         normalized_args[field_name] = parsed_value

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -882,14 +882,8 @@ def test_normalize_args_by_schema_wraps_scalar_for_array_only_field():
     assert normalized["add_label_ids"] == ["TRASH"]
 
 
-def test_normalize_args_by_schema_parses_json_encoded_array_string():
-    """Regression test: an LLM sometimes double-encodes an array-only
-    argument as a JSON string (e.g. '["date"]' instead of ["date"]). Without
-    parsing it first, the naive scalar-wrap path used to produce
-    ['["date"]'] — a single list item containing the literal brackets and
-    quotes — which then reached the downstream API as a garbled field name.
-    """
-    mcp_tool = SimpleNamespace(
+def _google_analytics_run_report_mcp_tool() -> SimpleNamespace:
+    return SimpleNamespace(
         name="google_analytics_run_report",
         description="Run a GA4 report",
         inputSchema={
@@ -907,8 +901,17 @@ def test_normalize_args_by_schema_parses_json_encoded_array_string():
             "required": ["property_id"],
         },
     )
+
+
+def test_normalize_args_by_schema_parses_json_encoded_array_string():
+    """Regression test: an LLM sometimes double-encodes an array-only
+    argument as a JSON string (e.g. '["date"]' instead of ["date"]). Without
+    parsing it first, the naive scalar-wrap path used to produce
+    ['["date"]'] — a single list item containing the literal brackets and
+    quotes — which then reached the downstream API as a garbled field name.
+    """
     adapter = MCPToolAdapter(
-        mcp_tool=mcp_tool,
+        mcp_tool=_google_analytics_run_report_mcp_tool(),
         connection={"transport": "stdio", "command": "python", "args": []},
     )
 
@@ -917,6 +920,48 @@ def test_normalize_args_by_schema_parses_json_encoded_array_string():
     )
 
     assert normalized["dimensions"] == ["date"]
+
+
+def test_normalize_args_by_schema_parses_json_encoded_scalar_string():
+    """Same bug, one step removed: a single item double-encoded as a JSON
+    string (e.g. '"date"' instead of "date") must not fall through to the
+    raw wrap, which would keep the item's own quotes as ['"date"'].
+    """
+    adapter = MCPToolAdapter(
+        mcp_tool=_google_analytics_run_report_mcp_tool(),
+        connection={"transport": "stdio", "command": "python", "args": []},
+    )
+
+    normalized = adapter._normalize_args_by_schema(
+        {"property_id": "550713710", "dimensions": '"date"'}
+    )
+
+    assert normalized["dimensions"] == ["date"]
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "TRASH",  # not valid JSON at all
+        '{"a": 1}',  # valid JSON, but neither a list nor a string
+        "null",  # valid JSON, decodes to None
+        "123",  # valid JSON, decodes to an int
+    ],
+)
+def test_normalize_args_by_schema_falls_back_to_raw_wrap_for_non_list_json(value):
+    """When the string isn't JSON, or is JSON that decodes to something
+    other than a list or a string, the field is wrapped as-is rather than
+    silently dropped or coerced into an unrelated shape."""
+    adapter = MCPToolAdapter(
+        mcp_tool=_google_analytics_run_report_mcp_tool(),
+        connection={"transport": "stdio", "command": "python", "args": []},
+    )
+
+    normalized = adapter._normalize_args_by_schema(
+        {"property_id": "550713710", "dimensions": value}
+    )
+
+    assert normalized["dimensions"] == [value]
 
 
 def test_normalize_args_by_schema_keeps_scalar_for_union_scalar_or_array_field():

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -964,6 +964,24 @@ def test_normalize_args_by_schema_falls_back_to_raw_wrap_for_non_list_json(value
     assert normalized["dimensions"] == [value]
 
 
+def test_normalize_args_by_schema_falls_back_to_raw_wrap_on_recursion_error():
+    """A pathologically deep bracket string makes json.loads raise
+    RecursionError rather than JSONDecodeError. That must be treated the
+    same as any other unparsable value (fall back to the raw wrap), not
+    propagate as an unhandled exception."""
+    adapter = MCPToolAdapter(
+        mcp_tool=_google_analytics_run_report_mcp_tool(),
+        connection={"transport": "stdio", "command": "python", "args": []},
+    )
+    deeply_nested = "[" * 100_000 + "]" * 100_000
+
+    normalized = adapter._normalize_args_by_schema(
+        {"property_id": "550713710", "dimensions": deeply_nested}
+    )
+
+    assert normalized["dimensions"] == [deeply_nested]
+
+
 def test_normalize_args_by_schema_keeps_scalar_for_union_scalar_or_array_field():
     mcp_tool = SimpleNamespace(
         name="multi_shape_tool",

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -964,16 +964,29 @@ def test_normalize_args_by_schema_falls_back_to_raw_wrap_for_non_list_json(value
     assert normalized["dimensions"] == [value]
 
 
-def test_normalize_args_by_schema_falls_back_to_raw_wrap_on_recursion_error():
+def test_normalize_args_by_schema_falls_back_to_raw_wrap_on_recursion_error(
+    monkeypatch,
+):
     """A pathologically deep bracket string makes json.loads raise
     RecursionError rather than JSONDecodeError. That must be treated the
     same as any other unparsable value (fall back to the raw wrap), not
-    propagate as an unhandled exception."""
+    propagate as an unhandled exception.
+
+    The nesting needed to actually trigger RecursionError (tens of
+    thousands of characters) is itself well past the recovery length cap,
+    so the cap is raised here — same as the digit-limit test below — to
+    reach json.loads at all and genuinely exercise the RecursionError
+    branch, rather than the length guard short-circuiting first.
+    """
+    monkeypatch.setattr(
+        MCPToolAdapter, "_ARRAY_ARG_JSON_RECOVERY_MAX_CHARS", 1_000_000, raising=True
+    )
     adapter = MCPToolAdapter(
         mcp_tool=_google_analytics_run_report_mcp_tool(),
         connection={"transport": "stdio", "command": "python", "args": []},
     )
     deeply_nested = "[" * 100_000 + "]" * 100_000
+    assert len(deeply_nested) <= adapter._ARRAY_ARG_JSON_RECOVERY_MAX_CHARS
 
     normalized = adapter._normalize_args_by_schema(
         {"property_id": "550713710", "dimensions": deeply_nested}

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -982,6 +982,79 @@ def test_normalize_args_by_schema_falls_back_to_raw_wrap_on_recursion_error():
     assert normalized["dimensions"] == [deeply_nested]
 
 
+def test_normalize_args_by_schema_falls_back_to_raw_wrap_on_oversized_json_string():
+    """A string longer than the recovery cap is never handed to json.loads
+    at all — even if it's valid JSON — and falls back to the raw wrap. This
+    also keeps a run of >4300 digits (which makes json.loads raise a plain
+    ValueError via CPython's int-string-conversion digit-limit guard, not
+    json.JSONDecodeError) from ever reaching the parser."""
+    adapter = MCPToolAdapter(
+        mcp_tool=_google_analytics_run_report_mcp_tool(),
+        connection={"transport": "stdio", "command": "python", "args": []},
+    )
+    oversized_valid_array = "[" + ",".join(['"d"'] * 2000) + "]"
+    assert len(oversized_valid_array) > adapter._ARRAY_ARG_JSON_RECOVERY_MAX_CHARS
+
+    normalized = adapter._normalize_args_by_schema(
+        {"property_id": "550713710", "dimensions": oversized_valid_array}
+    )
+
+    assert normalized["dimensions"] == [oversized_valid_array]
+
+
+def test_normalize_args_by_schema_falls_back_to_raw_wrap_on_digit_limit_value_error(
+    monkeypatch,
+):
+    """Directly pins the ValueError-catching behavior in isolation from the
+    length guard above: a run of more digits than CPython's
+    sys.get_int_max_str_digits() limit (default 4300) makes json.loads raise
+    a plain ValueError that is NOT a json.JSONDecodeError. That must still
+    fall back to the raw wrap rather than propagate uncaught."""
+    monkeypatch.setattr(
+        MCPToolAdapter, "_ARRAY_ARG_JSON_RECOVERY_MAX_CHARS", 10_000, raising=True
+    )
+    adapter = MCPToolAdapter(
+        mcp_tool=_google_analytics_run_report_mcp_tool(),
+        connection={"transport": "stdio", "command": "python", "args": []},
+    )
+    many_digits = "9" * 5000
+    assert len(many_digits) <= adapter._ARRAY_ARG_JSON_RECOVERY_MAX_CHARS
+
+    normalized = adapter._normalize_args_by_schema(
+        {"property_id": "550713710", "dimensions": many_digits}
+    )
+
+    assert normalized["dimensions"] == [many_digits]
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("[1, 2, 3]", [1, 2, 3]),  # non-string items pass through unchecked
+        ("[]", []),  # an explicit empty array stays empty
+        ('""', [""]),  # a decoded empty string is still "the one item meant"
+        ('["date", 5]', ["date", 5]),  # a mix of valid/invalid item types
+    ],
+)
+def test_normalize_args_by_schema_recovers_edge_case_shapes(value, expected):
+    """Pins the current, intentional behavior for shapes the recovery
+    doesn't specially validate: item types inside a recovered list aren't
+    checked against the schema's `items` type here (a real MCP tool call
+    still gets independently validated against its own typed arg model
+    downstream), and a decoded empty string is treated like any other
+    decoded scalar rather than being special-cased as "no value"."""
+    adapter = MCPToolAdapter(
+        mcp_tool=_google_analytics_run_report_mcp_tool(),
+        connection={"transport": "stdio", "command": "python", "args": []},
+    )
+
+    normalized = adapter._normalize_args_by_schema(
+        {"property_id": "550713710", "dimensions": value}
+    )
+
+    assert normalized["dimensions"] == expected
+
+
 def test_normalize_args_by_schema_keeps_scalar_for_union_scalar_or_array_field():
     mcp_tool = SimpleNamespace(
         name="multi_shape_tool",

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -882,6 +882,43 @@ def test_normalize_args_by_schema_wraps_scalar_for_array_only_field():
     assert normalized["add_label_ids"] == ["TRASH"]
 
 
+def test_normalize_args_by_schema_parses_json_encoded_array_string():
+    """Regression test: an LLM sometimes double-encodes an array-only
+    argument as a JSON string (e.g. '["date"]' instead of ["date"]). Without
+    parsing it first, the naive scalar-wrap path used to produce
+    ['["date"]'] — a single list item containing the literal brackets and
+    quotes — which then reached the downstream API as a garbled field name.
+    """
+    mcp_tool = SimpleNamespace(
+        name="google_analytics_run_report",
+        description="Run a GA4 report",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "property_id": {"type": "string"},
+                "dimensions": {
+                    "anyOf": [
+                        {"type": "array", "items": {"type": "string"}},
+                        {"type": "null"},
+                    ],
+                    "default": None,
+                },
+            },
+            "required": ["property_id"],
+        },
+    )
+    adapter = MCPToolAdapter(
+        mcp_tool=mcp_tool,
+        connection={"transport": "stdio", "command": "python", "args": []},
+    )
+
+    normalized = adapter._normalize_args_by_schema(
+        {"property_id": "550713710", "dimensions": '["date"]'}
+    )
+
+    assert normalized["dimensions"] == ["date"]
+
+
 def test_normalize_args_by_schema_keeps_scalar_for_union_scalar_or_array_field():
     mcp_tool = SimpleNamespace(
         name="multi_shape_tool",


### PR DESCRIPTION
## Summary
- Root-caused a production GA4 connector error (`Field ["date"] is not a valid dimension`) to `MCPToolAdapter._normalize_args_by_schema`: when an LLM emits an array-typed argument as a JSON-encoded string (e.g. `dimensions="[\"date\"]"` instead of `["date"]`), the normalizer blindly wrapped the whole string in a list, producing a single item with the brackets/quotes still attached.
- Now it tries `json.loads()` on the string first and uses the parsed list when valid, falling back to the original naive wrap only when the value isn't valid JSON or doesn't parse to a list. This is a general adapter-level fix, so it covers any MCP tool with array-typed args, not just Google Analytics.

## Test plan
- [x] Added a regression test reproducing the `dimensions="[\"date\"]"` case in `test_mcp_adapter.py`
- [x] Full `tests/core/tools/adapters/vibe/test_mcp_adapter.py` suite passes