### PR TITLE
fix(frontend): gate clarification retries on structured terminal command outcomes

### DIFF
--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -907,10 +907,14 @@ describe("ClarificationForm blank option filtering", () => {
 describe("ClarificationForm terminal command outcomes", () => {
   // Issue #1500: after a reply is durably accepted, its command can still
   // reach a terminal disposition before a turn is established. Whether the
-  // form may invite a resend is decided by the structured outcome the
-  // backend broadcasts for that exact command, never by task state alone.
-  // The accountable submission lives in context keyed by request id, so the
-  // gate survives the submitting component instance being replaced.
+  // form may invite a resend is decided by the structured outcomes the
+  // backend broadcasts for the round's tracked commands, never by task
+  // state alone. The accountable submissions live in context keyed by
+  // request id - an ordered list, so a resubmit after an ack timeout does
+  // not orphan the earlier command's outcome - and the gate survives the
+  // submitting component instance being replaced.
+  const ROUND = "inputreq_r1"
+
   beforeEach(() => {
     appContextMock.dispatch.mockReset()
     appContextMock.filesDisabled = false
@@ -922,11 +926,10 @@ describe("ClarificationForm terminal command outcomes", () => {
   })
 
   afterEach(() => {
-    appContextMock.state = { commandOutcomes: {}, clarificationSubmissions: {} }
     cleanup()
   })
 
-  const form = (active: boolean, requestId = "inputreq_r1") => (
+  const form = (active: boolean, requestId = ROUND) => (
     <ClarificationForm
       interactions={[{ type: "text_input" as const, field: "city", label: "City" }]}
       requestId={requestId}
@@ -937,56 +940,75 @@ describe("ClarificationForm terminal command outcomes", () => {
   const submitButton = () =>
     screen.queryByRole("button", { name: "chatPage.clarification.submit" })
 
+  // Mirrors the reducer: RECORD appends to the round's list.
+  const recordedSubmissions = () =>
+    appContextMock.dispatch.mock.calls
+      .map(([action]) => action)
+      .filter((action) => action?.type === "RECORD_CLARIFICATION_SUBMISSION")
+      .map((action) => action.payload as {
+        requestId: string
+        commandId: string
+        accepted: boolean
+      })
+
+  const mirrorSubmissions = () => {
+    appContextMock.state = {
+      ...appContextMock.state,
+      clarificationSubmissions: {
+        [ROUND]: recordedSubmissions().map(({ commandId, accepted }) => ({
+          commandId,
+          accepted,
+        })),
+      },
+    }
+  }
+
   // Drives one accepted submission and mirrors the RECORD dispatch into the
   // mock context state, the way the real reducer would.
-  const submitAccepted = async (requestId = "inputreq_r1") => {
+  const submitAccepted = async () => {
     fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
     fireEvent.click(
       screen.getByRole("button", { name: "chatPage.clarification.submit" }),
     )
-    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(1))
-    // Accepted submissions collapse the form.
-    await waitFor(() => expect(screen.queryByRole("textbox")).toBeNull())
-    const record = appContextMock.dispatch.mock.calls
-      .map(([action]) => action)
-      .find((action) => action?.type === "RECORD_CLARIFICATION_SUBMISSION")
+    await waitFor(() =>
+      expect(appContextMock.sendMessage).toHaveBeenCalledTimes(
+        recordedSubmissions().length,
+      ),
+    )
+    const record = recordedSubmissions().at(-1)
     expect(record).toEqual({
-      type: "RECORD_CLARIFICATION_SUBMISSION",
-      payload: { requestId, commandId: expect.any(String), accepted: true },
+      requestId: ROUND,
+      commandId: expect.any(String),
+      accepted: true,
     })
     // The recorded command id is the client message id the delivery used.
-    const config = appContextMock.sendMessage.mock.calls[0][1] as {
+    const config = appContextMock.sendMessage.mock.lastCall?.[1] as {
       clientMessageId?: string
     }
-    expect(record.payload.commandId).toBe(config.clientMessageId)
-    appContextMock.state = {
-      ...appContextMock.state,
-      clarificationSubmissions: {
-        [requestId]: { commandId: record.payload.commandId, accepted: true },
-      },
-    }
-    return record.payload.commandId as string
+    expect(record!.commandId).toBe(config.clientMessageId)
+    mirrorSubmissions()
+    return record!.commandId
   }
 
-  const withOutcome = (commandId: string, resendSafe: boolean) => {
+  const withOutcomes = (outcomes: Record<string, boolean>) => {
     appContextMock.state = {
       ...appContextMock.state,
-      commandOutcomes: {
-        [commandId]: {
-          outcome: "failed",
-          resendSafe,
-          messageCode: "task_command_deferred",
-        },
-      },
+      commandOutcomes: Object.fromEntries(
+        Object.entries(outcomes).map(([commandId, resendSafe]) => [
+          commandId,
+          { resendSafe },
+        ]),
+      ),
     }
   }
 
   it("reactivates the form and preserves the draft when the outcome proves retry safe", async () => {
     const { rerender } = render(form(true))
     const commandId = await submitAccepted()
+    await waitFor(() => expect(screen.queryByRole("textbox")).toBeNull())
 
     rerender(form(false))
-    withOutcome(commandId, true)
+    withOutcomes({ [commandId]: true })
     rerender(form(true))
 
     await waitFor(() => expect(submitButton()).toBeEnabled())
@@ -997,16 +1019,17 @@ describe("ClarificationForm terminal command outcomes", () => {
     // The record is consumed so the resend is armed exactly once.
     expect(appContextMock.dispatch).toHaveBeenCalledWith({
       type: "CLEAR_CLARIFICATION_SUBMISSION",
-      payload: { requestId: "inputreq_r1" },
+      payload: { requestId: ROUND },
     })
   })
 
   it("keeps the form locked and surfaces the ambiguity when the outcome is not proven safe", async () => {
     const { rerender } = render(form(true))
     const commandId = await submitAccepted()
+    await waitFor(() => expect(screen.queryByRole("textbox")).toBeNull())
 
     rerender(form(false))
-    withOutcome(commandId, false)
+    withOutcomes({ [commandId]: false })
     rerender(form(true))
 
     // The notice is visible, the draft is intact, and nothing invites a
@@ -1017,32 +1040,46 @@ describe("ClarificationForm terminal command outcomes", () => {
     expect(submitButton()).toBeDisabled()
   })
 
-  it("does not reactivate while the accepted reply has no terminal outcome yet", async () => {
+  it("locks and explains a reasserted round whose accepted reply is still in flight", async () => {
     const { rerender } = render(form(true))
     await submitAccepted()
+    await waitFor(() => expect(screen.queryByRole("textbox")).toBeNull())
 
     rerender(form(false))
     rerender(form(true))
 
-    // No outcome means the command may still be in flight: the form stays
-    // collapsed instead of inviting a duplicate.
-    expect(screen.queryByRole("textbox")).toBeNull()
-    expect(submitButton()).toBeNull()
+    // No outcome means the command may still be in flight: the form opens
+    // to explain the lock instead of showing a bare greyed-out button, and
+    // nothing invites a duplicate.
+    expect(
+      await screen.findByText("chatPage.clarification.replyPending"),
+    ).toBeInTheDocument()
+    expect(submitButton()).toBeDisabled()
   })
 
   it("is not reopened by a late terminal event after a turn is established", async () => {
     const { rerender } = render(form(true))
     const commandId = await submitAccepted()
+    await waitFor(() => expect(screen.queryByRole("textbox")).toBeNull())
 
     rerender(form(false))
     // The turn was established, the task is running, and only then does a
     // stale resend-safe terminal frame arrive: with the task not waiting,
     // nothing may reopen the submitted form.
-    withOutcome(commandId, true)
+    withOutcomes({ [commandId]: true })
     rerender(form(false))
 
     expect(screen.queryByRole("textbox")).toBeNull()
     expect(submitButton()).toBeNull()
+
+    // Only an authoritative return to waiting_for_user consumes the
+    // outcome and reactivates the form - this is the resend-safe branch
+    // actually running, so the test fails if the gating logic is removed.
+    rerender(form(true))
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    expect(
+      screen.getByText("chatPage.clarification.replyNotApplied"),
+    ).toBeInTheDocument()
   })
 
   it("gates a fresh component instance for a round another instance submitted", async () => {
@@ -1053,7 +1090,7 @@ describe("ClarificationForm terminal command outcomes", () => {
     const commandId = await submitAccepted()
     cleanup()
 
-    withOutcome(commandId, false)
+    withOutcomes({ [commandId]: false })
     render(form(true))
 
     const alert = await screen.findByRole("alert")
@@ -1072,14 +1109,17 @@ describe("ClarificationForm terminal command outcomes", () => {
 
     render(form(true))
 
-    expect(submitButton()).toBeDisabled()
+    await waitFor(() => expect(submitButton()).toBeDisabled())
+    expect(
+      screen.getByText("chatPage.clarification.replyPending"),
+    ).toBeInTheDocument()
   })
 
   it("does not lock a fresh instance for an unconfirmed ack-timeout delivery", async () => {
     appContextMock.state = {
       commandOutcomes: {},
       clarificationSubmissions: {
-        inputreq_r1: { commandId: "maybe-sent", accepted: false },
+        [ROUND]: [{ commandId: "maybe-sent", accepted: false }],
       },
     }
     render(form(true))
@@ -1087,6 +1127,144 @@ describe("ClarificationForm terminal command outcomes", () => {
     // The reply may never have been accepted at all: the composer keeps its
     // advisory retry until a terminal outcome for the command arrives.
     await waitFor(() => expect(submitButton()).toBeEnabled())
+  })
+
+  it("still surfaces an earlier command's unsafe outcome after a resubmit", async () => {
+    // The orphaned-outcome regression: an ack-timeout records command 1,
+    // the advisory retry sends command 2, and only then does command 1's
+    // terminal outcome arrive saying it may have been committed. The round
+    // must still lock and surface the ambiguity - a single-slot record
+    // would have overwritten command 1 and shown nothing.
+    appContextMock.sendMessage.mockRejectedValueOnce(Object.assign(
+      new Error("ack timed out"),
+      { disposition: "outcome_unknown", userFacing: true },
+    ))
+    const { rerender } = render(form(true))
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    await waitFor(() => expect(recordedSubmissions()).toHaveLength(1))
+    expect(recordedSubmissions()[0].accepted).toBe(false)
+    mirrorSubmissions()
+
+    // The advisory retry resubmits; the second record appends.
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    await waitFor(() => expect(recordedSubmissions()).toHaveLength(2))
+    mirrorSubmissions()
+    const [first, second] = recordedSubmissions()
+    expect(first.commandId).not.toBe(second.commandId)
+
+    withOutcomes({ [first.commandId]: false })
+    rerender(form(true))
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("chatPage.clarification.replyOutcomeUnknown")
+    expect(submitButton()).toBeDisabled()
+  })
+
+  it("withholds the proven-safe unlock notice while an unconfirmed reply is unresolved", async () => {
+    // Command 1's fate is unknown (ack timeout, no outcome); command 2 is
+    // proven not applied. The round returns to the advisory stance it
+    // already accepted for command 1 - but without the "not applied, safe
+    // to resend" promise, which cannot be made for command 1, and without
+    // consuming the record, so command 1's late outcome still gates.
+    appContextMock.state = {
+      commandOutcomes: { "cmd-2": { resendSafe: true } },
+      clarificationSubmissions: {
+        [ROUND]: [
+          { commandId: "cmd-1", accepted: false },
+          { commandId: "cmd-2", accepted: true },
+        ],
+      },
+    }
+    render(form(true))
+
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    expect(
+      screen.queryByText("chatPage.clarification.replyNotApplied"),
+    ).toBeNull()
+    expect(appContextMock.dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "CLEAR_CLARIFICATION_SUBMISSION" }),
+    )
+  })
+
+  it("returns a pending-locked instance to advisory once its accepted reply is proven not applied", async () => {
+    // The submitting instance's sequence: ack timeout (cmd 1) -> advisory
+    // resubmit accepted (cmd 2) -> pending lock -> cmd 2's outcome proves
+    // it was not applied while cmd 1 stays unresolved. The pending notice
+    // is now false and the lock has no exit, so the round returns to the
+    // advisory stance instead of diverging from a freshly mounted instance.
+    appContextMock.sendMessage.mockRejectedValueOnce(Object.assign(
+      new Error("ack timed out"),
+      { disposition: "outcome_unknown", userFacing: true },
+    ))
+    const { rerender } = render(form(true))
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    await waitFor(() => expect(recordedSubmissions()).toHaveLength(1))
+    mirrorSubmissions()
+
+    // Advisory resubmit succeeds and the accepted reply goes pending.
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    await waitFor(() => expect(recordedSubmissions()).toHaveLength(2))
+    mirrorSubmissions()
+    rerender(form(true))
+    expect(
+      await screen.findByText("chatPage.clarification.replyPending"),
+    ).toBeInTheDocument()
+    expect(submitButton()).toBeDisabled()
+
+    withOutcomes({ [recordedSubmissions()[1].commandId]: true })
+    rerender(form(true))
+
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    expect(
+      screen.queryByText("chatPage.clarification.replyPending"),
+    ).toBeNull()
+    expect(
+      screen.queryByText("chatPage.clarification.replyNotApplied"),
+    ).toBeNull()
+  })
+
+  it("replaces a lingering send-failure alert when the ambiguity notice takes over", async () => {
+    // An outcome_unknown send failure leaves its alert on screen; when the
+    // command's terminal outcome later proves unsafe, the two notices must
+    // not compete as two simultaneous role="alert" regions.
+    appContextMock.sendMessage.mockRejectedValueOnce(Object.assign(
+      new Error("ack timed out"),
+      { disposition: "outcome_unknown", userFacing: true },
+    ))
+    const { rerender } = render(form(true))
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    await waitFor(() => expect(recordedSubmissions()).toHaveLength(1))
+    await screen.findByRole("alert")
+    mirrorSubmissions()
+
+    withOutcomes({ [recordedSubmissions()[0].commandId]: false })
+    rerender(form(true))
+
+    await waitFor(() => {
+      const alerts = screen.getAllByRole("alert")
+      expect(alerts).toHaveLength(1)
+      expect(alerts[0]).toHaveTextContent(
+        "chatPage.clarification.replyOutcomeUnknown",
+      )
+    })
   })
 
   it("records the submission when the delivery outcome is unknown", async () => {
@@ -1102,32 +1280,16 @@ describe("ClarificationForm terminal command outcomes", () => {
     )
 
     // The reply may still have been durably accepted, so its eventual
-    // terminal outcome must gate this round like an acknowledged one.
-    await waitFor(() => {
-      expect(appContextMock.dispatch).toHaveBeenCalledWith({
-        type: "RECORD_CLARIFICATION_SUBMISSION",
-        payload: {
-          requestId: "inputreq_r1",
-          commandId: expect.any(String),
-          // Unconfirmed: an ack timeout must not lock the form while no
-          // terminal outcome exists.
-          accepted: false,
-        },
-      })
+    // terminal outcome must gate this round like an acknowledged one -
+    // recorded as unconfirmed, which must not lock the form while no
+    // terminal outcome exists.
+    await waitFor(() => expect(recordedSubmissions()).toHaveLength(1))
+    expect(recordedSubmissions()[0]).toEqual({
+      requestId: ROUND,
+      commandId: expect.any(String),
+      accepted: false,
     })
-    // The existing advisory behavior is unchanged until an outcome arrives -
-    // including on the gating effect's rerun after the entry is recorded.
-    appContextMock.state = {
-      ...appContextMock.state,
-      clarificationSubmissions: {
-        inputreq_r1: {
-          commandId: (appContextMock.sendMessage.mock.calls[0][1] as {
-            clientMessageId: string
-          }).clientMessageId,
-          accepted: false,
-        },
-      },
-    }
+    mirrorSubmissions()
     expect(submitButton()).toBeEnabled()
   })
 
@@ -1135,11 +1297,7 @@ describe("ClarificationForm terminal command outcomes", () => {
     appContextMock.state = {
       clarificationSubmissions: {},
       commandOutcomes: {
-        "someone-elses-command": {
-          outcome: "failed",
-          resendSafe: false,
-          messageCode: "task_command_failed",
-        },
+        "someone-elses-command": { resendSafe: false },
       },
     }
     const { rerender } = render(form(false))
@@ -1152,9 +1310,10 @@ describe("ClarificationForm terminal command outcomes", () => {
   it("resets the gate for a new clarification round", async () => {
     const { rerender } = render(form(true))
     const commandId = await submitAccepted()
+    await waitFor(() => expect(screen.queryByRole("textbox")).toBeNull())
 
     rerender(form(false))
-    withOutcome(commandId, false)
+    withOutcomes({ [commandId]: false })
     rerender(form(true))
     await screen.findByRole("alert")
 
@@ -1184,15 +1343,5 @@ describe("ClarificationForm terminal command outcomes", () => {
     expect(appContextMock.dispatch).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: "RECORD_CLARIFICATION_SUBMISSION" }),
     )
-  })
-
-  it("uses outcome notice keys that resolve in both locale trees", () => {
-    for (const key of [
-      "chatPage.clarification.replyNotApplied",
-      "chatPage.clarification.replyOutcomeUnknown",
-    ] as const) {
-      expect(resolveTranslation("en", key)).not.toBe(key)
-      expect(resolveTranslation("zh", key)).not.toBe(key)
-    }
   })
 })

--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -17,6 +17,10 @@ const appContextMock = vi.hoisted(() => ({
   filesDisabled: false,
   providerAvailable: true,
   sendMessage: vi.fn(),
+  state: {
+    commandOutcomes: {} as Record<string, unknown>,
+    clarificationSubmissions: {} as Record<string, unknown>,
+  },
 }))
 const toastErrorMock = vi.hoisted(() => vi.fn())
 const mcpAppsMock = vi.hoisted(() => ({
@@ -897,5 +901,255 @@ describe("ClarificationForm blank option filtering", () => {
 
     expect(screen.getByText("Import")).toBeInTheDocument()
     expect(blankOptionSpans(container)).toHaveLength(0)
+  })
+})
+
+describe("ClarificationForm terminal command outcomes", () => {
+  // Issue #1500: after a reply is durably accepted, its command can still
+  // reach a terminal disposition before a turn is established. Whether the
+  // form may invite a resend is decided by the structured outcome the
+  // backend broadcasts for that exact command, never by task state alone.
+  // The accountable submission lives in context keyed by request id, so the
+  // gate survives the submitting component instance being replaced.
+  beforeEach(() => {
+    appContextMock.dispatch.mockReset()
+    appContextMock.filesDisabled = false
+    appContextMock.providerAvailable = true
+    appContextMock.sendMessage.mockReset()
+    appContextMock.sendMessage.mockResolvedValue(undefined)
+    appContextMock.state = { commandOutcomes: {}, clarificationSubmissions: {} }
+    toastErrorMock.mockReset()
+  })
+
+  afterEach(() => {
+    appContextMock.state = { commandOutcomes: {}, clarificationSubmissions: {} }
+    cleanup()
+  })
+
+  const form = (active: boolean, requestId = "inputreq_r1") => (
+    <ClarificationForm
+      interactions={[{ type: "text_input" as const, field: "city", label: "City" }]}
+      requestId={requestId}
+      active={active}
+    />
+  )
+
+  const submitButton = () =>
+    screen.queryByRole("button", { name: "chatPage.clarification.submit" })
+
+  // Drives one accepted submission and mirrors the RECORD dispatch into the
+  // mock context state, the way the real reducer would.
+  const submitAccepted = async (requestId = "inputreq_r1") => {
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(1))
+    // Accepted submissions collapse the form.
+    await waitFor(() => expect(screen.queryByRole("textbox")).toBeNull())
+    const record = appContextMock.dispatch.mock.calls
+      .map(([action]) => action)
+      .find((action) => action?.type === "RECORD_CLARIFICATION_SUBMISSION")
+    expect(record).toEqual({
+      type: "RECORD_CLARIFICATION_SUBMISSION",
+      payload: { requestId, commandId: expect.any(String) },
+    })
+    // The recorded command id is the client message id the delivery used.
+    const config = appContextMock.sendMessage.mock.calls[0][1] as {
+      clientMessageId?: string
+    }
+    expect(record.payload.commandId).toBe(config.clientMessageId)
+    appContextMock.state = {
+      ...appContextMock.state,
+      clarificationSubmissions: {
+        [requestId]: { commandId: record.payload.commandId },
+      },
+    }
+    return record.payload.commandId as string
+  }
+
+  const withOutcome = (commandId: string, resendSafe: boolean) => {
+    appContextMock.state = {
+      ...appContextMock.state,
+      commandOutcomes: {
+        [commandId]: {
+          outcome: "failed",
+          resendSafe,
+          messageCode: "task_command_deferred",
+        },
+      },
+    }
+  }
+
+  it("reactivates the form and preserves the draft when the outcome proves retry safe", async () => {
+    const { rerender } = render(form(true))
+    const commandId = await submitAccepted()
+
+    rerender(form(false))
+    withOutcome(commandId, true)
+    rerender(form(true))
+
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    expect(screen.getByRole("textbox")).toHaveValue("Beijing")
+    expect(
+      screen.getByText("chatPage.clarification.replyNotApplied"),
+    ).toBeInTheDocument()
+    // The record is consumed so the resend is armed exactly once.
+    expect(appContextMock.dispatch).toHaveBeenCalledWith({
+      type: "CLEAR_CLARIFICATION_SUBMISSION",
+      payload: { requestId: "inputreq_r1" },
+    })
+  })
+
+  it("keeps the form locked and surfaces the ambiguity when the outcome is not proven safe", async () => {
+    const { rerender } = render(form(true))
+    const commandId = await submitAccepted()
+
+    rerender(form(false))
+    withOutcome(commandId, false)
+    rerender(form(true))
+
+    // The notice is visible, the draft is intact, and nothing invites a
+    // duplicate submission of the accepted reply.
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("chatPage.clarification.replyOutcomeUnknown")
+    expect(screen.getByRole("textbox")).toHaveValue("Beijing")
+    expect(submitButton()).toBeDisabled()
+  })
+
+  it("does not reactivate while the accepted reply has no terminal outcome yet", async () => {
+    const { rerender } = render(form(true))
+    await submitAccepted()
+
+    rerender(form(false))
+    rerender(form(true))
+
+    // No outcome means the command may still be in flight: the form stays
+    // collapsed instead of inviting a duplicate.
+    expect(screen.queryByRole("textbox")).toBeNull()
+    expect(submitButton()).toBeNull()
+  })
+
+  it("is not reopened by a late terminal event after a turn is established", async () => {
+    const { rerender } = render(form(true))
+    const commandId = await submitAccepted()
+
+    rerender(form(false))
+    // The turn was established, the task is running, and only then does a
+    // stale resend-safe terminal frame arrive: with the task not waiting,
+    // nothing may reopen the submitted form.
+    withOutcome(commandId, true)
+    rerender(form(false))
+
+    expect(screen.queryByRole("textbox")).toBeNull()
+    expect(submitButton()).toBeNull()
+  })
+
+  it("gates a fresh component instance for a round another instance submitted", async () => {
+    // The virtual waiting message and the persisted timeline message render
+    // the same round in different component instances; replacing the
+    // submitting instance must not drop the gate.
+    render(form(true))
+    const commandId = await submitAccepted()
+    cleanup()
+
+    withOutcome(commandId, false)
+    render(form(true))
+
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("chatPage.clarification.replyOutcomeUnknown")
+    expect(submitButton()).toBeDisabled()
+  })
+
+  it("records the submission when the delivery outcome is unknown", async () => {
+    appContextMock.sendMessage.mockRejectedValue(Object.assign(
+      new Error("ack timed out"),
+      { disposition: "outcome_unknown", userFacing: true },
+    ))
+    render(form(true))
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+
+    // The reply may still have been durably accepted, so its eventual
+    // terminal outcome must gate this round like an acknowledged one.
+    await waitFor(() => {
+      expect(appContextMock.dispatch).toHaveBeenCalledWith({
+        type: "RECORD_CLARIFICATION_SUBMISSION",
+        payload: {
+          requestId: "inputreq_r1",
+          commandId: expect.any(String),
+        },
+      })
+    })
+    // The existing advisory behavior is unchanged until an outcome arrives.
+    expect(submitButton()).toBeEnabled()
+  })
+
+  it("still reactivates a form that never submitted, ignoring unrelated outcomes", async () => {
+    appContextMock.state = {
+      clarificationSubmissions: {},
+      commandOutcomes: {
+        "someone-elses-command": {
+          outcome: "failed",
+          resendSafe: false,
+          messageCode: "task_command_failed",
+        },
+      },
+    }
+    const { rerender } = render(form(false))
+    rerender(form(true))
+
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("resets the gate for a new clarification round", async () => {
+    const { rerender } = render(form(true))
+    const commandId = await submitAccepted()
+
+    rerender(form(false))
+    withOutcome(commandId, false)
+    rerender(form(true))
+    await screen.findByRole("alert")
+
+    rerender(form(true, "inputreq_r2"))
+
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+    expect(screen.getByRole("textbox")).toHaveValue("")
+    expect(screen.queryByRole("alert")).toBeNull()
+  })
+
+  it("does not record a submission for a round without a request id", async () => {
+    render(
+      <ClarificationForm
+        interactions={[{ type: "text_input" as const, field: "city", label: "City" }]}
+        active
+      />,
+    )
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+
+    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(1))
+    // With no round identity to bind to, gating is skipped entirely rather
+    // than risking a recorded reply gating a different question.
+    expect(appContextMock.dispatch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "RECORD_CLARIFICATION_SUBMISSION" }),
+    )
+  })
+
+  it("uses outcome notice keys that resolve in both locale trees", () => {
+    for (const key of [
+      "chatPage.clarification.replyNotApplied",
+      "chatPage.clarification.replyOutcomeUnknown",
+    ] as const) {
+      expect(resolveTranslation("en", key)).not.toBe(key)
+      expect(resolveTranslation("zh", key)).not.toBe(key)
+    }
   })
 })

--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -952,7 +952,7 @@ describe("ClarificationForm terminal command outcomes", () => {
       .find((action) => action?.type === "RECORD_CLARIFICATION_SUBMISSION")
     expect(record).toEqual({
       type: "RECORD_CLARIFICATION_SUBMISSION",
-      payload: { requestId, commandId: expect.any(String) },
+      payload: { requestId, commandId: expect.any(String), accepted: true },
     })
     // The recorded command id is the client message id the delivery used.
     const config = appContextMock.sendMessage.mock.calls[0][1] as {
@@ -962,7 +962,7 @@ describe("ClarificationForm terminal command outcomes", () => {
     appContextMock.state = {
       ...appContextMock.state,
       clarificationSubmissions: {
-        [requestId]: { commandId: record.payload.commandId },
+        [requestId]: { commandId: record.payload.commandId, accepted: true },
       },
     }
     return record.payload.commandId as string
@@ -1061,6 +1061,34 @@ describe("ClarificationForm terminal command outcomes", () => {
     expect(submitButton()).toBeDisabled()
   })
 
+  it("locks a fresh component instance while the accepted reply is still in flight", async () => {
+    // A freshly mounted instance starts with isSubmitted=false, so without
+    // the in-flight lock it would offer Submit for a round whose durably
+    // accepted reply has not reached a terminal outcome yet (surfaced by
+    // review on #2126).
+    render(form(true))
+    await submitAccepted()
+    cleanup()
+
+    render(form(true))
+
+    expect(submitButton()).toBeDisabled()
+  })
+
+  it("does not lock a fresh instance for an unconfirmed ack-timeout delivery", async () => {
+    appContextMock.state = {
+      commandOutcomes: {},
+      clarificationSubmissions: {
+        inputreq_r1: { commandId: "maybe-sent", accepted: false },
+      },
+    }
+    render(form(true))
+
+    // The reply may never have been accepted at all: the composer keeps its
+    // advisory retry until a terminal outcome for the command arrives.
+    await waitFor(() => expect(submitButton()).toBeEnabled())
+  })
+
   it("records the submission when the delivery outcome is unknown", async () => {
     appContextMock.sendMessage.mockRejectedValue(Object.assign(
       new Error("ack timed out"),
@@ -1081,10 +1109,25 @@ describe("ClarificationForm terminal command outcomes", () => {
         payload: {
           requestId: "inputreq_r1",
           commandId: expect.any(String),
+          // Unconfirmed: an ack timeout must not lock the form while no
+          // terminal outcome exists.
+          accepted: false,
         },
       })
     })
-    // The existing advisory behavior is unchanged until an outcome arrives.
+    // The existing advisory behavior is unchanged until an outcome arrives -
+    // including on the gating effect's rerun after the entry is recorded.
+    appContextMock.state = {
+      ...appContextMock.state,
+      clarificationSubmissions: {
+        inputreq_r1: {
+          commandId: (appContextMock.sendMessage.mock.calls[0][1] as {
+            clientMessageId: string
+          }).clientMessageId,
+          accepted: false,
+        },
+      },
+    }
     expect(submitButton()).toBeEnabled()
   })
 

--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -1016,10 +1016,12 @@ describe("ClarificationForm terminal command outcomes", () => {
     expect(
       screen.getByText("chatPage.clarification.replyNotApplied"),
     ).toBeInTheDocument()
-    // The record is consumed so the resend is armed exactly once.
+    // The record is consumed so the resend is armed exactly once - and the
+    // CLEAR names exactly the verified command, so a concurrently recorded
+    // submission would survive it.
     expect(appContextMock.dispatch).toHaveBeenCalledWith({
       type: "CLEAR_CLARIFICATION_SUBMISSION",
-      payload: { requestId: ROUND },
+      payload: { requestId: ROUND, commandIds: [commandId] },
     })
   })
 
@@ -1265,6 +1267,40 @@ describe("ClarificationForm terminal command outcomes", () => {
         "chatPage.clarification.replyOutcomeUnknown",
       )
     })
+  })
+
+  it("keeps a visible send-failure alert when another round's submission is recorded", async () => {
+    // The untracked-round fallback must be identity-stable: a fresh [] per
+    // render would rerun the gating effect on ANY round's record and reach
+    // the tail that clears sendFailure. Trigger: this round's delivery
+    // fails visibly, then an older round's ack-timeout promise settles and
+    // records for THAT round (deliberately before the latestRequestIdRef
+    // guard).
+    appContextMock.sendMessage.mockRejectedValueOnce(Object.assign(
+      new Error("Durable storage is temporarily unavailable"),
+      { disposition: "not_sent", userFacing: true },
+    ))
+    const { rerender } = render(form(true, "inputreq_r2"))
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    await screen.findByRole("alert")
+
+    // An unrelated round's record lands in context state.
+    appContextMock.state = {
+      ...appContextMock.state,
+      clarificationSubmissions: {
+        inputreq_r1: [{ commandId: "older-round-cmd", accepted: false }],
+      },
+    }
+    rerender(form(true, "inputreq_r2"))
+
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Durable storage is temporarily unavailable",
+    )
+    expect(submitButton()).toBeEnabled()
   })
 
   it("records the submission when the delivery outcome is unknown", async () => {

--- a/frontend/src/components/chat/clarification-form.tsx
+++ b/frontend/src/components/chat/clarification-form.tsx
@@ -135,7 +135,9 @@ export function ClarificationForm({
   // If onSend is provided, use it (e.g., from builder chat), otherwise use useApp
   let sendMessage: any, dispatch: any, contextFilesDisabled: boolean | undefined;
   let commandOutcomes: Record<string, TerminalCommandOutcome> | undefined;
-  let clarificationSubmissions: Record<string, { commandId: string }> | undefined;
+  let clarificationSubmissions:
+    | Record<string, { commandId: string; accepted: boolean }>
+    | undefined;
   try {
     const appCtx = useApp();
     sendMessage = appCtx.sendMessage;
@@ -230,15 +232,24 @@ export function ClarificationForm({
     // While a submission is outstanding, reactivation requires a terminal
     // outcome for that exact command that proves non-application.
     if (outstandingSubmission) {
-      if (!outstandingOutcome || outstandingOutcome.resendSafe !== true) {
-        // Committed, still in flight, or unknown: surface the ambiguity
-        // (when a terminal outcome exists) without inviting a duplicate.
-        // The chat input remains available for a deliberate fresh message.
-        if (outstandingOutcome) {
-          setOutcomeNotice("unconfirmed")
+      if (!outstandingOutcome) {
+        // Still in flight with no terminal outcome. A confirmed-accepted
+        // reply locks the form even on a freshly mounted instance (whose
+        // initial isSubmitted is false); an unconfirmed ack-timeout
+        // delivery keeps the advisory retry the composer has always
+        // offered, because the reply may never have been accepted at all.
+        if (outstandingSubmission.accepted) {
           setIsSubmitted(true)
-          setIsOpen(true)
         }
+        return
+      }
+      if (outstandingOutcome.resendSafe !== true) {
+        // Committed or unknown: surface the ambiguity without inviting a
+        // duplicate. The chat input remains available for a deliberate
+        // fresh message.
+        setOutcomeNotice("unconfirmed")
+        setIsSubmitted(true)
+        setIsOpen(true)
         return
       }
       // Proven not applied: consume the record so the resend is armed once,
@@ -436,12 +447,19 @@ export function ClarificationForm({
     // request id - the gate would have no round identity to bind to, and a
     // recorded reply could end up gating a different question.
     const clientMessageId = generateClientMessageId()
-    const recordSubmission = () => {
+    // ``accepted`` separates a durably acknowledged reply from one whose
+    // ack timed out: only a confirmed acceptance may lock a freshly mounted
+    // form while its terminal outcome is still pending.
+    const recordSubmission = (accepted: boolean) => {
       if (onSend || !dispatch) return
       if (typeof submittedRequestId !== "string" || !submittedRequestId) return
       dispatch({
         type: "RECORD_CLARIFICATION_SUBMISSION",
-        payload: { requestId: submittedRequestId, commandId: clientMessageId },
+        payload: {
+          requestId: submittedRequestId,
+          commandId: clientMessageId,
+          accepted,
+        },
       })
     }
 
@@ -461,7 +479,7 @@ export function ClarificationForm({
           { force: true, metadata, clientMessageId },
           outboundFiles,
         )
-        recordSubmission()
+        recordSubmission(true)
       }
 
       if (latestRequestIdRef.current !== submittedRequestId) return
@@ -474,8 +492,9 @@ export function ClarificationForm({
       if (readSendDisposition(error) === "outcome_unknown") {
         // An ack timeout: the reply may still have been durably accepted,
         // so its eventual terminal outcome must gate this round exactly as
-        // an acknowledged submission's would.
-        recordSubmission()
+        // an acknowledged submission's would - but as an unconfirmed
+        // delivery it must not lock the form while no outcome exists.
+        recordSubmission(false)
       }
       if (latestRequestIdRef.current !== submittedRequestId) return
       console.error("Failed to send clarification response", error)

--- a/frontend/src/components/chat/clarification-form.tsx
+++ b/frontend/src/components/chat/clarification-form.tsx
@@ -1,5 +1,9 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
-import { Interaction, TerminalCommandOutcome } from "@/contexts/app-context-chat"
+import {
+  ClarificationSubmission,
+  Interaction,
+  TerminalCommandOutcome,
+} from "@/contexts/app-context-chat"
 import { generateClientMessageId } from "@/lib/utils"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
@@ -136,7 +140,7 @@ export function ClarificationForm({
   let sendMessage: any, dispatch: any, contextFilesDisabled: boolean | undefined;
   let commandOutcomes: Record<string, TerminalCommandOutcome> | undefined;
   let clarificationSubmissions:
-    | Record<string, { commandId: string; accepted: boolean }>
+    | Record<string, ClarificationSubmission[]>
     | undefined;
   try {
     const appCtx = useApp();
@@ -194,7 +198,7 @@ export function ClarificationForm({
   // Which outcome notice the form owes the user. Raw category only; the
   // sentence is resolved at render so a locale switch reaches it.
   const [outcomeNotice, setOutcomeNotice] = useState<
-    "notApplied" | "unconfirmed" | null
+    "notApplied" | "unconfirmed" | "pending" | null
   >(null)
 
   useLayoutEffect(() => {
@@ -211,49 +215,94 @@ export function ClarificationForm({
     setOutcomeNotice(null)
   }, [active, isConnectAppsOnly, requestId])
 
-  // The reply command this round is still accountable for, and its terminal
-  // disposition, both read from context so the gate survives this component
-  // instance being replaced (virtual waiting message vs. persisted timeline
-  // message render the same round). Derived per render: the effect below
-  // must re-run when either changes, and must NOT re-run when an unrelated
-  // command's outcome lands - that rerun used to wipe a visible failure
-  // alert.
-  const outstandingSubmission = requestId
-    ? clarificationSubmissions?.[requestId]
-    : undefined
-  const outstandingOutcome = outstandingSubmission
-    ? commandOutcomes?.[outstandingSubmission.commandId]
-    : undefined
+  // The reply commands this round is still accountable for, read from
+  // context so the gate survives this component instance being replaced
+  // (virtual waiting message vs. persisted timeline message render the same
+  // round). One round can hold several: an ack-timeout entry stays
+  // resubmittable, so a resubmit appends rather than replaces, and every
+  // tracked command's outcome still gets matched.
+  const outstandingSubmissions = useMemo<ClarificationSubmission[]>(
+    () => (requestId ? clarificationSubmissions?.[requestId] : undefined) ?? [],
+    [requestId, clarificationSubmissions],
+  )
+  // Reduced to booleans before entering the effect's dependency list: an
+  // unrelated command's outcome landing must not re-run the effect - that
+  // rerun used to wipe a visible failure alert.
+  const hasOutstanding = outstandingSubmissions.length > 0
+  // Any tracked reply whose terminal outcome cannot prove non-application
+  // may have been committed: the round must surface that and stay locked.
+  const anyUnsafeOutcome = outstandingSubmissions.some((submission) => {
+    const outcome = commandOutcomes?.[submission.commandId]
+    return outcome !== undefined && outcome.resendSafe !== true
+  })
+  // Every tracked reply is proven not applied: resending is safe.
+  const allProvenNotApplied =
+    hasOutstanding
+    && outstandingSubmissions.every(
+      (submission) => commandOutcomes?.[submission.commandId]?.resendSafe === true,
+    )
+  // A durably acknowledged reply is still awaiting its terminal outcome.
+  // (An unconfirmed ack-timeout entry without an outcome deliberately does
+  // not count: it may never have been accepted, and the composer keeps its
+  // advisory retry for it - which is also why it blocks the proven-safe
+  // unlock above without forcing a lock here.)
+  const confirmedPending = outstandingSubmissions.some(
+    (submission) =>
+      submission.accepted && commandOutcomes?.[submission.commandId] === undefined,
+  )
+  // Distinguishes the round that has heard nothing yet from the one whose
+  // resolved replies are all proven safe while unconfirmed ones remain.
+  const anyOutcome = outstandingSubmissions.some(
+    (submission) => commandOutcomes?.[submission.commandId] !== undefined,
+  )
 
   useEffect(() => {
     if (!active) return
     // Task state alone answers whether the task accepts input; it does not
     // prove that repeating this round's accepted reply is safe (#1500).
-    // While a submission is outstanding, reactivation requires a terminal
-    // outcome for that exact command that proves non-application.
-    if (outstandingSubmission) {
-      if (!outstandingOutcome) {
-        // Still in flight with no terminal outcome. A confirmed-accepted
-        // reply locks the form even on a freshly mounted instance (whose
-        // initial isSubmitted is false); an unconfirmed ack-timeout
-        // delivery keeps the advisory retry the composer has always
-        // offered, because the reply may never have been accepted at all.
-        if (outstandingSubmission.accepted) {
-          setIsSubmitted(true)
-        }
-        return
-      }
-      if (outstandingOutcome.resendSafe !== true) {
+    // While a submission is outstanding, reactivation requires terminal
+    // outcomes that prove non-application for every tracked reply.
+    if (hasOutstanding) {
+      if (anyUnsafeOutcome) {
         // Committed or unknown: surface the ambiguity without inviting a
         // duplicate. The chat input remains available for a deliberate
-        // fresh message.
+        // fresh message. The send-failure alert would compete with this
+        // one (two role="alert" regions), and this notice supersedes it.
         setOutcomeNotice("unconfirmed")
+        setIsSubmitted(true)
+        setIsOpen(true)
+        setSendFailure(null)
+        return
+      }
+      if (confirmedPending) {
+        // Accepted and still being applied: lock even a freshly mounted
+        // instance (whose initial isSubmitted is false), and say why the
+        // form is locked instead of leaving a bare greyed-out button.
+        setOutcomeNotice("pending")
         setIsSubmitted(true)
         setIsOpen(true)
         return
       }
-      // Proven not applied: consume the record so the resend is armed once,
-      // then reactivate below with the draft intact.
+      if (!allProvenNotApplied) {
+        if (anyOutcome) {
+          // Every resolved reply is proven not applied; only unconfirmed
+          // ack-timeout replies remain, and their duplicate risk is the
+          // same risk the advisory retry already accepted for them. Match
+          // the fresh-instance stance: return the round to advisory
+          // instead of leaving the submitting instance locked behind a
+          // now-stale pending notice. No proven-safe notice - that promise
+          // cannot be made while an unconfirmed reply is unresolved.
+          setOutcomeNotice((notice) => (notice === "pending" ? null : notice))
+          setIsSubmitted(false)
+          setIsOpen(true)
+        }
+        // Nothing resolved yet: keep the composer's advisory retry - and
+        // its ack-timeout warning alert - exactly as they stand.
+        return
+      }
+      // Every tracked reply is proven not applied: consume the record so
+      // the resend is armed once, then reactivate below with the draft
+      // intact.
       dispatch?.({
         type: "CLEAR_CLARIFICATION_SUBMISSION",
         payload: { requestId },
@@ -268,7 +317,16 @@ export function ClarificationForm({
     setIsSubmitted(false)
     setIsOpen(true)
     setSendFailure(null)
-  }, [active, outstandingSubmission, outstandingOutcome, requestId, dispatch])
+  }, [
+    active,
+    hasOutstanding,
+    anyUnsafeOutcome,
+    allProvenNotApplied,
+    confirmedPending,
+    anyOutcome,
+    requestId,
+    dispatch,
+  ])
 
   const normalizedInteractions = useMemo(() => {
     const seenFields = new Set<string>()
@@ -815,6 +873,11 @@ export function ClarificationForm({
             {outcomeNotice === "unconfirmed" && (
               <div role="alert" className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
                 {t("chatPage.clarification.replyOutcomeUnknown")}
+              </div>
+            )}
+            {outcomeNotice === "pending" && (
+              <div role="status" className="rounded-md border bg-muted/50 p-3 text-sm text-muted-foreground">
+                {t("chatPage.clarification.replyPending")}
               </div>
             )}
             {outcomeNotice === "notApplied" && (

--- a/frontend/src/components/chat/clarification-form.tsx
+++ b/frontend/src/components/chat/clarification-form.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react"
-import { Interaction } from "@/contexts/app-context-chat"
+import { Interaction, TerminalCommandOutcome } from "@/contexts/app-context-chat"
+import { generateClientMessageId } from "@/lib/utils"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Textarea } from "@/components/ui/textarea"
@@ -133,11 +134,15 @@ export function ClarificationForm({
 }: ClarificationFormProps) {
   // If onSend is provided, use it (e.g., from builder chat), otherwise use useApp
   let sendMessage: any, dispatch: any, contextFilesDisabled: boolean | undefined;
+  let commandOutcomes: Record<string, TerminalCommandOutcome> | undefined;
+  let clarificationSubmissions: Record<string, { commandId: string }> | undefined;
   try {
     const appCtx = useApp();
     sendMessage = appCtx.sendMessage;
     dispatch = appCtx.dispatch;
     contextFilesDisabled = appCtx.filesDisabled;
+    commandOutcomes = appCtx.state?.commandOutcomes;
+    clarificationSubmissions = appCtx.state?.clarificationSubmissions;
   } catch {
     // We might not be in the app context (e.g., agent builder chat)
   }
@@ -184,6 +189,11 @@ export function ClarificationForm({
       errorCode: ClientErrorCode | null
     } | null
   >(null)
+  // Which outcome notice the form owes the user. Raw category only; the
+  // sentence is resolved at render so a locale switch reaches it.
+  const [outcomeNotice, setOutcomeNotice] = useState<
+    "notApplied" | "unconfirmed" | null
+  >(null)
 
   useLayoutEffect(() => {
     latestRequestIdRef.current = requestId
@@ -194,18 +204,60 @@ export function ClarificationForm({
     setIsSubmitted(!active && !isConnectAppsOnly)
     setIsOpen(active || isConnectAppsOnly)
     setSendFailure(null)
+    // A new round is a new question: the previous round's outcome notice no
+    // longer belongs on top of it.
+    setOutcomeNotice(null)
   }, [active, isConnectAppsOnly, requestId])
 
+  // The reply command this round is still accountable for, and its terminal
+  // disposition, both read from context so the gate survives this component
+  // instance being replaced (virtual waiting message vs. persisted timeline
+  // message render the same round). Derived per render: the effect below
+  // must re-run when either changes, and must NOT re-run when an unrelated
+  // command's outcome lands - that rerun used to wipe a visible failure
+  // alert.
+  const outstandingSubmission = requestId
+    ? clarificationSubmissions?.[requestId]
+    : undefined
+  const outstandingOutcome = outstandingSubmission
+    ? commandOutcomes?.[outstandingSubmission.commandId]
+    : undefined
+
   useEffect(() => {
-    if (active) {
-      // A new clarification round reuses this component instance on the live
-      // turn render path, so a stale round-1 failure alert would sit on top
-      // of round 2's question.
-      setIsSubmitted(false)
-      setIsOpen(true)
-      setSendFailure(null)
+    if (!active) return
+    // Task state alone answers whether the task accepts input; it does not
+    // prove that repeating this round's accepted reply is safe (#1500).
+    // While a submission is outstanding, reactivation requires a terminal
+    // outcome for that exact command that proves non-application.
+    if (outstandingSubmission) {
+      if (!outstandingOutcome || outstandingOutcome.resendSafe !== true) {
+        // Committed, still in flight, or unknown: surface the ambiguity
+        // (when a terminal outcome exists) without inviting a duplicate.
+        // The chat input remains available for a deliberate fresh message.
+        if (outstandingOutcome) {
+          setOutcomeNotice("unconfirmed")
+          setIsSubmitted(true)
+          setIsOpen(true)
+        }
+        return
+      }
+      // Proven not applied: consume the record so the resend is armed once,
+      // then reactivate below with the draft intact.
+      dispatch?.({
+        type: "CLEAR_CLARIFICATION_SUBMISSION",
+        payload: { requestId },
+      })
+      setOutcomeNotice("notApplied")
     }
-  }, [active])
+    // A new clarification round reuses this component instance on the live
+    // turn render path, so a stale round-1 failure alert would sit on top
+    // of round 2's question. The outcome notice is deliberately not cleared
+    // here: it explains why the form re-opened, and it falls away on the
+    // next submit or the next round.
+    setIsSubmitted(false)
+    setIsOpen(true)
+    setSendFailure(null)
+  }, [active, outstandingSubmission, outstandingOutcome, requestId, dispatch])
 
   const normalizedInteractions = useMemo(() => {
     const seenFields = new Set<string>()
@@ -377,9 +429,26 @@ export function ClarificationForm({
       }
     })
 
+    // Minted here, not in sendMessage, so this round knows the id the
+    // durable command will carry and can correlate its terminal outcome
+    // (#1500). The builder onSend path has no durable command behind it and
+    // takes no part in outcome gating; neither does a round without a
+    // request id - the gate would have no round identity to bind to, and a
+    // recorded reply could end up gating a different question.
+    const clientMessageId = generateClientMessageId()
+    const recordSubmission = () => {
+      if (onSend || !dispatch) return
+      if (typeof submittedRequestId !== "string" || !submittedRequestId) return
+      dispatch({
+        type: "RECORD_CLARIFICATION_SUBMISSION",
+        payload: { requestId: submittedRequestId, commandId: clientMessageId },
+      })
+    }
+
     try {
       setIsSubmitting(true)
       setSendFailure(null)
+      setOutcomeNotice(null)
       // If textMessage is empty but we have files, send a generic message?
       const outboundFiles = filesDisabled ? [] : files
       const finalMessage = textMessage || (outboundFiles.length > 0 ? t("chatPage.clarification.uploadedFiles") : t("chatPage.clarification.confirmed"))
@@ -387,7 +456,12 @@ export function ClarificationForm({
       if (onSend) {
         await onSend(finalMessage, outboundFiles, metadata);
       } else if (sendMessage) {
-        await sendMessage(finalMessage, { force: true, metadata }, outboundFiles)
+        await sendMessage(
+          finalMessage,
+          { force: true, metadata, clientMessageId },
+          outboundFiles,
+        )
+        recordSubmission()
       }
 
       if (latestRequestIdRef.current !== submittedRequestId) return
@@ -397,6 +471,12 @@ export function ClarificationForm({
         dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
       }
     } catch (error) {
+      if (readSendDisposition(error) === "outcome_unknown") {
+        // An ack timeout: the reply may still have been durably accepted,
+        // so its eventual terminal outcome must gate this round exactly as
+        // an acknowledged submission's would.
+        recordSubmission()
+      }
       if (latestRequestIdRef.current !== submittedRequestId) return
       console.error("Failed to send clarification response", error)
       // The rejection reason ("a previous guidance message is still being
@@ -713,6 +793,16 @@ export function ClarificationForm({
               ))}
             </div>
 
+            {outcomeNotice === "unconfirmed" && (
+              <div role="alert" className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+                {t("chatPage.clarification.replyOutcomeUnknown")}
+              </div>
+            )}
+            {outcomeNotice === "notApplied" && (
+              <div role="status" className="rounded-md border bg-muted/50 p-3 text-sm text-muted-foreground">
+                {t("chatPage.clarification.replyNotApplied")}
+              </div>
+            )}
             {sendFailure && (
               <div role="alert" className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
                 <div>{sendFailureMessage}</div>

--- a/frontend/src/components/chat/clarification-form.tsx
+++ b/frontend/src/components/chat/clarification-form.tsx
@@ -119,6 +119,13 @@ const sendHintKey = (
     ? "chatPage.clarification.sendNotSent"
     : null
 
+// Stable empty fallback for rounds with no tracked submissions: minting a
+// fresh [] per render would change the gating effect's dependency identity
+// on ANY round's record/clear, and a rerun on an active untracked round
+// reaches the tail that clears a visible send-failure alert - the exact
+// regression class the boolean reduction below exists to prevent.
+const NO_SUBMISSIONS: ClarificationSubmission[] = []
+
 // Interaction types that are "live widgets" reflecting external state (e.g.
 // useMcpApps()'s connection state), not a question with an answer to submit
 // - see the comment on isConnectAppsOnly below for why that distinction
@@ -222,7 +229,9 @@ export function ClarificationForm({
   // resubmittable, so a resubmit appends rather than replaces, and every
   // tracked command's outcome still gets matched.
   const outstandingSubmissions = useMemo<ClarificationSubmission[]>(
-    () => (requestId ? clarificationSubmissions?.[requestId] : undefined) ?? [],
+    () =>
+      (requestId ? clarificationSubmissions?.[requestId] : undefined)
+      ?? NO_SUBMISSIONS,
     [requestId, clarificationSubmissions],
   )
   // Reduced to booleans before entering the effect's dependency list: an
@@ -302,10 +311,18 @@ export function ClarificationForm({
       }
       // Every tracked reply is proven not applied: consume the record so
       // the resend is armed once, then reactivate below with the draft
-      // intact.
+      // intact. The CLEAR names exactly the commands this render verified,
+      // so a submission recorded concurrently (another instance's resubmit
+      // landing between this render's snapshot and the dispatch) survives
+      // with its outcome still matchable.
       dispatch?.({
         type: "CLEAR_CLARIFICATION_SUBMISSION",
-        payload: { requestId },
+        payload: {
+          requestId,
+          commandIds: outstandingSubmissions.map(
+            (submission) => submission.commandId,
+          ),
+        },
       })
       setOutcomeNotice("notApplied")
     }
@@ -324,6 +341,7 @@ export function ClarificationForm({
     allProvenNotApplied,
     confirmedPending,
     anyOutcome,
+    outstandingSubmissions,
     requestId,
     dispatch,
   ])

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -602,6 +602,192 @@ describe("TaskConversationPanel", () => {
     expect(rendered[1]).toHaveAttribute("data-request-id", "inputreq_q2")
   })
 
+  it("adopts the ask frame's event_id as the waiting round id when no request_id exists", () => {
+    // No backend emits request_id today; the stable per-ask identity on the
+    // wire is event_id. The trace fallback must surface it so the round is
+    // identified even when the status frame carried nothing.
+    appState.messages = [{
+      id: "user-1",
+      role: "user",
+      content: "Start the question",
+      timestamp: 2000,
+    }]
+    appState.traceEvents = [
+      {
+        event_type: "agent_message",
+        timestamp: 1000,
+        data: {
+          expect_response: true,
+          message: "Which region should I use?",
+          event_id: "evt-round-1",
+          metadata: {
+            interactions: [{ type: "text_input", field: "region", label: "Region" }],
+          },
+        },
+      },
+    ]
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Which region should I use?",
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const activeWait = screen.getAllByTestId("chat-message").find(
+      (message) => message.getAttribute("data-active") === "true",
+    )
+    expect(activeWait).toBeDefined()
+    expect(activeWait).toHaveAttribute("data-request-id", "evt-round-1")
+  })
+
+  it("keeps at most one instance active for a waiting round", () => {
+    // The two-instances window: the round's question is persisted on the
+    // timeline AND an optimistic user message is the last item (so the
+    // virtual assistant message renders too). The timeline instance owns the
+    // round; the virtual copy must stay inert, or two forms accept the same
+    // question at once.
+    appState.messages = [
+      {
+        id: "q1",
+        role: "assistant",
+        content: "Which city?",
+        timestamp: "1000",
+        isResult: true,
+        interactions: [{ type: "text_input", field: "city", label: "City" }],
+        interactionRequestId: "round-1",
+      },
+      {
+        id: "u1",
+        role: "user",
+        content: "City: Beijing",
+        timestamp: "2000",
+        isOptimistic: true,
+      },
+    ]
+    appState.traceEvents = []
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Which city?",
+      waitingRequestId: "round-1",
+      waitingInteractions: [{ type: "text_input", field: "city", label: "City" }],
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const active = screen.getAllByTestId("chat-message")
+      .filter((node) => node.getAttribute("data-active") === "true")
+    expect(active).toHaveLength(1)
+    expect(active[0]).toHaveAttribute("data-request-id", "round-1")
+    expect(active[0]).toHaveTextContent("Which city?")
+  })
+
+  it("never adopts a client-minted trace id as the round id", () => {
+    // react_task_end rows in state get generateMessageId placeholders as
+    // their top-level event_id; adopting one would name a round no message
+    // carries, deactivating every instance. With no data-level id on the
+    // newest ask, the prompt-text match stays in charge and activates the
+    // persisted bubble.
+    appState.messages = [
+      {
+        id: "q1",
+        role: "assistant",
+        content: "Choose a region",
+        timestamp: 1000,
+        isResult: true,
+        interactions: [{ type: "text_input", field: "region", label: "Region" }],
+      },
+      {
+        id: "u1",
+        role: "user",
+        content: "Working on it",
+        timestamp: 2000,
+      },
+    ]
+    appState.traceEvents = [
+      {
+        event_id: "react-task-end-1757200000000-abc12",
+        event_type: "react_task_end",
+        timestamp: 1500,
+        data: {
+          result: {
+            status: "waiting_for_user",
+            message: "Choose a region",
+          },
+        },
+      },
+    ]
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Choose a region",
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const active = screen.getAllByTestId("chat-message")
+      .filter((node) => node.getAttribute("data-active") === "true")
+    expect(active).toHaveLength(1)
+    expect(active[0]).toHaveTextContent("Choose a region")
+    expect(active[0]).toHaveAttribute("data-request-id", "")
+  })
+
+  it("activates the round-id match rather than a same-text lookalike", () => {
+    // Prompt-text equality can pick the wrong message when two rounds asked
+    // the same question; the round id is authoritative when present.
+    appState.messages = [
+      {
+        id: "q1",
+        role: "assistant",
+        content: "Which city?",
+        timestamp: "1000",
+        isResult: true,
+        interactions: [{ type: "text_input", field: "city", label: "City" }],
+        interactionRequestId: "round-1",
+      },
+      {
+        id: "q2",
+        role: "assistant",
+        content: "Which city?",
+        timestamp: "2000",
+        isResult: true,
+        interactions: [{ type: "text_input", field: "city", label: "City" }],
+        interactionRequestId: "round-2",
+      },
+    ]
+    appState.traceEvents = []
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Which city?",
+      waitingRequestId: "round-1",
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const active = screen.getAllByTestId("chat-message")
+      .filter((node) => node.getAttribute("data-active") === "true")
+    expect(active).toHaveLength(1)
+    expect(active[0]).toHaveAttribute("data-request-id", "round-1")
+  })
+
   it("keeps an identified text-only wait separate from stale structured trace interactions", () => {
     appState.messages = [{
       id: "user-r2",

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -602,102 +602,6 @@ describe("TaskConversationPanel", () => {
     expect(rendered[1]).toHaveAttribute("data-request-id", "inputreq_q2")
   })
 
-  it("adopts the replayed waiting result's clarification event_id as the round id", () => {
-    // No backend emits request_id today, and replayed history rows carry no
-    // interactionRequestId; after a reload the round identity lives at the
-    // replayed react_task_end's result.clarification_draft.event_id.
-    appState.messages = [{
-      id: "user-1",
-      role: "user",
-      content: "Start the question",
-      timestamp: 2000,
-    }]
-    appState.traceEvents = [
-      {
-        event_id: "react-task-end-1757200000000-abc12",
-        event_type: "react_task_end",
-        timestamp: 1000,
-        data: {
-          result: {
-            status: "waiting_for_user",
-            message: "Which region should I use?",
-            interactions: [{ type: "text_input", field: "region", label: "Region" }],
-            clarification_draft: { event_id: "evt-round-1" },
-          },
-        },
-      },
-    ]
-    appState.currentTask = {
-      id: "42",
-      title: "Preview",
-      description: "Preview",
-      status: "waiting_for_user",
-      createdAt: "2026-01-01T00:00:00Z",
-      updatedAt: "2026-01-01T00:00:00Z",
-      waitingQuestion: "Which region should I use?",
-    }
-
-    render(<TaskConversationPanel mode="embedded-preview" />)
-
-    const activeWait = screen.getAllByTestId("chat-message").find(
-      (message) => message.getAttribute("data-active") === "true",
-    )
-    expect(activeWait).toBeDefined()
-    expect(activeWait).toHaveAttribute("data-request-id", "evt-round-1")
-  })
-
-  it("stops the round-id scan at the newest waiting result", () => {
-    // Reaching past an id-less newest result would return an OLDER round's
-    // id for the current question; the scan must stop and leave the round
-    // id-less so the prompt-text match stays in charge.
-    appState.messages = [{
-      id: "user-1",
-      role: "user",
-      content: "Working on it",
-      timestamp: 3000,
-    }]
-    appState.traceEvents = [
-      {
-        event_type: "react_task_end",
-        timestamp: 1000,
-        data: {
-          result: {
-            status: "waiting_for_user",
-            message: "Old question",
-            clarification_draft: { event_id: "evt-old-round" },
-          },
-        },
-      },
-      {
-        event_type: "react_task_end",
-        timestamp: 2000,
-        data: {
-          result: {
-            status: "waiting_for_user",
-            message: "Which city?",
-          },
-        },
-      },
-    ]
-    appState.currentTask = {
-      id: "42",
-      title: "Preview",
-      description: "Preview",
-      status: "waiting_for_user",
-      createdAt: "2026-01-01T00:00:00Z",
-      updatedAt: "2026-01-01T00:00:00Z",
-      waitingQuestion: "Which city?",
-    }
-
-    render(<TaskConversationPanel mode="embedded-preview" />)
-
-    const activeWait = screen.getAllByTestId("chat-message").find(
-      (message) => message.getAttribute("data-active") === "true",
-    )
-    expect(activeWait).toBeDefined()
-    expect(activeWait).toHaveAttribute("data-request-id", "")
-  })
-
   it("prefers the virtual bubble over an older round's form when the round id and text both miss", () => {
     // Round 2's status frame arrived (new id, new question) but its ask row
     // never landed. The only interactive timeline item belongs to round 1;
@@ -824,20 +728,18 @@ describe("TaskConversationPanel", () => {
     expect(active[0]).toHaveTextContent("Which city?")
   })
 
-  it("never adopts a client-minted trace id as the round id", () => {
-    // react_task_end rows in state get generateMessageId placeholders as
-    // their top-level event_id; adopting one would name a round no message
-    // carries, deactivating every instance. With no data-level id on the
-    // newest ask, the prompt-text match stays in charge and activates the
-    // persisted bubble.
+  it("gives the active id-less replayed row the resolved round id", () => {
+    // A replayed chat-history row carries no interactionRequestId. When the
+    // text fallback elects it as the active instance, it must submit with
+    // the round id the waiting frame delivered - not id-less.
     appState.messages = [
       {
         id: "q1",
         role: "assistant",
-        content: "Choose a region",
+        content: "Which city?",
         timestamp: 1000,
         isResult: true,
-        interactions: [{ type: "text_input", field: "region", label: "Region" }],
+        interactions: [{ type: "text_input", field: "city", label: "City" }],
       },
       {
         id: "u1",
@@ -846,19 +748,7 @@ describe("TaskConversationPanel", () => {
         timestamp: 2000,
       },
     ]
-    appState.traceEvents = [
-      {
-        event_id: "react-task-end-1757200000000-abc12",
-        event_type: "react_task_end",
-        timestamp: 1500,
-        data: {
-          result: {
-            status: "waiting_for_user",
-            message: "Choose a region",
-          },
-        },
-      },
-    ]
+    appState.traceEvents = []
     appState.currentTask = {
       id: "42",
       title: "Preview",
@@ -866,7 +756,8 @@ describe("TaskConversationPanel", () => {
       status: "waiting_for_user",
       createdAt: "2026-01-01T00:00:00Z",
       updatedAt: "2026-01-01T00:00:00Z",
-      waitingQuestion: "Choose a region",
+      waitingQuestion: "Which city?",
+      waitingRequestId: "evt-round-1",
     }
 
     render(<TaskConversationPanel mode="embedded-preview" />)
@@ -874,8 +765,61 @@ describe("TaskConversationPanel", () => {
     const active = screen.getAllByTestId("chat-message")
       .filter((node) => node.getAttribute("data-active") === "true")
     expect(active).toHaveLength(1)
-    expect(active[0]).toHaveTextContent("Choose a region")
-    expect(active[0]).toHaveAttribute("data-request-id", "")
+    expect(active[0]).toHaveTextContent("Which city?")
+    expect(active[0]).toHaveAttribute("data-request-id", "evt-round-1")
+  })
+
+  it("never text-elects a lookalike row that carries a different round id", () => {
+    // Same question text asked in an earlier round: that row provably
+    // belongs to the other round and must not be elected over the id-less
+    // current row.
+    // The lookalike carrying the OLD round id is deliberately the NEWEST
+    // text-matching row: the reverse scan reaches it first, so only the
+    // skip guard (not election order) keeps it from being elected.
+    appState.messages = [
+      {
+        id: "q1",
+        role: "assistant",
+        content: "Which city?",
+        timestamp: 1000,
+        isResult: true,
+        interactions: [{ type: "text_input", field: "city", label: "City" }],
+      },
+      {
+        id: "q2",
+        role: "assistant",
+        content: "Which city?",
+        timestamp: 2000,
+        isResult: true,
+        interactions: [{ type: "text_input", field: "city", label: "City" }],
+        interactionRequestId: "evt-old-round",
+      },
+      {
+        id: "u1",
+        role: "user",
+        content: "Working on it",
+        timestamp: 3000,
+      },
+    ]
+    appState.traceEvents = []
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Which city?",
+      waitingRequestId: "evt-round-2",
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const active = screen.getAllByTestId("chat-message")
+      .filter((node) => node.getAttribute("data-active") === "true")
+    expect(active).toHaveLength(1)
+    // The id-less newest row is elected and speaks with the current round id.
+    expect(active[0]).toHaveAttribute("data-request-id", "evt-round-2")
   })
 
   it("activates the round-id match rather than a same-text lookalike", () => {

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -602,10 +602,10 @@ describe("TaskConversationPanel", () => {
     expect(rendered[1]).toHaveAttribute("data-request-id", "inputreq_q2")
   })
 
-  it("adopts the ask frame's event_id as the waiting round id when no request_id exists", () => {
-    // No backend emits request_id today; the stable per-ask identity on the
-    // wire is event_id. The trace fallback must surface it so the round is
-    // identified even when the status frame carried nothing.
+  it("adopts the replayed waiting result's clarification event_id as the round id", () => {
+    // No backend emits request_id today, and replayed history rows carry no
+    // interactionRequestId; after a reload the round identity lives at the
+    // replayed react_task_end's result.clarification_draft.event_id.
     appState.messages = [{
       id: "user-1",
       role: "user",
@@ -614,14 +614,15 @@ describe("TaskConversationPanel", () => {
     }]
     appState.traceEvents = [
       {
-        event_type: "agent_message",
+        event_id: "react-task-end-1757200000000-abc12",
+        event_type: "react_task_end",
         timestamp: 1000,
         data: {
-          expect_response: true,
-          message: "Which region should I use?",
-          event_id: "evt-round-1",
-          metadata: {
+          result: {
+            status: "waiting_for_user",
+            message: "Which region should I use?",
             interactions: [{ type: "text_input", field: "region", label: "Region" }],
+            clarification_draft: { event_id: "evt-round-1" },
           },
         },
       },
@@ -643,6 +644,138 @@ describe("TaskConversationPanel", () => {
     )
     expect(activeWait).toBeDefined()
     expect(activeWait).toHaveAttribute("data-request-id", "evt-round-1")
+  })
+
+  it("stops the round-id scan at the newest waiting result", () => {
+    // Reaching past an id-less newest result would return an OLDER round's
+    // id for the current question; the scan must stop and leave the round
+    // id-less so the prompt-text match stays in charge.
+    appState.messages = [{
+      id: "user-1",
+      role: "user",
+      content: "Working on it",
+      timestamp: 3000,
+    }]
+    appState.traceEvents = [
+      {
+        event_type: "react_task_end",
+        timestamp: 1000,
+        data: {
+          result: {
+            status: "waiting_for_user",
+            message: "Old question",
+            clarification_draft: { event_id: "evt-old-round" },
+          },
+        },
+      },
+      {
+        event_type: "react_task_end",
+        timestamp: 2000,
+        data: {
+          result: {
+            status: "waiting_for_user",
+            message: "Which city?",
+          },
+        },
+      },
+    ]
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Which city?",
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const activeWait = screen.getAllByTestId("chat-message").find(
+      (message) => message.getAttribute("data-active") === "true",
+    )
+    expect(activeWait).toBeDefined()
+    expect(activeWait).toHaveAttribute("data-request-id", "")
+  })
+
+  it("prefers the virtual bubble over an older round's form when the round id and text both miss", () => {
+    // Round 2's status frame arrived (new id, new question) but its ask row
+    // never landed. The only interactive timeline item belongs to round 1;
+    // activating it would misbind the reply. The virtual bubble carrying
+    // the current question is the correct instance.
+    appState.messages = [
+      {
+        id: "q1",
+        role: "assistant",
+        content: "Which city?",
+        timestamp: 1000,
+        isResult: true,
+        interactions: [{ type: "text_input", field: "city", label: "City" }],
+        interactionRequestId: "round-1",
+      },
+      {
+        id: "u1",
+        role: "user",
+        content: "City: Beijing",
+        timestamp: 2000,
+      },
+    ]
+    appState.traceEvents = []
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Which hotel?",
+      waitingRequestId: "round-2",
+      waitingInteractions: [{ type: "text_input", field: "hotel", label: "Hotel" }],
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const active = screen.getAllByTestId("chat-message")
+      .filter((node) => node.getAttribute("data-active") === "true")
+    expect(active).toHaveLength(1)
+    expect(active[0]).toHaveAttribute("data-request-id", "round-2")
+    expect(active[0]).toHaveTextContent("Which hotel?")
+  })
+
+  it("falls back to the text match when no timeline item carries the round id", () => {
+    // Replayed history rows carry no interactionRequestId. With the ask as
+    // the last assistant message (virtual bubble suppressed), a failed
+    // id-match that short-circuited instead of falling through would leave
+    // ZERO active reply instances for a waiting task.
+    appState.messages = [
+      {
+        id: "q1",
+        role: "assistant",
+        content: "Which city?",
+        timestamp: 1000,
+        isResult: true,
+        interactions: [{ type: "text_input", field: "city", label: "City" }],
+        // No interactionRequestId - the replayed row never carried one.
+      },
+    ]
+    appState.traceEvents = []
+    appState.currentTask = {
+      id: "42",
+      title: "Preview",
+      description: "Preview",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Which city?",
+      waitingRequestId: "round-1",
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const active = screen.getAllByTestId("chat-message")
+      .filter((node) => node.getAttribute("data-active") === "true")
+    expect(active).toHaveLength(1)
+    expect(active[0]).toHaveTextContent("Which city?")
   })
 
   it("keeps at most one instance active for a waiting round", () => {

--- a/frontend/src/components/task/task-conversation-panel.test.tsx
+++ b/frontend/src/components/task/task-conversation-panel.test.tsx
@@ -682,6 +682,32 @@ describe("TaskConversationPanel", () => {
     expect(active[0]).toHaveTextContent("Which city?")
   })
 
+  it("does not leak the previous task's round id during a task switch", () => {
+    // During a switch, currentTask can still describe task A while
+    // state.taskId already points at task B; the round id read is gated on
+    // the ids matching, like the sibling ChatInput wiring.
+    appState.taskId = 99
+    appState.messages = []
+    appState.traceEvents = []
+    appState.currentTask = {
+      id: "42",
+      title: "Previous task",
+      description: "Previous task",
+      status: "waiting_for_user",
+      createdAt: "2026-01-01T00:00:00Z",
+      updatedAt: "2026-01-01T00:00:00Z",
+      waitingQuestion: "Old question?",
+      waitingRequestId: "round-of-task-42",
+    }
+
+    render(<TaskConversationPanel mode="embedded-preview" />)
+
+    const leaked = screen.getAllByTestId("chat-message")
+      .filter((node) => node.getAttribute("data-request-id") === "round-of-task-42")
+    expect(leaked).toHaveLength(0)
+    appState.taskId = 42
+  })
+
   it("keeps at most one instance active for a waiting round", () => {
     // The two-instances window: the round's question is persisted on the
     // timeline AND an optimistic user message is the last item (so the

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -151,6 +151,73 @@ const findWaitingPrompt = (currentTask: any, traceEvents: any[]) => {
   return null
 }
 
+// The waiting round's identity. Prefers the id the task-state handler
+// already extracted (request_id, falling back to the ask frame's event_id -
+// see the app context's task_waiting_for_user case); when the status frame
+// carried none, falls back to the same ask trace events the prompt and
+// interactions fall back to, so all three stay sourced from one ask.
+type WaitingRoundTraceEvent = {
+  event_id?: unknown
+  event_type?: unknown
+  data?: {
+    request_id?: unknown
+    event_id?: unknown
+    expect_response?: unknown
+    result?: {
+      status?: unknown
+      request_id?: unknown
+      event_id?: unknown
+    }
+  }
+}
+
+const firstRoundId = (...candidates: unknown[]): string | undefined => {
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate) return candidate
+  }
+  return undefined
+}
+
+const findWaitingRequestId = (
+  currentTask: { status?: unknown; waitingRequestId?: unknown } | null | undefined,
+  traceEvents: WaitingRoundTraceEvent[],
+): string | undefined => {
+  if (currentTask?.status !== "waiting_for_user") {
+    return undefined
+  }
+  if (
+    typeof currentTask.waitingRequestId === "string"
+    && currentTask.waitingRequestId
+  ) {
+    return currentTask.waitingRequestId
+  }
+
+  // Only data-level ids count: a trace row's top-level event_id can be a
+  // client-minted placeholder (react_task_end rows get generateMessageId
+  // ids), and adopting one would name a round no message ever carried,
+  // leaving no instance active. And the scan STOPS at the most recent ask
+  // whether or not it carries an id - reaching past it could return an
+  // older round's id for the current question. An id-less newest ask
+  // returns undefined so the prompt-text match below stays in charge.
+  for (let i = traceEvents.length - 1; i >= 0; i--) {
+    const event = traceEvents[i]
+    if (event.event_type === "agent_message" && event.data?.expect_response === true) {
+      return firstRoundId(event.data?.request_id, event.data?.event_id)
+    }
+    if (
+      event.event_type === "react_task_end"
+      && event.data?.result?.status === "waiting_for_user"
+    ) {
+      return firstRoundId(
+        event.data?.result?.request_id,
+        event.data?.result?.event_id,
+      )
+    }
+  }
+
+  return undefined
+}
+
 const findWaitingInteractions = (currentTask: any, traceEvents: any[]) => {
   if (currentTask?.status !== "waiting_for_user") {
     return undefined
@@ -480,9 +547,31 @@ export function TaskConversationPanel({
     () => findWaitingInteractions(state.currentTask, managerTraceEvents as any[]),
     [managerTraceEvents, state.currentTask]
   )
+  const waitingRoundId = useMemo(
+    () => findWaitingRequestId(
+      state.currentTask,
+      managerTraceEvents as WaitingRoundTraceEvent[],
+    ),
+    [managerTraceEvents, state.currentTask]
+  )
 
   const activeWaitingMessageId = useMemo(() => {
     if (state.currentTask?.status !== "waiting_for_user") {
+      return null
+    }
+
+    // When the waiting round has an identity, match by it exactly: the
+    // prompt-text fallback below can pick a message whose text merely equals
+    // the question while the round actually lives on a different item,
+    // leaving TWO instances active at once (the timeline one and the
+    // virtual one) with independently diverging state.
+    if (waitingRoundId) {
+      for (let i = messageItems.length - 1; i >= 0; i--) {
+        const item = messageItems[i]
+        if (item.role === "assistant" && item.interactionRequestId === waitingRoundId) {
+          return item.id
+        }
+      }
       return null
     }
 
@@ -504,7 +593,7 @@ export function TaskConversationPanel({
     }
 
     return null
-  }, [messageItems, state.currentTask?.status, waitingPrompt])
+  }, [messageItems, state.currentTask?.status, waitingPrompt, waitingRoundId])
 
   useEffect(() => {
     messagesEndRef.current?.scrollIntoView?.({ behavior: "smooth" })
@@ -815,8 +904,15 @@ export function TaskConversationPanel({
                       processStatus={state.currentTask?.status}
                       taskStatus={state.currentTask?.status}
                       interactions={state.currentTask?.status === "waiting_for_user" ? waitingInteractions : undefined}
-                      interactionRequestId={state.currentTask?.status === "waiting_for_user" ? state.currentTask.waitingRequestId : undefined}
-                      interactionsActive={state.currentTask?.status === "waiting_for_user"}
+                      interactionRequestId={state.currentTask?.status === "waiting_for_user" ? waitingRoundId : undefined}
+                      // At most one instance of a waiting round is active: a
+                      // timeline message already owning the round keeps the
+                      // virtual copy inert, so two forms can never both
+                      // accept a submission for the same question.
+                      interactionsActive={
+                        state.currentTask?.status === "waiting_for_user"
+                        && activeWaitingMessageId === null
+                      }
                       onOpenExecutionPlan={showDagPreview ? openDagPreview : undefined}
                       onAgentExecutionClick={onAgentExecutionClick}
                     />

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -21,7 +21,7 @@ import { useI18n } from "@/contexts/i18n-context"
 import { isStreamingFinalAnswerMessage } from "@/lib/streaming-final-answer"
 import { getProcessGroupIndex, getUserTimelineAnchors } from "@/lib/task-timeline"
 import { resolveTraceProcessStatus } from "@/lib/trace-process-status"
-import { cn } from "@/lib/utils"
+import { cn, firstNonEmptyString } from "@/lib/utils"
 
 export type TaskConversationPanelMode = "page" | "embedded-preview"
 
@@ -154,28 +154,19 @@ const findWaitingPrompt = (currentTask: any, traceEvents: any[]) => {
 // The waiting round's identity. Prefers the id the task-state handler
 // already extracted (request_id, falling back to the ask frame's event_id -
 // see the app context's task_waiting_for_user case); when the status frame
-// carried none, falls back to the same ask trace events the prompt and
-// interactions fall back to, so all three stay sourced from one ask.
+// carried none, falls back to the replayed waiting result the prompt and
+// interactions also fall back to, so all three stay sourced from one ask.
 type WaitingRoundTraceEvent = {
-  event_id?: unknown
   event_type?: unknown
   data?: {
-    request_id?: unknown
-    event_id?: unknown
-    expect_response?: unknown
     result?: {
       status?: unknown
       request_id?: unknown
-      event_id?: unknown
+      clarification_draft?: {
+        event_id?: unknown
+      }
     }
   }
-}
-
-const firstRoundId = (...candidates: unknown[]): string | undefined => {
-  for (const candidate of candidates) {
-    if (typeof candidate === "string" && candidate) return candidate
-  }
-  return undefined
 }
 
 const findWaitingRequestId = (
@@ -192,25 +183,24 @@ const findWaitingRequestId = (
     return currentTask.waitingRequestId
   }
 
-  // Only data-level ids count: a trace row's top-level event_id can be a
-  // client-minted placeholder (react_task_end rows get generateMessageId
-  // ids), and adopting one would name a round no message ever carried,
-  // leaving no instance active. And the scan STOPS at the most recent ask
-  // whether or not it carries an id - reaching past it could return an
-  // older round's id for the current question. An id-less newest ask
-  // returns undefined so the prompt-text match below stays in charge.
+  // Only react_task_end rows reach state.traceEvents for a waiting result
+  // (a live ask's agent_message lands in the transcript instead, already
+  // carrying its interactionRequestId), and the round identity on such a
+  // row lives at result.clarification_draft.event_id. A row's top-level
+  // event_id never counts: it is a client-minted placeholder, and adopting
+  // one would name a round no message ever carried. The scan STOPS at the
+  // most recent waiting result whether or not it yields an id - reaching
+  // past it could return an older round's id - and an id-less newest result
+  // returns undefined so the prompt-text match stays in charge.
   for (let i = traceEvents.length - 1; i >= 0; i--) {
     const event = traceEvents[i]
-    if (event.event_type === "agent_message" && event.data?.expect_response === true) {
-      return firstRoundId(event.data?.request_id, event.data?.event_id)
-    }
     if (
       event.event_type === "react_task_end"
       && event.data?.result?.status === "waiting_for_user"
     ) {
-      return firstRoundId(
+      return firstNonEmptyString(
         event.data?.result?.request_id,
-        event.data?.result?.event_id,
+        event.data?.result?.clarification_draft?.event_id,
       )
     }
   }
@@ -560,11 +550,15 @@ export function TaskConversationPanel({
       return null
     }
 
-    // When the waiting round has an identity, match by it exactly: the
+    // When the waiting round has an identity, prefer matching by it: the
     // prompt-text fallback below can pick a message whose text merely equals
     // the question while the round actually lives on a different item,
     // leaving TWO instances active at once (the timeline one and the
-    // virtual one) with independently diverging state.
+    // virtual one) with independently diverging state. A FAILED id-match
+    // falls through rather than short-circuiting: replayed history rows
+    // carry no interactionRequestId, and with the ask sitting as the last
+    // assistant message the virtual bubble is suppressed too - returning
+    // null here would leave zero active reply instances for a waiting task.
     if (waitingRoundId) {
       for (let i = messageItems.length - 1; i >= 0; i--) {
         const item = messageItems[i]
@@ -572,7 +566,6 @@ export function TaskConversationPanel({
           return item.id
         }
       }
-      return null
     }
 
     if (waitingPrompt) {
@@ -585,6 +578,14 @@ export function TaskConversationPanel({
       }
     }
 
+    // The bare newest-interactions fallback is for rounds with NO identity
+    // at all. Under a known round id whose item and text both failed to
+    // match, it could only pick an OLDER round's form (a dropped ask frame
+    // for the current round), misbinding the reply - the virtual bubble
+    // showing the current question is the right instance there.
+    if (waitingRoundId) {
+      return null
+    }
     for (let i = messageItems.length - 1; i >= 0; i--) {
       const item = messageItems[i]
       if (item.role === "assistant" && item.interactions && item.interactions.length > 0) {
@@ -960,7 +961,10 @@ export function TaskConversationPanel({
               currentInteractionRequestId={
                 state.currentTask?.status === "waiting_for_user" &&
                 state.currentTask.id === String(state.taskId)
-                  ? state.currentTask.waitingRequestId
+                  // The same round identity the form path uses - including
+                  // the ask-trace fallback - so a free-text reply after a
+                  // reload still binds to the round.
+                  ? waitingRoundId
                   : undefined
               }
               isLoading={

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -21,7 +21,7 @@ import { useI18n } from "@/contexts/i18n-context"
 import { isStreamingFinalAnswerMessage } from "@/lib/streaming-final-answer"
 import { getProcessGroupIndex, getUserTimelineAnchors } from "@/lib/task-timeline"
 import { resolveTraceProcessStatus } from "@/lib/trace-process-status"
-import { cn } from "@/lib/utils"
+import { cn, firstNonEmptyString } from "@/lib/utils"
 
 export type TaskConversationPanelMode = "page" | "embedded-preview"
 
@@ -484,8 +484,13 @@ export function TaskConversationPanel({
   // themselves (live/resume waiting task_info, replay task_info, replay
   // reassertion) - no client-side reconstruction. Undefined only for
   // backends predating the emission, where rounds stay unidentified.
+  // Gated on the task actually being the one on screen: during a task
+  // switch, currentTask can still describe the previous task while
+  // state.taskId already points at the new one (same guard as the
+  // ChatInput wiring below).
   const waitingRoundId =
     state.currentTask?.status === "waiting_for_user"
+    && state.currentTask.id === String(state.taskId)
       ? state.currentTask.waitingRequestId
       : undefined
 
@@ -839,7 +844,10 @@ export function TaskConversationPanel({
                         // submitting id-less.
                         interactionRequestId={
                           item.id === activeWaitingMessageId
-                            ? item.interactionRequestId ?? waitingRoundId
+                            ? firstNonEmptyString(
+                                item.interactionRequestId,
+                                waitingRoundId,
+                              )
                             : item.interactionRequestId
                         }
                         interactionsActive={item.id === activeWaitingMessageId}

--- a/frontend/src/components/task/task-conversation-panel.tsx
+++ b/frontend/src/components/task/task-conversation-panel.tsx
@@ -21,7 +21,7 @@ import { useI18n } from "@/contexts/i18n-context"
 import { isStreamingFinalAnswerMessage } from "@/lib/streaming-final-answer"
 import { getProcessGroupIndex, getUserTimelineAnchors } from "@/lib/task-timeline"
 import { resolveTraceProcessStatus } from "@/lib/trace-process-status"
-import { cn, firstNonEmptyString } from "@/lib/utils"
+import { cn } from "@/lib/utils"
 
 export type TaskConversationPanelMode = "page" | "embedded-preview"
 
@@ -149,63 +149,6 @@ const findWaitingPrompt = (currentTask: any, traceEvents: any[]) => {
   }
 
   return null
-}
-
-// The waiting round's identity. Prefers the id the task-state handler
-// already extracted (request_id, falling back to the ask frame's event_id -
-// see the app context's task_waiting_for_user case); when the status frame
-// carried none, falls back to the replayed waiting result the prompt and
-// interactions also fall back to, so all three stay sourced from one ask.
-type WaitingRoundTraceEvent = {
-  event_type?: unknown
-  data?: {
-    result?: {
-      status?: unknown
-      request_id?: unknown
-      clarification_draft?: {
-        event_id?: unknown
-      }
-    }
-  }
-}
-
-const findWaitingRequestId = (
-  currentTask: { status?: unknown; waitingRequestId?: unknown } | null | undefined,
-  traceEvents: WaitingRoundTraceEvent[],
-): string | undefined => {
-  if (currentTask?.status !== "waiting_for_user") {
-    return undefined
-  }
-  if (
-    typeof currentTask.waitingRequestId === "string"
-    && currentTask.waitingRequestId
-  ) {
-    return currentTask.waitingRequestId
-  }
-
-  // Only react_task_end rows reach state.traceEvents for a waiting result
-  // (a live ask's agent_message lands in the transcript instead, already
-  // carrying its interactionRequestId), and the round identity on such a
-  // row lives at result.clarification_draft.event_id. A row's top-level
-  // event_id never counts: it is a client-minted placeholder, and adopting
-  // one would name a round no message ever carried. The scan STOPS at the
-  // most recent waiting result whether or not it yields an id - reaching
-  // past it could return an older round's id - and an id-less newest result
-  // returns undefined so the prompt-text match stays in charge.
-  for (let i = traceEvents.length - 1; i >= 0; i--) {
-    const event = traceEvents[i]
-    if (
-      event.event_type === "react_task_end"
-      && event.data?.result?.status === "waiting_for_user"
-    ) {
-      return firstNonEmptyString(
-        event.data?.result?.request_id,
-        event.data?.result?.clarification_draft?.event_id,
-      )
-    }
-  }
-
-  return undefined
 }
 
 const findWaitingInteractions = (currentTask: any, traceEvents: any[]) => {
@@ -537,13 +480,14 @@ export function TaskConversationPanel({
     () => findWaitingInteractions(state.currentTask, managerTraceEvents as any[]),
     [managerTraceEvents, state.currentTask]
   )
-  const waitingRoundId = useMemo(
-    () => findWaitingRequestId(
-      state.currentTask,
-      managerTraceEvents as WaitingRoundTraceEvent[],
-    ),
-    [managerTraceEvents, state.currentTask]
-  )
+  // The waiting round's identity, delivered on the task-state frames
+  // themselves (live/resume waiting task_info, replay task_info, replay
+  // reassertion) - no client-side reconstruction. Undefined only for
+  // backends predating the emission, where rounds stay unidentified.
+  const waitingRoundId =
+    state.currentTask?.status === "waiting_for_user"
+      ? state.currentTask.waitingRequestId
+      : undefined
 
   const activeWaitingMessageId = useMemo(() => {
     if (state.currentTask?.status !== "waiting_for_user") {
@@ -572,6 +516,16 @@ export function TaskConversationPanel({
       const normalizedPrompt = waitingPrompt.trim()
       for (let i = messageItems.length - 1; i >= 0; i--) {
         const item = messageItems[i]
+        // A row that carries its OWN round id different from the current
+        // round is a lookalike from an earlier ask - electing it would
+        // misbind the reply. Only id-less rows may be text-elected.
+        if (
+          waitingRoundId
+          && item.interactionRequestId
+          && item.interactionRequestId !== waitingRoundId
+        ) {
+          continue
+        }
         if (item.role === "assistant" && typeof item.content === "string" && item.content.trim() === normalizedPrompt) {
           return item.id
         }
@@ -878,7 +832,16 @@ export function TaskConversationPanel({
                         }
                         timestamp={item.timestamp}
                         interactions={item.interactions}
-                        interactionRequestId={item.interactionRequestId}
+                        // The active waiting item speaks for the current
+                        // round: when a replayed row carries no id of its
+                        // own, the resolved round id keeps its reply - and
+                        // the retry gate - bound to the ask instead of
+                        // submitting id-less.
+                        interactionRequestId={
+                          item.id === activeWaitingMessageId
+                            ? item.interactionRequestId ?? waitingRoundId
+                            : item.interactionRequestId
+                        }
                         interactionsActive={item.id === activeWaitingMessageId}
                         showEmptyStatus={item.showEmptyStatus}
                         contextBadges={item.role === "user" ? userMessageContextBadges : undefined}

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -6646,3 +6646,136 @@ describe("error frame display projection", () => {
     ).toEqual(expected)
   })
 })
+
+describe("clarification round identity (#1500)", () => {
+  beforeEach(() => {
+    webSocketOptions.current = null
+    webSocketOptions.all = []
+    sessionControls = null
+    wsHarness.isConnected = true
+    apiRequestMock.mockReset()
+    routerPushMock.mockReset()
+    sendRawMessageMock.mockReset()
+    sendRawMessageMock.mockReturnValue("sent")
+    sendChatMessageMock.mockReset()
+    sendChatMessageMock.mockResolvedValue({
+      client_message_id: "turn-optimistic",
+      turn_id: "turn-optimistic",
+    })
+    localStorage.clear()
+    ;(window as typeof window & { clearDuplicateMessageCache?: () => void })
+      .clearDuplicateMessageCache?.()
+  })
+
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+  })
+
+  it("adopts the ask frame's event_id as the waiting round id", async () => {
+    // No backend emits request_id; the stable per-ask identity is event_id.
+    // request_id stays the preferred field so a backend that later adopts
+    // the explicit name wins over the fallback.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+        event_id: "evt-round-1",
+        interactions: [
+          { type: "text", prompt: "Which region should I use?" },
+        ],
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("evt-round-1")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which hotel?",
+        request_id: "req-explicit",
+        event_id: "evt-round-2",
+        interactions: [
+          { type: "text", prompt: "Which hotel?" },
+        ],
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("req-explicit")
+    })
+  })
+
+  it("keeps a stale-versioned error notice without rolling back task state", async () => {
+    // The version guard protects task state, but an error frame's body is
+    // not versioned state: it carries a notice (and, since #2124, the
+    // structured terminal command outcome) the backend sends exactly once.
+    // A stale control tuple must lose the state argument yet keep the
+    // notice.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 6,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 5,
+        data: {
+          type: "agent_error",
+          message: "This message was not applied to the task.",
+          command_id: "client-msg-1",
+          command_kind: "message",
+          task: { id: 1, status: "failed" },
+        },
+      } as TestWebSocketMessage)
+    })
+
+    // The notice reaches the transcript; the stale status assertion does not.
+    await waitFor(() => {
+      expect(screen.getByTestId("messages").textContent).toContain(
+        "This message was not applied to the task."
+      )
+    })
+    expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+  })
+})

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -6722,6 +6722,35 @@ describe("clarification round identity (#1500)", () => {
     })
   })
 
+  it("falls back to event_id when request_id is an empty string", async () => {
+    // Nullish coalescing alone would let an empty request_id block the
+    // event_id fallback and leave the round id-less.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+        request_id: "",
+        event_id: "evt-round-3",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("evt-round-3")
+    })
+  })
+
   it("keeps a stale-versioned error notice without rolling back task state", async () => {
     // The version guard protects task state, but an error frame's body is
     // not versioned state: it carries a notice (and, since #2124, the

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -7171,7 +7171,7 @@ function ClarificationSubmissionProbe() {
         onClick={() =>
           dispatch({
             type: "RECORD_CLARIFICATION_SUBMISSION",
-            payload: { requestId: "req-1", commandId: "cmd-1" },
+            payload: { requestId: "req-1", commandId: "cmd-1", accepted: true },
           })
         }
       />
@@ -7377,7 +7377,7 @@ describe("terminal command outcomes (#1500)", () => {
         JSON.parse(
           screen.getByTestId("clarification-submissions").textContent || "{}"
         )
-      ).toEqual({ "req-1": { commandId: "cmd-1" } })
+      ).toEqual({ "req-1": { commandId: "cmd-1", accepted: true } })
     })
 
     act(() => {

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -214,6 +214,7 @@ function StateProbe() {
       <div data-testid="history-loading">{String(state.isHistoryLoading)}</div>
       <div data-testid="preview-open">{String(state.filePreview.isOpen)}</div>
       <div data-testid="processing">{String(state.isProcessing)}</div>
+      <div data-testid="command-outcomes">{JSON.stringify(state.commandOutcomes)}</div>
     </>
   )
 }
@@ -7155,5 +7156,239 @@ describe("clarification round identity (#1500)", () => {
       )
     })
     expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+  })
+})
+
+function ClarificationSubmissionProbe() {
+  const { state, dispatch } = useApp()
+  return (
+    <>
+      <div data-testid="clarification-submissions">
+        {JSON.stringify(state.clarificationSubmissions)}
+      </div>
+      <button
+        data-testid="record-submission"
+        onClick={() =>
+          dispatch({
+            type: "RECORD_CLARIFICATION_SUBMISSION",
+            payload: { requestId: "req-1", commandId: "cmd-1" },
+          })
+        }
+      />
+      <button
+        data-testid="clear-submission"
+        onClick={() =>
+          dispatch({
+            type: "CLEAR_CLARIFICATION_SUBMISSION",
+            payload: { requestId: "req-1" },
+          })
+        }
+      />
+    </>
+  )
+}
+
+describe("terminal command outcomes (#1500)", () => {
+  beforeEach(() => {
+    webSocketOptions.current = null
+    webSocketOptions.all = []
+    sessionControls = null
+    wsHarness.isConnected = true
+    apiRequestMock.mockReset()
+    routerPushMock.mockReset()
+    sendRawMessageMock.mockReset()
+    sendRawMessageMock.mockReturnValue("sent")
+    sendChatMessageMock.mockReset()
+    sendChatMessageMock.mockResolvedValue({
+      client_message_id: "turn-optimistic",
+      turn_id: "turn-optimistic",
+    })
+    localStorage.clear()
+    ;(window as typeof window & { clearDuplicateMessageCache?: () => void })
+      .clearDuplicateMessageCache?.()
+  })
+
+  afterEach(() => {
+    cleanup()
+    localStorage.clear()
+  })
+
+  // A terminal agent_error for a durable command carries a structured
+  // disposition. The context records it keyed by command id so the
+  // clarification form that submitted that exact command can decide
+  // whether a resend is safe - task state alone must not decide that.
+  it("records a structured terminal outcome keyed by command id", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:04Z",
+        data: {
+          type: "agent_error",
+          message: "This message was not applied to the task.",
+          command_id: "client-msg-1",
+          command_kind: "message",
+          outcome: "failed",
+          resend_safe: true,
+          message_code: "task_command_deferred",
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
+      ).toEqual({
+        "client-msg-1": {
+          outcome: "failed",
+          resendSafe: true,
+          messageCode: "task_command_deferred",
+        },
+      })
+    })
+  })
+
+  it("keeps legacy frames without a structured outcome in the unsafe reading", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:04Z",
+        data: {
+          type: "agent_error",
+          message: "Task command message failed: something",
+          command_id: "client-msg-legacy",
+          command_kind: "message",
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("messages").textContent).toContain(
+        "Task command message failed"
+      )
+    })
+    // No structured outcome field, no recorded disposition: consumers keep
+    // treating the command as possibly committed or in flight.
+    expect(
+      JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
+    ).toEqual({})
+  })
+
+  it("records the outcome while a same-version waiting_for_user reassertion is retained", async () => {
+    // The full post-ack sequence at the context level: the task waits, the
+    // reply's terminal agent_error reasserts waiting_for_user for the same
+    // run and version, and the structured outcome lands beside the retained
+    // task state - the form layer decides the retry from both.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+        request_id: "req-1",
+        interactions: [
+          { type: "text", request_id: "req-1", prompt: "Which region should I use?" },
+        ],
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 3,
+        data: {
+          type: "agent_error",
+          message: "We could not confirm whether this message was applied to the task.",
+          command_id: "client-msg-2",
+          command_kind: "message",
+          outcome: "failed",
+          resend_safe: false,
+          message_code: "task_command_deferred",
+          task: { id: 1, status: "waiting_for_user" },
+        },
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
+      ).toEqual({
+        "client-msg-2": {
+          outcome: "failed",
+          resendSafe: false,
+          messageCode: "task_command_deferred",
+        },
+      })
+    })
+    // The reasserted waiting state is retained, exactly as before.
+    expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+    expect(screen.getByTestId("waiting-interactions").textContent).not.toBe("[]")
+  })
+
+  it("records and consumes the round's accountable submission", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <ClarificationSubmissionProbe />
+      </AppProvider>
+    )
+
+    act(() => {
+      screen.getByTestId("record-submission").click()
+    })
+    await waitFor(() => {
+      expect(
+        JSON.parse(
+          screen.getByTestId("clarification-submissions").textContent || "{}"
+        )
+      ).toEqual({ "req-1": { commandId: "cmd-1" } })
+    })
+
+    act(() => {
+      screen.getByTestId("clear-submission").click()
+    })
+    await waitFor(() => {
+      expect(
+        JSON.parse(
+          screen.getByTestId("clarification-submissions").textContent || "{}"
+        )
+      ).toEqual({})
+    })
   })
 })

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -6751,6 +6751,184 @@ describe("clarification round identity (#1500)", () => {
     })
   })
 
+  it("keeps the round id across a same-question reassertion without an id", async () => {
+    // Reload/reconnect reassertion frames re-send the unchanged question
+    // with no id; wiping the id there severs the open round's correlation.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+        event_id: "evt-round-1",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("evt-round-1")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("evt-round-1")
+    })
+  })
+
+  it("clears the round id when an id-less frame asks a different question", async () => {
+    // A legacy-backend NEW round (different question, no id) must not
+    // inherit the previous round's id.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+        event_id: "evt-round-1",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("evt-round-1")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which hotel?",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("")
+    })
+  })
+
+  it("keeps a stale-versioned plain error notice without rolling back task state", async () => {
+    // The parallel "error"-type path shares the exemption with agent_error.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 6,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "error",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 5,
+        task: { id: 1, status: "failed" },
+        message: "Task pause is still being applied; please retry shortly.",
+        error_code: "task_pause_in_progress",
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("messages").textContent).toContain(
+        "clientErrors.taskPauseInProgress"
+      )
+    })
+    expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+  })
+
+  it("still drops a stale-versioned task_error frame whole", async () => {
+    // task_error's bubble is the turn's terminal result; it deliberately
+    // stays outside the stale-frame exemption, mirroring the guard's
+    // unversioned rule.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 6,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "task_error",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 5,
+        task: { id: 1, status: "failed" },
+        message: "stale terminal result",
+      } as TestWebSocketMessage)
+    })
+
+    // The whole frame is dropped: no bubble, no status change.
+    expect(screen.getByTestId("messages").textContent).not.toContain(
+      "stale terminal result"
+    )
+    expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+  })
+
   it("keeps a stale-versioned error notice without rolling back task state", async () => {
     // The version guard protects task state, but an error frame's body is
     // not versioned state: it carries a notice (and, since #2124, the

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -6672,10 +6672,12 @@ describe("clarification round identity (#1500)", () => {
     localStorage.clear()
   })
 
-  it("adopts the ask frame's event_id as the waiting round id", async () => {
-    // No backend emits request_id; the stable per-ask identity is event_id.
-    // request_id stays the preferred field so a backend that later adopts
-    // the explicit name wins over the fallback.
+  it("adopts the waiting frame's request_id as the round id", async () => {
+    // The waiting/reassert frames carry the round identity as request_id
+    // (backend #2232). They never emit event_id, so there is deliberately
+    // no event_id fallback on this handler - the ask frame's event_id is
+    // adopted in the agent_message trace reader instead. An empty-string
+    // request_id reads as no identity.
     render(
       <AppProvider token="token">
         <SeedRunningTask />
@@ -6693,14 +6695,14 @@ describe("clarification round identity (#1500)", () => {
         task_id: 1,
         task: { id: 1, status: "waiting_for_user" },
         message: "Which region should I use?",
-        event_id: "evt-round-1",
+        request_id: "req-round-1",
         interactions: [
           { type: "text", prompt: "Which region should I use?" },
         ],
       } as TestWebSocketMessage)
     })
     await waitFor(() => {
-      expect(screen.getByTestId("waiting-request-id").textContent).toBe("evt-round-1")
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("req-round-1")
     })
 
     act(() => {
@@ -6710,16 +6712,17 @@ describe("clarification round identity (#1500)", () => {
         task_id: 1,
         task: { id: 1, status: "waiting_for_user" },
         message: "Which hotel?",
-        request_id: "req-explicit",
-        event_id: "evt-round-2",
+        request_id: "",
+        event_id: "evt-never-adopted-here",
         interactions: [
           { type: "text", prompt: "Which hotel?" },
         ],
       } as TestWebSocketMessage)
     })
     await waitFor(() => {
-      expect(screen.getByTestId("waiting-request-id").textContent).toBe("req-explicit")
+      expect(screen.getByTestId("messages").textContent).toContain("Which hotel?")
     })
+    expect(screen.getByTestId("waiting-request-id").textContent).toBe("")
   })
 
   it("adopts the live ask's event_id onto the transcript message", async () => {
@@ -6791,7 +6794,7 @@ describe("clarification round identity (#1500)", () => {
         task_id: 1,
         task: { id: 1, status: "waiting_for_user" },
         message: "Which region should I use?",
-        event_id: "evt-live-round",
+        request_id: "evt-live-round",
       } as TestWebSocketMessage)
     })
     await waitFor(() => {
@@ -6867,35 +6870,6 @@ describe("clarification round identity (#1500)", () => {
     })
   })
 
-  it("falls back to event_id when request_id is an empty string", async () => {
-    // Nullish coalescing alone would let an empty request_id block the
-    // event_id fallback and leave the round id-less.
-    render(
-      <AppProvider token="token">
-        <SeedRunningTask />
-        <StateProbe />
-      </AppProvider>
-    )
-
-    const onMessage = webSocketOptions.current?.onMessage
-    expect(onMessage).toBeDefined()
-
-    act(() => {
-      onMessage?.({
-        type: "task_waiting_for_user",
-        timestamp: "2026-05-27T05:00:01Z",
-        task_id: 1,
-        task: { id: 1, status: "waiting_for_user" },
-        message: "Which region should I use?",
-        request_id: "",
-        event_id: "evt-round-3",
-      } as TestWebSocketMessage)
-    })
-    await waitFor(() => {
-      expect(screen.getByTestId("waiting-request-id").textContent).toBe("evt-round-3")
-    })
-  })
-
   it("keeps the round id across a same-question reassertion without an id", async () => {
     // Reload/reconnect reassertion frames re-send the unchanged question
     // with no id; wiping the id there severs the open round's correlation.
@@ -6916,7 +6890,7 @@ describe("clarification round identity (#1500)", () => {
         task_id: 1,
         task: { id: 1, status: "waiting_for_user" },
         message: "Which region should I use?",
-        event_id: "evt-round-1",
+        request_id: "evt-round-1",
       } as TestWebSocketMessage)
     })
     await waitFor(() => {
@@ -6957,7 +6931,7 @@ describe("clarification round identity (#1500)", () => {
         task_id: 1,
         task: { id: 1, status: "waiting_for_user" },
         message: "Which region should I use?",
-        event_id: "evt-round-1",
+        request_id: "evt-round-1",
       } as TestWebSocketMessage)
     })
     await waitFor(() => {
@@ -6975,6 +6949,58 @@ describe("clarification round identity (#1500)", () => {
     })
     await waitFor(() => {
       expect(screen.getByTestId("waiting-request-id").textContent).toBe("")
+    })
+  })
+
+  it("adds one bubble for a duplicated terminal command frame", async () => {
+    // A terminal agent_error carries a durable identity (command_id +
+    // outcome_version); a duplicated delivery of the SAME broadcast must
+    // not add a second bubble, while two DISTINCT commands failing with
+    // identical text must both stay visible (identity-keyed, never
+    // text-keyed).
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    const terminalFrame = (commandId: string) => ({
+      type: "agent_error",
+      timestamp: "2026-05-27T05:00:02Z",
+      task_id: 1,
+      data: {
+        type: "agent_error",
+        message: "This message was not applied to the task.",
+        command_id: commandId,
+        command_kind: "message",
+        outcome: "failed",
+        outcome_version: 1,
+        resend_safe: true,
+      },
+    }) as TestWebSocketMessage
+
+    act(() => {
+      onMessage?.(terminalFrame("cmd-dup"))
+    })
+    act(() => {
+      onMessage?.(terminalFrame("cmd-dup"))
+    })
+    act(() => {
+      onMessage?.(terminalFrame("cmd-other"))
+    })
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ content: string }>
+      const bubbles = messages.filter((m) =>
+        m.content.includes("This message was not applied to the task.")
+      )
+      expect(bubbles).toHaveLength(2)
     })
   })
 

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -6722,6 +6722,151 @@ describe("clarification round identity (#1500)", () => {
     })
   })
 
+  it("adopts the live ask's event_id onto the transcript message", async () => {
+    // The one adoption site production always exercises: a live ask arrives
+    // as an agent_message trace event whose data.event_id is the round id,
+    // and the transcript message it produces must carry it as
+    // interactionRequestId.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        data: {
+          event_id: "trace-row-1",
+          event_type: "agent_message",
+          data: {
+            message: "Which region should I use?",
+            expect_response: true,
+            event_id: "evt-live-ask",
+            metadata: {
+              interactions: [
+                { type: "text_input", field: "region", label: "Region" },
+              ],
+            },
+          },
+        },
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      const messages = JSON.parse(
+        screen.getByTestId("messages").textContent || "[]"
+      ) as Array<{ content: string; interactionRequestId?: string }>
+      const ask = messages.find(
+        (m) => m.content === "Which region should I use?"
+      )
+      expect(ask?.interactionRequestId).toBe("evt-live-ask")
+    })
+  })
+
+  it("keeps a held round id when an id-less waiting task_info arrives", async () => {
+    // A backend predating the emission sends waiting task_info frames with
+    // no request_id; SET_CURRENT_TASK's merge must not wipe the id the
+    // waiting handler already extracted for the open round.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+        event_id: "evt-live-round",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe(
+        "evt-live-round"
+      )
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        data: {
+          event_id: "task-info-row-2",
+          event_type: "task_info",
+          data: {
+            id: 1,
+            title: "Task",
+            description: "Task",
+            status: "waiting_for_user",
+          },
+        },
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe(
+        "waiting_for_user"
+      )
+    })
+    expect(screen.getByTestId("waiting-request-id").textContent).toBe(
+      "evt-live-round"
+    )
+  })
+
+  it("adopts the waiting task_info frame's request_id as the round id", async () => {
+    // The replay/live waiting task_info now carries request_id; the task
+    // shaping must surface it as waitingRequestId.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "trace_event",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        data: {
+          event_id: "task-info-row",
+          event_type: "task_info",
+          data: {
+            id: 1,
+            title: "Task",
+            description: "Task",
+            status: "waiting_for_user",
+            request_id: "evt-info-round",
+          },
+        },
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe(
+        "evt-info-round"
+      )
+    })
+  })
+
   it("falls back to event_id when request_id is an empty string", async () => {
     // Nullish coalescing alone would let an empty request_id block the
     // event_id fallback and leave the round id-less.

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -153,6 +153,7 @@ import { ChatStartScreen } from "@/components/chat/ChatStartScreen"
 import { MarkdownRenderer } from "@/components/ui/markdown-renderer"
 import { TASK_ERROR_EVENT, type TaskErrorEventDetail } from "@/lib/task-error-events"
 import type { Translate } from "@/contexts/i18n-context"
+import { ClarificationForm } from "@/components/chat/clarification-form"
 
 type TaskControlMessage = Parameters<typeof extractTaskControlEnvelope>[0]
 
@@ -7189,7 +7190,25 @@ function ClarificationSubmissionProbe() {
         onClick={() =>
           dispatch({
             type: "CLEAR_CLARIFICATION_SUBMISSION",
-            payload: { requestId: "req-1" },
+            payload: { requestId: "req-1", commandIds: ["cmd-1"] },
+          })
+        }
+      />
+      <button
+        data-testid="record-unsafe-outcome"
+        onClick={() =>
+          dispatch({
+            type: "RECORD_COMMAND_OUTCOME",
+            payload: { commandId: "cmd-x", outcome: { resendSafe: false } },
+          })
+        }
+      />
+      <button
+        data-testid="record-safe-outcome"
+        onClick={() =>
+          dispatch({
+            type: "RECORD_COMMAND_OUTCOME",
+            payload: { commandId: "cmd-x", outcome: { resendSafe: true } },
           })
         }
       />
@@ -7496,6 +7515,216 @@ describe("terminal command outcomes (#1500)", () => {
         JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
       ).toEqual({ "other-task-command": { resendSafe: true } })
     })
+  })
+
+  it("gates the real form through the real reducer across a full round", async () => {
+    // Integration of the production pieces the unit suites mock away from
+    // each other (#2126 review round 3, F9): the real AppProvider reducer,
+    // the real ClarificationForm, one round identified by the ask frame's
+    // event_id. Sequence: waiting -> submit whose ack times out (the reply
+    // may still have been accepted; the round keeps its identity because no
+    // optimistic running flip happens) -> the command's terminal outcome
+    // arrives unproven-safe -> the form locks with the ambiguity notice.
+    // (The accepted-submit variant flips the task to running, which clears
+    // currentTask.waitingRequestId; the conversation panel bridges that via
+    // its ask-trace fallback, covered by the panel suite.)
+    sendChatMessageMock.mockRejectedValueOnce(Object.assign(
+      new Error("ack timed out"),
+      { disposition: "outcome_unknown", userFacing: true },
+    ))
+    function ClarificationRoundHarness() {
+      const { state } = useApp()
+      return (
+        <ClarificationForm
+          interactions={[{ type: "text_input" as const, field: "city", label: "City" }]}
+          requestId={state.currentTask?.waitingRequestId}
+          active={state.currentTask?.status === "waiting_for_user"}
+        />
+      )
+    }
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+        <ClarificationRoundHarness />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 6,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which city?",
+        event_id: "evt-int-1",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("waiting-request-id").textContent).toBe("evt-int-1")
+    })
+
+    fireEvent.change(screen.getByRole("textbox"), { target: { value: "Beijing" } })
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+    // The unconfirmed delivery keeps the advisory retry and records the
+    // submission through the real reducer.
+    await waitFor(() => {
+      expect(sendChatMessageMock).toHaveBeenCalledTimes(1)
+    })
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+      ).toBeEnabled()
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:03Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 6,
+        data: {
+          type: "agent_error",
+          message: "We could not confirm whether this message was applied to the task.",
+          command_id: sendChatMessageMock.mock.calls[0][3],
+          command_kind: "message",
+          outcome: "failed",
+          resend_safe: false,
+          task: { id: 1, status: "waiting_for_user" },
+        },
+      } as TestWebSocketMessage)
+    })
+
+    // The real reducer recorded the outcome for the id the real form
+    // minted, and the gate locks the round with the ambiguity notice.
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("chatPage.clarification.replyOutcomeUnknown")
+    expect(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    ).toBeDisabled()
+    expect(screen.getByRole("textbox")).toHaveValue("Beijing")
+  })
+
+  it("keeps an unsafe outcome unsafe when a later frame claims it safe", async () => {
+    // Monotone in the unsafe direction, mirroring UPDATE_TASK_STATUS's
+    // first-write-wins for terminal values (#2126 review round 3, F4).
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+        <ClarificationSubmissionProbe />
+      </AppProvider>
+    )
+
+    act(() => {
+      screen.getByTestId("record-unsafe-outcome").click()
+    })
+    act(() => {
+      screen.getByTestId("record-safe-outcome").click()
+    })
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
+      ).toEqual({ "cmd-x": { resendSafe: false } })
+    })
+  })
+
+  it("clears only the named commands, preserving a concurrent submission", async () => {
+    // The CLEAR names the commands the consuming render verified; a
+    // submission recorded between that snapshot and the dispatch survives
+    // (#2126 review round 3, F7).
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <ClarificationSubmissionProbe />
+      </AppProvider>
+    )
+
+    act(() => {
+      screen.getByTestId("record-submission").click()
+    })
+    act(() => {
+      screen.getByTestId("record-second-submission").click()
+    })
+    act(() => {
+      screen.getByTestId("clear-submission").click()
+    })
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(
+          screen.getByTestId("clarification-submissions").textContent || "{}"
+        )
+      ).toEqual({
+        "req-1": [{ commandId: "cmd-2", accepted: false }],
+      })
+    })
+  })
+
+  it("records the outcome from a stale-versioned agent_error frame", async () => {
+    // The version guard neutralizes a stale frame's control tuple but must
+    // not swallow the outcome it carries - the backend sends it exactly
+    // once (#2126 review round 3, F3; guard exemption shipped in the
+    // round-identity PR).
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "task_waiting_for_user",
+        timestamp: "2026-05-27T05:00:01Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 6,
+        task: { id: 1, status: "waiting_for_user" },
+        message: "Which region should I use?",
+      } as TestWebSocketMessage)
+    })
+    await waitFor(() => {
+      expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
+    })
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:02Z",
+        task_id: 1,
+        run_id: "run-1",
+        state_version: 5,
+        data: {
+          type: "agent_error",
+          message: "This message was not applied to the task.",
+          command_id: "client-msg-stale",
+          command_kind: "message",
+          outcome: "failed",
+          resend_safe: true,
+          task: { id: 1, status: "failed" },
+        },
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
+      ).toEqual({ "client-msg-stale": { resendSafe: true } })
+    })
+    expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
   })
 
   it("records and consumes the round's accountable submission", async () => {

--- a/frontend/src/contexts/app-context-chat.test.tsx
+++ b/frontend/src/contexts/app-context-chat.test.tsx
@@ -7176,6 +7176,15 @@ function ClarificationSubmissionProbe() {
         }
       />
       <button
+        data-testid="record-second-submission"
+        onClick={() =>
+          dispatch({
+            type: "RECORD_CLARIFICATION_SUBMISSION",
+            payload: { requestId: "req-1", commandId: "cmd-2", accepted: false },
+          })
+        }
+      />
+      <button
         data-testid="clear-submission"
         onClick={() =>
           dispatch({
@@ -7248,11 +7257,7 @@ describe("terminal command outcomes (#1500)", () => {
       expect(
         JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
       ).toEqual({
-        "client-msg-1": {
-          outcome: "failed",
-          resendSafe: true,
-          messageCode: "task_command_deferred",
-        },
+        "client-msg-1": { resendSafe: true },
       })
     })
   })
@@ -7349,16 +7354,148 @@ describe("terminal command outcomes (#1500)", () => {
       expect(
         JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
       ).toEqual({
-        "client-msg-2": {
-          outcome: "failed",
-          resendSafe: false,
-          messageCode: "task_command_deferred",
-        },
+        "client-msg-2": { resendSafe: false },
       })
     })
     // The reasserted waiting state is retained, exactly as before.
     expect(screen.getByTestId("task-status").textContent).toBe("waiting_for_user")
     expect(screen.getByTestId("waiting-interactions").textContent).not.toBe("[]")
+  })
+
+  it("appends a second submission for the same round instead of overwriting", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <ClarificationSubmissionProbe />
+      </AppProvider>
+    )
+
+    act(() => {
+      screen.getByTestId("record-submission").click()
+    })
+    act(() => {
+      screen.getByTestId("record-second-submission").click()
+    })
+
+    // Both commands stay accountable: overwriting would orphan the first
+    // command's still-pending outcome (#2126 review round 2, finding 1).
+    await waitFor(() => {
+      expect(
+        JSON.parse(
+          screen.getByTestId("clarification-submissions").textContent || "{}"
+        )
+      ).toEqual({
+        "req-1": [
+          { commandId: "cmd-1", accepted: true },
+          { commandId: "cmd-2", accepted: false },
+        ],
+      })
+    })
+  })
+
+  it("records resendSafe false when the structured frame omits resend_safe", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:04Z",
+        data: {
+          type: "agent_error",
+          message: "Task command message failed: something",
+          command_id: "client-msg-no-flag",
+          command_kind: "message",
+          outcome: "failed",
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
+      ).toEqual({ "client-msg-no-flag": { resendSafe: false } })
+    })
+  })
+
+  it("does not record a non-failed outcome", async () => {
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:04Z",
+        data: {
+          type: "agent_error",
+          message: "noise",
+          command_id: "client-msg-completed",
+          command_kind: "message",
+          outcome: "completed",
+          resend_safe: true,
+        },
+      })
+    })
+
+    await waitFor(() => {
+      expect(screen.getByTestId("messages").textContent).toContain("noise")
+    })
+    expect(
+      JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
+    ).toEqual({})
+  })
+
+  it("records an outcome from another task's frame (harmless by design)", async () => {
+    // RECORD_COMMAND_OUTCOME is deliberately not task-scoped: command ids
+    // are globally unique UUIDs, the only consumer looks one up by exact
+    // id, and scoping would silently drop the one-time terminal event for
+    // background tasks. This pins the current deliberate behavior.
+    render(
+      <AppProvider token="token">
+        <SeedRunningTask />
+        <StateProbe />
+      </AppProvider>
+    )
+
+    const onMessage = webSocketOptions.current?.onMessage
+    expect(onMessage).toBeDefined()
+
+    act(() => {
+      onMessage?.({
+        type: "agent_error",
+        timestamp: "2026-05-27T05:00:04Z",
+        task_id: 999,
+        data: {
+          type: "agent_error",
+          message: "This message was not applied to the task.",
+          command_id: "other-task-command",
+          command_kind: "message",
+          outcome: "failed",
+          resend_safe: true,
+          task: { id: 999, status: "waiting_for_user" },
+        },
+      } as TestWebSocketMessage)
+    })
+
+    await waitFor(() => {
+      expect(
+        JSON.parse(screen.getByTestId("command-outcomes").textContent || "{}")
+      ).toEqual({ "other-task-command": { resendSafe: true } })
+    })
   })
 
   it("records and consumes the round's accountable submission", async () => {
@@ -7377,7 +7514,7 @@ describe("terminal command outcomes (#1500)", () => {
         JSON.parse(
           screen.getByTestId("clarification-submissions").textContent || "{}"
         )
-      ).toEqual({ "req-1": { commandId: "cmd-1", accepted: true } })
+      ).toEqual({ "req-1": [{ commandId: "cmd-1", accepted: true }] })
     })
 
     act(() => {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -2864,6 +2864,16 @@ export function AppProvider({
     }
 
     const controlEnvelope = extractTaskControlEnvelope(message)
+    // A stale-versioned error frame must not roll task state back, but its
+    // body is not versioned state: it carries the error notice - and, since
+    // #2124, the structured terminal command outcome - which the backend
+    // sends exactly once. Dropping the whole frame silences that notice
+    // forever, so error frames fall through with their control tuple
+    // neutralized (this flag suppresses every status side effect below)
+    // instead of being swallowed. This extends the same reasoning
+    // ``canAcceptTaskControlVersion`` already applies to UNversioned error
+    // frames ("error frames remain informational") to versioned ones.
+    let staleControlErrorFrame = false
     if (controlEnvelope.isStateEvent && controlEnvelope.taskId !== undefined) {
       if (
         !acceptTaskControlVersion(
@@ -2871,13 +2881,16 @@ export function AppProvider({
           controlEnvelope,
           taskStateVersionsRef.current,
         )
-      ) return
+      ) {
+        if (message.type !== "error" && message.type !== "agent_error") return
+        staleControlErrorFrame = true
+      }
 
       // A late event may have an old semantic type (for example
       // ``task_paused``) after a newer run is already RUNNING. The backend
       // rewrites its state tuple to the canonical row; apply only that tuple
       // and skip the stale event-specific side effects.
-      if (!taskEventMatchesControlState(message, controlEnvelope)) {
+      if (!staleControlErrorFrame && !taskEventMatchesControlState(message, controlEnvelope)) {
         if (controlEnvelope.status) {
           dispatch({
             type: "UPDATE_TASK_STATUS",
@@ -3198,9 +3211,19 @@ export function AppProvider({
               return
             }
             const interactions = normalizeInteractions(eventData.metadata?.interactions)
-            const interactionRequestId = typeof eventData.request_id === "string"
-              ? eventData.request_id
-              : undefined
+            // The round identity: no backend emits ``request_id`` today - the
+            // stable per-ask id the runtime mints and every ask frame carries
+            // is ``event_id`` (see core/agent/clarification.py: "event_id is
+            // the clarification's stable identity"). ``request_id`` stays the
+            // preferred field so a backend that later adopts the explicit
+            // name wins over the fallback.
+            const interactionRequestId =
+              (typeof eventData.request_id === "string" && eventData.request_id
+                ? eventData.request_id
+                : undefined)
+              ?? (typeof eventData.event_id === "string" && eventData.event_id
+                ? eventData.event_id
+                : undefined)
             const isAgentMessage = eventType === "agent_message"
             const isAiMessage = eventType === "ai_message"
             const expectsUserResponse =
@@ -5685,10 +5708,15 @@ export function AppProvider({
         const interactions = normalizeInteractions(
           waitingRoot.interactions ?? waitingData.interactions
         )
+        // ``request_id`` first (the explicit name, if a backend ever emits
+        // it), then ``event_id`` - the stable per-ask identity the runtime
+        // actually mints and forwards on ask frames today.
         const waitingRequestIdValue = waitingRoot.request_id ?? waitingData.request_id
-        const waitingRequestId = typeof waitingRequestIdValue === "string"
-          ? waitingRequestIdValue
-          : undefined
+          ?? waitingRoot.event_id ?? waitingData.event_id
+        const waitingRequestId =
+          typeof waitingRequestIdValue === "string" && waitingRequestIdValue
+            ? waitingRequestIdValue
+            : undefined
         dispatch({
           type: "UPDATE_TASK_STATUS",
           payload: {
@@ -5747,7 +5775,11 @@ export function AppProvider({
         const agentErrorMessage = agentErrorCode
           ? t(clientErrorTranslationKey(agentErrorCode))
           : getWebSocketErrorMessage(message, trustLegacyErrorProse)
-        const agentErrorTaskStatus = getWebSocketTaskStatus(message)
+        // A stale-versioned frame keeps its notice but asserts nothing about
+        // task state - its control tuple lost to a newer version above.
+        const agentErrorTaskStatus = staleControlErrorFrame
+          ? null
+          : getWebSocketTaskStatus(message)
 
         if (agentErrorTaskStatus) {
           dispatch({
@@ -5796,11 +5828,17 @@ export function AppProvider({
           controlEnvelope,
         })
 
-        if (errorFrame.taskStatus) {
+        // Stale-versioned "error" frames keep their notice but assert
+        // nothing about task state (see staleControlErrorFrame above).
+        // task_error deliberately stays outside that exemption - its bubble
+        // IS the turn's terminal result, mirroring the unversioned rule in
+        // canAcceptTaskControlVersion - so for task_error this guard is
+        // vacuously true.
+        if (errorFrame.taskStatus && !staleControlErrorFrame) {
           dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: errorFrame.taskStatus } })
           dispatch({ type: "TRIGGER_TASK_UPDATE" })
         }
-        if (errorFrame.stopsProcessing) {
+        if (errorFrame.stopsProcessing && !staleControlErrorFrame) {
           dispatch({ type: "SET_PROCESSING", payload: false })
         }
 

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -3216,14 +3216,12 @@ export function AppProvider({
             // is ``event_id`` (see core/agent/clarification.py: "event_id is
             // the clarification's stable identity"). ``request_id`` stays the
             // preferred field so a backend that later adopts the explicit
-            // name wins over the fallback.
-            const interactionRequestId =
-              (typeof eventData.request_id === "string" && eventData.request_id
-                ? eventData.request_id
-                : undefined)
-              ?? (typeof eventData.event_id === "string" && eventData.event_id
-                ? eventData.event_id
-                : undefined)
+            // name wins over the fallback - but only with a non-empty
+            // string; anything else falls through to the next candidate.
+            const interactionRequestId = [
+              eventData.request_id,
+              eventData.event_id,
+            ].find((id): id is string => typeof id === "string" && id !== "")
             const isAgentMessage = eventType === "agent_message"
             const isAiMessage = eventType === "ai_message"
             const expectsUserResponse =
@@ -5710,13 +5708,15 @@ export function AppProvider({
         )
         // ``request_id`` first (the explicit name, if a backend ever emits
         // it), then ``event_id`` - the stable per-ask identity the runtime
-        // actually mints and forwards on ask frames today.
-        const waitingRequestIdValue = waitingRoot.request_id ?? waitingData.request_id
-          ?? waitingRoot.event_id ?? waitingData.event_id
-        const waitingRequestId =
-          typeof waitingRequestIdValue === "string" && waitingRequestIdValue
-            ? waitingRequestIdValue
-            : undefined
+        // actually mints and forwards on ask frames today. First non-empty
+        // string wins: nullish coalescing alone would let an empty or
+        // non-string ``request_id`` block the ``event_id`` fallback.
+        const waitingRequestId = [
+          waitingRoot.request_id,
+          waitingData.request_id,
+          waitingRoot.event_id,
+          waitingData.event_id,
+        ].find((id): id is string => typeof id === "string" && id !== "")
         dispatch({
           type: "UPDATE_TASK_STATUS",
           payload: {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -354,7 +354,7 @@ import {
   type WebSocketConnection,
   type WebSocketConnectionFailure,
 } from "@/hooks/use-websocket"
-import { generateClientMessageId, getApiUrl, getUploadApiUrl, shouldAutoOpenTaskPreview } from "@/lib/utils"
+import { generateClientMessageId, getApiUrl, getUploadApiUrl, shouldAutoOpenTaskPreview, firstNonEmptyString } from "@/lib/utils"
 import { apiRequest, classifyUploadError, getApiErrorMessage, isJsonRecord, parseApiResponse } from "@/lib/api-wrapper"
 import { clientErrorTranslationKey, readClientErrorCode } from "@/lib/client-errors"
 import { normalizeUploadFileIds } from "@/lib/upload-file-ids"
@@ -1609,8 +1609,19 @@ function projectAppState(state: AppState, action: AppAction): AppState {
             : undefined,
           waitingRequestId: isWaitingForUser
             ? action.payload.waitingRequestId ?? (
-              action.payload.waitingQuestion === undefined
-              && action.payload.waitingInteractions === undefined
+              // An id-less payload keeps the known id when it asserts
+              // nothing new - and also when it re-asserts the SAME question
+              // text: reload/reconnect reassertion frames re-send the
+              // unchanged question with no id, and wiping the id there
+              // severs the open round's correlation. An id-less payload
+              // carrying a DIFFERENT question (or fresh interactions
+              // without one) is a legacy-backend new round and must not
+              // inherit the previous round's id.
+              (action.payload.waitingQuestion === undefined
+                && action.payload.waitingInteractions === undefined)
+              || (action.payload.waitingQuestion !== undefined
+                && action.payload.waitingQuestion
+                  === state.currentTask.waitingQuestion)
                 ? state.currentTask.waitingRequestId
                 : undefined
             )
@@ -2870,9 +2881,10 @@ export function AppProvider({
     // sends exactly once. Dropping the whole frame silences that notice
     // forever, so error frames fall through with their control tuple
     // neutralized (this flag suppresses every status side effect below)
-    // instead of being swallowed. This extends the same reasoning
-    // ``canAcceptTaskControlVersion`` already applies to UNversioned error
-    // frames ("error frames remain informational") to versioned ones.
+    // instead of being swallowed. Weaker than the guard's UNversioned-error
+    // rule, deliberately: an unversioned error frame has no version to lose
+    // and passes whole, control tuple included; a stale VERSIONED one lost
+    // the version argument and keeps only its notice.
     let staleControlErrorFrame = false
     if (controlEnvelope.isStateEvent && controlEnvelope.taskId !== undefined) {
       if (
@@ -3218,10 +3230,10 @@ export function AppProvider({
             // preferred field so a backend that later adopts the explicit
             // name wins over the fallback - but only with a non-empty
             // string; anything else falls through to the next candidate.
-            const interactionRequestId = [
+            const interactionRequestId = firstNonEmptyString(
               eventData.request_id,
               eventData.event_id,
-            ].find((id): id is string => typeof id === "string" && id !== "")
+            )
             const isAgentMessage = eventType === "agent_message"
             const isAiMessage = eventType === "ai_message"
             const expectsUserResponse =
@@ -5711,12 +5723,12 @@ export function AppProvider({
         // actually mints and forwards on ask frames today. First non-empty
         // string wins: nullish coalescing alone would let an empty or
         // non-string ``request_id`` block the ``event_id`` fallback.
-        const waitingRequestId = [
+        const waitingRequestId = firstNonEmptyString(
           waitingRoot.request_id,
           waitingData.request_id,
           waitingRoot.event_id,
           waitingData.event_id,
-        ].find((id): id is string => typeof id === "string" && id !== "")
+        )
         dispatch({
           type: "UPDATE_TASK_STATUS",
           payload: {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1179,9 +1179,20 @@ const normalizeDagExecutionPayload = (raw: Record<string, unknown>): DAGExecutio
  * the field — reads as "may be committed or still in flight".
  */
 export interface TerminalCommandOutcome {
-  outcome: "failed"
   resendSafe: boolean
-  messageCode: string | null
+}
+
+/**
+ * One clarification reply the round is still accountable for. `accepted`
+ * distinguishes a reply the backend durably acknowledged from one recorded
+ * after an ack timeout (outcome unknown): only a confirmed acceptance may
+ * lock a freshly mounted form while no terminal outcome has arrived — an
+ * unconfirmed delivery keeps the advisory retry the composer has always
+ * offered.
+ */
+export interface ClarificationSubmission {
+  commandId: string
+  accepted: boolean
 }
 
 export interface AppState {
@@ -1241,12 +1252,17 @@ export interface AppState {
   // the submitting instance being replaced (#1500). Rounds without a
   // request id are deliberately not tracked - with no round identity a
   // recorded reply could gate a different question.
-  // ``accepted`` distinguishes a reply the backend durably acknowledged from
-  // one recorded after an ack timeout (outcome unknown): only a confirmed
-  // acceptance may lock a freshly mounted form while no terminal outcome has
-  // arrived - an unconfirmed delivery keeps the advisory retry the composer
-  // has always offered.
-  clarificationSubmissions: Record<string, { commandId: string; accepted: boolean }>
+  // An ordered list, not a single slot: an ack-timeout entry stays
+  // resubmittable, so one round can accumulate several outstanding replies,
+  // and overwriting the earlier one would orphan its still-pending outcome -
+  // exactly the undetected-duplicate risk this state exists to surface.
+  // Growth is bounded by the user's own resubmits within one round.
+  // Deliberately NOT persisted across reloads: rebuilding the gate from
+  // browser storage without the durable terminal-event replay (#1904) would
+  // turn a missed outcome frame into a permanent, unexplainable lock
+  // (fail-closed with no exit). Reload-during-ambiguity is tracked in
+  // #2142 as server-authoritative reconstruction on the #2135/#1904 arc.
+  clarificationSubmissions: Record<string, ClarificationSubmission[]>
 }
 
 type AppAction =
@@ -1361,14 +1377,20 @@ function projectAppState(state: AppState, action: AppAction): AppState {
         },
       }
     case "RECORD_CLARIFICATION_SUBMISSION":
+      // Append, never overwrite: the round stays accountable for every
+      // outstanding reply, so an earlier command's late outcome can still
+      // be matched and surfaced.
       return {
         ...state,
         clarificationSubmissions: {
           ...state.clarificationSubmissions,
-          [action.payload.requestId]: {
-            commandId: action.payload.commandId,
-            accepted: action.payload.accepted,
-          },
+          [action.payload.requestId]: [
+            ...(state.clarificationSubmissions[action.payload.requestId] ?? []),
+            {
+              commandId: action.payload.commandId,
+              accepted: action.payload.accepted,
+            },
+          ],
         },
       }
     case "CLEAR_CLARIFICATION_SUBMISSION": {
@@ -5878,11 +5900,7 @@ export function AppProvider({
             payload: {
               commandId: terminalCommandId,
               outcome: {
-                outcome: "failed",
                 resendSafe: agentErrorData.resend_safe === true,
-                messageCode: typeof agentErrorData.message_code === "string"
-                  ? agentErrorData.message_code
-                  : null,
               },
             },
           })

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -110,6 +110,12 @@ const MAX_TRACKED_TASK_STATE_VERSIONS = 500
 // retained only to reject late frames, so bound this lineage guard separately
 // from the unrelated task-state ordering cache.
 const MAX_RETIRED_SESSION_TASK_IDS = 500
+// Terminal command outcomes and per-round clarification submissions are
+// keyed by ids minted per submit/ask; both grow with session length and get
+// the same insertion-ordered eviction as the version map above (#2126
+// review round 3, finding F8). Task-switch pruning is tracked in #2143.
+const MAX_TRACKED_COMMAND_OUTCOMES = 500
+const MAX_TRACKED_CLARIFICATION_ROUNDS = 500
 const SESSION_RESET_ACK_TIMEOUT_MS = 30_000
 const SESSION_TASK_ADOPTION_TIMEOUT_MS = 30_000
 const MAX_SESSION_PRE_ADOPTION_FRAMES = 64
@@ -1277,7 +1283,7 @@ type AppAction =
   | { type: "UPDATE_TASK_STATUS"; payload: { status: Task["status"]; waitingQuestion?: string; waitingInteractions?: Interaction[]; waitingRequestId?: string; runId?: string | null; stateVersion?: number; controlState?: TaskControlState; updatedAt?: string } }
   | { type: "RECORD_COMMAND_OUTCOME"; payload: { commandId: string; outcome: TerminalCommandOutcome } }
   | { type: "RECORD_CLARIFICATION_SUBMISSION"; payload: { requestId: string; commandId: string; accepted: boolean } }
-  | { type: "CLEAR_CLARIFICATION_SUBMISSION"; payload: { requestId: string } }
+  | { type: "CLEAR_CLARIFICATION_SUBMISSION"; payload: { requestId: string; commandIds: string[] } }
   | { type: "TRIGGER_TASK_UPDATE" }
   | { type: "SET_DAG_EXECUTION"; payload: DAGExecution | null }
   | { type: "RESET_DAG_STATE" }
@@ -1368,37 +1374,79 @@ function projectAppState(state: AppState, action: AppAction): AppState {
       }
     case "SET_HISTORY_LOADING":
       return { ...state, isHistoryLoading: action.payload }
-    case "RECORD_COMMAND_OUTCOME":
-      return {
-        ...state,
-        commandOutcomes: {
-          ...state.commandOutcomes,
-          [action.payload.commandId]: action.payload.outcome,
-        },
+    case "RECORD_COMMAND_OUTCOME": {
+      const existing = state.commandOutcomes[action.payload.commandId]
+      // Monotone in the unsafe direction, mirroring UPDATE_TASK_STATUS's
+      // first-write-wins for terminal values: a duplicate or racing frame
+      // may downgrade a proven-safe reading, but can never upgrade an
+      // unsafe one - the flag gates a resend decision, and the unsafe
+      // reading is the one that must stick.
+      const resendSafe =
+        (existing === undefined || existing.resendSafe)
+        && action.payload.outcome.resendSafe
+      const commandOutcomes = {
+        ...state.commandOutcomes,
+        [action.payload.commandId]: { resendSafe },
       }
-    case "RECORD_CLARIFICATION_SUBMISSION":
+      // Bounded like the file's version map, but on a plain object, where
+      // canonical-integer keys iterate before insertion order - so eviction
+      // is oldest-out for the UUID-shaped ids this feature mints and merely
+      // approximate for an integer-looking backend id. Never evict the key
+      // just written: self-eviction would turn a fresh outcome into the
+      // exit-less pending lock.
+      const outcomeIds = Object.keys(commandOutcomes)
+      if (outcomeIds.length > MAX_TRACKED_COMMAND_OUTCOMES) {
+        const evictable = outcomeIds.find(
+          (key) => key !== action.payload.commandId,
+        )
+        if (evictable !== undefined) delete commandOutcomes[evictable]
+      }
+      return { ...state, commandOutcomes }
+    }
+    case "RECORD_CLARIFICATION_SUBMISSION": {
       // Append, never overwrite: the round stays accountable for every
       // outstanding reply, so an earlier command's late outcome can still
       // be matched and surfaced.
-      return {
-        ...state,
-        clarificationSubmissions: {
-          ...state.clarificationSubmissions,
-          [action.payload.requestId]: [
-            ...(state.clarificationSubmissions[action.payload.requestId] ?? []),
-            {
-              commandId: action.payload.commandId,
-              accepted: action.payload.accepted,
-            },
-          ],
-        },
+      const clarificationSubmissions = {
+        ...state.clarificationSubmissions,
+        [action.payload.requestId]: [
+          ...(state.clarificationSubmissions[action.payload.requestId] ?? []),
+          {
+            commandId: action.payload.commandId,
+            accepted: action.payload.accepted,
+          },
+        ],
       }
+      const roundIds = Object.keys(clarificationSubmissions)
+      if (roundIds.length > MAX_TRACKED_CLARIFICATION_ROUNDS) {
+        const evictable = roundIds.find(
+          (key) => key !== action.payload.requestId,
+        )
+        if (evictable !== undefined) delete clarificationSubmissions[evictable]
+      }
+      return { ...state, clarificationSubmissions }
+    }
     case "CLEAR_CLARIFICATION_SUBMISSION": {
-      if (!(action.payload.requestId in state.clarificationSubmissions)) {
+      const tracked = state.clarificationSubmissions[action.payload.requestId]
+      if (!tracked) {
+        return state
+      }
+      // Consume only the commands the effect actually verified: a fresh
+      // submission recorded between that render's snapshot and this
+      // dispatch must survive, or its outcome is orphaned.
+      const consumed = new Set(action.payload.commandIds)
+      const kept = tracked.filter(
+        (submission) => !consumed.has(submission.commandId),
+      )
+      if (kept.length === tracked.length) {
         return state
       }
       const remaining = { ...state.clarificationSubmissions }
-      delete remaining[action.payload.requestId]
+      if (kept.length === 0) {
+        delete remaining[action.payload.requestId]
+      } else {
+        remaining[action.payload.requestId] = kept
+      }
       return { ...state, clarificationSubmissions: remaining }
     }
 
@@ -5932,7 +5980,6 @@ export function AppProvider({
           dispatch({ type: "SET_PROCESSING", payload: false })
         }
 
-        const agentErrorData = asMessageRecord(message.data)
         // A terminal command frame carries a durable identity
         // (command_id, disambiguated by outcome_version): a duplicated
         // delivery of the SAME terminal broadcast must not add a second

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1241,7 +1241,12 @@ export interface AppState {
   // the submitting instance being replaced (#1500). Rounds without a
   // request id are deliberately not tracked - with no round identity a
   // recorded reply could gate a different question.
-  clarificationSubmissions: Record<string, { commandId: string }>
+  // ``accepted`` distinguishes a reply the backend durably acknowledged from
+  // one recorded after an ack timeout (outcome unknown): only a confirmed
+  // acceptance may lock a freshly mounted form while no terminal outcome has
+  // arrived - an unconfirmed delivery keeps the advisory retry the composer
+  // has always offered.
+  clarificationSubmissions: Record<string, { commandId: string; accepted: boolean }>
 }
 
 type AppAction =
@@ -1255,7 +1260,7 @@ type AppAction =
   | { type: "SET_TASK_RUNTIME_EXTENSIONS"; payload: { taskId: number; extensions: TaskRuntimeExtensions } }
   | { type: "UPDATE_TASK_STATUS"; payload: { status: Task["status"]; waitingQuestion?: string; waitingInteractions?: Interaction[]; waitingRequestId?: string; runId?: string | null; stateVersion?: number; controlState?: TaskControlState; updatedAt?: string } }
   | { type: "RECORD_COMMAND_OUTCOME"; payload: { commandId: string; outcome: TerminalCommandOutcome } }
-  | { type: "RECORD_CLARIFICATION_SUBMISSION"; payload: { requestId: string; commandId: string } }
+  | { type: "RECORD_CLARIFICATION_SUBMISSION"; payload: { requestId: string; commandId: string; accepted: boolean } }
   | { type: "CLEAR_CLARIFICATION_SUBMISSION"; payload: { requestId: string } }
   | { type: "TRIGGER_TASK_UPDATE" }
   | { type: "SET_DAG_EXECUTION"; payload: DAGExecution | null }
@@ -1360,7 +1365,10 @@ function projectAppState(state: AppState, action: AppAction): AppState {
         ...state,
         clarificationSubmissions: {
           ...state.clarificationSubmissions,
-          [action.payload.requestId]: { commandId: action.payload.commandId },
+          [action.payload.requestId]: {
+            commandId: action.payload.commandId,
+            accepted: action.payload.accepted,
+          },
         },
       }
     case "CLEAR_CLARIFICATION_SUBMISSION": {

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -5727,16 +5727,15 @@ export function AppProvider({
         const interactions = normalizeInteractions(
           waitingRoot.interactions ?? waitingData.interactions
         )
-        // ``request_id`` first (the explicit name, if a backend ever emits
-        // it), then ``event_id`` - the stable per-ask identity the runtime
-        // actually mints and forwards on ask frames today. First non-empty
-        // string wins: nullish coalescing alone would let an empty or
-        // non-string ``request_id`` block the ``event_id`` fallback.
+        // ``request_id`` only: the waiting/reassert frames' emitters carry
+        // the round identity under that explicit name (backend #2232) and
+        // never emit ``event_id`` - an event_id fallback here would be dead
+        // code testable only with hand-crafted frames. The ask frame's
+        // ``event_id`` is adopted where it genuinely lives, in the
+        // agent_message trace reader.
         const waitingRequestId = firstNonEmptyString(
           waitingRoot.request_id,
           waitingData.request_id,
-          waitingRoot.event_id,
-          waitingData.event_id,
         )
         dispatch({
           type: "UPDATE_TASK_STATUS",
@@ -5828,16 +5827,38 @@ export function AppProvider({
           dispatch({ type: "SET_PROCESSING", payload: false })
         }
 
-        dispatch({
-          type: "ADD_MESSAGE",
-          payload: {
-            id: generateMessageId("msg"),
-            role: "assistant",
-            content: `${t('agent.logs.event.messages.errorPrefix')} ${agentErrorMessage || t('common.errors.unknown')}`,
-            timestamp: message.timestamp,
-            status: "failed",
-          },
-        })
+        const agentErrorData = asMessageRecord(message.data)
+        // A terminal command frame carries a durable identity
+        // (command_id, disambiguated by outcome_version): a duplicated
+        // delivery of the SAME terminal broadcast must not add a second
+        // bubble. Identity-keyed only - never text-keyed - so two distinct
+        // commands failing with identical redacted text both stay visible.
+        const agentErrorOccurrence =
+          typeof agentErrorData.command_id === "string"
+          && agentErrorData.command_id
+            ? `${agentErrorData.command_id}:${String(
+                agentErrorData.outcome_version ?? "",
+              )}`
+            : undefined
+        if (
+          agentErrorOccurrence === undefined
+          || !isDuplicateMessageForViewedTask(
+            agentErrorMessage || "",
+            "agent-error-command",
+            agentErrorOccurrence,
+          )
+        ) {
+          dispatch({
+            type: "ADD_MESSAGE",
+            payload: {
+              id: generateMessageId("msg"),
+              role: "assistant",
+              content: `${t('agent.logs.event.messages.errorPrefix')} ${agentErrorMessage || t('common.errors.unknown')}`,
+              timestamp: message.timestamp,
+              status: "failed",
+            },
+          })
+        }
         break
 
       case "error":

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -1171,6 +1171,19 @@ const normalizeDagExecutionPayload = (raw: Record<string, unknown>): DAGExecutio
   } as DAGExecution
 }
 
+/**
+ * The structured disposition a terminal `agent_error` frame carries for one
+ * durable command (#1500). `resendSafe` is asserted by the backend only when
+ * the failed handoff proved the command never reached the downstream
+ * operation; everything else — including frames from backends that predate
+ * the field — reads as "may be committed or still in flight".
+ */
+export interface TerminalCommandOutcome {
+  outcome: "failed"
+  resendSafe: boolean
+  messageCode: string | null
+}
+
 export interface AppState {
   messages: Message[]
   currentTask: Task | null
@@ -1216,6 +1229,19 @@ export interface AppState {
   // Current context-window usage from the latest LLM call, for the usage gauge.
   contextUsage: { tokens: number; threshold: number } | null
   sessionConversation: SessionConversationState
+  // Terminal dispositions keyed by the durable command id (the sender's own
+  // client message id), so a submitter can decide whether its accepted reply
+  // is safe to resend. Command ids are unique, which is what makes exact-id
+  // correlation immune to stale or cross-run outcomes (#1500).
+  commandOutcomes: Record<string, TerminalCommandOutcome>
+  // The reply command each clarification round is still accountable for,
+  // keyed by request id. Context state, not component state: the same round
+  // can render in more than one ClarificationForm instance (virtual waiting
+  // message vs. persisted timeline message), and the retry gate must survive
+  // the submitting instance being replaced (#1500). Rounds without a
+  // request id are deliberately not tracked - with no round identity a
+  // recorded reply could gate a different question.
+  clarificationSubmissions: Record<string, { commandId: string }>
 }
 
 type AppAction =
@@ -1228,6 +1254,9 @@ type AppAction =
   | { type: "SET_CURRENT_TASK"; payload: Task | null }
   | { type: "SET_TASK_RUNTIME_EXTENSIONS"; payload: { taskId: number; extensions: TaskRuntimeExtensions } }
   | { type: "UPDATE_TASK_STATUS"; payload: { status: Task["status"]; waitingQuestion?: string; waitingInteractions?: Interaction[]; waitingRequestId?: string; runId?: string | null; stateVersion?: number; controlState?: TaskControlState; updatedAt?: string } }
+  | { type: "RECORD_COMMAND_OUTCOME"; payload: { commandId: string; outcome: TerminalCommandOutcome } }
+  | { type: "RECORD_CLARIFICATION_SUBMISSION"; payload: { requestId: string; commandId: string } }
+  | { type: "CLEAR_CLARIFICATION_SUBMISSION"; payload: { requestId: string } }
   | { type: "TRIGGER_TASK_UPDATE" }
   | { type: "SET_DAG_EXECUTION"; payload: DAGExecution | null }
   | { type: "RESET_DAG_STATE" }
@@ -1300,6 +1329,8 @@ const createInitialState = (): AppState => ({
   isHistoryLoading: false,
   contextUsage: null,
   sessionConversation: { ...initialSessionConversationState },
+  commandOutcomes: {},
+  clarificationSubmissions: {},
 })
 
 function projectAppState(state: AppState, action: AppAction): AppState {
@@ -1316,6 +1347,30 @@ function projectAppState(state: AppState, action: AppAction): AppState {
       }
     case "SET_HISTORY_LOADING":
       return { ...state, isHistoryLoading: action.payload }
+    case "RECORD_COMMAND_OUTCOME":
+      return {
+        ...state,
+        commandOutcomes: {
+          ...state.commandOutcomes,
+          [action.payload.commandId]: action.payload.outcome,
+        },
+      }
+    case "RECORD_CLARIFICATION_SUBMISSION":
+      return {
+        ...state,
+        clarificationSubmissions: {
+          ...state.clarificationSubmissions,
+          [action.payload.requestId]: { commandId: action.payload.commandId },
+        },
+      }
+    case "CLEAR_CLARIFICATION_SUBMISSION": {
+      if (!(action.payload.requestId in state.clarificationSubmissions)) {
+        return state
+      }
+      const remaining = { ...state.clarificationSubmissions }
+      delete remaining[action.payload.requestId]
+      return { ...state, clarificationSubmissions: remaining }
+    }
 
     case "SYNC_PROCESSING_STATUS":
       if (shouldStopProcessingForTaskStatus(state.currentTask?.status)) {
@@ -5800,6 +5855,30 @@ export function AppProvider({
         const agentErrorTaskStatus = staleControlErrorFrame
           ? null
           : getWebSocketTaskStatus(message)
+
+        // A terminal frame for a durable command carries a structured
+        // disposition (#1500). Record it keyed by command id so the
+        // submitter of that exact command can make its retry decision;
+        // `resend_safe` is trusted only as a literal true, so frames from
+        // backends that predate the field stay in the unsafe reading.
+        const agentErrorData = asMessageRecord(message.data)
+        const terminalCommandId = agentErrorData.command_id
+        if (typeof terminalCommandId === "string" && terminalCommandId
+          && agentErrorData.outcome === "failed") {
+          dispatch({
+            type: "RECORD_COMMAND_OUTCOME",
+            payload: {
+              commandId: terminalCommandId,
+              outcome: {
+                outcome: "failed",
+                resendSafe: agentErrorData.resend_safe === true,
+                messageCode: typeof agentErrorData.message_code === "string"
+                  ? agentErrorData.message_code
+                  : null,
+              },
+            },
+          })
+        }
 
         if (agentErrorTaskStatus) {
           dispatch({

--- a/frontend/src/contexts/app-context-chat.tsx
+++ b/frontend/src/contexts/app-context-chat.tsx
@@ -890,6 +890,15 @@ const taskFromTaskInfoData = (
   runtimeExtensionBindings: getStringArray(taskData.runtime_extension_bindings),
   waitingQuestion: taskData.waiting_question as string | undefined,
   waitingInteractions: normalizeInteractions(taskData.waiting_interactions),
+  // The waiting round's identity, emitted on waiting task_info frames
+  // (live, resume, and replay) so a reply binds to the exact ask (#1500).
+  // Key present only when the frame carries one: an explicit undefined
+  // would let SET_CURRENT_TASK's merge wipe an id the waiting handler
+  // already holds when an id-less task_info (a backend predating the
+  // emission) arrives mid-round.
+  ...(firstNonEmptyString(taskData.request_id) !== undefined
+    ? { waitingRequestId: firstNonEmptyString(taskData.request_id) }
+    : {}),
   runId: taskData.run_id as string | null | undefined,
   stateVersion: parseInteger(taskData.state_version),
   controlState: taskData.control_state as TaskControlState | undefined,

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -365,7 +365,7 @@ const en = {
       sendOutcomeUnknown: "Your response may already have been submitted. Reload the conversation before submitting again.",
       replyNotApplied: "Your reply was not applied to the task. You can submit it again.",
       replyPending: "Your reply was received and is still being applied.",
-      replyOutcomeUnknown: "We couldn't confirm whether your reply was applied. Review the conversation before submitting it again.",
+      replyOutcomeUnknown: "We couldn't confirm whether your reply was applied. Review the conversation, and use the message box below if you need to reply again.",
       selectOption: "Select an option",
       selectOptions: "Select options",
       acceptedFormats: "Accepted formats",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -363,6 +363,8 @@ const en = {
       sendError: "Failed to send response",
       sendNotSent: "Your answers were kept — you can submit again.",
       sendOutcomeUnknown: "Your response may already have been submitted. Reload the conversation before submitting again.",
+      replyNotApplied: "Your reply was not applied to the task. You can submit it again.",
+      replyOutcomeUnknown: "We couldn't confirm whether your reply was applied. Review the conversation before submitting it again.",
       selectOption: "Select an option",
       selectOptions: "Select options",
       acceptedFormats: "Accepted formats",

--- a/frontend/src/i18n/locales/en.ts
+++ b/frontend/src/i18n/locales/en.ts
@@ -364,6 +364,7 @@ const en = {
       sendNotSent: "Your answers were kept — you can submit again.",
       sendOutcomeUnknown: "Your response may already have been submitted. Reload the conversation before submitting again.",
       replyNotApplied: "Your reply was not applied to the task. You can submit it again.",
+      replyPending: "Your reply was received and is still being applied.",
       replyOutcomeUnknown: "We couldn't confirm whether your reply was applied. Review the conversation before submitting it again.",
       selectOption: "Select an option",
       selectOptions: "Select options",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -364,6 +364,7 @@ const zh = {
       sendNotSent: "你填写的内容已保留，可以重新提交。",
       sendOutcomeUnknown: "回复可能已经提交，请刷新会话后再重新提交。",
       replyNotApplied: "你的回复未生效，可以重新提交。",
+      replyPending: "你的回复已收到，正在生效中。",
       replyOutcomeUnknown: "无法确认回复是否已生效，请先查看会话内容，再决定是否重新提交。",
       selectOption: "请选择一个选项",
       selectOptions: "请选择选项",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -363,6 +363,8 @@ const zh = {
       sendError: "发送回复失败",
       sendNotSent: "你填写的内容已保留，可以重新提交。",
       sendOutcomeUnknown: "回复可能已经提交，请刷新会话后再重新提交。",
+      replyNotApplied: "你的回复未生效，可以重新提交。",
+      replyOutcomeUnknown: "无法确认回复是否已生效，请先查看会话内容，再决定是否重新提交。",
       selectOption: "请选择一个选项",
       selectOptions: "请选择选项",
       acceptedFormats: "支持的格式",

--- a/frontend/src/i18n/locales/zh.ts
+++ b/frontend/src/i18n/locales/zh.ts
@@ -365,7 +365,7 @@ const zh = {
       sendOutcomeUnknown: "回复可能已经提交，请刷新会话后再重新提交。",
       replyNotApplied: "你的回复未生效，可以重新提交。",
       replyPending: "你的回复已收到，正在生效中。",
-      replyOutcomeUnknown: "无法确认回复是否已生效，请先查看会话内容，再决定是否重新提交。",
+      replyOutcomeUnknown: "无法确认回复是否已生效，请先查看会话内容；如需再次回复，请使用下方输入框。",
       selectOption: "请选择一个选项",
       selectOptions: "请选择选项",
       acceptedFormats: "支持的格式",

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { resolveAgentLogoUrl } from "./utils"
+import { firstNonEmptyString, resolveAgentLogoUrl } from "./utils"
 
 const bigintValue = (globalThis as { BigInt: (value: number) => bigint }).BigInt(1)
 
@@ -173,5 +173,16 @@ describe("resolveAgentLogoUrl", () => {
     expect(resolveAgentLogoUrl("https://assets.example/logo.png", "\u0000invalid")).toBe(
       "https://assets.example/logo.png",
     )
+  })
+})
+
+describe("firstNonEmptyString", () => {
+  it("returns the first non-empty string candidate", () => {
+    expect(firstNonEmptyString(undefined, null, "", 0, "id-1", "id-2")).toBe("id-1")
+  })
+
+  it("skips non-string and empty values entirely", () => {
+    expect(firstNonEmptyString(null, 42, {}, [], "")).toBeUndefined()
+    expect(firstNonEmptyString()).toBeUndefined()
   })
 })

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -5,6 +5,20 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+/**
+ * First candidate that is a non-empty string. Shared by the clarification
+ * round-id extraction sites: nullish coalescing alone would let an empty or
+ * non-string preferred field block the fallback candidates.
+ */
+export function firstNonEmptyString(
+  ...candidates: unknown[]
+): string | undefined {
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate !== "") return candidate
+  }
+  return undefined
+}
+
 export function generateClientMessageId(): string {
   return globalThis.crypto?.randomUUID?.()
     ?? `msg-${Date.now()}-${Math.random().toString(36).slice(2)}`


### PR DESCRIPTION
## Summary

Part 2 of the #1500 re-slice: the clarification retry gate, re-cut on top of the round-identity PR (#2166). Closes #1500 when merged. Replaces #2126, whose three review rounds are all folded in here; see that PR's closing comment for the finding-by-finding map.

- The clarification form no longer re-enables just because the task returns to `waiting_for_user`. Each round's outstanding replies are tracked in `AppContext` (an ordered list keyed by the round id, surviving component-instance replacement), and reactivation requires the structured terminal outcome from #2124's `agent_error` frames to prove every tracked reply was not applied.
- Any tracked reply whose outcome cannot prove non-application locks the round with an ambiguity notice; a durably accepted reply still awaiting its outcome locks with a "reply pending" notice; an unconfirmed ack-timeout reply keeps the composer's advisory retry.
- Round-3 hardening: `RECORD_COMMAND_OUTCOME` is monotone in the unsafe direction (a racing frame can downgrade a proven-safe reading, never upgrade an unsafe one); `CLEAR_CLARIFICATION_SUBMISSION` names the verified commands and filters instead of deleting the round, so a concurrently recorded submission survives; both gating maps get the file's standard 500-entry insertion-ordered eviction; the ambiguity notice points at the message box instead of the locked Submit; an integration test drives the real reducer against the real `ClarificationForm` across a full round.

## Scope

- **Reload-during-ambiguity is a documented non-goal**: the gating maps are deliberately not persisted — without durable terminal-event replay (#1904), browser storage would turn a missed outcome frame into a permanent, unexplainable lock (fail-closed with no exit). Server-authoritative reconstruction is #2142 (P1), on the #2135/#1904 arc. The crash-restore variant (a checkpoint re-presenting the same round after its reply succeeded unheard) is the same reconstruction family, noted on #2142.
- Task-switch pruning of the gating maps beyond the in-PR caps: #2143 (P2). Guarding `sendMessage`'s post-delivery bookkeeping: #2144 (P2).
- External-scope terminal frames carry no `command_id` by disclosure policy (#2124); first-party clarification submissions never take external scope (client-supplied scope is refused server-side), so the gate never meets an identity-free frame for a command it tracks — an unmatched frame fails locked, never falsely unlocked.
- Rounds without any id (a backend predating the ask `event_id` forwarding) stay ungated, preserving today's behavior, pinned by test.
- **One-shot proof consumption, by design**: an operator retry can send one `command_id` through a second terminal broadcast (`outcome_version` exists for this); the frontend deliberately reads neither `outcome_version` nor `task_run_id`, so a second outcome arriving after the round's record was consumed downgrades the stored reading (monotone) but cannot re-lock the already-unlocked round. Revocable proofs belong to the durable-authority work in #2135/#1904.
- The 500-entry eviction can in theory drop state for a round still open (needs 500 further failed-command broadcasts in one un-reloaded session); noted on #2143 alongside the pruning work.

## Acceptance criteria mapping (#1500)

- Outcome correlated with the exact submitted command/round: the form mints the durable `command_id`; submissions are tracked per round id (from #2166).
- Proven-safe outcome + authoritative `waiting_for_user` → the form reactivates without reload, draft preserved, record consumed.
- Committed / in flight / unknown → locked with a visible notice; no accidental duplicate.
- Late terminal events reopen nothing; stale or cross-run outcomes are inert (exact-id correlation; the version guard's error exemption in #2166 ensures the outcome itself is never swallowed while task state stays protected).
- Full-sequence regression coverage including resend-safe, ambiguous, in-flight, instance-replacement, multi-reply rounds, and a real-reducer + real-form integration test.

## Verification

- 259 tests across the three touched suites; full frontend vitest suite passes (exit 0); tsc clean; zero eslint issues on added lines (line-level intersection).
- The F3-interplay test proves a stale-versioned `agent_error`'s outcome is recorded while its control tuple is discarded; the F4/F7 reducer behaviors are pinned through the real reducer.
