### PR TITLE
feat(web-ingestion): flag a site-blocked crawl without failing the import

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/web_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/web_ingestion_tool.py
@@ -206,8 +206,8 @@ async def _create_knowledge_base_from_url_impl(
                 collection_name=collection_name,
                 message=(
                     f"{result.message} '{collection_name}' is published and "
-                    f"usable with what did land. Do not re-import; the site "
-                    f"will refuse the same links again."
+                    f"usable with what did land. Re-importing under the same "
+                    f"crawl settings will hit the same refusals."
                 ),
                 pages_crawled=result.pages_crawled,
             ).model_dump()

--- a/src/xagent/core/tools/adapters/vibe/web_ingestion_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/web_ingestion_tool.py
@@ -193,6 +193,25 @@ async def _create_knowledge_base_from_url_impl(
             ).model_dump()
         await kb_service.refresh_collection_metadata(collection_name)
 
+        if result.crawl_blocked_by_site:
+            # Narrower than status == "partial" on purpose: a partial caused by
+            # individual pages failing to parse keeps reporting success, which
+            # is the existing policy. This is the other kind - nothing failed,
+            # the site simply refused everything past the start page. The pages
+            # that did land stay published (re-importing would re-crawl them),
+            # but calling it success would let an agent build on a knowledge
+            # base holding one page.
+            return CreateKnowledgeBaseFromUrlResult(
+                success=False,
+                collection_name=collection_name,
+                message=(
+                    f"{result.message} '{collection_name}' is published and "
+                    f"usable with what did land. Do not re-import; the site "
+                    f"will refuse the same links again."
+                ),
+                pages_crawled=result.pages_crawled,
+            ).model_dump()
+
         return CreateKnowledgeBaseFromUrlResult(
             success=True,
             collection_name=collection_name,

--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -2279,9 +2279,9 @@ class WebIngestionResult(BaseModel):
         default=False,
         description=(
             "The crawl ended because the site refused every link past the "
-            "start page. Callers need this to tell such a partial from one "
-            "caused by individual pages failing to parse, which is not the "
-            "site's doing and keeps its existing success policy."
+            "start page. Only ever set alongside status='success' - a run with "
+            "page failures is already partial or error, and this flag is about "
+            "what the site did rather than about how ingestion went."
         ),
     )
     collection: str = Field(..., description="Target collection name")

--- a/src/xagent/core/tools/core/RAG_tools/core/schemas.py
+++ b/src/xagent/core/tools/core/RAG_tools/core/schemas.py
@@ -2269,7 +2269,20 @@ class WebIngestionResult(BaseModel):
 
     status: str = Field(
         ...,
-        description="Overall status: success|error|partial",
+        description=(
+            "Overall status: success|error|partial. A crawl the site blocked "
+            "is still success when its pages were ingested; see "
+            "crawl_blocked_by_site."
+        ),
+    )
+    crawl_blocked_by_site: bool = Field(
+        default=False,
+        description=(
+            "The crawl ended because the site refused every link past the "
+            "start page. Callers need this to tell such a partial from one "
+            "caused by individual pages failing to parse, which is not the "
+            "site's doing and keeps its existing success policy."
+        ),
     )
     collection: str = Field(..., description="Target collection name")
 

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -34,14 +34,7 @@ from ..utils.string_utils import sanitize_for_doc_id
 from ..utils.user_scope import resolve_user_scope
 from ..web_crawler import WebCrawler
 from ..web_crawler.crawler import STOPPED_NO_ELIGIBLE_LINKS
-from ..web_crawler.url_filter import (
-    REJECTED_EXCLUDED,
-    REJECTED_NOT_INCLUDED,
-    REJECTED_OFF_DOMAIN,
-    REJECTED_ROBOTS,
-    REJECTED_UNPARSABLE,
-    SITE_REJECTIONS,
-)
+from ..web_crawler.url_filter import REJECTED_ROBOTS, SITE_REJECTIONS
 from .document_ingestion import run_document_ingestion
 
 if TYPE_CHECKING:
@@ -49,13 +42,11 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Reason keys are internal identifiers; this text reaches an end user.
+# Reason keys are internal identifiers; this text reaches an end user. Only
+# SITE_REJECTIONS reasons are ever rendered, so this covers exactly those -
+# a reason added to that set needs a label here too.
 _REJECTION_LABELS = {
-    REJECTED_OFF_DOMAIN: "blocked by the same-domain rule",
-    REJECTED_EXCLUDED: "blocked by an exclude pattern",
-    REJECTED_NOT_INCLUDED: "outside the include patterns",
     REJECTED_ROBOTS: "blocked by robots.txt rules",
-    REJECTED_UNPARSABLE: "not a crawlable http(s) link",
 }
 
 
@@ -73,10 +64,13 @@ def _blocked_crawl_explanation(
         for reason in sorted(SITE_REJECTIONS)
         if rejections.get(reason)
     )
+    # Unreachable today - the stop reason this message explains requires a site
+    # rejection - but an empty parenthetical would read as a formatting bug.
+    cause = f" ({refused})" if refused else ""
     return (
         f"Only {documents_created} document(s) from {pages_crawled} page(s) "
-        f"could be imported: every link found was refused ({refused}). The "
-        f"pages that were reachable have been ingested."
+        f"could be imported: every link found was refused{cause}. The pages "
+        f"that were reachable have been ingested."
     )
 
 

--- a/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
+++ b/src/xagent/core/tools/core/RAG_tools/pipelines/web_ingestion.py
@@ -33,12 +33,52 @@ from ..utils.config_utils import coerce_ingestion_config
 from ..utils.string_utils import sanitize_for_doc_id
 from ..utils.user_scope import resolve_user_scope
 from ..web_crawler import WebCrawler
+from ..web_crawler.crawler import STOPPED_NO_ELIGIBLE_LINKS
+from ..web_crawler.url_filter import (
+    REJECTED_EXCLUDED,
+    REJECTED_NOT_INCLUDED,
+    REJECTED_OFF_DOMAIN,
+    REJECTED_ROBOTS,
+    REJECTED_UNPARSABLE,
+    SITE_REJECTIONS,
+)
 from .document_ingestion import run_document_ingestion
 
 if TYPE_CHECKING:
     from ..kb import KBPipelineCompatibilityFacade
 
 logger = logging.getLogger(__name__)
+
+# Reason keys are internal identifiers; this text reaches an end user.
+_REJECTION_LABELS = {
+    REJECTED_OFF_DOMAIN: "blocked by the same-domain rule",
+    REJECTED_EXCLUDED: "blocked by an exclude pattern",
+    REJECTED_NOT_INCLUDED: "outside the include patterns",
+    REJECTED_ROBOTS: "blocked by robots.txt rules",
+    REJECTED_UNPARSABLE: "not a crawlable http(s) link",
+}
+
+
+def _blocked_crawl_explanation(
+    crawl_stats: dict, documents_created: int, pages_crawled: int
+) -> str:
+    """Say that the site refused the crawl, counting only what the site did.
+
+    Configured rejections are the operator's own scope rules; listing them in a
+    sentence that blames the site would report that filtering as a refusal.
+    """
+    rejections = crawl_stats.get("link_rejections", {})
+    refused = ", ".join(
+        f"{rejections[reason]} {_REJECTION_LABELS.get(reason, reason)}"
+        for reason in sorted(SITE_REJECTIONS)
+        if rejections.get(reason)
+    )
+    return (
+        f"Only {documents_created} document(s) from {pages_crawled} page(s) "
+        f"could be imported: every link found was refused ({refused}). The "
+        f"pages that were reachable have been ingested."
+    )
+
 
 FileHandlerCallback = Callable[..., Any]
 
@@ -857,6 +897,22 @@ async def _run_web_ingestion_impl(
     if rollback_failed_urls:
         status = "error"
 
+    # A crawl can end with zero failures and still not be what the user asked
+    # for: every link the start page offered was refused by the site. Configured
+    # stops (page cap, depth, deliberate filtering) are not this case, which is
+    # why the reason comes from the crawler rather than from link counts.
+    #
+    # This deliberately does not touch `status`. The pages that landed were
+    # ingested and published, which is what "success" means to every consumer
+    # of that enum - the REST handler returns 200 and both frontend call sites
+    # treat anything else as a hard failure. The blocked crawl is a different
+    # fact about the same run, so it travels as its own flag plus a warning.
+    crawl_stats = crawler.get_statistics()
+    blocked_stop = (
+        status == "success"
+        and crawl_stats.get("stop_reason") == STOPPED_NO_ELIGIBLE_LINKS
+    )
+
     crawled_urls_list = [r.url for r in crawl_results if r.status == "success"]
 
     # Build a status-aware message. Previously this was unconditionally
@@ -901,6 +957,11 @@ async def _run_web_ingestion_impl(
                     f"{pages_crawled} pages, {len(failed_urls)} failed "
                     f"(first: {first_url} returned {first_err})"
                 )
+    elif blocked_stop:
+        message = _blocked_crawl_explanation(
+            crawl_stats, documents_created, pages_crawled
+        )
+        warnings = [*warnings, message]
     else:
         message = (
             f"Web ingestion completed: {documents_created} documents, "
@@ -909,6 +970,7 @@ async def _run_web_ingestion_impl(
 
     result = WebIngestionResult(
         status=status,
+        crawl_blocked_by_site=blocked_stop,
         collection=collection,
         total_urls_found=crawler.total_urls_found,
         pages_crawled=pages_crawled,

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -354,6 +354,66 @@ async def test_create_kb_from_url_empty_crawl_publishes_nothing(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_create_kb_from_url_blocked_crawl_is_not_reported_as_success(monkeypatch):
+    """A site that refused every link past the start page yields documents and
+    no failures, so the pipeline reports success - correctly, for the REST and
+    UI consumers that publish and display what landed. An agent needs the
+    opposite answer: it would otherwise build on a one-page knowledge base."""
+    monkeypatch.setenv(WEB_CRAWL_TLS_IMPERSONATE, "auto")
+
+    ingest_result = WebIngestionResult(
+        status="success",
+        crawl_blocked_by_site=True,
+        collection="agent_url_kb",
+        total_urls_found=5,
+        pages_crawled=1,
+        pages_failed=0,
+        documents_created=1,
+        chunks_created=6,
+        embeddings_created=6,
+        crawled_urls=["https://example.com"],
+        failed_urls={},
+        message=(
+            "Web ingestion incomplete: 1 documents from 1 page(s). No further "
+            "pages could be crawled - every link found was refused "
+            "(5 blocked by robots.txt rules)."
+        ),
+        warnings=[],
+        elapsed_time_ms=1,
+    )
+    service = MagicMock()
+    service.prepare_collection = AsyncMock(return_value="agent_url_kb")
+    service.publish_collection = AsyncMock()
+    service.collection_exists = AsyncMock(return_value=False)
+    service.cleanup_failed_collection = AsyncMock()
+    service.refresh_collection_metadata = AsyncMock()
+
+    with (
+        patch(
+            "xagent.core.tools.adapters.vibe.agent_kb_service.AgentKnowledgeBaseService",
+            return_value=service,
+        ),
+        patch(
+            "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion.run_web_ingestion",
+            new=AsyncMock(return_value=ingest_result),
+        ),
+    ):
+        tool = CreateKnowledgeBaseFromUrlTool(user_id=71, is_admin=False)
+        result = await tool.run_json_async(
+            {"url": "https://example.com", "collection_name": "agent_url_kb"}
+        )
+
+    assert result["success"] is False
+    assert "blocked by robots.txt rules" in result["message"]
+    assert "Do not re-import" in result["message"]
+    assert result["pages_crawled"] == 1
+    # The one page that did land is kept: re-importing would re-crawl it, and
+    # discarding it helps nobody.
+    service.publish_collection.assert_awaited_once()
+    service.cleanup_failed_collection.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_create_kb_from_url_uses_shared_service(monkeypatch):
     monkeypatch.setenv(WEB_CRAWL_TLS_IMPERSONATE, "auto")
 

--- a/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
+++ b/tests/core/tools/adapters/vibe/test_kb_creation_tools.py
@@ -31,6 +31,9 @@ from xagent.core.tools.core.RAG_tools.kb.operation_compatibility import (
     RollbackStatus,
     SideEffectPlane,
 )
+from xagent.core.tools.core.RAG_tools.pipelines.web_ingestion import (
+    _blocked_crawl_explanation,
+)
 
 
 class _FakeMetadataStore:
@@ -373,10 +376,13 @@ async def test_create_kb_from_url_blocked_crawl_is_not_reported_as_success(monke
         embeddings_created=6,
         crawled_urls=["https://example.com"],
         failed_urls={},
-        message=(
-            "Web ingestion incomplete: 1 documents from 1 page(s). No further "
-            "pages could be crawled - every link found was refused "
-            "(5 blocked by robots.txt rules)."
+        # Built by the pipeline rather than hand-written, so a change to the
+        # wording cannot leave this fixture asserting a format that no longer
+        # exists.
+        message=_blocked_crawl_explanation(
+            {"link_rejections": {"robots_txt": 5}},
+            documents_created=1,
+            pages_crawled=1,
         ),
         warnings=[],
         elapsed_time_ms=1,
@@ -405,7 +411,7 @@ async def test_create_kb_from_url_blocked_crawl_is_not_reported_as_success(monke
 
     assert result["success"] is False
     assert "blocked by robots.txt rules" in result["message"]
-    assert "Do not re-import" in result["message"]
+    assert "same crawl settings will hit the same refusals" in result["message"]
     assert result["pages_crawled"] == 1
     # The one page that did land is kept: re-importing would re-crawl it, and
     # discarding it helps nobody.

--- a/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_pipeline_compatibility.py
@@ -27,6 +27,7 @@ from xagent.core.tools.core.RAG_tools.kb.models import (
     RollbackFailedIngestionRequest,
     RollbackFailedIngestionResult,
 )
+from xagent.core.tools.core.RAG_tools.web_crawler.crawler import STOPPED_NO_LINKS
 
 
 class _FakeMetadataStore:
@@ -554,6 +555,9 @@ class _SinglePageCrawler:
     ) -> None:
         self.total_urls_found = 1
         self.failed_urls: dict[str, str] = {}
+
+    def get_statistics(self) -> dict:
+        return {"stop_reason": STOPPED_NO_LINKS, "link_rejections": {}}
 
     async def crawl(self) -> list[CrawlResult]:
         return [

--- a/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
+++ b/tests/core/tools/core/RAG_tools/pipelines/test_web_ingestion.py
@@ -18,6 +18,11 @@ from xagent.core.tools.core.RAG_tools.pipelines.web_ingestion import (
 )
 from xagent.core.tools.core.RAG_tools.utils.string_utils import sanitize_for_doc_id
 from xagent.core.tools.core.RAG_tools.utils.user_scope import user_scope_context
+from xagent.core.tools.core.RAG_tools.web_crawler.crawler import (
+    STOPPED_NO_ELIGIBLE_LINKS,
+    STOPPED_NO_LINKS,
+    STOPPED_PAGE_CAP,
+)
 
 
 class TestWebIngestionPipeline:
@@ -1345,3 +1350,150 @@ class TestWebIngestionFileHandler:
 
         assert result.status == "success"
         assert events == [("commit", successful_ingestion)]
+
+
+class TestCrawlStopReasonDrivesStatus:
+    """A crawl that ends because the site refused every link is not a success,
+    but one that ends because the operator capped or filtered it is.
+
+    Predicates here read the crawler's stop reason rather than link counts:
+    `total_urls_found` is raw extractor output taken before URLFilter, so it
+    cannot tell a page cap or a deliberate filter from a site that blocked us.
+    """
+
+    @pytest.fixture
+    def crawl_config(self):
+        return WebCrawlConfig(
+            start_url="https://example.com",
+            max_pages=3,
+            max_depth=1,
+            concurrent_requests=1,
+            request_delay=0,
+        )
+
+    @pytest.fixture
+    def ingestion_config(self):
+        return IngestionConfig(chunk_size=500, chunk_overlap=100)
+
+    async def _run(self, crawl_config, ingestion_config, *, stop_reason, rejections):
+        ingestion_result = IngestionResult(
+            status="success",
+            doc_id="d",
+            parse_hash="h",
+            chunk_count=6,
+            embedding_count=6,
+            vector_count=6,
+            completed_steps=[],
+            failed_step=None,
+            message="Success",
+            warnings=[],
+        )
+        page = MagicMock(
+            url="https://example.com/",
+            title="Home",
+            content_markdown="# Home",
+            status="success",
+            depth=0,
+            timestamp=datetime(2025, 1, 1, 12, 0, 0),
+            content_length=50,
+        )
+        with patch(
+            "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion.WebCrawler"
+        ) as mock_crawler_class:
+            crawler = MagicMock()
+            crawler.crawl = AsyncMock(return_value=[page])
+            crawler.total_urls_found = sum(rejections.values())
+            crawler.failed_urls = {}
+            crawler.get_statistics.return_value = {
+                "stop_reason": stop_reason,
+                "link_rejections": rejections,
+                "total_links_queued": 0,
+            }
+            mock_crawler_class.return_value = crawler
+            with patch(
+                "xagent.core.tools.core.RAG_tools.pipelines.web_ingestion.run_document_ingestion",
+                return_value=ingestion_result,
+            ):
+                return await run_web_ingestion(
+                    collection="test_collection",
+                    crawl_config=crawl_config,
+                    ingestion_config=ingestion_config,
+                )
+
+    @pytest.mark.asyncio
+    async def test_every_link_refused_by_the_site_is_flagged(
+        self, crawl_config, ingestion_config
+    ):
+        """status stays success: the pages that landed were ingested and
+        published, which is what it means to every consumer of that enum. The
+        block is a separate fact and travels as its own flag and warning."""
+        result = await self._run(
+            crawl_config,
+            ingestion_config,
+            stop_reason=STOPPED_NO_ELIGIBLE_LINKS,
+            rejections={"robots_txt": 5},
+        )
+
+        assert result.status == "success"
+        assert result.crawl_blocked_by_site is True
+        assert "every link found was refused" in result.message
+        assert "5 blocked by robots.txt rules" in result.message
+        assert "robots_txt" not in result.message
+        assert result.message in result.warnings
+
+    @pytest.mark.asyncio
+    async def test_configured_rejections_stay_out_of_the_refusal_message(
+        self, crawl_config, ingestion_config
+    ):
+        """The same-domain rule is the operator's own scope restriction. Listing
+        it inside a sentence blaming the site reports that filtering as a
+        refusal, which is the distinction SITE_REJECTIONS exists to draw."""
+        result = await self._run(
+            crawl_config,
+            ingestion_config,
+            stop_reason=STOPPED_NO_ELIGIBLE_LINKS,
+            rejections={"off_domain": 40, "robots_txt": 5},
+        )
+
+        assert "5 blocked by robots.txt rules" in result.message
+        assert "same-domain" not in result.message
+        assert "40" not in result.message
+
+    @pytest.mark.asyncio
+    async def test_page_cap_is_a_success(self, crawl_config, ingestion_config):
+        result = await self._run(
+            crawl_config,
+            ingestion_config,
+            stop_reason=STOPPED_PAGE_CAP,
+            rejections={},
+        )
+
+        assert result.status == "success"
+        assert result.crawl_blocked_by_site is False
+        assert "Web ingestion completed" in result.message
+
+    @pytest.mark.asyncio
+    async def test_deliberate_filtering_is_a_success(
+        self, crawl_config, ingestion_config
+    ):
+        """Every outgoing link was off-domain: the filter did its job."""
+        result = await self._run(
+            crawl_config,
+            ingestion_config,
+            stop_reason=STOPPED_NO_LINKS,
+            rejections={"off_domain": 7},
+        )
+
+        assert result.status == "success"
+        assert "Web ingestion completed" in result.message
+
+    @pytest.mark.asyncio
+    async def test_single_page_site_is_a_success(self, crawl_config, ingestion_config):
+        result = await self._run(
+            crawl_config,
+            ingestion_config,
+            stop_reason=STOPPED_NO_LINKS,
+            rejections={},
+        )
+
+        assert result.status == "success"


### PR DESCRIPTION
## Invariant

A crawl the site blocked carries a machine-readable flag and a sentence of
explanation. `status` is unchanged.

Stacked on #2092, which is not yet merged, so GitHub shows both commits here.
**Review only `feat(web-ingestion): flag a site-blocked crawl...`** — the
crawler-layer commit belongs to #2092 and is under review there. The files
split cleanly: #2092 owns `web_crawler/`, this PR owns `pipelines/`,
`core/schemas.py` and `adapters/vibe/`. Once #2092 merges this diff narrows to
its own commit.

## Problem

#2092 makes the crawler say why it stopped, but nothing listens. A blocked
crawl still reports `1 documents, 6 chunks, 6 embeddings` — every field good
news.

## Why `status` is left alone

The previous revision (closed #2053) downgraded this case from `success` to
`partial`. That was wrong, and wrong across a layer boundary:

- `ingest_web` in `src/xagent/web/api/kb.py` only logs a warning for `partial`
  — it still returns HTTP 200 and keeps and publishes the collection.
- Both frontend call sites do `if (result.status !== "success") { throw ... }`
  (`knowledge-base-creation-dialog.tsx:784`,
  `knowledge-base-detail.tsx:694`).

Net effect of the downgrade: an import whose pages landed and were published
raised a red error toast, left the creation dialog open, never fired
`onSuccess` (so the parent list never learned about the collection), and left
the detail page stale.

The pages that landed *were* ingested and published, which is what `status`
means to every consumer of it. That the crawl was blocked is a different fact
about the same run, so it travels as its own field.

## Changes

1. **`WebIngestionResult.crawl_blocked_by_site`** — a boolean, set from the
   `blocked_stop` the pipeline already computes.

2. **The explanation goes into `warnings`**, which the creation dialog already
   renders (`knowledge-base-creation-dialog.tsx:1464-1474`). It counts only
   `SITE_REJECTIONS` reasons: the same-domain rule is the operator's own scope
   restriction, and listing it inside a sentence blaming the site would report
   that filtering as a refusal. This also gives `SITE_REJECTIONS` a real
   production consumer at this layer.

3. **The Vibe adapter** returns `success=False` on that flag, with the same
   kind of steer its sibling publish-failure branch carries: the collection is
   published and usable with what landed, do not re-import, the site will
   refuse the same links again. This is deliberately narrower than
   `status == "partial"` — an existing test pins that a partial caused by
   individual pages failing to parse still reports success, and widening the
   branch would silently reverse that policy.

All three consumer groups get the signal: the UI through `warnings`, the agent
through the flag, REST clients through the flag on the payload.

## Entry points

`run_web_ingestion` · `_blocked_crawl_explanation` · `CreateKnowledgeBaseFromUrlTool`

## Non-goals

- No frontend change. Whether the UI gives this flag dedicated treatment is
  frontend work and belongs in its own change.
- No change to the values or meaning of the `status` enum, and none to crawl
  behaviour.

## On issue #2052

The issue asks for a non-success signal for a blocked crawl, and this
deliberately does not change `status`. The signal reaches all three consumers,
but not through the status enum. I will say so on the issue rather than quietly
redefine what it asked for.

## Verification

Five mutations are each killed by a test: not filtering the message to site
reasons, not appending the explanation to `warnings`, pinning the flag to
`False`, removing the Vibe branch, and dropping the "do not re-import" steer.
`tests/core/tools/core/RAG_tools` and `tests/core/tools/adapters/vibe` pass;
pre-commit (incl. mypy) passes.
