### PR TITLE
fix(ci): restrict the nightly build to the upstream repository

### DIFF
--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -34,6 +34,9 @@ env:
 
 jobs:
   build-and-push-nightly:
+    # Upstream only: the schedule pushes to the xprobe/* Docker Hub namespace.
+    # workflow_dispatch stays open so a fork can test changes by hand.
+    if: github.event_name == 'workflow_dispatch' || github.repository_owner == 'xorbitsai'
     timeout-minutes: 240
     runs-on: ubuntu-latest
     permissions:
@@ -190,7 +193,8 @@ jobs:
           labels: ${{ steps.meta-frontend-ghcr.outputs.labels }}
 
       - name: Notify on failure
-        if: failure()
+        # Forks have Issues disabled by default, so this would just fail again.
+        if: ${{ failure() && github.repository_owner == 'xorbitsai' }}
         uses: actions/github-script@v9
         with:
           script: |


### PR DESCRIPTION
`nightly-build.yml` has no repository guard, so a fork that enables Actions starts running the nightly build daily at 20:00 UTC. GitHub disables scheduled workflows when a public repo is forked, but enabling Actions to run CI on a branch is a single click, and that re-enables the schedule too.

A fork run checks out its own `main`, then fails at the Docker Hub login because `DOCKERHUB_USERNAME`/`DOCKERHUB_PASSWORD` are empty — after burning a few minutes on the disk-cleanup, Buildx, and QEMU steps. `Notify on failure` then tries to open an issue, which forks have disabled by default, so it fails too and buries the real cause.

This applies the same guard already used by `image-security-scan.yml`:

- The job is scoped to `github.repository_owner == 'xorbitsai'` for scheduled runs. A skipped job allocates no runner, so a fork spends nothing.
- `workflow_dispatch` stays open everywhere, so a fork can still run it by hand to test changes to this file.
- `Notify on failure` is upstream-only as well, so a fork's manual dispatch fails cleanly on the real error instead of on a second error from the issue-creation step.

No behavior change upstream: `github.repository_owner` is `xorbitsai` here, so both the schedule and manual dispatch run exactly as before.

Out of scope: `BACKEND_IMAGE`/`FRONTEND_IMAGE` are still hardcoded to `xprobe/*`, so a fork's manual dispatch aims at this org's namespace and fails on push auth. Making those owner-derived is a separate change.
