### PR TITLE
test(web): stub durable-message injection outcome as a real enum member

### DIFF
--- a/tests/web/api/test_durable_message_resume_contention.py
+++ b/tests/web/api/test_durable_message_resume_contention.py
@@ -10,6 +10,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from xagent.core.agent.runner import UserMessageInjectionOutcome
 from xagent.web.api import websocket as websocket_api
 from xagent.web.api.websocket import (
     ResumeReservationOutcome,
@@ -107,7 +108,16 @@ def _live_control_environment(
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
-    agent.post_user_message = AsyncMock(return_value=True)
+    # The injection outcome is read two ways downstream: truthiness (did an
+    # exact checkpoint accept the message at all) and identity against
+    # ``POSTED_FRESH`` (did this call write a new turn, as opposed to a
+    # replayed one). A bare ``True`` satisfies the first read but is never
+    # ``is POSTED_FRESH``, so it silently skips the branch that fires only
+    # on identity -- the stub has to be a real enum member to exercise that
+    # branch at all.
+    agent.post_user_message = AsyncMock(
+        return_value=UserMessageInjectionOutcome.POSTED_FRESH
+    )
     if background_manager is None:
         background_manager = MagicMock()
         background_manager.try_reserve_resume.return_value = outcome
@@ -283,11 +293,24 @@ async def test_dispatcher_reclaims_and_applies_message_after_contention_clears(
         background_manager.release_resume_reservation(int(task.id))
         stored.claim_expires_at = None
         db_session.commit()
-        assert await dispatch_one_task_command(
-            execute_durable_task_command,
-            command_db_id=enqueued.command_id,
-        )
-        await asyncio.sleep(0)
+        # A stub that is truthy but not `is POSTED_FRESH` would let the
+        # dispatch above still report success while silently skipping the
+        # legacy-interaction close below it -- truthiness alone cannot tell
+        # the two apart. `wraps=` keeps the real close running (so its own
+        # behavior is unchanged) and only counts how often it ran, making a
+        # stub that regresses to a truthy-but-wrong-identity value fail
+        # here instead of passing unnoticed.
+        with patch.object(
+            websocket_api,
+            "close_legacy_resume_interaction_sync",
+            wraps=websocket_api.close_legacy_resume_interaction_sync,
+        ) as close_spy:
+            assert await dispatch_one_task_command(
+                execute_durable_task_command,
+                command_db_id=enqueued.command_id,
+            )
+            await asyncio.sleep(0)
+        assert close_spy.call_count == 1
 
     db_session.expire_all()
     stored = db_session.get(TaskExecutionCommand, enqueued.command_id)

--- a/tests/web/api/test_durable_message_resume_contention.py
+++ b/tests/web/api/test_durable_message_resume_contention.py
@@ -296,10 +296,11 @@ async def test_dispatcher_reclaims_and_applies_message_after_contention_clears(
         # A stub that is truthy but not `is POSTED_FRESH` would let the
         # dispatch above still report success while silently skipping the
         # legacy-interaction close below it -- truthiness alone cannot tell
-        # the two apart. `wraps=` keeps the real close running (so its own
-        # behavior is unchanged) and only counts how often it ran, making a
-        # stub that regresses to a truthy-but-wrong-identity value fail
-        # here instead of passing unnoticed.
+        # the two apart. Patching with a spy lets us assert
+        # `close_spy.call_count == 1`, which fails if that regression
+        # silently skips the close; `wraps=` is added separately so the
+        # real close still executes for its own side effects (the DB
+        # write), keeping the rest of the test's assertions valid.
         with patch.object(
             websocket_api,
             "close_legacy_resume_interaction_sync",
@@ -311,6 +312,11 @@ async def test_dispatcher_reclaims_and_applies_message_after_contention_clears(
             )
             await asyncio.sleep(0)
         assert close_spy.call_count == 1
+        # The call site swallows any internal failure into a warning
+        # (`except Exception: logger.warning(...)`), so call_count alone
+        # cannot tell a successful close from one that raised and was
+        # silently caught. Assert the warning is absent to catch that case.
+        assert "legacy resume interaction close failed" not in caplog.text
 
     db_session.expire_all()
     stored = db_session.get(TaskExecutionCommand, enqueued.command_id)


### PR DESCRIPTION
## What

The live-control resume fixture used across
`test_durable_message_resume_contention.py` stubbed the agent's message
injection result as a bare `True`. This change replaces it with the real
`UserMessageInjectionOutcome.POSTED_FRESH` enum member the production
code actually returns for a fresh write, and adds a spy assertion that
proves the downstream identity-comparison branch is now reached.

## Why

The injection outcome is read two different ways downstream: a
truthiness check ("did this post a usable context at all") and an
identity comparison against `POSTED_FRESH` ("was this a fresh write, as
opposed to a replayed one"). A bare `True` satisfies the first read
because it is truthy, but it is never `is POSTED_FRESH`, so any branch
gated on that identity comparison is silently skipped under this
fixture -- regardless of what the branch actually does. This is exactly
the distinction the enum's own docstring calls out: truthiness alone
cannot and must not stand in for the identity check.

Searching the rest of the test suite for the same shape of stub found
the remaining occurrences split into two groups: some already return the
enum member itself, and the others return `False`. `False` agrees with
`NOT_POSTED` under both readings and therefore causes no silent skip.
This file's bare `True` was the only stub in the repository that
disagreed between the two readings.

## Verification

- `pytest tests/web/api/test_durable_message_resume_contention.py -q`:
  10 passed, exit code 0, both before and after this change.
- Five neighboring test files that exercise related code paths were
  re-run and are unaffected (248 tests, all passing).
- Mutation check: temporarily reverting the stub back to `True`
  reproduces exactly one failure, on the newly added spy assertion,
  while the other nine tests in the file stay green; restoring the fix
  returns the file to fully green.
- `ruff check` and `ruff format --check` pass on the changed file.
- No production code under `src/` is touched; the diff is confined to
  the one test file.

---
