### PR TITLE
feat(mcp): isolate actor OAuth runtime

### DIFF
--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -235,6 +235,10 @@ class BuiltinOAuthServerDefinitionError(ValueError):
     """Raised when trusted builtin OAuth identity is absent or ambiguous."""
 
 
+class RemoteOAuthServerDefinitionError(ValueError):
+    """Raised when a remote catalog OAuth server is not canonical."""
+
+
 def _normalized_catalog_key(value: object) -> str | None:
     """Normalize only for collision detection, never for persisted identity."""
     if value is None:
@@ -787,3 +791,86 @@ def get_app_for_mcp_server(db: Session, server: Any) -> Dict[str, Any] | None:
     if len(owners) != 1:
         return None
     return _app_to_dict(candidates[0])
+
+
+def classify_actor_remote_oauth_server(
+    db: Session, server: Any
+) -> Dict[str, Any] | None:
+    """Require one non-owned server that exactly matches remote catalog data."""
+
+    from .models.mcp import MCPServer, UserMCPServer
+    from .services.mcp_runtime import HTTP_MCP_TRANSPORTS
+
+    auth = getattr(server, "auth", None)
+    is_remote_oauth = (
+        str(getattr(server, "transport", "") or "").lower() in HTTP_MCP_TRANSPORTS
+        and isinstance(auth, Mapping)
+        and auth.get("type") == "mcp_oauth"
+    )
+    app_info = get_app_for_mcp_server(db, server)
+    if app_info is None or app_info.get("auth_type") != "mcp_oauth":
+        if is_remote_oauth:
+            # Native OAuth servers have an owner. Catalog rows do not.
+            has_owner = (
+                db.query(UserMCPServer.id)
+                .filter(
+                    UserMCPServer.mcpserver_id == int(server.id),
+                    UserMCPServer.is_owner,
+                )
+                .first()
+                is not None
+            )
+            if not has_owner:
+                raise RemoteOAuthServerDefinitionError(
+                    "remote OAuth catalog identity is unavailable"
+                )
+        return None
+    if not app_info.get("is_visible_in_connector", True):
+        raise RemoteOAuthServerDefinitionError("remote OAuth app is hidden")
+
+    app_id = str(app_info["id"])
+    app_name = str(app_info["name"])
+    # Remote catalog identity is the reserved server name, not mutable auth.
+    candidates = (
+        db.query(MCPServer).filter(MCPServer.name.in_((app_id, app_name))).all()
+    )
+    if len(candidates) != 1 or int(candidates[0].id) != int(server.id):
+        raise RemoteOAuthServerDefinitionError(
+            "remote OAuth app must have exactly one server definition"
+        )
+
+    launch = app_info.get("launch_config") or {}
+    expected_auth = launch.get("auth") or {}
+    decrypted_auth = server._decrypt_auth_config(server.auth)
+    if not isinstance(decrypted_auth, Mapping):
+        raise RemoteOAuthServerDefinitionError("remote OAuth auth is invalid")
+    actual_auth = dict(decrypted_auth)
+    actual_auth.pop("app_id", None)
+    failures = []
+    if str(server.managed or "") != "external":
+        failures.append("managed")
+    if (
+        str(server.transport or "").lower()
+        != str(app_info.get("transport") or "").lower()
+    ):
+        failures.append("transport")
+    if server.url != launch.get("url"):
+        failures.append("url")
+    if actual_auth != expected_auth:
+        failures.append("auth")
+    if (
+        db.query(UserMCPServer.id)
+        .filter(
+            UserMCPServer.mcpserver_id == int(server.id),
+            UserMCPServer.is_owner,
+        )
+        .first()
+        is not None
+    ):
+        failures.append("ownership")
+    if failures:
+        raise RemoteOAuthServerDefinitionError(
+            f"remote OAuth app {app_id!r} has non-canonical fields: "
+            f"{', '.join(sorted(failures))}"
+        )
+    return app_info

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -739,6 +739,17 @@ def ensure_builtin_oauth_server_visibility_for_user(
     return server
 
 
+def _get_app_for_server_name(db: Session, name: str) -> Dict[str, Any] | None:
+    candidates = (
+        db.query(PublicMCPApp)
+        .filter((PublicMCPApp.app_id == name) | (PublicMCPApp.name == name))
+        .all()
+    )
+    if len({str(candidate.app_id) for candidate in candidates}) != 1:
+        return None
+    return _app_to_dict(candidates[0])
+
+
 def get_app_for_mcp_server(db: Session, server: Any) -> Dict[str, Any] | None:
     """Resolve a server's catalog app by stable identity when it is available.
 
@@ -782,15 +793,7 @@ def get_app_for_mcp_server(db: Session, server: Any) -> Dict[str, Any] | None:
     # fails closed -- deletion keeps the credentials, listing and runtime
     # decline to name an app -- rather than acting on a coin flip. Only the
     # stamp settles it, which is what the branch above is for.
-    candidates = (
-        db.query(PublicMCPApp)
-        .filter((PublicMCPApp.app_id == name) | (PublicMCPApp.name == name))
-        .all()
-    )
-    owners = {str(candidate.app_id) for candidate in candidates}
-    if len(owners) != 1:
-        return None
-    return _app_to_dict(candidates[0])
+    return _get_app_for_server_name(db, name)
 
 
 def classify_actor_remote_oauth_server(
@@ -807,7 +810,7 @@ def classify_actor_remote_oauth_server(
         and isinstance(auth, Mapping)
         and auth.get("type") == "mcp_oauth"
     )
-    app_info = get_app_for_mcp_server(db, server)
+    app_info = _get_app_for_server_name(db, str(getattr(server, "name", "")))
     if app_info is None or app_info.get("auth_type") != "mcp_oauth":
         if is_remote_oauth:
             # Native OAuth servers have an owner. Catalog rows do not.

--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -7,6 +7,7 @@ their OAuth configurations, and server launch configurations.
 from collections.abc import Iterable, Mapping, Sequence
 from copy import deepcopy
 from dataclasses import dataclass
+from enum import Enum
 from typing import Any, Dict, List
 
 from sqlalchemy.exc import IntegrityError
@@ -237,6 +238,11 @@ class BuiltinOAuthServerDefinitionError(ValueError):
 
 class RemoteOAuthServerDefinitionError(ValueError):
     """Raised when a remote catalog OAuth server is not canonical."""
+
+
+class RemoteOAuthDefinitionOwnership(Enum):
+    UNKNOWN = "unknown"
+    TEAM = "team"
 
 
 def _normalized_catalog_key(value: object) -> str | None:
@@ -797,9 +803,14 @@ def get_app_for_mcp_server(db: Session, server: Any) -> Dict[str, Any] | None:
 
 
 def classify_actor_remote_oauth_server(
-    db: Session, server: Any
+    db: Session,
+    server: Any,
+    *,
+    definition_ownership: RemoteOAuthDefinitionOwnership = (
+        RemoteOAuthDefinitionOwnership.UNKNOWN
+    ),
 ) -> Dict[str, Any] | None:
-    """Require one non-owned server that exactly matches remote catalog data."""
+    """Validate catalog OAuth or preserve a proven custom definition."""
 
     from .models.mcp import MCPServer, UserMCPServer
     from .services.mcp_runtime import HTTP_MCP_TRANSPORTS
@@ -823,7 +834,10 @@ def classify_actor_remote_oauth_server(
                 .first()
                 is not None
             )
-            if not has_owner:
+            if (
+                not has_owner
+                and definition_ownership is not RemoteOAuthDefinitionOwnership.TEAM
+            ):
                 raise RemoteOAuthServerDefinitionError(
                     "remote OAuth catalog identity is unavailable"
                 )

--- a/src/xagent/web/services/connector_team_scope.py
+++ b/src/xagent/web/services/connector_team_scope.py
@@ -11,7 +11,7 @@ import logging
 from collections.abc import Callable, Collection, Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Literal, Protocol, TypeVar, cast
 
 from sqlalchemy.sql.elements import ColumnElement
 
@@ -72,6 +72,22 @@ ConnectorAccessHook = Callable[
 ]
 
 ConnectorVisibilityHook = Callable[[Any, int], dict[str, set[int]]]
+TEAM_OWNED_MCP_DEFINITIONS_KEY = "owned_mcp_definitions"
+
+
+@dataclass(frozen=True)
+class TeamConnectorSelection:
+    """Team-visible connector ids plus positive definition ownership."""
+
+    mcp_ids: frozenset[int]
+    custom_api_ids: frozenset[int]
+    owned_mcp_definition_ids: frozenset[int]
+
+    def connector_ids(self) -> dict[str, set[int]]:
+        return {
+            "mcp": set(self.mcp_ids),
+            "custom_api": set(self.custom_api_ids),
+        }
 
 
 class TeamConnectorVisibilityHook(Protocol):
@@ -99,6 +115,10 @@ class TeamConnectorVisibilityHook(Protocol):
     necessarily a member of that team even in deployments whose policy
     layer is otherwise membership-scoped. This is accepted platform
     behavior, not a defect this hook is meant to close.
+
+    The optional ``owned_mcp_definitions`` set marks MCP definitions the team
+    owns. It must be a subset of ``mcp``. Absence means no positive ownership
+    evidence; xagent never infers ownership from visibility alone.
 
     Every connector id a hook returns becomes executable by *any* runner of
     that team's agents, not only members: for stdio and other static-auth
@@ -203,10 +223,8 @@ def _validate_team_connector_answer(answer: Any) -> dict[str, set[int]]:
     ``set`` requirement is exact and deliberate: ``frozenset`` and other
     iterables are rejected too, matching the hook Protocol's declared
     ``set[int]`` rather than duck-typing around it.
-    Extra keys beyond the two required ones are accepted and silently
-    ignored: only ``"mcp"`` and ``"custom_api"`` are ever read by callers,
-    so this function does not iterate the answer's keys at all, only probe
-    the two it needs.
+    Extra keys beyond the two required ones are accepted here. The selection
+    validator separately checks the reserved ``owned_mcp_definitions`` key.
     """
     if not isinstance(answer, dict):
         raise ValueError(
@@ -238,6 +256,49 @@ def _validate_team_connector_answer(answer: Any) -> dict[str, set[int]]:
     return {"mcp": set(answer["mcp"]), "custom_api": set(answer["custom_api"])}
 
 
+def _validate_team_connector_selection(answer: Any) -> TeamConnectorSelection:
+    connector_ids = _validate_team_connector_answer(answer)
+    owned = answer.get(TEAM_OWNED_MCP_DEFINITIONS_KEY, set())
+    if not isinstance(owned, set):
+        raise ValueError(
+            "team visibility hook returned a malformed answer: key "
+            f"{TEAM_OWNED_MCP_DEFINITIONS_KEY!r} must be a set, got "
+            f"{type(owned).__name__}"
+        )
+    for member in owned:
+        if isinstance(member, bool) or not isinstance(member, int):
+            raise ValueError(
+                "team visibility hook returned a malformed answer: key "
+                f"{TEAM_OWNED_MCP_DEFINITIONS_KEY!r} contains a member "
+                f"{member!r} that is not a connector id (must be int, not bool)"
+            )
+    if not owned.issubset(connector_ids["mcp"]):
+        raise ValueError(
+            "team visibility hook returned definition ownership for a hidden MCP connector"
+        )
+    return TeamConnectorSelection(
+        mcp_ids=frozenset(connector_ids["mcp"]),
+        custom_api_ids=frozenset(connector_ids["custom_api"]),
+        owned_mcp_definition_ids=frozenset(owned),
+    )
+
+
+def team_connector_selection(db: Any, *, team_id: int | None) -> TeamConnectorSelection:
+    """Resolve team visibility and positive definition ownership once."""
+    if team_id is None or _team_connector_visibility_hook is None:
+        return TeamConnectorSelection(frozenset(), frozenset(), frozenset())
+    return cast(
+        TeamConnectorSelection,
+        _call_connector_hook_gate(
+            db,
+            _team_connector_visibility_hook,
+            db,
+            team_id=int(team_id),
+            validate=_validate_team_connector_selection,
+        ),
+    )
+
+
 def team_connector_ids(db: Any, *, team_id: int | None) -> dict[str, set[int]]:
     """Connector ids owned by ``team_id``; empty for no team and for standalone.
 
@@ -246,15 +307,7 @@ def team_connector_ids(db: Any, *, team_id: int | None) -> dict[str, set[int]]:
     hook. A non-``None`` answer is shape-validated (see
     ``_validate_team_connector_answer``) before it reaches any caller.
     """
-    if team_id is None or _team_connector_visibility_hook is None:
-        return {"mcp": set(), "custom_api": set()}
-    return _call_connector_hook_gate(
-        db,
-        _team_connector_visibility_hook,
-        db,
-        team_id=int(team_id),
-        validate=_validate_team_connector_answer,
-    )
+    return team_connector_selection(db, team_id=team_id).connector_ids()
 
 
 def team_connector_hook_installed() -> bool:
@@ -601,6 +654,28 @@ def _call_connector_hook_gate(
         raise
 
 
+def resolve_team_connector_selection_or_raise(
+    db: Any, *, team_id: int | None, log_subject: int | None
+) -> TeamConnectorSelection:
+    """Resolve team connector visibility and provenance with a typed failure."""
+    try:
+        return team_connector_selection(db, team_id=team_id)
+    except ConnectorRuntimeError:
+        raise
+    except Exception as exc:
+        logger.warning(
+            "Failed to resolve team connector scope for user %s",
+            log_subject,
+            exc_info=True,
+        )
+        raise ConnectorRuntimeError(
+            ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
+            "Connector team scope is unavailable.",
+            details={"reason": "team_scope_resolution_failed"},
+            status_code=503,
+        ) from exc
+
+
 def resolve_team_connector_ids_or_raise(
     db: Any, *, team_id: int | None, log_subject: int | None
 ) -> dict[str, set[int]]:
@@ -636,22 +711,11 @@ def resolve_team_connector_ids_or_raise(
     rejects. Neither is something the generic-exception arm below could
     own, and both are restored before either arm sees the exception.
     """
-    try:
-        return team_connector_ids(db, team_id=team_id)
-    except ConnectorRuntimeError:
-        raise
-    except Exception as exc:
-        logger.warning(
-            "Failed to resolve team connector scope for user %s",
-            log_subject,
-            exc_info=True,
-        )
-        raise ConnectorRuntimeError(
-            ERROR_CONNECTOR_RUNTIME_UNAVAILABLE,
-            "Connector team scope is unavailable.",
-            details={"reason": "team_scope_resolution_failed"},
-            status_code=503,
-        ) from exc
+    return resolve_team_connector_selection_or_raise(
+        db,
+        team_id=team_id,
+        log_subject=log_subject,
+    ).connector_ids()
 
 
 def resolve_connector_access_or_raise(

--- a/src/xagent/web/services/mcp_oauth.py
+++ b/src/xagent/web/services/mcp_oauth.py
@@ -873,6 +873,30 @@ async def _refresh_runtime_grant_in_dedicated_session(  # noqa: PLR0913
         refresh_db.close()
 
 
+def select_mcp_oauth_owner(
+    db: Any,
+    *,
+    server_id: int,
+    user_id: int,
+    actor_owner_key: str,
+    auth_config: dict[str, Any],
+) -> str:
+    """Prefer one usable exact actor grant, otherwise use the workspace owner."""
+
+    actor_grants = select_mcp_oauth_grants(
+        db,
+        server_id=server_id,
+        user_id=user_id,
+        auth_config=auth_config,
+        resource_owner_key=actor_owner_key,
+    )
+    try:
+        _select_runtime_grant(actor_grants, set())
+    except MCPOAuthRuntimeError:
+        return f"xagent:user:{user_id}"
+    return actor_owner_key
+
+
 def select_mcp_oauth_grants(  # noqa: PLR0913
     db: Any,
     *,

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -26,10 +26,11 @@ class MCPBuiltinOAuthActorPolicyMismatchError(RuntimeError):
 
 @dataclass(frozen=True)
 class MCPBuiltinOAuthActorPolicy:
-    """Trusted actor owner namespace for builtin OAuth MCP execution.
+    """Trusted actor owner namespace for catalog OAuth MCP execution.
 
-    Server visibility and builtin classification remain xagent runtime
-    decisions. The caller supplies only the immutable credential owner.
+    Server visibility and catalog classification remain xagent runtime
+    decisions. The caller supplies only the immutable credential owner. The
+    owner governs both builtin-provider and remote MCP OAuth credentials.
     """
 
     resource_owner_key: str = dataclass_field(repr=False)

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -4227,7 +4227,11 @@ class WebToolConfig(BaseToolConfig):
                 app_info = (
                     dict(actor_catalog_app_info)
                     if actor_catalog_app_info is not None
-                    else None
+                    else (
+                        get_app_for_mcp_server(self.db, server)
+                        if resolver is not None
+                        else None
+                    )
                 )
             else:
                 app_info = (
@@ -4497,13 +4501,16 @@ class WebToolConfig(BaseToolConfig):
         # for "the scope could not be resolved". The typed error is what
         # survives the tool-creator frame -- an untyped one is dropped there
         # with a WARNING and no tool set at all.
-        from ..services.connector_team_scope import resolve_team_connector_ids_or_raise
-
-        team_mcp_ids = frozenset(
-            resolve_team_connector_ids_or_raise(
-                self.db, team_id=self._connector_team_id, log_subject=self._user_id
-            )["mcp"]
+        from ..services.connector_team_scope import (
+            resolve_team_connector_selection_or_raise,
         )
+
+        team_selection = resolve_team_connector_selection_or_raise(
+            self.db,
+            team_id=self._connector_team_id,
+            log_subject=self._user_id,
+        )
+        team_mcp_ids = team_selection.mcp_ids
 
         try:
             from ..services.mcp_runtime import (
@@ -4532,6 +4539,7 @@ class WebToolConfig(BaseToolConfig):
             if self._mcp_runtime_authorization_policy is not None:
                 from ...web.mcp_apps import (
                     BuiltinOAuthServerDefinitionError,
+                    RemoteOAuthDefinitionOwnership,
                     RemoteOAuthServerDefinitionError,
                     classify_actor_builtin_oauth_server,
                     classify_actor_remote_oauth_server,
@@ -4544,7 +4552,14 @@ class WebToolConfig(BaseToolConfig):
                         )
                         if catalog_app is None:
                             catalog_app = classify_actor_remote_oauth_server(
-                                self.db, visible_server
+                                self.db,
+                                visible_server,
+                                definition_ownership=(
+                                    RemoteOAuthDefinitionOwnership.TEAM
+                                    if int(visible_server.id)
+                                    in team_selection.owned_mcp_definition_ids
+                                    else RemoteOAuthDefinitionOwnership.UNKNOWN
+                                ),
                             )
                         actor_classifications[int(visible_server.id)] = (
                             catalog_app,

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -4211,22 +4211,77 @@ class WebToolConfig(BaseToolConfig):
 
         elif server.transport in ["sse", "websocket", "streamable_http"]:
             from ...web.mcp_apps import get_app_for_mcp_server
+            from ...web.services.mcp_oauth import select_mcp_oauth_owner
             from ...web.services.mcp_runtime import (
                 build_mcp_runtime_connection,
                 connection_to_transport_config,
                 effective_mcp_oauth_resource,
             )
 
+            resolver, registration_generation = _get_oauth_token_resolver_hook()
+            policy = self._mcp_runtime_authorization_policy
+            app_info = (
+                get_app_for_mcp_server(self.db, server)
+                if policy is not None or resolver is not None
+                else None
+            )
+            actor_remote_oauth = bool(
+                policy is not None
+                and app_info is not None
+                and app_info.get("auth_type") == "mcp_oauth"
+            )
+            if actor_remote_oauth:
+                runtime_bindings = None
+                allow_delegated_authorization = False
+                runtime_values = None
+                for key in (
+                    "runtime_input_schema",
+                    "runtime_bindings",
+                    "allow_delegated_authorization",
+                    "connector_runtime",
+                ):
+                    config.pop(key, None)
+            if actor_remote_oauth and (self._mcp_auth_context or {}).get(
+                str(server.id)
+            ):
+                policy_diagnostic = {
+                    "code": "config_load_failed",
+                    "message": "Task-supplied MCP authorization is not accepted",
+                    "server_id": int(server.id),
+                    "server_name": server.name,
+                }
+                self._mcp_oauth_diagnostics.append(policy_diagnostic)
+                return self._build_unavailable_mcp_config(
+                    server=server,
+                    reason="config_load_failed",
+                    diagnostic=policy_diagnostic,
+                )
+
             auth_context = self._mcp_auth_context_for_server(
                 server_id=int(server.id),
                 runtime_values=runtime_values,
             )
-            resolver, registration_generation = _get_oauth_token_resolver_hook()
+            if actor_remote_oauth:
+                policy = cast(
+                    Any,
+                    self._mcp_runtime_authorization_policy,
+                )
+                auth_context = {
+                    str(server.id): {
+                        "resource_owner_key": select_mcp_oauth_owner(
+                            self.db,
+                            server_id=int(server.id),
+                            user_id=int(cast(int, self._user_id)),
+                            actor_owner_key=policy.resource_owner_key,
+                            auth_config=server._decrypt_auth_config(server.auth),
+                        )
+                    }
+                }
+
             remote_providers_to_resolve: list[str] = []
             remote_configured_resource: str | None = None
             remote_hook_token: _ResolvedHookToken | None = None
-            if resolver is not None:
-                app_info = get_app_for_mcp_server(self.db, server)
+            if resolver is not None and not actor_remote_oauth:
                 remote_providers_to_resolve = (
                     _oauth_token_provider_candidates(app_info)
                     if app_info
@@ -4469,18 +4524,26 @@ class WebToolConfig(BaseToolConfig):
             if self._mcp_runtime_authorization_policy is not None:
                 from ...web.mcp_apps import (
                     BuiltinOAuthServerDefinitionError,
+                    RemoteOAuthServerDefinitionError,
                     classify_actor_builtin_oauth_server,
+                    classify_actor_remote_oauth_server,
                 )
 
                 for visible_server in servers:
                     try:
+                        builtin_app = classify_actor_builtin_oauth_server(
+                            self.db, visible_server
+                        )
+                        if builtin_app is None:
+                            classify_actor_remote_oauth_server(self.db, visible_server)
                         actor_classifications[int(visible_server.id)] = (
-                            classify_actor_builtin_oauth_server(
-                                self.db, visible_server
-                            ),
+                            builtin_app,
                             False,
                         )
-                    except BuiltinOAuthServerDefinitionError:
+                    except (
+                        BuiltinOAuthServerDefinitionError,
+                        RemoteOAuthServerDefinitionError,
+                    ):
                         actor_classifications[int(visible_server.id)] = (None, True)
 
             # Prefetch shared runtime state once before entering the isolated

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -4394,6 +4394,13 @@ class WebToolConfig(BaseToolConfig):
                             diagnostic=diagnostic,
                             failure_code="oauth_token_required",
                         )
+                    if actor_remote_oauth:
+                        # Actor catalog execution trusts only its selected bearer.
+                        runtime_build.connection["headers"] = {
+                            "Authorization": runtime_build.connection["headers"][
+                                "Authorization"
+                            ]
+                        }
                     transport_config.update(
                         connection_to_transport_config(runtime_build.connection)
                     )

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -3972,11 +3972,14 @@ class WebToolConfig(BaseToolConfig):
         user_env_by_id: Mapping[int, Any],
         shared_env_by_id: Mapping[int, Any],
         env_source_by_id: Mapping[int, Any],
-        actor_builtin_app_info: Mapping[str, Any] | None = None,
+        actor_catalog_app_info: Mapping[str, Any] | None = None,
         actor_builtin_invalid: bool = False,
     ) -> Dict[str, Any]:
         """Build one MCP server config, preserving explicit unavailable outcomes."""
-        actor_builtin = actor_builtin_app_info is not None
+        actor_builtin = bool(
+            actor_catalog_app_info is not None
+            and actor_catalog_app_info.get("auth_type") == "builtin_oauth"
+        )
         if actor_builtin_invalid:
             policy_diagnostic = {
                 "code": "config_load_failed",
@@ -4026,8 +4029,8 @@ class WebToolConfig(BaseToolConfig):
             "name": server.name,
             "transport": server.transport,
             "description": (
-                actor_builtin_app_info.get("description")
-                if actor_builtin_app_info is not None
+                actor_catalog_app_info.get("description")
+                if actor_catalog_app_info is not None
                 else server.description
             ),
         }
@@ -4055,8 +4058,8 @@ class WebToolConfig(BaseToolConfig):
             from ...web.mcp_apps import get_app_for_mcp_server
 
             app_info = (
-                dict(actor_builtin_app_info)
-                if actor_builtin_app_info is not None
+                dict(actor_catalog_app_info)
+                if actor_catalog_app_info is not None
                 else get_app_for_mcp_server(self.db, server)
             )
             if app_info is None:
@@ -4220,15 +4223,20 @@ class WebToolConfig(BaseToolConfig):
 
             resolver, registration_generation = _get_oauth_token_resolver_hook()
             policy = self._mcp_runtime_authorization_policy
-            app_info = (
-                get_app_for_mcp_server(self.db, server)
-                if policy is not None or resolver is not None
-                else None
-            )
-            actor_remote_oauth = bool(
-                policy is not None
-                and app_info is not None
-                and app_info.get("auth_type") == "mcp_oauth"
+            if policy is not None:
+                app_info = (
+                    dict(actor_catalog_app_info)
+                    if actor_catalog_app_info is not None
+                    else None
+                )
+            else:
+                app_info = (
+                    get_app_for_mcp_server(self.db, server)
+                    if resolver is not None
+                    else None
+                )
+            actor_remote_oauth = (
+                policy is not None and actor_catalog_app_info is not None
             )
             if actor_remote_oauth:
                 runtime_bindings = None
@@ -4429,7 +4437,7 @@ class WebToolConfig(BaseToolConfig):
         user_env_by_id: Mapping[int, Any],
         shared_env_by_id: Mapping[int, Any],
         env_source_by_id: Mapping[int, Any],
-        actor_builtin_app_info: Mapping[str, Any] | None = None,
+        actor_catalog_app_info: Mapping[str, Any] | None = None,
         actor_builtin_invalid: bool = False,
     ) -> Dict[str, Any]:
         """Isolate unexpected failures while loading one MCP server config."""
@@ -4439,7 +4447,7 @@ class WebToolConfig(BaseToolConfig):
                 user_env_by_id=user_env_by_id,
                 shared_env_by_id=shared_env_by_id,
                 env_source_by_id=env_source_by_id,
-                actor_builtin_app_info=actor_builtin_app_info,
+                actor_catalog_app_info=actor_catalog_app_info,
                 actor_builtin_invalid=actor_builtin_invalid,
             )
         except ConnectorRuntimeError:
@@ -4531,13 +4539,15 @@ class WebToolConfig(BaseToolConfig):
 
                 for visible_server in servers:
                     try:
-                        builtin_app = classify_actor_builtin_oauth_server(
+                        catalog_app = classify_actor_builtin_oauth_server(
                             self.db, visible_server
                         )
-                        if builtin_app is None:
-                            classify_actor_remote_oauth_server(self.db, visible_server)
+                        if catalog_app is None:
+                            catalog_app = classify_actor_remote_oauth_server(
+                                self.db, visible_server
+                            )
                         actor_classifications[int(visible_server.id)] = (
-                            builtin_app,
+                            catalog_app,
                             False,
                         )
                     except (
@@ -4620,7 +4630,7 @@ class WebToolConfig(BaseToolConfig):
                 user_env_by_id=user_env_by_id,
                 shared_env_by_id=shared_env_by_id,
                 env_source_by_id=env_source_by_id,
-                actor_builtin_app_info=actor_classifications.get(
+                actor_catalog_app_info=actor_classifications.get(
                     int(server.id), (None, False)
                 )[0],
                 actor_builtin_invalid=actor_classifications.get(

--- a/tests/web/tools/test_mcp_actor_owner_runtime.py
+++ b/tests/web/tools/test_mcp_actor_owner_runtime.py
@@ -21,11 +21,16 @@ from xagent.web.models.user_oauth import UserOAuth
 from xagent.web.services import connector_team_scope
 from xagent.web.services.mcp_runtime import MCPBuiltinOAuthActorPolicy
 from xagent.web.tools import config as web_tools_config
-from xagent.web.tools.config import WebToolConfig
+from xagent.web.tools.config import (
+    ResolvedToken,
+    WebToolConfig,
+    set_oauth_token_resolver_hook,
+)
 
 OWNER_A = "toby:slack:team:actor-a"
 OWNER_B = "toby:slack:team:actor-b"
 APP_ID = "actor-drive"
+REMOTE_APP_ID = "actor-remote"
 APP_EXECUTION = {
     "name": "Actor Drive",
     "transport": "oauth",
@@ -116,6 +121,87 @@ def _add_builtin_server(
     return server
 
 
+def _add_remote_server(db: Session, user: User) -> MCPServer:
+    app = PublicMCPApp(
+        app_id=REMOTE_APP_ID,
+        name="Actor Remote",
+        transport="streamable_http",
+        launch_config={
+            "url": "https://mcp.example.com/mcp",
+            "auth": {
+                "type": "mcp_oauth",
+                "resource": "https://mcp.example.com/mcp",
+                "issuer": "https://auth.example.com",
+                "scope": "records.read",
+                "client_id": "actor-client",
+            },
+        },
+        is_visible_in_connector=True,
+    )
+    server = MCPServer.from_config(
+        {
+            "name": REMOTE_APP_ID,
+            "managed": "external",
+            "transport": "streamable_http",
+            "url": "https://mcp.example.com/mcp",
+            "auth": dict(app.launch_config["auth"]),
+        }
+    )
+    db.add_all([app, server])
+    db.flush()
+    db.add(
+        UserMCPServer(
+            user_id=int(user.id),
+            mcpserver_id=int(server.id),
+            is_owner=False,
+            is_active=True,
+        )
+    )
+    db.commit()
+    return server
+
+
+def _add_remote_grant(
+    db: Session,
+    user: User,
+    server: MCPServer,
+    *,
+    owner: str,
+    token: str,
+) -> MCPOAuthGrant:
+    client = (
+        db.query(MCPOAuthClient)
+        .filter(MCPOAuthClient.mcp_server_id == int(server.id))
+        .one_or_none()
+    )
+    if client is None:
+        client = MCPOAuthClient(
+            mcp_server_id=int(server.id),
+            issuer="https://auth.example.com",
+            authorization_endpoint="https://auth.example.com/authorize",
+            token_endpoint="https://auth.example.com/token",
+            client_id="actor-client",
+            token_endpoint_auth_method="none",
+            redirect_uri="https://xagent.example.com/api/mcp/oauth/callback",
+        )
+        db.add(client)
+        db.flush()
+    grant = MCPOAuthGrant(
+        mcp_server_id=int(server.id),
+        user_id=int(user.id),
+        mcp_oauth_client_id=int(client.id),
+        resource_owner_key=owner,
+        issuer="https://auth.example.com",
+        resource="https://mcp.example.com/mcp",
+        scope="records.read",
+        access_token=encrypt_value(token),
+        status="active",
+    )
+    db.add(grant)
+    db.commit()
+    return grant
+
+
 def _add_actor_credential(
     db: Session,
     user: User,
@@ -173,6 +259,319 @@ def test_actor_policy_is_frozen_normalized_and_owner_only() -> None:
 def test_actor_policy_rejects_invalid_owner(value: object) -> None:
     with pytest.raises((TypeError, ValueError)):
         MCPBuiltinOAuthActorPolicy(resource_owner_key=value)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_prefers_exact_owner_over_workspace_grant(
+    db_session,
+) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=f"xagent:user:{db_session.user.id}",
+        token="workspace-token",
+    )
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_A,
+        token="actor-token",
+    )
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["config"]["headers"]["Authorization"] == "Bearer actor-token"
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_falls_back_to_workspace_grant(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=f"xagent:user:{db_session.user.id}",
+        token="workspace-token",
+    )
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["config"]["headers"]["Authorization"] == "Bearer workspace-token"
+
+
+@pytest.mark.parametrize("stale_kind", ["expired", "scope"])
+@pytest.mark.asyncio
+async def test_actor_remote_falls_back_from_unusable_actor_grant(
+    db_session, stale_kind
+) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=f"xagent:user:{db_session.user.id}",
+        token="workspace-token",
+    )
+    actor_grant = _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_A,
+        token="stale-actor-token",
+    )
+    if stale_kind == "expired":
+        actor_grant.expires_at = datetime.now(timezone.utc) - timedelta(minutes=1)
+    else:
+        actor_grant.scope = "old.read"
+    db_session.db.commit()
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["config"]["headers"]["Authorization"] == "Bearer workspace-token"
+    assert "stale-actor-token" not in str(configs)
+
+
+@pytest.mark.parametrize("drift", ["url", "transport", "auth", "managed", "ownership"])
+@pytest.mark.asyncio
+async def test_actor_remote_rejects_drifted_catalog_server(db_session, drift) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_A,
+        token="actor-token",
+    )
+    if drift == "url":
+        server.url = "https://attacker.example/mcp"
+    elif drift == "transport":
+        server.transport = "sse"
+    elif drift == "auth":
+        server.auth = {**server.auth, "scope": "records.write"}
+    elif drift == "managed":
+        server.managed = "internal"
+    elif drift == "ownership":
+        association = db_session.db.query(UserMCPServer).one()
+        association.is_owner = True
+    db_session.db.commit()
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert "actor-token" not in str(configs)
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_marks_missing_auth_unavailable(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    server.auth = None
+    db_session.db.commit()
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert configs[0]["config"]["reason"] == "config_load_failed"
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_ignores_foreign_auth_app_id(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_A,
+        token="actor-token",
+    )
+    attacker = User(username="foreign-user", password_hash="x", is_admin=False)
+    foreign_server = MCPServer.from_config(
+        {
+            "name": "foreign-server",
+            "managed": "external",
+            "transport": "streamable_http",
+            "url": "https://attacker.example/mcp",
+            "auth": {"app_id": REMOTE_APP_ID},
+        }
+    )
+    db_session.db.add_all([attacker, foreign_server])
+    db_session.db.flush()
+    db_session.db.add(
+        UserMCPServer(
+            user_id=int(attacker.id),
+            mcpserver_id=int(foreign_server.id),
+            is_active=True,
+            is_owner=True,
+        )
+    )
+    db_session.db.commit()
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert len(configs) == 1
+    assert configs[0]["config"]["headers"]["Authorization"] == "Bearer actor-token"
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_rejects_unverifiable_catalog_identity(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    server.name = "renamed-remote"
+    db_session.db.commit()
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=f"xagent:user:{db_session.user.id}",
+        token="workspace-token",
+    )
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert configs[0]["config"]["reason"] == "config_load_failed"
+    assert "workspace-token" not in str(configs)
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_rejects_catalog_auth_reclassification(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    app = (
+        db_session.db.query(PublicMCPApp)
+        .filter(PublicMCPApp.app_id == REMOTE_APP_ID)
+        .one()
+    )
+    app.launch_config = {
+        **app.launch_config,
+        "auth": {"type": "api_key"},
+    }
+    db_session.db.commit()
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=f"xagent:user:{db_session.user.id}",
+        token="workspace-token",
+    )
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert configs[0]["config"]["reason"] == "config_load_failed"
+    assert "workspace-token" not in str(configs)
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_never_uses_another_actor_grant(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_B,
+        token="other-actor-token",
+    )
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert "other-actor-token" not in str(configs)
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_rejects_task_supplied_owner(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_A,
+        token="actor-token",
+    )
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_B,
+        token="other-actor-token",
+    )
+
+    configs = await _config(
+        db_session,
+        policy=_policy(),
+        mcp_auth_context={str(server.id): {"resource_owner_key": OWNER_B}},
+    ).get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert configs[0]["config"]["reason"] == "config_load_failed"
+    assert "other-actor-token" not in str(configs)
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_ignores_delegated_authorization(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_A,
+        token="actor-token",
+    )
+    server.runtime_bindings = [
+        {
+            "source": {"input_type": "secrets", "key": "authorization"},
+            "target": {
+                "target_type": "transport_headers",
+                "key": "Authorization",
+            },
+        }
+    ]
+    server.allow_delegated_authorization = True
+    db_session.db.commit()
+    tool_config = _config(db_session, policy=_policy())
+    tool_config._connector_runtime_view = {
+        f"mcp:{server.id}": {
+            "context": {"account": "task-context"},
+            "secrets": {"authorization": "Bearer task-token"},
+            "auth_selector": {},
+        }
+    }
+
+    configs = await tool_config.get_mcp_server_configs()
+
+    assert configs[0]["config"]["headers"]["Authorization"] == "Bearer actor-token"
+    assert "task-token" not in str(configs)
+    assert "connector_runtime" not in configs[0]
+    assert "runtime_bindings" not in configs[0]
+
+
+@pytest.mark.asyncio
+async def test_actor_remote_ignores_resolver_hook(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_A,
+        token="actor-token",
+    )
+    calls = 0
+
+    async def resolver(_request) -> ResolvedToken:
+        nonlocal calls
+        calls += 1
+        return ResolvedToken(access_token="resolver-token")
+
+    set_oauth_token_resolver_hook(resolver)
+    try:
+        configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+    finally:
+        set_oauth_token_resolver_hook(None)
+
+    assert calls == 0
+    assert configs[0]["config"]["headers"]["Authorization"] == "Bearer actor-token"
+    assert "resolver-token" not in str(configs)
 
 
 @pytest.mark.asyncio

--- a/tests/web/tools/test_mcp_actor_owner_runtime.py
+++ b/tests/web/tools/test_mcp_actor_owner_runtime.py
@@ -415,6 +415,54 @@ async def test_actor_remote_ignores_foreign_auth_app_id(db_session) -> None:
 
 
 @pytest.mark.asyncio
+async def test_actor_policy_preserves_owned_custom_app_id_collision(db_session) -> None:
+    _add_remote_server(db_session.db, db_session.user)
+    custom_server = MCPServer.from_config(
+        {
+            "name": "custom-remote",
+            "managed": "external",
+            "transport": "streamable_http",
+            "url": "https://custom.example.com/mcp",
+            "auth": {
+                "type": "mcp_oauth",
+                "app_id": REMOTE_APP_ID,
+                "resource": "https://mcp.example.com/mcp",
+                "issuer": "https://auth.example.com",
+                "scope": "records.read",
+                "client_id": "actor-client",
+            },
+        }
+    )
+    db_session.db.add(custom_server)
+    db_session.db.flush()
+    db_session.db.add(
+        UserMCPServer(
+            user_id=int(db_session.user.id),
+            mcpserver_id=int(custom_server.id),
+            is_active=True,
+            is_owner=True,
+        )
+    )
+    db_session.db.commit()
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        custom_server,
+        owner=f"xagent:user:{db_session.user.id}",
+        token="custom-token",
+    )
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    custom_config = next(
+        config for config in configs if config["name"] == custom_server.name
+    )
+    assert custom_config["config"]["headers"]["Authorization"] == (
+        "Bearer custom-token"
+    )
+
+
+@pytest.mark.asyncio
 async def test_actor_remote_rejects_unverifiable_catalog_identity(db_session) -> None:
     server = _add_remote_server(db_session.db, db_session.user)
     server.name = "renamed-remote"

--- a/tests/web/tools/test_mcp_actor_owner_runtime.py
+++ b/tests/web/tools/test_mcp_actor_owner_runtime.py
@@ -365,6 +365,24 @@ async def test_actor_remote_rejects_drifted_catalog_server(db_session, drift) ->
 
 
 @pytest.mark.asyncio
+async def test_actor_remote_strips_non_catalog_headers(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    _add_remote_grant(
+        db_session.db,
+        db_session.user,
+        server,
+        owner=OWNER_A,
+        token="actor-token",
+    )
+    server.headers = {"Host": "attacker.example", "Cookie": "session=secret"}
+    db_session.db.commit()
+
+    configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+
+    assert configs[0]["config"]["headers"] == {"Authorization": "Bearer actor-token"}
+
+
+@pytest.mark.asyncio
 async def test_actor_remote_marks_missing_auth_unavailable(db_session) -> None:
     server = _add_remote_server(db_session.db, db_session.user)
     server.auth = None

--- a/tests/web/tools/test_mcp_actor_owner_runtime.py
+++ b/tests/web/tools/test_mcp_actor_owner_runtime.py
@@ -463,6 +463,124 @@ async def test_actor_policy_preserves_owned_custom_app_id_collision(db_session) 
 
 
 @pytest.mark.asyncio
+async def test_actor_policy_preserves_custom_resolver_candidates(db_session) -> None:
+    _add_remote_server(db_session.db, db_session.user)
+    app = (
+        db_session.db.query(PublicMCPApp)
+        .filter(PublicMCPApp.app_id == REMOTE_APP_ID)
+        .one()
+    )
+    app.provider_name = "records-provider"
+    custom_server = MCPServer.from_config(
+        {
+            "name": "custom-resolver-remote",
+            "managed": "external",
+            "transport": "streamable_http",
+            "url": "https://custom.example.com/mcp",
+            "auth": {"type": "mcp_oauth", "app_id": REMOTE_APP_ID},
+        }
+    )
+    db_session.db.add(custom_server)
+    db_session.db.flush()
+    db_session.db.add(
+        UserMCPServer(
+            user_id=int(db_session.user.id),
+            mcpserver_id=int(custom_server.id),
+            is_active=True,
+            is_owner=True,
+        )
+    )
+    db_session.db.commit()
+    providers = []
+
+    async def resolver(request) -> ResolvedToken | None:
+        providers.append(request.provider)
+        if request.provider == "records-provider":
+            return ResolvedToken(access_token="resolver-token")
+        return None
+
+    set_oauth_token_resolver_hook(resolver)
+    try:
+        configs = await _config(db_session, policy=_policy()).get_mcp_server_configs()
+    finally:
+        set_oauth_token_resolver_hook(None)
+
+    custom_config = next(
+        config for config in configs if config["name"] == custom_server.name
+    )
+    assert providers == ["records-provider"]
+    assert custom_config["config"]["headers"]["Authorization"] == (
+        "Bearer resolver-token"
+    )
+
+
+@pytest.mark.asyncio
+async def test_actor_policy_preserves_team_owned_custom_oauth(db_session) -> None:
+    custom_server = MCPServer.from_config(
+        {
+            "name": "retained-team-custom",
+            "managed": "external",
+            "transport": "streamable_http",
+            "url": "https://team.example.com/mcp",
+            "auth": {"type": "mcp_oauth"},
+        }
+    )
+    db_session.db.add(custom_server)
+    db_session.db.commit()
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=lambda _db, *, team_id: {
+            "mcp": {int(custom_server.id)} if team_id == 41 else set(),
+            "custom_api": set(),
+            "owned_mcp_definitions": {int(custom_server.id)},
+        }
+    )
+
+    async def resolver(request) -> ResolvedToken | None:
+        if request.provider == custom_server.name:
+            return ResolvedToken(access_token="team-custom-token")
+        return None
+
+    set_oauth_token_resolver_hook(resolver)
+    try:
+        configs = await _config(
+            db_session,
+            policy=_policy(),
+            connector_team_id=41,
+        ).get_mcp_server_configs()
+    finally:
+        set_oauth_token_resolver_hook(None)
+
+    assert configs[0]["name"] == custom_server.name
+    assert configs[0]["config"]["headers"]["Authorization"] == (
+        "Bearer team-custom-token"
+    )
+
+
+@pytest.mark.asyncio
+async def test_actor_policy_rejects_unowned_team_catalog_drift(db_session) -> None:
+    server = _add_remote_server(db_session.db, db_session.user)
+    db_session.db.query(UserMCPServer).delete()
+    server.name = "renamed-team-catalog"
+    db_session.db.commit()
+    connector_team_scope.set_connector_team_hooks(
+        team_visibility=lambda _db, *, team_id: {
+            "mcp": {int(server.id)} if team_id == 41 else set(),
+            "custom_api": set(),
+            "owned_mcp_definitions": set(),
+        }
+    )
+
+    configs = await _config(
+        db_session,
+        policy=_policy(),
+        connector_team_id=41,
+    ).get_mcp_server_configs()
+
+    assert configs[0]["transport"] == "unavailable"
+    assert configs[0]["config"]["reason"] == "config_load_failed"
+
+
+@pytest.mark.asyncio
 async def test_actor_remote_rejects_unverifiable_catalog_identity(db_session) -> None:
     server = _add_remote_server(db_session.db, db_session.user)
     server.name = "renamed-remote"


### PR DESCRIPTION
## Intention

Bind remote catalog MCP OAuth authorization to the exact trusted actor owner at runtime.

## Boundary

- Classify actor-accessible remote OAuth servers against canonical catalog configuration.
- Select a usable exact-actor grant, with the default workspace owner as fallback.
- Reject task-supplied owner overrides.
- Suppress delegated authorization, connector runtime credentials, and external OAuth resolvers for actor OAuth.
- Return unavailable connector configuration when canonical classification fails.

## Rejected behavior

- Actor tokens cannot be selected from another owner namespace.
- Mutable server URLs, transports, ownership, or OAuth configuration cannot inherit catalog actor credentials.
- Task input and resolver hooks cannot replace actor-owned authorization.
- Invalid actor OAuth servers do not fall through to weaker runtime behavior.

## Accepted errors and trade-offs

- Invalid canonical configuration produces `config_load_failed` instead of starting the connector.
- Runtime falls back to a usable default-owner grant only when no usable exact-actor grant exists.
- Custom and installer-owned MCP OAuth servers keep their existing non-catalog behavior.

## Verification

- 319 focused OAuth and actor-runtime tests
- Ruff check and format
- Mypy
