### PR TITLE
fix(agent): hand a forced turn back the tools compaction emptied, once

### DIFF
--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -734,6 +734,11 @@ class ReActPattern(AgentPattern):
             # Set only on a turn that undoes the forcing, and read after that
             # turn's tool batch to decide what the next turn is told.
             recovery_names: set[str] | None = None
+            # What a same-turn protocol repair may offer. It defaults to the
+            # run's whole set, which is what every turn but a recovery turn
+            # needs, and a recovery turn trims it below.
+            retry_tool_schemas = base_tool_schemas
+            recovery_turn = False
             interrupted = await self._interrupt_if_requested(
                 runtime=runtime,
                 context=context,
@@ -843,6 +848,18 @@ class ReActPattern(AgentPattern):
                     force_final_answer_now = False
                     tool_schemas = recovery_schemas
                     recovery_names = set(recoverable_work)
+                    # A repair on this turn keeps the whole-set recovery
+                    # semantics -- the model may genuinely need a tool the
+                    # narrowed set left out to reach the dropped values -- but
+                    # never reopens the two tools that contact the user, since
+                    # this turn deliberately withheld them.
+                    retry_tool_schemas = [
+                        schema
+                        for schema in base_tool_schemas
+                        if (schema.get("function") or {}).get("name")
+                        not in USER_INTERACTION_CONTROL_TOOL_NAMES
+                    ]
+                    recovery_turn = True
                     evidence_dropped = False
                     self.forced_answer_compaction_recoveries += 1
                     context.add_system_message(
@@ -962,11 +979,13 @@ class ReActPattern(AgentPattern):
                         llm=call_llm,
                         runtime=runtime,
                         iteration=iteration,
-                        tool_schemas=base_tool_schemas,
+                        tool_schemas=retry_tool_schemas,
                         force_final_answer=(
                             force_final_answer_now and not unavailable_tool_call
                         ),
                         recovery_reason=exc.code,
+                        narrowed_tool_set=recovery_turn,
+                        evidence_dropped=evidence_dropped,
                     )
                 except LLMCallInterrupted:
                     interrupted = await self._interrupt_if_requested(
@@ -1055,12 +1074,14 @@ class ReActPattern(AgentPattern):
                         llm=call_llm,
                         runtime=runtime,
                         iteration=iteration,
-                        tool_schemas=base_tool_schemas,
+                        tool_schemas=retry_tool_schemas,
                         force_final_answer=(
                             force_final_answer_now and not recover_full_tool_set
                         ),
                         recovery_reason=recovery_reason,
                         empty_final_answer=empty_final_answer is not None,
+                        narrowed_tool_set=recovery_turn,
+                        evidence_dropped=evidence_dropped,
                     )
                 except LLMCallInterrupted:
                     interrupted = await self._interrupt_if_requested(
@@ -1447,24 +1468,40 @@ class ReActPattern(AgentPattern):
         force_final_answer: bool,
         recovery_reason: str | None = None,
         empty_final_answer: bool = False,
+        narrowed_tool_set: bool = False,
+        evidence_dropped: bool = False,
     ) -> tuple[Any, ReActFinalAnswerStreamer]:
         tools = (
             [self._final_answer_tool_schema()] if force_final_answer else tool_schemas
         )
+        # The retry rebuilds the whole prompt, and on a turn whose evidence was
+        # destroyed it is the call that actually reaches the user. Without this
+        # the repair would hand back the very wording the first call replaced.
         messages = self._messages_for_llm(
             context,
             has_tools=True,
             force_final_answer=force_final_answer,
+            evidence_dropped=evidence_dropped,
             tool_names=self._schema_tool_names(tools),
         )
         if recovery_reason == "unavailable_tool_call":
+            # A turn that narrowed its own tools cannot be told this is the
+            # complete set: the retry set is wider than what that turn first
+            # offered, but still not everything the run has.
+            reconsider_instruction = (
+                "Re-decide this turn using the tool set listed above, which is "
+                "the set available on this turn."
+                if narrowed_tool_set
+                else "Re-decide this turn using the complete current tool set "
+                "listed above."
+            )
             retry_instruction = (
                 "The previous response called a tool that was unavailable in the "
-                "narrowed tool schema. Re-decide this turn using the complete "
-                "current tool set listed above. Call only a tool present in that "
-                "set. If the requested work or artifact has not been successfully "
-                "produced, call the appropriate work tool; call final_answer only "
-                "when the task is actually complete and its required results exist."
+                f"narrowed tool schema. {reconsider_instruction} Call only a tool "
+                "present in that set. If the requested work or artifact has not "
+                "been successfully produced, call the appropriate work tool; call "
+                "final_answer only when the task is actually complete and its "
+                "required results exist."
             )
             retry_phase = "unavailable_tool_call_recovery"
         elif recovery_reason == "malformed_tool_arguments":

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -861,6 +861,11 @@ class ReActPattern(AgentPattern):
                     ]
                     recovery_turn = True
                     evidence_dropped = False
+                    # Undo the durable half of the same decision. The marker
+                    # set above says this turn answers without the evidence;
+                    # this turn is going to fetch it back instead, so a pause
+                    # here must not resume into a forced answer.
+                    self.forced_answer_recovery_followup = None
                     self.forced_answer_compaction_recoveries += 1
                     context.add_system_message(
                         self._forced_answer_recovery_message(recoverable_work)

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -81,6 +81,7 @@ from ...context.enrichment import (
 )
 from ...context.execution import (
     COMPACT_DROPPED_TOOL_NAME_MAX_CHARS,
+    COMPACT_DROPPED_TOOL_NOTICE_MAX_CHARS,
     COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES,
 )
 from ...context.memory_tool import build_memory_tools
@@ -730,6 +731,9 @@ class ReActPattern(AgentPattern):
             evidence_dropped = (
                 followup is not None and followup != FORCED_ANSWER_FOLLOWUP_REFETCHED
             )
+            # Set only on a turn that undoes the forcing, and read after that
+            # turn's tool batch to decide what the next turn is told.
+            recovery_names: set[str] | None = None
             interrupted = await self._interrupt_if_requested(
                 runtime=runtime,
                 context=context,
@@ -829,7 +833,44 @@ class ReActPattern(AgentPattern):
                     decline_reason = "no_recoverable_tools"
                 else:
                     decline_reason = None
-                if decline_reason is not None:
+                if decline_reason is None:
+                    # Undo the forcing for this one turn and hand back exactly
+                    # the tools whose observations went missing. final_answer
+                    # stays available so the model can still finish if it
+                    # judges what remains to be enough.
+                    self.force_final_answer_next = False
+                    self.forced_answer_reason = None
+                    force_final_answer_now = False
+                    tool_schemas = recovery_schemas
+                    recovery_names = set(recoverable_work)
+                    evidence_dropped = False
+                    self.forced_answer_compaction_recoveries += 1
+                    context.add_system_message(
+                        self._forced_answer_recovery_message(recoverable_work)
+                    )
+                    await runtime.checkpoint(
+                        "forced_answer_evidence_dropped_recovered",
+                        context=context,
+                        pattern=self,
+                        metadata={
+                            "iteration": iteration,
+                            "dropped_tool_result_count": dropped_count,
+                            "restored_tools": sorted(recoverable_work)[
+                                :COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES
+                            ],
+                        },
+                    )
+                    logger.warning(
+                        "Forced answer turn lost tool evidence to compaction; "
+                        "restoring the dropped tools for one turn. dropped=%d "
+                        "restored=%s execution_id=%s",
+                        dropped_count,
+                        sorted(recoverable_work)[
+                            :COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES
+                        ],
+                        getattr(context, "execution_id", None),
+                    )
+                else:
                     logger.warning(
                         "Forced answer turn lost tool evidence to compaction and "
                         "will report it as unavailable. reason=%s dropped=%d "
@@ -1112,11 +1153,21 @@ class ReActPattern(AgentPattern):
                 )
                 if pending_result is not None:
                     return pending_result
-                # This turn ran to completion, so the marker it was carrying has
-                # been acted on. Clearing it only here, past every checkpoint
-                # this turn writes and every early return, is what makes it
-                # survive an interrupt and still apply exactly once.
-                if followup is not None:
+                # A recovery turn settles what the next turn is told; any other
+                # turn has finished acting on the marker it was carrying.
+                # Writing and clearing share one branch so that a write can
+                # never be undone by the clear in the same turn.
+                #
+                # Clearing only here, past every checkpoint this turn writes and
+                # every early return, is what makes the marker survive an
+                # interrupt and still apply exactly once.
+                if recovery_names is not None:
+                    self.forced_answer_recovery_followup = (
+                        FORCED_ANSWER_FOLLOWUP_REFETCHED
+                        if self._recovery_evidence_arrived(tool_calls, recovery_names)
+                        else FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
+                    )
+                elif followup is not None:
                     self.forced_answer_recovery_followup = None
                 self.current_iteration = iteration + 1
                 self.status = "thinking"
@@ -1745,6 +1796,81 @@ class ReActPattern(AgentPattern):
         if not isinstance(by_name, dict):
             return count, set()
         return count, {str(name) for name in by_name}
+
+    def _forced_answer_recovery_message(self, names: set[str]) -> str:
+        """System message that reopens the dropped tools for a single turn.
+
+        Four things have to be said and the message is useless without any of
+        them: which observations went missing, that fetching them again is the
+        expected move on this turn and outranks the standing advice against
+        repeating tool work, that only reading tools may be re-run, and that no
+        final answer is due until the values are back or reported missing.
+
+        The second point exists because the ordinary tool-turn instruction
+        tells the model to answer from the results it already has rather than
+        repeat the same tool work, which on this turn is advice against the one
+        action that helps.
+
+        The name list mirrors all three bounds the compaction notice applies --
+        a name cap, a per-name length cap, and a total budget that skips an
+        over-long line rather than stopping at it -- because the names come
+        from dynamic server configuration and this message enters the context
+        on every recovery.
+        """
+        ordered = sorted(names)
+        listed = ordered[:COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES]
+        omitted = len(ordered) - len(listed)
+        prefix = (
+            "Tool observations were removed from context by compaction on this "
+            "turn, and their values are no longer available to read. Calling "
+            "those tools again is the expected action now: this instruction "
+            "takes priority over any earlier one telling you to answer from "
+            "results you already gathered, or not to repeat completed tool "
+            "work. Only re-run tools that read; if a value came from a tool "
+            "that writes, sends, executes, or otherwise changes state, do not "
+            "re-run it -- re-read the artifact it produced, or report the "
+            "value as unavailable. Do not give the final answer before those "
+            "values are back; if they cannot be fetched, say plainly which "
+            "ones are missing instead of reconstructing, estimating, or "
+            "illustrating them. Tools to call again:\n"
+        )
+        lines: list[str] = []
+        current_chars = len(prefix)
+        for name in listed:
+            clamped = name[:COMPACT_DROPPED_TOOL_NAME_MAX_CHARS]
+            line = f"- {clamped}"
+            if current_chars + len(line) + 1 > COMPACT_DROPPED_TOOL_NOTICE_MAX_CHARS:
+                omitted += 1
+                continue
+            lines.append(line)
+            current_chars += len(line) + 1
+        if omitted:
+            name_label = "name" if omitted == 1 else "names"
+            lines.append(f"- ... {omitted} additional tool {name_label} omitted")
+        return prefix + "\n".join(lines)
+
+    def _recovery_evidence_arrived(
+        self,
+        tool_calls: list[dict[str, Any]],
+        recovery_names: set[str],
+    ) -> bool:
+        """Whether this turn's own batch got a recovery-set tool to succeed.
+
+        Scoped to this turn's tool_call ids on purpose. The observation the
+        compaction dropped was itself a successful call of one of these names,
+        and its ledger record outlives the compaction -- compaction removes
+        messages, not ledger entries -- so matching by name alone would report
+        evidence that is no longer in context.
+        """
+        for tool_call in tool_calls:
+            record = self.tool_ledger.get(str(tool_call.get("id") or ""))
+            if record is None or record.tool_name not in recovery_names:
+                continue
+            if record.status == "completed" and self._tool_result_success(
+                record.result
+            ):
+                return True
+        return False
 
     def _tool_decision_groups_for_tools(self, tools: list[Any]) -> dict[str, str]:
         groups: dict[str, str] = {}

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -699,9 +699,9 @@ class ReActPattern(AgentPattern):
             # every checkpoint this turn writes, or a resume would restore the
             # forcing without the reason for it and fall back to the ordinary
             # instruction. It is cleared once this turn has run, below. The
-            # gate further down overwrites this local when it declines, so
-            # treat it as "what this turn must clear", not a read-only
-            # snapshot of the previous turn.
+            # gate further down overwrites this local whenever it finds the
+            # evidence gone, so treat it as "what this turn must clear", not a
+            # read-only snapshot of the previous turn.
             followup = self.forced_answer_recovery_followup
             if followup is not None:
                 self.force_final_answer_next = True
@@ -781,8 +781,18 @@ class ReActPattern(AgentPattern):
             # dropped, or say plainly that they are unavailable.
             dropped_count, dropped_names = self._dropped_tool_evidence(compact_result)
             if force_final_answer_now and dropped_count > 0:
-                # Set first, cleared again only if the recovery below happens.
+                # Two halves of one decision. The loop local picks this turn's
+                # instruction; the marker carries the same decision across the
+                # checkpoint written below, so an interrupt between here and
+                # the LLM call resumes into a forced turn that still knows why.
+                # Reuse of the existing marker means the consumption block
+                # above and the clearing below already handle it. Anything that
+                # undoes the forcing has to undo both.
                 evidence_dropped = True
+                self.forced_answer_recovery_followup = (
+                    FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
+                )
+                followup = FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
                 base_names = set(self._schema_tool_names(base_tool_schemas))
                 # Subtracting the control names is redundant today -- the
                 # dropped-name mapping already excludes them upstream -- and is
@@ -820,16 +830,6 @@ class ReActPattern(AgentPattern):
                 else:
                     decline_reason = None
                 if decline_reason is not None:
-                    # Declining still has to survive a resume. Whether this
-                    # turn sends the honest instruction is otherwise only a
-                    # loop local, so an interrupt between here and the LLM call
-                    # would resume into a forced turn that has forgotten why.
-                    # Reuse of the existing marker means the consumption block
-                    # above and the clearing below already handle it.
-                    self.forced_answer_recovery_followup = (
-                        FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
-                    )
-                    followup = FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
                     logger.warning(
                         "Forced answer turn lost tool evidence to compaction and "
                         "will report it as unavailable. reason=%s dropped=%d "

--- a/src/xagent/core/agent/pattern/react/react.py
+++ b/src/xagent/core/agent/pattern/react/react.py
@@ -79,6 +79,10 @@ from ...context.enrichment import (
     enrich_context_with_memory,
     latest_user_text,
 )
+from ...context.execution import (
+    COMPACT_DROPPED_TOOL_NAME_MAX_CHARS,
+    COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES,
+)
 from ...context.memory_tool import build_memory_tools
 from ...context.skill_tool import build_load_skill_tool
 from ...grounding import grounding_rule
@@ -123,6 +127,47 @@ REACT_DECISION_TOOL_NAME = "react_decision"
 REACT_DECISION_FINAL_ANSWER = "final_answer"
 USER_INTERACTION_CONTROL_TOOL_NAMES = CONTROL_TOOL_NAMES - {REACT_DECISION_FINAL_ANSWER}
 REACT_DECISION_TOOL_CALL = "tool_call"
+# Why a turn was forced back to final_answer. Written at every site that sets
+# ``force_final_answer_next``, so the compaction-recovery gate in the main loop
+# can tell a forcing it may undo from one it must leave alone.
+FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION = "repeated_tool_decision"
+FORCED_ANSWER_REASON_FINALIZE_AFTER_TOOL = "finalize_after_tool_result"
+FORCED_ANSWER_REASON_EMPTY_FINAL_ANSWER = "empty_final_answer"
+FORCED_ANSWER_REASON_CONTROL_TOOL_DISABLED = "control_tool_disabled"
+FORCED_ANSWER_REASON_COMPACTION_RECOVERY = "compaction_recovery"
+FORCED_ANSWER_REASONS = frozenset(
+    {
+        FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION,
+        FORCED_ANSWER_REASON_FINALIZE_AFTER_TOOL,
+        FORCED_ANSWER_REASON_EMPTY_FINAL_ANSWER,
+        FORCED_ANSWER_REASON_CONTROL_TOOL_DISABLED,
+        FORCED_ANSWER_REASON_COMPACTION_RECOVERY,
+    }
+)
+# ``control_tool_disabled`` means nobody is reachable to talk to, so that forced
+# turn means "stop and report blocked" rather than "answer from the evidence you
+# gathered"; reopening work tools would spend a turn without changing that
+# outcome. ``compaction_recovery`` marks the turn a recovery already produced,
+# and undoing that one would let recovery chain into itself.
+FORCED_ANSWER_REASONS_EXEMPT_FROM_RECOVERY = frozenset(
+    {
+        FORCED_ANSWER_REASON_CONTROL_TOOL_DISABLED,
+        FORCED_ANSWER_REASON_COMPACTION_RECOVERY,
+    }
+)
+FORCED_ANSWER_RECOVERY_BUDGET = 1
+# A recovery turn spends the current iteration on re-fetching, so the forced
+# answer needs one more iteration after it. The loop is
+# ``range(self.current_iteration, self.max_iterations)`` and one iteration
+# carries one LLM call plus that call's tool batch, so "this turn plus one" is
+# the exact floor.
+FORCED_ANSWER_RECOVERY_MIN_REMAINING_ITERATIONS = 2
+# How a recovery turn ended, read by the turn immediately after it.
+FORCED_ANSWER_FOLLOWUP_REFETCHED = "refetched"
+FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE = "no_evidence"
+FORCED_ANSWER_FOLLOWUPS = frozenset(
+    {FORCED_ANSWER_FOLLOWUP_REFETCHED, FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE}
+)
 UNGROUPED_TOOL_DECISION_CATEGORIES = frozenset({"basic", "other"})
 # Bounds for the final_answer-strip warning's tool-name list. Tool names come
 # straight from the model, so the log line is shaped like the rest of this
@@ -443,6 +488,11 @@ class ReActPattern(AgentPattern):
         self.pending_tool_call_content: dict[str, str] = {}
         self.tool_ledger: dict[str, ToolCallRecord] = {}
         self.force_final_answer_next = False
+        # Read only while ``force_final_answer_next`` is true; every site that
+        # sets that flag writes this in the same statement block.
+        self.forced_answer_reason: str | None = None
+        self.forced_answer_compaction_recoveries = 0
+        self.forced_answer_recovery_followup: str | None = None
         self.repeated_tool_decision: dict[str, Any] | None = None
         self.waiting_for_user_request: dict[str, Any] | None = None
         self.pending_tool_interaction_responses: list[dict[str, str]] = []
@@ -643,15 +693,42 @@ class ReActPattern(AgentPattern):
                 if decision_result is not None:
                     return decision_result
 
-            force_final_answer_now = self.force_final_answer_next or (
+            # The turn after a recovery turn is always the forced answer turn,
+            # and the marker says whether the re-fetch actually brought the
+            # evidence back. Read without clearing: the marker has to outlive
+            # every checkpoint this turn writes, or a resume would restore the
+            # forcing without the reason for it and fall back to the ordinary
+            # instruction. It is cleared once this turn has run, below. The
+            # gate further down overwrites this local when it declines, so
+            # treat it as "what this turn must clear", not a read-only
+            # snapshot of the previous turn.
+            followup = self.forced_answer_recovery_followup
+            if followup is not None:
+                self.force_final_answer_next = True
+                self.forced_answer_reason = FORCED_ANSWER_REASON_COMPACTION_RECOVERY
+
+            if self.force_final_answer_next:
+                force_final_answer_now = True
+                forced_reason = self.forced_answer_reason
+            elif (
                 self.finalize_after_tool_result
                 and not self.pending_tool_calls
                 and self._latest_tool_result_success(context)
-            )
+            ):
+                force_final_answer_now = True
+                # Same source as the site that sets the flag after a
+                # successful tool result; this branch is its inline twin.
+                forced_reason = FORCED_ANSWER_REASON_FINALIZE_AFTER_TOOL
+            else:
+                force_final_answer_now = False
+                forced_reason = None
             tool_schemas = (
                 [self._final_answer_tool_schema()]
                 if force_final_answer_now
                 else base_tool_schemas
+            )
+            evidence_dropped = (
+                followup is not None and followup != FORCED_ANSWER_FOLLOWUP_REFETCHED
             )
             interrupted = await self._interrupt_if_requested(
                 runtime=runtime,
@@ -676,7 +753,7 @@ class ReActPattern(AgentPattern):
                 "iteration": iteration,
                 **resolved_llm_metadata(call_llm),
             }
-            await runtime.compact_context_if_needed(
+            compact_result = await runtime.compact_context_if_needed(
                 context=context,
                 # Fall back to the main model when no compact model is
                 # configured. PatternRuntime skips summarization entirely
@@ -696,10 +773,83 @@ class ReActPattern(AgentPattern):
                 metadata={"iteration": iteration},
             )
 
+            # A forced answer turn that just lost its evidence to compaction is
+            # the turn this whole block exists for: the model already decided
+            # to answer, the observations it decided from are gone, and the
+            # tool set it was about to receive is final_answer alone. Either
+            # undo the forcing and hand back the tools whose results were
+            # dropped, or say plainly that they are unavailable.
+            dropped_count, dropped_names = self._dropped_tool_evidence(compact_result)
+            if force_final_answer_now and dropped_count > 0:
+                # Set first, cleared again only if the recovery below happens.
+                evidence_dropped = True
+                base_names = set(self._schema_tool_names(base_tool_schemas))
+                # Subtracting the control names is redundant today -- the
+                # dropped-name mapping already excludes them upstream -- and is
+                # kept because it is the only thing that would stop
+                # send_message from reaching a recovery turn if that upstream
+                # exclusion ever changes.
+                recoverable_work = (
+                    dropped_names & base_names
+                ) - self._control_tool_names()
+                recovery_schemas = (
+                    [
+                        schema
+                        for schema in base_tool_schemas
+                        if (schema.get("function") or {}).get("name")
+                        in (recoverable_work | {"final_answer"})
+                    ]
+                    if recoverable_work
+                    else []
+                )
+                if forced_reason not in FORCED_ANSWER_REASONS:
+                    decline_reason: str | None = "unknown_reason"
+                elif forced_reason in FORCED_ANSWER_REASONS_EXEMPT_FROM_RECOVERY:
+                    decline_reason = "exempt"
+                elif (
+                    self.max_iterations - iteration
+                ) < FORCED_ANSWER_RECOVERY_MIN_REMAINING_ITERATIONS:
+                    decline_reason = "no_iteration_budget"
+                elif (
+                    self.forced_answer_compaction_recoveries
+                    >= FORCED_ANSWER_RECOVERY_BUDGET
+                ):
+                    decline_reason = "budget_spent"
+                elif not recovery_schemas:
+                    decline_reason = "no_recoverable_tools"
+                else:
+                    decline_reason = None
+                if decline_reason is not None:
+                    # Declining still has to survive a resume. Whether this
+                    # turn sends the honest instruction is otherwise only a
+                    # loop local, so an interrupt between here and the LLM call
+                    # would resume into a forced turn that has forgotten why.
+                    # Reuse of the existing marker means the consumption block
+                    # above and the clearing below already handle it.
+                    self.forced_answer_recovery_followup = (
+                        FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
+                    )
+                    followup = FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
+                    logger.warning(
+                        "Forced answer turn lost tool evidence to compaction and "
+                        "will report it as unavailable. reason=%s dropped=%d "
+                        "unrecoverable_names=%s execution_id=%s",
+                        decline_reason,
+                        dropped_count,
+                        [
+                            name[:COMPACT_DROPPED_TOOL_NAME_MAX_CHARS]
+                            for name in sorted(dropped_names - base_names)[
+                                :COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES
+                            ]
+                        ],
+                        getattr(context, "execution_id", None),
+                    )
+
             messages = self._messages_for_llm(
                 context,
                 has_tools=bool(tool_schemas),
                 force_final_answer=force_final_answer_now,
+                evidence_dropped=evidence_dropped,
                 tool_names=self._schema_tool_names(tool_schemas),
             )
             await runtime.checkpoint("before_llm", context=context, pattern=self)
@@ -962,11 +1112,20 @@ class ReActPattern(AgentPattern):
                 )
                 if pending_result is not None:
                     return pending_result
+                # This turn ran to completion, so the marker it was carrying has
+                # been acted on. Clearing it only here, past every checkpoint
+                # this turn writes and every early return, is what makes it
+                # survive an interrupt and still apply exactly once.
+                if followup is not None:
+                    self.forced_answer_recovery_followup = None
                 self.current_iteration = iteration + 1
                 self.status = "thinking"
                 continue
 
             await runtime.checkpoint("after_llm", context=context, pattern=self)
+            # Same one-shot clearing for the turn that called no tools.
+            if followup is not None:
+                self.forced_answer_recovery_followup = None
             if normalized.get("done", True):
                 return await self._finalize_success(
                     context=context,
@@ -1091,17 +1250,42 @@ class ReActPattern(AgentPattern):
         *,
         has_tools: bool,
         force_final_answer: bool = False,
+        evidence_dropped: bool = False,
         tool_names: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         messages = list(context.get_messages_for_llm())
         if force_final_answer:
+            if evidence_dropped:
+                # This turn's compaction removed the observations the answer
+                # was supposed to rest on, and this turn cannot fetch them
+                # back. The ordinary opening below would tell the model to
+                # answer "using the accumulated conversation and tool results"
+                # while those results are gone, which is an instruction to
+                # invent them, so it is replaced rather than appended to.
+                opening = (
+                    "Produce the final user-facing answer by calling the "
+                    "final_answer control tool exactly once, naming the tool "
+                    "observations that were removed from context and are no "
+                    "longer available on this turn. Do not reconstruct, "
+                    "estimate, or illustrate a removed value, and do not "
+                    "present one as an example. Set outcome=partial when part "
+                    "of the request is still answerable from what remains and "
+                    "outcome=blocked when none of it is; outcome=completed is "
+                    "not available on this turn. "
+                )
+            else:
+                opening = (
+                    "Produce the final user-facing answer by calling the "
+                    "final_answer control tool exactly once using the "
+                    "accumulated conversation and tool results. Set "
+                    "outcome=completed only when every requested action or "
+                    "verification succeeded; otherwise set outcome=partial or "
+                    "outcome=blocked and say what remains. "
+                )
             instruction = (
-                "Produce the final user-facing answer by calling the final_answer "
-                "control tool exactly once using the accumulated conversation and "
-                "tool results. Do not call any other tool and do not output "
-                "tool-call markup as plain text. Set outcome=completed only when "
-                "every requested action or verification succeeded; otherwise set "
-                "outcome=partial or outcome=blocked and say what remains. If a "
+                f"{opening}"
+                "Do not call any other tool and do not output "
+                "tool-call markup as plain text. If a "
                 "previous ask_user_question narrowed the request to a selected "
                 "subset of items or resources, the final answer must cover only "
                 "that subset — leave out anything outside it even if an earlier "
@@ -1531,6 +1715,37 @@ class ReActPattern(AgentPattern):
                 names.append(str(function["name"]))
         return names
 
+    def _dropped_tool_evidence(self, compact_result: Any) -> tuple[int, set[str]]:
+        """Read how much tool evidence a compaction just destroyed, and whose.
+
+        ``compacted`` cannot answer this on its own: the message-dropping path
+        reports ``compacted=True`` even when its tail window already held every
+        message and nothing was removed. The two metadata keys read here are
+        written together by both compacting paths and already exclude hidden,
+        superseded, failed and non-evidence observations, so they are the only
+        signal this gate accepts.
+
+        The count and the names defend independently rather than one implying
+        the other. A positive count with an unreadable name mapping is a real
+        state, and it must report "evidence was destroyed, nothing nameable to
+        restore" instead of restoring the wrong tools.
+
+        Raises nothing: reads only attributes and mapping keys. A compaction
+        that itself failed propagates through the caller as it always has.
+        """
+        if compact_result is None or not getattr(compact_result, "compacted", False):
+            return 0, set()
+        metadata = getattr(compact_result, "metadata", None)
+        if not isinstance(metadata, dict):
+            return 0, set()
+        count = metadata.get("dropped_tool_result_count")
+        if not isinstance(count, int) or isinstance(count, bool) or count <= 0:
+            return 0, set()
+        by_name = metadata.get("dropped_tool_results_by_name")
+        if not isinstance(by_name, dict):
+            return count, set()
+        return count, {str(name) for name in by_name}
+
     def _tool_decision_groups_for_tools(self, tools: list[Any]) -> dict[str, str]:
         groups: dict[str, str] = {}
         for tool in tools:
@@ -1588,6 +1803,11 @@ class ReActPattern(AgentPattern):
                 self.repeated_tool_decision_after_consecutive_work_tool_calls
             ),
             "force_final_answer_next": self.force_final_answer_next,
+            "forced_answer_reason": self.forced_answer_reason,
+            "forced_answer_compaction_recoveries": (
+                self.forced_answer_compaction_recoveries
+            ),
+            "forced_answer_recovery_followup": self.forced_answer_recovery_followup,
             "repeated_tool_decision": self.repeated_tool_decision,
             "waiting_for_user_request": self.waiting_for_user_request,
             "pending_tool_interaction_responses": (
@@ -1637,6 +1857,41 @@ class ReActPattern(AgentPattern):
                 int(raw_work_threshold) if raw_work_threshold is not None else None
             )
         self.force_final_answer_next = bool(state.get("force_final_answer_next", False))
+        # The three keys below default in different directions on purpose.
+        # A reason this build cannot name must not be undone, and a follow-up
+        # marker it cannot read must not force a turn -- both fail closed by
+        # doing less. The recovery counter is the opposite: reading a missing
+        # counter as "already spent" would close the recovery path permanently
+        # for every run checkpointed before the counter existed, and that path
+        # is itself the safety net, so a missing counter reads as unspent.
+        raw_forced_answer_reason = state.get("forced_answer_reason")
+        self.forced_answer_reason = (
+            raw_forced_answer_reason
+            if isinstance(raw_forced_answer_reason, str)
+            and raw_forced_answer_reason in FORCED_ANSWER_REASONS
+            else None
+        )
+        if "forced_answer_compaction_recoveries" not in state:
+            self.forced_answer_compaction_recoveries = 0
+        else:
+            raw_recoveries = state["forced_answer_compaction_recoveries"]
+            self.forced_answer_compaction_recoveries = (
+                raw_recoveries
+                if isinstance(raw_recoveries, int)
+                and not isinstance(raw_recoveries, bool)
+                and raw_recoveries >= 0
+                else FORCED_ANSWER_RECOVERY_BUDGET
+            )
+        # ``isinstance`` first because this payload is JSON: a list reaching the
+        # membership test would raise. An unreadable marker reads as ``None``
+        # (an ordinary next turn) and never as "refetched", which would claim
+        # evidence came back.
+        raw_followup = state.get("forced_answer_recovery_followup")
+        self.forced_answer_recovery_followup = (
+            raw_followup
+            if isinstance(raw_followup, str) and raw_followup in FORCED_ANSWER_FOLLOWUPS
+            else None
+        )
         repeated_tool_decision = state.get("repeated_tool_decision")
         self.repeated_tool_decision = (
             dict(repeated_tool_decision)
@@ -2335,6 +2590,7 @@ class ReActPattern(AgentPattern):
             )
             self.status = "thinking"
             self.force_final_answer_next = True
+            self.forced_answer_reason = FORCED_ANSWER_REASON_CONTROL_TOOL_DISABLED
             return None
 
         if name == "final_answer":
@@ -2586,6 +2842,7 @@ class ReActPattern(AgentPattern):
         )
         self.status = "thinking"
         self.force_final_answer_next = True
+        self.forced_answer_reason = FORCED_ANSWER_REASON_EMPTY_FINAL_ANSWER
 
     def _tool_is_concurrency_safe(self, name: str, tools: list[Any]) -> bool:
         """Whether ``name`` may run concurrently with other safe tools.
@@ -3091,6 +3348,7 @@ class ReActPattern(AgentPattern):
             and not self.repeated_tool_decision
         ):
             self.force_final_answer_next = True
+            self.forced_answer_reason = FORCED_ANSWER_REASON_FINALIZE_AFTER_TOOL
         return None
 
     async def _request_repeated_tool_decision_if_needed(
@@ -3183,6 +3441,7 @@ class ReActPattern(AgentPattern):
 
         if decision["action"] == REACT_DECISION_FINAL_ANSWER:
             self.force_final_answer_next = True
+            self.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
             await runtime.checkpoint(
                 "repeated_tool_decision_final_requested",
                 context=context,
@@ -3472,6 +3731,10 @@ class ReActPattern(AgentPattern):
         self.waiting_for_user_request = None
         self.pending_tool_interaction_responses = []
         self.force_final_answer_next = False
+        # The run is over, so a follow-up marker left in the final checkpoint
+        # would hand any later resume a forced turn plus an honest instruction
+        # about evidence that no longer matters.
+        self.forced_answer_recovery_followup = None
         self.status = "completed"
         await runtime.checkpoint("final", context=context, pattern=self)
         result = PatternResult(

--- a/tests/core/agent/test_react_forced_answer_compaction.py
+++ b/tests/core/agent/test_react_forced_answer_compaction.py
@@ -1,0 +1,857 @@
+"""Forced-answer turns whose evidence this turn's compaction destroyed.
+
+A ReAct turn can be forced back to ``final_answer`` alone while the very same
+turn's compaction removes the tool observations that answer was supposed to
+rest on. The engine must then either hand the dropped tools back for one
+re-fetch turn, or say plainly that the observations are unavailable -- never
+ask for an answer "using the accumulated conversation and tool results" that
+are gone.
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from pathlib import Path
+from typing import Any
+
+import pytest
+from pydantic import BaseModel
+
+import xagent.core.agent.pattern.react.react as react_module
+from xagent.core.agent import ExecutionContext, PatternRuntime, ReActPattern
+from xagent.core.agent.pattern.react.react import (
+    FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE,
+    FORCED_ANSWER_FOLLOWUP_REFETCHED,
+    FORCED_ANSWER_FOLLOWUPS,
+    FORCED_ANSWER_REASON_COMPACTION_RECOVERY,
+    FORCED_ANSWER_REASON_CONTROL_TOOL_DISABLED,
+    FORCED_ANSWER_REASON_EMPTY_FINAL_ANSWER,
+    FORCED_ANSWER_REASON_FINALIZE_AFTER_TOOL,
+    FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION,
+    FORCED_ANSWER_REASONS,
+    FORCED_ANSWER_REASONS_EXEMPT_FROM_RECOVERY,
+    FORCED_ANSWER_RECOVERY_BUDGET,
+    FORCED_ANSWER_RECOVERY_MIN_REMAINING_ITERATIONS,
+)
+
+REACT_SOURCE_PATH = Path(react_module.__file__)
+
+# The sentence the ordinary forced instruction opens with. On a turn whose
+# evidence was destroyed it is an instruction to invent, so it must be gone.
+STALE_EVIDENCE_PHRASE = "the accumulated conversation and tool results"
+HONEST_PHRASE = "naming the tool observations that were removed from context"
+COMPLETED_OFFERED_PHRASE = "Set outcome=completed only when"
+COMPLETED_WITHHELD_PHRASE = "outcome=completed is not available on this turn"
+RECOVERY_CHECKPOINT = "forced_answer_evidence_dropped_recovered"
+
+
+class _EmptyArgs(BaseModel):
+    pass
+
+
+class NamedTool:
+    """Minimal work tool whose schema name the test chooses."""
+
+    def __init__(self, name: str) -> None:
+        self.name = name
+        self.calls: list[dict[str, Any]] = []
+
+        class Metadata:
+            pass
+
+        self.metadata = Metadata()
+        self.metadata.name = name  # type: ignore[attr-defined]
+        self.metadata.description = f"Read {name}."  # type: ignore[attr-defined]
+
+    def args_type(self) -> type[BaseModel]:
+        return _EmptyArgs
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        self.calls.append(args)
+        return {"output": f"{self.name} result"}
+
+
+class RecordingLLM:
+    """Chat LLM that records every call and replays scripted responses."""
+
+    def __init__(self, responses: list[Any]) -> None:
+        self.responses = list(responses)
+        self.calls: list[dict[str, Any]] = []
+
+    async def chat(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        if not self.responses:
+            return {"content": "fallback answer", "done": True}
+        return self.responses.pop(0)
+
+
+class ScriptedCompactionRuntime(PatternRuntime):
+    """Runtime whose compaction returns a caller-supplied result per turn.
+
+    Used only for the metadata shapes real compaction cannot be steered into
+    reliably (an unreadable name mapping, say). The shapes it stands in for are
+    anchored to production by
+    ``test_real_compaction_reports_the_keys_the_gate_reads``.
+    """
+
+    def __init__(self, results: list[Any]) -> None:
+        super().__init__()
+        self.scripted_compactions = list(results)
+
+    async def compact_context_if_needed(self, **kwargs: Any) -> Any:
+        if not self.scripted_compactions:
+            return None
+        return self.scripted_compactions.pop(0)
+
+
+def final_answer_response(answer: str = "Here is what remains.") -> dict[str, Any]:
+    return {
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "call_final",
+                "type": "function",
+                "function": {
+                    "name": "final_answer",
+                    "arguments": (
+                        '{"response_language":"English","outcome":"partial",'
+                        f'"answer":"{answer}"}}'
+                    ),
+                },
+            }
+        ],
+        "done": False,
+    }
+
+
+def tool_call_response(tool_name: str, call_id: str = "call_work") -> dict[str, Any]:
+    return {
+        "content": "",
+        "tool_calls": [
+            {
+                "id": call_id,
+                "type": "function",
+                "function": {"name": tool_name, "arguments": "{}"},
+            }
+        ],
+        "done": False,
+    }
+
+
+def build_context(
+    *,
+    tool_name: str = "calculator",
+    observations: int = 3,
+    max_messages: int = 4,
+    result: Any | None = None,
+    execution_id: str = "forced-answer-compaction",
+) -> ExecutionContext:
+    """Context primed to compact on every turn.
+
+    ``max_messages`` decides whether the message-dropping fallback actually
+    removes anything: a window wider than the transcript keeps every message
+    and reports zero dropped observations even though it reports
+    ``compacted=True``.
+    """
+    context = ExecutionContext(execution_id=execution_id)
+    context.compact_config.threshold = 1
+    context.compact_config.max_messages = max_messages
+    context.add_user_message(f"Use {tool_name} and report every value.")
+    for index in range(observations):
+        call_id = f"seed_{index}"
+        context.add_assistant_message(
+            "",
+            tool_calls=[
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": tool_name},
+                }
+            ],
+        )
+        context.add_tool_result(
+            tool_name,
+            {"output": "x" * 400} if result is None else result,
+            tool_call_id=call_id,
+        )
+    return context
+
+
+def instruction_of(llm: RecordingLLM, index: int = 0) -> str:
+    return str(llm.calls[index]["messages"][0].get("content", ""))
+
+
+def whole_prompt_of(llm: RecordingLLM, index: int = 0) -> str:
+    return "\n".join(
+        str(message.get("content", "")) for message in llm.calls[index]["messages"]
+    )
+
+
+def tool_names_of(llm: RecordingLLM, index: int = 0) -> list[str]:
+    return [tool["function"]["name"] for tool in (llm.calls[index].get("tools") or [])]
+
+
+def checkpoint_labels(runtime: PatternRuntime) -> list[str]:
+    return [str(entry.get("label")) for entry in runtime.checkpoints]
+
+
+@pytest.mark.asyncio
+async def test_real_compaction_reports_the_keys_the_gate_reads() -> None:
+    """Anchor the gate's signal to what compaction actually writes.
+
+    Every scripted-metadata test below claims a shape this one proves the two
+    real compacting paths produce, so a rename or a semantic change upstream
+    cannot leave those tests passing against a fiction.
+    """
+    summary_context = build_context(max_messages=40)
+    summary_runtime = PatternRuntime()
+    summary_result = await summary_runtime.compact_context_if_needed(
+        context=summary_context,
+        llm=RecordingLLM([{"content": "A summary of the run."}]),
+    )
+    assert summary_result.compacted is True
+    assert summary_result.strategy == "llm_summary"
+    assert summary_result.metadata["dropped_tool_result_count"] == 3
+    assert summary_result.metadata["dropped_tool_results_by_name"] == {"calculator": 3}
+
+    drop_context = build_context(max_messages=4)
+    drop_runtime = PatternRuntime()
+    drop_result = await drop_runtime.compact_context_if_needed(
+        context=drop_context,
+        llm=RecordingLLM([{"content": ""}]),
+    )
+    assert drop_result.compacted is True
+    assert drop_result.strategy == "truncate"
+    assert drop_result.metadata["dropped_tool_result_count"] == 1
+    assert drop_result.metadata["dropped_tool_results_by_name"] == {"calculator": 1}
+    # The tail window kept a later successful observation of the same tool.
+    # "Is there still tool evidence in context" would answer yes here, which is
+    # why the engine never asks that question.
+    assert any(message.role == "tool" for message in drop_context.messages)
+
+
+def compact_result(
+    *,
+    compacted: bool = True,
+    count: Any = 1,
+    by_name: Any = None,
+    strategy: str = "llm_summary",
+) -> Any:
+    from xagent.core.agent.context.execution import CompactResult
+
+    metadata: dict[str, Any] = {}
+    if count is not None:
+        metadata["dropped_tool_result_count"] = count
+    if by_name is not None:
+        metadata["dropped_tool_results_by_name"] = by_name
+    return CompactResult(
+        compacted=compacted,
+        original_count=9,
+        final_count=2,
+        strategy=strategy,
+        metadata=metadata,
+    )
+
+
+DECLINE_CASES: list[tuple[str, bool]] = [
+    # Nothing was destroyed, so the forced turn proceeds exactly as before.
+    ("compaction_did_not_run", False),
+    ("truncate_removed_no_evidence", False),
+    ("summary_unusable_removed_no_evidence", False),
+    ("summary_error_removed_no_evidence", False),
+    ("dropped_only_failed_tool_messages", False),
+    ("dropped_only_control_pseudo_tools", False),
+    # Evidence was destroyed but recovery is refused, so the turn must say so.
+    ("names_absent_from_base", True),
+    ("whitespace_normalized_name", True),
+    ("tool_choice_none", True),
+    ("unreadable_name_mapping", True),
+    ("control_tool_disabled_is_exempt", True),
+    ("legacy_checkpoint_without_reason", True),
+    ("no_iteration_budget", True),
+    ("budget_already_spent", True),
+]
+
+
+async def run_declined_turn(case: str) -> tuple[ReActPattern, RecordingLLM, Any]:
+    """Drive one forced turn that the recovery gate refuses."""
+    tools: list[Any] = [NamedTool("calculator")]
+    llm = RecordingLLM([final_answer_response()])
+    runtime: PatternRuntime = PatternRuntime()
+    pattern = ReActPattern(max_iterations=6)
+    pattern.force_final_answer_next = True
+    pattern.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
+    compact_llm: Any = RecordingLLM([{"content": "A summary of the run."}])
+    context = build_context(max_messages=40)
+
+    if case == "compaction_did_not_run":
+        context.compact_config.threshold = 10**9
+    elif case == "truncate_removed_no_evidence":
+        # A wide tail window keeps every message: compacted, nothing dropped.
+        compact_llm = RecordingLLM([{"content": ""}])
+    elif case == "summary_unusable_removed_no_evidence":
+        compact_llm = RecordingLLM([{"content": "   "}])
+    elif case == "summary_error_removed_no_evidence":
+
+        class ExplodingCompactLLM:
+            async def chat(self, **kwargs: Any) -> Any:
+                raise RuntimeError("compaction model unavailable")
+
+        compact_llm = ExplodingCompactLLM()
+    elif case == "dropped_only_failed_tool_messages":
+        context = build_context(max_messages=40, result={"success": False})
+    elif case == "dropped_only_control_pseudo_tools":
+        context = build_context(max_messages=40, tool_name="load_skill")
+    elif case == "names_absent_from_base":
+        # The dropped observation names a tool this run can no longer call.
+        context = build_context(max_messages=40, tool_name="list_clients")
+    elif case == "whitespace_normalized_name":
+        # The dropped-name key collapses interior whitespace; the schema name
+        # does not, so the two namespaces miss each other.
+        tools = [NamedTool("list  clients")]
+        context = build_context(max_messages=40, tool_name="list  clients")
+    elif case == "tool_choice_none":
+        pattern.tool_choice = "none"
+    elif case == "unreadable_name_mapping":
+        runtime = ScriptedCompactionRuntime(
+            [compact_result(count=4, by_name=["calculator"])]
+        )
+    elif case == "control_tool_disabled_is_exempt":
+        pattern.forced_answer_reason = FORCED_ANSWER_REASON_CONTROL_TOOL_DISABLED
+    elif case == "legacy_checkpoint_without_reason":
+        pattern.forced_answer_reason = None
+    elif case == "no_iteration_budget":
+        pattern.max_iterations = 2
+        pattern.current_iteration = 1
+    elif case == "budget_already_spent":
+        pattern.forced_answer_compaction_recoveries = FORCED_ANSWER_RECOVERY_BUDGET
+    else:  # pragma: no cover - guards against a typo in the case table
+        raise AssertionError(f"unknown case {case}")
+
+    spent_before = pattern.forced_answer_compaction_recoveries
+    await pattern.run(
+        context=context,
+        tools=tools,
+        llm=llm,
+        compact_llm=compact_llm,
+        runtime=runtime,
+    )
+    return pattern, llm, (runtime, spent_before)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(("case", "expects_evidence_clause"), DECLINE_CASES)
+async def test_recovery_is_declined_and_the_turn_stays_on_final_answer(
+    case: str, expects_evidence_clause: bool
+) -> None:
+    """Every refusal keeps the single-tool turn and picks the right words.
+
+    Refusing recovery is not refusing to be honest: when the gate saw evidence
+    destroyed and still declined, the turn must ask for an answer that names
+    what is missing rather than one drawn from results that are gone.
+    """
+    pattern, llm, (runtime, spent_before) = await run_declined_turn(case)
+
+    assert tool_names_of(llm) == ["final_answer"]
+    assert llm.calls[0]["tool_choice"] == "required"
+    # Declining spends nothing: the budget is only for turns that really did
+    # hand the tools back.
+    assert pattern.forced_answer_compaction_recoveries == spent_before
+    assert RECOVERY_CHECKPOINT not in checkpoint_labels(runtime)
+
+    instruction = instruction_of(llm)
+    assert (HONEST_PHRASE in instruction) is expects_evidence_clause
+    if expects_evidence_clause:
+        # The whole prompt, not just the instruction: a stale copy of the same
+        # advice anywhere in the turn undoes it.
+        assert STALE_EVIDENCE_PHRASE not in whole_prompt_of(llm)
+        assert COMPLETED_OFFERED_PHRASE not in instruction
+        assert COMPLETED_WITHHELD_PHRASE in instruction
+    else:
+        assert STALE_EVIDENCE_PHRASE in instruction
+        assert COMPLETED_OFFERED_PHRASE in instruction
+
+
+@pytest.mark.asyncio
+async def test_declining_recovery_records_the_refusal_in_pattern_state() -> None:
+    """The refusal is state, not just a loop local.
+
+    Without this the decision to be honest lives only in a variable that no
+    checkpoint carries, and a resume between the refusal and the answer would
+    restore the forcing while forgetting the reason for it.
+    """
+    pattern, _llm, _rest = await run_declined_turn("budget_already_spent")
+
+    # The run ended through final_answer, which clears the marker on its way
+    # out, so the refusal is observed while the turn is still live below.
+    assert pattern.forced_answer_recovery_followup is None
+
+    live_pattern = ReActPattern(max_iterations=6)
+    live_pattern.force_final_answer_next = True
+    live_pattern.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
+    live_pattern.forced_answer_compaction_recoveries = FORCED_ANSWER_RECOVERY_BUDGET
+    llm = RecordingLLM([{"content": "plain text, not done", "done": False}])
+    await live_pattern.run(
+        context=build_context(max_messages=40),
+        tools=[NamedTool("calculator")],
+        llm=llm,
+        compact_llm=RecordingLLM([{"content": "A summary of the run."}]),
+        runtime=PatternRuntime(),
+    )
+    assert HONEST_PHRASE in instruction_of(llm)
+
+
+@pytest.mark.asyncio
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "the repeated-tool decision writes its own 'answer from the accumulated "
+        "tool results' guidance into the context; rewriting that text belongs to "
+        "the decision site and is left for separate work. Delete this marker "
+        "when it is done."
+    ),
+)
+async def test_stale_completion_guidance_survives_a_drop_window() -> None:
+    """A repeated-tool decision leaves its own "answer from the results" line.
+
+    That guidance is an ordinary context message, so the message-dropping path
+    can keep it in the tail window while removing the very results it points
+    at. The forced turn then carries the honest instruction and a stale
+    contradiction of it at once. Recorded here as an executable note rather
+    than prose, so the day it is fixed this test says so.
+    """
+    pattern = ReActPattern(max_iterations=6)
+    pattern.repeated_tool_decision = {
+        "tool_name": "calculator",
+        "consecutive_calls": 4,
+        "reason": "same tool four times",
+    }
+    pattern.forced_answer_compaction_recoveries = FORCED_ANSWER_RECOVERY_BUDGET
+    decision = {
+        "content": "",
+        "tool_calls": [
+            {
+                "id": "decision_1",
+                "type": "function",
+                "function": {
+                    "name": "react_decision",
+                    "arguments": (
+                        '{"action":"final_answer","reason":"enough data",'
+                        '"missing_verification":""}'
+                    ),
+                },
+            }
+        ],
+    }
+    llm = RecordingLLM([decision, final_answer_response()])
+
+    await pattern.run(
+        context=build_context(max_messages=4),
+        tools=[NamedTool("calculator")],
+        llm=llm,
+        compact_llm=RecordingLLM([{"content": ""}]),
+        runtime=PatternRuntime(),
+    )
+
+    forced_call = llm.calls[-1]
+    assert [tool["function"]["name"] for tool in (forced_call.get("tools") or [])] == [
+        "final_answer"
+    ]
+    assert HONEST_PHRASE in str(forced_call["messages"][0].get("content", ""))
+    assert STALE_EVIDENCE_PHRASE not in "\n".join(
+        str(message.get("content", "")) for message in forced_call["messages"]
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reason_shape", ["missing_key", "none", "valid_member", "invalid_string"]
+)
+@pytest.mark.parametrize("counter_shape", ["present", "missing_key", "non_integer"])
+@pytest.mark.parametrize(
+    "followup_shape",
+    ["missing_key", "none", "refetched", "no_evidence", "invalid_string"],
+)
+def test_forced_answer_recovery_state_round_trips_through_checkpoint(
+    reason_shape: str, counter_shape: str, followup_shape: str
+) -> None:
+    """Reload defaults differ per key, and each direction is deliberate.
+
+    A reason or a marker this build cannot read must not act -- doing less is
+    safe. The recovery counter is the opposite: treating a missing counter as
+    spent would permanently close the recovery path for every run checkpointed
+    before the counter existed, and that path is itself the safety net.
+    """
+    source = ReActPattern(max_iterations=6)
+    source.forced_answer_reason = FORCED_ANSWER_REASON_EMPTY_FINAL_ANSWER
+    source.forced_answer_compaction_recoveries = 1
+    source.forced_answer_recovery_followup = FORCED_ANSWER_FOLLOWUP_REFETCHED
+    state = source.get_state()
+
+    assert "forced_answer_reason" in state
+    assert "forced_answer_compaction_recoveries" in state
+    assert "forced_answer_recovery_followup" in state
+    assert state["forced_answer_reason"] == FORCED_ANSWER_REASON_EMPTY_FINAL_ANSWER
+    assert state["forced_answer_compaction_recoveries"] == 1
+    assert state["forced_answer_recovery_followup"] == FORCED_ANSWER_FOLLOWUP_REFETCHED
+
+    if reason_shape == "missing_key":
+        del state["forced_answer_reason"]
+        expected_reason = None
+    elif reason_shape == "none":
+        state["forced_answer_reason"] = None
+        expected_reason = None
+    elif reason_shape == "invalid_string":
+        state["forced_answer_reason"] = "some_future_reason"
+        expected_reason = None
+    else:
+        expected_reason = FORCED_ANSWER_REASON_EMPTY_FINAL_ANSWER
+
+    if counter_shape == "missing_key":
+        del state["forced_answer_compaction_recoveries"]
+        expected_counter = 0
+    elif counter_shape == "non_integer":
+        state["forced_answer_compaction_recoveries"] = "1"
+        expected_counter = FORCED_ANSWER_RECOVERY_BUDGET
+    else:
+        expected_counter = 1
+
+    if followup_shape == "missing_key":
+        del state["forced_answer_recovery_followup"]
+        expected_followup = None
+    elif followup_shape == "none":
+        state["forced_answer_recovery_followup"] = None
+        expected_followup = None
+    elif followup_shape == "invalid_string":
+        state["forced_answer_recovery_followup"] = ["refetched"]
+        expected_followup = None
+    elif followup_shape == "no_evidence":
+        state["forced_answer_recovery_followup"] = FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
+        expected_followup = FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
+    else:
+        expected_followup = FORCED_ANSWER_FOLLOWUP_REFETCHED
+
+    restored = ReActPattern(max_iterations=6)
+    restored.load_state(state)
+
+    assert restored.forced_answer_reason == expected_reason
+    assert restored.forced_answer_compaction_recoveries == expected_counter
+    assert restored.forced_answer_recovery_followup == expected_followup
+
+
+def test_a_forcing_reason_can_outlive_the_flag_that_carried_it() -> None:
+    """Cleared forcing plus a leftover reason is a legal state, not a crash.
+
+    Reason is only ever read while the flag is true, and every site that raises
+    the flag rewrites the reason, so a stale reason is unreachable rather than
+    scrubbed.
+    """
+    pattern = ReActPattern(max_iterations=6)
+    pattern.force_final_answer_next = False
+    pattern.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
+
+    restored = ReActPattern(max_iterations=6)
+    restored.load_state(pattern.get_state())
+
+    assert restored.force_final_answer_next is False
+    assert restored.forced_answer_reason == FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("marker", "expects_forced_turn", "expects_evidence_clause"),
+    [
+        (FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE, True, True),
+        (FORCED_ANSWER_FOLLOWUP_REFETCHED, True, False),
+        (None, False, False),
+    ],
+)
+async def test_a_reloaded_marker_decides_the_next_turn(
+    marker: str | None, expects_forced_turn: bool, expects_evidence_clause: bool
+) -> None:
+    """The marker's three readings drive three different next turns."""
+    source = ReActPattern(max_iterations=6)
+    source.forced_answer_recovery_followup = marker
+    restored = ReActPattern(max_iterations=6)
+    restored.load_state(source.get_state())
+
+    llm = RecordingLLM([final_answer_response(), {"content": "done", "done": True}])
+    context = build_context(max_messages=40)
+    context.compact_config.threshold = 10**9
+    await restored.run(
+        context=context,
+        tools=[NamedTool("calculator")],
+        llm=llm,
+        compact_llm=None,
+        runtime=PatternRuntime(),
+    )
+
+    forced = tool_names_of(llm) == ["final_answer"]
+    assert forced is expects_forced_turn
+    assert (HONEST_PHRASE in instruction_of(llm)) is expects_evidence_clause
+    if expects_forced_turn:
+        assert restored.forced_answer_reason == FORCED_ANSWER_REASON_COMPACTION_RECOVERY
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("shape", ["single_call_drop_window", "multi_turn_summary"])
+async def test_a_declined_turn_still_speaks_honestly_after_a_resume(
+    shape: str,
+) -> None:
+    """Interrupt a declined turn, reload it, and it must still be honest.
+
+    The two shapes fail differently without the refusal in state. Under the
+    message-dropping path the reloaded turn is still forced -- the tail window
+    kept a later successful observation, so the engine recomputes "evidence is
+    fine" and asks for an answer drawn from results it no longer has. Under the
+    summary path nothing tool-shaped survives, so a run that forces itself from
+    the latest tool result stops being a forced turn at all and burns its last
+    iteration without answering.
+    """
+    if shape == "single_call_drop_window":
+        pattern = ReActPattern(max_iterations=2, finalize_after_tool_result=True)
+        pattern.current_iteration = 1
+        context = build_context(max_messages=4)
+        compact_llm: Any = RecordingLLM([{"content": ""}])
+    else:
+        pattern = ReActPattern(max_iterations=6)
+        pattern.current_iteration = 1
+        pattern.force_final_answer_next = True
+        pattern.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
+        pattern.forced_answer_compaction_recoveries = FORCED_ANSWER_RECOVERY_BUDGET
+        context = build_context(max_messages=40)
+        compact_llm = RecordingLLM([{"content": "A summary of the run."}])
+
+    runtime = PatternRuntime()
+    interrupting_llm = RecordingLLM([])
+
+    async def interrupt_before_answering(**kwargs: Any) -> Any:
+        interrupting_llm.calls.append(kwargs)
+        runtime.request_interrupt("user stop")
+        return {"content": "", "done": False}
+
+    interrupting_llm.chat = interrupt_before_answering  # type: ignore[method-assign]
+    await pattern.run(
+        context=context,
+        tools=[NamedTool("calculator")],
+        llm=interrupting_llm,
+        compact_llm=compact_llm,
+        runtime=runtime,
+    )
+    state = pattern.get_state()
+    assert (
+        state["forced_answer_recovery_followup"] == FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
+    )
+    spent_before = state["forced_answer_compaction_recoveries"]
+
+    resumed = ReActPattern(max_iterations=pattern.max_iterations)
+    resumed.load_state(state)
+    resumed_runtime = PatternRuntime()
+    resumed_llm = RecordingLLM([final_answer_response()])
+    # The context has already been compacted once and is now under threshold,
+    # so this turn's compaction returns nothing and the gate never runs.
+    context.compact_config.threshold = 10**9
+    await resumed.run(
+        context=context,
+        tools=[NamedTool("calculator")],
+        llm=resumed_llm,
+        compact_llm=None,
+        runtime=resumed_runtime,
+    )
+
+    assert resumed_llm.calls[0]["tool_choice"] == "required"
+    assert tool_names_of(resumed_llm) == ["final_answer"]
+    assert HONEST_PHRASE in instruction_of(resumed_llm)
+    assert STALE_EVIDENCE_PHRASE not in instruction_of(resumed_llm)
+    assert resumed.forced_answer_compaction_recoveries == spent_before
+    assert RECOVERY_CHECKPOINT not in checkpoint_labels(resumed_runtime)
+    if shape == "single_call_drop_window":
+        assert resumed.max_iterations - resumed.current_iteration == 1
+
+
+@pytest.mark.asyncio
+async def test_a_declined_turn_clears_its_marker_once_it_has_run() -> None:
+    """The refusal applies to exactly one turn.
+
+    Reaching the clearing point at all takes a declined turn that ends with a
+    completed tool batch, and a declined turn only offers final_answer. The one
+    route there is the escape hatch the engine already has: the model names a
+    tool outside the narrowed set, the same-turn retry hands the full set back
+    and drops the forcing with it, and the work tool the model then calls runs
+    to completion.
+
+    Without the loop-local half of the refusal the marker survives that turn
+    and turns the next ordinary turn into a second forced one, repeating a
+    warning about missing evidence that was already delivered.
+    """
+    pattern = ReActPattern(max_iterations=6)
+    pattern.force_final_answer_next = True
+    pattern.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
+    pattern.forced_answer_compaction_recoveries = FORCED_ANSWER_RECOVERY_BUDGET
+    llm = RecordingLLM(
+        [
+            # Names a tool the narrowed set does not carry.
+            tool_call_response("calculator", call_id="stray"),
+            # The retry has the full set back, so this one actually runs.
+            tool_call_response("calculator", call_id="work"),
+            final_answer_response(),
+        ]
+    )
+    context = build_context(max_messages=40)
+
+    await pattern.run(
+        context=context,
+        tools=[NamedTool("calculator")],
+        llm=llm,
+        compact_llm=RecordingLLM(
+            [{"content": f"Summary {index}."} for index in range(4)]
+        ),
+        runtime=PatternRuntime(),
+    )
+
+    assert HONEST_PHRASE in instruction_of(llm, 0)
+    assert pattern.forced_answer_recovery_followup is None
+    # The turn after the completed batch is an ordinary one: the refusal was
+    # spent, so nothing forces this turn and nothing repeats the warning.
+    assert tool_names_of(llm, 2) != ["final_answer"]
+    assert HONEST_PHRASE not in instruction_of(llm, 2)
+
+
+@pytest.mark.asyncio
+async def test_a_finished_run_leaves_no_follow_up_marker_behind() -> None:
+    """Finishing clears the marker so a later reload is an ordinary turn."""
+    pattern = ReActPattern(max_iterations=6)
+    pattern.forced_answer_recovery_followup = FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
+    context = build_context(max_messages=40)
+    context.compact_config.threshold = 10**9
+    llm = RecordingLLM([final_answer_response()])
+
+    result = await pattern.run(
+        context=context,
+        tools=[NamedTool("calculator")],
+        llm=llm,
+        compact_llm=None,
+        runtime=PatternRuntime(),
+    )
+
+    assert result["success"] is True
+    assert pattern.get_state()["forced_answer_recovery_followup"] is None
+
+    resumed = ReActPattern(max_iterations=6)
+    resumed.load_state(pattern.get_state())
+    resumed.status = "thinking"
+    resumed.current_iteration = 0
+    resumed_llm = RecordingLLM([final_answer_response()])
+    await resumed.run(
+        context=build_context(max_messages=40, execution_id="after-final"),
+        tools=[NamedTool("calculator")],
+        llm=resumed_llm,
+        compact_llm=None,
+        runtime=PatternRuntime(),
+    )
+    assert tool_names_of(resumed_llm) != ["final_answer"]
+    assert HONEST_PHRASE not in instruction_of(resumed_llm)
+
+
+def _forced_answer_set_nodes(tree: ast.Module) -> list[tuple[ast.AST, ast.Assign]]:
+    """Every ``self.force_final_answer_next = True`` with its enclosing block."""
+    found: list[tuple[ast.AST, ast.Assign]] = []
+    for parent in ast.walk(tree):
+        for field_name in parent._fields:
+            body = getattr(parent, field_name, None)
+            if not isinstance(body, list):
+                continue
+            for node in body:
+                if not isinstance(node, ast.Assign):
+                    continue
+                if not _assigns_attribute(node, "force_final_answer_next"):
+                    continue
+                if isinstance(node.value, ast.Constant) and node.value.value is True:
+                    found.append((parent, node))
+    return found
+
+
+def _assigns_attribute(node: ast.Assign, attribute: str) -> bool:
+    for target in node.targets:
+        if (
+            isinstance(target, ast.Attribute)
+            and target.attr == attribute
+            and isinstance(target.value, ast.Name)
+            and target.value.id == "self"
+        ):
+            return True
+    return False
+
+
+def _reason_names_in_block(parent: ast.AST) -> list[str]:
+    names: list[str] = []
+    for field_name in parent._fields:
+        body = getattr(parent, field_name, None)
+        if not isinstance(body, list):
+            continue
+        for node in body:
+            if not isinstance(node, ast.Assign):
+                continue
+            if not _assigns_attribute(node, "forced_answer_reason"):
+                continue
+            if isinstance(node.value, ast.Name):
+                names.append(node.value.id)
+    return names
+
+
+def test_every_forced_answer_set_site_records_its_reason() -> None:
+    """Raising the forcing flag and naming the reason are one action.
+
+    The recovery gate refuses to undo a forcing it cannot name, so a site that
+    raises the flag without a reason does not break loudly -- it silently turns
+    the whole recovery path off for that source.
+
+    Bounds worth knowing about this check:
+      1. It reads this one module. Another module assigning the attribute on a
+         pattern object is invisible here; the repository-wide search below is
+         what covers that, and only for this literal spelling.
+      2. It recognises only ``ast.Assign`` of the literal ``True``. Assigning a
+         variable, a ``bool(...)`` call, or going through ``setattr`` slips past.
+      3. It reads statement blocks, not runtime reachability. A reason assigned
+         in the same block and overwritten later still counts as paired; the
+         behavioural tests above cover that layer.
+      4. It reads the syntax tree, never the source text. This module writes the
+         attribute name into comments and docstrings, and a text count would go
+         red for reasons that have nothing to do with a missing reason.
+    """
+    source = REACT_SOURCE_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(source)
+    pairs = _forced_answer_set_nodes(tree)
+
+    assert len(pairs) >= 4
+    for parent, node in pairs:
+        reason_names = _reason_names_in_block(parent)
+        assert reason_names, (
+            "force_final_answer_next is set to True at line "
+            f"{node.lineno} without a forced_answer_reason in the same block"
+        )
+        for name in reason_names:
+            assert name.startswith("FORCED_ANSWER_REASON_")
+            assert getattr(react_module, name) in FORCED_ANSWER_REASONS
+
+    assert FORCED_ANSWER_REASONS_EXEMPT_FROM_RECOVERY <= FORCED_ANSWER_REASONS
+    assert FORCED_ANSWER_FOLLOWUPS == {
+        FORCED_ANSWER_FOLLOWUP_REFETCHED,
+        FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE,
+    }
+    assert FORCED_ANSWER_RECOVERY_MIN_REMAINING_ITERATIONS == 2
+    assert FORCED_ANSWER_REASON_FINALIZE_AFTER_TOOL in FORCED_ANSWER_REASONS
+
+
+def test_the_forcing_flag_is_only_written_inside_the_react_module() -> None:
+    """Nothing outside this module raises the flag behind the gate's back."""
+    src_root = REACT_SOURCE_PATH.parents[4]
+    pattern = re.compile(r"force_final_answer_next\s*=")
+    offenders = [
+        path
+        for path in src_root.rglob("*.py")
+        if path != REACT_SOURCE_PATH
+        and pattern.search(path.read_text(encoding="utf-8"))
+    ]
+    assert offenders == []

--- a/tests/core/agent/test_react_forced_answer_compaction.py
+++ b/tests/core/agent/test_react_forced_answer_compaction.py
@@ -39,6 +39,7 @@ from xagent.core.agent.pattern.react.react import (
     FORCED_ANSWER_RECOVERY_BUDGET,
     FORCED_ANSWER_RECOVERY_MIN_REMAINING_ITERATIONS,
 )
+from xagent.core.model.chat.exceptions import LLMToolProtocolError
 
 REACT_SOURCE_PATH = Path(react_module.__file__)
 
@@ -1353,3 +1354,212 @@ async def test_an_older_successful_call_does_not_pass_for_a_recovered_one() -> N
         == FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
     )
     assert HONEST_PHRASE in instruction_of(llm, 2)
+
+
+COMPLETE_SET_PHRASE = "Re-decide this turn using the complete current tool set"
+TURN_SET_PHRASE = "which is the set available on this turn"
+
+
+class ProtocolErrorLLM(RecordingLLM):
+    """Chat LLM that raises a provider protocol error on a chosen call."""
+
+    def __init__(self, responses: list[Any], *, fail_on: int, code: str) -> None:
+        super().__init__(responses)
+        self.fail_on = fail_on
+        self.code = code
+
+    async def chat(self, **kwargs: Any) -> Any:
+        index = len(self.calls)
+        self.calls.append(kwargs)
+        if index == self.fail_on:
+            raise LLMToolProtocolError(
+                provider="deepseek",
+                code=self.code,
+                message=f"provider returned {self.code}",
+            )
+        if not self.responses:
+            return {"content": "fallback answer", "done": True}
+        return self.responses.pop(0)
+
+
+async def run_protocol_retry(
+    turn_kind: str,
+    protocol_error: str,
+    *,
+    user_interaction_enabled: bool = True,
+) -> tuple[ReActPattern, ProtocolErrorLLM, ScriptedCompactionRuntime, set[str]]:
+    """Drive one turn whose first LLM call fails the tool protocol."""
+    tools = [NamedTool("list_clients"), NamedTool("read_ledger")]
+    pattern = ReActPattern(
+        max_iterations=6, user_interaction_enabled=user_interaction_enabled
+    )
+    scripted: list[Any] = [None]
+    recovery_set: set[str] = set()
+
+    if turn_kind == "recovery_turn":
+        pattern.force_final_answer_next = True
+        pattern.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
+        scripted = [compact_result(by_name={"list_clients": 2}, count=2)]
+        recovery_set = {"list_clients", "final_answer"}
+    elif turn_kind == "forced_turn":
+        pattern.force_final_answer_next = True
+        pattern.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
+
+    llm = ProtocolErrorLLM(
+        [tool_call_response("list_clients"), final_answer_response()],
+        fail_on=0,
+        code=(
+            "unavailable_tool_call"
+            if protocol_error == "unavailable_tool_call"
+            else "invalid_tool_protocol"
+        ),
+    )
+    runtime = ScriptedCompactionRuntime(scripted)
+    await pattern.run(
+        context=build_context(tool_name="list_clients", max_messages=40),
+        tools=tools,
+        llm=llm,
+        compact_llm=None,
+        runtime=runtime,
+    )
+    return pattern, llm, runtime, recovery_set
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("turn_kind", ["recovery_turn", "ordinary_turn", "forced_turn"])
+@pytest.mark.parametrize(
+    "protocol_error", ["unavailable_tool_call", "invalid_protocol"]
+)
+async def test_the_protocol_retry_uses_this_turns_own_tool_set(
+    turn_kind: str, protocol_error: str
+) -> None:
+    """A retry must not quietly widen the turn it is repairing.
+
+    The retry exists to let the model re-decide with the full picture, so on an
+    ordinary or forced turn it keeps handing back the run's whole tool set,
+    unchanged. A recovery turn is the one case where that set has to be
+    trimmed: it deliberately narrowed the tools, and the two tools that contact
+    the user rather than read anything have no business reappearing through a
+    repair path.
+    """
+    _pattern, llm, _runtime, recovery_set = await run_protocol_retry(
+        turn_kind, protocol_error
+    )
+
+    base_names = {
+        "list_clients",
+        "read_ledger",
+        "final_answer",
+        "send_message",
+        "ask_user_question",
+    }
+    retry_names = set(tool_names_of(llm, 1))
+
+    if turn_kind == "recovery_turn":
+        assert retry_names == base_names - {"send_message", "ask_user_question"}
+        # Stated as properties rather than a copied name list: the retry set
+        # must be able to reach everything the recovery turn offered, and must
+        # not smuggle in a tool that talks to the user.
+        assert recovery_set <= retry_names
+        assert retry_names & {"send_message", "ask_user_question"} == set()
+    elif turn_kind == "ordinary_turn":
+        assert retry_names == base_names
+    elif protocol_error == "unavailable_tool_call":
+        # The forced turn's whole-set recovery semantics are untouched.
+        assert retry_names == base_names
+    else:
+        assert retry_names == {"final_answer"}
+
+    retry_instruction = instruction_of(llm, 1)
+    if protocol_error == "unavailable_tool_call":
+        if turn_kind == "recovery_turn":
+            assert TURN_SET_PHRASE in retry_instruction
+            assert COMPLETE_SET_PHRASE not in retry_instruction
+        else:
+            assert COMPLETE_SET_PHRASE in retry_instruction
+
+
+@pytest.mark.asyncio
+async def test_narrowing_the_retry_set_removes_nothing_when_asking_is_off() -> None:
+    """With user interaction off the trim is already done and takes no work."""
+    _pattern, llm, _runtime, _recovery_set = await run_protocol_retry(
+        "recovery_turn", "unavailable_tool_call", user_interaction_enabled=False
+    )
+    assert set(tool_names_of(llm, 1)) == {
+        "list_clients",
+        "read_ledger",
+        "final_answer",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("turn_kind", "protocol_error", "expects_honest_retry"),
+    [
+        ("declined_forced_turn", "empty_final_answer", True),
+        ("declined_forced_turn", "malformed_tool_arguments", True),
+        ("consumption_turn", "empty_final_answer", True),
+        ("declined_forced_turn", "unavailable_tool_call", False),
+    ],
+)
+async def test_the_retry_that_produces_the_answer_is_honest_too(
+    turn_kind: str, protocol_error: str, expects_honest_retry: bool
+) -> None:
+    """The retry is the call that reaches the user, so it needs the wording.
+
+    The first call of a turn can carry the honest instruction and still be
+    thrown away: a blank final_answer or malformed arguments makes the retry
+    the one that actually produces the answer. If the retry rebuilds its own
+    prompt without knowing the evidence is gone, it hands back the very
+    sentence the turn was supposed to replace.
+
+    The last case is the deliberate exception. There the model named a tool
+    outside the narrowed set, the retry hands the full set back, and the right
+    move is to fetch the missing values -- not to be told they are unreachable.
+    """
+    pattern = ReActPattern(max_iterations=6)
+    scripted: list[Any] = [compact_result(by_name={"list_clients": 2}, count=2)]
+    if turn_kind == "consumption_turn":
+        # This turn is forced because the previous recovery turn came back
+        # empty-handed; nothing is dropped on the turn itself.
+        pattern.forced_answer_recovery_followup = FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
+        scripted = [None]
+    else:
+        pattern.force_final_answer_next = True
+        pattern.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
+        pattern.forced_answer_compaction_recoveries = FORCED_ANSWER_RECOVERY_BUDGET
+
+    llm: RecordingLLM
+    if protocol_error == "empty_final_answer":
+        blank = final_answer_response()
+        blank["tool_calls"][0]["function"]["arguments"] = (
+            '{"response_language":"English","answer":"   "}'
+        )
+        llm = RecordingLLM([blank, final_answer_response()])
+    else:
+        llm = ProtocolErrorLLM(
+            [final_answer_response()],
+            fail_on=0,
+            code=(
+                "unavailable_tool_call"
+                if protocol_error == "unavailable_tool_call"
+                else "malformed_tool_arguments"
+            ),
+        )
+
+    await pattern.run(
+        context=build_context(tool_name="list_clients", max_messages=40),
+        tools=[NamedTool("list_clients")],
+        llm=llm,
+        compact_llm=None,
+        runtime=ScriptedCompactionRuntime(scripted),
+    )
+
+    assert HONEST_PHRASE in instruction_of(llm, 0)
+    retry_instruction = instruction_of(llm, 1)
+    assert (HONEST_PHRASE in retry_instruction) is expects_honest_retry
+    if expects_honest_retry:
+        assert STALE_EVIDENCE_PHRASE not in retry_instruction
+        assert tool_names_of(llm, 1) == ["final_answer"]
+    else:
+        assert COMPLETE_SET_PHRASE in retry_instruction

--- a/tests/core/agent/test_react_forced_answer_compaction.py
+++ b/tests/core/agent/test_react_forced_answer_compaction.py
@@ -1050,39 +1050,6 @@ async def test_a_recovery_turn_is_followed_by_a_forced_answer_turn() -> None:
 
 
 @pytest.mark.asyncio
-async def test_a_failed_refetch_leads_to_an_honest_forced_answer() -> None:
-    """Calling the tool is not the same as getting the evidence back.
-
-    The verdict reads this turn's own call ids against the ledger, not the tool
-    name. The dropped observation was itself a successful call of that name and
-    its ledger entry outlives the compaction, so a name match would always say
-    the evidence is back.
-    """
-    pattern = ReActPattern(max_iterations=6)
-    pattern.force_final_answer_next = True
-    pattern.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
-    runtime = recovery_runtime(by_name={"list_clients": 2}, count=2)
-    llm = RecordingLLM([tool_call_response("list_clients"), final_answer_response()])
-    context = build_context(tool_name="list_clients", max_messages=40)
-
-    await pattern.run(
-        context=context,
-        tools=[FailingTool("list_clients")],
-        llm=llm,
-        compact_llm=None,
-        runtime=runtime,
-    )
-
-    assert (
-        state_at(runtime, "before_llm", 1)["forced_answer_recovery_followup"]
-        == FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
-    )
-    assert tool_names_of(llm, 1) == ["final_answer"]
-    assert HONEST_PHRASE in instruction_of(llm, 1)
-    assert STALE_EVIDENCE_PHRASE not in whole_prompt_of(llm, 1)
-
-
-@pytest.mark.asyncio
 async def test_a_stale_success_left_in_the_tail_does_not_count_as_recovered() -> None:
     """The message-dropping path keeps a decoy, and the verdict ignores it.
 
@@ -1296,6 +1263,8 @@ async def test_an_evidence_loss_still_ends_the_run_with_an_answer(
         assert HONEST_PHRASE not in instruction_of(llm, 1)
     if outcome == "refetch_fails":
         assert HONEST_PHRASE in instruction_of(llm, 1)
+        assert tool_names_of(llm, 1) == ["final_answer"]
+        assert STALE_EVIDENCE_PHRASE not in whole_prompt_of(llm, 1)
     if outcome == "model_calls_out_of_set_tool":
         # The model fetched something, but not what went missing.
         assert HONEST_PHRASE in instruction_of(llm, 1)

--- a/tests/core/agent/test_react_forced_answer_compaction.py
+++ b/tests/core/agent/test_react_forced_answer_compaction.py
@@ -671,15 +671,17 @@ async def test_a_declined_turn_still_speaks_honestly_after_a_resume(
 
 
 @pytest.mark.asyncio
-async def test_a_recoverable_turn_still_speaks_honestly_after_a_resume() -> None:
-    """The gate can agree to recover on a build that cannot recover yet.
+async def test_a_recovery_turn_resumes_into_a_recovery_turn() -> None:
+    """A pause inside a recovery turn must not resume into a forced answer.
 
-    Handing the dropped tools back is not implemented here, so a turn the gate
-    cleared for recovery is left exactly where a refused one is: still forced
-    to final_answer, with observations it can no longer read. It must therefore
-    record the same refusal in state. Setup below is the refused summary shape
-    with one line removed -- the spent-budget override -- which is the only
-    thing that separates the two paths on this build.
+    The gate clears this turn for recovery, which undoes the forcing and hands
+    the dropped tool back. Both halves of that decision have to be undone
+    together: the loop local picks this turn's instruction, and the marker is
+    what a resume reads. A marker still saying "answer without the evidence"
+    would restore the forcing this turn had just dropped, and the resumed turn
+    would answer without the values it was on its way to fetch. Setup below is
+    the refused summary shape with one line removed -- the spent-budget
+    override -- which is the only thing that separates the two paths.
     """
     pattern = ReActPattern(max_iterations=6)
     pattern.current_iteration = 1
@@ -705,12 +707,12 @@ async def test_a_recoverable_turn_still_speaks_honestly_after_a_resume() -> None
         runtime=runtime,
     )
 
-    # The live turn was honest, so the checkpoint has to say so too.
-    assert HONEST_PHRASE in instruction_of(interrupting_llm)
+    # The live turn recovered: the forcing is gone and the dropped tool is
+    # back, so the marker that would reinstate the forcing has to be gone too.
+    assert RECOVERY_CHECKPOINT in checkpoint_labels(runtime)
+    assert tool_names_of(interrupting_llm) != ["final_answer"]
     state = pattern.get_state()
-    assert (
-        state["forced_answer_recovery_followup"] == FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
-    )
+    assert state["forced_answer_recovery_followup"] is None
 
     resumed = ReActPattern(max_iterations=pattern.max_iterations)
     resumed.load_state(state)
@@ -727,11 +729,8 @@ async def test_a_recoverable_turn_still_speaks_honestly_after_a_resume() -> None
         runtime=resumed_runtime,
     )
 
-    assert tool_names_of(resumed_llm) == ["final_answer"]
-    assert resumed_llm.calls[0]["tool_choice"] == "required"
-    assert HONEST_PHRASE in instruction_of(resumed_llm)
-    assert STALE_EVIDENCE_PHRASE not in whole_prompt_of(resumed_llm)
-    assert RECOVERY_CHECKPOINT not in checkpoint_labels(resumed_runtime)
+    # Resuming lands in the turn the pause interrupted, not in a forced answer.
+    assert tool_names_of(resumed_llm) != ["final_answer"]
 
 
 @pytest.mark.asyncio

--- a/tests/core/agent/test_react_forced_answer_compaction.py
+++ b/tests/core/agent/test_react_forced_answer_compaction.py
@@ -665,6 +665,70 @@ async def test_a_declined_turn_still_speaks_honestly_after_a_resume(
 
 
 @pytest.mark.asyncio
+async def test_a_recoverable_turn_still_speaks_honestly_after_a_resume() -> None:
+    """The gate can agree to recover on a build that cannot recover yet.
+
+    Handing the dropped tools back is not implemented here, so a turn the gate
+    cleared for recovery is left exactly where a refused one is: still forced
+    to final_answer, with observations it can no longer read. It must therefore
+    record the same refusal in state. Setup below is the refused summary shape
+    with one line removed -- the spent-budget override -- which is the only
+    thing that separates the two paths on this build.
+    """
+    pattern = ReActPattern(max_iterations=6)
+    pattern.current_iteration = 1
+    pattern.force_final_answer_next = True
+    pattern.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
+    context = build_context(max_messages=40)
+    compact_llm = RecordingLLM([{"content": "A summary of the run."}])
+
+    runtime = PatternRuntime()
+    interrupting_llm = RecordingLLM([])
+
+    async def interrupt_before_answering(**kwargs: Any) -> Any:
+        interrupting_llm.calls.append(kwargs)
+        runtime.request_interrupt("user stop")
+        return {"content": "", "done": False}
+
+    interrupting_llm.chat = interrupt_before_answering  # type: ignore[method-assign]
+    await pattern.run(
+        context=context,
+        tools=[NamedTool("calculator")],
+        llm=interrupting_llm,
+        compact_llm=compact_llm,
+        runtime=runtime,
+    )
+
+    # The live turn was honest, so the checkpoint has to say so too.
+    assert HONEST_PHRASE in instruction_of(interrupting_llm)
+    state = pattern.get_state()
+    assert (
+        state["forced_answer_recovery_followup"] == FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
+    )
+
+    resumed = ReActPattern(max_iterations=pattern.max_iterations)
+    resumed.load_state(state)
+    resumed_runtime = PatternRuntime()
+    resumed_llm = RecordingLLM([final_answer_response()])
+    # The context has already been compacted once and is now under threshold,
+    # so this turn's compaction returns nothing and the gate never runs.
+    context.compact_config.threshold = 10**9
+    await resumed.run(
+        context=context,
+        tools=[NamedTool("calculator")],
+        llm=resumed_llm,
+        compact_llm=None,
+        runtime=resumed_runtime,
+    )
+
+    assert tool_names_of(resumed_llm) == ["final_answer"]
+    assert resumed_llm.calls[0]["tool_choice"] == "required"
+    assert HONEST_PHRASE in instruction_of(resumed_llm)
+    assert STALE_EVIDENCE_PHRASE not in whole_prompt_of(resumed_llm)
+    assert RECOVERY_CHECKPOINT not in checkpoint_labels(resumed_runtime)
+
+
+@pytest.mark.asyncio
 async def test_a_declined_turn_clears_its_marker_once_it_has_run() -> None:
     """The refusal applies to exactly one turn.
 

--- a/tests/core/agent/test_react_forced_answer_compaction.py
+++ b/tests/core/agent/test_react_forced_answer_compaction.py
@@ -464,17 +464,38 @@ async def test_stale_completion_guidance_survives_a_drop_window() -> None:
     )
 
 
-@pytest.mark.asyncio
+# Sentinels for the reload table below.
+_DROP_KEY = object()  # the checkpoint has no such key at all
+_UNCHANGED = object()  # the stored value survives the round trip as written
+
+
 @pytest.mark.parametrize(
-    "reason_shape", ["missing_key", "none", "valid_member", "invalid_string"]
-)
-@pytest.mark.parametrize("counter_shape", ["present", "missing_key", "non_integer"])
-@pytest.mark.parametrize(
-    "followup_shape",
-    ["missing_key", "none", "refetched", "no_evidence", "invalid_string"],
+    ("key", "stored", "expected"),
+    [
+        ("forced_answer_reason", _DROP_KEY, None),
+        ("forced_answer_reason", None, None),
+        ("forced_answer_reason", "some_future_reason", None),
+        ("forced_answer_reason", FORCED_ANSWER_REASON_EMPTY_FINAL_ANSWER, _UNCHANGED),
+        ("forced_answer_compaction_recoveries", _DROP_KEY, 0),
+        ("forced_answer_compaction_recoveries", "1", FORCED_ANSWER_RECOVERY_BUDGET),
+        ("forced_answer_compaction_recoveries", 1, _UNCHANGED),
+        ("forced_answer_recovery_followup", _DROP_KEY, None),
+        ("forced_answer_recovery_followup", None, None),
+        ("forced_answer_recovery_followup", ["refetched"], None),
+        (
+            "forced_answer_recovery_followup",
+            FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE,
+            _UNCHANGED,
+        ),
+        (
+            "forced_answer_recovery_followup",
+            FORCED_ANSWER_FOLLOWUP_REFETCHED,
+            _UNCHANGED,
+        ),
+    ],
 )
 def test_forced_answer_recovery_state_round_trips_through_checkpoint(
-    reason_shape: str, counter_shape: str, followup_shape: str
+    key: str, stored: Any, expected: Any
 ) -> None:
     """Reload defaults differ per key, and each direction is deliberate.
 
@@ -482,62 +503,35 @@ def test_forced_answer_recovery_state_round_trips_through_checkpoint(
     safe. The recovery counter is the opposite: treating a missing counter as
     spent would permanently close the recovery path for every run checkpointed
     before the counter existed, and that path is itself the safety net.
+
+    Each case reshapes one key and asserts all three, because the keys are
+    normalized independently and crossing them yields no further behaviour.
     """
+    expected_attributes: dict[str, Any] = {
+        "forced_answer_reason": FORCED_ANSWER_REASON_EMPTY_FINAL_ANSWER,
+        "forced_answer_compaction_recoveries": 1,
+        "forced_answer_recovery_followup": FORCED_ANSWER_FOLLOWUP_REFETCHED,
+    }
+
     source = ReActPattern(max_iterations=6)
     source.forced_answer_reason = FORCED_ANSWER_REASON_EMPTY_FINAL_ANSWER
     source.forced_answer_compaction_recoveries = 1
     source.forced_answer_recovery_followup = FORCED_ANSWER_FOLLOWUP_REFETCHED
     state = source.get_state()
 
-    assert "forced_answer_reason" in state
-    assert "forced_answer_compaction_recoveries" in state
-    assert "forced_answer_recovery_followup" in state
-    assert state["forced_answer_reason"] == FORCED_ANSWER_REASON_EMPTY_FINAL_ANSWER
-    assert state["forced_answer_compaction_recoveries"] == 1
-    assert state["forced_answer_recovery_followup"] == FORCED_ANSWER_FOLLOWUP_REFETCHED
+    assert {name: state[name] for name in expected_attributes} == expected_attributes
 
-    if reason_shape == "missing_key":
-        del state["forced_answer_reason"]
-        expected_reason = None
-    elif reason_shape == "none":
-        state["forced_answer_reason"] = None
-        expected_reason = None
-    elif reason_shape == "invalid_string":
-        state["forced_answer_reason"] = "some_future_reason"
-        expected_reason = None
+    expected_attributes[key] = stored if expected is _UNCHANGED else expected
+    if stored is _DROP_KEY:
+        del state[key]
     else:
-        expected_reason = FORCED_ANSWER_REASON_EMPTY_FINAL_ANSWER
-
-    if counter_shape == "missing_key":
-        del state["forced_answer_compaction_recoveries"]
-        expected_counter = 0
-    elif counter_shape == "non_integer":
-        state["forced_answer_compaction_recoveries"] = "1"
-        expected_counter = FORCED_ANSWER_RECOVERY_BUDGET
-    else:
-        expected_counter = 1
-
-    if followup_shape == "missing_key":
-        del state["forced_answer_recovery_followup"]
-        expected_followup = None
-    elif followup_shape == "none":
-        state["forced_answer_recovery_followup"] = None
-        expected_followup = None
-    elif followup_shape == "invalid_string":
-        state["forced_answer_recovery_followup"] = ["refetched"]
-        expected_followup = None
-    elif followup_shape == "no_evidence":
-        state["forced_answer_recovery_followup"] = FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
-        expected_followup = FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
-    else:
-        expected_followup = FORCED_ANSWER_FOLLOWUP_REFETCHED
+        state[key] = stored
 
     restored = ReActPattern(max_iterations=6)
     restored.load_state(state)
 
-    assert restored.forced_answer_reason == expected_reason
-    assert restored.forced_answer_compaction_recoveries == expected_counter
-    assert restored.forced_answer_recovery_followup == expected_followup
+    for attribute, value in expected_attributes.items():
+        assert getattr(restored, attribute) == value
 
 
 def test_a_forcing_reason_can_outlive_the_flag_that_carried_it() -> None:

--- a/tests/core/agent/test_react_forced_answer_compaction.py
+++ b/tests/core/agent/test_react_forced_answer_compaction.py
@@ -20,6 +20,11 @@ from pydantic import BaseModel
 
 import xagent.core.agent.pattern.react.react as react_module
 from xagent.core.agent import ExecutionContext, PatternRuntime, ReActPattern
+from xagent.core.agent.context.execution import (
+    COMPACT_DROPPED_TOOL_NAME_MAX_CHARS,
+    COMPACT_DROPPED_TOOL_NOTICE_MAX_CHARS,
+    COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES,
+)
 from xagent.core.agent.pattern.react.react import (
     FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE,
     FORCED_ANSWER_FOLLOWUP_REFETCHED,
@@ -913,3 +918,438 @@ def test_the_forcing_flag_is_only_written_inside_the_react_module() -> None:
         and pattern.search(path.read_text(encoding="utf-8"))
     ]
     assert offenders == []
+
+
+class FailingTool(NamedTool):
+    """Work tool whose result is a structured failure."""
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        self.calls.append(args)
+        return {"success": False, "error": f"{self.name} is unavailable"}
+
+
+def state_at(
+    runtime: PatternRuntime, label: str, occurrence: int = 0
+) -> dict[str, Any]:
+    matching = [entry for entry in runtime.checkpoints if entry.get("label") == label]
+    return dict(matching[occurrence].get("pattern_state") or {})
+
+
+def recovery_runtime(**metadata: Any) -> ScriptedCompactionRuntime:
+    """Runtime that destroys evidence on the first turn and nothing after.
+
+    Only the first turn needs to lose evidence. Letting every turn compact
+    would make the recovery turn's own re-fetch the next casualty, which is a
+    different scenario from the one under test.
+    """
+    return ScriptedCompactionRuntime([compact_result(**metadata)])
+
+
+FORCING_SOURCES = [
+    "repeated_tool_decision",
+    "finalize_after_tool_result",
+    "latest_tool_result_inline",
+    "empty_final_answer_rejected",
+]
+
+
+def forced_pattern(source: str, **kwargs: Any) -> ReActPattern:
+    if source == "latest_tool_result_inline":
+        # No flag: the loop derives the forcing from the last tool result.
+        return ReActPattern(finalize_after_tool_result=True, **kwargs)
+    pattern = ReActPattern(**kwargs)  # type: ignore[arg-type]
+    pattern.force_final_answer_next = True
+    pattern.forced_answer_reason = {
+        "repeated_tool_decision": FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION,
+        "finalize_after_tool_result": FORCED_ANSWER_REASON_FINALIZE_AFTER_TOOL,
+        "empty_final_answer_rejected": FORCED_ANSWER_REASON_EMPTY_FINAL_ANSWER,
+    }[source]
+    return pattern
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("forcing_source", FORCING_SOURCES)
+@pytest.mark.parametrize("compact_strategy", ["llm_summary", "truncate"])
+async def test_recovery_hands_back_the_tools_whose_results_were_dropped(
+    forcing_source: str, compact_strategy: str
+) -> None:
+    """The turn stops being a forced answer and becomes a re-fetch instead.
+
+    Undoing the forcing is the whole point: the model is handed exactly the
+    tools whose observations went missing, plus final_answer so it can still
+    finish, and nothing else. Tools that lost nothing stay out, and the two
+    tools that talk to the user rather than read anything stay out on every
+    path.
+
+    The run picks ``tool_choice="auto"`` so the forcing override is visible: a
+    forced turn pins the choice to "required" regardless, and a recovery turn
+    has to be back on the run's own setting.
+    """
+    dropped = NamedTool("list_clients")
+    untouched = NamedTool("read_ledger")
+    pattern = forced_pattern(forcing_source, max_iterations=6, tool_choice="auto")
+    runtime = recovery_runtime(
+        by_name={"list_clients": 3}, count=3, strategy=compact_strategy
+    )
+    llm = RecordingLLM([tool_call_response("list_clients"), final_answer_response()])
+
+    await pattern.run(
+        context=build_context(tool_name="list_clients", max_messages=40),
+        tools=[dropped, untouched],
+        llm=llm,
+        compact_llm=None,
+        runtime=runtime,
+    )
+
+    recovery_tools = tool_names_of(llm, 0)
+    assert sorted(recovery_tools) == ["final_answer", "list_clients"]
+    assert "read_ledger" not in recovery_tools
+    assert "send_message" not in recovery_tools
+    assert "ask_user_question" not in recovery_tools
+    assert llm.calls[0]["tool_choice"] == "auto"
+    assert pattern.forced_answer_compaction_recoveries == 1
+    assert checkpoint_labels(runtime).count(RECOVERY_CHECKPOINT) == 1
+    # The recovery turn cleared the forcing outright rather than deferring it.
+    assert state_at(runtime, RECOVERY_CHECKPOINT)["force_final_answer_next"] is False
+    assert state_at(runtime, RECOVERY_CHECKPOINT)["forced_answer_reason"] is None
+    # The turn after it inherits a verdict, whichever way the re-fetch went.
+    assert (
+        state_at(runtime, "before_llm", 1)["forced_answer_recovery_followup"]
+        in FORCED_ANSWER_FOLLOWUPS
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_recovery_turn_is_followed_by_a_forced_answer_turn() -> None:
+    """A successful re-fetch buys exactly one ordinary forced answer turn."""
+    pattern = ReActPattern(max_iterations=6)
+    pattern.force_final_answer_next = True
+    pattern.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
+    runtime = recovery_runtime(by_name={"list_clients": 2}, count=2)
+    llm = RecordingLLM([tool_call_response("list_clients"), final_answer_response()])
+
+    await pattern.run(
+        context=build_context(tool_name="list_clients", max_messages=40),
+        tools=[NamedTool("list_clients")],
+        llm=llm,
+        compact_llm=None,
+        runtime=runtime,
+    )
+
+    assert (
+        state_at(runtime, "before_llm", 1)["forced_answer_recovery_followup"]
+        == FORCED_ANSWER_FOLLOWUP_REFETCHED
+    )
+    assert tool_names_of(llm, 1) == ["final_answer"]
+    assert llm.calls[1]["tool_choice"] == "required"
+    # The evidence came back, so the ordinary wording is correct again.
+    assert HONEST_PHRASE not in instruction_of(llm, 1)
+    assert STALE_EVIDENCE_PHRASE in instruction_of(llm, 1)
+    assert pattern.forced_answer_reason == FORCED_ANSWER_REASON_COMPACTION_RECOVERY
+
+
+@pytest.mark.asyncio
+async def test_a_failed_refetch_leads_to_an_honest_forced_answer() -> None:
+    """Calling the tool is not the same as getting the evidence back.
+
+    The verdict reads this turn's own call ids against the ledger, not the tool
+    name. The dropped observation was itself a successful call of that name and
+    its ledger entry outlives the compaction, so a name match would always say
+    the evidence is back.
+    """
+    pattern = ReActPattern(max_iterations=6)
+    pattern.force_final_answer_next = True
+    pattern.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
+    runtime = recovery_runtime(by_name={"list_clients": 2}, count=2)
+    llm = RecordingLLM([tool_call_response("list_clients"), final_answer_response()])
+    context = build_context(tool_name="list_clients", max_messages=40)
+
+    await pattern.run(
+        context=context,
+        tools=[FailingTool("list_clients")],
+        llm=llm,
+        compact_llm=None,
+        runtime=runtime,
+    )
+
+    assert (
+        state_at(runtime, "before_llm", 1)["forced_answer_recovery_followup"]
+        == FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
+    )
+    assert tool_names_of(llm, 1) == ["final_answer"]
+    assert HONEST_PHRASE in instruction_of(llm, 1)
+    assert STALE_EVIDENCE_PHRASE not in whole_prompt_of(llm, 1)
+
+
+@pytest.mark.asyncio
+async def test_a_stale_success_left_in_the_tail_does_not_count_as_recovered() -> None:
+    """The message-dropping path keeps a decoy, and the verdict ignores it.
+
+    Its tail window can hold an older successful observation of the same tool
+    while removing the one the answer needed. Asking "is there tool evidence in
+    context" answers yes here and is exactly the wrong question.
+    """
+    pattern = ReActPattern(max_iterations=6)
+    pattern.force_final_answer_next = True
+    pattern.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
+    runtime = recovery_runtime(
+        by_name={"list_clients": 1}, count=1, strategy="truncate"
+    )
+    llm = RecordingLLM([tool_call_response("list_clients"), final_answer_response()])
+    context = build_context(tool_name="list_clients", max_messages=40)
+
+    await pattern.run(
+        context=context,
+        tools=[FailingTool("list_clients")],
+        llm=llm,
+        compact_llm=None,
+        runtime=runtime,
+    )
+
+    assert any(message.role == "tool" for message in context.messages)
+    assert HONEST_PHRASE in instruction_of(llm, 1)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "second_forcing_from_repeated_decision",
+        "recovery_followup_never_chains",
+    ],
+)
+async def test_the_recovery_budget_is_spent_once_per_pattern(scenario: str) -> None:
+    """One re-fetch per pattern, and the turn it buys can never buy another.
+
+    Two separate things hold the line. The budget stops a second recovery in
+    the same run, and the follow-up turn's own reason sits in the exempt set so
+    that even with budget to spare it cannot recover again -- which is what
+    stops recovery from chaining indefinitely.
+    """
+    pattern = ReActPattern(max_iterations=8)
+    pattern.force_final_answer_next = True
+    pattern.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
+    if scenario == "recovery_followup_never_chains":
+        # Budget deliberately widened: whatever refuses the second recovery
+        # here, it is not the budget.
+        pattern.forced_answer_compaction_recoveries = -1
+    runtime = ScriptedCompactionRuntime(
+        [
+            compact_result(by_name={"list_clients": 2}, count=2),
+            compact_result(by_name={"list_clients": 2}, count=2),
+        ]
+    )
+    llm = RecordingLLM([tool_call_response("list_clients"), final_answer_response()])
+
+    await pattern.run(
+        context=build_context(tool_name="list_clients", max_messages=40),
+        tools=[NamedTool("list_clients")],
+        llm=llm,
+        compact_llm=None,
+        runtime=runtime,
+    )
+
+    # Turn 0 recovered. Turn 1 lost evidence again and must not recover.
+    assert checkpoint_labels(runtime).count(RECOVERY_CHECKPOINT) == 1
+    assert tool_names_of(llm, 1) == ["final_answer"]
+    assert HONEST_PHRASE in instruction_of(llm, 1)
+
+
+@pytest.mark.parametrize(
+    ("name_count", "name_length"),
+    [(0, 8), (1, 8), (20, 8), (21, 8), (1, 65), (20, 64)],
+)
+def test_the_recovery_message_authorizes_a_bounded_refetch(
+    name_count: int, name_length: int
+) -> None:
+    """Four things must be said, and the tool names must stay bounded.
+
+    The names come from dynamic server configuration and this message enters
+    the context on every recovery, so it mirrors all three bounds the
+    compaction notice already applies rather than inventing its own.
+    """
+    pattern = ReActPattern(max_iterations=6)
+    names = {
+        f"tool_{index}".ljust(name_length, "z")[:name_length]
+        for index in range(name_count)
+    }
+    message = pattern._forced_answer_recovery_message(names)
+
+    # 1: which observations went missing.
+    assert "removed from context by compaction" in message
+    # 2: re-fetching is expected, and it outranks the standing advice.
+    assert "expected action" in message
+    assert "takes priority over any earlier" in message
+    assert "not to repeat completed tool work" in message
+    # 3: only reading tools may be re-run.
+    assert "Only re-run tools that read" in message
+    assert "writes, sends, executes, or otherwise changes state" in message
+    # 4: no answer before the values are back, and no stand-in for them.
+    assert "Do not give the final answer before" in message
+    assert "reconstructing, estimating, or illustrating" in message
+
+    listed = [line for line in message.splitlines() if line.startswith("- tool_")]
+    assert len(listed) <= COMPACT_DROPPED_TOOL_NOTICE_MAX_NAMES
+    assert all(len(line) - 2 <= COMPACT_DROPPED_TOOL_NAME_MAX_CHARS for line in listed)
+    assert len(message) <= COMPACT_DROPPED_TOOL_NOTICE_MAX_CHARS + max(
+        (len(line) + 1 for line in message.splitlines()), default=0
+    )
+    if name_count > len(listed):
+        assert "additional tool name" in message
+    if name_count:
+        assert listed
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "outcome",
+    [
+        "no_evidence_dropped",
+        "refetch_succeeds",
+        "refetch_fails",
+        "model_answers_without_refetching",
+        "model_answers_in_plain_text",
+        "model_calls_out_of_set_tool",
+        "single_call_cannot_recover",
+        "recovery_at_the_exact_iteration_floor",
+    ],
+)
+async def test_an_evidence_loss_still_ends_the_run_with_an_answer(
+    outcome: str,
+) -> None:
+    """However the recovery turn ends, the run delivers an answer.
+
+    Spending a turn on re-fetching only helps if the run can still afford the
+    answer afterwards, which is what the remaining-iterations floor buys. A run
+    that recovers and then hits its iteration ceiling would have been better
+    off never recovering.
+    """
+    tools: list[Any] = [NamedTool("list_clients")]
+    pattern = ReActPattern(max_iterations=6)
+    pattern.force_final_answer_next = True
+    pattern.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
+    scripted: list[Any] = [compact_result(by_name={"list_clients": 2}, count=2)]
+    responses: list[Any] = [
+        tool_call_response("list_clients"),
+        final_answer_response(),
+    ]
+
+    if outcome == "no_evidence_dropped":
+        scripted = [compact_result(count=0, by_name={})]
+        responses = [final_answer_response()]
+    elif outcome == "refetch_fails":
+        tools = [FailingTool("list_clients")]
+    elif outcome == "model_answers_without_refetching":
+        responses = [final_answer_response()]
+    elif outcome == "model_answers_in_plain_text":
+        responses = [{"content": "Answering from the summary.", "done": True}]
+    elif outcome == "model_calls_out_of_set_tool":
+        tools = [NamedTool("list_clients"), NamedTool("read_ledger")]
+        responses = [
+            tool_call_response("read_ledger"),
+            final_answer_response(),
+        ]
+    elif outcome == "single_call_cannot_recover":
+        pattern = ReActPattern(max_iterations=2, finalize_after_tool_result=True)
+        pattern.current_iteration = 1
+        pattern.force_final_answer_next = True
+        pattern.forced_answer_reason = FORCED_ANSWER_REASON_FINALIZE_AFTER_TOOL
+        responses = [final_answer_response()]
+    elif outcome == "recovery_at_the_exact_iteration_floor":
+        # Exactly two iterations left: one to re-fetch, one to answer.
+        pattern = ReActPattern(max_iterations=4)
+        pattern.current_iteration = 2
+        pattern.force_final_answer_next = True
+        pattern.forced_answer_reason = FORCED_ANSWER_REASON_REPEATED_TOOL_DECISION
+        tools = [FailingTool("list_clients")]
+
+    runtime = ScriptedCompactionRuntime(scripted)
+    llm = RecordingLLM(responses)
+    result = await pattern.run(
+        context=build_context(tool_name="list_clients", max_messages=40),
+        tools=tools,
+        llm=llm,
+        compact_llm=None,
+        runtime=runtime,
+    )
+
+    assert result["success"] is True
+    assert isinstance(result["response"], str) and result["response"].strip()
+    assert result.get("status") != "max_iterations"
+    assert "max_iterations" not in checkpoint_labels(runtime)
+
+    if outcome == "single_call_cannot_recover":
+        assert checkpoint_labels(runtime).count(RECOVERY_CHECKPOINT) == 0
+        assert HONEST_PHRASE in instruction_of(llm, 0)
+    elif outcome == "no_evidence_dropped":
+        assert checkpoint_labels(runtime).count(RECOVERY_CHECKPOINT) == 0
+        assert HONEST_PHRASE not in instruction_of(llm, 0)
+    else:
+        assert checkpoint_labels(runtime).count(RECOVERY_CHECKPOINT) == 1
+
+    if outcome == "recovery_at_the_exact_iteration_floor":
+        # The floor is the only reason this run had room for both turns.
+        assert pattern.forced_answer_compaction_recoveries == 1
+        assert HONEST_PHRASE in instruction_of(llm, 1)
+    if outcome == "refetch_succeeds":
+        assert HONEST_PHRASE not in instruction_of(llm, 1)
+    if outcome == "refetch_fails":
+        assert HONEST_PHRASE in instruction_of(llm, 1)
+    if outcome == "model_calls_out_of_set_tool":
+        # The model fetched something, but not what went missing.
+        assert HONEST_PHRASE in instruction_of(llm, 1)
+
+
+class SucceedsThenFailsTool(NamedTool):
+    """Work tool that succeeds on its first call and fails afterwards."""
+
+    async def run_json_async(self, args: dict[str, Any]) -> Any:
+        self.calls.append(args)
+        if len(self.calls) == 1:
+            return {"output": f"{self.name} first result"}
+        return {"success": False, "error": f"{self.name} is unavailable now"}
+
+
+@pytest.mark.asyncio
+async def test_an_older_successful_call_does_not_pass_for_a_recovered_one() -> None:
+    """The ledger outlives compaction, so the verdict cannot go by name.
+
+    The observation compaction dropped was itself a successful call of a
+    recovery-set tool, and its ledger entry survives -- compaction removes
+    messages, not ledger entries. Asking "has a tool of this name ever
+    succeeded" therefore answers yes before the recovery turn even starts.
+    Here the same tool succeeds on the first turn and fails on the re-fetch,
+    so the two readings disagree and only the turn-scoped one is right.
+    """
+    tool = SucceedsThenFailsTool("list_clients")
+    pattern = ReActPattern(max_iterations=6, finalize_after_tool_result=True)
+    runtime = ScriptedCompactionRuntime(
+        [None, compact_result(by_name={"list_clients": 1}, count=1)]
+    )
+    llm = RecordingLLM(
+        [
+            tool_call_response("list_clients", call_id="first"),
+            tool_call_response("list_clients", call_id="refetch"),
+            final_answer_response(),
+        ]
+    )
+    context = ExecutionContext(execution_id="ledger-scope")
+    context.add_user_message("List every client.")
+
+    await pattern.run(
+        context=context,
+        tools=[tool],
+        llm=llm,
+        compact_llm=None,
+        runtime=runtime,
+    )
+
+    assert len(tool.calls) == 2
+    assert checkpoint_labels(runtime).count(RECOVERY_CHECKPOINT) == 1
+    assert "first" in pattern.tool_ledger
+    assert pattern.tool_ledger["first"].status == "completed"
+    assert (
+        state_at(runtime, "before_llm", 2)["forced_answer_recovery_followup"]
+        == FORCED_ANSWER_FOLLOWUP_NO_EVIDENCE
+    )
+    assert HONEST_PHRASE in instruction_of(llm, 2)


### PR DESCRIPTION
## Summary

Stacked on `fix/react-forced-answer-honest-instruction` (#2147); merge that one first. Until that PR merges, this diff also shows its commits.
Saying that the evidence is gone is the fallback, not the goal. When this turn's
compaction destroys the observations a forced turn was going to answer from, and
the run can still afford it, this change undoes the forcing for exactly one turn
and hands back only the reading tools whose results went missing, plus
`final_answer` so the model can still finish. The turn after that one is always
the forced answer turn: if the re-fetch brought the values back it gets the
ordinary instruction, and if it did not it gets the honest one. A tool-protocol
repair inside the same turn now rebuilds the request from that turn's own tool
set and keeps the honest wording instead of restoring the sentence the first call
had already replaced.

## Behavior changes

- A forced turn whose own compaction dropped tool results has its forcing undone
  for one turn, and receives the dropped reading tools plus `final_answer`.
- Tools that lost nothing stay out of that set, and so do the two control tools
  that contact the user rather than read anything.
- A system message on that turn names the missing observations, states that
  fetching them again outranks the standing advice against repeating tool work,
  limits re-runs to reading tools, and withholds the final answer until the
  values are back or reported missing.
- The turn immediately after a recovery turn is always forced back to
  `final_answer`, with the instruction chosen by whether the evidence actually
  returned.
- Whether the re-fetch worked is decided from the turn's own tool call ids, not
  from tool names. The dropped observation was itself a successful call of one of
  those names and its ledger entry outlives the compaction, so a name match would
  always claim the evidence came back.
- A same-turn tool-protocol repair now receives the turn's own tool set and the
  fact that evidence was dropped. Ordinary and forced turns are unchanged: the
  repair still offers the run's whole tool set and its wording is byte-identical.
  A turn that narrowed its own tools gets that narrowed set widened only by the
  tools it is still entitled to, and the "re-decide with the complete tool set"
  line becomes accurate for it.
- A recovery turn clears the persisted evidence marker together with the loop-local flag, so a pause during the recovery turn resumes into a recovery turn rather than a forced answer; `test_a_recovery_turn_resumes_into_a_recovery_turn` fails without that clearing line.

## Bounds and residual risk

- At most one recovery per pattern instance. The spent count travels in the
  checkpoint, so a pause and resume cannot buy a second one.
- Never when fewer than two iterations remain, one to re-fetch and one to answer,
  so recovering can never cost the run its answer; a run with room for a single
  call therefore never recovers.
- Never for a forcing that means "stop and report blocked", and never for the
  turn a previous recovery already produced, which is what stops recovery from
  chaining into itself.
- Residual risk: the restored set is chosen by which results were dropped, so it
  can contain a tool that writes as well as reads. The limit to reading is stated
  in the prompt, not enforced by the tool layer. Marking tools read-only in the
  tool protocol, so this set can be filtered rather than described, is the
  follow-up that closes it.
- Keeping the repair set wider than a narrowed turn's own set is deliberate: a
  model that needs some other tool to reach the dropped values would otherwise
  name it twice and fail the run outright.

## Not in this PR

- Any change to the honest instruction itself or to the three checkpoint keys,
  which land in the branch this one stacks on.
- Read-only enforcement in the tool protocol.
- Rewriting the guidance the repeated-tool decision writes into the context; the
  strict xfail test carried by the first branch still records that gap.

## Verification

- `tests/core/agent/test_react.py`, `tests/core/agent/test_grounding.py` and
  `tests/core/agent/test_react_forced_answer_compaction.py`: 314 passed,
  1 xfailed. This branch adds 38 cases to that file on top of the branch it
  stacks on, which alone runs 39 passed and 1 xfailed there.
- Mutation checks on the production file, each reverted immediately: making the
  re-fetch verdict match by tool name instead of the turn's own call ids, giving
  the recovery turn the run's whole tool set, dropping the recovery reason from
  the set exempt from recovery, clearing the follow-up marker as soon as it is
  read, folding every control tool into the restored set, rebuilding the repair
  request without the dropped-evidence fact, and rebuilding it from the run's
  whole tool set. Each turned red, caught by
  `test_an_older_successful_call_does_not_pass_for_a_recovered_one`,
  `test_recovery_hands_back_the_tools_whose_results_were_dropped`,
  `test_the_recovery_budget_is_spent_once_per_pattern`, the recovery-chain
  tests, `test_the_retry_that_produces_the_answer_is_honest_too` and
  `test_the_protocol_retry_uses_this_turns_own_tool_set`.
- `test_an_evidence_loss_still_ends_the_run_with_an_answer` walks the outcome
  matrix and asserts every one of them ends the run with an answer and never at
  the iteration ceiling.
- `pre-commit run --files` on both changed files: ruff check, ruff format, mypy,
  isort, codespell and the whitespace hooks all pass.

Part of #2146


