### PR TITLE
feat(startup): add host admission gates (toby)

### DIFF
--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -110,6 +110,7 @@ from .services.task_lease_recovery import run_task_lease_recovery_loop
 from .services.uploaded_file_recovery import (
     run_uploaded_file_compensation_recovery_loop,
 )
+from .startup_admission import run_host_startup_admissions
 
 # Configure logging when running under gunicorn/uwsgi (no __main__.py)
 setup_logging()  # Uses XAGENT_LOG_LEVEL env var or defaults to INFO
@@ -1231,14 +1232,16 @@ app.include_router(share_router)
 app.include_router(v1_router)
 
 
-# initial database and skill manager
-@app.on_event("startup")
-async def startup_event() -> None:
-    global _migration_task
-    logger.info("Agent runtime configured: %s", get_agent_runtime())
-    validate_interaction_rollout_at_startup()
+async def _initialize_database_and_admit_runtime(app_instance: FastAPI) -> None:
+    """Prepare the database, admit the host, then open runtime work ingress."""
     with _startup_phase("database init"):
         init_db()
+
+    # Host checks may rely on the fully migrated database. Nothing below this
+    # boundary may admit tasks or launch a writer/dispatcher until every check
+    # has passed. An exception deliberately aborts startup unchanged.
+    with _startup_phase("host admission"):
+        await run_host_startup_admissions(app_instance)
 
     # Keep built-in task-runtime providers scoped to the application lifespan.
     # Register even when disabled so task creation receives a precise 403
@@ -1251,11 +1254,20 @@ async def startup_event() -> None:
 
     background_task_manager.start_accepting()
 
-    start_file_storage_startup_sync_task(app)
-    start_trigger_dispatcher_task(app)
-    start_task_lease_recovery_task(app)
-    start_uploaded_file_recovery_task(app)
-    start_orphan_upload_gc_task(app)
+    start_file_storage_startup_sync_task(app_instance)
+    start_trigger_dispatcher_task(app_instance)
+    start_task_lease_recovery_task(app_instance)
+    start_uploaded_file_recovery_task(app_instance)
+    start_orphan_upload_gc_task(app_instance)
+
+
+# initial database and skill manager
+@app.on_event("startup")
+async def startup_event() -> None:
+    global _migration_task
+    logger.info("Agent runtime configured: %s", get_agent_runtime())
+    validate_interaction_rollout_at_startup()
+    await _initialize_database_and_admit_runtime(app)
 
     # Persisted ExecutionScope snapshots (workforce sub-tasks) keep a
     # sub-task scoped across process restarts. With no resolver registered

--- a/src/xagent/web/startup_admission.py
+++ b/src/xagent/web/startup_admission.py
@@ -1,0 +1,51 @@
+"""Host-provided gates that must pass before XAgent admits runtime work."""
+
+from __future__ import annotations
+
+from typing import Protocol
+
+from fastapi import FastAPI
+
+_CALLBACKS_STATE_KEY = "_host_startup_admission_callbacks"
+
+
+class HostStartupAdmissionCallback(Protocol):
+    """Async host check that returns on admission and raises on rejection."""
+
+    async def __call__(self) -> None: ...
+
+
+def register_host_startup_admission(
+    app: FastAPI,
+    callback: HostStartupAdmissionCallback,
+) -> None:
+    """Register a callback to run before this app starts runtime work.
+
+    Hosts must register callbacks before application startup. Callbacks run
+    sequentially in registration order on every application lifespan. Any
+    exception is terminal for that startup and is propagated unchanged.
+
+    The immutable tuple is stored on the application instance rather than in
+    module state, so separate app instances and tests cannot leak callbacks
+    into one another.
+    """
+    callbacks = _get_callbacks(app)
+    setattr(app.state, _CALLBACKS_STATE_KEY, (*callbacks, callback))
+
+
+async def run_host_startup_admissions(app: FastAPI) -> None:
+    """Run a stable snapshot of this app's registered admission callbacks."""
+    for callback in _get_callbacks(app):
+        await callback()
+
+
+def _get_callbacks(app: FastAPI) -> tuple[HostStartupAdmissionCallback, ...]:
+    callbacks = getattr(app.state, _CALLBACKS_STATE_KEY, ())
+    return tuple(callbacks)
+
+
+__all__ = [
+    "HostStartupAdmissionCallback",
+    "register_host_startup_admission",
+    "run_host_startup_admissions",
+]

--- a/tests/web/test_startup_admission.py
+++ b/tests/web/test_startup_admission.py
@@ -1,0 +1,208 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import FastAPI
+
+from tests.shared.db_teardown import drop_all_tables
+from xagent.web import app as app_module
+from xagent.web.models.agent import Agent
+from xagent.web.models.database import (
+    Base,
+    configure_db,
+    get_engine,
+    get_session_local,
+)
+from xagent.web.models.trigger import AgentTrigger, TriggerType
+from xagent.web.models.user import User
+from xagent.web.startup_admission import register_host_startup_admission
+
+
+def _patch_runtime_starts(
+    monkeypatch: pytest.MonkeyPatch,
+    events: list[str],
+) -> None:
+    monkeypatch.setattr(
+        app_module, "register_local_browser_runtime", lambda: events.append("runtime")
+    )
+
+    from xagent.web.api.websocket import background_task_manager
+
+    monkeypatch.setattr(
+        background_task_manager,
+        "start_accepting",
+        lambda: events.append("task admission"),
+    )
+    for name, event in (
+        ("start_file_storage_startup_sync_task", "file sync"),
+        ("start_trigger_dispatcher_task", "trigger dispatcher"),
+        ("start_task_lease_recovery_task", "lease recovery"),
+        ("start_uploaded_file_recovery_task", "file recovery"),
+        ("start_orphan_upload_gc_task", "upload gc"),
+    ):
+        monkeypatch.setattr(
+            app_module,
+            name,
+            lambda _app, event=event: events.append(event),
+        )
+
+
+@pytest.mark.asyncio
+async def test_no_host_admission_preserves_runtime_startup_order(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_app = FastAPI()
+    events: list[str] = []
+    monkeypatch.setattr(app_module, "init_db", lambda: events.append("database"))
+    _patch_runtime_starts(monkeypatch, events)
+
+    await app_module._initialize_database_and_admit_runtime(test_app)
+
+    assert events == [
+        "database",
+        "runtime",
+        "task admission",
+        "file sync",
+        "trigger dispatcher",
+        "lease recovery",
+        "file recovery",
+        "upload gc",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_host_admissions_run_after_database_and_before_runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_app = FastAPI()
+    events: list[str] = []
+    monkeypatch.setattr(app_module, "init_db", lambda: events.append("database"))
+    _patch_runtime_starts(monkeypatch, events)
+
+    async def first() -> None:
+        events.append("first admission")
+
+    async def second() -> None:
+        events.append("second admission")
+
+    register_host_startup_admission(test_app, first)
+    register_host_startup_admission(test_app, second)
+
+    await app_module._initialize_database_and_admit_runtime(test_app)
+
+    assert events[:5] == [
+        "database",
+        "first admission",
+        "second admission",
+        "runtime",
+        "task admission",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_host_admission_stops_at_first_error_and_propagates_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    test_app = FastAPI()
+    events: list[str] = []
+    rejection = RuntimeError("host rejected startup")
+    monkeypatch.setattr(app_module, "init_db", lambda: events.append("database"))
+    _patch_runtime_starts(monkeypatch, events)
+
+    async def first() -> None:
+        events.append("first admission")
+
+    async def reject() -> None:
+        events.append("rejected admission")
+        raise rejection
+
+    async def never_runs() -> None:
+        events.append("late admission")
+
+    register_host_startup_admission(test_app, first)
+    register_host_startup_admission(test_app, reject)
+    register_host_startup_admission(test_app, never_runs)
+
+    with pytest.raises(RuntimeError) as raised:
+        await app_module._initialize_database_and_admit_runtime(test_app)
+
+    assert raised.value is rejection
+    assert events == ["database", "first admission", "rejected admission"]
+
+
+@pytest.mark.asyncio
+async def test_failed_admission_with_due_trigger_launches_no_background_work(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    database_url = f"sqlite:///{tmp_path / 'startup-admission.db'}"
+    configure_db(database_url)
+    Base.metadata.create_all(bind=get_engine())
+    SessionLocal = get_session_local()
+    with SessionLocal() as db:
+        user = User(username="admission-test", password_hash="hash")
+        db.add(user)
+        db.flush()
+        agent = Agent(user_id=user.id, name="Admission test agent")
+        db.add(agent)
+        db.flush()
+        due_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+        trigger = AgentTrigger(
+            user_id=user.id,
+            agent_id=agent.id,
+            type=TriggerType.SCHEDULED.value,
+            name="Due before startup",
+            config={"interval_seconds": 60},
+            next_run_at=due_at,
+        )
+        db.add(trigger)
+        db.commit()
+        trigger_id = trigger.id
+
+    test_app = FastAPI()
+    runtime_starts: list[str] = []
+    observed_due_trigger: list[int] = []
+
+    def initialize_existing_database() -> None:
+        configure_db(database_url)
+
+    async def reject_after_checking_database() -> None:
+        SessionLocal = get_session_local()
+        with SessionLocal() as db:
+            due = (
+                db.query(AgentTrigger)
+                .filter(
+                    AgentTrigger.id == trigger_id,
+                    AgentTrigger.next_run_at <= datetime.now(timezone.utc),
+                )
+                .one()
+            )
+            observed_due_trigger.append(due.id)
+        raise RuntimeError("admission denied")
+
+    def unexpected_create_task(coroutine):
+        coroutine.close()
+        raise AssertionError("startup launched a background task before admission")
+
+    monkeypatch.setattr(app_module, "app", test_app)
+    monkeypatch.setattr(app_module, "init_db", initialize_existing_database)
+    monkeypatch.setattr(
+        app_module, "validate_interaction_rollout_at_startup", lambda: None
+    )
+    monkeypatch.setattr(app_module.asyncio, "create_task", unexpected_create_task)
+    _patch_runtime_starts(monkeypatch, runtime_starts)
+    register_host_startup_admission(test_app, reject_after_checking_database)
+
+    try:
+        with pytest.raises(RuntimeError, match="admission denied"):
+            await app_module.startup_event()
+
+        assert observed_due_trigger == [trigger_id]
+        assert runtime_starts == []
+        with SessionLocal() as db:
+            persisted = db.get(AgentTrigger, trigger_id)
+            assert persisted is not None
+            assert persisted.last_run_at is None
+    finally:
+        drop_all_tables(get_engine())


### PR DESCRIPTION
## Summary

- add an app-scoped, typed async host startup admission contract
- run registered callbacks deterministically after database initialization and before runtime work admission
- abort startup on the first callback failure without starting task, trigger, recovery, or channel/background dispatchers
- preserve the existing startup sequence when no callback is registered

## Scope

This PR only adds the generic XAgent host extension point. It does not add SaaS policy, catalog parsing, pricing data, platform model provenance, deployment changes, or memory activation.

## Tests

- `PYTHONPATH=src /opt/anaconda3/envs/xagent/bin/python -m pytest -q tests/web/test_startup_admission.py tests/integration/test_auto_migration_startup.py::test_startup_event_skips_when_auto_migrate_disabled`
- `ruff check src/xagent/web/startup_admission.py src/xagent/web/app.py tests/web/test_startup_admission.py`
- `ruff format --check src/xagent/web/startup_admission.py src/xagent/web/app.py tests/web/test_startup_admission.py`
- `PYTHONPATH=src /opt/anaconda3/envs/xagent/bin/python -m py_compile src/xagent/web/startup_admission.py src/xagent/web/app.py tests/web/test_startup_admission.py`

## Mutation verification

Moving host admission after runtime service startup caused three focused tests to fail: callback ordering, first-error isolation, and the due persisted trigger failure case. Restoring the boundary before runtime startup returned the suite to green.
