### PR TITLE
fix: stabilize concurrency tests with explicit synchronization

### DIFF
--- a/tests/core/model/chat/basic/test_xinference.py
+++ b/tests/core/model/chat/basic/test_xinference.py
@@ -745,12 +745,17 @@ class TestXinferenceLLM:
         discovery_task = asyncio.create_task(
             XinferenceLLM.list_available_models("http://localhost:9997")
         )
-        await asyncio.wait_for(discovery_started.wait(), timeout=0.1)
-        heartbeat = asyncio.create_task(asyncio.sleep(0))
-        await asyncio.wait_for(heartbeat, timeout=0.1)
-        release_discovery.set()
+        try:
+            # These guards bound a hang, not model-discovery latency.
+            await asyncio.wait_for(discovery_started.wait(), timeout=30)
+            heartbeat = asyncio.create_task(asyncio.sleep(0))
+            await asyncio.wait_for(heartbeat, timeout=30)
+            assert not discovery_task.done()
+        finally:
+            release_discovery.set()
+            models = await asyncio.wait_for(discovery_task, timeout=30)
 
-        assert await discovery_task == []
+        assert models == []
         mock_client.close.assert_awaited_once()
 
     @pytest.mark.asyncio

--- a/tests/core/test_workspace_durable_registration.py
+++ b/tests/core/test_workspace_durable_registration.py
@@ -1212,9 +1212,10 @@ def test_concurrent_registration_of_one_path_uses_one_workspace_owner(
                 attempts += 1
                 attempt = attempts
             if attempt == 2:
-                assert not registration_lock.acquire(blocking=False), (
-                    "the first registration must still hold the lock"
-                )
+                acquired = registration_lock.acquire(blocking=False)
+                if acquired:
+                    registration_lock.release()
+                assert not acquired, "the first registration must still hold the lock"
                 second_attempted.set()
             registration_lock.acquire()
             if attempt == 1:

--- a/tests/core/test_workspace_durable_registration.py
+++ b/tests/core/test_workspace_durable_registration.py
@@ -1,5 +1,5 @@
 from concurrent.futures import ThreadPoolExecutor
-from threading import Barrier, BrokenBarrierError
+from threading import Event, Lock, local
 from uuid import UUID
 
 import pytest
@@ -1188,29 +1188,60 @@ def test_concurrent_registration_of_one_path_uses_one_workspace_owner(
     )
     output_path = workspace.output_dir / "report.txt"
     output_path.write_text("one artifact", encoding="utf-8")
-    load_barrier = Barrier(2)
+    first_entered = Event()
+    second_attempted = Event()
+    release_first = Event()
+    attempts_lock = Lock()
+    attempts = 0
+    registration_lock = workspace._registration_lock
+    ownership = local()
     original_load = workspace._load_file_registration_plans
 
-    def synchronized_load(*args, **kwargs):
-        plans = original_load(*args, **kwargs)
-        try:
-            load_barrier.wait(timeout=0.2)
-        except BrokenBarrierError:
-            pass
-        return plans
+    def checked_load(*args, **kwargs):
+        assert getattr(ownership, "depth", 0) > 0, (
+            "registration read must hold the lock"
+        )
+        return original_load(*args, **kwargs)
 
-    monkeypatch.setattr(
-        workspace,
-        "_load_file_registration_plans",
-        synchronized_load,
-    )
+    monkeypatch.setattr(workspace, "_load_file_registration_plans", checked_load)
+
+    class ObservedRegistrationLock:
+        def __enter__(self):
+            nonlocal attempts
+            with attempts_lock:
+                attempts += 1
+                attempt = attempts
+            if attempt == 2:
+                assert not registration_lock.acquire(blocking=False), (
+                    "the first registration must still hold the lock"
+                )
+                second_attempted.set()
+            registration_lock.acquire()
+            if attempt == 1:
+                first_entered.set()
+                if not release_first.wait(timeout=30):
+                    registration_lock.release()
+                    raise AssertionError("first registration was never released")
+            ownership.depth = getattr(ownership, "depth", 0) + 1
+            return self
+
+        def __exit__(self, *_exc):
+            ownership.depth -= 1
+            registration_lock.release()
+
+    monkeypatch.setattr(workspace, "_registration_lock", ObservedRegistrationLock())
     try:
         with ThreadPoolExecutor(max_workers=2) as executor:
-            futures = [
-                executor.submit(workspace.register_file, str(output_path))
-                for _ in range(2)
-            ]
-            file_ids = [future.result() for future in futures]
+            first = executor.submit(workspace.register_file, str(output_path))
+            try:
+                assert first_entered.wait(timeout=30)
+                second = executor.submit(workspace.register_file, str(output_path))
+                assert second_attempted.wait(timeout=30)
+                assert not first.done()
+                assert not second.done()
+            finally:
+                release_first.set()
+            file_ids = [first.result(timeout=30), second.result(timeout=30)]
 
         assert file_ids[0] == file_ids[1]
         with SessionLocal() as verify_db:

--- a/tests/core/tools/core/RAG_tools/kb/test_list_collections_event_loop.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_list_collections_event_loop.py
@@ -167,11 +167,16 @@ async def test_collection_configs_load_concurrently(monkeypatch):
     so its cost scaled linearly with the number of collections.
     """
     collection_count = 8
-    per_call_delay = 0.05
+    all_started = asyncio.Event()
+    release = asyncio.Event()
+    started = set()
 
     class _SlowConfigStore:
         async def get_collection_config(self, collection, user_id, is_admin=False):
-            await asyncio.sleep(per_call_delay)
+            started.add(collection)
+            if len(started) == collection_count:
+                all_started.set()
+            await release.wait()
             return None
 
     monkeypatch.setattr(
@@ -179,15 +184,16 @@ async def test_collection_configs_load_concurrently(monkeypatch):
     )
 
     keys = [f"kb{index}" for index in range(collection_count)]
-    started = time.perf_counter()
-    await collections_module._load_collection_ingestion_configs(keys, 1, False)
-    elapsed = time.perf_counter() - started
-
-    serial_cost = per_call_delay * collection_count
-    assert elapsed < serial_cost / 2, (
-        f"config lookups look serialised: {elapsed:.3f}s for {collection_count} "
-        f"collections (serial would cost ~{serial_cost:.3f}s)"
+    loading = asyncio.create_task(
+        collections_module._load_collection_ingestion_configs(keys, 1, False)
     )
+    try:
+        await asyncio.wait_for(all_started.wait(), timeout=30)
+        assert started == set(keys)
+        assert not loading.done()
+    finally:
+        release.set()
+        await asyncio.wait_for(loading, timeout=30)
 
 
 # --------------------------------------------------------------------------

--- a/tests/core/tools/test_agent_tool_publish_status.py
+++ b/tests/core/tools/test_agent_tool_publish_status.py
@@ -6,6 +6,12 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from tests.web.pool_contention_shared import (
+    GUARD_TIMEOUT,
+    LOOP_LIVENESS_TICKS,
+    gated_pool_checkout,
+    wait_for_ticks,
+)
 from xagent.core.agent.result import tool_result_succeeded
 from xagent.core.tools.adapters.vibe.agent_tool import (
     AgentTool,
@@ -131,26 +137,30 @@ async def test_published_agent_prefetch_waits_for_pool_off_event_loop(tmp_path) 
             ticks += 1
             await asyncio.sleep(0.01)
 
-    ticker_task = asyncio.create_task(ticker())
-    build_task = asyncio.create_task(ToolFactory.create_all_tools(config))
-    try:
-        await asyncio.sleep(0.08)
-        assert ticks >= 4
-        assert not build_task.done()
+    with gated_pool_checkout(engine) as gate:
+        ticker_task = asyncio.create_task(ticker())
+        build_task = asyncio.create_task(ToolFactory.create_all_tools(config))
+        try:
+            await gate.wait_until_contending()
+            observed = await wait_for_ticks(lambda: ticks)
+            assert observed >= LOOP_LIVENESS_TICKS
+            assert not build_task.done()
 
-        held_connection.close()
-        tools = await build_task
-        assert published_tool_name in {tool.name for tool in tools}
-    finally:
-        if not held_connection.closed:
             held_connection.close()
-        if not build_task.done():
-            build_task.cancel()
+            gate.let_through()
+            tools = await asyncio.wait_for(build_task, timeout=GUARD_TIMEOUT)
+            assert published_tool_name in {tool.name for tool in tools}
+        finally:
+            if not held_connection.closed:
+                held_connection.close()
+                gate.let_through()
+            if not build_task.done():
+                build_task.cancel()
             await asyncio.gather(build_task, return_exceptions=True)
-        stop.set()
-        await ticker_task
-        config.close()
-        engine.dispose()
+            stop.set()
+            await ticker_task
+            config.close()
+            engine.dispose()
 
 
 def test_non_owner_cannot_see_other_users_published_agent_tools() -> None:

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -2148,23 +2148,27 @@ async def test_a2a_poll_pool_wait_does_not_block_event_loop(
             ticks += 1
             await asyncio.sleep(0.01)
 
-    fetch_task = asyncio.create_task(a2a_api._fetch_fresh_a2a_task_isolated(7, 101))
-    ticker_task = asyncio.create_task(ticker())
-    try:
-        await asyncio.sleep(0.08)
-        assert ticks >= 3, "A2A QueuePool checkout blocked the event loop"
-        assert not fetch_task.done()
-    finally:
-        held_connection.close()
+    with gated_pool_checkout(engine) as gate:
+        fetch_task = asyncio.create_task(a2a_api._fetch_fresh_a2a_task_isolated(7, 101))
+        ticker_task = asyncio.create_task(ticker())
+        try:
+            await gate.wait_until_contending()
+            observed = await wait_for_ticks(lambda: ticks)
+            assert observed >= LOOP_LIVENESS_TICKS
+            assert not fetch_task.done()
+        finally:
+            held_connection.close()
+            gate.let_through()
+            ticker_stop.set()
+            await asyncio.wait_for(
+                asyncio.gather(fetch_task, ticker_task, return_exceptions=True),
+                timeout=GUARD_TIMEOUT,
+            )
+            engine.dispose()
 
-    try:
-        snapshot = await asyncio.wait_for(fetch_task, timeout=1.0)
+        snapshot = fetch_task.result()
         assert snapshot is not None
         assert snapshot.id == 101
-    finally:
-        ticker_stop.set()
-        await ticker_task
-        engine.dispose()
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_durable_resume_contention.py
+++ b/tests/web/api/test_durable_resume_contention.py
@@ -719,15 +719,20 @@ async def test_two_concurrent_durable_resumes_schedule_one_execution(
         first = asyncio.ensure_future(
             _execute_durable_task_command(_command(task, owner, "resume-race-a"))
         )
-        await asyncio.wait_for(first_resume_entered.wait(), timeout=1)
+        try:
+            # These are hang guards, not latency assertions: database work and
+            # thread scheduling can take over a second on a loaded CI runner.
+            await asyncio.wait_for(first_resume_entered.wait(), timeout=30)
 
-        # The slot is reserved but no coordinator is registered yet, so the
-        # second command sees RESERVATION_HELD -- uncertain, not satisfied.
-        with pytest.raises(TaskCommandDeferred, match="resume slot"):
-            await _execute_durable_task_command(_command(task, owner, "resume-race-b"))
-
-        release_first_resume.set()
-        result = await asyncio.wait_for(first, timeout=1)
+            # The slot is reserved but no coordinator is registered yet, so the
+            # second command sees RESERVATION_HELD -- uncertain, not satisfied.
+            with pytest.raises(TaskCommandDeferred, match="resume slot"):
+                await _execute_durable_task_command(
+                    _command(task, owner, "resume-race-b")
+                )
+        finally:
+            release_first_resume.set()
+            result = await asyncio.wait_for(first, timeout=30)
 
     assert result is not None
     assert result["resume_outcome"] == ResumeCommandOutcome.SCHEDULED.value

--- a/tests/web/api/test_execute_task_background_snapshot_passthrough.py
+++ b/tests/web/api/test_execute_task_background_snapshot_passthrough.py
@@ -23,7 +23,6 @@ import asyncio
 import logging
 import threading
 from collections import Counter
-from time import monotonic
 from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -33,6 +32,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from tests.web.pool_contention_shared import (
+    GUARD_TIMEOUT,
+    LOOP_LIVENESS_TICKS,
+    wait_for_ticks,
+)
 from xagent.web.api.websocket import execute_task_background
 from xagent.web.models.agent import AgentStatus
 from xagent.web.models.task import Task, TaskStatus
@@ -456,16 +460,19 @@ async def test_snapshot_execution_start_stays_responsive_with_exhausted_pool(
         get_agent_for_task=AsyncMock(side_effect=blocked_get_agent)
     )
 
+    checkout = MagicMock(
+        side_effect=AssertionError("snapshot handoff checked out a connection")
+    )
     with _Patches(
         [
             *_common_patches(db, MagicMock()),
+            patch.object(engine.pool, "_do_get", checkout),
             patch(
                 "xagent.web.api.websocket._terminal_task_error_payload",
                 return_value=None,
             ),
         ]
     ):
-        started = monotonic()
         execution_task = asyncio.create_task(
             execute_task_background(
                 task_id=42,
@@ -479,14 +486,10 @@ async def test_snapshot_execution_start_stays_responsive_with_exhausted_pool(
         )
         ticker_task = asyncio.create_task(ticker())
         try:
-            await asyncio.wait_for(manager_entered.wait(), timeout=0.4)
-            elapsed = monotonic() - started
-            await asyncio.sleep(0.04)
-            assert elapsed < 0.15, (
-                "Snapshot handoff waited for the exhausted request pool; "
-                f"manager reached after {elapsed:.3f}s."
-            )
-            assert ticks >= 3, f"Event-loop ticker advanced only {ticks} time(s)."
+            await asyncio.wait_for(manager_entered.wait(), timeout=GUARD_TIMEOUT)
+            observed = await wait_for_ticks(lambda: ticks)
+            assert observed >= LOOP_LIVENESS_TICKS
+            checkout.assert_not_called()
         finally:
             release_manager.set()
             ticker_stop.set()

--- a/tests/web/api/test_get_agent_for_task_snapshot_passthrough.py
+++ b/tests/web/api/test_get_agent_for_task_snapshot_passthrough.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import ExitStack
-from time import monotonic
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -36,6 +35,11 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from tests.web.pool_contention_shared import (
+    GUARD_TIMEOUT,
+    LOOP_LIVENESS_TICKS,
+    wait_for_ticks,
+)
 from xagent.core.execution_scope import scope_fingerprint
 from xagent.web.api.chat import AgentServiceManager
 from xagent.web.models.agent import AgentStatus
@@ -197,12 +201,18 @@ async def test_snapshot_startup_stays_responsive_with_exhausted_pool(tmp_path) -
             await asyncio.sleep(0.01)
 
     with ExitStack() as stack:
+        checkout = stack.enter_context(
+            patch.object(
+                engine.pool,
+                "_do_get",
+                side_effect=AssertionError("snapshot startup checked out a connection"),
+            )
+        )
         for p in _common_patches(manager):
             stack.enter_context(p)
         stack.enter_context(
             patch.object(manager, "_get_or_create_task_sandbox", blocked_sandbox)
         )
-        started = monotonic()
         build_task = asyncio.create_task(
             manager.get_agent_for_task(
                 task_id=42,
@@ -215,14 +225,10 @@ async def test_snapshot_startup_stays_responsive_with_exhausted_pool(tmp_path) -
         )
         ticker_task = asyncio.create_task(ticker())
         try:
-            await asyncio.wait_for(sandbox_entered.wait(), timeout=0.4)
-            elapsed = monotonic() - started
-            await asyncio.sleep(0.04)
-            assert elapsed < 0.15, (
-                "Snapshot startup waited for the exhausted request pool; "
-                f"sandbox boundary reached after {elapsed:.3f}s."
-            )
-            assert ticks >= 3, f"Event-loop ticker advanced only {ticks} time(s)."
+            await asyncio.wait_for(sandbox_entered.wait(), timeout=GUARD_TIMEOUT)
+            observed = await wait_for_ticks(lambda: ticks)
+            assert observed >= LOOP_LIVENESS_TICKS
+            checkout.assert_not_called()
         finally:
             release_sandbox.set()
             ticker_stop.set()

--- a/tests/web/api/test_kb_collections_listing.py
+++ b/tests/web/api/test_kb_collections_listing.py
@@ -87,21 +87,31 @@ def team_listing_env(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_team_owner_scans_run_concurrently(team_listing_env):
-    """Each distinct team-KB owner scan must be awaited concurrently, not serially."""
+async def test_team_owner_scans_run_concurrently(team_listing_env, monkeypatch):
+    """Every owner scan must enter before any owner scan is released."""
     recorder = team_listing_env
     user = SimpleNamespace(id=1, is_admin=False)
+    started = set()
+    all_started = asyncio.Event()
+    release = asyncio.Event()
 
-    started = time.perf_counter()
-    await kb_api.list_collections_api(_user=user, db=None)
-    elapsed = time.perf_counter() - started
+    async def gated_scan(user_id, is_admin=False):
+        if user_id in OWNER_IDS:
+            started.add(user_id)
+            if started == set(OWNER_IDS):
+                all_started.set()
+            await release.wait()
+        return await recorder(user_id, is_admin)
 
+    monkeypatch.setattr(kb_api, "list_collections", gated_scan)
+    listing = asyncio.create_task(kb_api.list_collections_api(_user=user, db=None))
+    try:
+        await asyncio.wait_for(all_started.wait(), timeout=30)
+        assert not listing.done()
+    finally:
+        release.set()
+        await asyncio.wait_for(listing, timeout=30)
     assert recorder.max_in_flight == len(OWNER_IDS)
-    serial_cost = SCAN_DELAY_SECONDS * (len(OWNER_IDS) + 1)
-    assert elapsed < serial_cost * 0.6, (
-        f"team owner scans look serial: {elapsed:.3f}s "
-        f"(serial cost would be ~{serial_cost:.3f}s)"
-    )
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/v1/test_auth.py
+++ b/tests/web/api/v1/test_auth.py
@@ -284,13 +284,15 @@ async def test_runtime_key_auth_pool_wait_keeps_event_loop_responsive(
         poolclass=QueuePool,
         pool_size=1,
         max_overflow=0,
-        pool_timeout=1,
+        pool_timeout=30,
     )
+    event_loop_thread = threading.get_ident()
     worker_started = threading.Event()
     held_connection = engine.connect()
 
     def waiting_resolve(_credentials):  # type: ignore[no-untyped-def]
         worker_started.set()
+        assert threading.get_ident() != event_loop_thread
         with engine.connect() as connection:
             connection.execute(text("SELECT 1")).scalar_one()
         return deps.ApiKeyPrincipal(
@@ -310,26 +312,18 @@ async def test_runtime_key_auth_pool_wait_keeps_event_loop_responsive(
         waiting_resolve,
     )
     auth = asyncio.create_task(deps.get_principal_from_api_key(None))
-    await asyncio.to_thread(worker_started.wait, 2)
-
-    ticks = 0
-
-    async def ticker() -> None:
-        nonlocal ticks
-        for _ in range(5):
-            await asyncio.sleep(0.01)
-            ticks += 1
-
     try:
-        await ticker()
-        assert ticks == 5
-        assert auth.done() is False
+        assert await asyncio.to_thread(worker_started.wait, 30)
+        await asyncio.sleep(0)
+        assert not auth.done()
     finally:
         held_connection.close()
+        try:
+            principal = await asyncio.wait_for(auth, timeout=30)
+        finally:
+            engine.dispose()
 
-    principal = await auth
     assert principal.agent is not None
-    engine.dispose()
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/v1/test_tasks.py
+++ b/tests/web/api/v1/test_tasks.py
@@ -28,6 +28,10 @@ from fastapi import HTTPException
 from fastapi.datastructures import UploadFile
 from sqlalchemy.orm import Session
 
+from tests.web.pool_contention_shared import (
+    GUARD_TIMEOUT,
+    gated_pool_checkout,
+)
 from xagent.core.tools.adapters.vibe.selection_spec import ToolSelectionSpec
 from xagent.web.api.v1 import tasks as v1_tasks
 from xagent.web.api.v1.deps import (
@@ -3513,23 +3517,31 @@ async def test_task_read_pool_wait_does_not_block_event_loop(
         return original_helper(*args, **kwargs)
 
     monkeypatch.setattr(v1_tasks, helper_name, recording_helper)
-    operation = asyncio.create_task(
-        v1_tasks.get_chat_task(task_id, principal)
-        if read_surface == "task"
-        else v1_tasks.get_chat_task_steps(task_id, principal)
-    )
+    with gated_pool_checkout(engine) as gate:
+        operation = asyncio.create_task(
+            v1_tasks.get_chat_task(task_id, principal)
+            if read_surface == "task"
+            else v1_tasks.get_chat_task_steps(task_id, principal)
+        )
 
-    try:
-        assert await asyncio.to_thread(worker_entered.wait, 1)
-        await asyncio.wait_for(asyncio.sleep(0.02), timeout=0.1)
-        assert not operation.done()
-    finally:
-        held_connection.close()
+        try:
+            await gate.wait_until_contending()
+            # A checkpoint while the checkout is still parked proves loop progress.
+            await asyncio.sleep(0)
+            assert worker_entered.is_set()
+            assert not operation.done()
+        finally:
+            held_connection.close()
+            gate.let_through()
+            await asyncio.wait_for(
+                asyncio.gather(operation, return_exceptions=True), timeout=GUARD_TIMEOUT
+            )
+            checked_out = engine.pool.checkedout()
+            engine.dispose()
 
-    response = await operation
-    assert response.task_id == task_id
-    assert engine.pool.checkedout() == 0
-    engine.dispose()
+        response = operation.result()
+        assert response.task_id == task_id
+        assert checked_out == 0
 
 
 def test_get_missing_task_returns_404(mock_start_task):

--- a/tests/web/services/test_builder_chat_runtime.py
+++ b/tests/web/services/test_builder_chat_runtime.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import threading
-import time
 from types import SimpleNamespace
 from typing import Any
 
@@ -96,11 +95,14 @@ async def test_load_builder_chat_runtime_inputs_uses_worker_owned_session(
 async def test_load_builder_chat_runtime_inputs_keeps_event_loop_responsive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    event_loop_thread = threading.get_ident()
     worker_started = threading.Event()
+    allow_worker = threading.Event()
 
     def blocking_load(**_kwargs: Any) -> BuilderChatRuntimeInputs:
         worker_started.set()
-        time.sleep(0.05)
+        assert threading.get_ident() != event_loop_thread
+        assert allow_worker.wait(timeout=30)
         return BuilderChatRuntimeInputs(
             authorized_file_ids=(),
             llm=object(),
@@ -121,15 +123,10 @@ async def test_load_builder_chat_runtime_inputs_keeps_event_loop_responsive(
             compact_model_name=None,
         )
     )
-    await asyncio.to_thread(worker_started.wait, 1)
-    ticker_ran = False
-
-    async def ticker() -> None:
-        nonlocal ticker_ran
+    try:
+        assert await asyncio.to_thread(worker_started.wait, 30)
         await asyncio.sleep(0)
-        ticker_ran = True
-
-    await ticker()
-    await load_task
-
-    assert ticker_ran is True
+        assert not load_task.done()
+    finally:
+        allow_worker.set()
+        await asyncio.wait_for(load_task, timeout=30)

--- a/tests/web/services/test_channel_runtime.py
+++ b/tests/web/services/test_channel_runtime.py
@@ -1237,6 +1237,7 @@ def test_prepare_channel_task_rolls_back_new_task_when_claim_is_rejected(
 async def test_prepare_channel_task_keeps_event_loop_responsive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    event_loop_thread = threading.get_ident()
     worker_started = threading.Event()
     allow_worker = threading.Event()
 
@@ -1250,7 +1251,8 @@ async def test_prepare_channel_task_keeps_event_loop_responsive(
 
     def blocking_prepare(**_kwargs):  # type: ignore[no-untyped-def]
         worker_started.set()
-        assert allow_worker.wait(timeout=2)
+        assert threading.get_ident() != event_loop_thread
+        assert allow_worker.wait(timeout=30)
         return claim
 
     monkeypatch.setattr(
@@ -1271,12 +1273,15 @@ async def test_prepare_channel_task_keeps_event_loop_responsive(
             channel_name="Telegram",
         )
     )
-    await asyncio.to_thread(worker_started.wait, 2)
-    await asyncio.sleep(0)
+    try:
+        assert await asyncio.to_thread(worker_started.wait, 30)
+        await asyncio.sleep(0)
 
-    assert preparation.done() is False
-    allow_worker.set()
-    prepared = await preparation
+        assert preparation.done() is False
+    finally:
+        allow_worker.set()
+        result = await asyncio.wait_for(preparation, timeout=30)
+    prepared = result
     assert prepared is not None
     assert prepared.user_id == 7
     assert prepared.task_id == 11
@@ -1289,6 +1294,7 @@ async def test_register_channel_uploaded_files_keeps_event_loop_responsive(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
+    event_loop_thread = threading.get_ident()
     worker_started = threading.Event()
     allow_worker = threading.Event()
     downloaded = DownloadedChannelFile(
@@ -1301,7 +1307,8 @@ async def test_register_channel_uploaded_files_keeps_event_loop_responsive(
 
     def blocking_register(**_kwargs) -> tuple:  # type: ignore[no-untyped-def]
         worker_started.set()
-        assert allow_worker.wait(timeout=2)
+        assert threading.get_ident() != event_loop_thread
+        assert allow_worker.wait(timeout=30)
         return ()
 
     monkeypatch.setattr(
@@ -1317,12 +1324,15 @@ async def test_register_channel_uploaded_files_keeps_event_loop_responsive(
             files=(downloaded,),
         )
     )
-    await asyncio.to_thread(worker_started.wait, 2)
-    await asyncio.sleep(0)
+    try:
+        assert await asyncio.to_thread(worker_started.wait, 30)
+        await asyncio.sleep(0)
 
-    assert registration.done() is False
-    allow_worker.set()
-    assert await registration == ()
+        assert registration.done() is False
+    finally:
+        allow_worker.set()
+        result = await asyncio.wait_for(registration, timeout=30)
+    assert result == ()
 
 
 @pytest.mark.asyncio
@@ -1538,12 +1548,14 @@ async def test_prepare_channel_task_compensates_late_claim_before_cancellation(
 async def test_load_active_channel_configs_keeps_event_loop_responsive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    event_loop_thread = threading.get_ident()
     worker_started = threading.Event()
     allow_worker = threading.Event()
 
     def blocking_load(*_args, **_kwargs) -> tuple:  # type: ignore[no-untyped-def]
         worker_started.set()
-        assert allow_worker.wait(timeout=2)
+        assert threading.get_ident() != event_loop_thread
+        assert allow_worker.wait(timeout=30)
         return ()
 
     monkeypatch.setattr(
@@ -1557,12 +1569,15 @@ async def test_load_active_channel_configs_keeps_event_loop_responsive(
             required_config_keys=("bot_token",),
         )
     )
-    await asyncio.to_thread(worker_started.wait, 2)
-    await asyncio.sleep(0)
+    try:
+        assert await asyncio.to_thread(worker_started.wait, 30)
+        await asyncio.sleep(0)
 
-    assert loading.done() is False
-    allow_worker.set()
-    assert await loading == ()
+        assert loading.done() is False
+    finally:
+        allow_worker.set()
+        result = await asyncio.wait_for(loading, timeout=30)
+    assert result == ()
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_db_runtime.py
+++ b/tests/web/services/test_db_runtime.py
@@ -188,27 +188,42 @@ async def test_await_task_settlement_returns_late_result_and_cancellation() -> N
 
 
 @pytest.mark.asyncio
-async def test_await_task_settlement_preserves_child_process_control_after_caller_cancelled() -> (
-    None
-):
+async def test_await_task_settlement_preserves_child_process_control_after_caller_cancelled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A raw child control signal must not be rewritten as caller cancellation."""
 
     class WorkerShutdown(BaseException):
         pass
 
+    entered = asyncio.Event()
+    cancellation_processed = asyncio.Event()
+    shield = asyncio.shield
+
+    def observe_shield(task):
+        if task is child:
+            if entered.is_set():
+                cancellation_processed.set()
+            else:
+                entered.set()
+        return shield(task)
+
+    monkeypatch.setattr(asyncio, "shield", observe_shield)
     child: asyncio.Future[None] = asyncio.get_running_loop().create_future()
     waiter = asyncio.create_task(await_task_settlement(child))  # type: ignore[arg-type]
-    await asyncio.sleep(0)
-    waiter.cancel()
-    await asyncio.sleep(0)
-
-    shutdown = WorkerShutdown("controlled test shutdown")
-    child.set_exception(shutdown)
-
-    with pytest.raises(WorkerShutdown) as exc_info:
-        await asyncio.wait_for(waiter, timeout=1)
-
-    assert exc_info.value is shutdown
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=30)
+        waiter.cancel()
+        await asyncio.wait_for(cancellation_processed.wait(), timeout=30)
+        shutdown = WorkerShutdown("controlled test shutdown")
+        child.set_exception(shutdown)
+        with pytest.raises(WorkerShutdown) as exc_info:
+            await asyncio.wait_for(waiter, timeout=30)
+        assert exc_info.value is shutdown
+    finally:
+        if not child.done():
+            child.cancel()
+        await asyncio.gather(waiter, return_exceptions=True)
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -1635,22 +1635,18 @@ def test_replace_markdown_file_references_propagates_a_raising_callback():
 
 
 def test_the_parsers_skip_content_without_the_file_literal():
-    """A cheap containment check in front of a pattern whose atomic label
-    group explores bracket-run candidates.
-
-    ``"[" * 100000 + "]"`` measures at ~1.5s through ``finditer`` and is
-    instant with the precheck. Asserted as a time bound rather than by
-    inspection because the cost is the whole point; the threshold is two
-    orders of magnitude below the unguarded figure, so it cannot flake on a
-    slow machine while still failing outright if the precheck is removed."""
+    """Content without file: must bypass both regex scanning entry points."""
     pathological = "[" * 100_000 + "]"
-
-    started = time.perf_counter()
-    assert list(iter_markdown_file_references(pathological)) == []
-    assert replace_markdown_file_references(pathological, lambda _: "X") == pathological
-    elapsed = time.perf_counter() - started
-
-    assert elapsed < 0.2, f"the file: precheck is not short-circuiting ({elapsed:.3f}s)"
+    with patch(
+        "xagent.web.services.file_reference_output_service._MARKDOWN_FILE_REFERENCE_RE"
+    ) as pattern:
+        assert list(iter_markdown_file_references(pathological)) == []
+        assert (
+            replace_markdown_file_references(pathological, lambda _: "X")
+            == pathological
+        )
+        pattern.finditer.assert_not_called()
+        pattern.sub.assert_not_called()
 
 
 def test_a_non_string_still_raises_rather_than_yielding_nothing():

--- a/tests/web/services/test_managed_task_lease.py
+++ b/tests/web/services/test_managed_task_lease.py
@@ -161,12 +161,14 @@ async def test_isolated_finalize_rejects_replacement_runner_with_same_run_id(
 async def test_isolated_finalize_keeps_event_loop_responsive(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    event_loop_thread = threading.get_ident()
     worker_started = threading.Event()
     allow_worker = threading.Event()
 
     def blocking_finalize(*_args, **_kwargs) -> bool:  # type: ignore[no-untyped-def]
         worker_started.set()
-        assert allow_worker.wait(timeout=2)
+        assert threading.get_ident() != event_loop_thread
+        assert allow_worker.wait(timeout=30)
         return True
 
     monkeypatch.setattr(
@@ -181,12 +183,15 @@ async def test_isolated_finalize_keeps_event_loop_responsive(
             status=TaskStatus.FAILED,
         )
     )
-    await asyncio.to_thread(worker_started.wait, 2)
-    await asyncio.sleep(0)
+    try:
+        assert await asyncio.to_thread(worker_started.wait, 30)
+        await asyncio.sleep(0)
 
-    assert settlement.done() is False
-    allow_worker.set()
-    assert await settlement is True
+        assert settlement.done() is False
+    finally:
+        allow_worker.set()
+        result = await asyncio.wait_for(settlement, timeout=30)
+    assert result is True
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -1678,12 +1678,13 @@ async def test_dispatcher_worker_isolates_one_command_error(
         )
     )
     try:
-        await asyncio.wait_for(recovered.wait(), timeout=0.25)
+        await asyncio.wait_for(recovered.wait(), timeout=GUARD_TIMEOUT)
     finally:
         worker.cancel()
+        await asyncio.gather(worker, return_exceptions=True)
 
     with pytest.raises(asyncio.CancelledError):
-        await worker
+        worker.result()
     assert calls >= 2
     assert "component=task-command-dispatcher" in caplog.text
     assert "single command failure" in caplog.text
@@ -1989,7 +1990,9 @@ async def test_claim_heartbeat_survives_transient_database_error(
         renew,
     )
 
-    await asyncio.wait_for(_claim_heartbeat(7, "runner-a", 3, stop_event), timeout=0.2)
+    await asyncio.wait_for(
+        _claim_heartbeat(7, "runner-a", 3, stop_event), timeout=GUARD_TIMEOUT
+    )
 
     assert attempts == 2
 
@@ -1998,6 +2001,20 @@ async def test_claim_heartbeat_survives_transient_database_error(
 async def test_dispatcher_does_not_erase_wakeup_during_empty_claim(monkeypatch) -> None:
     second_claim = asyncio.Event()
     calls = 0
+    notification_delivered = asyncio.Event()
+    wakeup_at_empty_claim = []
+
+    class ObservedWakeup(asyncio.Event):
+        def set(self):
+            super().set()
+            notification_delivered.set()
+
+        async def wait(self):
+            if calls == 1:
+                wakeup_at_empty_claim.append(self.is_set())
+            return await super().wait()
+
+    wakeup = ObservedWakeup()
 
     async def fake_dispatch(_executor, *, command_db_id=None) -> bool:
         nonlocal calls
@@ -2005,6 +2022,8 @@ async def test_dispatcher_does_not_erase_wakeup_during_empty_claim(monkeypatch) 
         calls += 1
         if calls == 1:
             notify_task_command_dispatcher()
+            # Deliver the notification while the first claim is still in flight.
+            await notification_delivered.wait()
             return False
         second_claim.set()
         return False
@@ -2014,13 +2033,27 @@ async def test_dispatcher_does_not_erase_wakeup_during_empty_claim(monkeypatch) 
         fake_dispatch,
     )
 
-    start_task_command_dispatcher(lambda _command: asyncio.sleep(0))
+    monkeypatch.setattr(task_command_transport_module, "_dispatcher_wakeup", wakeup)
+    monkeypatch.setattr(
+        task_command_transport_module, "_dispatcher_loop", asyncio.get_running_loop()
+    )
+    # One worker must observe the notification; a sibling or the periodic poll
+    # must not make a lost wakeup look like success.
+    worker = asyncio.create_task(
+        task_command_transport_module._run_task_command_dispatcher_worker(
+            lambda _command: asyncio.sleep(0)
+        )
+    )
     try:
-        await asyncio.wait_for(second_claim.wait(), timeout=0.25)
+        await asyncio.wait_for(second_claim.wait(), timeout=GUARD_TIMEOUT)
     finally:
-        await stop_task_command_dispatcher()
+        worker.cancel()
+        await asyncio.gather(worker, return_exceptions=True)
 
+    with pytest.raises(asyncio.CancelledError):
+        worker.result()
     assert calls >= 2
+    assert wakeup_at_empty_claim == [True]
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -17,6 +17,12 @@ from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from tests.web.pool_contention_shared import (
+    GUARD_TIMEOUT,
+    LOOP_LIVENESS_TICKS,
+    gated_pool_checkout,
+    wait_for_ticks,
+)
 from xagent.core.agent.runner import UserMessageInjectionOutcome
 from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
 from xagent.web.api import websocket as websocket_api
@@ -1292,20 +1298,28 @@ async def test_dispatch_claim_pool_wait_does_not_block_event_loop(
     async def execute(command: ClaimedTaskCommand) -> None:
         assert isinstance(command, ClaimedTaskCommand)
 
-    ticker_task = asyncio.create_task(ticker())
-    dispatch_task = asyncio.create_task(
-        dispatch_one_task_command(execute, command_db_id=enqueued.command_id)
-    )
-    try:
-        await asyncio.sleep(0.08)
-        assert ticks >= 3, "command claim QueuePool checkout blocked the event loop"
-        assert not dispatch_task.done()
-    finally:
-        held_connection.close()
-        ticker_stop.set()
-        await ticker_task
+    with gated_pool_checkout(engine) as gate:
+        ticker_task = asyncio.create_task(ticker())
+        dispatch_task = asyncio.create_task(
+            dispatch_one_task_command(execute, command_db_id=enqueued.command_id)
+        )
+        try:
+            await gate.wait_until_contending()
+            observed = await wait_for_ticks(lambda: ticks)
+            assert observed >= LOOP_LIVENESS_TICKS, (
+                "command claim QueuePool checkout blocked the event loop"
+            )
+            assert not dispatch_task.done()
+        finally:
+            held_connection.close()
+            gate.let_through()
+            ticker_stop.set()
+            await asyncio.wait_for(
+                asyncio.gather(dispatch_task, ticker_task, return_exceptions=True),
+                timeout=GUARD_TIMEOUT,
+            )
 
-    assert await asyncio.wait_for(dispatch_task, timeout=1)
+    assert dispatch_task.result()
     assert session_threads
     assert session_threads[0] != loop_thread
 

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -1277,13 +1277,17 @@ async def test_begin_turn_schedules_even_when_caller_cancelled(db_session) -> No
     off-loop claim is in flight (which commits RUNNING in a worker thread),
     the owned claim+schedule task must settle before cancellation propagates,
     so a committed RUNNING task is never left with no scheduled worker."""
-    import time as _time
+    import threading
 
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.PENDING)
 
+    claim_started = threading.Event()
+    release_claim = threading.Event()
+
     def slow_claim(task_id, task_owner_user_id, *, payload, kind):
-        _time.sleep(0.15)  # window during which we cancel the caller
+        claim_started.set()
+        assert release_claim.wait(timeout=GUARD_TIMEOUT)
         return _ClaimedTurn(
             task_lease=TaskLease(
                 task_id=task_id,
@@ -1316,10 +1320,16 @@ async def test_begin_turn_schedules_even_when_caller_cancelled(db_session) -> No
                 kind=TurnKind.CREATE,
             )
         )
-        await asyncio.sleep(0.05)  # let it enter the off-loop claim
-        t.cancel()
+        try:
+            assert await asyncio.to_thread(claim_started.wait, GUARD_TIMEOUT)
+            t.cancel()
+        finally:
+            release_claim.set()
+            await asyncio.wait_for(
+                asyncio.gather(t, return_exceptions=True), timeout=GUARD_TIMEOUT
+            )
         with pytest.raises(asyncio.CancelledError):
-            await t
+            t.result()
 
     sched.assert_called_once()  # scheduled despite the cancellation
 

--- a/tests/web/services/test_task_runtime.py
+++ b/tests/web/services/test_task_runtime.py
@@ -464,17 +464,25 @@ async def test_blocking_provider_timeout_does_not_consume_default_executor(
     registered_names: list[str],
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    from concurrent.futures import ThreadPoolExecutor
+
     import xagent.web.services.task_runtime as task_runtime
 
     release_hook = threading.Event()
+    hook_started = asyncio.Event()
+    hook_finished = threading.Event()
 
     class _BlockingProvider(_Provider):
         def build_runtime(
             self,
             context: TaskRuntimeContext,
         ) -> TaskRuntimeContribution:
-            release_hook.wait()
-            return TaskRuntimeContribution(environment="released")
+            loop.call_soon_threadsafe(hook_started.set)
+            try:
+                release_hook.wait()
+                return TaskRuntimeContribution(environment="released")
+            finally:
+                hook_finished.set()
 
     _register(
         "blocking_runtime",
@@ -487,14 +495,27 @@ async def test_blocking_provider_timeout_does_not_consume_default_executor(
         0.01,
     )
 
+    loop = asyncio.get_running_loop()
+    original_executor = loop._default_executor
+    probe_executor = ThreadPoolExecutor(max_workers=1)
+    monkeypatch.setattr(loop, "_default_executor", probe_executor)
     try:
         contribution = await build_task_runtime(_context())
+        await asyncio.wait_for(hook_started.wait(), timeout=30)
+        assert not hook_finished.is_set()
+        # A single default worker exposes accidental use by the blocked hook;
+        # extra idle workers would let this probe pass despite that regression.
         default_executor_result = await asyncio.wait_for(
             asyncio.to_thread(lambda: "available"),
-            timeout=0.5,
+            timeout=30,
         )
     finally:
         release_hook.set()
+        try:
+            assert await asyncio.to_thread(hook_finished.wait, 30)
+        finally:
+            monkeypatch.setattr(loop, "_default_executor", original_executor)
+            probe_executor.shutdown(wait=True)
 
     assert contribution == TaskRuntimeContribution()
     assert default_executor_result == "available"

--- a/tests/web/test_agent_manager_sandbox_lifecycle.py
+++ b/tests/web/test_agent_manager_sandbox_lifecycle.py
@@ -89,7 +89,7 @@ async def test_worker_cleanup_does_not_block_other_users(sandbox_mgr) -> None:
     try:
         sandbox_key = await asyncio.wait_for(
             manager._acquire_sandbox_task("2"),
-            timeout=0.05,
+            timeout=30,
         )
     finally:
         cleanup_release.set()
@@ -151,7 +151,7 @@ async def test_worker_cleanup_blocks_same_user_provider_recreate(sandbox_mgr) ->
             await asyncio.wait_for(create_called.wait(), timeout=0.05)
 
         cleanup_release.set()
-        sandbox = await asyncio.wait_for(create_task, timeout=0.5)
+        sandbox = await asyncio.wait_for(create_task, timeout=30)
         await release_task
     finally:
         cleanup_release.set()

--- a/tests/web/test_execute_task_manage_task_lease.py
+++ b/tests/web/test_execute_task_manage_task_lease.py
@@ -13,6 +13,12 @@ from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from tests.web.pool_contention_shared import (
+    GUARD_TIMEOUT,
+    LOOP_LIVENESS_TICKS,
+    gated_pool_checkout,
+    wait_for_ticks,
+)
 from xagent.core.model.chat.token_context import TokenUsage
 from xagent.web.api.chat import AgentServiceManager, _update_task_title_isolated
 from xagent.web.models.agent import Agent, AgentStatus
@@ -809,48 +815,55 @@ async def test_execute_task_preflight_pool_wait_does_not_block_event_loop(
             ticks += 1
             await asyncio.sleep(0.01)
 
-    ticker_task = asyncio.create_task(ticker())
-    try:
-        with (
-            patch(
-                "xagent.web.models.database.get_session_local",
-                return_value=factory,
-            ),
-            patch.object(
-                manager, "_acquire_sandbox_task", new=AsyncMock(return_value=None)
-            ),
-            patch.object(manager, "_release_sandbox_task", new=AsyncMock()),
-            patch(
-                "xagent.web.tracking.task_tracker.TaskTracker",
-                side_effect=RuntimeError("skip tracking in pool-boundary test"),
-            ),
-        ):
-            await asyncio.sleep(0.02)
-            ticks_before_wait = ticks
-            execute = asyncio.create_task(
-                manager.execute_task(
-                    agent_service=_FakeAgentService(),
-                    task="hello",
-                    tracking_task_id=str(task_id),
-                    db_session=caller_db,
-                    manage_task_lease=False,
+    execute = None
+    with gated_pool_checkout(engine) as gate:
+        ticker_task = asyncio.create_task(ticker())
+        try:
+            with (
+                patch(
+                    "xagent.web.models.database.get_session_local",
+                    return_value=factory,
+                ),
+                patch.object(
+                    manager, "_acquire_sandbox_task", new=AsyncMock(return_value=None)
+                ),
+                patch.object(manager, "_release_sandbox_task", new=AsyncMock()),
+                patch(
+                    "xagent.web.tracking.task_tracker.TaskTracker",
+                    side_effect=RuntimeError("skip tracking in pool-boundary test"),
+                ),
+            ):
+                execute = asyncio.create_task(
+                    manager.execute_task(
+                        agent_service=_FakeAgentService(),
+                        task="hello",
+                        tracking_task_id=str(task_id),
+                        db_session=caller_db,
+                        manage_task_lease=False,
+                    )
                 )
-            )
-            await asyncio.sleep(0.08)
+                await gate.wait_until_contending()
+                observed = await wait_for_ticks(lambda: ticks)
+                assert observed >= LOOP_LIVENESS_TICKS
+                assert not execute.done()
 
-            assert ticks - ticks_before_wait >= 4
-            assert not execute.done()
-
-            held_connection.close()
-            result = await execute
-            assert result["success"] is True
-    finally:
-        if not held_connection.closed:
-            held_connection.close()
-        stop.set()
-        await ticker_task
-        caller_db.close()
-        engine.dispose()
+                held_connection.close()
+                gate.let_through()
+                result = await asyncio.wait_for(execute, timeout=GUARD_TIMEOUT)
+                assert result["success"] is True
+        finally:
+            if not held_connection.closed:
+                held_connection.close()
+                gate.let_through()
+            if execute is not None:
+                await asyncio.wait_for(
+                    asyncio.gather(execute, return_exceptions=True),
+                    timeout=GUARD_TIMEOUT,
+                )
+            stop.set()
+            await ticker_task
+            caller_db.close()
+            engine.dispose()
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_sandbox_manager_sweep.py
+++ b/tests/web/test_sandbox_manager_sweep.py
@@ -203,7 +203,7 @@ async def test_sweep_loop_exits_immediately_when_ttl_unset(monkeypatch) -> None:
     monkeypatch.delenv("XAGENT_SANDBOX_IDLE_TTL", raising=False)
     manager = _make_manager()
 
-    await asyncio.wait_for(manager.run_idle_sweep_loop(), timeout=0.1)
+    await asyncio.wait_for(manager.run_idle_sweep_loop(), timeout=30)
 
     manager._service.list_sandboxes.assert_not_awaited()
     manager._service.delete.assert_not_awaited()

--- a/tests/web/test_startup_file_storage_sync_wiring.py
+++ b/tests/web/test_startup_file_storage_sync_wiring.py
@@ -208,7 +208,7 @@ async def test_startup_file_storage_sync_wait_fails_fast_during_retry_loop():
         with pytest.raises(RuntimeError, match="s3 unavailable"):
             await asyncio.wait_for(
                 app_module.wait_for_file_storage_startup_sync(test_app),
-                timeout=0.1,
+                timeout=30,
             )
 
         assert not task.done()

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -14,6 +14,12 @@ from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import QueuePool
 
 from tests.shared.db_teardown import drop_all_tables
+from tests.web.pool_contention_shared import (
+    GUARD_TIMEOUT,
+    LOOP_LIVENESS_TICKS,
+    gated_pool_checkout,
+    wait_for_ticks,
+)
 from xagent.core.agent.checkpoint import CHECKPOINT_TYPE, LEGACY_CHECKPOINT_TYPES
 from xagent.web.models import database as database_module
 from xagent.web.models.database import Base, get_db, get_engine, init_db
@@ -532,26 +538,32 @@ async def test_lease_heartbeat_keeps_loop_responsive_during_pool_checkout(
             await asyncio.sleep(0.01)
             ticks += 1
 
-    heartbeat_task = asyncio.create_task(
-        run_task_lease_heartbeat(
-            TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a"),
-            stop_event,
+    with gated_pool_checkout(engine) as gate:
+        heartbeat_task = asyncio.create_task(
+            run_task_lease_heartbeat(
+                TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a"),
+                stop_event,
+            )
         )
-    )
-    ticker_task = asyncio.create_task(ticker())
-    try:
-        await asyncio.sleep(0.12)
-        assert ticks >= 3, "QueuePool checkout blocked the asyncio event loop"
-    finally:
-        held_connection.close()
-        stop_event.set()
-        await asyncio.wait_for(heartbeat_task, timeout=1)
-        ticker_stop.set()
-        await ticker_task
+        ticker_task = asyncio.create_task(ticker())
+        try:
+            await gate.wait_until_contending()
+            observed = await wait_for_ticks(lambda: ticks)
+            assert observed >= LOOP_LIVENESS_TICKS
+        finally:
+            held_connection.close()
+            gate.let_through()
+            stop_event.set()
+            ticker_stop.set()
+            await asyncio.wait_for(
+                asyncio.gather(heartbeat_task, ticker_task, return_exceptions=True),
+                timeout=GUARD_TIMEOUT,
+            )
+        heartbeat_task.result()
 
-    with SessionLocal() as verify_db:
-        refreshed = verify_db.query(Task).filter(Task.id == task_id).one()
-        assert refreshed.last_heartbeat_at is not None
+        with SessionLocal() as verify_db:
+            refreshed = verify_db.query(Task).filter(Task.id == task_id).one()
+            assert refreshed.last_heartbeat_at is not None
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -783,8 +783,35 @@ async def test_heartbeat_requires_exact_run_id() -> None:
         await run_task_lease_heartbeat(lease, asyncio.Event())
 
 
+@pytest.fixture
+def heartbeat_batch_ready(monkeypatch):
+    """Start the shared runner only after both test leases are registered."""
+    manager_type = task_lease_service._TaskLeaseHeartbeatManager
+    register = manager_type.register
+    run = manager_type._run
+    ready = asyncio.Event()
+    registrations = 0
+
+    def register_and_signal(manager, lease):
+        nonlocal registrations
+        registration = register(manager, lease)
+        registrations += 1
+        if registrations == 2:
+            ready.set()
+        return registration
+
+    async def run_when_ready(manager):
+        await asyncio.wait_for(ready.wait(), timeout=GUARD_TIMEOUT)
+        await run(manager)
+
+    monkeypatch.setattr(manager_type, "register", register_and_signal)
+    monkeypatch.setattr(manager_type, "_run", run_when_ready)
+
+
 @pytest.mark.asyncio
-async def test_heartbeat_batches_registered_leases(monkeypatch) -> None:
+async def test_heartbeat_batches_registered_leases(
+    monkeypatch, heartbeat_batch_ready
+) -> None:
     refreshed = threading.Event()
     batches: list[tuple[TaskLease, ...]] = []
 
@@ -825,16 +852,18 @@ async def test_heartbeat_batches_registered_leases(monkeypatch) -> None:
             second_stop,
         )
     )
-    assert await asyncio.to_thread(refreshed.wait, 1)
+    try:
+        assert await asyncio.to_thread(refreshed.wait, GUARD_TIMEOUT)
+    finally:
+        first_stop.set()
+        second_stop.set()
+        await asyncio.gather(
+            stop_task_lease_heartbeat(first_task, first_stop),
+            stop_task_lease_heartbeat(second_task, second_stop),
+        )
+        await task_lease_service.wait_for_heartbeat_manager_idle()
 
-    await stop_task_lease_heartbeat(first_task, first_stop)
-    await stop_task_lease_heartbeat(second_task, second_stop)
-    await task_lease_service.wait_for_heartbeat_manager_idle()
-
-    # The 1 ms test interval may legitimately permit another refresh for the
-    # second lease between the two sequential stop calls.  The batching
-    # invariant is that the first interval refreshes both active leases with
-    # one worker checkout, not that no later interval can run.
+    # Both registered leases must share the first worker checkout.
     assert batches
     assert {(lease.task_id, lease.run_id) for lease in batches[0]} == {
         (1, "run-a"),
@@ -917,7 +946,7 @@ async def test_old_batch_result_does_not_contaminate_replacement_registration(
 
 @pytest.mark.asyncio
 async def test_stop_heartbeat_reports_shared_batch_pool_timeout(
-    monkeypatch, caplog
+    monkeypatch, caplog, heartbeat_batch_ready
 ) -> None:
     refresh_attempted = threading.Event()
     allow_timeout = threading.Event()
@@ -927,7 +956,7 @@ async def test_stop_heartbeat_reports_shared_batch_pool_timeout(
         _leases: tuple[TaskLease, ...],
     ) -> dict[tuple[int, str, str | None], TaskLeaseRefreshState]:
         refresh_attempted.set()
-        assert allow_timeout.wait(timeout=2)
+        assert allow_timeout.wait(timeout=GUARD_TIMEOUT)
         raise heartbeat_timeout
 
     monkeypatch.setattr(
@@ -979,8 +1008,9 @@ async def test_stop_heartbeat_reports_shared_batch_pool_timeout(
                     second_stop_event,
                 )
             )
-            await asyncio.wait_for(
-                asyncio.to_thread(refresh_attempted.wait, 1), timeout=1
+            assert await asyncio.wait_for(
+                asyncio.to_thread(refresh_attempted.wait, GUARD_TIMEOUT),
+                timeout=GUARD_TIMEOUT,
             )
 
             first_stopping = asyncio.create_task(
@@ -996,7 +1026,7 @@ async def test_stop_heartbeat_reports_shared_batch_pool_timeout(
             allow_timeout.set()
             first_outcome, second_outcome = await asyncio.wait_for(
                 asyncio.gather(first_stopping, second_stopping),
-                timeout=1,
+                timeout=GUARD_TIMEOUT,
             )
 
         heartbeat_warnings = [

--- a/tests/web/test_trusted_actor_oauth_postgresql.py
+++ b/tests/web/test_trusted_actor_oauth_postgresql.py
@@ -470,27 +470,15 @@ def test_concurrent_actor_flows_for_distinct_apps_preserve_both_credentials(
             ("other", _start_actor_flow(db, user, app_id="drive", provider="other")),
         ]
 
-    monkeypatch.setattr(
-        auth_api.requests,
-        "post",
-        lambda *_args, **_kwargs: _Response(
-            {"access_token": "actor-token", "scope": "profile.read"}
-        ),
-    )
-    delete_accounts = auth_api.delete_scoped_user_oauth_accounts
-    delete_barrier = threading.Barrier(2)
+    exchange_barrier = threading.Barrier(2)
 
-    def synchronize_delete(*args, **kwargs):
-        deleted = delete_accounts(*args, **kwargs)
-        try:
-            delete_barrier.wait(timeout=1)
-        except threading.BrokenBarrierError:
-            pass
-        return deleted
+    def exchange_token(*_args, **_kwargs):
+        # Rendezvous before the callback locks the shared user row; waiting
+        # after credential deletion would deadlock the serialized writers.
+        exchange_barrier.wait(timeout=30)
+        return _Response({"access_token": "actor-token", "scope": "profile.read"})
 
-    monkeypatch.setattr(
-        auth_api, "delete_scoped_user_oauth_accounts", synchronize_delete
-    )
+    monkeypatch.setattr(auth_api.requests, "post", exchange_token)
 
     def callback(provider_name: str, request) -> int:
         with factory() as callback_db:
@@ -500,7 +488,7 @@ def test_concurrent_actor_flows_for_distinct_apps_preserve_both_credentials(
 
     with ThreadPoolExecutor(max_workers=2) as executor:
         statuses = sorted(
-            future.result(timeout=10)
+            future.result(timeout=60)
             for future in [
                 executor.submit(callback, provider_name, request)
                 for provider_name, request in flows

--- a/tests/web/tools/test_web_tool_config_session_factory.py
+++ b/tests/web/tools/test_web_tool_config_session_factory.py
@@ -17,6 +17,12 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.orm.state import InstanceState
 from sqlalchemy.pool import QueuePool
 
+from tests.web.pool_contention_shared import (
+    GUARD_TIMEOUT,
+    LOOP_LIVENESS_TICKS,
+    gated_pool_checkout,
+    wait_for_ticks,
+)
 from xagent.core.execution_scope import ExecutionScope
 from xagent.core.task_runtime import TaskRuntimeContext
 from xagent.core.tools.adapters.vibe.config import (
@@ -798,25 +804,29 @@ async def test_tool_factory_credential_prefetch_waits_off_event_loop(tmp_path):
     async def build_tools() -> list:
         return await ToolFactory.create_all_tools(cfg)
 
-    ticker_task = asyncio.create_task(ticker())
-    build_task = asyncio.create_task(build_tools())
-    try:
-        await asyncio.sleep(0.08)
-        assert ticks >= 4
-        assert not build_task.done()
+    with gated_pool_checkout(engine) as gate:
+        ticker_task = asyncio.create_task(ticker())
+        build_task = asyncio.create_task(build_tools())
+        try:
+            await gate.wait_until_contending()
+            observed = await wait_for_ticks(lambda: ticks)
+            assert observed >= LOOP_LIVENESS_TICKS
+            assert not build_task.done()
 
-        held_connection.close()
-        await build_task
-    finally:
-        if not held_connection.closed:
             held_connection.close()
-        if not build_task.done():
-            build_task.cancel()
+            gate.let_through()
+            await asyncio.wait_for(build_task, timeout=GUARD_TIMEOUT)
+        finally:
+            if not held_connection.closed:
+                held_connection.close()
+                gate.let_through()
+            if not build_task.done():
+                build_task.cancel()
             await asyncio.gather(build_task, return_exceptions=True)
-        stop.set()
-        await ticker_task
-        cfg.close()
-        engine.dispose()
+            stop.set()
+            await ticker_task
+            cfg.close()
+            engine.dispose()
 
 
 @pytest.mark.asyncio
@@ -2843,28 +2853,34 @@ async def test_runtime_policy_refresh_waits_for_pool_off_event_loop(tmp_path):
             ticks += 1
             await asyncio.sleep(0.01)
 
-    ticker_task = asyncio.create_task(ticker())
-    try:
-        await asyncio.sleep(0.02)
-        ticks_before_wait = ticks
-        refresh_task = asyncio.create_task(cfg.refresh_runtime_policy())
-        await asyncio.sleep(0.08)
-        assert ticks - ticks_before_wait >= 4
-        assert not refresh_task.done()
+    with gated_pool_checkout(engine) as gate:
+        ticker_task = asyncio.create_task(ticker())
+        try:
+            refresh_task = asyncio.create_task(cfg.refresh_runtime_policy())
+            await gate.wait_until_contending()
+            observed = await wait_for_ticks(lambda: ticks)
+            assert observed >= LOOP_LIVENESS_TICKS
+            assert not refresh_task.done()
 
-        held_connection.close()
-        await refresh_task
-        assert cfg.get_user_tool_overrides() == {"calculator": {"enabled": False}}
-        assert cfg.get_user_tool_allowlist() == ["file"]
-    finally:
-        if not held_connection.closed:
             held_connection.close()
-        stop.set()
-        await ticker_task
-        cfg.close()
-        set_user_tool_overrides_hook(None)
-        set_user_tool_allowlist_hook(None)
-        engine.dispose()
+            gate.let_through()
+            await asyncio.wait_for(refresh_task, timeout=GUARD_TIMEOUT)
+            assert cfg.get_user_tool_overrides() == {"calculator": {"enabled": False}}
+            assert cfg.get_user_tool_allowlist() == ["file"]
+        finally:
+            if not held_connection.closed:
+                held_connection.close()
+                gate.let_through()
+            await asyncio.wait_for(
+                asyncio.gather(refresh_task, return_exceptions=True),
+                timeout=GUARD_TIMEOUT,
+            )
+            stop.set()
+            await ticker_task
+            cfg.close()
+            set_user_tool_overrides_hook(None)
+            set_user_tool_allowlist_hook(None)
+            engine.dispose()
 
 
 def test_legacy_oauth_session_uses_engine_when_caller_is_connection_bound():

--- a/tests/web/tracking/test_task_tracker.py
+++ b/tests/web/tracking/test_task_tracker.py
@@ -11,6 +11,12 @@ from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from tests.web.pool_contention_shared import (
+    GUARD_TIMEOUT,
+    LOOP_LIVENESS_TICKS,
+    gated_pool_checkout,
+    wait_for_ticks,
+)
 from xagent.core.model.chat.token_context import (
     TokenUsage,
     add_token_usage,
@@ -153,15 +159,6 @@ def _run_tracker_ownership_race(
     return result["owned"], persisted
 
 
-# Loop progress is waited for, not counted inside a fixed window: an
-# oversubscribed CI runner can starve the loop for longer than the window, so a
-# rate assertion fails on scheduling rather than on the property under test
-# (#1993). The window stays under the pool's 1s timeout, which keeps the worker
-# parked while the assertions run.
-_REQUIRED_LOOP_TICKS = 3
-_LOOP_PROGRESS_WINDOW_SECONDS = 0.5
-
-
 def _create_tracker_pool_db(tmp_path, filename):
     engine = create_engine(
         f"sqlite:///{tmp_path / filename}",
@@ -200,7 +197,6 @@ async def _assert_tracker_operation_keeps_loop_responsive_under_pool_pressure(
     verify,
     *,
     operation_scheduled=None,
-    timer_created=None,
 ):
     """Exercise one tracker DB operation while its QueuePool is exhausted."""
     from xagent.web.models import database
@@ -212,23 +208,15 @@ async def _assert_tracker_operation_keeps_loop_responsive_under_pool_pressure(
     operation_task = None
     ticker_task = None
     held_connection = None
-    window_timer = None
     ticker_stop = threading.Event()
-    window_elapsed = threading.Event()
     ticker_ticks = 0
-    worker_entered = threading.Event()
     event_loop_thread_id = threading.get_ident()
     worker_thread_id: int | None = None
     original_helper = getattr(tracker_module, sync_helper_name)
 
     def traced_helper(*args, **kwargs):
-        nonlocal window_timer, worker_thread_id
+        nonlocal worker_thread_id
         worker_thread_id = threading.get_ident()
-        window_timer = threading.Timer(_LOOP_PROGRESS_WINDOW_SECONDS, end_window)
-        if timer_created is not None:
-            timer_created(window_timer)
-        window_timer.start()
-        worker_entered.set()
         return original_helper(*args, **kwargs)
 
     async def ticker():
@@ -236,68 +224,44 @@ async def _assert_tracker_operation_keeps_loop_responsive_under_pool_pressure(
         while not ticker_stop.is_set():
             await asyncio.sleep(0.01)
             ticker_ticks += 1
-            if ticker_ticks >= _REQUIRED_LOOP_TICKS:
-                # The timer is only the safety net; enough loop progress closes
-                # the window on its own.
-                end_window()
-
-    def end_window():
-        ticker_stop.set()
-        window_elapsed.set()
 
     try:
         await prepare(tracker)
         monkeypatch.setattr(tracker_module, sync_helper_name, traced_helper)
         held_connection = engine.connect()
-        ticker_task = asyncio.create_task(ticker())
-        await asyncio.sleep(0)
-        operation_task = asyncio.create_task(operation(tracker))
-        if operation_scheduled is not None:
-            operation_scheduled.set()
-        assert await asyncio.wait_for(
-            asyncio.to_thread(worker_entered.wait, 2), timeout=2
-        )
-
-        assert await asyncio.wait_for(
-            asyncio.to_thread(window_elapsed.wait, _LOOP_PROGRESS_WINDOW_SECONDS + 0.1),
-            timeout=_LOOP_PROGRESS_WINDOW_SECONDS + 0.2,
-        )
-        assert ticker_ticks >= _REQUIRED_LOOP_TICKS
-        assert not operation_task.done()
-        assert worker_thread_id is not None
-        assert worker_thread_id != event_loop_thread_id
-
-        held_connection.close()
-        held_connection = None
-        result = await asyncio.wait_for(operation_task, timeout=1)
-        verify(tracker, session_factory, result)
+        with gated_pool_checkout(engine) as gate:
+            ticker_task = asyncio.create_task(ticker())
+            operation_task = asyncio.create_task(operation(tracker))
+            if operation_scheduled is not None:
+                operation_scheduled.set()
+            try:
+                await gate.wait_until_contending()
+                observed = await wait_for_ticks(lambda: ticker_ticks)
+                assert observed >= LOOP_LIVENESS_TICKS
+                assert not operation_task.done()
+                assert worker_thread_id is not None
+                assert worker_thread_id != event_loop_thread_id
+            finally:
+                held_connection.close()
+                held_connection = None
+                gate.let_through()
+                # Drain even when cancelled before the worker reaches checkout.
+                await drain_async_task_cancellation_safe(operation_task)
+            result = operation_task.result()
+            verify(tracker, session_factory, result)
     finally:
-        window_elapsed.set()
         ticker_stop.set()
         try:
             if held_connection is not None:
                 held_connection.close()
+            if ticker_task is not None:
+                await drain_async_task_cancellation_safe(ticker_task)
         finally:
             try:
-                if operation_task is not None:
-                    await drain_async_task_cancellation_safe(operation_task)
+                if tracker.is_tracking:
+                    await tracker.stop_periodic_updates()
             finally:
-                try:
-                    if window_timer is not None:
-                        try:
-                            window_timer.cancel()
-                        finally:
-                            window_timer.join()
-                finally:
-                    try:
-                        if ticker_task is not None:
-                            await drain_async_task_cancellation_safe(ticker_task)
-                    finally:
-                        try:
-                            if tracker.is_tracking:
-                                await tracker.stop_periodic_updates()
-                        finally:
-                            engine.dispose()
+                engine.dispose()
 
 
 class TestTaskTracker:
@@ -447,21 +411,32 @@ class TestTaskTracker:
         ids=["normal-cleanup", "cleanup-error"],
     )
     @pytest.mark.asyncio
-    async def test_tracker_pool_helper_joins_timer_created_by_delayed_worker(
+    async def test_tracker_pool_helper_drains_delayed_worker(
         self, monkeypatch, tmp_path, inject_cleanup_error
     ):
-        """Cancellation must not leave a delayed worker's timer alive."""
+        """Cancellation must drain a worker queued before it reaches checkout."""
         loop = asyncio.get_running_loop()
         executor = ThreadPoolExecutor(max_workers=1)
         original_executor = getattr(loop, "_default_executor")
         blocker_started = asyncio.Event()
         release_worker = threading.Event()
         operation_scheduled = asyncio.Event()
-        recorded_timers = []
+        worker_finished = threading.Event()
+        from xagent.web.tracking import task_tracker as tracker_module
+
+        original_seed = tracker_module._load_task_seed_sync
+
+        def observed_seed(*args, **kwargs):
+            try:
+                return original_seed(*args, **kwargs)
+            finally:
+                worker_finished.set()
+
+        monkeypatch.setattr(tracker_module, "_load_task_seed_sync", observed_seed)
 
         def occupy_default_executor():
             loop.call_soon_threadsafe(blocker_started.set)
-            assert release_worker.wait(timeout=2)
+            assert release_worker.wait(timeout=GUARD_TIMEOUT)
 
         async def prepare(_tracker):
             return None
@@ -473,7 +448,7 @@ class TestTaskTracker:
             blocker = loop.run_in_executor(None, occupy_default_executor)
             helper_task = None
             try:
-                await asyncio.wait_for(blocker_started.wait(), timeout=1)
+                await asyncio.wait_for(blocker_started.wait(), timeout=GUARD_TIMEOUT)
                 helper_task = asyncio.create_task(
                     _assert_tracker_operation_keeps_loop_responsive_under_pool_pressure(
                         monkeypatch,
@@ -484,10 +459,11 @@ class TestTaskTracker:
                         lambda tracker: tracker.start_tracking(),
                         verify,
                         operation_scheduled=operation_scheduled,
-                        timer_created=recorded_timers.append,
                     )
                 )
-                await asyncio.wait_for(operation_scheduled.wait(), timeout=1)
+                await asyncio.wait_for(
+                    operation_scheduled.wait(), timeout=GUARD_TIMEOUT
+                )
                 helper_task.cancel()
                 release_worker.set()
                 await blocker
@@ -495,8 +471,7 @@ class TestTaskTracker:
                     await helper_task
 
                 assert helper_task.cancelled()
-                assert len(recorded_timers) == 1
-                assert not recorded_timers[0].is_alive()
+                assert worker_finished.is_set()
             finally:
                 try:
                     release_worker.set()


### PR DESCRIPTION
## Summary

Concurrency tests could fail when task or worker startup exceeded a short success-wait timeout, and some responsiveness tests could pass without exercising the intended overlap. Replace timing assumptions with explicit startup, registration, cancellation, and release handshakes; use generous guards for successful completion and drain background work during cleanup.

Strengthen regression assertions for dispatcher wakeups, default-executor isolation, and database work staying off the event loop. Move the OAuth callback rendezvous before the shared user-row lock so both callbacks can reach it, and let a broken barrier fail the test. Intentional business timeouts and negative timeout assertions remain in place.

This PR contains four commits and changes tests only.

## Validation

- Reproduced targeted failures using controlled task/worker delays before applying fixes.
- Success-wait guard batch: 184 tests passed across six files; all nine delayed target cases passed and all nine corresponding mutations were rejected.
- Final synchronization/coverage batch: 166 tests passed across seven files, including tests against a local disposable PostgreSQL database.
- All ten final target tests passed with 2.3-second startup delays; three ordering tests also passed with the previously failing 50 ms scheduling shift.
- All ten final targets detected their corresponding regressions. The six inline-database mutations were also rejected with delayed startup; an explicitly broken OAuth barrier failed as expected.
- Ruff lint/format checks and git diff whitespace checks passed for the changed files in each batch.
