### PR TITLE
test(core): assert UserMessageInjectionOutcome member set has not drifted

### DIFF
--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -315,6 +315,41 @@ def test_user_message_injection_outcome_truthiness_contract() -> None:
     assert UserMessageInjectionOutcome.POSTED_REPLAY
 
 
+def test_user_message_injection_outcome_member_set_has_not_drifted() -> None:
+    """The three call sites that key off this enum -- one in ``a2a.py`` and
+    two in ``websocket.py``, all spelled
+    ``is UserMessageInjectionOutcome.POSTED_FRESH`` -- use an allow-list
+    shape: only ``POSTED_FRESH`` retires the interaction row those sites are
+    guarding. A fourth member added to this enum falls into their
+    non-matching default branch without any of them raising or warning.
+
+    This test does not touch those three guards, and it does not give them
+    a branch per member -- a new member still lands in that same default
+    branch in production after this test exists. What it does instead is
+    make adding a member a deliberate act: the addition fails here first,
+    so whoever adds a fourth member is forced back to this line to read
+    what the default branch actually does before touching any guard.
+
+    That default is not equivalent to falling back to the legacy path. In
+    a deployment where the task's interaction protocol marker has been
+    written to 1 (nothing in this codebase writes that value today), an
+    interaction row left open by a non-matching outcome is read through the
+    structured view, so the same interaction is rendered again together
+    with its controls, and the resume-execution guard rejects the user's
+    "continue" action because it still finds that row open. A user can
+    still recover by sending another chat message -- that goes through the
+    online injection site, gets ``POSTED_FRESH``, and closes the row -- but
+    only at the cost of answering the same interaction a second time. That
+    is milder than a deny-list default, which would retire a still-open
+    interaction outright and lose data, but it is not free.
+    """
+    assert {member.name for member in UserMessageInjectionOutcome} == {
+        "NOT_POSTED",
+        "POSTED_FRESH",
+        "POSTED_REPLAY",
+    }
+
+
 @pytest.mark.asyncio
 async def test_runner_treats_canonical_empty_checkpoint_as_authoritative() -> None:
     checkpoint_store = EmptyCanonicalCheckpointStore()

--- a/tests/core/agent/test_runner.py
+++ b/tests/core/agent/test_runner.py
@@ -316,32 +316,18 @@ def test_user_message_injection_outcome_truthiness_contract() -> None:
 
 
 def test_user_message_injection_outcome_member_set_has_not_drifted() -> None:
-    """The three call sites that key off this enum -- one in ``a2a.py`` and
-    two in ``websocket.py``, all spelled
-    ``is UserMessageInjectionOutcome.POSTED_FRESH`` -- use an allow-list
-    shape: only ``POSTED_FRESH`` retires the interaction row those sites are
-    guarding. A fourth member added to this enum falls into their
-    non-matching default branch without any of them raising or warning.
+    """A fourth member added here falls through the ``is
+    UserMessageInjectionOutcome.POSTED_FRESH`` guards in ``a2a.py`` and
+    ``websocket.py`` silently -- see ``task_interaction_close.py`` for what
+    that means for an interaction row left open. The three guard sites are
+    not equally exposed to it, though: the deferred WebSocket guard is
+    documented defense-in-depth there, since it can only ever re-name a row
+    an earlier attempt already retired.
 
-    This test does not touch those three guards, and it does not give them
-    a branch per member -- a new member still lands in that same default
-    branch in production after this test exists. What it does instead is
-    make adding a member a deliberate act: the addition fails here first,
-    so whoever adds a fourth member is forced back to this line to read
-    what the default branch actually does before touching any guard.
-
-    That default is not equivalent to falling back to the legacy path. In
-    a deployment where the task's interaction protocol marker has been
-    written to 1 (nothing in this codebase writes that value today), an
-    interaction row left open by a non-matching outcome is read through the
-    structured view, so the same interaction is rendered again together
-    with its controls, and the resume-execution guard rejects the user's
-    "continue" action because it still finds that row open. A user can
-    still recover by sending another chat message -- that goes through the
-    online injection site, gets ``POSTED_FRESH``, and closes the row -- but
-    only at the cost of answering the same interaction a second time. That
-    is milder than a deny-list default, which would retire a still-open
-    interaction outright and lose data, but it is not free.
+    Relative to ``test_user_message_injection_outcome_truthiness_contract``
+    above, this test's only unique catch is a member being added -- a
+    rename or removal already raises ``AttributeError`` there. A member's
+    value changing is the reverse case: caught there, not here.
     """
     assert {member.name for member in UserMessageInjectionOutcome} == {
         "NOT_POSTED",


### PR DESCRIPTION
## What

Adds one test asserting that `UserMessageInjectionOutcome`'s member
names are exactly `{NOT_POSTED, POSTED_FRESH, POSTED_REPLAY}`, next to
the existing truthiness-contract test for the same enum. No production
code changes.

## Why

Three call sites (one in `a2a.py`, two in `websocket.py`) key off this
enum with an allow-list shape: `is UserMessageInjectionOutcome.POSTED_FRESH`.
A newly added member falls into their non-matching default branch
without any of them raising or warning. In a deployment where the
task's interaction protocol marker has been written to 1 -- nothing in
this codebase writes that value today -- that default branch's
consequence is not a fallback to the legacy path: it leaves an
interaction row open that gets rendered again through the structured
view alongside its controls, while the resume-execution guard rejects
the user's "continue" action because it still finds that row open. The
user can recover by sending another chat message, which re-enters
through the online injection path and closes the row, but only at the
cost of re-answering the same interaction.

This test does not change any of the three guard sites and does not
give them a branch per member. What it does is make adding a fourth
member a deliberate act: the addition fails this test first, forcing
whoever adds it to read what the default branch actually does before
touching any guard.

## Verification

- `pytest tests/core/agent/test_runner.py -q`: 67 -> 68 passed.
- `pytest tests/core/agent/ -q`: 1121 -> 1122 passed.
- `pytest tests/web/api/test_a2a_api.py tests/web/api/test_websocket_owner_actor.py tests/web/api/v1/test_task_reply.py -q`: 191 passed, unchanged.
- Mutation check: adding a fourth member turns the new assertion red
  (an `AssertionError`) while the neighboring truthiness test stays
  green; renaming an existing member also turns the new assertion red
  via `AssertionError`. Both reverted; full suite green again.
- `ruff check` and `ruff format --check` pass on the changed file.

---
