### PR TITLE
fix(tests): clear the whole degradation registry between interaction tests

### DIFF
--- a/tests/web/services/test_task_interaction_service.py
+++ b/tests/web/services/test_task_interaction_service.py
@@ -144,7 +144,6 @@ from xagent.web.models.task_interaction import TaskInteractionRequest
 from xagent.web.models.user import User
 from xagent.web.services import task_interaction_service as svc
 from xagent.web.services.ops_signals import (
-    CHECKPOINT_LOAD_UNAVAILABLE,
     CHECKPOINT_PK_ANCHOR_DANGLING,
     INTERACTION_READ_PAYLOAD_UNREADABLE,
     INTERACTION_READ_PROTOCOL_UNRECOGNIZED,
@@ -155,26 +154,27 @@ from xagent.web.services.task_clarification_draft import CLARIFICATION_REQUEST_T
 from xagent.web.services.task_interaction_staging import InteractionAnchor
 from xagent.web.services.task_lease_service import TASK_RUN_ID_TRACE_FIELD, TaskLease
 
-_DEGRADATION_SIGNALS_UNDER_TEST = (
-    CHECKPOINT_PK_ANCHOR_DANGLING,
-    CHECKPOINT_LOAD_UNAVAILABLE,
-    INTERACTION_READ_PROTOCOL_UNRECOGNIZED,
-    INTERACTION_READ_PAYLOAD_UNREADABLE,
-)
-
 
 @pytest.fixture(autouse=True)
 def _clean_degradation_registry():
-    """The anchor resolver and materialize_compatibility_view register
-    process-global degradation signals on their failure paths; clear this
-    module's four signals around every test so they cannot leak into tests
-    that read the shared registry (the /health suite asserts exact
-    payloads and fails on any leftover entry)."""
-    for signal in _DEGRADATION_SIGNALS_UNDER_TEST:
-        clear_degradation(signal)
+    """Clear the whole process-global registry around every test, the same
+    way every other interaction suite's fixture does.
+
+    A named subset is not enough here. Besides the anchor resolver and
+    materialize_compatibility_view, tests in this module drive create()
+    into ``interaction_handoff``'s swallow path, which registers
+    ``INTERACTION_HANDOFF_DEGRADED`` and
+    ``INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED`` -- the two signals with
+    no ``clear_degradation()`` call anywhere in production code, so nothing
+    else ever takes them back out of the registry. Whatever this module
+    leaves behind leaks into whichever module xdist schedules next on the
+    same worker, and the /health suite asserts an exact payload.
+    """
+    for name in list(active_degradations()):
+        clear_degradation(name)
     yield
-    for signal in _DEGRADATION_SIGNALS_UNDER_TEST:
-        clear_degradation(signal)
+    for name in list(active_degradations()):
+        clear_degradation(name)
 
 
 # ---------------------------------------------------------------------------
@@ -1750,8 +1750,6 @@ def test_unrecognized_protocol_version_raises_the_ops_signal_and_a_warning(
     ):
         svc.materialize_compatibility_view(_db, _seeded_task)
 
-    from xagent.web.services.ops_signals import INTERACTION_READ_PROTOCOL_UNRECOGNIZED
-
     assert INTERACTION_READ_PROTOCOL_UNRECOGNIZED in active_degradations()
     assert any(record.levelno == logging.WARNING for record in caplog.records)
 
@@ -1774,8 +1772,6 @@ def test_unreadable_payload_raises_the_ops_signal_and_a_warning(
         logging.WARNING, logger="xagent.web.services.task_interaction_service"
     ):
         svc.materialize_compatibility_view(_db, _seeded_task)
-
-    from xagent.web.services.ops_signals import INTERACTION_READ_PAYLOAD_UNREADABLE
 
     assert INTERACTION_READ_PAYLOAD_UNREADABLE in active_degradations()
     assert any(record.levelno == logging.WARNING for record in caplog.records)

--- a/tests/web/test_health_degradations.py
+++ b/tests/web/test_health_degradations.py
@@ -9,6 +9,7 @@ import pytest
 
 from xagent.web.services.ops_signals import (
     GMAIL_OIDC_SERVICE_ACCOUNT_UNVERIFIED,
+    active_degradations,
     clear_degradation,
     register_degradation,
 )
@@ -16,9 +17,21 @@ from xagent.web.services.ops_signals import (
 
 @pytest.fixture(autouse=True)
 def _clean_registry():
-    clear_degradation(GMAIL_OIDC_SERVICE_ACCOUNT_UNVERIFIED)
+    """Empty the whole registry, not just this suite's own signal.
+
+    Both tests below assert an exact /health payload, so any signal left
+    active by an earlier module on the same xdist worker fails them. Some
+    of those signals -- ``INTERACTION_HANDOFF_DEGRADED`` and
+    ``INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED`` -- have no production
+    clear site at all, so a producing suite is the only thing that could
+    remove them; clearing everything here keeps that a shared convention
+    rather than a single-file obligation.
+    """
+    for name in list(active_degradations()):
+        clear_degradation(name)
     yield
-    clear_degradation(GMAIL_OIDC_SERVICE_ACCOUNT_UNVERIFIED)
+    for name in list(active_degradations()):
+        clear_degradation(name)
 
 
 def test_health_is_plain_ok_without_degradations() -> None:


### PR DESCRIPTION
## What

Fixes an intermittent CI failure in `Pytest Fast (web)`, where the two `/health` degradation tests fail with unexpected extra signals in the payload.

Observed on [#2133](https://github.com/xorbitsai/xagent/pull/2133), attempt 1 of run [33909855211](https://github.com/xorbitsai/xagent/actions/runs/33909855211), which went green on a rerun without any code change:

```
FAILED tests/web/test_health_degradations.py::test_health_is_plain_ok_without_degradations
E   AssertionError: assert {'degradation...status': 'ok'} == {'status': 'ok'}
E     Left contains 1 more item:
E     {'degradations': ['interaction_handoff_degraded',
E                       'interaction_run_partition_mismatch_degraded']}

FAILED tests/web/test_health_degradations.py::test_health_reports_active_degradations_but_stays_ok
E   AssertionError: assert ['gmail_oidc_...tch_degraded'] == ['gmail_oidc_...t_unverified']
E     Left contains 2 more items, first extra item: 'interaction_handoff_degraded'
```

## Why it happened

`ops_signals` is a process-global registry, and the `/health` suite asserts an exact payload, so it fails on any signal an earlier module left active on the same xdist worker.

`tests/web/services/test_task_interaction_service.py` cleared only a four-name whitelist. Its `create()` tests drive `interaction_handoff`'s swallow path, which registers `INTERACTION_HANDOFF_DEGRADED` and `INTERACTION_RUN_PARTITION_MISMATCH_DEGRADED` (`src/xagent/web/services/task_interaction_staging.py`). Neither was on that whitelist, and per `interaction_handoff`'s own docstring those two are the only entries in the registry with no `clear_degradation()` call anywhere in production code, so nothing else ever takes them back out.

Whether the leak reached the `/health` suite depended on how `--dist=loadscope` happened to spread the two modules across the four workers, which is why it failed only intermittently.

## What changed

Both fixtures now clear every active signal, matching the fixture that every other interaction suite (`test_interaction_staging.py`, `test_interaction_handoff_surface.py`, `test_task_interaction_close.py`, `test_task_interaction_anchor.py`, `test_resume_interaction_seam.py`) already uses:

- `tests/web/services/test_task_interaction_service.py` — drops the whitelist tuple so the producing suite stops leaking.
- `tests/web/test_health_degradations.py` — clears everything so the assertions are immune to any future upstream leak.

Dropping the whitelist left `CHECKPOINT_LOAD_UNAVAILABLE` unused and turned two function-local re-imports into redefinitions of the module-level ones. Both are cleaned up; no assertion changed.

## Verification

| Check | Result |
| --- | --- |
| Repro command (before: 2 failed, 5 passed) | 7 passed |
| Both modules in full, service first | 364 passed |
| Both modules in full, health first | 364 passed |
| `tests/web tests/architecture -n 4 --dist=loadscope` | 0 failures/errors in both changed modules |
| `pre-commit run --files <the two files>` | ruff check, ruff format, mypy, isort, codespell all pass |

Repro of the original failure on `main`:

```bash
pytest tests/web/services/test_task_interaction_service.py tests/web/test_health_degradations.py -k "partition_mismatch or anchor_corrupt or slot_taken or request_closed or health" -p no:randomly
```

## Note

`tests/web/services/test_task_interaction_read.py` still uses the same whitelist pattern. It is not a leak source today because it never enters `interaction_handoff`, so it is left alone here. Hoisting a shared fixture into a `conftest.py` would remove the pattern for good.
