### PR TITLE
fix(posthog): gate proxied requests on trusted egress

### DIFF
--- a/src/xagent/web/tools/mcp/posthog.py
+++ b/src/xagent/web/tools/mcp/posthog.py
@@ -201,17 +201,29 @@ def _make_request(**kwargs: Any) -> requests.Response:
     configuration (`getproxies_macosx_sysconf()`/`getproxies_registry()`)
     once no env var is set -- the same DNS-rebinding-via-proxy bypass this
     gate exists to close, one layer deeper than an env-var scrub alone
-    reaches. Mirrors magento.py's identical `_make_request`.
+    reaches.
 
     `trust_env=False` also disables `requests`' `REQUESTS_CA_BUNDLE`/
     `CURL_CA_BUNDLE` lookup and `.netrc` auto-auth (both gated behind the
-    same `if self.trust_env:` check in `requests`' own Session code); no
-    re-application is needed here, unlike magento.py's self-hosted target,
-    since PostHog Cloud's two hosts always terminate TLS with a publicly
-    trusted CA and this connector always sends its own Bearer header.
+    same `if self.trust_env:` check in `requests`' own Session code) --
+    re-applying the CA bundle explicitly below matters even though PostHog
+    Cloud's own two hosts always terminate TLS with a publicly trusted CA:
+    the only case `proxies` is ever non-empty here is an operator opting in
+    via `XAGENT_TRUSTED_EGRESS_PROXY=1`, the textbook case for a corporate
+    egress proxy doing TLS interception with an internally-issued CA. Without
+    this, that proxy path would fail closed with an opaque `SSLError` for
+    every operator who actually needs it, rather than the intercepting
+    proxy's CA being honored the way it would under `requests`' own default
+    `trust_env=True`. `.netrc` is left disabled since this connector always
+    sends its own Bearer header.
     """
     with requests.Session() as session:
         session.trust_env = False
+        ca_bundle = os.environ.get("REQUESTS_CA_BUNDLE") or os.environ.get(
+            "CURL_CA_BUNDLE"
+        )
+        if ca_bundle:
+            session.verify = ca_bundle
         return session.request(**kwargs)
 
 
@@ -226,15 +238,15 @@ def _request(
     # the real connection, not this process -- silently bypassing
     # _base_url()'s own private-network validation of POSTHOG_HOST, which
     # only checks the addresses this process itself resolves. Mirrors
-    # web_content.py's fetch_web_content and magento.py's _request:
-    # get_trusted_proxy_url() raises unless the proxy is explicitly marked
-    # trusted to enforce its own private-range egress policy
-    # (XAGENT_TRUSTED_EGRESS_PROXY=1), rather than silently trusting every
-    # ambient proxy setup_proxy_env() promotes from the OS's own settings.
-    # The result is then passed to `_make_request()` (see above), which
-    # issues the call on a trust_env=False Session -- disabling every
-    # ambient/OS-native proxy source, not just the env vars this function
-    # checks -- so "no proxy" here is an actual guarantee for this call.
+    # web_content.py's fetch_web_content: get_trusted_proxy_url() raises
+    # unless the proxy is explicitly marked trusted to enforce its own
+    # private-range egress policy (XAGENT_TRUSTED_EGRESS_PROXY=1), rather
+    # than silently trusting every ambient proxy setup_proxy_env() promotes
+    # from the OS's own settings. The result is then passed to
+    # `_make_request()` (see above), which issues the call on a
+    # trust_env=False Session -- disabling every ambient/OS-native proxy
+    # source, not just the env vars this function checks -- so "no proxy"
+    # here is an actual guarantee for this call.
     proxy_url = get_trusted_proxy_url()
     proxies = {"http": proxy_url, "https": proxy_url} if proxy_url else {}
 
@@ -268,11 +280,11 @@ def _request(
             break
     except requests.RequestException as exc:
         # A connection/timeout/proxy failure's message can itself embed
-        # sensitive data -- e.g. a ProxyError echoing the ambient
-        # HTTPS_PROXY URL, which may carry embedded user:pass@ credentials
-        # (setup_proxy_env() exports whatever the OS has configured) -- so
-        # this gets the same redaction the HTTPError response-body path
-        # below already has, not just that one case.
+        # sensitive data -- e.g. a ProxyError connecting through a proxy
+        # that passed the trust check above can still echo that proxy's
+        # URL, which may carry embedded user:pass@ credentials -- so this
+        # gets the same redaction the HTTPError response-body path below
+        # already has, not just that one case.
         raise RuntimeError(redact_sensitive_text(str(exc))) from exc
 
     if 300 <= response.status_code < 400:

--- a/src/xagent/web/tools/mcp/posthog.py
+++ b/src/xagent/web/tools/mcp/posthog.py
@@ -246,8 +246,14 @@ def _request(
     # `_make_request()` (see above), which issues the call on a
     # trust_env=False Session -- disabling every ambient/OS-native proxy
     # source, not just the env vars this function checks -- so "no proxy"
-    # here is an actual guarantee for this call.
-    proxy_url = get_trusted_proxy_url()
+    # here is an actual guarantee for this call. Redacted the same as every
+    # other error path below: today's message text never echoes the proxy
+    # URL itself, but this keeps that an invariant of this function rather
+    # than of get_trusted_proxy_url()'s current wording.
+    try:
+        proxy_url = get_trusted_proxy_url()
+    except PrivateNetworkHostError as exc:
+        raise type(exc)(redact_sensitive_text(str(exc))) from exc
     proxies = {"http": proxy_url, "https": proxy_url} if proxy_url else {}
 
     url = f"{_base_url()}{path}"

--- a/src/xagent/web/tools/mcp/posthog.py
+++ b/src/xagent/web/tools/mcp/posthog.py
@@ -9,6 +9,7 @@ from urllib.parse import quote, urlsplit
 import requests
 from mcp.server.fastmcp import FastMCP
 
+from ....core.tools.core.web_content import get_trusted_proxy_url
 from ....core.utils.security import (
     PrivateNetworkHostError,
     redact_sensitive_text,
@@ -190,6 +191,30 @@ def _extract_error_detail(response: requests.Response) -> str | None:
     return detail if isinstance(detail, str) and detail else None
 
 
+def _make_request(**kwargs: Any) -> requests.Response:
+    """Issue the actual HTTP call with `trust_env=False`, so `requests`
+    never falls back to an ambient/OS-native proxy source
+    `get_trusted_proxy_url()` doesn't police -- passing `proxies=` alone
+    isn't enough, since a `trust_env=True` Session (`requests.request()`'s
+    default) still calls `urllib.request.getproxies()`, which itself falls
+    back *past* `HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY` to the OS's own proxy
+    configuration (`getproxies_macosx_sysconf()`/`getproxies_registry()`)
+    once no env var is set -- the same DNS-rebinding-via-proxy bypass this
+    gate exists to close, one layer deeper than an env-var scrub alone
+    reaches. Mirrors magento.py's identical `_make_request`.
+
+    `trust_env=False` also disables `requests`' `REQUESTS_CA_BUNDLE`/
+    `CURL_CA_BUNDLE` lookup and `.netrc` auto-auth (both gated behind the
+    same `if self.trust_env:` check in `requests`' own Session code); no
+    re-application is needed here, unlike magento.py's self-hosted target,
+    since PostHog Cloud's two hosts always terminate TLS with a publicly
+    trusted CA and this connector always sends its own Bearer header.
+    """
+    with requests.Session() as session:
+        session.trust_env = False
+        return session.request(**kwargs)
+
+
 def _request(
     method: str,
     path: str,
@@ -197,16 +222,33 @@ def _request(
     params: dict[str, Any] | None = None,
     json_data: dict[str, Any] | None = None,
 ) -> Any:
+    # An ambient HTTP(S) proxy makes the *proxy* perform DNS resolution for
+    # the real connection, not this process -- silently bypassing
+    # _base_url()'s own private-network validation of POSTHOG_HOST, which
+    # only checks the addresses this process itself resolves. Mirrors
+    # web_content.py's fetch_web_content and magento.py's _request:
+    # get_trusted_proxy_url() raises unless the proxy is explicitly marked
+    # trusted to enforce its own private-range egress policy
+    # (XAGENT_TRUSTED_EGRESS_PROXY=1), rather than silently trusting every
+    # ambient proxy setup_proxy_env() promotes from the OS's own settings.
+    # The result is then passed to `_make_request()` (see above), which
+    # issues the call on a trust_env=False Session -- disabling every
+    # ambient/OS-native proxy source, not just the env vars this function
+    # checks -- so "no proxy" here is an actual guarantee for this call.
+    proxy_url = get_trusted_proxy_url()
+    proxies = {"http": proxy_url, "https": proxy_url} if proxy_url else {}
+
     url = f"{_base_url()}{path}"
     try:
         for attempt in (0, 1):
-            response = requests.request(
+            response = _make_request(
                 method=method,
                 url=url,
                 headers=_headers(),
                 params=params,
                 json=json_data,
                 timeout=DEFAULT_TIMEOUT_SECONDS,
+                proxies=proxies,
                 # A redirect response is never followed with the Bearer
                 # header still attached: PostHog's documented API doesn't
                 # redirect, so a 3xx here is either a misconfiguration or

--- a/tests/web/tools/test_posthog_mcp.py
+++ b/tests/web/tools/test_posthog_mcp.py
@@ -54,6 +54,30 @@ class MockResponse:
             )
 
 
+class FakeSession:
+    """Stand-in for requests.Session, used by the _make_request tests below
+    to observe the state of a real Session instance at call time -- shared
+    rather than redefined per test so a future change to what those tests
+    need to capture only has to be made once."""
+
+    def __init__(self):
+        self.trust_env = True
+        self.verify = True
+        self.exited = False
+        self.captured_kwargs: dict | None = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        self.exited = True
+        return False
+
+    def request(self, **kwargs):
+        self.captured_kwargs = kwargs
+        return MockResponse(json_data={"ok": True})
+
+
 @pytest.fixture(autouse=True)
 def _credentials(monkeypatch):
     monkeypatch.setenv("POSTHOG_API_KEY", "phx_test_key")
@@ -371,6 +395,32 @@ def test_request_raises_when_proxy_is_configured_but_not_trusted(monkeypatch):
     mock_request.assert_not_called()
 
 
+def test_request_redacts_proxy_trust_error_message(monkeypatch):
+    # get_trusted_proxy_url()'s own message text never echoes the proxy URL
+    # today, but this call sits outside _request()'s try/except block, so
+    # nothing here was routing it through the same redact_sensitive_text()
+    # every other error path in this function already gets -- if that
+    # message ever grew to include the proxy URL (which can carry embedded
+    # user:pass@ credentials, exactly the concern already handled for a
+    # ProxyError below), it must not leak unredacted just because this one
+    # exception type raises before the try block.
+    monkeypatch.setattr(
+        posthog,
+        "get_trusted_proxy_url",
+        Mock(
+            side_effect=posthog.PrivateNetworkHostError(
+                "proxy https://user:sp-secret-proxy-pass@proxy.internal:8080/ "
+                "is not marked as trusted"
+            )
+        ),
+    )
+
+    with pytest.raises(posthog.PrivateNetworkHostError) as excinfo:
+        posthog._request("GET", "/api/users/@me/")
+
+    assert "sp-secret-proxy-pass" not in str(excinfo.value)
+
+
 def test_request_passes_proxy_explicitly_when_trusted(monkeypatch):
     monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:8080")
     monkeypatch.setenv("XAGENT_TRUSTED_EGRESS_PROXY", "1")
@@ -404,24 +454,8 @@ def test_make_request_disables_trust_env(monkeypatch):
     # context manager, would strip the exact security guards this module
     # adds while every other test here (which mocks _make_request itself
     # away) would still pass.
-    captured = {}
-    exited = {}
-
-    class FakeSession:
-        def __enter__(self):
-            self.trust_env = True
-            return self
-
-        def __exit__(self, *exc_info):
-            exited["called"] = True
-            return False
-
-        def request(self, **kwargs):
-            captured["trust_env"] = self.trust_env
-            captured["kwargs"] = kwargs
-            return MockResponse(json_data={"ok": True})
-
-    monkeypatch.setattr(posthog.requests, "Session", FakeSession)
+    session = FakeSession()
+    monkeypatch.setattr(posthog.requests, "Session", lambda: session)
 
     response = posthog._make_request(
         method="GET",
@@ -434,11 +468,11 @@ def test_make_request_disables_trust_env(monkeypatch):
         allow_redirects=False,
     )
 
-    assert captured["trust_env"] is False
-    assert captured["kwargs"]["proxies"] == {"https": "http://proxy.internal:8080"}
-    assert captured["kwargs"]["allow_redirects"] is False
+    assert session.trust_env is False
+    assert session.captured_kwargs["proxies"] == {"https": "http://proxy.internal:8080"}
+    assert session.captured_kwargs["allow_redirects"] is False
     assert response.json() == {"ok": True}
-    assert exited["called"] is True
+    assert session.exited is True
 
 
 def test_make_request_reapplies_ca_bundle_env_var(monkeypatch):
@@ -451,22 +485,8 @@ def test_make_request_reapplies_ca_bundle_env_var(monkeypatch):
     # explicitly, that proxy path would fail closed with an opaque
     # SSLError for exactly the operator who needs it.
     monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/etc/ssl/internal-ca.pem")
-    captured = {}
-
-    class FakeSession:
-        def __enter__(self):
-            self.trust_env = True
-            self.verify = True
-            return self
-
-        def __exit__(self, *exc_info):
-            return False
-
-        def request(self, **kwargs):
-            captured["verify"] = self.verify
-            return MockResponse(json_data={"ok": True})
-
-    monkeypatch.setattr(posthog.requests, "Session", FakeSession)
+    session = FakeSession()
+    monkeypatch.setattr(posthog.requests, "Session", lambda: session)
 
     posthog._make_request(
         method="GET",
@@ -479,7 +499,7 @@ def test_make_request_reapplies_ca_bundle_env_var(monkeypatch):
         allow_redirects=False,
     )
 
-    assert captured["verify"] == "/etc/ssl/internal-ca.pem"
+    assert session.verify == "/etc/ssl/internal-ca.pem"
 
 
 @pytest.mark.parametrize("status_code", [301, 302, 303, 307, 308])

--- a/tests/web/tools/test_posthog_mcp.py
+++ b/tests/web/tools/test_posthog_mcp.py
@@ -396,7 +396,16 @@ def test_make_request_disables_trust_env(monkeypatch):
     # set. trust_env=False skips that entire environment-and-OS-native
     # lookup in one place, so assert _make_request actually sets it before
     # issuing the real request.
+    #
+    # The full kwargs dict is captured (not just trust_env), and the
+    # context manager's __exit__ is asserted too: a body that silently
+    # dropped proxies=/allow_redirects=False before calling
+    # session.request(), or that never actually used the Session as a
+    # context manager, would strip the exact security guards this module
+    # adds while every other test here (which mocks _make_request itself
+    # away) would still pass.
     captured = {}
+    exited = {}
 
     class FakeSession:
         def __enter__(self):
@@ -404,10 +413,12 @@ def test_make_request_disables_trust_env(monkeypatch):
             return self
 
         def __exit__(self, *exc_info):
+            exited["called"] = True
             return False
 
         def request(self, **kwargs):
             captured["trust_env"] = self.trust_env
+            captured["kwargs"] = kwargs
             return MockResponse(json_data={"ok": True})
 
     monkeypatch.setattr(posthog.requests, "Session", FakeSession)
@@ -419,12 +430,56 @@ def test_make_request_disables_trust_env(monkeypatch):
         params=None,
         json=None,
         timeout=1,
-        proxies={},
+        proxies={"https": "http://proxy.internal:8080"},
         allow_redirects=False,
     )
 
     assert captured["trust_env"] is False
+    assert captured["kwargs"]["proxies"] == {"https": "http://proxy.internal:8080"}
+    assert captured["kwargs"]["allow_redirects"] is False
     assert response.json() == {"ok": True}
+    assert exited["called"] is True
+
+
+def test_make_request_reapplies_ca_bundle_env_var(monkeypatch):
+    # trust_env=False also disables requests' REQUESTS_CA_BUNDLE/
+    # CURL_CA_BUNDLE lookup (gated behind the same `if self.trust_env:` as
+    # the proxy lookup). The only case proxies is ever non-empty here is an
+    # operator opting into XAGENT_TRUSTED_EGRESS_PROXY=1 -- a corporate
+    # egress proxy doing TLS interception with an internally-issued CA is
+    # the textbook reason to do that -- so without re-applying this env var
+    # explicitly, that proxy path would fail closed with an opaque
+    # SSLError for exactly the operator who needs it.
+    monkeypatch.setenv("REQUESTS_CA_BUNDLE", "/etc/ssl/internal-ca.pem")
+    captured = {}
+
+    class FakeSession:
+        def __enter__(self):
+            self.trust_env = True
+            self.verify = True
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+        def request(self, **kwargs):
+            captured["verify"] = self.verify
+            return MockResponse(json_data={"ok": True})
+
+    monkeypatch.setattr(posthog.requests, "Session", FakeSession)
+
+    posthog._make_request(
+        method="GET",
+        url="https://us.posthog.com/api/users/@me/",
+        headers={},
+        params=None,
+        json=None,
+        timeout=1,
+        proxies={},
+        allow_redirects=False,
+    )
+
+    assert captured["verify"] == "/etc/ssl/internal-ca.pem"
 
 
 @pytest.mark.parametrize("status_code", [301, 302, 303, 307, 308])

--- a/tests/web/tools/test_posthog_mcp.py
+++ b/tests/web/tools/test_posthog_mcp.py
@@ -314,8 +314,8 @@ def test_create_annotation_rejects_empty_project_id():
 
 def test_create_annotation_raises_on_http_error(monkeypatch):
     monkeypatch.setattr(
-        posthog.requests,
-        "request",
+        posthog,
+        "_make_request",
         Mock(
             return_value=MockResponse(
                 status_code=403, json_data={"detail": "Permission denied."}
@@ -331,7 +331,7 @@ def test_create_annotation_raises_on_http_error(monkeypatch):
 
 def test_request_uses_configured_host_and_headers(monkeypatch):
     mock_request = Mock(return_value=MockResponse(json_data={"ok": True}))
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     result = posthog._request("GET", "/api/users/@me/")
 
@@ -346,11 +346,92 @@ def test_request_uses_configured_host_and_headers(monkeypatch):
     assert mock_request.call_args.kwargs["allow_redirects"] is False
 
 
+def test_request_passes_empty_proxies_when_none_configured(monkeypatch):
+    mock_request = Mock(return_value=MockResponse(json_data={"ok": True}))
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
+
+    posthog._request("GET", "/api/users/@me/")
+
+    assert mock_request.call_args.kwargs["proxies"] == {}
+
+
+def test_request_raises_when_proxy_is_configured_but_not_trusted(monkeypatch):
+    # An ambient proxy makes the *proxy* resolve DNS for the real
+    # connection, silently bypassing _base_url()'s own private-network
+    # validation of POSTHOG_HOST -- this must fail loudly instead of
+    # quietly connecting through an unvetted proxy.
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:8080")
+    monkeypatch.delenv("XAGENT_TRUSTED_EGRESS_PROXY", raising=False)
+    mock_request = Mock()
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
+
+    with pytest.raises(ValueError, match="not marked as trusted"):
+        posthog._request("GET", "/api/users/@me/")
+
+    mock_request.assert_not_called()
+
+
+def test_request_passes_proxy_explicitly_when_trusted(monkeypatch):
+    monkeypatch.setenv("HTTPS_PROXY", "http://proxy.internal:8080")
+    monkeypatch.setenv("XAGENT_TRUSTED_EGRESS_PROXY", "1")
+    mock_request = Mock(return_value=MockResponse(json_data={"ok": True}))
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
+
+    result = posthog._request("GET", "/api/users/@me/")
+
+    assert result == {"ok": True}
+    assert mock_request.call_args.kwargs["proxies"] == {
+        "http": "http://proxy.internal:8080",
+        "https": "http://proxy.internal:8080",
+    }
+
+
+def test_make_request_disables_trust_env(monkeypatch):
+    # requests.request() always runs on a fresh trust_env=True Session,
+    # which -- regardless of what proxies= is passed -- still falls back to
+    # get_environ_proxies() -> urllib.request.getproxies(), which itself
+    # falls back *past* HTTP_PROXY/HTTPS_PROXY/ALL_PROXY to the OS's own
+    # proxy configuration (getproxies_macosx_sysconf() on macOS,
+    # getproxies_registry() on Windows) once none of those env vars are
+    # set. trust_env=False skips that entire environment-and-OS-native
+    # lookup in one place, so assert _make_request actually sets it before
+    # issuing the real request.
+    captured = {}
+
+    class FakeSession:
+        def __enter__(self):
+            self.trust_env = True
+            return self
+
+        def __exit__(self, *exc_info):
+            return False
+
+        def request(self, **kwargs):
+            captured["trust_env"] = self.trust_env
+            return MockResponse(json_data={"ok": True})
+
+    monkeypatch.setattr(posthog.requests, "Session", FakeSession)
+
+    response = posthog._make_request(
+        method="GET",
+        url="https://us.posthog.com/api/users/@me/",
+        headers={},
+        params=None,
+        json=None,
+        timeout=1,
+        proxies={},
+        allow_redirects=False,
+    )
+
+    assert captured["trust_env"] is False
+    assert response.json() == {"ok": True}
+
+
 @pytest.mark.parametrize("status_code", [301, 302, 303, 307, 308])
 def test_request_rejects_redirect_response(monkeypatch, status_code):
     monkeypatch.setattr(
-        posthog.requests,
-        "request",
+        posthog,
+        "_make_request",
         Mock(
             return_value=MockResponse(
                 status_code=status_code, url="https://us.posthog.com/api/users/@me/"
@@ -364,7 +445,7 @@ def test_request_rejects_redirect_response(monkeypatch, status_code):
 
 def test_request_passes_configured_timeout(monkeypatch):
     mock_request = Mock(return_value=MockResponse(json_data={"ok": True}))
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     posthog._request("GET", "/api/users/@me/")
 
@@ -373,8 +454,8 @@ def test_request_passes_configured_timeout(monkeypatch):
 
 def test_request_returns_empty_dict_for_204(monkeypatch):
     monkeypatch.setattr(
-        posthog.requests,
-        "request",
+        posthog,
+        "_make_request",
         Mock(return_value=MockResponse(status_code=204, text="")),
     )
 
@@ -387,7 +468,7 @@ def test_request_retries_once_on_429_with_retry_after(monkeypatch):
         MockResponse(json_data={"ok": True}),
     ]
     mock_request = Mock(side_effect=responses)
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
     monkeypatch.setattr(posthog.time, "sleep", Mock())
 
     result = posthog._request("GET", "/api/users/@me/")
@@ -400,7 +481,7 @@ def test_request_retries_once_on_429_with_retry_after(monkeypatch):
 def test_request_does_not_retry_a_second_429(monkeypatch):
     response = MockResponse(status_code=429, url="x", headers={"Retry-After": "1"})
     mock_request = Mock(return_value=response)
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
     monkeypatch.setattr(posthog.time, "sleep", Mock())
 
     with pytest.raises(RuntimeError):
@@ -410,16 +491,15 @@ def test_request_does_not_retry_a_second_429(monkeypatch):
 
 
 def test_request_redacts_connection_error_message(monkeypatch):
-    # setup_proxy_env() exports whatever ambient HTTPS_PROXY the OS has
-    # configured, which requests honors; a ProxyError connecting through
-    # it can echo the full proxy URL, credentials included.
+    # A ProxyError connecting through a trusted proxy can echo the full
+    # proxy URL, credentials included.
     def _raise(*args, **kwargs):
         raise requests.exceptions.ProxyError(
             "Unable to connect to proxy: "
             "https://user:sp-secret-proxy-pass@proxy.internal:8080/"
         )
 
-    monkeypatch.setattr(posthog.requests, "request", _raise)
+    monkeypatch.setattr(posthog, "_make_request", _raise)
 
     with pytest.raises(RuntimeError) as excinfo:
         posthog._request("GET", "/api/users/@me/")
@@ -429,8 +509,8 @@ def test_request_redacts_connection_error_message(monkeypatch):
 
 def test_request_raises_with_structured_error_detail(monkeypatch):
     monkeypatch.setattr(
-        posthog.requests,
-        "request",
+        posthog,
+        "_make_request",
         Mock(
             return_value=MockResponse(
                 status_code=401,
@@ -449,8 +529,8 @@ def test_request_raises_with_structured_error_detail(monkeypatch):
 
 def test_request_redacts_bearer_token_in_error_detail(monkeypatch):
     monkeypatch.setattr(
-        posthog.requests,
-        "request",
+        posthog,
+        "_make_request",
         Mock(
             return_value=MockResponse(
                 status_code=502,
@@ -473,8 +553,8 @@ def test_request_redacts_bearer_token_in_error_detail(monkeypatch):
 
 def test_request_raises_clear_error_for_non_json_2xx_body(monkeypatch):
     monkeypatch.setattr(
-        posthog.requests,
-        "request",
+        posthog,
+        "_make_request",
         Mock(
             return_value=MockResponse(
                 status_code=200, text="<html>not json</html>", json_raises=True
@@ -495,8 +575,8 @@ def test_extract_error_detail_returns_none_for_non_json_body():
 def test_request_truncates_unstructured_error_body(monkeypatch):
     long_body = "x" * 5000
     monkeypatch.setattr(
-        posthog.requests,
-        "request",
+        posthog,
+        "_make_request",
         Mock(return_value=MockResponse(status_code=500, text=long_body)),
     )
 
@@ -509,8 +589,8 @@ def test_request_truncates_unstructured_error_body(monkeypatch):
 
 def test_get_current_user_returns_profile(monkeypatch):
     monkeypatch.setattr(
-        posthog.requests,
-        "request",
+        posthog,
+        "_make_request",
         Mock(
             return_value=MockResponse(
                 json_data={
@@ -531,8 +611,8 @@ def test_get_current_user_returns_profile(monkeypatch):
 
 def test_get_current_user_returns_error_payload_on_failure(monkeypatch):
     monkeypatch.setattr(
-        posthog.requests,
-        "request",
+        posthog,
+        "_make_request",
         Mock(
             return_value=MockResponse(
                 status_code=401,
@@ -549,8 +629,8 @@ def test_get_current_user_returns_error_payload_on_failure(monkeypatch):
 
 def test_list_organizations_returns_results_and_truncated_flag(monkeypatch):
     monkeypatch.setattr(
-        posthog.requests,
-        "request",
+        posthog,
+        "_make_request",
         Mock(
             return_value=MockResponse(
                 json_data={
@@ -571,8 +651,8 @@ def test_list_organizations_returns_results_and_truncated_flag(monkeypatch):
 
 def test_list_organizations_not_truncated_when_no_next_page(monkeypatch):
     monkeypatch.setattr(
-        posthog.requests,
-        "request",
+        posthog,
+        "_make_request",
         Mock(
             return_value=MockResponse(
                 json_data={"results": [{"id": "org1", "name": "Acme"}], "next": None}
@@ -596,7 +676,7 @@ def test_list_organizations_passes_offset_and_returns_next_offset(monkeypatch):
             }
         )
     )
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     result = json.loads(posthog.posthog_list_organizations(offset=50))
 
@@ -606,7 +686,7 @@ def test_list_organizations_passes_offset_and_returns_next_offset(monkeypatch):
 
 def test_list_organizations_clamps_negative_offset(monkeypatch):
     mock_request = Mock(return_value=MockResponse(json_data={"results": []}))
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     posthog.posthog_list_organizations(offset=-5)
 
@@ -619,7 +699,7 @@ def test_list_projects_uses_organization_id_in_path(monkeypatch):
             json_data={"results": [{"id": 1, "name": "Default Project"}]}
         )
     )
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     result = json.loads(posthog.posthog_list_projects(organization_id="org1"))
 
@@ -632,7 +712,7 @@ def test_list_projects_uses_organization_id_in_path(monkeypatch):
 
 def test_list_projects_defaults_organization_id_to_current(monkeypatch):
     mock_request = Mock(return_value=MockResponse(json_data={"results": []}))
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     posthog.posthog_list_projects()
 
@@ -643,7 +723,7 @@ def test_list_projects_defaults_organization_id_to_current(monkeypatch):
 
 def test_list_projects_encodes_hostile_organization_id(monkeypatch):
     mock_request = Mock(return_value=MockResponse(json_data={"results": []}))
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     posthog.posthog_list_projects(organization_id="1/../2")
 
@@ -662,7 +742,7 @@ def test_query_sends_hogql_query_body(monkeypatch):
             }
         )
     )
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     result = json.loads(
         posthog.posthog_query("select event, count() from events", name="my query")
@@ -684,7 +764,7 @@ def test_query_sends_hogql_query_body(monkeypatch):
 
 def test_query_omits_name_when_not_provided(monkeypatch):
     mock_request = Mock(return_value=MockResponse(json_data={"results": []}))
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     posthog.posthog_query("select 1")
 
@@ -697,7 +777,7 @@ def test_query_clamps_results_to_limit_and_reports_truncated(monkeypatch):
             json_data={"results": [[1], [2], [3]], "columns": ["n"]}
         )
     )
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     result = json.loads(posthog.posthog_query("select n from numbers", limit=2))
 
@@ -709,7 +789,7 @@ def test_query_not_truncated_when_results_within_limit(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(json_data={"results": [[1]], "columns": ["n"]})
     )
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     result = json.loads(posthog.posthog_query("select 1", limit=50))
 
@@ -721,8 +801,8 @@ def test_query_reports_clear_error_for_malformed_results_shape(monkeypatch):
     # rather than a silent bad slice (e.g. slicing a dict, or slicing a
     # string into a garbled row) or an opaque AttributeError/TypeError.
     monkeypatch.setattr(
-        posthog.requests,
-        "request",
+        posthog,
+        "_make_request",
         Mock(return_value=MockResponse(json_data={"results": {"not": "a-list"}})),
     )
 
@@ -738,7 +818,7 @@ def test_list_persons_includes_search_param(monkeypatch):
             json_data={"results": [{"id": 1, "distinct_ids": ["abc"]}]}
         )
     )
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     result = json.loads(posthog.posthog_list_persons(search="ada@example.com"))
 
@@ -750,7 +830,7 @@ def test_get_person_returns_person(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(json_data={"id": 1, "distinct_ids": ["abc"]})
     )
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     result = json.loads(posthog.posthog_get_person("1"))
 
@@ -763,7 +843,7 @@ def test_get_person_returns_person(monkeypatch):
 
 def test_get_person_encodes_hostile_person_id(monkeypatch):
     mock_request = Mock(return_value=MockResponse(json_data={"id": 1}))
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     posthog.posthog_get_person("1/../2", project_id="proj1")
 
@@ -776,7 +856,7 @@ def test_list_insights_requests_basic_shape(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(json_data={"results": [{"id": 1, "name": "Signups"}]})
     )
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     result = json.loads(posthog.posthog_list_insights())
 
@@ -786,8 +866,8 @@ def test_list_insights_requests_basic_shape(monkeypatch):
 
 def test_get_insight_returns_insight(monkeypatch):
     monkeypatch.setattr(
-        posthog.requests,
-        "request",
+        posthog,
+        "_make_request",
         Mock(return_value=MockResponse(json_data={"id": 1, "name": "Signups"})),
     )
 
@@ -799,8 +879,8 @@ def test_get_insight_returns_insight(monkeypatch):
 
 def test_list_feature_flags_returns_results(monkeypatch):
     monkeypatch.setattr(
-        posthog.requests,
-        "request",
+        posthog,
+        "_make_request",
         Mock(
             return_value=MockResponse(
                 json_data={"results": [{"id": 1, "key": "new-onboarding"}]}
@@ -816,8 +896,8 @@ def test_list_feature_flags_returns_results(monkeypatch):
 
 def test_list_dashboards_returns_results(monkeypatch):
     monkeypatch.setattr(
-        posthog.requests,
-        "request",
+        posthog,
+        "_make_request",
         Mock(
             return_value=MockResponse(
                 json_data={"results": [{"id": 1, "name": "KPIs"}]}
@@ -833,8 +913,8 @@ def test_list_dashboards_returns_results(monkeypatch):
 
 def test_list_annotations_returns_results(monkeypatch):
     monkeypatch.setattr(
-        posthog.requests,
-        "request",
+        posthog,
+        "_make_request",
         Mock(
             return_value=MockResponse(
                 json_data={"results": [{"id": 1, "content": "Deployed v2"}]}
@@ -852,7 +932,7 @@ def test_create_annotation_sends_content_and_scope(monkeypatch):
     mock_request = Mock(
         return_value=MockResponse(json_data={"id": 1, "content": "Deployed v2"})
     )
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     result = json.loads(posthog.posthog_create_annotation("Deployed v2", "proj1"))
 
@@ -868,7 +948,7 @@ def test_create_annotation_sends_content_and_scope(monkeypatch):
 
 def test_create_annotation_includes_date_marker_when_provided(monkeypatch):
     mock_request = Mock(return_value=MockResponse(json_data={"id": 1}))
-    monkeypatch.setattr(posthog.requests, "request", mock_request)
+    monkeypatch.setattr(posthog, "_make_request", mock_request)
 
     posthog.posthog_create_annotation(
         "Deployed v2", "proj1", date_marker="2026-08-18T00:00:00Z"


### PR DESCRIPTION
## Summary
- An ambient HTTP(S)/OS-native proxy performs its own DNS resolution, silently bypassing `_base_url()`'s private-network validation of `POSTHOG_HOST` -- the same class of SSRF bypass just closed in `magento.py`'s `_request()`.
- Gate on `get_trusted_proxy_url()` and issue the request on a `trust_env=False` `requests.Session` so no ambient env-var or OS-native proxy source is picked up unless `XAGENT_TRUSTED_EGRESS_PROXY=1` is explicitly set.

## Test plan
- [x] `tests/web/tools/test_posthog_mcp.py` (existing + new proxy-trust/`trust_env` tests, mirroring `test_magento_mcp.py`)
- [x] `tests/web/tools/` full directory
- [x] `ruff check` / `ruff format`
- [x] `mypy src/xagent/web/tools/mcp/posthog.py`
- [x] Self-review pass (code-review skill, high effort) -- no findings