### PR TITLE
feat(mcp): add atomic app-scoped teardown primitive (toby)

### DIFF
--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -23,6 +23,7 @@ import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse, Response
 from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -51,6 +52,7 @@ from ..models.mcp_oauth import (
     mcp_oauth_client_registration_lookup_hash,
     mcp_oauth_grant_lookup_hash,
 )
+from ..models.public_mcp import PublicMCPApp
 from ..models.user import User
 from ..services.mcp_oauth import (
     MCP_OAUTH_HTTP_TIMEOUT_SECONDS,
@@ -4177,6 +4179,302 @@ def _catalog_server_has_platform_key(db: Session, server: MCPServer) -> bool:
             required = (app.get("launch_config") or {}).get("required_env") or []
             return _env_covers_required(env, required)
     return False
+
+
+def _lock_catalog_for_app_teardown(db: Session) -> None:
+    """Serialize catalog ownership reads before an app-scoped teardown."""
+    dialect = db.get_bind().dialect.name
+    if dialect == "postgresql":
+        # A row lock on the expected app cannot exclude a different row being
+        # renamed into a legacy server's name. SHARE conflicts with catalog
+        # INSERT/UPDATE/DELETE while still allowing concurrent readers.
+        db.execute(text("LOCK TABLE public_mcp_apps IN SHARE MODE"))
+    elif dialect == "sqlite":
+        # SQLite ignores FOR UPDATE. Reuse the producer fence's owned
+        # BEGIN IMMEDIATE transaction so no catalog or lifecycle writer can
+        # pass identity validation before the destructive work commits.
+        _begin_sqlite_oauth_persistence(db)
+
+
+def _locked_catalog_app_for_server(
+    db: Session,
+    *,
+    server: MCPServer,
+    expected_app: PublicMCPApp,
+) -> PublicMCPApp | None:
+    """Return the locked catalog row only when it still owns ``server``."""
+    app_id = str(expected_app.app_id)
+    if str(server.transport or "").lower() != "oauth":
+        # Catalog provisioning names non-OAuth rows by exact app id. Their
+        # caller-authored auth mapping is not trusted as ownership evidence.
+        return expected_app if str(server.name or "") == app_id else None
+
+    auth = server.auth
+    if isinstance(auth, dict) and "app_id" in auth:
+        return expected_app if auth.get("app_id") == app_id else None
+
+    # Legacy builtin OAuth rows may use app id or mutable display name. The
+    # catalog table lock keeps this ownership set stable through commit.
+    server_name = str(server.name or "")
+    owners = {
+        str(candidate.app_id)
+        for candidate in db.query(PublicMCPApp)
+        .filter(
+            (PublicMCPApp.app_id == server_name) | (PublicMCPApp.name == server_name)
+        )
+        .all()
+    }
+    return expected_app if owners == {app_id} else None
+
+
+async def teardown_mcp_app_server(
+    server_id: int,
+    *,
+    app_id: str,
+    expected_provider_name: str | None,
+    expected_catalog_generation: UUID,
+    expected_association_generation: UUID,
+    current_user: User,
+    db: Session,
+) -> None:
+    """Atomically disconnect one exact catalog-app association lifecycle.
+
+    The caller pins both generations during preflight. This function owns the
+    local transaction, revalidates every destructive identity while locked,
+    commits local cleanup once, and only then performs best-effort provider
+    revocation without ORM access or database locks.
+    """
+    revocations: list[_MCPOAuthGrantRevocationSnapshot] = []
+    try:
+        with db.no_autoflush:
+            user_id = int(current_user.id)
+            current_user_is_admin = bool(getattr(current_user, "is_admin", False))
+        if (
+            not isinstance(server_id, int)
+            or isinstance(server_id, bool)
+            or not isinstance(app_id, str)
+            or not app_id
+            or app_id != app_id.strip()
+            or (
+                expected_provider_name is not None
+                and not isinstance(expected_provider_name, str)
+            )
+            or not isinstance(expected_catalog_generation, UUID)
+            or not isinstance(expected_association_generation, UUID)
+        ):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="MCP app teardown identity could not be verified",
+            )
+
+        _lock_catalog_for_app_teardown(db)
+        # Preflight may have populated the identity map before another session
+        # committed. Locks serialize future writes; expiration makes these
+        # reads observe the state that existed when serialization was won.
+        db.expire_all()
+        with db.no_autoflush:
+            expected_app = (
+                db.query(PublicMCPApp)
+                .filter(
+                    PublicMCPApp.generation == expected_catalog_generation,
+                    PublicMCPApp.app_id == app_id,
+                    PublicMCPApp.provider_name == expected_provider_name,
+                )
+                .with_for_update()
+                .one_or_none()
+            )
+            if expected_app is None:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="MCP app teardown owner changed",
+                )
+
+            # Match the producer fence's lock order after the teardown-only
+            # catalog fence: server, exact association generation, artifacts.
+            server = (
+                db.query(MCPServer)
+                .filter(MCPServer.id == server_id)
+                .with_for_update()
+                .one_or_none()
+            )
+            if server is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="MCP server not found",
+                )
+            user_mcp = (
+                db.query(UserMCPServer)
+                .filter(
+                    UserMCPServer.user_id == user_id,
+                    UserMCPServer.mcpserver_id == server_id,
+                    UserMCPServer.lifecycle_generation
+                    == expected_association_generation,
+                )
+                .with_for_update()
+                .one_or_none()
+            )
+            if user_mcp is None:
+                raise HTTPException(
+                    status_code=status.HTTP_404_NOT_FOUND,
+                    detail="MCP server not found",
+                )
+            if (
+                _locked_catalog_app_for_server(
+                    db, server=server, expected_app=expected_app
+                )
+                is None
+            ):
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail="MCP app teardown owner changed",
+                )
+
+        if not _check_mcp_permission(user_mcp, current_user_is_admin, require="delete"):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="You do not have permission to delete this MCP server",
+            )
+
+        from ..services.connector_team_scope import delete_team_connector
+
+        team_delete = delete_team_connector(db, user_id, "mcp", server_id)
+        if team_delete.blocked_reason:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail=team_delete.blocked_reason,
+            )
+        if team_delete.team_owned and not team_delete.authorized:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Only a team admin can delete a team MCP server",
+            )
+
+        if str(server.transport or "").lower() == "oauth":
+            provider = expected_app.provider_name
+            providers_to_delete = restrict_to_app_scoped_oauth_grant(
+                app_id, [provider, app_id]
+            )
+            if providers_to_delete:
+                delete_scoped_user_oauth_accounts(
+                    db,
+                    user_id=user_id,
+                    resource_owner_key=None,
+                    providers=providers_to_delete,
+                )
+            if provider and provider not in providers_to_delete:
+                other_servers = (
+                    db.query(MCPServer)
+                    .join(UserMCPServer, UserMCPServer.mcpserver_id == MCPServer.id)
+                    .filter(
+                        UserMCPServer.user_id == user_id,
+                        MCPServer.id != server_id,
+                    )
+                    .all()
+                )
+                normalized_provider = _normalize_app_key(provider)
+                sibling_still_connected = any(
+                    (sibling_app := get_app_for_mcp_server(db, other_server))
+                    and _normalize_app_key(sibling_app.get("provider"))
+                    == normalized_provider
+                    for other_server in other_servers
+                )
+                if not sibling_still_connected:
+                    delete_scoped_user_oauth_accounts(
+                        db,
+                        user_id=user_id,
+                        resource_owner_key=None,
+                        providers=[provider],
+                    )
+
+        for grant in (
+            db.query(MCPOAuthGrant)
+            .filter(
+                MCPOAuthGrant.mcp_server_id == server_id,
+                MCPOAuthGrant.user_id == user_id,
+            )
+            .with_for_update()
+            .all()
+        ):
+            if str(grant.status) == "active" and isinstance(
+                grant.oauth_client, MCPOAuthClient
+            ):
+                revocations.append(
+                    _mcp_oauth_grant_revocation_snapshot(
+                        client=grant.oauth_client, grant=grant
+                    )
+                )
+            db.delete(grant)
+
+        db.query(MCPOAuthFlowState).filter(
+            MCPOAuthFlowState.mcp_server_id == server_id,
+            MCPOAuthFlowState.user_id == user_id,
+        ).delete(synchronize_session=False)
+        db.delete(user_mcp)
+        db.flush()
+
+        other_user = (
+            db.query(UserMCPServer)
+            .filter(UserMCPServer.mcpserver_id == server_id)
+            .with_for_update()
+            .first()
+        )
+        if other_user is None:
+            if team_delete.team_owned and not team_delete.delete_definition:
+                logger.info(
+                    "Kept team-owned MCP server %s after app teardown", server_id
+                )
+            elif _catalog_server_has_platform_key(db, server):
+                logger.info(
+                    "Kept platform-key MCP server %s after app teardown", server_id
+                )
+            else:
+                # FK cascades delete clients, client secrets, and any remaining
+                # server-scoped artifacts in this same local transaction.
+                db.delete(server)
+
+        db.commit()
+    except HTTPException:
+        db.rollback()
+        raise
+    except _SQLiteOAuthPersistenceTransactionError:
+        # The write-intent helper has not changed caller state on this path.
+        logger.error(
+            "App-scoped MCP teardown requires an owned SQLite transaction "
+            "for app %r, server %s",
+            app_id,
+            server_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete MCP server",
+        ) from None
+    except Exception:
+        db.rollback()
+        logger.error(
+            "App-scoped MCP teardown failed for app %r, server %s",
+            app_id,
+            server_id,
+        )
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to delete MCP server",
+        ) from None
+
+    # No provider call may run until the local commit releases every lock.
+    for revocation in revocations:
+        try:
+            await _revoke_mcp_oauth_grant_snapshot_externally(revocation)
+        except Exception:
+            logger.warning(
+                "MCP OAuth token revocation failed after teardown for grant %s",
+                revocation.grant_id,
+            )
+    logger.info(
+        "Completed app-scoped MCP teardown for app %r, server %s, user %s",
+        app_id,
+        server_id,
+        user_id,
+    )
 
 
 @mcp_router.delete("/servers/{server_id}", status_code=status.HTTP_204_NO_CONTENT)

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -46,6 +46,7 @@ from xagent.web.models.mcp import MCPServer, UserMCPServer
 from xagent.web.models.mcp_oauth import mcp_oauth_client_registration_lookup_hash
 from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
+from xagent.web.models.user_oauth import UserOAuth
 from xagent.web.services import connector_team_scope
 from xagent.web.services import mcp_oauth as mcp_oauth_service
 from xagent.web.services.mcp_oauth import (
@@ -4494,3 +4495,404 @@ async def test_status_reports_discovered_grant_without_configured_selectors(db_s
     status_response = await get_mcp_oauth_status(server.id, user, db)
 
     assert [item.id for item in status_response.grants] == [grant.id]
+
+
+def _teardown_app(
+    db, *, app_id: str, transport: str, provider: str | None = None, **launch
+) -> PublicMCPApp:
+    app = PublicMCPApp(
+        app_id=app_id,
+        name=app_id.replace("-", " ").title(),
+        transport=transport,
+        provider_name=provider,
+        launch_config=launch or None,
+    )
+    db.add(app)
+    db.commit()
+    return app
+
+
+def _teardown_association(db, user: User, server: MCPServer) -> UserMCPServer:
+    association = UserMCPServer(
+        user_id=user.id,
+        mcpserver_id=server.id,
+        is_owner=True,
+        can_delete=True,
+        is_active=True,
+    )
+    db.add(association)
+    db.commit()
+    return association
+
+
+@pytest.mark.asyncio
+async def test_app_teardown_builtin_uses_exact_catalog_credential(db_session):
+    db, user, _ = db_session
+    app = _teardown_app(
+        db, app_id="calendar", transport="oauth", provider="calendar-provider"
+    )
+    server = MCPServer.from_config(
+        {
+            "name": "calendar",
+            "managed": "external",
+            "transport": "oauth",
+            "auth": {"app_id": "calendar", "provider": "calendar-provider"},
+        }
+    )
+    db.add(server)
+    db.flush()
+    association = _teardown_association(db, user, server)
+    db.add_all(
+        [
+            UserOAuth(
+                user_id=user.id,
+                provider="calendar-provider",
+                access_token=encrypt_value("delete-me"),
+            ),
+            UserOAuth(
+                user_id=user.id,
+                provider="unrelated",
+                access_token=encrypt_value("keep-me"),
+            ),
+        ]
+    )
+    db.commit()
+
+    await mcp_api.teardown_mcp_app_server(
+        int(server.id),
+        app_id="calendar",
+        expected_provider_name="calendar-provider",
+        expected_catalog_generation=app.generation,
+        expected_association_generation=association.lifecycle_generation,
+        current_user=user,
+        db=db,
+    )
+
+    assert db.get(MCPServer, server.id) is None
+    assert {row.provider for row in db.query(UserOAuth).all()} == {"unrelated"}
+
+
+@pytest.mark.asyncio
+async def test_app_teardown_rolls_back_then_commits_once_before_safe_revoke(
+    db_session, monkeypatch, caplog
+):
+    db, user, _ = db_session
+    db.connection().exec_driver_sql("PRAGMA foreign_keys=ON")
+    db.rollback()
+    app = _teardown_app(db, app_id="remote-notes", transport="streamable_http")
+    server = _add_mcp_oauth_server(db, user, name="remote-notes")
+    server.auth = {**server.auth, "app_id": "remote-notes"}
+    association = (
+        db.query(UserMCPServer).filter_by(user_id=user.id, mcpserver_id=server.id).one()
+    )
+    association.can_delete = True
+    client = _add_oauth_client(
+        db,
+        server,
+        metadata_json={"revocation_endpoint": "https://auth.example/revoke"},
+    )
+    for state in ("active", "revoked", "inactive"):
+        db.add(
+            MCPOAuthGrant(
+                mcp_server_id=server.id,
+                user_id=user.id,
+                mcp_oauth_client_id=client.id,
+                resource_owner_key=f"owner-{state}",
+                issuer="https://auth.example",
+                resource="https://mcp.example",
+                scope=state,
+                access_token=encrypt_value(f"{state}-secret"),
+                status=state,
+            )
+        )
+    db.add(
+        MCPOAuthFlowState(
+            state="delete-flow",
+            mcp_server_id=server.id,
+            user_id=user.id,
+            association_lifecycle_generation=association.lifecycle_generation,
+            mcp_oauth_client_id=client.id,
+            resource_owner_key="owner-flow",
+            issuer="https://auth.example",
+            resource="https://mcp.example",
+            scope="notes.read",
+            code_verifier=encrypt_value("flow-secret"),
+            expires_at=mcp_api._utc_now() + timedelta(minutes=10),
+        )
+    )
+    db.commit()
+    ids = int(server.id), int(client.id)
+    fail = {"once": True}
+    commits: list[None] = []
+    revoked_grants: list[int] = []
+
+    @event.listens_for(MCPServer, "before_delete")
+    def fail_first_delete(_mapper, _connection, target):
+        if target.id == ids[0] and fail.pop("once", False):
+            raise RuntimeError("local-secret-detail")
+
+    @event.listens_for(db, "after_commit")
+    def record_commit(_session):
+        commits.append(None)
+
+    kwargs = dict(
+        app_id="remote-notes",
+        expected_provider_name=None,
+        expected_catalog_generation=app.generation,
+        expected_association_generation=association.lifecycle_generation,
+        current_user=user,
+        db=db,
+    )
+    try:
+        with pytest.raises(HTTPException) as exc:
+            await mcp_api.teardown_mcp_app_server(ids[0], **kwargs)
+        assert exc.value.status_code == 500
+        assert db.get(MCPServer, ids[0]) is not None
+        assert db.get(MCPOAuthClient, ids[1]) is not None
+        assert db.query(MCPOAuthGrant).count() == 3
+        assert db.query(MCPOAuthFlowState).count() == 1
+
+        async def fail_revoke(snapshot):
+            assert not db.in_transaction()
+            revoked_grants.append(snapshot.grant_id)
+            raise RuntimeError("remote-secret-detail")
+
+        monkeypatch.setattr(
+            mcp_api, "_revoke_mcp_oauth_grant_snapshot_externally", fail_revoke
+        )
+        await mcp_api.teardown_mcp_app_server(ids[0], **kwargs)
+    finally:
+        event.remove(MCPServer, "before_delete", fail_first_delete)
+        event.remove(db, "after_commit", record_commit)
+
+    assert len(commits) == 1
+    assert db.get(MCPServer, ids[0]) is None
+    assert db.get(MCPOAuthClient, ids[1]) is None
+    assert db.query(MCPOAuthGrant).count() == 0
+    assert db.query(MCPOAuthFlowState).count() == 0
+    assert len(revoked_grants) == 1
+    assert "local-secret-detail" not in caplog.text
+    assert "remote-secret-detail" not in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("retention", "expected_server", "refused"),
+    [
+        ("plain", False, False),
+        ("shared", True, False),
+        ("team", True, False),
+        ("team-refused", True, True),
+        ("platform", True, False),
+    ],
+)
+@pytest.mark.asyncio
+async def test_app_teardown_preserves_only_governed_non_oauth_servers(
+    db_session, monkeypatch, retention, expected_server, refused
+):
+    db, user, other_user = db_session
+    launch = {"command": "notes", "required_env": ["API_KEY"]}
+    app = _teardown_app(db, app_id="local-notes", transport="stdio", **launch)
+    server = MCPServer.from_config(
+        {
+            "name": "local-notes",
+            "managed": "external",
+            "transport": "stdio",
+            "command": "notes",
+            "env": {"API_KEY": "platform"} if retention == "platform" else None,
+        }
+    )
+    db.add(server)
+    db.flush()
+    association = _teardown_association(db, user, server)
+    if retention == "shared":
+        db.add(
+            UserMCPServer(user_id=other_user.id, mcpserver_id=server.id, is_active=True)
+        )
+        db.commit()
+    if retention.startswith("team"):
+        monkeypatch.setattr(
+            connector_team_scope,
+            "delete_team_connector",
+            lambda *args: SimpleNamespace(
+                blocked_reason=None,
+                team_owned=True,
+                authorized=not refused,
+                delete_definition=False,
+            ),
+        )
+
+    call = mcp_api.teardown_mcp_app_server(
+        int(server.id),
+        app_id="local-notes",
+        expected_provider_name=None,
+        expected_catalog_generation=app.generation,
+        expected_association_generation=association.lifecycle_generation,
+        current_user=user,
+        db=db,
+    )
+    if refused:
+        with pytest.raises(HTTPException) as exc:
+            await call
+        assert exc.value.status_code == 403
+    else:
+        await call
+
+    assert (db.get(MCPServer, server.id) is not None) is expected_server
+    assert (db.get(UserMCPServer, association.id) is not None) is refused
+
+
+@pytest.mark.parametrize("replaced", ["catalog", "association", "provider", "server"])
+@pytest.mark.asyncio
+async def test_app_teardown_rejects_replacement_generation(db_session, replaced):
+    db, user, other_user = db_session
+    app = _teardown_app(db, app_id="replace-me", transport="streamable_http")
+    server = _add_mcp_oauth_server(db, user, name="replace-me")
+    association = (
+        db.query(UserMCPServer).filter_by(user_id=user.id, mcpserver_id=server.id).one()
+    )
+    association.can_delete = True
+    db.add(UserMCPServer(user_id=other_user.id, mcpserver_id=server.id, is_active=True))
+    db.commit()
+    catalog_generation = app.generation
+    association_generation = association.lifecycle_generation
+    if replaced == "catalog":
+        db.delete(app)
+        db.commit()
+        replacement = _teardown_app(
+            db, app_id="replace-me", transport="streamable_http"
+        )
+        assert replacement.generation != catalog_generation
+    elif replaced == "association":
+        db.delete(association)
+        db.commit()
+        replacement = _teardown_association(db, user, server)
+        assert replacement.lifecycle_generation != association_generation
+    elif replaced == "provider":
+        app.provider_name = "replacement-provider"
+        db.commit()
+        replacement = app
+    else:
+        db.delete(server)
+        db.commit()
+        replacement = None
+
+    with pytest.raises(HTTPException) as exc:
+        await mcp_api.teardown_mcp_app_server(
+            int(server.id),
+            app_id="replace-me",
+            expected_provider_name=None,
+            expected_catalog_generation=catalog_generation,
+            expected_association_generation=association_generation,
+            current_user=user,
+            db=db,
+        )
+
+    assert exc.value.status_code == (
+        404 if replaced in {"association", "server"} else 403
+    )
+    assert (db.get(MCPServer, server.id) is not None) is (replaced != "server")
+    if replacement is not None:
+        db.refresh(replacement)
+
+
+@pytest.mark.parametrize("replaced", ["catalog", "association"])
+def test_app_teardown_serializes_later_sqlite_replacement(
+    db_session, monkeypatch, replaced
+):
+    db, user, other_user = db_session
+    app = _teardown_app(db, app_id="serialize-me", transport="streamable_http")
+    server = _add_mcp_oauth_server(db, user, name="serialize-me")
+    association = (
+        db.query(UserMCPServer).filter_by(user_id=user.id, mcpserver_id=server.id).one()
+    )
+    association.can_delete = True
+    db.add(UserMCPServer(user_id=other_user.id, mcpserver_id=server.id, is_active=True))
+    db.commit()
+    ids = int(user.id), int(server.id)
+    generations = app.generation, association.lifecycle_generation
+    factory = sessionmaker(bind=db.get_bind(), autoflush=False, autocommit=False)
+    identity_locked = threading.Event()
+    release_teardown = threading.Event()
+    mutation_sent = threading.Event()
+    mutation_done = threading.Event()
+    mutation_thread_id: list[int] = []
+    replacement_generation: list[object] = []
+    real_owner_check = mcp_api._locked_catalog_app_for_server
+
+    def hold_identity(*args, **kwargs):
+        result = real_owner_check(*args, **kwargs)
+        identity_locked.set()
+        assert release_teardown.wait(timeout=5)
+        return result
+
+    def observe_mutation(_conn, _cursor, statement, _params, _context, _many):
+        if (
+            mutation_thread_id
+            and threading.get_ident() == mutation_thread_id[0]
+            and statement.lstrip().startswith("DELETE FROM")
+        ):
+            mutation_sent.set()
+
+    monkeypatch.setattr(mcp_api, "_locked_catalog_app_for_server", hold_identity)
+    event.listen(db.get_bind(), "before_cursor_execute", observe_mutation)
+
+    def teardown():
+        with factory() as teardown_db:
+            asyncio.run(
+                mcp_api.teardown_mcp_app_server(
+                    ids[1],
+                    app_id="serialize-me",
+                    expected_provider_name=None,
+                    expected_catalog_generation=generations[0],
+                    expected_association_generation=generations[1],
+                    current_user=teardown_db.get(User, ids[0]),
+                    db=teardown_db,
+                )
+            )
+
+    def replace():
+        mutation_thread_id.append(threading.get_ident())
+        with factory() as mutation_db:
+            if replaced == "catalog":
+                mutation_db.query(PublicMCPApp).filter_by(
+                    app_id="serialize-me"
+                ).delete()
+                replacement = PublicMCPApp(
+                    app_id="serialize-me",
+                    name="Serialize Me",
+                    transport="streamable_http",
+                )
+            else:
+                mutation_db.query(UserMCPServer).filter_by(
+                    user_id=ids[0], mcpserver_id=ids[1]
+                ).delete()
+                replacement = UserMCPServer(
+                    user_id=ids[0], mcpserver_id=ids[1], is_active=True
+                )
+            mutation_db.add(replacement)
+            mutation_db.commit()
+            replacement_generation.append(
+                replacement.generation
+                if replaced == "catalog"
+                else replacement.lifecycle_generation
+            )
+        mutation_done.set()
+
+    teardown_thread = threading.Thread(target=teardown)
+    mutation_thread = threading.Thread(target=replace)
+    try:
+        teardown_thread.start()
+        assert identity_locked.wait(timeout=5)
+        mutation_thread.start()
+        assert mutation_sent.wait(timeout=5)
+        assert not mutation_done.wait(timeout=0.2)
+        release_teardown.set()
+        teardown_thread.join(timeout=5)
+        mutation_thread.join(timeout=5)
+    finally:
+        release_teardown.set()
+        event.remove(db.get_bind(), "before_cursor_execute", observe_mutation)
+
+    assert not teardown_thread.is_alive() and not mutation_thread.is_alive()
+    expected_index = 0 if replaced == "catalog" else 1
+    assert replacement_generation[0] != generations[expected_index]

--- a/tests/web/api/test_mcp_oauth_lifecycle_postgresql.py
+++ b/tests/web/api/test_mcp_oauth_lifecycle_postgresql.py
@@ -4,12 +4,14 @@ from __future__ import annotations
 
 import asyncio
 import threading
+import time
 from datetime import timedelta
 from types import SimpleNamespace
 from typing import Any
 from urllib.parse import urlparse
 
 import pytest
+from sqlalchemy import event, text
 from sqlalchemy.orm import sessionmaker
 from starlette.requests import Request
 
@@ -19,6 +21,7 @@ from xagent.web.api import mcp as mcp_api
 from xagent.web.models import MCPOAuthClient, MCPOAuthFlowState, MCPOAuthGrant
 from xagent.web.models.database import Base
 from xagent.web.models.mcp import MCPServer, UserMCPServer
+from xagent.web.models.public_mcp import PublicMCPApp
 from xagent.web.models.user import User
 from xagent.web.services import connector_team_scope
 
@@ -35,6 +38,7 @@ def postgresql_engine():
                 User.__table__,
                 MCPServer.__table__,
                 UserMCPServer.__table__,
+                PublicMCPApp.__table__,
                 MCPOAuthClient.__table__,
                 MCPOAuthGrant.__table__,
                 MCPOAuthFlowState.__table__,
@@ -56,7 +60,17 @@ def _seed_lifecycle(factory, *, flow_consumed: bool = True):
                 "auth": {"type": "mcp_oauth"},
             }
         )
-        db.add_all([user, other_user, server])
+        app = PublicMCPApp(
+            app_id="postgres-oauth-records",
+            name="Postgres OAuth Records",
+            transport="streamable_http",
+        )
+        other_app = PublicMCPApp(
+            app_id="postgres-other-app",
+            name="Postgres Other App",
+            transport="streamable_http",
+        )
+        db.add_all([user, other_user, server, app, other_app])
         db.flush()
         association = UserMCPServer(
             user_id=user.id,
@@ -104,6 +118,9 @@ def _seed_lifecycle(factory, *, flow_consumed: bool = True):
             "client_id": int(client.id),
             "flow_id": int(flow.id),
             "generation": association.lifecycle_generation,
+            "catalog_generation": app.generation,
+            "catalog_id": int(app.id),
+            "other_catalog_id": int(other_app.id),
         }
 
 
@@ -347,6 +364,204 @@ def test_producer_first_holds_lifecycle_locks_until_grant_commit(
             .count()
             == 1
         )
+
+
+def _allow_app_teardown(monkeypatch) -> None:
+    monkeypatch.setattr(
+        connector_team_scope,
+        "delete_team_connector",
+        lambda *args: SimpleNamespace(
+            blocked_reason=None,
+            team_owned=False,
+            authorized=False,
+            delete_definition=False,
+        ),
+    )
+
+
+@pytest.mark.parametrize("replaced", ["catalog", "association"])
+def test_app_teardown_rejects_preexisting_replacement_generation(
+    postgresql_engine, monkeypatch, replaced
+) -> None:
+    factory = sessionmaker(bind=postgresql_engine, autoflush=False, autocommit=False)
+    seed = _seed_lifecycle(factory)
+    _allow_app_teardown(monkeypatch)
+    with factory() as mutation_db:
+        if replaced == "catalog":
+            mutation_db.query(PublicMCPApp).filter_by(id=seed["catalog_id"]).delete()
+            replacement = PublicMCPApp(
+                app_id="postgres-oauth-records",
+                name="Postgres OAuth Records",
+                transport="streamable_http",
+            )
+        else:
+            mutation_db.query(UserMCPServer).filter_by(
+                user_id=seed["user_id"], mcpserver_id=seed["server_id"]
+            ).delete()
+            replacement = UserMCPServer(
+                user_id=seed["user_id"],
+                mcpserver_id=seed["server_id"],
+                is_owner=True,
+                is_active=True,
+            )
+        mutation_db.add(replacement)
+        mutation_db.commit()
+
+    with factory() as teardown_db, pytest.raises(mcp_api.HTTPException) as exc:
+        asyncio.run(
+            mcp_api.teardown_mcp_app_server(
+                seed["server_id"],
+                app_id="postgres-oauth-records",
+                expected_provider_name=None,
+                expected_catalog_generation=seed["catalog_generation"],
+                expected_association_generation=seed["generation"],
+                current_user=teardown_db.get(User, seed["user_id"]),
+                db=teardown_db,
+            )
+        )
+    assert exc.value.status_code == (403 if replaced == "catalog" else 404)
+
+
+@pytest.mark.parametrize("replaced", ["catalog", "association"])
+def test_app_teardown_serializes_later_replacement_with_lock_evidence(
+    postgresql_engine, monkeypatch, replaced
+) -> None:
+    factory = sessionmaker(bind=postgresql_engine, autoflush=False, autocommit=False)
+    seed = _seed_lifecycle(factory)
+    _allow_app_teardown(monkeypatch)
+    identity_locked = threading.Event()
+    release_teardown = threading.Event()
+    mutation_sent = threading.Event()
+    different_row_update_returned = threading.Event()
+    replacement_generation: list[object] = []
+    teardown_pid: list[int] = []
+    mutation_pid: list[int] = []
+    mutation_thread_id: list[int] = []
+    errors: list[BaseException] = []
+    real_owner_check = mcp_api._locked_catalog_app_for_server
+
+    def hold_identity(*args, **kwargs):
+        result = real_owner_check(*args, **kwargs)
+        identity_locked.set()
+        assert release_teardown.wait(timeout=10)
+        return result
+
+    def observe_mutation(_conn, _cursor, statement, _params, _context, _many):
+        normalized = " ".join(statement.split())
+        expected = (
+            "UPDATE public_mcp_apps"
+            if replaced == "catalog"
+            else "DELETE FROM user_mcpservers"
+        )
+        if (
+            mutation_thread_id
+            and threading.get_ident() == mutation_thread_id[0]
+            and normalized.startswith(expected)
+        ):
+            mutation_sent.set()
+
+    def observe_mutation_return(_conn, _cursor, statement, _params, _context, _many):
+        if (
+            replaced == "catalog"
+            and mutation_thread_id
+            and threading.get_ident() == mutation_thread_id[0]
+            and " ".join(statement.split()).startswith("UPDATE public_mcp_apps")
+        ):
+            different_row_update_returned.set()
+
+    monkeypatch.setattr(mcp_api, "_locked_catalog_app_for_server", hold_identity)
+    event.listen(postgresql_engine, "before_cursor_execute", observe_mutation)
+    event.listen(postgresql_engine, "after_cursor_execute", observe_mutation_return)
+
+    def teardown() -> None:
+        try:
+            with factory() as teardown_db:
+                teardown_pid.append(teardown_db.scalar(text("SELECT pg_backend_pid()")))
+                asyncio.run(
+                    mcp_api.teardown_mcp_app_server(
+                        seed["server_id"],
+                        app_id="postgres-oauth-records",
+                        expected_provider_name=None,
+                        expected_catalog_generation=seed["catalog_generation"],
+                        expected_association_generation=seed["generation"],
+                        current_user=teardown_db.get(User, seed["user_id"]),
+                        db=teardown_db,
+                    )
+                )
+        except BaseException as exc:  # pragma: no cover - assertion reports it
+            errors.append(exc)
+
+    def replace() -> None:
+        try:
+            mutation_thread_id.append(threading.get_ident())
+            with factory() as mutation_db:
+                mutation_pid.append(mutation_db.scalar(text("SELECT pg_backend_pid()")))
+                if replaced == "catalog":
+                    other = mutation_db.get(PublicMCPApp, seed["other_catalog_id"])
+                    other.name = "Mutation Proving Table Share Lock"
+                    mutation_db.commit()
+                    mutation_db.query(PublicMCPApp).filter_by(
+                        id=seed["catalog_id"]
+                    ).delete()
+                    replacement = PublicMCPApp(
+                        app_id="postgres-oauth-records",
+                        name="Postgres OAuth Records",
+                        transport="streamable_http",
+                    )
+                else:
+                    mutation_db.query(UserMCPServer).filter_by(
+                        user_id=seed["user_id"], mcpserver_id=seed["server_id"]
+                    ).delete()
+                    replacement = UserMCPServer(
+                        user_id=seed["user_id"],
+                        mcpserver_id=seed["server_id"],
+                        is_owner=True,
+                        is_active=True,
+                    )
+                mutation_db.add(replacement)
+                mutation_db.commit()
+                replacement_generation.append(
+                    replacement.generation
+                    if replaced == "catalog"
+                    else replacement.lifecycle_generation
+                )
+        except BaseException as exc:  # pragma: no cover - assertion reports it
+            errors.append(exc)
+
+    teardown_thread = threading.Thread(target=teardown)
+    mutation_thread = threading.Thread(target=replace)
+    try:
+        teardown_thread.start()
+        assert identity_locked.wait(timeout=10)
+        mutation_thread.start()
+        assert mutation_sent.wait(timeout=10)
+        deadline = time.monotonic() + 10
+        blockers: list[int] = []
+        while time.monotonic() < deadline and teardown_pid[0] not in blockers:
+            if replaced == "catalog" and different_row_update_returned.is_set():
+                break
+            with postgresql_engine.connect() as observer:
+                blockers = list(
+                    observer.scalar(
+                        text("SELECT pg_blocking_pids(:pid)"),
+                        {"pid": mutation_pid[0]},
+                    )
+                    or []
+                )
+        assert not different_row_update_returned.is_set()
+        assert teardown_pid[0] in blockers
+        release_teardown.set()
+        teardown_thread.join(timeout=10)
+        mutation_thread.join(timeout=10)
+    finally:
+        release_teardown.set()
+        event.remove(postgresql_engine, "before_cursor_execute", observe_mutation)
+        event.remove(postgresql_engine, "after_cursor_execute", observe_mutation_return)
+
+    assert not teardown_thread.is_alive() and not mutation_thread.is_alive()
+    assert errors == []
+    old = seed["catalog_generation"] if replaced == "catalog" else seed["generation"]
+    assert replacement_generation[0] != old
 
 
 def test_real_callback_producer_blocks_disconnect_until_grant_commit(


### PR DESCRIPTION
## Summary

- add a reusable app-scoped MCP teardown primitive pinned to exact catalog and association generations
- serialize destructive identity validation on SQLite and PostgreSQL with the producer-compatible lock order
- commit scoped credentials, every grant state, flow state, association, and eligible last-user server cleanup atomically before best-effort external revocation
- preserve multi-user, team-owned, and platform-key server semantics without changing the generic delete route or enabling a downstream SaaS consumer

## Validation

- `uv run --group dev pytest -q --disable-warnings tests/web/api/test_mcp_oauth_flow.py -k 'app_teardown_ or producer_first_blocks_disconnect or disconnect_first_rejects_stale_callback or stale_real_disconnect or real_disconnect_uses_generation or last_user_disconnect or delete_mcp_server_revokes or delete_mcp_server_purges or delete_mcp_server_preserves'`
- `XAGENT_TEST_POSTGRES_URL=postgresql://xagent:xagent@127.0.0.1:55433/xagent_test uv run --group dev pytest -q --disable-warnings tests/web/api/test_mcp_oauth_lifecycle_postgresql.py`
- `uv run --group dev pytest -q --disable-warnings tests/migrations/test_migration_workflow_contract.py`
- `uv run --group dev ruff check src/xagent/web/api/mcp.py tests/web/api/test_mcp_oauth_flow.py tests/web/api/test_mcp_oauth_lifecycle_postgresql.py`
- `uv run --group dev ruff format --check src/xagent/web/api/mcp.py tests/web/api/test_mcp_oauth_flow.py tests/web/api/test_mcp_oauth_lifecycle_postgresql.py`
- `uv run --group dev python -m py_compile src/xagent/web/api/mcp.py tests/web/api/test_mcp_oauth_flow.py tests/web/api/test_mcp_oauth_lifecycle_postgresql.py`
- `git diff --check`

## Mutation checks

- removing either catalog or association generation predicate fails its replacement test
- removing rollback fails the rollback/retry test
- weakening the PostgreSQL catalog table lock from `SHARE` to `ACCESS SHARE` fails the different-row deterministic blocker test
- moving external revocation before the local commit fails the transaction-boundary test

Closes #2033
