### PR TITLE
feat(connectors): add MYOB AccountRight OAuth MCP connector

### DIFF
--- a/example.env
+++ b/example.env
@@ -766,6 +766,24 @@ DEPUTY_CLIENT_SECRET=""
 DEPUTY_REDIRECT_URI=""
 
 # ===========================================
+# MYOB OAuth Configuration (Optional)
+# ===========================================
+# Required for the MYOB AccountRight integration in MCP (look up contacts,
+# invoices, purchase bills, and general ledger accounts). Register an
+# app at https://developer.myob.com to get a Key/Secret. MYOB_CLIENT_ID
+# doubles as the x-myobapi-key header every myob_*.py tool call sends
+# (forwarded via launch_config.static_env, not env_mapping) -- it must be
+# set here even if client_id/client_secret are also configured via the
+# admin UI's provider settings, since static_env only ever reads the host
+# process env, with no database fallback.
+MYOB_CLIENT_ID=""
+MYOB_CLIENT_SECRET=""
+# Redirect URI for MYOB OAuth callback — must exactly match the URL
+# registered on the app.
+# Example: http://localhost:8000/api/auth/myob/callback
+MYOB_REDIRECT_URI=""
+
+# ===========================================
 # Linear OAuth Configuration (Optional)
 # ===========================================
 # Required for the Linear integration in MCP (search/manage issues, teams,

--- a/src/xagent/migrations/versions/20260903_seed_myob_mcp_app.py
+++ b/src/xagent/migrations/versions/20260903_seed_myob_mcp_app.py
@@ -1,0 +1,254 @@
+"""seed built-in MYOB (OAuth) MCP connector
+
+Revision ID: 20260903_seed_myob_mcp_app
+Revises: 20260903_model_management
+Create Date: 2026-09-03 00:00:00.000000
+
+"""
+
+import os
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "20260903_seed_myob_mcp_app"
+down_revision: Union[str, None] = "20260903_model_management"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+FULL_OAUTH_PROVIDERS_TABLE = sa.table(
+    "oauth_providers",
+    sa.column("provider_name", sa.String),
+    sa.column("name", sa.String),
+    sa.column("client_id", sa.String),
+    sa.column("client_secret", sa.String),
+    sa.column("auth_url", sa.String),
+    sa.column("token_url", sa.String),
+    sa.column("redirect_uri", sa.String),
+    sa.column("userinfo_url", sa.String),
+    sa.column("user_id_path", sa.String),
+    sa.column("email_path", sa.String),
+    sa.column("default_scopes", sa.JSON),
+)
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("name", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("icon", sa.String),
+    sa.column("transport", sa.String),
+    sa.column("provider_name", sa.String),
+    sa.column("category", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+    sa.column("is_visible_in_connector", sa.Boolean),
+    sa.column("launch_config", sa.JSON),
+)
+
+APP_ID = "myob"
+
+# Granular AuthAccount scopes matching the tool set myob.py exposes -- see
+# the matching comment on the registry row for why sme-banking/sme-payroll/
+# sme-contacts-employee/sme-contacts-personal/sme-timebilling are excluded.
+MYOB_SCOPES = [
+    "sme-company-file",
+    "sme-contacts-customer",
+    "sme-contacts-supplier",
+    "sme-sales",
+    "sme-purchases",
+    "sme-general-ledger",
+]
+
+
+def _filter_row(row: dict[str, object], allowed_columns: set[str]) -> dict[str, object]:
+    return {key: value for key, value in row.items() if key in allowed_columns}
+
+
+def _myob_provider_row() -> dict[str, object]:
+    return {
+        "provider_name": "myob",
+        "name": "MYOB",
+        "client_id": os.environ.get("MYOB_CLIENT_ID", ""),
+        "client_secret": os.environ.get("MYOB_CLIENT_SECRET", ""),
+        "auth_url": "https://secure.myob.com/oauth2/account/authorize/",
+        "token_url": "https://secure.myob.com/oauth2/v1/authorize/",
+        "redirect_uri": os.environ.get("MYOB_REDIRECT_URI", ""),
+        # Left empty on purpose, not because the URL is unknown -- see the
+        # matching comment on the registry row for why.
+        "userinfo_url": "",
+        "user_id_path": "",
+        "email_path": "",
+        "default_scopes": [],
+    }
+
+
+def _myob_app_row() -> dict[str, object]:
+    return {
+        "app_id": APP_ID,
+        "name": "MYOB",
+        "description": "Connect to MYOB AccountRight to look up contacts, invoices, purchase bills, and general ledger accounts.",
+        "icon": "https://www.google.com/s2/favicons?domain=myob.com&sz=128",
+        "transport": "oauth",
+        "provider_name": "myob",
+        "category": "Operations",
+        "oauth_scopes": MYOB_SCOPES,
+        "is_visible_in_connector": True,
+        "launch_config": {
+            "command": "python",
+            "args": ["-m", "xagent.web.tools.mcp.myob"],
+            "env_mapping": {
+                "MYOB_ACCESS_TOKEN": "access_token",
+                "MYOB_BUSINESS_ID": "instance_url",
+            },
+            "static_env": {"MYOB_API_KEY": "MYOB_CLIENT_ID"},
+        },
+    }
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "oauth_providers" in existing_tables:
+        oauth_columns = {
+            column["name"] for column in inspector.get_columns("oauth_providers")
+        }
+        existing_provider_names = set(
+            bind.execute(
+                sa.select(FULL_OAUTH_PROVIDERS_TABLE.c.provider_name)
+            ).scalars()
+        )
+        if "myob" not in existing_provider_names:
+            bind.execute(
+                sa.insert(FULL_OAUTH_PROVIDERS_TABLE),
+                [_filter_row(_myob_provider_row(), oauth_columns)],
+            )
+
+    if "public_mcp_apps" in existing_tables:
+        app_columns = {
+            column["name"] for column in inspector.get_columns("public_mcp_apps")
+        }
+        existing_app_ids = set(
+            bind.execute(sa.select(PUBLIC_MCP_APPS_TABLE.c.app_id)).scalars()
+        )
+        if APP_ID not in existing_app_ids:
+            bind.execute(
+                sa.insert(PUBLIC_MCP_APPS_TABLE),
+                [_filter_row(_myob_app_row(), app_columns)],
+            )
+
+
+def _row_matches_seeded_shape(
+    row: sa.engine.Row, seeded: dict[str, object], compare_columns: set[str]
+) -> bool:
+    """Compare a fetched row against the seeded row dict in Python.
+
+    Deliberately not pushed into the SQL WHERE clause: PostgreSQL's plain
+    ``json`` column type (what oauth_scopes/launch_config/default_scopes
+    actually are -- see the models, no ``.with_variant(JSONB(), ...)``
+    escape hatch here) has no ``=`` operator at all, so
+    ``.where(json_column == python_value)`` compiles fine but raises
+    ``UndefinedFunction: operator does not exist: json = json`` at
+    execute time on Postgres. Comparing in Python after a plain SELECT
+    sidesteps that entirely and works identically on every backend.
+    """
+    return all(row._mapping[column] == seeded[column] for column in compare_columns)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    existing_tables = set(inspector.get_table_names())
+
+    if "public_mcp_apps" in existing_tables:
+        # Only delete the catalog entry when it still matches the FULL
+        # static shape this migration seeded -- an unconditional
+        # delete-by-app_id would remove a pre-existing operator row that
+        # happened to already occupy app_id "myob" before this migration
+        # ever ran (upgrade()'s own `if APP_ID not in existing_app_ids`
+        # check would have skipped inserting over it, so upgrade and
+        # downgrade must agree on what "this migration's row" means).
+        # Matching only a handful of structural columns
+        # (name/transport/provider_name) isn't enough: admin_mcp.py's
+        # _BUILTIN_PROTECTED_FIELDS blocks a PATCH from changing
+        # oauth_scopes/launch_config away from the built-in registry's
+        # values while this app_id stays registered as built-in, but
+        # description/is_visible_in_connector are freely PATCHable today,
+        # and a raw DB edit (or the app_id later being dropped from the
+        # built-in registry while this row persists) could diverge any of
+        # them -- so every one of this row's non-env-dependent columns is
+        # compared, not just the always-PATCHable few. In Python, see
+        # _row_matches_seeded_shape's docstring for why not in SQL.
+        app_row = bind.execute(
+            sa.select(PUBLIC_MCP_APPS_TABLE).where(
+                PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID
+            )
+        ).first()
+        if app_row is not None and _row_matches_seeded_shape(
+            app_row,
+            _myob_app_row(),
+            {
+                "name",
+                "description",
+                "icon",
+                "transport",
+                "provider_name",
+                "category",
+                "oauth_scopes",
+                "is_visible_in_connector",
+                "launch_config",
+            },
+        ):
+            bind.execute(
+                sa.delete(PUBLIC_MCP_APPS_TABLE).where(
+                    PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID
+                )
+            )
+
+    if "oauth_providers" not in existing_tables:
+        return
+
+    if "public_mcp_apps" in existing_tables:
+        remaining_myob_apps = bind.execute(
+            sa.select(sa.func.count())
+            .select_from(PUBLIC_MCP_APPS_TABLE)
+            .where(PUBLIC_MCP_APPS_TABLE.c.provider_name == "myob")
+        ).scalar()
+        if remaining_myob_apps:
+            return
+
+    # Only delete the provider row when it still matches the FULL static
+    # shape this migration seeded, so an admin-created or admin-edited
+    # "myob" provider (via POST/PUT /admin/mcp/providers) is preserved.
+    # client_id/client_secret/redirect_uri are env-dependent and
+    # intentionally excluded from the guard; every other column is static
+    # and matched, not just the structural few (name/auth_url/token_url) --
+    # an admin who edited userinfo_url/user_id_path/email_path/
+    # default_scopes without touching those few fields would otherwise
+    # still match and get silently deleted.
+    provider_row = bind.execute(
+        sa.select(FULL_OAUTH_PROVIDERS_TABLE).where(
+            FULL_OAUTH_PROVIDERS_TABLE.c.provider_name == "myob"
+        )
+    ).first()
+    if provider_row is not None and _row_matches_seeded_shape(
+        provider_row,
+        _myob_provider_row(),
+        {
+            "name",
+            "auth_url",
+            "token_url",
+            "userinfo_url",
+            "user_id_path",
+            "email_path",
+            "default_scopes",
+        },
+    ):
+        bind.execute(
+            sa.delete(FULL_OAUTH_PROVIDERS_TABLE).where(
+                FULL_OAUTH_PROVIDERS_TABLE.c.provider_name == "myob"
+            )
+        )

--- a/src/xagent/migrations/versions/20260903_seed_myob_mcp_app.py
+++ b/src/xagent/migrations/versions/20260903_seed_myob_mcp_app.py
@@ -88,7 +88,7 @@ def _myob_app_row() -> dict[str, object]:
     return {
         "app_id": APP_ID,
         "name": "MYOB",
-        "description": "Connect to MYOB AccountRight to look up contacts, invoices, purchase bills, and general ledger accounts.",
+        "description": "Connect to MYOB AccountRight to look up and manage contacts, sales invoices, and purchase bills, and browse general ledger accounts and tax codes.",
         "icon": "https://www.google.com/s2/favicons?domain=myob.com&sz=128",
         "transport": "oauth",
         "provider_name": "myob",

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -2703,12 +2703,30 @@ def generic_oauth_callback(
                 )
                 or "longlife_refresh_token"
             )
-        # MYOB's own docs list `scope` as required here too, but the
-        # production-grade pymyob SDK's code-exchange request omits it and
-        # works -- client_id/client_secret/redirect_uri (sent below/above
-        # for every provider already) are what MYOB's endpoint actually
-        # checks. Trusting the working implementation over the stale docs;
-        # revisit if MYOB ever starts rejecting exchanges without it.
+        if is_myob:
+            # MYOB's own docs list `scope` as a required body param here,
+            # with a worked example -- sent, unlike the Deputy branch above,
+            # from the app row's oauth_scopes rather than
+            # db_provider.default_scopes: MYOB's provider row deliberately
+            # carries no default_scopes of its own (see its registry row's
+            # comment), since every functional sme-* scope this connector
+            # needs is granular and app-specific. target_app_info is the
+            # same lookup already performed above (for the hidden-app
+            # check) when app_id is present; MYOB requires an app-scoped
+            # grant (APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT), so a real
+            # connection always has one -- the `app_id and` guard only
+            # covers a hypothetical stale/crafted state token missing it,
+            # in which case there's nothing to source a scope from anyway.
+            myob_app_scopes = (
+                target_app_info.get("oauth_scopes")
+                if app_id and isinstance(target_app_info, dict)
+                else None
+            )
+            myob_scopes = _merge_oauth_scopes(
+                db_provider.default_scopes or [], myob_app_scopes
+            )
+            if myob_scopes:
+                data["scope"] = _oauth_scope_separator(provider).join(myob_scopes)
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         if requires_json_accept_header(provider):
             headers["Accept"] = "application/json"

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -353,19 +353,26 @@ def _merged_oauth_scopes(
     default_scopes: list[str] | None, app_scopes: list[str] | None, provider: str
 ) -> tuple[list[str], str]:
     """Merge provider default scopes with an app row's oauth_scopes, and
-    join them into one scope string -- the ONE place both computations
-    happen, for every caller that needs either or both.
+    join them into one scope string -- the shared place for this specific
+    "merge default+app scopes, dedupe, join" pattern, used by
+    _generic_oauth_login's authorize-redirect leg and MYOB's token-exchange
+    leg in generic_oauth_callback.
 
-    Returns (merged_list, joined_string): the list is needed by
-    _generic_oauth_login's authorize-redirect leg (to exclude required
-    scopes from optional_scope below), the string by any leg that just
-    needs a request param (MYOB's token-exchange leg in
-    generic_oauth_callback, which has no default_scopes of its own and
-    sources everything from the app row). A single-caller wrapper around
-    the string alone was tried first and correctly called out as pointless
-    indirection when the other leg still inlined the same computation
-    separately -- this version is what actually makes it one shared
-    computation instead of a same-shaped copy.
+    Returns (merged_list, joined_string): the list is needed by the
+    authorize-redirect leg (to exclude required scopes from optional_scope
+    below), the string by MYOB's leg, which has no default_scopes of its
+    own and sources everything from the app row. A single-caller wrapper
+    around the string alone was tried first and correctly called out as
+    pointless indirection when the other leg still inlined the same
+    computation separately -- this version is what actually makes it one
+    shared computation for those two, instead of a same-shaped copy.
+
+    NOT the only scope-string mechanism in this file: Deputy's own
+    code-exchange leg (see its `if is_deputy:` block above) builds its
+    scope string by hand instead, for reasons specific to it -- it needs a
+    literal fallback ("longlife_refresh_token") this function has no
+    concept of, and doesn't dedupe, both deliberate per that block's own
+    comment. Left as-is rather than folded in here.
     """
     scopes = _merge_oauth_scopes(default_scopes or [], app_scopes)
     scope_str = _oauth_scope_separator(provider).join(scopes)
@@ -3342,20 +3349,33 @@ def generic_oauth_callback(
                     else ""
                 )
                 provider_user_id = uid_str or None
-                if raw_provider_user_id and provider_user_id is None:
-                    # Same "truthy but wrong type" convention as the
-                    # Salesforce branch above -- a missing "uid" would be a
-                    # genuinely malformed MYOB response (unlike Salesforce's
-                    # own "id", which real responses can legitimately omit),
-                    # but that case is covered by the outer warning below;
-                    # this one is specifically for a present-but-unusable
-                    # value.
-                    logger.warning(
-                        "MYOB token response's user.uid was not a usable "
-                        "string/int (got %s); falling back to NULL "
-                        "provider_user_id for this grant",
-                        type(raw_provider_user_id).__name__,
-                    )
+                if provider_user_id is None:
+                    if raw_provider_user_id:
+                        # Same "truthy but wrong type" convention as the
+                        # Salesforce branch above.
+                        logger.warning(
+                            "MYOB token response's user.uid was not a usable "
+                            "string/int (got %s); falling back to NULL "
+                            "provider_user_id for this grant",
+                            type(raw_provider_user_id).__name__,
+                        )
+                    else:
+                        # A missing/empty "uid" inside an otherwise-present
+                        # user object -- unlike Salesforce's own "id", which
+                        # real responses can legitimately omit, MYOB's
+                        # user.uid is documented as always present, so this
+                        # is genuinely malformed, not an expected variation.
+                        # Distinct from (and NOT covered by) the outer
+                        # "no usable user object" warning below, which only
+                        # fires when `user` itself isn't a dict at all --
+                        # a dict missing just "uid" never reaches that
+                        # branch.
+                        logger.warning(
+                            "MYOB token response's user object had no usable "
+                            "uid (got %s); connecting with no identity for "
+                            "this grant",
+                            type(raw_provider_user_id).__name__,
+                        )
                 raw_username = raw_user.get("username")
                 email = (
                     raw_username

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -237,6 +237,38 @@ def _normalize_deputy_endpoint(raw_endpoint: object) -> Optional[str]:
     return f"{parsed.scheme}://{hostname}{port}"
 
 
+_MYOB_BUSINESS_ID_PATTERN = re.compile(
+    r"^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$"
+)
+
+
+def _normalize_myob_business_id(raw_business_id: object) -> Optional[str]:
+    """Validate the `businessId` MYOB appends to its own authorization
+    redirect as a well-formed GUID.
+
+    This is the *only* place MYOB ever names the business the user
+    consented to -- never the token response (unlike every other
+    per-connection identifier this file normalizes, e.g. Salesforce's/
+    Deputy's), and there is no discovery endpoint to recover it after the
+    fact the way Xero's /connections is: MYOB's own equivalent (GET
+    https://api.myob.com/accountright/) stopped returning company files
+    for API keys created under the post-2025 granular-scope model. So a
+    malformed or missing value here is unrecoverable for this connection,
+    not just a "let a later call fail with a clear error" case the way an
+    unvalidated instance_url elsewhere would be. UserOAuth.instance_url
+    stores this (myob.py reads it via env_mapping's "instance_url" token
+    type, the same mechanism Salesforce/Deputy already use for their own
+    per-connection value), so it's checked with the same strictness here as
+    at connect time, not left to fail opaquely on the first tool call.
+    """
+    if not isinstance(raw_business_id, str):
+        return None
+    business_id = raw_business_id.strip()
+    if not _MYOB_BUSINESS_ID_PATTERN.match(business_id):
+        return None
+    return business_id
+
+
 def _resolve_oauth_secret(
     provider: str, encrypted_value: Optional[str], env_suffix: str
 ) -> str:
@@ -2242,6 +2274,14 @@ def _generic_oauth_login(
         # (read only) followed by an app-scoped connect (read+write) is
         # guaranteed to end up with the broader grant either way.
         params["prompt"] = "consent"
+    if provider.lower() == "myob":
+        # Unlike every other provider's prompt=consent above, this isn't
+        # about re-prompting for a broader grant -- MYOB only appends
+        # businessId (the company file the user picked) to the
+        # authorization redirect at all when the request forces the
+        # consent screen. Without this, the callback's businessId guard
+        # (see _normalize_myob_business_id) would reject every connection.
+        params["prompt"] = "consent"
     meta_config_id = _meta_login_config_id() if provider.lower() == "meta" else ""
     if meta_config_id:
         params["config_id"] = meta_config_id
@@ -2373,11 +2413,21 @@ def generic_oauth_callback(
     # `normalized_provider` precedent, rather than re-lowering/re-comparing
     # the same string five separate times across the function.
     is_deputy = provider.lower() == "deputy"
+    is_myob = provider.lower() == "myob"
     if db is None:
         raise RuntimeError("db session is required")
     code = request.query_params.get("code")
     state = request.query_params.get("state")
     error = request.query_params.get("error")
+    # MYOB appends this to the redirect itself, not the token response --
+    # captured from the raw request here (not deferred to after the token
+    # exchange, the way Deputy's `endpoint`/Salesforce's `instance_url` are
+    # read from token_data below) because it never appears anywhere else.
+    myob_business_id = (
+        _normalize_myob_business_id(request.query_params.get("businessId"))
+        if is_myob
+        else None
+    )
     provider_error_response = (
         HTMLResponse(
             content=f"<h1>Error: {html.escape(str(error))}</h1>", status_code=400
@@ -2630,6 +2680,12 @@ def generic_oauth_callback(
                 )
                 or "longlife_refresh_token"
             )
+        # MYOB's own docs list `scope` as required here too, but the
+        # production-grade pymyob SDK's code-exchange request omits it and
+        # works -- client_id/client_secret/redirect_uri (sent below/above
+        # for every provider already) are what MYOB's endpoint actually
+        # checks. Trusting the working implementation over the stale docs;
+        # revisit if MYOB ever starts rejecting exchanges without it.
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         if requires_json_accept_header(provider):
             headers["Accept"] = "application/json"
@@ -2827,6 +2883,28 @@ def generic_oauth_callback(
                 status_code=400,
             )
 
+        if is_myob and not myob_business_id:
+            # myob_business_id was already extracted (and validated as a
+            # GUID) from the raw callback request before the token exchange
+            # above -- unlike Deputy/Salesforce, there is no token_data
+            # field to re-derive it from here, so a missing/malformed value
+            # at this point can only mean MYOB's own redirect never carried
+            # one (or carried a value astray of the documented GUID shape).
+            # Same "fail before the delete-then-recreate below" reasoning as
+            # the Salesforce/Deputy guards: this connector's env_mapping
+            # requires it, so letting this through would either come back
+            # unavailable on the next load or destroy a prior *working*
+            # grant while still reporting "Connected Successfully".
+            return HTMLResponse(
+                content=(
+                    "<h1>Error exchanging token</h1>"
+                    f"<p>{html.escape(provider)} did not return a businessId. "
+                    "Make sure the authorization request included "
+                    "prompt=consent.</p>"
+                ),
+                status_code=400,
+            )
+
         provider_user_id = None
         email = None
 
@@ -2951,6 +3029,28 @@ def generic_oauth_callback(
                         f"{html.escape(str(e))}</p>"
                     ),
                     status_code=400,
+                )
+        elif is_myob:
+            # MYOB's userinfo_url is deliberately left empty (see the
+            # registry row's comment) -- unlike Deputy/Linear, there's no
+            # extra round-trip to skip a fixed host for: MYOB's token
+            # response already embeds the identity inline as
+            # `user: {uid, username}`, so this only reads what's already in
+            # hand from the exchange above.
+            raw_user = token_data.get("user")
+            if isinstance(raw_user, dict):
+                raw_provider_user_id = raw_user.get("uid")
+                provider_user_id = (
+                    str(raw_provider_user_id)
+                    if isinstance(raw_provider_user_id, (str, int))
+                    and str(raw_provider_user_id)
+                    else None
+                )
+                raw_username = raw_user.get("username")
+                email = (
+                    raw_username
+                    if isinstance(raw_username, str) and raw_username
+                    else None
                 )
         elif userinfo_url and access_token:
             info_headers = {"Authorization": f"Bearer {access_token}"}
@@ -3107,6 +3207,12 @@ def generic_oauth_callback(
                 # already-guarded, normalized value from above (Deputy
                 # can't reach this branch without it).
                 resolved_instance_url = deputy_instance_url
+            elif is_myob:
+                # MYOB's equivalent is the company file GUID from the
+                # authorization redirect, not anything in token_data --
+                # myob_business_id is the already-guarded value from above
+                # (MYOB can't reach this branch without it).
+                resolved_instance_url = myob_business_id
             setattr(oauth_account, "instance_url", resolved_instance_url)
             if "expires_in" in token_data:
                 setattr(

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -335,6 +335,26 @@ def _oauth_scope_separator(provider: str) -> str:
     return " "
 
 
+def _oauth_scope_str(
+    default_scopes: list[str] | None, app_scopes: list[str] | None, provider: str
+) -> str:
+    """Merge provider default scopes with an app row's oauth_scopes and join
+    them into one scope string, using the same two shared primitives
+    (_merge_oauth_scopes, _oauth_scope_separator) every scope computation in
+    this file already goes through.
+
+    Used by MYOB's token-exchange leg in generic_oauth_callback, which has
+    no default_scopes of its own and sources everything from the app row.
+    _generic_oauth_login's own authorize-redirect leg computes the merged
+    list inline instead of through this helper, since it needs that
+    intermediate list again afterward (to exclude required scopes from
+    optional_scope) -- not a second reimplementation of this logic, just a
+    second caller of the same two primitives this wraps.
+    """
+    scopes = _merge_oauth_scopes(default_scopes or [], app_scopes)
+    return _oauth_scope_separator(provider).join(scopes)
+
+
 def _meta_login_config_id() -> str:
     return os.environ.get("META_CONFIG_ID", "")
 
@@ -2722,11 +2742,11 @@ def generic_oauth_callback(
                 if app_id and isinstance(target_app_info, dict)
                 else None
             )
-            myob_scopes = _merge_oauth_scopes(
-                db_provider.default_scopes or [], myob_app_scopes
+            myob_scope_str = _oauth_scope_str(
+                db_provider.default_scopes, myob_app_scopes, provider
             )
-            if myob_scopes:
-                data["scope"] = _oauth_scope_separator(provider).join(myob_scopes)
+            if myob_scope_str:
+                data["scope"] = myob_scope_str
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
         if requires_json_accept_header(provider):
             headers["Accept"] = "application/json"
@@ -3059,13 +3079,13 @@ def generic_oauth_callback(
             raw_user = token_data.get("user")
             if isinstance(raw_user, dict):
                 raw_provider_user_id = raw_user.get("uid")
-                provider_user_id = (
+                uid_str = (
                     str(raw_provider_user_id)
                     if isinstance(raw_provider_user_id, (str, int))
                     and not isinstance(raw_provider_user_id, bool)
-                    and str(raw_provider_user_id)
-                    else None
+                    else ""
                 )
+                provider_user_id = uid_str or None
                 raw_username = raw_user.get("username")
                 email = (
                     raw_username

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -2643,6 +2643,29 @@ def generic_oauth_callback(
         missing_config.append(_oauth_env_name(provider, "CLIENT_SECRET"))
     if missing_config:
         return _oauth_provider_config_error(provider, missing_config)
+
+    if is_myob and not myob_business_id:
+        # myob_business_id was already extracted (and validated as a GUID)
+        # from the raw callback request, before this point -- unlike
+        # Deputy/Salesforce's own instance_url-shaped guards (checked further
+        # below, after their own token exchange), there is no token_data
+        # field this could instead be re-derived from post-exchange, so
+        # nothing is gained by waiting: a missing/malformed value here can
+        # only mean MYOB's own redirect never carried one (or carried a
+        # value astray of the documented GUID shape). Checked here, before
+        # the token exchange even starts, so a doomed connection attempt
+        # doesn't burn a network round trip to MYOB or consume the
+        # single-use authorization code for an outcome already decided.
+        return HTMLResponse(
+            content=(
+                "<h1>Error exchanging token</h1>"
+                f"<p>{html.escape(provider)} did not return a businessId. "
+                "Make sure the authorization request included "
+                "prompt=consent.</p>"
+            ),
+            status_code=400,
+        )
+
     token_url = db_provider.token_url
     userinfo_url = db_provider.userinfo_url
 
@@ -2879,28 +2902,6 @@ def generic_oauth_callback(
                 content=(
                     "<h1>Error exchanging token</h1>"
                     f"<p>{html.escape(provider)} did not return an endpoint.</p>"
-                ),
-                status_code=400,
-            )
-
-        if is_myob and not myob_business_id:
-            # myob_business_id was already extracted (and validated as a
-            # GUID) from the raw callback request before the token exchange
-            # above -- unlike Deputy/Salesforce, there is no token_data
-            # field to re-derive it from here, so a missing/malformed value
-            # at this point can only mean MYOB's own redirect never carried
-            # one (or carried a value astray of the documented GUID shape).
-            # Same "fail before the delete-then-recreate below" reasoning as
-            # the Salesforce/Deputy guards: this connector's env_mapping
-            # requires it, so letting this through would either come back
-            # unavailable on the next load or destroy a prior *working*
-            # grant while still reporting "Connected Successfully".
-            return HTMLResponse(
-                content=(
-                    "<h1>Error exchanging token</h1>"
-                    f"<p>{html.escape(provider)} did not return a businessId. "
-                    "Make sure the authorization request included "
-                    "prompt=consent.</p>"
                 ),
                 status_code=400,
             )

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -349,24 +349,27 @@ def _oauth_scope_separator(provider: str) -> str:
     return " "
 
 
-def _oauth_scope_str(
+def _merged_oauth_scopes(
     default_scopes: list[str] | None, app_scopes: list[str] | None, provider: str
-) -> str:
-    """Merge provider default scopes with an app row's oauth_scopes and join
-    them into one scope string, using the same two shared primitives
-    (_merge_oauth_scopes, _oauth_scope_separator) every scope computation in
-    this file already goes through.
+) -> tuple[list[str], str]:
+    """Merge provider default scopes with an app row's oauth_scopes, and
+    join them into one scope string -- the ONE place both computations
+    happen, for every caller that needs either or both.
 
-    Used by MYOB's token-exchange leg in generic_oauth_callback, which has
-    no default_scopes of its own and sources everything from the app row.
-    _generic_oauth_login's own authorize-redirect leg computes the merged
-    list inline instead of through this helper, since it needs that
-    intermediate list again afterward (to exclude required scopes from
-    optional_scope) -- not a second reimplementation of this logic, just a
-    second caller of the same two primitives this wraps.
+    Returns (merged_list, joined_string): the list is needed by
+    _generic_oauth_login's authorize-redirect leg (to exclude required
+    scopes from optional_scope below), the string by any leg that just
+    needs a request param (MYOB's token-exchange leg in
+    generic_oauth_callback, which has no default_scopes of its own and
+    sources everything from the app row). A single-caller wrapper around
+    the string alone was tried first and correctly called out as pointless
+    indirection when the other leg still inlined the same computation
+    separately -- this version is what actually makes it one shared
+    computation instead of a same-shaped copy.
     """
     scopes = _merge_oauth_scopes(default_scopes or [], app_scopes)
-    return _oauth_scope_separator(provider).join(scopes)
+    scope_str = _oauth_scope_separator(provider).join(scopes)
+    return scopes, scope_str
 
 
 def _meta_login_config_id() -> str:
@@ -2454,8 +2457,9 @@ def _generic_oauth_login(
                 app_scopes = app_info["oauth_scopes"]
             app_optional_scopes = app_info.get("optional_oauth_scopes") or []
 
-    scopes = _merge_oauth_scopes(db_provider.default_scopes or [], app_scopes)
-    scope_str = _oauth_scope_separator(provider).join(scopes)
+    scopes, scope_str = _merged_oauth_scopes(
+        db_provider.default_scopes, app_scopes, provider
+    )
     # Sent via the authorize request's own optional_scope parameter (see
     # get_builtin_execution_fields_and_optional_scopes) rather than merged
     # into `scopes` above: a scope tier-gated on the connected account's
@@ -2964,7 +2968,7 @@ def generic_oauth_callback(
                 if app_id and isinstance(target_app_info, dict)
                 else None
             )
-            myob_scope_str = _oauth_scope_str(
+            _, myob_scope_str = _merged_oauth_scopes(
                 db_provider.default_scopes, myob_app_scopes, provider
             )
             if myob_scope_str:
@@ -3338,11 +3342,40 @@ def generic_oauth_callback(
                     else ""
                 )
                 provider_user_id = uid_str or None
+                if raw_provider_user_id and provider_user_id is None:
+                    # Same "truthy but wrong type" convention as the
+                    # Salesforce branch above -- a missing "uid" would be a
+                    # genuinely malformed MYOB response (unlike Salesforce's
+                    # own "id", which real responses can legitimately omit),
+                    # but that case is covered by the outer warning below;
+                    # this one is specifically for a present-but-unusable
+                    # value.
+                    logger.warning(
+                        "MYOB token response's user.uid was not a usable "
+                        "string/int (got %s); falling back to NULL "
+                        "provider_user_id for this grant",
+                        type(raw_provider_user_id).__name__,
+                    )
                 raw_username = raw_user.get("username")
                 email = (
                     raw_username
                     if isinstance(raw_username, str) and raw_username
                     else None
+                )
+            else:
+                # Every real MYOB token response embeds `user: {uid,
+                # username}` inline -- unlike Salesforce's optional "id",
+                # this is documented as always present, so a missing or
+                # malformed `user` object here means something is actually
+                # wrong with the response, not an expected per-provider
+                # variation. provider_user_id/email were already
+                # initialized to None above; this just makes the anomaly
+                # visible server-side instead of silently connecting with
+                # no identity.
+                logger.warning(
+                    "MYOB token response had no usable user object (got %s); "
+                    "connecting with no identity for this grant",
+                    type(raw_user).__name__,
                 )
         elif matches_provider_family(
             provider, "employment-hero"

--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -3043,6 +3043,7 @@ def generic_oauth_callback(
                 provider_user_id = (
                     str(raw_provider_user_id)
                     if isinstance(raw_provider_user_id, (str, int))
+                    and not isinstance(raw_provider_user_id, bool)
                     and str(raw_provider_user_id)
                     else None
                 )

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -346,6 +346,32 @@ def get_builtin_oauth_provider_rows() -> list[dict[str, Any]]:
                 "read:me",
             ],
         },
+        {
+            "provider_name": "myob",
+            "name": "MYOB",
+            "client_id": os.environ.get("MYOB_CLIENT_ID", ""),
+            "client_secret": os.environ.get("MYOB_CLIENT_SECRET", ""),
+            "auth_url": "https://secure.myob.com/oauth2/account/authorize/",
+            "token_url": "https://secure.myob.com/oauth2/v1/authorize/",
+            "redirect_uri": os.environ.get("MYOB_REDIRECT_URI", ""),
+            # MYOB has no dedicated userinfo endpoint -- the token response
+            # already embeds identity inline as `user: {uid, username}`, so
+            # generic_oauth_callback's `elif userinfo_url and access_token:`
+            # REST-GET branch is skipped entirely (left empty, same as
+            # Deputy/Linear/Salesforce above for their own reasons); identity
+            # instead comes from a dedicated `elif is_myob` branch there that
+            # reads those two fields straight off token_data.
+            "userinfo_url": "",
+            "user_id_path": "",
+            "email_path": "",
+            # Empty, not identity-only like zoom/github above: MYOB has no
+            # separate identity scope to request, and every functional scope
+            # this connector needs is granular (AuthAccount-scoped, e.g.
+            # sme-sales/sme-contacts-customer) and app-specific, so it lives
+            # on the app row's oauth_scopes below instead, merged in at
+            # authorize time by _merge_oauth_scopes.
+            "default_scopes": [],
+        },
     ]
 
 
@@ -1194,6 +1220,68 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
                 "command": "python",
                 "args": ["-m", "xagent.web.tools.mcp.chartmogul"],
                 "required_env": ["CHARTMOGUL_API_KEY"],
+            },
+        },
+        {
+            "app_id": "myob",
+            "name": "MYOB",
+            "description": "Connect to MYOB AccountRight to look up contacts, invoices, purchase bills, and general ledger accounts.",
+            "icon": "https://www.google.com/s2/favicons?domain=myob.com&sz=128",
+            "transport": "oauth",
+            "provider_name": "myob",
+            "category": "Operations",
+            # Granular AuthAccount scopes (MYOB retired the old blanket
+            # CompanyFile scope) matching the tool set this connector
+            # exposes -- sme-company-file for myob_get_business_info, the
+            # rest one per resource family (contacts/sales/purchases/
+            # general ledger). Deliberately excludes sme-banking (no
+            # banking tools exposed) and sme-payroll/sme-contacts-employee/
+            # sme-contacts-personal/sme-timebilling (no payroll or
+            # personal-employee-data tools) -- nothing here would justify
+            # requesting access to any of them.
+            "oauth_scopes": [
+                "sme-company-file",
+                "sme-contacts-customer",
+                "sme-contacts-supplier",
+                "sme-sales",
+                "sme-purchases",
+                "sme-general-ledger",
+            ],
+            "is_visible_in_connector": True,
+            "launch_config": {
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.myob"],
+                "env_mapping": {
+                    "MYOB_ACCESS_TOKEN": "access_token",
+                    # The company file GUID captured from the authorization
+                    # redirect (see api/auth.py's is_myob handling) -- same
+                    # instance_url mechanism Salesforce/Deputy already use
+                    # for their own per-connection value, just sourced from
+                    # a different place in the OAuth flow.
+                    "MYOB_BUSINESS_ID": "instance_url",
+                },
+                # x-myobapi-key identifies the calling *application*, not the
+                # end user -- every MYOB connection made by this deployment
+                # uses the same client_id, so it's forwarded verbatim from
+                # this process's own env rather than threaded through
+                # env_mapping like the per-user access token above.
+                # Unlike Google Ads' developer-token static_env above,
+                # MYOB_CLIENT_ID is also the same value the OAuth login/
+                # token-exchange flow resolves via _resolve_oauth_secret
+                # (DB-first, env-fallback -- see the provider row above and
+                # admin_mcp.py's provider-edit routes). static_env itself
+                # only ever reads the bare host env var, with no DB
+                # fallback of its own, so an admin who configures MYOB's
+                # client_id purely through the admin UI (never setting this
+                # env var) would see OAuth connect succeed while every
+                # actual myob_*.py tool call then fails on a missing
+                # MYOB_API_KEY -- a real deployment footgun, not just a
+                # theoretical one, but one shared by static_env's design
+                # generally rather than something specific to fix here.
+                # MYOB_CLIENT_ID must be set as an env var for this
+                # connector to work, even if client_id/client_secret are
+                # also configured via the admin UI.
+                "static_env": {"MYOB_API_KEY": "MYOB_CLIENT_ID"},
             },
         },
     ]

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -1289,7 +1289,7 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
         {
             "app_id": "myob",
             "name": "MYOB",
-            "description": "Connect to MYOB AccountRight to look up contacts, invoices, purchase bills, and general ledger accounts.",
+            "description": "Connect to MYOB AccountRight to look up and manage contacts, sales invoices, and purchase bills, and browse general ledger accounts and tax codes.",
             "icon": "https://www.google.com/s2/favicons?domain=myob.com&sz=128",
             "transport": "oauth",
             "provider_name": "myob",

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -36,7 +36,16 @@ from .models.public_mcp import PublicMCPApp
 # (the catalog UI always passes app_id="github", and app_id == provider_name
 # for this connector, so an already-connected grant already satisfies the
 # app-scoped match trivially).
-APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT = frozenset({"facebook", "github"})
+#
+# myob: same structural situation as github, just more extreme -- the myob
+# oauth_providers row's own default_scopes is empty (there's no shared
+# identity scope to request; see the provider row's own comment), and every
+# functional sme-* scope this connector needs lives solely on the app row.
+# Without this entry, a bare GET /api/auth/myob/login would request NO
+# scopes at all, yet the callback would still complete (MYOB's businessId
+# guard has nothing to do with scopes) and activate the app's UserMCPServer
+# against a grant with zero sme-* permissions.
+APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT = frozenset({"facebook", "github", "myob"})
 
 
 def _normalize_oauth_grant_key(value: object) -> str | None:

--- a/src/xagent/web/models/user_oauth.py
+++ b/src/xagent/web/models/user_oauth.py
@@ -59,9 +59,13 @@ class UserOAuth(Base):  # type: ignore[no-any-unimported]
         String, nullable=True
     )  # The user's ID in the provider system
     email = Column(String, nullable=True)
-    # Salesforce (and no other provider here) returns a per-org API host in
-    # the token response instead of using a fixed API domain -- every
-    # subsequent API call must go through this URL, not a hardcoded one.
+    # A per-connection value some providers need beyond a fixed API domain,
+    # reused for different shapes by whichever provider populates it:
+    # Salesforce's per-org API host (a real URL), Deputy's per-install API
+    # host (a bare hostname, no scheme), MYOB's company-file businessId (a
+    # bare GUID, not a URL at all despite the column name) -- see each
+    # provider's own handling in api/auth.py for how it's populated and
+    # tools/mcp/<provider>.py for how it's used at call time.
     instance_url = Column(String, nullable=True)
 
     created_at = Column(DateTime(timezone=True), server_default=func.now())

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -1065,8 +1065,18 @@ async def refresh_oauth_token_if_needed(
                             "endpoint; keeping the previously stored value"
                         )
                 if "expires_in" in data:
+                    # int(), not a bare pass-through: MYOB's documented token
+                    # response (both the code-exchange and refresh legs)
+                    # returns this as a JSON *string* (e.g. "1200"), which
+                    # timedelta()'s seconds kwarg rejects outright
+                    # (TypeError) -- MYOB is the first provider whose
+                    # refresh reaches this generic branch with no
+                    # provider-specific handling (unlike Meta's own branch
+                    # a few lines above, or the code-exchange leg in
+                    # api/auth.py's generic_oauth_callback, both of which
+                    # already cast this the same way).
                     oauth_account.expires_at = datetime.now(timezone.utc) + timedelta(
-                        seconds=data["expires_in"]
+                        seconds=int(data["expires_in"])
                     )
                 db.flush([oauth_account])
                 logger.info(

--- a/src/xagent/web/tools/mcp/myob.py
+++ b/src/xagent/web/tools/mcp/myob.py
@@ -174,12 +174,19 @@ def _list_items(result: Any) -> tuple[list[Any], int | None]:
     tolerates a bare JSON array in case a given endpoint (or a future MYOB
     API revision) returns one directly, rather than crashing on
     ``.get("Items")`` against a list.
+
+    total_count is None for the bare-array shape, not len(result): that
+    length is only the current page, not MYOB's true across-all-pages
+    total the way ``Count`` is -- returning it as total_count would make
+    _success_with_capped_list's has_more/next_skip pagination silently
+    report "no more results" the moment this fallback fires, even when
+    more genuinely exist server-side.
     """
     if isinstance(result, dict):
         items = result.get("Items")
         return (items if isinstance(items, list) else [], result.get("Count"))
     if isinstance(result, list):
-        return result, len(result)
+        return result, None
     return [], None
 
 

--- a/src/xagent/web/tools/mcp/myob.py
+++ b/src/xagent/web/tools/mcp/myob.py
@@ -48,7 +48,12 @@ def _business_id() -> str:
     business_id = os.environ.get("MYOB_BUSINESS_ID")
     if not business_id:
         raise ValueError("MYOB_BUSINESS_ID environment variable is missing")
-    return business_id
+    # Interpolated directly into every request URL below (_base_url) --
+    # validated/percent-encoded the same way every other uid in this file
+    # is, for house consistency, even though this specific value already
+    # passed GUID validation once at connect time
+    # (_normalize_myob_business_id in api/auth.py).
+    return url_path_id(business_id, "MYOB_BUSINESS_ID")
 
 
 def _base_url() -> str:
@@ -241,7 +246,13 @@ def _update_resource(path: str, uid: str, fields: dict[str, Any]) -> dict[str, A
     """
     safe_uid = url_path_id(uid, "uid")
     current = _request("GET", f"{path}{safe_uid}/")
-    if not isinstance(current, dict):
+    # Rejects an empty dict too, not just a non-dict -- _request returns {}
+    # on a 204/empty response, and {} would otherwise pass straight through
+    # to `merged = {**{}, **fields}` below, silently wiping every field
+    # this record has other than the ones the caller named (including
+    # RowVersion, which MYOB needs back on the PUT for optimistic
+    # concurrency).
+    if not current:
         raise RuntimeError(f"MYOB returned no existing record for uid {uid}")
     merged = {**current, **fields}
     response = _raw_request(
@@ -588,13 +599,17 @@ def myob_get_account(uid: str) -> str:
 
 
 @mcp.tool()
-def myob_list_tax_codes(top: int = DEFAULT_PAGE_LIMIT, skip: int = 0) -> str:
+def myob_list_tax_codes(
+    filter: str = "", orderby: str = "", top: int = DEFAULT_PAGE_LIMIT, skip: int = 0
+) -> str:
     """
     List tax codes configured on the business (e.g. GST, FRE, N-T).
+    filter: an optional raw OData $filter expression, e.g. "Type eq 'GST'".
+    orderby: an optional OData $orderby expression, e.g. "Code".
     top/skip: server-side page size (max 100) and offset.
     """
     try:
-        params = _list_params(filter_str="", orderby="", top=top, skip=skip)
+        params = _list_params(filter_str=filter, orderby=orderby, top=top, skip=skip)
         result = _request("GET", "GeneralLedger/TaxCode/", params=params)
         items, total_count = _list_items(result)
         return _success_with_capped_list("tax_codes", items, total_count=total_count)

--- a/src/xagent/web/tools/mcp/myob.py
+++ b/src/xagent/web/tools/mcp/myob.py
@@ -110,8 +110,8 @@ def _raise_for_status(response: requests.Response) -> None:
     detail = _extract_error_detail(response)
     if detail is None:
         detail = response.text.strip()
-        if len(detail) > MAX_ERROR_RESPONSE_TEXT_CHARS:
-            detail = detail[:MAX_ERROR_RESPONSE_TEXT_CHARS] + "... [truncated]"
+    if detail and len(detail) > MAX_ERROR_RESPONSE_TEXT_CHARS:
+        detail = detail[:MAX_ERROR_RESPONSE_TEXT_CHARS] + "... [truncated]"
     message = f"MYOB API error (status {response.status_code})"
     if detail:
         message = f"{message}: {detail}"

--- a/src/xagent/web/tools/mcp/myob.py
+++ b/src/xagent/web/tools/mcp/myob.py
@@ -104,7 +104,18 @@ def _extract_error_detail(response: requests.Response) -> str | None:
             continue
         name = entry.get("Name") or ""
         message = entry.get("Message") or ""
-        details = entry.get("AdditionalDetails") or ""
+        # AdditionalDetails is usually a plain string, but at least one
+        # documented MYOB error shape carries it as a list of per-field
+        # messages -- joined into readable text here rather than left to
+        # fall through to the generic str(part) below, which would embed a
+        # raw Python list repr (e.g. "['TaxCode is required']") in the
+        # message surfaced to the LLM.
+        raw_details = entry.get("AdditionalDetails")
+        details = (
+            ", ".join(str(item) for item in raw_details if item)
+            if isinstance(raw_details, list)
+            else raw_details or ""
+        )
         parts.append(" ".join(str(part) for part in (name, message, details) if part))
     return "; ".join(part for part in parts if part) or None
 

--- a/src/xagent/web/tools/mcp/myob.py
+++ b/src/xagent/web/tools/mcp/myob.py
@@ -184,21 +184,38 @@ def _list_items(result: Any) -> tuple[list[Any], int | None]:
 
 
 def _success_with_capped_list(
-    list_field: str, items: list[Any], *, total_count: int | None, **extra: Any
+    list_field: str,
+    items: list[Any],
+    *,
+    total_count: int | None,
+    skip: int,
+    **extra: Any,
 ) -> str:
     """Build a success payload, halving ``items`` until the response fits
     the platform's output limit.
 
-    Matches salesforce.py's _success_with_capped_list: MYOB's own $top/
-    $skip already lets a caller retry for a narrower page, so items dropped
-    here purely for output size are recoverable via a smaller ``top``, not
-    unrecoverable the way a SOQL query's client-side cap is.
+    ``next_skip``/``has_more`` reflect how many items actually made it into
+    this response (post-halving), the same convention salesforce.py's own
+    offset-based capped-page helper uses -- a caller resuming from
+    ``next_skip`` picks up exactly where this response left off, including
+    any items a halving pass dropped, rather than jumping straight to
+    ``skip + top`` and silently skipping over them the way returning a bare
+    ``truncated: true`` with no cursor would.
     """
 
     def _build(items: list[Any], truncated: bool) -> str:
-        payload: dict[str, Any] = {list_field: items, "truncated": truncated, **extra}
+        next_skip = skip + len(items)
+        has_more = total_count is not None and next_skip < total_count
+        payload: dict[str, Any] = {
+            list_field: items,
+            "truncated": truncated,
+            "has_more": has_more,
+            **extra,
+        }
         if total_count is not None:
             payload["total_count"] = total_count
+        if has_more:
+            payload["next_skip"] = next_skip
         return _success(**payload)
 
     max_output_length = get_tool_max_output_length()
@@ -254,6 +271,14 @@ def _update_resource(path: str, uid: str, fields: dict[str, Any]) -> dict[str, A
     RowVersion themselves, this fetches the current body first and merges
     the caller's changes on top of it, so a caller only has to name what's
     actually changing.
+
+    This is still a GET-then-PUT with no retry: a concurrent edit landing
+    between the two (another tool call, or a change made directly in MYOB)
+    is a classic lost-update race -- MYOB's own RowVersion check makes the
+    PUT fail cleanly with a 409 rather than silently overwriting, but this
+    function doesn't re-fetch and retry on that, it just surfaces the
+    error. Not unique to this connector (other connectors in this codebase
+    PUT the same way), so left as a known tradeoff rather than solved here.
     """
     safe_uid = url_path_id(uid, "uid")
     current = _request("GET", f"{path}{safe_uid}/")
@@ -309,7 +334,9 @@ def myob_list_customers(
         params = _list_params(filter_str=filter, orderby=orderby, top=top, skip=skip)
         result = _request("GET", "Contact/Customer/", params=params)
         items, total_count = _list_items(result)
-        return _success_with_capped_list("customers", items, total_count=total_count)
+        return _success_with_capped_list(
+            "customers", items, total_count=total_count, skip=params["$skip"]
+        )
     except Exception as e:
         logger.error(f"Error listing MYOB customers: {e}")
         return _error(str(e))
@@ -379,7 +406,9 @@ def myob_list_suppliers(
         params = _list_params(filter_str=filter, orderby=orderby, top=top, skip=skip)
         result = _request("GET", "Contact/Supplier/", params=params)
         items, total_count = _list_items(result)
-        return _success_with_capped_list("suppliers", items, total_count=total_count)
+        return _success_with_capped_list(
+            "suppliers", items, total_count=total_count, skip=params["$skip"]
+        )
     except Exception as e:
         logger.error(f"Error listing MYOB suppliers: {e}")
         return _error(str(e))
@@ -450,7 +479,9 @@ def myob_list_sales_invoices(
         params = _list_params(filter_str=filter, orderby=orderby, top=top, skip=skip)
         result = _request("GET", "Sale/Invoice/Item/", params=params)
         items, total_count = _list_items(result)
-        return _success_with_capped_list("invoices", items, total_count=total_count)
+        return _success_with_capped_list(
+            "invoices", items, total_count=total_count, skip=params["$skip"]
+        )
     except Exception as e:
         logger.error(f"Error listing MYOB sales invoices: {e}")
         return _error(str(e))
@@ -523,7 +554,9 @@ def myob_list_purchase_bills(
         params = _list_params(filter_str=filter, orderby=orderby, top=top, skip=skip)
         result = _request("GET", "Purchase/Bill/Item/", params=params)
         items, total_count = _list_items(result)
-        return _success_with_capped_list("bills", items, total_count=total_count)
+        return _success_with_capped_list(
+            "bills", items, total_count=total_count, skip=params["$skip"]
+        )
     except Exception as e:
         logger.error(f"Error listing MYOB purchase bills: {e}")
         return _error(str(e))
@@ -594,7 +627,9 @@ def myob_list_accounts(
         params = _list_params(filter_str=filter, orderby=orderby, top=top, skip=skip)
         result = _request("GET", "GeneralLedger/Account/", params=params)
         items, total_count = _list_items(result)
-        return _success_with_capped_list("accounts", items, total_count=total_count)
+        return _success_with_capped_list(
+            "accounts", items, total_count=total_count, skip=params["$skip"]
+        )
     except Exception as e:
         logger.error(f"Error listing MYOB accounts: {e}")
         return _error(str(e))
@@ -626,7 +661,9 @@ def myob_list_tax_codes(
         params = _list_params(filter_str=filter, orderby=orderby, top=top, skip=skip)
         result = _request("GET", "GeneralLedger/TaxCode/", params=params)
         items, total_count = _list_items(result)
-        return _success_with_capped_list("tax_codes", items, total_count=total_count)
+        return _success_with_capped_list(
+            "tax_codes", items, total_count=total_count, skip=params["$skip"]
+        )
     except Exception as e:
         logger.error(f"Error listing MYOB tax codes: {e}")
         return _error(str(e))

--- a/src/xagent/web/tools/mcp/myob.py
+++ b/src/xagent/web/tools/mcp/myob.py
@@ -246,13 +246,16 @@ def _update_resource(path: str, uid: str, fields: dict[str, Any]) -> dict[str, A
     """
     safe_uid = url_path_id(uid, "uid")
     current = _request("GET", f"{path}{safe_uid}/")
-    # Rejects an empty dict too, not just a non-dict -- _request returns {}
-    # on a 204/empty response, and {} would otherwise pass straight through
-    # to `merged = {**{}, **fields}` below, silently wiping every field
-    # this record has other than the ones the caller named (including
+    # Both checks needed, not just one: `not current` alone lets a truthy
+    # non-dict (e.g. a bare list) through, which would blow up as an opaque
+    # TypeError at the dict-spread below instead of this clear message;
+    # `isinstance` alone lets an empty {} through -- _request returns {} on
+    # a 204/empty response, and {} would otherwise pass straight through to
+    # `merged = {**{}, **fields}` below, silently wiping every field this
+    # record has other than the ones the caller named (including
     # RowVersion, which MYOB needs back on the PUT for optimistic
     # concurrency).
-    if not current:
+    if not current or not isinstance(current, dict):
         raise RuntimeError(f"MYOB returned no existing record for uid {uid}")
     merged = {**current, **fields}
     response = _raw_request(

--- a/src/xagent/web/tools/mcp/myob.py
+++ b/src/xagent/web/tools/mcp/myob.py
@@ -1,0 +1,607 @@
+import json
+import logging
+import os
+from typing import Any
+
+import requests
+from mcp.server.fastmcp import FastMCP
+
+from ....config import get_tool_max_output_length
+from .utils import (
+    clamp_limit,
+    clamp_offset,
+    setup_proxy_env,
+    success_with_capped_dict,
+    url_path_id,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("myob-mcp")
+
+# Ensure standard proxy environment variables are set to prevent hanging requests
+setup_proxy_env()
+
+mcp = FastMCP("myob-mcp")
+
+MYOB_BASE_URL = "https://api.myob.com/accountright/"
+DEFAULT_TIMEOUT_SECONDS = 30
+# Matches zoom.py's/salesforce.py's convention: an error body that isn't the
+# expected {"Errors": [...]} shape (e.g. an HTML gateway error page) must not
+# be forwarded to the LLM/logs verbatim and unbounded.
+MAX_ERROR_RESPONSE_TEXT_CHARS = 1000
+# MYOB's own default page size (per the reference uptick/pymyob client) is
+# 400 -- far larger than this connector's default, which is sized for the
+# LLM's output budget rather than MYOB's own server-side ceiling.
+DEFAULT_PAGE_LIMIT = 20
+MAX_PAGE_LIMIT = 100
+
+
+def _success(**payload: Any) -> str:
+    return json.dumps({"status": "success", **payload}, ensure_ascii=False)
+
+
+def _error(message: str) -> str:
+    return json.dumps({"status": "error", "message": message}, ensure_ascii=False)
+
+
+def _business_id() -> str:
+    business_id = os.environ.get("MYOB_BUSINESS_ID")
+    if not business_id:
+        raise ValueError("MYOB_BUSINESS_ID environment variable is missing")
+    return business_id
+
+
+def _base_url() -> str:
+    return f"{MYOB_BASE_URL}{_business_id()}/"
+
+
+def _headers() -> dict[str, str]:
+    access_token = os.environ.get("MYOB_ACCESS_TOKEN")
+    if not access_token:
+        raise ValueError("MYOB_ACCESS_TOKEN environment variable is missing")
+    api_key = os.environ.get("MYOB_API_KEY")
+    if not api_key:
+        raise ValueError("MYOB_API_KEY environment variable is missing")
+    return {
+        "Authorization": f"Bearer {access_token}",
+        # Identifies the calling application (this deployment's own OAuth
+        # client id), not the end user -- x-myobapi-cftoken (company-file
+        # username/password auth) is a dead concept as of the current MYOB
+        # auth model and deliberately not sent here; the OAuth token above
+        # is sufficient on its own.
+        "x-myobapi-key": api_key,
+        "x-myobapi-version": "v2",
+    }
+
+
+def _extract_error_detail(response: requests.Response) -> str | None:
+    """Pull the human-readable message out of a MYOB error body.
+
+    MYOB error responses are ``{"Errors": [{"Name", "Message",
+    "AdditionalDetails"}, ...]}`` -- joining every entry's Name/Message is
+    more useful to the LLM than the raw envelope. Returns None if the body
+    isn't in that shape, so the caller can fall back to the raw response
+    text.
+    """
+    try:
+        payload = response.json()
+    except ValueError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    errors = payload.get("Errors")
+    if not isinstance(errors, list) or not errors:
+        return None
+    parts = []
+    for entry in errors:
+        if not isinstance(entry, dict):
+            parts.append(str(entry))
+            continue
+        name = entry.get("Name") or ""
+        message = entry.get("Message") or ""
+        details = entry.get("AdditionalDetails") or ""
+        parts.append(" ".join(str(part) for part in (name, message, details) if part))
+    return "; ".join(part for part in parts if part) or None
+
+
+def _raise_for_status(response: requests.Response) -> None:
+    if response.status_code < 400:
+        return
+    detail = _extract_error_detail(response)
+    if detail is None:
+        detail = response.text.strip()
+        if len(detail) > MAX_ERROR_RESPONSE_TEXT_CHARS:
+            detail = detail[:MAX_ERROR_RESPONSE_TEXT_CHARS] + "... [truncated]"
+    message = f"MYOB API error (status {response.status_code})"
+    if detail:
+        message = f"{message}: {detail}"
+    raise RuntimeError(message)
+
+
+def _raw_request(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    json_data: dict[str, Any] | None = None,
+) -> requests.Response:
+    return requests.request(
+        method=method,
+        url=f"{_base_url()}{path}",
+        headers=_headers(),
+        params=params,
+        json=json_data,
+        timeout=DEFAULT_TIMEOUT_SECONDS,
+    )
+
+
+def _request(
+    method: str,
+    path: str,
+    *,
+    params: dict[str, Any] | None = None,
+    json_data: dict[str, Any] | None = None,
+) -> Any:
+    response = _raw_request(method, path, params=params, json_data=json_data)
+    _raise_for_status(response)
+    if response.status_code == 204 or not response.content:
+        return {}
+    return response.json()
+
+
+def _list_items(result: Any) -> tuple[list[Any], int | None]:
+    """Normalize a MYOB list response into (items, total_count).
+
+    MYOB's documented list envelope is ``{"Count": N, "Items": [...],
+    "NextPageLink": ...}``, but the reference pymyob client passes the raw
+    response straight through without asserting that shape, so this also
+    tolerates a bare JSON array in case a given endpoint (or a future MYOB
+    API revision) returns one directly, rather than crashing on
+    ``.get("Items")`` against a list.
+    """
+    if isinstance(result, dict):
+        items = result.get("Items")
+        return (items if isinstance(items, list) else [], result.get("Count"))
+    if isinstance(result, list):
+        return result, len(result)
+    return [], None
+
+
+def _success_with_capped_list(
+    list_field: str, items: list[Any], *, total_count: int | None, **extra: Any
+) -> str:
+    """Build a success payload, halving ``items`` until the response fits
+    the platform's output limit.
+
+    Matches salesforce.py's _success_with_capped_list: MYOB's own $top/
+    $skip already lets a caller retry for a narrower page, so items dropped
+    here purely for output size are recoverable via a smaller ``top``, not
+    unrecoverable the way a SOQL query's client-side cap is.
+    """
+
+    def _build(items: list[Any], truncated: bool) -> str:
+        payload: dict[str, Any] = {list_field: items, "truncated": truncated, **extra}
+        if total_count is not None:
+            payload["total_count"] = total_count
+        return _success(**payload)
+
+    max_output_length = get_tool_max_output_length()
+    response = _build(items, False)
+    while len(response) > max_output_length and items:
+        items = items[: len(items) // 2]
+        response = _build(items, True)
+    return response
+
+
+def _list_params(
+    *, filter_str: str, orderby: str, top: int, skip: int
+) -> dict[str, Any]:
+    top = clamp_limit(top, max_limit=MAX_PAGE_LIMIT)
+    skip = clamp_offset(skip)
+    params: dict[str, Any] = {"$top": top, "$skip": skip}
+    if filter_str:
+        params["$filter"] = filter_str
+    if orderby:
+        params["$orderby"] = orderby
+    return params
+
+
+def _create_resource(path: str, fields: dict[str, Any]) -> dict[str, Any]:
+    """POST a new resource, returning its full body.
+
+    MYOB's write endpoints only include the created/updated body in the
+    response when ``returnBody=true`` is passed -- sent on every write here,
+    matching the reference pymyob client's own build_request_kwargs (which
+    adds it unconditionally for PUT/POST). Falls back to the ``Location``
+    response header's trailing id segment on the rare chance a 200/201 comes
+    back with no body despite that.
+    """
+    response = _raw_request(
+        "POST", path, params={"returnBody": "true"}, json_data=fields
+    )
+    _raise_for_status(response)
+    if response.content:
+        body: dict[str, Any] = response.json()
+        return body
+    location = response.headers.get("Location", "").rstrip("/")
+    uid = location.rsplit("/", 1)[-1] if location else None
+    return {"UID": uid} if uid else {}
+
+
+def _update_resource(path: str, uid: str, fields: dict[str, Any]) -> dict[str, Any]:
+    """PUT changes onto an existing resource, returning its full body.
+
+    MYOB's PUT replaces the entire resource and enforces optimistic
+    concurrency via a ``RowVersion`` field embedded in the object body
+    itself (not an HTTP header) -- there is no partial-update verb. Rather
+    than requiring every caller to round-trip the object's other fields and
+    RowVersion themselves, this fetches the current body first and merges
+    the caller's changes on top of it, so a caller only has to name what's
+    actually changing.
+    """
+    safe_uid = url_path_id(uid, "uid")
+    current = _request("GET", f"{path}{safe_uid}/")
+    if not isinstance(current, dict):
+        raise RuntimeError(f"MYOB returned no existing record for uid {uid}")
+    merged = {**current, **fields}
+    response = _raw_request(
+        "PUT", f"{path}{safe_uid}/", params={"returnBody": "true"}, json_data=merged
+    )
+    _raise_for_status(response)
+    return response.json() if response.content else merged
+
+
+@mcp.tool()
+def myob_get_business_info() -> str:
+    """
+    Get the connected business's own details (name, product version, and
+    other company-file-level fields).
+    """
+    try:
+        result = _request("GET", "")
+        business = result.get("CompanyFile") if isinstance(result, dict) else None
+        if not isinstance(business, dict):
+            return _error("MYOB returned no CompanyFile data")
+        return success_with_capped_dict("business", business)
+    except Exception as e:
+        logger.error(f"Error getting MYOB business info: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_list_customers(
+    filter: str = "", orderby: str = "", top: int = DEFAULT_PAGE_LIMIT, skip: int = 0
+) -> str:
+    """
+    List customer contacts.
+    filter: an optional raw OData $filter expression, e.g. "IsActive eq true"
+    or "substringof('Acme', CompanyName)".
+    orderby: an optional OData $orderby expression, e.g. "CompanyName" or
+    "CompanyName desc".
+    top/skip: server-side page size (max 100) and offset.
+    """
+    try:
+        params = _list_params(filter_str=filter, orderby=orderby, top=top, skip=skip)
+        result = _request("GET", "Contact/Customer/", params=params)
+        items, total_count = _list_items(result)
+        return _success_with_capped_list("customers", items, total_count=total_count)
+    except Exception as e:
+        logger.error(f"Error listing MYOB customers: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_get_customer(uid: str) -> str:
+    """Get one customer contact by its UID."""
+    try:
+        safe_uid = url_path_id(uid, "uid")
+        result = _request("GET", f"Contact/Customer/{safe_uid}/")
+        return success_with_capped_dict("customer", result)
+    except Exception as e:
+        logger.error(f"Error getting MYOB customer {uid}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_create_customer(fields: dict[str, Any]) -> str:
+    """
+    Create a new customer contact.
+    fields: MYOB Contact/Customer field name -> value pairs, e.g.
+    {"CompanyName": "Acme Pty Ltd", "IsIndividual": False,
+    "Addresses": [{"Location": 1, "Email": "billing@acme.example"}]}.
+    Use myob_get_customer on an existing record to see the full field shape
+    MYOB expects.
+    """
+    try:
+        if not fields:
+            return _error("No fields provided to create the customer")
+        result = _create_resource("Contact/Customer/", fields)
+        return success_with_capped_dict("customer", result)
+    except Exception as e:
+        logger.error(f"Error creating MYOB customer: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_update_customer(uid: str, fields: dict[str, Any]) -> str:
+    """
+    Update an existing customer contact. Only the fields provided are
+    changed; every other field keeps its current value.
+    fields: MYOB Contact/Customer field name -> value pairs to change.
+    """
+    try:
+        if not fields:
+            return _error("No fields provided to update")
+        result = _update_resource("Contact/Customer/", uid, fields)
+        return success_with_capped_dict("customer", result)
+    except Exception as e:
+        logger.error(f"Error updating MYOB customer {uid}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_list_suppliers(
+    filter: str = "", orderby: str = "", top: int = DEFAULT_PAGE_LIMIT, skip: int = 0
+) -> str:
+    """
+    List supplier contacts.
+    filter: an optional raw OData $filter expression, e.g. "IsActive eq true"
+    or "substringof('Acme', CompanyName)".
+    orderby: an optional OData $orderby expression, e.g. "CompanyName".
+    top/skip: server-side page size (max 100) and offset.
+    """
+    try:
+        params = _list_params(filter_str=filter, orderby=orderby, top=top, skip=skip)
+        result = _request("GET", "Contact/Supplier/", params=params)
+        items, total_count = _list_items(result)
+        return _success_with_capped_list("suppliers", items, total_count=total_count)
+    except Exception as e:
+        logger.error(f"Error listing MYOB suppliers: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_get_supplier(uid: str) -> str:
+    """Get one supplier contact by its UID."""
+    try:
+        safe_uid = url_path_id(uid, "uid")
+        result = _request("GET", f"Contact/Supplier/{safe_uid}/")
+        return success_with_capped_dict("supplier", result)
+    except Exception as e:
+        logger.error(f"Error getting MYOB supplier {uid}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_create_supplier(fields: dict[str, Any]) -> str:
+    """
+    Create a new supplier contact.
+    fields: MYOB Contact/Supplier field name -> value pairs, e.g.
+    {"CompanyName": "Acme Supplies Pty Ltd", "IsIndividual": False}.
+    Use myob_get_supplier on an existing record to see the full field shape
+    MYOB expects.
+    """
+    try:
+        if not fields:
+            return _error("No fields provided to create the supplier")
+        result = _create_resource("Contact/Supplier/", fields)
+        return success_with_capped_dict("supplier", result)
+    except Exception as e:
+        logger.error(f"Error creating MYOB supplier: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_update_supplier(uid: str, fields: dict[str, Any]) -> str:
+    """
+    Update an existing supplier contact. Only the fields provided are
+    changed; every other field keeps its current value.
+    fields: MYOB Contact/Supplier field name -> value pairs to change.
+    """
+    try:
+        if not fields:
+            return _error("No fields provided to update")
+        result = _update_resource("Contact/Supplier/", uid, fields)
+        return success_with_capped_dict("supplier", result)
+    except Exception as e:
+        logger.error(f"Error updating MYOB supplier {uid}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_list_sales_invoices(
+    filter: str = "", orderby: str = "", top: int = DEFAULT_PAGE_LIMIT, skip: int = 0
+) -> str:
+    """
+    List item-type sale invoices (invoices that bill inventory items, MYOB's
+    most common invoice layout). Service/professional/time-billing layout
+    invoices are not covered by this connector.
+    filter: an optional raw OData $filter expression, e.g. "Status eq
+    'Open'" or "Customer/UID eq guid'<customer-uid>'".
+    orderby: an optional OData $orderby expression, e.g. "Date desc".
+    top/skip: server-side page size (max 100) and offset.
+    """
+    try:
+        params = _list_params(filter_str=filter, orderby=orderby, top=top, skip=skip)
+        result = _request("GET", "Sale/Invoice/Item/", params=params)
+        items, total_count = _list_items(result)
+        return _success_with_capped_list("invoices", items, total_count=total_count)
+    except Exception as e:
+        logger.error(f"Error listing MYOB sales invoices: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_get_sales_invoice(uid: str) -> str:
+    """Get one item-type sale invoice by its UID."""
+    try:
+        safe_uid = url_path_id(uid, "uid")
+        result = _request("GET", f"Sale/Invoice/Item/{safe_uid}/")
+        return success_with_capped_dict("invoice", result)
+    except Exception as e:
+        logger.error(f"Error getting MYOB sales invoice {uid}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_create_sales_invoice(fields: dict[str, Any]) -> str:
+    """
+    Create a new item-type sale invoice.
+    fields: MYOB Sale/Invoice/Item field name -> value pairs, e.g.
+    {"Customer": {"UID": "<customer-uid>"}, "Lines": [{"Type": "Transaction",
+    "Item": {"UID": "<item-uid>"}, "ShipQuantity": 1, "UnitPrice": 100.0}]}.
+    Use myob_get_sales_invoice on an existing record to see the full field
+    shape MYOB expects.
+    """
+    try:
+        if not fields:
+            return _error("No fields provided to create the invoice")
+        result = _create_resource("Sale/Invoice/Item/", fields)
+        return success_with_capped_dict("invoice", result)
+    except Exception as e:
+        logger.error(f"Error creating MYOB sales invoice: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_update_sales_invoice(uid: str, fields: dict[str, Any]) -> str:
+    """
+    Update an existing item-type sale invoice. Only the fields provided are
+    changed; every other field (including existing Lines) keeps its current
+    value unless explicitly overwritten.
+    fields: MYOB Sale/Invoice/Item field name -> value pairs to change.
+    """
+    try:
+        if not fields:
+            return _error("No fields provided to update")
+        result = _update_resource("Sale/Invoice/Item/", uid, fields)
+        return success_with_capped_dict("invoice", result)
+    except Exception as e:
+        logger.error(f"Error updating MYOB sales invoice {uid}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_list_purchase_bills(
+    filter: str = "", orderby: str = "", top: int = DEFAULT_PAGE_LIMIT, skip: int = 0
+) -> str:
+    """
+    List item-type purchase bills (bills for inventory items, the most
+    common bill layout). Service/miscellaneous layout bills are not covered
+    by this connector.
+    filter: an optional raw OData $filter expression, e.g. "Status eq
+    'Open'" or "Supplier/UID eq guid'<supplier-uid>'".
+    orderby: an optional OData $orderby expression, e.g. "Date desc".
+    top/skip: server-side page size (max 100) and offset.
+    """
+    try:
+        params = _list_params(filter_str=filter, orderby=orderby, top=top, skip=skip)
+        result = _request("GET", "Purchase/Bill/Item/", params=params)
+        items, total_count = _list_items(result)
+        return _success_with_capped_list("bills", items, total_count=total_count)
+    except Exception as e:
+        logger.error(f"Error listing MYOB purchase bills: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_get_purchase_bill(uid: str) -> str:
+    """Get one item-type purchase bill by its UID."""
+    try:
+        safe_uid = url_path_id(uid, "uid")
+        result = _request("GET", f"Purchase/Bill/Item/{safe_uid}/")
+        return success_with_capped_dict("bill", result)
+    except Exception as e:
+        logger.error(f"Error getting MYOB purchase bill {uid}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_create_purchase_bill(fields: dict[str, Any]) -> str:
+    """
+    Create a new item-type purchase bill.
+    fields: MYOB Purchase/Bill/Item field name -> value pairs, e.g.
+    {"Supplier": {"UID": "<supplier-uid>"}, "Lines": [{"Type": "Transaction",
+    "Item": {"UID": "<item-uid>"}, "Quantity": 1, "UnitPrice": 50.0}]}.
+    Use myob_get_purchase_bill on an existing record to see the full field
+    shape MYOB expects.
+    """
+    try:
+        if not fields:
+            return _error("No fields provided to create the bill")
+        result = _create_resource("Purchase/Bill/Item/", fields)
+        return success_with_capped_dict("bill", result)
+    except Exception as e:
+        logger.error(f"Error creating MYOB purchase bill: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_update_purchase_bill(uid: str, fields: dict[str, Any]) -> str:
+    """
+    Update an existing item-type purchase bill. Only the fields provided are
+    changed; every other field (including existing Lines) keeps its current
+    value unless explicitly overwritten.
+    fields: MYOB Purchase/Bill/Item field name -> value pairs to change.
+    """
+    try:
+        if not fields:
+            return _error("No fields provided to update")
+        result = _update_resource("Purchase/Bill/Item/", uid, fields)
+        return success_with_capped_dict("bill", result)
+    except Exception as e:
+        logger.error(f"Error updating MYOB purchase bill {uid}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_list_accounts(
+    filter: str = "", orderby: str = "", top: int = DEFAULT_PAGE_LIMIT, skip: int = 0
+) -> str:
+    """
+    List general ledger accounts (the chart of accounts).
+    filter: an optional raw OData $filter expression, e.g. "Type eq
+    'Expense'".
+    orderby: an optional OData $orderby expression, e.g. "DisplayID".
+    top/skip: server-side page size (max 100) and offset.
+    """
+    try:
+        params = _list_params(filter_str=filter, orderby=orderby, top=top, skip=skip)
+        result = _request("GET", "GeneralLedger/Account/", params=params)
+        items, total_count = _list_items(result)
+        return _success_with_capped_list("accounts", items, total_count=total_count)
+    except Exception as e:
+        logger.error(f"Error listing MYOB accounts: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_get_account(uid: str) -> str:
+    """Get one general ledger account by its UID."""
+    try:
+        safe_uid = url_path_id(uid, "uid")
+        result = _request("GET", f"GeneralLedger/Account/{safe_uid}/")
+        return success_with_capped_dict("account", result)
+    except Exception as e:
+        logger.error(f"Error getting MYOB account {uid}: {e}")
+        return _error(str(e))
+
+
+@mcp.tool()
+def myob_list_tax_codes(top: int = DEFAULT_PAGE_LIMIT, skip: int = 0) -> str:
+    """
+    List tax codes configured on the business (e.g. GST, FRE, N-T).
+    top/skip: server-side page size (max 100) and offset.
+    """
+    try:
+        params = _list_params(filter_str="", orderby="", top=top, skip=skip)
+        result = _request("GET", "GeneralLedger/TaxCode/", params=params)
+        items, total_count = _list_items(result)
+        return _success_with_capped_list("tax_codes", items, total_count=total_count)
+    except Exception as e:
+        logger.error(f"Error listing MYOB tax codes: {e}")
+        return _error(str(e))
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tests/alembic/test_20260903_seed_myob_mcp_app.py
+++ b/tests/alembic/test_20260903_seed_myob_mcp_app.py
@@ -1,0 +1,307 @@
+"""Tests for the MYOB MCP connector seed migration."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260903_seed_myob_mcp_app.py"
+    )
+    spec = importlib.util.spec_from_file_location("seed_myob_migration", migration_file)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_tables(connection):
+    connection.execute(
+        text(
+            """
+            CREATE TABLE oauth_providers (
+                id INTEGER PRIMARY KEY,
+                provider_name VARCHAR(50) NOT NULL UNIQUE,
+                name VARCHAR(100) NOT NULL,
+                client_id VARCHAR(500) NOT NULL,
+                client_secret VARCHAR(500) NOT NULL,
+                auth_url VARCHAR(500) NOT NULL,
+                token_url VARCHAR(500) NOT NULL,
+                redirect_uri VARCHAR(500),
+                userinfo_url VARCHAR(500),
+                user_id_path VARCHAR(100),
+                email_path VARCHAR(100),
+                default_scopes JSON
+            )
+            """
+        )
+    )
+    connection.execute(
+        text(
+            """
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                name VARCHAR(200) NOT NULL,
+                description TEXT,
+                icon VARCHAR(1000),
+                transport VARCHAR(50) NOT NULL DEFAULT 'oauth',
+                provider_name VARCHAR(50),
+                category VARCHAR(100),
+                oauth_scopes JSON,
+                is_visible_in_connector BOOLEAN NOT NULL DEFAULT 1,
+                launch_config JSON
+            )
+            """
+        )
+    )
+
+
+def _app_ids(connection):
+    return set(connection.execute(text("SELECT app_id FROM public_mcp_apps")).scalars())
+
+
+def _provider_names(connection):
+    return set(
+        connection.execute(text("SELECT provider_name FROM oauth_providers")).scalars()
+    )
+
+
+def test_upgrade_inserts_provider_and_app(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        assert "myob" in _provider_names(connection)
+        assert "myob" in _app_ids(connection)
+
+        provider_row = connection.execute(
+            text(
+                "SELECT auth_url, token_url, default_scopes FROM oauth_providers"
+                " WHERE provider_name='myob'"
+            )
+        ).first()
+        assert provider_row[0] == "https://secure.myob.com/oauth2/account/authorize/"
+        assert provider_row[1] == "https://secure.myob.com/oauth2/v1/authorize/"
+        assert provider_row[2] == "[]"
+
+        app_row = connection.execute(
+            text(
+                "SELECT transport, provider_name, category, oauth_scopes,"
+                " launch_config FROM public_mcp_apps WHERE app_id='myob'"
+            )
+        ).first()
+        assert app_row[0] == "oauth"
+        assert app_row[1] == "myob"
+        assert app_row[2] == "Operations"
+        assert "sme-contacts-customer" in str(app_row[3])
+        assert "sme-banking" not in str(app_row[3])
+        assert "xagent.web.tools.mcp.myob" in str(app_row[4])
+        assert "MYOB_ACCESS_TOKEN" in str(app_row[4])
+        assert "MYOB_BUSINESS_ID" in str(app_row[4])
+        assert "MYOB_API_KEY" in str(app_row[4])
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()  # second run must not raise or duplicate
+        app_count = connection.execute(
+            text("SELECT COUNT(*) FROM public_mcp_apps WHERE app_id='myob'")
+        ).scalar()
+        assert app_count == 1
+        provider_count = connection.execute(
+            text("SELECT COUNT(*) FROM oauth_providers WHERE provider_name='myob'")
+        ).scalar()
+        assert provider_count == 1
+
+
+def test_seed_rows_match_registry(tmp_path):
+    """The migration snapshot and the runtime registry must define the same
+    myob rows (the migration is a frozen copy; this catches drift)."""
+    from xagent.web.builtin_mcp_registry import (
+        get_builtin_oauth_provider_rows,
+        get_builtin_public_mcp_app_rows,
+    )
+
+    migration = _load_migration_module()
+
+    registry_app = next(
+        row for row in get_builtin_public_mcp_app_rows() if row["app_id"] == "myob"
+    )
+    assert migration._myob_app_row() == registry_app
+
+    registry_provider = next(
+        row
+        for row in get_builtin_oauth_provider_rows()
+        if row["provider_name"] == "myob"
+    )
+    assert migration._myob_provider_row() == registry_provider
+
+
+def test_downgrade_removes_provider_and_app(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "myob" not in _app_ids(connection)
+        assert "myob" not in _provider_names(connection)
+
+
+def test_downgrade_keeps_provider_when_custom_myob_app_exists(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            connection.execute(
+                text(
+                    "INSERT INTO public_mcp_apps (app_id, name, transport, provider_name)"
+                    " VALUES ('custom-myob', 'Custom MYOB', 'oauth', 'myob')"
+                )
+            )
+            migration.downgrade()
+        assert "myob" in _provider_names(connection)
+
+
+def test_downgrade_preserves_pre_existing_myob_app(tmp_path):
+    """A pre-existing "myob" app row (different shape than the seeded one)
+    must survive downgrade -- upgrade()'s own `app_id not in
+    existing_app_ids` check skipped inserting over it, so it was never
+    "this migration's row" to remove. Deleting it unconditionally would
+    also make the remaining-myob-apps count wrongly read as zero, letting
+    the oauth_providers row underneath it be deleted too."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        connection.execute(
+            text(
+                "INSERT INTO public_mcp_apps (app_id, name, transport, provider_name)"
+                " VALUES ('myob', 'Custom MYOB App', 'oauth', 'myob')"
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "myob" in _app_ids(connection)
+        assert "myob" in _provider_names(connection)
+
+
+def test_downgrade_preserves_app_row_admin_edited_beyond_structural_fields(tmp_path):
+    """An admin who PATCHed the seeded app row's oauth_scopes without
+    touching app_id/name/transport/provider_name must not have that edit
+    silently discarded by downgrade -- matching only those four structural
+    columns isn't enough to prove this is still "this migration's row"
+    once anything else about it has been customized."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        connection.execute(
+            text(
+                "UPDATE public_mcp_apps SET oauth_scopes = '[\"custom_scope\"]'"
+                " WHERE app_id = 'myob'"
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.downgrade()
+        assert "myob" in _app_ids(connection)
+
+
+def test_downgrade_preserves_admin_created_myob_provider(tmp_path):
+    """A pre-existing admin-created "myob" provider (different shape than
+    the seeded row) must survive downgrade even when no myob apps
+    remain."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        connection.execute(
+            text(
+                "INSERT INTO oauth_providers"
+                " (provider_name, name, client_id, client_secret, auth_url, token_url)"
+                " VALUES ('myob', 'Custom MYOB', 'cid', 'secret',"
+                " 'https://custom.myob.com/oauth2/account/authorize/',"
+                " 'https://custom.myob.com/oauth2/v1/authorize/')"
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        assert "myob" not in _app_ids(connection)
+        assert "myob" in _provider_names(connection)
+
+
+def test_downgrade_preserves_provider_row_admin_edited_beyond_structural_fields(
+    tmp_path,
+):
+    """An admin who edited the seeded provider row's default_scopes without
+    touching provider_name/name/auth_url/token_url must not have that edit
+    silently discarded by downgrade -- the app row is removed as usual (it
+    still matches the seeded shape exactly), but the provider row it
+    depends on must survive since its own shape no longer matches."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_tables(connection)
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        connection.execute(
+            text(
+                "UPDATE oauth_providers SET default_scopes = '[\"custom_scope\"]'"
+                " WHERE provider_name = 'myob'"
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.downgrade()
+        assert "myob" not in _app_ids(connection)
+        assert "myob" in _provider_names(connection)
+
+
+def test_upgrade_and_downgrade_no_op_without_tables(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        table_names = set(
+            connection.execute(
+                text("SELECT name FROM sqlite_master WHERE type='table'")
+            ).scalars()
+        )
+        assert "oauth_providers" not in table_names
+        assert "public_mcp_apps" not in table_names
+
+
+def test_down_revision_matches_current_head():
+    """Pin down_revision to the confirmed true head as of this branch's
+    last rebase onto upstream/main, so a future migration insertion
+    between them would be caught here rather than only surfacing as a
+    confusing multiple-heads error from `alembic heads`."""
+    migration = _load_migration_module()
+
+    assert migration.down_revision == "20260903_model_management"

--- a/tests/alembic/test_20260903_seed_myob_mcp_app.py
+++ b/tests/alembic/test_20260903_seed_myob_mcp_app.py
@@ -298,10 +298,32 @@ def test_upgrade_and_downgrade_no_op_without_tables(tmp_path):
 
 
 def test_down_revision_matches_current_head():
-    """Pin down_revision to the confirmed true head as of this branch's
-    last rebase onto upstream/main, so a future migration insertion
-    between them would be caught here rather than only surfacing as a
-    confusing multiple-heads error from `alembic heads`."""
-    migration = _load_migration_module()
+    """down_revision must be a real revision in the on-disk migration
+    graph, and this migration must be its only child.
 
-    assert migration.down_revision == "20260903_model_management"
+    A bare hardcoded-string comparison (this test's original form) only
+    checks two literals a person typed independently -- it can't catch a
+    typo'd revision id, nor a sibling migration that also claims the same
+    parent (which needs a merge migration, not just landing both). Walking
+    the real graph via alembic's own ScriptDirectory catches both.
+    """
+    from alembic.script import ScriptDirectory
+
+    migration = _load_migration_module()
+    migrations_dir = str(Path(__file__).parent.parent.parent / "src/xagent/migrations")
+    script_dir = ScriptDirectory(migrations_dir)
+
+    # Raises CommandError (not None) if down_revision doesn't exist at all.
+    script_dir.get_revision(migration.down_revision)
+
+    siblings = [
+        rev.revision
+        for rev in script_dir.walk_revisions()
+        if rev.down_revision == migration.down_revision
+        and rev.revision != migration.revision
+    ]
+    assert not siblings, (
+        f"down_revision {migration.down_revision!r} has another child "
+        f"migration too: {siblings} -- needs a merge migration, not just "
+        "updating down_revision here"
+    )

--- a/tests/web/test_myob_oauth.py
+++ b/tests/web/test_myob_oauth.py
@@ -180,6 +180,16 @@ def test_login_sets_prompt_consent_for_myob(db_session):
     qs = parse_qs(urlparse(url).query)
 
     assert qs.get("prompt") == ["consent"], f"myob prompt missing: {url}"
+    # Closes the gap a review round flagged: the authorize-redirect leg and
+    # the token-exchange leg (test_callback_persists_business_id_and_identity
+    # below) both compute this scope string via the same shared
+    # _oauth_scope_str helper now -- this pins the authorize side so a
+    # future change to either leg alone would show up as a mismatch between
+    # the two tests, not silently diverge unnoticed.
+    assert qs.get("scope") == [
+        "sme-company-file sme-contacts-customer sme-contacts-supplier "
+        "sme-general-ledger sme-purchases sme-sales"
+    ]
 
 
 def test_bare_myob_login_is_rejected_once_authenticated_and_configured(db_session):

--- a/tests/web/test_myob_oauth.py
+++ b/tests/web/test_myob_oauth.py
@@ -56,6 +56,11 @@ class MockResponse:
         ),
         ("not-a-guid", None),
         ("11111111-2222-3333-4444-55555555555", None),  # one hex digit short
+        # A valid GUID prefix followed by a path-traversal-style suffix
+        # must still be rejected outright by the trailing $ anchor itself
+        # -- not merely relying on url_path_id's own rejection downstream
+        # in myob.py, which is a separate, later line of defense.
+        ("11111111-2222-3333-4444-555555555555/../evil", None),
         ("", None),
         ("   ", None),
         (None, None),
@@ -183,7 +188,7 @@ def test_login_sets_prompt_consent_for_myob(db_session):
     # Closes the gap a review round flagged: the authorize-redirect leg and
     # the token-exchange leg (test_callback_persists_business_id_and_identity
     # below) both compute this scope string via the same shared
-    # _oauth_scope_str helper now -- this pins the authorize side so a
+    # _merged_oauth_scopes helper now -- this pins the authorize side so a
     # future change to either leg alone would show up as a mismatch between
     # the two tests, not silently diverge unnoticed.
     assert qs.get("scope") == [
@@ -272,7 +277,17 @@ def test_callback_persists_business_id_and_identity(db_session, monkeypatch):
     assert oauth_account.instance_url == BUSINESS_ID
     assert oauth_account.provider_user_id == "42"
     assert oauth_account.email == "alice@acme.example"
-    assert oauth_account.expires_at is not None
+    # Pins the actual 3600s duration from the mocked response, not just
+    # "some timestamp got set" -- a timedelta(seconds=...) ->
+    # timedelta(minutes=...) unit regression would still pass a bare
+    # is-not-None check.
+    # SQLite doesn't round-trip tzinfo, so oauth_account.expires_at comes
+    # back naive regardless of what was stored -- compare against a
+    # matching naive value rather than assuming either side's awareness.
+    expected_expiry = datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(
+        seconds=3600
+    )
+    assert abs((oauth_account.expires_at - expected_expiry).total_seconds()) < 30
 
 
 def test_callback_rejects_missing_business_id_without_touching_prior_grant(
@@ -396,21 +411,27 @@ def test_callback_rejects_non_2xx_status_for_myob(db_session, monkeypatch):
     )
 
 
-def test_callback_succeeds_when_identity_fields_are_absent(db_session, monkeypatch):
+def test_callback_succeeds_when_identity_fields_are_absent(
+    db_session, monkeypatch, caplog
+):
     """A deliberately lenient design, matching every other identity branch
     in this file: a token response with no recognizable `user` shape must
     still succeed the connect, leaving provider_user_id/email as None
-    rather than failing the whole connect."""
+    rather than failing the whole connect -- but unlike Salesforce's own
+    optional "id" field, MYOB's docs say `user` is always present, so this
+    case is anomalous enough to warn about server-side, not silently
+    expected."""
     db, user = db_session
     mock_post = Mock(return_value=MockResponse({"access_token": "myob-token"}))
     monkeypatch.setattr(auth_api.requests, "post", mock_post)
 
-    response = generic_oauth_callback(
-        "myob",
-        _callback_request(db, user, business_id=BUSINESS_ID),
-        db,
-        _myob_provider(),
-    )
+    with caplog.at_level("WARNING"):
+        response = generic_oauth_callback(
+            "myob",
+            _callback_request(db, user, business_id=BUSINESS_ID),
+            db,
+            _myob_provider(),
+        )
 
     assert response.status_code == 200
     oauth_account = (
@@ -420,6 +441,41 @@ def test_callback_succeeds_when_identity_fields_are_absent(db_session, monkeypat
     )
     assert oauth_account.provider_user_id is None
     assert oauth_account.email is None
+    assert any("no usable user object" in record.message for record in caplog.records)
+
+
+def test_callback_warns_on_unusable_uid_type(db_session, monkeypatch, caplog):
+    """A present-but-wrong-typed uid (e.g. a nested object) must still warn
+    server-side, matching the same "truthy but wrong type" convention the
+    Salesforce identity branch above it already uses."""
+    db, user = db_session
+    mock_post = Mock(
+        return_value=MockResponse(
+            {
+                "access_token": "myob-token",
+                "user": {"uid": {"nested": "object"}, "username": "alice@acme.example"},
+            }
+        )
+    )
+    monkeypatch.setattr(auth_api.requests, "post", mock_post)
+
+    with caplog.at_level("WARNING"):
+        response = generic_oauth_callback(
+            "myob",
+            _callback_request(db, user, business_id=BUSINESS_ID),
+            db,
+            _myob_provider(),
+        )
+
+    assert response.status_code == 200
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "myob")
+        .one()
+    )
+    assert oauth_account.provider_user_id is None
+    assert oauth_account.email == "alice@acme.example"
+    assert any("not a usable string/int" in record.message for record in caplog.records)
 
 
 def test_callback_rejects_boolean_uid_instead_of_stringifying_it(

--- a/tests/web/test_myob_oauth.py
+++ b/tests/web/test_myob_oauth.py
@@ -351,3 +351,38 @@ def test_callback_succeeds_when_identity_fields_are_absent(db_session, monkeypat
     )
     assert oauth_account.provider_user_id is None
     assert oauth_account.email is None
+
+
+def test_callback_rejects_boolean_uid_instead_of_stringifying_it(
+    db_session, monkeypatch
+):
+    """`bool` is a subclass of `int` in Python, so `isinstance(uid, (str,
+    int))` alone would let a boolean `uid` through and stringify it to the
+    nonsensical "True"/"False" -- must be treated the same as no usable uid
+    at all (None), not silently accepted."""
+    db, user = db_session
+    mock_post = Mock(
+        return_value=MockResponse(
+            {
+                "access_token": "myob-token",
+                "user": {"uid": True, "username": "alice@acme.example"},
+            }
+        )
+    )
+    monkeypatch.setattr(auth_api.requests, "post", mock_post)
+
+    response = generic_oauth_callback(
+        "myob",
+        _callback_request(db, user, business_id=BUSINESS_ID),
+        db,
+        _myob_provider(),
+    )
+
+    assert response.status_code == 200
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "myob")
+        .one()
+    )
+    assert oauth_account.provider_user_id is None
+    assert oauth_account.email == "alice@acme.example"

--- a/tests/web/test_myob_oauth.py
+++ b/tests/web/test_myob_oauth.py
@@ -1,0 +1,353 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import Mock
+from urllib.parse import parse_qs, urlparse
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from xagent.core.utils.encryption import encrypt_value
+from xagent.web.api import auth as auth_api
+from xagent.web.api.auth import (
+    create_access_token,
+    generic_oauth_callback,
+    generic_oauth_login,
+)
+from xagent.web.models.database import Base
+from xagent.web.models.public_mcp import PublicMCPApp
+from xagent.web.models.user import User
+from xagent.web.models.user_oauth import UserOAuth
+
+
+class MockResponse:
+    def __init__(self, json_data=None, status_code: int = 200, text: str = ""):
+        self._json_data = json_data or {}
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.mark.parametrize(
+    "raw_business_id,expected",
+    [
+        (
+            "11111111-2222-3333-4444-555555555555",
+            "11111111-2222-3333-4444-555555555555",
+        ),
+        # Case-insensitivity: MYOB's own GUIDs are typically uppercase.
+        (
+            "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+            "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE",
+        ),
+        # Surrounding whitespace is stripped before validating, unlike
+        # require_clean_identifier's stricter rejection elsewhere -- this
+        # value comes straight off the raw callback query string, not a
+        # caller-typed id, so tolerating incidental whitespace here is safe.
+        (
+            "  11111111-2222-3333-4444-555555555555  ",
+            "11111111-2222-3333-4444-555555555555",
+        ),
+        ("not-a-guid", None),
+        ("11111111-2222-3333-4444-55555555555", None),  # one hex digit short
+        ("", None),
+        ("   ", None),
+        (None, None),
+        (123, None),
+    ],
+)
+def test_normalize_myob_business_id(raw_business_id, expected):
+    assert auth_api._normalize_myob_business_id(raw_business_id) == expected
+
+
+@pytest.fixture()
+def db_session(tmp_path):
+    db_path = tmp_path / "test.db"
+    engine = create_engine(
+        f"sqlite:///{db_path}", connect_args={"check_same_thread": False}
+    )
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+    db = SessionLocal()
+
+    user = User(username="alice", password_hash="x", is_admin=False)
+    db.add(user)
+    db.add(
+        PublicMCPApp(
+            app_id="myob",
+            name="MYOB",
+            description="Connect to MYOB AccountRight.",
+            transport="oauth",
+            provider_name="myob",
+            category="Operations",
+            oauth_scopes=["sme-company-file", "sme-contacts-customer"],
+            is_visible_in_connector=True,
+            launch_config={
+                "command": "python",
+                "args": ["-m", "xagent.web.tools.mcp.myob"],
+                "env_mapping": {
+                    "MYOB_ACCESS_TOKEN": "access_token",
+                    "MYOB_BUSINESS_ID": "instance_url",
+                },
+                "static_env": {"MYOB_API_KEY": "MYOB_CLIENT_ID"},
+            },
+        )
+    )
+    db.commit()
+    db.refresh(user)
+
+    yield db, user
+    db.close()
+    engine.dispose()
+
+
+def _myob_provider() -> SimpleNamespace:
+    return SimpleNamespace(
+        provider_name="myob",
+        client_id=encrypt_value("myob-client-id"),
+        client_secret=encrypt_value("myob-client-secret"),
+        auth_url="https://secure.myob.com/oauth2/account/authorize/",
+        token_url="https://secure.myob.com/oauth2/v1/authorize/",
+        redirect_uri="https://app.example.com/api/auth/myob/callback",
+        userinfo_url="",
+        user_id_path="",
+        email_path="",
+        default_scopes=[],
+    )
+
+
+def _token_for(user: User) -> str:
+    return create_access_token(
+        data={"sub": user.username, "type": "access"},
+        expires_delta=timedelta(minutes=5),
+    )
+
+
+def _callback_request(
+    db, user, provider: str = "myob", *, business_id: str | None = None
+):
+    state = create_access_token(
+        data={
+            "type": "oauth_state",
+            "user_id": user.id,
+            "provider": provider,
+            "app_id": provider,
+        },
+        expires_delta=timedelta(minutes=10),
+    )
+    query_params = {"code": "myob-code", "state": state}
+    if business_id is not None:
+        query_params["businessId"] = business_id
+    return SimpleNamespace(query_params=query_params)
+
+
+BUSINESS_ID = "11111111-2222-3333-4444-555555555555"
+
+
+def test_login_sets_prompt_consent_for_myob(db_session):
+    """Without prompt=consent, MYOB never appends businessId to the
+    authorization redirect at all -- the callback's businessId guard would
+    then always trigger, so this must hold for every MYOB login, not just
+    the resource-owner flow."""
+    db, user = db_session
+    token = _token_for(user)
+
+    provider = SimpleNamespace(
+        client_id=encrypt_value("myob-client-id"),
+        auth_url="https://secure.myob.com/oauth2/account/authorize/",
+        redirect_uri="https://app.example.com/api/auth/myob/callback",
+        default_scopes=[],
+    )
+
+    resp = generic_oauth_login(
+        provider="myob",
+        token=token,
+        app_id=None,
+        redirect=None,
+        db=db,
+        db_provider=provider,
+    )
+    url = resp.headers["location"]
+    qs = parse_qs(urlparse(url).query)
+
+    assert qs.get("prompt") == ["consent"], f"myob prompt missing: {url}"
+
+
+def test_callback_persists_business_id_and_identity(db_session, monkeypatch):
+    db, user = db_session
+    mock_post = Mock(
+        return_value=MockResponse(
+            {
+                "access_token": "myob-token",
+                "refresh_token": "myob-refresh",
+                "token_type": "bearer",
+                "expires_in": 3600,
+                "user": {"uid": "42", "username": "alice@acme.example"},
+            }
+        )
+    )
+    monkeypatch.setattr(auth_api.requests, "post", mock_post)
+
+    response = generic_oauth_callback(
+        "myob",
+        _callback_request(db, user, business_id=BUSINESS_ID),
+        db,
+        _myob_provider(),
+    )
+
+    assert response.status_code == 200
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "myob")
+        .one()
+    )
+    assert oauth_account.access_token == "myob-token"
+    assert oauth_account.refresh_token == "myob-refresh"
+    assert oauth_account.instance_url == BUSINESS_ID
+    assert oauth_account.provider_user_id == "42"
+    assert oauth_account.email == "alice@acme.example"
+
+
+def test_callback_rejects_missing_business_id_without_touching_prior_grant(
+    db_session, monkeypatch
+):
+    """A callback with no businessId (prompt=consent missing/ignored) must
+    be rejected before the delete-then-recreate persistence step -- letting
+    it through would destroy a prior *working* grant while still reporting
+    success, since instance_url is required for the connector to launch at
+    all (launch_config.env_mapping)."""
+    db, user = db_session
+    existing = UserOAuth(
+        user_id=user.id,
+        provider="myob",
+        access_token="old-working-token",
+        instance_url="99999999-8888-7777-6666-555555555555",
+    )
+    db.add(existing)
+    db.commit()
+
+    mock_post = Mock(
+        return_value=MockResponse(
+            {
+                "access_token": "myob-token",
+                "user": {"uid": "42", "username": "alice@acme.example"},
+            }
+        )
+    )
+    monkeypatch.setattr(auth_api.requests, "post", mock_post)
+
+    response = generic_oauth_callback(
+        "myob", _callback_request(db, user, business_id=None), db, _myob_provider()
+    )
+
+    assert response.status_code == 400
+    assert "businessId" in response.body.decode()
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "myob")
+        .one()
+    )
+    assert oauth_account.access_token == "old-working-token"
+    assert oauth_account.instance_url == "99999999-8888-7777-6666-555555555555"
+
+
+def test_callback_rejects_malformed_business_id(db_session, monkeypatch):
+    db, user = db_session
+    mock_post = Mock(return_value=MockResponse({"access_token": "myob-token"}))
+    monkeypatch.setattr(auth_api.requests, "post", mock_post)
+
+    response = generic_oauth_callback(
+        "myob",
+        _callback_request(db, user, business_id="not-a-guid"),
+        db,
+        _myob_provider(),
+    )
+
+    assert response.status_code == 400
+    assert (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "myob")
+        .first()
+        is None
+    )
+
+
+def test_callback_reports_error_in_token_data_for_myob(db_session, monkeypatch):
+    db, user = db_session
+    mock_post = Mock(
+        return_value=MockResponse(
+            {"error": "invalid_grant", "error_description": "bad code"}
+        )
+    )
+    monkeypatch.setattr(auth_api.requests, "post", mock_post)
+
+    response = generic_oauth_callback(
+        "myob",
+        _callback_request(db, user, business_id=BUSINESS_ID),
+        db,
+        _myob_provider(),
+    )
+
+    assert response.status_code == 400
+    assert (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "myob")
+        .first()
+        is None
+    )
+
+
+def test_callback_rejects_non_2xx_status_for_myob(db_session, monkeypatch):
+    db, user = db_session
+    mock_post = Mock(
+        return_value=MockResponse(
+            {"access_token": "myob-token"},
+            status_code=502,
+        )
+    )
+    monkeypatch.setattr(auth_api.requests, "post", mock_post)
+
+    response = generic_oauth_callback(
+        "myob",
+        _callback_request(db, user, business_id=BUSINESS_ID),
+        db,
+        _myob_provider(),
+    )
+
+    assert response.status_code == 400
+    assert (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "myob")
+        .first()
+        is None
+    )
+
+
+def test_callback_succeeds_when_identity_fields_are_absent(db_session, monkeypatch):
+    """A deliberately lenient design, matching every other identity branch
+    in this file: a token response with no recognizable `user` shape must
+    still succeed the connect, leaving provider_user_id/email as None
+    rather than failing the whole connect."""
+    db, user = db_session
+    mock_post = Mock(return_value=MockResponse({"access_token": "myob-token"}))
+    monkeypatch.setattr(auth_api.requests, "post", mock_post)
+
+    response = generic_oauth_callback(
+        "myob",
+        _callback_request(db, user, business_id=BUSINESS_ID),
+        db,
+        _myob_provider(),
+    )
+
+    assert response.status_code == 200
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "myob")
+        .one()
+    )
+    assert oauth_account.provider_user_id is None
+    assert oauth_account.email is None

--- a/tests/web/test_myob_oauth.py
+++ b/tests/web/test_myob_oauth.py
@@ -152,7 +152,40 @@ def test_login_sets_prompt_consent_for_myob(db_session):
     """Without prompt=consent, MYOB never appends businessId to the
     authorization redirect at all -- the callback's businessId guard would
     then always trigger, so this must hold for every MYOB login, not just
-    the resource-owner flow."""
+    the resource-owner flow. Uses app_id="myob" (the only reachable path,
+    now that bare app_id-less logins are rejected -- see
+    test_bare_myob_login_is_rejected_once_authenticated_and_configured
+    below), matching how the catalog UI actually connects this app."""
+    db, user = db_session
+    token = _token_for(user)
+
+    provider = SimpleNamespace(
+        client_id=encrypt_value("myob-client-id"),
+        auth_url="https://secure.myob.com/oauth2/account/authorize/",
+        redirect_uri="https://app.example.com/api/auth/myob/callback",
+        default_scopes=[],
+    )
+
+    resp = generic_oauth_login(
+        provider="myob",
+        token=token,
+        app_id="myob",
+        redirect=None,
+        db=db,
+        db_provider=provider,
+    )
+    url = resp.headers["location"]
+    qs = parse_qs(urlparse(url).query)
+
+    assert qs.get("prompt") == ["consent"], f"myob prompt missing: {url}"
+
+
+def test_bare_myob_login_is_rejected_once_authenticated_and_configured(db_session):
+    """MYOB is in APPS_REQUIRING_APP_SCOPED_OAUTH_GRANT (see mcp_apps.py):
+    its oauth_providers row has no default_scopes at all, so a bare
+    (app_id-less) login would request zero sme-* scopes yet still complete
+    and report success -- this guard must reject it before any state token
+    is minted, the same way it already does for github."""
     db, user = db_session
     token = _token_for(user)
 
@@ -171,10 +204,8 @@ def test_login_sets_prompt_consent_for_myob(db_session):
         db=db,
         db_provider=provider,
     )
-    url = resp.headers["location"]
-    qs = parse_qs(urlparse(url).query)
 
-    assert qs.get("prompt") == ["consent"], f"myob prompt missing: {url}"
+    assert resp.status_code == 404
 
 
 def test_callback_persists_business_id_and_identity(db_session, monkeypatch):
@@ -219,7 +250,11 @@ def test_callback_rejects_missing_business_id_without_touching_prior_grant(
     be rejected before the delete-then-recreate persistence step -- letting
     it through would destroy a prior *working* grant while still reporting
     success, since instance_url is required for the connector to launch at
-    all (launch_config.env_mapping)."""
+    all (launch_config.env_mapping). Rejected before the token exchange even
+    starts (mock_post is never called): myob_business_id is already fully
+    known from the raw callback request, so there's nothing to gain by
+    burning a network round trip and the single-use authorization code on an
+    outcome that's already decided."""
     db, user = db_session
     existing = UserOAuth(
         user_id=user.id,
@@ -246,6 +281,7 @@ def test_callback_rejects_missing_business_id_without_touching_prior_grant(
 
     assert response.status_code == 400
     assert "businessId" in response.body.decode()
+    mock_post.assert_not_called()
     oauth_account = (
         db.query(UserOAuth)
         .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "myob")
@@ -268,6 +304,7 @@ def test_callback_rejects_malformed_business_id(db_session, monkeypatch):
     )
 
     assert response.status_code == 400
+    mock_post.assert_not_called()
     assert (
         db.query(UserOAuth)
         .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "myob")

--- a/tests/web/test_myob_oauth.py
+++ b/tests/web/test_myob_oauth.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest.mock import Mock
 from urllib.parse import parse_qs, urlparse
@@ -17,9 +17,11 @@ from xagent.web.api.auth import (
     generic_oauth_login,
 )
 from xagent.web.models.database import Base
+from xagent.web.models.oauth_provider import OAuthProvider
 from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
 from xagent.web.models.user_oauth import UserOAuth
+from xagent.web.tools import config as tool_config
 
 
 class MockResponse:
@@ -216,7 +218,13 @@ def test_callback_persists_business_id_and_identity(db_session, monkeypatch):
                 "access_token": "myob-token",
                 "refresh_token": "myob-refresh",
                 "token_type": "bearer",
-                "expires_in": 3600,
+                # MYOB's documented response returns this as a JSON *string*
+                # (e.g. "1200"), not a number -- pinned here, not just the
+                # more forgiving int the fixture used to carry, so a
+                # regression back to an unguarded int(...)/timedelta(...)
+                # cast would be caught the same way it would against the
+                # real API.
+                "expires_in": "3600",
                 "user": {"uid": "42", "username": "alice@acme.example"},
             }
         )
@@ -231,6 +239,19 @@ def test_callback_persists_business_id_and_identity(db_session, monkeypatch):
     )
 
     assert response.status_code == 200
+    # MYOB's provider row carries no default_scopes of its own -- every
+    # sme-* scope sent on the exchange must come from the app's own
+    # oauth_scopes, matching what MYOB's own docs require on this leg.
+    # get_app_by_id resolves a builtin app_id's oauth_scopes from the
+    # builtin_mcp_registry.py definition, not whatever the db_session
+    # fixture's PublicMCPApp row happens to carry (a builtin app's DB row
+    # is a catalog/display shell; the registry is the source of truth for
+    # its actual scopes) -- so this is the real production scope list,
+    # sorted per _merge_oauth_scopes' app-scope ordering.
+    assert mock_post.call_args.kwargs["data"]["scope"] == (
+        "sme-company-file sme-contacts-customer sme-contacts-supplier "
+        "sme-general-ledger sme-purchases sme-sales"
+    )
     oauth_account = (
         db.query(UserOAuth)
         .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "myob")
@@ -241,6 +262,7 @@ def test_callback_persists_business_id_and_identity(db_session, monkeypatch):
     assert oauth_account.instance_url == BUSINESS_ID
     assert oauth_account.provider_user_id == "42"
     assert oauth_account.email == "alice@acme.example"
+    assert oauth_account.expires_at is not None
 
 
 def test_callback_rejects_missing_business_id_without_touching_prior_grant(
@@ -423,3 +445,67 @@ def test_callback_rejects_boolean_uid_instead_of_stringifying_it(
     )
     assert oauth_account.provider_user_id is None
     assert oauth_account.email == "alice@acme.example"
+
+
+@pytest.mark.asyncio
+async def test_myob_refresh_handles_string_expires_in(db_session, monkeypatch):
+    """MYOB's documented refresh response returns expires_in as a JSON
+    *string* (e.g. "1200"), not a number -- timedelta()'s seconds kwarg
+    raises TypeError on a bare string, and refresh_oauth_token_if_needed's
+    outer except swallows that as a silent False, which is exactly what
+    would otherwise make every MYOB connection stop refreshing ~20 minutes
+    after connect with no visible error."""
+    db, user = db_session
+    db.add(
+        OAuthProvider(
+            provider_name="myob",
+            name="MYOB",
+            client_id=encrypt_value("myob-client-id"),
+            client_secret=encrypt_value("myob-client-secret"),
+            auth_url="https://secure.myob.com/oauth2/account/authorize/",
+            token_url="https://secure.myob.com/oauth2/v1/authorize/",
+            redirect_uri="https://app.example.com/api/auth/myob/callback",
+            userinfo_url="",
+            user_id_path="",
+            email_path="",
+            default_scopes=[],
+        )
+    )
+    oauth_account = UserOAuth(
+        user_id=user.id,
+        provider="myob",
+        access_token="old-token",
+        refresh_token="old-refresh",
+        instance_url=BUSINESS_ID,
+        expires_at=datetime.now(timezone.utc) - timedelta(minutes=1),
+        provider_user_id="42",
+    )
+    db.add(oauth_account)
+    db.commit()
+
+    class FakeAsyncClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def post(self, url, **kwargs):
+            return MockResponse(
+                {
+                    "access_token": "new-token",
+                    "refresh_token": "new-refresh",
+                    "token_type": "bearer",
+                    "expires_in": "1200",
+                },
+                status_code=200,
+            )
+
+    monkeypatch.setattr(tool_config.httpx, "AsyncClient", FakeAsyncClient)
+
+    assert (
+        await tool_config.refresh_oauth_token_if_needed(db, oauth_account, "myob")
+        is True
+    )
+    assert oauth_account.access_token == "new-token"
+    assert oauth_account.expires_at > datetime.now(timezone.utc) + timedelta(minutes=15)

--- a/tests/web/test_myob_oauth.py
+++ b/tests/web/test_myob_oauth.py
@@ -478,6 +478,42 @@ def test_callback_warns_on_unusable_uid_type(db_session, monkeypatch, caplog):
     assert any("not a usable string/int" in record.message for record in caplog.records)
 
 
+def test_callback_warns_on_user_object_missing_uid(db_session, monkeypatch, caplog):
+    """A `user` object that's a dict (so it never reaches the outer 'no
+    usable user object' warning) but has no `uid` key at all must still
+    warn -- a self-review round found this exact gap: the code's own
+    comment claimed this case was "covered by the outer warning below",
+    which is only true when `user` isn't a dict in the first place."""
+    db, user = db_session
+    mock_post = Mock(
+        return_value=MockResponse(
+            {
+                "access_token": "myob-token",
+                "user": {"username": "alice@acme.example"},
+            }
+        )
+    )
+    monkeypatch.setattr(auth_api.requests, "post", mock_post)
+
+    with caplog.at_level("WARNING"):
+        response = generic_oauth_callback(
+            "myob",
+            _callback_request(db, user, business_id=BUSINESS_ID),
+            db,
+            _myob_provider(),
+        )
+
+    assert response.status_code == 200
+    oauth_account = (
+        db.query(UserOAuth)
+        .filter(UserOAuth.user_id == user.id, UserOAuth.provider == "myob")
+        .one()
+    )
+    assert oauth_account.provider_user_id is None
+    assert oauth_account.email == "alice@acme.example"
+    assert any("no usable uid" in record.message for record in caplog.records)
+
+
 def test_callback_rejects_boolean_uid_instead_of_stringifying_it(
     db_session, monkeypatch
 ):

--- a/tests/web/tools/test_legacy_oauth_provider_scoping.py
+++ b/tests/web/tools/test_legacy_oauth_provider_scoping.py
@@ -69,6 +69,19 @@ def test_requires_app_scoped_oauth_grant_github_addition_leaves_meta_unaffected(
     assert requires_app_scoped_oauth_grant("meta") is False
 
 
+def test_requires_app_scoped_oauth_grant_covers_myob():
+    """MYOB's oauth_providers row seeds an empty default_scopes (there is no
+    shared identity scope; every functional sme-* scope lives solely on the
+    app row) -- an even more extreme version of github's situation, since a
+    bare grant here would request zero scopes, not just an under-scoped
+    identity-only set. Pin membership the same way as github's own
+    regression test above, and confirm it didn't flip anything unrelated."""
+    assert requires_app_scoped_oauth_grant("myob") is True
+    assert requires_app_scoped_oauth_grant("MyOB") is True
+    assert requires_app_scoped_oauth_grant("instagram") is False
+    assert requires_app_scoped_oauth_grant("meta") is False
+
+
 def test_restrict_to_app_scoped_oauth_grant_dedupes_and_preserves_order():
     assert restrict_to_app_scoped_oauth_grant(
         "instagram", ["meta", "meta", "instagram", None, ""]

--- a/tests/web/tools/test_myob_mcp.py
+++ b/tests/web/tools/test_myob_mcp.py
@@ -417,6 +417,19 @@ def test_update_resource_rejects_an_empty_get_response(monkeypatch):
     mock_request.assert_called_once()  # the GET only -- no PUT attempted
 
 
+def test_update_resource_rejects_a_non_dict_get_response(monkeypatch):
+    # A truthy non-dict (e.g. a bare list) passes `not current` alone --
+    # must still be rejected with the same clear message, not left to blow
+    # up as an opaque TypeError at the dict-spread merge below.
+    mock_request = Mock(return_value=MockResponse(json_data=[1, 2, 3]))
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    with pytest.raises(RuntimeError, match="no existing record"):
+        myob._update_resource("Contact/Customer/", "c1", {"CompanyName": "New Name"})
+
+    mock_request.assert_called_once()  # the GET only -- no PUT attempted
+
+
 def test_update_supplier_merges_fetched_record_with_changes(monkeypatch):
     current = {"UID": "s1", "CompanyName": "Old Supplier", "RowVersion": "abc=="}
     updated = {**current, "CompanyName": "New Supplier"}

--- a/tests/web/tools/test_myob_mcp.py
+++ b/tests/web/tools/test_myob_mcp.py
@@ -1,0 +1,418 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from xagent.web.tools.mcp import myob
+from xagent.web.tools.mcp import utils as mcp_utils
+
+
+class MockResponse:
+    def __init__(
+        self,
+        json_data=None,
+        status_code: int = 200,
+        text: str = "",
+        headers: dict | None = None,
+    ):
+        self._json_data = json_data if json_data is not None else {}
+        self.status_code = status_code
+        self.text = text or (json.dumps(self._json_data) if json_data else "")
+        self.content = self.text.encode()
+        self.headers = headers or {}
+
+    def json(self):
+        return self._json_data
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("MYOB_ACCESS_TOKEN", "access-token")
+    monkeypatch.setenv("MYOB_API_KEY", "consumer-key")
+    monkeypatch.setenv("MYOB_BUSINESS_ID", "11111111-2222-3333-4444-555555555555")
+
+
+def test_headers_require_access_token(monkeypatch):
+    monkeypatch.delenv("MYOB_ACCESS_TOKEN")
+
+    with pytest.raises(ValueError, match="MYOB_ACCESS_TOKEN"):
+        myob._headers()
+
+
+def test_headers_require_api_key(monkeypatch):
+    monkeypatch.delenv("MYOB_API_KEY")
+
+    with pytest.raises(ValueError, match="MYOB_API_KEY"):
+        myob._headers()
+
+
+def test_headers_do_not_include_cftoken():
+    # cftoken (x-myobapi-cftoken) is a dead concept in the current MYOB auth
+    # model -- the OAuth token plus x-myobapi-key is sufficient on its own,
+    # confirmed against uptick/pymyob's own build_request_kwargs.
+    headers = myob._headers()
+
+    assert headers == {
+        "Authorization": "Bearer access-token",
+        "x-myobapi-key": "consumer-key",
+        "x-myobapi-version": "v2",
+    }
+
+
+def test_business_id_requires_env_var(monkeypatch):
+    monkeypatch.delenv("MYOB_BUSINESS_ID")
+
+    with pytest.raises(ValueError, match="MYOB_BUSINESS_ID"):
+        myob._business_id()
+
+
+def test_base_url_includes_business_id():
+    assert myob._base_url() == (
+        "https://api.myob.com/accountright/11111111-2222-3333-4444-555555555555/"
+    )
+
+
+def test_request_uses_base_url_and_headers(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"ok": True}))
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = myob._request("GET", "Contact/Customer/")
+
+    assert result == {"ok": True}
+    assert mock_request.call_args.kwargs["url"] == (
+        "https://api.myob.com/accountright/11111111-2222-3333-4444-555555555555/"
+        "Contact/Customer/"
+    )
+    assert mock_request.call_args.kwargs["headers"]["x-myobapi-key"] == "consumer-key"
+
+
+def test_request_raises_with_joined_errors_array(monkeypatch):
+    monkeypatch.setattr(
+        myob.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=400,
+                json_data={
+                    "Errors": [
+                        {
+                            "Name": "ValidationException",
+                            "Message": "CompanyName is required",
+                            "AdditionalDetails": "",
+                        }
+                    ]
+                },
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        myob._request("GET", "Contact/Customer/")
+
+    assert "ValidationException" in str(excinfo.value)
+    assert "CompanyName is required" in str(excinfo.value)
+
+
+def test_request_falls_back_to_raw_text_for_unstructured_error(monkeypatch):
+    monkeypatch.setattr(
+        myob.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text="Gateway error")),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        myob._request("GET", "Contact/Customer/")
+
+    assert "Gateway error" in str(excinfo.value)
+
+
+def test_request_truncates_long_error_body(monkeypatch):
+    long_body = "x" * 5000
+    monkeypatch.setattr(
+        myob.requests,
+        "request",
+        Mock(return_value=MockResponse(status_code=500, text=long_body)),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        myob._request("GET", "Contact/Customer/")
+
+    assert "[truncated]" in str(excinfo.value)
+    assert len(str(excinfo.value)) < len(long_body)
+
+
+def test_list_items_unwraps_items_and_count():
+    items, total_count = myob._list_items(
+        {"Count": 2, "Items": [{"UID": "1"}, {"UID": "2"}]}
+    )
+
+    assert items == [{"UID": "1"}, {"UID": "2"}]
+    assert total_count == 2
+
+
+def test_list_items_tolerates_bare_array():
+    items, total_count = myob._list_items([{"UID": "1"}])
+
+    assert items == [{"UID": "1"}]
+    assert total_count == 1
+
+
+def test_list_customers_sends_filter_orderby_and_paging(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"Count": 1, "Items": [{"UID": "c1"}]})
+    )
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(
+        myob.myob_list_customers(
+            filter="IsActive eq true", orderby="CompanyName", top=10, skip=5
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["customers"] == [{"UID": "c1"}]
+    assert result["total_count"] == 1
+    assert mock_request.call_args.kwargs["params"] == {
+        "$top": 10,
+        "$skip": 5,
+        "$filter": "IsActive eq true",
+        "$orderby": "CompanyName",
+    }
+    assert mock_request.call_args.kwargs["url"].endswith("Contact/Customer/")
+
+
+def test_list_customers_clamps_page_size(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"Items": []}))
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    myob.myob_list_customers(top=99999, skip=-5)
+
+    params = mock_request.call_args.kwargs["params"]
+    assert params["$top"] == myob.MAX_PAGE_LIMIT
+    assert params["$skip"] == 0
+
+
+def test_get_customer_percent_encodes_uid(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"UID": "c1"}))
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    myob.myob_get_customer("c1/../evil")
+
+    url = mock_request.call_args.kwargs["url"]
+    assert url.endswith("Contact/Customer/c1%2F..%2Fevil/")
+
+
+def test_get_sales_invoice_caps_output_size(monkeypatch):
+    # A real invoice's Lines array (unlike a flat customer/supplier record)
+    # is open-ended -- this is the shape success_with_capped_dict exists to
+    # protect against, unlike the list endpoints above which are already
+    # bounded by top/skip.
+    big_invoice = {
+        "UID": "inv1",
+        "Lines": [{"Description": "x" * 200} for _ in range(50)],
+    }
+    monkeypatch.setattr(
+        myob.requests, "request", Mock(return_value=MockResponse(json_data=big_invoice))
+    )
+    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 500)
+
+    raw = myob.myob_get_sales_invoice("inv1")
+    result = json.loads(raw)
+
+    assert len(raw) <= 500
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+
+
+def test_get_customer_rejects_empty_uid(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(myob.myob_get_customer(""))
+
+    assert result["status"] == "error"
+    mock_request.assert_not_called()
+
+
+def test_create_customer_sends_return_body_and_json(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"UID": "c1", "CompanyName": "Acme"})
+    )
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(
+        myob.myob_create_customer({"CompanyName": "Acme", "IsIndividual": False})
+    )
+
+    assert result["status"] == "success"
+    assert result["customer"]["UID"] == "c1"
+    assert mock_request.call_args.kwargs["json"] == {
+        "CompanyName": "Acme",
+        "IsIndividual": False,
+    }
+    assert mock_request.call_args.kwargs["params"] == {"returnBody": "true"}
+    assert mock_request.call_args.kwargs["method"] == "POST"
+    assert mock_request.call_args.kwargs["url"].endswith("Contact/Customer/")
+
+
+def test_create_customer_rejects_empty_fields(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(myob.myob_create_customer({}))
+
+    assert result["status"] == "error"
+    mock_request.assert_not_called()
+
+
+def test_create_customer_falls_back_to_location_header_when_body_is_empty(
+    monkeypatch,
+):
+    mock_request = Mock(
+        return_value=MockResponse(
+            status_code=201,
+            text="",
+            headers={
+                "Location": (
+                    "https://api.myob.com/accountright/biz-id/Contact/Customer/c1-uid/"
+                )
+            },
+        )
+    )
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(myob.myob_create_customer({"CompanyName": "Acme"}))
+
+    assert result["status"] == "success"
+    assert result["customer"]["UID"] == "c1-uid"
+
+
+def test_update_customer_merges_fetched_record_with_changes(monkeypatch):
+    current = {
+        "UID": "c1",
+        "CompanyName": "Old Name",
+        "IsIndividual": False,
+        "RowVersion": "abc123==",
+    }
+    updated = {**current, "CompanyName": "New Name"}
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=current),  # the GET inside _update_resource
+            MockResponse(json_data=updated),  # the PUT
+        ]
+    )
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(myob.myob_update_customer("c1", {"CompanyName": "New Name"}))
+
+    assert result["status"] == "success"
+    assert result["customer"]["CompanyName"] == "New Name"
+    put_call = mock_request.call_args_list[1]
+    assert put_call.kwargs["method"] == "PUT"
+    # RowVersion/IsIndividual carried forward from the GET untouched, not
+    # dropped just because the caller only named CompanyName.
+    assert put_call.kwargs["json"] == updated
+    assert put_call.kwargs["params"] == {"returnBody": "true"}
+
+
+def test_update_customer_rejects_empty_fields(monkeypatch):
+    mock_request = Mock()
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(myob.myob_update_customer("c1", {}))
+
+    assert result["status"] == "error"
+    mock_request.assert_not_called()
+
+
+def test_get_business_info_unwraps_company_file(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(
+            json_data={"CompanyFile": {"Name": "Acme Pty Ltd", "Uri": "..."}}
+        )
+    )
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(myob.myob_get_business_info())
+
+    assert result["status"] == "success"
+    assert result["business"]["Name"] == "Acme Pty Ltd"
+    # The business-info call hits the base business URL itself, not a
+    # resource path underneath it.
+    assert mock_request.call_args.kwargs["url"] == myob._base_url()
+
+
+def test_list_sales_invoices_uses_item_layout_endpoint(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"Items": []}))
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    myob.myob_list_sales_invoices()
+
+    assert mock_request.call_args.kwargs["url"].endswith("Sale/Invoice/Item/")
+
+
+def test_list_purchase_bills_uses_item_layout_endpoint(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"Items": []}))
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    myob.myob_list_purchase_bills()
+
+    assert mock_request.call_args.kwargs["url"].endswith("Purchase/Bill/Item/")
+
+
+def test_list_accounts_uses_general_ledger_endpoint(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"Items": []}))
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    myob.myob_list_accounts()
+
+    assert mock_request.call_args.kwargs["url"].endswith("GeneralLedger/Account/")
+
+
+def test_list_tax_codes_uses_general_ledger_endpoint(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"Items": []}))
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    myob.myob_list_tax_codes()
+
+    assert mock_request.call_args.kwargs["url"].endswith("GeneralLedger/TaxCode/")
+
+
+def test_capped_list_halves_items_to_fit_output_limit(monkeypatch):
+    monkeypatch.setattr(myob, "get_tool_max_output_length", lambda: 200)
+
+    raw = myob._success_with_capped_list(
+        "customers",
+        [{"UID": str(i), "Name": "x" * 50} for i in range(20)],
+        total_count=20,
+    )
+    result = json.loads(raw)
+
+    assert len(raw) <= 200
+    assert result["truncated"] is True
+    assert len(result["customers"]) < 20
+
+
+def test_myob_app_registry_scopes_exclude_unused_families():
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    myob_app = next(
+        row for row in get_builtin_public_mcp_app_rows() if row["app_id"] == "myob"
+    )
+    assert "sme-contacts-customer" in myob_app["oauth_scopes"]
+    assert "sme-general-ledger" in myob_app["oauth_scopes"]
+    # No payroll/employee/personal/timebilling/banking tools are exposed, so
+    # none of those scopes should be requested.
+    for unused_scope in (
+        "sme-banking",
+        "sme-payroll",
+        "sme-contacts-employee",
+        "sme-contacts-personal",
+        "sme-timebilling",
+    ):
+        assert unused_scope not in myob_app["oauth_scopes"]
+    assert myob_app["launch_config"]["env_mapping"] == {
+        "MYOB_ACCESS_TOKEN": "access_token",
+        "MYOB_BUSINESS_ID": "instance_url",
+    }
+    assert myob_app["launch_config"]["static_env"] == {"MYOB_API_KEY": "MYOB_CLIENT_ID"}

--- a/tests/web/tools/test_myob_mcp.py
+++ b/tests/web/tools/test_myob_mcp.py
@@ -378,6 +378,61 @@ def test_create_customer_rejects_empty_fields(monkeypatch):
     mock_request.assert_not_called()
 
 
+def test_create_customer_returns_error_payload_on_non_2xx(monkeypatch):
+    # Every prior create/update error-path test in this file goes through
+    # a GET (e.g. _update_resource's guards) -- this pins the write-request
+    # error path itself: a real MYOB validation failure on POST/PUT must
+    # surface as the tool's {"status": "error"} contract, not an unhandled
+    # exception.
+    mock_request = Mock(
+        return_value=MockResponse(
+            status_code=400,
+            json_data={
+                "Errors": [
+                    {
+                        "Name": "ValidationException",
+                        "Message": "CompanyName is required",
+                        "AdditionalDetails": "",
+                    }
+                ]
+            },
+        )
+    )
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(myob.myob_create_customer({"IsIndividual": False}))
+
+    assert result["status"] == "error"
+    assert "CompanyName is required" in result["message"]
+
+
+def test_update_customer_returns_error_payload_on_non_2xx_put(monkeypatch):
+    current = {"UID": "c1", "CompanyName": "Old Name", "RowVersion": "abc=="}
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=current),  # the GET succeeds
+            MockResponse(
+                status_code=409,
+                json_data={
+                    "Errors": [
+                        {
+                            "Name": "ConcurrencyException",
+                            "Message": "RowVersion mismatch",
+                            "AdditionalDetails": "",
+                        }
+                    ]
+                },
+            ),
+        ]
+    )
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(myob.myob_update_customer("c1", {"CompanyName": "New Name"}))
+
+    assert result["status"] == "error"
+    assert "RowVersion mismatch" in result["message"]
+
+
 def test_create_customer_falls_back_to_location_header_when_body_is_empty(
     monkeypatch,
 ):
@@ -462,6 +517,99 @@ def test_update_resource_rejects_a_non_dict_get_response(monkeypatch):
         myob._update_resource("Contact/Customer/", "c1", {"CompanyName": "New Name"})
 
     mock_request.assert_called_once()  # the GET only -- no PUT attempted
+
+
+def test_list_suppliers_sends_filter_orderby_and_paging(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"Count": 1, "Items": [{"UID": "s1"}]})
+    )
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(
+        myob.myob_list_suppliers(
+            filter="IsActive eq true", orderby="CompanyName", top=10, skip=5
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["suppliers"] == [{"UID": "s1"}]
+    assert mock_request.call_args.kwargs["params"] == {
+        "$top": 10,
+        "$skip": 5,
+        "$filter": "IsActive eq true",
+        "$orderby": "CompanyName",
+    }
+    assert mock_request.call_args.kwargs["url"].endswith("Contact/Supplier/")
+
+
+def test_get_supplier_percent_encodes_uid(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"UID": "s1"}))
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(myob.myob_get_supplier("s1/../evil"))
+
+    assert result["status"] == "success"
+    url = mock_request.call_args.kwargs["url"]
+    assert url.endswith("Contact/Supplier/s1%2F..%2Fevil/")
+
+
+def test_create_supplier_sends_return_body_and_json(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"UID": "s1", "CompanyName": "Acme"})
+    )
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(
+        myob.myob_create_supplier({"CompanyName": "Acme", "IsIndividual": False})
+    )
+
+    assert result["status"] == "success"
+    assert result["supplier"]["UID"] == "s1"
+    assert mock_request.call_args.kwargs["json"] == {
+        "CompanyName": "Acme",
+        "IsIndividual": False,
+    }
+    assert mock_request.call_args.kwargs["params"] == {"returnBody": "true"}
+    assert mock_request.call_args.kwargs["method"] == "POST"
+    assert mock_request.call_args.kwargs["url"].endswith("Contact/Supplier/")
+
+
+def test_get_purchase_bill_percent_encodes_uid(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"UID": "bill1"}))
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(myob.myob_get_purchase_bill("bill1/../evil"))
+
+    assert result["status"] == "success"
+    url = mock_request.call_args.kwargs["url"]
+    assert url.endswith("Purchase/Bill/Item/bill1%2F..%2Fevil/")
+
+
+def test_create_purchase_bill_sends_return_body_and_json(monkeypatch):
+    mock_request = Mock(
+        return_value=MockResponse(json_data={"UID": "bill1", "Status": "Open"})
+    )
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(myob.myob_create_purchase_bill({"Supplier": {"UID": "s1"}}))
+
+    assert result["status"] == "success"
+    assert result["bill"]["UID"] == "bill1"
+    assert mock_request.call_args.kwargs["json"] == {"Supplier": {"UID": "s1"}}
+    assert mock_request.call_args.kwargs["params"] == {"returnBody": "true"}
+    assert mock_request.call_args.kwargs["method"] == "POST"
+    assert mock_request.call_args.kwargs["url"].endswith("Purchase/Bill/Item/")
+
+
+def test_get_account_percent_encodes_uid(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"UID": "acc1"}))
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(myob.myob_get_account("acc1/../evil"))
+
+    assert result["status"] == "success"
+    url = mock_request.call_args.kwargs["url"]
+    assert url.endswith("GeneralLedger/Account/acc1%2F..%2Fevil/")
 
 
 def test_update_supplier_merges_fetched_record_with_changes(monkeypatch):
@@ -586,12 +734,48 @@ def test_capped_list_halves_items_to_fit_output_limit(monkeypatch):
         "customers",
         [{"UID": str(i), "Name": "x" * 50} for i in range(20)],
         total_count=20,
+        skip=0,
     )
     result = json.loads(raw)
 
     assert len(raw) <= 200
     assert result["truncated"] is True
     assert len(result["customers"]) < 20
+
+
+def test_capped_list_next_skip_reflects_items_actually_returned(monkeypatch):
+    # A halving pass that drops items must not let a caller's next fetch
+    # jump straight to skip+top (which would silently skip the dropped
+    # items) -- next_skip must reflect only what actually made it into
+    # *this* response, the same convention salesforce.py's own capped-page
+    # helper uses.
+    monkeypatch.setattr(myob, "get_tool_max_output_length", lambda: 200)
+
+    raw = myob._success_with_capped_list(
+        "customers",
+        [{"UID": str(i), "Name": "x" * 50} for i in range(20)],
+        total_count=50,
+        skip=10,
+    )
+    result = json.loads(raw)
+
+    returned = len(result["customers"])
+    assert returned < 20
+    assert result["has_more"] is True
+    assert result["next_skip"] == 10 + returned
+
+
+def test_capped_list_has_more_false_and_no_next_skip_on_last_page(monkeypatch):
+    raw = myob._success_with_capped_list(
+        "customers",
+        [{"UID": "1"}, {"UID": "2"}],
+        total_count=12,
+        skip=10,
+    )
+    result = json.loads(raw)
+
+    assert result["has_more"] is False
+    assert "next_skip" not in result
 
 
 def test_myob_app_registry_scopes_exclude_unused_families():

--- a/tests/web/tools/test_myob_mcp.py
+++ b/tests/web/tools/test_myob_mcp.py
@@ -113,6 +113,40 @@ def test_request_raises_with_joined_errors_array(monkeypatch):
     assert "CompanyName is required" in str(excinfo.value)
 
 
+def test_request_joins_list_shaped_additional_details(monkeypatch):
+    # At least one documented MYOB error shape carries AdditionalDetails as
+    # a list of per-field messages, not a plain string -- must be joined
+    # into readable text, not fall through to a raw Python list repr like
+    # "['TaxCode is required', 'Customer is required']".
+    monkeypatch.setattr(
+        myob.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=400,
+                json_data={
+                    "Errors": [
+                        {
+                            "Name": "ValidationException",
+                            "Message": "Required fields are missing",
+                            "AdditionalDetails": [
+                                "TaxCode is required",
+                                "Customer is required",
+                            ],
+                        }
+                    ]
+                },
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        myob._request("GET", "Contact/Customer/")
+
+    assert "TaxCode is required, Customer is required" in str(excinfo.value)
+    assert "[" not in str(excinfo.value)
+
+
 def test_request_falls_back_to_raw_text_for_unstructured_error(monkeypatch):
     monkeypatch.setattr(
         myob.requests,

--- a/tests/web/tools/test_myob_mcp.py
+++ b/tests/web/tools/test_myob_mcp.py
@@ -141,6 +141,38 @@ def test_request_truncates_long_error_body(monkeypatch):
     assert len(str(excinfo.value)) < len(long_body)
 
 
+def test_request_truncates_long_structured_error_detail(monkeypatch):
+    # Truncation must apply to a successfully-extracted {"Errors": [...]}
+    # detail too, not just the raw-text fallback used when that extraction
+    # fails -- a single AdditionalDetails field (or many stacked errors) can
+    # be just as unbounded as raw response text.
+    long_message = "x" * 5000
+    monkeypatch.setattr(
+        myob.requests,
+        "request",
+        Mock(
+            return_value=MockResponse(
+                status_code=400,
+                json_data={
+                    "Errors": [
+                        {
+                            "Name": "ValidationException",
+                            "Message": long_message,
+                            "AdditionalDetails": "",
+                        }
+                    ]
+                },
+            )
+        ),
+    )
+
+    with pytest.raises(RuntimeError) as excinfo:
+        myob._request("GET", "Contact/Customer/")
+
+    assert "[truncated]" in str(excinfo.value)
+    assert len(str(excinfo.value)) < len(long_message)
+
+
 def test_list_items_unwraps_items_and_count():
     items, total_count = myob._list_items(
         {"Count": 2, "Items": [{"UID": "1"}, {"UID": "2"}]}

--- a/tests/web/tools/test_myob_mcp.py
+++ b/tests/web/tools/test_myob_mcp.py
@@ -217,10 +217,16 @@ def test_list_items_unwraps_items_and_count():
 
 
 def test_list_items_tolerates_bare_array():
+    # total_count must stay None, not the page length -- a self-review
+    # round found that returning len(result) here made
+    # _success_with_capped_list's has_more math silently report "no more
+    # results" the instant this fallback fires, since next_skip would
+    # always equal a total_count that was never a real across-all-pages
+    # total to begin with.
     items, total_count = myob._list_items([{"UID": "1"}])
 
     assert items == [{"UID": "1"}]
-    assert total_count == 1
+    assert total_count is None
 
 
 def test_list_customers_sends_filter_orderby_and_paging(monkeypatch):

--- a/tests/web/tools/test_myob_mcp.py
+++ b/tests/web/tools/test_myob_mcp.py
@@ -256,6 +256,53 @@ def test_get_sales_invoice_caps_output_size(monkeypatch):
     assert result["truncated"] is True
 
 
+def test_create_sales_invoice_caps_output_size(monkeypatch):
+    # returnBody=true means create/update tools echo back the full object
+    # too, so they carry the same open-ended-Lines-array risk as the get
+    # tool above, not just the list/get tools.
+    big_invoice = {
+        "UID": "inv1",
+        "Lines": [{"Description": "x" * 200} for _ in range(50)],
+    }
+    monkeypatch.setattr(
+        myob.requests, "request", Mock(return_value=MockResponse(json_data=big_invoice))
+    )
+    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 500)
+
+    raw = myob.myob_create_sales_invoice({"Customer": {"UID": "c1"}})
+    result = json.loads(raw)
+
+    assert len(raw) <= 500
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+
+
+def test_update_sales_invoice_caps_output_size(monkeypatch):
+    current = {"UID": "inv1"}
+    big_updated = {
+        "UID": "inv1",
+        "Lines": [{"Description": "x" * 200} for _ in range(50)],
+    }
+    monkeypatch.setattr(
+        myob.requests,
+        "request",
+        Mock(
+            side_effect=[
+                MockResponse(json_data=current),
+                MockResponse(json_data=big_updated),
+            ]
+        ),
+    )
+    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 500)
+
+    raw = myob.myob_update_sales_invoice("inv1", {"Status": "Closed"})
+    result = json.loads(raw)
+
+    assert len(raw) <= 500
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+
+
 def test_get_customer_rejects_empty_uid(monkeypatch):
     mock_request = Mock()
     monkeypatch.setattr(myob.requests, "request", mock_request)
@@ -355,6 +402,81 @@ def test_update_customer_rejects_empty_fields(monkeypatch):
 
     assert result["status"] == "error"
     mock_request.assert_not_called()
+
+
+def test_update_resource_rejects_an_empty_get_response(monkeypatch):
+    # {} passes `isinstance(current, dict)` but must still be rejected --
+    # letting it through would merge as `{**{}, **fields}`, silently
+    # wiping every existing field (including RowVersion) on the PUT.
+    mock_request = Mock(return_value=MockResponse(json_data={}))
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    with pytest.raises(RuntimeError, match="no existing record"):
+        myob._update_resource("Contact/Customer/", "c1", {"CompanyName": "New Name"})
+
+    mock_request.assert_called_once()  # the GET only -- no PUT attempted
+
+
+def test_update_supplier_merges_fetched_record_with_changes(monkeypatch):
+    current = {"UID": "s1", "CompanyName": "Old Supplier", "RowVersion": "abc=="}
+    updated = {**current, "CompanyName": "New Supplier"}
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=current),
+            MockResponse(json_data=updated),
+        ]
+    )
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(
+        myob.myob_update_supplier("s1", {"CompanyName": "New Supplier"})
+    )
+
+    assert result["status"] == "success"
+    assert result["supplier"]["CompanyName"] == "New Supplier"
+    put_call = mock_request.call_args_list[1]
+    assert put_call.kwargs["method"] == "PUT"
+    assert put_call.kwargs["json"] == updated
+
+
+def test_update_sales_invoice_merges_fetched_record_with_changes(monkeypatch):
+    current = {"UID": "inv1", "Status": "Open", "RowVersion": "abc=="}
+    updated = {**current, "Status": "Closed"}
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=current),
+            MockResponse(json_data=updated),
+        ]
+    )
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(myob.myob_update_sales_invoice("inv1", {"Status": "Closed"}))
+
+    assert result["status"] == "success"
+    assert result["invoice"]["Status"] == "Closed"
+    put_call = mock_request.call_args_list[1]
+    assert put_call.kwargs["method"] == "PUT"
+    assert put_call.kwargs["json"] == updated
+
+
+def test_update_purchase_bill_merges_fetched_record_with_changes(monkeypatch):
+    current = {"UID": "bill1", "Status": "Open", "RowVersion": "abc=="}
+    updated = {**current, "Status": "Closed"}
+    mock_request = Mock(
+        side_effect=[
+            MockResponse(json_data=current),
+            MockResponse(json_data=updated),
+        ]
+    )
+    monkeypatch.setattr(myob.requests, "request", mock_request)
+
+    result = json.loads(myob.myob_update_purchase_bill("bill1", {"Status": "Closed"}))
+
+    assert result["status"] == "success"
+    assert result["bill"]["Status"] == "Closed"
+    put_call = mock_request.call_args_list[1]
+    assert put_call.kwargs["method"] == "PUT"
+    assert put_call.kwargs["json"] == updated
 
 
 def test_get_business_info_unwraps_company_file(monkeypatch):


### PR DESCRIPTION
## Summary
- Adds a MYOB AccountRight OAuth MCP connector: contacts (customers/suppliers), sales invoices, purchase bills, and general ledger (accounts/tax codes) tools, following the granular `sme-*` data scope model.
- Extends the shared `generic_oauth_callback`/authorize-redirect builder in `auth.py` with the two pieces MYOB needs beyond the generic OAuth flow:
  - `prompt=consent` on the authorize redirect — MYOB only appends the `businessId` (the company file GUID, required for every API call) to the redirect when this is set, and there is no other way to discover it (the old company-file-listing endpoint no longer works under the granular-scope model).
  - Inline `user: {uid, username}` identity extraction from the token response, since MYOB has no dedicated userinfo endpoint.
- Verified the current MYOB auth model directly against the actively-maintained `uptick/pymyob` client's source (not just official docs, which are stale on this point): the old `x-myobapi-cftoken` company-file login is dead — the OAuth token plus `x-myobapi-key` is sufficient.

## Test plan
- [x] `pytest tests/web/tools/test_myob_mcp.py tests/web/test_myob_oauth.py tests/alembic/test_20260903_seed_myob_mcp_app.py` — new coverage, all passing
- [x] `pytest tests/web/test_generic_oauth_login.py tests/web/test_deputy_oauth.py tests/web/tools/test_salesforce_mcp.py tests/web/tools/test_deputy_mcp.py` — regression check on shared `auth.py` code paths, all passing
- [x] `ruff check` / `ruff format --check` / `mypy` on all new/changed files
- [x] Self-reviewed (two independent passes covering correctness and security/conventions); fixed dead exception-class plumbing and added output-size capping on single-record get/create/update tools whose `Lines` arrays are otherwise unbounded