### PR TITLE
fix: preserve currency in Markdown rendering

### DIFF
--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -213,6 +213,110 @@ describe('MarkdownRenderer', () => {
     expect(screen.queryByText(/\$x\^2 \+ y\^2 = 1\$/)).toBeNull()
   })
 
+  it.each([
+    '$15/month or $25/month.',
+    'Budget: $10–$25.',
+    'Price ratio: $15/$25.',
+    'A$5.6M ≈ US$3.7M',
+    'S$15 vs S$25',
+    'Prices: $ 15 and $ 25.',
+    '$0.50, $1,200.00 and $-25',
+  ])('preserves currency as ordinary text: %s', (content) => {
+    const { container } = render(<MarkdownRenderer content={content} />)
+
+    expect(container.querySelector('p')?.textContent).toBe(content)
+    expect(container.querySelector('.katex')).toBeNull()
+  })
+
+  it('preserves bold plan names and prices in the SIMBA comparison', () => {
+    const { container } = render(<MarkdownRenderer content={[
+      '**SIMBA $15:** 600GB, budget $10–$25.',
+      'A$5.6M ≈ US$3.7M',
+    ].join('\n\n')} />)
+
+    expect(screen.getByText('SIMBA $15:').tagName).toBe('STRONG')
+    expect(container.querySelector('p')?.textContent).toBe('SIMBA $15: 600GB, budget $10–$25.')
+    expect(screen.getByText('A$5.6M ≈ US$3.7M')).toBeInTheDocument()
+    expect(container.querySelector('.katex')).toBeNull()
+  })
+
+  it('preserves price cells, bold labels, and source links in a comparison table', () => {
+    const { container } = render(<MarkdownRenderer content={[
+      '| Plan | Price | Source |',
+      '| --- | --- | --- |',
+      '| **SIMBA** | $15–$25 | [Plans $15–$25](https://example.com/plans?min=$15&max=$25) |',
+      '| Other | A$5.6M ≈ US$3.7M | — |',
+    ].join('\n')} />)
+
+    expect(screen.getAllByRole('row')).toHaveLength(3)
+    expect(screen.getAllByRole('cell')).toHaveLength(6)
+    expect(screen.getByRole('cell', { name: '$15–$25' })).toBeInTheDocument()
+    expect(screen.getByRole('cell', { name: 'A$5.6M ≈ US$3.7M' })).toBeInTheDocument()
+    expect(screen.getByText('SIMBA').tagName).toBe('STRONG')
+    expect(screen.getByRole('link', { name: 'Plans $15–$25' })).toHaveAttribute(
+      'href', 'https://example.com/plans?min=$15&max=$25',
+    )
+    expect(container.querySelector('.katex')).toBeNull()
+  })
+
+  it('keeps an unfinished second price from swallowing the first during rerenders', () => {
+    const { container, rerender } = render(<MarkdownRenderer content="" />)
+
+    for (const content of ['SIMBA $15, budget $', 'SIMBA $15, budget $10', 'SIMBA $15, budget $10–$25.']) {
+      rerender(<MarkdownRenderer content={content} />)
+      expect(container.querySelector('p')?.textContent).toBe(content)
+      expect(container.querySelector('.katex')).toBeNull()
+    }
+  })
+
+  it('renders numeric formulas alongside currency without merging their delimiters', () => {
+    const { container } = render(
+      <MarkdownRenderer content="Pay $15 or $25; the equation is $2 + 2 = 4$, then $x^2$." />,
+    )
+
+    expect(container.querySelector('p')?.textContent).toMatch(/^Pay \$15 or \$25; the equation is /)
+    expect(container.querySelectorAll('.katex')).toHaveLength(2)
+    expect(Array.from(container.querySelectorAll('annotation')).map((node) => node.textContent)).toEqual([
+      '2 + 2 = 4', 'x^2',
+    ])
+  })
+
+  it.each([
+    ['Number: $10$.', '10'],
+    ['Inline $$ x + y $$ math.', 'x + y'],
+    ['$$\nE = mc^2\n$$', 'E = mc^2'],
+    ['Formula: $x_1 + \\frac{1}{2}$.', 'x_1 + \\frac{1}{2}'],
+  ])('preserves explicit math delimiters: %s', (content, formula) => {
+    const { container } = render(<MarkdownRenderer content={content} />)
+
+    expect(container.querySelectorAll('.katex')).toHaveLength(1)
+    expect(container.querySelector('annotation')?.textContent).toBe(formula)
+  })
+
+  it.each(['$ x$', '$x $', '$x$2'])(
+    'requires tight single-dollar delimiters and a non-digit after the closer: %s',
+    (content) => {
+      const { container } = render(<MarkdownRenderer content={content} />)
+
+      expect(container.querySelector('p')?.textContent).toBe(content)
+      expect(container.querySelector('.katex')).toBeNull()
+    },
+  )
+
+  it('leaves escaped dollars and code containing prices unchanged', () => {
+    const { container } = render(<MarkdownRenderer content={[
+      String.raw`Prices: \$15 and \$25.`,
+      '`$15 and $25`',
+      '```text\n$15 and $25\n```',
+    ].join('\n\n')} />)
+
+    expect(screen.getByText('Prices: $15 and $25.')).toBeInTheDocument()
+    expect(Array.from(container.querySelectorAll('code')).map((node) => node.textContent?.trim())).toEqual([
+      '$15 and $25', '$15 and $25',
+    ])
+    expect(container.querySelector('.katex')).toBeNull()
+  })
+
   it('does not treat $PATH inside code block as math', () => {
     const content = '```bash\necho $PATH\n```'
     render(<MarkdownRenderer content={content} />)

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -283,7 +283,11 @@ describe('MarkdownRenderer', () => {
 
   it.each([
     ['Number: $10$.', '10'],
+    ['The $x$-axis.', 'x'],
+    ['Coordinate ($x$).', 'x'],
+    ['At end $x$', 'x'],
     ['Inline $$ x + y $$ math.', 'x + y'],
+    ['Inline $$\tx\t$$ math.', '\tx\t'],
     ['$$\nE = mc^2\n$$', 'E = mc^2'],
     ['Formula: $x_1 + \\frac{1}{2}$.', 'x_1 + \\frac{1}{2}'],
   ])('preserves explicit math delimiters: %s', (content, formula) => {
@@ -293,7 +297,7 @@ describe('MarkdownRenderer', () => {
     expect(container.querySelector('annotation')?.textContent).toBe(formula)
   })
 
-  it.each(['$ x$', '$x $', '$x$2'])(
+  it.each(['$ x$', '$x $', '$x$2', '$\tx\t$', '$\u00a0x\u00a0$'])(
     'requires tight single-dollar delimiters and a non-digit after the closer: %s',
     (content) => {
       const { container } = render(<MarkdownRenderer content={content} />)
@@ -303,7 +307,19 @@ describe('MarkdownRenderer', () => {
     },
   )
 
-  it('leaves escaped dollars and code containing prices unchanged', () => {
+  it.each([
+    [String.raw`It costs \$20 (USD\$).`, 'It costs $20 (USD$).'],
+    [String.raw`Cost \$5, currency USD\$`, 'Cost $5, currency USD$'],
+    [String.raw`\$X+\$Y`, '$X+$Y'],
+    [String.raw`\$10\$`, '$10$'],
+  ])('supports explicit literal dollars in ambiguous prose: %s', (content, expected) => {
+    const { container } = render(<MarkdownRenderer content={content} />)
+
+    expect(container.querySelector('p')?.textContent).toBe(expected)
+    expect(container.querySelector('.katex')).toBeNull()
+  })
+
+  it('preserves existing escaped-dollar and code behavior', () => {
     const { container } = render(<MarkdownRenderer content={[
       String.raw`Prices: \$15 and \$25.`,
       '`$15 and $25`',

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -1,8 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import ReactMarkdown, { defaultUrlTransform } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import remarkMath from 'remark-math'
 import rehypeKatex from 'rehype-katex'
+import { remarkCurrencySafeMath } from '@/lib/remark-currency-safe-math'
 import type { Components, ExtraProps } from 'react-markdown'
 import { apiRequest } from '@/lib/api-wrapper'
 import { AgentCard } from '@/components/chat/AgentCard'
@@ -604,7 +604,7 @@ export function MarkdownRenderer({
     <MarkdownRendererContext.Provider value={contextValue}>
       <div className={`prose prose-invert max-w-none break-words [overflow-wrap:anywhere] ${className}`}>
         <ReactMarkdown
-          remarkPlugins={[remarkGfm, remarkMath]}
+          remarkPlugins={[remarkGfm, remarkCurrencySafeMath]}
           rehypePlugins={[rehypeKatex]}
           components={markdownComponents}
           urlTransform={safeUrlTransform}

--- a/frontend/src/lib/remark-currency-safe-math.test.ts
+++ b/frontend/src/lib/remark-currency-safe-math.test.ts
@@ -88,6 +88,24 @@ describe('currency-safe math registration', () => {
     expect(getMathText(extensions[2]).tokenize).not.toBe(newTokenizer)
     expect(getMathText(existing).tokenize).toBe(existingTokenizer)
     expect(otherDollar.tokenize).toBe(otherTokenizer)
+
+    // Exercise the selected tokenizer, not just its identity. Isolate it from
+    // the deliberately unguarded older parser fixtures; this is a registration
+    // contract test, not a claim that remark-math currently emits this shape.
+    const parser = unified().use(remarkParse).data({
+      ...processor.data(),
+      micromarkExtensions: [{ text: { [DOLLAR_CODE]: getMathText(extensions[2]) } }],
+    })
+    expect(parser.parse('Budget $10–$25; $x^2$.')).toMatchObject({
+      children: [{
+        type: 'paragraph',
+        children: [
+          { type: 'text', value: 'Budget $10–$25; ' },
+          { type: 'inlineMath', value: 'x^2' },
+          { type: 'text', value: '.' },
+        ],
+      }],
+    })
   })
 
   it('keeps currency literal and math enabled with the real dependency', () => {

--- a/frontend/src/lib/remark-currency-safe-math.test.ts
+++ b/frontend/src/lib/remark-currency-safe-math.test.ts
@@ -1,0 +1,107 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { unified, type Data, type Processor } from 'unified'
+import remarkParse from 'remark-parse'
+import remarkMath from 'remark-math'
+import { remarkCurrencySafeMath } from './remark-currency-safe-math'
+
+vi.mock('remark-math', () => ({ default: vi.fn() }))
+
+let realRemarkMath: typeof remarkMath
+const DOLLAR_CODE = '$'.charCodeAt(0)
+const registrationError = 'remarkCurrencySafeMath: remark-math did not register a mathText tokenizer'
+
+function createMathExtension() {
+  return unified().use(realRemarkMath).freeze().data().micromarkExtensions![0]
+}
+
+function getMathText(extension: NonNullable<Data['micromarkExtensions']>[number]) {
+  const text = extension.text![DOLLAR_CODE]!
+  return (Array.isArray(text) ? text : [text]).find((construct) => construct.name === 'mathText')!
+}
+
+describe('currency-safe math registration', () => {
+  beforeEach(async () => {
+    realRemarkMath = (await vi.importActual<typeof import('remark-math')>('remark-math')).default
+    vi.mocked(remarkMath).mockImplementation(realRemarkMath)
+  })
+  afterEach(() => vi.mocked(remarkMath).mockReset())
+
+  it.each([
+    ['missing registry', undefined],
+    ['empty registry', []],
+    ['missing dollar syntax', [{}]],
+    ['empty dollar constructs', [{ text: { [DOLLAR_CODE]: [] } }]],
+  ] satisfies Array<[string, Data['micromarkExtensions']]>)(
+    'reports incompatible remark-math registration: %s',
+    (_name, extensions) => {
+      vi.mocked(remarkMath).mockImplementation(function (this: Processor) {
+        this.data().micromarkExtensions = extensions
+      })
+
+      expect(() => unified().use(remarkCurrencySafeMath).freeze()).toThrow(registrationError)
+    },
+  )
+
+  it('rejects a newly registered dollar construct with an unexpected name', () => {
+    vi.mocked(remarkMath).mockImplementation(function (this: Processor) {
+      const extension = createMathExtension()
+      getMathText(extension).name = 'renamedMathText'
+      this.data().micromarkExtensions = [extension]
+    })
+
+    expect(() => unified().use(remarkCurrencySafeMath).freeze()).toThrow(registrationError)
+  })
+
+  it('does not mistake an existing mathText for a missing new registration', () => {
+    const existing = createMathExtension()
+    const originalTokenizer = getMathText(existing).tokenize
+    vi.mocked(remarkMath).mockImplementation(() => undefined)
+    const processor = unified().data('micromarkExtensions', [existing])
+
+    expect(() => processor.use(remarkCurrencySafeMath).freeze()).toThrow(registrationError)
+    expect(getMathText(existing).tokenize).toBe(originalTokenizer)
+  })
+
+  it('selects the new mathText even with earlier dollar plugins and later registrations', () => {
+    const existing = createMathExtension()
+    const existingTokenizer = getMathText(existing).tokenize
+    const otherDollar = { ...getMathText(createMathExtension()), name: 'otherDollarSyntax' }
+    const otherTokenizer = otherDollar.tokenize
+    let newTokenizer: typeof otherTokenizer | undefined
+
+    vi.mocked(remarkMath).mockImplementation(function (this: Processor) {
+      realRemarkMath.call(this)
+      const extensions = this.data().micromarkExtensions!
+      const added = extensions[extensions.length - 1]
+      const mathText = getMathText(added)
+      newTokenizer = mathText.tokenize
+      added.text![DOLLAR_CODE] = [otherDollar, mathText]
+      extensions.push({})
+    })
+
+    const processor = unified()
+      .data('micromarkExtensions', [{ text: { [DOLLAR_CODE]: otherDollar } }, existing])
+      .use(remarkCurrencySafeMath)
+      .freeze()
+    const extensions = processor.data().micromarkExtensions!
+
+    expect(getMathText(extensions[2]).tokenize).not.toBe(newTokenizer)
+    expect(getMathText(existing).tokenize).toBe(existingTokenizer)
+    expect(otherDollar.tokenize).toBe(otherTokenizer)
+  })
+
+  it('keeps currency literal and math enabled with the real dependency', () => {
+    const tree = unified().use(remarkParse).use(remarkCurrencySafeMath).parse('Budget $10–$25; $x^2$.')
+
+    expect(tree).toMatchObject({
+      children: [{
+        type: 'paragraph',
+        children: [
+          { type: 'text', value: 'Budget $10–$25; ' },
+          { type: 'inlineMath', value: 'x^2' },
+          { type: 'text', value: '.' },
+        ],
+      }],
+    })
+  })
+})

--- a/frontend/src/lib/remark-currency-safe-math.ts
+++ b/frontend/src/lib/remark-currency-safe-math.ts
@@ -5,7 +5,14 @@ const DOLLAR_CODE = '$'.charCodeAt(0)
 const ZERO_CODE = '0'.charCodeAt(0)
 const NINE_CODE = '9'.charCodeAt(0)
 
-/** Keep ordinary prices from opening math while retaining $math$ and $$math$$. */
+/**
+ * Exclude common price-pair delimiters while retaining explicit $math$.
+ * This is not a semantic currency classifier: ambiguous $...$ pairs (including
+ * $10$ and math followed by punctuation) remain math. Escape literal dollars
+ * in ambiguous prose, or use code spans for expressions such as $X+$Y.
+ * Tight single-dollar delimiters exclude all whitespace, including tabs and
+ * Unicode spaces; explicit multi-dollar math retains its padding behavior.
+ */
 export const remarkCurrencySafeMath: Plugin = function () {
   const extensionStart = this.data().micromarkExtensions?.length ?? 0
   remarkMath.call(this)

--- a/frontend/src/lib/remark-currency-safe-math.ts
+++ b/frontend/src/lib/remark-currency-safe-math.ts
@@ -1,0 +1,39 @@
+import remarkMath from 'remark-math'
+import type { Plugin } from 'unified'
+
+/** Keep ordinary prices from opening math while retaining $math$ and $$math$$. */
+export const remarkCurrencySafeMath: Plugin = function () {
+  remarkMath.call(this)
+
+  // Extend remark-math's tokenizer rather than rewriting Markdown source: code,
+  // escapes, link destinations, and display math must retain their own parsing.
+  const extensions = this.data().micromarkExtensions
+  const text = extensions?.[extensions.length - 1].text?.[36]
+  const constructs = Array.isArray(text) ? text : text ? [text] : []
+
+  for (const construct of constructs) {
+    if (construct.name !== 'mathText') continue
+    const tokenize = construct.tokenize
+
+    construct.tokenize = function (effects, ok, nok) {
+      const start = this.now()
+
+      return tokenize.call(this, effects, (code) => {
+        const source = this.sliceSerialize({ start, end: this.now() })
+
+        // A single-dollar opener/closer must touch non-whitespace content, and
+        // a closer cannot precede a digit (the next price in "$10–$25"). Reject
+        // the entire attempt so Markdown can still parse intervening emphasis
+        // and links. Explicit multi-dollar math keeps remark-math's behavior.
+        if (!source.startsWith('$$') && (
+          /^\$\s|\s\$$/.test(source) ||
+          (code !== null && code >= 48 && code <= 57)
+        )) {
+          return nok(code)
+        }
+
+        return ok(code)
+      }, nok)
+    }
+  }
+}

--- a/frontend/src/lib/remark-currency-safe-math.ts
+++ b/frontend/src/lib/remark-currency-safe-math.ts
@@ -1,39 +1,48 @@
 import remarkMath from 'remark-math'
 import type { Plugin } from 'unified'
 
+const DOLLAR_CODE = '$'.charCodeAt(0)
+const ZERO_CODE = '0'.charCodeAt(0)
+const NINE_CODE = '9'.charCodeAt(0)
+
 /** Keep ordinary prices from opening math while retaining $math$ and $$math$$. */
 export const remarkCurrencySafeMath: Plugin = function () {
+  const extensionStart = this.data().micromarkExtensions?.length ?? 0
   remarkMath.call(this)
 
   // Extend remark-math's tokenizer rather than rewriting Markdown source: code,
   // escapes, link destinations, and display math must retain their own parsing.
-  const extensions = this.data().micromarkExtensions
-  const text = extensions?.[extensions.length - 1].text?.[36]
-  const constructs = Array.isArray(text) ? text : text ? [text] : []
+  // Only inspect this invocation's registrations: another plugin may already
+  // own a dollar construct, or even an earlier mathText tokenizer.
+  const extensions = this.data().micromarkExtensions?.slice(extensionStart)
+  const mathText = extensions?.flatMap((extension) => {
+    const text = extension.text?.[DOLLAR_CODE]
+    return Array.isArray(text) ? text : text ? [text] : []
+  }).find((construct) => construct.name === 'mathText')
 
-  for (const construct of constructs) {
-    if (construct.name !== 'mathText') continue
-    const tokenize = construct.tokenize
+  if (!mathText) {
+    throw new Error('remarkCurrencySafeMath: remark-math did not register a mathText tokenizer')
+  }
 
-    construct.tokenize = function (effects, ok, nok) {
-      const start = this.now()
+  const tokenize = mathText.tokenize
+  mathText.tokenize = function (effects, ok, nok) {
+    const start = this.now()
 
-      return tokenize.call(this, effects, (code) => {
-        const source = this.sliceSerialize({ start, end: this.now() })
+    return tokenize.call(this, effects, (code) => {
+      const source = this.sliceSerialize({ start, end: this.now() })
 
-        // A single-dollar opener/closer must touch non-whitespace content, and
-        // a closer cannot precede a digit (the next price in "$10–$25"). Reject
-        // the entire attempt so Markdown can still parse intervening emphasis
-        // and links. Explicit multi-dollar math keeps remark-math's behavior.
-        if (!source.startsWith('$$') && (
-          /^\$\s|\s\$$/.test(source) ||
-          (code !== null && code >= 48 && code <= 57)
-        )) {
-          return nok(code)
-        }
+      // A single-dollar opener/closer must touch non-whitespace content, and
+      // a closer cannot precede a digit (the next price in "$10–$25"). Reject
+      // the entire attempt so Markdown can still parse intervening emphasis
+      // and links. Explicit multi-dollar math keeps remark-math's behavior.
+      if (!source.startsWith('$$') && (
+        /^\$\s|\s\$$/.test(source) ||
+        (code !== null && code >= ZERO_CODE && code <= NINE_CODE)
+      )) {
+        return nok(code)
+      }
 
-        return ok(code)
-      }, nok)
-    }
+      return ok(code)
+    }, nok)
   }
 }

--- a/frontend/vitest.widget.config.ts
+++ b/frontend/vitest.widget.config.ts
@@ -30,6 +30,7 @@ const widgetConfig = mergeConfig(baseConfig, defineConfig({
         "src/lib/api-wrapper.ts",
         "src/lib/auth-cache.ts",
         "src/lib/files-disabled-presentation.ts",
+        "src/lib/remark-currency-safe-math.ts",
         "src/lib/widget-parent-message.ts",
         "src/contexts/presentation-capabilities.tsx",
         "src/app/settings/page.tsx",
@@ -75,6 +76,9 @@ const widgetConfig = mergeConfig(baseConfig, defineConfig({
           statements: 85, branches: 80, functions: 90, lines: 85,
         },
         "src/lib/auth-cache.ts": { statements: 90, branches: 80, functions: 90, lines: 90 },
+        "src/lib/remark-currency-safe-math.ts": {
+          statements: 100, branches: 100, functions: 100, lines: 100,
+        },
         "src/contexts/presentation-capabilities.tsx": {
           statements: 100, branches: 100, functions: 100, lines: 100,
         },

--- a/frontend/vitest.widget.config.ts
+++ b/frontend/vitest.widget.config.ts
@@ -166,6 +166,7 @@ export default defineConfig({
       "src/lib/api-wrapper.test.ts",
       "src/lib/auth-cache.test.ts",
       "src/lib/files-disabled-presentation.test.ts",
+      "src/lib/remark-currency-safe-math.test.ts",
     ],
   },
 })


### PR DESCRIPTION
## Summary

- Keep common price pairs such as `$10–$25`, `S$15 vs S$25`, and `A$5.6M ≈ US$3.7M` from being parsed as inline math and breaking surrounding Markdown.
- Wrap the existing remark-math text tokenizer: single-dollar delimiters must touch non-whitespace content, and a closing dollar cannot be followed by a digit. Reject invalid pairs during parsing so bold text, tables, and links are still parsed normally.
- Retain tight `$math$`, numeric formulas, math followed by punctuation or EOF, multi-dollar inline/display math, escaped dollars, code blocks, and link destinations.
- Locate only this remark-math invocation's newly registered math tokenizer and fail explicitly if its expected registration is absent. Cover both the installed dependency and synthetic registration contracts in the required widget CI lane.
- Add targeted currency bug reproductions plus compatibility tests, registration tests, and explicit per-file coverage thresholds. No backend or dependency changes.

## Scope and compatibility

- This is a delimiter guard for common price-pair mistakes, not a semantic currency classifier. Ambiguous unescaped pairs such as `$10$`, `It costs $20 (USD$).`, and `Cost $5, currency USD$` still follow math syntax. Escape literal dollar signs (`\$`) or use code spans for raw expressions such as `$X+$Y`; tests cover these literal representations.
- All whitespace immediately inside a single-dollar delimiter, including tabs and Unicode spaces, now makes the pair literal. This intentionally differs from remark-math's padding behavior; multi-dollar math retains its existing padding behavior.
- Tests for escaped dollars, code, and valid math protect existing behavior and are expected to pass before the fix. They are distinct from the currency bug-reproduction tests.

## Validation

- Confirmed the targeted currency bug reproductions fail with the original parser; compatibility tests are not claimed to fail before the fix.
- `npm run test:run -- src/lib/remark-currency-safe-math.test.ts src/components/ui/__tests__/markdown-renderer.test.tsx`: 84 passed (8 registration / 76 component).
- `npm run test:widget:coverage`: 34 files / 1125 tests passed; all coverage thresholds passed. The new helper is explicitly included in coverage and has 100% statements, branches, functions, and lines, enforced by 100% per-file thresholds.
- `npm run test:ci-manifest`: 82 passed.
- `npm run lint`, `npm run type-check`, targeted pre-commit hooks, and `git diff --check` passed.
- Historical-task browser verification was blocked by the local account onboarding screen; no onboarding state was changed and no model task was rerun.