### PR TITLE
feat(models): support transactional platform model staging (toby)

### DIFF
--- a/src/xagent/web/services/llm_utils.py
+++ b/src/xagent/web/services/llm_utils.py
@@ -3,6 +3,7 @@
 import logging
 import os
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Callable, List, Optional, Tuple, Union
 
 from sqlalchemy.orm import Session
@@ -38,6 +39,13 @@ PLATFORM_MODEL_MANAGER = "platform"
 
 class PlatformModelIdentityError(ValueError):
     """Raised when an ordinary write crosses the platform model boundary."""
+
+
+class ModelWriteMode(Enum):
+    """Control whether a model write owns or joins the current transaction."""
+
+    COMMIT = "commit"
+    STAGE = "stage"
 
 
 def is_platform_model_id(model_id: object) -> bool:
@@ -199,8 +207,18 @@ class CoreStorage:
             )
         self._store(model)
 
-    def _store(self, model: ModelConfig, *, managed_by: str | None = None) -> None:
+    def _store(
+        self,
+        model: ModelConfig,
+        *,
+        managed_by: str | None = None,
+        is_active: bool = True,
+        write_mode: ModelWriteMode = ModelWriteMode.COMMIT,
+    ) -> Model:
         """Persist a model, with provenance available only to trusted wrappers."""
+
+        if not isinstance(write_mode, ModelWriteMode):
+            raise TypeError("write_mode must be a ModelWriteMode")
 
         db_data: dict[str, Any] = {
             "model_id": model.id,
@@ -210,7 +228,7 @@ class CoreStorage:
             "abilities": model.abilities,
             "description": model.description,
             "max_retries": model.max_retries,
-            "is_active": True,
+            "is_active": is_active,
             "managed_by": managed_by,
         }
 
@@ -290,7 +308,13 @@ class CoreStorage:
 
         db_model = self.Model(**db_data)
         self.db.add(db_model)
-        self.db.commit()
+        if write_mode is ModelWriteMode.STAGE:
+            # Staged callers need the database ID for links/defaults while
+            # retaining ownership of the surrounding transaction.
+            self.db.flush()
+        else:
+            self.db.commit()
+        return db_model
 
     def delete(self, model_id: str) -> None:
         """Delete model by model_id."""
@@ -532,8 +556,18 @@ class PlatformModelStore:
         self.Model = model_class
         self._storage = CoreStorage(db, model_class)
 
-    def create(self, model: ModelConfig) -> Model:
-        """Create a platform model without tenant ownership or default links."""
+    def create(
+        self,
+        model: ModelConfig,
+        *,
+        is_active: bool = True,
+        write_mode: ModelWriteMode = ModelWriteMode.COMMIT,
+    ) -> Model:
+        """Create a platform model without tenant ownership or default links.
+
+        ``STAGE`` flushes the INSERT so the returned row has a stable database
+        ID, but leaves final commit or rollback ownership with the caller.
+        """
 
         if not is_platform_model_id(model.id):
             raise PlatformModelIdentityError(
@@ -545,10 +579,12 @@ class PlatformModelStore:
         if existing is not None:
             raise PlatformModelIdentityError(f"Model ID is already claimed: {model.id}")
 
-        self._storage._store(model, managed_by=PLATFORM_MODEL_MANAGER)
-        created = self.get(model.id)
-        assert created is not None
-        return created
+        return self._storage._store(
+            model,
+            managed_by=PLATFORM_MODEL_MANAGER,
+            is_active=is_active,
+            write_mode=write_mode,
+        )
 
     def get(self, model_id: str) -> Model | None:
         """Read an exactly matching platform-managed row."""

--- a/src/xagent/web/services/model_store.py
+++ b/src/xagent/web/services/model_store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from sqlalchemy import event
 from sqlalchemy.orm import Session, joinedload
 
 from ..models.model import Model as DBModel
@@ -18,7 +19,7 @@ from .hot_path_cache import (
     user_default_model_key,
     user_default_models_key,
 )
-from .llm_utils import CoreStorage
+from .llm_utils import CoreStorage, ModelWriteMode
 
 logger = logging.getLogger(__name__)
 
@@ -38,6 +39,44 @@ DEFAULT_MODEL_CONFIG_TYPES = [
 
 class ModelSharingConflictError(ValueError):
     """Raised when a model sharing state transition violates model constraints."""
+
+
+_PENDING_CACHE_INVALIDATIONS = "xagent_pending_model_cache_invalidations"
+_MODEL_TRANSACTION_COMMITTED = "xagent_model_transaction_committed"
+
+
+def _stage_cache_invalidation(db: Session, user_id: int | None) -> None:
+    pending = db.info.setdefault(_PENDING_CACHE_INVALIDATIONS, set())
+    pending.add(user_id)
+
+
+@event.listens_for(Session, "after_commit")
+def _mark_model_transaction_committed(db: Session) -> None:
+    if db.in_nested_transaction():
+        return
+    db.info[_MODEL_TRANSACTION_COMMITTED] = True
+
+
+@event.listens_for(Session, "after_rollback")
+def _mark_model_transaction_rolled_back(db: Session) -> None:
+    if db.in_nested_transaction():
+        return
+    db.info[_MODEL_TRANSACTION_COMMITTED] = False
+
+
+@event.listens_for(Session, "after_transaction_end")
+def _finish_staged_model_cache_invalidation(db: Session, transaction: Any) -> None:
+    if transaction.parent is not None:
+        return
+    pending = db.info.pop(_PENDING_CACHE_INVALIDATIONS, set())
+    committed = db.info.pop(_MODEL_TRANSACTION_COMMITTED, False)
+    if not committed:
+        return
+    if None in pending:
+        invalidate_model_cache(None)
+        return
+    for user_id in pending:
+        invalidate_model_cache(user_id)
 
 
 class ModelStore:
@@ -298,8 +337,17 @@ class ModelStore:
         return response
 
     def create_user_model_link(
-        self, *, user_id: int, model_id: int, is_shared: bool
+        self,
+        *,
+        user_id: int,
+        model_id: int,
+        is_shared: bool,
+        write_mode: ModelWriteMode = ModelWriteMode.COMMIT,
     ) -> UserModel:
+        """Create an owner link, optionally joining a caller-owned transaction."""
+
+        if not isinstance(write_mode, ModelWriteMode):
+            raise TypeError("write_mode must be a ModelWriteMode")
         user_model = UserModel(
             user_id=user_id,
             model_id=model_id,
@@ -309,8 +357,13 @@ class ModelStore:
             is_shared=is_shared,
         )
         self.db.add(user_model)
-        self.db.commit()
-        invalidate_model_cache(None if is_shared else user_id)
+        invalidation_user_id = None if is_shared else user_id
+        if write_mode is ModelWriteMode.COMMIT:
+            self.db.commit()
+            invalidate_model_cache(invalidation_user_id)
+        else:
+            self.db.flush()
+            _stage_cache_invalidation(self.db, invalidation_user_id)
         return user_model
 
     def set_user_default_model(
@@ -320,7 +373,12 @@ class ModelStore:
         model_id: int,
         config_type: str,
         user_model: UserModel,
+        write_mode: ModelWriteMode = ModelWriteMode.COMMIT,
     ) -> UserDefaultModel:
+        """Upsert a default, optionally joining a caller-owned transaction."""
+
+        if not isinstance(write_mode, ModelWriteMode):
+            raise TypeError("write_mode must be a ModelWriteMode")
         # Use a single atomic upsert to avoid UNIQUE-constraint races
         # when the client (e.g. React strict mode, double click) fires
         # two set_default requests for the same (user_id, config_type)
@@ -346,7 +404,10 @@ class ModelStore:
                 set_={"model_id": model_id},
             )
             self.db.execute(stmt)
-            self.db.commit()
+            if write_mode is ModelWriteMode.COMMIT:
+                self.db.commit()
+            else:
+                self.db.flush()
         else:
             # Fallback: delete + insert (kept for any other dialect)
             existing_default = (
@@ -365,7 +426,10 @@ class ModelStore:
                     user_id=user_id, model_id=model_id, config_type=config_type
                 )
             )
-            self.db.commit()
+            if write_mode is ModelWriteMode.COMMIT:
+                self.db.commit()
+            else:
+                self.db.flush()
 
         user_default = (
             self.db.query(UserDefaultModel)
@@ -376,8 +440,12 @@ class ModelStore:
             .first()
         )
         new_default_is_shared = bool(user_model.is_shared)
-        invalidate_model_cache(None if new_default_is_shared else user_id)
-        return user_default  # type: ignore[return-value]  # Always exists after commit
+        invalidation_user_id = None if new_default_is_shared else user_id
+        if write_mode is ModelWriteMode.COMMIT:
+            invalidate_model_cache(invalidation_user_id)
+        else:
+            _stage_cache_invalidation(self.db, invalidation_user_id)
+        return user_default  # type: ignore[return-value]  # Always exists after flush
 
     def delete_user_default_model(
         self, *, user_id: int, config_type: str

--- a/tests/web/services/test_platform_model_transactions.py
+++ b/tests/web/services/test_platform_model_transactions.py
@@ -1,0 +1,175 @@
+from unittest.mock import patch
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.core.model.model import ChatModelConfig, EmbeddingModelConfig
+from xagent.web.models.database import Base
+from xagent.web.models.model import Model
+from xagent.web.models.user import UserDefaultModel, UserModel
+from xagent.web.services.llm_utils import (
+    PLATFORM_MODEL_MANAGER,
+    CoreStorage,
+    ModelWriteMode,
+    PlatformModelIdentityError,
+    PlatformModelStore,
+)
+from xagent.web.services.model_store import ModelStore
+
+
+@pytest.fixture
+def sessions(tmp_path):
+    engine = create_engine(
+        f"sqlite:///{tmp_path / 'models.db'}",
+        connect_args={"check_same_thread": False},
+    )
+    Base.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, autoflush=False)
+    try:
+        yield session_factory
+    finally:
+        engine.dispose()
+
+
+def _config(model_id: str, *, embedding: bool = False):
+    common = {
+        "id": model_id,
+        "model_provider": "openai",
+        "api_key": "platform-key",
+        "base_url": "https://api.openai.com/v1",
+    }
+    if embedding:
+        return EmbeddingModelConfig(
+            **common,
+            model_name="text-embedding-3-small",
+            abilities=["embedding"],
+            dimension=1536,
+        )
+    return ChatModelConfig(**common, model_name="gpt-4", abilities=["chat"])
+
+
+def test_default_platform_create_remains_active_and_committed(sessions):
+    with sessions() as db, sessions() as observer:
+        created = PlatformModelStore(db).create(_config("platform/default-commit"))
+
+        observed = observer.query(Model).filter_by(id=created.id).one()
+        assert observed.is_active is True
+        assert observed.managed_by == PLATFORM_MODEL_MANAGER
+
+
+def test_staged_catalog_commits_model_link_and_default_together(sessions):
+    with sessions() as db, sessions() as observer:
+        created = PlatformModelStore(db).create(
+            _config("platform/staged-embedding", embedding=True),
+            is_active=False,
+            write_mode=ModelWriteMode.STAGE,
+        )
+        assert created.id is not None
+        assert created.is_active is False
+        assert observer.query(Model).filter_by(id=created.id).first() is None
+
+        model_store = ModelStore(db)
+        link = model_store.create_user_model_link(
+            user_id=1,
+            model_id=created.id,
+            is_shared=True,
+            write_mode=ModelWriteMode.STAGE,
+        )
+        default = model_store.set_user_default_model(
+            user_id=1,
+            model_id=created.id,
+            config_type="embedding",
+            user_model=link,
+            write_mode=ModelWriteMode.STAGE,
+        )
+        assert link.id is not None
+        assert default.id is not None
+
+        with patch(
+            "xagent.web.services.model_store.invalidate_model_cache"
+        ) as invalidate:
+            db.commit()
+            invalidate.assert_called_once_with(None)
+
+        observer.close()
+        with sessions() as committed_observer:
+            assert (
+                committed_observer.query(Model).filter_by(id=created.id).one().is_active
+                is False
+            )
+            assert committed_observer.query(UserModel).filter_by(id=link.id).one()
+            assert (
+                committed_observer.query(UserDefaultModel)
+                .filter_by(id=default.id)
+                .one()
+            )
+
+
+def test_staged_catalog_rollback_discards_everything(sessions):
+    with sessions() as db:
+        created = PlatformModelStore(db).create(
+            _config("platform/rolled-back", embedding=True),
+            is_active=False,
+            write_mode=ModelWriteMode.STAGE,
+        )
+        model_store = ModelStore(db)
+        link = model_store.create_user_model_link(
+            user_id=1,
+            model_id=created.id,
+            is_shared=False,
+            write_mode=ModelWriteMode.STAGE,
+        )
+        model_store.set_user_default_model(
+            user_id=1,
+            model_id=created.id,
+            config_type="embedding",
+            user_model=link,
+            write_mode=ModelWriteMode.STAGE,
+        )
+
+        with patch(
+            "xagent.web.services.model_store.invalidate_model_cache"
+        ) as invalidate:
+            try:
+                raise RuntimeError("injected catalog failure")
+            except RuntimeError:
+                db.rollback()
+            invalidate.assert_not_called()
+
+        assert (
+            db.query(Model).filter_by(model_id="platform/rolled-back").first() is None
+        )
+        assert db.query(UserModel).filter_by(model_id=created.id).first() is None
+        assert db.query(UserDefaultModel).filter_by(model_id=created.id).first() is None
+
+
+def test_link_and_default_helpers_commit_by_default(sessions):
+    with sessions() as db, sessions() as observer:
+        created = PlatformModelStore(db).create(
+            _config("platform/helper-compatibility")
+        )
+        model_store = ModelStore(db)
+        link = model_store.create_user_model_link(
+            user_id=1, model_id=created.id, is_shared=False
+        )
+        default = model_store.set_user_default_model(
+            user_id=1,
+            model_id=created.id,
+            config_type="general",
+            user_model=link,
+        )
+
+        assert observer.query(UserModel).filter_by(id=link.id).one()
+        assert observer.query(UserDefaultModel).filter_by(id=default.id).one()
+
+
+def test_ordinary_store_cannot_forge_or_mutate_platform_identity(sessions):
+    with sessions() as db:
+        ordinary_store = CoreStorage(db, Model)
+        with pytest.raises(PlatformModelIdentityError, match="reserved"):
+            ordinary_store.store(_config("platform/forged"))
+
+        created = PlatformModelStore(db).create(_config("platform/protected"))
+        with pytest.raises(PlatformModelIdentityError, match="ordinary"):
+            ordinary_store.set_model_active(created.model_id, False)


### PR DESCRIPTION
## Summary

- add an explicit typed write mode for trusted platform model creation and model ownership/default helpers
- allow platform models to be inserted with their intended active state and flushed without committing
- defer model cache invalidation until the caller-owned root transaction commits, and discard it after rollback
- preserve active, auto-commit defaults and platform namespace/provenance protections for existing callers

## Validation

- `PYTHONPATH=src:tests/_stubs /opt/anaconda3/envs/xagent/bin/pytest -q tests/web/services/test_platform_model_transactions.py tests/web/services/test_hot_path_cache.py` (9 passed)
- `ruff check src/xagent/web/services/llm_utils.py src/xagent/web/services/model_store.py tests/web/services/test_platform_model_transactions.py`
- `ruff format --check src/xagent/web/services/llm_utils.py src/xagent/web/services/model_store.py tests/web/services/test_platform_model_transactions.py`
- `python -m py_compile src/xagent/web/services/llm_utils.py src/xagent/web/services/model_store.py`
- mutation checks confirmed failures when staged creation commits, ignores `is_active`, or a staged link helper commits

## Size

- production: 138 changed lines (121 additions, 17 deletions)
- tests: 175 changed lines (175 additions)
- total: 313 changed lines

## Downstream integration

The platform host must pass `ModelWriteMode.STAGE` to model, link, and default writes, then call `Session.commit()` once for the complete catalog or `Session.rollback()` on any failure.