### PR TITLE
feat: deliver explicit Base64 outputs as managed attachments

### DIFF
--- a/example.env
+++ b/example.env
@@ -5,6 +5,10 @@
 # Options: DEBUG, INFO, WARNING, ERROR, CRITICAL
 # XAGENT_LOG_LEVEL="INFO"
 
+# Maximum total decoded Base64 attachment bytes per execution (default: 8 MiB).
+# Only explicit file deliveries are converted. Zero disables conversion.
+# XAGENT_INLINE_FILE_DELIVERY_MAX_BYTES="8388608"
+
 # ===========================================
 # Docker Compose Configuration
 # ===========================================

--- a/example.env
+++ b/example.env
@@ -6,7 +6,8 @@
 # XAGENT_LOG_LEVEL="INFO"
 
 # Maximum total decoded Base64 attachment bytes per execution (default: 8 MiB).
-# Only explicit file deliveries are converted. Zero disables conversion.
+# Only explicit file deliveries are converted. Zero rejects attachments with
+# an unavailable notice; it does not expose the raw Base64 in the final answer.
 # XAGENT_INLINE_FILE_DELIVERY_MAX_BYTES="8388608"
 
 # ===========================================

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -2922,10 +2922,16 @@ def get_tool_max_field_count() -> int:
 
 
 def get_inline_file_delivery_max_bytes() -> int:
-    """Decoded inline-file budget per run; zero disables delivery, default 8 MiB."""
-    value = int(os.getenv(INLINE_FILE_DELIVERY_MAX_BYTES, str(8 * 1024 * 1024)))
-    if value < 0:
-        raise ValueError("Inline file delivery budget must be non-negative")
+    """Decoded budget per run; zero rejects attachments, not Base64 passthrough."""
+    try:
+        value = int(os.getenv(INLINE_FILE_DELIVERY_MAX_BYTES, str(8 * 1024 * 1024)))
+        if value < 0:
+            raise ValueError("Inline file delivery budget must be non-negative")
+    except ValueError:
+        logger.warning(
+            "Invalid XAGENT_INLINE_FILE_DELIVERY_MAX_BYTES; rejecting inline attachments"
+        )
+        return 0
     return value
 
 

--- a/src/xagent/config.py
+++ b/src/xagent/config.py
@@ -221,6 +221,7 @@ TOOL_MAX_OUTPUT_LENGTH = "XAGENT_TOOL_MAX_OUTPUT_LENGTH"
 TOOL_MAX_RECURSION_DEPTH = "XAGENT_TOOL_MAX_RECURSION_DEPTH"
 TOOL_MAX_FIELD_COUNT = "XAGENT_TOOL_MAX_FIELD_COUNT"
 MAX_TRACE_PAYLOAD_BYTES = "XAGENT_MAX_TRACE_PAYLOAD_BYTES"
+INLINE_FILE_DELIVERY_MAX_BYTES = "XAGENT_INLINE_FILE_DELIVERY_MAX_BYTES"
 
 WEB_SEARCH_PROVIDERS = {"auto", "google", "tavily", "exa", "zhipu"}
 
@@ -2918,6 +2919,14 @@ def get_tool_max_field_count() -> int:
         except ValueError:
             logger.warning("Invalid TOOL_MAX_FIELDS value: {env_str}")
     return 1000
+
+
+def get_inline_file_delivery_max_bytes() -> int:
+    """Decoded inline-file budget per run; zero disables delivery, default 8 MiB."""
+    value = int(os.getenv(INLINE_FILE_DELIVERY_MAX_BYTES, str(8 * 1024 * 1024)))
+    if value < 0:
+        raise ValueError("Inline file delivery budget must be non-negative")
+    return value
 
 
 def get_max_trace_payload_bytes() -> int:

--- a/src/xagent/core/agent/pattern/auto/auto.py
+++ b/src/xagent/core/agent/pattern/auto/auto.py
@@ -209,6 +209,9 @@ class _AutoChildRuntime:
     async def end_final_answer_stream(self, message_id: str, content: str) -> None:
         await self.parent.end_final_answer_stream(message_id, content)
 
+    async def prepare_final_answer(self, content: str) -> str:
+        return await self.parent.prepare_final_answer(content)
+
     async def fail_final_answer_stream(self, message_id: str, error: str) -> None:
         await self.parent.fail_final_answer_stream(message_id, error)
 

--- a/src/xagent/core/agent/result.py
+++ b/src/xagent/core/agent/result.py
@@ -75,14 +75,34 @@ def tool_result_succeeded(result: Any) -> bool:
     return not (isinstance(status, str) and status.lower() == "error")
 
 
-def extract_assistant_message(result: dict[str, Any]) -> str | None:
-    """Return the assistant-facing output from a normalized pattern result."""
+FINAL_ANSWER_KEYS = ("response", "answer", "output", "content", "message")
 
-    for key in ("response", "answer", "output", "content", "message"):
+
+def assistant_message_key(result: dict[str, Any]) -> str | None:
+    """Select one canonical answer without treating other strings as aliases."""
+
+    for key in FINAL_ANSWER_KEYS:
         value = result.get(key)
         if isinstance(value, str) and value:
-            return unwrap_final_answer_content(value)
+            return key
     return None
+
+
+def extract_assistant_message(result: dict[str, Any]) -> str | None:
+    """Return the assistant-facing output from a normalized pattern result."""
+    key = assistant_message_key(result)
+    return unwrap_final_answer_content(str(result[key])) if key is not None else None
+
+
+def set_assistant_message(result: dict[str, Any], content: str) -> None:
+    """Replace the canonical answer and exact aliases, preserving other fields."""
+    key = assistant_message_key(result)
+    if key is None:
+        return
+    original = result[key]
+    for candidate in FINAL_ANSWER_KEYS:
+        if result.get(candidate) == original:
+            result[candidate] = content
 
 
 def unwrap_final_answer_content(content: str) -> str:

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -339,7 +339,7 @@ class AgentRunner:
                         )
                         continue
 
-                    # Normalize only the final answer, never tool arguments,
+                    # Normalize user-facing answer text, never tool arguments,
                     # input files or reasoning. Streaming and buffered patterns
                     # share this delivery owner and its registered-file cache.
                     raw_answer = (

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -253,7 +253,7 @@ class AgentRunner:
                     workspace = await workspace
             runtime.context_ref_resolver = WorkspaceContextReferenceResolver(workspace)
         if workspace is not None and callable(
-            getattr(workspace, "register_file", None)
+            getattr(workspace, "register_delivery_file", None)
         ):
             runtime.inline_file_delivery = InlineFileDelivery(workspace)
         self._active_controls[execution_id] = ExecutionControl(
@@ -464,6 +464,7 @@ class AgentRunner:
             )
             return result
         finally:
+            runtime.discard_inline_file_streams()
             self._active_controls.pop(execution_id, None)
             exit_goal(goal_token)
 

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -22,7 +22,7 @@ from .attachments import build_image_context_references
 from .checkpoint import CheckpointCorruptError, read_latest_checkpoint_payload
 from .context import ContextManager, ExecutionContext
 from .language import reset_output_language_to_request_context
-from .result import extract_assistant_message
+from .result import extract_assistant_message, set_assistant_message
 from .runtime import ExecutionInterrupted, PatternRuntime, load_pattern_checkpoint
 
 logger = logging.getLogger(__name__)
@@ -354,15 +354,7 @@ class AgentRunner:
                         if delivered_answer != raw_answer:
                             if isinstance(result, dict):
                                 result = dict(result)
-                                for key in (
-                                    "response",
-                                    "answer",
-                                    "output",
-                                    "content",
-                                    "message",
-                                ):
-                                    if isinstance(result.get(key), str):
-                                        result[key] = delivered_answer
+                                set_assistant_message(result, delivered_answer)
                             else:
                                 result = {"success": True, "output": delivered_answer}
                             for index in range(len(context.messages) - 1, -1, -1):
@@ -1235,9 +1227,7 @@ class AgentRunner:
 
         assistant_message = extract_assistant_message(normalized)
         if assistant_message:
-            for key in ("response", "answer", "output", "content", "message"):
-                if isinstance(normalized.get(key), str):
-                    normalized[key] = assistant_message
+            set_assistant_message(normalized, assistant_message)
         if assistant_message and not self._has_assistant_message(
             context, assistant_message
         ):

--- a/src/xagent/core/agent/runner.py
+++ b/src/xagent/core/agent/runner.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import inspect
 import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 from pathlib import Path
 from typing import Any, cast
@@ -11,6 +11,7 @@ from uuid import uuid4
 from ...config import get_compact_threshold_default, get_compact_threshold_ratio
 from ..context_materializer import WorkspaceContextReferenceResolver
 from ..context_ref import CONTEXT_REFS_KEY, ContextReference
+from ..inline_file_delivery import InlineFileDelivery
 from ..model.intent import enter_goal, exit_goal
 from ..task_runtime import (
     PREFERRED_INPUT_MODALITIES_METADATA_KEY,
@@ -251,6 +252,10 @@ class AgentRunner:
                 if inspect.isawaitable(workspace):
                     workspace = await workspace
             runtime.context_ref_resolver = WorkspaceContextReferenceResolver(workspace)
+        if workspace is not None and callable(
+            getattr(workspace, "register_file", None)
+        ):
+            runtime.inline_file_delivery = InlineFileDelivery(workspace)
         self._active_controls[execution_id] = ExecutionControl(
             runtime=runtime,
             task=task,
@@ -334,6 +339,42 @@ class AgentRunner:
                         )
                         continue
 
+                    # Normalize only the final answer, never tool arguments,
+                    # input files or reasoning. Streaming and buffered patterns
+                    # share this delivery owner and its registered-file cache.
+                    raw_answer = (
+                        extract_assistant_message(result)
+                        if isinstance(result, dict)
+                        else result
+                    )
+                    if isinstance(raw_answer, str):
+                        delivered_answer = await runtime.prepare_final_answer(
+                            raw_answer
+                        )
+                        if delivered_answer != raw_answer:
+                            if isinstance(result, dict):
+                                result = dict(result)
+                                for key in (
+                                    "response",
+                                    "answer",
+                                    "output",
+                                    "content",
+                                    "message",
+                                ):
+                                    if isinstance(result.get(key), str):
+                                        result[key] = delivered_answer
+                            else:
+                                result = {"success": True, "output": delivered_answer}
+                            for index in range(len(context.messages) - 1, -1, -1):
+                                context_message = context.messages[index]
+                                if (
+                                    context_message.role == "assistant"
+                                    and context_message.content == raw_answer
+                                ):
+                                    context.messages[index] = replace(
+                                        context_message, content=delivered_answer
+                                    )
+                                    break
                     normalized = self._normalize_result(
                         result=result,
                         pattern=pattern,

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -348,13 +348,15 @@ class PatternRuntime:
             response = await self.run_streaming_llm_call(
                 llm, on_chunk=emit_text_delta, **kwargs
             )
+            content = self._response_content(response)
+            await stream.finish(content)
+            return response
         except Exception as exc:
             await stream.fail(str(exc))
             raise
-        content = self._response_content(response)
-
-        await stream.finish(content)
-        return response
+        finally:
+            # Includes cancellation, which is not an Exception on Python 3.11+.
+            await stream.fail("Final answer stream abandoned")
 
     async def run_streaming_llm_call(
         self,
@@ -651,13 +653,17 @@ class PatternRuntime:
         if self.inline_file_delivery is not None:
             self._inline_stream_guards[message_id] = InlineFileStreamGuard()
         self.last_final_answer_stream_message_id = None
-        await self._emit_outbound(
-            {
-                "type": "final_answer_start",
-                "message_id": message_id,
-                "task_id": self.execution_id,
-            }
-        )
+        try:
+            await self._emit_outbound(
+                {
+                    "type": "final_answer_start",
+                    "message_id": message_id,
+                    "task_id": self.execution_id,
+                }
+            )
+        except BaseException:
+            self._inline_stream_guards.pop(message_id, None)
+            raise
         logger.info(
             "final_answer stream opened. task_id=%s step=%s turn=%s message_id=%s",
             self.execution_id,
@@ -688,8 +694,8 @@ class PatternRuntime:
         return await asyncio.to_thread(self.inline_file_delivery.transform, content)
 
     async def end_final_answer_stream(self, message_id: str, content: str) -> None:
-        content = await self.prepare_final_answer(content)
         guard = self._inline_stream_guards.pop(message_id, None)
+        content = await self.prepare_final_answer(content)
         if guard is not None:
             await self.emit_final_answer_delta(message_id, guard.flush())
         self.last_final_answer_stream_message_id = message_id
@@ -710,6 +716,10 @@ class PatternRuntime:
             message_id,
             len(content),
         )
+
+    def discard_inline_file_streams(self) -> None:
+        """Release per-run buffers even if a pattern abandoned a candidate."""
+        self._inline_stream_guards.clear()
 
     async def fail_final_answer_stream(self, message_id: str, error: str) -> None:
         self._inline_stream_guards.pop(message_id, None)

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -225,7 +225,7 @@ class PatternRuntime:
     last_final_answer_stream_message_id: str | None = None
     inline_file_delivery: InlineFileDelivery | None = None
     _inline_stream_guards: dict[str, InlineFileStreamGuard] = field(
-        default_factory=dict
+        default_factory=dict, init=False, repr=False
     )
     _active_llm_tasks: set[asyncio.Future[Any]] = field(
         default_factory=set,
@@ -352,11 +352,15 @@ class PatternRuntime:
             await stream.finish(content)
             return response
         except Exception as exc:
-            await stream.fail(str(exc))
+            if self.last_final_answer_stream_message_id != stream.message_id:
+                await stream.fail(str(exc))
             raise
         finally:
             # Includes cancellation, which is not an Exception on Python 3.11+.
-            await stream.fail("Final answer stream abandoned")
+            # Once end has started broadcasting, it cannot safely be retracted
+            # with a contradictory error frame after partial delivery.
+            if self.last_final_answer_stream_message_id != stream.message_id:
+                await stream.fail("Final answer stream abandoned")
 
     async def run_streaming_llm_call(
         self,

--- a/src/xagent/core/agent/runtime.py
+++ b/src/xagent/core/agent/runtime.py
@@ -20,6 +20,7 @@ from ..context_materializer import (
     ContextReferenceResolver,
     materialize_llm_kwargs,
 )
+from ..inline_file_delivery import InlineFileDelivery, InlineFileStreamGuard
 from ..model.chat.basic.base import BaseLLM
 from ..model.chat.error import retry_on
 from ..model.chat.exceptions import LLMToolProtocolError
@@ -222,6 +223,10 @@ class PatternRuntime:
     # relying on step_id or timestamp-adjacency heuristics.
     active_turn_id: str | None = None
     last_final_answer_stream_message_id: str | None = None
+    inline_file_delivery: InlineFileDelivery | None = None
+    _inline_stream_guards: dict[str, InlineFileStreamGuard] = field(
+        default_factory=dict
+    )
     _active_llm_tasks: set[asyncio.Future[Any]] = field(
         default_factory=set,
         init=False,
@@ -643,6 +648,8 @@ class PatternRuntime:
         if self.outbound_message_handler is None:
             return None
         message_id = f"final_answer_{uuid4().hex}"
+        if self.inline_file_delivery is not None:
+            self._inline_stream_guards[message_id] = InlineFileStreamGuard()
         self.last_final_answer_stream_message_id = None
         await self._emit_outbound(
             {
@@ -661,6 +668,9 @@ class PatternRuntime:
         return message_id
 
     async def emit_final_answer_delta(self, message_id: str, delta: str) -> None:
+        guard = self._inline_stream_guards.get(message_id)
+        if guard is not None:
+            delta = guard.feed(delta)
         if not delta:
             return
         await self._emit_outbound(
@@ -672,7 +682,16 @@ class PatternRuntime:
             }
         )
 
+    async def prepare_final_answer(self, content: str) -> str:
+        if self.inline_file_delivery is None or "base64" not in content.lower():
+            return content
+        return await asyncio.to_thread(self.inline_file_delivery.transform, content)
+
     async def end_final_answer_stream(self, message_id: str, content: str) -> None:
+        content = await self.prepare_final_answer(content)
+        guard = self._inline_stream_guards.pop(message_id, None)
+        if guard is not None:
+            await self.emit_final_answer_delta(message_id, guard.flush())
         self.last_final_answer_stream_message_id = message_id
         await self._emit_outbound(
             {
@@ -693,6 +712,7 @@ class PatternRuntime:
         )
 
     async def fail_final_answer_stream(self, message_id: str, error: str) -> None:
+        self._inline_stream_guards.pop(message_id, None)
         if self.last_final_answer_stream_message_id == message_id:
             self.last_final_answer_stream_message_id = None
         await self._emit_outbound(

--- a/src/xagent/core/inline_file_delivery.py
+++ b/src/xagent/core/inline_file_delivery.py
@@ -1,6 +1,7 @@
 """Turn explicit encoded-file deliveries into registered workspace attachments.
 
-This is an output boundary, not a general Base64 detector or a format validator.
+This is a final-answer delivery boundary, not a general Base64 detector or a
+format validator. Intermediate messages and execution checkpoints are unchanged.
 Only data-URI Markdown links outside code and explicitly named Base64 fences
 opt in. Arbitrary prose, source code and unnamed encoded examples are preserved.
 """
@@ -44,8 +45,12 @@ _DATA_LINK = re.compile(
     re.IGNORECASE,
 )
 _FENCE = re.compile(r"^ {0,3}(`{3,}|~{3,})([^\r\n]*)")
+_STREAM_FENCE = re.compile(r"^[ \t]*(`{3,}|~{3,})([^\r\n]*)")
 _NAMED_BASE64 = re.compile(r"base64[ \t]+filename=([^\r\n]+)\Z", re.IGNORECASE)
-_STREAM_MARKER = re.compile(r"\]\(data:", re.IGNORECASE)
+_STREAM_MARKER = re.compile(
+    r"\]\(data:[\w.+/-]+(?:;charset=[\w-]+)?;base64,", re.IGNORECASE
+)
+_LIST_ITEM = re.compile(r"^( *)(?:[-+*]|\d{1,9}[.)])[ \t]+")
 _DATA_CONTINUATION = re.compile(
     r"[ \t]*(?P<payload>[A-Za-z0-9+/=]*)[ \t]*(?P<closed>\))?"
 )
@@ -57,6 +62,7 @@ class InlineFileStreamGuard:
     def __init__(self) -> None:
         self.pending = ""
         self.held = False
+        self._at_line_start = True
 
     def feed(self, delta: str) -> str:
         if self.held:
@@ -66,7 +72,7 @@ class InlineFileStreamGuard:
         marker_start = marker.start() if marker else None
         offset = 0
         for line in self.pending.splitlines(keepends=True):
-            fence = _FENCE.match(line)
+            fence = _STREAM_FENCE.match(line) if offset or self._at_line_start else None
             if fence and _NAMED_BASE64.fullmatch(fence.group(2).strip()):
                 marker_start = (
                     min(marker_start, offset) if marker_start is not None else offset
@@ -82,10 +88,22 @@ class InlineFileStreamGuard:
         keep = 6
         # A fence header can contain whitespace or a longer delimiter. Retain
         # its incomplete line until its language is known, not ordinary prose.
-        fence = re.search(r"(?:^|\n) {0,3}[`~][^\r\n]*$", self.pending)
-        if fence:
+        fence = re.search(
+            r"(?:^|\n)[ \t]*(?:`{1,2}|~{1,2}|`{3,}[^\r\n]*|~{3,}[^\r\n]*)$",
+            self.pending,
+        )
+        if fence and (
+            fence.start() or self._at_line_start or self.pending.startswith("\n")
+        ):
             keep = max(keep, len(self.pending) - fence.start())
+        # Retain a split data-URI header only until its comma disambiguates
+        # Base64 from ordinary data URLs. Non-Base64 URLs keep streaming.
+        header = re.search(r"\]\(data:[^,\s()\[\]]*$", self.pending, re.IGNORECASE)
+        if header:
+            keep = max(keep, len(self.pending) - header.start())
         prefix, self.pending = self.pending[:-keep], self.pending[-keep:]
+        if prefix:
+            self._at_line_start = prefix.endswith("\n")
         return prefix
 
     def flush(self) -> str:
@@ -113,11 +131,22 @@ class InlineFileDelivery:
         output: list[str] = []
         i = 0
         inline_ticks = 0
+        list_indents: list[int] = []
         while i < len(lines):
             line = lines[i]
             if not line.strip():
                 inline_ticks = 0
-            fence = _FENCE.match(line) if not inline_ticks else None
+            indent = len(line) - len(line.lstrip(" "))
+            if line.strip() and not inline_ticks:
+                while list_indents and indent < list_indents[-1]:
+                    list_indents.pop()
+                item = _LIST_ITEM.match(line)
+                parent_indent = list_indents[-1] if list_indents else 0
+                if item and indent < parent_indent + 4:
+                    list_indents.append(item.end())
+            content_indent = list_indents[-1] if list_indents else 0
+            fence_indent = content_indent if indent >= content_indent else 0
+            fence = _FENCE.match(line[fence_indent:]) if not inline_ticks else None
             if fence:
                 marker, info = fence.groups()
                 end = i + 1
@@ -128,7 +157,9 @@ class InlineFileDelivery:
                     + str(len(marker))
                     + r",}[ \t]*(?:\r?\n)?$"
                 )
-                while end < len(lines) and not closing.fullmatch(lines[end]):
+                while end < len(lines) and not closing.fullmatch(
+                    lines[end][fence_indent:]
+                ):
                     end += 1
                 named = _NAMED_BASE64.fullmatch(info.strip())
                 if named:
@@ -144,7 +175,8 @@ class InlineFileDelivery:
                         "".join(lines[i + 1 : end]) if end < len(lines) else "",
                     )
                     output.append(
-                        replacement
+                        line[:fence_indent]
+                        + replacement
                         + (
                             "\n"
                             if end < len(lines) and lines[end].endswith("\n")
@@ -155,7 +187,11 @@ class InlineFileDelivery:
                     output.extend(lines[i : min(end + 1, len(lines))])
                 i = end + 1
                 continue
-            if line.startswith(("    ", "\t")) or re.match(r"^ {0,3}>", line):
+            if (
+                indent >= content_indent + 4
+                or line.startswith("\t")
+                or re.match(r"^\s*>", line)
+            ):
                 # Decline indented code/quoted examples, including nested fences.
                 output.append(line)
                 i += 1
@@ -276,6 +312,8 @@ class InlineFileDelivery:
                 if not output.is_relative_to(root):
                     return unavailable
                 output.mkdir(parents=True, exist_ok=True)
+                # These are durable workspace outputs, not disposable temp
+                # files. A unique directory avoids overwriting earlier runs.
                 directory = Path(tempfile.mkdtemp(prefix="inline-", dir=output))
                 path = directory / name
                 try:

--- a/src/xagent/core/inline_file_delivery.py
+++ b/src/xagent/core/inline_file_delivery.py
@@ -1,0 +1,242 @@
+"""Turn explicit encoded-file deliveries into registered workspace attachments.
+
+This is an output boundary, not a general Base64 detector or a format validator.
+Only data-URI Markdown links outside code and explicitly named Base64 fences
+opt in. Arbitrary prose, source code and unnamed encoded examples are preserved.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import logging
+import re
+import tempfile
+from pathlib import Path
+from threading import Lock
+from typing import Any
+
+from ..config import get_inline_file_delivery_max_bytes
+from .file_ref import build_workspace_file_ref
+
+logger = logging.getLogger(__name__)
+
+# Never infer active HTML/SVG or executable types from untrusted model output.
+_EXTENSIONS = {
+    "text/plain": ".txt",
+    "text/csv": ".csv",
+    "text/tab-separated-values": ".tsv",
+    "application/json": ".json",
+    "application/pdf": ".pdf",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": ".xlsx",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": ".docx",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": ".pptx",
+    "image/png": ".png",
+    "image/jpeg": ".jpg",
+    "image/webp": ".webp",
+    "image/gif": ".gif",
+}
+_DATA_LINK = re.compile(
+    r"(?P<image>!)?\[(?P<label>[^\[\]\r\n]*)\]\("
+    r"data:(?P<mime>[\w.+/-]+)(?:;charset=[\w-]+)?;base64,"
+    r"(?P<payload>[^\s()\[\]]*)(?P<closed>\))?",
+    re.IGNORECASE,
+)
+_FENCE = re.compile(r"^ {0,3}(`{3,}|~{3,})([^\r\n]*)")
+_NAMED_BASE64 = re.compile(r"base64[ \t]+filename=([^\r\n]+)\Z", re.IGNORECASE)
+
+
+class InlineFileStreamGuard:
+    """Hold a possible encoded tail until the authoritative final replacement."""
+
+    def __init__(self) -> None:
+        self.pending = ""
+        self.held = False
+
+    def feed(self, delta: str) -> str:
+        if self.held:
+            return ""
+        self.pending += delta
+        lower = self.pending.lower()
+        starts = [i for marker in ("data:", "base64") if (i := lower.find(marker)) >= 0]
+        if starts:
+            prefix = self.pending[: min(starts)]
+            self.pending = ""
+            self.held = True
+            return prefix
+        # Retain enough suffix to recognize markers split across any chunk edge.
+        prefix, self.pending = self.pending[:-5], self.pending[-5:]
+        return prefix
+
+    def flush(self) -> str:
+        pending, self.pending = self.pending, ""
+        return pending
+
+
+class InlineFileDelivery:
+    """Per-run bounded, idempotent delivery; all I/O runs off the event loop."""
+
+    def __init__(self, workspace: Any) -> None:
+        self.workspace = workspace
+        self._lock = Lock()
+        self._refs: dict[tuple[str, str], dict[str, Any]] = {}
+        self._bytes = 0
+
+    def transform(self, content: str) -> str:
+        if "base64" not in content.lower():
+            return content
+        with self._lock:
+            return self._transform(content)
+
+    def _transform(self, content: str) -> str:
+        lines = content.splitlines(keepends=True)
+        output: list[str] = []
+        i = 0
+        inline_ticks = 0
+        while i < len(lines):
+            line = lines[i]
+            fence = _FENCE.match(line) if not inline_ticks else None
+            if fence:
+                marker, info = fence.groups()
+                end = i + 1
+                closing = re.compile(
+                    r"^ {0,3}"
+                    + re.escape(marker[0])
+                    + "{"
+                    + str(len(marker))
+                    + r",}[ \t]*(?:\r?\n)?$"
+                )
+                while end < len(lines) and not closing.fullmatch(lines[end]):
+                    end += 1
+                named = _NAMED_BASE64.fullmatch(info.strip())
+                if named:
+                    filename = named.group(1).strip().strip('"')
+                    mime = next(
+                        (
+                            m
+                            for m, ext in _EXTENSIONS.items()
+                            if Path(filename).suffix.lower() == ext
+                        ),
+                        "",
+                    )
+                    replacement = self._deliver(
+                        filename,
+                        mime,
+                        "".join(lines[i + 1 : end]) if end < len(lines) else "",
+                    )
+                    output.append(
+                        replacement
+                        + (
+                            "\n"
+                            if end < len(lines) and lines[end].endswith("\n")
+                            else ""
+                        )
+                    )
+                else:
+                    output.extend(lines[i : min(end + 1, len(lines))])
+                i = end + 1
+                continue
+            if line.startswith(("    ", "\t")) or re.match(r"^ {0,3}>", line):
+                # Decline indented code/quoted examples, including nested fences.
+                output.append(line)
+                i += 1
+                continue
+            # Scan code delimiters and links together, so a backtick inside an
+            # explicit link label cannot accidentally turn its payload into code.
+            pieces: list[str] = []
+            pos = 0
+            while pos < len(line):
+                if line[pos] == "`":
+                    end = pos + 1
+                    while end < len(line) and line[end] == "`":
+                        end += 1
+                    ticks = end - pos
+                    if not inline_ticks:
+                        inline_ticks = ticks
+                    elif inline_ticks == ticks:
+                        inline_ticks = 0
+                    pieces.append(line[pos:end])
+                    pos = end
+                    continue
+                match = (
+                    _DATA_LINK.match(line, pos)
+                    if not inline_ticks and line[pos] in "!["
+                    else None
+                )
+                if match and (pos == 0 or line[pos - 1] != "\\"):
+                    pieces.append(
+                        self._deliver(
+                            match["label"],
+                            match["mime"].lower(),
+                            match["payload"] if match["closed"] else "",
+                            image=bool(match["image"]),
+                        )
+                    )
+                    pos = match.end()
+                else:
+                    pieces.append(line[pos])
+                    pos += 1
+            output.append("".join(pieces))
+            i += 1
+        return "".join(output)
+
+    def _deliver(
+        self, label: str, mime: str, encoded: str, *, image: bool = False
+    ) -> str:
+        extension = _EXTENSIONS.get(mime)
+        # Labels are never paths or authority to select an executable suffix.
+        name = label.replace("\\", "/").rsplit("/", 1)[-1]
+        name = (
+            "".join(c for c in name if c.isalnum() or c in " ._-()").strip(" .")[:100]
+            or "attachment"
+        )
+        if extension and not name.lower().endswith(extension):
+            name = (Path(name).stem or "attachment") + extension
+        unavailable = f"{name} (attachment unavailable)"
+        if not extension:
+            return unavailable
+        try:
+            limit = get_inline_file_delivery_max_bytes()
+            if limit <= 0 or len(encoded) > ((limit + 2) // 3) * 4 + 4096:
+                return unavailable
+            encoded = re.sub(r"[\r\n\t ]", "", encoded)
+            if len(encoded) > ((limit + 2) // 3) * 4:
+                return unavailable
+            data = base64.b64decode(encoded, validate=True)
+            if not data or len(data) > limit:
+                return unavailable
+            key = (mime, hashlib.sha256(data).hexdigest())
+            ref = self._refs.get(key)
+            if ref is None:
+                if len(self._refs) >= 8 or self._bytes + len(data) > limit:
+                    return unavailable
+                root = Path(self.workspace.workspace_dir).resolve()
+                output = Path(self.workspace.output_dir).resolve()
+                if not output.is_relative_to(root):
+                    return unavailable
+                output.mkdir(parents=True, exist_ok=True)
+                directory = Path(tempfile.mkdtemp(prefix="inline-", dir=output))
+                path = directory / name
+                try:
+                    with path.open("xb") as stream:
+                        stream.write(data)
+                    ref = build_workspace_file_ref(
+                        workspace=self.workspace, file_path=path, mime_type=mime
+                    )
+                    if not ref.get("markdown_link"):
+                        raise ValueError("Attachment registration returned no link")
+                except Exception:
+                    logger.exception("Inline file registration failed")
+                    path.unlink(missing_ok=True)
+                    directory.rmdir()
+                    return unavailable
+                self._refs[key] = ref
+                self._bytes += len(data)
+            link = str(ref["markdown_link"])
+            return "!" + link if image and mime.startswith("image/") else link
+        except (ValueError, binascii.Error):
+            return unavailable
+        except Exception:
+            logger.exception("Inline file delivery failed")
+            return unavailable

--- a/src/xagent/core/inline_file_delivery.py
+++ b/src/xagent/core/inline_file_delivery.py
@@ -112,12 +112,9 @@ class InlineFileDelivery:
                 named = _NAMED_BASE64.fullmatch(info.strip())
                 if named:
                     filename = named.group(1).strip().strip('"')
+                    suffix = Path(filename).suffix.lower()
                     mime = next(
-                        (
-                            m
-                            for m, ext in _EXTENSIONS.items()
-                            if Path(filename).suffix.lower() == ext
-                        ),
+                        (m for m, ext in _EXTENSIONS.items() if suffix == ext),
                         "",
                     )
                     replacement = self._deliver(

--- a/src/xagent/core/inline_file_delivery.py
+++ b/src/xagent/core/inline_file_delivery.py
@@ -45,8 +45,9 @@ _DATA_LINK = re.compile(
 )
 _FENCE = re.compile(r"^ {0,3}(`{3,}|~{3,})([^\r\n]*)")
 _NAMED_BASE64 = re.compile(r"base64[ \t]+filename=([^\r\n]+)\Z", re.IGNORECASE)
-_STREAM_MARKER = re.compile(
-    r"\]\(data:|(?:^|\n) {0,3}(?:`{3,}|~{3,})[ \t]*base64", re.IGNORECASE
+_STREAM_MARKER = re.compile(r"\]\(data:", re.IGNORECASE)
+_DATA_CONTINUATION = re.compile(
+    r"[ \t]*(?P<payload>[A-Za-z0-9+/=]*)[ \t]*(?P<closed>\))?"
 )
 
 
@@ -62,8 +63,18 @@ class InlineFileStreamGuard:
             return ""
         self.pending += delta
         marker = _STREAM_MARKER.search(self.pending)
-        if marker:
-            prefix = self.pending[: marker.start()]
+        marker_start = marker.start() if marker else None
+        offset = 0
+        for line in self.pending.splitlines(keepends=True):
+            fence = _FENCE.match(line)
+            if fence and _NAMED_BASE64.fullmatch(fence.group(2).strip()):
+                marker_start = (
+                    min(marker_start, offset) if marker_start is not None else offset
+                )
+                break
+            offset += len(line)
+        if marker_start is not None:
+            prefix = self.pending[:marker_start]
             self.pending = ""
             self.held = True
             return prefix
@@ -184,15 +195,34 @@ class InlineFileDelivery:
                     else None
                 )
                 if match and (pos == 0 or line[pos - 1] != "\\"):
+                    payload = match["payload"]
+                    closed = bool(match["closed"])
+                    pos = match.end()
+                    # A reflowed payload is still one explicit delivery. Consume
+                    # only Base64 continuation lines, leaving following prose,
+                    # code blocks and independent links to the normal scanner.
+                    while not closed and not line[pos:].strip() and i + 1 < len(lines):
+                        following_line = lines[i + 1]
+                        continuation = _DATA_CONTINUATION.match(following_line)
+                        assert continuation is not None
+                        if not continuation["closed"] and (
+                            not continuation["payload"]
+                            or following_line[continuation.end() :].strip()
+                        ):
+                            break
+                        payload += continuation["payload"]
+                        closed = bool(continuation["closed"])
+                        i += 1
+                        line = following_line
+                        pos = continuation.end()
                     pieces.append(
                         self._deliver(
                             match["label"],
                             match["mime"].lower(),
-                            match["payload"] if match["closed"] else "",
+                            payload if closed else "",
                             image=bool(match["image"]),
                         )
                     )
-                    pos = match.end()
                 else:
                     pieces.append(line[pos])
                     pos += 1
@@ -225,10 +255,13 @@ class InlineFileDelivery:
             return unavailable
         try:
             limit = get_inline_file_delivery_max_bytes()
-            if limit <= 0 or len(encoded) > ((limit + 2) // 3) * 4 + 4096:
+            max_encoded = ((limit + 2) // 3) * 4
+            # Allow ordinary MIME wrapping (including CRLF) without removing
+            # the bound on whitespace-heavy input before normalization.
+            if limit <= 0 or len(encoded) > max_encoded + max_encoded // 16 + 4096:
                 return unavailable
             encoded = re.sub(r"[\r\n\t ]", "", encoded)
-            if len(encoded) > ((limit + 2) // 3) * 4:
+            if len(encoded) > max_encoded:
                 return unavailable
             data = base64.b64decode(encoded, validate=True)
             if not data or len(data) > limit:
@@ -251,11 +284,11 @@ class InlineFileDelivery:
                     register_delivery = getattr(
                         self.workspace, "register_delivery_file", None
                     )
-                    file_id = (
-                        register_delivery(str(path))
-                        if callable(register_delivery)
-                        else None
-                    )
+                    if not callable(register_delivery):
+                        raise ValueError("Workspace does not support durable delivery")
+                    file_id = register_delivery(str(path))
+                    if not file_id:
+                        raise ValueError("Attachment registration returned no file ID")
                     ref = build_workspace_file_ref(
                         workspace=self.workspace,
                         file_path=path,

--- a/src/xagent/core/inline_file_delivery.py
+++ b/src/xagent/core/inline_file_delivery.py
@@ -22,6 +22,8 @@ from ..config import get_inline_file_delivery_max_bytes
 from .file_ref import build_workspace_file_ref
 
 logger = logging.getLogger(__name__)
+_MAX_FILES_PER_RUN = 8
+_DATA_PARAMETERS = r"(?:;[\w!#$%&'*+.^`|~-]+=[^;\s,()\[\]]*)*"
 
 # Never infer active HTML/SVG or executable types from untrusted model output.
 _EXTENSIONS = {
@@ -40,7 +42,7 @@ _EXTENSIONS = {
 }
 _DATA_LINK = re.compile(
     r"(?P<image>!)?\[(?P<label>[^\[\]\r\n]*)\]\("
-    r"data:(?P<mime>[\w.+/-]+)(?:;charset=[\w-]+)?;base64,"
+    r"data:(?P<mime>[\w.+/-]+)" + _DATA_PARAMETERS + r";base64,"
     r"(?P<payload>[^\s()\[\]]*)(?P<closed>\))?",
     re.IGNORECASE,
 )
@@ -48,7 +50,7 @@ _FENCE = re.compile(r"^ {0,3}(`{3,}|~{3,})([^\r\n]*)")
 _STREAM_FENCE = re.compile(r"^[ \t]*(`{3,}|~{3,})([^\r\n]*)")
 _NAMED_BASE64 = re.compile(r"base64[ \t]+filename=([^\r\n]+)\Z", re.IGNORECASE)
 _STREAM_MARKER = re.compile(
-    r"\]\(data:[\w.+/-]+(?:;charset=[\w-]+)?;base64,", re.IGNORECASE
+    r"\]\(data:[\w.+/-]+" + _DATA_PARAMETERS + r";base64,", re.IGNORECASE
 )
 _LIST_ITEM = re.compile(r"^( *)(?:[-+*]|\d{1,9}[.)])[ \t]+")
 _DATA_CONTINUATION = re.compile(
@@ -165,6 +167,8 @@ class InlineFileDelivery:
                 if named:
                     filename = named.group(1).strip().strip('"')
                     suffix = Path(filename).suffix.lower()
+                    if suffix == ".jpeg":
+                        suffix = ".jpg"
                     mime = next(
                         (m for m, ext in _EXTENSIONS.items() if suffix == ext),
                         "",
@@ -305,7 +309,10 @@ class InlineFileDelivery:
             key = (mime, hashlib.sha256(data).hexdigest())
             ref = self._refs.get(key)
             if ref is None:
-                if len(self._refs) >= 8 or self._bytes + len(data) > limit:
+                if (
+                    len(self._refs) >= _MAX_FILES_PER_RUN
+                    or self._bytes + len(data) > limit
+                ):
                     return unavailable
                 root = Path(self.workspace.workspace_dir).resolve()
                 output = Path(self.workspace.output_dir).resolve()

--- a/src/xagent/core/inline_file_delivery.py
+++ b/src/xagent/core/inline_file_delivery.py
@@ -45,6 +45,9 @@ _DATA_LINK = re.compile(
 )
 _FENCE = re.compile(r"^ {0,3}(`{3,}|~{3,})([^\r\n]*)")
 _NAMED_BASE64 = re.compile(r"base64[ \t]+filename=([^\r\n]+)\Z", re.IGNORECASE)
+_STREAM_MARKER = re.compile(
+    r"\]\(data:|(?:^|\n) {0,3}(?:`{3,}|~{3,})[ \t]*base64", re.IGNORECASE
+)
 
 
 class InlineFileStreamGuard:
@@ -58,15 +61,20 @@ class InlineFileStreamGuard:
         if self.held:
             return ""
         self.pending += delta
-        lower = self.pending.lower()
-        starts = [i for marker in ("data:", "base64") if (i := lower.find(marker)) >= 0]
-        if starts:
-            prefix = self.pending[: min(starts)]
+        marker = _STREAM_MARKER.search(self.pending)
+        if marker:
+            prefix = self.pending[: marker.start()]
             self.pending = ""
             self.held = True
             return prefix
         # Retain enough suffix to recognize markers split across any chunk edge.
-        prefix, self.pending = self.pending[:-5], self.pending[-5:]
+        keep = 6
+        # A fence header can contain whitespace or a longer delimiter. Retain
+        # its incomplete line until its language is known, not ordinary prose.
+        fence = re.search(r"(?:^|\n) {0,3}[`~][^\r\n]*$", self.pending)
+        if fence:
+            keep = max(keep, len(self.pending) - fence.start())
+        prefix, self.pending = self.pending[:-keep], self.pending[-keep:]
         return prefix
 
     def flush(self) -> str:
@@ -96,6 +104,8 @@ class InlineFileDelivery:
         inline_ticks = 0
         while i < len(lines):
             line = lines[i]
+            if not line.strip():
+                inline_ticks = 0
             fence = _FENCE.match(line) if not inline_ticks else None
             if fence:
                 marker, info = fence.groups()
@@ -150,7 +160,19 @@ class InlineFileDelivery:
                         end += 1
                     ticks = end - pos
                     if not inline_ticks:
-                        inline_ticks = ticks
+                        # Only matched delimiters open inline code. Code spans
+                        # may cross soft line breaks, but not blank-line/fence
+                        # boundaries; an unmatched tick is ordinary text.
+                        paragraph = line[end:]
+                        following = i + 1
+                        while following < len(lines):
+                            candidate = lines[following]
+                            if not candidate.strip() or _FENCE.match(candidate):
+                                break
+                            paragraph += candidate
+                            following += 1
+                        if re.search(r"(?<!`)`{" + str(ticks) + r"}(?!`)", paragraph):
+                            inline_ticks = ticks
                     elif inline_ticks == ticks:
                         inline_ticks = 0
                     pieces.append(line[pos:end])
@@ -190,6 +212,14 @@ class InlineFileDelivery:
         )
         if extension and not name.lower().endswith(extension):
             name = (Path(name).stem or "attachment") + extension
+        if extension:
+            stem = name[: -len(extension)]
+            name = (
+                stem.encode("utf-8")[: 240 - len(extension)].decode(
+                    "utf-8", errors="ignore"
+                )
+                + name[-len(extension) :]
+            )
         unavailable = f"{name} (attachment unavailable)"
         if not extension:
             return unavailable
@@ -218,8 +248,19 @@ class InlineFileDelivery:
                 try:
                     with path.open("xb") as stream:
                         stream.write(data)
+                    register_delivery = getattr(
+                        self.workspace, "register_delivery_file", None
+                    )
+                    file_id = (
+                        register_delivery(str(path))
+                        if callable(register_delivery)
+                        else None
+                    )
                     ref = build_workspace_file_ref(
-                        workspace=self.workspace, file_path=path, mime_type=mime
+                        workspace=self.workspace,
+                        file_path=path,
+                        mime_type=mime,
+                        file_id=file_id,
                     )
                     if not ref.get("markdown_link"):
                         raise ValueError("Attachment registration returned no link")

--- a/src/xagent/core/workspace.py
+++ b/src/xagent/core/workspace.py
@@ -391,6 +391,15 @@ class TaskWorkspace:
         )
         return registered[0]
 
+    def register_delivery_file(self, file_path: str) -> str:
+        """Register a host-delivered attachment only with durable task ownership."""
+        if in_sandbox_tool_runner():
+            raise ValueError("User delivery requires host-side registration")
+        with self._registration_lock:
+            return self._register_files_locked(
+                ((file_path, None),), db_session=None, require_persistence=True
+            )[0]
+
     def register_files(
         self,
         files: Sequence[tuple[str, Optional[str]]],
@@ -414,6 +423,7 @@ class TaskWorkspace:
         files: Sequence[tuple[str, Optional[str]]],
         *,
         db_session: Any,
+        require_persistence: bool = False,
     ) -> tuple[str, ...]:
         """Register files through detached read, storage, and metadata phases.
 
@@ -435,6 +445,8 @@ class TaskWorkspace:
             registrations,
             db_session=resolved_db_session,
         )
+        if require_persistence and any(not plan.should_persist for plan in plans):
+            raise ValueError("Attachment registration requires a persisted task owner")
 
         prepared: list[PreparedWorkspaceFileRegistration] = []
         try:

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -2725,13 +2725,14 @@ class TestUrlUserinfoRejectionIsScopedToDeepDoc:
         assert get_s2s_api_base_url() == "http://user:pw@api.example.com"
 
 
-def test_inline_file_delivery_budget(monkeypatch):
+def test_inline_file_delivery_budget(monkeypatch, caplog):
     monkeypatch.delenv(config.INLINE_FILE_DELIVERY_MAX_BYTES, raising=False)
     assert config.get_inline_file_delivery_max_bytes() == 8 * 1024 * 1024
     for value in ("0", "1024"):
         monkeypatch.setenv(config.INLINE_FILE_DELIVERY_MAX_BYTES, value)
         assert config.get_inline_file_delivery_max_bytes() == int(value)
-    for value in ("-1", "invalid"):
+    for value in ("-1", "invalid", ""):
         monkeypatch.setenv(config.INLINE_FILE_DELIVERY_MAX_BYTES, value)
-        with pytest.raises(ValueError):
-            config.get_inline_file_delivery_max_bytes()
+        caplog.clear()
+        assert config.get_inline_file_delivery_max_bytes() == 0
+        assert "Invalid XAGENT_INLINE_FILE_DELIVERY_MAX_BYTES" in caplog.text

--- a/tests/core/test_config.py
+++ b/tests/core/test_config.py
@@ -2723,3 +2723,15 @@ class TestUrlUserinfoRejectionIsScopedToDeepDoc:
 
         assert get_public_api_base_url() == "http://user:pw@api.example.com"
         assert get_s2s_api_base_url() == "http://user:pw@api.example.com"
+
+
+def test_inline_file_delivery_budget(monkeypatch):
+    monkeypatch.delenv(config.INLINE_FILE_DELIVERY_MAX_BYTES, raising=False)
+    assert config.get_inline_file_delivery_max_bytes() == 8 * 1024 * 1024
+    for value in ("0", "1024"):
+        monkeypatch.setenv(config.INLINE_FILE_DELIVERY_MAX_BYTES, value)
+        assert config.get_inline_file_delivery_max_bytes() == int(value)
+    for value in ("-1", "invalid"):
+        monkeypatch.setenv(config.INLINE_FILE_DELIVERY_MAX_BYTES, value)
+        with pytest.raises(ValueError):
+            config.get_inline_file_delivery_max_bytes()

--- a/tests/core/test_inline_file_delivery.py
+++ b/tests/core/test_inline_file_delivery.py
@@ -48,9 +48,10 @@ def test_registers_exact_bytes_and_deduplicates_repeated_deliveries(delivery):
 
 
 @pytest.mark.parametrize("fence", ["```", "~~~~"])
-def test_explicit_named_base64_fence(delivery, fence):
-    source = f'{fence}base64 filename="report.csv"\nYSwK\nYiwK\n{fence}\n'
-    assert delivery.transform(source) == "[report.csv](file:registered-0)\n"
+@pytest.mark.parametrize("filename", ["report.csv", "report.CSV"])
+def test_explicit_named_base64_fence(delivery, fence, filename):
+    source = f'{fence}base64 filename="{filename}"\nYSwK\nYiwK\n{fence}\n'
+    assert delivery.transform(source) == f"[{filename}](file:registered-0)\n"
     assert Path(next(iter(delivery.workspace.files))).read_bytes() == b"a,\nb,\n"
 
 

--- a/tests/core/test_inline_file_delivery.py
+++ b/tests/core/test_inline_file_delivery.py
@@ -177,6 +177,67 @@ def test_ordinary_stream_text_flushes_without_loss():
     assert emitted == source
 
 
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "Use `df to load.\n",
+        "Use `df to load.\n\n",
+        "Use ``df to load.\n",
+        "An unmatched ` tick.\n\nA later ` paragraph.\n",
+    ],
+)
+def test_unmatched_backtick_does_not_hide_later_delivery(delivery, prefix):
+    assert (
+        delivery.transform(prefix + link())
+        == prefix + "[report.csv](file:registered-0)"
+    )
+
+
+def test_inline_code_does_not_cross_paragraphs(delivery):
+    source = "`Example\n\n" + link() + "\n`"
+    assert (
+        delivery.transform(source) == "`Example\n\n[report.csv](file:registered-0)\n`"
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "Config uses metadata: values",
+        "This explains base64 encoding without an attachment.",
+        "Normal data: values and base64.",
+    ],
+)
+def test_prose_markers_do_not_stall_stream(source):
+    for offset in range(len(source) + 1):
+        guard = InlineFileStreamGuard()
+        emitted = guard.feed(source[:offset]) + guard.feed(source[offset:])
+        assert not guard.held
+        assert len(emitted) >= len(source) - 6
+        assert emitted + guard.flush() == source
+
+
+@pytest.mark.parametrize("fence", ["```", "~~~~", "````````"])
+def test_named_fence_stream_splits_withhold_payload(fence):
+    source = f"Download:\n{fence}base64 filename=report.csv\nYSwK\n{fence}"
+    for offset in range(len(source) + 1):
+        guard = InlineFileStreamGuard()
+        emitted = (
+            guard.feed(source[:offset]) + guard.feed(source[offset:]) + guard.flush()
+        )
+        assert "YSwK" not in emitted
+        assert source.startswith(emitted)
+
+
+def test_long_unicode_filename_fits_byte_budget(delivery):
+    result = delivery.transform(link(name="报" * 100 + ".csv"))
+    assert "file:registered-0" in result
+    path = Path(next(iter(delivery.workspace.files)))
+    assert len(path.name.encode("utf-8")) <= 240
+    assert path.suffix == ".csv"
+    assert path.read_bytes() == b"order,rate\r\nA01,0.15\r\n"
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("use_child_runtime", [False, True])
 async def test_runtime_stream_end_and_buffered_result_share_registered_file(

--- a/tests/core/test_inline_file_delivery.py
+++ b/tests/core/test_inline_file_delivery.py
@@ -1,6 +1,8 @@
 """Explicit encoded artifacts share real FileRef delivery, not text heuristics."""
 
+import asyncio
 import base64
+import textwrap
 from pathlib import Path
 
 import pytest
@@ -17,7 +19,7 @@ class Workspace:
     def get_file_id_from_path(self, path):
         return self.files.get(path)
 
-    def register_file(self, path):
+    def register_delivery_file(self, path):
         file_id = f"registered-{len(self.files)}"
         self.files[path] = file_id
         return file_id
@@ -130,7 +132,7 @@ def test_registration_failure_is_logged_without_exposing_details(
     def fail(path):
         raise ValueError("server private detail")
 
-    monkeypatch.setattr(delivery.workspace, "register_file", fail)
+    monkeypatch.setattr(delivery.workspace, "register_delivery_file", fail)
     assert delivery.transform(link()) == "report.csv (attachment unavailable)"
     assert not list(delivery.workspace.output_dir.iterdir())
     assert caplog.records[-1].exc_info[1].args == ("server private detail",)
@@ -156,6 +158,68 @@ def test_incomplete_link_does_not_swallow_following_text_or_deliveries(delivery)
         delivery.transform(source)
         == "report.csv (attachment unavailable) See [second.csv](file:registered-0)"
     )
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+@pytest.mark.parametrize("closed", [True, False])
+def test_wrapped_data_link_consumes_encoded_continuations(delivery, newline, closed):
+    payload = base64.b64encode(b"some exact file bytes\n").decode()
+    wrapped = newline.join(textwrap.wrap(payload, 8))
+    source = f"Get [report.csv](data:text/csv;base64,{wrapped}"
+    if closed:
+        source += newline + ")"
+    source += newline + "Next paragraph: " + link(name="next.csv")
+    result = delivery.transform(source)
+    expected = (
+        "[report.csv](file:registered-0)"
+        if closed
+        else "report.csv (attachment unavailable)"
+    )
+    next_id = 1 if closed else 0
+    assert (
+        result
+        == f"Get {expected}{newline}Next paragraph: [next.csv](file:registered-{next_id})"
+    )
+    if closed:
+        assert (
+            Path(next(iter(delivery.workspace.files))).read_bytes()
+            == b"some exact file bytes\n"
+        )
+
+
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+def test_budget_accepts_mime_wrapped_named_fence(delivery, monkeypatch, newline):
+    data = b"a" * (512 * 1024)
+    monkeypatch.setenv("XAGENT_INLINE_FILE_DELIVERY_MAX_BYTES", str(len(data)))
+    encoded = newline.join(textwrap.wrap(base64.b64encode(data).decode(), 76))
+    assert len(encoded) - len(encoded.replace(newline, "")) > 4096
+    source = f"```base64 filename=report.csv{newline}{encoded}{newline}```"
+    assert delivery.transform(source) == "[report.csv](file:registered-0)"
+    assert Path(next(iter(delivery.workspace.files))).read_bytes() == data
+
+
+def test_excessive_whitespace_remains_bounded(delivery, monkeypatch):
+    monkeypatch.setenv("XAGENT_INLINE_FILE_DELIVERY_MAX_BYTES", "10")
+    source = "```base64 filename=report.csv\n" + " " * 5000 + "YQ==\n```"
+    assert delivery.transform(source) == "report.csv (attachment unavailable)"
+    assert not delivery.workspace.files
+
+
+def test_legacy_registration_is_not_a_delivery_fallback(delivery, monkeypatch):
+    monkeypatch.setattr(delivery.workspace, "register_delivery_file", None)
+    legacy_calls = []
+    monkeypatch.setattr(
+        delivery.workspace, "register_file", legacy_calls.append, raising=False
+    )
+    assert delivery.transform(link()) == "report.csv (attachment unavailable)"
+    assert not legacy_calls
+    assert not list(delivery.workspace.output_dir.iterdir())
+
+
+def test_missing_delivery_file_id_does_not_fall_back(delivery, monkeypatch):
+    monkeypatch.setattr(delivery.workspace, "register_delivery_file", lambda path: None)
+    assert delivery.transform(link()) == "report.csv (attachment unavailable)"
+    assert not list(delivery.workspace.output_dir.iterdir())
 
 
 def test_every_possible_stream_split_withholds_encoded_tail():
@@ -214,6 +278,17 @@ def test_prose_markers_do_not_stall_stream(source):
         emitted = guard.feed(source[:offset]) + guard.feed(source[offset:])
         assert not guard.held
         assert len(emitted) >= len(source) - 6
+        assert emitted + guard.flush() == source
+
+
+@pytest.mark.parametrize("fence", ["```", "~~~~"])
+@pytest.mark.parametrize("newline", ["\n", "\r\n"])
+def test_unnamed_base64_example_keeps_streaming(fence, newline):
+    source = f"Example:{newline}{fence}base64{newline}YSwK{newline}{fence}{newline}More prose."
+    for offset in range(len(source) + 1):
+        guard = InlineFileStreamGuard()
+        emitted = guard.feed(source[:offset]) + guard.feed(source[offset:])
+        assert not guard.held
         assert emitted + guard.flush() == source
 
 
@@ -294,3 +369,104 @@ async def test_runner_wires_delivery_and_normalizes_context(delivery):
     assert result["output"] == "[report.csv](file:registered-0)"
     assert result["context"].messages[-1].content == result["output"]
     assert len(delivery.workspace.files) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["llm", "finish", "cancel"])
+async def test_runtime_stream_failure_releases_guard_without_flushing_payload(
+    delivery, monkeypatch, failure
+):
+    from xagent.core.agent import PatternRuntime
+
+    events = []
+    runtime = PatternRuntime(
+        outbound_message_handler=events.append, inline_file_delivery=delivery
+    )
+    monkeypatch.setattr(runtime, "_has_native_stream_chat", lambda llm: True)
+    started = asyncio.Event()
+
+    async def stream_call(llm, *, on_chunk, **kwargs):
+        message_id = next(iter(runtime._inline_stream_guards))
+        await runtime.emit_final_answer_delta(message_id, link())
+        started.set()
+        if failure == "cancel":
+            await asyncio.Event().wait()
+        if failure == "llm":
+            raise RuntimeError("LLM failed")
+        return link()
+
+    async def fail_finish(content):
+        raise RuntimeError("Delivery failed")
+
+    monkeypatch.setattr(runtime, "run_streaming_llm_call", stream_call)
+    if failure == "finish":
+        monkeypatch.setattr(runtime, "prepare_final_answer", fail_finish)
+    task = asyncio.create_task(runtime.stream_final_answer(object()))
+    if failure == "cancel":
+        await started.wait()
+        task.cancel()
+    with pytest.raises(asyncio.CancelledError if failure == "cancel" else RuntimeError):
+        await task
+    assert not runtime._inline_stream_guards
+    assert events[-1]["type"] == "final_answer_error"
+    assert not any("base64" in str(event) or "b3JkZX" in str(event) for event in events)
+
+
+@pytest.mark.asyncio
+async def test_start_callback_failure_releases_guard(delivery):
+    from xagent.core.agent import PatternRuntime
+
+    def fail(event):
+        raise RuntimeError("Disconnected")
+
+    runtime = PatternRuntime(
+        outbound_message_handler=fail, inline_file_delivery=delivery
+    )
+    with pytest.raises(RuntimeError, match="Disconnected"):
+        await runtime.start_final_answer_stream()
+    assert not runtime._inline_stream_guards
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["success", "error", "cancel"])
+async def test_runner_releases_abandoned_candidate_guards(delivery, outcome):
+    from xagent.core.agent import Agent, PatternRuntime
+    from xagent.core.agent.runner import AgentRunner
+
+    events = []
+    runtime = PatternRuntime(
+        outbound_message_handler=events.append, inline_file_delivery=delivery
+    )
+    started = asyncio.Event()
+
+    class Pattern:
+        async def run(self, **kwargs):
+            # Two retries can leave distinct candidate IDs pending. Keep the
+            # keyed ownership model, but release all buffers at run teardown.
+            for _ in range(2):
+                message_id = await runtime.start_final_answer_stream()
+                await runtime.emit_final_answer_delta(message_id, link())
+            assert len(runtime._inline_stream_guards) == 2
+            started.set()
+            if outcome == "cancel":
+                await asyncio.Event().wait()
+            if outcome == "error":
+                raise RuntimeError("Candidate parse failed")
+            return {"success": True, "output": "Final answer"}
+
+    runner = AgentRunner(
+        Agent(name="inline-test", patterns=[Pattern()]), workspace_enabled=False
+    )
+    task = asyncio.create_task(
+        runner.run("Answer", execution_id="inline-test", runtime=runtime)
+    )
+    if outcome == "cancel":
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+    else:
+        result = await task
+        assert result["success"] == (outcome == "success")
+    assert not runtime._inline_stream_guards
+    assert not any("base64" in str(event) for event in events)

--- a/tests/core/test_inline_file_delivery.py
+++ b/tests/core/test_inline_file_delivery.py
@@ -1,0 +1,234 @@
+"""Explicit encoded artifacts share real FileRef delivery, not text heuristics."""
+
+import base64
+from pathlib import Path
+
+import pytest
+
+from xagent.core.inline_file_delivery import InlineFileDelivery, InlineFileStreamGuard
+
+
+class Workspace:
+    def __init__(self, root):
+        self.workspace_dir = root
+        self.output_dir = root / "output"
+        self.files = {}
+
+    def get_file_id_from_path(self, path):
+        return self.files.get(path)
+
+    def register_file(self, path):
+        file_id = f"registered-{len(self.files)}"
+        self.files[path] = file_id
+        return file_id
+
+
+def link(data=b"order,rate\r\nA01,0.15\r\n", name="report.csv", mime="text/csv"):
+    return f"[{name}](data:{mime};base64,{base64.b64encode(data).decode()})"
+
+
+@pytest.fixture
+def delivery(tmp_path):
+    return InlineFileDelivery(Workspace(tmp_path))
+
+
+def test_registers_exact_bytes_and_deduplicates_repeated_deliveries(delivery):
+    data = b"order,rate\r\nA01,0.15\r\n\x1a\x00\xff"
+    source = f"Download: {link(data)}\n\nAgain: {link(data, name='copy.csv')}"
+    result = delivery.transform(source)
+    assert (
+        result
+        == "Download: [report.csv](file:registered-0)\n\nAgain: [report.csv](file:registered-0)"
+    )
+    assert len(delivery.workspace.files) == 1
+    assert Path(next(iter(delivery.workspace.files))).read_bytes() == data
+    assert delivery.transform(source) == result
+    assert delivery.transform(result) == result
+    assert len(delivery.workspace.files) == 1
+
+
+@pytest.mark.parametrize("fence", ["```", "~~~~"])
+def test_explicit_named_base64_fence(delivery, fence):
+    source = f'{fence}base64 filename="report.csv"\nYSwK\nYiwK\n{fence}\n'
+    assert delivery.transform(source) == "[report.csv](file:registered-0)\n"
+    assert Path(next(iter(delivery.workspace.files))).read_bytes() == b"a,\nb,\n"
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "A long token: " + "YQ==" * 100,
+        "`" + link() + "`",
+        "``" + link() + "``",
+        "`multi\n" + link() + "\nline`",
+        "```python\n" + link() + "\n```",
+        "~~~~text\n" + link() + "\n~~~~",
+        "````markdown\n```base64 filename=report.csv\nYQ==\n```\n````",
+        "```base64\nYQ==\n```",
+        "```\n" + link(),
+        "    " + link(),
+        "> " + link(),
+        "  > " + link(),
+        "\\" + link(),
+    ],
+)
+def test_does_not_turn_code_or_ambiguous_text_into_files(delivery, source):
+    assert delivery.transform(source) == source
+    assert not delivery.workspace.files
+
+
+@pytest.mark.parametrize("payload", ["not-base64!!!", "Y", "YQ=", "", "YQ==garbage"])
+def test_malformed_payload_has_no_raw_blob_or_fake_file(delivery, payload):
+    result = delivery.transform(f"[report.csv](data:text/csv;base64,{payload})")
+    assert result == "report.csv (attachment unavailable)"
+    assert not delivery.workspace.files
+
+
+def test_mime_controls_suffix_and_filename_cannot_escape_workspace(delivery):
+    result = delivery.transform(link(name="../../outside.exe"))
+    assert result == "[outside.csv](file:registered-0)"
+    path = Path(next(iter(delivery.workspace.files)))
+    assert path.is_relative_to(delivery.workspace.output_dir)
+    assert path.name == "outside.csv"
+
+
+def test_image_delivery_uses_inline_file_ref(delivery):
+    result = delivery.transform("!" + link(b"image bytes", "figure.png", "image/png"))
+    assert result == "![figure.png](file:registered-0)"
+
+
+@pytest.mark.parametrize(
+    "mime", ["text/html", "image/svg+xml", "application/x-executable"]
+)
+def test_active_or_unknown_types_are_not_materialized(delivery, mime):
+    assert "attachment unavailable" in delivery.transform(link(mime=mime))
+    assert not delivery.workspace.files
+
+
+@pytest.mark.parametrize("budget", ["0", "-1", "invalid", "3"])
+def test_budget_rejects_before_registration(delivery, monkeypatch, budget):
+    monkeypatch.setenv("XAGENT_INLINE_FILE_DELIVERY_MAX_BYTES", budget)
+    assert "attachment unavailable" in delivery.transform(link())
+    assert not delivery.workspace.output_dir.exists()
+
+
+def test_total_bytes_and_file_count_are_bounded(delivery, monkeypatch):
+    monkeypatch.setenv("XAGENT_INLINE_FILE_DELIVERY_MAX_BYTES", "5")
+    assert "file:" in delivery.transform(link(b"abc"))
+    assert "attachment unavailable" in delivery.transform(link(b"def"))
+    monkeypatch.setenv("XAGENT_INLINE_FILE_DELIVERY_MAX_BYTES", "1000")
+    for index in range(7):
+        assert "file:" in delivery.transform(link(bytes([index])))
+    assert "attachment unavailable" in delivery.transform(link(b"ninth"))
+    assert len(delivery.workspace.files) == 8
+
+
+def test_registration_failure_is_logged_without_exposing_details(
+    delivery, monkeypatch, caplog
+):
+    def fail(path):
+        raise ValueError("server private detail")
+
+    monkeypatch.setattr(delivery.workspace, "register_file", fail)
+    assert delivery.transform(link()) == "report.csv (attachment unavailable)"
+    assert not list(delivery.workspace.output_dir.iterdir())
+    assert caplog.records[-1].exc_info[1].args == ("server private detail",)
+
+
+def test_output_symlink_cannot_redirect_delivery(delivery, tmp_path):
+    outside = tmp_path.parent / f"{tmp_path.name}-outside"
+    outside.mkdir()
+    delivery.workspace.output_dir.symlink_to(outside, target_is_directory=True)
+    assert "attachment unavailable" in delivery.transform(link())
+    assert not list(outside.iterdir())
+
+
+@pytest.mark.parametrize("source", [link()[:-1], "```base64 filename=report.csv\nYQ=="])
+def test_incomplete_explicit_deliveries_do_not_dump_encoded_content(delivery, source):
+    assert delivery.transform(source) == "report.csv (attachment unavailable)"
+    assert not delivery.workspace.files
+
+
+def test_incomplete_link_does_not_swallow_following_text_or_deliveries(delivery):
+    source = link()[:-1] + " See " + link(name="second.csv")
+    assert (
+        delivery.transform(source)
+        == "report.csv (attachment unavailable) See [second.csv](file:registered-0)"
+    )
+
+
+def test_every_possible_stream_split_withholds_encoded_tail():
+    source = "Download: " + link()
+    for offset in range(len(source) + 1):
+        guard = InlineFileStreamGuard()
+        emitted = (
+            guard.feed(source[:offset]) + guard.feed(source[offset:]) + guard.flush()
+        )
+        assert "base64" not in emitted
+        assert "b3JkZX" not in emitted
+        assert source.startswith(emitted)
+
+
+def test_ordinary_stream_text_flushes_without_loss():
+    guard = InlineFileStreamGuard()
+    source = "Ordinary answer, no attachment."
+    emitted = "".join(guard.feed(c) for c in source) + guard.flush()
+    assert emitted == source
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("use_child_runtime", [False, True])
+async def test_runtime_stream_end_and_buffered_result_share_registered_file(
+    delivery, use_child_runtime
+):
+    from xagent.core.agent import PatternRuntime
+    from xagent.core.agent.pattern.final_answer_stream import FinalAnswerStreamSession
+
+    events = []
+    runtime = PatternRuntime(
+        outbound_message_handler=events.append, inline_file_delivery=delivery
+    )
+    stream_runtime = runtime
+    if use_child_runtime:
+        from xagent.core.agent.pattern.auto.auto import AutoPattern, _AutoChildRuntime
+
+        stream_runtime = _AutoChildRuntime(
+            parent=runtime, auto_pattern=AutoPattern(), root_context=None
+        )
+    stream = FinalAnswerStreamSession(stream_runtime)
+    source = "Download: " + link()
+    for char in source:
+        await stream.emit_delta(char)
+    await stream.finish(source)
+    assert events[-1]["type"] == "final_answer_end"
+    assert events[-1]["content"] == "Download: [report.csv](file:registered-0)"
+    assert all("base64" not in str(e) for e in events)
+    assert await stream_runtime.prepare_final_answer(source) == events[-1]["content"]
+    assert len(delivery.workspace.files) == 1
+    assert not runtime._inline_stream_guards
+
+
+@pytest.mark.asyncio
+async def test_runner_wires_delivery_and_normalizes_context(delivery):
+    from xagent.core.agent import Agent
+    from xagent.core.agent.runner import AgentRunner
+
+    class Manager:
+        def get_or_create_workspace(self, **kwargs):
+            delivery.workspace.id = "inline-test"
+            delivery.workspace.input_dir = delivery.workspace.workspace_dir / "input"
+            delivery.workspace.temp_dir = delivery.workspace.workspace_dir / "temp"
+            return delivery.workspace
+
+    class Pattern:
+        async def run(self, context, **kwargs):
+            context.add_assistant_message(link())
+            return {"success": True, "output": link()}
+
+    runner = AgentRunner(
+        Agent(name="inline-test", patterns=[Pattern()]), workspace_manager=Manager()
+    )
+    result = await runner.run("Create a CSV", execution_id="inline-test")
+    assert result["output"] == "[report.csv](file:registered-0)"
+    assert result["context"].messages[-1].content == result["output"]
+    assert len(delivery.workspace.files) == 1

--- a/tests/core/test_inline_file_delivery.py
+++ b/tests/core/test_inline_file_delivery.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import base64
+import json
 import textwrap
 from pathlib import Path
 
@@ -55,6 +56,34 @@ def test_explicit_named_base64_fence(delivery, fence, filename):
     source = f'{fence}base64 filename="{filename}"\nYSwK\nYiwK\n{fence}\n'
     assert delivery.transform(source) == f"[{filename}](file:registered-0)\n"
     assert Path(next(iter(delivery.workspace.files))).read_bytes() == b"a,\nb,\n"
+
+
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        ";name=x",
+        ";charset=utf-8;name=my%20file",
+        ";name=x;charset=UTF-8",
+        ";name=",
+        ";x-custom=base64",
+    ],
+)
+def test_data_uri_parameters_share_stream_and_delivery_grammar(delivery, parameters):
+    source = link().replace(";base64,", parameters + ";base64,")
+    for offset in range(len(source) + 1):
+        guard = InlineFileStreamGuard()
+        emitted = (
+            guard.feed(source[:offset]) + guard.feed(source[offset:]) + guard.flush()
+        )
+        assert "b3JkZX" not in emitted
+    assert delivery.transform(source) == "[report.csv](file:registered-0)"
+
+
+@pytest.mark.parametrize("extension", ["jpg", "jpeg", "JPEG"])
+def test_named_jpeg_alias_is_a_registered_download(delivery, extension):
+    source = f"```base64 filename=photo.{extension}\nYQ==\n```"
+    assert delivery.transform(source) == "[photo.jpg](file:registered-0)"
+    assert Path(next(iter(delivery.workspace.files))).read_bytes() == b"a"
 
 
 @pytest.mark.parametrize(
@@ -497,6 +526,85 @@ async def test_start_callback_failure_releases_guard(delivery):
     with pytest.raises(RuntimeError, match="Disconnected"):
         await runtime.start_final_answer_stream()
     assert not runtime._inline_stream_guards
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["success", "cancel", "error"])
+async def test_terminal_broadcast_never_gets_contradictory_error(
+    delivery, monkeypatch, outcome
+):
+    from xagent.core.agent import PatternRuntime
+
+    events = []
+    end_sent = asyncio.Event()
+
+    async def outbound(event):
+        events.append(event)
+        if event["type"] == "final_answer_end":
+            end_sent.set()
+            if outcome == "cancel":
+                await asyncio.Event().wait()
+            if outcome == "error":
+                raise RuntimeError("Broadcast interrupted after delivery")
+
+    runtime = PatternRuntime(
+        outbound_message_handler=outbound, inline_file_delivery=delivery
+    )
+    monkeypatch.setattr(runtime, "_has_native_stream_chat", lambda llm: True)
+
+    async def response(*args, **kwargs):
+        return link()
+
+    monkeypatch.setattr(runtime, "run_streaming_llm_call", response)
+    task = asyncio.create_task(runtime.stream_final_answer(object()))
+    if outcome == "cancel":
+        await asyncio.wait_for(end_sent.wait(), timeout=5)
+        task.cancel()
+    if outcome == "success":
+        await task
+    else:
+        with pytest.raises(
+            asyncio.CancelledError if outcome == "cancel" else RuntimeError
+        ):
+            await task
+    assert [event["type"] for event in events].count("final_answer_end") == 1
+    assert not any(event["type"] == "final_answer_error" for event in events)
+    assert events[-1]["content"] == "[report.csv](file:registered-0)"
+    assert not runtime._inline_stream_guards
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "answer_key", ["response", "answer", "output", "content", "message"]
+)
+@pytest.mark.parametrize("legacy", [False, True])
+async def test_delivery_changes_only_the_selected_result_field(
+    delivery, answer_key, legacy
+):
+    from xagent.core.agent import Agent, PatternRuntime
+    from xagent.core.agent.runner import AgentRunner
+
+    keys = ["response", "answer", "output", "content", "message"]
+    original = {
+        key: "" if keys.index(key) < keys.index(answer_key) else f"unrelated {key}"
+        for key in keys
+    }
+    original[answer_key] = json.dumps({"final_answer": link()}) if legacy else link()
+
+    class Pattern:
+        async def run(self, **kwargs):
+            return dict(original)
+
+    runner = AgentRunner(
+        Agent(name="field-test", patterns=[Pattern()]), workspace_enabled=False
+    )
+    result = await runner.run(
+        "Deliver", runtime=PatternRuntime(inline_file_delivery=delivery)
+    )
+    assert result[answer_key] == "[report.csv](file:registered-0)"
+    for key in keys:
+        if key != answer_key:
+            assert result[key] == original[key]
 
 
 @pytest.mark.asyncio

--- a/tests/core/test_inline_file_delivery.py
+++ b/tests/core/test_inline_file_delivery.py
@@ -80,6 +80,36 @@ def test_does_not_turn_code_or_ambiguous_text_into_files(delivery, source):
     assert not delivery.workspace.files
 
 
+@pytest.mark.parametrize(
+    "prefix",
+    [
+        "- Files:\n    - ",
+        "1. Files:\n    1. ",
+        "- Files:\n  - More:\n      - ",
+        "- Files:\n\n    ",
+    ],
+)
+def test_nested_list_deliveries_are_not_indented_code(delivery, prefix):
+    assert (
+        delivery.transform(prefix + link())
+        == prefix + "[report.csv](file:registered-0)"
+    )
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "    - " + link(),
+        "- Example:\n\n      " + link(),
+        "- Example:\n    ```markdown\n    " + link() + "\n    ```",
+        "- Example:\n    > " + link(),
+    ],
+)
+def test_nested_code_and_quotes_stay_literal(delivery, source):
+    assert delivery.transform(source) == source
+    assert not delivery.workspace.files
+
+
 @pytest.mark.parametrize("payload", ["not-base64!!!", "Y", "YQ=", "", "YQ==garbage"])
 def test_malformed_payload_has_no_raw_blob_or_fake_file(delivery, payload):
     result = delivery.transform(f"[report.csv](data:text/csv;base64,{payload})")
@@ -281,6 +311,24 @@ def test_prose_markers_do_not_stall_stream(source):
         assert emitted + guard.flush() == source
 
 
+@pytest.mark.parametrize(
+    "source",
+    [
+        "Use `df` to inspect the result. " * 10,
+        "`df` is the result. " * 10,
+        "An unmatched ` tick followed by prose. " * 10,
+        "Read [text](data:text/plain,hello) then continue. " * 10,
+    ],
+)
+def test_prose_backticks_and_plain_data_urls_keep_streaming(source):
+    for chunks in ([source], list(source), [source[:20], source[20:]]):
+        guard = InlineFileStreamGuard()
+        emitted = "".join(guard.feed(chunk) for chunk in chunks)
+        assert not guard.held
+        assert len(guard.pending) <= 6
+        assert emitted + guard.flush() == source
+
+
 @pytest.mark.parametrize("fence", ["```", "~~~~"])
 @pytest.mark.parametrize("newline", ["\n", "\r\n"])
 def test_unnamed_base64_example_keeps_streaming(fence, newline):
@@ -302,6 +350,17 @@ def test_named_fence_stream_splits_withhold_payload(fence):
         )
         assert "YSwK" not in emitted
         assert source.startswith(emitted)
+
+
+def test_nested_named_fence_is_delivered_without_streaming_payload(delivery):
+    source = "- Files:\n    ```base64 filename=report.csv\n    YSwK\n    ```\n"
+    for offset in range(len(source) + 1):
+        guard = InlineFileStreamGuard()
+        emitted = (
+            guard.feed(source[:offset]) + guard.feed(source[offset:]) + guard.flush()
+        )
+        assert "YSwK" not in emitted
+    assert delivery.transform(source) == "- Files:\n  [report.csv](file:registered-0)\n"
 
 
 def test_long_unicode_filename_fits_byte_budget(delivery):
@@ -346,8 +405,9 @@ async def test_runtime_stream_end_and_buffered_result_share_registered_file(
 
 
 @pytest.mark.asyncio
-async def test_runner_wires_delivery_and_normalizes_context(delivery):
-    from xagent.core.agent import Agent
+@pytest.mark.parametrize("restored", [False, True])
+async def test_runner_wires_delivery_and_normalizes_context(delivery, restored):
+    from xagent.core.agent import Agent, ExecutionContext
     from xagent.core.agent.runner import AgentRunner
 
     class Manager:
@@ -359,13 +419,25 @@ async def test_runner_wires_delivery_and_normalizes_context(delivery):
 
     class Pattern:
         async def run(self, context, **kwargs):
+            if restored:
+                assert context.messages[-1].content == link()
             context.add_assistant_message(link())
             return {"success": True, "output": link()}
 
     runner = AgentRunner(
         Agent(name="inline-test", patterns=[Pattern()]), workspace_manager=Manager()
     )
-    result = await runner.run("Create a CSV", execution_id="inline-test")
+    checkpoint = None
+    if restored:
+        saved_context = ExecutionContext(execution_id="inline-test")
+        saved_context.add_assistant_message(link())
+        checkpoint = {"context": saved_context.to_dict()}
+    result = await runner.run(
+        "Create a CSV",
+        execution_id="inline-test",
+        resume=restored,
+        checkpoint=checkpoint,
+    )
     assert result["output"] == "[report.csv](file:registered-0)"
     assert result["context"].messages[-1].content == result["output"]
     assert len(delivery.workspace.files) == 1

--- a/tests/core/test_workspace_durable_registration.py
+++ b/tests/core/test_workspace_durable_registration.py
@@ -50,6 +50,26 @@ def _seed_workspace_task(db, *, task_id: int, username: str) -> User:
     return user
 
 
+def test_inline_delivery_rejects_registration_without_durable_task_owner(
+    monkeypatch, tmp_path, constrained_workspace_db
+):
+    from xagent.core.inline_file_delivery import InlineFileDelivery
+
+    engine, SessionLocal, db = constrained_workspace_db
+    monkeypatch.setattr(
+        "xagent.web.models.database.get_session_local", lambda: SessionLocal
+    )
+    monkeypatch.setattr("xagent.core.storage.manager.create_db_session", SessionLocal)
+    workspace = TaskWorkspace(id="web_task_9999", base_dir=str(tmp_path))
+    delivery = InlineFileDelivery(workspace)
+    result = delivery.transform("[report.csv](data:text/csv;base64,YSwK)")
+    assert result == "report.csv (attachment unavailable)"
+    assert db.query(UploadedFile).count() == 0
+    db.rollback()
+    assert engine.pool.checkedout() == 0
+    assert not list(workspace.output_dir.iterdir())
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("file_kind", ["csv", "xlsx", "png"])
 @pytest.mark.parametrize("delivery_kind", ["link", "fence"])

--- a/tests/core/test_workspace_durable_registration.py
+++ b/tests/core/test_workspace_durable_registration.py
@@ -51,20 +51,41 @@ def _seed_workspace_task(db, *, task_id: int, username: str) -> User:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("file_kind", ["csv", "xlsx", "png"])
+@pytest.mark.parametrize("delivery_kind", ["link", "fence"])
 async def test_inline_delivery_uses_task_owned_durable_file_registration(
-    monkeypatch, tmp_path, constrained_workspace_db
+    monkeypatch, tmp_path, constrained_workspace_db, file_kind, delivery_kind
 ):
+    import base64
+    from io import BytesIO
     from pathlib import Path
+
+    from fastapi import FastAPI
+    from httpx import ASGITransport, AsyncClient
+    from openpyxl import Workbook, load_workbook
 
     from xagent.core.agent import PatternRuntime
     from xagent.core.inline_file_delivery import InlineFileDelivery
-    from xagent.web.services.managed_file_ref import ManagedFileRef
+    from xagent.web.api.auth import create_access_token
+    from xagent.web.api.files import file_router
+    from xagent.web.models.database import get_db
 
     engine, SessionLocal, db = constrained_workspace_db
     user = _seed_workspace_task(db, task_id=9019, username="inline-delivery-owner")
     user_id = int(user.id)
+    owner_headers = {
+        "Authorization": "Bearer "
+        + create_access_token(data={"sub": user.username, "user_id": user_id})
+    }
+    stranger = _seed_workspace_task(db, task_id=9020, username="inline-delivery-other")
+    other_headers = {
+        "Authorization": "Bearer "
+        + create_access_token(data={"sub": stranger.username, "user_id": stranger.id})
+    }
     db.rollback()
     monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
+    monkeypatch.setenv("XAGENT_UPLOADS_DIR", str(tmp_path / "uploads"))
+    monkeypatch.setenv("XAGENT_FILE_DELIVERY_REDIRECT_ENABLED", "false")
     get_unscoped_file_storage.cache_clear()
     monkeypatch.setattr(
         "xagent.web.models.database.get_session_local", lambda: SessionLocal
@@ -74,25 +95,98 @@ async def test_inline_delivery_uses_task_owned_durable_file_registration(
         lambda: SessionLocal,
     )
     monkeypatch.setattr("xagent.core.storage.manager.create_db_session", SessionLocal)
-    workspace = TaskWorkspace(id="web_task_9019", base_dir=str(tmp_path / "workspaces"))
+    workspace = TaskWorkspace(
+        id="web_task_9019", base_dir=str(tmp_path / "uploads" / f"user_{user_id}")
+    )
+
+    rows = [
+        ["order_id", "reason_code", "remake_rate"],
+        ["A001", "CUST", 0.04],
+        ["A002", "POWER", 0.15],
+        ["A003", "CUST", 0.07],
+        ["A004", "COATING", 0.11],
+    ]
+    if file_kind == "xlsx":
+        workbook = Workbook()
+        sheet = workbook.active
+        for row in rows:
+            sheet.append(row)
+        output = BytesIO()
+        workbook.save(output)
+        workbook.close()
+        data = output.getvalue()
+        mime = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+    elif file_kind == "png":
+        data = base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8"
+            "/x8AAwMCAO+aXioAAAAASUVORK5CYII="
+        )
+        mime = "image/png"
+    else:
+        # The four-row replacement used for the original file-delivery smoke
+        # test, not the unavailable original TC5 business attachment.
+        data = "\r\n".join(",".join(map(str, row)) for row in rows).encode() + b"\r\n"
+        mime = "text/csv"
+    name = f"remake_analysis.{file_kind}"
+    encoded = base64.b64encode(data).decode()
+    if delivery_kind == "fence":
+        source = f"```base64 filename={name}\n{encoded}\n```"
+    else:
+        source = f"[{name}](data:{mime};base64,{encoded})"
+        if file_kind == "png":
+            source = "!" + source
+
+    def isolated_db():
+        with SessionLocal() as session:
+            yield session
+
+    app = FastAPI()
+    app.include_router(file_router)
+    app.dependency_overrides[get_db] = isolated_db
     try:
         runtime = PatternRuntime(inline_file_delivery=InlineFileDelivery(workspace))
-        answer = await runtime.prepare_final_answer(
-            "[report.csv](data:text/csv;base64,YSwK)"
-        )
-        assert answer.startswith("[report.csv](file:")
+        answer = await runtime.prepare_final_answer(source)
+        assert "base64" not in answer
         with SessionLocal() as verify_db:
             record = verify_db.query(UploadedFile).one()
             assert record.user_id == user_id
             assert record.task_id == 9019
             assert record.storage_status == "available"
-            assert answer == f"[report.csv](file:{record.file_id})"
+            prefix = "!" if file_kind == "png" and delivery_kind == "link" else ""
+            assert answer == f"{prefix}[{name}](file:{record.file_id})"
+            file_id = record.file_id
             local_path = Path(record.storage_path)
-            assert local_path.read_bytes() == b"a,\n"
-            verify_db.expunge(record)
+            assert local_path.read_bytes() == data
         assert engine.pool.checkedout() == 0
-        local_path.unlink()
-        assert ManagedFileRef(record).materialize().read_bytes() == b"a,\n"
+        # Exercise production HTTP routes and real Bearer authentication, not
+        # a mocked FileRef or a direct materialize() call. Repeat without the
+        # workspace copy to cover durable-storage recovery on both endpoints.
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://testserver"
+        ) as client:
+            for remove_local in (False, True):
+                for endpoint in ("preview", "download"):
+                    if remove_local:
+                        local_path.unlink(missing_ok=True)
+                    url = f"/api/files/{endpoint}/{file_id}"
+                    response = await client.get(url, headers=owner_headers)
+                    assert response.status_code == 200, response.text
+                    assert response.content == data
+                    assert response.headers["content-type"].split(";")[0] == mime
+                    assert response.headers["x-content-type-options"] == "nosniff"
+                    if endpoint == "preview":
+                        assert response.headers["content-disposition"] == "inline"
+                    else:
+                        assert name in response.headers["content-disposition"]
+                    if file_kind == "xlsx":
+                        downloaded = load_workbook(BytesIO(response.content))
+                        assert list(downloaded.active.values) == list(map(tuple, rows))
+                        downloaded.close()
+                    assert (await client.get(url)).status_code in (401, 403)
+                    assert (
+                        await client.get(url, headers=other_headers)
+                    ).status_code == 403
+            assert engine.pool.checkedout() == 0
     finally:
         get_unscoped_file_storage.cache_clear()
 

--- a/tests/core/test_workspace_durable_registration.py
+++ b/tests/core/test_workspace_durable_registration.py
@@ -50,6 +50,53 @@ def _seed_workspace_task(db, *, task_id: int, username: str) -> User:
     return user
 
 
+@pytest.mark.asyncio
+async def test_inline_delivery_uses_task_owned_durable_file_registration(
+    monkeypatch, tmp_path, constrained_workspace_db
+):
+    from pathlib import Path
+
+    from xagent.core.agent import PatternRuntime
+    from xagent.core.inline_file_delivery import InlineFileDelivery
+    from xagent.web.services.managed_file_ref import ManagedFileRef
+
+    engine, SessionLocal, db = constrained_workspace_db
+    user = _seed_workspace_task(db, task_id=9019, username="inline-delivery-owner")
+    user_id = int(user.id)
+    db.rollback()
+    monkeypatch.setenv("XAGENT_FILE_STORAGE_URI", (tmp_path / "objects").as_uri())
+    get_unscoped_file_storage.cache_clear()
+    monkeypatch.setattr(
+        "xagent.web.models.database.get_session_local", lambda: SessionLocal
+    )
+    monkeypatch.setattr(
+        "xagent.web.services.uploaded_file_store.get_session_local",
+        lambda: SessionLocal,
+    )
+    monkeypatch.setattr("xagent.core.storage.manager.create_db_session", SessionLocal)
+    workspace = TaskWorkspace(id="web_task_9019", base_dir=str(tmp_path / "workspaces"))
+    try:
+        runtime = PatternRuntime(inline_file_delivery=InlineFileDelivery(workspace))
+        answer = await runtime.prepare_final_answer(
+            "[report.csv](data:text/csv;base64,YSwK)"
+        )
+        assert answer.startswith("[report.csv](file:")
+        with SessionLocal() as verify_db:
+            record = verify_db.query(UploadedFile).one()
+            assert record.user_id == user_id
+            assert record.task_id == 9019
+            assert record.storage_status == "available"
+            assert answer == f"[report.csv](file:{record.file_id})"
+            local_path = Path(record.storage_path)
+            assert local_path.read_bytes() == b"a,\n"
+            verify_db.expunge(record)
+        assert engine.pool.checkedout() == 0
+        local_path.unlink()
+        assert ManagedFileRef(record).materialize().read_bytes() == b"a,\n"
+    finally:
+        get_unscoped_file_storage.cache_clear()
+
+
 def _assert_task_output_generation_key(
     storage_key: str,
     *,


### PR DESCRIPTION
## Summary

- Convert explicit data-URI Markdown file links and named Base64 fences into registered, task-owned workspace attachments at the final-answer boundary.
- Reuse existing FileRef/durable storage and authenticated preview/download paths; prevent raw encoded delivery tails from leaking through streamed output before final replacement.
- Bound decoded bytes per run (8 MiB by default, configurable), limit unique files, deduplicate identical payloads, sanitize names and restrict MIME types. Invalid, truncated, disabled or failed deliveries show an unavailable result without a fake link.
- Preserve ordinary prose, code examples and unnamed Base64 blocks. Keep the delivery module independent of skill availability and artifact format validation. No docs files.

## Validation

- Agent/runtime, config, inline delivery and durable workspace suites: 1,689 tests passed after review fixes; an additional 170 workspace regressions passed.
- Six parametrized integration cases exercise CSV/XLSX/PNG through both explicit delivery syntaxes, real workspace registration, real Bearer authentication, and the production FastAPI preview/download routes. Bytes and content types match; XLSX opens with the original rows; owner access works with and without a local workspace copy; anonymous and other-user access is rejected.
- Isolated browser smoke with the actual frontend renderer and file-preview dialog: generated CSV/XLSX render inline and in the dialog, both download successfully, and downloaded SHA-256 hashes match the original files.
- Pre-commit including package mypy passed.

## Scope and evidence limits

- No model-selection or model-routing changes. The existing auto child-runtime facade only forwards the new final-answer preparation method to its parent.
- This is user-visible delivery normalization, not global redaction: original tool arguments/results and execution checkpoints are not rewritten. No historical-message backfill, arbitrary Base64-string detection, or file-format/business correctness claim; artifact validation remains a separate PR.
- The browser smoke uses the four-row replacement dataset from the earlier file-delivery test, not the unavailable original TC5 attachment. The recorded local TC7 task had no connected Google Ads data and produced no Base64 artifact to replay, so this is not presented as an original TC7 business acceptance run.
- The isolated smoke server/page are not included; the user's running environment and database were not changed.

## Latest review follow-up (4ff1a77e8)

- TaskWorkspace inline delivery now requires durable task ownership before registration succeeds; normal workspace registration remains compatible.
- Unmatched backticks no longer disable later attachments; valid multi-line code spans stay intact.
- Stream holds are anchored to delivery markers instead of ordinary metadata:/base64 prose; long Unicode filenames are bounded in UTF-8 bytes.
- Invalid budget settings log a warning and reject attachments. Zero is a rejection budget, not a raw-Base64 passthrough switch.
- No checkpoint rewrite, global tool-history sanitization, parser framework or docs files were added.
