### PR TITLE
feat: read MCP write annotations and allow same-run channel claims

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/base.py
+++ b/src/xagent/core/tools/adapters/vibe/base.py
@@ -85,6 +85,34 @@ class ToolMetadata(BaseModel):
     # metadata is constructed).
     read_only: bool = False
     concurrency_safe: bool = False
+    # What a *remote* MCP server's own annotations claimed about this tool's
+    # writes, or None for any tool that is not an MCP tool. Deliberately not
+    # folded into ``read_only`` above: that field is a local guarantee the
+    # scheduler acts on (it implies ``concurrency_safe``), while this one is
+    # an untrusted third-party hint that must never widen what the scheduler
+    # is allowed to do. Kept as the declaration's three states rather than a
+    # boolean so "the server said read-only" stays distinguishable from "the
+    # server said nothing" -- see ``MCPWriteHint``. A consumer gating an
+    # action must treat everything except an explicit read-only claim as a
+    # write, and must not treat even that claim as a security fact.
+    mcp_write_hint: Optional[str] = None
+
+
+def _write_hint_value(tool: Any) -> Optional[str]:
+    """Read a tool's MCP write hint as a plain string, if it has one.
+
+    ``getattr`` rather than an isinstance check against the MCP adapter:
+    this module is the common tool contract and must not import a concrete
+    adapter, and a wrapper that delegates the attribute has to work exactly
+    like the adapter itself. A tool without the attribute reports ``None``,
+    meaning "not an MCP declaration" -- distinct from an MCP tool whose
+    server declared nothing, which reports ``"undeclared"``.
+    """
+    hint = getattr(tool, "write_hint", None)
+    if hint is None:
+        return None
+    value = getattr(hint, "value", None)
+    return value if isinstance(value, str) else None
 
 
 @runtime_checkable
@@ -138,6 +166,12 @@ class AbstractBaseTool(ABC, Tool):
                 getattr(self, "concurrency_safe", False)
                 or getattr(self, "read_only", False)
             ),
+            # Populated from whatever the concrete tool exposes, so an MCP
+            # adapter's declaration reaches the common contract without every
+            # other tool having to know the field exists. Stored as the
+            # enum's value (a plain string) to keep this module free of a
+            # dependency on the MCP adapter.
+            mcp_write_hint=_write_hint_value(self),
         )
 
     @abstractmethod

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -12,7 +12,7 @@ import math
 import os
 import re
 import weakref
-from collections.abc import Coroutine, Iterator
+from collections.abc import Coroutine, Iterator, Mapping
 from dataclasses import dataclass
 from enum import Enum
 from typing import (
@@ -36,7 +36,7 @@ from pydantic import BaseModel, Field, create_model
 from ..... import config as _root_config
 from .....sandbox.base import Sandbox
 from ...core.mcp.sessions import Connection, create_session
-from ...core.mcp.tools import load_mcp_tools
+from ...core.mcp.tools import load_mcp_tools, raw_annotations_for
 from .base import AbstractBaseTool, ToolVisibility
 from .connector_runtime import (
     ERROR_DELEGATED_AUTHORIZATION_FAILED,
@@ -105,6 +105,53 @@ class MCPWriteHint(Enum):
     READ_ONLY = "read_only"
     DESTRUCTIVE = "destructive"
     UNDECLARED = "undeclared"
+
+
+# The annotation keys this classifier reads, spelled as the MCP wire schema
+# spells them (camelCase is the protocol's, not this codebase's).
+_READ_ONLY_HINT = "readOnlyHint"
+_DESTRUCTIVE_HINT = "destructiveHint"
+
+
+def classify_write_hint(raw_annotations: object) -> MCPWriteHint:
+    """Classify a tool's *raw* wire annotations into a write hint.
+
+    Takes the annotation mapping as it arrived on the wire, before the mcp
+    SDK's models see it. That is deliberate and it is the whole reason this
+    function exists: ``ToolAnnotations`` declares ``bool | None`` under
+    non-strict Pydantic validation, so by the time a parsed object is in
+    hand, ``1`` and ``"true"`` have already become an indistinguishable
+    Python ``True``. Classifying after that boundary cannot tell a server
+    that promised ``true`` from one that sent a coercible non-boolean, which
+    would turn "only an exact boolean counts" into a promise this code does
+    not keep.
+
+    Fail-closed in both directions that matter:
+
+    * A declared ``destructiveHint`` outranks a simultaneous ``readOnlyHint``.
+      The schema marks the two independent with no mutual exclusion, so a peer
+      can send both, and the safe reading of a contradiction is the one that
+      keeps a human in front of the action.
+    * Everything else -- absent, ``None``, ``false``, a non-boolean, or an
+      annotations value that is not even a mapping -- is ``UNDECLARED``,
+      which a consumer must treat as a write.
+
+    None of this makes the result trustworthy: annotations come from a server
+    the client does not control, and the spec says outright that a client
+    "should never make tool use decisions based on ToolAnnotations received
+    from untrusted servers". What this buys is that a *malformed* or
+    *contradictory* claim can never read as the permissive one.
+    """
+    if not isinstance(raw_annotations, Mapping):
+        return MCPWriteHint.UNDECLARED
+    # ``is True`` against the raw value, which is the only place it means what
+    # it says. Checked destructive-first so a both-true peer lands on the
+    # safe side.
+    if raw_annotations.get(_DESTRUCTIVE_HINT) is True:
+        return MCPWriteHint.DESTRUCTIVE
+    if raw_annotations.get(_READ_ONLY_HINT) is True:
+        return MCPWriteHint.READ_ONLY
+    return MCPWriteHint.UNDECLARED
 
 
 @dataclass(frozen=True)
@@ -808,6 +855,7 @@ class MCPToolAdapter(AbstractBaseTool):
         source_server: Optional[str] = None,
         concurrency_safe: bool = False,
         concurrent_tools: Optional[List[str]] = None,
+        raw_annotations: Optional[Mapping[str, Any]] = None,
     ):
         """Initialize MCP tool adapter.
 
@@ -826,8 +874,16 @@ class MCPToolAdapter(AbstractBaseTool):
                 after interruption.
             concurrent_tools: Optional allowlist of raw MCP tool names. Empty
                 means every tool from an opted-in server is safe.
+            raw_annotations: The tool's ``annotations`` object exactly as it
+                arrived on the wire, before the mcp SDK's non-strict models
+                coerced it. Required for an honest ``write_hint``: once
+                parsed, ``1`` and ``"true"`` are indistinguishable from a
+                real ``true``. Omitted means no wire evidence reached this
+                adapter, which classifies as ``UNDECLARED`` -- never as a
+                read-only promise.
         """
         self.mcp_tool = mcp_tool
+        self._raw_annotations = raw_annotations
         self.connection = connection
         self._name_prefix = name_prefix or ""
         self._visibility = visibility or ToolVisibility.PRIVATE
@@ -896,34 +952,20 @@ class MCPToolAdapter(AbstractBaseTool):
     def write_hint(self) -> "MCPWriteHint":
         """What the server's own annotations claim about this tool's writes.
 
-        Read straight from the MCP spec's ``readOnlyHint`` /
-        ``destructiveHint`` tool annotations, which nothing in this package
-        consumed before. They are the only machine-readable signal a
-        connector author has for "this call changes the world", so a caller
-        that must decide whether to gate an action has to start here.
+        Classified from the raw wire annotations captured at load time, not
+        from the parsed ``ToolAnnotations`` object -- see
+        ``classify_write_hint`` for why the distinction is the point rather
+        than a detail. An adapter built without that evidence reports
+        ``UNDECLARED``, which a consumer must treat as a write.
 
-        Deliberately *not* trusted as a security fact. The spec says so in
-        as many words -- annotations are hints, and a client "should never
-        make tool use decisions based on ToolAnnotations received from
-        untrusted servers" -- and the shape below is built so the unsafe
-        reading is never the accidental one: anything absent, malformed, or
-        not exactly ``True`` reads as :data:`MCPWriteHint.UNDECLARED`, which
-        a gate is expected to treat the same as a declared write. A server
-        that lies in the permissive direction is the case this cannot fix
-        (it is upstream of every consumer); a server that says nothing at
-        all is the case this must not silently wave through, and does not.
+        Not a trust boundary. The spec says annotations are hints and a
+        client "should never make tool use decisions based on
+        ToolAnnotations received from untrusted servers". A server that lies
+        in the permissive direction is upstream of anything this can check;
+        what is guaranteed here is only that malformed or self-contradictory
+        input never reads as the permissive answer.
         """
-        annotations = getattr(self.mcp_tool, "annotations", None)
-        if annotations is None:
-            return MCPWriteHint.UNDECLARED
-        # ``is True`` rather than truthiness: these arrive as ``bool | None``
-        # from a remote peer, and a JSON string or number surviving into one
-        # of them must not read as a promise about writes.
-        if getattr(annotations, "readOnlyHint", None) is True:
-            return MCPWriteHint.READ_ONLY
-        if getattr(annotations, "destructiveHint", None) is True:
-            return MCPWriteHint.DESTRUCTIVE
-        return MCPWriteHint.UNDECLARED
+        return classify_write_hint(self._raw_annotations)
 
     @property
     def tags(self) -> List[str]:
@@ -1699,6 +1741,10 @@ def _build_mcp_tool_adapter(
         source_server=normalize_mcp_server_name(server_name),
         concurrency_safe=concurrency_safe,
         concurrent_tools=concurrent_tools,
+        # Read off the tool the loader produced -- both the direct and the
+        # sandboxed loader attach it, so one builder serves both paths and
+        # neither can quietly lose the evidence the other keeps.
+        raw_annotations=raw_annotations_for(mcp_tool),
     )
 
 

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -87,6 +87,26 @@ def mcp_load_failure_message(phase: MCPFailurePhase) -> str:
     return _MCP_LOAD_FAILURE_MESSAGES[phase]
 
 
+class MCPWriteHint(Enum):
+    """What a server's tool annotations claim about a tool's side effects.
+
+    Three states rather than a boolean, because "the server told us this is
+    read-only" and "the server told us nothing" are different facts and only
+    the first one is a claim. Collapsing them into ``is_read_only: bool``
+    would make silence indistinguishable from a promise -- and silence is
+    the common case, since annotations are optional and most connectors
+    omit them.
+
+    A consumer deciding whether an action needs a human in front of it
+    should treat everything except :data:`READ_ONLY` as a write. See
+    ``MCPToolAdapter.write_hint`` for why none of this is a trust boundary.
+    """
+
+    READ_ONLY = "read_only"
+    DESTRUCTIVE = "destructive"
+    UNDECLARED = "undeclared"
+
+
 @dataclass(frozen=True)
 class MCPServerLoadFailure:
     """Safe MCP load failure data that excludes raw exception details."""
@@ -871,6 +891,39 @@ class MCPToolAdapter(AbstractBaseTool):
     def description(self) -> str:
         """Get tool description from MCP tool."""
         return self.mcp_tool.description or f"Execute MCP tool: {self.mcp_tool.name}"
+
+    @property
+    def write_hint(self) -> "MCPWriteHint":
+        """What the server's own annotations claim about this tool's writes.
+
+        Read straight from the MCP spec's ``readOnlyHint`` /
+        ``destructiveHint`` tool annotations, which nothing in this package
+        consumed before. They are the only machine-readable signal a
+        connector author has for "this call changes the world", so a caller
+        that must decide whether to gate an action has to start here.
+
+        Deliberately *not* trusted as a security fact. The spec says so in
+        as many words -- annotations are hints, and a client "should never
+        make tool use decisions based on ToolAnnotations received from
+        untrusted servers" -- and the shape below is built so the unsafe
+        reading is never the accidental one: anything absent, malformed, or
+        not exactly ``True`` reads as :data:`MCPWriteHint.UNDECLARED`, which
+        a gate is expected to treat the same as a declared write. A server
+        that lies in the permissive direction is the case this cannot fix
+        (it is upstream of every consumer); a server that says nothing at
+        all is the case this must not silently wave through, and does not.
+        """
+        annotations = getattr(self.mcp_tool, "annotations", None)
+        if annotations is None:
+            return MCPWriteHint.UNDECLARED
+        # ``is True`` rather than truthiness: these arrive as ``bool | None``
+        # from a remote peer, and a JSON string or number surviving into one
+        # of them must not read as a promise about writes.
+        if getattr(annotations, "readOnlyHint", None) is True:
+            return MCPWriteHint.READ_ONLY
+        if getattr(annotations, "destructiveHint", None) is True:
+            return MCPWriteHint.DESTRUCTIVE
+        return MCPWriteHint.UNDECLARED
 
     @property
     def tags(self) -> List[str]:

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -12,7 +12,7 @@ import math
 import os
 import re
 import weakref
-from collections.abc import Coroutine, Iterator, Mapping
+from collections.abc import Coroutine, Iterator
 from dataclasses import dataclass
 from enum import Enum
 from typing import (

--- a/src/xagent/core/tools/adapters/vibe/sandboxed_tool/mcp_runner.py
+++ b/src/xagent/core/tools/adapters/vibe/sandboxed_tool/mcp_runner.py
@@ -15,7 +15,11 @@ from xagent.core.tools.adapters.vibe.sandboxed_tool.runner_utils import (
     ensure_user_bin_in_path,
 )
 from xagent.core.tools.core.mcp.sessions import Connection
-from xagent.core.tools.core.mcp.tools import load_mcp_tools
+from xagent.core.tools.core.mcp.tools import (
+    SANDBOX_RAW_ANNOTATIONS_KEY,
+    load_mcp_tools,
+    raw_annotations_for,
+)
 
 
 def _parse_args() -> argparse.Namespace:
@@ -33,9 +37,26 @@ def _load_connection(connection_b64: str) -> Connection:
 
 
 async def _list_tools(connection: Connection) -> list[dict[str, Any]]:
-    """List and serialize MCP tools for JSON output."""
+    """List and serialize MCP tools for JSON output.
+
+    ``model_dump`` alone would lose the wire types of the ``annotations``
+    values: the SDK's models declare them ``bool | None`` under non-strict
+    validation, so a server that sent ``1`` or ``"true"`` is already
+    indistinguishable from one that sent ``true`` by the time a tool is
+    dumped here. The captured mapping is re-attached under a private key so
+    the host side can classify the declaration honestly -- without it, every
+    sandboxed connector would look like it made whatever claim the coercion
+    produced.
+    """
     tools = await load_mcp_tools(None, connection=connection)
-    return [cast(dict[str, Any], tool.model_dump(mode="json")) for tool in tools]
+    serialized: list[dict[str, Any]] = []
+    for tool in tools:
+        item = cast(dict[str, Any], tool.model_dump(mode="json"))
+        raw = raw_annotations_for(tool)
+        if raw is not None:
+            item[SANDBOX_RAW_ANNOTATIONS_KEY] = raw
+        serialized.append(item)
+    return serialized
 
 
 def main() -> None:

--- a/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_mcp_tool_helper.py
+++ b/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_mcp_tool_helper.py
@@ -163,7 +163,9 @@ async def list_tools_in_sandbox(
         for item in tool_data:
             raw = None
             if isinstance(item, dict):
-                payload = {k: v for k, v in item.items() if k != SANDBOX_RAW_ANNOTATIONS_KEY}
+                payload = {
+                    k: v for k, v in item.items() if k != SANDBOX_RAW_ANNOTATIONS_KEY
+                }
                 candidate = item.get(SANDBOX_RAW_ANNOTATIONS_KEY)
                 raw = candidate if isinstance(candidate, dict) else None
             else:

--- a/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_mcp_tool_helper.py
+++ b/src/xagent/core/tools/adapters/vibe/sandboxed_tool/sandboxed_mcp_tool_helper.py
@@ -15,6 +15,10 @@ from mcp.types import Tool as MCPTool
 
 from ......sandbox.base import Sandbox
 from ....core.mcp.sessions import Connection
+from ....core.mcp.tools import (
+    SANDBOX_RAW_ANNOTATIONS_KEY,
+    attach_raw_annotations,
+)
 from ..base import AbstractBaseTool
 from .sandbox_config import SandboxConfig, set_instance_sandbox_config
 from .sandboxed_tool_wrapper import (
@@ -151,7 +155,23 @@ async def list_tools_in_sandbox(
             )
             raise RuntimeError(f"Failed to parse MCP list_tools output: {e}") from e
 
-        return [MCPTool.model_validate(item) for item in tool_data]
+        # The private annotations key the in-sandbox runner attached is
+        # stripped before validation (``Tool`` would otherwise reject it or
+        # carry it as extra) and re-attached afterwards, so a sandboxed tool
+        # classifies from the same wire evidence a directly loaded one does.
+        tools: list[MCPTool] = []
+        for item in tool_data:
+            raw = None
+            if isinstance(item, dict):
+                payload = {k: v for k, v in item.items() if k != SANDBOX_RAW_ANNOTATIONS_KEY}
+                candidate = item.get(SANDBOX_RAW_ANNOTATIONS_KEY)
+                raw = candidate if isinstance(candidate, dict) else None
+            else:
+                payload = item
+            tool = MCPTool.model_validate(payload)
+            attach_raw_annotations(tool, raw)
+            tools.append(tool)
+        return tools
     finally:
         try:
             await target_sandbox.exec("rm", "-f", result_file)

--- a/src/xagent/core/tools/core/mcp/tools.py
+++ b/src/xagent/core/tools/core/mcp/tools.py
@@ -2,16 +2,143 @@
 This module provides MCP tools
 """
 
+from collections.abc import Mapping
+from typing import Any
+
 from mcp import ClientSession
+from mcp.types import (
+    ClientRequest,
+    ListToolsRequest,
+    ListToolsResult,
+    PaginatedRequestParams,
+)
 from mcp.types import Tool as MCPTool
+from pydantic import BaseModel, ConfigDict, model_validator
 
 from .sessions import Connection, create_session
 
 MAX_ITERATIONS = 1000
 
+# The wire name of the annotations object on a tool listing.
+RAW_ANNOTATIONS_KEY = "annotations"
+# Private key the sandbox runner adds to each serialized tool so the wire
+# annotations survive the JSON hop out of the sandbox. Namespaced because it
+# travels inside a payload otherwise shaped exactly like the MCP wire tool.
+SANDBOX_RAW_ANNOTATIONS_KEY = "_xagentRawAnnotations"
+
+
+_RAW_ANNOTATIONS_ATTR = "_xagent_raw_annotations"
+
+
+def _list_tools_request(cursor: str | None) -> "ClientRequest":
+    """Build the same ``tools/list`` request ``ClientSession`` would send."""
+    params = PaginatedRequestParams(cursor=cursor) if cursor is not None else None
+    return ClientRequest(ListToolsRequest(params=params))
+
+
+def _tools_with_raw_annotations(payload: Any) -> list[MCPTool]:
+    """Parse one ``tools/list`` payload into tools carrying wire annotations.
+
+    Two reads of the same payload, deliberately: ``ListToolsResult`` for the
+    tools themselves, so the protocol keeps exactly one definition and this
+    module never re-implements the SDK's parsing; then the raw mapping for
+    each tool's ``annotations``, which the parsed model can no longer answer
+    because ``bool | None`` under non-strict validation has already turned
+    ``1`` and ``"true"`` into ``True``.
+
+    A plain function rather than a validator on a result subclass. The
+    validator version needed class-level state to carry the raw values from
+    the "before" pass to the "after" pass, and MCP servers are loaded
+    concurrently here -- two validations interleaving on one class would
+    attach one server's annotations to another's tools. Nothing here is
+    shared: the alignment is a local zip over one payload.
+
+    Alignment is positional, so it is verified rather than assumed. If the
+    SDK's parse yields a different number of tools than the payload listed,
+    every tool is left without wire evidence, which classifies as undeclared
+    -- the safe reading -- instead of shifting annotations onto neighbours.
+    """
+    parsed = ListToolsResult.model_validate(payload)
+    raw_items: list[Any] = []
+    if isinstance(payload, Mapping):
+        listed = payload.get("tools")
+        if isinstance(listed, list):
+            raw_items = listed
+
+    if len(raw_items) != len(parsed.tools):
+        for tool in parsed.tools:
+            attach_raw_annotations(tool, None)
+        return list(parsed.tools)
+
+    for tool, item in zip(parsed.tools, raw_items):
+        raw = item.get(RAW_ANNOTATIONS_KEY) if isinstance(item, Mapping) else None
+        attach_raw_annotations(tool, raw if isinstance(raw, dict) else None)
+    return list(parsed.tools)
+
+
+class _RawListToolsResult(BaseModel):
+    """A ``tools/list`` result that keeps the undecoded payload.
+
+    Passed to ``send_request`` as the result type so the response survives
+    the SDK's own validation untouched; ``_tools_with_raw_annotations`` then
+    reads it twice. ``extra="allow"`` and the model-level capture together
+    mean a field this model does not name can never make a listing
+    unparseable here when the SDK itself accepted it.
+    """
+
+    model_config = ConfigDict(extra="allow")
+
+    nextCursor: str | None = None  # noqa: N815 - MCP wire field name
+    payload: dict[str, Any] = {}
+
+    @model_validator(mode="before")
+    @classmethod
+    def _keep_payload(cls, data: Any) -> Any:
+        if isinstance(data, Mapping):
+            # Copied into a field on this instance -- no class-level state, so
+            # concurrent validations cannot see each other's payloads.
+            return {**data, "payload": dict(data)}
+        return data
+
+
+def raw_annotations_for(tool: MCPTool) -> dict[str, Any] | None:
+    """Return the wire annotations captured for ``tool``, if any.
+
+    The mapping is attached at load time by the functions below. It is read
+    back through this accessor rather than off the attribute so that a tool
+    that never went through a capturing loader answers ``None`` instead of
+    raising -- a caller then classifies it as undeclared, which is the safe
+    reading, rather than crashing on a shape it did not choose.
+    """
+    captured = getattr(tool, _RAW_ANNOTATIONS_ATTR, None)
+    return captured if isinstance(captured, dict) else None
+
+
+def attach_raw_annotations(
+    tool: MCPTool, raw: dict[str, Any] | None
+) -> MCPTool:
+    """Carry one tool's wire annotations alongside the SDK's parsed model.
+
+    Set with ``object.__setattr__`` because ``Tool`` is a Pydantic model that
+    does not declare this field: assigning normally would either be rejected
+    or land in ``__pydantic_extra__`` and travel into ``model_dump``, which
+    would put a private sidecar into the payload the sandbox runner
+    serializes. This keeps it a plain Python attribute -- invisible to
+    serialization, readable through ``raw_annotations_for``.
+    """
+    object.__setattr__(tool, _RAW_ANNOTATIONS_ATTR, raw)
+    return tool
+
 
 async def _list_all_tools(session: ClientSession) -> list[MCPTool]:
     """List all available tools from an MCP session with pagination support.
+
+    Each returned tool carries its wire ``annotations`` mapping (see
+    ``_attach_raw_annotations``) so a consumer can tell a declared boolean
+    from a coercible non-boolean the SDK's non-strict models have already
+    flattened. One request per page still: the page is validated twice --
+    once by the SDK for the tools everything consumes, once by the shadow
+    model for the raw annotations -- but it is the same response either way.
 
     Args:
         session: The MCP client session.
@@ -33,17 +160,26 @@ async def _list_all_tools(session: ClientSession) -> list[MCPTool]:
             msg = "Reached max of 1000 iterations while listing tools."
             raise RuntimeError(msg)
 
-        list_tools_page_result = await session.list_tools(cursor=current_cursor)
+        # ``_RawListToolsResult`` rather than ``session.list_tools()``: the
+        # SDK validates straight into ``ListToolsResult`` and the raw wire
+        # types are gone by the time it returns. This asks for the same
+        # request and keeps the payload, then hands it to the helper which
+        # produces SDK-parsed tools *and* their wire annotations.
+        page = await session.send_request(
+            _list_tools_request(current_cursor),
+            _RawListToolsResult,
+        )
 
-        if list_tools_page_result.tools:
-            all_tools.extend(list_tools_page_result.tools)
+        page_tools = _tools_with_raw_annotations(page.payload)
+        if page_tools:
+            all_tools.extend(page_tools)
 
         # Pagination spec: https://modelcontextprotocol.io/specification/2025-06-18/server/utilities/pagination
         # compatible with None or ""
-        if not list_tools_page_result.nextCursor:
+        if not page.nextCursor:
             break
 
-        current_cursor = list_tools_page_result.nextCursor
+        current_cursor = page.nextCursor
     return all_tools
 
 

--- a/src/xagent/core/tools/core/mcp/tools.py
+++ b/src/xagent/core/tools/core/mcp/tools.py
@@ -83,7 +83,7 @@ class _RawListToolsResult(BaseModel):
     the SDK's own validation untouched; ``_tools_with_raw_annotations`` then
     reads it twice. ``extra="allow"`` and the model-level capture together
     mean a field this model does not name can never make a listing
-    unparseable here when the SDK itself accepted it.
+    unparsable here when the SDK itself accepted it.
     """
 
     model_config = ConfigDict(extra="allow")
@@ -114,9 +114,7 @@ def raw_annotations_for(tool: MCPTool) -> dict[str, Any] | None:
     return captured if isinstance(captured, dict) else None
 
 
-def attach_raw_annotations(
-    tool: MCPTool, raw: dict[str, Any] | None
-) -> MCPTool:
+def attach_raw_annotations(tool: MCPTool, raw: dict[str, Any] | None) -> MCPTool:
     """Carry one tool's wire annotations alongside the SDK's parsed model.
 
     Set with ``object.__setattr__`` because ``Tool`` is a Pydantic model that

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -1331,6 +1331,14 @@ class AgentServiceManager:
         self._agent_owner_ids: Dict[int, Optional[int]] = {}
         # Run generation that currently owns each cached runtime.
         self._agent_run_ids: Dict[int, str] = {}
+        # Which *acquisition* of that run owns the runtime. The run id alone
+        # cannot answer this: a resume claims the same run deliberately (so a
+        # waiting checkpoint stays readable), which makes two acquisitions of
+        # one run indistinguishable by id. A previous turn's late cleanup then
+        # matched the resume's runtime and evicted it mid-execution. Bumped on
+        # every acquisition, so a cleanup scheduled by an earlier one no longer
+        # recognizes the runtime and correctly does nothing.
+        self._agent_run_generations: Dict[int, int] = {}
         # Keep only the owner needed to retry a failed workspace cleanup.
         self._agent_cleanup_owner_ids: Dict[int, int] = {}
         self._agent_sandbox_keys: Dict[int, str] = {}
@@ -2210,6 +2218,9 @@ class AgentServiceManager:
             )
             if task_setup_snapshot is not None and task_setup_snapshot.task.run_id:
                 self._agent_run_ids[task_id] = task_setup_snapshot.task.run_id
+            self._agent_run_generations[task_id] = (
+                self._agent_run_generations.get(task_id, 0) + 1
+            )
             return agent
 
     async def _get_agent_for_task_unlocked(
@@ -3281,16 +3292,46 @@ class AgentServiceManager:
                 deferred_task_ids,
             )
 
+    def current_run_generation(self, task_id: int) -> Optional[int]:
+        """Which acquisition of this task's runtime is current, if any.
+
+        A caller that will schedule cleanup for the runtime it just acquired
+        reads this and passes it back as ``expected_run_generation``, so its
+        cleanup cannot evict a runtime a *later* acquisition owns. Needed
+        because a resume deliberately re-claims the same run id, which leaves
+        the id unable to tell two acquisitions apart.
+        """
+        return self._agent_run_generations.get(task_id)
+
     def remove_agent(
         self,
         task_id: int,
         user_id: Optional[int] = None,
         *,
         expected_run_id: Optional[str] = None,
+        expected_run_generation: Optional[int] = None,
     ) -> None:
         """Clean a task runtime only for the run that scheduled cleanup."""
         current_run_id = self._agent_run_ids.get(task_id)
+        current_generation = self._agent_run_generations.get(task_id)
         build_lock = self._agent_build_locks.get(task_id)
+        # Checked before the run-id comparison and independently of it: within
+        # one run, the generation is the only thing that distinguishes the
+        # acquisition that scheduled this cleanup from a later one that now
+        # owns the runtime.
+        if (
+            expected_run_generation is not None
+            and current_generation is not None
+            and current_generation != expected_run_generation
+        ):
+            logger.info(
+                "Skipping stale runtime cleanup for task %s generation %s; "
+                "current generation is %s",
+                task_id,
+                expected_run_generation,
+                current_generation,
+            )
+            return
         if expected_run_id is not None and (
             (current_run_id is not None and current_run_id != expected_run_id)
             or (build_lock is not None and build_lock.locked())
@@ -3337,6 +3378,7 @@ class AgentServiceManager:
             self._agents.pop(task_id, None)
             self._agent_owner_ids.pop(task_id, None)
             self._agent_run_ids.pop(task_id, None)
+            self._agent_run_generations.pop(task_id, None)
             self._agent_sandbox_keys.pop(task_id, None)
             self._agent_sandbox_providers.pop(task_id, None)
             self._agent_scope_fingerprints.pop(task_id, None)

--- a/src/xagent/web/services/channel_runtime.py
+++ b/src/xagent/web/services/channel_runtime.py
@@ -718,6 +718,7 @@ def _prepare_channel_task_sync(
     mcp_runtime_authorization_policy_required: bool = False,
     mcp_runtime_authorization_policy_identity: str | None = None,
     task_mode: ChannelTaskMode = ChannelTaskMode.DEFAULT,
+    resume_run_id: str | None = None,
 ) -> _ChannelTaskClaimSnapshot | None:
     if not isinstance(task_mode, ChannelTaskMode):
         raise ValueError("Unsupported channel task mode")
@@ -910,6 +911,19 @@ def _prepare_channel_task_sync(
                     agent_id=agent_id,
                 )
 
+            # A resume has to land in the *same* run the waiting checkpoint
+            # was written under. `new_run=True` mints a fresh run id and nulls
+            # both checkpoint pointer columns (acquire_task_lease_no_commit),
+            # which leaves the pending question unreadable in the new run's
+            # partition -- the agent then replans from scratch instead of
+            # handing the answer back to the tool call that asked. Claiming
+            # with the caller's own run id keeps the pointers, which is what
+            # the websocket resume path already relies on.
+            #
+            # Only ever the run id the caller *read off the waiting task*: this
+            # is a resume of an existing run, so a caller that cannot name that
+            # run has nothing to resume and must take the fresh-run path.
+            resuming = resume_run_id is not None
             lease = acquire_task_lease_no_commit(
                 db,
                 task_id,
@@ -918,7 +932,8 @@ def _prepare_channel_task_sync(
                     if task_mode is ChannelTaskMode.ACTOR_INTERACTION
                     else None
                 ),
-                new_run=True,
+                expected_run_id=resume_run_id,
+                new_run=not resuming,
                 claim_predicates=claim_predicates,
             )
             if lease is None:
@@ -974,12 +989,19 @@ async def prepare_channel_task(
     mcp_runtime_authorization_policy_required: bool = False,
     mcp_runtime_authorization_policy_identity: str | None = None,
     task_mode: ChannelTaskMode = ChannelTaskMode.DEFAULT,
+    resume_run_id: str | None = None,
 ) -> ClaimedChannelTask | None:
     """Authorize, resolve or create, and claim one channel run atomically.
 
     The trusted actor path sets both ``new_task_is_visible=False`` and
     ``mcp_runtime_authorization_policy_required=True``. That marker is written
     in the creation transaction before the returned lease can be executed.
+
+    ``resume_run_id`` claims an existing run instead of starting a new one, so
+    the run's checkpoint pointers survive the claim and a waiting execution can
+    actually be resumed. Pass the run id read off the waiting task; omitting it
+    keeps the default fresh-run claim, which is what every non-resume turn
+    wants.
     """
 
     worker = asyncio.create_task(
@@ -1000,6 +1022,7 @@ async def prepare_channel_task(
                 mcp_runtime_authorization_policy_identity
             ),
             task_mode=task_mode,
+            resume_run_id=resume_run_id,
         )
     )
     snapshot, cancellation = await await_task_settlement(worker)

--- a/src/xagent/web/services/channel_runtime.py
+++ b/src/xagent/web/services/channel_runtime.py
@@ -18,6 +18,7 @@ from typing import Any, Iterable, Sequence
 from uuid import uuid4
 
 from sqlalchemy import or_
+from sqlalchemy.orm import Session
 
 from ...config import get_default_task_execution_mode
 from ...core.file_storage.keys import build_task_output_storage_key
@@ -113,6 +114,16 @@ class _ChannelTaskClaimSnapshot:
     is_new_task: bool
     lease: TaskLease
     requested_agent_missing: bool = False
+    # The status this claim took the task away from, for a claim that is
+    # resuming an existing run rather than starting a new one. None for every
+    # fresh claim.
+    #
+    # Deliberately not derived from ``is_new_task``: an actor interaction that
+    # passes no resume run id also reuses an existing row, so that flag cannot
+    # tell "resuming a waiting run" from "re-claiming a row for a new run".
+    # Compensation reads this to decide whether an abandoned claim should be
+    # put back where it was or failed -- see ``_compensate_channel_task_claim_sync``.
+    resumed_from_status: TaskStatus | None = None
 
 
 @dataclass(frozen=True)
@@ -924,6 +935,13 @@ def _prepare_channel_task_sync(
             # is a resume of an existing run, so a caller that cannot name that
             # run has nothing to resume and must take the fresh-run path.
             resuming = resume_run_id is not None
+            # Read before the claim, which flips the row to RUNNING: after it,
+            # the status this claim interrupted is no longer on the row to
+            # read. Only captured for a resume -- a fresh claim compensates as
+            # FAILED and has nothing to restore.
+            resumed_from_status = (
+                _resumable_prior_status(db, task_id) if resuming else None
+            )
             lease = acquire_task_lease_no_commit(
                 db,
                 task_id,
@@ -970,6 +988,7 @@ def _prepare_channel_task_sync(
                 is_new_task=is_new_task,
                 lease=lease,
                 requested_agent_missing=requested_agent_missing,
+                resumed_from_status=resumed_from_status,
             )
         except Exception:
             db.rollback()
@@ -1075,17 +1094,45 @@ async def prepare_channel_task(
     )
 
 
+def _resumable_prior_status(db: Session, task_id: int) -> TaskStatus | None:
+    """Return the status a resume claim should restore, or None.
+
+    Only WAITING_FOR_USER is restorable. Any other status means the row was
+    not parked on a question when this claim reached it -- there is no
+    pending interaction to hand back to, so an abandoned claim there is an
+    ordinary failed turn rather than a resume to undo.
+    """
+    row = db.query(Task.status).filter(Task.id == task_id).first()
+    if row is None:
+        return None
+    status = row[0]
+    return status if status is TaskStatus.WAITING_FOR_USER else None
+
+
 def _compensate_channel_task_claim_sync(
     snapshot: _ChannelTaskClaimSnapshot,
 ) -> bool:
-    """Settle the exact committed claim or leave its lease to TTL recovery."""
+    """Settle the exact committed claim or leave its lease to TTL recovery.
+
+    A fresh claim that is abandoned before execution is a turn that never
+    ran, and FAILED is the honest record of it.
+
+    A resumed claim is not: the task was parked on a question, and the answer
+    was never injected, so nothing about the pending interaction has changed.
+    Failing it there would be destructive rather than merely inaccurate --
+    the loader and the next claim both require WAITING_FOR_USER, so a task
+    failed here can never be resumed again and the approval it was waiting on
+    becomes permanently unanswerable, checkpoint and all. Put it back where
+    the claim found it instead, which is what every other resume path
+    (websocket, A2A, V1) does on the same cancellation.
+    """
 
     SessionLocal = get_session_local()
     with SessionLocal() as db:
         return finalize_managed_task_lease_result(
             db,
             snapshot.lease,
-            status=TaskStatus.FAILED,
+            status=snapshot.resumed_from_status or TaskStatus.FAILED,
         )
 
 

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -11,7 +11,7 @@ from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
-from mcp.types import CallToolResult, TextContent
+from mcp.types import CallToolResult, ListToolsResult, TextContent
 from pydantic import BaseModel, ConfigDict, create_model
 from pydantic.alias_generators import to_camel
 
@@ -24,12 +24,15 @@ from xagent.core.tools.adapters.vibe.mcp_adapter import (
     MCPServerLoadFailure,
     MCPToolAdapter,
     MCPWriteHint,
+    classify_write_hint,
     _build_mcp_tool_adapter,
     _compact_json,
     _exception_indicates_http_401,
     _mcp_return_value_as_string,
     load_mcp_tools_as_agent_tools,
 )
+from xagent.core.tools.core.mcp import tools as mcp_tools_module
+from xagent.core.tools.core.mcp.tools import _tools_with_raw_annotations
 from xagent.core.tools.adapters.vibe.tool_naming_limits import (
     MAX_AGENT_TOOL_NAME_LENGTH,
 )
@@ -2914,76 +2917,154 @@ def test_description_length_boundary(length, truncated):
         assert description == raw
 
 
-def _annotated_tool(**annotations: Any) -> SimpleNamespace:
-    """An MCP tool carrying exactly the annotation fields given."""
-    tool = _mcp_tool()
-    tool.annotations = SimpleNamespace(**annotations)
-    return tool
+def _listing(*annotations: object) -> dict[str, Any]:
+    """A ``tools/list`` payload whose tools carry the given raw annotations."""
+    tools = []
+    for index, raw in enumerate(annotations):
+        tool: dict[str, Any] = {
+            "name": f"tool{index}",
+            "description": "d",
+            "inputSchema": {"type": "object"},
+        }
+        if raw is not None:
+            tool["annotations"] = raw
+        tools.append(tool)
+    return {"tools": tools}
 
 
-def _adapter_for(tool: SimpleNamespace) -> MCPToolAdapter:
-    return _build_mcp_tool_adapter("srv", SimpleNamespace(), tool)
+def _hints_from_wire(*annotations: object) -> list[MCPWriteHint]:
+    """Classify annotations the way a real listing would deliver them.
+
+    Goes through ``_tools_with_raw_annotations`` -- the same helper both
+    loaders use -- rather than assigning an already-parsed object. That is
+    the whole point of these tests: ``ToolAnnotations`` validates
+    non-strictly, so assigning ``"true"`` to a parsed model yields ``True``
+    and a test built that way cannot see the difference it claims to check.
+    """
+    tools = _tools_with_raw_annotations(_listing(*annotations))
+    return [
+        _build_mcp_tool_adapter("srv", SimpleNamespace(), tool).write_hint
+        for tool in tools
+    ]
 
 
 @pytest.mark.parametrize(
-    "annotations,expected",
+    "raw,expected",
     [
+        # Exact wire booleans: the only declarations that count.
         ({"readOnlyHint": True}, MCPWriteHint.READ_ONLY),
-        ({"readOnlyHint": True, "destructiveHint": True}, MCPWriteHint.READ_ONLY),
         ({"destructiveHint": True}, MCPWriteHint.DESTRUCTIVE),
         ({"readOnlyHint": False, "destructiveHint": True}, MCPWriteHint.DESTRUCTIVE),
+        # A contradiction resolves to the safe side, not the permissive one.
+        ({"readOnlyHint": True, "destructiveHint": True}, MCPWriteHint.DESTRUCTIVE),
+        # Coercible non-booleans. The SDK turns each of these into a Python
+        # bool; none of them is a promise, so none may read as one.
+        ({"readOnlyHint": "true"}, MCPWriteHint.UNDECLARED),
+        ({"readOnlyHint": 1}, MCPWriteHint.UNDECLARED),
+        ({"readOnlyHint": "false"}, MCPWriteHint.UNDECLARED),
+        ({"readOnlyHint": 0}, MCPWriteHint.UNDECLARED),
+        ({"destructiveHint": "true"}, MCPWriteHint.UNDECLARED),
+        ({"destructiveHint": 1}, MCPWriteHint.UNDECLARED),
+        # Declared false, and nothing declared at all.
         ({"readOnlyHint": False}, MCPWriteHint.UNDECLARED),
-        ({"readOnlyHint": False, "destructiveHint": False}, MCPWriteHint.UNDECLARED),
         ({"readOnlyHint": None, "destructiveHint": None}, MCPWriteHint.UNDECLARED),
         ({"title": "Echo"}, MCPWriteHint.UNDECLARED),
+        ({}, MCPWriteHint.UNDECLARED),
+        (None, MCPWriteHint.UNDECLARED),
     ],
 )
-def test_write_hint_reads_the_spec_annotations(annotations, expected):
-    """readOnlyHint wins over destructiveHint; neither set is UNDECLARED."""
-    assert _adapter_for(_annotated_tool(**annotations)).write_hint is expected
+def test_write_hint_classifies_wire_annotations(raw, expected):
+    """Only an exact wire boolean is a declaration, destructive first."""
+    assert _hints_from_wire(raw) == [expected]
 
 
-def test_write_hint_without_any_annotations_is_undeclared():
-    """The common case -- a connector that annotates nothing -- is not a promise."""
-    tool = _mcp_tool()
-    assert not hasattr(tool, "annotations")
+def test_coercible_hint_is_indistinguishable_after_the_sdk_parses_it():
+    """Why these tests must go through the wire, stated as an assertion.
 
-    assert _adapter_for(tool).write_hint is MCPWriteHint.UNDECLARED
-    assert _adapter_for(_annotated_tool()).write_hint is MCPWriteHint.UNDECLARED
-
-
-@pytest.mark.parametrize("planted", ["true", "false", 1, 0, [], {}, "readOnly"])
-def test_non_boolean_hints_never_read_as_a_read_only_promise(planted):
-    """A remote peer's non-boolean value must not pass for ``True``.
-
-    ``readOnlyHint`` is typed ``bool | None``, but it arrives over the wire
-    from a server this client does not control. Truthiness would let the
-    string "false" -- or any non-empty string -- claim the tool is read-only
-    and skip whatever gate a consumer puts behind this.
+    If this ever fails because the SDK started validating strictly, the
+    sidecar this module carries could be simplified away -- but until then,
+    a test that assigns to a parsed model is testing nothing.
     """
-    hint = _adapter_for(_annotated_tool(readOnlyHint=planted)).write_hint
+    tools = _tools_with_raw_annotations(
+        _listing({"readOnlyHint": True}, {"readOnlyHint": "true"})
+    )
+    declared, coerced = tools
 
-    assert hint is not MCPWriteHint.READ_ONLY
-    assert hint is MCPWriteHint.UNDECLARED
-
-
-def test_non_boolean_destructive_hint_does_not_claim_destructive():
-    """Symmetric to the read-only case: only ``True`` is a declaration."""
-    assert (
-        _adapter_for(_annotated_tool(destructiveHint="true")).write_hint
-        is MCPWriteHint.UNDECLARED
+    # The SDK cannot tell them apart...
+    assert declared.annotations.readOnlyHint is True
+    assert coerced.annotations.readOnlyHint is True
+    # ...but the classification does.
+    assert _build_mcp_tool_adapter("srv", SimpleNamespace(), declared).write_hint is (
+        MCPWriteHint.READ_ONLY
+    )
+    assert _build_mcp_tool_adapter("srv", SimpleNamespace(), coerced).write_hint is (
+        MCPWriteHint.UNDECLARED
     )
 
 
-def test_annotations_explicitly_none_is_undeclared():
-    """``annotations=None`` is what the SDK gives for an unannotated tool."""
-    assert _adapter_for(_annotated_tool_none()).write_hint is MCPWriteHint.UNDECLARED
-
-
-def _annotated_tool_none() -> SimpleNamespace:
+def test_write_hint_is_undeclared_without_loader_evidence():
+    """A tool built outside a capturing loader claims nothing."""
     tool = _mcp_tool()
-    tool.annotations = None
-    return tool
+
+    adapter = _build_mcp_tool_adapter("srv", SimpleNamespace(), tool)
+
+    assert adapter.write_hint is MCPWriteHint.UNDECLARED
+    assert adapter.metadata.mcp_write_hint == MCPWriteHint.UNDECLARED.value
+
+
+@pytest.mark.parametrize("malformed", ["readOnly", 1, [], "true"])
+def test_non_mapping_annotations_are_undeclared(malformed):
+    """An ``annotations`` value that is not even an object claims nothing."""
+    assert classify_write_hint(malformed) is MCPWriteHint.UNDECLARED
+
+
+def test_annotations_reach_the_common_metadata_contract():
+    """A gate reads this off ``metadata``, not off a concrete adapter type."""
+    tools = _tools_with_raw_annotations(
+        _listing({"readOnlyHint": True}, {"destructiveHint": True}, None)
+    )
+    read_only, destructive, undeclared = (
+        _build_mcp_tool_adapter("srv", SimpleNamespace(), tool) for tool in tools
+    )
+
+    assert read_only.metadata.mcp_write_hint == "read_only"
+    assert destructive.metadata.mcp_write_hint == "destructive"
+    assert undeclared.metadata.mcp_write_hint == "undeclared"
+    # The scheduler's own read-only flag is a different, local guarantee and
+    # must not be moved by an untrusted remote claim.
+    assert read_only.metadata.read_only is False
+
+
+def test_misaligned_listing_yields_no_declarations(monkeypatch):
+    """Positional alignment is verified, not assumed.
+
+    The raw entries are zipped onto the parsed tools by position. If a parse
+    ever yields a different count than the payload listed, shifting
+    annotations onto a neighbouring tool would attribute one server's
+    read-only claim to a different tool -- so every tool loses its evidence
+    instead, which classifies as undeclared.
+
+    Reached by making the parse disagree with the payload, because a payload
+    that is merely malformed cannot get here: the SDK rejects a page
+    containing an invalid tool outright, which is pre-existing whole-list
+    loader behavior.
+    """
+    payload = _listing({"readOnlyHint": True}, {"readOnlyHint": True})
+    parsed = ListToolsResult.model_validate(payload)
+    truncated = ListToolsResult(tools=parsed.tools[:1])
+    monkeypatch.setattr(
+        mcp_tools_module.ListToolsResult,
+        "model_validate",
+        classmethod(lambda cls, data: truncated),
+    )
+
+    tools = mcp_tools_module._tools_with_raw_annotations(payload)
+
+    assert len(tools) == 1
+    assert (
+        _build_mcp_tool_adapter("srv", SimpleNamespace(), tools[0]).write_hint
+        is MCPWriteHint.UNDECLARED
+    )
 
 
 def test_only_read_only_is_a_safe_reading():

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -23,6 +23,7 @@ from xagent.core.tools.adapters.vibe.mcp_adapter import (
     MCPFailurePhase,
     MCPServerLoadFailure,
     MCPToolAdapter,
+    MCPWriteHint,
     _build_mcp_tool_adapter,
     _compact_json,
     _exception_indicates_http_401,
@@ -2911,3 +2912,83 @@ def test_description_length_boundary(length, truncated):
         assert description == "a" * (_FIELD_TEXT_MAX_CHARS - 1) + "…"
     else:
         assert description == raw
+
+
+def _annotated_tool(**annotations: Any) -> SimpleNamespace:
+    """An MCP tool carrying exactly the annotation fields given."""
+    tool = _mcp_tool()
+    tool.annotations = SimpleNamespace(**annotations)
+    return tool
+
+
+def _adapter_for(tool: SimpleNamespace) -> MCPToolAdapter:
+    return _build_mcp_tool_adapter("srv", SimpleNamespace(), tool)
+
+
+@pytest.mark.parametrize(
+    "annotations,expected",
+    [
+        ({"readOnlyHint": True}, MCPWriteHint.READ_ONLY),
+        ({"readOnlyHint": True, "destructiveHint": True}, MCPWriteHint.READ_ONLY),
+        ({"destructiveHint": True}, MCPWriteHint.DESTRUCTIVE),
+        ({"readOnlyHint": False, "destructiveHint": True}, MCPWriteHint.DESTRUCTIVE),
+        ({"readOnlyHint": False}, MCPWriteHint.UNDECLARED),
+        ({"readOnlyHint": False, "destructiveHint": False}, MCPWriteHint.UNDECLARED),
+        ({"readOnlyHint": None, "destructiveHint": None}, MCPWriteHint.UNDECLARED),
+        ({"title": "Echo"}, MCPWriteHint.UNDECLARED),
+    ],
+)
+def test_write_hint_reads_the_spec_annotations(annotations, expected):
+    """readOnlyHint wins over destructiveHint; neither set is UNDECLARED."""
+    assert _adapter_for(_annotated_tool(**annotations)).write_hint is expected
+
+
+def test_write_hint_without_any_annotations_is_undeclared():
+    """The common case -- a connector that annotates nothing -- is not a promise."""
+    tool = _mcp_tool()
+    assert not hasattr(tool, "annotations")
+
+    assert _adapter_for(tool).write_hint is MCPWriteHint.UNDECLARED
+    assert _adapter_for(_annotated_tool()).write_hint is MCPWriteHint.UNDECLARED
+
+
+@pytest.mark.parametrize("planted", ["true", "false", 1, 0, [], {}, "readOnly"])
+def test_non_boolean_hints_never_read_as_a_read_only_promise(planted):
+    """A remote peer's non-boolean value must not pass for ``True``.
+
+    ``readOnlyHint`` is typed ``bool | None``, but it arrives over the wire
+    from a server this client does not control. Truthiness would let the
+    string "false" -- or any non-empty string -- claim the tool is read-only
+    and skip whatever gate a consumer puts behind this.
+    """
+    hint = _adapter_for(_annotated_tool(readOnlyHint=planted)).write_hint
+
+    assert hint is not MCPWriteHint.READ_ONLY
+    assert hint is MCPWriteHint.UNDECLARED
+
+
+def test_non_boolean_destructive_hint_does_not_claim_destructive():
+    """Symmetric to the read-only case: only ``True`` is a declaration."""
+    assert (
+        _adapter_for(_annotated_tool(destructiveHint="true")).write_hint
+        is MCPWriteHint.UNDECLARED
+    )
+
+
+def test_annotations_explicitly_none_is_undeclared():
+    """``annotations=None`` is what the SDK gives for an unannotated tool."""
+    assert _adapter_for(_annotated_tool_none()).write_hint is MCPWriteHint.UNDECLARED
+
+
+def _annotated_tool_none() -> SimpleNamespace:
+    tool = _mcp_tool()
+    tool.annotations = None
+    return tool
+
+
+def test_only_read_only_is_a_safe_reading():
+    """The enum's contract: everything except READ_ONLY means "treat as write"."""
+    assert {h for h in MCPWriteHint if h is not MCPWriteHint.READ_ONLY} == {
+        MCPWriteHint.DESTRUCTIVE,
+        MCPWriteHint.UNDECLARED,
+    }

--- a/tests/core/tools/adapters/vibe/test_mcp_adapter.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_adapter.py
@@ -24,18 +24,18 @@ from xagent.core.tools.adapters.vibe.mcp_adapter import (
     MCPServerLoadFailure,
     MCPToolAdapter,
     MCPWriteHint,
-    classify_write_hint,
     _build_mcp_tool_adapter,
     _compact_json,
     _exception_indicates_http_401,
     _mcp_return_value_as_string,
+    classify_write_hint,
     load_mcp_tools_as_agent_tools,
 )
-from xagent.core.tools.core.mcp import tools as mcp_tools_module
-from xagent.core.tools.core.mcp.tools import _tools_with_raw_annotations
 from xagent.core.tools.adapters.vibe.tool_naming_limits import (
     MAX_AGENT_TOOL_NAME_LENGTH,
 )
+from xagent.core.tools.core.mcp import tools as mcp_tools_module
+from xagent.core.tools.core.mcp.tools import _tools_with_raw_annotations
 
 
 def _http_status_error(

--- a/tests/web/api/test_actor_task_context.py
+++ b/tests/web/api/test_actor_task_context.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -443,6 +444,73 @@ def _seed_manager_maps(manager: AgentServiceManager, agent: Any) -> None:
     manager._mcp_actor_policies[42] = MCPBuiltinOAuthActorPolicy(
         resource_owner_key="actor:alice"
     )
+
+
+def test_remove_agent_ignores_stale_cleanup_within_the_same_run() -> None:
+    """A resume re-claims its own run, so the run id cannot date a cleanup.
+
+    An approval continuation deliberately claims the run the waiting
+    checkpoint was written under -- that is what keeps the checkpoint
+    readable. Both the previous turn's runtime and the continuation's then
+    carry the same run id, so a late cleanup scheduled by the earlier one
+    would match and evict the runtime the continuation is executing in.
+    The generation is what tells the two acquisitions apart.
+    """
+    manager = AgentServiceManager()
+    agent = MagicMock()
+    _seed_manager_maps(manager, agent)
+    # The continuation's acquisition; the stale cleanup below belongs to the
+    # previous one, under the very same run id.
+    manager._agent_run_generations[42] = 2
+
+    manager.remove_agent(42, expected_run_id="current-run", expected_run_generation=1)
+
+    assert manager._agents[42] is agent
+    assert manager._agent_run_generations[42] == 2
+    agent.cleanup_workspace.assert_not_called()
+
+
+def test_remove_agent_evicts_when_the_generation_is_its_own() -> None:
+    """The guard must not become fail-stuck: the owning cleanup still runs."""
+    manager = AgentServiceManager()
+    agent = MagicMock()
+    _seed_manager_maps(manager, agent)
+    manager._agent_run_generations[42] = 2
+
+    manager.remove_agent(42, expected_run_id="current-run", expected_run_generation=2)
+
+    assert 42 not in manager._agents
+    assert 42 not in manager._agent_run_generations
+    agent.cleanup_workspace.assert_called_once()
+
+
+def test_get_agent_for_task_bumps_the_run_generation() -> None:
+    """Each acquisition is a new generation, including a same-run resume."""
+    manager = AgentServiceManager()
+    agent = MagicMock()
+    marker = object()
+
+    async def acquire() -> None:
+        with (
+            patch.object(manager, "_get_agent_for_task_unlocked", return_value=agent),
+        ):
+            await manager.get_agent_for_task(
+                42,
+                task_setup_snapshot=_snapshot(marker=marker),
+                task_owner_user_id=1,
+                resolved_execution_scope=None,
+            )
+
+    assert manager.current_run_generation(42) is None
+    asyncio.run(acquire())
+    first = manager.current_run_generation(42)
+    asyncio.run(acquire())
+    second = manager.current_run_generation(42)
+
+    assert first == 1
+    # The snapshot carries one run id, so only the generation distinguishes
+    # these two acquisitions -- which is the whole point of having it.
+    assert second == 2
 
 
 def test_remove_agent_ignores_stale_run_cleanup() -> None:

--- a/tests/web/services/test_channel_runtime.py
+++ b/tests/web/services/test_channel_runtime.py
@@ -394,6 +394,190 @@ async def test_actor_interaction_resume_claim_keeps_run_and_checkpoint(
 
 
 @pytest.mark.asyncio
+async def test_abandoned_resume_claim_restores_the_waiting_state(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+) -> None:
+    """A resume abandoned before the answer lands must stay resumable.
+
+    Compensation exists for a claim that committed and then had nobody to
+    execute it. For a fresh claim, FAILED is the honest record. For a resume
+    it is destructive: the loader and the next claim both require
+    WAITING_FOR_USER, so failing the row makes the pending approval
+    permanently unanswerable -- checkpoint intact and unreachable.
+    """
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    agent_id = _add_agent(SessionLocal, user_id=user_id, name="Actor Agent")
+    monkeypatch.setattr(channel_runtime, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    task_id = await _create_waiting_actor_task(
+        SessionLocal,
+        channel_id=channel_id,
+        agent_id=agent_id,
+    )
+    with SessionLocal() as db:
+        task = db.get(Task, task_id)
+        assert task is not None
+        waiting_run_id = task.run_id
+        task.last_checkpoint_event_id = "waiting-checkpoint"
+        task.last_checkpoint_trace_event_id = 77
+        db.commit()
+
+    def _explode(_lease):
+        raise RuntimeError("heartbeat could not start")
+
+    monkeypatch.setattr(channel_runtime, "start_managed_task_lease", _explode)
+    with pytest.raises(RuntimeError):
+        await prepare_channel_task(
+            channel_id=channel_id,
+            external_user_id="telegram-user",
+            active_task_id=task_id,
+            text="approve",
+            channel_name="Trusted direct channel",
+            expected_owner_user_id=user_id,
+            agent_id=agent_id,
+            new_task_is_visible=False,
+            mcp_runtime_authorization_policy_required=True,
+            task_mode=channel_runtime.ChannelTaskMode.ACTOR_INTERACTION,
+            resume_run_id=waiting_run_id,
+        )
+    monkeypatch.undo()
+    monkeypatch.setattr(channel_runtime, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+
+    # Nothing was injected; the claim is abandoned. Driven through the real
+    # trigger -- heartbeat startup failing after the claim committed -- rather
+    # than by calling compensation directly, so the test covers the path
+    # production actually takes.
+
+    with SessionLocal() as db:
+        task = db.get(Task, task_id)
+        assert task is not None
+        assert task.status == TaskStatus.WAITING_FOR_USER
+        assert task.run_id == waiting_run_id
+        assert task.last_checkpoint_event_id == "waiting-checkpoint"
+        assert task.last_checkpoint_trace_event_id == 77
+
+    # And the same resume can be taken again.
+    again = await prepare_channel_task(
+        channel_id=channel_id,
+        external_user_id="telegram-user",
+        active_task_id=task_id,
+        text="approve",
+        channel_name="Trusted direct channel",
+        expected_owner_user_id=user_id,
+        agent_id=agent_id,
+        new_task_is_visible=False,
+        mcp_runtime_authorization_policy_required=True,
+        task_mode=channel_runtime.ChannelTaskMode.ACTOR_INTERACTION,
+        resume_run_id=waiting_run_id,
+    )
+    assert again is not None
+    assert await again.managed_lease.finalize_result(status=TaskStatus.FAILED)
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_abandoned_resume_of_a_non_waiting_task_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+) -> None:
+    """Only a genuinely waiting task is restored to waiting.
+
+    ``resume_run_id`` is not restricted to actor interactions, and outside
+    that mode the claim carries no ``expected_status`` -- only "not
+    RUNNING". So a resume can commit against an ordinary channel task that
+    was never parked on a question. Assuming WAITING_FOR_USER for every
+    resume would then write a status the task never held, presenting a row
+    as answerable when no interaction is pending.
+    """
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    agent_id = _add_agent(SessionLocal, user_id=user_id, name="Actor Agent")
+    monkeypatch.setattr(channel_runtime, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    # An ordinary channel task, not actor-marked: DEFAULT mode refuses to
+    # reuse an actor-marked row, so that is the shape this path can reach.
+    seed = await prepare_channel_task(
+        channel_id=channel_id,
+        external_user_id="telegram-user",
+        active_task_id=None,
+        text="ordinary turn",
+        channel_name="Trusted direct channel",
+        agent_id=agent_id,
+    )
+    assert seed is not None
+    task_id = seed.task_id
+    assert await seed.managed_lease.finalize_result(status=TaskStatus.PAUSED)
+    with SessionLocal() as db:
+        task = db.get(Task, task_id)
+        assert task is not None
+        run_id = task.run_id
+        assert task.status == TaskStatus.PAUSED
+
+    def _explode(_lease):
+        raise RuntimeError("heartbeat could not start")
+
+    monkeypatch.setattr(channel_runtime, "start_managed_task_lease", _explode)
+    with pytest.raises(RuntimeError):
+        await prepare_channel_task(
+            channel_id=channel_id,
+            external_user_id="telegram-user",
+            active_task_id=task_id,
+            text="resume me",
+            channel_name="Trusted direct channel",
+            expected_owner_user_id=user_id,
+            agent_id=agent_id,
+            resume_run_id=run_id,
+        )
+
+    with SessionLocal() as db:
+        task = db.get(Task, task_id)
+        assert task is not None
+        # Not restored to WAITING_FOR_USER, which it never was.
+        assert task.status == TaskStatus.FAILED
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_abandoned_fresh_claim_still_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+) -> None:
+    """The restore must not leak into fresh claims: those still fail."""
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    agent_id = _add_agent(SessionLocal, user_id=user_id, name="Actor Agent")
+    monkeypatch.setattr(channel_runtime, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+
+    def _explode(_lease):
+        raise RuntimeError("heartbeat could not start")
+
+    monkeypatch.setattr(channel_runtime, "start_managed_task_lease", _explode)
+    with pytest.raises(RuntimeError):
+        await prepare_channel_task(
+            channel_id=channel_id,
+            external_user_id="telegram-user",
+            active_task_id=None,
+            text="hello",
+            channel_name="Trusted direct channel",
+            expected_owner_user_id=user_id,
+            agent_id=agent_id,
+        )
+
+    with SessionLocal() as db:
+        task = db.query(Task).order_by(Task.id.desc()).first()
+        assert task is not None
+        assert task.status == TaskStatus.FAILED
+    engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_resume_claim_refuses_a_run_id_that_is_not_the_waiting_one(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,

--- a/tests/web/services/test_channel_runtime.py
+++ b/tests/web/services/test_channel_runtime.py
@@ -334,6 +334,120 @@ async def test_actor_interaction_reuses_exact_waiting_task(
 
 
 @pytest.mark.asyncio
+async def test_actor_interaction_resume_claim_keeps_run_and_checkpoint(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+) -> None:
+    """``resume_run_id`` claims the waiting run instead of replacing it.
+
+    The default claim mints a new run id and nulls the checkpoint pointers
+    (pinned by ``test_actor_interaction_reuses_exact_waiting_task``), which
+    leaves the waiting checkpoint unreadable in the new run's partition. A
+    resume has to land in the same run, or there is nothing to resume.
+    """
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    agent_id = _add_agent(SessionLocal, user_id=user_id, name="Actor Agent")
+    monkeypatch.setattr(channel_runtime, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    task_id = await _create_waiting_actor_task(
+        SessionLocal,
+        channel_id=channel_id,
+        agent_id=agent_id,
+    )
+    with SessionLocal() as db:
+        task = db.get(Task, task_id)
+        assert task is not None
+        waiting_run_id = task.run_id
+        assert waiting_run_id is not None
+        task.last_checkpoint_event_id = "waiting-checkpoint"
+        task.last_checkpoint_trace_event_id = 4242
+        db.commit()
+
+    prepared = await prepare_channel_task(
+        channel_id=channel_id,
+        external_user_id="telegram-user",
+        active_task_id=task_id,
+        text="approve",
+        channel_name="Trusted direct channel",
+        expected_owner_user_id=user_id,
+        agent_id=agent_id,
+        new_task_is_visible=False,
+        mcp_runtime_authorization_policy_required=True,
+        task_mode=channel_runtime.ChannelTaskMode.ACTOR_INTERACTION,
+        resume_run_id=waiting_run_id,
+    )
+
+    assert prepared is not None
+    assert prepared.task_id == task_id
+    with SessionLocal() as db:
+        task = db.get(Task, task_id)
+        assert task is not None
+        assert task.status == TaskStatus.RUNNING
+        # The run the checkpoint was written under, still current.
+        assert task.run_id == waiting_run_id
+        assert task.last_checkpoint_event_id == "waiting-checkpoint"
+        assert task.last_checkpoint_trace_event_id == 4242
+    assert await prepared.managed_lease.finalize_result(status=TaskStatus.FAILED)
+    engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_resume_claim_refuses_a_run_id_that_is_not_the_waiting_one(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    mock_workspace_db,
+) -> None:
+    """A stale or guessed run id must not claim the task.
+
+    The run id names which execution is being resumed. If a mismatched id
+    still claimed, a caller holding a stale id would resume a run that has
+    since moved on -- and take the waiting task's lease while doing it.
+    """
+    del mock_workspace_db
+    engine, SessionLocal, user_id, channel_id = _create_channel_session_local(tmp_path)
+    agent_id = _add_agent(SessionLocal, user_id=user_id, name="Actor Agent")
+    monkeypatch.setattr(channel_runtime, "get_session_local", lambda: SessionLocal)
+    monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
+    task_id = await _create_waiting_actor_task(
+        SessionLocal,
+        channel_id=channel_id,
+        agent_id=agent_id,
+    )
+    with SessionLocal() as db:
+        task = db.get(Task, task_id)
+        assert task is not None
+        waiting_run_id = task.run_id
+        task.last_checkpoint_event_id = "waiting-checkpoint"
+        db.commit()
+
+    prepared = await prepare_channel_task(
+        channel_id=channel_id,
+        external_user_id="telegram-user",
+        active_task_id=task_id,
+        text="approve",
+        channel_name="Trusted direct channel",
+        expected_owner_user_id=user_id,
+        agent_id=agent_id,
+        new_task_is_visible=False,
+        mcp_runtime_authorization_policy_required=True,
+        task_mode=channel_runtime.ChannelTaskMode.ACTOR_INTERACTION,
+        resume_run_id="not-the-waiting-run",
+    )
+
+    assert prepared is None
+    with SessionLocal() as db:
+        task = db.get(Task, task_id)
+        assert task is not None
+        # Untouched: still waiting, still on its own run, checkpoint intact.
+        assert task.status == TaskStatus.WAITING_FOR_USER
+        assert task.run_id == waiting_run_id
+        assert task.last_checkpoint_event_id == "waiting-checkpoint"
+    engine.dispose()
+
+
+@pytest.mark.asyncio
 async def test_actor_interaction_rejects_live_waiting_lease(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,


### PR DESCRIPTION
Part of the frozen-payload approval work tracked in #2001 (and the gap #1585 describes). Downstream tracking: xorbitsai/xagent-saas#972.

Two independent, additive changes. Neither has a consumer yet, so neither changes behavior on its own.

## 1. Surface the spec's write annotations (`mcp_adapter.py`)

MCP defines `readOnlyHint` / `destructiveHint` tool annotations, but nothing in this package read them — so a caller that needs to know whether a connector call changes the world had no machine-readable signal.

`MCPToolAdapter.write_hint` returns a three-state `MCPWriteHint` rather than a boolean. "The server says this is read-only" and "the server said nothing" are different facts, annotations are optional, and silence is the common case — collapsing them would make silence indistinguishable from a promise.

Only an exact `True` counts as a declaration. These values arrive from a server the client does not control (the spec itself says annotations are hints and must not be trusted from untrusted servers), and truthiness would let the string `"false"` pass for a read-only promise. Absent, `None`, malformed and non-boolean all read `UNDECLARED`, which a consumer is expected to treat as a write.

## 2. Let a channel turn claim the run it is resuming (`channel_runtime.py`)

`prepare_channel_task` claimed every turn with `new_run=True`, actor interactions included. `acquire_task_lease_no_commit` reads that as "start a new run": it mints a fresh run id and nulls `last_checkpoint_event_id` / `last_checkpoint_trace_event_id`. A task waiting on a tool question therefore lost its checkpoint partition the moment a continuation claimed it — the resume had nothing to load, and the agent replanned from scratch instead of handing the answer back to the tool call that asked.

The new optional `resume_run_id` carries the caller's run id as `expected_run_id` with `new_run=False` — the shape the websocket resume path (`execute_resume_background`) already relies on — so the pointers survive and the waiting execution stays resumable. Omitted, the claim is unchanged; both existing call sites pass nothing and keep today's behavior. A mismatched id refuses the claim rather than falling back to a fresh run: a caller holding a stale id would otherwise resume a run that has moved on, taking the waiting task's lease on the way.

## Testing

- `tests/core/tools/adapters/vibe/test_mcp_adapter.py`: 19 cases covering read-only / destructive precedence, no annotations at all, `annotations=None`, and non-boolean values planted in either hint.
- `tests/web/services/test_channel_runtime.py`: 39 pass (37 existing untouched + 2 new) — same-run claim preserves run id and both checkpoint pointers; a mismatched run id refuses and leaves the waiting task untouched.
- Mutation-checked, six mutations, each killed its pinning test: truthiness instead of `is True`; hint precedence flipped; missing-annotations default flipped to `READ_ONLY`; `resume_run_id` ignored; run id passed but still `new_run=True`; `expected_run_id` dropped.
