### PR TITLE
fix: restore CA-bundle verification on trust_env=False httpx transports

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/a2a_agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/a2a_agent_tool.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 import httpx
 from pydantic import BaseModel, Field
 
-from ....utils.security import build_isolated_ssl_context, reject_private_network_host
+from ....utils.security import build_ca_bundle_ssl_context, reject_private_network_host
 from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 from .config import BaseToolConfig
 from .factory import register_tool
@@ -511,7 +511,7 @@ class _PinnedA2ATransport(httpx.AsyncBaseTransport):
     def __init__(self, *, allow_private_networks: bool):
         self._allow_private_networks = allow_private_networks
         self._transport = httpx.AsyncHTTPTransport(
-            trust_env=False, http2=False, verify=build_isolated_ssl_context()
+            trust_env=False, http2=False, verify=build_ca_bundle_ssl_context()
         )
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:

--- a/src/xagent/core/tools/adapters/vibe/a2a_agent_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/a2a_agent_tool.py
@@ -14,7 +14,7 @@ from uuid import uuid4
 import httpx
 from pydantic import BaseModel, Field
 
-from ....utils.security import reject_private_network_host
+from ....utils.security import build_isolated_ssl_context, reject_private_network_host
 from .base import AbstractBaseTool, ToolCategory, ToolVisibility
 from .config import BaseToolConfig
 from .factory import register_tool
@@ -510,7 +510,9 @@ class _PinnedA2ATransport(httpx.AsyncBaseTransport):
 
     def __init__(self, *, allow_private_networks: bool):
         self._allow_private_networks = allow_private_networks
-        self._transport = httpx.AsyncHTTPTransport(trust_env=False, http2=False)
+        self._transport = httpx.AsyncHTTPTransport(
+            trust_env=False, http2=False, verify=build_isolated_ssl_context()
+        )
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
         if self._allow_private_networks:

--- a/src/xagent/core/utils/security.py
+++ b/src/xagent/core/utils/security.py
@@ -82,17 +82,23 @@ def reject_private_network_host(hostname: str) -> None:
         raise PrivateNetworkHostError("Host must not resolve to a private network.")
 
 
-def build_isolated_ssl_context() -> ssl.SSLContext:
-    """Return a CA-bundle-aware SSL context for use with ``trust_env=False``.
+def build_ca_bundle_ssl_context() -> ssl.SSLContext:
+    """Return an SSL context that still honors ``SSL_CERT_FILE``/``SSL_CERT_DIR``
+    on a transport pinned to ``trust_env=False``.
 
-    ``httpx.create_ssl_context()`` only honors ``SSL_CERT_FILE``/
+    ``httpx.create_ssl_context()`` only reads ``SSL_CERT_FILE``/
     ``SSL_CERT_DIR`` when ``trust_env`` is true, since both env var lookups
-    are gated behind that same flag. Callers that pin a transport's
-    ``trust_env=False`` (to stop httpx from also falling back to the OS's
-    own proxy configuration -- see ``_PinnedA2ATransport`` and
-    ``SafeOAuthAsyncHTTPTransport``) must build this context explicitly and
-    pass it as ``verify=``, or TLS verification silently stops honoring a
-    private/internal CA bundle configured via those env vars.
+    are gated behind that same flag. ``_PinnedA2ATransport`` and
+    ``SafeOAuthAsyncHTTPTransport`` set ``trust_env=False`` on their inner
+    ``httpx.AsyncHTTPTransport`` -- not to affect proxy handling (transport-
+    level ``trust_env`` has no effect there; proxy-env fallback is gated at
+    the ``httpx.AsyncClient`` level via ``allow_env_proxies = trust_env and
+    transport is None``, which is already ``False`` once an explicit
+    ``transport=`` is passed) but because it also feeds
+    ``create_ssl_context()`` internally, and ``verify=True`` there would
+    otherwise silently skip a private/internal CA bundle configured via
+    those env vars. Build that context explicitly here, with
+    ``trust_env=True``, and pass it as ``verify=`` instead.
     """
 
     return httpx.create_ssl_context(trust_env=True)

--- a/src/xagent/core/utils/security.py
+++ b/src/xagent/core/utils/security.py
@@ -4,6 +4,7 @@ import asyncio
 import ipaddress
 import re
 import socket
+import ssl
 from dataclasses import dataclass
 from typing import Mapping
 from urllib.parse import (
@@ -79,6 +80,22 @@ def reject_private_network_host(hostname: str) -> None:
         or not address.is_global
     ):
         raise PrivateNetworkHostError("Host must not resolve to a private network.")
+
+
+def build_isolated_ssl_context() -> ssl.SSLContext:
+    """Return a CA-bundle-aware SSL context for use with ``trust_env=False``.
+
+    ``httpx.create_ssl_context()`` only honors ``SSL_CERT_FILE``/
+    ``SSL_CERT_DIR`` when ``trust_env`` is true, since both env var lookups
+    are gated behind that same flag. Callers that pin a transport's
+    ``trust_env=False`` (to stop httpx from also falling back to the OS's
+    own proxy configuration -- see ``_PinnedA2ATransport`` and
+    ``SafeOAuthAsyncHTTPTransport``) must build this context explicitly and
+    pass it as ``verify=``, or TLS verification silently stops honoring a
+    private/internal CA bundle configured via those env vars.
+    """
+
+    return httpx.create_ssl_context(trust_env=True)
 
 
 async def validate_public_http_url(url: str) -> list[str]:

--- a/src/xagent/web/services/mcp_oauth.py
+++ b/src/xagent/web/services/mcp_oauth.py
@@ -135,11 +135,22 @@ class MCPOAuthRuntimeAuth:
     refreshed: bool = False
 
 
+def _ca_bundle_error_detail(configured_ca_vars: list[str]) -> str:
+    if configured_ca_vars:
+        return (
+            f"Server TLS trust store is misconfigured ({'/'.join(configured_ca_vars)})."
+        )
+    return "Server TLS trust store could not be initialized."
+
+
 class SafeOAuthAsyncHTTPTransport(httpx.AsyncBaseTransport):
     """HTTP transport that resolves and pins OAuth hosts before connecting."""
 
     def __init__(self) -> None:
         proxy_url = get_mcp_oauth_proxy_url()
+        configured_ca_vars = [
+            name for name in ("SSL_CERT_FILE", "SSL_CERT_DIR") if os.environ.get(name)
+        ]
         try:
             ssl_context = build_ca_bundle_ssl_context()
         except OSError as exc:
@@ -153,17 +164,22 @@ class SafeOAuthAsyncHTTPTransport(httpx.AsyncBaseTransport):
             # from the certifi-backed default path when neither is set (a
             # broken/partial certifi install), which is an environment
             # problem, not an admin misconfiguration of these two vars.
-            configured_vars = [
-                name
-                for name in ("SSL_CERT_FILE", "SSL_CERT_DIR")
-                if os.environ.get(name)
-            ]
-            detail = (
-                f"Server TLS trust store is misconfigured ({'/'.join(configured_vars)})."
-                if configured_vars
-                else "Server TLS trust store could not be initialized."
+            raise MCPOAuthDiscoveryError(
+                "invalid_configuration", _ca_bundle_error_detail(configured_ca_vars)
+            ) from exc
+        if configured_ca_vars and not ssl_context.get_ca_certs():
+            # ssl.create_default_context(capath=...) silently loads zero
+            # certs -- no OSError -- when SSL_CERT_DIR names a directory
+            # that doesn't exist or contains no certs (unlike SSL_CERT_FILE,
+            # which does raise for a missing/empty file). Left unguarded,
+            # this transport would build successfully with an empty trust
+            # store, and every TLS request through it would fail later with
+            # a generic httpx.ConnectError instead of this structured error.
+            raise MCPOAuthDiscoveryError(
+                "invalid_configuration",
+                _ca_bundle_error_detail(configured_ca_vars)
+                + " No CA certificates were loaded.",
             )
-            raise MCPOAuthDiscoveryError("invalid_configuration", detail) from exc
         # An https:// proxy also needs the isolated context on its own CONNECT
         # TLS leg -- passing proxy_url as a bare string leaves that leg's
         # ssl_context as None, which httpx/httpcore then defaults to the

--- a/src/xagent/web/services/mcp_oauth.py
+++ b/src/xagent/web/services/mcp_oauth.py
@@ -18,6 +18,7 @@ from sqlalchemy.orm import sessionmaker
 from ...config import get_mcp_oauth_allow_private_hosts, get_mcp_oauth_proxy_url
 from ...core.utils.security import (
     PrivateNetworkHostError,
+    build_isolated_ssl_context,
     reject_private_network_host,
 )
 
@@ -143,6 +144,7 @@ class SafeOAuthAsyncHTTPTransport(httpx.AsyncBaseTransport):
             trust_env=False,
             http2=False,
             proxy=proxy_url,
+            verify=build_isolated_ssl_context(),
         )
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:

--- a/src/xagent/web/services/mcp_oauth.py
+++ b/src/xagent/web/services/mcp_oauth.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import sessionmaker
 from ...config import get_mcp_oauth_allow_private_hosts, get_mcp_oauth_proxy_url
 from ...core.utils.security import (
     PrivateNetworkHostError,
-    build_isolated_ssl_context,
+    build_ca_bundle_ssl_context,
     reject_private_network_host,
 )
 
@@ -139,12 +139,33 @@ class SafeOAuthAsyncHTTPTransport(httpx.AsyncBaseTransport):
 
     def __init__(self) -> None:
         proxy_url = get_mcp_oauth_proxy_url()
+        try:
+            ssl_context = build_ca_bundle_ssl_context()
+        except OSError as exc:
+            # SSL_CERT_FILE/SSL_CERT_DIR were never read on this path before
+            # this transport verified against an explicit context, so a
+            # stale/misconfigured value was previously harmless. Surface it
+            # as a structured OAuth error instead of letting the raw
+            # FileNotFoundError/ssl.SSLError (a subclass of OSError) escape
+            # as an unhandled 500.
+            raise MCPOAuthDiscoveryError(
+                "invalid_configuration",
+                "Server TLS trust store is misconfigured (SSL_CERT_FILE/SSL_CERT_DIR).",
+            ) from exc
+        # An https:// proxy also needs the isolated context on its own CONNECT
+        # TLS leg -- passing proxy_url as a bare string leaves that leg's
+        # ssl_context as None, which httpx/httpcore then defaults to the
+        # certifi-only trust store, bypassing a private CA configured via
+        # SSL_CERT_FILE/SSL_CERT_DIR for the proxy hop itself.
+        proxy = (
+            httpx.Proxy(url=proxy_url, ssl_context=ssl_context) if proxy_url else None
+        )
         self._transport = httpx.AsyncHTTPTransport(
             limits=httpx.Limits(max_keepalive_connections=0),
             trust_env=False,
             http2=False,
-            proxy=proxy_url,
-            verify=build_isolated_ssl_context(),
+            proxy=proxy,
+            verify=ssl_context,
         )
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:

--- a/src/xagent/web/services/mcp_oauth.py
+++ b/src/xagent/web/services/mcp_oauth.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import os
 import re
 import socket
 from dataclasses import dataclass
@@ -147,19 +148,33 @@ class SafeOAuthAsyncHTTPTransport(httpx.AsyncBaseTransport):
             # stale/misconfigured value was previously harmless. Surface it
             # as a structured OAuth error instead of letting the raw
             # FileNotFoundError/ssl.SSLError (a subclass of OSError) escape
-            # as an unhandled 500.
-            raise MCPOAuthDiscoveryError(
-                "invalid_configuration",
-                "Server TLS trust store is misconfigured (SSL_CERT_FILE/SSL_CERT_DIR).",
-            ) from exc
+            # as an unhandled 500. Only blame the env vars when one is
+            # actually set -- create_ssl_context() can also raise OSError
+            # from the certifi-backed default path when neither is set (a
+            # broken/partial certifi install), which is an environment
+            # problem, not an admin misconfiguration of these two vars.
+            configured_vars = [
+                name
+                for name in ("SSL_CERT_FILE", "SSL_CERT_DIR")
+                if os.environ.get(name)
+            ]
+            detail = (
+                f"Server TLS trust store is misconfigured ({'/'.join(configured_vars)})."
+                if configured_vars
+                else "Server TLS trust store could not be initialized."
+            )
+            raise MCPOAuthDiscoveryError("invalid_configuration", detail) from exc
         # An https:// proxy also needs the isolated context on its own CONNECT
         # TLS leg -- passing proxy_url as a bare string leaves that leg's
         # ssl_context as None, which httpx/httpcore then defaults to the
         # certifi-only trust store, bypassing a private CA configured via
-        # SSL_CERT_FILE/SSL_CERT_DIR for the proxy hop itself.
-        proxy = (
-            httpx.Proxy(url=proxy_url, ssl_context=ssl_context) if proxy_url else None
-        )
+        # SSL_CERT_FILE/SSL_CERT_DIR for the proxy hop itself. httpcore
+        # rejects a non-None proxy_ssl_context outright for a plain http://
+        # proxy (there's no TLS leg to configure there), so only attach it
+        # for an https:// proxy.
+        proxy: httpx.Proxy | str | None = proxy_url
+        if proxy_url and urlsplit(proxy_url).scheme == "https":
+            proxy = httpx.Proxy(url=proxy_url, ssl_context=ssl_context)
         self._transport = httpx.AsyncHTTPTransport(
             limits=httpx.Limits(max_keepalive_connections=0),
             trust_env=False,

--- a/tests/core/tools/test_a2a_agent_tool.py
+++ b/tests/core/tools/test_a2a_agent_tool.py
@@ -406,6 +406,11 @@ def test_pinned_a2a_transport_disables_http2_and_pins_ca_bundle(monkeypatch) -> 
             return None
 
     monkeypatch.setattr(a2a_agent_tool.httpx, "AsyncHTTPTransport", CaptureTransport)
+    # This constructs the real build_ca_bundle_ssl_context() (only
+    # AsyncHTTPTransport is mocked); clear both env vars so an ambient
+    # SSL_CERT_FILE/SSL_CERT_DIR can't make this fail nondeterministically.
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.delenv("SSL_CERT_DIR", raising=False)
 
     _PinnedA2ATransport(allow_private_networks=False)
 

--- a/tests/core/tools/test_a2a_agent_tool.py
+++ b/tests/core/tools/test_a2a_agent_tool.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ssl
 from typing import Any
 
 import httpx
@@ -9,6 +10,7 @@ from xagent.core.tools.adapters.vibe import a2a_agent_tool
 from xagent.core.tools.adapters.vibe.a2a_agent_tool import (
     A2A_TOOL_ERROR_MESSAGE,
     A2AAgentTool,
+    _PinnedA2ATransport,
     create_a2a_agent_tools,
 )
 from xagent.core.tools.adapters.vibe.config import ToolConfig
@@ -388,3 +390,25 @@ async def test_a2a_agent_tool_reports_timeout_as_failure(monkeypatch) -> None:
 
     assert result["success"] is False
     assert result["error"] == "A2A call timed out after 1s."
+
+
+def test_pinned_a2a_transport_disables_http2_and_pins_ca_bundle(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    class CaptureTransport(httpx.AsyncBaseTransport):
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, request=request)
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr(a2a_agent_tool.httpx, "AsyncHTTPTransport", CaptureTransport)
+
+    _PinnedA2ATransport(allow_private_networks=False)
+
+    assert captured["trust_env"] is False
+    assert captured["http2"] is False
+    assert isinstance(captured["verify"], ssl.SSLContext)

--- a/tests/core/utils/test_security.py
+++ b/tests/core/utils/test_security.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+import ssl
+from typing import Any
+
+from xagent.core.utils import security
+
+
+class TestBuildIsolatedSslContext:
+    """build_isolated_ssl_context() backs every transport that pins
+    trust_env=False (to stop httpx from also falling back to the OS's own
+    proxy configuration -- see _PinnedA2ATransport and
+    SafeOAuthAsyncHTTPTransport). httpx.create_ssl_context() only honors
+    SSL_CERT_FILE/SSL_CERT_DIR when trust_env is true, so the context must
+    be built with trust_env=True explicitly and passed as verify=, which
+    httpx then honors regardless of the transport's own trust_env setting.
+    """
+
+    def test_returns_a_concrete_ssl_context(self) -> None:
+        context = security.build_isolated_ssl_context()
+
+        assert isinstance(context, ssl.SSLContext)
+
+    def test_builds_context_with_trust_env_true(self, monkeypatch) -> None:
+        sentinel_ctx = object()
+        captured: dict[str, object] = {}
+
+        def _fake_create_ssl_context(**kwargs: Any) -> object:
+            captured.update(kwargs)
+            return sentinel_ctx
+
+        monkeypatch.setattr(
+            security.httpx, "create_ssl_context", _fake_create_ssl_context
+        )
+
+        result = security.build_isolated_ssl_context()
+
+        assert captured == {"trust_env": True}
+        assert result is sentinel_ctx

--- a/tests/core/utils/test_security.py
+++ b/tests/core/utils/test_security.py
@@ -50,7 +50,14 @@ class TestBuildCaBundleSslContext:
     then honors regardless of the transport's own trust_env setting.
     """
 
-    def test_returns_a_concrete_ssl_context(self) -> None:
+    def test_returns_a_concrete_ssl_context(self, monkeypatch) -> None:
+        # Clear both env vars so this doesn't nondeterministically fail on
+        # an ambient SSL_CERT_FILE/SSL_CERT_DIR left over in the process
+        # environment (this test only cares about the return type, not
+        # about a specific CA bundle).
+        monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+        monkeypatch.delenv("SSL_CERT_DIR", raising=False)
+
         context = security.build_ca_bundle_ssl_context()
 
         assert isinstance(context, ssl.SSLContext)

--- a/tests/core/utils/test_security.py
+++ b/tests/core/utils/test_security.py
@@ -1,30 +1,41 @@
 from __future__ import annotations
 
+import datetime
 import ssl
-import textwrap
 from typing import Any
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.x509.oid import NameOID
 
 from xagent.core.utils import security
 
-# A short-lived, self-signed CA cert generated purely for this test -- it is
-# never used to verify a real connection, only to prove build_ca_bundle_ssl_context()
-# actually loads whatever SSL_CERT_FILE points at into the resulting context's
-# trust store.
-_TEST_CA_PEM = textwrap.dedent(
-    """\
-    -----BEGIN CERTIFICATE-----
-    MIIBfjCCASOgAwIBAgIUJy8vvflj4iZFGcIOHxvXEKK4WHwwCgYIKoZIzj0EAwIw
-    FDESMBAGA1UEAwwJdGVzdC1yb290MB4XDTI2MDkwNDA1MzgxM1oXDTM2MDkwMTA1
-    MzgxM1owFDESMBAGA1UEAwwJdGVzdC1yb290MFkwEwYHKoZIzj0CAQYIKoZIzj0D
-    AQcDQgAEJBvNMaVhLnQvDmVv+q13d1usFhEVDxM2GATOxbR7L3iQVGn6SpbLlQq+
-    7S9t7XjlKhC/vDTaeYCFOW7DF44vLKNTMFEwHQYDVR0OBBYEFFJ8SEgt8Im88lSw
-    TBsWnRdX6aFVMB8GA1UdIwQYMBaAFFJ8SEgt8Im88lSwTBsWnRdX6aFVMA8GA1Ud
-    EwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSQAwRgIhAI9qxcfjyWlf0/umk3rcz684
-    QXTQwsywHV9QosmFrxXzAiEA4z1QKZ7W2DUnDWCGlK20Oam6O6USv4nI4S1kQES6
-    3mI=
-    -----END CERTIFICATE-----
+
+def _generate_test_ca_pem() -> bytes:
+    """Build a throwaway self-signed CA cert, purely to prove
+    build_ca_bundle_ssl_context() actually loads whatever SSL_CERT_FILE
+    points at into the resulting context's trust store -- generated at test
+    time (matching this repo's convention, e.g.
+    tests/web/api/test_gmail_oidc_real_signature.py) rather than checked in
+    as an opaque static blob.
     """
-)
+
+    key = ec.generate_private_key(ec.SECP256R1())
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test-root")])
+    now = datetime.datetime.now(datetime.timezone.utc)
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(days=1))
+        .not_valid_after(now + datetime.timedelta(days=1))
+        .add_extension(x509.BasicConstraints(ca=True, path_length=None), critical=True)
+        .sign(key, hashes.SHA256())
+    )
+    return cert.public_bytes(serialization.Encoding.PEM)
 
 
 class TestBuildCaBundleSslContext:
@@ -69,7 +80,7 @@ class TestBuildCaBundleSslContext:
         # was called (a mocked-kwargs test would still pass if the underlying
         # cert never made it into the context).
         cert_file = tmp_path / "test-ca.pem"
-        cert_file.write_text(_TEST_CA_PEM)
+        cert_file.write_bytes(_generate_test_ca_pem())
         monkeypatch.setenv("SSL_CERT_FILE", str(cert_file))
         monkeypatch.delenv("SSL_CERT_DIR", raising=False)
 

--- a/tests/core/utils/test_security.py
+++ b/tests/core/utils/test_security.py
@@ -1,23 +1,46 @@
 from __future__ import annotations
 
 import ssl
+import textwrap
 from typing import Any
 
 from xagent.core.utils import security
 
+# A short-lived, self-signed CA cert generated purely for this test -- it is
+# never used to verify a real connection, only to prove build_ca_bundle_ssl_context()
+# actually loads whatever SSL_CERT_FILE points at into the resulting context's
+# trust store.
+_TEST_CA_PEM = textwrap.dedent(
+    """\
+    -----BEGIN CERTIFICATE-----
+    MIIBfjCCASOgAwIBAgIUJy8vvflj4iZFGcIOHxvXEKK4WHwwCgYIKoZIzj0EAwIw
+    FDESMBAGA1UEAwwJdGVzdC1yb290MB4XDTI2MDkwNDA1MzgxM1oXDTM2MDkwMTA1
+    MzgxM1owFDESMBAGA1UEAwwJdGVzdC1yb290MFkwEwYHKoZIzj0CAQYIKoZIzj0D
+    AQcDQgAEJBvNMaVhLnQvDmVv+q13d1usFhEVDxM2GATOxbR7L3iQVGn6SpbLlQq+
+    7S9t7XjlKhC/vDTaeYCFOW7DF44vLKNTMFEwHQYDVR0OBBYEFFJ8SEgt8Im88lSw
+    TBsWnRdX6aFVMB8GA1UdIwQYMBaAFFJ8SEgt8Im88lSwTBsWnRdX6aFVMA8GA1Ud
+    EwEB/wQFMAMBAf8wCgYIKoZIzj0EAwIDSQAwRgIhAI9qxcfjyWlf0/umk3rcz684
+    QXTQwsywHV9QosmFrxXzAiEA4z1QKZ7W2DUnDWCGlK20Oam6O6USv4nI4S1kQES6
+    3mI=
+    -----END CERTIFICATE-----
+    """
+)
 
-class TestBuildIsolatedSslContext:
-    """build_isolated_ssl_context() backs every transport that pins
-    trust_env=False (to stop httpx from also falling back to the OS's own
-    proxy configuration -- see _PinnedA2ATransport and
-    SafeOAuthAsyncHTTPTransport). httpx.create_ssl_context() only honors
-    SSL_CERT_FILE/SSL_CERT_DIR when trust_env is true, so the context must
-    be built with trust_env=True explicitly and passed as verify=, which
-    httpx then honors regardless of the transport's own trust_env setting.
+
+class TestBuildCaBundleSslContext:
+    """build_ca_bundle_ssl_context() backs every transport that pins
+    trust_env=False. Transport-level trust_env has no effect on proxy
+    handling (see _PinnedA2ATransport/SafeOAuthAsyncHTTPTransport, which get
+    their proxy-bypass protection from passing an explicit transport= to
+    AsyncClient, not from this flag) -- but it also feeds
+    httpx.create_ssl_context() internally, which only honors SSL_CERT_FILE/
+    SSL_CERT_DIR when trust_env is true. This helper builds that context
+    with trust_env=True explicitly and passes it as verify=, which httpx
+    then honors regardless of the transport's own trust_env setting.
     """
 
     def test_returns_a_concrete_ssl_context(self) -> None:
-        context = security.build_isolated_ssl_context()
+        context = security.build_ca_bundle_ssl_context()
 
         assert isinstance(context, ssl.SSLContext)
 
@@ -33,7 +56,27 @@ class TestBuildIsolatedSslContext:
             security.httpx, "create_ssl_context", _fake_create_ssl_context
         )
 
-        result = security.build_isolated_ssl_context()
+        result = security.build_ca_bundle_ssl_context()
 
         assert captured == {"trust_env": True}
         assert result is sentinel_ctx
+
+    def test_actually_trusts_the_ca_named_by_ssl_cert_file(
+        self, tmp_path, monkeypatch
+    ) -> None:
+        # End-to-end: prove the env var is actually loaded into the returned
+        # context's trust store, not just that create_ssl_context(trust_env=True)
+        # was called (a mocked-kwargs test would still pass if the underlying
+        # cert never made it into the context).
+        cert_file = tmp_path / "test-ca.pem"
+        cert_file.write_text(_TEST_CA_PEM)
+        monkeypatch.setenv("SSL_CERT_FILE", str(cert_file))
+        monkeypatch.delenv("SSL_CERT_DIR", raising=False)
+
+        context = security.build_ca_bundle_ssl_context()
+
+        assert any(
+            ("commonName", "test-root") in rdn
+            for cert in context.get_ca_certs()
+            for rdn in cert["subject"]
+        )

--- a/tests/web/services/test_mcp_oauth_discovery.py
+++ b/tests/web/services/test_mcp_oauth_discovery.py
@@ -328,8 +328,33 @@ def test_safe_oauth_transport_uses_explicit_proxy_configuration(monkeypatch):
     SafeOAuthAsyncHTTPTransport()
 
     assert captured["trust_env"] is False
-    assert captured["proxy"] == "http://proxy.example.com:8080"
+    assert isinstance(captured["proxy"], httpx.Proxy)
+    assert captured["proxy"].url == httpx.URL("http://proxy.example.com:8080")
+    # The proxy's own CONNECT/TLS leg must trust the same isolated CA bundle
+    # as the tunneled target origin, not fall back to httpcore's
+    # certifi-only default (see build_ca_bundle_ssl_context()'s docstring).
+    assert captured["proxy"].ssl_context is captured["verify"]
     assert isinstance(captured["verify"], ssl.SSLContext)
+
+
+def test_safe_oauth_transport_reports_bad_ca_bundle_as_discovery_error(monkeypatch):
+    # SSL_CERT_FILE/SSL_CERT_DIR were never read on this path before this
+    # transport started verifying against an explicit context, so a stale
+    # misconfigured value used to be harmless. A FileNotFoundError (an
+    # OSError subclass, same as ssl.SSLError) from building that context
+    # must surface as a structured MCPOAuthDiscoveryError, not propagate as
+    # a raw OSError past every caller's `except MCPOAuthDiscoveryError`.
+    def _broken_ssl_context():
+        raise FileNotFoundError("no such CA bundle")
+
+    monkeypatch.setattr(
+        mcp_oauth_service, "build_ca_bundle_ssl_context", _broken_ssl_context
+    )
+
+    with pytest.raises(MCPOAuthDiscoveryError) as exc:
+        SafeOAuthAsyncHTTPTransport()
+
+    assert exc.value.code == "invalid_configuration"
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_mcp_oauth_discovery.py
+++ b/tests/web/services/test_mcp_oauth_discovery.py
@@ -310,6 +310,10 @@ def test_safe_oauth_transport_disables_proxy_http2_and_keepalive(monkeypatch):
 
 
 def test_safe_oauth_transport_uses_explicit_proxy_configuration(monkeypatch):
+    # A plain http:// proxy has no TLS leg of its own -- httpcore rejects a
+    # non-None proxy_ssl_context outright for this scheme (RuntimeError: "The
+    # proxy_ssl_context argument is not allowed for the http scheme"), so the
+    # proxy must stay a bare string/URL, not an httpx.Proxy carrying one.
     captured: dict[str, object] = {}
 
     class CaptureTransport(httpx.AsyncBaseTransport):
@@ -328,13 +332,58 @@ def test_safe_oauth_transport_uses_explicit_proxy_configuration(monkeypatch):
     SafeOAuthAsyncHTTPTransport()
 
     assert captured["trust_env"] is False
+    assert captured["proxy"] == "http://proxy.example.com:8080"
+    assert isinstance(captured["verify"], ssl.SSLContext)
+
+
+def test_safe_oauth_transport_attaches_ca_bundle_to_https_proxy_leg(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class CaptureTransport(httpx.AsyncBaseTransport):
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+
+        async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, request=request)
+
+        async def aclose(self) -> None:
+            return None
+
+    monkeypatch.setattr(mcp_oauth_service.httpx, "AsyncHTTPTransport", CaptureTransport)
+    monkeypatch.setenv("XAGENT_MCP_OAUTH_PROXY_URL", "https://proxy.example.com:8443")
+
+    SafeOAuthAsyncHTTPTransport()
+
+    assert captured["trust_env"] is False
     assert isinstance(captured["proxy"], httpx.Proxy)
-    assert captured["proxy"].url == httpx.URL("http://proxy.example.com:8080")
+    assert captured["proxy"].url == httpx.URL("https://proxy.example.com:8443")
     # The proxy's own CONNECT/TLS leg must trust the same isolated CA bundle
     # as the tunneled target origin, not fall back to httpcore's
     # certifi-only default (see build_ca_bundle_ssl_context()'s docstring).
     assert captured["proxy"].ssl_context is captured["verify"]
     assert isinstance(captured["verify"], ssl.SSLContext)
+
+
+@pytest.mark.parametrize(
+    "proxy_url",
+    ["http://proxy.example.com:8080", "https://proxy.example.com:8443", None],
+)
+def test_safe_oauth_transport_constructs_against_real_httpx_transport(
+    monkeypatch, proxy_url
+):
+    # Regression test for a real bug: mocking httpx.AsyncHTTPTransport (as
+    # the tests above do, to inspect kwargs) hid that httpcore raises
+    # RuntimeError when a plain http:// proxy is given a non-None
+    # proxy_ssl_context. Construct against the *real* AsyncHTTPTransport so
+    # httpcore's own scheme validation actually runs.
+    if proxy_url is None:
+        monkeypatch.delenv("XAGENT_MCP_OAUTH_PROXY_URL", raising=False)
+    else:
+        monkeypatch.setenv("XAGENT_MCP_OAUTH_PROXY_URL", proxy_url)
+
+    transport = SafeOAuthAsyncHTTPTransport()
+
+    assert transport is not None
 
 
 def test_safe_oauth_transport_reports_bad_ca_bundle_as_discovery_error(monkeypatch):
@@ -350,11 +399,37 @@ def test_safe_oauth_transport_reports_bad_ca_bundle_as_discovery_error(monkeypat
     monkeypatch.setattr(
         mcp_oauth_service, "build_ca_bundle_ssl_context", _broken_ssl_context
     )
+    monkeypatch.setenv("SSL_CERT_FILE", "/no/such/file.pem")
+    monkeypatch.delenv("SSL_CERT_DIR", raising=False)
 
     with pytest.raises(MCPOAuthDiscoveryError) as exc:
         SafeOAuthAsyncHTTPTransport()
 
     assert exc.value.code == "invalid_configuration"
+    assert "SSL_CERT_FILE" in exc.value.message
+    assert "SSL_CERT_DIR" not in exc.value.message
+
+
+def test_safe_oauth_transport_does_not_blame_env_vars_that_are_unset(monkeypatch):
+    # A build_ca_bundle_ssl_context() failure can also come from the
+    # certifi-backed default path (neither env var set) -- e.g. a
+    # broken/partial certifi install. Don't misattribute that to
+    # SSL_CERT_FILE/SSL_CERT_DIR when neither is actually configured.
+    def _broken_ssl_context():
+        raise FileNotFoundError("certifi bundle missing")
+
+    monkeypatch.setattr(
+        mcp_oauth_service, "build_ca_bundle_ssl_context", _broken_ssl_context
+    )
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.delenv("SSL_CERT_DIR", raising=False)
+
+    with pytest.raises(MCPOAuthDiscoveryError) as exc:
+        SafeOAuthAsyncHTTPTransport()
+
+    assert exc.value.code == "invalid_configuration"
+    assert "SSL_CERT_FILE" not in exc.value.message
+    assert "SSL_CERT_DIR" not in exc.value.message
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_mcp_oauth_discovery.py
+++ b/tests/web/services/test_mcp_oauth_discovery.py
@@ -299,6 +299,12 @@ def test_safe_oauth_transport_disables_proxy_http2_and_keepalive(monkeypatch):
 
     monkeypatch.setattr(mcp_oauth_service.httpx, "AsyncHTTPTransport", CaptureTransport)
     monkeypatch.delenv("XAGENT_MCP_OAUTH_PROXY_URL", raising=False)
+    # This constructs the real build_ca_bundle_ssl_context() (only
+    # AsyncHTTPTransport is mocked); an ambient SSL_CERT_FILE/SSL_CERT_DIR
+    # left over from the environment could otherwise make this fail on a
+    # value unrelated to what's under test here.
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.delenv("SSL_CERT_DIR", raising=False)
 
     SafeOAuthAsyncHTTPTransport()
 
@@ -328,6 +334,8 @@ def test_safe_oauth_transport_uses_explicit_proxy_configuration(monkeypatch):
 
     monkeypatch.setattr(mcp_oauth_service.httpx, "AsyncHTTPTransport", CaptureTransport)
     monkeypatch.setenv("XAGENT_MCP_OAUTH_PROXY_URL", "http://proxy.example.com:8080")
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.delenv("SSL_CERT_DIR", raising=False)
 
     SafeOAuthAsyncHTTPTransport()
 
@@ -351,6 +359,8 @@ def test_safe_oauth_transport_attaches_ca_bundle_to_https_proxy_leg(monkeypatch)
 
     monkeypatch.setattr(mcp_oauth_service.httpx, "AsyncHTTPTransport", CaptureTransport)
     monkeypatch.setenv("XAGENT_MCP_OAUTH_PROXY_URL", "https://proxy.example.com:8443")
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.delenv("SSL_CERT_DIR", raising=False)
 
     SafeOAuthAsyncHTTPTransport()
 
@@ -380,10 +390,14 @@ def test_safe_oauth_transport_constructs_against_real_httpx_transport(
         monkeypatch.delenv("XAGENT_MCP_OAUTH_PROXY_URL", raising=False)
     else:
         monkeypatch.setenv("XAGENT_MCP_OAUTH_PROXY_URL", proxy_url)
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.delenv("SSL_CERT_DIR", raising=False)
 
     transport = SafeOAuthAsyncHTTPTransport()
 
-    assert transport is not None
+    # Prove a real, non-mocked connection pool was actually built (not just
+    # that construction didn't raise, which pytest would already catch).
+    assert isinstance(transport._transport, httpx.AsyncHTTPTransport)
 
 
 def test_safe_oauth_transport_reports_bad_ca_bundle_as_discovery_error(monkeypatch):
@@ -430,6 +444,28 @@ def test_safe_oauth_transport_does_not_blame_env_vars_that_are_unset(monkeypatch
     assert exc.value.code == "invalid_configuration"
     assert "SSL_CERT_FILE" not in exc.value.message
     assert "SSL_CERT_DIR" not in exc.value.message
+
+
+def test_safe_oauth_transport_rejects_ssl_cert_dir_that_loads_no_certs(
+    monkeypatch, tmp_path
+):
+    # ssl.create_default_context(capath=...) does NOT raise for a directory
+    # that doesn't exist or contains no certs (unlike SSL_CERT_FILE, which
+    # does raise for a missing/empty file) -- it silently returns a context
+    # with zero trusted CAs. Left unguarded, this transport would build
+    # "successfully" with an effectively empty trust store, and every TLS
+    # request through it would fail later with a generic httpx.ConnectError
+    # instead of this structured, actionable error.
+    empty_dir = tmp_path / "empty-ca-dir"
+    empty_dir.mkdir()
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    monkeypatch.setenv("SSL_CERT_DIR", str(empty_dir))
+
+    with pytest.raises(MCPOAuthDiscoveryError) as exc:
+        SafeOAuthAsyncHTTPTransport()
+
+    assert exc.value.code == "invalid_configuration"
+    assert "SSL_CERT_DIR" in exc.value.message
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_mcp_oauth_discovery.py
+++ b/tests/web/services/test_mcp_oauth_discovery.py
@@ -1,4 +1,5 @@
 import gzip
+import ssl
 from pathlib import Path
 
 import httpx
@@ -305,6 +306,7 @@ def test_safe_oauth_transport_disables_proxy_http2_and_keepalive(monkeypatch):
     assert captured["proxy"] is None
     assert captured["http2"] is False
     assert captured["limits"].max_keepalive_connections == 0
+    assert isinstance(captured["verify"], ssl.SSLContext)
 
 
 def test_safe_oauth_transport_uses_explicit_proxy_configuration(monkeypatch):
@@ -327,6 +329,7 @@ def test_safe_oauth_transport_uses_explicit_proxy_configuration(monkeypatch):
 
     assert captured["trust_env"] is False
     assert captured["proxy"] == "http://proxy.example.com:8080"
+    assert isinstance(captured["verify"], ssl.SSLContext)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- `_PinnedA2ATransport` and `SafeOAuthAsyncHTTPTransport` already set `trust_env=False` on their `httpx.AsyncHTTPTransport` to close the OS-native-proxy DNS-rebinding bypass (same class of fix as #2100), but neither re-applied the `SSL_CERT_FILE`/`SSL_CERT_DIR` CA-bundle handling that `trust_env=False` also silently disables.
- Added a shared `build_isolated_ssl_context()` helper in `core/utils/security.py` (built with `httpx.create_ssl_context(trust_env=True)`) and pass it as `verify=` on both transports, so private/internal CA bundles keep working while the proxy bypass stays closed.

## Test plan
- [x] `pytest tests/core/tools/test_a2a_agent_tool.py tests/web/services/test_mcp_oauth_discovery.py tests/core/utils/test_security.py` (new/extended regression tests included)
- [x] `ruff format --check` / `ruff check` on touched files
- [x] `mypy` on touched source files