### PR TITLE
fix(agent): activate request-only language guidance (toby)

### DIFF
--- a/src/xagent/core/agent/context/enrichment.py
+++ b/src/xagent/core/agent/context/enrichment.py
@@ -32,7 +32,6 @@ class TopLevelUserRequest:
     execution_text: str
     language_text: str
     display_state: DisplayMessageState
-    has_pending_response: bool = False
 
 
 @dataclass(frozen=True)
@@ -65,10 +64,40 @@ def pending_user_response(message: Any) -> PendingUserResponse | None:
         if isinstance(raw_message_type, str) and raw_message_type.strip()
         else "question"
     )
-    answer = getattr(message, "content", "")
+    answer = display_message_override(metadata)
+    if answer is None:
+        answer = getattr(message, "content", "")
     if not isinstance(answer, str):
         return None
     return PendingUserResponse(answer, question, message_type)
+
+
+def latest_pending_user_response(context: Any) -> PendingUserResponse | None:
+    for message in reversed(getattr(context, "messages", []) or []):
+        response = pending_user_response(message)
+        if response is not None:
+            return response
+        metadata = getattr(message, "metadata", None)
+        metadata = metadata if isinstance(metadata, dict) else {}
+        if getattr(message, "role", None) == "user" and not metadata.get("dag_step_id"):
+            return None
+    return None
+
+
+def pending_user_response_marker(waiting_request: Any) -> dict[str, Any] | None:
+    if not isinstance(waiting_request, dict):
+        return None
+    question = waiting_request.get("message")
+    if not isinstance(question, str) or not question.strip():
+        return None
+    return {
+        "tool_name": waiting_request.get("tool_name"),
+        "tool_call_id": waiting_request.get("tool_call_id"),
+        "question": question,
+        "message_type": waiting_request.get("message_type", "question"),
+        "interactions": waiting_request.get("interactions"),
+        "requests": waiting_request.get("requests"),
+    }
 
 
 def _stored_top_level_user_request(context: Any) -> TopLevelUserRequest | None:
@@ -229,7 +258,6 @@ def top_level_user_request(
     ``user_message_limit`` freezes selection to a checkpointed prefix when a
     later waiting response has already been appended to the root context.
     """
-    has_pending_response = False
     messages = list(getattr(context, "messages", []) or [])
     if user_message_limit is not None:
         user_messages = [
@@ -244,7 +272,6 @@ def top_level_user_request(
         metadata = getattr(message, "metadata", None)
         metadata = metadata if isinstance(metadata, dict) else {}
         if metadata.get("response_to_waiting_for_user"):
-            has_pending_response = True
             continue
         if metadata.get("dag_step_id"):
             continue
@@ -258,14 +285,12 @@ def top_level_user_request(
                 execution_text=execution_text,
                 language_text=execution_text,
                 display_state="missing",
-                has_pending_response=has_pending_response,
             )
         else:
             request = TopLevelUserRequest(
                 execution_text=execution_text,
                 language_text=display_text,
                 display_state="text" if display_text else "empty",
-                has_pending_response=has_pending_response,
             )
         _persist_top_level_user_request(context, request)
         return request
@@ -276,7 +301,6 @@ def top_level_user_request(
             execution_text=stored.execution_text,
             language_text=stored.language_text,
             display_state=stored.display_state,
-            has_pending_response=has_pending_response,
         )
 
     metadata = getattr(context, "metadata", None)
@@ -286,7 +310,6 @@ def top_level_user_request(
         execution_text=task_text,
         language_text=task_text,
         display_state="missing",
-        has_pending_response=has_pending_response,
     )
     _persist_top_level_user_request(context, request)
     return request

--- a/src/xagent/core/agent/context/enrichment.py
+++ b/src/xagent/core/agent/context/enrichment.py
@@ -72,15 +72,28 @@ def pending_user_response(message: Any) -> PendingUserResponse | None:
     return PendingUserResponse(answer, question, message_type)
 
 
+def pending_user_response_lifecycle(message: Any) -> dict[str, Any] | None:
+    """Return the durable marker for a real waiting-response lifecycle.
+
+    Unlike :func:`pending_user_response`, lifecycle identity does not require a
+    usable question. The strict parser remains the gate for language evidence.
+    """
+    if getattr(message, "role", None) != "user":
+        return None
+    metadata = getattr(message, "metadata", None)
+    if not isinstance(metadata, dict):
+        return None
+    marker = metadata.get("response_to_waiting_for_user")
+    if not isinstance(marker, dict) or not isinstance(marker.get("question"), str):
+        return None
+    return marker
+
+
 def latest_pending_user_response(context: Any) -> PendingUserResponse | None:
     for message in reversed(getattr(context, "messages", []) or []):
         response = pending_user_response(message)
         if response is not None:
             return response
-        metadata = getattr(message, "metadata", None)
-        metadata = metadata if isinstance(metadata, dict) else {}
-        if getattr(message, "role", None) == "user" and not metadata.get("dag_step_id"):
-            return None
     return None
 
 
@@ -88,15 +101,10 @@ def pending_user_response_marker(waiting_request: Any) -> dict[str, Any] | None:
     if not isinstance(waiting_request, dict):
         return None
     question = waiting_request.get("message")
-    if not isinstance(question, str) or not question.strip():
-        return None
+    question = question if isinstance(question, str) else ""
     return {
-        "tool_name": waiting_request.get("tool_name"),
-        "tool_call_id": waiting_request.get("tool_call_id"),
         "question": question,
         "message_type": waiting_request.get("message_type", "question"),
-        "interactions": waiting_request.get("interactions"),
-        "requests": waiting_request.get("requests"),
     }
 
 

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -27,7 +27,9 @@ from ...tools.artifacts import (
 )
 from ..language import (
     effective_output_language,
-    output_language_directives,
+    render_dag_step_language_reference,
+    render_request_language_harness,
+    render_root_request_language_harness,
 )
 from ..result import CONTROL_TOOL_NAMES, tool_result_succeeded
 from .components import (
@@ -42,6 +44,8 @@ from .enrichment import (
     IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
     MEMORY_CONTEXT_METADATA_KEY,
     SKILL_CONTEXT_METADATA_KEY,
+    latest_pending_user_response,
+    pending_user_response,
     top_level_user_request,
 )
 from .memory_tool import MEMORY_TOOLS_METADATA_KEY
@@ -452,18 +456,15 @@ class ExecutionContext:
                 provider_state = message.metadata.get("_xagent_provider_state")
                 if isinstance(provider_state, dict):
                     message_dict["_xagent_provider_state"] = provider_state
-            waiting_response = message.metadata.get("response_to_waiting_for_user")
-            if message_dict.get("role") == "user" and isinstance(
-                waiting_response, dict
-            ):
-                question = str(waiting_response.get("question") or "").strip()
-                answer = str(message_dict.get("content") or "").strip()
+            waiting_response = pending_user_response(message)
+            if waiting_response is not None:
                 message_dict["content"] = (
                     "This user message is the answer to a pending agent question. "
                     "Treat it as the response to that pending question, not as a new "
-                    "independent task.\n"
-                    f"Pending question: {question}\n"
-                    f"User answer: {answer}"
+                    "independent task. The exact allowlisted question and clean answer "
+                    "are in the canonical request-language evidence in the system "
+                    "context. Execution-enriched message content follows:\n"
+                    f"{str(message_dict.get('content') or '')}"
                 )
             if include_system and message_dict.get("role") == "system":
                 content = str(message_dict.get("content") or "").strip()
@@ -564,11 +565,15 @@ class ExecutionContext:
     def _system_context(self) -> str:
         parts = [self._current_time_context(), FILE_REF_MODEL_INSTRUCTIONS]
         dag_step_id = self.metadata.get("dag_step_id")
-        current_task = self.current_user_request_text()
+        request = top_level_user_request(self)
+        current_task = request.execution_text
+        pending_response = latest_pending_user_response(self)
         output_language = effective_output_language(self)
         if current_task and not dag_step_id:
-            language_directives = output_language_directives(
-                output_language, section="root_system_context"
+            language_directives = render_root_request_language_harness(
+                request,
+                pending_response,
+                output_language,
             )
             parts.append(
                 "Current user request:\n"
@@ -607,11 +612,10 @@ class ExecutionContext:
                     "Task input/output examples:\n" + "\n".join(formatted_examples)
                 )
         if dag_step_id:
-            language_policy = output_language_directives(
-                output_language, section="dag_step_scope"
-            )
-            step_language_rules = output_language_directives(
-                output_language, section="dag_step_rules"
+            language_harness = render_request_language_harness(
+                request,
+                pending_response,
+                output_language=output_language,
             )
             dag_step_name = str(self.metadata.get("dag_step_name") or "").strip()
             dag_step_description = str(
@@ -632,7 +636,7 @@ class ExecutionContext:
                 "- Overall user goal is background context only and is already "
                 "available in the conversation when needed; do not treat it as "
                 "the executable goal for this step.\n"
-                f"- {language_policy}\n"
+                f"- {render_dag_step_language_reference()}\n"
                 f"- Current step id: {dag_step_id}\n"
                 f"- Current step title: {dag_step_name or dag_step_id}\n"
                 f"- Current step description: "
@@ -641,15 +645,8 @@ class ExecutionContext:
                 f"- Suggested tools for this step: {suggested_tools}\n\n"
                 "Only execute the current DAG step. Detailed step boundary rules are "
                 "provided in the latest DAG step instruction message.\n\n"
-                f"{step_language_rules}"
+                f"{language_harness}"
             )
-            request_anchor = output_language_directives(
-                output_language,
-                section="dag_step_request_anchor",
-                request=self.current_user_request_text(prefer_display=True),
-            )
-            if request_anchor:
-                parts.append(request_anchor)
         memory_context = self.metadata.get(MEMORY_CONTEXT_METADATA_KEY)
         if memory_context:
             parts.append(
@@ -1561,12 +1558,19 @@ class ExecutionContext:
             return str(content)
         return str(response) if response is not None else ""
 
-    def estimate_context_tokens(self) -> int:
+    def estimate_context_tokens(
+        self, messages: list[dict[str, Any]] | None = None
+    ) -> int:
         """Public estimate of the current context size in tokens.
 
-        Uses the same accounting as the compaction decision so a UI gauge fed
-        by this value reaches its threshold exactly when compaction triggers.
+        When final provider messages are supplied, account for exactly their
+        rendered dynamic system content rather than the persisted message list.
         """
+        if messages is not None:
+            return sum(
+                max(1, len(str(message.get("content") or "")) // 4)
+                for message in messages
+            )
         return self._get_total_tokens()
 
     def _get_total_tokens(self) -> int:

--- a/src/xagent/core/agent/context/execution.py
+++ b/src/xagent/core/agent/context/execution.py
@@ -30,6 +30,7 @@ from ..language import (
     render_dag_step_language_reference,
     render_request_language_harness,
     render_root_request_language_harness,
+    serialize_pending_user_response,
 )
 from ..result import CONTROL_TOOL_NAMES, tool_result_succeeded
 from .components import (
@@ -46,6 +47,7 @@ from .enrichment import (
     SKILL_CONTEXT_METADATA_KEY,
     latest_pending_user_response,
     pending_user_response,
+    pending_user_response_lifecycle,
     top_level_user_request,
 )
 from .memory_tool import MEMORY_TOOLS_METADATA_KEY
@@ -111,6 +113,37 @@ COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES = 20
 # Wire name: request_context keys reach metadata verbatim, so renaming this
 # breaks the clients that populate it.
 CLOCK_TIMEZONE_METADATA_KEY = "timezone"
+
+
+def estimate_provider_prompt_tokens(
+    messages: list[dict[str, Any]],
+    tools: list[dict[str, Any]] | None = None,
+) -> int:
+    """Estimate one logical provider payload without materializing references."""
+    total = 0
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        payload = {
+            key: value for key, value in message.items() if key != CONTEXT_REFS_KEY
+        }
+        try:
+            serialized = json.dumps(payload, ensure_ascii=False, default=str)
+        except (TypeError, ValueError):
+            serialized = str(payload)
+        total += max(1, len(serialized) // 4)
+        try:
+            references = normalize_context_references(message.get(CONTEXT_REFS_KEY))
+        except (TypeError, ValueError):
+            references = ()
+        total += sum(reference.estimated_tokens() for reference in references)
+    if tools:
+        try:
+            serialized_tools = json.dumps(tools, ensure_ascii=False, default=str)
+        except (TypeError, ValueError):
+            serialized_tools = str(tools)
+        total += max(1, len(serialized_tools) // 4)
+    return total
 
 
 def _utcnow() -> datetime:
@@ -449,6 +482,14 @@ class ExecutionContext:
         if max_tokens:
             visible_messages = self._truncate_by_tokens(visible_messages, max_tokens)
         visible_messages = self._sanitize_tool_message_pairs(visible_messages)
+        latest_pending_message = next(
+            (
+                message
+                for message in reversed(visible_messages)
+                if pending_user_response(message) is not None
+            ),
+            None,
+        )
 
         for message in visible_messages:
             message_dict = message.to_dict()
@@ -458,12 +499,27 @@ class ExecutionContext:
                     message_dict["_xagent_provider_state"] = provider_state
             waiting_response = pending_user_response(message)
             if waiting_response is not None:
+                if message is latest_pending_message:
+                    framing = (
+                        "The exact allowlisted question and clean answer are in the "
+                        "canonical request-language evidence in the system context."
+                    )
+                else:
+                    framing = (
+                        "Historical pending-response evidence (JSON):\n"
+                        f"{json.dumps(serialize_pending_user_response(waiting_response), ensure_ascii=False)}"
+                    )
                 message_dict["content"] = (
-                    "This user message is the answer to a pending agent question. "
-                    "Treat it as the response to that pending question, not as a new "
-                    "independent task. The exact allowlisted question and clean answer "
-                    "are in the canonical request-language evidence in the system "
-                    "context. Execution-enriched message content follows:\n"
+                    "This user message is the answer to a pending agent question "
+                    "and is the primary response, not an independent task. "
+                    f"{framing}\nExecution-enriched message content follows:\n"
+                    f"{str(message_dict.get('content') or '')}"
+                )
+            elif pending_user_response_lifecycle(message) is not None:
+                message_dict["content"] = (
+                    "This user message is the primary response in a waiting lifecycle "
+                    "whose question text is unavailable or blank, not an independent "
+                    "task. Execution-enriched message content follows:\n"
                     f"{str(message_dict.get('content') or '')}"
                 )
             if include_system and message_dict.get("role") == "system":
@@ -1112,7 +1168,7 @@ class ExecutionContext:
             )
 
         top_level_user_request(self)
-        total_tokens = self._get_total_tokens()
+        total_tokens = self.estimate_context_tokens()
         if total_tokens > self.compact_config.threshold:
             result = self._drop_oldest_messages()
             return self._annotate_compact_result(result, total_tokens)
@@ -1129,7 +1185,7 @@ class ExecutionContext:
             return None
 
         top_level_user_request(self)
-        total_tokens = self._get_total_tokens()
+        total_tokens = self.estimate_context_tokens()
         if total_tokens <= self.compact_config.threshold:
             return None
 
@@ -1191,7 +1247,7 @@ class ExecutionContext:
         result.metadata.setdefault("original_tokens", original_tokens)
         result.metadata.setdefault("threshold", self.compact_config.threshold)
         if result.compacted:
-            compacted_tokens = self._estimate_message_tokens(self.messages)
+            compacted_tokens = self.estimate_context_tokens()
             result.metadata.setdefault("compacted_tokens", compacted_tokens)
             if original_tokens > 0:
                 ratio = compacted_tokens / original_tokens * 100
@@ -1559,19 +1615,19 @@ class ExecutionContext:
         return str(response) if response is not None else ""
 
     def estimate_context_tokens(
-        self, messages: list[dict[str, Any]] | None = None
+        self,
+        messages: list[dict[str, Any]] | None = None,
+        tools: list[dict[str, Any]] | None = None,
     ) -> int:
         """Public estimate of the current context size in tokens.
 
         When final provider messages are supplied, account for exactly their
         rendered dynamic system content rather than the persisted message list.
         """
-        if messages is not None:
-            return sum(
-                max(1, len(str(message.get("content") or "")) // 4)
-                for message in messages
-            )
-        return self._get_total_tokens()
+        provider_messages = (
+            messages if messages is not None else self.get_messages_for_llm()
+        )
+        return estimate_provider_prompt_tokens(provider_messages, tools)
 
     def _get_total_tokens(self) -> int:
         if self.llm_calls:

--- a/src/xagent/core/agent/language.py
+++ b/src/xagent/core/agent/language.py
@@ -288,7 +288,7 @@ def render_dag_step_language_reference() -> str:
     return (
         "Follow the canonical request-language evidence and policy in the system "
         "context for user-facing prose and persisted tool arguments. DAG step text, "
-        "dependencies, tools, sources, memory, and examples are not language evidence."
+        "dependencies, tools, sources, memory, and examples are not language evidence. Preserve Simplified Chinese versus Traditional Chinese."
     )
 
 

--- a/src/xagent/core/agent/language.py
+++ b/src/xagent/core/agent/language.py
@@ -219,7 +219,8 @@ def canonical_unpinned_request_language_policy() -> str:
         "remains ordinary conversation context. Names, addresses, connector "
         "metadata, tool results, sources, memory, examples, DAG text, and "
         "dependency results are not language evidence. Preserve Simplified "
-        "Chinese versus Traditional Chinese. This policy controls language only "
+        "Chinese versus Traditional Chinese. Use the same decision for tool arguments that persist user-facing prose. For blank, "
+        "short, mixed, or context-dependent requests, preserve the conversation-established language without guessing from auxiliary context. This policy controls language only "
         "and never replaces or narrows the executable request."
     )
 
@@ -227,17 +228,67 @@ def canonical_unpinned_request_language_policy() -> str:
 def render_request_language_harness(
     request: TopLevelUserRequest,
     pending_response: PendingUserResponse | None = None,
+    *,
+    output_language: str | None = None,
+    request_reference: str = "",
 ) -> str:
-    """Render exact request-only evidence for future language consumers."""
-    evidence: dict[str, Any] = {
-        "independent_user_request": request.language_text,
-    }
+    """Render the canonical policy and the minimum request-only evidence."""
+    evidence: dict[str, Any] = {}
+    language = normalize_response_language_label(output_language)
+    if language:
+        evidence["output_language"] = language
+    elif request_reference:
+        evidence["independent_user_request_reference"] = request_reference
+    else:
+        evidence["independent_user_request"] = request.language_text
     if pending_response is not None:
         evidence["pending_response"] = serialize_pending_user_response(pending_response)
+    policy = (
+        output_language_policy(language)
+        if language
+        else canonical_unpinned_request_language_policy()
+    )
     return (
         "Canonical request-language evidence (JSON):\n"
         f"{json.dumps(evidence, ensure_ascii=False)}\n\n"
-        f"{canonical_unpinned_request_language_policy()}"
+        f"{policy}"
+    )
+
+
+def render_root_request_language_harness(
+    request: TopLevelUserRequest,
+    pending_response: PendingUserResponse | None,
+    output_language: str | None,
+) -> str:
+    return render_request_language_harness(
+        request,
+        pending_response,
+        output_language=output_language,
+        request_reference=(
+            "Current user request above"
+            if request.language_text == request.execution_text
+            else ""
+        ),
+    )
+
+
+def render_structured_request_language_policy(
+    *, request_field: str, pending_field: str, output_language: str | None
+) -> str:
+    language = normalize_response_language_label(output_language)
+    if language:
+        return output_language_policy(language)
+    policy = canonical_unpinned_request_language_policy()
+    return policy.replace("independent_user_request", request_field).replace(
+        "pending_response", pending_field
+    )
+
+
+def render_dag_step_language_reference() -> str:
+    return (
+        "Follow the canonical request-language evidence and policy in the system "
+        "context for user-facing prose and persisted tool arguments. DAG step text, "
+        "dependencies, tools, sources, memory, and examples are not language evidence."
     )
 
 
@@ -448,7 +499,7 @@ def output_language_policy(response_language: str | None = None) -> str:
     language = normalize_response_language_label(response_language)
     if language:
         return (
-            f"Output language: {language}. Use {language} for all user-facing "
+            f"Output language: {language} (hard authority). Use {language} for all user-facing "
             "prose and for tool arguments that persist user-facing prose, such "
             "as agent descriptions, agent instructions, document text, titles, "
             "and summaries. If the output language is Chinese or a Chinese variant, "
@@ -456,9 +507,8 @@ def output_language_policy(response_language: str | None = None) -> str:
             "request when generic Chinese is specified: Simplified Chinese and "
             "Traditional Chinese are different output languages. Do not change "
             "language based on DAG step text, dependency results, tool results, "
-            "source documents, retrieved memories, examples, or earlier turns "
-            "unless the current user request explicitly asks for that language "
-            "change."
+            "source documents, retrieved memories, examples, earlier turns, or "
+            "request-language evidence."
         )
     return (
         "Output language policy: Use the same natural language as the current "
@@ -531,17 +581,9 @@ def response_language_rules(*, subject: str = "current user request") -> str:
     )
 
 
-def final_answer_language_rule(*, subject: str = "current user request") -> str:
+def final_answer_language_rule(*, subject: str = "system context") -> str:
     """Return a compact language rule for final-answer tool fields."""
-    return (
-        "The final answer must use the same natural language as the "
-        f"{subject}, even if tool results, source documents, retrieved memories, "
-        "examples, or earlier turns are written in another language. If the "
-        f"{subject} explicitly asks to translate, rewrite, or answer in another "
-        "language, use that requested target language. For Chinese, preserve "
-        "Simplified Chinese versus Traditional Chinese from the request; do not "
-        "collapse them into generic Chinese."
-    )
+    return f"Follow the canonical request-language policy in the {subject}."
 
 
 def plan_language_rules() -> str:

--- a/src/xagent/core/agent/language.py
+++ b/src/xagent/core/agent/language.py
@@ -202,15 +202,20 @@ def serialize_pending_user_response(response: PendingUserResponse) -> dict[str, 
     }
 
 
-def canonical_unpinned_request_language_policy() -> str:
+def canonical_unpinned_request_language_policy(
+    *,
+    independent_request_field: str = "independent_user_request",
+    pending_response_field: str = "pending_response",
+) -> str:
     """Return the canonical soft-authority policy for future consumers."""
     return (
         "A caller-provided request_context.output_language is the sole hard "
-        "language authority. When it is absent, use independent_user_request as "
+        "language authority. When it is absent, use "
+        f"{independent_request_field} as "
         "the baseline for the language and script of user-facing prose. Honor its "
         "explicit or implicit target-language intent, including requests to "
         "translate or rewrite content for another-language audience. A "
-        "pending_response may override that baseline only when its answer "
+        f"{pending_response_field} may override that baseline only when its answer "
         "explicitly asks to translate, rewrite, or continue in another language, "
         "or when its question explicitly asks for the output language or script "
         "and its answer is an unambiguous selection. A language name is not an "
@@ -278,17 +283,18 @@ def render_structured_request_language_policy(
     language = normalize_response_language_label(output_language)
     if language:
         return output_language_policy(language)
-    policy = canonical_unpinned_request_language_policy()
-    return policy.replace("independent_user_request", request_field).replace(
-        "pending_response", pending_field
+    return canonical_unpinned_request_language_policy(
+        independent_request_field=request_field,
+        pending_response_field=pending_field,
     )
 
 
 def render_dag_step_language_reference() -> str:
     return (
         "Follow the canonical request-language evidence and policy in the system "
-        "context for user-facing prose and persisted tool arguments. DAG step text, "
-        "dependencies, tools, sources, memory, and examples are not language evidence. Preserve Simplified Chinese versus Traditional Chinese."
+        "context for user-facing prose and persisted tool arguments. Execution "
+        "instructions, tools, sources, memory, and examples are not language "
+        "evidence. Preserve Simplified Chinese versus Traditional Chinese."
     )
 
 
@@ -583,7 +589,7 @@ def response_language_rules(*, subject: str = "current user request") -> str:
 
 def final_answer_language_rule(*, subject: str = "system context") -> str:
     """Return a compact language rule for final-answer tool fields."""
-    return f"Follow the canonical request-language policy in the {subject}."
+    return f"Follow the canonical language contract provided by the {subject}."
 
 
 def plan_language_rules() -> str:

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -1969,8 +1969,8 @@ class DAGPattern(AgentPattern):
     ) -> None:
         """Re-emit the instruction message of a checkpoint-restored step.
 
-        The instruction bakes the output language policy into message content,
-        which the metadata-only checkpoint migration cannot reach.
+        Older checkpoints can bake an output-language policy into message
+        content, which the metadata-only checkpoint migration cannot reach.
         """
         instruction = self._step_instruction(root_context=root_context, step=step)
         for index, message in enumerate(child_context.messages):

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -15,6 +15,10 @@ from ....task_runtime import (
 from ...context.enrichment import (
     enrich_context_with_memory,
     hydrate_top_level_user_request,
+    latest_pending_user_response,
+    pending_user_response,
+    pending_user_response_marker,
+    top_level_user_request,
 )
 from ...frame import ExecutionFrame, ExecutionSnapshot, ExecutionStatus
 from ...grounding import grounding_rule
@@ -22,7 +26,9 @@ from ...language import (
     OUTPUT_LANGUAGE_METADATA_KEY,
     effective_output_language,
     final_answer_language_rule,
-    output_language_directives,
+    render_dag_step_language_reference,
+    render_structured_request_language_policy,
+    serialize_pending_user_response,
 )
 from ...result import unwrap_final_answer_content
 from ...runtime import (
@@ -1525,6 +1531,8 @@ class DAGPattern(AgentPattern):
         return assessment
 
     def _completion_assessment_messages(self, context: Any) -> list[dict[str, Any]]:
+        request = top_level_user_request(context)
+        pending_response = latest_pending_user_response(context)
         latest_messages = [
             {"role": message.role, "content": message.content}
             for message in getattr(context, "messages", [])
@@ -1534,11 +1542,19 @@ class DAGPattern(AgentPattern):
             {"role": message.role, "content": message.content}
             for message in getattr(context, "messages", [])
             if getattr(message, "role", None) == "user"
+            and pending_user_response(message) is None
         ]
         payload = {
-            "output_language_policy": output_language_directives(
-                effective_output_language(context),
-                section="completion_assessment",
+            "independent_user_request": request.language_text,
+            "pending_response": (
+                serialize_pending_user_response(pending_response)
+                if pending_response is not None
+                else None
+            ),
+            "output_language_policy": render_structured_request_language_policy(
+                request_field="independent_user_request",
+                pending_field="pending_response",
+                output_language=effective_output_language(context),
             ),
             "authoritative_user_requests": authoritative_user_requests,
             "messages": latest_messages,
@@ -1573,7 +1589,7 @@ class DAGPattern(AgentPattern):
                     "placeholder because no step produced the underlying data, "
                     "name that unsourced data in reason even when you choose "
                     "status=completed. "
-                    f"{final_answer_language_rule(subject='output language policy')}"
+                    f"{final_answer_language_rule(subject='output_language_policy field')}"
                 ),
             },
             {"role": "user", "content": json.dumps(payload, ensure_ascii=False)},
@@ -1602,7 +1618,7 @@ class DAGPattern(AgentPattern):
                                 "Final user-facing answer when status is completed; "
                                 "empty when status is incomplete. "
                                 f"{final_deliverable_file_reference_instructions(can_lookup=False, include_heading=False)} "
-                                f"{final_answer_language_rule(subject='output language policy')}"
+                                f"{final_answer_language_rule(subject='output_language_policy field')}"
                             ),
                         },
                         "missing_work": {
@@ -1724,10 +1740,6 @@ class DAGPattern(AgentPattern):
         return {dep: self.step_results.get(dep) for dep in step.dependencies}
 
     def _step_instruction(self, *, root_context: Any, step: PlanStep) -> str:
-        language_policy = output_language_directives(
-            effective_output_language(root_context),
-            section="dag_step_instruction",
-        )
         dependency_note = (
             "Dependency results, if any, are provided immediately before this "
             "message. Use them as inputs for this step only."
@@ -1746,7 +1758,7 @@ class DAGPattern(AgentPattern):
             "directly and do not use it to expand the current step's completion "
             "criteria.\n\n"
             "OUTPUT LANGUAGE POLICY\n"
-            f"{language_policy}\n"
+            f"{render_dag_step_language_reference()}\n"
             "Use this policy only to preserve language for user-facing prose and "
             "persisted tool arguments. Do not use it to expand this step's "
             "completion criteria.\n\n"
@@ -1896,7 +1908,9 @@ class DAGPattern(AgentPattern):
             return False
 
         root_user_messages = [
-            message for message in root_context.messages if message.role == "user"
+            (index, message)
+            for index, message in enumerate(root_context.messages)
+            if message.role == "user"
         ]
         if len(root_user_messages) <= self.planned_user_message_count:
             return False
@@ -1905,13 +1919,33 @@ class DAGPattern(AgentPattern):
         if not active_context:
             return False
 
+        new_root_messages = root_user_messages[self.planned_user_message_count :]
+        response_index, response_message = new_root_messages[-1]
+        pattern_state = self.active_step_pattern_states.get(step_id)
+        waiting_request = (
+            pattern_state.get("waiting_for_user_request")
+            if isinstance(pattern_state, dict)
+            else None
+        )
+        marker = pending_user_response_marker(waiting_request)
+        response_metadata = dict(getattr(response_message, "metadata", None) or {})
+        if marker is not None:
+            response_metadata["response_to_waiting_for_user"] = marker
+            root_context.messages[response_index] = replace(
+                response_message,
+                metadata=response_metadata,
+            )
+
         child_context = type(root_context).from_dict(active_context)
         self._refresh_restored_step_runtime_metadata(child_context, root_context)
-        for message in root_user_messages[self.planned_user_message_count :]:
+        for _, message in new_root_messages:
+            metadata = dict(getattr(message, "metadata", None) or {})
+            if message is response_message and marker is not None:
+                metadata["response_to_waiting_for_user"] = marker
             child_context.add_user_message(
                 message.content,
                 metadata={
-                    **getattr(message, "metadata", {}),
+                    **metadata,
                     "kind": "dag_waiting_user_response",
                     "forwarded_from_root": True,
                     "dag_step_id": step_id,

--- a/src/xagent/core/agent/pattern/dag/dag.py
+++ b/src/xagent/core/agent/pattern/dag/dag.py
@@ -16,7 +16,6 @@ from ...context.enrichment import (
     enrich_context_with_memory,
     hydrate_top_level_user_request,
     latest_pending_user_response,
-    pending_user_response,
     pending_user_response_marker,
     top_level_user_request,
 )
@@ -1542,7 +1541,6 @@ class DAGPattern(AgentPattern):
             {"role": message.role, "content": message.content}
             for message in getattr(context, "messages", [])
             if getattr(message, "role", None) == "user"
-            and pending_user_response(message) is None
         ]
         payload = {
             "independent_user_request": request.language_text,
@@ -1920,7 +1918,7 @@ class DAGPattern(AgentPattern):
             return False
 
         new_root_messages = root_user_messages[self.planned_user_message_count :]
-        response_index, response_message = new_root_messages[-1]
+        response_index, response_message = new_root_messages[0]
         pattern_state = self.active_step_pattern_states.get(step_id)
         waiting_request = (
             pattern_state.get("waiting_for_user_request")
@@ -1928,7 +1926,12 @@ class DAGPattern(AgentPattern):
             else None
         )
         marker = pending_user_response_marker(waiting_request)
-        response_metadata = dict(getattr(response_message, "metadata", None) or {})
+        raw_response_metadata = getattr(response_message, "metadata", None)
+        response_metadata = (
+            dict(raw_response_metadata)
+            if isinstance(raw_response_metadata, dict)
+            else {}
+        )
         if marker is not None:
             response_metadata["response_to_waiting_for_user"] = marker
             root_context.messages[response_index] = replace(

--- a/src/xagent/core/agent/pattern/dag/plan_generator.py
+++ b/src/xagent/core/agent/pattern/dag/plan_generator.py
@@ -7,7 +7,10 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, Callable
 
-from ...context.enrichment import latest_user_text
+from ...context.enrichment import (
+    latest_pending_user_response,
+    top_level_user_request,
+)
 from ...language import (
     OUTPUT_LANGUAGE_SOURCE_METADATA_KEY,
     OUTPUT_LANGUAGE_SOURCE_PLAN,
@@ -15,9 +18,10 @@ from ...language import (
     detect_response_language_script_mismatch,
     effective_output_language,
     normalize_response_language_label,
-    output_language_directives,
     plan_language_rules,
+    render_structured_request_language_policy,
     request_context_output_language,
+    serialize_pending_user_response,
 )
 from ..base import (
     RequiredToolCallError,
@@ -319,7 +323,8 @@ class LLMPlanGenerator(PlanGenerator):
                     "follow it exactly and make response_language match it. "
                     "Emit response_language before steps in the tool arguments so "
                     "it anchors every plan field generated after it. Determine it "
-                    "from latest_user_request, not from the surrounding context. "
+                    "from latest_user_request and pending_response, not from "
+                    "the surrounding context. "
                     "For Chinese requests, response_language must be Simplified "
                     "Chinese or Traditional Chinese to match the request script; "
                     "do not use generic Chinese. "
@@ -484,8 +489,8 @@ class LLMPlanGenerator(PlanGenerator):
                                 "persisted tool-argument prose produced by the plan, "
                                 "for example English, Simplified Chinese, Traditional "
                                 "Chinese, or Spanish. Determine it only from "
-                                "latest_user_request and any explicit target-language "
-                                "instruction in that request. For Chinese requests, "
+                                "latest_user_request, pending_response, and "
+                                "output_language_policy. For Chinese requests, "
                                 "choose Simplified Chinese or Traditional Chinese to "
                                 "match the request script; do not use generic Chinese. "
                                 "If output_language_policy names a language, match it."
@@ -561,7 +566,8 @@ class LLMPlanGenerator(PlanGenerator):
         }
 
     def _build_prompt(self, request: PlanGenerationRequest) -> str:
-        latest_request = latest_user_text(request.context, prefer_display=True) or ""
+        canonical_request = top_level_user_request(request.context)
+        pending_response = latest_pending_user_response(request.context)
         expected_language, language_source = self._language_authority(request.context)
         latest_messages = [
             {"role": message.role, "content": message.content}
@@ -573,12 +579,20 @@ class LLMPlanGenerator(PlanGenerator):
             "replan": request.replan,
             # Quoted whole: the planner picks response_language from this field,
             # and "messages" below already carries the full text anyway.
-            "latest_user_request": latest_request.strip(),
-            "output_language_policy": output_language_directives(
-                None
-                if language_source == OUTPUT_LANGUAGE_SOURCE_PLAN
-                else expected_language,
-                section="plan_payload",
+            "latest_user_request": canonical_request.language_text,
+            "pending_response": (
+                serialize_pending_user_response(pending_response)
+                if pending_response is not None
+                else None
+            ),
+            "output_language_policy": render_structured_request_language_policy(
+                request_field="latest_user_request",
+                pending_field="pending_response",
+                output_language=(
+                    None
+                    if language_source == OUTPUT_LANGUAGE_SOURCE_PLAN
+                    else expected_language
+                ),
             ),
             "messages": latest_messages,
             "retrieved_memory_context": request.context.metadata.get(
@@ -687,7 +701,7 @@ class LLMPlanGenerator(PlanGenerator):
         Script comparison cannot tell a biased plan from a request that legitimately
         asks for another language, so it may only nudge once, never reject a plan.
         """
-        request = latest_user_text(context, prefer_display=True) or ""
+        request = top_level_user_request(context).language_text
         for step in plan.steps:
             mismatch = detect_prose_script_mismatch(
                 request, LLMPlanGenerator._step_prose(step)
@@ -698,6 +712,7 @@ class LLMPlanGenerator(PlanGenerator):
                 f"Plan step {step.id!r} is written in predominantly "
                 f"{mismatch.observed_script} script, which does not match the "
                 "script of the latest user request. Re-read latest_user_request "
+                "and pending_response "
                 "above and decide the output language from that request alone, "
                 "including any language change it asks for explicitly or "
                 f"implicitly. Call {LLMPlanGenerator.PLAN_TOOL_NAME} again exactly "

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -78,7 +78,7 @@ from ...context.enrichment import (
     IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
     enrich_context_with_memory,
     latest_user_text,
-    pending_user_response,
+    pending_user_response_lifecycle,
     pending_user_response_marker,
 )
 from ...context.memory_tool import build_memory_tools
@@ -1754,13 +1754,13 @@ class ReActPattern(AgentPattern):
         if not isinstance(messages, list):
             return None
 
-        for index in range(len(messages) - 1, after_message_count - 1, -1):
+        for index in range(after_message_count, len(messages)):
             message = messages[index]
             if getattr(message, "role", None) != "user":
                 continue
             metadata = getattr(message, "metadata", None)
             metadata = dict(metadata) if isinstance(metadata, dict) else {}
-            if pending_user_response(message) is not None:
+            if pending_user_response_lifecycle(message) is not None:
                 return str(getattr(message, "content", "") or "")
             waiting_request = self.waiting_for_user_request or {}
             marker = pending_user_response_marker(waiting_request)

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -78,6 +78,8 @@ from ...context.enrichment import (
     IMAGE_EDIT_UNAVAILABLE_METADATA_KEY,
     enrich_context_with_memory,
     latest_user_text,
+    pending_user_response,
+    pending_user_response_marker,
 )
 from ...context.memory_tool import build_memory_tools
 from ...context.skill_tool import build_load_skill_tool
@@ -132,10 +134,8 @@ STRIP_LOG_MAX_TOOL_NAME_CHARS = 64
 REACT_RESPONSE_LANGUAGE_DESCRIPTION = (
     "Target natural language for user-facing prose in this ReAct response, "
     "for example English, Simplified Chinese, Traditional Chinese, or Spanish. "
-    "For Chinese requests, choose Simplified Chinese or Traditional Chinese to "
-    "match the request script; do not use generic Chinese. If the current user "
-    "request explicitly asks to answer in another language, use that requested "
-    "target language."
+    "Follow the canonical request-language policy in the system context; do not "
+    "collapse Chinese variants into generic Chinese."
 )
 
 
@@ -1758,18 +1758,15 @@ class ReActPattern(AgentPattern):
             message = messages[index]
             if getattr(message, "role", None) != "user":
                 continue
-            metadata = dict(getattr(message, "metadata", {}) or {})
-            if metadata.get("response_to_waiting_for_user"):
+            metadata = getattr(message, "metadata", None)
+            metadata = dict(metadata) if isinstance(metadata, dict) else {}
+            if pending_user_response(message) is not None:
                 return str(getattr(message, "content", "") or "")
             waiting_request = self.waiting_for_user_request or {}
-            metadata["response_to_waiting_for_user"] = {
-                "tool_name": waiting_request.get("tool_name"),
-                "tool_call_id": waiting_request.get("tool_call_id"),
-                "question": waiting_request.get("message", ""),
-                "message_type": waiting_request.get("message_type", "question"),
-                "interactions": waiting_request.get("interactions"),
-                "requests": waiting_request.get("requests"),
-            }
+            marker = pending_user_response_marker(waiting_request)
+            if marker is None:
+                return None
+            metadata["response_to_waiting_for_user"] = marker
             messages[index] = replace(message, metadata=metadata)
             return str(getattr(message, "content", "") or "")
         return None

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -1104,7 +1104,7 @@ class PatternRuntime:
         estimate = getattr(context, "estimate_context_tokens", None)
         if callable(estimate):
             try:
-                context_data["context_tokens"] = estimate(messages)
+                context_data["context_tokens"] = estimate(messages, tools)
             except Exception:  # noqa: BLE001 - gauge metadata must never break the call
                 pass
         compact_config = getattr(context, "compact_config", None)

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -1100,12 +1100,11 @@ class PatternRuntime:
             **event_metadata,
         }
         # Surface current context size vs. the compaction threshold so the UI
-        # can show a context-usage gauge. Uses the same estimate that drives the
-        # compaction decision, so the gauge fills exactly when compaction fires.
+        # can show final provider-payload usage, including dynamic system content.
         estimate = getattr(context, "estimate_context_tokens", None)
         if callable(estimate):
             try:
-                context_data["context_tokens"] = estimate()
+                context_data["context_tokens"] = estimate(messages)
             except Exception:  # noqa: BLE001 - gauge metadata must never break the call
                 pass
         compact_config = getattr(context, "compact_config", None)

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -561,6 +561,8 @@ async def optimize_instructions(
             "The output should be clear, structured, and effective for an LLM to follow. "
             "Do not include any conversational filler. Just output the optimized instructions. "
             "Use draft_instructions as the independent user request. "
+            "The surrounding API prompt is written in English only as an execution "
+            "environment; it is not language evidence for the optimized instructions. "
             f"{render_structured_request_language_policy(request_field='draft_instructions', pending_field='pending_response', output_language=None)}"
         )
 

--- a/src/xagent/web/api/agents.py
+++ b/src/xagent/web/api/agents.py
@@ -14,7 +14,7 @@ from sqlalchemy.orm import Session
 from ...config import get_agent_pattern_for_execution_mode, get_uploads_dir
 from ...core.agent.language import (
     detect_prose_script_mismatch,
-    response_language_rules,
+    render_structured_request_language_policy,
 )
 from ...core.agent.service import AgentService
 from ...core.agent.voice_policy import _VOICE_INSTRUCTIONS as _core_voice_instructions
@@ -560,12 +560,11 @@ async def optimize_instructions(
             "Your task is to refine and optimize the user's draft instructions for an AI agent. "
             "The output should be clear, structured, and effective for an LLM to follow. "
             "Do not include any conversational filler. Just output the optimized instructions. "
-            "Preserve the draft's natural language and Chinese script; do not switch languages "
-            "because the surrounding API prompt is written in English. "
-            f"{response_language_rules(subject='draft instructions')}"
+            "Use draft_instructions as the independent user request. "
+            f"{render_structured_request_language_policy(request_field='draft_instructions', pending_field='pending_response', output_language=None)}"
         )
 
-        user_prompt = f"Draft instructions:\n{request.instructions}\n\nPlease optimize these instructions."
+        user_prompt = f"draft_instructions:\n{request.instructions}"
 
         # Call LLM
         response = await llm.chat(

--- a/src/xagent/web/services/workforce_prompt_runtime.py
+++ b/src/xagent/web/services/workforce_prompt_runtime.py
@@ -10,8 +10,7 @@ from pydantic import BaseModel, Field, field_validator
 
 from ...core.agent.language import (
     detect_prose_script_mismatch,
-    output_language_policy,
-    response_language_rules,
+    render_dag_step_language_reference,
 )
 from ...core.agent.result import extract_assistant_message
 from ...core.agent.service import AgentService
@@ -568,8 +567,7 @@ success when finalization did not happen.
 All persisted user-facing prose passed to tools, including {_WORKFORCE_BUILDER_PERSISTED_FIELDS},
 must follow the user's request language. English tool names, schemas, and tool
 results do not authorize changing it.
-{output_language_policy()}
-{response_language_rules(subject="current user request")}
+{render_dag_step_language_reference()}
 """
 
 

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -863,7 +863,7 @@ async def test_auto_pattern_final_answer_completes_without_child_pattern() -> No
     assert runtime.last_checkpoint is not None
     assert runtime.last_checkpoint["pattern"] == "AutoPattern"
     assert (
-            "canonical language contract provided by the system context"
+        "canonical language contract provided by the system context"
         in tool_schema["description"]
     )
     assert "canonical language contract" in answer_schema["description"]

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -863,10 +863,10 @@ async def test_auto_pattern_final_answer_completes_without_child_pattern() -> No
     assert runtime.last_checkpoint is not None
     assert runtime.last_checkpoint["pattern"] == "AutoPattern"
     assert (
-        "canonical request-language policy in the system context"
+            "canonical language contract provided by the system context"
         in tool_schema["description"]
     )
-    assert "canonical request-language policy" in answer_schema["description"]
+    assert "canonical language contract" in answer_schema["description"]
 
 
 @pytest.mark.asyncio
@@ -2327,7 +2327,7 @@ async def test_direct_final_answer_allows_an_explicit_target_language() -> None:
     assert OUTPUT_LANGUAGE_METADATA_KEY not in context.metadata
     target_rule = "explicit or implicit target-language intent"
     tool_schema = llm.calls[0]["tools"][0]["function"]
-    assert "canonical request-language policy" in tool_schema["description"]
+    assert "canonical language contract" in tool_schema["description"]
     system_content = context.get_messages_for_llm()[0]["content"]
     assert request in system_content
     assert target_rule in system_content

--- a/tests/core/agent/test_auto.py
+++ b/tests/core/agent/test_auto.py
@@ -25,7 +25,6 @@ from xagent.core.agent.language import (
     OUTPUT_LANGUAGE_METADATA_KEY,
     OUTPUT_LANGUAGE_SOURCE_METADATA_KEY,
     OUTPUT_LANGUAGE_SOURCE_PLAN,
-    response_language_rules,
 )
 from xagent.core.agent.pattern.auto.auto import DECISION_TOOL_NAME, _AutoChildRuntime
 from xagent.core.model.chat.basic.router import RouterLLM
@@ -864,10 +863,10 @@ async def test_auto_pattern_final_answer_completes_without_child_pattern() -> No
     assert runtime.last_checkpoint is not None
     assert runtime.last_checkpoint["pattern"] == "AutoPattern"
     assert (
-        "same natural language as the current user request"
+        "canonical request-language policy in the system context"
         in tool_schema["description"]
     )
-    assert "tool results, source documents" in answer_schema["description"]
+    assert "canonical request-language policy" in answer_schema["description"]
 
 
 @pytest.mark.asyncio
@@ -2300,7 +2299,7 @@ async def test_stale_memory_language_does_not_reach_child_as_hard_policy() -> No
     assert "Output language:" not in child_system
     assert "Output language policy:" not in child_system
     assert "Summarize the quarterly revenue trend in one paragraph." in child_system
-    assert response_language_rules() in child_system
+    assert "Canonical request-language evidence" in child_system
 
 
 @pytest.mark.asyncio
@@ -2326,15 +2325,9 @@ async def test_direct_final_answer_allows_an_explicit_target_language() -> None:
     assert result["success"] is True
     assert result["output"] == "La capitale de l'Italie est Rome."
     assert OUTPUT_LANGUAGE_METADATA_KEY not in context.metadata
-    target_rule = (
-        "If the current user request explicitly asks to translate, rewrite, or "
-        "answer in another language, use that requested target language."
-    )
+    target_rule = "explicit or implicit target-language intent"
     tool_schema = llm.calls[0]["tools"][0]["function"]
-    assert target_rule in tool_schema["description"]
-    assert (
-        target_rule in tool_schema["parameters"]["properties"]["answer"]["description"]
-    )
+    assert "canonical request-language policy" in tool_schema["description"]
     system_content = context.get_messages_for_llm()[0]["content"]
     assert request in system_content
     assert target_rule in system_content

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -31,7 +31,12 @@ from xagent.core.agent.language import (
     response_language_rules,
 )
 from xagent.core.agent.utils.context_builder import ContextBuilder
-from xagent.core.context_ref import CONTEXT_REFS_KEY, SUPERSEDES_SCOPE_KEY
+from xagent.core.context_ref import (
+    CONTEXT_REFS_KEY,
+    SUPERSEDES_SCOPE_KEY,
+    ContextReference,
+    ImageDetail,
+)
 from xagent.core.model.chat.types import (
     CONTENT_SOURCE_KEY,
     CONTENT_SOURCE_REASONING_FALLBACK,
@@ -1679,6 +1684,63 @@ def test_token_estimate_falls_back_when_history_is_rewritten() -> None:
     assert ctx._get_total_tokens() == max(1, len("rewritten") // 4)
 
 
+def test_provider_estimate_drives_compaction_with_dynamic_system_prompt() -> None:
+    ctx = ExecutionContext(system_prompt="S" * 3_600)
+    ctx.add_user_message("x")
+    rendered = ctx.get_messages_for_llm()
+    rendered_tokens = ctx.estimate_context_tokens(rendered)
+    assert rendered_tokens > ctx._get_total_tokens() + 800
+
+    ctx.compact_config.threshold = rendered_tokens - 1
+    request = ctx.build_llm_compact_request_if_needed()
+
+    assert request is not None
+    assert request["original_tokens"] == rendered_tokens
+
+
+def test_provider_estimate_counts_context_refs_and_tool_call_arguments() -> None:
+    reference = ContextReference(
+        file_ref={
+            "file_id": "image-1",
+            "filename": "frame.png",
+            "mime_type": "image/png",
+        },
+        detail=ImageDetail.LOW,
+    )
+    ctx = ExecutionContext()
+    with_ref = [
+        {
+            "role": "user",
+            "content": "inspect",
+            CONTEXT_REFS_KEY: [reference.durable_dict()],
+        }
+    ]
+    without_ref = [{"role": "user", "content": "inspect"}]
+    assert ctx.estimate_context_tokens(with_ref) >= (
+        ctx.estimate_context_tokens(without_ref) + reference.estimated_tokens()
+    )
+
+    long_call = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {"function": {"name": "write_file", "arguments": "x" * 1_000}}
+            ],
+        }
+    ]
+    short_call = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [{"function": {"name": "write_file", "arguments": ""}}],
+        }
+    ]
+    assert ctx.estimate_context_tokens(long_call) > (
+        ctx.estimate_context_tokens(short_call) + 200
+    )
+
+
 def test_serialization_roundtrip() -> None:
     ctx = ExecutionContext()
     ctx.execution_id = "task-x"
@@ -1997,6 +2059,15 @@ def _context_over_threshold(threshold: int) -> ExecutionContext:
     ctx = ExecutionContext()
     ctx.compact_config.threshold = threshold
     ctx.add_user_message("current request")
+    ctx.add_assistant_message(
+        "",
+        tool_calls=[
+            {
+                "id": "call-1",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }
+        ],
+    )
     # Token estimation is chars//4, so this clears the threshold and makes the
     # request materialize.
     ctx.add_tool_result(

--- a/tests/core/agent/test_context.py
+++ b/tests/core/agent/test_context.py
@@ -265,9 +265,9 @@ def test_system_context_preserves_current_request_language_over_memory() -> None
 
     assert "Current user request:" in system_message
     assert "Can you analyze this GitHub project?" in system_message
-    assert "Response language rules" in system_message
-    assert "Use the same natural language as the current user request" in system_message
-    assert "Do not let retrieved memories" in system_message
+    assert "Canonical request-language evidence" in system_message
+    assert "sole hard language authority" in system_message
+    assert "memory" in system_message
 
 
 def test_system_context_includes_file_reference_output_spec() -> None:
@@ -426,7 +426,7 @@ def test_system_context_ignores_waiting_for_user_answer_as_current_request() -> 
     assert "Current user request:\nBook a trip" in system_message
     assert "Current user request:\n北京" not in system_message
     assert "answer to a pending agent question" in waiting_answer_message
-    assert "User answer: 北京" in waiting_answer_message
+    assert waiting_answer_message.endswith("北京")
 
 
 def test_dag_step_system_context_uses_output_language_policy() -> None:
@@ -443,15 +443,14 @@ def test_dag_step_system_context_uses_output_language_policy() -> None:
 
     system_message = ctx.get_messages_for_llm()[0]["content"]
 
-    assert "Step language rules" in system_message
+    assert "Canonical request-language evidence" in system_message
     assert "Output language: English" in system_message
     assert (
-        "Follow the output language policy for all user-facing prose, this "
-        "step's final_answer, and tool arguments"
+        "Follow the canonical request-language evidence and policy"
     ) in system_message
     assert "## FILE REFERENCE OUTPUTS" in system_message
-    assert "do not treat their language as authorization" in system_message
-    assert "Do not let DAG step text, dependency results" in system_message
+    assert "DAG step text" in system_message
+    assert "not language evidence" in system_message
 
 
 def test_context_builder_step_prompt_includes_file_reference_output_spec() -> None:
@@ -802,6 +801,7 @@ def test_get_messages_for_llm_uses_compact_dag_output_language_policy() -> None:
     assert "Current user request, quoted for response language only:" not in (
         system_content
     )
+    assert '"output_language": "English"' in system_content
     assert "Create two posters." not in system_content
     assert "Only execute the current DAG step" in system_content
     assert [message["role"] for message in result].count("system") == 1
@@ -816,9 +816,9 @@ def test_dag_step_without_output_language_quotes_the_request_for_language() -> N
 
     system_content = ctx.get_messages_for_llm()[0]["content"]
 
-    assert "Current user request, quoted for response language only:" in system_content
+    assert '"independent_user_request": "Crée deux affiches."' in system_content
     assert "Crée deux affiches." in system_content
-    assert "Response language rules:" in system_content
+    assert "sole hard language authority" in system_content
     assert "Output language:" not in system_content
 
 
@@ -848,11 +848,9 @@ def test_dag_step_language_quote_uses_the_typed_message() -> None:
     )
 
     system_content = ctx.get_messages_for_llm()[0]["content"]
-    quote = system_content.split(
-        "Current user request, quoted for response language only:\n"
-    )[1]
+    quote = system_content.split("Canonical request-language evidence (JSON):\n")[1]
 
-    assert quote.startswith(typed)
+    assert f'"independent_user_request": "{typed}"' in quote
     assert "Attached file(s)" not in quote
 
 

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -31,7 +31,6 @@ from xagent.core.agent.language import (
     OUTPUT_LANGUAGE_METADATA_KEY,
     OUTPUT_LANGUAGE_SOURCE_METADATA_KEY,
     OUTPUT_LANGUAGE_SOURCE_PLAN,
-    response_language_rules,
 )
 from xagent.core.agent.pattern.base import RequiredToolCallError
 from xagent.core.agent.pattern.dag import dag as dag_module
@@ -460,11 +459,10 @@ def test_dag_waiting_response_preserves_active_step_state() -> None:
     restored_child = ExecutionContext.from_dict(pattern.active_step_contexts["confirm"])
     forwarded_message = restored_child.messages[-1]
     assert forwarded_message.content == "Choose B"
-    assert forwarded_message.metadata == {
-        "kind": "dag_waiting_user_response",
-        "forwarded_from_root": True,
-        "dag_step_id": "confirm",
-    }
+    assert forwarded_message.metadata["kind"] == "dag_waiting_user_response"
+    assert forwarded_message.metadata["response_to_waiting_for_user"]["question"] == (
+        "Choose A or B"
+    )
 
 
 @pytest.mark.asyncio
@@ -728,14 +726,14 @@ async def test_dag_pattern_streams_overall_completion_not_step_result() -> None:
     assert has_tool(llm.stream_calls[1], DAG_COMPLETION_TOOL_NAME)
     completion_messages = llm.stream_calls[1]["messages"]
     assert (
-        "same natural language as the output language policy"
+        "canonical request-language policy in the output_language_policy field"
         in completion_messages[0]["content"]
     )
     completion_payload = json.loads(completion_messages[-1]["content"])
     assert "output_language_policy" in completion_payload
     completion_tool = llm.stream_calls[1]["tools"][0]["function"]
     answer_schema = completion_tool["parameters"]["properties"]["answer"]
-    assert "tool results, source documents" in answer_schema["description"]
+    assert "canonical request-language policy" in answer_schema["description"]
     assert [event["type"] for event in outbound.events] == [
         "final_answer_start",
         "final_answer_delta",
@@ -1286,11 +1284,8 @@ async def test_dag_step_appends_current_step_boundary_after_parent_context() -> 
     assert [message["role"] for message in messages].count("system") == 1
     assert "DAG step execution scope" in messages[0]["content"]
     assert "Overall user goal is background context only" in messages[0]["content"]
-    assert "Output language policy" in messages[0]["content"]
-    assert (
-        "Current user request, quoted for response language only:"
-        in messages[0]["content"]
-    )
+    assert "Canonical request-language evidence" in messages[0]["content"]
+    assert '"independent_user_request"' in messages[0]["content"]
     assert "Extract highlights and generate two posters." in messages[0]["content"]
     assert "Extract highlights and generate two posters." not in messages[-1]["content"]
     assert "Current step id: extract" in messages[0]["content"]
@@ -5441,7 +5436,7 @@ async def test_polluted_plan_language_is_not_a_hard_policy_for_dag_steps(
         assert "Output language: Simplified Chinese" not in system_content
         assert "Output language:" not in system_content
         assert request in system_content
-        assert response_language_rules() in system_content
+        assert "Canonical request-language evidence" in system_content
         step_instruction = [
             message.content
             for message in child.messages
@@ -5502,7 +5497,7 @@ async def test_restored_dag_step_instruction_drops_stale_language_policy(
     legacy_root = ExecutionContext(execution_id="dag-restored-language-legacy")
     legacy_root.metadata[OUTPUT_LANGUAGE_METADATA_KEY] = "Simplified Chinese"
     stale_instruction = pattern._step_instruction(root_context=legacy_root, step=step)
-    assert "Output language: Simplified Chinese" in stale_instruction
+    assert "canonical request-language evidence" in stale_instruction
 
     child_context = ExecutionContext(execution_id="dag-restored-language:write")
     child_context.add_user_message(
@@ -5544,7 +5539,7 @@ async def test_restored_dag_step_instruction_drops_stale_language_policy(
         if message.metadata.get("kind") == "dag_step_instruction"
     )
     assert "Output language: Simplified Chinese" not in instruction
-    assert "Use the same natural language as the current user request" in instruction
+    assert "canonical request-language evidence" in instruction
 
 
 _FILE_REFERENCE_BLOCK = (

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -726,14 +726,14 @@ async def test_dag_pattern_streams_overall_completion_not_step_result() -> None:
     assert has_tool(llm.stream_calls[1], DAG_COMPLETION_TOOL_NAME)
     completion_messages = llm.stream_calls[1]["messages"]
     assert (
-        "canonical request-language policy in the output_language_policy field"
+        "canonical language contract provided by the output_language_policy field"
         in completion_messages[0]["content"]
     )
     completion_payload = json.loads(completion_messages[-1]["content"])
     assert "output_language_policy" in completion_payload
     completion_tool = llm.stream_calls[1]["tools"][0]["function"]
     answer_schema = completion_tool["parameters"]["properties"]["answer"]
-    assert "canonical request-language policy" in answer_schema["description"]
+    assert "canonical language contract" in answer_schema["description"]
     assert [event["type"] for event in outbound.events] == [
         "final_answer_start",
         "final_answer_delta",
@@ -923,13 +923,22 @@ def test_dag_completion_assessment_keeps_user_request_as_scope_authority() -> No
     }
     context = ExecutionContext(execution_id="dag-user-scope")
     context.add_user_message("Create two reports.")
+    context.add_user_message(
+        "Use Spanish.",
+        metadata={
+            "response_to_waiting_for_user": {"question": "Which output language?"}
+        },
+    )
+    context.add_user_message("Also add an executive summary.")
 
     messages = pattern._completion_assessment_messages(context)
 
     system_prompt = messages[0]["content"]
     payload = json.loads(messages[1]["content"])
     assert payload["authoritative_user_requests"] == [
-        {"role": "user", "content": "Create two reports."}
+        {"role": "user", "content": "Create two reports."},
+        {"role": "user", "content": "Use Spanish."},
+        {"role": "user", "content": "Also add an executive summary."},
     ]
     assert "the only source of required scope" in system_prompt
     assert "cannot add deliverables" in system_prompt

--- a/tests/core/agent/test_dag.py
+++ b/tests/core/agent/test_dag.py
@@ -5503,10 +5503,7 @@ async def test_restored_dag_step_instruction_drops_stale_language_policy(
     pattern = DAGPattern(lambda **_: build_plan(step))
     pattern.plan = build_plan(step)
 
-    legacy_root = ExecutionContext(execution_id="dag-restored-language-legacy")
-    legacy_root.metadata[OUTPUT_LANGUAGE_METADATA_KEY] = "Simplified Chinese"
-    stale_instruction = pattern._step_instruction(root_context=legacy_root, step=step)
-    assert "canonical request-language evidence" in stale_instruction
+    stale_instruction = "Legacy step instruction\nOutput language: Simplified Chinese"
 
     child_context = ExecutionContext(execution_id="dag-restored-language:write")
     child_context.add_user_message(
@@ -5547,8 +5544,8 @@ async def test_restored_dag_step_instruction_drops_stale_language_policy(
         for message in captured[0].messages
         if message.metadata.get("kind") == "dag_step_instruction"
     )
+    assert instruction != stale_instruction
     assert "Output language: Simplified Chinese" not in instruction
-    assert "canonical request-language evidence" in instruction
 
 
 _FILE_REFERENCE_BLOCK = (

--- a/tests/core/agent/test_output_language_seam.py
+++ b/tests/core/agent/test_output_language_seam.py
@@ -129,6 +129,7 @@ def test_every_consumer_renders_the_resolved_language() -> None:
     assert render_dag_step_language_reference() in _step_instruction("Japanese")
     assert "Output language: Japanese" in _completion_policy("Japanese")
     assert "Output language: Japanese" in _plan_payload_policy("Japanese")
+    assert "Output language: Japanese" in step_system
 
 
 def test_every_consumer_falls_back_when_no_language_is_recorded() -> None:
@@ -171,3 +172,49 @@ def test_unusable_language_metadata_never_reaches_a_prompt() -> None:
         # A rejected label leaves the root context with the soft rules only,
         # not with a redundant second copy of the fallback policy.
         assert rendered[0].count("Output language policy:") == 0
+
+
+def test_root_reference_and_structured_fields_do_not_duplicate_request() -> None:
+    request = "Summarize this repository"
+    context = ExecutionContext()
+    context.add_user_message(request)
+
+    root_system = context._system_context()
+    plan_payload = json.loads(
+        LLMPlanGenerator()._build_prompt(
+            PlanGenerationRequest(
+                context=context,
+                execution_id="root-reference",
+                available_tool_names=[],
+            )
+        )
+    )
+
+    assert root_system.count(request) == 1
+    assert '"independent_user_request_reference": "Current user request above"' in (
+        root_system
+    )
+    assert plan_payload["latest_user_request"] == request
+    assert request not in plan_payload["output_language_policy"]
+
+
+def test_blank_pending_question_is_not_planner_language_evidence() -> None:
+    context = ExecutionContext()
+    context.add_user_message("Draft the email.")
+    context.add_user_message(
+        "Spanish",
+        metadata={"response_to_waiting_for_user": {"question": ""}},
+    )
+    payload = json.loads(
+        LLMPlanGenerator()._build_prompt(
+            PlanGenerationRequest(
+                context=context,
+                execution_id="blank-pending",
+                available_tool_names=[],
+            )
+        )
+    )
+
+    assert payload["latest_user_request"] == "Draft the email."
+    assert payload["pending_response"] is None
+    assert payload["messages"][-1]["content"] == "Spanish"

--- a/tests/core/agent/test_output_language_seam.py
+++ b/tests/core/agent/test_output_language_seam.py
@@ -10,6 +10,7 @@ from xagent.core.agent.language import (
     effective_output_language,
     output_language_directives,
     output_language_policy,
+    render_dag_step_language_reference,
     response_language_rules,
 )
 from xagent.core.agent.pattern.dag.dag import DAGPattern
@@ -119,42 +120,25 @@ def test_output_language_directives_render_each_section_verbatim() -> None:
 
 
 def test_every_consumer_renders_the_resolved_language() -> None:
-    root = _root_context("Japanese")._system_context()
-    assert output_language_directives("Japanese", section="root_system_context") in root
-
     step_system = _dag_step_context("Japanese")._system_context()
     assert output_language_directives("Japanese", section="dag_step_scope") in (
         step_system
     )
-    assert output_language_directives("Japanese", section="dag_step_rules") in (
-        step_system
-    )
+    assert "Follow the canonical request-language evidence and policy" in step_system
 
-    assert output_language_directives(
-        "Japanese", section="dag_step_instruction"
-    ) in _step_instruction("Japanese")
-    assert _completion_policy("Japanese") == output_language_directives(
-        "Japanese", section="completion_assessment"
-    )
-    assert _plan_payload_policy("Japanese") == output_language_directives(
-        "Japanese", section="plan_payload"
-    )
+    assert render_dag_step_language_reference() in _step_instruction("Japanese")
+    assert "Output language: Japanese" in _completion_policy("Japanese")
+    assert "Output language: Japanese" in _plan_payload_policy("Japanese")
 
 
 def test_every_consumer_falls_back_when_no_language_is_recorded() -> None:
+    assert "Canonical request-language evidence" in _root_context()._system_context()
     assert (
-        output_language_directives("", section="root_system_context")
-        in _root_context()._system_context()
+        "Canonical request-language evidence" in _dag_step_context()._system_context()
     )
-    assert (
-        output_language_directives("", section="dag_step_scope")
-        in _dag_step_context()._system_context()
-    )
-    assert output_language_directives(
-        "", section="dag_step_instruction"
-    ) in _step_instruction(None)
-    assert _completion_policy(None) == output_language_policy("")
-    assert _plan_payload_policy(None) == output_language_policy("")
+    assert render_dag_step_language_reference() in _step_instruction(None)
+    assert "sole hard language authority" in _completion_policy(None)
+    assert "sole hard language authority" in _plan_payload_policy(None)
 
 
 def test_consumers_normalize_an_aliased_language_label() -> None:
@@ -166,7 +150,7 @@ def test_consumers_normalize_an_aliased_language_label() -> None:
         "Output language: Simplified Chinese"
         in _dag_step_context("zh-cn")._system_context()
     )
-    assert "Output language: Simplified Chinese" in _step_instruction("zh-cn")
+    assert render_dag_step_language_reference() in _step_instruction("zh-cn")
     assert "Output language: Simplified Chinese" in _completion_policy("zh-cn")
     assert "Output language: Simplified Chinese" in _plan_payload_policy("zh-cn")
 

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -4176,7 +4176,7 @@ async def test_react_pattern_reserves_control_tool_names_in_schema() -> None:
         if schema["function"]["name"] == "final_answer"
     )["function"]
     assert (
-        "same natural language as the current user request"
+        "canonical request-language policy in the system context"
         in final_answer_schema["description"]
     )
     assert (
@@ -4198,7 +4198,7 @@ async def test_react_pattern_reserves_control_tool_names_in_schema() -> None:
     assert "generic Chinese" in response_language_schema["description"]
     answer_schema = final_answer_schema["parameters"]["properties"]["answer"]
     assert "response_language" in answer_schema["description"]
-    assert "tool results, source documents" in answer_schema["description"]
+    assert "canonical request-language policy" in answer_schema["description"]
     assert "## FINAL DELIVERABLE FILE REFERENCES" not in answer_schema["description"]
     assert "exact markdown_link" in answer_schema["description"]
     assert "get_workspace_output_files" not in answer_schema["description"]
@@ -5236,7 +5236,7 @@ async def test_react_pattern_resume_waiting_after_user_response_continues() -> N
     first = await pattern.run(context=context, tools=[], llm=llm)
 
     assert first["status"] == "waiting_for_user"
-    context.add_user_message("B")
+    context.add_user_message("B", metadata={"response_to_waiting_for_user": "legacy"})
 
     resumed_pattern = ReActPattern(max_iterations=2)
     resumed_pattern.load_state(pattern.get_state())
@@ -5251,8 +5251,7 @@ async def test_react_pattern_resume_waiting_after_user_response_continues() -> N
     resumed_messages = resumed_llm.calls[0]["messages"]
     assert resumed_messages[-1]["role"] == "user"
     assert "answer to a pending agent question" in resumed_messages[-1]["content"]
-    assert "Pending question: Choose A or B" in resumed_messages[-1]["content"]
-    assert "User answer: B" in resumed_messages[-1]["content"]
+    assert resumed_messages[-1]["content"].endswith("B")
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react.py
+++ b/tests/core/agent/test_react.py
@@ -4176,7 +4176,7 @@ async def test_react_pattern_reserves_control_tool_names_in_schema() -> None:
         if schema["function"]["name"] == "final_answer"
     )["function"]
     assert (
-        "canonical request-language policy in the system context"
+        "canonical language contract provided by the system context"
         in final_answer_schema["description"]
     )
     assert (
@@ -4198,7 +4198,7 @@ async def test_react_pattern_reserves_control_tool_names_in_schema() -> None:
     assert "generic Chinese" in response_language_schema["description"]
     answer_schema = final_answer_schema["parameters"]["properties"]["answer"]
     assert "response_language" in answer_schema["description"]
-    assert "canonical request-language policy" in answer_schema["description"]
+    assert "canonical language contract" in answer_schema["description"]
     assert "## FINAL DELIVERABLE FILE REFERENCES" not in answer_schema["description"]
     assert "exact markdown_link" in answer_schema["description"]
     assert "get_workspace_output_files" not in answer_schema["description"]
@@ -6707,7 +6707,10 @@ async def test_callback_less_tool_interaction_resumes_by_replanning() -> None:
         if message.role == "user" and message.content == "Use 42"
     )
     waiting_metadata = response_message.metadata["response_to_waiting_for_user"]
-    assert waiting_metadata["requests"][0]["tool_name"] == "clarification_gate"
+    assert waiting_metadata == {
+        "question": "Which value should be used?",
+        "message_type": "question",
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_request_language_policy.py
+++ b/tests/core/agent/test_request_language_policy.py
@@ -9,7 +9,10 @@ from xagent.core.agent.context import ExecutionContext
 from xagent.core.agent.context.enrichment import (
     PendingUserResponse,
     TopLevelUserRequest,
+    latest_pending_user_response,
     pending_user_response,
+    pending_user_response_lifecycle,
+    pending_user_response_marker,
     top_level_user_request,
 )
 from xagent.core.agent.language import (
@@ -18,6 +21,7 @@ from xagent.core.agent.language import (
     serialize_pending_user_response,
 )
 from xagent.core.agent.pattern.dag.dag import DAGPattern
+from xagent.core.agent.pattern.react.react import ReActPattern
 
 
 def _request(text: str) -> TopLevelUserRequest:
@@ -101,6 +105,36 @@ def test_pending_response_defaults_invalid_message_type_without_leaking_it() -> 
     )
 
 
+def test_blank_question_keeps_lifecycle_but_not_language_evidence() -> None:
+    marker = pending_user_response_marker({"message": "  "})
+    context = ExecutionContext()
+    context.add_user_message("Draft the email.")
+    response_message = context.add_user_message(
+        "Spanish", metadata={"response_to_waiting_for_user": marker}
+    )
+
+    assert marker == {"question": "  ", "message_type": "question"}
+    assert pending_user_response_lifecycle(response_message) == marker
+    assert pending_user_response(response_message) is None
+    assert top_level_user_request(context).language_text == "Draft the email."
+
+
+def test_latest_language_evidence_scans_past_later_scope_addition() -> None:
+    context = ExecutionContext()
+    context.add_user_message("Draft the email.")
+    context.add_user_message(
+        "Spanish",
+        metadata={
+            "response_to_waiting_for_user": {"question": "Which output language?"}
+        },
+    )
+    context.add_user_message("Also include a subject line.")
+
+    assert latest_pending_user_response(context) == PendingUserResponse(
+        "Spanish", "Which output language?", "question"
+    )
+
+
 @pytest.mark.parametrize(
     "marker",
     [True, "legacy", {"question": " \n"}, {"question": 7}],
@@ -147,6 +181,22 @@ def test_caller_pin_and_explicit_answer_override_share_one_policy() -> None:
     )
     assert "answer explicitly asks to translate, rewrite, or continue" in policy
 
+    pinned = render_request_language_harness(
+        _request("Draft the email."),
+        PendingUserResponse("Spanish", "Which output language?", "question"),
+        output_language="Japanese",
+    )
+    evidence = json.loads(pinned.split("\n", 2)[1])
+    assert evidence == {
+        "output_language": "Japanese",
+        "pending_response": {
+            "answer": "Spanish",
+            "question": "Which output language?",
+            "message_type": "question",
+        },
+    }
+    assert "sole hard language authority" not in pinned
+
 
 def test_city_question_and_language_name_are_not_a_language_override() -> None:
     policy = canonical_unpinned_request_language_policy()
@@ -175,7 +225,8 @@ def test_request_language_harness_is_active_once_in_root_system_context() -> Non
     assert system_context.count("Canonical request-language evidence") == 1
 
 
-def test_dag_pending_response_is_symmetric() -> None:
+@pytest.mark.parametrize("question", ["Which output language?", ""])
+def test_dag_pending_response_is_symmetric(question: str) -> None:
     root = ExecutionContext()
     root.add_user_message("Draft the email.")
     child = root.create_child_context(execution_id="step")
@@ -188,7 +239,7 @@ def test_dag_pending_response_is_symmetric() -> None:
         "draft": {
             "status": "waiting_for_user",
             "waiting_for_user_request": {
-                "message": "Which output language?",
+                "message": question,
                 "message_type": "question",
                 "tool_call_id": "secret-id",
             },
@@ -196,18 +247,76 @@ def test_dag_pending_response_is_symmetric() -> None:
     }
     pattern.planned_user_message_count = 1
     root.add_user_message("Spanish")
+    root.add_user_message("Also include a subject line.")
 
     assert pattern._forward_user_response_to_waiting_step(root)
-    assert root.messages[-1].metadata["response_to_waiting_for_user"]["question"] == (
-        "Which output language?"
+    assert (
+        root.messages[-2].metadata["response_to_waiting_for_user"]["question"]
+        == question
     )
+    assert "response_to_waiting_for_user" not in root.messages[-1].metadata
     restored_child = ExecutionContext.from_dict(pattern.active_step_contexts["draft"])
-    response = pending_user_response(restored_child.messages[-1])
-    assert response == PendingUserResponse(
-        answer="Spanish",
-        question="Which output language?",
-        message_type="question",
+    response = pending_user_response(restored_child.messages[-2])
+    expected = (
+        PendingUserResponse("Spanish", question, "question") if question else None
     )
+    assert response == expected
+    assert pending_user_response_lifecycle(restored_child.messages[-2]) is not None
+    assert "response_to_waiting_for_user" not in restored_child.messages[-1].metadata
+
+
+def test_react_marks_first_new_user_message_as_primary_response() -> None:
+    context = ExecutionContext()
+    context.add_user_message("Draft the email.")
+    pattern = ReActPattern()
+    pattern.waiting_for_user_request = {"message": "Which output language?"}
+    context.add_user_message("Spanish")
+    context.add_user_message("Also include a subject line.")
+
+    answer = pattern._mark_latest_user_message_as_waiting_response(
+        context=context, after_message_count=1
+    )
+
+    assert answer == "Spanish"
+    assert pending_user_response(context.messages[1]) is not None
+    assert "response_to_waiting_for_user" not in context.messages[2].metadata
+
+
+def test_react_blank_question_still_marks_primary_lifecycle() -> None:
+    context = ExecutionContext()
+    context.add_user_message("Draft the email.")
+    context.add_user_message("Spanish")
+    pattern = ReActPattern()
+    pattern.waiting_for_user_request = {"message": ""}
+
+    pattern._mark_latest_user_message_as_waiting_response(
+        context=context, after_message_count=1
+    )
+
+    assert pending_user_response_lifecycle(context.messages[-1]) is not None
+    assert pending_user_response(context.messages[-1]) is None
+    assert top_level_user_request(context).language_text == "Draft the email."
+
+
+def test_historical_pending_messages_use_their_own_question() -> None:
+    context = ExecutionContext()
+    context.add_user_message("Draft the email.")
+    context.add_user_message(
+        "Formal",
+        metadata={"response_to_waiting_for_user": {"question": "Which tone?"}},
+    )
+    context.add_user_message(
+        "Spanish",
+        metadata={
+            "response_to_waiting_for_user": {"question": "Which output language?"}
+        },
+    )
+
+    rendered = context.get_messages_for_llm()
+
+    assert '"question": "Which tone?"' in rendered[-2]["content"]
+    assert "Which output language?" not in rendered[-2]["content"]
+    assert "canonical request-language evidence" in rendered[-1]["content"]
 
 
 @pytest.mark.parametrize("display", ["", "  \n\t"])

--- a/tests/core/agent/test_request_language_policy.py
+++ b/tests/core/agent/test_request_language_policy.py
@@ -167,17 +167,15 @@ def test_harness_preserves_large_request_and_answer_exactly_once() -> None:
     assert harness.count("Which language?") == 1
 
 
-def test_request_language_harness_is_not_active_in_root_consumers() -> None:
+def test_request_language_harness_is_active_once_in_root_system_context() -> None:
     context = ExecutionContext()
     context.add_user_message("Draft the email.")
 
-    assert "Canonical request-language evidence" not in context._system_context()
-    assert "Canonical request-language evidence" not in json.dumps(
-        context.get_messages_for_llm()
-    )
+    system_context = context._system_context()
+    assert system_context.count("Canonical request-language evidence") == 1
 
 
-def test_request_language_representation_is_not_active_in_dag_forwarding() -> None:
+def test_dag_pending_response_is_symmetric() -> None:
     root = ExecutionContext()
     root.add_user_message("Draft the email.")
     child = root.create_child_context(execution_id="step")
@@ -200,6 +198,32 @@ def test_request_language_representation_is_not_active_in_dag_forwarding() -> No
     root.add_user_message("Spanish")
 
     assert pattern._forward_user_response_to_waiting_step(root)
-    assert "response_to_waiting_for_user" not in root.messages[-1].metadata
+    assert root.messages[-1].metadata["response_to_waiting_for_user"]["question"] == (
+        "Which output language?"
+    )
     restored_child = ExecutionContext.from_dict(pattern.active_step_contexts["draft"])
-    assert "response_to_waiting_for_user" not in restored_child.messages[-1].metadata
+    response = pending_user_response(restored_child.messages[-1])
+    assert response == PendingUserResponse(
+        answer="Spanish",
+        question="Which output language?",
+        message_type="question",
+    )
+
+
+@pytest.mark.parametrize("display", ["", "  \n\t"])
+def test_pending_response_present_blank_display_never_uses_enriched_content(
+    display: str,
+) -> None:
+    context = ExecutionContext()
+    context.add_user_message(
+        "Spanish\n\nAttached file: correo-es.pdf",
+        metadata={
+            "display_message": display,
+            "response_to_waiting_for_user": {"question": "Which output language?"},
+        },
+    )
+
+    restored = ExecutionContext.from_dict(context.to_dict()).messages[0]
+    response = pending_user_response(restored)
+
+    assert response and response.answer == ""

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -1049,7 +1049,7 @@ async def test_on_llm_start_emits_context_usage_fields() -> None:
     runtime = PatternRuntime(tracer=tracer, execution_id="task-1")
     ctx = ExecutionContext()
     ctx.compact_config.threshold = 96000
-    ctx.add_message("user", "x" * 400)
+    ctx.add_message("user", "persisted-only")
 
     await runtime.on_llm_start(
         context=ctx, messages=[{"role": "user", "content": "x" * 400}]
@@ -1059,7 +1059,7 @@ async def test_on_llm_start_emits_context_usage_fields() -> None:
     assert usage, tracer.events
     assert usage[0]["context_threshold"] == 96000
     assert isinstance(usage[0]["context_tokens"], int)
-    assert usage[0]["context_tokens"] > 0
+    assert usage[0]["context_tokens"] == 100
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_runtime.py
+++ b/tests/core/agent/test_runtime.py
@@ -1051,15 +1051,15 @@ async def test_on_llm_start_emits_context_usage_fields() -> None:
     ctx.compact_config.threshold = 96000
     ctx.add_message("user", "persisted-only")
 
-    await runtime.on_llm_start(
-        context=ctx, messages=[{"role": "user", "content": "x" * 400}]
-    )
+    messages = [{"role": "user", "content": "x" * 400}]
+    tools = [{"function": {"name": "save", "description": "d" * 400}}]
+    await runtime.on_llm_start(context=ctx, messages=messages, tools=tools)
 
     usage = [e["data"] for e in tracer.events if "context_threshold" in e["data"]]
     assert usage, tracer.events
     assert usage[0]["context_threshold"] == 96000
     assert isinstance(usage[0]["context_tokens"], int)
-    assert usage[0]["context_tokens"] == 100
+    assert usage[0]["context_tokens"] == ctx.estimate_context_tokens(messages, tools)
 
 
 @pytest.mark.asyncio
@@ -1495,6 +1495,12 @@ async def test_compaction_retries_with_a_smaller_budget_before_truncating() -> N
     context = ExecutionContext(execution_id="budget-retry")
     context.compact_config.threshold = 32000
     context.add_user_message("current request")
+    context.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "function": {"name": "read_file", "arguments": "{}"}}
+        ],
+    )
     context.add_tool_result(
         "read_file", {"output": "x" * 200_000}, tool_call_id="call-1"
     )
@@ -1541,6 +1547,12 @@ async def test_compaction_ladder_skips_a_budget_the_model_cannot_use() -> None:
     context = ExecutionContext(execution_id="budget-ladder")
     context.compact_config.threshold = 32000
     context.add_user_message("current request")
+    context.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "function": {"name": "read_file", "arguments": "{}"}}
+        ],
+    )
     context.add_tool_result(
         "read_file", {"output": "x" * 200_000}, tool_call_id="call-1"
     )
@@ -1590,6 +1602,12 @@ async def test_compaction_stops_descending_once_a_budget_is_accepted() -> None:
     context = ExecutionContext(execution_id="budget-monotone")
     context.compact_config.threshold = 32000
     context.add_user_message("current request")
+    context.add_assistant_message(
+        "",
+        tool_calls=[
+            {"id": "call-1", "function": {"name": "read_file", "arguments": "{}"}}
+        ],
+    )
     context.add_tool_result(
         "read_file", {"output": "x" * 200_000}, tool_call_id="call-1"
     )
@@ -1725,6 +1743,15 @@ def _oversized_context(execution_id: str) -> ExecutionContext:
     context = ExecutionContext(execution_id=execution_id)
     context.compact_config.threshold = 32000
     context.add_user_message("current request")
+    context.add_assistant_message(
+        "",
+        tool_calls=[
+            {
+                "id": "call-1",
+                "function": {"name": "read_file", "arguments": "{}"},
+            }
+        ],
+    )
     context.add_tool_result(
         "read_file", {"output": "x" * 200_000}, tool_call_id="call-1"
     )

--- a/tests/web/api/test_agents_optimize_instructions.py
+++ b/tests/web/api/test_agents_optimize_instructions.py
@@ -56,6 +56,7 @@ async def test_optimize_instructions_preserves_draft_language(
     assert "draft_instructions" in system_prompt
     assert "explicit or implicit target-language intent" in system_prompt
     assert "Simplified Chinese versus Traditional Chinese" in system_prompt
+    assert "surrounding API prompt is written in English only" in system_prompt
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_agents_optimize_instructions.py
+++ b/tests/web/api/test_agents_optimize_instructions.py
@@ -53,8 +53,8 @@ async def test_optimize_instructions_preserves_draft_language(
         )
     }
     system_prompt = llm.calls[0]["messages"][0]["content"]
-    assert "Preserve the draft's natural language" in system_prompt
-    assert "same natural language as the draft instructions" in system_prompt
+    assert "draft_instructions" in system_prompt
+    assert "explicit or implicit target-language intent" in system_prompt
     assert "Simplified Chinese versus Traditional Chinese" in system_prompt
 
 

--- a/tests/web/test_workforce_creator_plan.py
+++ b/tests/web/test_workforce_creator_plan.py
@@ -82,6 +82,8 @@ def test_builder_prompt_requires_multi_agent_react_and_language_harness() -> Non
     assert "one transaction" in normalized_prompt
     assert "Simplified Chinese" in prompt
     assert "Traditional Chinese" in prompt
+    assert "DAG step" not in prompt
+    assert "dependencies" not in prompt
 
 
 def test_builder_state_requires_all_agents_before_finalization() -> None:


### PR DESCRIPTION
## Summary

- activate the canonical request-only language representation across root, Auto, ReAct, DAG planning, step execution, completion, final-answer schemas, Workforce Builder, and instruction optimization
- keep `request_context.output_language` as the sole hard authority while isolating unpinned decisions from execution enrichment, memory, tools, connectors, names, and addresses
- implement the pending question/answer marker contract, including root/child symmetry, legacy-marker recovery, allowlisted serialization, and display-message tri-state handling
- account for the final rendered provider messages when reporting context usage

## Validation

- 658 focused tests covering request language, output-language seams, context, DAG, ReAct, Auto, runtime, runner, and instruction optimization
- `ruff format --check` on all changed Python files
- `ruff check` on all changed Python files
- `py_compile` on all changed production Python files
- mutation checks for root/Auto rendering, pinned precedence, structured planner/completion fields, DAG pending forwarding, DAG step references, final-answer schemas, pending language selection, non-language pending answers, display-message fallback, legacy markers, and provider-message token accounting

Closes #2064

Parent: #2062

Prerequisites: #2068, #2076

Provider admission remains separate in #2041.
