### PR TITLE
fix(frontend): give clarification rounds a real wire identity

### DIFF
--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -602,6 +602,192 @@ describe("TaskConversationPanel", () => {
     expect(rendered[1]).toHaveAttribute("data-request-id", "inputreq_q2")
   })
 
+  it("adopts the ask frame's event_id as the waiting round id when no request_id exists", () => {
+    // No backend emits request_id today; the stable per-ask identity on the
+    // wire is event_id. The trace fallback must surface it so the round is
+    // identified even when the status frame carried nothing.
+    appState.messages = [{
+      id: "user-1",
+      role: "user",
+      content: "Start the question",
+      timestamp: 2000,
+    }]
+    appState.traceEvents = [
+      {
+        event_type: "agent_message",
+        timestamp: 1000,
+        data: {
+          expect_response: true,
+          message: "Which region should I use?",
+          event_id: "evt-round-1",
+          metadata: {
+            interactions: [{ type: "text_input", field: "region", label: "Region" }],
+          },
+        },
+      },
+    ]
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Which region should I use?",
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const activeWait = screen.getAllByTestId("chat-message").find(
+      (message) => message.getAttribute("data-active") === "true",
+    )
+    expect(activeWait).toBeDefined()
+    expect(activeWait).toHaveAttribute("data-request-id", "evt-round-1")
+  })
+
+  it("keeps at most one instance active for a waiting round", () => {
+    // The two-instances window: the round's question is persisted on the
+    // timeline AND an optimistic user message is the last item (so the
+    // virtual assistant message renders too). The timeline instance owns the
+    // round; the virtual copy must stay inert, or two forms accept the same
+    // question at once.
+    appState.messages = [
+      {
+        id: "q1",
+        role: "assistant",
+        content: "Which city?",
+        timestamp: "1000",
+        isResult: true,
+        interactions: [{ type: "text_input", field: "city", label: "City" }],
+        interactionRequestId: "round-1",
+      },
+      {
+        id: "u1",
+        role: "user",
+        content: "City: Beijing",
+        timestamp: "2000",
+        isOptimistic: true,
+      },
+    ]
+    appState.traceEvents = []
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Which city?",
+      waitingRequestId: "round-1",
+      waitingInteractions: [{ type: "text_input", field: "city", label: "City" }],
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const active = screen.getAllByTestId("chat-message")
+      .filter((node) => node.getAttribute("data-active") === "true")
+    expect(active).toHaveLength(1)
+    expect(active[0]).toHaveAttribute("data-request-id", "round-1")
+    expect(active[0]).toHaveTextContent("Which city?")
+  })
+
+  it("never adopts a client-minted trace id as the round id", () => {
+    // react_task_end rows in state get generateMessageId placeholders as
+    // their top-level event_id; adopting one would name a round no message
+    // carries, deactivating every instance. With no data-level id on the
+    // newest ask, the prompt-text match stays in charge and activates the
+    // persisted bubble.
+    appState.messages = [
+      {
+        id: "q1",
+        role: "assistant",
+        content: "Choose a region",
+        timestamp: 1000,
+        isResult: true,
+        interactions: [{ type: "text_input", field: "region", label: "Region" }],
+      },
+      {
+        id: "u1",
+        role: "user",
+        content: "Working on it",
+        timestamp: 2000,
+      },
+    ]
+    appState.traceEvents = [
+      {
+        event_id: "react-task-end-1757200000000-abc12",
+        event_type: "react_task_end",
+        timestamp: 1500,
+        data: {
+          result: {
+            status: "waiting_for_user",
+            message: "Choose a region",
+          },
+        },
+      },
+    ]
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Choose a region",
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const active = screen.getAllByTestId("chat-message")
+      .filter((node) => node.getAttribute("data-active") === "true")
+    expect(active).toHaveLength(1)
+    expect(active[0]).toHaveTextContent("Choose a region")
+    expect(active[0]).toHaveAttribute("data-request-id", "")
+  })
+
+  it("activates the round-id match rather than a same-text lookalike", () => {
+    // Prompt-text equality can pick the wrong message when two rounds asked
+    // the same question; the round id is authoritative when present.
+    appState.messages = [
+      {
+        id: "q1",
+        role: "assistant",
+        content: "Which city?",
+        timestamp: "1000",
+        isResult: true,
+        interactions: [{ type: "text_input", field: "city", label: "City" }],
+        interactionRequestId: "round-1",
+      },
+      {
+        id: "q2",
+        role: "assistant",
+        content: "Which city?",
+        timestamp: "2000",
+        isResult: true,
+        interactions: [{ type: "text_input", field: "city", label: "City" }],
+        interactionRequestId: "round-2",
+      },
+    ]
+    appState.traceEvents = []
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Which city?",
+      waitingRequestId: "round-1",
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const active = screen.getAllByTestId("chat-message")
+      .filter((node) => node.getAttribute("data-active") === "true")
+    expect(active).toHaveLength(1)
+    expect(active[0]).toHaveAttribute("data-request-id", "round-1")
+  })
+
   it("keeps an identified text-only wait separate from stale structured trace interactions", () => {
     appState.messages = [{
       id: "user-r2",

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -602,102 +602,6 @@ describe("TaskConversationPanel", () => {
     expect(rendered[1]).toHaveAttribute("data-request-id", "inputreq_q2")
   })
 
-  it("adopts the replayed waiting result's clarification event_id as the round id", () => {
-    // No backend emits request_id today, and replayed history rows carry no
-    // interactionRequestId; after a reload the round identity lives at the
-    // replayed react_task_end's result.clarification_draft.event_id.
-    appState.messages = [{
-      id: "user-1",
-      role: "user",
-      content: "Start the question",
-      timestamp: 2000,
-    }]
-    appState.traceEvents = [
-      {
-        event_id: "react-task-end-1757200000000-abc12",
-        event_type: "react_task_end",
-        timestamp: 1000,
-        data: {
-          result: {
-            status: "waiting_for_user",
-            message: "Which region should I use?",
-            interactions: [{ type: "text_input", field: "region", label: "Region" }],
-            clarification_draft: { event_id: "evt-round-1" },
-          },
-        },
-      },
-    ]
-    appState.currentTask = {
-      id: "42",
-      title: "Preview",
-      description: "Preview",
-      status: "waiting_for_user",
-      createdAt: "2026-01-01T00:00:00Z",
-      updatedAt: "2026-01-01T00:00:00Z",
-      waitingQuestion: "Which region should I use?",
-    }
-
-    render(<TaskConversationPanel mode="embedded-preview" />)
-
-    const activeWait = screen.getAllByTestId("chat-message").find(
-      (message) => message.getAttribute("data-active") === "true",
-    )
-    expect(activeWait).toBeDefined()
-    expect(activeWait).toHaveAttribute("data-request-id", "evt-round-1")
-  })
-
-  it("stops the round-id scan at the newest waiting result", () => {
-    // Reaching past an id-less newest result would return an OLDER round's
-    // id for the current question; the scan must stop and leave the round
-    // id-less so the prompt-text match stays in charge.
-    appState.messages = [{
-      id: "user-1",
-      role: "user",
-      content: "Working on it",
-      timestamp: 3000,
-    }]
-    appState.traceEvents = [
-      {
-        event_type: "react_task_end",
-        timestamp: 1000,
-        data: {
-          result: {
-            status: "waiting_for_user",
-            message: "Old question",
-            clarification_draft: { event_id: "evt-old-round" },
-          },
-        },
-      },
-      {
-        event_type: "react_task_end",
-        timestamp: 2000,
-        data: {
-          result: {
-            status: "waiting_for_user",
-            message: "Which city?",
-          },
-        },
-      },
-    ]
-    appState.currentTask = {
-      id: "42",
-      title: "Preview",
-      description: "Preview",
-      status: "waiting_for_user",
-      createdAt: "2026-01-01T00:00:00Z",
-      updatedAt: "2026-01-01T00:00:00Z",
-      waitingQuestion: "Which city?",
-    }
-
-    render(<TaskConversationPanel mode="embedded-preview" />)
-
-    const activeWait = screen.getAllByTestId("chat-message").find(
-      (message) => message.getAttribute("data-active") === "true",
-    )
-    expect(activeWait).toBeDefined()
-    expect(activeWait).toHaveAttribute("data-request-id", "")
-  })
-
   it("prefers the virtual bubble over an older round's form when the round id and text both miss", () => {
     // Round 2's status frame arrived (new id, new question) but its ask row
     // never landed. The only interactive timeline item belongs to round 1;
@@ -824,20 +728,18 @@ describe("TaskConversationPanel", () => {
     expect(active[0]).toHaveTextContent("Which city?")
   })
 
-  it("never adopts a client-minted trace id as the round id", () => {
-    // react_task_end rows in state get generateMessageId placeholders as
-    // their top-level event_id; adopting one would name a round no message
-    // carries, deactivating every instance. With no data-level id on the
-    // newest ask, the prompt-text match stays in charge and activates the
-    // persisted bubble.
+  it("gives the active id-less replayed row the resolved round id", () => {
+    // A replayed chat-history row carries no interactionRequestId. When the
+    // text fallback elects it as the active instance, it must submit with
+    // the round id the waiting frame delivered - not id-less.
     appState.messages = [
       {
         id: "q1",
         role: "assistant",
-        content: "Choose a region",
+        content: "Which city?",
         timestamp: 1000,
         isResult: true,
-        interactions: [{ type: "text_input", field: "region", label: "Region" }],
+        interactions: [{ type: "text_input", field: "city", label: "City" }],
       },
       {
         id: "u1",
@@ -846,19 +748,7 @@ describe("TaskConversationPanel", () => {
         timestamp: 2000,
       },
     ]
-    appState.traceEvents = [
-      {
-        event_id: "react-task-end-1757200000000-abc12",
-        event_type: "react_task_end",
-        timestamp: 1500,
-        data: {
-          result: {
-            status: "waiting_for_user",
-            message: "Choose a region",
-          },
-        },
-      },
-    ]
+    appState.traceEvents = []
     appState.currentTask = {
       id: "42",
       title: "Preview",
@@ -866,7 +756,8 @@ describe("TaskConversationPanel", () => {
       status: "waiting_for_user",
       createdAt: "2026-01-01T00:00:00Z",
       updatedAt: "2026-01-01T00:00:00Z",
-      waitingQuestion: "Choose a region",
+      waitingQuestion: "Which city?",
+      waitingRequestId: "evt-round-1",
     }
 
     render(<TaskConversationPanel mode="embedded-preview" />)
@@ -874,8 +765,61 @@ describe("TaskConversationPanel", () => {
     const active = screen.getAllByTestId("chat-message")
       .filter((node) => node.getAttribute("data-active") === "true")
     expect(active).toHaveLength(1)
-    expect(active[0]).toHaveTextContent("Choose a region")
-    expect(active[0]).toHaveAttribute("data-request-id", "")
+    expect(active[0]).toHaveTextContent("Which city?")
+    expect(active[0]).toHaveAttribute("data-request-id", "evt-round-1")
+  })
+
+  it("never text-elects a lookalike row that carries a different round id", () => {
+    // Same question text asked in an earlier round: that row provably
+    // belongs to the other round and must not be elected over the id-less
+    // current row.
+    // The lookalike carrying the OLD round id is deliberately the NEWEST
+    // text-matching row: the reverse scan reaches it first, so only the
+    // skip guard (not election order) keeps it from being elected.
+    appState.messages = [
+      {
+        id: "q1",
+        role: "assistant",
+        content: "Which city?",
+        timestamp: 1000,
+        isResult: true,
+        interactions: [{ type: "text_input", field: "city", label: "City" }],
+      },
+      {
+        id: "q2",
+        role: "assistant",
+        content: "Which city?",
+        timestamp: 2000,
+        isResult: true,
+        interactions: [{ type: "text_input", field: "city", label: "City" }],
+        interactionRequestId: "evt-old-round",
+      },
+      {
+        id: "u1",
+        role: "user",
+        content: "Working on it",
+        timestamp: 3000,
+      },
+    ]
+    appState.traceEvents = []
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Which city?",
+      waitingRequestId: "evt-round-2",
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const active = screen.getAllByTestId("chat-message")
+      .filter((node) => node.getAttribute("data-active") === "true")
+    expect(active).toHaveLength(1)
+    // The id-less newest row is elected and speaks with the current round id.
+    expect(active[0]).toHaveAttribute("data-request-id", "evt-round-2")
   })
 
   it("activates the round-id match rather than a same-text lookalike", () => {

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -602,10 +602,10 @@ describe("TaskConversationPanel", () => {
     expect(rendered[1]).toHaveAttribute("data-request-id", "inputreq_q2")
   })
 
-  it("adopts the ask frame's event_id as the waiting round id when no request_id exists", () => {
-    // No backend emits request_id today; the stable per-ask identity on the
-    // wire is event_id. The trace fallback must surface it so the round is
-    // identified even when the status frame carried nothing.
+  it("adopts the replayed waiting result's clarification event_id as the round id", () => {
+    // No backend emits request_id today, and replayed history rows carry no
+    // interactionRequestId; after a reload the round identity lives at the
+    // replayed react_task_end's result.clarification_draft.event_id.
     appState.messages = [{
       id: "user-1",
       role: "user",
@@ -614,14 +614,15 @@ describe("TaskConversationPanel", () => {
     }]
     appState.traceEvents = [
       {
-        event_type: "agent_message",
+        event_id: "react-task-end-1757200000000-abc12",
+        event_type: "react_task_end",
         timestamp: 1000,
         data: {
-          expect_response: true,
-          message: "Which region should I use?",
-          event_id: "evt-round-1",
-          metadata: {
+          result: {
+            status: "waiting_for_user",
+            message: "Which region should I use?",
             interactions: [{ type: "text_input", field: "region", label: "Region" }],
+            clarification_draft: { event_id: "evt-round-1" },
           },
         },
       },
@@ -643,6 +644,138 @@ describe("TaskConversationPanel", () => {
     )
     expect(activeWait).toBeDefined()
     expect(activeWait).toHaveAttribute("data-request-id", "evt-round-1")
+  })
+
+  it("stops the round-id scan at the newest waiting result", () => {
+    // Reaching past an id-less newest result would return an OLDER round's
+    // id for the current question; the scan must stop and leave the round
+    // id-less so the prompt-text match stays in charge.
+    appState.messages = [{
+      id: "user-1",
+      role: "user",
+      content: "Working on it",
+      timestamp: 3000,
+    }]
+    appState.traceEvents = [
+      {
+        event_type: "react_task_end",
+        timestamp: 1000,
+        data: {
+          result: {
+            status: "waiting_for_user",
+            message: "Old question",
+            clarification_draft: { event_id: "evt-old-round" },
+          },
+        },
+      },
+      {
+        event_type: "react_task_end",
+        timestamp: 2000,
+        data: {
+          result: {
+            status: "waiting_for_user",
+            message: "Which city?",
+          },
+        },
+      },
+    ]
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Which city?",
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const activeWait = screen.getAllByTestId("chat-message").find(
+      (message) => message.getAttribute("data-active") === "true",
+    )
+    expect(activeWait).toBeDefined()
+    expect(activeWait).toHaveAttribute("data-request-id", "")
+  })
+
+  it("prefers the virtual bubble over an older round's form when the round id and text both miss", () => {
+    // Round 2's status frame arrived (new id, new question) but its ask row
+    // never landed. The only interactive timeline item belongs to round 1;
+    // activating it would misbind the reply. The virtual bubble carrying
+    // the current question is the correct instance.
+    appState.messages = [
+      {
+        id: "q1",
+        role: "assistant",
+        content: "Which city?",
+        timestamp: 1000,
+        isResult: true,
+        interactions: [{ type: "text_input", field: "city", label: "City" }],
+        interactionRequestId: "round-1",
+      },
+      {
+        id: "u1",
+        role: "user",
+        content: "City: Beijing",
+        timestamp: 2000,
+      },
+    ]
+    appState.traceEvents = []
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Which hotel?",
+      waitingRequestId: "round-2",
+      waitingInteractions: [{ type: "text_input", field: "hotel", label: "Hotel" }],
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const active = screen.getAllByTestId("chat-message")
+      .filter((node) => node.getAttribute("data-active") === "true")
+    expect(active).toHaveLength(1)
+    expect(active[0]).toHaveAttribute("data-request-id", "round-2")
+    expect(active[0]).toHaveTextContent("Which hotel?")
+  })
+
+  it("falls back to the text match when no timeline item carries the round id", () => {
+    // Replayed history rows carry no interactionRequestId. With the ask as
+    // the last assistant message (virtual bubble suppressed), a failed
+    // id-match that short-circuited instead of falling through would leave
+    // ZERO active reply instances for a waiting task.
+    appState.messages = [
+      {
+        id: "q1",
+        role: "assistant",
+        content: "Which city?",
+        timestamp: 1000,
+        isResult: true,
+        interactions: [{ type: "text_input", field: "city", label: "City" }],
+        // No interactionRequestId - the replayed row never carried one.
+      },
+    ]
+    appState.traceEvents = []
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Which city?",
+      waitingRequestId: "round-1",
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const active = screen.getAllByTestId("chat-message")
+      .filter((node) => node.getAttribute("data-active") === "true")
+    expect(active).toHaveLength(1)
+    expect(active[0]).toHaveTextContent("Which city?")
   })
 
   it("keeps at most one instance active for a waiting round", () => {

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -682,6 +682,32 @@ describe("TaskConversationPanel", () => {
     expect(active[0]).toHaveTextContent("Which city?")
   })
 
+  it("does not leak the previous task's round id during a task switch", () => {
+    // During a switch, currentTask can still describe task A while
+    // state.taskId already points at task B; the round id read is gated on
+    // the ids matching, like the sibling ChatInput wiring.
+    appState.taskId = 99
+    appState.messages = []
+    appState.traceEvents = []
+    appState.currentTask = {
+      id: "42",
+      title: "Previous task",
+      description: "Previous task",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Old question?",
+      waitingRequestId: "round-of-task-42",
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const leaked = screen.getAllByTestId("chat-message")
+      .filter((node) => node.getAttribute("data-request-id") === "round-of-task-42")
+    expect(leaked).toHaveLength(0)
+    appState.taskId = 42
+  })
+
   it("keeps at most one instance active for a waiting round", () => {
     // The two-instances window: the round's question is persisted on the
     // timeline AND an optimistic user message is the last item (so the

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -151,6 +151,73 @@ const findWaitingPrompt = (currentTask: any, traceEvents: any[]) => {
   return null
 }
 
+// The waiting round's identity. Prefers the id the task-state handler
+// already extracted (request_id, falling back to the ask frame's event_id -
+// see the app context's task_waiting_for_user case); when the status frame
+// carried none, falls back to the same ask trace events the prompt and
+// interactions fall back to, so all three stay sourced from one ask.
+type WaitingRoundTraceEvent = {
+  event_id?: unknown
+  event_type?: unknown
+  data?: {
+    request_id?: unknown
+    event_id?: unknown
+    expect_response?: unknown
+    result?: {
+      status?: unknown
+      request_id?: unknown
+      event_id?: unknown
+    }
+  }
+}
+
+const firstRoundId = (...candidates: unknown[]): string | undefined => {
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate) return candidate
+  }
+  return undefined
+}
+
+const findWaitingRequestId = (
+  currentTask: { status?: unknown; waitingRequestId?: unknown } | null | undefined,
+  traceEvents: WaitingRoundTraceEvent[],
+): string | undefined => {
+  if (currentTask?.status !== "waiting_for_user") {
+    return undefined
+  }
+  if (
+    typeof currentTask.waitingRequestId === "string"
+    && currentTask.waitingRequestId
+  ) {
+    return currentTask.waitingRequestId
+  }
+
+  // Only data-level ids count: a trace row's top-level event_id can be a
+  // client-minted placeholder (react_task_end rows get generateMessageId
+  // ids), and adopting one would name a round no message ever carried,
+  // leaving no instance active. And the scan STOPS at the most recent ask
+  // whether or not it carries an id - reaching past it could return an
+  // older round's id for the current question. An id-less newest ask
+  // returns undefined so the prompt-text match below stays in charge.
+  for (let i = traceEvents.length - 1; i >= 0; i--) {
+    const event = traceEvents[i]
+    if (event.event_type === "agent_message" && event.data?.expect_response === true) {
+      return firstRoundId(event.data?.request_id, event.data?.event_id)
+    }
+    if (
+      event.event_type === "react_task_end"
+      && event.data?.result?.status === "waiting_for_user"
+    ) {
+      return firstRoundId(
+        event.data?.result?.request_id,
+        event.data?.result?.event_id,
+      )
+    }
+  }
+
+  return undefined
+}
+
 const findWaitingInteractions = (currentTask: any, traceEvents: any[]) => {
   if (currentTask?.status !== "waiting_for_user") {
     return undefined
@@ -480,9 +547,31 @@ export function TaskConversationPanel({
     () => findWaitingInteractions(state.currentTask, managerTraceEvents as any[]),
     [managerTraceEvents, state.currentTask]
   )
+  const waitingRoundId = useMemo(
+    () => findWaitingRequestId(
+      state.currentTask,
+      managerTraceEvents as WaitingRoundTraceEvent[],
+    ),
+    [managerTraceEvents, state.currentTask]
+  )
 
   const activeWaitingMessageId = useMemo(() => {
     if (state.currentTask?.status !== "waiting_for_user") {
+      return null
+    }
+
+    // When the waiting round has an identity, match by it exactly: the
+    // prompt-text fallback below can pick a message whose text merely equals
+    // the question while the round actually lives on a different item,
+    // leaving TWO instances active at once (the timeline one and the
+    // virtual one) with independently diverging state.
+    if (waitingRoundId) {
+      for (let i = messageItems.length - 1; i >= 0; i--) {
+        const item = messageItems[i]
+        if (item.role === "assistant" && item.interactionRequestId === waitingRoundId) {
+          return item.id
+        }
+      }
       return null
     }
 
@@ -504,7 +593,7 @@ export function TaskConversationPanel({
     }
 
     return null
-  }, [messageItems, state.currentTask?.status, waitingPrompt])
+  }, [messageItems, state.currentTask?.status, waitingPrompt, waitingRoundId])
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView?.({ behavior: "smooth" })
@@ -815,8 +904,15 @@ export function TaskConversationPanel({
                       processStatus={state.currentTask?.status}
                       taskStatus={state.currentTask?.status}
                       interactions={state.currentTask?.status === "waiting_for_user" ? waitingInteractions : undefined}
-                      interactionRequestId={state.currentTask?.status === "waiting_for_user" ? state.currentTask.waitingRequestId : undefined}
-                      interactionsActive={state.currentTask?.status === "waiting_for_user"}
+                      interactionRequestId={state.currentTask?.status === "waiting_for_user" ? waitingRoundId : undefined}
+                      // At most one instance of a waiting round is active: a
+                      // timeline message already owning the round keeps the
+                      // virtual copy inert, so two forms can never both
+                      // accept a submission for the same question.
+                      interactionsActive={
+                        state.currentTask?.status === "waiting_for_user"
+                        && activeWaitingMessageId === null
+                      }
                       onOpenExecutionPlan={showDagPreview ? openDagPreview : undefined}
                       onAgentExecutionClick={onAgentExecutionClick}
                     />

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -21,7 +21,7 @@ import { useI18n } from "@/contexts/i18n-context"
 import { isStreamingFinalAnswerMessage } from "@/lib/streaming-final-answer"
 import { getProcessGroupIndex, getUserTimelineAnchors } from "@/lib/task-timeline"
 import { resolveTraceProcessStatus } from "@/lib/trace-process-status"
-import { cn } from "@/lib/utils"
+import { cn, firstNonEmptyString } from "@/lib/utils"
 
 export type TaskConversationPanelMode = "page" | "embedded-preview"
 
@@ -154,28 +154,19 @@ const findWaitingPrompt = (currentTask: any, traceEvents: any[]) => {
 // The waiting round's identity. Prefers the id the task-state handler
 // already extracted (request_id, falling back to the ask frame's event_id -
 // see the app context's task_waiting_for_user case); when the status frame
-// carried none, falls back to the same ask trace events the prompt and
-// interactions fall back to, so all three stay sourced from one ask.
+// carried none, falls back to the replayed waiting result the prompt and
+// interactions also fall back to, so all three stay sourced from one ask.
 type WaitingRoundTraceEvent = {
-  event_id?: unknown
   event_type?: unknown
   data?: {
-    request_id?: unknown
-    event_id?: unknown
-    expect_response?: unknown
     result?: {
       status?: unknown
       request_id?: unknown
-      event_id?: unknown
+      clarification_draft?: {
+        event_id?: unknown
+      }
     }
   }
-}
-
-const firstRoundId = (...candidates: unknown[]): string | undefined => {
-  for (const candidate of candidates) {
-    if (typeof candidate === "string" && candidate) return candidate
-  }
-  return undefined
 }
 
 const findWaitingRequestId = (
@@ -192,25 +183,24 @@ const findWaitingRequestId = (
     return currentTask.waitingRequestId
   }
 
-  // Only data-level ids count: a trace row's top-level event_id can be a
-  // client-minted placeholder (react_task_end rows get generateMessageId
-  // ids), and adopting one would name a round no message ever carried,
-  // leaving no instance active. And the scan STOPS at the most recent ask
-  // whether or not it carries an id - reaching past it could return an
-  // older round's id for the current question. An id-less newest ask
-  // returns undefined so the prompt-text match below stays in charge.
+  // Only react_task_end rows reach state.traceEvents for a waiting result
+  // (a live ask's agent_message lands in the transcript instead, already
+  // carrying its interactionRequestId), and the round identity on such a
+  // row lives at result.clarification_draft.event_id. A row's top-level
+  // event_id never counts: it is a client-minted placeholder, and adopting
+  // one would name a round no message ever carried. The scan STOPS at the
+  // most recent waiting result whether or not it yields an id - reaching
+  // past it could return an older round's id - and an id-less newest result
+  // returns undefined so the prompt-text match stays in charge.
   for (let i = traceEvents.length - 1; i >= 0; i--) {
     const event = traceEvents[i]
-    if (event.event_type === "agent_message" && event.data?.expect_response === true) {
-      return firstRoundId(event.data?.request_id, event.data?.event_id)
-    }
     if (
       event.event_type === "react_task_end"
       && event.data?.result?.status === "waiting_for_user"
     ) {
-      return firstRoundId(
+      return firstNonEmptyString(
         event.data?.result?.request_id,
-        event.data?.result?.event_id,
+        event.data?.result?.clarification_draft?.event_id,
       )
     }
   }
@@ -560,11 +550,15 @@ export function TaskConversationPanel({
       return null
     }
 
-    // When the waiting round has an identity, match by it exactly: the
+    // When the waiting round has an identity, prefer matching by it: the
     // prompt-text fallback below can pick a message whose text merely equals
     // the question while the round actually lives on a different item,
     // leaving TWO instances active at once (the timeline one and the
-    // virtual one) with independently diverging state.
+    // virtual one) with independently diverging state. A FAILED id-match
+    // falls through rather than short-circuiting: replayed history rows
+    // carry no interactionRequestId, and with the ask sitting as the last
+    // assistant message the virtual bubble is suppressed too - returning
+    // null here would leave zero active reply instances for a waiting task.
     if (waitingRoundId) {
       for (let i = messageItems.length - 1; i >= 0; i--) {
         const item = messageItems[i]
@@ -572,7 +566,6 @@ export function TaskConversationPanel({
           return item.id
         }
       }
-      return null
     }
 
     if (waitingPrompt) {
@@ -585,6 +578,14 @@ export function TaskConversationPanel({
       }
     }
 
+    // The bare newest-interactions fallback is for rounds with NO identity
+    // at all. Under a known round id whose item and text both failed to
+    // match, it could only pick an OLDER round's form (a dropped ask frame
+    // for the current round), misbinding the reply - the virtual bubble
+    // showing the current question is the right instance there.
+    if (waitingRoundId) {
+      return null
+    }
     for (let i = messageItems.length - 1; i >= 0; i--) {
       const item = messageItems[i]
       if (item.role === "assistant" && item.interactions && item.interactions.length > 0) {
@@ -960,7 +961,10 @@ export function TaskConversationPanel({
               currentInteractionRequestId={
                 state.currentTask?.status === "waiting_for_user" &&
                 state.currentTask.id === String(state.taskId)
-                  ? state.currentTask.waitingRequestId
+                  // The same round identity the form path uses - including
+                  // the ask-trace fallback - so a free-text reply after a
+                  // reload still binds to the round.
+                  ? waitingRoundId
                   : undefined
               }
               isLoading={

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -21,7 +21,7 @@ import { useI18n } from "@/contexts/i18n-context"
 import { isStreamingFinalAnswerMessage } from "@/lib/streaming-final-answer"
 import { getProcessGroupIndex, getUserTimelineAnchors } from "@/lib/task-timeline"
 import { resolveTraceProcessStatus } from "@/lib/trace-process-status"
-import { cn } from "@/lib/utils"
+import { cn, firstNonEmptyString } from "@/lib/utils"
 
 export type TaskConversationPanelMode = "page" | "embedded-preview"
 
@@ -484,8 +484,13 @@ export function TaskConversationPanel({
   // themselves (live/resume waiting task_info, replay task_info, replay
   // reassertion) - no client-side reconstruction. Undefined only for
   // backends predating the emission, where rounds stay unidentified.
+  // Gated on the task actually being the one on screen: during a task
+  // switch, currentTask can still describe the previous task while
+  // state.taskId already points at the new one (same guard as the
+  // ChatInput wiring below).
   const waitingRoundId =
     state.currentTask?.status === "waiting_for_user"
+    && state.currentTask.id === String(state.taskId)
       ? state.currentTask.waitingRequestId
       : undefined
 
@@ -839,7 +844,10 @@ export function TaskConversationPanel({
                         // submitting id-less.
                         interactionRequestId={
                           item.id === activeWaitingMessageId
-                            ? item.interactionRequestId ?? waitingRoundId
+                            ? firstNonEmptyString(
+                                item.interactionRequestId,
+                                waitingRoundId,
+                              )
                             : item.interactionRequestId
                         }
                         interactionsActive={item.id === activeWaitingMessageId}

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -21,7 +21,7 @@ import { useI18n } from "@/contexts/i18n-context"
 import { isStreamingFinalAnswerMessage } from "@/lib/streaming-final-answer"
 import { getProcessGroupIndex, getUserTimelineAnchors } from "@/lib/task-timeline"
 import { resolveTraceProcessStatus } from "@/lib/trace-process-status"
-import { cn, firstNonEmptyString } from "@/lib/utils"
+import { cn } from "@/lib/utils"
 
 export type TaskConversationPanelMode = "page" | "embedded-preview"
 
@@ -149,63 +149,6 @@ const findWaitingPrompt = (currentTask: any, traceEvents: any[]) => {
   }
 
   return null
-}
-
-// The waiting round's identity. Prefers the id the task-state handler
-// already extracted (request_id, falling back to the ask frame's event_id -
-// see the app context's task_waiting_for_user case); when the status frame
-// carried none, falls back to the replayed waiting result the prompt and
-// interactions also fall back to, so all three stay sourced from one ask.
-type WaitingRoundTraceEvent = {
-  event_type?: unknown
-  data?: {
-    result?: {
-      status?: unknown
-      request_id?: unknown
-      clarification_draft?: {
-        event_id?: unknown
-      }
-    }
-  }
-}
-
-const findWaitingRequestId = (
-  currentTask: { status?: unknown; waitingRequestId?: unknown } | null | undefined,
-  traceEvents: WaitingRoundTraceEvent[],
-): string | undefined => {
-  if (currentTask?.status !== "waiting_for_user") {
-    return undefined
-  }
-  if (
-    typeof currentTask.waitingRequestId === "string"
-    && currentTask.waitingRequestId
-  ) {
-    return currentTask.waitingRequestId
-  }
-
-  // Only react_task_end rows reach state.traceEvents for a waiting result
-  // (a live ask's agent_message lands in the transcript instead, already
-  // carrying its interactionRequestId), and the round identity on such a
-  // row lives at result.clarification_draft.event_id. A row's top-level
-  // event_id never counts: it is a client-minted placeholder, and adopting
-  // one would name a round no message ever carried. The scan STOPS at the
-  // most recent waiting result whether or not it yields an id - reaching
-  // past it could return an older round's id - and an id-less newest result
-  // returns undefined so the prompt-text match stays in charge.
-  for (let i = traceEvents.length - 1; i >= 0; i--) {
-    const event = traceEvents[i]
-    if (
-      event.event_type === "react_task_end"
-      && event.data?.result?.status === "waiting_for_user"
-    ) {
-      return firstNonEmptyString(
-        event.data?.result?.request_id,
-        event.data?.result?.clarification_draft?.event_id,
-      )
-    }
-  }
-
-  return undefined
 }
 
 const findWaitingInteractions = (currentTask: any, traceEvents: any[]) => {
@@ -537,13 +480,14 @@ export function TaskConversationPanel({
     () => findWaitingInteractions(state.currentTask, managerTraceEvents as any[]),
     [managerTraceEvents, state.currentTask]
   )
-  const waitingRoundId = useMemo(
-    () => findWaitingRequestId(
-      state.currentTask,
-      managerTraceEvents as WaitingRoundTraceEvent[],
-    ),
-    [managerTraceEvents, state.currentTask]
-  )
+  // The waiting round's identity, delivered on the task-state frames
+  // themselves (live/resume waiting task_info, replay task_info, replay
+  // reassertion) - no client-side reconstruction. Undefined only for
+  // backends predating the emission, where rounds stay unidentified.
+  const waitingRoundId =
+    state.currentTask?.status === "waiting_for_user"
+      ? state.currentTask.waitingRequestId
+      : undefined
 
   const activeWaitingMessageId = useMemo(() => {
     if (state.currentTask?.status !== "waiting_for_user") {
@@ -572,6 +516,16 @@ export function TaskConversationPanel({
       const normalizedPrompt = waitingPrompt.trim()
       for (let i = messageItems.length - 1; i >= 0; i--) {
         const item = messageItems[i]
+        // A row that carries its OWN round id different from the current
+        // round is a lookalike from an earlier ask - electing it would
+        // misbind the reply. Only id-less rows may be text-elected.
+        if (
+          waitingRoundId
+          && item.interactionRequestId
+          && item.interactionRequestId !== waitingRoundId
+        ) {
+          continue
+        }
         if (item.role === "assistant" && typeof item.content === "string" && item.content.trim() === normalizedPrompt) {
           return item.id
         }
@@ -878,7 +832,16 @@ export function TaskConversationPanel({
                         }
                         timestamp={item.timestamp}
                         interactions={item.interactions}
-                        interactionRequestId={item.interactionRequestId}
+                        // The active waiting item speaks for the current
+                        // round: when a replayed row carries no id of its
+                        // own, the resolved round id keeps its reply - and
+                        // the retry gate - bound to the ask instead of
+                        // submitting id-less.
+                        interactionRequestId={
+                          item.id === activeWaitingMessageId
+                            ? item.interactionRequestId ?? waitingRoundId
+                            : item.interactionRequestId
+                        }
                         interactionsActive={item.id === activeWaitingMessageId}
                         showEmptyStatus={item.showEmptyStatus}
                         contextBadges={item.role === "user" ? userMessageContextBadges : undefined}

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -6646,3 +6646,136 @@ describe("error frame display projection", () => {
     ).toEqual(expected)
   })
 })
+
+describe("clarification round identity (#1500)", () => {
+  beforeEach(() => {
+    webSocketOptions.current = null
+    webSocketOptions.all = []
+    sessionControls = null
+    wsHarness.isConnected = true
+    apiRequestMock.mockReset()
+    routerPushMock.mockReset()
+    sendRawMessageMock.mockReset()
+    sendRawMessageMock.mockReturnValue("sent")
+    sendChatMessageMock.mockReset()
+    sendChatMessageMock.mockResolvedValue({
+      client_message_id: "turn-optimistic",
+      turn_id: "turn-optimistic",
+    })
+    localStorage.clear()
+    ;(window as typeof window & { clearDuplicateMessageCache?: () => void })
+      .clearDuplicateMessageCache?.()
+  })
+
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+  })
+
+  it("adopts the ask frame's event_id as the waiting round id", async () => {
+    // No backend emits request_id; the stable per-ask identity is event_id.
+    // request_id stays the preferred field so a backend that later adopts
+    // the explicit name wins over the fallback.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+        event_id: "evt-round-1",
+        interactions: [
+          { type: "text", prompt: "Which region should I use?" },
+        ],
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("evt-round-1")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which hotel?",
+        request_id: "req-explicit",
+        event_id: "evt-round-2",
+        interactions: [
+          { type: "text", prompt: "Which hotel?" },
+        ],
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("req-explicit")
+    })
+  })
+
+  it("keeps a stale-versioned error notice without rolling back task state", async () => {
+    // The version guard protects task state, but an error frame's body is
+    // not versioned state: it carries a notice (and, since #2124, the
+    // structured terminal command outcome) the backend sends exactly once.
+    // A stale control tuple must lose the state argument yet keep the
+    // notice.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 6,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 5,
+        data: {
+          type: "agent_error",
+          message: "This message was not applied to the task.",
+          command_id: "client-msg-1",
+          command_kind: "message",
+          task: { id: 1, status: "failed" },
+        },
+      } as TestWebSocketMessage)
+    })
+
+    // The notice reaches the transcript; the stale status assertion does not.
+    await waitFor(() => {
+      expect(screen.getByTestId("messages").textContent).toContain(
+        "This message was not applied to the task."
+      )
+    })
+    expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+  })
+})

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -6722,6 +6722,35 @@ describe("clarification round identity (#1500)", () => {
     })
   })
 
+  it("falls back to event_id when request_id is an empty string", async () => {
+    // Nullish coalescing alone would let an empty request_id block the
+    // event_id fallback and leave the round id-less.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+        request_id: "",
+        event_id: "evt-round-3",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("evt-round-3")
+    })
+  })
+
   it("keeps a stale-versioned error notice without rolling back task state", async () => {
     // The version guard protects task state, but an error frame's body is
     // not versioned state: it carries a notice (and, since #2124, the

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -6751,6 +6751,184 @@ describe("clarification round identity (#1500)", () => {
     })
   })
 
+  it("keeps the round id across a same-question reassertion without an id", async () => {
+    // Reload/reconnect reassertion frames re-send the unchanged question
+    // with no id; wiping the id there severs the open round's correlation.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+        event_id: "evt-round-1",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("evt-round-1")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("evt-round-1")
+    })
+  })
+
+  it("clears the round id when an id-less frame asks a different question", async () => {
+    // A legacy-backend NEW round (different question, no id) must not
+    // inherit the previous round's id.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+        event_id: "evt-round-1",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("evt-round-1")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which hotel?",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("")
+    })
+  })
+
+  it("keeps a stale-versioned plain error notice without rolling back task state", async () => {
+    // The parallel "error"-type path shares the exemption with agent_error.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 6,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "error",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 5,
+        task: { id: 1, status: "failed" },
+        message: "Task pause is still being applied; please retry shortly.",
+        error_code: "task_pause_in_progress",
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("messages").textContent).toContain(
+        "clientErrors.taskPauseInProgress"
+      )
+    })
+    expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+  })
+
+  it("still drops a stale-versioned task_error frame whole", async () => {
+    // task_error's bubble is the turn's terminal result; it deliberately
+    // stays outside the stale-frame exemption, mirroring the guard's
+    // unversioned rule.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 6,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "task_error",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 5,
+        task: { id: 1, status: "failed" },
+        message: "stale terminal result",
+      } as TestWebSocketMessage)
+    })
+
+    // The whole frame is dropped: no bubble, no status change.
+    expect(screen.getByTestId("messages").textContent).not.toContain(
+      "stale terminal result"
+    )
+    expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+  })
+
   it("keeps a stale-versioned error notice without rolling back task state", async () => {
     // The version guard protects task state, but an error frame's body is
     // not versioned state: it carries a notice (and, since #2124, the

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -6672,10 +6672,12 @@ describe("clarification round identity (#1500)", () => {
     localStorage.clear()
   })
 
-  it("adopts the ask frame's event_id as the waiting round id", async () => {
-    // No backend emits request_id; the stable per-ask identity is event_id.
-    // request_id stays the preferred field so a backend that later adopts
-    // the explicit name wins over the fallback.
+  it("adopts the waiting frame's request_id as the round id", async () => {
+    // The waiting/reassert frames carry the round identity as request_id
+    // (backend #2232). They never emit event_id, so there is deliberately
+    // no event_id fallback on this handler - the ask frame's event_id is
+    // adopted in the agent_message trace reader instead. An empty-string
+    // request_id reads as no identity.
     render(
       <AppProvider token="token">
         <SeedRunningTask />
@@ -6693,14 +6695,14 @@ describe("clarification round identity (#1500)", () => {
         task_id: 1,
         task: { id: 1, status: "waiting_for_user" },
         message: "Which region should I use?",
-        event_id: "evt-round-1",
+        request_id: "req-round-1",
         interactions: [
           { type: "text", prompt: "Which region should I use?" },
         ],
       } as TestWebSocketMessage)
     })
     await waitFor(() => {
-      expect(screen.getByTestId("waiting-request-id").textContent).toBe("evt-round-1")
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("req-round-1")
     })
 
     act(() => {
@@ -6710,16 +6712,17 @@ describe("clarification round identity (#1500)", () => {
         task_id: 1,
         task: { id: 1, status: "waiting_for_user" },
         message: "Which hotel?",
-        request_id: "req-explicit",
-        event_id: "evt-round-2",
+        request_id: "",
+        event_id: "evt-never-adopted-here",
         interactions: [
           { type: "text", prompt: "Which hotel?" },
         ],
       } as TestWebSocketMessage)
     })
     await waitFor(() => {
-      expect(screen.getByTestId("waiting-request-id").textContent).toBe("req-explicit")
+      expect(screen.getByTestId("messages").textContent).toContain("Which hotel?")
     })
+    expect(screen.getByTestId("waiting-request-id").textContent).toBe("")
   })
 
   it("adopts the live ask's event_id onto the transcript message", async () => {
@@ -6791,7 +6794,7 @@ describe("clarification round identity (#1500)", () => {
         task_id: 1,
         task: { id: 1, status: "waiting_for_user" },
         message: "Which region should I use?",
-        event_id: "evt-live-round",
+        request_id: "evt-live-round",
       } as TestWebSocketMessage)
     })
     await waitFor(() => {
@@ -6867,35 +6870,6 @@ describe("clarification round identity (#1500)", () => {
     })
   })
 
-  it("falls back to event_id when request_id is an empty string", async () => {
-    // Nullish coalescing alone would let an empty request_id block the
-    // event_id fallback and leave the round id-less.
-    render(
-      <AppProvider token="token">
-        <SeedRunningTask />
-        <StateProbe />
-      </AppProvider>
-    )
-
-    const onMessage = webSocketOptions.current?.onMessage
-    expect(onMessage).toBeDefined()
-
-    act(() => {
-      onMessage?.({
-        type: "task_waiting_for_user",
-        timestamp: "2026-05-27T05:00:01Z",
-        task_id: 1,
-        task: { id: 1, status: "waiting_for_user" },
-        message: "Which region should I use?",
-        request_id: "",
-        event_id: "evt-round-3",
-      } as TestWebSocketMessage)
-    })
-    await waitFor(() => {
-      expect(screen.getByTestId("waiting-request-id").textContent).toBe("evt-round-3")
-    })
-  })
-
   it("keeps the round id across a same-question reassertion without an id", async () => {
     // Reload/reconnect reassertion frames re-send the unchanged question
     // with no id; wiping the id there severs the open round's correlation.
@@ -6916,7 +6890,7 @@ describe("clarification round identity (#1500)", () => {
         task_id: 1,
         task: { id: 1, status: "waiting_for_user" },
         message: "Which region should I use?",
-        event_id: "evt-round-1",
+        request_id: "evt-round-1",
       } as TestWebSocketMessage)
     })
     await waitFor(() => {
@@ -6957,7 +6931,7 @@ describe("clarification round identity (#1500)", () => {
         task_id: 1,
         task: { id: 1, status: "waiting_for_user" },
         message: "Which region should I use?",
-        event_id: "evt-round-1",
+        request_id: "evt-round-1",
       } as TestWebSocketMessage)
     })
     await waitFor(() => {
@@ -6975,6 +6949,58 @@ describe("clarification round identity (#1500)", () => {
     })
     await waitFor(() => {
       expect(screen.getByTestId("waiting-request-id").textContent).toBe("")
+    })
+  })
+
+  it("adds one bubble for a duplicated terminal command frame", async () => {
+    // A terminal agent_error carries a durable identity (command_id +
+    // outcome_version); a duplicated delivery of the SAME broadcast must
+    // not add a second bubble, while two DISTINCT commands failing with
+    // identical text must both stay visible (identity-keyed, never
+    // text-keyed).
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    const terminalFrame = (commandId: string) => ({
+      type: "agent_error",
+      timestamp: "2026-05-27T05:00:02Z",
+      task_id: 1,
+      data: {
+        type: "agent_error",
+        message: "This message was not applied to the task.",
+        command_id: commandId,
+        command_kind: "message",
+        outcome: "failed",
+        outcome_version: 1,
+        resend_safe: true,
+      },
+    }) as TestWebSocketMessage
+
+    act(() => {
+      onMessage?.(terminalFrame("cmd-dup"))
+    })
+    act(() => {
+      onMessage?.(terminalFrame("cmd-dup"))
+    })
+    act(() => {
+      onMessage?.(terminalFrame("cmd-other"))
+    })
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ content: string }>
+      const bubbles = messages.filter((m) =>
+        m.content.includes("This message was not applied to the task.")
+      )
+      expect(bubbles).toHaveLength(2)
     })
   })
 

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -6722,6 +6722,151 @@ describe("clarification round identity (#1500)", () => {
     })
   })
 
+  it("adopts the live ask's event_id onto the transcript message", async () => {
+    // The one adoption site production always exercises: a live ask arrives
+    // as an agent_message trace event whose data.event_id is the round id,
+    // and the transcript message it produces must carry it as
+    // interactionRequestId.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        data: {
+          event_id: "trace-row-1",
+          event_type: "agent_message",
+          data: {
+            message: "Which region should I use?",
+            expect_response: true,
+            event_id: "evt-live-ask",
+            metadata: {
+              interactions: [
+                { type: "text_input", field: "region", label: "Region" },
+              ],
+            },
+          },
+        },
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ content: string; interactionRequestId?: string }>
+      const ask = messages.find(
+        (m) => m.content === "Which region should I use?"
+      )
+      expect(ask?.interactionRequestId).toBe("evt-live-ask")
+    })
+  })
+
+  it("keeps a held round id when an id-less waiting task_info arrives", async () => {
+    // A backend predating the emission sends waiting task_info frames with
+    // no request_id; SET_CURRENT_TASK's merge must not wipe the id the
+    // waiting handler already extracted for the open round.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+        event_id: "evt-live-round",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe(
+        "evt-live-round"
+      )
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        data: {
+          event_id: "task-info-row-2",
+          event_type: "task_info",
+          data: {
+            id: 1,
+            title: "Task",
+            description: "Task",
+            status: "waiting_for_user",
+          },
+        },
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe(
+        "waiting_for_user"
+      )
+    })
+    expect(screen.getByTestId("waiting-request-id").textContent).toBe(
+      "evt-live-round"
+    )
+  })
+
+  it("adopts the waiting task_info frame's request_id as the round id", async () => {
+    // The replay/live waiting task_info now carries request_id; the task
+    // shaping must surface it as waitingRequestId.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        data: {
+          event_id: "task-info-row",
+          event_type: "task_info",
+          data: {
+            id: 1,
+            title: "Task",
+            description: "Task",
+            status: "waiting_for_user",
+            request_id: "evt-info-round",
+          },
+        },
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe(
+        "evt-info-round"
+      )
+    })
+  })
+
   it("falls back to event_id when request_id is an empty string", async () => {
     // Nullish coalescing alone would let an empty request_id block the
     // event_id fallback and leave the round id-less.

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -2864,6 +2864,16 @@ export function AppProvider({
     }
 
     const controlEnvelope = extractTaskControlEnvelope(message)
+    // A stale-versioned error frame must not roll task state back, but its
+    // body is not versioned state: it carries the error notice - and, since
+    // #2124, the structured terminal command outcome - which the backend
+    // sends exactly once. Dropping the whole frame silences that notice
+    // forever, so error frames fall through with their control tuple
+    // neutralized (this flag suppresses every status side effect below)
+    // instead of being swallowed. This extends the same reasoning
+    // ``canAcceptTaskControlVersion`` already applies to UNversioned error
+    // frames ("error frames remain informational") to versioned ones.
+    let staleControlErrorFrame = false
     if (controlEnvelope.isStateEvent && controlEnvelope.taskId !== undefined) {
       if (
         !acceptTaskControlVersion(
@@ -2871,13 +2881,16 @@ export function AppProvider({
           controlEnvelope,
           taskStateVersionsRef.current,
         )
-      ) return
+      ) {
+        if (message.type !== "error" && message.type !== "agent_error") return
+        staleControlErrorFrame = true
+      }
 
       // A late event may have an old semantic type (for example
       // ``task_paused``) after a newer run is already RUNNING. The backend
       // rewrites its state tuple to the canonical row; apply only that tuple
       // and skip the stale event-specific side effects.
-      if (!taskEventMatchesControlState(message, controlEnvelope)) {
+      if (!staleControlErrorFrame && !taskEventMatchesControlState(message, controlEnvelope)) {
         if (controlEnvelope.status) {
           dispatch({
             type: "UPDATE_TASK_STATUS",
@@ -3198,9 +3211,19 @@ export function AppProvider({
               return
             }
             const interactions = normalizeInteractions(eventData.metadata?.interactions)
-            const interactionRequestId = typeof eventData.request_id === "string"
-              ? eventData.request_id
-              : undefined
+            // The round identity: no backend emits ``request_id`` today - the
+            // stable per-ask id the runtime mints and every ask frame carries
+            // is ``event_id`` (see core/agent/clarification.py: "event_id is
+            // the clarification's stable identity"). ``request_id`` stays the
+            // preferred field so a backend that later adopts the explicit
+            // name wins over the fallback.
+            const interactionRequestId =
+              (typeof eventData.request_id === "string" && eventData.request_id
+                ? eventData.request_id
+                : undefined)
+              ?? (typeof eventData.event_id === "string" && eventData.event_id
+                ? eventData.event_id
+                : undefined)
             const isAgentMessage = eventType === "agent_message"
             const isAiMessage = eventType === "ai_message"
             const expectsUserResponse =
@@ -5685,10 +5708,15 @@ export function AppProvider({
         const interactions = normalizeInteractions(
           waitingRoot.interactions ?? waitingData.interactions
         )
+        // ``request_id`` first (the explicit name, if a backend ever emits
+        // it), then ``event_id`` - the stable per-ask identity the runtime
+        // actually mints and forwards on ask frames today.
         const waitingRequestIdValue = waitingRoot.request_id ?? waitingData.request_id
-        const waitingRequestId = typeof waitingRequestIdValue === "string"
-          ? waitingRequestIdValue
-          : undefined
+          ?? waitingRoot.event_id ?? waitingData.event_id
+        const waitingRequestId =
+          typeof waitingRequestIdValue === "string" && waitingRequestIdValue
+            ? waitingRequestIdValue
+            : undefined
         dispatch({
           type: "UPDATE_TASK_STATUS",
           payload: {
@@ -5747,7 +5775,11 @@ export function AppProvider({
         const agentErrorMessage = agentErrorCode
           ? t(clientErrorTranslationKey(agentErrorCode))
           : getWebSocketErrorMessage(message, trustLegacyErrorProse)
-        const agentErrorTaskStatus = getWebSocketTaskStatus(message)
+        // A stale-versioned frame keeps its notice but asserts nothing about
+        // task state - its control tuple lost to a newer version above.
+        const agentErrorTaskStatus = staleControlErrorFrame
+          ? null
+          : getWebSocketTaskStatus(message)
 
         if (agentErrorTaskStatus) {
           dispatch({
@@ -5796,11 +5828,17 @@ export function AppProvider({
           controlEnvelope,
         })
 
-        if (errorFrame.taskStatus) {
+        // Stale-versioned "error" frames keep their notice but assert
+        // nothing about task state (see staleControlErrorFrame above).
+        // task_error deliberately stays outside that exemption - its bubble
+        // IS the turn's terminal result, mirroring the unversioned rule in
+        // canAcceptTaskControlVersion - so for task_error this guard is
+        // vacuously true.
+        if (errorFrame.taskStatus && !staleControlErrorFrame) {
           dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: errorFrame.taskStatus } })
           dispatch({ type: "TRIGGER_TASK_UPDATE" })
         }
-        if (errorFrame.stopsProcessing) {
+        if (errorFrame.stopsProcessing && !staleControlErrorFrame) {
           dispatch({ type: "SET_PROCESSING", payload: false })
         }
 

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -3216,14 +3216,12 @@ export function AppProvider({
             // is ``event_id`` (see core/agent/clarification.py: "event_id is
             // the clarification's stable identity"). ``request_id`` stays the
             // preferred field so a backend that later adopts the explicit
-            // name wins over the fallback.
-            const interactionRequestId =
-              (typeof eventData.request_id === "string" && eventData.request_id
-                ? eventData.request_id
-                : undefined)
-              ?? (typeof eventData.event_id === "string" && eventData.event_id
-                ? eventData.event_id
-                : undefined)
+            // name wins over the fallback - but only with a non-empty
+            // string; anything else falls through to the next candidate.
+            const interactionRequestId = [
+              eventData.request_id,
+              eventData.event_id,
+            ].find((id): id is string => typeof id === "string" && id !== "")
             const isAgentMessage = eventType === "agent_message"
             const isAiMessage = eventType === "ai_message"
             const expectsUserResponse =
@@ -5710,13 +5708,15 @@ export function AppProvider({
         )
         // ``request_id`` first (the explicit name, if a backend ever emits
         // it), then ``event_id`` - the stable per-ask identity the runtime
-        // actually mints and forwards on ask frames today.
-        const waitingRequestIdValue = waitingRoot.request_id ?? waitingData.request_id
-          ?? waitingRoot.event_id ?? waitingData.event_id
-        const waitingRequestId =
-          typeof waitingRequestIdValue === "string" && waitingRequestIdValue
-            ? waitingRequestIdValue
-            : undefined
+        // actually mints and forwards on ask frames today. First non-empty
+        // string wins: nullish coalescing alone would let an empty or
+        // non-string ``request_id`` block the ``event_id`` fallback.
+        const waitingRequestId = [
+          waitingRoot.request_id,
+          waitingData.request_id,
+          waitingRoot.event_id,
+          waitingData.event_id,
+        ].find((id): id is string => typeof id === "string" && id !== "")
         dispatch({
           type: "UPDATE_TASK_STATUS",
           payload: {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -354,7 +354,7 @@ import {
   type WebSocketConnection,
   type WebSocketConnectionFailure,
 } from "@/hooks/use-websocket"
-import { generateClientMessageId, getApiUrl, getUploadApiUrl, shouldAutoOpenTaskPreview } from "@/lib/utils"
+import { generateClientMessageId, getApiUrl, getUploadApiUrl, shouldAutoOpenTaskPreview, firstNonEmptyString } from "@/lib/utils"
 import { apiRequest, classifyUploadError, getApiErrorMessage, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper"
 import { clientErrorTranslationKey, readClientErrorCode } from "@/lib/client-errors"
 import { normalizeUploadFileIds } from "@/lib/upload-file-ids"
@@ -1609,8 +1609,19 @@ function projectAppState(state: AppState, action: AppAction): AppState {
             : undefined,
           waitingRequestId: isWaitingForUser
             ? action.payload.waitingRequestId ?? (
-              action.payload.waitingQuestion === undefined
-              && action.payload.waitingInteractions === undefined
+              // An id-less payload keeps the known id when it asserts
+              // nothing new - and also when it re-asserts the SAME question
+              // text: reload/reconnect reassertion frames re-send the
+              // unchanged question with no id, and wiping the id there
+              // severs the open round's correlation. An id-less payload
+              // carrying a DIFFERENT question (or fresh interactions
+              // without one) is a legacy-backend new round and must not
+              // inherit the previous round's id.
+              (action.payload.waitingQuestion === undefined
+                && action.payload.waitingInteractions === undefined)
+              || (action.payload.waitingQuestion !== undefined
+                && action.payload.waitingQuestion
+                  === state.currentTask.waitingQuestion)
                 ? state.currentTask.waitingRequestId
                 : undefined
             )
@@ -2870,9 +2881,10 @@ export function AppProvider({
     // sends exactly once. Dropping the whole frame silences that notice
     // forever, so error frames fall through with their control tuple
     // neutralized (this flag suppresses every status side effect below)
-    // instead of being swallowed. This extends the same reasoning
-    // ``canAcceptTaskControlVersion`` already applies to UNversioned error
-    // frames ("error frames remain informational") to versioned ones.
+    // instead of being swallowed. Weaker than the guard's UNversioned-error
+    // rule, deliberately: an unversioned error frame has no version to lose
+    // and passes whole, control tuple included; a stale VERSIONED one lost
+    // the version argument and keeps only its notice.
     let staleControlErrorFrame = false
     if (controlEnvelope.isStateEvent && controlEnvelope.taskId !== undefined) {
       if (
@@ -3218,10 +3230,10 @@ export function AppProvider({
             // preferred field so a backend that later adopts the explicit
             // name wins over the fallback - but only with a non-empty
             // string; anything else falls through to the next candidate.
-            const interactionRequestId = [
+            const interactionRequestId = firstNonEmptyString(
               eventData.request_id,
               eventData.event_id,
-            ].find((id): id is string => typeof id === "string" && id !== "")
+            )
             const isAgentMessage = eventType === "agent_message"
             const isAiMessage = eventType === "ai_message"
             const expectsUserResponse =
@@ -5711,12 +5723,12 @@ export function AppProvider({
         // actually mints and forwards on ask frames today. First non-empty
         // string wins: nullish coalescing alone would let an empty or
         // non-string ``request_id`` block the ``event_id`` fallback.
-        const waitingRequestId = [
+        const waitingRequestId = firstNonEmptyString(
           waitingRoot.request_id,
           waitingData.request_id,
           waitingRoot.event_id,
           waitingData.event_id,
-        ].find((id): id is string => typeof id === "string" && id !== "")
+        )
         dispatch({
           type: "UPDATE_TASK_STATUS",
           payload: {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -5727,16 +5727,15 @@ export function AppProvider({
         const interactions = normalizeInteractions(
           waitingRoot.interactions ?? waitingData.interactions
         )
-        // ``request_id`` first (the explicit name, if a backend ever emits
-        // it), then ``event_id`` - the stable per-ask identity the runtime
-        // actually mints and forwards on ask frames today. First non-empty
-        // string wins: nullish coalescing alone would let an empty or
-        // non-string ``request_id`` block the ``event_id`` fallback.
+        // ``request_id`` only: the waiting/reassert frames' emitters carry
+        // the round identity under that explicit name (backend #2232) and
+        // never emit ``event_id`` - an event_id fallback here would be dead
+        // code testable only with hand-crafted frames. The ask frame's
+        // ``event_id`` is adopted where it genuinely lives, in the
+        // agent_message trace reader.
         const waitingRequestId = firstNonEmptyString(
           waitingRoot.request_id,
           waitingData.request_id,
-          waitingRoot.event_id,
-          waitingData.event_id,
         )
         dispatch({
           type: "UPDATE_TASK_STATUS",
@@ -5828,16 +5827,38 @@ export function AppProvider({
           dispatch({ type: "SET_PROCESSING", payload: false })
         }
 
-        dispatch({
-          type: "ADD_MESSAGE",
-          payload: {
-            id: generateMessageId("msg"),
-            role: "assistant",
-            content: `${t('agent.logs.event.messages.errorPrefix')} ${agentErrorMessage || t('common.errors.unknown')}`,
-            timestamp: message.timestamp,
-            status: "failed",
-          },
-        })
+        const agentErrorData = asMessageRecord(message.data)
+        // A terminal command frame carries a durable identity
+        // (command_id, disambiguated by outcome_version): a duplicated
+        // delivery of the SAME terminal broadcast must not add a second
+        // bubble. Identity-keyed only - never text-keyed - so two distinct
+        // commands failing with identical redacted text both stay visible.
+        const agentErrorOccurrence =
+          typeof agentErrorData.command_id === "string"
+          && agentErrorData.command_id
+            ? `${agentErrorData.command_id}:${String(
+                agentErrorData.outcome_version ?? "",
+              )}`
+            : undefined
+        if (
+          agentErrorOccurrence === undefined
+          || !isDuplicateMessageForViewedTask(
+            agentErrorMessage || "",
+            "agent-error-command",
+            agentErrorOccurrence,
+          )
+        ) {
+          dispatch({
+            type: "ADD_MESSAGE",
+            payload: {
+              id: generateMessageId("msg"),
+              role: "assistant",
+              content: `${t('agent.logs.event.messages.errorPrefix')} ${agentErrorMessage || t('common.errors.unknown')}`,
+              timestamp: message.timestamp,
+              status: "failed",
+            },
+          })
+        }
         break
 
       case "error":

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -890,6 +890,15 @@ const taskFromTaskInfoData = (
   runtimeExtensionBindings: getStringArray(taskData.runtime_extension_bindings),
   waitingQuestion: taskData.waiting_question as string | undefined,
   waitingInteractions: normalizeInteractions(taskData.waiting_interactions),
+  // The waiting round's identity, emitted on waiting task_info frames
+  // (live, resume, and replay) so a reply binds to the exact ask (#1500).
+  // Key present only when the frame carries one: an explicit undefined
+  // would let SET_CURRENT_TASK's merge wipe an id the waiting handler
+  // already holds when an id-less task_info (a backend predating the
+  // emission) arrives mid-round.
+  ...(firstNonEmptyString(taskData.request_id) !== undefined
+    ? { waitingRequestId: firstNonEmptyString(taskData.request_id) }
+    : {}),
   runId: taskData.run_id as string | null | undefined,
   stateVersion: parseInteger(taskData.state_version),
   controlState: taskData.control_state as TaskControlState | undefined,

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { resolveAgentLogoUrl } from "./utils"
+import { firstNonEmptyString, resolveAgentLogoUrl } from "./utils"
 
 const bigintValue = (globalThis as { BigInt: (value: number) => bigint }).BigInt(1)
 
@@ -173,5 +173,16 @@ describe("resolveAgentLogoUrl", () => {
     expect(resolveAgentLogoUrl("https://assets.example/logo.png", "\u0000invalid")).toBe(
       "https://assets.example/logo.png",
     )
+  })
+})
+
+describe("firstNonEmptyString", () => {
+  it("returns the first non-empty string candidate", () => {
+    expect(firstNonEmptyString(undefined, null, "", 0, "id-1", "id-2")).toBe("id-1")
+  })
+
+  it("skips non-string and empty values entirely", () => {
+    expect(firstNonEmptyString(null, 42, {}, [], "")).toBeUndefined()
+    expect(firstNonEmptyString()).toBeUndefined()
   })
 })

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -5,6 +5,20 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+/**
+ * First candidate that is a non-empty string. Shared by the clarification
+ * round-id extraction sites: nullish coalescing alone would let an empty or
+ * non-string preferred field block the fallback candidates.
+ */
+export function firstNonEmptyString(
+  ...candidates: unknown[]
+): string | undefined {
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate !== "") return candidate
+  }
+  return undefined
+}
+
 export function generateClientMessageId(): string {
   return globalThis.crypto?.randomUUID?.()
     ?? `msg-${Date.now()}-${Math.random().toString(36).slice(2)}`


### PR DESCRIPTION
## Summary

Part 1 of the #1500 re-slice agreed after review round 3 on #2126: before the retry gate can work, clarification rounds need an identity that actually exists on the wire.

- **Round identity (round-3 finding F1)**: the frontend's entire `request_id` plumbing predates this PR and had never been fed by a real backend frame. Each read surface now reads the identity where it genuinely lives: the `agent_message` trace reader adopts the ask frame's `data.event_id` (`core/agent/clarification.py`: "event_id is the clarification's stable identity" — the one field production always carried), while the `task_waiting_for_user` handler and the `task_info` shaping read `request_id`, the explicit field the companion backend PR #2232 emits on waiting/reassert frames. No client-side reconstruction remains.
- **Version-guard exemption for error notices (round-3 finding F3)**: `canAcceptTaskControlVersion` dropped stale-versioned `error`/`agent_error` frames whole, silencing a notice — and, since #2124, the structured terminal command outcome — that the backend sends exactly once. Stale error frames now fall through with their control tuple neutralized: every status side effect is suppressed, the notice keeps flowing. This extends the guard's own documented rule for unversioned error frames ("error frames remain informational") to versioned ones. Differentially verified: the regression test fails on the unfixed code. `task_error` deliberately stays outside the exemption, mirroring the unversioned rule — its bubble is the turn's terminal result.
- **At most one active instance per round (round-3 finding F6)**: `activeWaitingMessageId` matched by prompt-text equality, so the persisted timeline message and the virtual waiting message could be simultaneously active for one round (reachable in the window where an optimistic user message is the last item while the task still waits). With a round id present, activeness is keyed by it, and the virtual copy stays inert whenever a timeline message owns the round.

## Scope

- **Round 3 changed this PR's shape**: client-side reconstruction of the round id was shown to be unworkable (the waiting frames carried no id, chat-history rows carry none, and `public_trace_events` strips `clarification_draft` for every audience), so the trace-archaeology fallback machinery was deleted and the id is now read directly off the frames. The companion backend PR #2232 emits `request_id` on the waiting `task_info` and replay reassertion frames; this PR consumes it (`request_id ?? event_id`, so the explicit field wins wherever emitted) and degrades to today's ungated behavior against a backend without it.
- The live ask's transcript identity (the `agent_message` trace event's `data.event_id`) is the one adoption site production always exercised; it now has its own test.
- The retry-gating layer that consumes this identity is the follow-up PR (stacked on this one); #1500's acceptance criteria are closed there.

## Verification

- New regression tests: event_id adoption + request_id precedence (context), stale-versioned error notice kept without status rollback (context; fails on the unfixed code), single-active instance, round-id-beats-text-lookalike, and never adopting a client-minted trace id (panel).
- Full frontend vitest suite passes (exit 0); tsc clean; zero eslint issues on added lines (line-level intersection against the base).
