### PR TITLE
feat(models): enforce platform model identities (toby)

### DIFF
--- a/src/xagent/core/model/storage/db/db_models.py
+++ b/src/xagent/core/model/storage/db/db_models.py
@@ -46,6 +46,7 @@ def create_model_table(Base: Type[Any]) -> Type[Any]:
             JSON, nullable=True
         )  # Model abilities: ["chat", "vision", etc.]
         description = Column(Text, nullable=True)
+        managed_by = Column(String(50), nullable=True)
         max_retries = Column(Integer, nullable=True, default=10)
         created_at = Column(DateTime(timezone=True), server_default=func.now())
         updated_at = Column(DateTime(timezone=True), onupdate=func.now())

--- a/src/xagent/migrations/versions/20260903_add_model_management_provenance.py
+++ b/src/xagent/migrations/versions/20260903_add_model_management_provenance.py
@@ -17,8 +17,20 @@ depends_on: Union[str, Sequence[str], None] = None
 
 
 def upgrade() -> None:
-    op.add_column("models", sa.Column("managed_by", sa.String(50), nullable=True))
+    inspector = sa.inspect(op.get_bind())
+    if "models" not in inspector.get_table_names():
+        return
+    if "managed_by" not in {
+        column["name"] for column in inspector.get_columns("models")
+    }:
+        op.add_column("models", sa.Column("managed_by", sa.String(50), nullable=True))
 
 
 def downgrade() -> None:
-    op.drop_column("models", "managed_by")
+    inspector = sa.inspect(op.get_bind())
+    if "models" not in inspector.get_table_names():
+        return
+    if "managed_by" in {
+        column["name"] for column in inspector.get_columns("models")
+    }:
+        op.drop_column("models", "managed_by")

--- a/src/xagent/migrations/versions/20260903_add_model_management_provenance.py
+++ b/src/xagent/migrations/versions/20260903_add_model_management_provenance.py
@@ -1,0 +1,24 @@
+"""Add durable model management provenance.
+
+Revision ID: 20260903_model_management
+Revises: 20260901_seed_chartmogul_mcp_app
+Create Date: 2026-09-03
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260903_model_management"
+down_revision: Union[str, None] = "20260901_seed_chartmogul_mcp_app"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("models", sa.Column("managed_by", sa.String(50), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("models", "managed_by")

--- a/src/xagent/migrations/versions/20260903_add_model_management_provenance.py
+++ b/src/xagent/migrations/versions/20260903_add_model_management_provenance.py
@@ -30,7 +30,5 @@ def downgrade() -> None:
     inspector = sa.inspect(op.get_bind())
     if "models" not in inspector.get_table_names():
         return
-    if "managed_by" in {
-        column["name"] for column in inspector.get_columns("models")
-    }:
+    if "managed_by" in {column["name"] for column in inspector.get_columns("models")}:
         op.drop_column("models", "managed_by")

--- a/src/xagent/web/api/model.py
+++ b/src/xagent/web/api/model.py
@@ -52,7 +52,11 @@ from ..schemas.model import (
     UserDefaultModelCreate,
     UserDefaultModelResponse,
 )
-from ..services.llm_utils import CoreStorage
+from ..services.llm_utils import (
+    PLATFORM_MODEL_MANAGER,
+    CoreStorage,
+    is_platform_model_id,
+)
 from ..services.model_store import ModelSharingConflictError, ModelStore
 from ..user_isolated_memory import UserContext
 
@@ -436,6 +440,12 @@ async def create_model(
     logger.info(f"  Provider: {model.model_provider}")
     logger.info(f"  Abilities: {model.abilities}")
     logger.info(f"  Model name: {model.model_name}")
+
+    if is_platform_model_id(model.model_id):
+        raise HTTPException(
+            status_code=403,
+            detail="Model IDs beginning with 'platform/' are reserved",
+        )
 
     # Check if model_id already exists
     model_storage = CoreStorage(db, DBModel)
@@ -1883,6 +1893,23 @@ async def update_model(
     """Update a model configuration"""
     _, db_model_ref, user_model = _resolve_accessible_model(db, user, model_id)
 
+    category_changes = (
+        model_update.category is not None
+        and model_update.category != db_model_ref.category
+    )
+    if db_model_ref.managed_by == PLATFORM_MODEL_MANAGER and category_changes:
+        raise HTTPException(
+            status_code=409,
+            detail="The category of a platform-managed model is immutable",
+        )
+    if is_platform_model_id(db_model_ref.model_id) or (
+        db_model_ref.managed_by == PLATFORM_MODEL_MANAGER
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="Platform model identities cannot be mutated by users",
+        )
+
     # Permission: only owner can edit
     if user_model.user_id != user.id or not user_model.can_edit:
         raise HTTPException(status_code=403, detail="No permission to edit this model")
@@ -1968,7 +1995,15 @@ async def delete_model(
     model_id: str, db: Session = Depends(get_db), user: User = Depends(get_current_user)
 ) -> dict:
     """Delete a model configuration"""
-    model_storage, _, user_model = _resolve_accessible_model(db, user, model_id)
+    model_storage, db_model, user_model = _resolve_accessible_model(db, user, model_id)
+
+    if is_platform_model_id(db_model.model_id) or (
+        db_model.managed_by == PLATFORM_MODEL_MANAGER
+    ):
+        raise HTTPException(
+            status_code=403,
+            detail="Platform model identities cannot be mutated by users",
+        )
 
     # Permission: only owner can delete
     if user_model.user_id != user.id or not user_model.can_delete:

--- a/src/xagent/web/models/model.py
+++ b/src/xagent/web/models/model.py
@@ -25,6 +25,7 @@ if TYPE_CHECKING:
         dimension = Column(Integer, nullable=True)
         abilities = Column(JSON, nullable=True)
         description = Column(Text, nullable=True)
+        managed_by = Column(String(50), nullable=True)
         created_at = Column(DateTime(timezone=True), server_default=func.now())
         updated_at = Column(DateTime(timezone=True), onupdate=func.now())
         is_active = Column(Boolean, default=True)

--- a/src/xagent/web/services/llm_utils.py
+++ b/src/xagent/web/services/llm_utils.py
@@ -32,6 +32,30 @@ from ..models.user import UserDefaultModel, UserModel
 
 logger = logging.getLogger(__name__)
 
+PLATFORM_MODEL_ID_PREFIX = "platform/"
+PLATFORM_MODEL_MANAGER = "platform"
+
+
+class PlatformModelIdentityError(ValueError):
+    """Raised when an ordinary write crosses the platform model boundary."""
+
+
+def is_platform_model_id(model_id: object) -> bool:
+    """Return whether an identifier belongs to the reserved platform namespace."""
+
+    return isinstance(model_id, str) and model_id.strip().startswith(
+        PLATFORM_MODEL_ID_PREFIX
+    )
+
+
+def _ensure_ordinary_model(model: Model) -> None:
+    if is_platform_model_id(model.model_id) or (
+        model.managed_by == PLATFORM_MODEL_MANAGER
+    ):
+        raise PlatformModelIdentityError(
+            "Platform-managed models cannot be mutated through ordinary model storage"
+        )
+
 
 def _create_llm_instance(db_model: Model) -> BaseLLM:
     if db_model.category == "llm":
@@ -169,6 +193,15 @@ class CoreStorage:
     def store(self, model: ModelConfig) -> None:
         """Store model configuration to database."""
 
+        if is_platform_model_id(model.id):
+            raise PlatformModelIdentityError(
+                "Model IDs beginning with 'platform/' are reserved"
+            )
+        self._store(model)
+
+    def _store(self, model: ModelConfig, *, managed_by: str | None = None) -> None:
+        """Persist a model, with provenance available only to trusted wrappers."""
+
         db_data: dict[str, Any] = {
             "model_id": model.id,
             "model_name": model.model_name,
@@ -178,6 +211,7 @@ class CoreStorage:
             "description": model.description,
             "max_retries": model.max_retries,
             "is_active": True,
+            "managed_by": managed_by,
         }
 
         if isinstance(model, ChatModelConfig):
@@ -264,6 +298,7 @@ class CoreStorage:
             self.db.query(self.Model).filter(self.Model.model_id == model_id).first()
         )
         if db_model:
+            _ensure_ordinary_model(db_model)
             self.db.delete(db_model)
             self.db.commit()
 
@@ -402,7 +437,11 @@ class CoreStorage:
             # Strip whitespace from model_id
             model_id = model_id.strip() if isinstance(model_id, str) else model_id
 
-            model_config = self.load(model_id)
+            db_model = self.get_db_model(model_id)
+            if db_model is None:
+                raise ValueError(f"Model not found: {model_id}")
+            _ensure_ordinary_model(db_model)
+            model_config = self._db_model_to_config(db_model)
 
             # Strip whitespace from string fields
             for key, value in kwargs.items():
@@ -478,9 +517,50 @@ class CoreStorage:
         if not db_model:
             return False
 
+        _ensure_ordinary_model(db_model)
+
         db_model.is_active = bool(is_active)  # type: ignore[assignment]
         self.db.commit()
         return True
+
+
+class PlatformModelStore:
+    """Trusted persistence boundary for host-managed platform models."""
+
+    def __init__(self, db: Session, model_class: type[Model] = Model):
+        self.db = db
+        self.Model = model_class
+        self._storage = CoreStorage(db, model_class)
+
+    def create(self, model: ModelConfig) -> Model:
+        """Create a platform model without tenant ownership or default links."""
+
+        if not is_platform_model_id(model.id):
+            raise PlatformModelIdentityError(
+                "Platform-managed model IDs must begin with 'platform/'"
+            )
+        existing = (
+            self.db.query(self.Model).filter(self.Model.model_id == model.id).first()
+        )
+        if existing is not None:
+            raise PlatformModelIdentityError(f"Model ID is already claimed: {model.id}")
+
+        self._storage._store(model, managed_by=PLATFORM_MODEL_MANAGER)
+        created = self.get(model.id)
+        assert created is not None
+        return created
+
+    def get(self, model_id: str) -> Model | None:
+        """Read an exactly matching platform-managed row."""
+
+        return (
+            self.db.query(self.Model)
+            .filter(
+                self.Model.model_id == model_id,
+                self.Model.managed_by == PLATFORM_MODEL_MANAGER,
+            )
+            .first()
+        )
 
 
 class UserAwareModelStorage:

--- a/tests/web/test_model_api.py
+++ b/tests/web/test_model_api.py
@@ -14,6 +14,15 @@ from xagent.web.api import model as model_module
 from xagent.web.api.auth import auth_router
 from xagent.web.api.model import model_router
 from xagent.web.models.database import Base, get_db, get_engine
+from xagent.web.models.model import Model as DBModel
+from xagent.web.models.user import UserDefaultModel, UserModel
+from xagent.web.services.llm_utils import (
+    PLATFORM_MODEL_MANAGER,
+    CoreStorage,
+    PlatformModelIdentityError,
+    PlatformModelStore,
+)
+from xagent.core.model.model import ChatModelConfig, EmbeddingModelConfig
 
 # Create temporary directory for database
 
@@ -220,6 +229,210 @@ def sample_video_model_data():
         "description": "Test Seedance video model",
         "share_with_users": False,
     }
+
+
+def _platform_config(model_id: str, category: str = "llm"):
+    common = {
+        "id": model_id,
+        "model_provider": "openai",
+        "api_key": "platform-key",
+        "base_url": "https://api.openai.com/v1",
+    }
+    if category == "embedding":
+        return EmbeddingModelConfig(
+            **common,
+            model_name="text-embedding-3-small",
+            abilities=["embedding"],
+            dimension=1536,
+        )
+    return ChatModelConfig(**common, model_name="gpt-4", abilities=["chat"])
+
+
+@pytest.mark.parametrize("path", ["/api/models/", "/api/models/register"])
+def test_user_creation_rejects_platform_namespace(
+    test_db, regular_headers, sample_model_data, path
+):
+    payload = {**sample_model_data, "model_id": "platform/forged"}
+
+    response = client.post(path, headers=regular_headers, json=payload)
+
+    assert response.status_code == 403
+    db = next(get_db())
+    try:
+        assert db.query(DBModel).filter_by(model_id="platform/forged").first() is None
+    finally:
+        db.close()
+
+
+def test_trusted_platform_store_persists_provenance_without_user_ownership(test_db):
+    db = next(get_db())
+    try:
+        store = PlatformModelStore(db)
+        created = store.create(_platform_config("platform/toby-embedding", "embedding"))
+
+        assert created.managed_by == PLATFORM_MODEL_MANAGER
+        assert store.get("platform/toby-embedding") is created
+        assert db.query(UserModel).filter_by(model_id=created.id).first() is None
+        assert db.query(UserDefaultModel).filter_by(model_id=created.id).first() is None
+    finally:
+        db.close()
+
+
+def test_trusted_platform_store_does_not_adopt_preclaimed_collision(test_db):
+    db = next(get_db())
+    try:
+        collision = DBModel(
+            model_id="platform/preclaimed",
+            category="llm",
+            model_provider="openai",
+            model_name="tenant-model",
+            api_key="tenant-key",
+            abilities=["chat"],
+            is_active=True,
+        )
+        db.add(collision)
+        db.commit()
+
+        store = PlatformModelStore(db)
+        assert store.get("platform/preclaimed") is None
+        with pytest.raises(PlatformModelIdentityError, match="already claimed"):
+            store.create(_platform_config("platform/preclaimed"))
+
+        db.refresh(collision)
+        assert collision.managed_by is None
+        assert collision.model_name == "tenant-model"
+        assert collision.is_active is True
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize(
+    ("initial_category", "requested_category"),
+    [("llm", "embedding"), ("embedding", "llm")],
+)
+def test_platform_category_is_immutable_without_partial_mutation(
+    test_db, admin_user, admin_headers, initial_category, requested_category
+):
+    db = next(get_db())
+    model_id = f"platform/category-{initial_category}"
+    try:
+        created = PlatformModelStore(db).create(
+            _platform_config(model_id, initial_category)
+        )
+        ownership = UserModel(
+            user_id=admin_user["id"],
+            model_id=created.id,
+            is_owner=True,
+            can_edit=True,
+            can_delete=True,
+            is_shared=False,
+        )
+        db.add(ownership)
+        db.add(
+            UserDefaultModel(
+                user_id=admin_user["id"],
+                model_id=created.id,
+                config_type="general" if initial_category == "llm" else "embedding",
+            )
+        )
+        db.commit()
+        ownership_id = ownership.id
+        default_id = db.query(UserDefaultModel).filter_by(model_id=created.id).one().id
+    finally:
+        db.close()
+
+    response = client.put(
+        f"/api/models/by-id/{quote(model_id, safe='')}",
+        headers=admin_headers,
+        json={
+            "category": requested_category,
+            "model_name": "mutated-name",
+            "share_with_users": True,
+        },
+    )
+
+    assert response.status_code == 409
+    db = next(get_db())
+    try:
+        unchanged = db.query(DBModel).filter_by(model_id=model_id).one()
+        assert unchanged.category == initial_category
+        assert unchanged.model_name != "mutated-name"
+        assert db.query(UserModel).filter_by(id=ownership_id).one().is_shared is False
+        assert (
+            db.query(UserDefaultModel).filter_by(id=default_id).one().model_id
+            == unchanged.id
+        )
+    finally:
+        db.close()
+
+
+def test_preclaimed_platform_id_cannot_be_updated_deactivated_or_deleted(
+    test_db, admin_user, admin_headers
+):
+    db = next(get_db())
+    try:
+        collision = DBModel(
+            model_id="platform/tenant-row",
+            category="llm",
+            model_provider="openai",
+            model_name="tenant-model",
+            api_key="tenant-key",
+            abilities=["chat"],
+            is_active=True,
+        )
+        db.add(collision)
+        db.flush()
+        db.add(
+            UserModel(
+                user_id=admin_user["id"],
+                model_id=collision.id,
+                is_owner=True,
+                can_edit=True,
+                can_delete=True,
+                is_shared=False,
+            )
+        )
+        db.commit()
+        with pytest.raises(PlatformModelIdentityError):
+            CoreStorage(db, DBModel).set_model_active(collision.model_id, False)
+    finally:
+        db.close()
+
+    path = f"/api/models/by-id/{quote('platform/tenant-row', safe='')}"
+    assert (
+        client.put(
+            path, headers=admin_headers, json={"model_name": "forged"}
+        ).status_code
+        == 403
+    )
+    assert client.delete(path, headers=admin_headers).status_code == 403
+
+    db = next(get_db())
+    try:
+        unchanged = db.query(DBModel).filter_by(model_id="platform/tenant-row").one()
+        assert unchanged.managed_by is None
+        assert unchanged.model_name == "tenant-model"
+        assert unchanged.is_active is True
+    finally:
+        db.close()
+
+
+def test_ordinary_model_create_update_delete_remains_compatible(
+    test_db, admin_headers, sample_model_data
+):
+    created = client.post("/api/models/", headers=admin_headers, json=sample_model_data)
+    assert created.status_code == 200
+
+    updated = client.put(
+        "/api/models/test-openai-model",
+        headers=admin_headers,
+        json={"model_name": "gpt-4o"},
+    )
+    assert updated.status_code == 200
+    assert updated.json()["model_name"] == "gpt-4o"
+
+    deleted = client.delete("/api/models/test-openai-model", headers=admin_headers)
+    assert deleted.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_model_api.py
+++ b/tests/web/test_model_api.py
@@ -10,6 +10,7 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from xagent.core.model.model import ChatModelConfig, EmbeddingModelConfig
 from xagent.web.api import model as model_module
 from xagent.web.api.auth import auth_router
 from xagent.web.api.model import model_router
@@ -22,7 +23,6 @@ from xagent.web.services.llm_utils import (
     PlatformModelIdentityError,
     PlatformModelStore,
 )
-from xagent.core.model.model import ChatModelConfig, EmbeddingModelConfig
 
 # Create temporary directory for database
 


### PR DESCRIPTION
## Summary
- reserve the platform/ model namespace across ordinary API and storage mutations
- persist platform management provenance and add a trusted create/read boundary
- reject platform category changes before any model, sharing, or default state can change
- preserve colliding legacy rows without adopting, modifying, deactivating, or deleting them

## Validation
- 8 focused model identity API/storage tests
- Ruff check and format verification
- Python compile check
- Alembic single-head verification
- Mutation verification: removing namespace, provenance, and category guards makes 5 targeted cases fail