### PR TITLE
fix(frontend): gate clarification retries on structured terminal command outcomes

### DIFF
--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -907,10 +907,14 @@ describe("ClarificationForm blank option filtering", () => {
 describe("ClarificationForm terminal command outcomes", () => {
   // Issue #1500: after a reply is durably accepted, its command can still
   // reach a terminal disposition before a turn is established. Whether the
-  // form may invite a resend is decided by the structured outcome the
-  // backend broadcasts for that exact command, never by task state alone.
-  // The accountable submission lives in context keyed by request id, so the
-  // gate survives the submitting component instance being replaced.
+  // form may invite a resend is decided by the structured outcomes the
+  // backend broadcasts for the round's tracked commands, never by task
+  // state alone. The accountable submissions live in context keyed by
+  // request id - an ordered list, so a resubmit after an ack timeout does
+  // not orphan the earlier command's outcome - and the gate survives the
+  // submitting component instance being replaced.
+  const ROUND = "inputreq_r1"
+
   beforeEach(() => {
     appContextMock.dispatch.mockReset()
     appContextMock.filesDisabled = false
@@ -922,11 +926,10 @@ describe("ClarificationForm terminal command outcomes", () => {
   })
 
   afterEach(() => {
-    appContextMock.state = { commandOutcomes: {}, clarificationSubmissions: {} }
     cleanup()
   })
 
-  const form = (active: boolean, requestId = "inputreq_r1") => (
+  const form = (active: boolean, requestId = ROUND) => (
     <ClarificationForm
       interactions={[{ type: "text_input" as const, field: "city", label: "City" }]}
       requestId={requestId}
@@ -937,56 +940,75 @@ describe("ClarificationForm terminal command outcomes", () => {
   const submitButton = () =>
     screen.queryByRole("button", { name: "chatPage.clarification.submit" })
 
+  // Mirrors the reducer: RECORD appends to the round's list.
+  const recordedSubmissions = () =>
+    appContextMock.dispatch.mock.calls
+      .map(([action]) => action)
+      .filter((action) => action?.type === "RECORD_CLARIFICATION_SUBMISSION")
+      .map((action) => action.payload as {
+        requestId: string
+        commandId: string
+        accepted: boolean
+      })
+
+  const mirrorSubmissions = () => {
+    appContextMock.state = {
+      ...appContextMock.state,
+      clarificationSubmissions: {
+        [ROUND]: recordedSubmissions().map(({ commandId, accepted }) => ({
+          commandId,
+          accepted,
+        })),
+      },
+    }
+  }
+
   // Drives one accepted submission and mirrors the RECORD dispatch into the
   // mock context state, the way the real reducer would.
-  const submitAccepted = async (requestId = "inputreq_r1") => {
+  const submitAccepted = async () => {
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
     fireEvent.click(
       screen.getByRole("button", { name: "chatPage.clarification.submit" }),
     )
-    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(1))
-    // Accepted submissions collapse the form.
-    await waitFor(() => expect(screen.queryByRole("textbox")).toBeNull())
-    const record = appContextMock.dispatch.mock.calls
-      .map(([action]) => action)
-      .find((action) => action?.type === "RECORD_CLARIFICATION_SUBMISSION")
+    await waitFor(() =>
+      expect(appContextMock.sendMessage).toHaveBeenCalledTimes(
+        recordedSubmissions().length,
+      ),
+    )
+    const record = recordedSubmissions().at(-1)
     expect(record).toEqual({
-      type: "RECORD_CLARIFICATION_SUBMISSION",
-      payload: { requestId, commandId: expect.any(String), accepted: true },
+      requestId: ROUND,
+      commandId: expect.any(String),
+      accepted: true,
     })
     // The recorded command id is the client message id the delivery used.
-    const config = appContextMock.sendMessage.mock.calls[0][1] as {
+    const config = appContextMock.sendMessage.mock.lastCall?.[1] as {
       clientMessageId?: string
     }
-    expect(record.payload.commandId).toBe(config.clientMessageId)
-    appContextMock.state = {
-      ...appContextMock.state,
-      clarificationSubmissions: {
-        [requestId]: { commandId: record.payload.commandId, accepted: true },
-      },
-    }
-    return record.payload.commandId as string
+    expect(record!.commandId).toBe(config.clientMessageId)
+    mirrorSubmissions()
+    return record!.commandId
   }
 
-  const withOutcome = (commandId: string, resendSafe: boolean) => {
+  const withOutcomes = (outcomes: Record<string, boolean>) => {
     appContextMock.state = {
       ...appContextMock.state,
-      commandOutcomes: {
-        [commandId]: {
-          outcome: "failed",
-          resendSafe,
-          messageCode: "task_command_deferred",
-        },
-      },
+      commandOutcomes: Object.fromEntries(
+        Object.entries(outcomes).map(([commandId, resendSafe]) => [
+          commandId,
+          { resendSafe },
+        ]),
+      ),
     }
   }
 
   it("reactivates the form and preserves the draft when the outcome proves retry safe", async () => {
     const { rerender } = render(form(true))
     const commandId = await submitAccepted()
+    await waitFor(() => expect(screen.queryByRole("textbox")).toBeNull())
 
     rerender(form(false))
-    withOutcome(commandId, true)
+    withOutcomes({ [commandId]: true })
     rerender(form(true))
 
     await waitFor(() => expect(submitButton()).toBeEnabled())
@@ -997,16 +1019,17 @@ describe("ClarificationForm terminal command outcomes", () => {
     // The record is consumed so the resend is armed exactly once.
     expect(appContextMock.dispatch).toHaveBeenCalledWith({
       type: "CLEAR_CLARIFICATION_SUBMISSION",
-      payload: { requestId: "inputreq_r1" },
+      payload: { requestId: ROUND },
     })
   })
 
   it("keeps the form locked and surfaces the ambiguity when the outcome is not proven safe", async () => {
     const { rerender } = render(form(true))
     const commandId = await submitAccepted()
+    await waitFor(() => expect(screen.queryByRole("textbox")).toBeNull())
 
     rerender(form(false))
-    withOutcome(commandId, false)
+    withOutcomes({ [commandId]: false })
     rerender(form(true))
 
     // The notice is visible, the draft is intact, and nothing invites a
@@ -1017,32 +1040,46 @@ describe("ClarificationForm terminal command outcomes", () => {
     expect(submitButton()).toBeDisabled()
   })
 
-  it("does not reactivate while the accepted reply has no terminal outcome yet", async () => {
+  it("locks and explains a reasserted round whose accepted reply is still in flight", async () => {
     const { rerender } = render(form(true))
     await submitAccepted()
+    await waitFor(() => expect(screen.queryByRole("textbox")).toBeNull())
 
     rerender(form(false))
     rerender(form(true))
 
-    // No outcome means the command may still be in flight: the form stays
-    // collapsed instead of inviting a duplicate.
-    expect(screen.queryByRole("textbox")).toBeNull()
-    expect(submitButton()).toBeNull()
+    // No outcome means the command may still be in flight: the form opens
+    // to explain the lock instead of showing a bare greyed-out button, and
+    // nothing invites a duplicate.
+    expect(
+      await screen.findByText("chatPage.clarification.replyPending"),
+    ).toBeInTheDocument()
+    expect(submitButton()).toBeDisabled()
   })
 
   it("is not reopened by a late terminal event after a turn is established", async () => {
     const { rerender } = render(form(true))
     const commandId = await submitAccepted()
+    await waitFor(() => expect(screen.queryByRole("textbox")).toBeNull())
 
     rerender(form(false))
     // The turn was established, the task is running, and only then does a
     // stale resend-safe terminal frame arrive: with the task not waiting,
     // nothing may reopen the submitted form.
-    withOutcome(commandId, true)
+    withOutcomes({ [commandId]: true })
     rerender(form(false))
 
     expect(screen.queryByRole("textbox")).toBeNull()
     expect(submitButton()).toBeNull()
+
+    // Only an authoritative return to waiting_for_user consumes the
+    // outcome and reactivates the form - this is the resend-safe branch
+    // actually running, so the test fails if the gating logic is removed.
+    rerender(form(true))
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    expect(
+      screen.getByText("chatPage.clarification.replyNotApplied"),
+    ).toBeInTheDocument()
   })
 
   it("gates a fresh component instance for a round another instance submitted", async () => {
@@ -1053,7 +1090,7 @@ describe("ClarificationForm terminal command outcomes", () => {
     const commandId = await submitAccepted()
     cleanup()
 
-    withOutcome(commandId, false)
+    withOutcomes({ [commandId]: false })
     render(form(true))
 
     const alert = await screen.findByRole("alert")
@@ -1072,14 +1109,17 @@ describe("ClarificationForm terminal command outcomes", () => {
 
     render(form(true))
 
-    expect(submitButton()).toBeDisabled()
+    await waitFor(() => expect(submitButton()).toBeDisabled())
+    expect(
+      screen.getByText("chatPage.clarification.replyPending"),
+    ).toBeInTheDocument()
   })
 
   it("does not lock a fresh instance for an unconfirmed ack-timeout delivery", async () => {
     appContextMock.state = {
       commandOutcomes: {},
       clarificationSubmissions: {
-        inputreq_r1: { commandId: "maybe-sent", accepted: false },
+        [ROUND]: [{ commandId: "maybe-sent", accepted: false }],
       },
     }
     render(form(true))
@@ -1087,6 +1127,144 @@ describe("ClarificationForm terminal command outcomes", () => {
     // The reply may never have been accepted at all: the composer keeps its
     // advisory retry until a terminal outcome for the command arrives.
     await waitFor(() => expect(submitButton()).toBeEnabled())
+  })
+
+  it("still surfaces an earlier command's unsafe outcome after a resubmit", async () => {
+    // The orphaned-outcome regression: an ack-timeout records command 1,
+    // the advisory retry sends command 2, and only then does command 1's
+    // terminal outcome arrive saying it may have been committed. The round
+    // must still lock and surface the ambiguity - a single-slot record
+    // would have overwritten command 1 and shown nothing.
+    appContextMock.sendMessage.mockRejectedValueOnce(Object.assign(
+      new Error("ack timed out"),
+      { disposition: "outcome_unknown", userFacing: true },
+    ))
+    const { rerender } = render(form(true))
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    await waitFor(() => expect(recordedSubmissions()).toHaveLength(1))
+    expect(recordedSubmissions()[0].accepted).toBe(false)
+    mirrorSubmissions()
+
+    // The advisory retry resubmits; the second record appends.
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    await waitFor(() => expect(recordedSubmissions()).toHaveLength(2))
+    mirrorSubmissions()
+    const [first, second] = recordedSubmissions()
+    expect(first.commandId).not.toBe(second.commandId)
+
+    withOutcomes({ [first.commandId]: false })
+    rerender(form(true))
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("chatPage.clarification.replyOutcomeUnknown")
+    expect(submitButton()).toBeDisabled()
+  })
+
+  it("withholds the proven-safe unlock notice while an unconfirmed reply is unresolved", async () => {
+    // Command 1's fate is unknown (ack timeout, no outcome); command 2 is
+    // proven not applied. The round returns to the advisory stance it
+    // already accepted for command 1 - but without the "not applied, safe
+    // to resend" promise, which cannot be made for command 1, and without
+    // consuming the record, so command 1's late outcome still gates.
+    appContextMock.state = {
+      commandOutcomes: { "cmd-2": { resendSafe: true } },
+      clarificationSubmissions: {
+        [ROUND]: [
+          { commandId: "cmd-1", accepted: false },
+          { commandId: "cmd-2", accepted: true },
+        ],
+      },
+    }
+    render(form(true))
+
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    expect(
+      screen.queryByText("chatPage.clarification.replyNotApplied"),
+    ).toBeNull()
+    expect(appContextMock.dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "CLEAR_CLARIFICATION_SUBMISSION" }),
+    )
+  })
+
+  it("returns a pending-locked instance to advisory once its accepted reply is proven not applied", async () => {
+    // The submitting instance's sequence: ack timeout (cmd 1) -> advisory
+    // resubmit accepted (cmd 2) -> pending lock -> cmd 2's outcome proves
+    // it was not applied while cmd 1 stays unresolved. The pending notice
+    // is now false and the lock has no exit, so the round returns to the
+    // advisory stance instead of diverging from a freshly mounted instance.
+    appContextMock.sendMessage.mockRejectedValueOnce(Object.assign(
+      new Error("ack timed out"),
+      { disposition: "outcome_unknown", userFacing: true },
+    ))
+    const { rerender } = render(form(true))
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    await waitFor(() => expect(recordedSubmissions()).toHaveLength(1))
+    mirrorSubmissions()
+
+    // Advisory resubmit succeeds and the accepted reply goes pending.
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    await waitFor(() => expect(recordedSubmissions()).toHaveLength(2))
+    mirrorSubmissions()
+    rerender(form(true))
+    expect(
+      await screen.findByText("chatPage.clarification.replyPending"),
+    ).toBeInTheDocument()
+    expect(submitButton()).toBeDisabled()
+
+    withOutcomes({ [recordedSubmissions()[1].commandId]: true })
+    rerender(form(true))
+
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    expect(
+      screen.queryByText("chatPage.clarification.replyPending"),
+    ).toBeNull()
+    expect(
+      screen.queryByText("chatPage.clarification.replyNotApplied"),
+    ).toBeNull()
+  })
+
+  it("replaces a lingering send-failure alert when the ambiguity notice takes over", async () => {
+    // An outcome_unknown send failure leaves its alert on screen; when the
+    // command's terminal outcome later proves unsafe, the two notices must
+    // not compete as two simultaneous role="alert" regions.
+    appContextMock.sendMessage.mockRejectedValueOnce(Object.assign(
+      new Error("ack timed out"),
+      { disposition: "outcome_unknown", userFacing: true },
+    ))
+    const { rerender } = render(form(true))
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    await waitFor(() => expect(recordedSubmissions()).toHaveLength(1))
+    await screen.findByRole("alert")
+    mirrorSubmissions()
+
+    withOutcomes({ [recordedSubmissions()[0].commandId]: false })
+    rerender(form(true))
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole("alert")
+      expect(alerts).toHaveLength(1)
+      expect(alerts[0]).toHaveTextContent(
+        "chatPage.clarification.replyOutcomeUnknown",
+      )
+    })
   })
 
   it("records the submission when the delivery outcome is unknown", async () => {
@@ -1102,32 +1280,16 @@ describe("ClarificationForm terminal command outcomes", () => {
     )
 
     // The reply may still have been durably accepted, so its eventual
-    // terminal outcome must gate this round like an acknowledged one.
-    await waitFor(() => {
-      expect(appContextMock.dispatch).toHaveBeenCalledWith({
-        type: "RECORD_CLARIFICATION_SUBMISSION",
-        payload: {
-          requestId: "inputreq_r1",
-          commandId: expect.any(String),
-          // Unconfirmed: an ack timeout must not lock the form while no
-          // terminal outcome exists.
-          accepted: false,
-        },
-      })
+    // terminal outcome must gate this round like an acknowledged one -
+    // recorded as unconfirmed, which must not lock the form while no
+    // terminal outcome exists.
+    await waitFor(() => expect(recordedSubmissions()).toHaveLength(1))
+    expect(recordedSubmissions()[0]).toEqual({
+      requestId: ROUND,
+      commandId: expect.any(String),
+      accepted: false,
     })
-    // The existing advisory behavior is unchanged until an outcome arrives -
-    // including on the gating effect's rerun after the entry is recorded.
-    appContextMock.state = {
-      ...appContextMock.state,
-      clarificationSubmissions: {
-        inputreq_r1: {
-          commandId: (appContextMock.sendMessage.mock.calls[0][1] as {
-            clientMessageId: string
-          }).clientMessageId,
-          accepted: false,
-        },
-      },
-    }
+    mirrorSubmissions()
     expect(submitButton()).toBeEnabled()
   })
 
@@ -1135,11 +1297,7 @@ describe("ClarificationForm terminal command outcomes", () => {
     appContextMock.state = {
       clarificationSubmissions: {},
       commandOutcomes: {
-        "someone-elses-command": {
-          outcome: "failed",
-          resendSafe: false,
-          messageCode: "task_command_failed",
-        },
+        "someone-elses-command": { resendSafe: false },
       },
     }
     const { rerender } = render(form(false))
@@ -1152,9 +1310,10 @@ describe("ClarificationForm terminal command outcomes", () => {
   it("resets the gate for a new clarification round", async () => {
     const { rerender } = render(form(true))
     const commandId = await submitAccepted()
+    await waitFor(() => expect(screen.queryByRole("textbox")).toBeNull())
 
     rerender(form(false))
-    withOutcome(commandId, false)
+    withOutcomes({ [commandId]: false })
     rerender(form(true))
     await screen.findByRole("alert")
 
@@ -1184,15 +1343,5 @@ describe("ClarificationForm terminal command outcomes", () => {
     expect(appContextMock.dispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: "RECORD_CLARIFICATION_SUBMISSION" }),
     )
-  })
-
-  it("uses outcome notice keys that resolve in both locale trees", () => {
-    for (const key of [
-      "chatPage.clarification.replyNotApplied",
-      "chatPage.clarification.replyOutcomeUnknown",
-    ] as const) {
-      expect(resolveTranslation("en", key)).not.toBe(key)
-      expect(resolveTranslation("zh", key)).not.toBe(key)
-    }
   })
 })

--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -17,6 +17,10 @@ const appContextMock = vi.hoisted(() => ({
   filesDisabled: false,
   providerAvailable: true,
   sendMessage: vi.fn(),
+  state: {
+    commandOutcomes: {} as Record<string, unknown>,
+    clarificationSubmissions: {} as Record<string, unknown>,
+  },
 }))
 const toastErrorMock = vi.hoisted(() => vi.fn())
 const mcpAppsMock = vi.hoisted(() => ({
@@ -897,5 +901,255 @@ describe("ClarificationForm blank option filtering", () => {
 
     expect(screen.getByText("Import")).toBeInTheDocument()
     expect(blankOptionSpans(container)).toHaveLength(0)
+  })
+})
+
+describe("ClarificationForm terminal command outcomes", () => {
+  // Issue #1500: after a reply is durably accepted, its command can still
+  // reach a terminal disposition before a turn is established. Whether the
+  // form may invite a resend is decided by the structured outcome the
+  // backend broadcasts for that exact command, never by task state alone.
+  // The accountable submission lives in context keyed by request id, so the
+  // gate survives the submitting component instance being replaced.
+  beforeEach(() => {
+    appContextMock.dispatch.mockReset()
+    appContextMock.filesDisabled = false
+    appContextMock.providerAvailable = true
+    appContextMock.sendMessage.mockReset()
+    appContextMock.sendMessage.mockResolvedValue(undefined)
+    appContextMock.state = { commandOutcomes: {}, clarificationSubmissions: {} }
+    toastErrorMock.mockReset()
+  })
+
+  afterEach(() => {
+    appContextMock.state = { commandOutcomes: {}, clarificationSubmissions: {} }
+    cleanup()
+  })
+
+  const form = (active: boolean, requestId = "inputreq_r1") => (
+    <ClarificationForm
+      interactions={[{ type: "text_input" as const, field: "city", label: "City" }]}
+      requestId={requestId}
+      active={active}
+    />
+  )
+
+  const submitButton = () =>
+    screen.queryByRole("button", { name: "chatPage.clarification.submit" })
+
+  // Drives one accepted submission and mirrors the RECORD dispatch into the
+  // mock context state, the way the real reducer would.
+  const submitAccepted = async (requestId = "inputreq_r1") => {
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(1))
+    // Accepted submissions collapse the form.
+    await waitFor(() => expect(screen.queryByRole("textbox")).toBeNull())
+    const record = appContextMock.dispatch.mock.calls
+      .map(([action]) => action)
+      .find((action) => action?.type === "RECORD_CLARIFICATION_SUBMISSION")
+    expect(record).toEqual({
+      type: "RECORD_CLARIFICATION_SUBMISSION",
+      payload: { requestId, commandId: expect.any(String) },
+    })
+    // The recorded command id is the client message id the delivery used.
+    const config = appContextMock.sendMessage.mock.calls[0][1] as {
+      clientMessageId?: string
+    }
+    expect(record.payload.commandId).toBe(config.clientMessageId)
+    appContextMock.state = {
+      ...appContextMock.state,
+      clarificationSubmissions: {
+        [requestId]: { commandId: record.payload.commandId },
+      },
+    }
+    return record.payload.commandId as string
+  }
+
+  const withOutcome = (commandId: string, resendSafe: boolean) => {
+    appContextMock.state = {
+      ...appContextMock.state,
+      commandOutcomes: {
+        [commandId]: {
+          outcome: "failed",
+          resendSafe,
+          messageCode: "task_command_deferred",
+        },
+      },
+    }
+  }
+
+  it("reactivates the form and preserves the draft when the outcome proves retry safe", async () => {
+    const { rerender } = render(form(true))
+    const commandId = await submitAccepted()
+
+    rerender(form(false))
+    withOutcome(commandId, true)
+    rerender(form(true))
+
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    expect(screen.getByRole("textbox")).toHaveValue("Beijing")
+    expect(
+      screen.getByText("chatPage.clarification.replyNotApplied"),
+    ).toBeInTheDocument()
+    // The record is consumed so the resend is armed exactly once.
+    expect(appContextMock.dispatch).toHaveBeenCalledWith({
+      type: "CLEAR_CLARIFICATION_SUBMISSION",
+      payload: { requestId: "inputreq_r1" },
+    })
+  })
+
+  it("keeps the form locked and surfaces the ambiguity when the outcome is not proven safe", async () => {
+    const { rerender } = render(form(true))
+    const commandId = await submitAccepted()
+
+    rerender(form(false))
+    withOutcome(commandId, false)
+    rerender(form(true))
+
+    // The notice is visible, the draft is intact, and nothing invites a
+    // duplicate submission of the accepted reply.
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("chatPage.clarification.replyOutcomeUnknown")
+    expect(screen.getByRole("textbox")).toHaveValue("Beijing")
+    expect(submitButton()).toBeDisabled()
+  })
+
+  it("does not reactivate while the accepted reply has no terminal outcome yet", async () => {
+    const { rerender } = render(form(true))
+    await submitAccepted()
+
+    rerender(form(false))
+    rerender(form(true))
+
+    // No outcome means the command may still be in flight: the form stays
+    // collapsed instead of inviting a duplicate.
+    expect(screen.queryByRole("textbox")).toBeNull()
+    expect(submitButton()).toBeNull()
+  })
+
+  it("is not reopened by a late terminal event after a turn is established", async () => {
+    const { rerender } = render(form(true))
+    const commandId = await submitAccepted()
+
+    rerender(form(false))
+    // The turn was established, the task is running, and only then does a
+    // stale resend-safe terminal frame arrive: with the task not waiting,
+    // nothing may reopen the submitted form.
+    withOutcome(commandId, true)
+    rerender(form(false))
+
+    expect(screen.queryByRole("textbox")).toBeNull()
+    expect(submitButton()).toBeNull()
+  })
+
+  it("gates a fresh component instance for a round another instance submitted", async () => {
+    // The virtual waiting message and the persisted timeline message render
+    // the same round in different component instances; replacing the
+    // submitting instance must not drop the gate.
+    render(form(true))
+    const commandId = await submitAccepted()
+    cleanup()
+
+    withOutcome(commandId, false)
+    render(form(true))
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("chatPage.clarification.replyOutcomeUnknown")
+    expect(submitButton()).toBeDisabled()
+  })
+
+  it("records the submission when the delivery outcome is unknown", async () => {
+    appContextMock.sendMessage.mockRejectedValue(Object.assign(
+      new Error("ack timed out"),
+      { disposition: "outcome_unknown", userFacing: true },
+    ))
+    render(form(true))
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+
+    // The reply may still have been durably accepted, so its eventual
+    // terminal outcome must gate this round like an acknowledged one.
+    await waitFor(() => {
+      expect(appContextMock.dispatch).toHaveBeenCalledWith({
+        type: "RECORD_CLARIFICATION_SUBMISSION",
+        payload: {
+          requestId: "inputreq_r1",
+          commandId: expect.any(String),
+        },
+      })
+    })
+    // The existing advisory behavior is unchanged until an outcome arrives.
+    expect(submitButton()).toBeEnabled()
+  })
+
+  it("still reactivates a form that never submitted, ignoring unrelated outcomes", async () => {
+    appContextMock.state = {
+      clarificationSubmissions: {},
+      commandOutcomes: {
+        "someone-elses-command": {
+          outcome: "failed",
+          resendSafe: false,
+          messageCode: "task_command_failed",
+        },
+      },
+    }
+    const { rerender } = render(form(false))
+    rerender(form(true))
+
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("resets the gate for a new clarification round", async () => {
+    const { rerender } = render(form(true))
+    const commandId = await submitAccepted()
+
+    rerender(form(false))
+    withOutcome(commandId, false)
+    rerender(form(true))
+    await screen.findByRole("alert")
+
+    rerender(form(true, "inputreq_r2"))
+
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    expect(screen.getByRole("textbox")).toHaveValue("")
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("does not record a submission for a round without a request id", async () => {
+    render(
+      <ClarificationForm
+        interactions={[{ type: "text_input" as const, field: "city", label: "City" }]}
+        active
+      />,
+    )
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+
+    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(1))
+    // With no round identity to bind to, gating is skipped entirely rather
+    // than risking a recorded reply gating a different question.
+    expect(appContextMock.dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "RECORD_CLARIFICATION_SUBMISSION" }),
+    )
+  })
+
+  it("uses outcome notice keys that resolve in both locale trees", () => {
+    for (const key of [
+      "chatPage.clarification.replyNotApplied",
+      "chatPage.clarification.replyOutcomeUnknown",
+    ] as const) {
+      expect(resolveTranslation("en", key)).not.toBe(key)
+      expect(resolveTranslation("zh", key)).not.toBe(key)
+    }
   })
 })

--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -952,7 +952,7 @@ describe("ClarificationForm terminal command outcomes", () => {
       .find((action) => action?.type === "RECORD_CLARIFICATION_SUBMISSION")
     expect(record).toEqual({
       type: "RECORD_CLARIFICATION_SUBMISSION",
-      payload: { requestId, commandId: expect.any(String) },
+      payload: { requestId, commandId: expect.any(String), accepted: true },
     })
     // The recorded command id is the client message id the delivery used.
     const config = appContextMock.sendMessage.mock.calls[0][1] as {
@@ -962,7 +962,7 @@ describe("ClarificationForm terminal command outcomes", () => {
     appContextMock.state = {
       ...appContextMock.state,
       clarificationSubmissions: {
-        [requestId]: { commandId: record.payload.commandId },
+        [requestId]: { commandId: record.payload.commandId, accepted: true },
       },
     }
     return record.payload.commandId as string
@@ -1061,6 +1061,34 @@ describe("ClarificationForm terminal command outcomes", () => {
     expect(submitButton()).toBeDisabled()
   })
 
+  it("locks a fresh component instance while the accepted reply is still in flight", async () => {
+    // A freshly mounted instance starts with isSubmitted=false, so without
+    // the in-flight lock it would offer Submit for a round whose durably
+    // accepted reply has not reached a terminal outcome yet (surfaced by
+    // review on #2126).
+    render(form(true))
+    await submitAccepted()
+    cleanup()
+
+    render(form(true))
+
+    expect(submitButton()).toBeDisabled()
+  })
+
+  it("does not lock a fresh instance for an unconfirmed ack-timeout delivery", async () => {
+    appContextMock.state = {
+      commandOutcomes: {},
+      clarificationSubmissions: {
+        inputreq_r1: { commandId: "maybe-sent", accepted: false },
+      },
+    }
+    render(form(true))
+
+    // The reply may never have been accepted at all: the composer keeps its
+    // advisory retry until a terminal outcome for the command arrives.
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+  })
+
   it("records the submission when the delivery outcome is unknown", async () => {
     appContextMock.sendMessage.mockRejectedValue(Object.assign(
       new Error("ack timed out"),
@@ -1081,10 +1109,25 @@ describe("ClarificationForm terminal command outcomes", () => {
         payload: {
           requestId: "inputreq_r1",
           commandId: expect.any(String),
+          // Unconfirmed: an ack timeout must not lock the form while no
+          // terminal outcome exists.
+          accepted: false,
         },
       })
     })
-    // The existing advisory behavior is unchanged until an outcome arrives.
+    // The existing advisory behavior is unchanged until an outcome arrives -
+    // including on the gating effect's rerun after the entry is recorded.
+    appContextMock.state = {
+      ...appContextMock.state,
+      clarificationSubmissions: {
+        inputreq_r1: {
+          commandId: (appContextMock.sendMessage.mock.calls[0][1] as {
+            clientMessageId: string
+          }).clientMessageId,
+          accepted: false,
+        },
+      },
+    }
     expect(submitButton()).toBeEnabled()
   })
 

--- a/frontend/src/components/chat/clarification-form.tsx
+++ b/frontend/src/components/chat/clarification-form.tsx
@@ -135,7 +135,9 @@ export function ClarificationForm({
   // If onSend is provided, use it (e.g., from builder chat), otherwise use useApp
   let sendMessage: any, dispatch: any, contextFilesDisabled: boolean | undefined;
   let commandOutcomes: Record<string, TerminalCommandOutcome> | undefined;
-  let clarificationSubmissions: Record<string, { commandId: string }> | undefined;
+  let clarificationSubmissions:
+    | Record<string, { commandId: string; accepted: boolean }>
+    | undefined;
   try {
     const appCtx = useApp();
     sendMessage = appCtx.sendMessage;
@@ -230,15 +232,24 @@ export function ClarificationForm({
     // While a submission is outstanding, reactivation requires a terminal
     // outcome for that exact command that proves non-application.
     if (outstandingSubmission) {
-      if (!outstandingOutcome || outstandingOutcome.resendSafe !== true) {
-        // Committed, still in flight, or unknown: surface the ambiguity
-        // (when a terminal outcome exists) without inviting a duplicate.
-        // The chat input remains available for a deliberate fresh message.
-        if (outstandingOutcome) {
-          setOutcomeNotice("unconfirmed")
+      if (!outstandingOutcome) {
+        // Still in flight with no terminal outcome. A confirmed-accepted
+        // reply locks the form even on a freshly mounted instance (whose
+        // initial isSubmitted is false); an unconfirmed ack-timeout
+        // delivery keeps the advisory retry the composer has always
+        // offered, because the reply may never have been accepted at all.
+        if (outstandingSubmission.accepted) {
           setIsSubmitted(true)
-          setIsOpen(true)
         }
+        return
+      }
+      if (outstandingOutcome.resendSafe !== true) {
+        // Committed or unknown: surface the ambiguity without inviting a
+        // duplicate. The chat input remains available for a deliberate
+        // fresh message.
+        setOutcomeNotice("unconfirmed")
+        setIsSubmitted(true)
+        setIsOpen(true)
         return
       }
       // Proven not applied: consume the record so the resend is armed once,
@@ -436,12 +447,19 @@ export function ClarificationForm({
     // request id - the gate would have no round identity to bind to, and a
     // recorded reply could end up gating a different question.
     const clientMessageId = generateClientMessageId()
-    const recordSubmission = () => {
+    // ``accepted`` separates a durably acknowledged reply from one whose
+    // ack timed out: only a confirmed acceptance may lock a freshly mounted
+    // form while its terminal outcome is still pending.
+    const recordSubmission = (accepted: boolean) => {
       if (onSend || !dispatch) return
       if (typeof submittedRequestId !== "string" || !submittedRequestId) return
       dispatch({
         type: "RECORD_CLARIFICATION_SUBMISSION",
-        payload: { requestId: submittedRequestId, commandId: clientMessageId },
+        payload: {
+          requestId: submittedRequestId,
+          commandId: clientMessageId,
+          accepted,
+        },
       })
     }
 
@@ -461,7 +479,7 @@ export function ClarificationForm({
           { force: true, metadata, clientMessageId },
           outboundFiles,
         )
-        recordSubmission()
+        recordSubmission(true)
       }
 
       if (latestRequestIdRef.current !== submittedRequestId) return
@@ -474,8 +492,9 @@ export function ClarificationForm({
       if (readSendDisposition(error) === "outcome_unknown") {
         // An ack timeout: the reply may still have been durably accepted,
         // so its eventual terminal outcome must gate this round exactly as
-        // an acknowledged submission's would.
-        recordSubmission()
+        // an acknowledged submission's would - but as an unconfirmed
+        // delivery it must not lock the form while no outcome exists.
+        recordSubmission(false)
       }
       if (latestRequestIdRef.current !== submittedRequestId) return
       console.error("Failed to send clarification response", error)

--- a/frontend/src/components/chat/clarification-form.tsx
+++ b/frontend/src/components/chat/clarification-form.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
-import { Interaction, TerminalCommandOutcome } from "@/contexts/app-context-chat"
+import {
+  ClarificationSubmission,
+  Interaction,
+  TerminalCommandOutcome,
+} from "@/contexts/app-context-chat"
 import { generateClientMessageId } from "@/lib/utils"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
@@ -136,7 +140,7 @@ export function ClarificationForm({
   let sendMessage: any, dispatch: any, contextFilesDisabled: boolean | undefined;
   let commandOutcomes: Record<string, TerminalCommandOutcome> | undefined;
   let clarificationSubmissions:
-    | Record<string, { commandId: string; accepted: boolean }>
+    | Record<string, ClarificationSubmission[]>
     | undefined;
   try {
     const appCtx = useApp();
@@ -194,7 +198,7 @@ export function ClarificationForm({
   // Which outcome notice the form owes the user. Raw category only; the
   // sentence is resolved at render so a locale switch reaches it.
   const [outcomeNotice, setOutcomeNotice] = useState<
-    "notApplied" | "unconfirmed" | null
+    "notApplied" | "unconfirmed" | "pending" | null
   >(null)
 
   useLayoutEffect(() => {
@@ -211,49 +215,94 @@ export function ClarificationForm({
     setOutcomeNotice(null)
   }, [active, isConnectAppsOnly, requestId])
 
-  // The reply command this round is still accountable for, and its terminal
-  // disposition, both read from context so the gate survives this component
-  // instance being replaced (virtual waiting message vs. persisted timeline
-  // message render the same round). Derived per render: the effect below
-  // must re-run when either changes, and must NOT re-run when an unrelated
-  // command's outcome lands - that rerun used to wipe a visible failure
-  // alert.
-  const outstandingSubmission = requestId
-    ? clarificationSubmissions?.[requestId]
-    : undefined
-  const outstandingOutcome = outstandingSubmission
-    ? commandOutcomes?.[outstandingSubmission.commandId]
-    : undefined
+  // The reply commands this round is still accountable for, read from
+  // context so the gate survives this component instance being replaced
+  // (virtual waiting message vs. persisted timeline message render the same
+  // round). One round can hold several: an ack-timeout entry stays
+  // resubmittable, so a resubmit appends rather than replaces, and every
+  // tracked command's outcome still gets matched.
+  const outstandingSubmissions = useMemo<ClarificationSubmission[]>(
+    () => (requestId ? clarificationSubmissions?.[requestId] : undefined) ?? [],
+    [requestId, clarificationSubmissions],
+  )
+  // Reduced to booleans before entering the effect's dependency list: an
+  // unrelated command's outcome landing must not re-run the effect - that
+  // rerun used to wipe a visible failure alert.
+  const hasOutstanding = outstandingSubmissions.length > 0
+  // Any tracked reply whose terminal outcome cannot prove non-application
+  // may have been committed: the round must surface that and stay locked.
+  const anyUnsafeOutcome = outstandingSubmissions.some((submission) => {
+    const outcome = commandOutcomes?.[submission.commandId]
+    return outcome !== undefined && outcome.resendSafe !== true
+  })
+  // Every tracked reply is proven not applied: resending is safe.
+  const allProvenNotApplied =
+    hasOutstanding
+    && outstandingSubmissions.every(
+      (submission) => commandOutcomes?.[submission.commandId]?.resendSafe === true,
+    )
+  // A durably acknowledged reply is still awaiting its terminal outcome.
+  // (An unconfirmed ack-timeout entry without an outcome deliberately does
+  // not count: it may never have been accepted, and the composer keeps its
+  // advisory retry for it - which is also why it blocks the proven-safe
+  // unlock above without forcing a lock here.)
+  const confirmedPending = outstandingSubmissions.some(
+    (submission) =>
+      submission.accepted && commandOutcomes?.[submission.commandId] === undefined,
+  )
+  // Distinguishes the round that has heard nothing yet from the one whose
+  // resolved replies are all proven safe while unconfirmed ones remain.
+  const anyOutcome = outstandingSubmissions.some(
+    (submission) => commandOutcomes?.[submission.commandId] !== undefined,
+  )
 
   useEffect(() => {
     if (!active) return
     // Task state alone answers whether the task accepts input; it does not
     // prove that repeating this round's accepted reply is safe (#1500).
-    // While a submission is outstanding, reactivation requires a terminal
-    // outcome for that exact command that proves non-application.
-    if (outstandingSubmission) {
-      if (!outstandingOutcome) {
-        // Still in flight with no terminal outcome. A confirmed-accepted
-        // reply locks the form even on a freshly mounted instance (whose
-        // initial isSubmitted is false); an unconfirmed ack-timeout
-        // delivery keeps the advisory retry the composer has always
-        // offered, because the reply may never have been accepted at all.
-        if (outstandingSubmission.accepted) {
-          setIsSubmitted(true)
-        }
-        return
-      }
-      if (outstandingOutcome.resendSafe !== true) {
+    // While a submission is outstanding, reactivation requires terminal
+    // outcomes that prove non-application for every tracked reply.
+    if (hasOutstanding) {
+      if (anyUnsafeOutcome) {
         // Committed or unknown: surface the ambiguity without inviting a
         // duplicate. The chat input remains available for a deliberate
-        // fresh message.
+        // fresh message. The send-failure alert would compete with this
+        // one (two role="alert" regions), and this notice supersedes it.
         setOutcomeNotice("unconfirmed")
+        setIsSubmitted(true)
+        setIsOpen(true)
+        setSendFailure(null)
+        return
+      }
+      if (confirmedPending) {
+        // Accepted and still being applied: lock even a freshly mounted
+        // instance (whose initial isSubmitted is false), and say why the
+        // form is locked instead of leaving a bare greyed-out button.
+        setOutcomeNotice("pending")
         setIsSubmitted(true)
         setIsOpen(true)
         return
       }
-      // Proven not applied: consume the record so the resend is armed once,
-      // then reactivate below with the draft intact.
+      if (!allProvenNotApplied) {
+        if (anyOutcome) {
+          // Every resolved reply is proven not applied; only unconfirmed
+          // ack-timeout replies remain, and their duplicate risk is the
+          // same risk the advisory retry already accepted for them. Match
+          // the fresh-instance stance: return the round to advisory
+          // instead of leaving the submitting instance locked behind a
+          // now-stale pending notice. No proven-safe notice - that promise
+          // cannot be made while an unconfirmed reply is unresolved.
+          setOutcomeNotice((notice) => (notice === "pending" ? null : notice))
+          setIsSubmitted(false)
+          setIsOpen(true)
+        }
+        // Nothing resolved yet: keep the composer's advisory retry - and
+        // its ack-timeout warning alert - exactly as they stand.
+        return
+      }
+      // Every tracked reply is proven not applied: consume the record so
+      // the resend is armed once, then reactivate below with the draft
+      // intact.
       dispatch?.({
         type: "CLEAR_CLARIFICATION_SUBMISSION",
         payload: { requestId },
@@ -268,7 +317,16 @@ export function ClarificationForm({
     setIsSubmitted(false)
     setIsOpen(true)
     setSendFailure(null)
-  }, [active, outstandingSubmission, outstandingOutcome, requestId, dispatch])
+  }, [
+    active,
+    hasOutstanding,
+    anyUnsafeOutcome,
+    allProvenNotApplied,
+    confirmedPending,
+    anyOutcome,
+    requestId,
+    dispatch,
+  ])
 
   const normalizedInteractions = useMemo(() => {
     const seenFields = new Set<string>()
@@ -815,6 +873,11 @@ export function ClarificationForm({
             {outcomeNotice === "unconfirmed" && (
               <div role="alert" className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
                 {t("chatPage.clarification.replyOutcomeUnknown")}
+              </div>
+            )}
+            {outcomeNotice === "pending" && (
+              <div role="status" className="rounded-md border bg-muted/50 p-3 text-sm text-muted-foreground">
+                {t("chatPage.clarification.replyPending")}
               </div>
             )}
             {outcomeNotice === "notApplied" && (

--- a/frontend/src/components/chat/clarification-form.tsx
+++ b/frontend/src/components/chat/clarification-form.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
-import { Interaction } from "@/contexts/app-context-chat"
+import { Interaction, TerminalCommandOutcome } from "@/contexts/app-context-chat"
+import { generateClientMessageId } from "@/lib/utils"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
@@ -133,11 +134,15 @@ export function ClarificationForm({
 }: ClarificationFormProps) {
   // If onSend is provided, use it (e.g., from builder chat), otherwise use useApp
   let sendMessage: any, dispatch: any, contextFilesDisabled: boolean | undefined;
+  let commandOutcomes: Record<string, TerminalCommandOutcome> | undefined;
+  let clarificationSubmissions: Record<string, { commandId: string }> | undefined;
   try {
     const appCtx = useApp();
     sendMessage = appCtx.sendMessage;
     dispatch = appCtx.dispatch;
     contextFilesDisabled = appCtx.filesDisabled;
+    commandOutcomes = appCtx.state?.commandOutcomes;
+    clarificationSubmissions = appCtx.state?.clarificationSubmissions;
   } catch {
     // We might not be in the app context (e.g., agent builder chat)
   }
@@ -184,6 +189,11 @@ export function ClarificationForm({
       errorCode: ClientErrorCode | null
     } | null
   >(null)
+  // Which outcome notice the form owes the user. Raw category only; the
+  // sentence is resolved at render so a locale switch reaches it.
+  const [outcomeNotice, setOutcomeNotice] = useState<
+    "notApplied" | "unconfirmed" | null
+  >(null)
 
   useLayoutEffect(() => {
     latestRequestIdRef.current = requestId
@@ -194,18 +204,60 @@ export function ClarificationForm({
     setIsSubmitted(!active && !isConnectAppsOnly)
     setIsOpen(active || isConnectAppsOnly)
     setSendFailure(null)
+    // A new round is a new question: the previous round's outcome notice no
+    // longer belongs on top of it.
+    setOutcomeNotice(null)
   }, [active, isConnectAppsOnly, requestId])
 
+  // The reply command this round is still accountable for, and its terminal
+  // disposition, both read from context so the gate survives this component
+  // instance being replaced (virtual waiting message vs. persisted timeline
+  // message render the same round). Derived per render: the effect below
+  // must re-run when either changes, and must NOT re-run when an unrelated
+  // command's outcome lands - that rerun used to wipe a visible failure
+  // alert.
+  const outstandingSubmission = requestId
+    ? clarificationSubmissions?.[requestId]
+    : undefined
+  const outstandingOutcome = outstandingSubmission
+    ? commandOutcomes?.[outstandingSubmission.commandId]
+    : undefined
+
   useEffect(() => {
-    if (active) {
-      // A new clarification round reuses this component instance on the live
-      // turn render path, so a stale round-1 failure alert would sit on top
-      // of round 2's question.
-      setIsSubmitted(false)
-      setIsOpen(true)
-      setSendFailure(null)
+    if (!active) return
+    // Task state alone answers whether the task accepts input; it does not
+    // prove that repeating this round's accepted reply is safe (#1500).
+    // While a submission is outstanding, reactivation requires a terminal
+    // outcome for that exact command that proves non-application.
+    if (outstandingSubmission) {
+      if (!outstandingOutcome || outstandingOutcome.resendSafe !== true) {
+        // Committed, still in flight, or unknown: surface the ambiguity
+        // (when a terminal outcome exists) without inviting a duplicate.
+        // The chat input remains available for a deliberate fresh message.
+        if (outstandingOutcome) {
+          setOutcomeNotice("unconfirmed")
+          setIsSubmitted(true)
+          setIsOpen(true)
+        }
+        return
+      }
+      // Proven not applied: consume the record so the resend is armed once,
+      // then reactivate below with the draft intact.
+      dispatch?.({
+        type: "CLEAR_CLARIFICATION_SUBMISSION",
+        payload: { requestId },
+      })
+      setOutcomeNotice("notApplied")
     }
-  }, [active])
+    // A new clarification round reuses this component instance on the live
+    // turn render path, so a stale round-1 failure alert would sit on top
+    // of round 2's question. The outcome notice is deliberately not cleared
+    // here: it explains why the form re-opened, and it falls away on the
+    // next submit or the next round.
+    setIsSubmitted(false)
+    setIsOpen(true)
+    setSendFailure(null)
+  }, [active, outstandingSubmission, outstandingOutcome, requestId, dispatch])
 
   const normalizedInteractions = useMemo(() => {
     const seenFields = new Set<string>()
@@ -377,9 +429,26 @@ export function ClarificationForm({
       }
     })
 
+    // Minted here, not in sendMessage, so this round knows the id the
+    // durable command will carry and can correlate its terminal outcome
+    // (#1500). The builder onSend path has no durable command behind it and
+    // takes no part in outcome gating; neither does a round without a
+    // request id - the gate would have no round identity to bind to, and a
+    // recorded reply could end up gating a different question.
+    const clientMessageId = generateClientMessageId()
+    const recordSubmission = () => {
+      if (onSend || !dispatch) return
+      if (typeof submittedRequestId !== "string" || !submittedRequestId) return
+      dispatch({
+        type: "RECORD_CLARIFICATION_SUBMISSION",
+        payload: { requestId: submittedRequestId, commandId: clientMessageId },
+      })
+    }
+
     try {
       setIsSubmitting(true)
       setSendFailure(null)
+      setOutcomeNotice(null)
       // If textMessage is empty but we have files, send a generic message?
       const outboundFiles = filesDisabled ? [] : files
       const finalMessage = textMessage || (outboundFiles.length > 0 ? t("chatPage.clarification.uploadedFiles") : t("chatPage.clarification.confirmed"))
@@ -387,7 +456,12 @@ export function ClarificationForm({
       if (onSend) {
         await onSend(finalMessage, outboundFiles, metadata);
       } else if (sendMessage) {
-        await sendMessage(finalMessage, { force: true, metadata }, outboundFiles)
+        await sendMessage(
+          finalMessage,
+          { force: true, metadata, clientMessageId },
+          outboundFiles,
+        )
+        recordSubmission()
       }
 
       if (latestRequestIdRef.current !== submittedRequestId) return
@@ -397,6 +471,12 @@ export function ClarificationForm({
         dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
       }
     } catch (error) {
+      if (readSendDisposition(error) === "outcome_unknown") {
+        // An ack timeout: the reply may still have been durably accepted,
+        // so its eventual terminal outcome must gate this round exactly as
+        // an acknowledged submission's would.
+        recordSubmission()
+      }
       if (latestRequestIdRef.current !== submittedRequestId) return
       console.error("Failed to send clarification response", error)
       // The rejection reason ("a previous guidance message is still being
@@ -713,6 +793,16 @@ export function ClarificationForm({
               ))}
             </div>
 
+            {outcomeNotice === "unconfirmed" && (
+              <div role="alert" className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+                {t("chatPage.clarification.replyOutcomeUnknown")}
+              </div>
+            )}
+            {outcomeNotice === "notApplied" && (
+              <div role="status" className="rounded-md border bg-muted/50 p-3 text-sm text-muted-foreground">
+                {t("chatPage.clarification.replyNotApplied")}
+              </div>
+            )}
             {sendFailure && (
               <div role="alert" className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
                 <div>{sendFailureMessage}</div>

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -214,6 +214,7 @@ function StateProbe() {
       <div data-testid="history-loading">{String(state.isHistoryLoading)}</div>
       <div data-testid="preview-open">{String(state.filePreview.isOpen)}</div>
       <div data-testid="processing">{String(state.isProcessing)}</div>
+      <div data-testid="command-outcomes">{JSON.stringify(state.commandOutcomes)}</div>
     </>
   )
 }
@@ -6644,5 +6645,239 @@ describe("error frame display projection", () => {
     expect(
       projectErrorFrameForDisplay(frame, { trustLegacyErrorProse, translate, controlEnvelope }),
     ).toEqual(expected)
+  })
+})
+
+function ClarificationSubmissionProbe() {
+  const { state, dispatch } = useApp()
+  return (
+    <>
+      <div data-testid="clarification-submissions">
+        {JSON.stringify(state.clarificationSubmissions)}
+      </div>
+      <button
+        data-testid="record-submission"
+        onClick={() =>
+          dispatch({
+            type: "RECORD_CLARIFICATION_SUBMISSION",
+            payload: { requestId: "req-1", commandId: "cmd-1" },
+          })
+        }
+      />
+      <button
+        data-testid="clear-submission"
+        onClick={() =>
+          dispatch({
+            type: "CLEAR_CLARIFICATION_SUBMISSION",
+            payload: { requestId: "req-1" },
+          })
+        }
+      />
+    </>
+  )
+}
+
+describe("terminal command outcomes (#1500)", () => {
+  beforeEach(() => {
+    webSocketOptions.current = null
+    webSocketOptions.all = []
+    sessionControls = null
+    wsHarness.isConnected = true
+    apiRequestMock.mockReset()
+    routerPushMock.mockReset()
+    sendRawMessageMock.mockReset()
+    sendRawMessageMock.mockReturnValue("sent")
+    sendChatMessageMock.mockReset()
+    sendChatMessageMock.mockResolvedValue({
+      client_message_id: "turn-optimistic",
+      turn_id: "turn-optimistic",
+    })
+    localStorage.clear()
+    ;(window as typeof window & { clearDuplicateMessageCache?: () => void })
+      .clearDuplicateMessageCache?.()
+  })
+
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+  })
+
+  // A terminal agent_error for a durable command carries a structured
+  // disposition. The context records it keyed by command id so the
+  // clarification form that submitted that exact command can decide
+  // whether a resend is safe - task state alone must not decide that.
+  it("records a structured terminal outcome keyed by command id", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:04Z",
+        data: {
+          type: "agent_error",
+          message: "This message was not applied to the task.",
+          command_id: "client-msg-1",
+          command_kind: "message",
+          outcome: "failed",
+          resend_safe: true,
+          message_code: "task_command_deferred",
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
+      ).toEqual({
+        "client-msg-1": {
+          outcome: "failed",
+          resendSafe: true,
+          messageCode: "task_command_deferred",
+        },
+      })
+    })
+  })
+
+  it("keeps legacy frames without a structured outcome in the unsafe reading", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:04Z",
+        data: {
+          type: "agent_error",
+          message: "Task command message failed: something",
+          command_id: "client-msg-legacy",
+          command_kind: "message",
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("messages").textContent).toContain(
+        "Task command message failed"
+      )
+    })
+    // No structured outcome field, no recorded disposition: consumers keep
+    // treating the command as possibly committed or in flight.
+    expect(
+      JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
+    ).toEqual({})
+  })
+
+  it("records the outcome while a same-version waiting_for_user reassertion is retained", async () => {
+    // The full post-ack sequence at the context level: the task waits, the
+    // reply's terminal agent_error reasserts waiting_for_user for the same
+    // run and version, and the structured outcome lands beside the retained
+    // task state - the form layer decides the retry from both.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+        request_id: "req-1",
+        interactions: [
+          { type: "text", request_id: "req-1", prompt: "Which region should I use?" },
+        ],
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 3,
+        data: {
+          type: "agent_error",
+          message: "We could not confirm whether this message was applied to the task.",
+          command_id: "client-msg-2",
+          command_kind: "message",
+          outcome: "failed",
+          resend_safe: false,
+          message_code: "task_command_deferred",
+          task: { id: 1, status: "waiting_for_user" },
+        },
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
+      ).toEqual({
+        "client-msg-2": {
+          outcome: "failed",
+          resendSafe: false,
+          messageCode: "task_command_deferred",
+        },
+      })
+    })
+    // The reasserted waiting state is retained, exactly as before.
+    expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+    expect(screen.getByTestId("waiting-interactions").textContent).not.toBe("[]")
+  })
+
+  it("records and consumes the round's accountable submission", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <ClarificationSubmissionProbe />
+      </AppProvider>
+    )
+
+    act(() => {
+      screen.getByTestId("record-submission").click()
+    })
+    await waitFor(() => {
+      expect(
+        JSON.parse(
+          screen.getByTestId("clarification-submissions").textContent || "{}"
+        )
+      ).toEqual({ "req-1": { commandId: "cmd-1" } })
+    })
+
+    act(() => {
+      screen.getByTestId("clear-submission").click()
+    })
+    await waitFor(() => {
+      expect(
+        JSON.parse(
+          screen.getByTestId("clarification-submissions").textContent || "{}"
+        )
+      ).toEqual({})
+    })
   })
 })

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -6665,6 +6665,15 @@ function ClarificationSubmissionProbe() {
         }
       />
       <button
+        data-testid="record-second-submission"
+        onClick={() =>
+          dispatch({
+            type: "RECORD_CLARIFICATION_SUBMISSION",
+            payload: { requestId: "req-1", commandId: "cmd-2", accepted: false },
+          })
+        }
+      />
+      <button
         data-testid="clear-submission"
         onClick={() =>
           dispatch({
@@ -6737,11 +6746,7 @@ describe("terminal command outcomes (#1500)", () => {
       expect(
         JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
       ).toEqual({
-        "client-msg-1": {
-          outcome: "failed",
-          resendSafe: true,
-          messageCode: "task_command_deferred",
-        },
+        "client-msg-1": { resendSafe: true },
       })
     })
   })
@@ -6838,16 +6843,148 @@ describe("terminal command outcomes (#1500)", () => {
       expect(
         JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
       ).toEqual({
-        "client-msg-2": {
-          outcome: "failed",
-          resendSafe: false,
-          messageCode: "task_command_deferred",
-        },
+        "client-msg-2": { resendSafe: false },
       })
     })
     // The reasserted waiting state is retained, exactly as before.
     expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
     expect(screen.getByTestId("waiting-interactions").textContent).not.toBe("[]")
+  })
+
+  it("appends a second submission for the same round instead of overwriting", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <ClarificationSubmissionProbe />
+      </AppProvider>
+    )
+
+    act(() => {
+      screen.getByTestId("record-submission").click()
+    })
+    act(() => {
+      screen.getByTestId("record-second-submission").click()
+    })
+
+    // Both commands stay accountable: overwriting would orphan the first
+    // command's still-pending outcome (#2126 review round 2, finding 1).
+    await waitFor(() => {
+      expect(
+        JSON.parse(
+          screen.getByTestId("clarification-submissions").textContent || "{}"
+        )
+      ).toEqual({
+        "req-1": [
+          { commandId: "cmd-1", accepted: true },
+          { commandId: "cmd-2", accepted: false },
+        ],
+      })
+    })
+  })
+
+  it("records resendSafe false when the structured frame omits resend_safe", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:04Z",
+        data: {
+          type: "agent_error",
+          message: "Task command message failed: something",
+          command_id: "client-msg-no-flag",
+          command_kind: "message",
+          outcome: "failed",
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
+      ).toEqual({ "client-msg-no-flag": { resendSafe: false } })
+    })
+  })
+
+  it("does not record a non-failed outcome", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:04Z",
+        data: {
+          type: "agent_error",
+          message: "noise",
+          command_id: "client-msg-completed",
+          command_kind: "message",
+          outcome: "completed",
+          resend_safe: true,
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("messages").textContent).toContain("noise")
+    })
+    expect(
+      JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
+    ).toEqual({})
+  })
+
+  it("records an outcome from another task's frame (harmless by design)", async () => {
+    // RECORD_COMMAND_OUTCOME is deliberately not task-scoped: command ids
+    // are globally unique UUIDs, the only consumer looks one up by exact
+    // id, and scoping would silently drop the one-time terminal event for
+    // background tasks. This pins the current deliberate behavior.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:04Z",
+        task_id: 999,
+        data: {
+          type: "agent_error",
+          message: "This message was not applied to the task.",
+          command_id: "other-task-command",
+          command_kind: "message",
+          outcome: "failed",
+          resend_safe: true,
+          task: { id: 999, status: "waiting_for_user" },
+        },
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
+      ).toEqual({ "other-task-command": { resendSafe: true } })
+    })
   })
 
   it("records and consumes the round's accountable submission", async () => {
@@ -6866,7 +7003,7 @@ describe("terminal command outcomes (#1500)", () => {
         JSON.parse(
           screen.getByTestId("clarification-submissions").textContent || "{}"
         )
-      ).toEqual({ "req-1": { commandId: "cmd-1", accepted: true } })
+      ).toEqual({ "req-1": [{ commandId: "cmd-1", accepted: true }] })
     })
 
     act(() => {

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -6660,7 +6660,7 @@ function ClarificationSubmissionProbe() {
         onClick={() =>
           dispatch({
             type: "RECORD_CLARIFICATION_SUBMISSION",
-            payload: { requestId: "req-1", commandId: "cmd-1" },
+            payload: { requestId: "req-1", commandId: "cmd-1", accepted: true },
           })
         }
       />
@@ -6866,7 +6866,7 @@ describe("terminal command outcomes (#1500)", () => {
         JSON.parse(
           screen.getByTestId("clarification-submissions").textContent || "{}"
         )
-      ).toEqual({ "req-1": { commandId: "cmd-1" } })
+      ).toEqual({ "req-1": { commandId: "cmd-1", accepted: true } })
     })
 
     act(() => {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1232,7 +1232,12 @@ export interface AppState {
   // the submitting instance being replaced (#1500). Rounds without a
   // request id are deliberately not tracked - with no round identity a
   // recorded reply could gate a different question.
-  clarificationSubmissions: Record<string, { commandId: string }>
+  // ``accepted`` distinguishes a reply the backend durably acknowledged from
+  // one recorded after an ack timeout (outcome unknown): only a confirmed
+  // acceptance may lock a freshly mounted form while no terminal outcome has
+  // arrived - an unconfirmed delivery keeps the advisory retry the composer
+  // has always offered.
+  clarificationSubmissions: Record<string, { commandId: string; accepted: boolean }>
 }
 
 type AppAction =
@@ -1246,7 +1251,7 @@ type AppAction =
   | { type: "SET_TASK_RUNTIME_EXTENSIONS"; payload: { taskId: number; extensions: TaskRuntimeExtensions } }
   | { type: "UPDATE_TASK_STATUS"; payload: { status: Task["status"]; waitingQuestion?: string; waitingInteractions?: Interaction[]; waitingRequestId?: string; runId?: string | null; stateVersion?: number; controlState?: TaskControlState; updatedAt?: string } }
   | { type: "RECORD_COMMAND_OUTCOME"; payload: { commandId: string; outcome: TerminalCommandOutcome } }
-  | { type: "RECORD_CLARIFICATION_SUBMISSION"; payload: { requestId: string; commandId: string } }
+  | { type: "RECORD_CLARIFICATION_SUBMISSION"; payload: { requestId: string; commandId: string; accepted: boolean } }
   | { type: "CLEAR_CLARIFICATION_SUBMISSION"; payload: { requestId: string } }
   | { type: "TRIGGER_TASK_UPDATE" }
   | { type: "SET_DAG_EXECUTION"; payload: DAGExecution | null }
@@ -1351,7 +1356,10 @@ function projectAppState(state: AppState, action: AppAction): AppState {
         ...state,
         clarificationSubmissions: {
           ...state.clarificationSubmissions,
-          [action.payload.requestId]: { commandId: action.payload.commandId },
+          [action.payload.requestId]: {
+            commandId: action.payload.commandId,
+            accepted: action.payload.accepted,
+          },
         },
       }
     case "CLEAR_CLARIFICATION_SUBMISSION": {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1170,9 +1170,20 @@ const normalizeDagExecutionPayload = (raw: Record<string, unknown>): DAGExecutio
  * the field — reads as "may be committed or still in flight".
  */
 export interface TerminalCommandOutcome {
-  outcome: "failed"
   resendSafe: boolean
-  messageCode: string | null
+}
+
+/**
+ * One clarification reply the round is still accountable for. `accepted`
+ * distinguishes a reply the backend durably acknowledged from one recorded
+ * after an ack timeout (outcome unknown): only a confirmed acceptance may
+ * lock a freshly mounted form while no terminal outcome has arrived — an
+ * unconfirmed delivery keeps the advisory retry the composer has always
+ * offered.
+ */
+export interface ClarificationSubmission {
+  commandId: string
+  accepted: boolean
 }
 
 export interface AppState {
@@ -1232,12 +1243,17 @@ export interface AppState {
   // the submitting instance being replaced (#1500). Rounds without a
   // request id are deliberately not tracked - with no round identity a
   // recorded reply could gate a different question.
-  // ``accepted`` distinguishes a reply the backend durably acknowledged from
-  // one recorded after an ack timeout (outcome unknown): only a confirmed
-  // acceptance may lock a freshly mounted form while no terminal outcome has
-  // arrived - an unconfirmed delivery keeps the advisory retry the composer
-  // has always offered.
-  clarificationSubmissions: Record<string, { commandId: string; accepted: boolean }>
+  // An ordered list, not a single slot: an ack-timeout entry stays
+  // resubmittable, so one round can accumulate several outstanding replies,
+  // and overwriting the earlier one would orphan its still-pending outcome -
+  // exactly the undetected-duplicate risk this state exists to surface.
+  // Growth is bounded by the user's own resubmits within one round.
+  // Deliberately NOT persisted across reloads: rebuilding the gate from
+  // browser storage without the durable terminal-event replay (#1904) would
+  // turn a missed outcome frame into a permanent, unexplainable lock
+  // (fail-closed with no exit). Reload-during-ambiguity is tracked in
+  // #2142 as server-authoritative reconstruction on the #2135/#1904 arc.
+  clarificationSubmissions: Record<string, ClarificationSubmission[]>
 }
 
 type AppAction =
@@ -1352,14 +1368,20 @@ function projectAppState(state: AppState, action: AppAction): AppState {
         },
       }
     case "RECORD_CLARIFICATION_SUBMISSION":
+      // Append, never overwrite: the round stays accountable for every
+      // outstanding reply, so an earlier command's late outcome can still
+      // be matched and surfaced.
       return {
         ...state,
         clarificationSubmissions: {
           ...state.clarificationSubmissions,
-          [action.payload.requestId]: {
-            commandId: action.payload.commandId,
-            accepted: action.payload.accepted,
-          },
+          [action.payload.requestId]: [
+            ...(state.clarificationSubmissions[action.payload.requestId] ?? []),
+            {
+              commandId: action.payload.commandId,
+              accepted: action.payload.accepted,
+            },
+          ],
         },
       }
     case "CLEAR_CLARIFICATION_SUBMISSION": {
@@ -5826,11 +5848,7 @@ export function AppProvider({
             payload: {
               commandId: terminalCommandId,
               outcome: {
-                outcome: "failed",
                 resendSafe: agentErrorData.resend_safe === true,
-                messageCode: typeof agentErrorData.message_code === "string"
-                  ? agentErrorData.message_code
-                  : null,
               },
             },
           })

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1162,6 +1162,19 @@ const normalizeDagExecutionPayload = (raw: Record<string, unknown>): DAGExecutio
   } as DAGExecution
 }
 
+/**
+ * The structured disposition a terminal `agent_error` frame carries for one
+ * durable command (#1500). `resendSafe` is asserted by the backend only when
+ * the failed handoff proved the command never reached the downstream
+ * operation; everything else — including frames from backends that predate
+ * the field — reads as "may be committed or still in flight".
+ */
+export interface TerminalCommandOutcome {
+  outcome: "failed"
+  resendSafe: boolean
+  messageCode: string | null
+}
+
 export interface AppState {
   messages: Message[]
   currentTask: Task | null
@@ -1207,6 +1220,19 @@ export interface AppState {
   // Current context-window usage from the latest LLM call, for the usage gauge.
   contextUsage: { tokens: number; threshold: number } | null
   sessionConversation: SessionConversationState
+  // Terminal dispositions keyed by the durable command id (the sender's own
+  // client message id), so a submitter can decide whether its accepted reply
+  // is safe to resend. Command ids are unique, which is what makes exact-id
+  // correlation immune to stale or cross-run outcomes (#1500).
+  commandOutcomes: Record<string, TerminalCommandOutcome>
+  // The reply command each clarification round is still accountable for,
+  // keyed by request id. Context state, not component state: the same round
+  // can render in more than one ClarificationForm instance (virtual waiting
+  // message vs. persisted timeline message), and the retry gate must survive
+  // the submitting instance being replaced (#1500). Rounds without a
+  // request id are deliberately not tracked - with no round identity a
+  // recorded reply could gate a different question.
+  clarificationSubmissions: Record<string, { commandId: string }>
 }
 
 type AppAction =
@@ -1219,6 +1245,9 @@ type AppAction =
   | { type: "SET_CURRENT_TASK"; payload: Task | null }
   | { type: "SET_TASK_RUNTIME_EXTENSIONS"; payload: { taskId: number; extensions: TaskRuntimeExtensions } }
   | { type: "UPDATE_TASK_STATUS"; payload: { status: Task["status"]; waitingQuestion?: string; waitingInteractions?: Interaction[]; waitingRequestId?: string; runId?: string | null; stateVersion?: number; controlState?: TaskControlState; updatedAt?: string } }
+  | { type: "RECORD_COMMAND_OUTCOME"; payload: { commandId: string; outcome: TerminalCommandOutcome } }
+  | { type: "RECORD_CLARIFICATION_SUBMISSION"; payload: { requestId: string; commandId: string } }
+  | { type: "CLEAR_CLARIFICATION_SUBMISSION"; payload: { requestId: string } }
   | { type: "TRIGGER_TASK_UPDATE" }
   | { type: "SET_DAG_EXECUTION"; payload: DAGExecution | null }
   | { type: "RESET_DAG_STATE" }
@@ -1291,6 +1320,8 @@ const createInitialState = (): AppState => ({
   isHistoryLoading: false,
   contextUsage: null,
   sessionConversation: { ...initialSessionConversationState },
+  commandOutcomes: {},
+  clarificationSubmissions: {},
 })
 
 function projectAppState(state: AppState, action: AppAction): AppState {
@@ -1307,6 +1338,30 @@ function projectAppState(state: AppState, action: AppAction): AppState {
       }
     case "SET_HISTORY_LOADING":
       return { ...state, isHistoryLoading: action.payload }
+    case "RECORD_COMMAND_OUTCOME":
+      return {
+        ...state,
+        commandOutcomes: {
+          ...state.commandOutcomes,
+          [action.payload.commandId]: action.payload.outcome,
+        },
+      }
+    case "RECORD_CLARIFICATION_SUBMISSION":
+      return {
+        ...state,
+        clarificationSubmissions: {
+          ...state.clarificationSubmissions,
+          [action.payload.requestId]: { commandId: action.payload.commandId },
+        },
+      }
+    case "CLEAR_CLARIFICATION_SUBMISSION": {
+      if (!(action.payload.requestId in state.clarificationSubmissions)) {
+        return state
+      }
+      const remaining = { ...state.clarificationSubmissions }
+      delete remaining[action.payload.requestId]
+      return { ...state, clarificationSubmissions: remaining }
+    }
 
     case "SYNC_PROCESSING_STATUS":
       if (shouldStopProcessingForTaskStatus(state.currentTask?.status)) {
@@ -5748,6 +5803,30 @@ export function AppProvider({
           ? t(clientErrorTranslationKey(agentErrorCode))
           : getWebSocketErrorMessage(message, trustLegacyErrorProse)
         const agentErrorTaskStatus = getWebSocketTaskStatus(message)
+
+        // A terminal frame for a durable command carries a structured
+        // disposition (#1500). Record it keyed by command id so the
+        // submitter of that exact command can make its retry decision;
+        // `resend_safe` is trusted only as a literal true, so frames from
+        // backends that predate the field stay in the unsafe reading.
+        const agentErrorData = asMessageRecord(message.data)
+        const terminalCommandId = agentErrorData.command_id
+        if (typeof terminalCommandId === "string" && terminalCommandId
+          && agentErrorData.outcome === "failed") {
+          dispatch({
+            type: "RECORD_COMMAND_OUTCOME",
+            payload: {
+              commandId: terminalCommandId,
+              outcome: {
+                outcome: "failed",
+                resendSafe: agentErrorData.resend_safe === true,
+                messageCode: typeof agentErrorData.message_code === "string"
+                  ? agentErrorData.message_code
+                  : null,
+              },
+            },
+          })
+        }
 
         if (agentErrorTaskStatus) {
           dispatch({

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -363,6 +363,8 @@ const en = {
       sendError: "Failed to send response",
       sendNotSent: "Your answers were kept — you can submit again.",
       sendOutcomeUnknown: "Your response may already have been submitted. Reload the conversation before submitting again.",
+      replyNotApplied: "Your reply was not applied to the task. You can submit it again.",
+      replyOutcomeUnknown: "We couldn't confirm whether your reply was applied. Review the conversation before submitting it again.",
       selectOption: "Select an option",
       selectOptions: "Select options",
       acceptedFormats: "Accepted formats",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -364,6 +364,7 @@ const en = {
       sendNotSent: "Your answers were kept — you can submit again.",
       sendOutcomeUnknown: "Your response may already have been submitted. Reload the conversation before submitting again.",
       replyNotApplied: "Your reply was not applied to the task. You can submit it again.",
+      replyPending: "Your reply was received and is still being applied.",
       replyOutcomeUnknown: "We couldn't confirm whether your reply was applied. Review the conversation before submitting it again.",
       selectOption: "Select an option",
       selectOptions: "Select options",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -364,6 +364,7 @@ const zh = {
       sendNotSent: "你填写的内容已保留，可以重新提交。",
       sendOutcomeUnknown: "回复可能已经提交，请刷新会话后再重新提交。",
       replyNotApplied: "你的回复未生效，可以重新提交。",
+      replyPending: "你的回复已收到，正在生效中。",
       replyOutcomeUnknown: "无法确认回复是否已生效，请先查看会话内容，再决定是否重新提交。",
       selectOption: "请选择一个选项",
       selectOptions: "请选择选项",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -363,6 +363,8 @@ const zh = {
       sendError: "发送回复失败",
       sendNotSent: "你填写的内容已保留，可以重新提交。",
       sendOutcomeUnknown: "回复可能已经提交，请刷新会话后再重新提交。",
+      replyNotApplied: "你的回复未生效，可以重新提交。",
+      replyOutcomeUnknown: "无法确认回复是否已生效，请先查看会话内容，再决定是否重新提交。",
       selectOption: "请选择一个选项",
       selectOptions: "请选择选项",
       acceptedFormats: "支持的格式",


### PR DESCRIPTION
## Summary

Part 2 of #1500 (frontend consumption; the wire contract is PR #2124). Closes #1500 when merged together with #2124.

- The clarification form no longer re-enables just because the task returned to `waiting_for_user`. While a durably accepted reply is outstanding, reactivation requires the structured terminal outcome broadcast for that exact command to prove the reply was not applied (`resend_safe`).
- The form mints its own client message id (the durable command id) and records the round's accountable submission in `AppContext` keyed by `request_id`, so the gate survives the submitting component instance being replaced (virtual waiting message vs. persisted timeline message rendering the same round).
- An ack-timeout (`outcome_unknown`) delivery records the submission too: the reply may still have been durably accepted, and its eventual terminal outcome gates the round the same way.
- A resend-safe outcome reactivates the existing form without reload, preserves the draft, shows a "not applied" notice, and consumes the record so the resend is armed exactly once. An outcome that cannot prove non-application locks the form with a persistent notice and the draft preserved; the chat input remains available for a deliberate fresh message.
- `AppContext` records terminal `agent_error` dispositions keyed by `command_id`. Exact-id correlation is what makes stale or cross-run outcomes inert; a late terminal event while the task is not waiting reopens nothing. The reactivation effect depends on per-round derived values, so an unrelated command's outcome cannot wipe a visible failure alert.

## Scope

**Reload-during-ambiguity is a documented non-goal** (added in review round 2): the gating maps are deliberately not persisted to browser storage — without the durable terminal-event replay (#1904), a reload that missed the outcome frame would rehydrate a locked entry whose terminal event is never re-broadcast, turning fail-open into fail-closed with no exit. Server-authoritative reconstruction of the gate across reloads is tracked in #2142, on the same arc as #2135 (durable events as the auto-gating authority) and #1904.

Review-round deferrals, each with a tracking issue: #2142 (reload gate reconstruction, P1), #2143 (prune the gating maps on task switch; clear orphaned entries, P2), #2144 (guard sendMessage post-delivery bookkeeping, P2).


- Rounds without a `request_id` (legacy backends) are deliberately not gated: with no round identity, a recorded reply could gate a different question. Their behavior is unchanged and pinned by a test.
- Frames without the structured fields (backends without #2124) stay in the unsafe reading: outcomes are simply never recorded, so an outstanding submission keeps the form conservative rather than inviting a duplicate.
- The builder `onSend` path has no durable command behind it and takes no part in outcome gating; unchanged.
- Surfacing an explicit "still in flight" notice before any terminal outcome exists is not implemented — the form stays collapsed, which satisfies the no-duplicate invariant; richer in-flight UX is left for follow-up if wanted.

## Acceptance criteria mapping (#1500)

- Correlation with the submission that produced the outcome: `command_id` == the form's minted client message id, stored per `request_id`.
- Proven-safe outcome + authoritative `waiting_for_user` → form reactivates without reload, draft preserved.
- Committed / in flight / unknown → terminal notice stays visible, no accidental duplicate submission.
- Established turn is not reopened by a late terminal event (regression test).
- Stale or cross-run outcomes are inert via exact-id correlation; task-state staleness guards are the pre-existing `UPDATE_TASK_STATUS` path, unchanged.
- Full-sequence regression coverage: accepted submit → terminal outcome → retry decision, for resend-safe, ambiguous, in-flight, instance-replacement, and legacy (no structured fields) variants.
- The same-run, same-version `waiting_for_user` reassertion behavior is retained (context-level regression test).

## Verification

- 208 tests across `clarification-form.test.tsx` (40) and `app-context-chat.test.tsx` (168) pass; full frontend vitest suite passes (exit 0).
- `tsc --noEmit` clean; the diff's added lines introduce 0 new eslint errors or warnings (line-level intersection against the `origin/main` baseline — the two touched hub files carry 66 pre-existing errors).

