### PR TITLE
fix: close the OS-native proxy bypass in httpx web-fetch clients

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/download_web_asset.py
+++ b/src/xagent/core/tools/adapters/vibe/download_web_asset.py
@@ -18,6 +18,7 @@ from ....workspace import TaskWorkspace
 from ...core.web_content import (
     DEFAULT_MAX_CONTENT_BYTES,
     DEFAULT_USER_AGENT,
+    build_isolated_httpx_client_kwargs,
     get_trusted_proxy_url,
 )
 from .base import AbstractBaseTool, ToolCategory, ToolVisibility
@@ -128,10 +129,8 @@ class DownloadWebAssetTool(AbstractBaseTool):
             ).model_dump()
 
     async def _download(self, url: str) -> tuple[bytes, str, str]:
-        client_kwargs: dict[str, Any] = {}
         proxy_url = get_trusted_proxy_url()
-        if proxy_url:
-            client_kwargs["proxy"] = proxy_url
+        client_kwargs = build_isolated_httpx_client_kwargs(proxy_url)
 
         async with httpx.AsyncClient(**client_kwargs) as client:
             response = await fetch_public_http_bytes(

--- a/src/xagent/core/tools/core/vision_tool.py
+++ b/src/xagent/core/tools/core/vision_tool.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel, Field
 from ...model.chat.basic.base import BaseLLM
 from ...utils.security import fetch_public_http_bytes
 from ...utils.svg import MAX_SVG_BYTES, rasterize_svg_bytes, validate_svg_bytes
-from .web_content import get_trusted_proxy_url
+from .web_content import build_isolated_httpx_client_kwargs, get_trusted_proxy_url
 
 try:
     from PIL import Image, ImageDraw, ImageFont
@@ -241,10 +241,8 @@ class VisionCore:
         )
 
     async def _download_remote_svg_source(self, url: str) -> str:
-        client_kwargs: dict[str, Any] = {}
         proxy_url = get_trusted_proxy_url()
-        if proxy_url:
-            client_kwargs["proxy"] = proxy_url
+        client_kwargs = build_isolated_httpx_client_kwargs(proxy_url)
 
         async with httpx.AsyncClient(**client_kwargs) as client:
             response = await fetch_public_http_bytes(

--- a/src/xagent/core/tools/core/web_content.py
+++ b/src/xagent/core/tools/core/web_content.py
@@ -124,6 +124,42 @@ def get_trusted_proxy_url() -> str | None:
     return proxy_url
 
 
+def build_isolated_httpx_client_kwargs(proxy_url: str | None) -> dict[str, Any]:
+    """Return ``httpx.AsyncClient`` kwargs that never trust ambient proxy config.
+
+    ``httpx.AsyncClient`` defaults to ``trust_env=True``, which (via
+    ``httpx._utils.get_environment_proxies()``) falls back to
+    ``urllib.request.getproxies()`` once no ``HTTP(S)_PROXY``/``ALL_PROXY``
+    env var is set -- and that function itself falls back to the OS's own
+    proxy configuration (``getproxies_macosx_sysconf()``/
+    ``getproxies_registry()`` on macOS/Windows, confirmed against the
+    installed httpx source). That reopens the DNS-rebinding TOCTOU window
+    ``get_trusted_proxy_url()`` exists to close, even when it returns
+    ``None`` because no proxy is explicitly trusted: the caller of this
+    module would still silently route through whatever proxy the OS itself
+    is configured with. ``trust_env=False`` disables that whole lookup, but
+    an explicit ``proxy=`` kwarg (passed by the caller here, never derived
+    from the client) is honored regardless of ``trust_env``.
+
+    ``trust_env=False`` also stops httpx from honoring ``SSL_CERT_FILE``/
+    ``SSL_CERT_DIR`` for the default CA bundle (both gated behind the same
+    ``trust_env`` flag in ``httpx.create_ssl_context()``), which would break
+    TLS verification for a host behind a private/internal CA. Build that SSL
+    context explicitly with ``trust_env=True`` and pass it as ``verify=``:
+    once ``verify`` is already a concrete ``ssl.SSLContext``,
+    ``create_ssl_context()`` returns it unchanged, so the client's own
+    ``trust_env=False`` no longer affects CA lookup at all.
+    """
+
+    client_kwargs: dict[str, Any] = {
+        "trust_env": False,
+        "verify": httpx.create_ssl_context(trust_env=True),
+    }
+    if proxy_url:
+        client_kwargs["proxy"] = proxy_url
+    return client_kwargs
+
+
 class WebContentFetcher:
     """Fetch webpages and convert readable HTML content to markdown."""
 
@@ -146,10 +182,9 @@ class WebContentFetcher:
 
         headers = {"User-Agent": DEFAULT_USER_AGENT}
         try:
-            client_kwargs: dict[str, Any] = {}
             if self._proxy_url:
-                client_kwargs["proxy"] = self._proxy_url
                 logger.info("Using proxy for webpage fetch: %s", self._proxy_url)
+            client_kwargs = build_isolated_httpx_client_kwargs(self._proxy_url)
 
             async with httpx.AsyncClient(**client_kwargs) as client:
                 response = await fetch_public_http_bytes(

--- a/tests/core/tools/test_download_web_asset.py
+++ b/tests/core/tools/test_download_web_asset.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import io
+import ssl
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
 import pytest
@@ -296,3 +297,43 @@ async def test_download_web_asset_rejects_invalid_declared_length(
     assert result["success"] is False
     assert result["error"] == f"Invalid remote asset content length: {declared_length}"
     assert list(workspace.output_dir.iterdir()) == []
+
+
+@pytest.mark.asyncio
+async def test_download_disables_trust_env_but_honors_explicit_proxy(
+    workspace: TaskWorkspace,
+) -> None:
+    # httpx.AsyncClient defaults to trust_env=True, which falls back to the
+    # OS's own proxy configuration (getproxies_macosx_sysconf()/
+    # getproxies_registry()) once no HTTP(S)_PROXY env var is set --
+    # reopening the DNS-rebinding TOCTOU window get_trusted_proxy_url()
+    # exists to close. trust_env=False must be set explicitly, while the
+    # proxy this connector *does* trust must still be passed through.
+    content = _png_bytes()
+    response = httpx.Response(
+        200,
+        content=content,
+        headers={"content-type": "image/png", "content-length": str(len(content))},
+        request=httpx.Request("GET", "https://brand.example/logo.png"),
+    )
+    tool = DownloadWebAssetTool(workspace)
+
+    with (
+        patch(
+            "xagent.core.tools.adapters.vibe.download_web_asset.get_trusted_proxy_url",
+            return_value="http://trusted-proxy.internal:8080",
+        ),
+        patch(
+            "xagent.core.tools.adapters.vibe.download_web_asset.httpx.AsyncClient"
+        ) as async_client,
+    ):
+        client = async_client.return_value.__aenter__.return_value
+        client.stream = Mock(return_value=_ResponseContext(response))
+        result = await tool.run_json_async({"url": "https://brand.example/logo.png"})
+
+    assert result["success"] is True
+    async_client.assert_called_once()
+    client_kwargs = async_client.call_args.kwargs
+    assert client_kwargs["proxy"] == "http://trusted-proxy.internal:8080"
+    assert client_kwargs["trust_env"] is False
+    assert isinstance(client_kwargs["verify"], ssl.SSLContext)

--- a/tests/core/tools/test_fetch_web_content.py
+++ b/tests/core/tools/test_fetch_web_content.py
@@ -1,5 +1,6 @@
 """Tests for FetchWebContent tool."""
 
+import ssl
 from unittest.mock import AsyncMock, Mock, patch
 
 import httpx
@@ -10,7 +11,12 @@ from xagent.core.tools.adapters.vibe.fetch_web_content import (
     FetchWebContentResult,
     FetchWebContentTool,
 )
-from xagent.core.tools.core.web_content import WebContentFetcher, get_trusted_proxy_url
+from xagent.core.tools.core import web_content
+from xagent.core.tools.core.web_content import (
+    WebContentFetcher,
+    build_isolated_httpx_client_kwargs,
+    get_trusted_proxy_url,
+)
 from xagent.core.utils.security import PrivateNetworkHostError
 
 
@@ -423,3 +429,90 @@ class TestGetTrustedProxyUrl:
         assert result["success"] is False
         assert "XAGENT_TRUSTED_EGRESS_PROXY" in result["error"]
         mock_stream.assert_not_called()
+
+
+class TestBuildIsolatedHttpxClientKwargs:
+    """httpx.AsyncClient defaults to trust_env=True, which (via
+    httpx._utils.get_environment_proxies() -> urllib.request.getproxies())
+    falls back to the OS's own proxy configuration
+    (getproxies_macosx_sysconf()/getproxies_registry() on macOS/Windows)
+    once no HTTP(S)_PROXY/ALL_PROXY env var is set -- the same
+    DNS-rebinding-via-proxy bypass closed for the Magento MCP connector's
+    requests.Session in _make_request. build_isolated_httpx_client_kwargs()
+    must disable that whole lookup while still honoring an explicitly
+    trusted proxy and the SSL_CERT_FILE/SSL_CERT_DIR CA bundle trust_env=False
+    would otherwise silently stop honoring."""
+
+    def test_disables_trust_env(self):
+        kwargs = build_isolated_httpx_client_kwargs(None)
+
+        assert kwargs["trust_env"] is False
+
+    def test_omits_proxy_when_none_given(self):
+        kwargs = build_isolated_httpx_client_kwargs(None)
+
+        assert "proxy" not in kwargs
+
+    def test_passes_through_an_explicit_proxy(self):
+        kwargs = build_isolated_httpx_client_kwargs(
+            "http://trusted-proxy.internal:8080"
+        )
+
+        assert kwargs["proxy"] == "http://trusted-proxy.internal:8080"
+        assert kwargs["trust_env"] is False
+
+    def test_verify_is_a_concrete_ssl_context(self):
+        kwargs = build_isolated_httpx_client_kwargs(None)
+
+        assert isinstance(kwargs["verify"], ssl.SSLContext)
+
+    def test_ssl_context_is_built_with_trust_env_true(self, monkeypatch):
+        # trust_env=False on the client would also silently stop httpx
+        # from honoring SSL_CERT_FILE/SSL_CERT_DIR for the default CA
+        # bundle (create_ssl_context() gates that env lookup behind the
+        # same trust_env flag) -- breaking TLS verification for a host
+        # behind a private/internal CA. The context must instead be built
+        # with trust_env=True explicitly, then passed as verify=, which
+        # httpx honors regardless of the client's own trust_env setting.
+        sentinel_ctx = object()
+        captured: dict[str, object] = {}
+
+        def _fake_create_ssl_context(**kwargs):
+            captured.update(kwargs)
+            return sentinel_ctx
+
+        monkeypatch.setattr(
+            web_content.httpx, "create_ssl_context", _fake_create_ssl_context
+        )
+
+        kwargs = build_isolated_httpx_client_kwargs(None)
+
+        assert captured == {"trust_env": True}
+        assert kwargs["verify"] is sentinel_ctx
+
+    @pytest.mark.asyncio
+    async def test_fetch_constructs_client_with_trust_env_disabled(self):
+        # End-to-end: WebContentFetcher.fetch() must actually pass these
+        # kwargs to httpx.AsyncClient, not just have the helper compute them.
+        captured: dict[str, object] = {}
+        original_init = httpx.AsyncClient.__init__
+
+        def _capture_init(self, *args, **kwargs):
+            captured.update(kwargs)
+            return original_init(self, *args, **kwargs)
+
+        response = _MockStreamResponse(
+            body=b"<html><body>hi</body></html>",
+            headers={"content-type": "text/html"},
+        )
+
+        with (
+            patch.object(httpx.AsyncClient, "__init__", _capture_init),
+            patch(
+                "httpx.AsyncClient.stream", return_value=_MockStreamContext(response)
+            ),
+        ):
+            await WebContentFetcher().fetch("https://example.com")
+
+        assert captured.get("trust_env") is False
+        assert isinstance(captured.get("verify"), ssl.SSLContext)

--- a/tests/core/tools/test_vision_tool.py
+++ b/tests/core/tools/test_vision_tool.py
@@ -4,6 +4,7 @@ Tests for Vision Tool
 
 import base64
 import os
+import ssl
 import tempfile
 from pathlib import Path
 from unittest.mock import AsyncMock, Mock, patch
@@ -578,7 +579,14 @@ class TestVisionToolUnderstandMedia:
         assert svg_source in content[1]["text"]
         assert "#7B0099" in content[1]["text"]
         assert all(item["type"] != "image_url" for item in content[1:])
-        async_client.assert_called_once_with(proxy="http://proxy.example:8080")
+        async_client.assert_called_once()
+        client_kwargs = async_client.call_args.kwargs
+        assert client_kwargs["proxy"] == "http://proxy.example:8080"
+        # trust_env=False keeps this call from falling back to the OS's own
+        # proxy configuration once no HTTP(S)_PROXY env var is set -- the
+        # explicit proxy= above must still be honored regardless.
+        assert client_kwargs["trust_env"] is False
+        assert isinstance(client_kwargs["verify"], ssl.SSLContext)
         validate_url.assert_awaited_once_with(
             "https://cdn.example.com/official-logo.svg"
         )


### PR DESCRIPTION
## Summary
- `httpx.AsyncClient` defaults to `trust_env=True`, which falls back to the OS's own proxy config (macOS/Windows) once no `HTTP(S)_PROXY` env var is set -- the same DNS-rebinding-via-proxy bypass just closed for the Magento MCP connector's `requests.Session`.
- Added `build_isolated_httpx_client_kwargs()` in `web_content.py` and wired it into all three `httpx.AsyncClient` construction sites (`WebContentFetcher.fetch`, `VisionCore._download_remote_svg_source`, `DownloadWebAssetTool._download`): sets `trust_env=False` while explicitly rebuilding the CA-bundle-aware SSL context (`trust_env=True`) and passing it as `verify=`, so `SSL_CERT_FILE`/`SSL_CERT_DIR` keep working for a private/internal CA.
- An explicitly-trusted proxy (`get_trusted_proxy_url()`) is still passed through and honored regardless of `trust_env`.

## Test plan
- [x] Unit tests for `build_isolated_httpx_client_kwargs` (trust_env, proxy pass-through, SSL context construction)
- [x] End-to-end tests for all three call sites asserting the actual `httpx.AsyncClient` kwargs
- [x] `ruff check` / `ruff format --check` clean
- [x] `mypy src/xagent` shows no new errors (confirmed pre-existing errors are identical to `main`)
- [x] Full `tests/core/tools` suite passes (excluding two files broken by a missing `bashlex` dependency in this environment, unrelated to this change)