### PR TITLE
feat(web-crawler): record why a crawl stopped and who refused each link

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
@@ -76,10 +76,11 @@ _WEAK_CHALLENGE_PAGE_MARKERS: Tuple[str, ...] = (
 
 # Why the crawl loop ended. NO_LINKS and PAGE_CAP are the crawl doing what it
 # was configured to do; NO_ELIGIBLE_LINKS means links existed but the site
-# refused them, which is the case worth surfacing to the user. UNKNOWN is an
-# inert placeholder, not a signal: nothing reads it, and the loop's epilogue
-# always overwrites it. It exists so an unset stop_reason cannot read as one
-# of the three real answers.
+# refused them, which is the case worth surfacing to the user. UNKNOWN is what
+# get_statistics() reports when the loop did not reach its epilogue, which
+# happens when an exception propagates out of it - crawl() has no try/finally.
+# No caller handles it today; it exists so that state cannot be mistaken for
+# one of the three real answers.
 STOPPED_UNKNOWN = "unknown"
 STOPPED_NO_LINKS = "no_more_links"
 STOPPED_PAGE_CAP = "page_cap_reached"
@@ -531,11 +532,13 @@ class WebCrawler:
         # total_urls_found counts raw extractor output and is diagnostic. Only
         # total_links_queued tracks frontier progress - a link can survive every
         # filter and still queue nothing, having been seen already or sitting
-        # past max_depth.
+        # past max_depth. It counts queue insertions, which are keyed on the raw
+        # link, so /a#x and /a#y each count; deduplicating those would change
+        # which pages get fetched, so it does not belong in this PR.
         self.total_urls_found = 0
         self.total_links_queued = 0
         self.rejected_urls: Set[str] = set()
-        self.link_rejections: Counter = Counter()
+        self.link_rejections: Counter[str] = Counter()
         self.stop_reason: str = STOPPED_UNKNOWN
         self.start_time: Optional[float] = None
 
@@ -1024,11 +1027,14 @@ class WebCrawler:
                     )
                     if reason is None:
                         valid_links.add(link)
-                    elif link not in self.rejected_urls:
-                        # Counted per distinct URL: a nav link rejected on every
-                        # page is one refused link, not one per page.
-                        self.rejected_urls.add(link)
-                        self.link_rejections[reason] += 1
+                    else:
+                        # Keyed on the normalized URL because that is what
+                        # rejection_reason judged: /a#x, /a#y and //EXAMPLE.com/a
+                        # are one refused link, as is a nav link on every page.
+                        seen = self.url_filter.normalize_url(link) or link
+                        if seen not in self.rejected_urls:
+                            self.rejected_urls.add(seen)
+                            self.link_rejections[reason] += 1
 
                 self.total_urls_found += len(links)
 
@@ -1092,7 +1098,9 @@ class WebCrawler:
             total_urls_found (raw extractor output, before filtering),
             total_links_queued (links that actually entered the frontier),
             link_rejections (count per rejection reason, per distinct URL),
-            and stop_reason (one of the STOPPED_* values).
+            and stop_reason (one of the STOPPED_* values). The page cap is
+            checked first, so with max_pages=1 a crawl reports
+            page_cap_reached even if the site also refused every link.
         """
         return {
             "total_urls_found": self.total_urls_found,

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/crawler.py
@@ -5,7 +5,7 @@ import importlib
 import importlib.util
 import logging
 import time
-from collections import deque
+from collections import Counter, deque
 from contextlib import AsyncExitStack, asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -16,7 +16,7 @@ import httpx
 from ..core.schemas import CrawlResult, WebCrawlConfig
 from .content_cleaner import ContentCleaner
 from .link_extractor import LinkExtractor
-from .url_filter import URLFilter
+from .url_filter import SITE_REJECTIONS, URLFilter
 
 logger = logging.getLogger(__name__)
 
@@ -73,6 +73,17 @@ _WEAK_CHALLENGE_PAGE_MARKERS: Tuple[str, ...] = (
     "just a moment",
     "needs to review the security",
 )
+
+# Why the crawl loop ended. NO_LINKS and PAGE_CAP are the crawl doing what it
+# was configured to do; NO_ELIGIBLE_LINKS means links existed but the site
+# refused them, which is the case worth surfacing to the user. UNKNOWN is an
+# inert placeholder, not a signal: nothing reads it, and the loop's epilogue
+# always overwrites it. It exists so an unset stop_reason cannot read as one
+# of the three real answers.
+STOPPED_UNKNOWN = "unknown"
+STOPPED_NO_LINKS = "no_more_links"
+STOPPED_PAGE_CAP = "page_cap_reached"
+STOPPED_NO_ELIGIBLE_LINKS = "no_eligible_links"
 
 _MIN_MARKDOWN_TEXT_LENGTH = 10
 _SHORT_TEXT_LENGTH = 200
@@ -517,8 +528,15 @@ class WebCrawler:
         self.crawl_results: List[CrawlResult] = []
         self.failed_urls: Dict[str, str] = {}
 
-        # Statistics
+        # total_urls_found counts raw extractor output and is diagnostic. Only
+        # total_links_queued tracks frontier progress - a link can survive every
+        # filter and still queue nothing, having been seen already or sitting
+        # past max_depth.
         self.total_urls_found = 0
+        self.total_links_queued = 0
+        self.rejected_urls: Set[str] = set()
+        self.link_rejections: Counter = Counter()
+        self.stop_reason: str = STOPPED_UNKNOWN
         self.start_time: Optional[float] = None
 
     async def crawl(self) -> List[CrawlResult]:
@@ -849,6 +867,26 @@ class WebCrawler:
                         self.config.max_pages,
                     )
 
+        if len(self.visited_urls) >= self.config.max_pages:
+            self.stop_reason = STOPPED_PAGE_CAP
+        elif self._site_refused_the_frontier():
+            self.stop_reason = STOPPED_NO_ELIGIBLE_LINKS
+        else:
+            self.stop_reason = STOPPED_NO_LINKS
+
+    def _site_refused_the_frontier(self) -> bool:
+        """Whether the site's own policy is why there was nothing left to crawl.
+
+        Asks about the frontier, not about rejection counts: a crawl that
+        queued a page was making progress whatever else it turned away. Depth
+        needs no separate guard - WebCrawlConfig.max_depth is Field(ge=1), so a
+        page dropped for depth is always behind one that was queued. A crawl
+        that could stop at depth 0 would need one.
+        """
+        if self.total_links_queued:
+            return False
+        return any(self.link_rejections[reason] for reason in SITE_REJECTIONS)
+
     async def _crawl_page(
         self,
         sessions: Dict[Optional[str], Any],
@@ -981,8 +1019,16 @@ class WebCrawler:
                 # consistent with what the WAF actually sees.
                 valid_links = set()
                 for link in links:
-                    if self.url_filter.should_crawl(link, self._policy_user_agent):
+                    reason = self.url_filter.rejection_reason(
+                        link, self._policy_user_agent
+                    )
+                    if reason is None:
                         valid_links.add(link)
+                    elif link not in self.rejected_urls:
+                        # Counted per distinct URL: a nav link rejected on every
+                        # page is one refused link, not one per page.
+                        self.rejected_urls.add(link)
+                        self.link_rejections[reason] += 1
 
                 self.total_urls_found += len(links)
 
@@ -1036,15 +1082,23 @@ class WebCrawler:
             # Only add if not visited and not already pending
             if link not in self.visited_urls and link not in pending_urls_set:
                 self.pending_urls.append((link, next_depth))
+                self.total_links_queued += 1
 
     def get_statistics(self) -> dict:
         """Get crawl statistics.
 
         Returns:
-            Dictionary with statistics
+            Dictionary with statistics. Beyond the page counts:
+            total_urls_found (raw extractor output, before filtering),
+            total_links_queued (links that actually entered the frontier),
+            link_rejections (count per rejection reason, per distinct URL),
+            and stop_reason (one of the STOPPED_* values).
         """
         return {
             "total_urls_found": self.total_urls_found,
+            "total_links_queued": self.total_links_queued,
+            "link_rejections": dict(self.link_rejections),
+            "stop_reason": self.stop_reason,
             "visited_urls": len(self.visited_urls),
             "successful_pages": len(self.crawl_results),
             "failed_pages": len(self.failed_urls),

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/url_filter.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/url_filter.py
@@ -13,6 +13,20 @@ from ..core.web_url_utils import normalize_web_url
 
 logger = logging.getLogger(__name__)
 
+# Why a discovered link was not queued.
+REJECTED_OFF_DOMAIN = "off_domain"
+REJECTED_EXCLUDED = "excluded_pattern"
+REJECTED_NOT_INCLUDED = "not_included_pattern"
+REJECTED_ROBOTS = "robots_txt"
+REJECTED_UNPARSABLE = "unparsable"
+
+# Only robots.txt speaks for the site. Scope rules belong to the operator and
+# an unsupported scheme (ftp:, data:, intent:) is this crawler's own limit, so
+# neither may make the site look responsible for a crawl that went nowhere.
+# Membership, never the complement: a reason added later is not a refusal
+# until someone says it is.
+SITE_REJECTIONS = frozenset({REJECTED_ROBOTS})
+
 
 class URLFilter:
     """URL filtering and validation.
@@ -185,8 +199,43 @@ class URLFilter:
         """
         return any(pattern.search(url) for pattern in self.exclude_patterns)
 
+    def rejection_reason(self, url: str, user_agent: str = "*") -> Optional[str]:
+        """Return why this URL will not be crawled, or None if it will be.
+
+        Callers aggregate these to tell a crawl that stopped because the
+        operator configured it that way from one that stopped unexpectedly.
+        Every configured rule is therefore checked before robots.txt: a link
+        that is both out of scope and robots-disallowed was never going to be
+        crawled regardless of what the site said, so attributing it to the site
+        would blame it for the operator's own filtering.
+        """
+        normalized = self.normalize_url(url)
+        if not normalized:
+            return REJECTED_UNPARSABLE
+
+        if self.same_domain_only and not self.is_same_domain(normalized):
+            logger.debug("Skipping %s: different domain", normalized)
+            return REJECTED_OFF_DOMAIN
+
+        if self.is_excluded(normalized):
+            logger.debug("Skipping %s: matches exclusion pattern", normalized)
+            return REJECTED_EXCLUDED
+
+        if not self.matches_patterns(normalized):
+            logger.debug("Skipping %s: does not match inclusion pattern", normalized)
+            return REJECTED_NOT_INCLUDED
+
+        if self.respect_robots_txt and not self.is_allowed(normalized, user_agent):
+            logger.debug("Skipping %s: disallowed by robots.txt", normalized)
+            return REJECTED_ROBOTS
+
+        return None
+
     def should_crawl(self, url: str, user_agent: str = "*") -> bool:
         """Check if URL should be crawled based on all rules.
+
+        A convenience wrapper kept for external callers; the crawler itself
+        uses rejection_reason() because it needs to record why.
 
         Args:
             url: URL to check
@@ -195,32 +244,7 @@ class URLFilter:
         Returns:
             True if URL should be crawled, False otherwise
         """
-        # Normalize URL
-        normalized = self.normalize_url(url)
-        if not normalized:
-            return False
-
-        # Check domain
-        if self.same_domain_only and not self.is_same_domain(normalized):
-            logger.debug("Skipping %s: different domain", normalized)
-            return False
-
-        # Check robots.txt
-        if self.respect_robots_txt and not self.is_allowed(normalized, user_agent):
-            logger.debug("Skipping %s: disallowed by robots.txt", normalized)
-            return False
-
-        # Check exclusion patterns
-        if self.is_excluded(normalized):
-            logger.debug("Skipping %s: matches exclusion pattern", normalized)
-            return False
-
-        # Check inclusion patterns
-        if not self.matches_patterns(normalized):
-            logger.debug("Skipping %s: does not match inclusion pattern", normalized)
-            return False
-
-        return True
+        return self.rejection_reason(url, user_agent) is None
 
     def normalize_url(self, url: str, base_url: Optional[str] = None) -> Optional[str]:
         """Normalize URL by handling relative URLs and removing fragments.

--- a/src/xagent/core/tools/core/RAG_tools/web_crawler/url_filter.py
+++ b/src/xagent/core/tools/core/RAG_tools/web_crawler/url_filter.py
@@ -234,8 +234,9 @@ class URLFilter:
     def should_crawl(self, url: str, user_agent: str = "*") -> bool:
         """Check if URL should be crawled based on all rules.
 
-        A convenience wrapper kept for external callers; the crawler itself
-        uses rejection_reason() because it needs to record why.
+        No production caller: the crawler uses rejection_reason() because it
+        needs to record why. Kept because it is public API on an exported
+        class, and the tests read better through it.
 
         Args:
             url: URL to check

--- a/tests/core/tools/core/RAG_tools/web_crawler/conftest.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/conftest.py
@@ -1,0 +1,24 @@
+"""Shared fixtures for web crawler tests."""
+
+from unittest.mock import MagicMock
+
+import httpx
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _no_real_robots_fetch(monkeypatch):
+    """URLFilter fetches robots.txt synchronously in __init__, so any test that
+    builds one with the default respect_robots_txt fires a real request at the
+    start URL's host. The fetch swallows its own exception, so an offline run
+    would quietly exercise a different code path instead of failing.
+
+    404 keeps the behaviour these tests were already getting from the live
+    request, minus the network. Tests that care about robots.txt override this
+    by patching httpx.Client themselves.
+    """
+    client = MagicMock()
+    client.return_value.__enter__.return_value.get.return_value = MagicMock(
+        status_code=404, text=""
+    )
+    monkeypatch.setattr(httpx, "Client", client)

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
@@ -18,6 +18,12 @@ from xagent.core.tools.core.RAG_tools.web_crawler.crawler import (
     WebCrawler,
     _get_httpx_accept_encoding,
 )
+from xagent.core.tools.core.RAG_tools.web_crawler.url_filter import (
+    REJECTED_EXCLUDED,
+    REJECTED_OFF_DOMAIN,
+    REJECTED_ROBOTS,
+    REJECTED_UNPARSABLE,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -1098,12 +1104,12 @@ class TestStopReason:
         ):
             crawler = WebCrawler(config)
             # Site allows the start page but refuses everything it links to.
-            crawler.url_filter.rejection_reason = lambda url, ua="*": "robots_txt"
+            crawler.url_filter.rejection_reason = lambda url, ua="*": REJECTED_ROBOTS
             await crawler.crawl()
 
         assert crawler.stop_reason == STOPPED_NO_ELIGIBLE_LINKS
         assert crawler.total_links_queued == 0
-        assert crawler.link_rejections["robots_txt"] == 2
+        assert crawler.link_rejections[REJECTED_ROBOTS] == 2
 
     @pytest.mark.asyncio
     async def test_off_domain_links_only_is_not_flagged(self):
@@ -1127,7 +1133,7 @@ class TestStopReason:
             crawler = WebCrawler(config)
             await crawler.crawl()
 
-        assert crawler.link_rejections["off_domain"] == 2
+        assert crawler.link_rejections[REJECTED_OFF_DOMAIN] == 2
         assert crawler.stop_reason == STOPPED_NO_LINKS
 
     @pytest.mark.asyncio
@@ -1150,9 +1156,9 @@ class TestStopReason:
         with patch("httpx.AsyncClient", return_value=self._mock_client(html)):
             crawler = WebCrawler(config)
             crawler.url_filter.rejection_reason = (
-                lambda url, ua="*": "robots_txt"
+                lambda url, ua="*": REJECTED_ROBOTS
                 if url.startswith("https://example.com/")
-                else "off_domain"
+                else REJECTED_OFF_DOMAIN
             )
             await crawler.crawl()
 
@@ -1180,7 +1186,7 @@ class TestStopReason:
             crawler = WebCrawler(config)
             await crawler.crawl()
 
-        assert crawler.link_rejections["unparsable"] > 0
+        assert crawler.link_rejections[REJECTED_UNPARSABLE] > 0
         assert crawler.stop_reason == STOPPED_NO_LINKS
 
     @pytest.mark.asyncio
@@ -1203,7 +1209,7 @@ class TestStopReason:
         with patch("httpx.AsyncClient", return_value=self._mock_client(html)):
             crawler = WebCrawler(config)
             crawler.url_filter.rejection_reason = (
-                lambda url, ua="*": "robots_txt" if url.endswith("/child") else None
+                lambda url, ua="*": REJECTED_ROBOTS if url.endswith("/child") else None
             )
             await crawler.crawl()
 
@@ -1226,11 +1232,11 @@ class TestStopReason:
         ):
             crawler = WebCrawler(config)
             crawler.url_filter.rejection_reason = (
-                lambda url, ua="*": "robots_txt" if url.endswith("/b") else None
+                lambda url, ua="*": REJECTED_ROBOTS if url.endswith("/b") else None
             )
             await crawler.crawl()
 
-        assert crawler.link_rejections["robots_txt"] > 0
+        assert crawler.link_rejections[REJECTED_ROBOTS] > 0
         assert crawler.total_links_queued > 0
         assert crawler.stop_reason == STOPPED_NO_LINKS
 
@@ -1258,7 +1264,34 @@ class TestStopReason:
             await crawler.crawl()
 
         assert len(crawler.visited_urls) > 1
-        assert crawler.link_rejections["off_domain"] == 1
+        assert crawler.link_rejections[REJECTED_OFF_DOMAIN] == 1
+
+    @pytest.mark.asyncio
+    async def test_the_same_link_written_differently_is_counted_once(self):
+        """rejection_reason() judges the normalized URL, so the count has to be
+        keyed on it too. Keying on the raw href counts one refused link three
+        times, which is the number the user is shown."""
+        html = """
+            <html><body><h1>Docs</h1>
+            <p>Enough body text here to pass the content length check.</p>
+            <a href="/blog#top">a</a><a href="/blog#new">b</a>
+            <a href="https://EXAMPLE.com/blog">c</a>
+            </body></html>
+        """
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+            exclude_patterns=[r"/blog"],
+            respect_robots_txt=False,
+        )
+        with patch("httpx.AsyncClient", return_value=self._mock_client(html)):
+            crawler = WebCrawler(config)
+            await crawler.crawl()
+
+        assert crawler.link_rejections[REJECTED_EXCLUDED] == 1
 
     @pytest.mark.asyncio
     async def test_page_cap_is_recorded(self):
@@ -1293,14 +1326,14 @@ class TestStopReason:
             "httpx.AsyncClient", return_value=self._mock_client(self.HTML_WITH_LINKS)
         ):
             crawler = WebCrawler(config)
-            reasons = iter(["off_domain", "robots_txt"])
+            reasons = iter([REJECTED_OFF_DOMAIN, REJECTED_ROBOTS])
             crawler.url_filter.rejection_reason = lambda url, ua="*": next(
-                reasons, "off_domain"
+                reasons, REJECTED_OFF_DOMAIN
             )
             await crawler.crawl()
 
-        assert crawler.link_rejections["off_domain"] == 1
-        assert crawler.link_rejections["robots_txt"] == 1
+        assert crawler.link_rejections[REJECTED_OFF_DOMAIN] == 1
+        assert crawler.link_rejections[REJECTED_ROBOTS] == 1
         # The off-domain link was never a candidate, so it cannot vouch for a
         # site that refused the only one that was.
         assert crawler.stop_reason == STOPPED_NO_ELIGIBLE_LINKS

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
@@ -11,9 +11,31 @@ import pytest
 
 from xagent.core.tools.core.RAG_tools.core.schemas import WebCrawlConfig
 from xagent.core.tools.core.RAG_tools.web_crawler.crawler import (
+    STOPPED_NO_ELIGIBLE_LINKS,
+    STOPPED_NO_LINKS,
+    STOPPED_PAGE_CAP,
+    STOPPED_UNKNOWN,
     WebCrawler,
     _get_httpx_accept_encoding,
 )
+
+
+@pytest.fixture(autouse=True)
+def _no_real_robots_fetch(monkeypatch):
+    """URLFilter fetches robots.txt synchronously in __init__, but these tests
+    patch only httpx.AsyncClient. Without this, every crawler built with the
+    default respect_robots_txt fires a real request at example.com - silently,
+    since the fetch swallows its own exception, so an offline CI would quietly
+    exercise a different code path instead of failing.
+
+    404 keeps the behaviour these tests were already getting from the live
+    request, minus the network.
+    """
+    client = MagicMock()
+    client.return_value.__enter__.return_value.get.return_value = MagicMock(
+        status_code=404, text=""
+    )
+    monkeypatch.setattr(httpx, "Client", client)
 
 
 class TestWebCrawler:
@@ -1032,3 +1054,279 @@ class TestRobotsAtCrawlLevel:
             results = await WebCrawler(config).crawl()
 
         assert len(results) == 1
+
+
+class TestStopReason:
+    """The crawl loop records why it ended, so ingestion can tell a configured
+    stop from a site that refused every link."""
+
+    @staticmethod
+    def _mock_client(html: str):
+        response = MagicMock()
+        response.status_code = 200
+        response.text = html
+        client = AsyncMock()
+        client.get.return_value = response
+        client.__aenter__ = AsyncMock(return_value=client)
+        client.__aexit__ = AsyncMock()
+        return client
+
+    HTML_WITH_LINKS = """
+        <html><body><h1>Docs</h1>
+        <p>Enough body text here to pass the content length check.</p>
+        <a href="/a">A</a><a href="/b">B</a>
+        </body></html>
+    """
+
+    HTML_NO_LINKS = """
+        <html><body><h1>Only page</h1>
+        <p>Enough body text here to pass the content length check.</p>
+        </body></html>
+    """
+
+    @pytest.mark.asyncio
+    async def test_robots_refusing_every_link_is_flagged(self):
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+        with patch(
+            "httpx.AsyncClient", return_value=self._mock_client(self.HTML_WITH_LINKS)
+        ):
+            crawler = WebCrawler(config)
+            # Site allows the start page but refuses everything it links to.
+            crawler.url_filter.rejection_reason = lambda url, ua="*": "robots_txt"
+            await crawler.crawl()
+
+        assert crawler.stop_reason == STOPPED_NO_ELIGIBLE_LINKS
+        assert crawler.total_links_queued == 0
+        assert crawler.link_rejections["robots_txt"] == 2
+
+    @pytest.mark.asyncio
+    async def test_off_domain_links_only_is_not_flagged(self):
+        """Deliberate filtering is the crawl doing what it was told. Uses the
+        real filter: same_domain_only is what has to reject these."""
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+            respect_robots_txt=False,
+        )
+        html = """
+            <html><body><h1>Docs</h1>
+            <p>Enough body text here to pass the content length check.</p>
+            <a href="https://other.com/a">A</a><a href="https://other.com/b">B</a>
+            </body></html>
+        """
+        with patch("httpx.AsyncClient", return_value=self._mock_client(html)):
+            crawler = WebCrawler(config)
+            await crawler.crawl()
+
+        assert crawler.link_rejections["off_domain"] == 2
+        assert crawler.stop_reason == STOPPED_NO_LINKS
+
+    @pytest.mark.asyncio
+    async def test_one_in_scope_refusal_outweighs_many_out_of_scope_links(self):
+        """Links that were never in scope cannot vouch for the site. A ratio
+        over all rejections lets fifty off-domain links bury the one refusal
+        that actually closed the crawl."""
+        html = (
+            "<html><body><h1>Docs</h1><p>Enough body text to pass the check.</p>"
+            + "".join(f'<a href="https://other{i}.com/x">O</a>' for i in range(50))
+            + '<a href="/blocked">B</a></body></html>'
+        )
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+        with patch("httpx.AsyncClient", return_value=self._mock_client(html)):
+            crawler = WebCrawler(config)
+            crawler.url_filter.rejection_reason = (
+                lambda url, ua="*": "robots_txt"
+                if url.startswith("https://example.com/")
+                else "off_domain"
+            )
+            await crawler.crawl()
+
+        assert crawler.stop_reason == STOPPED_NO_ELIGIBLE_LINKS
+
+    @pytest.mark.asyncio
+    async def test_unsupported_schemes_alone_are_not_a_refusal(self):
+        """ftp:/data:/intent: anchors are this crawler's own limit. No site
+        policy was consulted, so a one-page import stays a success."""
+        html = """
+            <html><body><h1>Only page</h1>
+            <p>Enough body text here to pass the content length check.</p>
+            <a href="ftp://example.com/f">F</a><a href="data:text/plain,x">D</a>
+            </body></html>
+        """
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+            respect_robots_txt=False,
+        )
+        with patch("httpx.AsyncClient", return_value=self._mock_client(html)):
+            crawler = WebCrawler(config)
+            await crawler.crawl()
+
+        assert crawler.link_rejections["unparsable"] > 0
+        assert crawler.stop_reason == STOPPED_NO_LINKS
+
+    @pytest.mark.asyncio
+    async def test_an_already_seen_link_is_not_frontier_progress(self):
+        """A self link survives every filter and queues nothing. Counting it as
+        progress hides that the only forward page was refused."""
+        html = """
+            <html><body><h1>Docs</h1>
+            <p>Enough body text here to pass the content length check.</p>
+            <a href="https://example.com">home</a><a href="/child">C</a>
+            </body></html>
+        """
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+        with patch("httpx.AsyncClient", return_value=self._mock_client(html)):
+            crawler = WebCrawler(config)
+            crawler.url_filter.rejection_reason = (
+                lambda url, ua="*": "robots_txt" if url.endswith("/child") else None
+            )
+            await crawler.crawl()
+
+        assert crawler.total_links_queued == 0
+        assert crawler.stop_reason == STOPPED_NO_ELIGIBLE_LINKS
+
+    @pytest.mark.asyncio
+    async def test_a_refusal_alongside_real_progress_is_not_a_blocked_crawl(self):
+        """The common shape: robots forbids /private and the rest crawls fine.
+        A refusal only closed the door if nothing was queued behind it."""
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+        with patch(
+            "httpx.AsyncClient", return_value=self._mock_client(self.HTML_WITH_LINKS)
+        ):
+            crawler = WebCrawler(config)
+            crawler.url_filter.rejection_reason = (
+                lambda url, ua="*": "robots_txt" if url.endswith("/b") else None
+            )
+            await crawler.crawl()
+
+        assert crawler.link_rejections["robots_txt"] > 0
+        assert crawler.total_links_queued > 0
+        assert crawler.stop_reason == STOPPED_NO_LINKS
+
+    @pytest.mark.asyncio
+    async def test_a_shared_link_is_counted_once_across_pages(self):
+        """A nav or footer link rejected on every page is one refused link, not
+        one per page. The count reaches the user, so inflating it misstates how
+        much the site turned away."""
+        html = """
+            <html><body><h1>Docs</h1>
+            <p>Enough body text here to pass the content length check.</p>
+            <a href="/next">next</a><a href="https://other.com/nav">nav</a>
+            </body></html>
+        """
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+            respect_robots_txt=False,
+        )
+        with patch("httpx.AsyncClient", return_value=self._mock_client(html)):
+            crawler = WebCrawler(config)
+            await crawler.crawl()
+
+        assert len(crawler.visited_urls) > 1
+        assert crawler.link_rejections["off_domain"] == 1
+
+    @pytest.mark.asyncio
+    async def test_page_cap_is_recorded(self):
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=1,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+        with patch(
+            "httpx.AsyncClient", return_value=self._mock_client(self.HTML_WITH_LINKS)
+        ):
+            crawler = WebCrawler(config)
+            await crawler.crawl()
+
+        assert crawler.stop_reason == STOPPED_PAGE_CAP
+
+    @pytest.mark.asyncio
+    async def test_an_out_of_scope_link_does_not_excuse_a_refusal(self):
+        """Presence is not dominance: a scoped crawl that rejects many
+        off-domain links and meets one robots-disallowed link was doing what it
+        was configured to do."""
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+        with patch(
+            "httpx.AsyncClient", return_value=self._mock_client(self.HTML_WITH_LINKS)
+        ):
+            crawler = WebCrawler(config)
+            reasons = iter(["off_domain", "robots_txt"])
+            crawler.url_filter.rejection_reason = lambda url, ua="*": next(
+                reasons, "off_domain"
+            )
+            await crawler.crawl()
+
+        assert crawler.link_rejections["off_domain"] == 1
+        assert crawler.link_rejections["robots_txt"] == 1
+        # The off-domain link was never a candidate, so it cannot vouch for a
+        # site that refused the only one that was.
+        assert crawler.stop_reason == STOPPED_NO_ELIGIBLE_LINKS
+
+    def test_stop_reason_defaults_to_unknown_before_the_loop_runs(self):
+        """A success-implying default would misreport a crawl that raised
+        before the loop epilogue assigned a real reason."""
+        config = WebCrawlConfig(
+            start_url="https://example.com", request_delay=0, tls_impersonate=None
+        )
+        assert WebCrawler(config).stop_reason == STOPPED_UNKNOWN
+
+    @pytest.mark.asyncio
+    async def test_site_with_no_links_is_not_flagged(self):
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=10,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+        with patch(
+            "httpx.AsyncClient", return_value=self._mock_client(self.HTML_NO_LINKS)
+        ):
+            crawler = WebCrawler(config)
+            await crawler.crawl()
+
+        assert crawler.stop_reason == STOPPED_NO_LINKS
+        assert crawler.link_rejections == {}

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_crawler.py
@@ -26,24 +26,6 @@ from xagent.core.tools.core.RAG_tools.web_crawler.url_filter import (
 )
 
 
-@pytest.fixture(autouse=True)
-def _no_real_robots_fetch(monkeypatch):
-    """URLFilter fetches robots.txt synchronously in __init__, but these tests
-    patch only httpx.AsyncClient. Without this, every crawler built with the
-    default respect_robots_txt fires a real request at example.com - silently,
-    since the fetch swallows its own exception, so an offline CI would quietly
-    exercise a different code path instead of failing.
-
-    404 keeps the behaviour these tests were already getting from the live
-    request, minus the network.
-    """
-    client = MagicMock()
-    client.return_value.__enter__.return_value.get.return_value = MagicMock(
-        status_code=404, text=""
-    )
-    monkeypatch.setattr(httpx, "Client", client)
-
-
 class TestWebCrawler:
     """Test web crawler functionality."""
 
@@ -1057,9 +1039,14 @@ class TestRobotsAtCrawlLevel:
             respect_robots_txt=True,
         )
         with patch("httpx.AsyncClient", return_value=self._client()):
-            results = await WebCrawler(config).crawl()
+            crawler = WebCrawler(config)
+            results = await crawler.crawl()
 
         assert len(results) == 1
+        # Every other stop_reason test stubs rejection_reason. This is the one
+        # place the real URLFilter decides, so it is where the signal has to be
+        # checked against an actual Disallow rule.
+        assert crawler.stop_reason == STOPPED_NO_ELIGIBLE_LINKS
 
 
 class TestStopReason:
@@ -1292,6 +1279,29 @@ class TestStopReason:
             await crawler.crawl()
 
         assert crawler.link_rejections[REJECTED_EXCLUDED] == 1
+
+    @pytest.mark.asyncio
+    async def test_the_page_cap_outranks_a_refusal(self):
+        """Documented in get_statistics(): at max_pages=1 the cap wins even
+        when the site also refused every link. The crawl was told to fetch one
+        page and did, so the refusal did not change the outcome."""
+        config = WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=1,
+            max_depth=2,
+            request_delay=0,
+            tls_impersonate=None,
+        )
+        with patch(
+            "httpx.AsyncClient", return_value=self._mock_client(self.HTML_WITH_LINKS)
+        ):
+            crawler = WebCrawler(config)
+            crawler.url_filter.rejection_reason = lambda url, ua="*": REJECTED_ROBOTS
+            await crawler.crawl()
+
+        assert crawler.link_rejections[REJECTED_ROBOTS] > 0
+        assert crawler.total_links_queued == 0
+        assert crawler.stop_reason == STOPPED_PAGE_CAP
 
     @pytest.mark.asyncio
     async def test_page_cap_is_recorded(self):

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_url_filter.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_url_filter.py
@@ -184,11 +184,16 @@ def test_web_crawl_config_rejects_invalid_start_urls():
         WebCrawlConfig(start_url="http://@")
 
 
+# Captured at import, before the autouse fixture in conftest replaces
+# httpx.Client - these tests need the real one to drive redirects and rules.
+_REAL_HTTPX_CLIENT = httpx.Client
+
+
 def _patch_client_with_handler(monkeypatch, handler):
     monkeypatch.setattr(
         httpx,
         "Client",
-        partial(httpx.Client, transport=httpx.MockTransport(handler)),
+        partial(_REAL_HTTPX_CLIENT, transport=httpx.MockTransport(handler)),
     )
 
 

--- a/tests/core/tools/core/RAG_tools/web_crawler/test_url_filter.py
+++ b/tests/core/tools/core/RAG_tools/web_crawler/test_url_filter.py
@@ -8,7 +8,15 @@ import pytest
 from pydantic import ValidationError
 
 from xagent.core.tools.core.RAG_tools.core.schemas import WebCrawlConfig
-from xagent.core.tools.core.RAG_tools.web_crawler.url_filter import URLFilter
+from xagent.core.tools.core.RAG_tools.web_crawler.url_filter import (
+    REJECTED_EXCLUDED,
+    REJECTED_NOT_INCLUDED,
+    REJECTED_OFF_DOMAIN,
+    REJECTED_ROBOTS,
+    REJECTED_UNPARSABLE,
+    SITE_REJECTIONS,
+    URLFilter,
+)
 
 
 class TestURLFilter:
@@ -176,6 +184,14 @@ def test_web_crawl_config_rejects_invalid_start_urls():
         WebCrawlConfig(start_url="http://@")
 
 
+def _patch_client_with_handler(monkeypatch, handler):
+    monkeypatch.setattr(
+        httpx,
+        "Client",
+        partial(httpx.Client, transport=httpx.MockTransport(handler)),
+    )
+
+
 class _FakeResponse:
     def __init__(self, status_code: int, text: str = "") -> None:
         self.status_code = status_code
@@ -268,7 +284,7 @@ class TestRobotsTxtAvailability:
         """The kwarg assertion above cannot show the sixth hop is refused.
         s2.3.1.2 permits treating an over-long chain as unavailable (allow);
         this takes the stricter reading, so it needs a behavioural anchor."""
-        self._patch_client_with_handler(
+        _patch_client_with_handler(
             monkeypatch,
             lambda request: httpx.Response(
                 301, headers={"Location": f"{request.url}/again"}
@@ -277,13 +293,6 @@ class TestRobotsTxtAvailability:
         f = URLFilter("https://example.com", respect_robots_txt=True)
 
         assert f.should_crawl("https://example.com/docs/intro") is False
-
-    def _patch_client_with_handler(self, monkeypatch, handler):
-        monkeypatch.setattr(
-            httpx,
-            "Client",
-            partial(httpx.Client, transport=httpx.MockTransport(handler)),
-        )
 
     def test_disallow_rules_behind_a_redirect_are_honoured(self, monkeypatch):
         """http->https and www canonicalisation redirect /robots.txt routinely.
@@ -297,7 +306,7 @@ class TestRobotsTxtAvailability:
                 )
             return httpx.Response(200, text="User-agent: *\nDisallow: /private\n")
 
-        self._patch_client_with_handler(monkeypatch, handler)
+        _patch_client_with_handler(monkeypatch, handler)
         f = URLFilter("https://example.com", respect_robots_txt=True)
 
         assert f.should_crawl("https://example.com/private/secret") is False
@@ -328,3 +337,97 @@ class TestRobotsTxtAvailability:
         )
         assert f.should_crawl("https://example.com/private/secret") is False
         assert f.should_crawl("https://example.com/public/page") is True
+
+
+class TestRejectionReason:
+    """should_crawl only says no; callers need to know which rule said it."""
+
+    def test_reason_is_none_when_crawlable(self):
+        f = URLFilter("https://example.com", respect_robots_txt=False)
+        assert f.rejection_reason("https://example.com/docs") is None
+
+    def test_off_domain_is_reported_as_configuration(self):
+        f = URLFilter(
+            "https://example.com", same_domain_only=True, respect_robots_txt=False
+        )
+        assert f.rejection_reason("https://other.com/x") == REJECTED_OFF_DOMAIN
+        assert REJECTED_OFF_DOMAIN not in SITE_REJECTIONS
+
+    def test_exclusion_is_reported_as_configuration(self):
+        f = URLFilter(
+            "https://example.com",
+            exclude_patterns=[r"/private"],
+            respect_robots_txt=False,
+        )
+        assert f.rejection_reason("https://example.com/private/x") == REJECTED_EXCLUDED
+        assert REJECTED_EXCLUDED not in SITE_REJECTIONS
+
+    def test_robots_is_not_configuration(self, monkeypatch):
+        """The site refusing us is not the operator configuring us."""
+        _patch_client_with_handler(
+            monkeypatch,
+            lambda request: httpx.Response(
+                200, text="User-agent: *\nDisallow: /private\n"
+            ),
+        )
+        f = URLFilter("https://example.com", respect_robots_txt=True)
+        assert f.rejection_reason("https://example.com/private/x") == REJECTED_ROBOTS
+        assert REJECTED_ROBOTS in SITE_REJECTIONS
+
+    def test_an_unsupported_scheme_is_not_the_site_refusing(self):
+        """ftp:/data:/intent: anchors are this crawler's own limit, so they
+        must not make the site look responsible for a crawl going nowhere."""
+        f = URLFilter("https://example.com", respect_robots_txt=False)
+
+        assert f.rejection_reason("ftp://example.com/file") == REJECTED_UNPARSABLE
+        assert REJECTED_UNPARSABLE not in SITE_REJECTIONS
+
+    def test_configured_rules_win_over_robots(self, monkeypatch):
+        """A link that is both out of scope and robots-disallowed was never
+        going to be crawled regardless of what the site said, so blaming the
+        site would report the operator's own filtering as a refusal."""
+        _patch_client_with_handler(
+            monkeypatch,
+            lambda request: httpx.Response(
+                200, text="User-agent: *\nDisallow: /blog\n"
+            ),
+        )
+        f = URLFilter(
+            "https://example.com", url_patterns=[r"/docs"], respect_robots_txt=True
+        )
+
+        assert f.rejection_reason("https://example.com/blog/post") == (
+            REJECTED_NOT_INCLUDED
+        )
+        assert REJECTED_NOT_INCLUDED not in SITE_REJECTIONS
+
+    def test_excluded_wins_over_robots(self, monkeypatch):
+        _patch_client_with_handler(
+            monkeypatch,
+            lambda request: httpx.Response(
+                200, text="User-agent: *\nDisallow: /blog\n"
+            ),
+        )
+        f = URLFilter(
+            "https://example.com", exclude_patterns=[r"/blog"], respect_robots_txt=True
+        )
+
+        assert f.rejection_reason("https://example.com/blog/post") == REJECTED_EXCLUDED
+
+    def test_robots_still_reported_when_no_configured_rule_applies(self, monkeypatch):
+        _patch_client_with_handler(
+            monkeypatch,
+            lambda request: httpx.Response(
+                200, text="User-agent: *\nDisallow: /blog\n"
+            ),
+        )
+        f = URLFilter("https://example.com", respect_robots_txt=True)
+
+        assert f.rejection_reason("https://example.com/blog/post") == REJECTED_ROBOTS
+
+    def test_should_crawl_still_agrees_with_the_reason(self):
+        f = URLFilter(
+            "https://example.com", same_domain_only=True, respect_robots_txt=False
+        )
+        for url in ("https://example.com/ok", "https://other.com/no"):
+            assert f.should_crawl(url) is (f.rejection_reason(url) is None)


### PR DESCRIPTION
## Invariant

The crawler records why it stopped, and only robots.txt counts as the site
refusing. Crawl behaviour itself is unchanged — this PR only changes what is
recorded.

## Problem

A crawl with zero failures can still produce a one-page knowledge base while
every field reads as good news. Telling "configuration stopped it" apart from
"the site refused every link" requires the crawler to say why it stopped.
Today it does not.

## Changes

1. **`URLFilter.rejection_reason()`** returns which rule rejected a link
   (`off_domain`, `excluded_pattern`, `not_included_pattern`, `robots_txt`,
   `unparsable`); `should_crawl()` becomes a wrapper over it and behaves
   identically. Every configured rule is checked **before** robots.txt: a link
   that was out of scope was never going to be crawled regardless of what the
   site said, so attributing the overlap to robots would report the operator's
   own filtering as a refusal.

2. **`SITE_REJECTIONS = frozenset({REJECTED_ROBOTS})`** — membership, never the
   complement. Scope rules belong to the operator and an unsupported scheme
   (`ftp:`, `data:`, `intent:`) is this crawler's own limit; neither may make
   the site look responsible. With a complement, every reason added later
   silently defaults to "the site refused us".

3. **`WebCrawler`** tracks `total_links_queued` (links that actually entered
   the frontier), `link_rejections` (per reason, **deduplicated per distinct
   URL**), and `stop_reason` (`page_cap_reached` / `no_more_links` /
   `no_eligible_links`), all exposed through `get_statistics()`.

4. **`_site_refused_the_frontier()`** asks about the frontier rather than about
   rejection ratios: a crawl that queued a page was making progress whatever
   else it turned away, and only when nothing was queued does a robots refusal
   mean the site closed the door.

## Entry points

`URLFilter.rejection_reason` · `WebCrawler._crawl_loop` · `WebCrawler.get_statistics`

## Non-goals

- **No consumer.** No field on `WebIngestionResult`, no change to `status`, no
  change to the ingestion pipeline or the Vibe adapter. This PR is the
  groundwork; a follow-up hands the signal to callers.
- No change to crawl behaviour, content extraction, chunking, or retrieval
  scoring.

## Known scope limit

`total_links_queued` is lifetime-cumulative and checked once after the loop
ends, and `max_depth >= 1` guarantees the start page's links are always
depth-eligible. The refusal signal therefore fires **only when the crawl
produced exactly one page in total**.

It structurally cannot detect the more common shape where robots.txt allows a
handful of pages and blocks a large subtree: that records `no_more_links`,
indistinguishable from a genuinely small site. Per-generation tracking is
follow-up work; the tradeoff is pinned by
`test_a_refusal_alongside_real_progress_is_not_a_blocked_crawl`.

## Blocking criteria

- Page cap, depth, deliberate filtering, and a genuinely single-page site all
  still report a configured stop
- A site refusing every link reports `no_eligible_links`
- `should_crawl()` and `rejection_reason()` never disagree

## Verification

This also fixes a pre-existing test defect. `URLFilter.__init__` fetches
robots.txt **synchronously** when `respect_robots_txt` defaults to true, while
`test_crawler.py` patches only `httpx.AsyncClient` — so 20+ cases in that file
were each firing a real HTTPS request at `example.com/robots.txt`. The failure
mode was silent (the fetch swallows its own exception), so an offline or
sandboxed CI degraded quietly into exercising a different code path instead of
failing. A module-level autouse fixture closes it: the file drops from ~60s to
3.7s and passes with the network blackholed.

Mutations each killed by a test: widening the site-refusal check back to any
rejection, dropping the frontier guard, dropping the queue increment, keying
the rejection dedup on the raw link instead of the normalized URL, dropping
that dedup entirely, swapping the page-cap/refusal precedence, and emptying
`SITE_REJECTIONS`.

The robots.txt fetch is synchronous inside `URLFilter.__init__`, so the
autouse fixture that blocks it lives in a shared `conftest.py` rather than in
one test module: `test_url_filter.py` was still issuing live requests from six
cases. The whole `web_crawler` test directory now runs in 3.8s at 99% CPU and
passes with the network blackholed.
`tests/core/tools/core/RAG_tools` passes; pre-commit (incl. mypy) passes.

