### PR TITLE
fix: allow attached-task output downloads

### DIFF
--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -755,6 +755,12 @@ def _validate_public_task_file_access(
     file_record: UploadedFile,
     token: str | None,
 ) -> None:
+    """Apply guest-token isolation without changing normal file capabilities.
+
+    Ordinary signed-in tasks use the unguessable file ID as the capability for
+    public preview and download URLs. Share and widget tasks additionally bind
+    file access to a signed guest token, which must resolve to the same task.
+    """
     if not file_record.task_id:
         return
 

--- a/src/xagent/web/api/files.py
+++ b/src/xagent/web/api/files.py
@@ -762,11 +762,13 @@ def _validate_public_task_file_access(
     if not task or not isinstance(task.agent_config, dict):
         return
 
-    if not token:
-        raise HTTPException(status_code=403, detail="Public file access token required")
     auth_mode = task.agent_config.get("auth_mode")
 
     if auth_mode == "share":
+        if not token:
+            raise HTTPException(
+                status_code=403, detail="Public file access token required"
+            )
         from .public_chat_access import get_share_chat_user, get_task_for_share_context
 
         access_context = get_share_chat_user(token, db)
@@ -776,6 +778,9 @@ def _validate_public_task_file_access(
     guest_id = task.agent_config.get("guest_id")
     if not isinstance(guest_id, str) or not guest_id:
         return
+
+    if not token:
+        raise HTTPException(status_code=403, detail="Public file access token required")
 
     from .public_chat_access import get_public_chat_user, get_task_for_public_context
 

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -1049,9 +1049,12 @@ class TestFileUpload:
         assert download.status_code == 200
         assert download.content == b"source content"
 
-    @pytest.mark.parametrize("route", ["preview", "download"])
+    @pytest.mark.parametrize(
+        ("route", "expected_disposition"),
+        [("preview", "inline"), ("download", "attachment")],
+    )
     def test_public_output_for_authenticated_task_with_selected_files_needs_no_token(
-        self, route, client, test_db, temp_uploads_dir
+        self, route, expected_disposition, client, test_db, temp_uploads_dir
     ):
         """An input attachment must not turn a signed-in task into a guest task.
 
@@ -1100,6 +1103,53 @@ class TestFileUpload:
 
         assert response.status_code == 200, response.text
         assert response.content == b"generated analysis"
+        assert response.headers["content-disposition"].startswith(expected_disposition)
+
+    def test_public_output_for_widget_task_requires_token(
+        self, client, test_db, temp_uploads_dir
+    ):
+        """Widget task outputs must not fall back to file-ID-only access."""
+        from xagent.web.models.task import Task
+
+        admin_user, test_app = test_db
+        output_path = (
+            temp_uploads_dir
+            / f"user_{admin_user.id}"
+            / "widget_task_output"
+            / "analysis.txt"
+        )
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(b"private widget analysis")
+
+        db = next(test_app.dependency_overrides[get_db]())
+        try:
+            task = Task(
+                title="Widget task",
+                user_id=admin_user.id,
+                agent_config={"auth_mode": "widget", "guest_id": "guest-1"},
+            )
+            db.add(task)
+            db.flush()
+
+            output = UploadedFile(
+                user_id=admin_user.id,
+                task_id=task.id,
+                filename="analysis.txt",
+                storage_path=str(output_path),
+                mime_type="text/plain",
+                file_size=output_path.stat().st_size,
+            )
+            db.add(output)
+            db.commit()
+            db.refresh(output)
+            file_id = output.file_id
+        finally:
+            db.close()
+
+        response = client.get(f"/api/files/public/download/{file_id}")
+
+        assert response.status_code == 403, response.text
+        assert response.json()["detail"] == "Public file access token required"
 
     def test_public_download_sets_attachment_content_disposition(
         self, client, temp_uploads_dir, auth_headers

--- a/tests/web/test_file_upload.py
+++ b/tests/web/test_file_upload.py
@@ -1049,6 +1049,58 @@ class TestFileUpload:
         assert download.status_code == 200
         assert download.content == b"source content"
 
+    @pytest.mark.parametrize("route", ["preview", "download"])
+    def test_public_output_for_authenticated_task_with_selected_files_needs_no_token(
+        self, route, client, test_db, temp_uploads_dir
+    ):
+        """An input attachment must not turn a signed-in task into a guest task.
+
+        ``selected_file_ids`` makes ``agent_config`` a dict, but generated outputs
+        still use the normal file-id capability. Only share/widget tasks require
+        an additional public-access token.
+        """
+        from xagent.web.models.task import Task
+
+        admin_user, test_app = test_db
+        output_path = (
+            temp_uploads_dir
+            / f"user_{admin_user.id}"
+            / "web_task_output"
+            / "analysis.txt"
+        )
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_bytes(b"generated analysis")
+
+        db = next(test_app.dependency_overrides[get_db]())
+        try:
+            task = Task(
+                title="Authenticated task with an attachment",
+                user_id=admin_user.id,
+                agent_config={"selected_file_ids": ["input-file-id"]},
+            )
+            db.add(task)
+            db.flush()
+
+            output = UploadedFile(
+                user_id=admin_user.id,
+                task_id=task.id,
+                filename="analysis.txt",
+                storage_path=str(output_path),
+                mime_type="text/plain",
+                file_size=output_path.stat().st_size,
+            )
+            db.add(output)
+            db.commit()
+            db.refresh(output)
+            file_id = output.file_id
+        finally:
+            db.close()
+
+        response = client.get(f"/api/files/public/{route}/{file_id}")
+
+        assert response.status_code == 200, response.text
+        assert response.content == b"generated analysis"
+
     def test_public_download_sets_attachment_content_disposition(
         self, client, temp_uploads_dir, auth_headers
     ):


### PR DESCRIPTION
## Summary

- require a public-access token only for actual share or widget guest tasks
- preserve the existing file-ID capability behavior for signed-in tasks whose `agent_config` contains `selected_file_ids`
- add regression coverage for both inline preview and source download

## Verification

- `pytest -q tests/web/test_file_upload.py -k public_output_for_authenticated_task_with_selected_files_needs_no_token`
- `pytest -q tests/web/api/test_agents_management.py -k "share_public_file_preview_requires_valid_share_token or share_public_file_download_requires_valid_share_token or unpublishing_agent_revokes_widget_guest_access_to_task_files"`
- `pytest -q tests/web/test_file_upload.py -k "not TestSvgPreviewSecurity"`
- `ruff check src/xagent/web/api/files.py tests/web/test_file_upload.py`
- `ruff format --check src/xagent/web/api/files.py tests/web/test_file_upload.py`
- `mypy src/xagent/web/api/files.py`
- live Task 879 XLSX/CSV preview and download endpoints return HTTP 200 after backend restart

## Local environment note

The complete `tests/web/test_file_upload.py` run has three existing SVG-to-PNG rasterization failures in this local environment; the non-SVG portion passes.