### PR TITLE
feat(mcp): hold a connector write for approval above both transports (toby)

### DIFF
--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -2197,10 +2197,9 @@ async def load_mcp_tools_as_agent_tools(
 
             # The one place both transports meet: ``server_tools`` is either
             # sandbox-wrapped tools or bare adapters by this point, and the
-            # gate wraps whichever it is. Deliberately not inside the adapter
-            # -- a sandboxed connector rebuilds that class in a guest process
-            # where no host hook or database exists, so a gate placed there
-            # is absent exactly for the transport that most needs it.
+            # gate wraps whichever it is. Why here and not inside the
+            # adapter is the whole subject of ``write_gate_tool``'s module
+            # docstring; it is not repeated here.
             agent_tools.extend(gate_mcp_tools(server_tools))
             if server_tools:
                 loaded_servers.append(server_name)

--- a/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_adapter.py
@@ -54,6 +54,7 @@ from .sandboxed_tool.sandboxed_mcp_tool_helper import (
     should_sandbox_mcp_connection,
 )
 from .tool_naming_limits import MAX_AGENT_TOOL_NAME_LENGTH
+from .write_gate_tool import gate_mcp_tools
 
 
 class MCPFailurePhase(str, Enum):
@@ -2194,7 +2195,13 @@ async def load_mcp_tools_as_agent_tools(
                 server_tools = direct_result.tools
                 failures.extend(direct_result.failures)
 
-            agent_tools.extend(server_tools)
+            # The one place both transports meet: ``server_tools`` is either
+            # sandbox-wrapped tools or bare adapters by this point, and the
+            # gate wraps whichever it is. Deliberately not inside the adapter
+            # -- a sandboxed connector rebuilds that class in a guest process
+            # where no host hook or database exists, so a gate placed there
+            # is absent exactly for the transport that most needs it.
+            agent_tools.extend(gate_mcp_tools(server_tools))
             if server_tools:
                 loaded_servers.append(server_name)
             logger.info(f"Found {len(server_tools)} tools from server {server_name}")

--- a/src/xagent/core/tools/adapters/vibe/mcp_tools.py
+++ b/src/xagent/core/tools/adapters/vibe/mcp_tools.py
@@ -99,7 +99,14 @@ def _build_mcp_load_summary(
             continue
 
         successful_tool_count += 1
-        source_server = getattr(tool, "source_server", None)
+        # Read through the metadata contract, not off the tool. Every wrapper
+        # in this pipeline delegates ``metadata`` and forwards no other
+        # attribute -- ``SandboxedToolWrapper`` already did, so a healthy
+        # npx/uvx connector counted its tools here while never being marked
+        # loaded, and the loop below then synthesized ``no_tools_returned``
+        # for it and failed STRICT setup. Fixing the wrapper instead would
+        # have left the sandbox transport broken exactly as it is today.
+        source_server = getattr(getattr(tool, "metadata", None), "source_server", None)
         if type(source_server) is not str:
             continue
         key = normalize_mcp_server_name(source_server)

--- a/src/xagent/core/tools/adapters/vibe/write_gate.py
+++ b/src/xagent/core/tools/adapters/vibe/write_gate.py
@@ -82,8 +82,11 @@ field without it would be another value nobody reads.
 from __future__ import annotations
 
 from collections.abc import Mapping
+import logging
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -133,8 +136,19 @@ class GateDecision:
     """
 
     approval_required: bool
-    interaction_id: str = ""
+    interaction_id: str
     message: str = ""
+
+    def __post_init__(self) -> None:
+        # Required, not defaulted. An empty identity does not degrade the
+        # pause, it loses the write: ReAct falls back to the raw
+        # ``tool_call_id`` (see its pending-response construction), which the
+        # host never recorded, so the answer arrives against an interaction
+        # nobody is holding and the approved call never runs. That was a
+        # silent default away, so the field has no default and an empty one
+        # is refused here rather than three layers later.
+        if self.approval_required and not self.interaction_id:
+            raise ValueError("a pause must carry the interaction id it is stored under")
 
 
 WriteGateHook = Callable[[GatedCall], Optional[GateDecision]]
@@ -145,6 +159,14 @@ WriteGateHook = Callable[[GatedCall], Optional[GateDecision]]
 # executor is passed in rather than imported because only the tool knows how
 # to place a call on its own connection -- and going through it is what keeps
 # the replay on the tool's normal authorization and error-mapping path.
+#
+# **Precondition on the host.** This seam correlates a resume by the
+# interaction id and the tool's runtime name, and neither is proof of
+# ownership: the name is user-editable and an id is only as scoped as
+# whoever minted it. So the host must verify that the interaction it loads
+# belongs to the conversation, workspace and user the answer arrived from,
+# before it hands the payload to the executor. Nothing here can do that
+# check -- this module has no notion of a tenant.
 WriteGateResumeHook = Callable[..., Any]
 
 _HOOK: WriteGateHook | None = None
@@ -194,13 +216,27 @@ def consult_write_gate(call: GatedCall) -> GateDecision | None:
     if hook is None:
         return None
     try:
-        return hook(call)
+        decision = hook(call)
     except Exception:  # noqa: BLE001 - see the docstring
-        import logging
-
-        logging.getLogger(__name__).warning(
+        logger.warning(
             "Write gate hook failed for %s; executing ungated",
             call.tool_name,
             exc_info=True,
         )
         return None
+    if decision is None or isinstance(decision, GateDecision):
+        return decision
+    # Checked, not trusted. A hook written ``async def`` returns a coroutine
+    # rather than raising, so the type error would surface as an
+    # ``AttributeError`` on ``decision.approval_required`` at the call site
+    # -- and it would do that for every gated call thereafter, since nothing
+    # about the hook has changed. Treated as no decision, the same as a hook
+    # that raised: this seam's documented direction on hook failure is to
+    # execute rather than strand a workspace behind an unanswerable pause.
+    logger.warning(
+        "Write gate hook returned %s rather than a GateDecision for %s; "
+        "executing ungated",
+        type(decision).__name__,
+        call.tool_name,
+    )
+    return None

--- a/src/xagent/core/tools/adapters/vibe/write_gate.py
+++ b/src/xagent/core/tools/adapters/vibe/write_gate.py
@@ -81,8 +81,8 @@ field without it would be another value nobody reads.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
 

--- a/src/xagent/core/tools/adapters/vibe/write_gate.py
+++ b/src/xagent/core/tools/adapters/vibe/write_gate.py
@@ -1,0 +1,173 @@
+"""The seam a host uses to require approval before an MCP write executes.
+
+A gated call is not executed. The hook is handed the call exactly as it was
+about to run -- tool name and arguments -- and answers with either "run it"
+or a pause carrying the frozen payload's identity. On approval the same
+arguments are executed verbatim, because they were never handed back to the
+model to be written a second time.
+
+**Why a host-injected hook rather than a direct call into the web layer.**
+This module is imported by the tool adapters, which
+``sandboxed_tool/tool_runner.py`` reconstructs inside the sandbox for every
+npx/uvx MCP tool -- a process where sqlalchemy is not installed. Anything
+here that reached for a database would turn every sandboxed tool call into a
+``ModuleNotFoundError``. So this file stays free of the web layer and the
+host injects the policy instead.
+
+Where the gate is *consulted* is a separate question, answered in
+``write_gate_tool.py``: on the host, in ``WriteGateTool``, above both the
+direct adapter and the sandbox wrapper. A sandboxed write is therefore gated
+before anything crosses into the guest, which an earlier revision -- asking
+from inside the adapter, where a supported npx/uvx connector only ever runs
+in the guest -- got exactly backwards.
+
+Not registering a hook *is* the off switch. No hook means no gate: nothing
+to consult, nothing to record, and no behavior change at all -- including
+the tool metadata the scheduler reads.
+
+**Not a trust boundary.** The hook decides using, among other things, a
+server's own ``readOnlyHint``/``destructiveHint`` annotations, which the MCP
+spec says a client must not trust from an untrusted server. What this seam
+guarantees is narrower and worth stating exactly: *if* a call is gated, the
+arguments that eventually execute are the ones that were shown, byte for
+byte. It does not guarantee that every dangerous call gets gated.
+
+**Known limits of this version.** Both are deliberate, and neither is
+described elsewhere in this module as if it were solved:
+
+*An approval is not bound to a connector identity.* It is bound to the
+interaction it was shown for, and nothing more. If a same-name MCP server is
+repointed to another endpoint, reauthorized to a different account, or
+deleted and recreated between the pause and the answer, the approved
+arguments still execute -- against whatever that name resolves to when the
+answer arrives. Carrying an immutable server/account identity would need the
+MCP connection layer to expose one, which it does not today.
+
+*Only a surface that delivers the chosen option value verbatim can grant an
+approval.* The pause offers machine values (``approve``/``reject``), and the
+host decides what counts as consent. xagent's own ``ClarificationForm``
+cannot take part: it submits each answer's *display label* rather than the
+option's value -- for every interaction type, not just ``confirm``, which it
+renders as a localized yes/no switch that ignores ``options`` entirely. A
+pause surfaced through that form therefore reaches the host as ``"Yes"`` and
+is voided, not executed. The supported surface in this version is a host
+that passes the value through untouched (Toby delivers the Slack button's
+value as the resume message).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+
+@dataclass(frozen=True)
+class GatedCall:
+    """One MCP call presented to the gate before it runs."""
+
+    tool_name: str
+    """The tool's runtime name, as the model called it."""
+
+    server_name: str
+    """Normalized identity of the MCP server the tool came from."""
+
+    arguments: Mapping[str, Any]
+    """The arguments the call would have executed with.
+
+    Exactly as the model produced them, which is also exactly what a replay
+    re-enters the tool with: the adapter's own deterministic handling of them
+    then runs identically both times.
+    """
+
+    write_hint: str
+    """The server's own write declaration: an ``MCPWriteHint`` value.
+
+    Carried as a plain string so this module stays independent of the
+    adapter's enum. A hook must treat everything except ``"read_only"`` as a
+    write: ``"undeclared"`` is the common case, not a promise of safety.
+    """
+
+
+@dataclass(frozen=True)
+class GateDecision:
+    """What the host decided about one gated call.
+
+    ``interaction_id`` is the identity the frozen payload was stored under
+    and the identity the resume callback will be handed back. It is the
+    hook's to mint: the adapter neither generates nor interprets it, it only
+    carries it into the pause so the two halves meet.
+    """
+
+    approval_required: bool
+    interaction_id: str = ""
+    message: str = ""
+
+
+WriteGateHook = Callable[[GatedCall], Optional[GateDecision]]
+
+# Given the interaction's identity, whether the user approved, and a callable
+# that runs one frozen argument set, the host loads the payload it recorded,
+# settles that approval exactly once, and returns the tool result. The
+# executor is passed in rather than imported because only the tool knows how
+# to place a call on its own connection -- and going through it is what keeps
+# the replay on the tool's normal authorization and error-mapping path.
+WriteGateResumeHook = Callable[..., Any]
+
+_HOOK: WriteGateHook | None = None
+_RESUME_HOOK: WriteGateResumeHook | None = None
+
+
+def set_write_gate_hook(hook: WriteGateHook | None) -> None:
+    """Install (or clear) the process-wide approval hook.
+
+    Idempotent and last-writer-wins, matching ``set_connector_runtime_resolver``.
+    Passing ``None`` restores ungated execution.
+    """
+    global _HOOK
+    _HOOK = hook
+
+
+def get_write_gate_hook() -> WriteGateHook | None:
+    """Return the installed hook, or ``None`` when nothing gates writes."""
+    return _HOOK
+
+
+def set_write_gate_resume_hook(hook: WriteGateResumeHook | None) -> None:
+    """Install (or clear) the hook that settles an approved or rejected call."""
+    global _RESUME_HOOK
+    _RESUME_HOOK = hook
+
+
+def get_write_gate_resume_hook() -> WriteGateResumeHook | None:
+    """Return the installed resume hook, or ``None``."""
+    return _RESUME_HOOK
+
+
+def consult_write_gate(call: GatedCall) -> GateDecision | None:
+    """Ask the installed hook about ``call``; ``None`` means "just run it".
+
+    A hook that raises is treated as no decision and the call proceeds. That
+    direction is deliberate and is the opposite of what a security boundary
+    would do, for the reason in the module docstring: this seam makes an
+    approved call faithful, it is not what keeps a dangerous call from
+    running. Failing closed here would let a transient database error strand
+    every connector call in a workspace behind an approval nobody can grant,
+    which trades a bounded loss of gating for an unbounded loss of function.
+    The host owns the decision to fail closed on its own side, where it can
+    tell a policy miss from an outage.
+    """
+    hook = _HOOK
+    if hook is None:
+        return None
+    try:
+        return hook(call)
+    except Exception:  # noqa: BLE001 - see the docstring
+        import logging
+
+        logging.getLogger(__name__).warning(
+            "Write gate hook failed for %s; executing ungated",
+            call.tool_name,
+            exc_info=True,
+        )
+        return None

--- a/src/xagent/core/tools/adapters/vibe/write_gate.py
+++ b/src/xagent/core/tools/adapters/vibe/write_gate.py
@@ -53,6 +53,30 @@ pause surfaced through that form therefore reaches the host as ``"Yes"`` and
 is voided, not executed. The supported surface in this version is a host
 that passes the value through untouched (Toby delivers the Slack button's
 value as the resume message).
+
+*Runtime-bound arguments are re-derived at execution, not frozen.* What is
+frozen and replayed byte for byte is everything the model authored -- which
+is also everything the approver was shown. On top of that the adapter
+injects its runtime bindings' current values (``_runtime_tool_arguments``,
+``_runtime_mcp_meta``), resolved from the connector runtime of whichever
+adapter instance executes. A resume runs on a rebuilt instance, so if a
+binding's source changed while the question waited, the value that goes out
+is the new one. This is the connector-identity limit above, seen in the
+argument dimension rather than the endpoint dimension.
+
+Closing it needs one of two things that are deliberately not in this
+change. Freezing the *prepared* payload means the guest can no longer
+prepare it: ``sandboxed_tool/tool_runner.py`` re-enters ``run_json_async``
+with the arguments it is handed, and preparation is not idempotent: the key
+set ``_runtime_bound_tool_argument_names`` strips is exactly the key set
+``_runtime_tool_arguments`` injects, so a prepared payload fed back through
+that entry point has its frozen runtime values stripped as though the model
+had set them and then replaced with current ones -- the round trip discards
+precisely the half that was worth freezing. So it needs a second guest
+entry point and a marker in the execution spec. Detecting the change instead
+needs the *host* to store the binding values with the approval and compare
+them at replay, which is a consumer this seam does not have; adding the
+field without it would be another value nobody reads.
 """
 
 from __future__ import annotations
@@ -73,11 +97,20 @@ class GatedCall:
     """Normalized identity of the MCP server the tool came from."""
 
     arguments: Mapping[str, Any]
-    """The arguments the call would have executed with.
+    """The model-authored arguments, exactly as the model produced them.
 
-    Exactly as the model produced them, which is also exactly what a replay
-    re-enters the tool with: the adapter's own deterministic handling of them
-    then runs identically both times.
+    Not the payload that goes on the wire, and the difference is worth
+    stating precisely because this seam's whole promise is about fidelity.
+    Before a call executes, the adapter normalizes these against the tool's
+    schema, applies the args model's defaults and coercion, strips any
+    runtime-bound field the model tried to set, and injects the current
+    values of its runtime bindings.
+
+    The first three of those are pure functions of these arguments and the
+    tool's schema, so they produce the same result at preview and at replay
+    -- the replay re-enters the same public entry point with these exact
+    arguments. The injected runtime values are not: see the third known
+    limit in the module docstring.
     """
 
     write_hint: str

--- a/src/xagent/core/tools/adapters/vibe/write_gate_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/write_gate_tool.py
@@ -157,6 +157,12 @@ class WriteGateTool(AbstractBaseTool):
         and makes both transports refuse identically -- which is the point of
         wrapping them in the same place.
         """
+        if get_write_gate_hook() is None:
+            # Nothing in this process can pause a call, so there is no gate
+            # to bypass -- and refusing here anyway would contradict the off
+            # switch this module documents. The target still refuses on its
+            # own if it is async-only, which every MCP adapter is.
+            return self._target.run_json_sync(args)
         raise RuntimeError(
             f"MCP tool {self.name} is async only; please use run_json_async()"
         )
@@ -180,7 +186,11 @@ class WriteGateTool(AbstractBaseTool):
                 # ``target.source_server`` reported no server at all for
                 # exactly the npx/uvx transport this wrapper exists to cover.
                 server_name=metadata.source_server or "",
-                arguments=args,
+                # A copy, not the caller's mapping. The host records this
+                # as the payload it will replay, and a live reference would
+                # let anything that mutates ``args`` afterwards rewrite what
+                # was approved.
+                arguments=dict(args),
                 write_hint=self._write_hint_value(metadata),
             )
         )
@@ -239,6 +249,37 @@ class WriteGateTool(AbstractBaseTool):
             return await self._target.run_json_async(arguments)
         finally:
             _REPLAYING.reset(token)
+
+    @property
+    def category(self) -> Any:
+        """Forwarded like the rest of the descriptive surface.
+
+        Delegated explicitly rather than through ``__getattr__``: every name
+        below is defined on ``AbstractBaseTool``, so normal lookup succeeds
+        on this class and ``__getattr__`` is never consulted -- it would
+        silently answer with the *wrapper's* base implementation instead of
+        the target's. ``metadata`` is the case that makes this concrete: the
+        base rebuilds it from attributes this wrapper does not have, which
+        is how a wrapped tool once reported no source server at all.
+
+        A blanket ``__getattr__`` would also forward ``__sandbox_config__``,
+        which is *not* on the base -- and ``resolve_sandbox_config`` reading
+        it through the wrapper would offer an already-sandboxed tool up for
+        sandboxing a second time.
+        """
+        return getattr(self._target, "category", None)
+
+    async def setup(self, task_id: Optional[str] = None) -> None:
+        await self._target.setup(task_id)
+
+    async def teardown(self, task_id: Optional[str] = None) -> None:
+        await self._target.teardown(task_id)
+
+    async def save_state_json(self) -> Mapping[str, Any]:
+        return await self._target.save_state_json()
+
+    async def load_state_json(self, state: Mapping[str, Any]) -> None:
+        await self._target.load_state_json(state)
 
     def _write_hint_value(self, metadata: ToolMetadata) -> str:
         """The target's write declaration, as a plain string."""

--- a/src/xagent/core/tools/adapters/vibe/write_gate_tool.py
+++ b/src/xagent/core/tools/adapters/vibe/write_gate_tool.py
@@ -1,0 +1,258 @@
+"""The host-side boundary where a connector write waits for approval.
+
+**Why this is a wrapper and not a check inside the adapter.** A supported
+npx/uvx connector does not execute in this process at all: the sandbox
+serializes the adapter class and its constructor data, and
+``sandboxed_tool/tool_runner.py`` rebuilds it with ``importlib`` and
+``cloudpickle`` in a guest process, then calls ``run_json_async`` there.
+Anything the host installs as module state -- a hook, a database session --
+does not exist on that side, so a gate placed inside the adapter is simply
+absent for the transport that most needs it. The first version of this
+feature did exactly that and left every sandboxed write ungated.
+
+Placed here, the gate wraps *whatever* the loader produced: a bare
+``MCPToolAdapter`` for a direct connection, or a ``SandboxedToolWrapper``
+around one for npx/uvx. Both look identical from outside, both are entered
+in the host process, and neither can be reached without passing through
+this object first.
+
+The wrapper is also what makes resumption honest. It replays an approved
+call by re-entering the target's own ``run_json_async`` with a flag that
+suppresses re-gating, so the authorization check, ``UserContext``, the
+delegated-credential refresh retry and the safe connector-error mapping all
+still run -- rather than reaching past them into the low-level call, which
+is what an earlier revision did.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Mapping
+from contextvars import ContextVar
+from typing import Any, Optional, Type
+
+from pydantic import BaseModel
+
+from ...user_interaction import WAITING_FOR_USER_STATUS
+from .base import AbstractBaseTool, ToolMetadata
+from .write_gate import (
+    GatedCall,
+    consult_write_gate,
+    get_write_gate_hook,
+    get_write_gate_resume_hook,
+)
+
+logger = logging.getLogger(__name__)
+
+# Set while a wrapper is replaying an approved call, so the nested
+# ``run_json_async`` runs its normal authorization, retry and error handling
+# without asking the gate a second question about a call the user already
+# answered. A ContextVar rather than an attribute: the replay is awaited on
+# the same task, and a flag on the instance would leak across concurrent
+# calls to the same tool.
+_REPLAYING: ContextVar[bool] = ContextVar("xagent_write_gate_replaying", default=False)
+
+
+def is_replaying_approved_call() -> bool:
+    """Whether the current task is replaying an already-approved call."""
+    return _REPLAYING.get()
+
+
+class WriteGateTool(AbstractBaseTool):
+    """Holds a connector write until a human answers, then replays it verbatim.
+
+    Delegates every descriptive surface to the wrapped tool, so the model and
+    the tool-selection layers cannot tell the difference: what a gate changes
+    is *when* a call runs, never what it looks like.
+    """
+
+    def __init__(self, target_tool: AbstractBaseTool) -> None:
+        self._target = target_tool
+
+    @property
+    def target(self) -> AbstractBaseTool:
+        """The wrapped tool, for callers that need the transport itself."""
+        return self._target
+
+    @property
+    def name(self) -> str:
+        return self._target.name
+
+    @property
+    def description(self) -> str:
+        return self._target.description
+
+    @property
+    def tags(self) -> list[str]:
+        return self._target.tags
+
+    @property
+    def metadata(self) -> ToolMetadata:
+        """The target's metadata, except that a gated write is never batched.
+
+        ReAct groups consecutive ``concurrency_safe`` calls into one segment
+        and then delivers **one** answer string to every pending interaction
+        in it. A single ``approve`` would therefore authorize every
+        independently frozen write in the batch, and the approver never got
+        to judge them separately.
+
+        Reporting ``False`` is not a workaround for that scheduling detail;
+        it is what the flag actually means here. The pattern's own contract
+        (see its I5 note) makes ``concurrency_safe`` an idempotency promise
+        as well as a concurrency one, and a call parked for human approval
+        is not idempotent -- replaying it publishes twice. So a gated tool
+        runs alone, one approval decides one write, and the answer cannot be
+        spread across calls the user never saw.
+
+        Scope: only a connection whose operator opted into
+        ``concurrency_safe`` is affected, and only while a gate is actually
+        installed. Reads on such a connection lose batching too --
+        ``metadata`` is read before there is a call to ask the hook about, so
+        it cannot know whether *this* invocation would pause. That is the
+        conservative direction; the alternative is a batch whose single
+        answer authorizes a write nobody was shown.
+        """
+        metadata = self._target.metadata
+        if not metadata.concurrency_safe:
+            return metadata
+        if get_write_gate_hook() is None:
+            # Nothing in this process can pause a call, so nothing can spread
+            # one answer across a batch. Returning the target's own metadata
+            # is what keeps the off switch total: an unregistered gate must
+            # not silently cost an operator the batching they configured.
+            return metadata
+        return metadata.model_copy(update={"concurrency_safe": False})
+
+    @property
+    def is_sandboxed(self) -> bool:
+        return bool(getattr(self._target, "is_sandboxed", False))
+
+    def args_type(self) -> Type[BaseModel]:
+        return self._target.args_type()
+
+    def return_type(self) -> Type[BaseModel]:
+        return self._target.return_type()
+
+    def state_type(self) -> Optional[Type[BaseModel]]:
+        return self._target.state_type()
+
+    def return_value_as_string(self, value: Any) -> str:
+        return self._target.return_value_as_string(value)
+
+    def is_async(self) -> bool:
+        return True
+
+    def run_json_sync(self, args: Mapping[str, Any]) -> Any:
+        """Refused: nothing on this path can pause for an answer.
+
+        ``MCPToolAdapter.run_json_sync`` already raises -- MCP tools are
+        async-only -- so the direct transport was never reachable this way.
+        The sandbox wrapper's is different: it drives its own async path
+        through ``asyncio.run`` and works. Delegating here would therefore
+        run a sandboxed npx/uvx write with no gate consulted at all, through
+        exactly the transport this wrapper exists to cover.
+
+        Raising instead keeps "no execution without passing the gate" a
+        property of the object rather than of one of its two entry points,
+        and makes both transports refuse identically -- which is the point of
+        wrapping them in the same place.
+        """
+        raise RuntimeError(
+            f"MCP tool {self.name} is async only; please use run_json_async()"
+        )
+
+    async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+        """Ask the gate, then either run the call or park it for approval."""
+        if is_replaying_approved_call():
+            # Already answered. Fall through so the target performs its own
+            # authorization, retry and error mapping on the replay.
+            return await self._target.run_json_async(args)
+
+        metadata = self.metadata
+        decision = consult_write_gate(
+            GatedCall(
+                tool_name=self.name,
+                # Both fields are read through ``metadata`` rather than off
+                # the target. The adapter mirrors its normalized server
+                # identity and its write declaration there, and
+                # ``SandboxedToolWrapper`` delegates ``metadata`` while
+                # forwarding no other attribute -- so reaching for
+                # ``target.source_server`` reported no server at all for
+                # exactly the npx/uvx transport this wrapper exists to cover.
+                server_name=metadata.source_server or "",
+                arguments=args,
+                write_hint=self._write_hint_value(metadata),
+            )
+        )
+        if decision is None or not decision.approval_required:
+            return await self._target.run_json_async(args)
+
+        return {
+            "status": WAITING_FOR_USER_STATUS,
+            "interaction_id": decision.interaction_id,
+            "message": decision.message or f"Approve running {self.name}?",
+            "interactions": [
+                {
+                    "type": "confirm",
+                    "field": "approve",
+                    "label": "Approve",
+                    "options": [
+                        {"label": "Approve", "value": "approve"},
+                        {"label": "Reject", "value": "reject"},
+                    ],
+                }
+            ],
+        }
+
+    async def resume_user_interaction(
+        self,
+        *,
+        interaction_id: str,
+        response: str,
+    ) -> Any:
+        """Replay the approved call, or void it.
+
+        The model is not consulted: the whole point is that the arguments
+        which execute are the ones that were shown. The replay re-enters the
+        target's ``run_json_async`` under ``_REPLAYING``, so authorization,
+        credential refresh and error mapping behave exactly as they do for
+        an ungated call.
+        """
+        hook = get_write_gate_resume_hook()
+        if hook is None:
+            return {
+                "success": False,
+                "status": "error",
+                "error": "This approval can no longer be completed.",
+            }
+        return await hook(
+            interaction_id=interaction_id,
+            response=response,
+            tool_name=self.name,
+            executor=self._replay,
+        )
+
+    async def _replay(self, arguments: Mapping[str, Any]) -> Any:
+        """Run one frozen argument set through the target's normal path."""
+        token = _REPLAYING.set(True)
+        try:
+            return await self._target.run_json_async(arguments)
+        finally:
+            _REPLAYING.reset(token)
+
+    def _write_hint_value(self, metadata: ToolMetadata) -> str:
+        """The target's write declaration, as a plain string."""
+        hint = metadata.mcp_write_hint
+        return hint if isinstance(hint, str) else "undeclared"
+
+
+def gate_mcp_tools(tools: "Iterable[AbstractBaseTool]") -> list[AbstractBaseTool]:
+    """Wrap loaded MCP tools so a write cannot execute before approval.
+
+    Applied once where the direct and sandboxed loaders converge, so neither
+    transport can be gated by accident and neither can be missed. Wrapping is
+    unconditional and cheap: whether a given call actually needs approval is
+    the installed hook's decision, made per call, and with no hook installed
+    every wrapper is a pass-through.
+    """
+    return [WriteGateTool(tool) for tool in tools]

--- a/tests/core/tools/adapters/vibe/test_mcp_init_timeout.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_init_timeout.py
@@ -5,6 +5,7 @@ import asyncio
 
 import pytest
 
+from tests.core.tools.conftest import gated_targets
 from xagent.config import MCP_TOOL_INIT_TIMEOUT_SECONDS
 from xagent.core.tools.adapters.vibe import mcp_adapter as mcp_adapter_module
 from xagent.core.tools.adapters.vibe.config import MCPFailurePolicy
@@ -43,7 +44,7 @@ async def test_stalled_server_times_out_and_other_servers_still_load(monkeypatch
         }
     )
 
-    assert result.tools == (healthy_tool,)
+    assert gated_targets(result.tools) == (healthy_tool,)
     assert result.loaded_servers == ("healthy",)
     assert len(result.failures) == 1
     assert result.failures[0].server_name == "stalled"

--- a/tests/core/tools/adapters/vibe/test_mcp_load_summary.py
+++ b/tests/core/tools/adapters/vibe/test_mcp_load_summary.py
@@ -1,0 +1,158 @@
+"""A healthy connector must not be reported as having returned no tools.
+
+``_build_mcp_load_summary`` decided which servers loaded by reading
+``source_server`` off each tool. Every wrapper in this pipeline delegates
+``metadata`` and forwards no other attribute, so a wrapped tool answered
+``None``: its tools were counted, its server was never marked loaded, and the
+loop that follows then synthesized ``no_tools_returned`` for it -- failing
+STRICT setup for a connector that had just answered.
+
+That was already true on the sandbox transport before any gate existed, which
+is why the fix is here and not on one wrapper: reading through the metadata
+contract covers every wrapper that honours it, including the ones not written
+yet.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, Type
+
+import pytest
+from pydantic import BaseModel
+
+from xagent.core.tools.adapters.vibe.base import AbstractBaseTool
+from xagent.core.tools.adapters.vibe.mcp_tools import _build_mcp_load_summary
+from xagent.core.tools.adapters.vibe.write_gate_tool import gate_mcp_tools
+
+CONFIGS = [{"name": "slack"}]
+
+
+class _ArgsModel(BaseModel):
+    pass
+
+
+class _AdapterLike(AbstractBaseTool):
+    """The shape ``MCPToolAdapter`` presents: the attribute *and* the metadata."""
+
+    source_server = "slack"
+
+    @property
+    def name(self) -> str:
+        return "slack_post_message"
+
+    @property
+    def description(self) -> str:
+        return "post"
+
+    @property
+    def tags(self) -> list[str]:
+        return []
+
+    def args_type(self) -> Type[BaseModel]:
+        return _ArgsModel
+
+    def return_type(self) -> Type[BaseModel]:
+        return _ArgsModel
+
+    def run_json_sync(self, args: Mapping[str, Any]) -> Any:
+        return {}
+
+    async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+        return {}
+
+
+class _MetadataOnlyWrapper(AbstractBaseTool):
+    """A wrapper that delegates ``metadata`` and forwards nothing else.
+
+    Not a stand-in for one particular class: this is the contract every
+    wrapper in the pipeline actually keeps. ``SandboxedToolWrapper`` has kept
+    exactly this shape since before the write gate existed.
+    """
+
+    def __init__(self, target: AbstractBaseTool) -> None:
+        self._target = target
+
+    @property
+    def name(self) -> str:
+        return self._target.name
+
+    @property
+    def description(self) -> str:
+        return self._target.description
+
+    @property
+    def tags(self) -> list[str]:
+        return self._target.tags
+
+    @property
+    def metadata(self):  # type: ignore[override]
+        return self._target.metadata
+
+    def args_type(self) -> Type[BaseModel]:
+        return self._target.args_type()
+
+    def return_type(self) -> Type[BaseModel]:
+        return self._target.return_type()
+
+    def run_json_sync(self, args: Mapping[str, Any]) -> Any:
+        return self._target.run_json_sync(args)
+
+    async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+        return await self._target.run_json_async(args)
+
+
+def test_a_bare_adapter_marks_its_server_loaded() -> None:
+    """The baseline: this never broke, and must keep working."""
+    summary = _build_mcp_load_summary(CONFIGS, [_AdapterLike()])
+
+    assert summary.loaded_servers == ("slack",)
+    assert summary.failures == ()
+    assert summary.successful_tool_count == 1
+
+
+def test_a_metadata_only_wrapper_marks_its_server_loaded() -> None:
+    """The pre-existing bug, independent of the write gate.
+
+    Reading the raw attribute made this answer ``None``, so the server fell
+    through to ``no_tools_returned`` while its tool was still counted -- an
+    internally contradictory summary that failed STRICT setup for a connector
+    that had answered.
+    """
+    summary = _build_mcp_load_summary(CONFIGS, [_MetadataOnlyWrapper(_AdapterLike())])
+
+    assert summary.loaded_servers == ("slack",)
+    assert summary.failures == ()
+    assert summary.successful_tool_count == 1
+
+
+def test_a_gated_tool_marks_its_server_loaded() -> None:
+    """And the wrapper this PR adds, through the real ``gate_mcp_tools``."""
+    summary = _build_mcp_load_summary(CONFIGS, list(gate_mcp_tools([_AdapterLike()])))
+
+    assert summary.loaded_servers == ("slack",)
+    assert summary.failures == ()
+    assert summary.successful_tool_count == 1
+
+
+def test_a_gated_sandbox_wrapper_marks_its_server_loaded() -> None:
+    """Both wrappers stacked, which is the production npx/uvx shape."""
+    stacked = gate_mcp_tools([_MetadataOnlyWrapper(_AdapterLike())])
+
+    summary = _build_mcp_load_summary(CONFIGS, list(stacked))
+
+    assert summary.loaded_servers == ("slack",)
+    assert summary.failures == ()
+
+
+@pytest.mark.parametrize("tools", [[], None])
+def test_a_server_that_returned_nothing_is_still_reported(tools) -> None:
+    """The guard on the other side: the failure path must stay reachable.
+
+    A fix that marked every requested server loaded would silence the real
+    ``no_tools_returned``, which is the condition STRICT setup exists to catch.
+    """
+    summary = _build_mcp_load_summary(CONFIGS, list(tools or []))
+
+    assert summary.loaded_servers == ()
+    assert [failure.reason for failure in summary.failures] == ["no_tools_returned"]
+    assert summary.successful_tool_count == 0

--- a/tests/core/tools/adapters/vibe/test_selection_spec.py
+++ b/tests/core/tools/adapters/vibe/test_selection_spec.py
@@ -500,7 +500,21 @@ async def test_mcp_summary_reports_partial_success_and_same_server_failure(
     from xagent.core.tools.adapters.vibe import mcp_tools
 
     class _LoadedTool:
+        # Carries ``metadata``, because every tool that reaches the summary
+        # does: they are all ``AbstractBaseTool`` instances (whose metadata
+        # property mirrors ``source_server``) or ``UnavailableMCPTool``,
+        # which the summary takes on an earlier branch. A double with only
+        # the bare attribute is thinner than anything production produces,
+        # and the summary reads the metadata contract so that a wrapper --
+        # which forwards ``metadata`` and no other attribute -- is not
+        # mistaken for a server that returned nothing.
         source_server = "gmail"
+
+        @property
+        def metadata(self):
+            from xagent.core.tools.adapters.vibe.base import ToolMetadata
+
+            return ToolMetadata(name="gmail_send", source_server=self.source_server)
 
     gmail_failure = UnavailableMCPTool(
         server_name="Gmail",

--- a/tests/core/tools/adapters/vibe/test_write_gate.py
+++ b/tests/core/tools/adapters/vibe/test_write_gate.py
@@ -1,11 +1,10 @@
 """A gated MCP write must not execute before it is approved -- on either transport.
 
-The first version of this feature consulted the gate inside
-``MCPToolAdapter.run_json_async``, which is the one place a supported npx/uvx
-connector never reaches: the sandbox serializes that adapter and
-``tool_runner.py`` rebuilds it in a guest process where no host hook and no
-database exist. Every sandboxed write went out ungated while the host tests
-were green, because those tests called the adapter directly.
+The first version consulted the gate inside the adapter -- the one place a
+supported npx/uvx connector never reaches (``write_gate_tool``'s module
+docstring has the mechanism). Every sandboxed write went out ungated while
+the host tests stayed green, because those tests called the adapter
+directly.
 
 So the tests here refuse a hand-rolled stand-in for that boundary. They drive
 a real ``SandboxedToolWrapper`` and watch its guest dispatch (``sandbox.exec``
@@ -14,6 +13,7 @@ transport, or an approval whose arguments are re-derived on the way into the
 guest, fails here rather than in production.
 """
 
+import asyncio
 import base64
 import json
 from typing import Any, Mapping, Optional
@@ -97,11 +97,22 @@ class _RecordingGate:
 
 
 class _RecordingResume:
-    """The host half: holds the frozen arguments and spends them once."""
+    """The host half: replays what the gate recorded, and only that.
 
-    def __init__(self, frozen: dict[str, Any]) -> None:
-        self.frozen = frozen
+    Takes the gate rather than a copy of the arguments. Reading them from a
+    separate test constant would let a gate that recorded the *wrong*
+    arguments still pass every fidelity assertion here -- the payload and
+    the expectation would come from the same place, and the subject would
+    never be consulted.
+    """
+
+    def __init__(self, gate: "_RecordingGate") -> None:
+        self._gate = gate
         self.calls: list[tuple[str, str, str]] = []
+
+    @property
+    def frozen(self) -> dict[str, Any]:
+        return dict(self._gate.calls[0].arguments)
 
     async def __call__(
         self,
@@ -194,8 +205,9 @@ async def test_sandboxed_write_does_not_reach_the_guest_before_approval():
 
 async def test_approved_sandboxed_call_carries_the_shown_arguments_into_the_guest():
     """What executes is what was shown, across the wrapper/runner seam."""
-    set_write_gate_hook(_RecordingGate())
-    resume = _RecordingResume(dict(SHOWN_ARGUMENTS))
+    gate = _RecordingGate()
+    set_write_gate_hook(gate)
+    resume = _RecordingResume(gate)
     set_write_gate_resume_hook(resume)
     gated, _target, sandbox = _sandboxed_gated_tool()
 
@@ -211,8 +223,9 @@ async def test_approved_sandboxed_call_carries_the_shown_arguments_into_the_gues
 
 
 async def test_rejected_sandboxed_call_never_reaches_the_guest():
-    set_write_gate_hook(_RecordingGate())
-    set_write_gate_resume_hook(_RecordingResume(dict(SHOWN_ARGUMENTS)))
+    gate = _RecordingGate()
+    set_write_gate_hook(gate)
+    set_write_gate_resume_hook(_RecordingResume(gate))
     gated, _target, sandbox = _sandboxed_gated_tool()
 
     paused = await gated.run_json_async(SHOWN_ARGUMENTS)
@@ -252,8 +265,9 @@ async def test_approved_direct_call_replays_through_the_targets_own_entry_point(
     still run for an approved call. A replay that reached for a lower-level
     call would skip every one of them, and the row is already spent.
     """
-    set_write_gate_hook(_RecordingGate())
-    resume = _RecordingResume(dict(SHOWN_ARGUMENTS))
+    gate = _RecordingGate()
+    set_write_gate_hook(gate)
+    resume = _RecordingResume(gate)
     set_write_gate_resume_hook(resume)
     target = _FakeMCPTool()
     (gated,) = gate_mcp_tools([target])
@@ -273,7 +287,7 @@ async def test_replay_is_not_gated_a_second_time():
     """And the replay marker does not outlive the replay."""
     gate = _RecordingGate()
     set_write_gate_hook(gate)
-    set_write_gate_resume_hook(_RecordingResume(dict(SHOWN_ARGUMENTS)))
+    set_write_gate_resume_hook(_RecordingResume(gate))
     target = _FakeMCPTool()
     (gated,) = gate_mcp_tools([target])
 
@@ -377,3 +391,145 @@ def test_the_sync_entry_point_cannot_run_a_gated_write():
 
     assert _guest_arguments(sandbox) == []
     assert target.direct_calls == []
+
+
+async def test_a_hook_that_returns_a_coroutine_executes_ungated():
+    """The easy mistake, and it must not be a crash.
+
+    Writing the hook ``async def`` returns a coroutine instead of raising,
+    so a type error would surface as ``AttributeError`` on
+    ``decision.approval_required`` -- and it would do that for every gated
+    call afterwards, since nothing about the hook has changed. Treated as no
+    decision, the same as a hook that raised.
+    """
+
+    async def _async_hook(call: GatedCall) -> Optional[GateDecision]:
+        return GateDecision(approval_required=True, interaction_id="i-1")
+
+    set_write_gate_hook(_async_hook)  # type: ignore[arg-type]
+    target = _FakeMCPTool()
+    (gated,) = gate_mcp_tools([target])
+
+    result = await gated.run_json_async(SHOWN_ARGUMENTS)
+
+    assert result["success"] is True
+    assert target.direct_calls == [SHOWN_ARGUMENTS]
+
+
+async def test_a_hook_that_returns_a_bare_string_executes_ungated():
+    """Any non-decision, not just a coroutine."""
+    set_write_gate_hook(lambda call: "approve")  # type: ignore[arg-type,return-value]
+    target = _FakeMCPTool()
+    (gated,) = gate_mcp_tools([target])
+
+    assert (await gated.run_json_async(SHOWN_ARGUMENTS))["success"] is True
+    assert target.direct_calls == [SHOWN_ARGUMENTS]
+
+
+def test_a_pause_without_an_interaction_id_is_refused():
+    """The identity is what makes the two halves meet.
+
+    An empty one does not weaken the pause, it loses the write: ReAct falls
+    back to the raw ``tool_call_id``, which the host never recorded, so the
+    answer arrives against an interaction nobody holds. Refused where it is
+    constructed rather than three layers later.
+    """
+    with pytest.raises(ValueError, match="interaction id"):
+        GateDecision(approval_required=True, interaction_id="")
+
+    # A decision that does not pause needs no identity.
+    assert GateDecision(approval_required=False, interaction_id="").interaction_id == ""
+
+
+def test_the_sync_entry_point_passes_through_with_no_hook_installed():
+    """The off switch has to cover both entry points.
+
+    With nothing installed there is no gate to bypass, so refusing here
+    would contradict the module's own "no behavior change" claim. The target
+    still refuses on its own if it is async-only, which every MCP adapter
+    is.
+    """
+    target = _FakeMCPTool()
+    (gated,) = gate_mcp_tools([target])
+
+    assert gated.run_json_sync(SHOWN_ARGUMENTS) == {}
+
+
+class _SelectiveGate:
+    """Pauses one tool by name and lets everything else through."""
+
+    def __init__(self, paused_tool: str) -> None:
+        self._paused = paused_tool
+        self.calls: list[GatedCall] = []
+
+    def __call__(self, call: GatedCall) -> Optional[GateDecision]:
+        self.calls.append(call)
+        if call.tool_name != self._paused:
+            return None
+        return GateDecision(approval_required=True, interaction_id="interaction-1")
+
+
+@sandbox_config()
+class _SlowMCPTool(_FakeMCPTool):
+    """Blocks inside ``run_json_async`` so two calls genuinely interleave."""
+
+    def __init__(self, released: asyncio.Event, entered: asyncio.Event) -> None:
+        super().__init__()
+        self._released = released
+        self._entered = entered
+
+    @property
+    def name(self) -> str:
+        return "slack_post_message"
+
+    async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+        self.replay_flags.append(is_replaying_approved_call())
+        self._entered.set()
+        await self._released.wait()
+        self.direct_calls.append(dict(args))
+        return {"success": True}
+
+
+@sandbox_config()
+class _OtherMCPTool(_FakeMCPTool):
+    @property
+    def name(self) -> str:
+        return "slack_list_channels"
+
+
+async def test_the_replay_marker_does_not_leak_into_a_concurrent_call():
+    """A ContextVar, not an attribute, and this is why.
+
+    While one call is mid-replay, an ordinary call on another tool runs in a
+    different task. If the marker were shared state, that second call would
+    see itself as an approved replay and skip the gate entirely.
+    """
+    released = asyncio.Event()
+    entered = asyncio.Event()
+    gate = _SelectiveGate("slack_post_message")
+    set_write_gate_hook(gate)
+    slow = _SlowMCPTool(released, entered)
+    other = _OtherMCPTool()
+    gated_slow, gated_other = gate_mcp_tools([slow, other])
+    set_write_gate_resume_hook(_RecordingResume(gate))  # type: ignore[arg-type]
+
+    paused = await gated_slow.run_json_async(SHOWN_ARGUMENTS)
+    assert paused["status"] == WAITING_FOR_USER_STATUS
+
+    replay = asyncio.ensure_future(
+        gated_slow.resume_user_interaction(
+            interaction_id=paused["interaction_id"], response="approve"
+        )
+    )
+    await entered.wait()
+
+    # Mid-replay: an unrelated call must not inherit the marker.
+    assert is_replaying_approved_call() is False
+    await gated_other.run_json_async({"limit": 10})
+    assert other.replay_flags == [False]
+
+    released.set()
+    await replay
+
+    assert slow.replay_flags == [True]
+    assert is_replaying_approved_call() is False

--- a/tests/core/tools/adapters/vibe/test_write_gate.py
+++ b/tests/core/tools/adapters/vibe/test_write_gate.py
@@ -1,0 +1,379 @@
+"""A gated MCP write must not execute before it is approved -- on either transport.
+
+The first version of this feature consulted the gate inside
+``MCPToolAdapter.run_json_async``, which is the one place a supported npx/uvx
+connector never reaches: the sandbox serializes that adapter and
+``tool_runner.py`` rebuilds it in a guest process where no host hook and no
+database exist. Every sandboxed write went out ungated while the host tests
+were green, because those tests called the adapter directly.
+
+So the tests here refuse a hand-rolled stand-in for that boundary. They drive
+a real ``SandboxedToolWrapper`` and watch its guest dispatch (``sandbox.exec``
+carrying ``--args-b64``), which means a gate that is absent for the sandbox
+transport, or an approval whose arguments are re-derived on the way into the
+guest, fails here rather than in production.
+"""
+
+import base64
+import json
+from typing import Any, Mapping, Optional
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.core.tools.adapters.sandboxed_tool.conftest import FakeBaseTool
+from xagent.core.tools.adapters.vibe.mcp_adapter import MCPWriteHint
+from xagent.core.tools.adapters.vibe.sandboxed_tool.sandbox_config import sandbox_config
+from xagent.core.tools.adapters.vibe.sandboxed_tool.sandboxed_tool_wrapper import (
+    SandboxedToolWrapper,
+)
+from xagent.core.tools.adapters.vibe.write_gate import (
+    GatedCall,
+    GateDecision,
+    set_write_gate_hook,
+    set_write_gate_resume_hook,
+)
+from xagent.core.tools.adapters.vibe.write_gate_tool import (
+    gate_mcp_tools,
+    is_replaying_approved_call,
+)
+from xagent.core.tools.user_interaction import WAITING_FOR_USER_STATUS
+
+# The arguments a human would have been shown. Deliberately not a flat
+# {"text": "hi"}: nesting and a non-ASCII body are where a "re-serialize it
+# again on the way out" bug shows up as a difference instead of a coincidence.
+SHOWN_ARGUMENTS = {
+    "channel": "C123",
+    "blocks": [{"type": "section", "text": "内容 A"}],
+    "unfurl": False,
+}
+
+
+@sandbox_config()
+class _FakeMCPTool(FakeBaseTool):
+    """One MCP tool adapter's surface, without a connection behind it.
+
+    ``source_server``/``concurrency_safe``/``write_hint`` are the three
+    attributes ``AbstractBaseTool.metadata`` reads off a concrete tool, so a
+    wrapper that goes through ``metadata`` sees exactly what it would see
+    from a real adapter -- and one that reaches for a raw attribute instead
+    sees nothing once this is behind the sandbox wrapper.
+    """
+
+    source_server = "slack"
+    concurrency_safe = True
+
+    def __init__(self) -> None:
+        self.direct_calls: list[dict[str, Any]] = []
+        self.replay_flags: list[bool] = []
+
+    @property
+    def name(self) -> str:
+        return "slack_post_message"
+
+    @property
+    def write_hint(self) -> MCPWriteHint:
+        return MCPWriteHint.UNDECLARED
+
+    async def run_json_async(self, args: Mapping[str, Any]) -> Any:
+        self.direct_calls.append(dict(args))
+        self.replay_flags.append(is_replaying_approved_call())
+        return {"success": True, "posted": dict(args)}
+
+
+class _RecordingGate:
+    """A host gate that always demands approval and remembers what it saw."""
+
+    def __init__(self) -> None:
+        self.calls: list[GatedCall] = []
+
+    def __call__(self, call: GatedCall) -> Optional[GateDecision]:
+        self.calls.append(call)
+        return GateDecision(
+            approval_required=True,
+            interaction_id="interaction-1",
+            message="Post this to Slack?",
+        )
+
+
+class _RecordingResume:
+    """The host half: holds the frozen arguments and spends them once."""
+
+    def __init__(self, frozen: dict[str, Any]) -> None:
+        self.frozen = frozen
+        self.calls: list[tuple[str, str, str]] = []
+
+    async def __call__(
+        self,
+        *,
+        interaction_id: str,
+        response: str,
+        tool_name: str,
+        executor: Any,
+    ) -> Any:
+        # The keyword set is the contract the saas side implements against.
+        # Pinned by signature: a new kwarg on the caller breaks this here
+        # rather than at runtime in the other repository.
+        self.calls.append((interaction_id, response, tool_name))
+        if response != "approve":
+            return {"success": False, "status": "voided"}
+        return await executor(self.frozen)
+
+
+def _make_sandbox() -> MagicMock:
+    """A sandbox that reports success without running anything."""
+    payload = {"success": True, "output": "sent"}
+
+    def _exec(*args: Any, **kwargs: Any) -> MagicMock:
+        result = MagicMock()
+        result.exit_code = 0
+        result.stdout = json.dumps(payload) if args[0] == "cat" else ""
+        result.stderr = ""
+        return result
+
+    sandbox = MagicMock()
+    sandbox.name = "sandbox-test"
+    sandbox.exec = AsyncMock(side_effect=_exec)
+    sandbox.write_file = AsyncMock()
+    return sandbox
+
+
+def _guest_arguments(sandbox: MagicMock) -> list[dict[str, Any]]:
+    """The argument payloads that actually crossed into the guest process.
+
+    Read back out of the ``--args-b64`` the wrapper puts on the tool-runner
+    command line, so this asserts on what the guest would decode -- not on
+    what the host meant to send.
+    """
+    payloads = []
+    for call in sandbox.exec.call_args_list:
+        argv = list(call.args)
+        if "--args-b64" not in argv:
+            continue
+        encoded = argv[argv.index("--args-b64") + 1]
+        payloads.append(json.loads(base64.b64decode(encoded).decode("utf-8")))
+    return payloads
+
+
+@pytest.fixture(autouse=True)
+def _clear_gate_hooks():
+    """The hooks are process-global; a leak would silently gate other tests."""
+    yield
+    set_write_gate_hook(None)
+    set_write_gate_resume_hook(None)
+
+
+def _sandboxed_gated_tool() -> tuple[Any, _FakeMCPTool, MagicMock]:
+    target = _FakeMCPTool()
+    sandbox = _make_sandbox()
+    wrapper = SandboxedToolWrapper(target, sandbox)
+    (gated,) = gate_mcp_tools([wrapper])
+    return gated, target, sandbox
+
+
+async def test_sandboxed_write_does_not_reach_the_guest_before_approval():
+    """The regression the whole redesign exists for.
+
+    A gate inside the adapter cannot stop this call: by the time the adapter
+    runs, it is running in the guest. Asserting on ``sandbox.exec`` is what
+    makes that failure visible from the host side.
+    """
+    gate = _RecordingGate()
+    set_write_gate_hook(gate)
+    gated, target, sandbox = _sandboxed_gated_tool()
+
+    result = await gated.run_json_async(SHOWN_ARGUMENTS)
+
+    assert result["status"] == WAITING_FOR_USER_STATUS
+    assert result["interaction_id"] == "interaction-1"
+    assert _guest_arguments(sandbox) == []
+    assert sandbox.exec.await_count == 0
+    assert target.direct_calls == []
+    assert len(gate.calls) == 1
+
+
+async def test_approved_sandboxed_call_carries_the_shown_arguments_into_the_guest():
+    """What executes is what was shown, across the wrapper/runner seam."""
+    set_write_gate_hook(_RecordingGate())
+    resume = _RecordingResume(dict(SHOWN_ARGUMENTS))
+    set_write_gate_resume_hook(resume)
+    gated, _target, sandbox = _sandboxed_gated_tool()
+
+    paused = await gated.run_json_async(SHOWN_ARGUMENTS)
+    assert paused["status"] == WAITING_FOR_USER_STATUS
+
+    await gated.resume_user_interaction(
+        interaction_id=paused["interaction_id"], response="approve"
+    )
+
+    assert _guest_arguments(sandbox) == [SHOWN_ARGUMENTS]
+    assert resume.calls == [("interaction-1", "approve", "slack_post_message")]
+
+
+async def test_rejected_sandboxed_call_never_reaches_the_guest():
+    set_write_gate_hook(_RecordingGate())
+    set_write_gate_resume_hook(_RecordingResume(dict(SHOWN_ARGUMENTS)))
+    gated, _target, sandbox = _sandboxed_gated_tool()
+
+    paused = await gated.run_json_async(SHOWN_ARGUMENTS)
+    settled = await gated.resume_user_interaction(
+        interaction_id=paused["interaction_id"], response="reject"
+    )
+
+    assert settled["success"] is False
+    assert _guest_arguments(sandbox) == []
+
+
+async def test_the_gate_sees_the_server_name_through_the_sandbox_wrapper():
+    """``SandboxedToolWrapper`` forwards ``metadata`` and nothing else.
+
+    Reading ``target.source_server`` therefore reported no server at all for
+    exactly the transport this wrapper exists to cover, leaving the host
+    policy to decide about an anonymous call.
+    """
+    gate = _RecordingGate()
+    set_write_gate_hook(gate)
+    gated, _target, _sandbox = _sandboxed_gated_tool()
+
+    await gated.run_json_async(SHOWN_ARGUMENTS)
+
+    (call,) = gate.calls
+    assert call.server_name == "slack"
+    assert call.tool_name == "slack_post_message"
+    assert call.write_hint == MCPWriteHint.UNDECLARED.value
+    assert call.arguments == SHOWN_ARGUMENTS
+
+
+async def test_approved_direct_call_replays_through_the_targets_own_entry_point():
+    """Not past it.
+
+    The replay re-enters ``run_json_async``, so the target's authorization
+    check, delegated-credential refresh retry and connector-error mapping all
+    still run for an approved call. A replay that reached for a lower-level
+    call would skip every one of them, and the row is already spent.
+    """
+    set_write_gate_hook(_RecordingGate())
+    resume = _RecordingResume(dict(SHOWN_ARGUMENTS))
+    set_write_gate_resume_hook(resume)
+    target = _FakeMCPTool()
+    (gated,) = gate_mcp_tools([target])
+
+    paused = await gated.run_json_async(SHOWN_ARGUMENTS)
+    assert target.direct_calls == []
+
+    result = await gated.resume_user_interaction(
+        interaction_id=paused["interaction_id"], response="approve"
+    )
+
+    assert target.direct_calls == [SHOWN_ARGUMENTS]
+    assert result["posted"] == SHOWN_ARGUMENTS
+
+
+async def test_replay_is_not_gated_a_second_time():
+    """And the replay marker does not outlive the replay."""
+    gate = _RecordingGate()
+    set_write_gate_hook(gate)
+    set_write_gate_resume_hook(_RecordingResume(dict(SHOWN_ARGUMENTS)))
+    target = _FakeMCPTool()
+    (gated,) = gate_mcp_tools([target])
+
+    paused = await gated.run_json_async(SHOWN_ARGUMENTS)
+    await gated.resume_user_interaction(
+        interaction_id=paused["interaction_id"], response="approve"
+    )
+
+    assert len(gate.calls) == 1
+    assert target.replay_flags == [True]
+    assert is_replaying_approved_call() is False
+
+
+async def test_a_gated_write_is_never_batched_with_another():
+    """ReAct copies one answer to every interaction in a concurrent segment.
+
+    One ``approve`` would then authorize every independently frozen write in
+    the batch, including the ones the approver was never shown.
+    """
+    set_write_gate_hook(_RecordingGate())
+    target = _FakeMCPTool()
+    (gated,) = gate_mcp_tools([target])
+
+    assert target.metadata.concurrency_safe is True
+    assert gated.metadata.concurrency_safe is False
+    # Everything else about the tool is unchanged: the model must not be able
+    # to tell a gated tool from an ungated one.
+    assert gated.metadata.model_dump(exclude={"concurrency_safe"}) == (
+        target.metadata.model_dump(exclude={"concurrency_safe"})
+    )
+
+
+async def test_no_installed_gate_means_no_behavior_change_at_all():
+    """The off switch is "install nothing", and it has to be total.
+
+    Suppressing batching unconditionally would quietly cost every operator
+    who opted into ``concurrency_safe`` on a connection their batching, in a
+    process where nothing can pause a call in the first place.
+    """
+    target = _FakeMCPTool()
+    (gated,) = gate_mcp_tools([target])
+
+    assert gated.metadata == target.metadata
+
+    result = await gated.run_json_async(SHOWN_ARGUMENTS)
+
+    assert target.direct_calls == [SHOWN_ARGUMENTS]
+    assert result["success"] is True
+
+
+async def test_a_failing_gate_executes_ungated():
+    """Deliberate, and the opposite of what a security boundary would do.
+
+    This seam makes an approved call faithful; it is not what keeps a
+    dangerous call from running. Failing closed here would strand every
+    connector call in a workspace behind an approval nobody can grant.
+    """
+
+    def _broken_gate(call: GatedCall) -> Optional[GateDecision]:
+        raise RuntimeError("policy lookup failed")
+
+    set_write_gate_hook(_broken_gate)
+    target = _FakeMCPTool()
+    (gated,) = gate_mcp_tools([target])
+
+    result = await gated.run_json_async(SHOWN_ARGUMENTS)
+
+    assert result["success"] is True
+    assert target.direct_calls == [SHOWN_ARGUMENTS]
+
+
+async def test_an_approval_with_no_resume_hook_reports_an_error_instead_of_executing():
+    set_write_gate_hook(_RecordingGate())
+    target = _FakeMCPTool()
+    (gated,) = gate_mcp_tools([target])
+
+    paused = await gated.run_json_async(SHOWN_ARGUMENTS)
+    settled = await gated.resume_user_interaction(
+        interaction_id=paused["interaction_id"], response="approve"
+    )
+
+    assert settled["success"] is False
+    assert settled["status"] == "error"
+    assert target.direct_calls == []
+
+
+def test_the_sync_entry_point_cannot_run_a_gated_write():
+    """A gate is only a gate if there is no second door.
+
+    The direct adapter refuses ``run_json_sync`` on its own (MCP tools are
+    async-only), but ``SandboxedToolWrapper.run_json_sync`` works -- it just
+    drives its async path through ``asyncio.run``. Forwarding here would run
+    a sandboxed npx/uvx write with nothing consulted, through the one
+    transport the wrapper exists to cover.
+    """
+    set_write_gate_hook(_RecordingGate())
+    _gated, target, sandbox = _sandboxed_gated_tool()
+
+    with pytest.raises(RuntimeError, match="async only"):
+        _gated.run_json_sync(SHOWN_ARGUMENTS)
+
+    assert _guest_arguments(sandbox) == []
+    assert target.direct_calls == []

--- a/tests/core/tools/conftest.py
+++ b/tests/core/tools/conftest.py
@@ -1,0 +1,23 @@
+"""Shared helpers for the MCP tool-loading tests."""
+
+from typing import Any
+
+from xagent.core.tools.adapters.vibe.write_gate_tool import WriteGateTool
+
+
+def gated_targets(tools: Any) -> tuple[Any, ...]:
+    """The loader's tools, unwrapped from the approval gate it applies.
+
+    Every loaded MCP tool leaves ``load_mcp_tools_as_agent_tools`` inside a
+    ``WriteGateTool``: that function is the one place the direct and
+    sandboxed transports converge, which is why the gate is applied there
+    rather than inside the adapter -- a sandboxed npx/uvx connector rebuilds
+    the adapter in a guest process where no host hook exists, so a gate
+    placed there is absent for exactly the transport that most needs it.
+
+    Asserting through this helper keeps each caller's test about the thing it
+    was written for -- which transport ran, what a timeout did -- while still
+    failing if a tool ever escapes the loader ungated.
+    """
+    assert all(isinstance(tool, WriteGateTool) for tool in tools), tools
+    return tuple(tool.target for tool in tools)

--- a/tests/core/tools/conftest.py
+++ b/tests/core/tools/conftest.py
@@ -10,10 +10,8 @@ def gated_targets(tools: Any) -> tuple[Any, ...]:
 
     Every loaded MCP tool leaves ``load_mcp_tools_as_agent_tools`` inside a
     ``WriteGateTool``: that function is the one place the direct and
-    sandboxed transports converge, which is why the gate is applied there
-    rather than inside the adapter -- a sandboxed npx/uvx connector rebuilds
-    the adapter in a guest process where no host hook exists, so a gate
-    placed there is absent for exactly the transport that most needs it.
+    sandboxed transports converge (see ``write_gate_tool``'s module
+    docstring for why the gate lives there and not in the adapter).
 
     Asserting through this helper keeps each caller's test about the thing it
     was written for -- which transport ran, what a timeout did -- while still

--- a/tests/core/tools/test_mcp_sandbox_integration.py
+++ b/tests/core/tools/test_mcp_sandbox_integration.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from mcp.types import Tool as MCPTool
 
+from tests.core.tools.conftest import gated_targets
 from xagent.core.tools.adapters.vibe.mcp_adapter import (
     MCPFailurePhase,
     MCPLoadResult,
@@ -127,7 +128,7 @@ class TestLoadMcpToolsAsAgentTools:
                 sandbox=sandbox,
             )
 
-        assert result.tools == (wrapped_tool,)
+        assert gated_targets(result.tools) == (wrapped_tool,)
         assert result.loaded_servers == ("demo",)
         assert result.failures == ()
         mock_list.assert_awaited_once_with(sandbox, connection)
@@ -162,7 +163,7 @@ class TestLoadMcpToolsAsAgentTools:
                 sandbox=MagicMock(),
             )
 
-        assert result.tools == (direct_tool,)
+        assert gated_targets(result.tools) == (direct_tool,)
         assert result.loaded_servers == ("demo",)
         assert result.failures == ()
         mock_direct.assert_awaited_once()
@@ -266,7 +267,7 @@ class TestLoadMcpToolsAsAgentTools:
                 {"demo": connection}, sandbox=sandbox
             )
 
-        assert result.tools == (wrapped_tool,)
+        assert gated_targets(result.tools) == (wrapped_tool,)
         assert result.loaded_servers == ("demo",)
         assert len(result.failures) == 1
         assert result.failures[0].phase is MCPFailurePhase.SANDBOX_TOOL_WRAP


### PR DESCRIPTION
## What this does

An MCP write that needs a human in front of it pauses today by returning
`waiting_for_user` — and when the run resumes, the model writes the arguments a
second time. What executes is not what was shown. That is the production
incident behind this: a post was approved in Slack and a different post went
out, twice.

This PR adds the seam that fixes it. A host installs a hook; the hook answers
"run it" or "pause, here is the interaction's identity"; an approved call is
replayed with the arguments the approver saw, verbatim, because they were never
handed back to the model.

## Where the gate is consulted, and why it matters

In a wrapper on the host — `WriteGateTool` — not inside the adapter.

A supported npx/uvx connector does not run in this process at all: the sandbox
serializes the adapter and `sandboxed_tool/tool_runner.py` rebuilds it with
`importlib` and `cloudpickle` in a guest process, where no host hook and no
database exist. A check inside `MCPToolAdapter.run_json_async` is therefore
absent for exactly the transport that most needs it — which is what the first
revision of this PR shipped. The wrapper wraps whatever the loader produced (a
bare adapter, or a `SandboxedToolWrapper` around one), applied at the single
line where the direct and sandboxed loaders converge.

Both entry points are covered: `run_json_async` consults the gate, and
`run_json_sync` refuses — the sandbox wrapper's sync path works (it drives its
own async path through `asyncio.run`), so forwarding it would run a sandboxed
write with nothing consulted.

A replay re-enters the target's own `run_json_async` under a `ContextVar` that
suppresses re-gating, so the authorization check, the delegated-credential
refresh retry and the safe connector-error mapping all still run for an
approved call.

A gated tool reports `concurrency_safe=False`, but only while a hook is
installed: ReAct copies one answer to every interaction in a concurrent
segment, so a single `approve` would otherwise authorize every independently
frozen write in the batch. With no hook installed the wrapper is a total
pass-through, metadata included — that is the off switch.

## Known limits of this version

Both are deliberate, both are stated in the module where the seam is defined,
and neither is described anywhere in the code as if it were solved.

**An approval is not bound to a connector identity.** It is bound to the
interaction it was shown for and nothing more. If a same-name MCP server is
repointed, reauthorized to another account, or deleted and recreated between
the pause and the answer, the approved arguments still execute against
whatever that name resolves to. Binding would need the MCP connection layer to
expose an immutable server/account identity; nothing in the tree does today.
An earlier revision of this PR carried a `connector_identity` field for this —
it read an attribute no adapter has, so it was always empty while the
docstrings described a comparison that protected against exactly this. Removed
rather than left in place.

**Only a surface that delivers the chosen option value verbatim can grant an
approval.** The pause offers machine values (`approve`/`reject`) and the host
decides what counts as consent. xagent's own `ClarificationForm` cannot take
part: it submits each answer's *display label* rather than the option's value —
for every interaction type, not just `confirm`, which it renders as a localized
yes/no switch that ignores `options`. A pause surfaced through that form
reaches the host as `"Yes"` and is voided, not executed. Fail-closed, but not
usable. **The supported surface in this version is Slack**, where Toby delivers
the button's value as the resume message. Carrying machine values through
form/WebSocket/backend/runner is a separate change and is not in this PR.

## Not a trust boundary

The hook decides using, among other things, a server's own
`readOnlyHint`/`destructiveHint`, which the MCP spec says a client must not
trust from an untrusted server. What this guarantees is narrower and worth
stating exactly: *if* a call is gated, the arguments that execute are the ones
that were shown, byte for byte. It does not guarantee that every dangerous call
gets gated. A hook that raises is treated as no decision and the call proceeds —
deliberately, because failing closed here would strand every connector call in
a workspace behind an approval nobody can grant.

## Tests

The first revision was green while every sandboxed write went out ungated,
because its tests called the adapter directly. So these drive a real
`SandboxedToolWrapper` and assert on the guest dispatch itself (`sandbox.exec`
carrying `--args-b64`): a gate absent for the sandbox transport, or an approval
whose arguments are re-derived on the way in, fails in the suite rather than in
production. All nine assertions were mutation-verified — each reverted property
is killed by its own test.

The four existing loader tests now assert through a shared helper that every
tool leaves `load_mcp_tools_as_agent_tools` inside a `WriteGateTool`, so
deleting the wiring line stops being silent. Those four were failing on this
branch and nobody had seen it: the lint failure fail-fast'd pytest away on
every run.

## Not in this PR

The resumed result is still discarded by ReAct — `resume(...)` is awaited and
its value dropped (`react.py:1863-1876`), so the model replans without knowing
whether the external write succeeded. That is a change to the resume protocol
itself rather than to this transport boundary, and it is tracked in #2256.

