### PR TITLE
fix(mcp): Allow hidden actor OAuth disconnect

### DIFF
--- a/src/xagent/web/mcp_apps.py
+++ b/src/xagent/web/mcp_apps.py
@@ -245,6 +245,11 @@ class RemoteOAuthDefinitionOwnership(Enum):
     TEAM = "team"
 
 
+class RemoteOAuthUse(Enum):
+    EXECUTION = "execution"
+    DISCONNECT = "disconnect"
+
+
 def _normalized_catalog_key(value: object) -> str | None:
     """Normalize only for collision detection, never for persisted identity."""
     if value is None:
@@ -809,8 +814,9 @@ def classify_actor_remote_oauth_server(
     definition_ownership: RemoteOAuthDefinitionOwnership = (
         RemoteOAuthDefinitionOwnership.UNKNOWN
     ),
+    use: RemoteOAuthUse = RemoteOAuthUse.EXECUTION,
 ) -> Dict[str, Any] | None:
-    """Validate catalog OAuth or preserve a proven custom definition."""
+    """Validate catalog OAuth; disconnect may include hidden canonical apps."""
 
     from .models.mcp import MCPServer, UserMCPServer
     from .services.mcp_runtime import HTTP_MCP_TRANSPORTS
@@ -842,7 +848,10 @@ def classify_actor_remote_oauth_server(
                     "remote OAuth catalog identity is unavailable"
                 )
         return None
-    if not app_info.get("is_visible_in_connector", True):
+    # Hiding an app blocks use, not cleanup of its existing credentials.
+    if use is not RemoteOAuthUse.DISCONNECT and not app_info.get(
+        "is_visible_in_connector", True
+    ):
         raise RemoteOAuthServerDefinitionError("remote OAuth app is hidden")
 
     app_id = str(app_info["id"])

--- a/tests/web/tools/test_mcp_actor_owner_runtime.py
+++ b/tests/web/tools/test_mcp_actor_owner_runtime.py
@@ -161,6 +161,54 @@ def _add_remote_server(db: Session, user: User) -> MCPServer:
     return server
 
 
+def test_hidden_remote_disconnect(db_session) -> None:
+    db, user = db_session.db, db_session.user
+    server = _add_remote_server(db, user)
+    app = db.query(PublicMCPApp).filter_by(app_id=REMOTE_APP_ID).one()
+    app.is_visible_in_connector = False
+    db.commit()
+
+    with pytest.raises(mcp_apps.RemoteOAuthServerDefinitionError, match="hidden"):
+        mcp_apps.classify_actor_remote_oauth_server(db, server)
+    classified = mcp_apps.classify_actor_remote_oauth_server(
+        db, server, use=mcp_apps.RemoteOAuthUse.DISCONNECT
+    )
+    assert classified["id"] == REMOTE_APP_ID
+    assert classified["is_visible_in_connector"] is False
+    assert app.is_visible_in_connector is False
+
+
+@pytest.mark.parametrize("drift", ["url", "auth", "managed", "ownership", "identity"])
+def test_hidden_disconnect_drift(db_session, drift) -> None:
+    db, user = db_session.db, db_session.user
+    server = _add_remote_server(db, user)
+    db.query(PublicMCPApp).filter_by(
+        app_id=REMOTE_APP_ID
+    ).one().is_visible_in_connector = False
+    if drift == "ownership":
+        db.query(UserMCPServer).filter_by(mcpserver_id=server.id).one().is_owner = True
+    elif drift == "identity":
+        db.add(
+            MCPServer(
+                name="Actor Remote",
+                managed="external",
+                transport="streamable_http",
+                url=server.url,
+                auth={"type": "mcp_oauth"},
+            )
+        )
+    elif drift == "auth":
+        server.auth = {"type": "mcp_oauth", "unexpected": "value"}
+    else:
+        setattr(server, drift, "changed")
+    db.commit()
+
+    with pytest.raises(mcp_apps.RemoteOAuthServerDefinitionError):
+        mcp_apps.classify_actor_remote_oauth_server(
+            db, server, use=mcp_apps.RemoteOAuthUse.DISCONNECT
+        )
+
+
 def _add_remote_grant(
     db: Session,
     user: User,


### PR DESCRIPTION
## Intention and boundary

Let trusted actor disconnect validate hidden catalog OAuth apps. This supports xorbitsai/xagent-saas#990 without duplicating canonical validation.

Only the explicit disconnect mode skips connector visibility. Default execution remains unchanged.

## Rejected behavior

- Hidden apps cannot execute through the default classifier.
- Disconnect does not bypass catalog identity, server uniqueness, ownership, transport, URL, or auth validation.
- No catalog visibility changes, schema changes, or public route changes.

## Accepted errors and trade-offs

Invalid or ambiguous definitions still raise RemoteOAuthServerDefinitionError. Callers must select disconnect mode only for credential cleanup.

## Verification

- 396 focused OAuth, runtime, resolver, and catalog tests passed.
- Six new cases cover hidden disconnect and canonical validation failures.
- Applicable pre-commit hooks, including mypy, passed.
- Dependent SaaS checks: 479 tests and three real PostgreSQL lifecycle cases passed.