### PR TITLE
feat(mcp): add owner-scoped OAuth APIs

### DIFF
--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -2142,9 +2142,14 @@ def _actor_oauth_cookie_name(nonce: str) -> str:
 
 
 def is_actor_oauth_cookie_header(value: str) -> bool:
-    """Accept only a Set-Cookie header for an actor OAuth flow."""
-    name, separator, _rest = value.partition("=")
-    return separator == "=" and name.strip().startswith(_ACTOR_OAUTH_COOKIE_PREFIX)
+    """Accept only a non-empty Set-Cookie header for an actor OAuth flow."""
+    name, separator, rest = value.partition("=")
+    cookie_value = rest.partition(";")[0].strip()
+    return (
+        separator == "="
+        and name.strip().startswith(_ACTOR_OAUTH_COOKIE_PREFIX)
+        and bool(cookie_value)
+    )
 
 
 def _actor_oauth_cookie_scope(provider: str, db_provider: Any) -> tuple[bool, str]:

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -15,6 +15,7 @@ import shlex
 from collections.abc import Collection
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
+from enum import Enum
 from typing import Annotated, Any, Callable, Dict, List, Literal, Optional, Union, cast
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 from uuid import UUID
@@ -826,6 +827,11 @@ def _upsert_mcp_oauth_client(
         return client
 
 
+class _OAuthPersistence(Enum):
+    COMMIT = "commit"
+    CALLER = "caller"
+
+
 class _SQLiteOAuthPersistenceTransactionError(RuntimeError):
     """The caller has SQLite writes that the persistence fence cannot reset."""
 
@@ -945,6 +951,38 @@ def _lock_active_mcp_oauth_lifecycle(
     return server, association, flow_state
 
 
+def _lock_caller_oauth_lifecycle(
+    db: Session,
+    *,
+    association_identity: _MCPOAuthAssociationIdentity,
+) -> tuple[MCPServer, UserMCPServer] | None:
+    """Lock a caller-owned transaction without resetting its pending writes."""
+    db.flush()
+    server = (
+        db.query(MCPServer)
+        .filter(MCPServer.id == association_identity.server_id)
+        .with_for_update()
+        .one_or_none()
+    )
+    if server is None:
+        return None
+    association = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == association_identity.user_id,
+            UserMCPServer.mcpserver_id == association_identity.server_id,
+            UserMCPServer.lifecycle_generation
+            == association_identity.lifecycle_generation,
+            UserMCPServer.is_active.is_(True),
+        )
+        .with_for_update()
+        .one_or_none()
+    )
+    if association is None:
+        return None
+    return server, association
+
+
 def _sweep_expired_mcp_oauth_flow_states(db: Session) -> None:
     """Delete one bounded batch of dead flow states outside lifecycle locks."""
     # Sweep this table's dead rows before adding another, mirroring the Slack
@@ -991,18 +1029,25 @@ def _persist_mcp_oauth_connect_flow(
     selected_resource: str,
     selected_scope: str,
     redirect_after: str | None,
+    persistence: _OAuthPersistence = _OAuthPersistence.COMMIT,
 ) -> tuple[str, str, str] | None:
     """Persist a client and flow only for the preflight association generation."""
-    # This global maintenance write is independent of the new flow. Commit it
-    # before taking per-lifecycle row locks so unrelated expired rows cannot
-    # widen the server -> association critical section.
-    _sweep_expired_mcp_oauth_flow_states(db)
-    lifecycle = _lock_active_mcp_oauth_lifecycle(
-        db,
-        association_identity=association_identity,
-    )
+    if persistence is _OAuthPersistence.COMMIT:
+        # Commit independent maintenance before taking lifecycle row locks.
+        _sweep_expired_mcp_oauth_flow_states(db)
+        lifecycle = _lock_active_mcp_oauth_lifecycle(
+            db,
+            association_identity=association_identity,
+        )
+    else:
+        caller_lifecycle = _lock_caller_oauth_lifecycle(
+            db,
+            association_identity=association_identity,
+        )
+        lifecycle = (*caller_lifecycle, None) if caller_lifecycle is not None else None
     if lifecycle is None:
-        db.rollback()
+        if persistence is _OAuthPersistence.COMMIT:
+            db.rollback()
         return None
 
     try:
@@ -1038,10 +1083,14 @@ def _persist_mcp_oauth_connect_flow(
             )
         )
         persisted_client_id = str(oauth_client.client_id)
-        db.commit()
+        if persistence is _OAuthPersistence.COMMIT:
+            db.commit()
+        else:
+            db.flush()
         return persisted_client_id, state_value, code_verifier
     except Exception:
-        db.rollback()
+        if persistence is _OAuthPersistence.COMMIT:
+            db.rollback()
         raise
 
 
@@ -3450,7 +3499,7 @@ def _ensure_catalog_mcp_oauth_server(
                 if value and isinstance(value, str):
                     encrypted_auth[key] = encrypt_value(value)
             cast(Any, server).auth = encrypted_auth
-            db.commit()
+            db.flush()
     if not server:
         try:
             config = _build_server_config(
@@ -3466,7 +3515,68 @@ def _ensure_catalog_mcp_oauth_server(
                 status_code=status.HTTP_400_BAD_REQUEST,
                 detail=f"Invalid app configuration: {str(e)}",
             )
-        server = _add_catalog_server_with_race_recovery(db, config, server_name)
+
+        candidate = MCPServer.from_config(config.model_dump())
+        try:
+            with db.begin_nested():
+                db.add(candidate)
+                db.flush()
+            server = candidate
+        except IntegrityError as exc:
+            server = db.query(MCPServer).filter(MCPServer.name == server_name).first()
+            if server is None:
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail=f"Failed to create catalog server: {str(exc)}",
+                ) from exc
+            return _ensure_catalog_mcp_oauth_server(db, app_id)
+    return server, app_info
+
+
+def _ensure_mcp_oauth_app_user(
+    db: Session,
+    *,
+    app_id: str,
+    user_id: int,
+) -> tuple[MCPServer, dict]:
+    """Ensure one catalog server and active non-owning user link."""
+    server, app_info = _ensure_catalog_mcp_oauth_server(db, app_id)
+    association = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user_id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .first()
+    )
+    if association is None:
+        candidate = UserMCPServer(
+            user_id=user_id,
+            mcpserver_id=server.id,
+            is_active=True,
+            is_owner=False,
+            can_edit=False,
+            can_delete=True,
+        )
+        try:
+            with db.begin_nested():
+                db.add(candidate)
+                db.flush()
+            association = candidate
+        except IntegrityError:
+            association = (
+                db.query(UserMCPServer)
+                .filter(
+                    UserMCPServer.user_id == user_id,
+                    UserMCPServer.mcpserver_id == server.id,
+                )
+                .first()
+            )
+            if association is None:
+                raise
+    elif not association.is_active:
+        setattr(association, "is_active", True)
+        db.flush()
     return server, app_info
 
 
@@ -3621,53 +3731,60 @@ async def connect_mcp_oauth_app(
     server; only the server row's origin (catalog vs. a user-typed URL)
     differs.
     """
-    server, app_info = _ensure_catalog_mcp_oauth_server(db, app_id)
-
-    assoc: Any = (
-        db.query(UserMCPServer)
-        .filter(
-            UserMCPServer.user_id == current_user.id,
-            UserMCPServer.mcpserver_id == server.id,
-        )
-        .first()
+    user_id = cast(int, current_user.id)
+    server, app_info = _ensure_mcp_oauth_app_user(
+        db,
+        app_id=app_id,
+        user_id=user_id,
     )
-    if assoc is None:
-        assoc = UserMCPServer(
-            user_id=current_user.id,
-            mcpserver_id=server.id,
-            is_active=True,
-            is_owner=False,
-            can_edit=False,
-            can_delete=True,
-        )
-        db.add(assoc)
-        try:
-            db.commit()
-        except IntegrityError:
-            # Concurrent same-user connect (double-click/client retry): another
-            # request already inserted the (user_id, mcpserver_id) association.
-            db.rollback()
-            assoc = (
-                db.query(UserMCPServer)
-                .filter(
-                    UserMCPServer.user_id == current_user.id,
-                    UserMCPServer.mcpserver_id == server.id,
-                )
-                .first()
-            )
-            if assoc is None:
-                raise
-    elif not assoc.is_active:
-        # A reconnect after the user previously disconnected their own
-        # association — re-activate it rather than leaving it dormant.
-        assoc.is_active = True
-        db.commit()
-
+    # Release durable catalog and association writes before provider I/O.
+    db.commit()
     logger.info(
-        f"User {current_user.id} starting OAuth connect for MCP app '{app_info['id']}'"
+        "User %s starting OAuth connect for MCP app %r",
+        user_id,
+        app_info["id"],
     )
     return await connect_mcp_oauth(
         cast(int, server.id), request_data, current_user, db, accept
+    )
+
+
+async def connect_mcp_oauth_app_for_owner(
+    app_id: str,
+    request_data: MCPOAuthConnectRequest,
+    current_user: User,
+    db: Session,
+    *,
+    resource_owner_key: str,
+    accept: str | None = None,
+) -> RedirectResponse | JSONResponse:
+    """Start catalog MCP OAuth for a trusted server-owned resource owner.
+
+    The caller commits or rolls back the returned flow and catalog visibility.
+    """
+
+    # Keep nested race-recovery savepoints inside one caller-owned transaction,
+    # including on SQLite where releasing a top-level savepoint commits it.
+    db.begin_nested()
+    user_id = cast(int, current_user.id)
+    server, app_info = _ensure_mcp_oauth_app_user(
+        db,
+        app_id=app_id,
+        user_id=user_id,
+    )
+    logger.info(
+        "User %s starting trusted OAuth connect for MCP app %r",
+        user_id,
+        app_info["id"],
+    )
+    return await _connect_mcp_oauth_for_owner(
+        cast(int, server.id),
+        request_data,
+        current_user,
+        db,
+        resource_owner_key=resource_owner_key,
+        accept=accept,
+        persistence=_OAuthPersistence.CALLER,
     )
 
 
@@ -5351,6 +5468,28 @@ async def connect_mcp_oauth(
     accept: Annotated[str | None, Header()] = None,
 ) -> RedirectResponse | JSONResponse:
     """Start MCP OAuth Authorization Code + PKCE for the current user."""
+    return await _connect_mcp_oauth_for_owner(
+        server_id,
+        request_data,
+        current_user,
+        db,
+        resource_owner_key=_default_resource_owner_key(cast(int, current_user.id)),
+        accept=accept,
+        persistence=_OAuthPersistence.COMMIT,
+    )
+
+
+async def _connect_mcp_oauth_for_owner(
+    server_id: int,
+    request_data: MCPOAuthConnectRequest,
+    current_user: User,
+    db: Session,
+    *,
+    resource_owner_key: str,
+    accept: str | None,
+    persistence: _OAuthPersistence,
+) -> RedirectResponse | JSONResponse:
+    """Start OAuth for one exact owner with an explicit transaction owner."""
     user_id = cast(int, current_user.id)
     association, server = _get_user_mcp_server_or_404(
         db, user_id=user_id, server_id=server_id, require_active=True
@@ -5424,9 +5563,9 @@ async def connect_mcp_oauth(
                 registered_client.token_endpoint_auth_method
             )
         else:
-            # Dynamic registration is provider I/O too; release the client
-            # lookup transaction before awaiting it.
-            db.rollback()
+            # Public requests own their transaction and release it before I/O.
+            if persistence is _OAuthPersistence.COMMIT:
+                db.rollback()
             try:
                 registration = await register_mcp_oauth_public_client(
                     discovery.authorization_server,
@@ -5442,7 +5581,7 @@ async def connect_mcp_oauth(
             token_endpoint_auth_method = registration.token_endpoint_auth_method
     selected_scope = _scope_string(auth_config.get("scope") or discovery.scopes)
     resource_owner_key = _bounded_mcp_oauth_value(
-        _default_resource_owner_key(user_id),
+        resource_owner_key,
         field_name="resource_owner_key",
         max_length=MCP_OAUTH_RESOURCE_OWNER_KEY_MAX_LENGTH,
     )
@@ -5464,6 +5603,7 @@ async def connect_mcp_oauth(
         selected_resource=selected_resource,
         selected_scope=selected_scope,
         redirect_after=request_data.redirect_after,
+        persistence=persistence,
     )
     if persisted is None:
         raise HTTPException(
@@ -5528,6 +5668,55 @@ async def get_mcp_oauth_status(
         scope=auth_config.get("scope") if isinstance(auth_config, dict) else None,
         grants=[_mcp_oauth_grant_response(grant) for grant in grants],
     )
+
+
+async def revoke_mcp_oauth_grants_for_owner(
+    server_id: int,
+    current_user: User,
+    db: Session,
+    *,
+    resource_owner_key: str,
+) -> int:
+    """Revoke active grants for one trusted resource-owner namespace."""
+
+    user_id = cast(int, current_user.id)
+    _get_user_mcp_server_or_404(
+        db,
+        user_id=user_id,
+        server_id=server_id,
+        require_active=False,
+    )
+    owner_key = _bounded_mcp_oauth_value(
+        resource_owner_key,
+        field_name="resource_owner_key",
+        max_length=MCP_OAUTH_RESOURCE_OWNER_KEY_MAX_LENGTH,
+    )
+    db.query(MCPOAuthFlowState).filter(
+        MCPOAuthFlowState.mcp_server_id == server_id,
+        MCPOAuthFlowState.user_id == user_id,
+        MCPOAuthFlowState.resource_owner_key == owner_key,
+    ).delete(synchronize_session=False)
+    grants = (
+        db.query(MCPOAuthGrant)
+        .filter(
+            MCPOAuthGrant.mcp_server_id == server_id,
+            MCPOAuthGrant.user_id == user_id,
+            MCPOAuthGrant.resource_owner_key == owner_key,
+            MCPOAuthGrant.status == "active",
+        )
+        .all()
+    )
+    now = _utc_now()
+    for grant in grants:
+        if isinstance(grant.oauth_client, MCPOAuthClient):
+            await _revoke_mcp_oauth_grant_externally(
+                client=grant.oauth_client,
+                grant=grant,
+            )
+        setattr(grant, "status", "revoked")
+        setattr(grant, "revoked_at", now)
+    db.flush()
+    return len(grants)
 
 
 @mcp_router.delete(

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -79,6 +79,7 @@ from ..services.mcp_runtime import HTTP_MCP_TRANSPORTS
 from ..services.user_oauth import (
     delete_scoped_user_oauth_accounts,
     list_scoped_user_oauth_accounts,
+    normalize_user_oauth_resource_owner_key,
 )
 
 logger = logging.getLogger(__name__)
@@ -956,7 +957,7 @@ def _lock_caller_oauth_lifecycle(
     *,
     association_identity: _MCPOAuthAssociationIdentity,
 ) -> tuple[MCPServer, UserMCPServer] | None:
-    """Lock a caller-owned transaction without resetting its pending writes."""
+    """Lock and activate a caller-owned lifecycle after provider I/O."""
     db.flush()
     server = (
         db.query(MCPServer)
@@ -973,13 +974,15 @@ def _lock_caller_oauth_lifecycle(
             UserMCPServer.mcpserver_id == association_identity.server_id,
             UserMCPServer.lifecycle_generation
             == association_identity.lifecycle_generation,
-            UserMCPServer.is_active.is_(True),
         )
         .with_for_update()
         .one_or_none()
     )
     if association is None:
         return None
+    if not association.is_active:
+        setattr(association, "is_active", True)
+        db.flush()
     return server, association
 
 
@@ -1569,6 +1572,35 @@ async def _revoke_mcp_oauth_grant_externally(
     await _revoke_mcp_oauth_grant_snapshot_externally(
         _mcp_oauth_grant_revocation_snapshot(client=client, grant=grant)
     )
+
+
+@dataclass(frozen=True)
+class MCPOAuthOwnerRevocation:
+    """Provider work staged by an exact-owner local transaction."""
+
+    grant_count: int
+    _snapshots: tuple[_MCPOAuthGrantRevocationSnapshot, ...]
+
+    async def revoke_tokens(self) -> None:
+        """Revoke provider tokens only after the caller commits local state."""
+        for snapshot in self._snapshots:
+            await _revoke_mcp_oauth_grant_snapshot_externally(snapshot)
+
+
+def _trusted_mcp_oauth_owner_key(resource_owner_key: str) -> str:
+    try:
+        owner_key = normalize_user_oauth_resource_owner_key(resource_owner_key)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(exc),
+        ) from exc
+    if owner_key is None:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="resource_owner_key must not be null",
+        )
+    return owner_key
 
 
 def _upsert_mcp_oauth_grant(
@@ -3538,8 +3570,9 @@ def _ensure_mcp_oauth_app_user(
     *,
     app_id: str,
     user_id: int,
+    persistence: _OAuthPersistence,
 ) -> tuple[MCPServer, dict]:
-    """Ensure one catalog server and active non-owning user link."""
+    """Ensure one catalog server and non-owning user link."""
     server, app_info = _ensure_catalog_mcp_oauth_server(db, app_id)
     association = (
         db.query(UserMCPServer)
@@ -3574,7 +3607,7 @@ def _ensure_mcp_oauth_app_user(
             )
             if association is None:
                 raise
-    elif not association.is_active:
+    elif not association.is_active and persistence is _OAuthPersistence.COMMIT:
         setattr(association, "is_active", True)
         db.flush()
     return server, app_info
@@ -3736,6 +3769,7 @@ async def connect_mcp_oauth_app(
         db,
         app_id=app_id,
         user_id=user_id,
+        persistence=_OAuthPersistence.COMMIT,
     )
     # Release durable catalog and association writes before provider I/O.
     db.commit()
@@ -3763,6 +3797,7 @@ async def connect_mcp_oauth_app_for_owner(
     The caller commits or rolls back the returned flow and catalog visibility.
     """
 
+    owner_key = _trusted_mcp_oauth_owner_key(resource_owner_key)
     # Keep nested race-recovery savepoints inside one caller-owned transaction,
     # including on SQLite where releasing a top-level savepoint commits it.
     db.begin_nested()
@@ -3771,6 +3806,7 @@ async def connect_mcp_oauth_app_for_owner(
         db,
         app_id=app_id,
         user_id=user_id,
+        persistence=_OAuthPersistence.CALLER,
     )
     logger.info(
         "User %s starting trusted OAuth connect for MCP app %r",
@@ -3782,7 +3818,7 @@ async def connect_mcp_oauth_app_for_owner(
         request_data,
         current_user,
         db,
-        resource_owner_key=resource_owner_key,
+        resource_owner_key=owner_key,
         accept=accept,
         persistence=_OAuthPersistence.CALLER,
     )
@@ -5492,7 +5528,10 @@ async def _connect_mcp_oauth_for_owner(
     """Start OAuth for one exact owner with an explicit transaction owner."""
     user_id = cast(int, current_user.id)
     association, server = _get_user_mcp_server_or_404(
-        db, user_id=user_id, server_id=server_id, require_active=True
+        db,
+        user_id=user_id,
+        server_id=server_id,
+        require_active=persistence is _OAuthPersistence.COMMIT,
     )
     association_generation = association.lifecycle_generation
     if not isinstance(association_generation, UUID):
@@ -5676,20 +5715,16 @@ async def revoke_mcp_oauth_grants_for_owner(
     db: Session,
     *,
     resource_owner_key: str,
-) -> int:
-    """Revoke active grants for one trusted resource-owner namespace."""
+) -> MCPOAuthOwnerRevocation:
+    """Stage exact-owner revocation in the caller-owned transaction."""
 
+    owner_key = _trusted_mcp_oauth_owner_key(resource_owner_key)
     user_id = cast(int, current_user.id)
     _get_user_mcp_server_or_404(
         db,
         user_id=user_id,
         server_id=server_id,
         require_active=False,
-    )
-    owner_key = _bounded_mcp_oauth_value(
-        resource_owner_key,
-        field_name="resource_owner_key",
-        max_length=MCP_OAUTH_RESOURCE_OWNER_KEY_MAX_LENGTH,
     )
     db.query(MCPOAuthFlowState).filter(
         MCPOAuthFlowState.mcp_server_id == server_id,
@@ -5706,17 +5741,20 @@ async def revoke_mcp_oauth_grants_for_owner(
         )
         .all()
     )
+    snapshots = tuple(
+        _mcp_oauth_grant_revocation_snapshot(client=grant.oauth_client, grant=grant)
+        for grant in grants
+        if isinstance(grant.oauth_client, MCPOAuthClient)
+    )
     now = _utc_now()
     for grant in grants:
-        if isinstance(grant.oauth_client, MCPOAuthClient):
-            await _revoke_mcp_oauth_grant_externally(
-                client=grant.oauth_client,
-                grant=grant,
-            )
         setattr(grant, "status", "revoked")
         setattr(grant, "revoked_at", now)
     db.flush()
-    return len(grants)
+    return MCPOAuthOwnerRevocation(
+        grant_count=len(grants),
+        _snapshots=snapshots,
+    )
 
 
 @mcp_router.delete(

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -1587,7 +1587,7 @@ class MCPOAuthOwnerRevocation:
             await _revoke_mcp_oauth_grant_snapshot_externally(snapshot)
 
 
-def _trusted_mcp_oauth_owner_key(resource_owner_key: str) -> str:
+def _trusted_mcp_oauth_owner_key(resource_owner_key: str, *, user_id: int) -> str:
     try:
         owner_key = normalize_user_oauth_resource_owner_key(resource_owner_key)
     except ValueError as exc:
@@ -1599,6 +1599,11 @@ def _trusted_mcp_oauth_owner_key(resource_owner_key: str) -> str:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="resource_owner_key must not be null",
+        )
+    if owner_key == _default_resource_owner_key(user_id):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="resource_owner_key must not use the default user namespace",
         )
     return owner_key
 
@@ -3797,11 +3802,11 @@ async def connect_mcp_oauth_app_for_owner(
     The caller commits or rolls back the returned flow and catalog visibility.
     """
 
-    owner_key = _trusted_mcp_oauth_owner_key(resource_owner_key)
+    user_id = cast(int, current_user.id)
+    owner_key = _trusted_mcp_oauth_owner_key(resource_owner_key, user_id=user_id)
     # Keep nested race-recovery savepoints inside one caller-owned transaction,
     # including on SQLite where releasing a top-level savepoint commits it.
     db.begin_nested()
-    user_id = cast(int, current_user.id)
     server, app_info = _ensure_mcp_oauth_app_user(
         db,
         app_id=app_id,
@@ -5718,8 +5723,8 @@ async def revoke_mcp_oauth_grants_for_owner(
 ) -> MCPOAuthOwnerRevocation:
     """Stage exact-owner revocation in the caller-owned transaction."""
 
-    owner_key = _trusted_mcp_oauth_owner_key(resource_owner_key)
     user_id = cast(int, current_user.id)
+    owner_key = _trusted_mcp_oauth_owner_key(resource_owner_key, user_id=user_id)
     _get_user_mcp_server_or_404(
         db,
         user_id=user_id,

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -2204,7 +2204,7 @@ async def test_connect_app_creates_server_and_association_then_starts_dcr_flow(
 
 
 @pytest.mark.asyncio
-async def test_trusted_connect_app_stores_exact_resource_owner(db_session, monkeypatch):
+async def test_trusted_connect_app_normalizes_resource_owner(db_session, monkeypatch):
     db, user, _ = db_session
     _add_remote_oauth_catalog_app(db)
 
@@ -2226,7 +2226,7 @@ async def test_trusted_connect_app_stores_exact_resource_owner(db_session, monke
         MCPOAuthConnectRequest(redirect_after="/settings/mcp"),
         user,
         db,
-        resource_owner_key="toby:slack:workspace:alice",
+        resource_owner_key="  toby:slack:workspace:alice  ",
         accept="application/json",
     )
 
@@ -4446,14 +4446,14 @@ async def test_trusted_revoke_removes_only_exact_resource_owner(db_session):
     association.is_active = False
     db.commit()
 
-    revoked = await mcp_api.revoke_mcp_oauth_grants_for_owner(
+    revocation = await mcp_api.revoke_mcp_oauth_grants_for_owner(
         server.id,
         user,
         db,
-        resource_owner_key="toby:slack:workspace:alice",
+        resource_owner_key="  toby:slack:workspace:alice  ",
     )
 
-    assert revoked == 1
+    assert revocation.grant_count == 1
     db.expire_all()
     assert [grant.status for grant in grants] == ["active", "revoked", "active"]
     assert [row.resource_owner_key for row in db.query(MCPOAuthFlowState).all()] == [
@@ -4467,6 +4467,75 @@ async def test_trusted_revoke_removes_only_exact_resource_owner(db_session):
         "toby:slack:workspace:alice",
         "toby:slack:workspace:bob",
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["commit", "rollback"])
+async def test_trusted_revoke_defers_provider_work(db_session, monkeypatch, outcome):
+    db, user, _ = db_session
+    server = _add_mcp_oauth_server(db, user)
+    client = _add_oauth_client(
+        db,
+        server,
+        metadata_json={"revocation_endpoint": "https://auth.example.com/revoke"},
+    )
+    grant = MCPOAuthGrant(
+        mcp_server_id=server.id,
+        user_id=user.id,
+        mcp_oauth_client_id=client.id,
+        resource_owner_key="toby:slack:workspace:alice",
+        issuer="https://auth.example.com",
+        resource="https://mcp.example.com/mcp",
+        scope="records.read",
+        access_token=encrypt_value("access-token"),
+        refresh_token=encrypt_value("refresh-token"),
+    )
+    db.add(grant)
+    db.commit()
+    db.refresh(grant)
+    revoked_grants: list[int] = []
+
+    async def record_revoke(snapshot):
+        revoked_grants.append(snapshot.grant_id)
+
+    monkeypatch.setattr(
+        mcp_api, "_revoke_mcp_oauth_grant_snapshot_externally", record_revoke
+    )
+
+    revocation = await mcp_api.revoke_mcp_oauth_grants_for_owner(
+        server.id,
+        user,
+        db,
+        resource_owner_key="toby:slack:workspace:alice",
+    )
+
+    assert revocation.grant_count == 1
+    assert revoked_grants == []
+    if outcome == "commit":
+        db.commit()
+        await revocation.revoke_tokens()
+        assert revoked_grants == [grant.id]
+        return
+
+    db.rollback()
+    assert revoked_grants == []
+    assert db.get(MCPOAuthGrant, grant.id).status == "active"
+
+
+@pytest.mark.asyncio
+async def test_trusted_revoke_rejects_blank_resource_owner(db_session):
+    db, user, _ = db_session
+    server = _add_mcp_oauth_server(db, user)
+
+    with pytest.raises(HTTPException) as exc:
+        await mcp_api.revoke_mcp_oauth_grants_for_owner(
+            server.id,
+            user,
+            db,
+            resource_owner_key=" \t ",
+        )
+
+    assert exc.value.status_code == 400
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -2236,6 +2236,22 @@ async def test_trusted_connect_app_normalizes_resource_owner(db_session, monkeyp
 
 
 @pytest.mark.asyncio
+async def test_trusted_connect_rejects_default_resource_owner(db_session):
+    db, user, _ = db_session
+
+    with pytest.raises(HTTPException) as exc:
+        await mcp_api.connect_mcp_oauth_app_for_owner(
+            "remote-notes",
+            MCPOAuthConnectRequest(),
+            user,
+            db,
+            resource_owner_key=f"xagent:user:{user.id}",
+        )
+
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
 async def test_trusted_connect_app_can_roll_back_all_local_state(
     db_session, monkeypatch
 ):
@@ -4533,6 +4549,21 @@ async def test_trusted_revoke_rejects_blank_resource_owner(db_session):
             user,
             db,
             resource_owner_key=" \t ",
+        )
+
+    assert exc.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_trusted_revoke_rejects_default_resource_owner(db_session):
+    db, user, _ = db_session
+
+    with pytest.raises(HTTPException) as exc:
+        await mcp_api.revoke_mcp_oauth_grants_for_owner(
+            1,
+            user,
+            db,
+            resource_owner_key=f"xagent:user:{user.id}",
         )
 
     assert exc.value.status_code == 400

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -2204,6 +2204,73 @@ async def test_connect_app_creates_server_and_association_then_starts_dcr_flow(
 
 
 @pytest.mark.asyncio
+async def test_trusted_connect_app_stores_exact_resource_owner(db_session, monkeypatch):
+    db, user, _ = db_session
+    _add_remote_oauth_catalog_app(db)
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+
+    async def register_client(*_args, **_kwargs):
+        return SimpleNamespace(
+            client_id="dynamic-client-123",
+            token_endpoint_auth_method="none",
+        )
+
+    monkeypatch.setattr(mcp_api, "register_mcp_oauth_public_client", register_client)
+
+    response = await mcp_api.connect_mcp_oauth_app_for_owner(
+        "remote-notes",
+        MCPOAuthConnectRequest(redirect_after="/settings/mcp"),
+        user,
+        db,
+        resource_owner_key="toby:slack:workspace:alice",
+        accept="application/json",
+    )
+
+    assert response.status_code == 200
+    flow_state = db.query(MCPOAuthFlowState).one()
+    assert flow_state.resource_owner_key == "toby:slack:workspace:alice"
+
+
+@pytest.mark.asyncio
+async def test_trusted_connect_app_can_roll_back_all_local_state(
+    db_session, monkeypatch
+):
+    db, user, _ = db_session
+    _add_remote_oauth_catalog_app(db)
+
+    async def fake_discover(*args, **kwargs):
+        return _discovery()
+
+    async def register_client(*_args, **_kwargs):
+        return SimpleNamespace(
+            client_id="dynamic-client-123",
+            token_endpoint_auth_method="none",
+        )
+
+    monkeypatch.setattr(mcp_api, "discover_mcp_oauth_metadata", fake_discover)
+    monkeypatch.setattr(mcp_api, "register_mcp_oauth_public_client", register_client)
+
+    await mcp_api.connect_mcp_oauth_app_for_owner(
+        "remote-notes",
+        MCPOAuthConnectRequest(redirect_after="/settings/mcp"),
+        user,
+        db,
+        resource_owner_key="toby:slack:workspace:alice",
+        accept="application/json",
+    )
+    db.rollback()
+
+    assert db.query(MCPServer).filter(MCPServer.name == "remote-notes").count() == 0
+    assert db.query(UserMCPServer).filter(UserMCPServer.user_id == user.id).count() == 0
+    assert db.query(MCPOAuthClient).count() == 0
+    assert db.query(MCPOAuthFlowState).count() == 0
+
+
+@pytest.mark.asyncio
 async def test_connect_app_is_idempotent_across_repeated_connects(
     db_session, monkeypatch
 ):
@@ -4322,6 +4389,84 @@ async def test_status_and_delete_are_scoped_to_default_owner(db_session):
 
     status_response = await get_mcp_oauth_status(server.id, user, db)
     assert status_response.grants == []
+
+
+@pytest.mark.asyncio
+async def test_trusted_revoke_removes_only_exact_resource_owner(db_session):
+    db, user, _ = db_session
+    server = _add_mcp_oauth_server(db, user)
+    client = _add_oauth_client(db, server)
+    grants = [
+        MCPOAuthGrant(
+            mcp_server_id=server.id,
+            user_id=user.id,
+            mcp_oauth_client_id=client.id,
+            resource_owner_key=owner,
+            issuer="https://auth.example.com",
+            resource="https://mcp.example.com/mcp",
+            scope="records.read",
+            access_token=encrypt_value(f"{owner}-token"),
+        )
+        for owner in (
+            f"xagent:user:{user.id}",
+            "toby:slack:workspace:alice",
+            "toby:slack:workspace:bob",
+        )
+    ]
+    db.add_all(grants)
+    db.flush()
+    flows = [
+        MCPOAuthFlowState(
+            state=f"pending-{owner.rsplit(':', 1)[-1]}",
+            mcp_server_id=server.id,
+            user_id=user.id,
+            mcp_oauth_client_id=client.id,
+            resource_owner_key=owner,
+            issuer="https://auth.example.com",
+            resource="https://mcp.example.com/mcp",
+            scope="records.read",
+            code_verifier=encrypt_value("verifier"),
+            expires_at=mcp_api._utc_now() + timedelta(minutes=10),
+        )
+        for owner in (
+            "toby:slack:workspace:alice",
+            "toby:slack:workspace:bob",
+        )
+    ]
+    flows[0].consumed_at = mcp_api._utc_now()
+    db.add_all(flows)
+    association = (
+        db.query(UserMCPServer)
+        .filter(
+            UserMCPServer.user_id == user.id,
+            UserMCPServer.mcpserver_id == server.id,
+        )
+        .one()
+    )
+    association.is_active = False
+    db.commit()
+
+    revoked = await mcp_api.revoke_mcp_oauth_grants_for_owner(
+        server.id,
+        user,
+        db,
+        resource_owner_key="toby:slack:workspace:alice",
+    )
+
+    assert revoked == 1
+    db.expire_all()
+    assert [grant.status for grant in grants] == ["active", "revoked", "active"]
+    assert [row.resource_owner_key for row in db.query(MCPOAuthFlowState).all()] == [
+        "toby:slack:workspace:bob"
+    ]
+
+    db.rollback()
+    db.expire_all()
+    assert [grant.status for grant in grants] == ["active", "active", "active"]
+    assert [row.resource_owner_key for row in db.query(MCPOAuthFlowState).all()] == [
+        "toby:slack:workspace:alice",
+        "toby:slack:workspace:bob",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_mcp_oauth_lifecycle_postgresql.py
+++ b/tests/web/api/test_mcp_oauth_lifecycle_postgresql.py
@@ -874,3 +874,132 @@ def test_callback_rejects_deactivation_during_exchange(
             .one()
         )
         assert association.is_active is False
+
+
+def test_trusted_reconnect_and_disconnect_use_one_lock_order(
+    postgresql_engine, monkeypatch
+) -> None:
+    factory = sessionmaker(bind=postgresql_engine, autoflush=False, autocommit=False)
+    seed = _seed_lifecycle(factory, flow_consumed=False)
+    with factory() as setup_db:
+        association = (
+            setup_db.query(UserMCPServer)
+            .filter(
+                UserMCPServer.user_id == seed["user_id"],
+                UserMCPServer.mcpserver_id == seed["server_id"],
+            )
+            .one()
+        )
+        association.is_owner = False
+        association.can_delete = True
+        association.is_active = False
+        setup_db.query(MCPOAuthFlowState).delete()
+        setup_db.commit()
+
+    discovery_started = threading.Event()
+    allow_discovery = threading.Event()
+    delete_locked = threading.Event()
+    allow_delete = threading.Event()
+    connect_finished = threading.Event()
+    connect_errors: list[BaseException] = []
+    disconnect_errors: list[BaseException] = []
+
+    def ensure_catalog(db, app_id):
+        assert app_id == "postgres-oauth-records"
+        return db.get(MCPServer, seed["server_id"]), {"id": app_id}
+
+    async def discover(*args, **kwargs):
+        discovery_started.set()
+        assert allow_discovery.wait(timeout=10)
+        return _discovery()
+
+    async def register(*args, **kwargs):
+        return SimpleNamespace(
+            client_id="postgres-dynamic-client",
+            token_endpoint_auth_method="none",
+        )
+
+    def gated_team_delete(*args):
+        delete_locked.set()
+        assert allow_delete.wait(timeout=10)
+        return SimpleNamespace(
+            blocked_reason=None,
+            team_owned=False,
+            authorized=False,
+            delete_definition=False,
+        )
+
+    monkeypatch.setattr(mcp_api, "_ensure_catalog_mcp_oauth_server", ensure_catalog)
+    monkeypatch.setattr(mcp_api, "_discover_mcp_oauth_for_server", discover)
+    monkeypatch.setattr(mcp_api, "register_mcp_oauth_public_client", register)
+    monkeypatch.setattr(
+        connector_team_scope, "delete_team_connector", gated_team_delete
+    )
+
+    def connect() -> None:
+        try:
+            with factory() as connect_db:
+                asyncio.run(
+                    mcp_api.connect_mcp_oauth_app_for_owner(
+                        "postgres-oauth-records",
+                        mcp_api.MCPOAuthConnectRequest(redirect_after="/settings/mcp"),
+                        current_user=connect_db.get(User, seed["user_id"]),
+                        db=connect_db,
+                        resource_owner_key="toby:slack:workspace:alice",
+                        accept="application/json",
+                    )
+                )
+                connect_db.commit()
+        except BaseException as exc:  # pragma: no cover - assertion reports it
+            connect_errors.append(exc)
+        finally:
+            connect_finished.set()
+
+    def disconnect() -> None:
+        try:
+            with factory() as disconnect_db:
+                asyncio.run(
+                    mcp_api.delete_mcp_server(
+                        seed["server_id"],
+                        current_user=disconnect_db.get(User, seed["user_id"]),
+                        db=disconnect_db,
+                    )
+                )
+        except BaseException as exc:  # pragma: no cover - assertion reports it
+            disconnect_errors.append(exc)
+
+    connect_thread = threading.Thread(target=connect, name="postgres-owner-connect")
+    disconnect_thread = threading.Thread(
+        target=disconnect, name="postgres-owner-disconnect"
+    )
+    try:
+        connect_thread.start()
+        assert discovery_started.wait(timeout=10)
+        disconnect_thread.start()
+        assert delete_locked.wait(timeout=10)
+        allow_discovery.set()
+        assert not connect_finished.wait(timeout=0.2)
+        allow_delete.set()
+        connect_thread.join(timeout=10)
+        disconnect_thread.join(timeout=10)
+    finally:
+        allow_discovery.set()
+        allow_delete.set()
+
+    assert not connect_thread.is_alive()
+    assert not disconnect_thread.is_alive()
+    assert disconnect_errors == []
+    assert len(connect_errors) == 1
+    assert isinstance(connect_errors[0], HTTPException)
+    assert connect_errors[0].status_code == 409
+    with factory() as verify_db:
+        assert (
+            verify_db.query(UserMCPServer)
+            .filter(
+                UserMCPServer.user_id == seed["user_id"],
+                UserMCPServer.mcpserver_id == seed["server_id"],
+            )
+            .count()
+            == 0
+        )
+        assert verify_db.query(MCPOAuthFlowState).count() == 0

--- a/tests/web/test_trusted_actor_oauth.py
+++ b/tests/web/test_trusted_actor_oauth.py
@@ -260,6 +260,9 @@ def test_actor_cookie_header_check() -> None:
 
     assert auth_api.is_actor_oauth_cookie_header(actor_cookie)
     assert not auth_api.is_actor_oauth_cookie_header("session=proof; HttpOnly; Secure")
+    assert not auth_api.is_actor_oauth_cookie_header(
+        f"xagent_actor_oauth_{'a' * 24}=; Max-Age=0"
+    )
 
 
 def test_actor_start_leaves_commit_to_caller(oauth_db) -> None:


### PR DESCRIPTION
## Intention

Add trusted owner-scoped MCP OAuth connect and revoke operations for actor-based consumers that share one xagent account.

This builds on the lifecycle fencing merged in #2073. The trusted operations preserve the exact `resource_owner_key` and leave transaction ownership with the caller.

## Boundary

- Add owner-scoped connect and revoke helpers.
- Reuse the existing MCP OAuth PKCE, lifecycle, and provider-revocation paths.
- Keep public MCP OAuth routes scoped to the default `xagent:user:<id>` owner.
- Add exact-owner isolation and caller-rollback regressions.
- Do not add actor runtime selection or Toby wiring. Those remain in later follow-up changes.

## Rejected behavior

- Public callers cannot supply an actor owner key.
- Revocation cannot affect another owner namespace.
- Trusted helpers do not commit or roll back unrelated caller state.
- Invalid, missing, or inactive connector associations fail closed.

## Errors and trade-offs

Provider revocation remains best effort. Local exact-owner state is still revoked when a provider has no revocation endpoint or the request fails.

## Verification

- 140 MCP OAuth and trusted-actor tests
- 18 PostgreSQL lifecycle tests
- Ruff, formatting, and mypy hooks
