### PR TITLE
test: replace flaky timing assertions with behavioral checks

### DIFF
--- a/tests/core/tools/core/RAG_tools/kb/test_list_collections_event_loop.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_list_collections_event_loop.py
@@ -16,15 +16,13 @@ The blocking calls live at two layers, and each is asserted where it belongs:
   hands the worker thread a coroutine object and never runs it. Their dispatch
   lives inside ``LanceDBMetadataStore`` and is asserted against that class.
 
-Every blocking call is scored **individually**. A single cumulative tick total
-cannot tell a fully-fixed run from one that dropped a single dispatch, because
-the calls that still yield donate far more than enough idle time to clear the
-threshold on their own.
+Every blocking call must individually observe an acknowledgement from the event
+loop while it runs on a worker thread. Progress in one call cannot hide another
+call that accidentally runs inline.
 """
 
 import asyncio
 import threading
-import time
 
 import pyarrow as pa
 import pytest
@@ -36,58 +34,36 @@ from xagent.core.tools.core.RAG_tools.storage.lancedb_stores import (
     LanceDBMetadataStore,
 )
 
-BLOCKING_SECONDS = 0.3
-HEARTBEAT_INTERVAL = 0.01
-# A 0.3s call that yields the loop leaves room for ~30 ticks; one that holds the
-# loop thread leaves room for zero or one.
-MIN_TICKS_PER_CALL = 10
-
 
 class _Heartbeat:
-    """Tick counter that scores each blocking call over its own window."""
+    """Record loop progress during each blocked worker call, without a rate."""
 
     def __init__(self) -> None:
-        self.ticks = 0
-        self.ticks_per_call: dict[str, int] = {}
         self.thread_per_call: dict[str, int] = {}
-        self._task: asyncio.Task | None = None
+        self.acknowledged: set[str] = set()
 
     async def __aenter__(self) -> "_Heartbeat":
-        async def beat() -> None:
-            while True:
-                await asyncio.sleep(HEARTBEAT_INTERVAL)
-                self.ticks += 1
-
-        self._task = asyncio.create_task(beat())
+        self._loop = asyncio.get_running_loop()
+        self._loop_thread = threading.get_ident()
         return self
 
     async def __aexit__(self, *_exc: object) -> None:
-        assert self._task is not None
-        self._task.cancel()
+        pass
 
     def block(self, label: str) -> None:
-        """Block the calling thread the way a real LanceDB call does."""
-        before = self.ticks
         self.thread_per_call[label] = threading.get_ident()
-        time.sleep(BLOCKING_SECONDS)
-        self.ticks_per_call[label] = self.ticks - before
+        assert self.thread_per_call[label] != self._loop_thread, (
+            f"{label} ran on the event loop thread"
+        )
+        acknowledged = threading.Event()
+        self._loop.call_soon_threadsafe(acknowledged.set)
+        assert acknowledged.wait(timeout=30), f"the loop never acknowledged {label}"
+        self.acknowledged.add(label)
 
     def assert_yielded_the_loop(self, *labels: str) -> None:
-        """Assert each named call ran off-loop and left the loop running.
-
-        Must be awaited from the event loop thread so ``get_ident`` identifies
-        the loop rather than a worker.
-        """
-        loop_thread = threading.get_ident()
         for label in labels:
-            assert label in self.ticks_per_call, f"{label} was never called"
-            assert self.thread_per_call[label] != loop_thread, (
-                f"{label} ran on the event loop thread"
-            )
-            assert self.ticks_per_call[label] >= MIN_TICKS_PER_CALL, (
-                f"{label} blocked the event loop: only "
-                f"{self.ticks_per_call[label]} ticks elapsed during its call"
-            )
+            assert label in self.acknowledged, f"{label} did not observe loop progress"
+            assert self.thread_per_call[label] != threading.get_ident()
 
 
 # --------------------------------------------------------------------------

--- a/tests/core/tools/core/RAG_tools/kb/test_rebuild_collection_stats_event_loop.py
+++ b/tests/core/tools/core/RAG_tools/kb/test_rebuild_collection_stats_event_loop.py
@@ -21,7 +21,6 @@ from xagent.core.tools.core.RAG_tools.management import (
 )
 
 BLOCKING_SECONDS = 0.5
-HEARTBEAT_INTERVAL = 0.02
 COLLECTION_NAME = "stats_rebuild_event_loop"
 
 
@@ -75,30 +74,36 @@ def slow_vector_store(monkeypatch: pytest.MonkeyPatch) -> _SlowVectorStore:
 
 async def test_rebuild_collection_stats_keeps_event_loop_responsive(
     slow_vector_store: _SlowVectorStore,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Given a slow aggregation, the stats rebuild leaves the loop responsive."""
-    ticks = 0
+    """The loop must resume while aggregation is parked on a worker."""
+    entered = threading.Event()
+    release = threading.Event()
+    loop_thread = threading.get_ident()
+    original = slow_vector_store.aggregate_collection_stats
 
-    async def heartbeat() -> None:
-        nonlocal ticks
-        while True:
-            await asyncio.sleep(HEARTBEAT_INTERVAL)
-            ticks += 1
+    def blocked_aggregate(**kwargs):
+        entered.set()
+        assert threading.get_ident() != loop_thread
+        assert release.wait(timeout=30), "aggregation was never released"
+        return original(**kwargs)
 
-    beat = asyncio.create_task(heartbeat())
+    monkeypatch.setattr(
+        slow_vector_store, "aggregate_collection_stats", blocked_aggregate
+    )
+    rebuild = asyncio.create_task(
+        collection_manager_module._rebuild_collection_stats_impl(COLLECTION_NAME)
+    )
     try:
-        rebuilt = await collection_manager_module._rebuild_collection_stats_impl(
-            COLLECTION_NAME
-        )
+        assert await asyncio.to_thread(entered.wait, 30)
+        assert not rebuild.done()
     finally:
-        beat.cancel()
+        release.set()
+        rebuilt = await asyncio.wait_for(rebuild, timeout=30)
 
     assert rebuilt is not None
     assert rebuilt.documents == 2
     assert rebuilt.chunks == 4
-    # A 0.5s blocking call: a responsive loop ticks tens of times. Held on the
-    # event loop thread it manages one or two.
-    assert ticks >= 15, f"event loop was blocked, only {ticks} ticks"
 
 
 async def test_rebuild_collection_stats_aggregates_off_the_event_loop(

--- a/tests/core/utils/test_api_key.py
+++ b/tests/core/utils/test_api_key.py
@@ -12,18 +12,18 @@ Covers the three key contracts callers rely on:
 
 Plus a couple of robustness checks:
 
-  - verify_dummy spends roughly the same time as a real verify_api_key
-    call, so an attacker can't enumerate prefixes by timing.
+  - verify_dummy performs a bcrypt check with the same cost as real API
+    keys, so missing prefixes do not skip the expensive verification.
   - generate_api_key retries on prefix collision and gives up cleanly
     if a mock keeps colliding.
 """
 
 import re
-import time
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
+from xagent.core.utils import api_key as api_key_module
 from xagent.core.utils.api_key import (
     BCRYPT_COST,
     KEY_ALPHABET,
@@ -200,32 +200,20 @@ def test_verify_dummy_runs_without_raising() -> None:
     assert verify_dummy() is None
 
 
-def test_verify_dummy_timing_similar_to_verify() -> None:
-    """verify_dummy() runs roughly as long as a real verify_api_key() call.
-
-    We don't need tight bounds; the threat model is "an attacker can tell
-    fast (index miss) from slow (bcrypt run) responses". A ratio inside
-    [0.3, 3.0] is good enough -- bcrypt timing is dominated by the cost
-    factor, not by what's being verified. Generous bounds keep CI happy
-    on overcommitted runners.
-    """
+def test_verify_dummy_uses_the_same_bcrypt_cost_as_real_verification() -> None:
+    """Both paths execute bcrypt at the configured cost, without timing CI."""
     full, _prefix, key_hash = generate_api_key(db=None)
+    with patch.object(
+        api_key_module.bcrypt, "checkpw", wraps=api_key_module.bcrypt.checkpw
+    ) as checkpw:
+        assert verify_api_key(full, key_hash) is True
+        checkpw.assert_called_once_with(full.encode(), key_hash.encode())
+        checkpw.reset_mock()
 
-    # Warm any lazy bcrypt init so we don't measure first-call overhead
-    verify_api_key(full, key_hash)
-    verify_dummy()
-
-    t0 = time.perf_counter()
-    verify_api_key(full, key_hash)
-    real_elapsed = time.perf_counter() - t0
-
-    t0 = time.perf_counter()
-    verify_dummy()
-    dummy_elapsed = time.perf_counter() - t0
-
-    ratio = dummy_elapsed / real_elapsed
-    assert 0.3 < ratio < 3.0, (
-        f"verify_dummy timing diverged from verify_api_key: "
-        f"real={real_elapsed * 1000:.1f}ms, dummy={dummy_elapsed * 1000:.1f}ms, "
-        f"ratio={ratio:.2f}"
-    )
+        assert verify_dummy() is None
+        checkpw.assert_called_once()
+        dummy_password, dummy_hash = checkpw.call_args.args
+        assert isinstance(dummy_password, bytes)
+        assert isinstance(dummy_hash, bytes)
+        assert int(dummy_hash.split(b"$")[2]) == BCRYPT_COST
+        assert int(key_hash.split("$")[2]) == BCRYPT_COST

--- a/tests/integration/test_progress_monitoring.py
+++ b/tests/integration/test_progress_monitoring.py
@@ -345,11 +345,11 @@ class TestProgressMonitoringIntegration:
             assert len(active_tasks) == 1
 
     def test_performance_under_load(self, progress_manager):
-        """Test performance with many concurrent tasks and steps."""
+        """Bound CPU work for many tasks and steps, excluding scheduler stalls."""
         num_tasks = 50
         steps_per_task = 5
 
-        start_time = time.time()
+        start_time = time.thread_time()
 
         # Create many tasks
         task_ids = []
@@ -372,7 +372,7 @@ class TestProgressMonitoringIntegration:
                     step_tracker.update(message=f"Processing {step_name}")
                     step_tracker.complete(f"Completed {step_name}")
 
-        total_time = time.time() - start_time
+        total_time = time.thread_time() - start_time
 
         # Verify all work completed
         for task_id in task_ids:
@@ -380,10 +380,10 @@ class TestProgressMonitoringIntegration:
             assert task is not None
             assert task.status == DocumentProcessingStatus.RUNNING
 
-        # Performance check: should complete within reasonable time
+        # CPU regression guard: descheduling is not computation
         # 50 tasks * 5 steps = 250 operations, should be fast
-        assert total_time < 5.0  # Less than 5 seconds for all operations
+        assert total_time < 5.0  # Less than 5 CPU seconds for all operations
 
         print(
-            f"Performance test completed: {num_tasks} tasks, {steps_per_task} steps each, {total_time:.2f}s"
+            f"CPU performance test completed: {num_tasks} tasks, {steps_per_task} steps each, {total_time:.2f}s"
         )

--- a/tests/integration/test_websocket.py
+++ b/tests/integration/test_websocket.py
@@ -288,7 +288,7 @@ class TestWebSocket(unittest.IsolatedAsyncioTestCase):
 
         for i in range(max_connections):
             websocket = AsyncMock()
-            await manager.connect(websocket, f"task_{i}")
+            await manager.connect(websocket, i)
             websockets.append(websocket)
 
         # 验证连接数量
@@ -299,21 +299,27 @@ class TestWebSocket(unittest.IsolatedAsyncioTestCase):
 
         import time
 
-        start_time = time.time()
+        start_time = time.thread_time()
 
         # 向所有连接广播消息
         for i in range(max_connections):
             await manager.broadcast_to_task(test_message, i)
 
-        end_time = time.time()
+        end_time = time.thread_time()
         duration = end_time - start_time
 
-        # 验证性能
-        self.assertLess(duration, 5.0, f"{max_connections}次广播应该在5秒内完成")
+        # Count only CPU work; CI scheduling stalls are not a broadcast regression.
+        for websocket in websockets:
+            websocket.send_text.assert_awaited_once()
+            self.assertEqual(
+                json.loads(websocket.send_text.call_args.args[0]), test_message
+            )
+
+        self.assertLess(duration, 5.0, f"{max_connections}次广播应该在5个 CPU 秒内完成")
 
         print("连接限制验证: ✅")
         print(f"  最大连接数: {max_connections}")
-        print(f"  广播耗时: {duration:.3f}秒")
+        print(f"  广播 CPU 耗时: {duration:.3f}秒")
         print(f"  平均每次广播: {duration / max_connections * 1000:.3f}毫秒")
 
     async def test_websocket_message_validation(self):

--- a/tests/web/api/test_get_agent_for_task_snapshot_threaded.py
+++ b/tests/web/api/test_get_agent_for_task_snapshot_threaded.py
@@ -9,12 +9,9 @@ What this test pins:
        The test asserts the loader's ``threading.get_ident()`` differs
        from the loop thread's.
 
-    2. While the loader is sleeping, the event loop is still able to
-       drive other coroutines forward. We verify by kicking off a
-       concurrent ``asyncio.sleep`` task and confirming it advances
-       during the snapshot load window. This is the core invariant
-       the off-loop snapshot loader exists to provide -- main-loop
-       release during the synchronous DB block (issue #427).
+    2. While the loader is parked on a release event, the event loop resumes
+       the test coroutine. The test releases the worker only after observing
+       that the load is still pending (issue #427).
 
     3. The snapshot's fields are observed by ``get_agent_for_task``
        on the loop thread without lazy-loading from the loader's
@@ -426,39 +423,17 @@ async def test_snapshot_runs_off_loop_thread() -> None:
 
 @pytest.mark.asyncio
 async def test_event_loop_stays_responsive_during_snapshot_load() -> None:
-    """The other half of the off-loop contract: while the snapshot
-    loader is sleeping (simulating a slow DB read), other coroutines
-    on the same loop must still be able to make progress.
-
-    We block the loader for 0.3s and concurrently schedule a tight
-    polling task that records its tick count. If ``to_thread`` works,
-    the polling task progresses across many ticks during the loader's
-    sleep. If the loader regresses back to an inline synchronous
-    call, the polling task records at most one tick (no progress
-    until the blocking sleep returns).
-    """
+    """The loop resumes while the actual snapshot loader is parked off-loop."""
     snapshot = _build_snapshot()
-    ticks: list[float] = []
-    loader_done = asyncio.Event()
+    entered = threading.Event()
+    release = threading.Event()
+    loop_thread = threading.get_ident()
 
     def slow_loader(task_id: int, user_id: int | None) -> TaskSetupSnapshot:
-        # Synchronous sleep on the worker thread. If the call is
-        # actually executed inline on the loop thread, this freezes
-        # the entire loop and the poll task can't tick.
-        import time
-
-        time.sleep(0.3)
+        entered.set()
+        assert threading.get_ident() != loop_thread
+        assert release.wait(timeout=30), "snapshot loader was never released"
         return snapshot
-
-    async def poll() -> None:
-        loop = asyncio.get_running_loop()
-        start = loop.time()
-        while not loader_done.is_set():
-            ticks.append(loop.time() - start)
-            # Short sleep to yield, but the *loop* must run to come
-            # back to us. If the loader is hogging the loop this
-            # await never resumes until the sleep returns.
-            await asyncio.sleep(0.02)
 
     manager = AgentServiceManager()
     user = _make_user()
@@ -492,20 +467,14 @@ async def test_event_loop_stays_responsive_during_snapshot_load() -> None:
                 await manager.get_agent_for_task(task_id=42, db=db, user=user)
             except Exception:
                 pass
-        loader_done.set()
 
-    await asyncio.gather(driver(), poll())
-
-    # With a 0.3s blocking sleep on the worker thread and 0.02s
-    # polling intervals on the loop, we expect on the order of ~10
-    # ticks. Use a permissive floor of >= 5 to keep the test stable
-    # under busy CI while still failing loudly if the loop genuinely
-    # freezes (which would yield 0-1 ticks).
-    assert len(ticks) >= 5, (
-        f"Loop ticked only {len(ticks)} times during the 0.3s snapshot "
-        "load -- the loader appears to be running inline on the loop "
-        "thread (the off-loop invariant regressed)."
-    )
+    loading = asyncio.create_task(driver())
+    try:
+        assert await asyncio.to_thread(entered.wait, 30)
+        assert not loading.done()
+    finally:
+        release.set()
+        await asyncio.wait_for(loading, timeout=30)
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/test_websocket_preview.py
+++ b/tests/web/api/test_websocket_preview.py
@@ -9,6 +9,7 @@ from sqlalchemy.exc import TimeoutError as SQLAlchemyTimeoutError
 from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
+from tests.web.pool_contention_shared import assert_pool_checkout_off_loop
 from xagent.core.memory.in_memory import InMemoryMemoryStore
 from xagent.web import dynamic_memory_store as dynamic_memory_store_module
 from xagent.web.api import chat as chat_api
@@ -336,28 +337,15 @@ async def test_memory_policy_pool_timeout_does_not_block_loop_or_fallback(
     monkeypatch.setattr(chat_api, "get_memory_store", memory_manager.get_memory_store)
 
     held_connection = engine.connect()
-    stop_ticker = asyncio.Event()
-    ticks = 0
-
-    async def ticker() -> None:
-        nonlocal ticks
-        while not stop_ticker.is_set():
-            ticks += 1
-            await asyncio.sleep(0.005)
-
-    ticker_task = asyncio.create_task(ticker())
     try:
-        with pytest.raises(SQLAlchemyTimeoutError):
-            await chat_api.resolve_agent_service_memory_policy_async(
-                agent_config={},
-            )
+        with assert_pool_checkout_off_loop(engine):
+            with pytest.raises(SQLAlchemyTimeoutError):
+                await chat_api.resolve_agent_service_memory_policy_async(
+                    agent_config={},
+                )
     finally:
-        stop_ticker.set()
-        await ticker_task
         held_connection.close()
         engine.dispose()
-
-    assert ticks >= 3
 
 
 def test_historical_file_projection_never_writes_unregistered_output(

--- a/tests/web/api/v1/test_agent_management_runtime.py
+++ b/tests/web/api/v1/test_agent_management_runtime.py
@@ -11,6 +11,12 @@ import pytest
 from sqlalchemy import event, text
 from sqlalchemy.orm import Session
 
+from tests.web.pool_contention_shared import (
+    CONTENTION_POOL_TIMEOUT,
+    GUARD_TIMEOUT,
+    assert_pool_checkout_off_loop,
+    gated_pool_checkout,
+)
 from xagent.web.models.agent import Agent
 from xagent.web.models.agent_api_key import AgentApiKey
 from xagent.web.models.user import User
@@ -152,28 +158,25 @@ async def test_list_pool_wait_does_not_block_event_loop(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     user_id, _is_admin = _admin_identity()
-    engine = _install_one_slot_queue_pool(monkeypatch, pool_timeout=0.5)
+    engine = _install_one_slot_queue_pool(
+        monkeypatch, pool_timeout=CONTENTION_POOL_TIMEOUT
+    )
     held_connection = engine.connect()
     runtime = AgentManagementRuntime()
-    listing = asyncio.create_task(runtime.list_agents(user_id=user_id))
-
-    ticks = 0
-
-    async def ticker() -> None:
-        nonlocal ticks
-        for _ in range(4):
-            await asyncio.sleep(0.01)
-            ticks += 1
-
     try:
-        await ticker()
-        assert ticks == 4
-        assert listing.done() is False
+        with gated_pool_checkout(engine) as gate:
+            listing = asyncio.create_task(runtime.list_agents(user_id=user_id))
+            try:
+                await gate.wait_until_contending()
+                assert not listing.done()
+            finally:
+                held_connection.close()
+                gate.let_through()
+                result = await asyncio.wait_for(listing, timeout=GUARD_TIMEOUT)
+        assert result == ()
     finally:
         held_connection.close()
-
-    assert await listing == ()
-    engine.dispose()
+        engine.dispose()
 
 
 @pytest.mark.asyncio
@@ -1178,7 +1181,9 @@ async def test_compensation_keeps_the_event_loop_responsive_while_pool_is_held(
     from xagent.web.services import agent_management
 
     user_id, is_admin = _admin_identity()
-    engine = _install_one_slot_queue_pool(monkeypatch, pool_timeout=2)
+    engine = _install_one_slot_queue_pool(
+        monkeypatch, pool_timeout=CONTENTION_POOL_TIMEOUT
+    )
     committed = threading.Event()
     release = threading.Event()
     original_create = (
@@ -1205,22 +1210,25 @@ async def test_compensation_keeps_the_event_loop_responsive_while_pool_is_held(
     )
     assert await asyncio.to_thread(committed.wait, _HANDSHAKE_TIMEOUT)
     held_connection = engine.connect()
-    operation.cancel()
-    release.set()
     try:
-        ticks = 0
-        for _ in range(4):
-            await asyncio.sleep(0.01)
-            ticks += 1
-        assert ticks == 4
-        assert operation.done() is False
+        # Cancellation may swallow a worker failure. Assert the checkout's
+        # thread outside the worker as well as observing the parked operation.
+        with assert_pool_checkout_off_loop(engine), gated_pool_checkout(engine) as gate:
+            operation.cancel()
+            release.set()
+            try:
+                await gate.wait_until_contending()
+                assert not operation.done()
+            finally:
+                held_connection.close()
+                gate.let_through()
+                with pytest.raises(asyncio.CancelledError):
+                    await asyncio.wait_for(operation, timeout=_HANDSHAKE_TIMEOUT)
     finally:
+        release.set()
         held_connection.close()
-
-    with pytest.raises(asyncio.CancelledError):
-        await asyncio.wait_for(operation, timeout=_HANDSHAKE_TIMEOUT)
-    assert engine.pool.checkedout() == 0
-    engine.dispose()
+        assert engine.pool.checkedout() == 0
+        engine.dispose()
 
 
 @pytest.mark.asyncio

--- a/tests/web/api/v1/test_auth.py
+++ b/tests/web/api/v1/test_auth.py
@@ -9,7 +9,6 @@ Test plumbing (client, _test_db fixture, auth helpers) is shared via
 
 import asyncio
 import threading
-import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
@@ -535,45 +534,31 @@ async def test_record_key_usage_pool_wait_keeps_event_loop_responsive(
 # ===== timing oracle defense =====
 
 
-def test_unknown_prefix_takes_similar_time_to_wrong_secret():
-    """Prefix-miss must burn bcrypt time like a real verify would.
-
-    Both paths should be ~100ms on commodity hardware. We use generous
-    bounds (each within 2x of the other) so CI runners' jitter doesn't
-    flake the test. The defense is to keep the order of magnitude the
-    same, not to clock to the millisecond.
-    """
+def test_unknown_prefix_performs_the_same_bcrypt_work_as_wrong_secret():
+    """Both HTTP rejection paths perform one real bcrypt check at equal cost."""
     full_key, _prefix = _create_personal_key()
     parts = full_key.split("_")
     parts[3] = "z" * 32
     wrong_secret_key = "_".join(parts)
 
-    # Warm the bcrypt module a bit so first-call overhead doesn't skew
-    bcrypt.checkpw(b"warm", bcrypt.hashpw(b"warm", bcrypt.gensalt(rounds=BCRYPT_COST)))
+    with patch.object(bcrypt, "checkpw", wraps=bcrypt.checkpw) as checkpw:
+        resp1 = client.get(
+            "/v1/me", headers={"Authorization": f"Bearer {wrong_secret_key}"}
+        )
+        assert resp1.status_code == 401
+        checkpw.assert_called_once()
+        real_password, real_hash = checkpw.call_args.args
+        assert real_password == wrong_secret_key.encode()
+        assert int(real_hash.split(b"$")[2]) == BCRYPT_COST
+        checkpw.reset_mock()
 
-    # Wrong secret (prefix hits index, then bcrypt runs)
-    t0 = time.perf_counter()
-    resp1 = client.get(
-        "/v1/me", headers={"Authorization": f"Bearer {wrong_secret_key}"}
-    )
-    real_t = time.perf_counter() - t0
-    assert resp1.status_code == 401
-
-    # Unknown prefix (index miss, then verify_dummy runs)
-    fake_key = "xag_personal_ZZZZZZ_" + "x" * 32
-    t0 = time.perf_counter()
-    resp2 = client.get("/v1/me", headers={"Authorization": f"Bearer {fake_key}"})
-    dummy_t = time.perf_counter() - t0
-    assert resp2.status_code == 401
-
-    # They should be within an order of magnitude. Asserting roughly:
-    # the slower one is at most 3x the faster one. Wide bounds keep CI
-    # flakes down; the real safeguard is the verify_dummy call itself.
-    ratio = max(real_t, dummy_t) / max(min(real_t, dummy_t), 1e-6)
-    assert ratio < 3.0, (
-        f"timing asymmetry too large: real={real_t * 1000:.1f}ms, "
-        f"dummy={dummy_t * 1000:.1f}ms, ratio={ratio:.2f}"
-    )
+        fake_key = "xag_personal_ZZZZZZ_" + "x" * 32
+        resp2 = client.get("/v1/me", headers={"Authorization": f"Bearer {fake_key}"})
+        assert resp2.status_code == 401
+        assert resp2.json() == resp1.json()
+        checkpw.assert_called_once()
+        _dummy_password, dummy_hash = checkpw.call_args.args
+        assert int(dummy_hash.split(b"$")[2]) == BCRYPT_COST
 
 
 # ===== /v1/* internal_error envelope (catch-all) =====

--- a/tests/web/pool_contention_shared.py
+++ b/tests/web/pool_contention_shared.py
@@ -170,3 +170,40 @@ async def wait_for_ticks(
     while read_ticks() - baseline < minimum and loop.time() < deadline:
         await asyncio.sleep(0.01)
     return read_ticks() - baseline
+
+
+@contextmanager
+def assert_pool_checkout_off_loop(engine) -> Iterator[None]:
+    """Check loop progress at each real checkout, preserving pool exhaustion.
+
+    Unlike the contention gate, this does not release the held connection.
+    The worker waits for one loop acknowledgement and then performs the real
+    checkout, so timeout/error assertions remain about SQLAlchemy's pool.
+    """
+    loop = asyncio.get_running_loop()
+    loop_thread = threading.get_ident()
+    original_do_get = engine.pool._do_get
+    checkout_threads: list[int] = []
+    acknowledged = 0
+
+    def checked_do_get():
+        nonlocal acknowledged
+        thread_id = threading.get_ident()
+        checkout_threads.append(thread_id)
+        assert thread_id != loop_thread, "pool checkout ran on the event loop"
+        progress = threading.Event()
+        loop.call_soon_threadsafe(progress.set)
+        assert progress.wait(GUARD_TIMEOUT), "loop never acknowledged pool checkout"
+        acknowledged += 1
+        return original_do_get()
+
+    engine.pool._do_get = checked_do_get
+    try:
+        yield
+        # Workflows may catch checkout failures; don't let that swallow a failed
+        # thread/progress assertion inside the probe.
+        assert checkout_threads, "the operation never attempted a pool checkout"
+        assert loop_thread not in checkout_threads
+        assert acknowledged == len(checkout_threads)
+    finally:
+        engine.pool._do_get = original_do_get

--- a/tests/web/services/test_file_reference_output_service.py
+++ b/tests/web/services/test_file_reference_output_service.py
@@ -1226,18 +1226,19 @@ def test_reconcile_stays_fast_on_a_large_unresolvable_reference():
     # and scale quadratically, on a function that reruns on every read of
     # attacker-influenceable chat history. Generous bound (real fix runs in
     # well under a second even at far larger sizes) to avoid environment
-    # flakiness while still catching a real regression.
+    # flakiness while still catching a real regression. Measure thread CPU
+    # time so a preempted CI worker is not mistaken for regex backtracking.
     db, user, task = _create_context()
     try:
         content = "[x](file:" + "a" * 100_000
-        start = time.monotonic()
+        start = time.thread_time()
         result = reconcile_assistant_file_references(
             db,
             task_id=int(task.id),
             user_id=int(user.id),
             content=content,
         )
-        elapsed = time.monotonic() - start
+        elapsed = time.thread_time() - start
 
         assert result == content
         assert elapsed < 2.0

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -5,6 +5,7 @@ import logging
 import os
 import time
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import ExitStack
 from dataclasses import FrozenInstanceError, is_dataclass
 from datetime import datetime, timedelta
 from threading import Barrier, Event, get_ident
@@ -20,6 +21,7 @@ from sqlalchemy.pool import QueuePool
 from tests.web.pool_contention_shared import (
     GUARD_TIMEOUT,
     LOOP_LIVENESS_TICKS,
+    assert_pool_checkout_off_loop,
     gated_pool_checkout,
     wait_for_ticks,
 )
@@ -1349,14 +1351,7 @@ async def test_command_handler_pool_timeout_does_not_checkout_again(
 
     monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
     held_connections = []
-    ticker_stop = asyncio.Event()
-    ticks = 0
-
-    async def ticker() -> None:
-        nonlocal ticks
-        while not ticker_stop.is_set():
-            ticks += 1
-            await asyncio.sleep(0.01)
+    checkout_probe = ExitStack()
 
     def checkout_from_exhausted_pool() -> None:
         with SessionLocal() as db:
@@ -1364,27 +1359,24 @@ async def test_command_handler_pool_timeout_does_not_checkout_again(
 
     async def execute(_command: ClaimedTaskCommand) -> None:
         held_connections.append(engine.connect())
+        checkout_probe.enter_context(assert_pool_checkout_off_loop(engine))
         await asyncio.to_thread(checkout_from_exhausted_pool)
 
     caplog.set_level(
         logging.ERROR,
         logger="xagent.web.services.task_command_transport",
     )
-    ticker_task = asyncio.create_task(ticker())
     try:
         assert await dispatch_one_task_command(
             execute,
             command_db_id=enqueued.command_id,
         )
-        assert ticks >= 10, (
-            "command handler QueuePool timeout blocked the event loop; "
-            f"ticker advanced only {ticks} times"
-        )
     finally:
-        ticker_stop.set()
-        await ticker_task
-        for connection in held_connections:
-            connection.close()
+        try:
+            checkout_probe.close()
+        finally:
+            for connection in held_connections:
+                connection.close()
 
     with SessionLocal() as verify_db:
         stored = verify_db.get(TaskExecutionCommand, enqueued.command_id)
@@ -1509,38 +1501,28 @@ async def test_real_final_disposition_pool_timeout_stays_off_event_loop(
 
     monkeypatch.setattr(database_module, "get_session_local", lambda: SessionLocal)
     held_connections = []
-    ticker_stop = asyncio.Event()
-    ticks = 0
-
-    async def ticker() -> None:
-        nonlocal ticks
-        while not ticker_stop.is_set():
-            ticks += 1
-            await asyncio.sleep(0.01)
+    checkout_probe = ExitStack()
 
     async def execute(_command: ClaimedTaskCommand) -> dict[str, bool]:
         held_connections.append(engine.connect())
+        checkout_probe.enter_context(assert_pool_checkout_off_loop(engine))
         return {"ok": True}
 
     caplog.set_level(
         logging.ERROR,
         logger="xagent.web.services.task_command_transport",
     )
-    ticker_task = asyncio.create_task(ticker())
     try:
         assert await dispatch_one_task_command(
             execute,
             command_db_id=enqueued.command_id,
         )
-        assert ticks >= 10, (
-            "final disposition QueuePool timeout blocked the event loop; "
-            f"ticker advanced only {ticks} times"
-        )
     finally:
-        ticker_stop.set()
-        await ticker_task
-        for connection in held_connections:
-            connection.close()
+        try:
+            checkout_probe.close()
+        finally:
+            for connection in held_connections:
+                connection.close()
 
     with SessionLocal() as verify_db:
         stored = verify_db.get(TaskExecutionCommand, enqueued.command_id)

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -127,8 +127,7 @@ def low_timeout_sqlite_engine(tmp_path):
         f"sqlite:///{tmp_path / 'task-command-lock-path.db'}",
         connect_args={"check_same_thread": False},
     )
-    # Long enough to stay clear of thread-scheduling jitter under a loaded
-    # test run, short enough to keep the lock-path tests well under 2s.
+    # Keep SQLite lock waits short without asserting wall-clock performance.
     apply_sqlite_concurrency_pragmas(engine, busy_timeout_ms=200)
     Base.metadata.create_all(bind=engine)
     SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
@@ -2765,6 +2764,7 @@ async def test_dispatch_with_staged_id_before_commit_is_noop_and_converges_after
         await stop_task_command_dispatcher()
 
 
+@pytest.mark.timeout(30)
 def test_owner_holding_a_flushed_command_blocks_a_concurrent_claim(
     low_timeout_sqlite_engine,
 ) -> None:
@@ -2773,7 +2773,8 @@ def test_owner_holding_a_flushed_command_blocks_a_concurrent_claim(
     transaction -- far longer than the microseconds an insert that committed
     itself holds it for. SQLite's writer lock is database-wide, so a concurrent claim
     of a different, already-committed command must still wait out
-    busy_timeout and fail with OperationalError rather than hang."""
+    busy_timeout and fail with OperationalError. Once the owner commits,
+    the same command must be claimable."""
 
     engine, SessionLocal = low_timeout_sqlite_engine
     with SessionLocal() as setup_db:
@@ -2802,18 +2803,25 @@ def test_owner_holding_a_flushed_command_blocks_a_concurrent_claim(
             payload={"agent_id": 1},
         )
         # Deliberately not committed yet -- this is the window under test.
-        started = time.monotonic()
         with SessionLocal() as claimant_db:
-            with pytest.raises(OperationalError):
+            with pytest.raises(OperationalError, match="database is locked"):
                 claim_task_command(
                     claimant_db,
                     runner_id="lock-path-claimant",
                     command_db_id=claimable.command_id,
                 )
-        elapsed = time.monotonic() - started
         owner_db.commit()
 
-    assert elapsed < 2.0
+    with SessionLocal() as claimant_db:
+        claimed = claim_task_command(
+            claimant_db,
+            runner_id="lock-path-claimant",
+            command_db_id=claimable.command_id,
+        )
+
+    assert claimed is not None
+    assert claimed.id == claimable.command_id
+    assert claimed.attempt_count == 1
 
 
 @pytest.mark.asyncio

--- a/tests/web/services/test_task_interaction_service_postgresql.py
+++ b/tests/web/services/test_task_interaction_service_postgresql.py
@@ -815,73 +815,73 @@ def test_concurrent_ownership_change_is_blocked_until_respond_commits(
     _respond_pg, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     import time
+    from concurrent.futures import ThreadPoolExecutor
 
     owner_id, task_id = _pg_waiting_task(_respond_pg)
     interaction_id = _pg_active_row(_respond_pg, task_id=task_id)
-    setup_db = _respond_pg()
-    try:
+    with _respond_pg() as setup_db:
         intruder_id = make_user(setup_db)
-    finally:
-        setup_db.close()
 
-    results: dict = {}
-
-    # Sleep injected between step 2's lock and the fence write, standing in
-    # for step 3's authorization work, by wrapping the fence statement
-    # builder. Patched via monkeypatch (not a manual assign-then-restore)
-    # so the module-global attribute is restored at fixture teardown no
-    # matter what happens on the holder thread below -- a raise before its
-    # own restore code ran would otherwise leave every later test in this
-    # process patched.
+    pids: dict[str, int] = {}
+    lock_taken = threading.Event()
+    release_holder = threading.Event()
+    racer_ready = threading.Event()
     real_fence_stmt = svc._answer_fence_stmt
 
-    # The holder signals here rather than letting the racer guess with a
-    # wall-clock stagger. This function runs after respond()'s step 2 has
-    # taken the tasks row lock and before its fence write, so setting the
-    # event here is the exact moment the racer's UPDATE must start blocking
-    # from. With a fixed 0.1s stagger instead, the test could fail in both
-    # directions on a loaded runner: a holder more than 0.1s late to reach
-    # step 2 lets the racer's UPDATE through unblocked, and a racer late to
-    # issue its UPDATE measures less than the full hold.
-    lock_taken = threading.Event()
+    def holder_session():
+        db = _respond_pg()
+        pids["holder"] = db.scalar(sa.text("SELECT pg_backend_pid()"))
+        return db
 
-    def _slow_fence_stmt(*args, **kwargs):
+    monkeypatch.setattr(database_module, "get_session_local", lambda: holder_session)
+
+    def paused_fence_stmt(*args, **kwargs):
+        # respond() has acquired the task lock. Keep it held until PostgreSQL
+        # itself confirms that this owner update is blocked by this session.
         lock_taken.set()
-        time.sleep(1.0)
+        assert release_holder.wait(timeout=30), "holder was never released"
         return real_fence_stmt(*args, **kwargs)
 
-    monkeypatch.setattr(svc, "_answer_fence_stmt", _slow_fence_stmt)
+    monkeypatch.setattr(svc, "_answer_fence_stmt", paused_fence_stmt)
 
-    def holder() -> None:
-        principal = _pg_owning_principal(owner_id)
-        outcome = svc.respond(
+    def holder():
+        return svc.respond(
             interaction_id=interaction_id,
             task_id=task_id,
-            principal=principal,
+            principal=_pg_owning_principal(owner_id),
             envelope=_pg_envelope("pg-a5-holder"),
         )
-        results["holder_outcome"] = outcome
 
     def racer() -> None:
-        assert lock_taken.wait(timeout=30.0), "holder never reached the fence"
-        t0 = time.monotonic()
-        db = _respond_pg()
-        try:
+        with _respond_pg() as db:
+            pids["racer"] = db.scalar(sa.text("SELECT pg_backend_pid()"))
+            racer_ready.set()
             db.query(Task).filter(Task.id == task_id).update({"user_id": intruder_id})
             db.commit()
+
+    with ThreadPoolExecutor(max_workers=2) as workers:
+        held = workers.submit(holder)
+        try:
+            assert lock_taken.wait(timeout=30), "holder never reached the fence"
+            raced = workers.submit(racer)
+            assert racer_ready.wait(timeout=30), "racer never acquired its connection"
+            deadline = time.monotonic() + 30
+            blockers: list[int] = []
+            while time.monotonic() < deadline and not raced.done():
+                with _respond_pg() as observer:
+                    blockers = observer.scalar(
+                        sa.text("SELECT pg_blocking_pids(:pid)"),
+                        {"pid": pids["racer"]},
+                    )
+                if pids["holder"] in blockers:
+                    break
+                time.sleep(0.01)
+            assert pids["holder"] in blockers, "owner update did not wait on respond()"
+            assert not raced.done()
         finally:
-            db.close()
-        results["racer_wait_s"] = time.monotonic() - t0
-
-    t1 = threading.Thread(target=holder)
-    t2 = threading.Thread(target=racer)
-    t1.start()
-    t2.start()
-    t1.join()
-    t2.join()
-
-    assert isinstance(results["holder_outcome"], svc.RespondAccepted), results
-    assert results["racer_wait_s"] >= 0.8, results
+            release_holder.set()
+        assert isinstance(held.result(timeout=30), svc.RespondAccepted)
+        raced.result(timeout=30)
 
 
 def test_two_concurrent_respond_calls_serialize_on_the_tasks_row(_respond_pg) -> None:

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -35,6 +35,7 @@ from tests.web.pool_contention_shared import (
     EXHAUSTION_POOL_TIMEOUT,
     GUARD_TIMEOUT,
     LOOP_LIVENESS_TICKS,
+    assert_pool_checkout_off_loop,
     gated_pool_checkout,
     wait_for_ticks,
 )
@@ -2161,14 +2162,6 @@ async def test_schedule_bg_pool_timeout_defers_settlement_to_lease_recovery(
         seed_db.commit()
 
     lease = TaskLease(task_id=task_id, runner_id="test-runner", run_id="run-a")
-    ticker_stop = asyncio.Event()
-    ticks = 0
-
-    async def ticker() -> None:
-        nonlocal ticks
-        while not ticker_stop.is_set():
-            ticks += 1
-            await asyncio.sleep(0.01)
 
     def load_snapshot_from_contended_pool(*_args, **_kwargs):
         with SessionLocal() as snapshot_db:
@@ -2180,9 +2173,9 @@ async def test_schedule_bg_pool_timeout_defers_settlement_to_lease_recovery(
         logging.ERROR,
         logger="xagent.web.services.task_orchestrator",
     )
-    ticker_task = asyncio.create_task(ticker())
     try:
         with (
+            assert_pool_checkout_off_loop(engine),
             patch(
                 "xagent.web.services.task_orchestrator.acquire_task_lease_isolated",
                 return_value=lease,
@@ -2225,13 +2218,7 @@ async def test_schedule_bg_pool_timeout_defers_settlement_to_lease_recovery(
         mock_execute.assert_not_awaited()
         mock_stop_heartbeat.assert_awaited_once()
         mock_settle.assert_not_called()
-        assert ticks >= 10, (
-            "setup QueuePool timeout blocked the asyncio event loop; "
-            f"ticker advanced only {ticks} times"
-        )
     finally:
-        ticker_stop.set()
-        await ticker_task
         held_connection.close()
 
     with SessionLocal() as verify_db:

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import asyncio
 import threading
-import time
 from collections.abc import Iterator
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
@@ -689,13 +688,17 @@ async def test_historical_replay_detaches_before_slow_network_send(
     event_loop_thread = threading.get_ident()
     cache_threads: list[int] = []
     sent_events: list[dict] = []
-    ticker_stop = asyncio.Event()
-    ticks = 0
+    cache_entered = threading.Event()
+    release_cache = threading.Event()
+    send_entered = asyncio.Event()
+    release_send = asyncio.Event()
 
     def slow_cache_get(_key: str):
         assert engine.pool.checkedout() == 0
         cache_threads.append(threading.get_ident())
-        time.sleep(0.05)
+        cache_entered.set()
+        assert threading.get_ident() != event_loop_thread
+        assert release_cache.wait(timeout=30), "history cache was never released"
         return None
 
     def record_cache_set(*_args, **_kwargs) -> None:
@@ -711,13 +714,8 @@ async def test_historical_replay_detaches_before_slow_network_send(
 
         await asyncio.to_thread(read_during_send)
         sent_events.append(event)
-        await asyncio.sleep(0.02)
-
-    async def ticker() -> None:
-        nonlocal ticks
-        while not ticker_stop.is_set():
-            ticks += 1
-            await asyncio.sleep(0.01)
+        send_entered.set()
+        await release_send.wait()
 
     monkeypatch.setattr(database_module, "get_db", get_test_db)
     monkeypatch.setattr(websocket_api, "get_session_local", lambda: SessionLocal)
@@ -729,19 +727,29 @@ async def test_historical_replay_detaches_before_slow_network_send(
         slow_send,
     )
 
-    ticker_task = asyncio.create_task(ticker())
-    try:
-        await send_historical_data_as_stream(
+    replay = asyncio.create_task(
+        send_historical_data_as_stream(
             websocket=object(),
             task_id=task_id,
             user=SimpleNamespace(id=owner_id, is_admin=False),
         )
+    )
+    try:
+        assert await asyncio.to_thread(cache_entered.wait, 30)
+        assert not replay.done()
+        assert not sent_events
+        release_cache.set()
+        await asyncio.wait_for(send_entered.wait(), timeout=30)
+        assert not replay.done()
+        assert engine.pool.checkedout() == 0
     finally:
-        ticker_stop.set()
-        await ticker_task
-        engine.dispose()
+        release_cache.set()
+        release_send.set()
+        try:
+            await asyncio.wait_for(replay, timeout=30)
+        finally:
+            engine.dispose()
 
-    assert ticks >= 5
     assert cache_threads
     assert all(thread_id != event_loop_thread for thread_id in cache_threads)
     assert [event["event_type"] for event in sent_events] == [

--- a/tests/web/test_svg_preview_cache.py
+++ b/tests/web/test_svg_preview_cache.py
@@ -9,7 +9,7 @@ Covers review findings from PR #977:
 """
 
 import asyncio
-import time
+import threading
 
 import pytest
 
@@ -74,44 +74,34 @@ def test_rasterize_svg_preview_does_not_alias_across_relative_assets(
 async def test_inline_preview_response_does_not_block_event_loop(
     storage_root, tmp_path, monkeypatch
 ) -> None:
-    """``_inline_preview_response`` must offload the synchronous SVG
-    read+rasterize work (e.g. via ``asyncio.to_thread``) rather than run it
-    inline on the async request path — otherwise one expensive preview
-    blocks every other request handled by the same event loop."""
-
+    """Rasterization must leave the loop running while its worker is blocked."""
     svg_path = tmp_path / "big.svg"
     svg_path.write_bytes(SVG_A)
+    entered = threading.Event()
+    release = threading.Event()
+    loop_thread = threading.get_ident()
 
-    def slow_rasterize(svg_bytes: bytes) -> bytes:
-        time.sleep(0.3)
-        return SVG_A  # placeholder bytes; content isn't checked here
+    def blocked_rasterize(svg_bytes: bytes) -> bytes:
+        entered.set()
+        assert threading.get_ident() != loop_thread
+        assert release.wait(timeout=30), "rasterization was never released"
+        return SVG_A
 
-    monkeypatch.setattr(files_module, "rasterize_svg_bytes", slow_rasterize)
-
-    ticks: list[float] = []
-
-    async def ticker() -> None:
-        for _ in range(20):
-            ticks.append(time.monotonic())
-            await asyncio.sleep(0.01)
-
-    ticker_task = asyncio.ensure_future(ticker())
-    await asyncio.sleep(0.01)
-    await files_module._inline_preview_response(
-        svg_path,
-        filename="big.svg",
-        media_type="image/svg+xml",
-        file_id="event-loop-test-file-id",
+    monkeypatch.setattr(files_module, "rasterize_svg_bytes", blocked_rasterize)
+    preview = asyncio.create_task(
+        files_module._inline_preview_response(
+            svg_path,
+            filename="big.svg",
+            media_type="image/svg+xml",
+            file_id="event-loop-test-file-id",
+        )
     )
-    await ticker_task
-
-    gaps = [b - a for a, b in zip(ticks, ticks[1:])]
-    assert gaps, "ticker should have produced measurable ticks"
-    assert max(gaps) < 0.2, (
-        "the ticker was starved for a stretch close to the 0.3s "
-        "rasterization delay — the SVG preview is still running "
-        "synchronously on the event loop thread"
-    )
+    try:
+        assert await asyncio.to_thread(entered.wait, 30)
+        assert not preview.done()
+    finally:
+        release.set()
+        await asyncio.wait_for(preview, timeout=30)
 
 
 @pytest.mark.asyncio

--- a/tests/web/test_workforce_run_service.py
+++ b/tests/web/test_workforce_run_service.py
@@ -1,5 +1,5 @@
 import asyncio
-import time
+import threading
 from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from typing import Any
@@ -884,11 +884,16 @@ async def test_create_workforce_run_releases_connection_before_worker_transactio
     db.commit()
 
     checked_out: list[int] = []
+    entered = threading.Event()
+    release = threading.Event()
+    loop_thread = threading.get_ident()
     original = workforce_runs_module._create_claimed_workforce_run_isolated
 
     def observed(*args: Any, **kwargs: Any):
         checked_out.append(engine.pool.checkedout())
-        time.sleep(0.05)
+        entered.set()
+        assert threading.get_ident() != loop_thread
+        assert release.wait(timeout=30), "workforce transaction was never released"
         return original(*args, **kwargs)
 
     monkeypatch.setattr(
@@ -897,32 +902,26 @@ async def test_create_workforce_run_releases_connection_before_worker_transactio
         observed,
     )
 
-    ticker_stop = asyncio.Event()
-    ticks = 0
-
-    async def ticker() -> None:
-        nonlocal ticks
-        while not ticker_stop.is_set():
-            ticks += 1
-            await asyncio.sleep(0.005)
-
-    ticker_task = asyncio.create_task(ticker())
-    try:
-        result = await create_workforce_run(
+    startup = asyncio.create_task(
+        create_workforce_run(
             db,
             user,
             workforce,
             message="Coordinate a launch brief",
         )
-        await result.background_task
+    )
+    try:
+        assert await asyncio.to_thread(entered.wait, 30)
+        assert not startup.done()
+        assert checked_out == [0]
     finally:
-        ticker_stop.set()
-        await ticker_task
+        release.set()
+        result = await asyncio.wait_for(startup, timeout=30)
+    await result.background_task
 
     assert result.task.status == TaskStatus.RUNNING
     assert result.workforce_run.status == "running"
     assert checked_out == [0]
-    assert ticks >= 3, "workforce turn startup blocked the asyncio event loop"
 
 
 @pytest.mark.asyncio
@@ -939,11 +938,16 @@ async def test_create_preview_workforce_run_releases_connection_before_worker_tr
     db.commit()
 
     checked_out: list[int] = []
+    entered = threading.Event()
+    release = threading.Event()
+    loop_thread = threading.get_ident()
     original = workforce_runs_module._create_claimed_preview_run_isolated
 
     def observed(*args: Any, **kwargs: Any):
         checked_out.append(engine.pool.checkedout())
-        time.sleep(0.05)
+        entered.set()
+        assert threading.get_ident() != loop_thread
+        assert release.wait(timeout=30), "workforce transaction was never released"
         return original(*args, **kwargs)
 
     monkeypatch.setattr(
@@ -952,18 +956,8 @@ async def test_create_preview_workforce_run_releases_connection_before_worker_tr
         observed,
     )
 
-    ticker_stop = asyncio.Event()
-    ticks = 0
-
-    async def ticker() -> None:
-        nonlocal ticks
-        while not ticker_stop.is_set():
-            ticks += 1
-            await asyncio.sleep(0.005)
-
-    ticker_task = asyncio.create_task(ticker())
-    try:
-        result = await create_preview_workforce_run(
+    startup = asyncio.create_task(
+        create_preview_workforce_run(
             db,
             user_id=user.id,
             name="Launch Team",
@@ -978,15 +972,19 @@ async def test_create_preview_workforce_run_releases_connection_before_worker_tr
             ],
             message="Draft a launch brief",
         )
-        await result.background_task
+    )
+    try:
+        assert await asyncio.to_thread(entered.wait, 30)
+        assert not startup.done()
+        assert checked_out == [0]
     finally:
-        ticker_stop.set()
-        await ticker_task
+        release.set()
+        result = await asyncio.wait_for(startup, timeout=30)
+    await result.background_task
 
     assert result.task.status == TaskStatus.RUNNING
     assert result.workforce_run.status == "running"
     assert checked_out == [0]
-    assert ticks >= 3, "preview workforce turn startup blocked the asyncio event loop"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Shared CI scheduling pauses can fail tests that compare one-shot bcrypt durations or count heartbeats inside short windows, even when the underlying behavior is correct. This replaces the remaining 22 timing-sensitive tests identified after #2154 with checks of the behavior they protect. Production code is unchanged.

- Check that both API-key rejection paths execute real bcrypt verification at the configured cost, with identical HTTP rejection responses.
- Synchronize at blocking operations and assert worker-thread execution and event-loop progress. Preserve real SQLAlchemy pool-exhaustion behavior, and detect checkout failures swallowed during cancellation compensation.
- Use PostgreSQL's `pg_blocking_pids` to prove the ownership update waits on the responding transaction before releasing its lock.
- Retain the three performance budgets using current-thread CPU time, excluding scheduler pauses. These guard CPU cost, not end-to-end latency. Fix the WebSocket workload's mismatched task IDs and assert all 100 connections actually receive the broadcast.

Validation:
- All 561 tests across the 16 affected test modules passed, including real PostgreSQL tests. Three initial local environment failures passed after configuring the installed Cairo library and PostgreSQL connection environment; no production changes were needed.
- All 22 changed tests passed with real pauses injected into the measured work or thread dispatch. The final cancellation-compensation module also passed all 34 tests after its assertions were strengthened.
- Temporary mutation checks confirmed each of the 22 tests fails when its protected behavior is broken: inline blocking work, skipped bcrypt, removed row locking, excess CPU work, or removal of regex atomic groups. Additional checks caught reduced dummy bcrypt cost and an independently broken second vector-store dispatch.
- Ruff check, Ruff format --check, and git diff --check passed.
