### PR TITLE
fix: preserve Markdown table content and readability

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -193,6 +193,36 @@ body .hover\:\text-\[\#E6EDF3\]:hover {
   font-weight: 600;
 }
 
+/* Keep wide Markdown tables inside the conversation, with readable columns.
+   Scope this to the Markdown wrapper; file previews own their table layout. */
+.prose .markdown-table-scroll {
+  max-width: 100%;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  margin-bottom: 1em;
+}
+
+.prose .markdown-table-scroll:focus-visible {
+  outline: 2px solid var(--ring);
+  outline-offset: 2px;
+}
+
+.prose .markdown-table-scroll > table {
+  width: max-content;
+  min-width: 100%;
+  margin: 0;
+}
+
+.prose .markdown-table-scroll th,
+.prose .markdown-table-scroll td {
+  min-width: 6rem;
+  max-width: 24rem;
+  vertical-align: top;
+  white-space: normal;
+  word-break: normal;
+  overflow-wrap: break-word;
+}
+
 .prose a {
   color: var(--primary);
   text-decoration: underline;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -194,7 +194,7 @@ body .hover\:\text-\[\#E6EDF3\]:hover {
 }
 
 /* Keep wide Markdown tables inside the conversation, with readable columns.
-   Scope this to the Markdown wrapper; file previews own their table layout. */
+   Also applies to Markdown file previews; other file renderers own their layout. */
 .prose .markdown-table-scroll {
   max-width: 100%;
   overflow-x: auto;

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -203,7 +203,7 @@ body .hover\:\text-\[\#E6EDF3\]:hover {
 }
 
 .prose .markdown-table-scroll:focus-visible {
-  outline: 2px solid var(--ring);
+  outline: 2px solid hsl(var(--ring));
   outline-offset: 2px;
 }
 

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -333,10 +333,18 @@ describe('MarkdownRenderer', () => {
       '| Valid | Table |', '| --- | --- |', '| yes | $15 |', '', 'After table.',
     ].join('\n')} />)
     expect(container.querySelector('blockquote pre code')?.textContent).toBe(source.slice(2) + '\n')
-    expect(container.querySelector('li pre code')?.textContent).toContain('| x | y | z |')
+    expect(container.querySelector('li pre code')?.textContent).toBe('| A | B |\n  | --- | --- |\n  | x | y | z |\n')
     expect(screen.getAllByRole('table')).toHaveLength(1)
     expect(screen.getByText('After table.')).toBeInTheDocument()
     expect(container.querySelector('strong')?.textContent).toBe('table')
+  })
+
+  it('preserves surplus cells from CRLF input and renders valid CRLF tables', () => {
+    const header = '| A | B |\r\n| --- | --- |\r\n'
+    const { container, rerender } = render(<MarkdownRenderer content={header + '| x | y | z |'} />)
+    expect(container.querySelector('pre code')?.textContent).toBe(header + '| x | y | z |\n')
+    rerender(<MarkdownRenderer content={header + '| x | y |'} />)
+    expect(screen.getAllByRole('cell').map((cell) => cell.textContent)).toEqual(['x', 'y'])
   })
 
   it('switches safely between incomplete, valid and overflowing streamed rows', () => {

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -269,6 +269,48 @@ describe('MarkdownRenderer', () => {
     }
   })
 
+  it('wraps each table in its own keyboard-accessible scroll region', () => {
+    render(<MarkdownRenderer content={[
+      '| Long plan description | Price |', '| :--- | ---: |', '| SIMBA | $15 |',
+      '', 'Another comparison:', '',
+      '| Country | Status |', '| --- | --- |', '| AU | Paused |',
+    ].join('\n')} />)
+    const tables = screen.getAllByRole('table')
+    expect(tables).toHaveLength(2)
+    for (const table of tables) {
+      expect(table.parentElement).toHaveClass('markdown-table-scroll')
+      expect(table.parentElement).toHaveAttribute('tabindex', '0')
+      expect(table.parentElement).toHaveAttribute('role', 'region')
+      expect(table.parentElement).toHaveAttribute('aria-label', 'markdownRenderer.tableScrollLabel')
+    }
+    expect(screen.getByRole('columnheader', { name: 'Price' })).toHaveStyle({ textAlign: 'right' })
+    expect(screen.getByRole('cell', { name: '$15' })).toHaveStyle({ textAlign: 'right' })
+  })
+
+  it('preserves escaped pipes and code inside cells without moving values between columns', () => {
+    render(<MarkdownRenderer content={[
+      '| Campaign | Country | Status | Spend |', '| --- | --- | --- | --- |',
+      String.raw`| Jack \| TEST | AU | Paused | $1,909.81 |`,
+      String.raw`| \`a\|b\` | SG | Active | $15–$25 |`.replaceAll('\\`', '`'),
+    ].join('\n')} />)
+    expect(screen.getAllByRole('cell').map((cell) => cell.textContent)).toEqual([
+      'Jack | TEST', 'AU', 'Paused', '$1,909.81', 'a|b', 'SG', 'Active', '$15–$25',
+    ])
+  })
+
+  it('keeps the table and scroll wrapper stable while a streamed row grows', () => {
+    const header = '| Plan | Price |\n| --- | --- |\n'
+    const { rerender } = render(<MarkdownRenderer content={header + '| SIMBA |'} />)
+    const table = screen.getByRole('table')
+    const wrapper = table.parentElement
+    for (const row of ['| SIMBA | $', '| SIMBA | $15', '| SIMBA | $15–$25 |']) {
+      rerender(<MarkdownRenderer content={header + row} />)
+      expect(screen.getByRole('table')).toBe(table)
+      expect(table.parentElement).toBe(wrapper)
+    }
+    expect(screen.getAllByRole('cell').map((cell) => cell.textContent)).toEqual(['SIMBA', '$15–$25'])
+  })
+
   it('renders numeric formulas alongside currency without merging their delimiters', () => {
     const { container } = render(
       <MarkdownRenderer content="Pay $15 or $25; the equation is $2 + 2 = 4$, then $x^2$." />,

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -300,10 +300,11 @@ describe('MarkdownRenderer', () => {
 
   it('keeps the table and scroll wrapper stable while a streamed row grows', () => {
     const header = '| Plan | Price |\n| --- | --- |\n'
-    const { rerender } = render(<MarkdownRenderer content={header + '| SIMBA | $'} />)
+    const { rerender } = render(<MarkdownRenderer content={header + '| SIMBA |'} />)
     const table = screen.getByRole('table')
     const wrapper = table.parentElement
-    for (const row of ['| SIMBA | $', '| SIMBA | $15', '| SIMBA | $15–$25 |']) {
+    expect(screen.getAllByRole('cell').map((cell) => cell.textContent)).toEqual(['SIMBA', ''])
+    for (const row of ['| SIMBA |', '| SIMBA | $', '| SIMBA | $15', '| SIMBA | $15–$25 |']) {
       rerender(<MarkdownRenderer content={header + row} />)
       expect(screen.getByRole('table')).toBe(table)
       expect(table.parentElement).toBe(wrapper)
@@ -313,7 +314,6 @@ describe('MarkdownRenderer', () => {
 
   it.each([
     '| SIMBA | $15 | never discard this |',
-    '| SIMBA |',
     '| Jack | TEST | $1,909.81 |',
     '| `a|b` | $15 |',
     '| <img src=x onerror=alert(1)> | $15 | private value |',
@@ -342,7 +342,8 @@ describe('MarkdownRenderer', () => {
   it('switches safely between incomplete, valid and overflowing streamed rows', () => {
     const header = '| Campaign | Spend |\n| --- | --- |\n'
     const { container, rerender } = render(<MarkdownRenderer content={header + '| Jack |'} />)
-    expect(container.querySelector('pre code')?.textContent).toBe(header + '| Jack |\n')
+    expect(screen.getAllByRole('cell').map((cell) => cell.textContent)).toEqual(['Jack', ''])
+    expect(container.querySelector('pre')).toBeNull()
     rerender(<MarkdownRenderer content={header + '| Jack | $15 |'} />)
     expect(screen.getAllByRole('cell').map((cell) => cell.textContent)).toEqual(['Jack', '$15'])
     const overflow = header + '| Jack | TEST | $15 |'
@@ -360,6 +361,19 @@ describe('MarkdownRenderer', () => {
     ].join('\n')} />)
     expect(screen.getAllByRole('cell').map((cell) => cell.textContent)).toEqual(['one', '', '', 'two'])
     expect(container.querySelector('pre code')?.textContent).toBe('| A | B |\n| --- | --- |\n| x | y | z |\n')
+  })
+
+  it.each([
+    ['| A | B |\n| --- | --- |', 2, []],
+    ['| A |\n| --- |\n| one |', 1, ['one']],
+    ['| A |\n| --- |', 1, []],
+    ['| A | B | C |\n| --- | --- | --- |\n| one |\n| two | three |', 3, ['one', '', '', 'two', 'three', '']],
+  ])('keeps lossless GFM tables rendered: %s', (source, columns, cells) => {
+    const { container } = render(<MarkdownRenderer content={source} />)
+    expect(screen.getByRole('table')).toBeInTheDocument()
+    expect(screen.getAllByRole('columnheader')).toHaveLength(columns)
+    expect(screen.queryAllByRole('cell').map((cell) => cell.textContent)).toEqual(cells)
+    expect(container.querySelector('pre')).toBeNull()
   })
 
   it('replays the plan comparison table captured from the original TC6 task', () => {

--- a/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
+++ b/frontend/src/components/ui/__tests__/markdown-renderer.test.tsx
@@ -300,7 +300,7 @@ describe('MarkdownRenderer', () => {
 
   it('keeps the table and scroll wrapper stable while a streamed row grows', () => {
     const header = '| Plan | Price |\n| --- | --- |\n'
-    const { rerender } = render(<MarkdownRenderer content={header + '| SIMBA |'} />)
+    const { rerender } = render(<MarkdownRenderer content={header + '| SIMBA | $'} />)
     const table = screen.getByRole('table')
     const wrapper = table.parentElement
     for (const row of ['| SIMBA | $', '| SIMBA | $15', '| SIMBA | $15–$25 |']) {
@@ -309,6 +309,80 @@ describe('MarkdownRenderer', () => {
       expect(table.parentElement).toBe(wrapper)
     }
     expect(screen.getAllByRole('cell').map((cell) => cell.textContent)).toEqual(['SIMBA', '$15–$25'])
+  })
+
+  it.each([
+    '| SIMBA | $15 | never discard this |',
+    '| SIMBA |',
+    '| Jack | TEST | $1,909.81 |',
+    '| `a|b` | $15 |',
+    '| <img src=x onerror=alert(1)> | $15 | private value |',
+  ])('preserves the exact source of a table with mismatched cells: %s', (row) => {
+    const source = ['| Plan | Price |', '| --- | --- |', row].join('\n')
+    const { container } = render(<MarkdownRenderer content={source} />)
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    expect(container.querySelector('pre code')?.textContent).toBe(source + '\n')
+    expect(container.querySelector('img')).toBeNull()
+  })
+
+  it('preserves nested mismatched tables without changing surrounding content', () => {
+    const source = '> | A | B |\n> | --- | --- |\n> | one | two | three |'
+    const { container } = render(<MarkdownRenderer content={[
+      'Before **table**.', '', source, '',
+      '- Nested list:', '', '  | A | B |', '  | --- | --- |', '  | x | y | z |', '',
+      '| Valid | Table |', '| --- | --- |', '| yes | $15 |', '', 'After table.',
+    ].join('\n')} />)
+    expect(container.querySelector('blockquote pre code')?.textContent).toBe(source.slice(2) + '\n')
+    expect(container.querySelector('li pre code')?.textContent).toContain('| x | y | z |')
+    expect(screen.getAllByRole('table')).toHaveLength(1)
+    expect(screen.getByText('After table.')).toBeInTheDocument()
+    expect(container.querySelector('strong')?.textContent).toBe('table')
+  })
+
+  it('switches safely between incomplete, valid and overflowing streamed rows', () => {
+    const header = '| Campaign | Spend |\n| --- | --- |\n'
+    const { container, rerender } = render(<MarkdownRenderer content={header + '| Jack |'} />)
+    expect(container.querySelector('pre code')?.textContent).toBe(header + '| Jack |\n')
+    rerender(<MarkdownRenderer content={header + '| Jack | $15 |'} />)
+    expect(screen.getAllByRole('cell').map((cell) => cell.textContent)).toEqual(['Jack', '$15'])
+    const overflow = header + '| Jack | TEST | $15 |'
+    rerender(<MarkdownRenderer content={overflow} />)
+    expect(container.querySelector('pre code')?.textContent).toBe(overflow + '\n')
+    expect(screen.queryByRole('table')).not.toBeInTheDocument()
+    rerender(<MarkdownRenderer content={header + String.raw`| Jack \| TEST | $15 |`} />)
+    expect(screen.getAllByRole('cell').map((cell) => cell.textContent)).toEqual(['Jack | TEST', '$15'])
+  })
+
+  it('retains explicitly empty cells and leaves table-shaped code examples alone', () => {
+    const { container } = render(<MarkdownRenderer content={[
+      '| A | B |', '| --- | --- |', '| one | |', '| | two |', '',
+      '```markdown', '| A | B |', '| --- | --- |', '| x | y | z |', '```',
+    ].join('\n')} />)
+    expect(screen.getAllByRole('cell').map((cell) => cell.textContent)).toEqual(['one', '', '', 'two'])
+    expect(container.querySelector('pre code')?.textContent).toBe('| A | B |\n| --- | --- |\n| x | y | z |\n')
+  })
+
+  it('replays the plan comparison table captured from the original TC6 task', () => {
+    // Verbatim table excerpt from local benchmark task 880, assistant message
+    // 2555. This is a rendering fixture, not a claim about current plan prices.
+    const source = [
+      '| Provider | Representative plans | Main proposition | Competitive strength | Weakness |',
+      '|---|---:|---|---|---|',
+      '| **SIMBA** | $10–$25 per 30 days | 500–800GB local data, large APAC/global roaming bundles, IDD and local-call benefits | Best international value; highly generous roaming; low prices | Plan architecture is complicated; very large headline data quotas can look less credible or less relevant to ordinary users |',
+      '| **Singtel hi!** | About $15–$40 per 4 weeks, plus senior options | Large local data bundles, Singtel 5G+ network, roaming and IDD, app-based top-up | Strongest brand and perceived network reliability; broad retail and service ecosystem | Usually weaker raw value than SIMBA, Maxx or eight; higher prices for comparable heavy-data users |',
+      '| **eight** | About $8–$18 per 30 days | 488–688GB headline data, 4G/5G tiers, roaming, IDD and local benefits | Strong data value plus automatic rollover; rollover balance can build up to eight months of current-plan entitlement | More complex naming and benefit structure; customers may struggle to understand what is local data versus roaming data |',
+      '| **Maxx** | About $7.90–$12 per month | 290–500GB plans, 4G/5G options, Singapore/Malaysia or wider Asian usage, IDD and roaming | Very sharp price points; simple proposition; backed by M1’s network | Less generous than SIMBA/eight at the top end; no data rollover in the surfaced comparison; physical SIM availability may be less flexible than eSIM-led rivals |',
+    ].join('\n')
+    const { container } = render(<MarkdownRenderer content={source} />)
+    expect(screen.getAllByRole('columnheader')).toHaveLength(5)
+    expect(screen.getAllByRole('row')).toHaveLength(5)
+    expect(screen.getAllByRole('cell').map((cell) => cell.textContent)).toEqual(
+      source.split('\n').slice(2).flatMap((row) => row.split('|').slice(1, -1).map(
+        (cell) => cell.trim().replaceAll('**', ''),
+      )),
+    )
+    expect(screen.getByRole('table').parentElement).toHaveClass('markdown-table-scroll')
+    expect(container.querySelector('.katex')).toBeNull()
   })
 
   it('renders numeric formulas alongside currency without merging their delimiters', () => {

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -338,6 +338,20 @@ function MarkdownParagraph({
   return <p {...props}>{children}</p>
 }
 
+function MarkdownTable({ node: _node, children, ...props }: MarkdownComponentProps<'table'>) {
+  const { t } = useI18n()
+  return (
+    <div
+      className="markdown-table-scroll"
+      role="region"
+      aria-label={t('markdownRenderer.tableScrollLabel')}
+      tabIndex={0}
+    >
+      <table {...props}>{children}</table>
+    </div>
+  )
+}
+
 function MarkdownLink({
   node,
   href,
@@ -566,6 +580,7 @@ const markdownComponents: Components = {
   p: MarkdownParagraph,
   a: MarkdownLink,
   img: MarkdownImage,
+  table: MarkdownTable,
 }
 
 export function MarkdownRenderer({

--- a/frontend/src/components/ui/markdown-renderer.tsx
+++ b/frontend/src/components/ui/markdown-renderer.tsx
@@ -3,6 +3,7 @@ import ReactMarkdown, { defaultUrlTransform } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeKatex from 'rehype-katex'
 import { remarkCurrencySafeMath } from '@/lib/remark-currency-safe-math'
+import { remarkPreserveTableContent } from '@/lib/remark-preserve-table-content'
 import type { Components, ExtraProps } from 'react-markdown'
 import { apiRequest } from '@/lib/api-wrapper'
 import { AgentCard } from '@/components/chat/AgentCard'
@@ -619,7 +620,7 @@ export function MarkdownRenderer({
     <MarkdownRendererContext.Provider value={contextValue}>
       <div className={`prose prose-invert max-w-none break-words [overflow-wrap:anywhere] ${className}`}>
         <ReactMarkdown
-          remarkPlugins={[remarkGfm, remarkCurrencySafeMath]}
+          remarkPlugins={[remarkGfm, remarkCurrencySafeMath, remarkPreserveTableContent]}
           rehypePlugins={[rehypeKatex]}
           components={markdownComponents}
           urlTransform={safeUrlTransform}

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -2949,6 +2949,7 @@ Build when you need.`,
     }
   },
   markdownRenderer: {
+    tableScrollLabel: "Table (scroll horizontally to see more columns)",
     loadAgentDetailsFailed: "Unable to load agent details",
   },
   agent: {

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -2944,6 +2944,7 @@ const zh = {
     }
   },
   markdownRenderer: {
+    tableScrollLabel: "表格（可横向滚动查看更多列）",
     loadAgentDetailsFailed: "无法加载 Agent 详情",
   },
   agent: {

--- a/frontend/src/lib/remark-preserve-table-content.ts
+++ b/frontend/src/lib/remark-preserve-table-content.ts
@@ -3,7 +3,8 @@ import type { Plugin } from 'unified'
 
 /**
  * GFM parses surplus cells, but the HTML conversion silently discards them.
- * Preserve a mismatched table as inert source before that conversion. Do not
+ * Preserve a table with surplus cells as inert source before that conversion.
+ * Under-filled rows are losslessly padded by GFM and remain tables. Do not
  * infer which pipes were intended as text or shift values between columns.
  */
 export const remarkPreserveTableContent: Plugin<[], Root> = () => (tree, file) => {
@@ -12,8 +13,8 @@ export const remarkPreserveTableContent: Plugin<[], Root> = () => (tree, file) =
   function walk(parent: Parents) {
     parent.children.forEach((node, index) => {
       if (node.type === 'table') {
-        const columns = node.children[0]?.children.length
-        if (node.children.some((row) => row.children.length !== columns)) {
+        const columns = node.children[0]?.children.length ?? 0
+        if (node.children.some((row) => row.children.length > columns)) {
           const start = node.position?.start.offset
           const end = node.position?.end.offset
           // Parsed Markdown always has offsets; leave synthetic plugin nodes

--- a/frontend/src/lib/remark-preserve-table-content.ts
+++ b/frontend/src/lib/remark-preserve-table-content.ts
@@ -1,0 +1,36 @@
+import type { Parents, Root } from 'mdast'
+import type { Plugin } from 'unified'
+
+/**
+ * GFM parses surplus cells, but the HTML conversion silently discards them.
+ * Preserve a mismatched table as inert source before that conversion. Do not
+ * infer which pipes were intended as text or shift values between columns.
+ */
+export const remarkPreserveTableContent: Plugin<[], Root> = () => (tree, file) => {
+  const source = String(file)
+
+  function walk(parent: Parents) {
+    parent.children.forEach((node, index) => {
+      if (node.type === 'table') {
+        const columns = node.children[0]?.children.length
+        if (node.children.some((row) => row.children.length !== columns)) {
+          const start = node.position?.start.offset
+          const end = node.position?.end.offset
+          // Parsed Markdown always has offsets; leave synthetic plugin nodes
+          // alone when there is no original source to preserve.
+          if (start !== undefined && end !== undefined) {
+            parent.children[index] = {
+              type: 'code',
+              value: source.slice(start, end),
+              position: node.position,
+            }
+          }
+        }
+      } else if ('children' in node) {
+        walk(node)
+      }
+    })
+  }
+
+  walk(tree)
+}

--- a/frontend/vitest.widget.config.ts
+++ b/frontend/vitest.widget.config.ts
@@ -31,6 +31,7 @@ const widgetConfig = mergeConfig(baseConfig, defineConfig({
         "src/lib/auth-cache.ts",
         "src/lib/files-disabled-presentation.ts",
         "src/lib/remark-currency-safe-math.ts",
+        "src/lib/remark-preserve-table-content.ts",
         "src/lib/widget-parent-message.ts",
         "src/contexts/presentation-capabilities.tsx",
         "src/app/settings/page.tsx",
@@ -78,6 +79,9 @@ const widgetConfig = mergeConfig(baseConfig, defineConfig({
         "src/lib/auth-cache.ts": { statements: 90, branches: 80, functions: 90, lines: 90 },
         "src/lib/remark-currency-safe-math.ts": {
           statements: 100, branches: 100, functions: 100, lines: 100,
+        },
+        "src/lib/remark-preserve-table-content.ts": {
+          statements: 95, branches: 80, functions: 100, lines: 95,
         },
         "src/contexts/presentation-capabilities.tsx": {
           statements: 100, branches: 100, functions: 100, lines: 100,


### PR DESCRIPTION
## Summary

- Keep wide Markdown tables inside independently scrollable, keyboard-accessible regions with localized labels and readable cell widths.
- Preserve tables with surplus cells as inert original source before the GFM-to-HTML conversion can silently discard surplus cells. This also avoids guessing how an unescaped pipe should move values between columns.
- Keep valid tables, escaped pipes, inline code, alignment, currency text and surrounding Markdown intact; support nested and streamed tables.
- Add a verbatim table excerpt from the original TC6 benchmark output as a rendering regression fixture. No docs files or new dependencies.

## Validation

- Demonstrated the gap first: seven new malformed-table regression cases failed before the preservation plugin, then passed after the fix.
- Markdown renderer: 91 tests passed after the under-filled-row review fix.
- Required widget coverage lane: 1,140 tests passed, coverage thresholds passed.
- Frontend CI manifest: 82 tests passed; pre-commit including lint and TypeScript passed.
- Browser replay using the actual Next.js frontend and shared Markdown renderer at 320/375/768/1280 px: all 20 original TC6 data cells retained, no page-level horizontal overflow, malformed row preserved verbatim.

## Scope

This is conservative rendering, not automatic repair of ambiguous Markdown. Tables with surplus cells remain visible as source until there is no risk of dropped cells. Under-filled rows retain standard GFM empty-cell padding. The original TC6 output was replayed; this does not claim a new live-model business benchmark run. The temporary browser-smoke route is not included.
