### PR TITLE
fix(rag): stop the chunk splitter from deleting separators

### DIFF
--- a/src/xagent/core/tools/core/RAG_tools/chunk/chunk_strategies.py
+++ b/src/xagent/core/tools/core/RAG_tools/chunk/chunk_strategies.py
@@ -58,7 +58,9 @@ def _split_by_separators_core(text: str, separators: Optional[List[str]]) -> Lis
         separators: List of separator strings to use for splitting (defaults applied inside)
 
     Returns:
-        List of text chunks with delimiters attached to the previous chunk
+        List of text chunks with delimiters attached to the previous chunk.
+        Joining them reproduces the input exactly - no character is dropped,
+        including runs that consist only of separators.
     """
     if not separators:
         separators = DEFAULT_SEPARATORS
@@ -75,8 +77,8 @@ def _split_by_separators_core(text: str, separators: Optional[List[str]]) -> Lis
 
     chunks: List[str] = []
     for i in range(0, len(parts), 2):
-        text_part = parts[i] or ""
-        delimiter_part = (parts[i + 1] or "") if i + 1 < len(parts) else ""
+        text_part = parts[i]
+        delimiter_part = parts[i + 1] if i + 1 < len(parts) else ""
         chunk = text_part + delimiter_part
         if not chunk:
             continue
@@ -104,13 +106,21 @@ def _split_by_separators_with_metadata(
     separators: Optional[List[str]],
     source_paragraph: Optional[Dict[str, Any]] = None,
 ) -> List[Dict[str, Any]]:
-    """Wrapper: returns structured chunks with metadata using the core splitter."""
+    """Wrapper: returns structured chunks with metadata using the core splitter.
+
+    Carries the core splitter's guarantee: joining the units reproduces the
+    input. A unit with no text of its own joins the one before it rather than
+    being dropped - between two protected regions that unit is the separator
+    holding them apart, and discarding it deletes it from the document.
+    """
     units = _split_by_separators_core(text, separators)
-    return [
-        {"text": unit, "source_paragraph": source_paragraph}
-        for unit in units
-        if unit.strip()
-    ]
+    out: List[Dict[str, Any]] = []
+    for unit in units:
+        if unit.strip() or not out:
+            out.append({"text": unit, "source_paragraph": source_paragraph})
+        else:
+            out[-1]["text"] += unit
+    return out
 
 
 def _find_protected_ranges(

--- a/src/xagent/core/tools/core/RAG_tools/chunk/chunk_strategies.py
+++ b/src/xagent/core/tools/core/RAG_tools/chunk/chunk_strategies.py
@@ -64,22 +64,31 @@ def _split_by_separators_core(text: str, separators: Optional[List[str]]) -> Lis
         separators = DEFAULT_SEPARATORS
 
     escaped_separators = [re.escape(sep) for sep in separators]
-    pattern = "|".join(f"({escaped_sep})" for escaped_sep in escaped_separators)
+    # One capturing group around the whole alternation, not one per separator:
+    # re.split emits an element for *every* group on each match, so N groups
+    # make the stride N+1 while the loop below walks it in twos. With the eight
+    # default separators that dropped every other delimiter, gluing words
+    # together ("CSV integration" -> "CSVintegration").
+    pattern = "(" + "|".join(escaped_separators) + ")"
 
     parts = re.split(pattern, text)
 
     chunks: List[str] = []
     for i in range(0, len(parts), 2):
-        if i + 1 < len(parts):
-            text_part = parts[i] if parts[i] is not None else ""
-            delimiter_part = parts[i + 1] if parts[i + 1] is not None else ""
-            chunk = text_part + delimiter_part
-            if chunk.strip():
-                chunks.append(chunk)
+        text_part = parts[i] or ""
+        delimiter_part = (parts[i + 1] or "") if i + 1 < len(parts) else ""
+        chunk = text_part + delimiter_part
+        if not chunk:
+            continue
+        if chunk.strip():
+            chunks.append(chunk)
+        elif chunks:
+            # Whitespace-only runs (adjacent separators, e.g. "。 ") carry no
+            # text but are still part of the document. Dropping them silently
+            # deleted characters; they belong to the chunk they follow.
+            chunks[-1] += chunk
         else:
-            text_part = parts[i] if parts[i] is not None else ""
-            if text_part.strip():
-                chunks.append(text_part)
+            chunks.append(chunk)
 
     return chunks
 

--- a/src/xagent/core/tools/core/RAG_tools/chunk/chunk_strategies.py
+++ b/src/xagent/core/tools/core/RAG_tools/chunk/chunk_strategies.py
@@ -80,12 +80,13 @@ def _split_by_separators_core(text: str, separators: Optional[List[str]]) -> Lis
         chunk = text_part + delimiter_part
         if not chunk:
             continue
-        if chunk.strip():
+        if text_part.strip():
             chunks.append(chunk)
         elif chunks:
-            # Whitespace-only runs (adjacent separators, e.g. "。 ") carry no
-            # text but are still part of the document. Dropping them silently
-            # deleted characters; they belong to the chunk they follow.
+            # Adjacent separators ("。 " after a space) leave a piece with a
+            # delimiter but no text. It is still part of the document, so it
+            # joins the chunk it follows - dropping it deleted characters, and
+            # keeping it standalone made a chunk of pure punctuation.
             chunks[-1] += chunk
         else:
             chunks.append(chunk)

--- a/src/xagent/core/tools/core/RAG_tools/chunk/chunk_strategies.py
+++ b/src/xagent/core/tools/core/RAG_tools/chunk/chunk_strategies.py
@@ -59,8 +59,9 @@ def _split_by_separators_core(text: str, separators: Optional[List[str]]) -> Lis
 
     Returns:
         List of text chunks with delimiters attached to the previous chunk.
-        Joining them reproduces the input exactly - no character is dropped,
-        including runs that consist only of separators.
+        Joining *these* chunks reproduces the input exactly, separator-only
+        runs included. The guarantee is this function's alone: callers further
+        up strip and drop blank windows by design.
     """
     if not separators:
         separators = DEFAULT_SEPARATORS
@@ -91,6 +92,8 @@ def _split_by_separators_core(text: str, separators: Optional[List[str]]) -> Lis
             # keeping it standalone made a chunk of pure punctuation.
             chunks[-1] += chunk
         else:
+            # Only reachable for the very first fragment, when the text opens
+            # with a separator and there is nothing yet to attach it to.
             chunks.append(chunk)
 
     return chunks
@@ -108,19 +111,13 @@ def _split_by_separators_with_metadata(
 ) -> List[Dict[str, Any]]:
     """Wrapper: returns structured chunks with metadata using the core splitter.
 
-    Carries the core splitter's guarantee: joining the units reproduces the
-    input. A unit with no text of its own joins the one before it rather than
-    being dropped - between two protected regions that unit is the separator
-    holding them apart, and discarding it deletes it from the document.
+    Passes every unit through, which is what carries the core splitter's
+    lossless guarantee to this level. Filtering blank units here used to drop
+    the separator between two protected regions - the whole of a segment can be
+    blank when a code fence ends and the next one begins.
     """
     units = _split_by_separators_core(text, separators)
-    out: List[Dict[str, Any]] = []
-    for unit in units:
-        if unit.strip() or not out:
-            out.append({"text": unit, "source_paragraph": source_paragraph})
-        else:
-            out[-1]["text"] += unit
-    return out
+    return [{"text": unit, "source_paragraph": source_paragraph} for unit in units]
 
 
 def _find_protected_ranges(

--- a/tests/core/tools/core/RAG_tools/chunk/test_chunk_strategies.py
+++ b/tests/core/tools/core/RAG_tools/chunk/test_chunk_strategies.py
@@ -126,6 +126,38 @@ class TestSplitBySeparatorsCore:
         assert "block1" in result[0]
         assert "block2" in result[1] or "block3" in result[1]
 
+    def test_splitting_is_lossless(self) -> None:
+        """The one invariant a splitter owes its caller: rejoining the pieces
+        reproduces the input exactly. Nothing else here checked that, and every
+        other case uses a single separator, so a bug that dropped every other
+        delimiter across mixed separators went unseen."""
+        texts = [
+            "attach documents and Qualifications in bulk using our CSV integration.",
+            "Line one\n\nLine two\nLine three with words",
+            "第一句。第二句！第三句？结束",
+            "a, b, c. d e f",
+            "mixed\n\npara, with. all 。 separators！ present？ here",
+        ]
+        for text in texts:
+            assert "".join(_split_by_separators_core(text, None)) == text
+
+    def test_words_keep_their_spaces(self) -> None:
+        """The default separators include ' ', and one capturing group per
+        separator made re.split emit N elements per match while the reader
+        walked them in twos - so every other space vanished and words fused."""
+        text = "attach documents and Qualifications in bulk using our CSV integration."
+
+        assert "".join(_split_by_separators_core(text, None)) == text
+        assert "CSVintegration" not in "".join(_split_by_separators_core(text, None))
+
+    def test_delimiters_attach_to_the_preceding_chunk(self) -> None:
+        """The docstring's contract. One capturing group per separator makes
+        re.split emit N elements per match, so a two-step read lands on the
+        wrong element and delimiters end up leading the *next* chunk instead."""
+        result = _split_by_separators_core("attach documents and more", None)
+
+        assert result == ["attach ", "documents ", "and ", "more"]
+
     def test_empty_separators_list_uses_default(self) -> None:
         text = "a\n\nb"
         result = _split_by_separators_core(text, [])

--- a/tests/core/tools/core/RAG_tools/chunk/test_chunk_strategies.py
+++ b/tests/core/tools/core/RAG_tools/chunk/test_chunk_strategies.py
@@ -158,6 +158,14 @@ class TestSplitBySeparatorsCore:
 
         assert result == ["attach ", "documents ", "and ", "more"]
 
+    def test_adjacent_separators_do_not_form_a_punctuation_chunk(self) -> None:
+        """A separator that follows another separator has a delimiter but no
+        text of its own. Judging the piece by the whole string counts the
+        punctuation as content and emits a chunk holding only that."""
+        result = _split_by_separators_core("hello 。 world", None)
+
+        assert result == ["hello 。 ", "world"]
+
     def test_empty_separators_list_uses_default(self) -> None:
         text = "a\n\nb"
         result = _split_by_separators_core(text, [])

--- a/tests/core/tools/core/RAG_tools/chunk/test_chunk_strategies.py
+++ b/tests/core/tools/core/RAG_tools/chunk/test_chunk_strategies.py
@@ -1,9 +1,13 @@
 """Unit tests for chunk strategies (P0 token merge, P1 protected content & headers, custom separators)."""
 
+import pytest
+
 from xagent.core.tools.core.RAG_tools.chunk.chunk_strategies import (
     _find_protected_ranges,
     _split_by_headers,
     _split_by_separators_core,
+    _split_by_separators_with_metadata,
+    _split_by_separators_with_metadata_and_protection,
     apply_markdown_strategy,
     apply_recursive_strategy,
     attach_media_context,
@@ -166,12 +170,61 @@ class TestSplitBySeparatorsCore:
 
         assert result == ["hello 。 ", "world"]
 
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "",
+            "x",
+            "no separators present here at all",
+            "。leading delimiter then text",
+            "trailing delimiter then nothing。",
+        ],
+    )
+    def test_splitting_is_lossless_at_the_edges(self, text: str) -> None:
+        assert "".join(_split_by_separators_core(text, None)) == text
+
+    def test_splitting_is_lossless_with_custom_separators(self) -> None:
+        """Every other case here uses the defaults, so a bug that only showed
+        up with a caller-supplied list would go unseen."""
+        text = "one|two||three|four"
+        assert "".join(_split_by_separators_core(text, ["||", "|"])) == text
+
     def test_empty_separators_list_uses_default(self) -> None:
         text = "a\n\nb"
         result = _split_by_separators_core(text, [])
         assert len(result) == 2
         assert "a" in result[0]
         assert "b" in result[1]
+
+
+class TestSplitWithMetadataIsLossless:
+    """The core splitter's guarantee has to survive the wrappers. It did not:
+    the metadata wrapper dropped whitespace-only units, and the protected-content
+    path - which apply_recursive_strategy uses by default - runs the wrapper once
+    per segment between fenced regions, so the separator holding two code blocks
+    apart was deleted."""
+
+    def test_metadata_wrapper_keeps_every_character(self) -> None:
+        text = "alpha beta\n\ngamma delta"
+        units = _split_by_separators_with_metadata(text, None)
+
+        assert "".join(u["text"] for u in units) == text
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "intro text\n\n```\ncode here\n```\n\ntail words",
+            "a\n\n```\nx\n```\n\n```\ny\n```\n\nb",
+            "```\nonly a fence\n```",
+            "no fence anywhere in this text",
+        ],
+    )
+    def test_protected_regions_keep_the_text_between_them(self, text: str) -> None:
+        units = _split_by_separators_with_metadata_and_protection(
+            text, None, None, None
+        )
+
+        assert "".join(u["text"] for u in units) == text
 
 
 class TestApplyRecursiveStrategyCustomSeparators:

--- a/tests/core/tools/core/RAG_tools/chunk/test_chunk_strategies.py
+++ b/tests/core/tools/core/RAG_tools/chunk/test_chunk_strategies.py
@@ -145,15 +145,6 @@ class TestSplitBySeparatorsCore:
         for text in texts:
             assert "".join(_split_by_separators_core(text, None)) == text
 
-    def test_words_keep_their_spaces(self) -> None:
-        """The default separators include ' ', and one capturing group per
-        separator made re.split emit N elements per match while the reader
-        walked them in twos - so every other space vanished and words fused."""
-        text = "attach documents and Qualifications in bulk using our CSV integration."
-
-        assert "".join(_split_by_separators_core(text, None)) == text
-        assert "CSVintegration" not in "".join(_split_by_separators_core(text, None))
-
     def test_delimiters_attach_to_the_preceding_chunk(self) -> None:
         """The docstring's contract. One capturing group per separator makes
         re.split emit N elements per match, so a two-step read lands on the
@@ -204,10 +195,15 @@ class TestSplitWithMetadataIsLossless:
     per segment between fenced regions, so the separator holding two code blocks
     apart was deleted."""
 
-    def test_metadata_wrapper_keeps_every_character(self) -> None:
-        text = "alpha beta\n\ngamma delta"
+    def test_metadata_wrapper_keeps_a_blank_leading_unit(self) -> None:
+        """Text opening with a separator makes the core splitter emit a blank
+        first unit. Filtering blank units here is what deleted the separator
+        between two protected regions, so the input has to contain one - a
+        string with no blank unit passes whether or not the filter is there."""
+        text = "\n\nalpha beta"
         units = _split_by_separators_with_metadata(text, None)
 
+        assert [u["text"] for u in units] == ["\n\n", "alpha ", "beta"]
         assert "".join(u["text"] for u in units) == text
 
     @pytest.mark.parametrize(
@@ -225,6 +221,27 @@ class TestSplitWithMetadataIsLossless:
         )
 
         assert "".join(u["text"] for u in units) == text
+
+
+class TestApplyRecursiveStrategyKeepsWordsApart:
+    """The bug reached users through this entry point, not through the private
+    helpers, so the regression guard belongs here too. Every other test around
+    it asserts chunk counts and substring presence, neither of which notices
+    words fusing together."""
+
+    def test_words_are_not_fused(self) -> None:
+        """chunk_size is a character budget, so it is set well above the text
+        to keep the window from cutting words itself - what is under test is
+        the separator handling, not where the window lands."""
+        text = "attach documents and Qualifications in bulk using our CSV integration"
+        chunks = apply_recursive_strategy(
+            [{"text": text}], {"chunk_size": 500, "chunk_overlap": 0}
+        )
+
+        joined = " ".join(c["text"] for c in chunks)
+        for glued in ("CSVintegration", "documentsand", "inbulk", "usingour"):
+            assert glued not in joined
+        assert "CSV integration" in joined
 
 
 class TestApplyRecursiveStrategyCustomSeparators:


### PR DESCRIPTION
## Invariant

Splitting text into chunks does not change the text: rejoining the pieces
reproduces the input exactly, and each separator stays attached to the chunk it
follows.

## Problem

`_split_by_separators_core` deleted characters from every document it chunked.
Two independent bugs in the same function, both silent.

**1. One capturing group per separator.** The pattern was built as
`(sep1)|(sep2)|...|(sepN)`, and `re.split` emits an element for *every* group on
each match — the one that matched plus `None` for the rest. With the eight
default separators the stride is 9:

```
re.split(pattern, "attach documents")
-> ['attach', None, None, None, None, None, None, None, ' ', 'documents', ...]
```

The loop walks it in twos, so it reads the wrong elements.

**2. Whitespace-only fragments were dropped.** `if chunk.strip()` discarded any
piece that was pure whitespace. Adjacent separators (`"。 "`, `". "` followed by
a space) produce exactly that, and those characters were part of the document.

Together they deleted every other space in ordinary prose:

```
in:  "attach documents and Qualifications in bulk using our CSV integration."
out: "attach documentsand Qualificationsin bulkusing ourCSV integration."
```

## Why this matters more than it looks

This runs on **every** ingested document — PDF, Word, Markdown, crawled web
pages — so it silently degraded every knowledge base in the product.

The damage is invisible to every health check we have. Document counts, chunk
counts and vector counts all come out correct and consistent; only the text
inside is fused. Retrieval then misses: `CSV integration` and `CSVintegration`
are different tokens to an embedding model and to any literal match. Because
roughly half the spaces survive, recall degrades rather than collapses, which
reads as "the agent is unreliable" rather than as a bug.

Observed on a real 408-page ingestion: 408 documents, 5839 chunks, 5839
embeddings — a perfect-looking knowledge base whose chunks contained
`ttachdocuments andQualifications inbulk usingour CSVintegration`.

## Changes

- The alternation gets a single capturing group, so the stride is 2 and matches
  the loop.
- Whitespace-only fragments are appended to the preceding chunk instead of
  being discarded, which is also what the function's docstring already promised
  ("delimiters attached to the previous chunk").

## Entry points

`_split_by_separators_core`

## Non-goals

- No change to separator choice, chunk sizing, or overlap.
- No backfill. Existing collections keep their damaged chunks and need
  re-ingesting; that is an operational step, not a code change.

## Blocking criteria

- Rejoining the split pieces reproduces the input, across mixed separators
- Delimiters attach to the preceding chunk, not the following one

## Verification

The existing tests could not catch either bug: every case used a single
separator in isolation, and none of them asserted that splitting is lossless —
which is the one thing the function owes its caller. Two tests are added for
exactly those properties, and each kills its own mutation (restoring
per-separator groups fails the delimiter-attachment test; restoring the
whitespace discard fails the lossless test).

`tests/core/tools/core/RAG_tools/chunk` passes; pre-commit (incl. mypy) passes.
