### PR TITLE
feat(persistence): add unwired execution event storage

### DIFF
--- a/docs/architecture/task-execution-event-storage.md
+++ b/docs/architecture/task-execution-event-storage.md
@@ -1,0 +1,77 @@
+# Execution-event storage: migration stage 3.1
+
+This stage adds storage primitives only. No Web, channel, runner, checkpoint,
+or historical-reader path writes or reads these events in production yet.
+
+## Version boundary
+
+`tasks.conversation_storage_version` defaults to `1` (legacy), both in the
+ORM and in SQL. A database CHECK pins it to `1`: the event-backed runtime is
+not available in this release. Activating another version requires a later
+migration **and** the complete writer/reader routing from stages 3.2–3.3.
+This is a conversation-storage version, not an agent runtime version.
+
+Existing rows and inserts from older applications retain legacy behavior.
+The migration adds columns with inline CHECKs, avoiding a SQLite tasks-table
+rebuild and its inbound foreign-key hazards. PostgreSQL still takes an ALTER
+TABLE lock; rollout needs a short lock window, not a zero-lock assumption.
+The new indexes apply only to the new, initially empty event table.
+
+## Event envelope
+
+`task_execution_events` records one fact with:
+
+- A generated stable `event_id` and a task-local `sequence`.
+- An explicit nonempty `scope_id` (`root` or a stable child execution scope).
+- Optional `run_id`, `turn_id`, `assistant_message_id`, and `tool_attempt_id`.
+  An assistant tool-call batch and each tool attempt have distinct identities.
+- A nonempty producer-supplied `idempotency_key`, unique within task and scope.
+  Keys for per-run facts must include the run/attempt identity; user acceptance
+  keys can instead identify the durable input command across delivery retries.
+- A `kind`, positive `payload_version`, JSON payload, and occurrence timestamp.
+
+The envelope can carry message/attachment data, full tool results, input
+application facts, recovery state and references. Event-specific schemas and
+runtime identity producers belong to stage 3.2; this store does not invent
+missing run state or infer event kinds from existing Trace rows. No history
+backfill is performed here.
+
+Payloads use the existing JSON sanitizer before persistence, including the
+PostgreSQL JSONB code-point policy. They are not clipped or summarized.
+This normalization is not an authorization or client-disclosure policy.
+
+## Transaction contract
+
+`append_task_execution_event_no_commit` stages a fact in the caller's Session;
+the caller commits or rolls back alongside its business state. It first
+locks the task with an UPDATE, then checks idempotency and allocates the next
+`conversation_event_sequence` in the same transaction. Task `updated_at` is
+preserved. No writer can commit a later task sequence past a pending append;
+a rollback rolls back the sequence allocation as well as the event.
+
+A retry with the same key and normalized fact returns the original event ID,
+sequence and first occurrence timestamp. Reusing a key for different content
+or correlation raises `ExecutionEventConflict`. Callers must finish their
+transaction, including on errors; this helper never commits or rolls it back.
+
+`load_task_execution_events` requires task and scope, and reads by sequence
+with a bounded page size. It uses the caller's transaction snapshot; another
+connection cannot see uncommitted events, while read-your-writes in the same
+Session is intentional. Authorization remains the future calling service's
+responsibility. Neither helper is an externally exposed endpoint.
+
+Only the append interface is provided; there is no edit or pruning API.
+Task deletion cascades at the database foreign key. Stage 3.2 must integrate
+the full application lifecycle before production events are enabled.
+
+## Validation
+
+The migration tests cover SQLite and PostgreSQL upgrade/downgrade, old SQL
+inserts, retained chat rows and foreign keys, create_all parity, and offline
+SQL generation. Store tests cover uncommitted visibility, rollback, concurrent
+commit ordering and replay, conflicting identities, scope pagination, JSON
+payload fidelity and database constraints.
+
+Code rollback may retain the additive schema. Alembic downgrade deletes the
+new event table and counter: it is suitable for this unwired stage, not a way
+to revert an event-backed task after later stages have been activated.

--- a/docs/architecture/task-execution-event-storage.md
+++ b/docs/architecture/task-execution-event-storage.md
@@ -55,7 +55,8 @@ or correlation raises `ExecutionEventConflict`. Callers must finish their
 transaction, including on errors; this helper never commits or rolls it back.
 
 `load_task_execution_events` requires task and scope, and reads by sequence
-with a bounded page size. It uses the caller's transaction snapshot; another
+with a page size of 1–100 (default 100). Out-of-range sizes raise `ValueError`
+before querying the database. It uses the caller's transaction snapshot; another
 connection cannot see uncommitted events, while read-your-writes in the same
 Session is intentional. Authorization remains the future calling service's
 responsibility. Neither helper is an externally exposed endpoint.

--- a/src/xagent/migrations/versions/20260905_add_task_execution_events.py
+++ b/src/xagent/migrations/versions/20260905_add_task_execution_events.py
@@ -1,0 +1,120 @@
+"""Add unwired execution-event storage and a legacy-only task version.
+
+Revision ID: 20260905_task_execution_events
+Revises: 20260902_seed_magento_mcp_app
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import JSONB
+
+revision: str = "20260905_task_execution_events"
+down_revision: Union[str, None] = "20260902_seed_magento_mcp_app"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+TABLE = "task_execution_events"
+
+
+def _create_events() -> None:
+    op.create_table(
+        TABLE,
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("event_id", sa.String(36), nullable=False),
+        sa.Column(
+            "task_id",
+            sa.Integer(),
+            sa.ForeignKey("tasks.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("sequence", sa.BigInteger(), nullable=False),
+        sa.Column("scope_id", sa.String(255), nullable=False),
+        sa.Column("run_id", sa.String(64), nullable=True),
+        sa.Column("turn_id", sa.String(64), nullable=True),
+        sa.Column("assistant_message_id", sa.String(255), nullable=True),
+        sa.Column("tool_attempt_id", sa.String(255), nullable=True),
+        sa.Column("idempotency_key", sa.String(255), nullable=False),
+        sa.Column("kind", sa.String(64), nullable=False),
+        sa.Column("payload_version", sa.Integer(), nullable=False),
+        sa.Column(
+            "payload", sa.JSON().with_variant(JSONB(), "postgresql"), nullable=False
+        ),
+        sa.Column("occurred_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.UniqueConstraint("event_id", name="uq_task_execution_events_event_id"),
+        sa.UniqueConstraint(
+            "task_id", "sequence", name="uq_task_execution_events_sequence"
+        ),
+        sa.UniqueConstraint(
+            "task_id",
+            "scope_id",
+            "idempotency_key",
+            name="uq_task_execution_events_idempotency",
+        ),
+        sa.CheckConstraint("sequence > 0", name="ck_task_execution_events_sequence"),
+        sa.CheckConstraint(
+            "payload_version > 0", name="ck_task_execution_events_payload_version"
+        ),
+        sa.CheckConstraint(
+            "scope_id <> '' AND idempotency_key <> '' AND kind <> ''",
+            name="ck_task_execution_events_identity",
+        ),
+    )
+    op.create_index(
+        "ix_task_execution_events_scope_cursor",
+        TABLE,
+        ["task_id", "scope_id", "sequence"],
+    )
+
+
+def upgrade() -> None:
+    offline = op.get_context().as_sql
+    if not offline:
+        inspector = sa.inspect(op.get_bind())
+        if not inspector.has_table("tasks"):
+            return
+        columns = {column["name"] for column in inspector.get_columns("tasks")}
+    else:
+        columns = set()
+    # Inline CHECKs work with ADD COLUMN on both supported databases. Avoid
+    # rebuilding SQLite's tasks table (and disturbing its inbound FKs).
+    if "conversation_storage_version" not in columns:
+        op.execute(
+            "ALTER TABLE tasks ADD COLUMN conversation_storage_version INTEGER "
+            "DEFAULT 1 NOT NULL CONSTRAINT ck_tasks_conversation_storage_version "
+            "CHECK (conversation_storage_version = 1)"
+        )
+    if "conversation_event_sequence" not in columns:
+        op.execute(
+            "ALTER TABLE tasks ADD COLUMN conversation_event_sequence BIGINT "
+            "DEFAULT 0 NOT NULL CONSTRAINT ck_tasks_conversation_event_sequence "
+            "CHECK (conversation_event_sequence >= 0)"
+        )
+    if offline or not inspector.has_table(TABLE):
+        _create_events()
+
+
+def downgrade() -> None:
+    offline = op.get_context().as_sql
+    if not offline:
+        inspector = sa.inspect(op.get_bind())
+        if inspector.has_table(TABLE):
+            op.drop_table(TABLE)
+        if not inspector.has_table("tasks"):
+            return
+        columns = {column["name"] for column in inspector.get_columns("tasks")}
+    else:
+        op.drop_table(TABLE)
+        columns = {"conversation_event_sequence", "conversation_storage_version"}
+    # DROP COLUMN also removes its inline CHECK, without copying tasks.
+    if "conversation_event_sequence" in columns:
+        op.drop_column("tasks", "conversation_event_sequence")
+    if "conversation_storage_version" in columns:
+        op.drop_column("tasks", "conversation_storage_version")

--- a/src/xagent/web/models/__init__.py
+++ b/src/xagent/web/models/__init__.py
@@ -20,6 +20,7 @@ from .system_setting import SystemSetting
 from .task import DAGExecution, Task, TaskConnectorRuntimeContext
 from .task_command import TaskExecutionCommand
 from .task_command_terminal_event import TaskCommandTerminalEvent
+from .task_execution_event import TaskExecutionEvent
 from .task_interaction import TaskInteractionRequest
 from .template_stats import TemplateStats, UserTemplateRelation
 from .tool_config import ToolConfig, ToolUsage
@@ -67,6 +68,7 @@ __all__ = [
     "Task",
     "TaskExecutionCommand",
     "TaskCommandTerminalEvent",
+    "TaskExecutionEvent",
     "TaskInteractionRequest",
     "TaskConnectorRuntimeContext",
     "DAGExecution",

--- a/src/xagent/web/models/task.py
+++ b/src/xagent/web/models/task.py
@@ -3,6 +3,7 @@ from typing import Any, Collection
 
 from sqlalchemy import (
     JSON,
+    BigInteger,
     Boolean,
     CheckConstraint,
     Column,
@@ -277,6 +278,28 @@ class Task(Base):  # type: ignore
     user_id = Column(Integer, ForeignKey("users.id"), nullable=False)
     title = Column(String(200), nullable=False)
     description = Column(Text)
+    # Stage 3.1 only supports legacy routing. Widen this pin together with
+    # the event-backed runtime, never by changing the creation default alone.
+    conversation_storage_version = Column(
+        Integer,
+        CheckConstraint(
+            "conversation_storage_version = 1",
+            name="ck_tasks_conversation_storage_version",
+        ),
+        nullable=False,
+        default=1,
+        server_default="1",
+    )
+    conversation_event_sequence = Column(
+        BigInteger,
+        CheckConstraint(
+            "conversation_event_sequence >= 0",
+            name="ck_tasks_conversation_event_sequence",
+        ),
+        nullable=False,
+        default=0,
+        server_default="0",
+    )
     # sqlalchemy.Enum(TaskStatus) with no values_callable persists member
     # *names* (e.g. "WAITING_FOR_USER"), not member values
     # ("waiting_for_user"). validate_strings=True rejects a raw string that

--- a/src/xagent/web/models/task_execution_event.py
+++ b/src/xagent/web/models/task_execution_event.py
@@ -1,0 +1,68 @@
+"""Conversation/execution facts; not wired into runtime producers yet."""
+
+from sqlalchemy import (
+    JSON,
+    BigInteger,
+    CheckConstraint,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    UniqueConstraint,
+)
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.sql import func
+
+from .database import Base
+
+
+class TaskExecutionEvent(Base):  # type: ignore
+    __tablename__ = "task_execution_events"
+    __table_args__ = (
+        UniqueConstraint("event_id", name="uq_task_execution_events_event_id"),
+        UniqueConstraint(
+            "task_id", "sequence", name="uq_task_execution_events_sequence"
+        ),
+        UniqueConstraint(
+            "task_id",
+            "scope_id",
+            "idempotency_key",
+            name="uq_task_execution_events_idempotency",
+        ),
+        CheckConstraint("sequence > 0", name="ck_task_execution_events_sequence"),
+        CheckConstraint(
+            "payload_version > 0", name="ck_task_execution_events_payload_version"
+        ),
+        CheckConstraint(
+            "scope_id <> '' AND idempotency_key <> '' AND kind <> ''",
+            name="ck_task_execution_events_identity",
+        ),
+        Index(
+            "ix_task_execution_events_scope_cursor", "task_id", "scope_id", "sequence"
+        ),
+    )
+
+    id = Column(Integer, primary_key=True)
+    event_id = Column(String(36), nullable=False)
+    task_id = Column(
+        Integer, ForeignKey("tasks.id", ondelete="CASCADE"), nullable=False
+    )
+    sequence = Column(BigInteger, nullable=False)
+    # "root" for the manager; child producers supply their stable scope id.
+    scope_id = Column(String(255), nullable=False)
+    run_id = Column(String(64), nullable=True)
+    turn_id = Column(String(64), nullable=True)
+    # One assistant response may declare multiple tool calls. Keep the batch
+    # identity separate from each retryable tool attempt's identity.
+    assistant_message_id = Column(String(255), nullable=True)
+    tool_attempt_id = Column(String(255), nullable=True)
+    idempotency_key = Column(String(255), nullable=False)
+    kind = Column(String(64), nullable=False)
+    payload_version = Column(Integer, nullable=False)
+    payload = Column(JSON().with_variant(JSONB(), "postgresql"), nullable=False)
+    occurred_at = Column(DateTime(timezone=True), nullable=False)
+    created_at = Column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )

--- a/src/xagent/web/services/task_execution_event_store.py
+++ b/src/xagent/web/services/task_execution_event_store.py
@@ -18,6 +18,8 @@ from ..models.task import Task
 from ..models.task_execution_event import TaskExecutionEvent
 from ..utils.json_payload_sanitizer import sanitize_json_payload
 
+MAX_EXECUTION_EVENT_PAGE_SIZE = 100
+
 
 class ExecutionEventConflict(ValueError):
     """An idempotency key was reused for a different fact."""
@@ -118,9 +120,11 @@ def load_task_execution_events(
     task_id: int,
     scope_id: str,
     after_sequence: int = 0,
-    limit: int = 100,
+    limit: int = MAX_EXECUTION_EVENT_PAGE_SIZE,
 ) -> list[TaskExecutionEvent]:
-    """Read one scope in commit order using the caller's transaction snapshot."""
+    """Read one scope in commit order; reject page sizes outside 1–100."""
+    if not 1 <= limit <= MAX_EXECUTION_EVENT_PAGE_SIZE:
+        raise ValueError(f"limit must be between 1 and {MAX_EXECUTION_EVENT_PAGE_SIZE}")
     return list(
         db.scalars(
             select(TaskExecutionEvent)

--- a/src/xagent/web/services/task_execution_event_store.py
+++ b/src/xagent/web/services/task_execution_event_store.py
@@ -1,0 +1,135 @@
+"""Unwired event-store primitives for the conversation migration.
+
+The caller owns the transaction. Runtime integration and event-specific payload
+contracts ship in stage 3.2; no existing task producer calls this module.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from typing import Any
+from uuid import uuid4
+
+from sqlalchemy import select, update
+from sqlalchemy.orm import Session
+
+from ..models.task import Task
+from ..models.task_execution_event import TaskExecutionEvent
+from ..utils.json_payload_sanitizer import sanitize_json_payload
+
+
+class ExecutionEventConflict(ValueError):
+    """An idempotency key was reused for a different fact."""
+
+
+def append_task_execution_event_no_commit(
+    db: Session,
+    *,
+    task_id: int,
+    scope_id: str,
+    idempotency_key: str,
+    kind: str,
+    payload: dict[str, Any],
+    occurred_at: datetime,
+    run_id: str | None = None,
+    turn_id: str | None = None,
+    assistant_message_id: str | None = None,
+    tool_attempt_id: str | None = None,
+    payload_version: int = 1,
+) -> TaskExecutionEvent:
+    """Stage one fact, serializing appends until the caller commits/rolls back.
+
+    An UPDATE acquires a task-row lock on PostgreSQL and a writer lock on
+    SQLite, including when SQLite SELECT FOR UPDATE would do nothing. The
+    counter belongs to the same transaction as the event: no later append can
+    commit past an uncommitted sequence. A replay keeps the first occurrence
+    timestamp and event id, without allocating another sequence.
+    """
+    # Freeze a JSON value at the persistence boundary. Python equality would
+    # otherwise equate {"value": True} with {"value": 1} on an idempotent replay.
+    serialized_payload = json.dumps(
+        sanitize_json_payload(payload), sort_keys=True, allow_nan=False
+    )
+    values = {
+        "kind": kind,
+        "payload_version": payload_version,
+        "payload": json.loads(serialized_payload),
+        "run_id": run_id,
+        "turn_id": turn_id,
+        "assistant_message_id": assistant_message_id,
+        "tool_attempt_id": tool_attempt_id,
+    }
+    sequence = db.execute(
+        update(Task)
+        .where(Task.id == task_id)
+        .values(
+            conversation_event_sequence=Task.conversation_event_sequence,
+            # Allocating an internal cursor must not reorder the task list.
+            updated_at=Task.updated_at,
+        )
+        .returning(Task.conversation_event_sequence)
+        .execution_options(synchronize_session=False)
+    ).scalar_one_or_none()
+    if sequence is None:
+        raise ValueError(f"Task {task_id} does not exist")
+
+    existing = db.scalars(
+        select(TaskExecutionEvent).where(
+            TaskExecutionEvent.task_id == task_id,
+            TaskExecutionEvent.scope_id == scope_id,
+            TaskExecutionEvent.idempotency_key == idempotency_key,
+        )
+    ).first()
+    if existing is not None:
+        if json.dumps(
+            existing.payload, sort_keys=True, allow_nan=False
+        ) != serialized_payload or any(
+            getattr(existing, key) != value
+            for key, value in values.items()
+            if key != "payload"
+        ):
+            raise ExecutionEventConflict("Idempotency key identifies a different event")
+        return existing
+
+    db.execute(
+        update(Task)
+        .where(Task.id == task_id)
+        .values(conversation_event_sequence=sequence + 1, updated_at=Task.updated_at)
+        .execution_options(synchronize_session=False)
+    )
+    event = TaskExecutionEvent(
+        event_id=str(uuid4()),
+        task_id=task_id,
+        scope_id=scope_id,
+        idempotency_key=idempotency_key,
+        sequence=sequence + 1,
+        occurred_at=occurred_at,
+        **values,
+    )
+    db.add(event)
+    db.flush()
+    return event
+
+
+def load_task_execution_events(
+    db: Session,
+    *,
+    task_id: int,
+    scope_id: str,
+    after_sequence: int = 0,
+    limit: int = 100,
+) -> list[TaskExecutionEvent]:
+    """Read one scope in commit order using the caller's transaction snapshot."""
+    return list(
+        db.scalars(
+            select(TaskExecutionEvent)
+            .where(
+                TaskExecutionEvent.task_id == task_id,
+                TaskExecutionEvent.scope_id == scope_id,
+                TaskExecutionEvent.sequence > after_sequence,
+            )
+            .order_by(TaskExecutionEvent.sequence)
+            .limit(limit)
+        )
+    )

--- a/tests/migrations/test_20260905_add_task_execution_events.py
+++ b/tests/migrations/test_20260905_add_task_execution_events.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+from io import StringIO
+from pathlib import Path
+
+import pytest
+import sqlalchemy as sa
+from alembic import command
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+from tests.shared.postgres_disposable import (
+    disposable_database_factory,
+    load_migration_module,
+)
+from xagent.db.config import create_alembic_config
+from xagent.web.models.database import Base
+
+REVISION = "20260905_task_execution_events"
+PREVIOUS = "20260902_seed_magento_mcp_app"
+MIGRATION = load_migration_module(
+    Path(__file__).parents[2]
+    / "src/xagent/migrations/versions/20260905_add_task_execution_events.py"
+)
+
+
+@pytest.fixture(
+    params=["sqlite", pytest.param("postgresql", marks=pytest.mark.postgresql)]
+)
+def engine(request, tmp_path):
+    if request.param == "postgresql":
+        with disposable_database_factory("event_migration") as make:
+            yield make("schema")
+    else:
+        result = sa.create_engine(f"sqlite:///{tmp_path / 'migration.db'}")
+
+        @sa.event.listens_for(result, "connect")
+        def foreign_keys(connection, _record):
+            connection.execute("PRAGMA foreign_keys=ON")
+
+        try:
+            yield result
+        finally:
+            result.dispose()
+
+
+def _assert_schema(connection):
+    inspector = sa.inspect(connection)
+    columns = {c["name"]: c for c in inspector.get_columns("tasks")}
+    assert columns["conversation_storage_version"]["nullable"] is False
+    assert columns["conversation_event_sequence"]["nullable"] is False
+    assert {
+        "ck_tasks_conversation_storage_version",
+        "ck_tasks_conversation_event_sequence",
+    } <= {c["name"] for c in inspector.get_check_constraints("tasks")}
+    event_table = Base.metadata.tables["task_execution_events"]
+    assert {c["name"] for c in inspector.get_columns(event_table.name)} == set(
+        event_table.columns.keys()
+    )
+    assert {
+        c.name for c in event_table.constraints if isinstance(c, sa.UniqueConstraint)
+    } == {c["name"] for c in inspector.get_unique_constraints(event_table.name)}
+    assert {
+        c.name for c in event_table.constraints if isinstance(c, sa.CheckConstraint)
+    } == {c["name"] for c in inspector.get_check_constraints(event_table.name)}
+    assert {i.name for i in event_table.indexes} == {
+        i["name"]
+        for i in inspector.get_indexes(event_table.name)
+        if not i.get("duplicates_constraint")
+    }
+    assert (
+        inspector.get_foreign_keys(event_table.name)[0]["options"]["ondelete"]
+        == "CASCADE"
+    )
+    if connection.dialect.name == "postgresql":
+        payload = next(
+            c for c in inspector.get_columns(event_table.name) if c["name"] == "payload"
+        )
+        assert isinstance(payload["type"], sa.dialects.postgresql.JSONB)
+
+
+def test_upgrade_preserves_legacy_rows_and_round_trips(engine):
+    with engine.begin() as connection:
+        connection.execute(
+            sa.text(
+                "CREATE TABLE tasks (id INTEGER PRIMARY KEY, title VARCHAR(200) NOT NULL)"
+            )
+        )
+        connection.execute(
+            sa.text(
+                "CREATE TABLE task_chat_messages (id INTEGER PRIMARY KEY, "
+                "task_id INTEGER REFERENCES tasks(id), content TEXT NOT NULL)"
+            )
+        )
+        connection.execute(sa.text("INSERT INTO tasks VALUES (1, 'existing')"))
+        connection.execute(
+            sa.text("INSERT INTO task_chat_messages VALUES (1, 1, 'hello')")
+        )
+    config = create_alembic_config(engine)
+    with engine.connect() as connection:
+        config.attributes["connection"] = connection
+        command.stamp(config, PREVIOUS)
+        connection.commit()
+        command.upgrade(config, REVISION)
+        connection.commit()
+        _assert_schema(connection)
+        assert connection.execute(
+            sa.text(
+                "SELECT id, title, conversation_storage_version, conversation_event_sequence FROM tasks"
+            )
+        ).all() == [(1, "existing", 1, 0)]
+        assert connection.execute(
+            sa.text("SELECT * FROM task_chat_messages")
+        ).all() == [(1, 1, "hello")]
+        connection.execute(
+            sa.text("INSERT INTO tasks (id, title) VALUES (2, 'old writer')")
+        )
+        connection.commit()
+        assert connection.execute(
+            sa.text(
+                "SELECT conversation_storage_version, conversation_event_sequence FROM tasks WHERE id = 2"
+            )
+        ).one() == (1, 0)
+        connection.rollback()
+        for statement in (
+            "UPDATE tasks SET conversation_storage_version = 2 WHERE id = 1",
+            "UPDATE tasks SET conversation_event_sequence = -1 WHERE id = 1",
+        ):
+            with pytest.raises(sa.exc.IntegrityError):
+                connection.execute(sa.text(statement))
+            connection.rollback()
+        command.downgrade(config, PREVIOUS)
+        connection.commit()
+        assert not sa.inspect(connection).has_table("task_execution_events")
+        assert connection.execute(sa.text("SELECT * FROM tasks ORDER BY id")).all() == [
+            (1, "existing"),
+            (2, "old writer"),
+        ]
+        assert connection.execute(
+            sa.text("SELECT * FROM task_chat_messages")
+        ).all() == [(1, 1, "hello")]
+        connection.rollback()
+        command.upgrade(config, REVISION)
+        connection.commit()
+        _assert_schema(connection)
+
+
+def test_create_all_schema_and_upgrade_are_compatible(engine):
+    Base.metadata.create_all(engine)
+    with engine.begin() as connection:
+        with Operations.context(MigrationContext.configure(connection)):
+            MIGRATION.upgrade()
+            MIGRATION.upgrade()
+        _assert_schema(connection)
+
+
+@pytest.mark.parametrize("dialect", ["sqlite", "postgresql"])
+def test_offline_ddl_keeps_legacy_default_without_tasks_rebuild(dialect):
+    output = StringIO()
+    context = MigrationContext.configure(
+        dialect_name=dialect, opts={"as_sql": True, "output_buffer": output}
+    )
+    with Operations.context(context):
+        MIGRATION.upgrade()
+    sql = output.getvalue()
+    assert "conversation_storage_version INTEGER DEFAULT 1 NOT NULL" in sql
+    assert "CHECK (conversation_storage_version = 1)" in sql
+    assert "CREATE TABLE task_execution_events" in sql
+    assert "DROP TABLE tasks" not in sql
+    if dialect == "sqlite":
+        with sa.create_engine("sqlite://").connect() as connection:
+            connection.exec_driver_sql("CREATE TABLE tasks (id INTEGER PRIMARY KEY)")
+            connection.connection.driver_connection.executescript(sql)
+            _assert_schema(connection)

--- a/tests/web/services/test_task_execution_event_store.py
+++ b/tests/web/services/test_task_execution_event_store.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor, TimeoutError
+from datetime import datetime, timezone
+from threading import Event
+from uuid import uuid4
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from tests.shared.postgres_disposable import disposable_database_factory
+from xagent.web.models.database import Base
+from xagent.web.models.task import Task
+from xagent.web.models.task_execution_event import TaskExecutionEvent
+from xagent.web.models.user import User
+from xagent.web.services.task_execution_event_store import (
+    ExecutionEventConflict,
+    append_task_execution_event_no_commit,
+    load_task_execution_events,
+)
+
+
+@pytest.fixture(
+    params=["sqlite", pytest.param("postgresql", marks=pytest.mark.postgresql)]
+)
+def engine(request, tmp_path):
+    if request.param == "postgresql":
+        with disposable_database_factory("execution_events") as make:
+            yield make("store")
+    else:
+        result = sa.create_engine(f"sqlite:///{tmp_path / 'events.db'}")
+
+        @sa.event.listens_for(result, "connect")
+        def enable_foreign_keys(connection, _record):
+            connection.execute("PRAGMA foreign_keys=ON")
+
+        try:
+            yield result
+        finally:
+            result.dispose()
+
+
+@pytest.fixture
+def task_id(engine):
+    Base.metadata.create_all(engine)
+    with Session(engine) as db:
+        user = User(username="event-owner", password_hash="unused")
+        db.add(user)
+        db.flush()
+        task = Task(user_id=user.id, title="Existing task", description="unchanged")
+        db.add(task)
+        db.commit()
+        return task.id
+
+
+def append(db, task_id, key="turn-1", **overrides):
+    values = dict(
+        task_id=task_id,
+        scope_id="root",
+        idempotency_key=key,
+        kind="user_message_accepted",
+        payload={"content": "hello", "attachments": []},
+        occurred_at=datetime(2026, 9, 5, tzinfo=timezone.utc),
+        turn_id=key,
+    )
+    values.update(overrides)
+    return append_task_execution_event_no_commit(db, **values)
+
+
+def test_defaults_pin_legacy_without_events(engine, task_id):
+    with Session(engine) as db:
+        task = db.get(Task, task_id)
+        assert task.conversation_storage_version == 1
+        assert task.conversation_event_sequence == 0
+        assert load_task_execution_events(db, task_id=task_id, scope_id="root") == []
+        task.conversation_storage_version = 2
+        with pytest.raises(IntegrityError):
+            db.flush()
+
+
+def test_append_is_atomic_with_business_state_and_does_not_touch_task_time(
+    engine, task_id
+):
+    with Session(engine) as writer, Session(engine) as reader:
+        original_time = writer.get(Task, task_id).updated_at
+        writer.get(Task, task_id).description = "uncommitted business change"
+        row = append(writer, task_id)
+        assert row.sequence == 1
+        assert (
+            load_task_execution_events(reader, task_id=task_id, scope_id="root") == []
+        )
+        assert reader.get(Task, task_id).conversation_event_sequence == 0
+        assert reader.get(Task, task_id).description == "unchanged"
+        writer.rollback()
+        assert writer.get(Task, task_id).conversation_event_sequence == 0
+        assert writer.get(Task, task_id).description == "unchanged"
+        assert (
+            load_task_execution_events(writer, task_id=task_id, scope_id="root") == []
+        )
+        row = append(writer, task_id)
+        assert row.sequence == 1
+        writer.commit()
+        reader.rollback()
+        assert reader.get(Task, task_id).updated_at == original_time
+        assert [
+            r.sequence
+            for r in load_task_execution_events(
+                reader, task_id=task_id, scope_id="root"
+            )
+        ] == [1]
+
+
+def test_replay_preserves_identity_and_rejects_conflicting_fact(engine, task_id):
+    with Session(engine) as db:
+        first = append(db, task_id)
+        identity = first.event_id
+        db.commit()
+        replay = append(db, task_id, occurred_at=datetime.now(timezone.utc))
+        assert replay.event_id == identity
+        assert replay.sequence == 1
+        assert db.scalar(sa.select(Task.conversation_event_sequence)) == 1
+        db.commit()
+        with pytest.raises(ExecutionEventConflict):
+            append(db, task_id, payload={"content": "different"})
+        db.rollback()
+        assert (
+            db.scalar(sa.select(sa.func.count()).select_from(TaskExecutionEvent)) == 1
+        )
+
+
+def test_scope_cursor_and_tool_batch_metadata(engine, task_id):
+    with Session(engine) as db:
+        append(db, task_id, scope_id="child-1")
+        append(
+            db,
+            task_id,
+            kind="assistant_tools_requested",
+            run_id="run-1",
+            assistant_message_id="assistant-1",
+        )
+        append(
+            db,
+            task_id,
+            key="tool-1",
+            kind="tool_attempt_finished",
+            assistant_message_id="assistant-1",
+            tool_attempt_id="attempt-1",
+        )
+        db.commit()
+        rows = load_task_execution_events(db, task_id=task_id, scope_id="root", limit=1)
+        assert [row.sequence for row in rows] == [2]
+        assert rows[0].run_id == "run-1"
+        rows = load_task_execution_events(
+            db, task_id=task_id, scope_id="root", after_sequence=2
+        )
+        assert [
+            (r.sequence, r.assistant_message_id, r.tool_attempt_id) for r in rows
+        ] == [(3, "assistant-1", "attempt-1")]
+        assert (
+            load_task_execution_events(db, task_id=task_id + 1, scope_id="root") == []
+        )
+
+
+def test_idempotency_distinguishes_json_booleans_and_snapshots_input(engine, task_id):
+    payload = {"result": {"value": True}}
+    with Session(engine) as db:
+        original = append(db, task_id, payload=payload)
+        payload["result"]["value"] = False
+        assert original.payload == {"result": {"value": True}}
+        db.commit()
+        with pytest.raises(ExecutionEventConflict):
+            append(db, task_id, payload={"result": {"value": 1}})
+
+
+@pytest.mark.parametrize("value", [float("nan"), float("inf")])
+def test_invalid_json_does_not_allocate_sequence(engine, task_id, value):
+    with Session(engine) as db:
+        with pytest.raises(ValueError):
+            append(db, task_id, payload={"value": value})
+        assert db.scalar(sa.select(Task.conversation_event_sequence)) == 0
+
+
+@pytest.mark.parametrize("rollback_first", [False, True])
+@pytest.mark.parametrize("same_key", [False, True])
+def test_concurrent_append_cannot_commit_past_pending_event(
+    engine, task_id, rollback_first, same_key
+):
+    reached_update = Event()
+
+    def second_writer():
+        with Session(engine) as db:
+            connection = db.connection()
+
+            @sa.event.listens_for(connection, "before_cursor_execute")
+            def reached_lock(_conn, _cursor, statement, _params, _context, _many):
+                if statement.startswith("UPDATE tasks"):
+                    reached_update.set()
+
+            row = append(db, task_id, key="turn-1" if same_key else "turn-2")
+            result = (row.sequence, row.event_id)
+            db.commit()
+            return result
+
+    with Session(engine) as first, ThreadPoolExecutor(max_workers=1) as pool:
+        row = append(first, task_id)
+        first_id = row.event_id
+        future = pool.submit(second_writer)
+        try:
+            assert reached_update.wait(5)
+            with pytest.raises(TimeoutError):
+                future.result(timeout=0.1)
+        finally:
+            if rollback_first:
+                first.rollback()
+            else:
+                first.commit()
+        sequence, event_id = future.result(timeout=10)
+        assert sequence == (1 if rollback_first or same_key else 2)
+        if same_key and not rollback_first:
+            assert event_id == first_id
+
+
+def test_database_constraints_and_task_cascade(engine, task_id):
+    with Session(engine) as db:
+        row = append(db, task_id)
+        db.commit()
+        for replacement in ({"sequence": 0}, {"payload_version": 0}, {"scope_id": ""}):
+            with pytest.raises(IntegrityError):
+                with db.begin_nested():
+                    db.execute(
+                        sa.update(TaskExecutionEvent)
+                        .where(TaskExecutionEvent.id == row.id)
+                        .values(**replacement)
+                    )
+        stored = dict(
+            db.execute(sa.select(TaskExecutionEvent.__table__)).mappings().one()
+        )
+        stored.pop("id")
+        for duplicate in (
+            {"event_id": str(uuid4()), "idempotency_key": "other"},
+            {"sequence": 2, "idempotency_key": "other"},
+            {"sequence": 2, "event_id": str(uuid4())},
+        ):
+            with pytest.raises(IntegrityError):
+                with db.begin_nested():
+                    db.execute(sa.insert(TaskExecutionEvent).values(stored | duplicate))
+        db.execute(sa.delete(Task).where(Task.id == task_id))
+        db.commit()
+        assert (
+            db.scalar(sa.select(sa.func.count()).select_from(TaskExecutionEvent)) == 0
+        )
+
+
+def test_payload_keeps_complete_tool_results_and_normalizes_jsonb_hazards(
+    engine, task_id
+):
+    result = {
+        "handle": {"branch": "调查完整性", "node_id": "node-1"},
+        "output": "结果" * 5000,
+    }
+    with Session(engine) as db:
+        append(db, task_id, kind="tool_attempt_finished", payload=result)
+        append(db, task_id, key="unsafe", payload={"value": "a\x00b\ud800c"})
+        db.commit()
+    with Session(engine) as db:
+        rows = load_task_execution_events(db, task_id=task_id, scope_id="root")
+        assert rows[0].payload == result
+        assert rows[1].payload == {"value": "a\ufffdb\ufffdc"}
+        assert (
+            append(
+                db, task_id, key="unsafe", payload={"value": "a\x00b\ud800c"}
+            ).event_id
+            == rows[1].event_id
+        )

--- a/tests/web/services/test_task_execution_event_store.py
+++ b/tests/web/services/test_task_execution_event_store.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from concurrent.futures import ThreadPoolExecutor, TimeoutError
 from datetime import datetime, timezone
 from threading import Event
+from unittest.mock import Mock
 from uuid import uuid4
 
 import pytest
@@ -274,3 +275,31 @@ def test_payload_keeps_complete_tool_results_and_normalizes_jsonb_hazards(
             ).event_id
             == rows[1].event_id
         )
+
+
+@pytest.mark.parametrize("limit", [-1, 0, 101, 10**9])
+def test_page_size_rejected_before_database_access(limit):
+    db = Mock(spec=Session)
+    with pytest.raises(ValueError, match="limit must be between 1 and 100"):
+        load_task_execution_events(db, task_id=1, scope_id="root", limit=limit)
+    db.scalars.assert_not_called()
+
+
+def test_page_size_bounds_and_default_preserve_cursor_pagination(engine, task_id):
+    with Session(engine) as db:
+        for index in range(101):
+            append(db, task_id, key=f"event-{index}")
+        db.commit()
+        for options in ({}, {"limit": 100}):
+            rows = load_task_execution_events(
+                db, task_id=task_id, scope_id="root", **options
+            )
+            assert [row.sequence for row in rows] == list(range(1, 101))
+        first = load_task_execution_events(
+            db, task_id=task_id, scope_id="root", limit=1
+        )
+        assert [row.sequence for row in first] == [1]
+        last = load_task_execution_events(
+            db, task_id=task_id, scope_id="root", after_sequence=100
+        )
+        assert [row.sequence for row in last] == [101]


### PR DESCRIPTION
The conversation and execution paths currently persist overlapping facts independently. This adds the storage foundation for a single authoritative event source: task-scoped ordered events with correlation metadata, idempotent appends, and a task storage-version boundary.

This is migration stage 3.1 for #2089. The new store has no production callers, and the database pins every task to legacy storage version 1. Existing chat, Trace, checkpoint, and history paths remain unchanged; this PR does not yet remove dual writes or duplicate failure context.

- Add an additive Alembic migration and ORM model, preserving existing rows and old SQL inserts without rebuilding SQLite's tasks table.
- Serialize sequence allocation and event insertion in the caller's transaction; retries preserve event identity, conflicting facts are rejected, and readers cannot observe another transaction's uncommitted events.
- Document the envelope, transaction contract, and activation boundary for subsequent migration stages.

Validation: 175 tests passed, including SQLite and UTF-8 PostgreSQL migration/store tests and existing chat-history/task-orchestrator regressions. Ruff checks/formatting and type checks for the two new application modules passed.

PostgreSQL ALTER TABLE still requires a lock window. Code rollback can retain the additive schema; schema downgrade drops the new event storage and is only appropriate before production activation.

Related to #2089.
