### PR TITLE
fix(kb): own team ingest jobs by the acting member

### DIFF
--- a/src/xagent/web/api/kb.py
+++ b/src/xagent/web/api/kb.py
@@ -4478,7 +4478,10 @@ async def create_ingest_job(
     try:
         job = create_background_job(
             db,
-            user_id=int(_user.id),
+            # Owner is the real member who polls /api/jobs/{id}, not the team
+            # storage tenant _user was swapped to; the worker keeps reading the
+            # tenant from payload["user_id"].
+            user_id=int(actor_user.id),
             job_type=BackgroundJobType.KB_INGEST_DOCUMENT,
             payload=job_payload,
             idempotency_key=idempotency_key,
@@ -6178,7 +6181,10 @@ async def create_ingest_web_job(
     try:
         job = create_background_job(
             db,
-            user_id=int(_user.id),
+            # Owner is the real member who polls /api/jobs/{id}, not the team
+            # storage tenant _user was swapped to; the worker keeps reading the
+            # tenant from payload["user_id"].
+            user_id=int(actor_user.id),
             job_type=BackgroundJobType.KB_INGEST_WEB,
             payload={
                 "collection": safe_collection,

--- a/tests/web/api/test_kb_team_ingest_job_owner.py
+++ b/tests/web/api/test_kb_team_ingest_job_owner.py
@@ -1,0 +1,186 @@
+"""A team-collection ingest job must be owned by the acting member.
+
+Regression for the team-KB upload 404: the endpoint swaps ``_user`` to the
+team storage tenant so the worker writes into the shared collection, but the
+background job the browser polls under ``/api/jobs/{id}`` must stay owned by
+the real member. Otherwise the member's own poll is rejected 404 and the UI
+reports a failure for an ingest that actually succeeded.
+
+The two dimensions were each covered before and never crossed: the ingest-job
+tests only ever used a personally owned collection, where the swap is a no-op
+and the two ids coincide, and the team-scope tests never create a job.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import xagent.web.api.kb as kb_module
+from xagent.web.api.kb import _EffectiveKnowledgeBaseUser, kb_router
+from xagent.web.auth_dependencies import get_current_user
+from xagent.web.models.background_job import (
+    BackgroundJob,
+    BackgroundJobStatus,
+    BackgroundJobType,
+)
+from xagent.web.models.database import get_db
+from xagent.web.models.user import User
+from xagent.web.services.knowledge_base_team_scope import KnowledgeBaseAccess
+
+ACTOR_ID = 101
+STORAGE_ID = 999
+
+
+def _actor() -> User:
+    return User(id=ACTOR_ID, username="member", email="m@example.com", is_admin=False)
+
+
+def _client(actor: User) -> TestClient:
+    app = FastAPI()
+    app.include_router(kb_router)
+    app.dependency_overrides[get_current_user] = lambda: actor
+    app.dependency_overrides[get_db] = lambda: MagicMock()
+    return TestClient(app)
+
+
+def test_web_ingest_job_owner_is_actor_not_team_storage_tenant() -> None:
+    captured: dict[str, int] = {}
+
+    def capture_create(
+        db: object, *, user_id: int, payload: dict[str, Any], **kwargs: object
+    ) -> BackgroundJob:
+        captured["job_user_id"] = user_id
+        captured["payload_user_id"] = int(payload["user_id"])
+        return BackgroundJob(
+            id="job-1",
+            user_id=user_id,
+            job_type=BackgroundJobType.KB_INGEST_WEB.value,
+            queue="kb_ingest",
+            status=BackgroundJobStatus.ENQUEUED.value,
+            payload=payload,
+            attempts=0,
+            max_attempts=3,
+        )
+
+    async def passthrough(db: object, job: BackgroundJob) -> BackgroundJob:
+        return job
+
+    actor = _actor()
+    team_access = KnowledgeBaseAccess(
+        name="team-handbook", storage_user_id=STORAGE_ID, team_owned=True
+    )
+
+    with (
+        patch.object(
+            kb_module,
+            "_effective_knowledge_base_user",
+            return_value=(_EffectiveKnowledgeBaseUser(actor, STORAGE_ID), team_access),
+        ),
+        patch.object(
+            kb_module, "_ensure_background_job_queue_available_async", new=AsyncMock()
+        ),
+        patch.object(kb_module, "get_collection_sync", side_effect=ValueError),
+        patch(
+            "xagent.core.tools.core.RAG_tools.storage.factory.get_metadata_store",
+            return_value=MagicMock(save_collection_config=AsyncMock()),
+        ),
+        patch.object(
+            kb_module,
+            "get_non_terminal_background_job_by_idempotency_key",
+            return_value=None,
+        ),
+        patch.object(kb_module, "create_background_job", side_effect=capture_create),
+        patch.object(
+            kb_module, "_enqueue_background_job_or_503_async", side_effect=passthrough
+        ),
+    ):
+        response = _client(actor).post(
+            "/api/kb/ingest-web/jobs",
+            data={"collection": "team-handbook", "start_url": "https://example.com"},
+        )
+
+    assert response.status_code == 202, response.text
+    # Owned by the real member, so their own /api/jobs/{id} poll authorizes.
+    assert captured["job_user_id"] == ACTOR_ID
+    # The worker still writes into the team storage tenant.
+    assert captured["payload_user_id"] == STORAGE_ID
+
+
+def test_document_ingest_job_owner_is_actor_not_team_storage_tenant(
+    tmp_path: Path,
+) -> None:
+    """The path the reported 404 came from: a file upload into a team KB."""
+    captured: dict[str, int] = {}
+
+    def capture_create(
+        db: object, *, user_id: int, payload: dict[str, Any], **kwargs: object
+    ) -> BackgroundJob:
+        captured["job_user_id"] = user_id
+        captured["payload_user_id"] = int(payload["user_id"])
+        return BackgroundJob(
+            id="job-2",
+            user_id=user_id,
+            job_type=BackgroundJobType.KB_INGEST_DOCUMENT.value,
+            queue="kb_ingest",
+            status=BackgroundJobStatus.ENQUEUED.value,
+            payload=payload,
+            attempts=0,
+            max_attempts=3,
+        )
+
+    async def passthrough(db: object, job: BackgroundJob) -> BackgroundJob:
+        return job
+
+    actor = _actor()
+    team_access = KnowledgeBaseAccess(
+        name="team-handbook", storage_user_id=STORAGE_ID, team_owned=True
+    )
+    staged = tmp_path / "staged.txt"
+
+    with (
+        patch.object(
+            kb_module,
+            "_effective_knowledge_base_user",
+            return_value=(_EffectiveKnowledgeBaseUser(actor, STORAGE_ID), team_access),
+        ),
+        patch.object(kb_module, "_ensure_collection_access", new=AsyncMock()),
+        patch.object(
+            kb_module, "_ensure_background_job_queue_available_async", new=AsyncMock()
+        ),
+        patch.object(kb_module, "get_collection_sync", side_effect=ValueError),
+        patch.object(
+            kb_module, "get_upload_path", return_value=str(tmp_path / "target.txt")
+        ),
+        patch.object(
+            kb_module, "_build_background_ingest_staging_path", return_value=staged
+        ),
+        patch.object(
+            kb_module,
+            "_copy_upload_file_to_path",
+            return_value=SimpleNamespace(total_size=3, sha256="abc"),
+        ),
+        patch.object(
+            kb_module,
+            "get_non_terminal_background_job_by_idempotency_key",
+            return_value=None,
+        ),
+        patch.object(kb_module, "create_background_job", side_effect=capture_create),
+        patch.object(kb_module, "admit_kb_ingest_target"),
+        patch.object(kb_module, "_cleanup_background_ingest_staging_file"),
+        patch.object(
+            kb_module, "_enqueue_background_job_or_503_async", side_effect=passthrough
+        ),
+    ):
+        response = _client(actor).post(
+            "/api/kb/ingest/jobs",
+            data={"collection": "team-handbook"},
+            files={"file": ("notes.txt", b"abc", "text/plain")},
+        )
+
+    assert response.status_code == 202, response.text
+    assert captured["job_user_id"] == ACTOR_ID
+    assert captured["payload_user_id"] == STORAGE_ID

--- a/tests/web/api/test_kb_team_ingest_job_owner.py
+++ b/tests/web/api/test_kb_team_ingest_job_owner.py
@@ -11,6 +11,7 @@ tests only ever used a personally owned collection, where the swap is a no-op
 and the two ids coincide, and the team-scope tests never create a job.
 """
 
+from collections.abc import Callable
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Any
@@ -47,8 +48,10 @@ def _client(actor: User) -> TestClient:
     return TestClient(app)
 
 
-def test_web_ingest_job_owner_is_actor_not_team_storage_tenant() -> None:
-    captured: dict[str, int] = {}
+def _capture_owner(
+    captured: dict[str, int], job_id: str, job_type: BackgroundJobType
+) -> Callable[..., BackgroundJob]:
+    """Record both ids the endpoint assigns, and hand back a usable job row."""
 
     def capture_create(
         db: object, *, user_id: int, payload: dict[str, Any], **kwargs: object
@@ -56,9 +59,9 @@ def test_web_ingest_job_owner_is_actor_not_team_storage_tenant() -> None:
         captured["job_user_id"] = user_id
         captured["payload_user_id"] = int(payload["user_id"])
         return BackgroundJob(
-            id="job-1",
+            id=job_id,
             user_id=user_id,
-            job_type=BackgroundJobType.KB_INGEST_WEB.value,
+            job_type=job_type.value,
             queue="kb_ingest",
             status=BackgroundJobStatus.ENQUEUED.value,
             payload=payload,
@@ -66,9 +69,15 @@ def test_web_ingest_job_owner_is_actor_not_team_storage_tenant() -> None:
             max_attempts=3,
         )
 
-    async def passthrough(db: object, job: BackgroundJob) -> BackgroundJob:
-        return job
+    return capture_create
 
+
+async def _passthrough(db: object, job: BackgroundJob) -> BackgroundJob:
+    return job
+
+
+def test_web_ingest_job_owner_is_actor_not_team_storage_tenant() -> None:
+    captured: dict[str, int] = {}
     actor = _actor()
     team_access = KnowledgeBaseAccess(
         name="team-handbook", storage_user_id=STORAGE_ID, team_owned=True
@@ -93,9 +102,15 @@ def test_web_ingest_job_owner_is_actor_not_team_storage_tenant() -> None:
             "get_non_terminal_background_job_by_idempotency_key",
             return_value=None,
         ),
-        patch.object(kb_module, "create_background_job", side_effect=capture_create),
         patch.object(
-            kb_module, "_enqueue_background_job_or_503_async", side_effect=passthrough
+            kb_module,
+            "create_background_job",
+            side_effect=_capture_owner(
+                captured, "job-1", BackgroundJobType.KB_INGEST_WEB
+            ),
+        ),
+        patch.object(
+            kb_module, "_enqueue_background_job_or_503_async", side_effect=_passthrough
         ),
     ):
         response = _client(actor).post(
@@ -115,26 +130,6 @@ def test_document_ingest_job_owner_is_actor_not_team_storage_tenant(
 ) -> None:
     """The path the reported 404 came from: a file upload into a team KB."""
     captured: dict[str, int] = {}
-
-    def capture_create(
-        db: object, *, user_id: int, payload: dict[str, Any], **kwargs: object
-    ) -> BackgroundJob:
-        captured["job_user_id"] = user_id
-        captured["payload_user_id"] = int(payload["user_id"])
-        return BackgroundJob(
-            id="job-2",
-            user_id=user_id,
-            job_type=BackgroundJobType.KB_INGEST_DOCUMENT.value,
-            queue="kb_ingest",
-            status=BackgroundJobStatus.ENQUEUED.value,
-            payload=payload,
-            attempts=0,
-            max_attempts=3,
-        )
-
-    async def passthrough(db: object, job: BackgroundJob) -> BackgroundJob:
-        return job
-
     actor = _actor()
     team_access = KnowledgeBaseAccess(
         name="team-handbook", storage_user_id=STORAGE_ID, team_owned=True
@@ -168,11 +163,17 @@ def test_document_ingest_job_owner_is_actor_not_team_storage_tenant(
             "get_non_terminal_background_job_by_idempotency_key",
             return_value=None,
         ),
-        patch.object(kb_module, "create_background_job", side_effect=capture_create),
+        patch.object(
+            kb_module,
+            "create_background_job",
+            side_effect=_capture_owner(
+                captured, "job-2", BackgroundJobType.KB_INGEST_DOCUMENT
+            ),
+        ),
         patch.object(kb_module, "admit_kb_ingest_target"),
         patch.object(kb_module, "_cleanup_background_ingest_staging_file"),
         patch.object(
-            kb_module, "_enqueue_background_job_or_503_async", side_effect=passthrough
+            kb_module, "_enqueue_background_job_or_503_async", side_effect=_passthrough
         ),
     ):
         response = _client(actor).post(

--- a/tests/web/api/test_kb_team_ingest_job_owner.py
+++ b/tests/web/api/test_kb_team_ingest_job_owner.py
@@ -17,10 +17,13 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+import xagent.web.api.jobs as jobs_module
 import xagent.web.api.kb as kb_module
+from xagent.web.api.jobs import jobs_router
 from xagent.web.api.kb import _EffectiveKnowledgeBaseUser, kb_router
 from xagent.web.auth_dependencies import get_current_user
 from xagent.web.models.background_job import (
@@ -40,11 +43,22 @@ def _actor() -> User:
     return User(id=ACTOR_ID, username="member", email="m@example.com", is_admin=False)
 
 
+def _mock_db() -> MagicMock:
+    """Pin the one query the ingest paths make, as the sibling ingest tests do.
+
+    Left unpinned, ``UploadedFile ... .first()`` answers a truthy MagicMock and
+    the document path silently takes its "file already registered" branch.
+    """
+    db = MagicMock()
+    db.query.return_value.filter.return_value.first.return_value = None
+    return db
+
+
 def _client(actor: User) -> TestClient:
     app = FastAPI()
     app.include_router(kb_router)
     app.dependency_overrides[get_current_user] = lambda: actor
-    app.dependency_overrides[get_db] = lambda: MagicMock()
+    app.dependency_overrides[get_db] = _mock_db
     return TestClient(app)
 
 
@@ -74,6 +88,42 @@ def _capture_owner(
 
 async def _passthrough(db: object, job: BackgroundJob) -> BackgroundJob:
     return job
+
+
+@pytest.mark.parametrize(
+    ("owner_id", "expected_status"),
+    [(ACTOR_ID, 200), (STORAGE_ID, 404)],
+    ids=["owned-by-actor", "owned-by-storage-tenant"],
+)
+def test_member_polls_their_own_job_but_not_a_tenant_owned_one(
+    owner_id: int, expected_status: int
+) -> None:
+    """The 404 -> 200 transition itself, through the real ``_authorize_job``.
+
+    The ingest tests above pin which id the endpoint assigns; this pins what
+    that choice costs the member at the endpoint the browser actually polls.
+    ``owner_id=STORAGE_ID`` is the pre-fix state and reproduces the reported
+    failure verbatim.
+    """
+    job = BackgroundJob(
+        id="job-1",
+        user_id=owner_id,
+        job_type=BackgroundJobType.KB_INGEST_DOCUMENT.value,
+        queue="kb_ingest",
+        status=BackgroundJobStatus.ENQUEUED.value,
+        payload={"user_id": STORAGE_ID},
+        attempts=0,
+        max_attempts=3,
+    )
+    app = FastAPI()
+    app.include_router(jobs_router)
+    app.dependency_overrides[get_current_user] = _actor
+    app.dependency_overrides[get_db] = _mock_db
+
+    with patch.object(jobs_module, "get_background_job", return_value=job):
+        response = TestClient(app).get("/api/jobs/job-1")
+
+    assert response.status_code == expected_status
 
 
 def test_web_ingest_job_owner_is_actor_not_team_storage_tenant() -> None:
@@ -121,6 +171,8 @@ def test_web_ingest_job_owner_is_actor_not_team_storage_tenant() -> None:
     assert response.status_code == 202, response.text
     # Owned by the real member, so their own /api/jobs/{id} poll authorizes.
     assert captured["job_user_id"] == ACTOR_ID
+    # The id the browser reads back and polls with.
+    assert response.json()["user_id"] == ACTOR_ID
     # The worker still writes into the team storage tenant.
     assert captured["payload_user_id"] == STORAGE_ID
 
@@ -170,7 +222,7 @@ def test_document_ingest_job_owner_is_actor_not_team_storage_tenant(
                 captured, "job-2", BackgroundJobType.KB_INGEST_DOCUMENT
             ),
         ),
-        patch.object(kb_module, "admit_kb_ingest_target"),
+        patch.object(kb_module, "admit_kb_ingest_target") as admit,
         patch.object(kb_module, "_cleanup_background_ingest_staging_file"),
         patch.object(
             kb_module, "_enqueue_background_job_or_503_async", side_effect=_passthrough
@@ -184,4 +236,8 @@ def test_document_ingest_job_owner_is_actor_not_team_storage_tenant(
 
     assert response.status_code == 202, response.text
     assert captured["job_user_id"] == ACTOR_ID
+    assert response.json()["user_id"] == ACTOR_ID
     assert captured["payload_user_id"] == STORAGE_ID
+    # The per-target concurrency lock must stay tenant-keyed, or two members
+    # writing the same file would each take their own lock.
+    assert admit.call_args.kwargs["user_id"] == STORAGE_ID


### PR DESCRIPTION
## Invariant

A KB ingest job's `background_jobs.user_id` must be the real member who started the upload — the identity that polls `GET /api/jobs/{id}` — while `payload["user_id"]`, which the worker uses to locate the storage tenant, stays the storage account.

## Problem

Uploading a file into a **team-owned** knowledge base makes the UI report `Failed to fetch background job <id>`, even though the ingest actually succeeds and the document lands in the collection.

## Root cause

To make the worker write into the team tenant, the ingest endpoints swap `_user` from the real member to the team storage account (`_EffectiveKnowledgeBaseUser`). `create_background_job(user_id=...)` was handed that swapped `_user.id`, so the job row ended up owned by the storage account.

The browser polls `GET /api/jobs/{id}` as the real member. `_authorize_job` (`src/xagent/web/api/jobs.py`) sees `job.user_id != user.id` for a non-admin and answers 404; `waitForBackgroundJob` throws once those 404s outlast its 10s transient-failure window.

Personally owned collections are unaffected: no swap happens there, so the two ids coincide and the change is a no-op.

## Fix

Both `create_background_job` call sites now pass `int(actor_user.id)` for the job's owner. The payload's `user_id` keeps the storage tenant, so ingestion behavior is unchanged — the worker reads the tenant only from the payload (`src/xagent/web/jobs/kb_tasks.py` resolves it from `payload["user_id"]` throughout and never reads the job's own `user_id`).

Affected endpoints: `POST /api/kb/ingest/jobs`, `POST /api/kb/ingest-web/jobs`.

A side benefit: these jobs now show up in the member's own `GET /api/jobs` listing, instead of being filed under a synthetic account nobody signs in as.

## Non-goals

- **Concurrent identical submissions across members.** The idempotency key is still derived from the storage tenant, and `get_non_terminal_background_job_by_idempotency_key` does not filter by user. So if member B submits a byte-identical file with an identical ingestion config into the same team collection while member A's job is still non-terminal, B receives A's job and still gets a 404. The window is narrow — terminal jobs release their key, so sequential uploads are fine, and only genuinely concurrent ones collide. Every way to close it (adding the actor to the key, forking a new job on owner mismatch, or widening `_authorize_job`) changes dedup or authorization semantics and deserves its own change. Tracked in #2120.
- No change to `_authorize_job`'s authorization model — this PR does not introduce "team members may read a teammate's job".
- Call sites that legitimately need the storage tenant keep it. `admit_kb_ingest_target` in particular **must** stay on the tenant: it takes the per-target concurrency lock on `(user_id, collection, target_path)`, so keying it by actor would stop two members writing the same file from excluding each other.

## Tests

New `tests/web/api/test_kb_team_ingest_job_owner.py` covers both the document and the web ingest path, asserting the job is owned by the acting member while the payload still names the storage tenant.

The two dimensions were each covered before and never crossed, which is why this slipped through: the existing ingest-job tests only ever use a personally owned collection, where the swap is a no-op and the two ids coincide, and the team-scope tests never create a background job. The bug lives exactly at the intersection.

## Verification

- Mutation-checked in both directions: reverting either call site to `_user.id` fails its corresponding test with `assert 999 == 101`; the payload assertion catches the opposite mistake.
- `pre-commit` (ruff, ruff-format, mypy, isort, codespell) green on the changed files.
- Regression: KB ingest, KB lifecycle, team-scope and related suites pass.
- `tests/web/test_background_jobs.py` has pre-existing local failures from an alembic path resolved across two checkouts; confirmed identical on a clean baseline without this change.