### PR TITLE
fix(memory): make LanceDB compatibility lifecycle explicit (toby)

### DIFF
--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 from typing import Any, List, Optional, Union
 from uuid import uuid4
 
@@ -20,7 +21,10 @@ from .base import MemoryStore
 from .core import MemoryNote, MemoryResponse
 from .schema_migration import (
     MemoryMismatchKind,
+    VECTOR_SPACE_METADATA_KEY,
+    VectorSpaceCompatibility,
     classify_memory_schema_mismatch,
+    inspect_vector_space,
     migrate_table_swap,
 )
 from .scope_columns import (
@@ -34,10 +38,11 @@ from .scope_columns import (
 )
 
 logger = logging.getLogger(__name__)
+_SCHEMA_MAINTENANCE_LOCK = threading.Lock()
 
 
 class LanceDBMemoryStore(MemoryStore):
-    """LanceDB-based memory store implementation with vector search capabilities."""
+    """Persistent memory store with one authoritative vector space per table."""
 
     _embedding_model: Optional[BaseEmbedding]
 
@@ -47,6 +52,8 @@ class LanceDBMemoryStore(MemoryStore):
         collection_name: str = "memories",
         embedding_model: Optional[Union[BaseEmbedding, EmbeddingModelConfig]] = None,
         similarity_threshold: float = 1.0,
+        vector_space_identity: Optional[dict[str, Any]] = None,
+        run_schema_maintenance: bool = False,
         **embedding_kwargs: Any,
     ):
         """
@@ -60,6 +67,8 @@ class LanceDBMemoryStore(MemoryStore):
             **embedding_kwargs: Additional arguments for embedding model
         """
         self._collection_name = collection_name
+        self._vector_space_identity = vector_space_identity
+        self._run_schema_maintenance = run_schema_maintenance
 
         # Handle different types of embedding_model input
         if embedding_model is None:
@@ -86,22 +95,107 @@ class LanceDBMemoryStore(MemoryStore):
             raise ValueError(
                 f"Unsupported embedding model type: {type(embedding_model)}"
             )
+        if vector_space_identity is None and isinstance(
+            self._embedding_model, DashScopeEmbedding
+        ):
+            self._vector_space_identity = {
+                "provider": "dashscope",
+                "model": self._embedding_model.model,
+                "endpoint": self._embedding_model.base_url,
+                "dimension": self._embedding_model.dimension or 1024,
+                "instruct": self._embedding_model.instruct,
+            }
         self._similarity_threshold = similarity_threshold
-        self._vector_store = LanceDBVectorStore(db_dir, collection_name)
         self._conn_manager = LanceDBConnectionManager()
-        self._ensure_table_schema()
+        self._vector_store = LanceDBVectorStore(
+            db_dir,
+            collection_name,
+            connection_manager=self._conn_manager,
+            initial_data=self._initial_table_data(),
+        )
+        if run_schema_maintenance:
+            self.maintain_schema()
+
+    def _configured_embedding_dim(self) -> Optional[int]:
+        if self._vector_space_identity is not None:
+            try:
+                return int(self._vector_space_identity["dimension"])
+            except (KeyError, TypeError, ValueError):
+                return None
+        if self._embedding_model is None:
+            return None
+        try:
+            dimension = self._embedding_model.get_dimension()
+        except Exception:
+            return None
+        return int(dimension) if dimension else None
+
+    def _initial_table_data(self) -> Any:
+        """Build a typed empty-table seed without calling the embedding service."""
+        data: dict[str, Any] = {
+            "id": ["sample"],
+            "text": ["sample"],
+            "metadata": ["{}"],
+            USER_ID_COLUMN: pa.array([0], pa.int64()),
+            SCOPE_DIMS_COLUMN: pa.array([["sample"]], pa.list_(pa.string())),
+        }
+        dimension = self._configured_embedding_dim()
+        if dimension is not None:
+            data["vector"] = pa.array(
+                [[0.0] * dimension], pa.list_(pa.float32(), dimension)
+            )
+        table = pa.table(data)
+        if self._vector_space_identity is not None:
+            metadata = dict(table.schema.metadata or {})
+            metadata[VECTOR_SPACE_METADATA_KEY] = json.dumps(
+                self._vector_space_identity, sort_keys=True, separators=(",", ":")
+            ).encode()
+            table = table.replace_schema_metadata(metadata)
+        return table
+
+    def inspect_vector_space(self) -> VectorSpaceCompatibility:
+        """Inspect compatibility without embeddings, scans, or mutations."""
+        if self._vector_space_identity is None:
+            return VectorSpaceCompatibility.MISMATCHING
+        table = self._vector_store.get_raw_connection().open_table(
+            self._collection_name
+        )
+        try:
+            return inspect_vector_space(table.schema, self._vector_space_identity)
+        finally:
+            _safe_close_table(table)
+
+    def _vectors_are_compatible(self) -> bool:
+        dimension = self._configured_embedding_dim()
+        if dimension is None:
+            return False
+        table = self._vector_store.get_raw_connection().open_table(
+            self._collection_name
+        )
+        try:
+            vector_type = table.schema.field("vector").type
+            dimension_matches = (
+                pa.types.is_fixed_size_list(vector_type)
+                and int(vector_type.list_size) == dimension
+            )
+        except (KeyError, ValueError):
+            dimension_matches = False
+        finally:
+            _safe_close_table(table)
+        if not dimension_matches:
+            return False
+        return (
+            self._vector_space_identity is None
+            or self.inspect_vector_space() is not VectorSpaceCompatibility.MISMATCHING
+        )
+
+    def maintain_schema(self) -> None:
+        """Run ordinary schema maintenance at a serialized lifecycle boundary."""
+        with _SCHEMA_MAINTENANCE_LOCK:
+            self._ensure_table_schema()
 
     def _ensure_table_schema(self) -> None:
-        """Ensure the table has the correct schema for memory storage.
-
-        If the table is missing a required column, migrate it in place
-        (preserving all rows) instead of dropping and recreating it. This path
-        runs on every store construction, so a wipe here would destroy data with
-        no write in flight. On any migration failure the original table is left
-        intact and the error propagates (out of ``__init__``); we never fall back
-        to a wipe. Note the migration branch may perform a batched re-embed when
-        a table is both missing a base column and vector-mismatched.
-        """
+        """Maintain non-vector columns without changing the vector space."""
         conn = self._vector_store.get_raw_connection()
 
         # Determine whether the table already exists and read its columns.
@@ -117,18 +211,15 @@ class LanceDBMemoryStore(MemoryStore):
         finally:
             _safe_close_table(table)
 
-        # Table exists. Init's trigger is a missing required non-vector column;
-        # a vector-dimension mismatch is detected and migrated lazily on the
-        # add() path instead. Route the resolution through the shared classifier
-        # and transform-then-swap primitive so we migrate rather than wipe.
-        if not {"id", "text", "metadata"} <= column_names:
+        missing = tuple(
+            name for name in ("id", "text", "metadata") if name not in column_names
+        )
+        if missing:
             logger.warning(
                 f"Table {self._collection_name} has incompatible schema, "
-                "migrating in place"
+                "backfilling non-vector columns"
             )
-            self._resolve_schema_mismatch(
-                conn, self._current_embedding_dim(), raise_when_compatible=False
-            )
+            self._backfill_missing_columns(conn, missing)
 
         # #822: promote user_id + scope_dims to real columns so scope filters
         # can be pushed into a `where` prefilter (slice 001). Idempotent and
@@ -179,6 +270,12 @@ class LanceDBMemoryStore(MemoryStore):
     def _get_embedding(self, text: str) -> Optional[list[float]]:
         """Get embedding for text using the configured embedding model."""
         if not self._embedding_model or not text.strip():
+            return None
+        if not self._vectors_are_compatible():
+            logger.warning(
+                "Configured embedding does not match the table vector space; "
+                "using text-only fallback"
+            )
             return None
 
         try:
@@ -317,7 +414,7 @@ class LanceDBMemoryStore(MemoryStore):
         user_ids, scope_dims = self._derive_scope_arrays(metadata_column)
         columns[USER_ID_COLUMN] = user_ids
         columns[SCOPE_DIMS_COLUMN] = scope_dims
-        return pa.table(columns)
+        return pa.table(columns).replace_schema_metadata(existing.schema.metadata)
 
     def _ensure_scope_columns(self, conn: Any) -> None:
         """Promote user_id + scope_dims to real columns on an existing table (#822).
@@ -358,10 +455,9 @@ class LanceDBMemoryStore(MemoryStore):
     ) -> None:
         """Classify and safely resolve a schema mismatch (shared by add/init).
 
-        Missing non-vector columns are backfilled in place; a vector
-        dimension/presence change rebuilds the table via transform-then-swap.
-        On any failure the original table is left intact and the error
-        propagates; no path drops or empties the table.
+        Missing non-vector columns are backfilled in place. Vector-space changes
+        require a dedicated offline administrative workflow; this ordinary schema
+        maintenance path never re-embeds or replaces persisted vectors.
 
         When the schema is classified compatible, ``raise_when_compatible``
         controls behavior: the ``add()`` path passes ``True`` (its insert failed,
@@ -379,11 +475,8 @@ class LanceDBMemoryStore(MemoryStore):
         if mismatch.kind is MemoryMismatchKind.MISSING_NON_VECTOR_COLUMN:
             self._backfill_missing_columns(conn, mismatch.missing_columns)
         elif mismatch.kind is MemoryMismatchKind.VECTOR_REBUILD:
-            target_dim = expected_dim
-            migrate_table_swap(
-                conn,
-                self._collection_name,
-                lambda existing: self._build_migrated_table(existing, target_dim),
+            raise RuntimeError(
+                "vector-space migration requires an offline administrative workflow"
             )
         elif raise_when_compatible:
             # add() failed but the schema looks compatible: do NOT drop the
@@ -393,23 +486,16 @@ class LanceDBMemoryStore(MemoryStore):
             )
 
     def _migrate_schema_mismatch(self, conn: Any, record: dict[str, Any]) -> None:
-        """Resolve the schema mismatch that made an ``add()`` insert fail."""
-        # The dimension we are trying to store now determines the target schema.
-        if record.get("vector"):
-            expected_dim: Optional[int] = len(record["vector"])
-        elif self._embedding_model:
-            expected_dim = self._current_embedding_dim()
-        else:
-            expected_dim = None
-
+        """Compatibility shim for explicit administrative callers only."""
+        expected_dim = len(record["vector"]) if record.get("vector") else None
         self._resolve_schema_mismatch(conn, expected_dim, raise_when_compatible=True)
 
     def _insert_record(self, table: Any, record: dict[str, Any]) -> None:
-        """Insert a record, adapting it to the (possibly migrated) table schema."""
+        """Insert a record while tolerating pre-upgrade internal columns."""
         schema_names = set(table.schema.names)
-        if "vector" in record and "vector" not in schema_names:
-            record = {k: v for k, v in record.items() if k != "vector"}
-        table.add([record])
+        table.add(
+            [{key: value for key, value in record.items() if key in schema_names}]
+        )
 
     def _memory_note_to_dict(self, note: MemoryNote) -> dict[str, Any]:
         """Convert MemoryNote to dictionary for storage."""
@@ -507,25 +593,23 @@ class LanceDBMemoryStore(MemoryStore):
                 if data["vector"]:
                     record["vector"] = data["vector"]
 
-                # Try to add the record. On a schema mismatch, migrate the
-                # existing table in place (preserving all rows) instead of
-                # dropping and recreating it.
+                # Explicit maintenance-mode callers may backfill additive columns.
                 try:
-                    table.add([record])
+                    self._insert_record(table, record)
                 except Exception as add_error:
+                    if not self._run_schema_maintenance:
+                        raise
                     logger.warning(
                         f"add() failed on possible schema mismatch: {add_error}; "
-                        "attempting safe in-place migration"
+                        "attempting additive schema maintenance"
                     )
                     _safe_close_table(table)
                     table = None
-                    # Migrate safely; on any failure the original table is left
-                    # intact and we surface an error WITHOUT dropping data.
                     try:
                         self._migrate_schema_mismatch(conn, record)
                     except Exception as migrate_error:
                         logger.error(
-                            "Safe schema migration failed; table left intact: %s",
+                            "Schema maintenance failed; table left intact: %s",
                             migrate_error,
                         )
                         return MemoryResponse(
@@ -533,7 +617,6 @@ class LanceDBMemoryStore(MemoryStore):
                             error=f"Failed to add memory: {migrate_error}",
                             memory_id=data["id"],
                         )
-                    # Retry the insert against the migrated schema.
                     table = conn.open_table(self._collection_name)
                     self._insert_record(table, record)
             finally:

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -483,12 +483,7 @@ class LanceDBMemoryStore(MemoryStore):
             if missing_fields:
                 table.add_columns(pa.schema(missing_fields))
 
-            reader = (
-                table.search()
-                .select(["id", "metadata"])
-                .limit(None)
-                .to_batches(batch_size=512)
-            )
+            reader = table.search().limit(None).to_batches(batch_size=512)
             try:
                 for batch in reader:
                     rows = batch.to_pylist()
@@ -497,8 +492,7 @@ class LanceDBMemoryStore(MemoryStore):
                     ]
                     source = pa.table(
                         {
-                            "id": [row["id"] for row in rows],
-                            "metadata": [row["metadata"] for row in rows],
+                            **dict(zip(batch.schema.names, batch.columns, strict=True)),
                             USER_ID_COLUMN: pa.array(
                                 [projection[0] for projection in projections],
                                 pa.int64(),

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -2,30 +2,34 @@ from __future__ import annotations
 
 import json
 import logging
-import threading
+import os
 from typing import Any, List, Optional, Union
 from uuid import uuid4
 
 import pyarrow as pa  # type: ignore
 import pyarrow.compute as pc  # type: ignore
+from filelock import FileLock
 
 from ...providers.vector_store.lancedb import (
     LanceDBConnectionManager,
     LanceDBVectorStore,
 )
 from ..model.embedding import BaseEmbedding, DashScopeEmbedding
-from ..model.embedding.adapter import create_embedding_adapter
+from ..model.embedding.adapter import (
+    create_embedding_adapter,
+    embedding_identity_from_config,
+)
 from ..model.model import EmbeddingModelConfig
 from ..tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
+from ..tools.core.RAG_tools.utils.string_utils import escape_lancedb_string
 from .base import MemoryStore
 from .core import MemoryNote, MemoryResponse
 from .schema_migration import (
-    MemoryMismatchKind,
     VECTOR_SPACE_METADATA_KEY,
+    MemoryMismatchKind,
     VectorSpaceCompatibility,
     classify_memory_schema_mismatch,
     inspect_vector_space,
-    migrate_table_swap,
 )
 from .scope_columns import (
     SCOPE_DIMS_COLUMN,
@@ -38,7 +42,6 @@ from .scope_columns import (
 )
 
 logger = logging.getLogger(__name__)
-_SCHEMA_MAINTENANCE_LOCK = threading.Lock()
 
 
 class LanceDBMemoryStore(MemoryStore):
@@ -67,8 +70,11 @@ class LanceDBMemoryStore(MemoryStore):
             **embedding_kwargs: Additional arguments for embedding model
         """
         self._collection_name = collection_name
+        self._db_dir = db_dir
         self._vector_space_identity = vector_space_identity
         self._run_schema_maintenance = run_schema_maintenance
+        self._vectors_compatible_cache: Optional[bool] = None
+        self._resolved_embedding_dim: Optional[int] = None
 
         # Handle different types of embedding_model input
         if embedding_model is None:
@@ -90,6 +96,10 @@ class LanceDBMemoryStore(MemoryStore):
         elif isinstance(embedding_model, BaseEmbedding):
             self._embedding_model = embedding_model
         elif isinstance(embedding_model, EmbeddingModelConfig):
+            if vector_space_identity is None:
+                self._vector_space_identity = embedding_identity_from_config(
+                    embedding_model
+                )
             self._embedding_model = create_embedding_adapter(embedding_model)
         else:
             raise ValueError(
@@ -111,7 +121,7 @@ class LanceDBMemoryStore(MemoryStore):
             db_dir,
             collection_name,
             connection_manager=self._conn_manager,
-            initial_data=self._initial_table_data(),
+            initial_data=self._initial_table_data,
         )
         if run_schema_maintenance:
             self.maintain_schema()
@@ -121,7 +131,9 @@ class LanceDBMemoryStore(MemoryStore):
             try:
                 return int(self._vector_space_identity["dimension"])
             except (KeyError, TypeError, ValueError):
-                return None
+                pass
+        if self._resolved_embedding_dim is not None:
+            return self._resolved_embedding_dim
         if self._embedding_model is None:
             return None
         try:
@@ -131,7 +143,7 @@ class LanceDBMemoryStore(MemoryStore):
         return int(dimension) if dimension else None
 
     def _initial_table_data(self) -> Any:
-        """Build a typed empty-table seed without calling the embedding service."""
+        """Build a typed seed, probing only after absence of the table is known."""
         data: dict[str, Any] = {
             "id": ["sample"],
             "text": ["sample"],
@@ -140,6 +152,18 @@ class LanceDBMemoryStore(MemoryStore):
             SCOPE_DIMS_COLUMN: pa.array([["sample"]], pa.list_(pa.string())),
         }
         dimension = self._configured_embedding_dim()
+        if dimension is None and self._embedding_model is not None:
+            result = self._embedding_model.encode("sample")
+            vector = result[0] if result and isinstance(result[0], list) else result
+            if not isinstance(vector, list) or not vector:
+                raise RuntimeError("Embedding dimension is unavailable for a new table")
+            dimension = len(vector)
+            self._resolved_embedding_dim = dimension
+            if self._vector_space_identity is not None:
+                self._vector_space_identity = {
+                    **self._vector_space_identity,
+                    "dimension": dimension,
+                }
         if dimension is not None:
             data["vector"] = pa.array(
                 [[0.0] * dimension], pa.list_(pa.float32(), dimension)
@@ -166,33 +190,43 @@ class LanceDBMemoryStore(MemoryStore):
             _safe_close_table(table)
 
     def _vectors_are_compatible(self) -> bool:
+        if self._vectors_compatible_cache is not None:
+            return self._vectors_compatible_cache
         dimension = self._configured_embedding_dim()
         if dimension is None:
+            self._vectors_compatible_cache = False
             return False
         table = self._vector_store.get_raw_connection().open_table(
             self._collection_name
         )
         try:
-            vector_type = table.schema.field("vector").type
+            schema = table.schema
+            vector_type = schema.field("vector").type
             dimension_matches = (
                 pa.types.is_fixed_size_list(vector_type)
                 and int(vector_type.list_size) == dimension
             )
+            compatible = dimension_matches and (
+                self._vector_space_identity is None
+                or inspect_vector_space(schema, self._vector_space_identity)
+                is not VectorSpaceCompatibility.MISMATCHING
+            )
+            self._vectors_compatible_cache = compatible
+            return compatible
         except (KeyError, ValueError):
-            dimension_matches = False
+            self._vectors_compatible_cache = False
+            return False
         finally:
             _safe_close_table(table)
-        if not dimension_matches:
-            return False
-        return (
-            self._vector_space_identity is None
-            or self.inspect_vector_space() is not VectorSpaceCompatibility.MISMATCHING
-        )
 
     def maintain_schema(self) -> None:
         """Run ordinary schema maintenance at a serialized lifecycle boundary."""
-        with _SCHEMA_MAINTENANCE_LOCK:
+        lock_path = os.path.join(
+            self._db_dir, f".{self._collection_name}.memory-maintenance.lock"
+        )
+        with FileLock(lock_path):
             self._ensure_table_schema()
+            self._vectors_compatible_cache = None
 
     def _ensure_table_schema(self) -> None:
         """Maintain non-vector columns without changing the vector space."""
@@ -295,21 +329,8 @@ class LanceDBMemoryStore(MemoryStore):
             return None
 
     def _current_embedding_dim(self) -> Optional[int]:
-        """Return the vector dimension the store currently produces, or None.
-
-        None means no embedding model is available and the store operates in
-        vector-less (text-search) mode.
-        """
-        if not self._embedding_model:
-            return None
-        try:
-            dim = self._embedding_model.get_dimension()
-            if dim:
-                return int(dim)
-        except Exception:
-            pass
-        sample = self._get_embedding("sample")
-        return len(sample) if sample else None
+        """Return the configured store dimension without an embedding call."""
+        return self._configured_embedding_dim()
 
     def _embed_texts_batch(
         self, texts: list[str], target_dim: int
@@ -397,48 +418,59 @@ class LanceDBMemoryStore(MemoryStore):
             pa.array(scope_dims, pa.list_(pa.string())),
         )
 
-    def _add_scope_columns(self, existing: Any) -> Any:
-        """Migration transform: add derived scope columns, preserve everything else.
-
-        Unlike the vector rebuild, this preserves the existing ``vector`` column
-        as-is (no re-embedding) — it only projects ``user_id`` / ``scope_dims``
-        out of each row's metadata JSON.
-        """
-        columns: dict[str, Any] = {
-            name: existing.column(name) for name in existing.schema.names
-        }
-        if "metadata" in columns:
-            metadata_column = columns["metadata"].cast(pa.string())
-        else:
-            metadata_column = pa.array([None] * existing.num_rows, pa.string())
-        user_ids, scope_dims = self._derive_scope_arrays(metadata_column)
-        columns[USER_ID_COLUMN] = user_ids
-        columns[SCOPE_DIMS_COLUMN] = scope_dims
-        return pa.table(columns).replace_schema_metadata(existing.schema.metadata)
-
     def _ensure_scope_columns(self, conn: Any) -> None:
         """Promote user_id + scope_dims to real columns on an existing table (#822).
 
-        Idempotent: does nothing when both columns already exist (fresh tables are
-        created with them). Otherwise rebuilds the table via transform-then-swap,
-        back-filling both columns from each row's metadata JSON and preserving all
-        other columns (including ``vector``). On failure the original table is left
-        intact and the error propagates — this never drops data.
+        Adds nullable columns, then idempotently updates their projections from
+        authoritative metadata. It never replaces the table, so a concurrent append
+        cannot be overwritten by a stale snapshot.
         """
         table = conn.open_table(self._collection_name)
         try:
             names = set(table.schema.names)
+            missing_fields = [
+                field
+                for field in (
+                    pa.field(USER_ID_COLUMN, pa.int64()),
+                    pa.field(SCOPE_DIMS_COLUMN, pa.list_(pa.string())),
+                )
+                if field.name not in names
+            ]
+            if missing_fields:
+                table.add_columns(pa.schema(missing_fields))
+
+            rows = (
+                table.search()
+                .select(["id", "metadata", USER_ID_COLUMN, SCOPE_DIMS_COLUMN])
+                .limit(None)
+                .to_arrow()
+            )
+            for row in rows.to_pylist():
+                user_id, scope_dims = derive_scope_columns(row["metadata"])
+                if (
+                    row[USER_ID_COLUMN] == user_id
+                    and row[SCOPE_DIMS_COLUMN] == scope_dims
+                ):
+                    continue
+                note_id = row["id"]
+                if not isinstance(note_id, str):
+                    raise ValueError("Memory scope maintenance requires string ids")
+                where = f"id = '{escape_lancedb_string(note_id)}'"
+                if scope_dims:
+                    table.update(
+                        where,
+                        {USER_ID_COLUMN: user_id, SCOPE_DIMS_COLUMN: scope_dims},
+                    )
+                else:
+                    table.update(
+                        where,
+                        values_sql={
+                            USER_ID_COLUMN: "NULL" if user_id is None else str(user_id),
+                            SCOPE_DIMS_COLUMN: "array_slice([''], 1, 0)",
+                        },
+                    )
         finally:
             _safe_close_table(table)
-
-        if {USER_ID_COLUMN, SCOPE_DIMS_COLUMN} <= names:
-            return
-
-        logger.info(
-            "Promoting user_id/scope_dims to real columns on table '%s'",
-            self._collection_name,
-        )
-        migrate_table_swap(conn, self._collection_name, self._add_scope_columns)
 
     def _backfill_missing_columns(self, conn: Any, columns: tuple[str, ...]) -> None:
         """Add missing non-vector columns in place (no data loss, no rebuild)."""
@@ -450,19 +482,14 @@ class LanceDBMemoryStore(MemoryStore):
         finally:
             _safe_close_table(table)
 
-    def _resolve_schema_mismatch(
-        self, conn: Any, expected_dim: Optional[int], *, raise_when_compatible: bool
-    ) -> None:
+    def _resolve_schema_mismatch(self, conn: Any, expected_dim: Optional[int]) -> None:
         """Classify and safely resolve a schema mismatch (shared by add/init).
 
         Missing non-vector columns are backfilled in place. Vector-space changes
         require a dedicated offline administrative workflow; this ordinary schema
         maintenance path never re-embeds or replaces persisted vectors.
 
-        When the schema is classified compatible, ``raise_when_compatible``
-        controls behavior: the ``add()`` path passes ``True`` (its insert failed,
-        so a compatible schema means an unexpected error to surface rather than
-        silently drop); the init path passes ``False`` (nothing to migrate).
+        A compatible schema means the failed insert was unrelated to maintenance.
         """
         table = conn.open_table(self._collection_name)
         try:
@@ -478,7 +505,7 @@ class LanceDBMemoryStore(MemoryStore):
             raise RuntimeError(
                 "vector-space migration requires an offline administrative workflow"
             )
-        elif raise_when_compatible:
+        else:
             # add() failed but the schema looks compatible: do NOT drop the
             # table. Surface the original failure to the caller.
             raise RuntimeError(
@@ -487,12 +514,22 @@ class LanceDBMemoryStore(MemoryStore):
 
     def _migrate_schema_mismatch(self, conn: Any, record: dict[str, Any]) -> None:
         """Compatibility shim for explicit administrative callers only."""
-        expected_dim = len(record["vector"]) if record.get("vector") else None
-        self._resolve_schema_mismatch(conn, expected_dim, raise_when_compatible=True)
+        expected_dim = (
+            len(record["vector"])
+            if record.get("vector")
+            else self._current_embedding_dim()
+        )
+        self._resolve_schema_mismatch(conn, expected_dim)
 
     def _insert_record(self, table: Any, record: dict[str, Any]) -> None:
         """Insert a record while tolerating pre-upgrade internal columns."""
         schema_names = set(table.schema.names)
+        missing = {"id", "text", "metadata"} - schema_names
+        if missing:
+            raise ValueError(
+                "Memory table is missing required columns: "
+                + ", ".join(sorted(missing))
+            )
         table.add(
             [{key: value for key, value in record.items() if key in schema_names}]
         )

--- a/src/xagent/core/memory/lancedb.py
+++ b/src/xagent/core/memory/lancedb.py
@@ -21,7 +21,6 @@ from ..model.embedding.adapter import (
 )
 from ..model.model import EmbeddingModelConfig
 from ..tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
-from ..tools.core.RAG_tools.utils.string_utils import escape_lancedb_string
 from .base import MemoryStore
 from .core import MemoryNote, MemoryResponse
 from .schema_migration import (
@@ -236,18 +235,31 @@ class LanceDBMemoryStore(MemoryStore):
         table = None
         try:
             table = conn.open_table(self._collection_name)
-            column_names = set(table.schema.names)
-        except Exception:
-            # Table doesn't exist yet, create it with the basic schema.
-            logger.info(f"Creating table {self._collection_name} with basic schema")
+        except Exception as error:
+            if "was not found" not in str(error):
+                raise
+            logger.info("Creating table %s with basic schema", self._collection_name)
             self._create_empty_table()
             return
+        try:
+            column_names = set(table.schema.names)
+            missing = tuple(
+                name for name in ("id", "text", "metadata") if name not in column_names
+            )
+            scope_missing = (
+                not {
+                    USER_ID_COLUMN,
+                    SCOPE_DIMS_COLUMN,
+                }
+                <= column_names
+            )
+            if not missing and not scope_missing:
+                return
+            if not self._legacy_ids_are_maintainable(table):
+                return
         finally:
             _safe_close_table(table)
 
-        missing = tuple(
-            name for name in ("id", "text", "metadata") if name not in column_names
-        )
         if missing:
             logger.warning(
                 f"Table {self._collection_name} has incompatible schema, "
@@ -259,7 +271,8 @@ class LanceDBMemoryStore(MemoryStore):
         # can be pushed into a `where` prefilter (slice 001). Idempotent and
         # data-preserving; runs after the base-schema resolution above so it sees
         # a table that already has id/text/metadata.
-        self._ensure_scope_columns(conn)
+        if scope_missing:
+            self._ensure_scope_columns(conn)
 
     def _create_empty_table(self) -> None:
         """Create an empty table with the correct schema."""
@@ -418,6 +431,34 @@ class LanceDBMemoryStore(MemoryStore):
             pa.array(scope_dims, pa.list_(pa.string())),
         )
 
+    def _legacy_ids_are_maintainable(self, table: Any) -> bool:
+        """Validate legacy row identifiers before any schema mutation."""
+        if (
+            "id" not in table.schema.names
+            or table.schema.field("id").type != pa.string()
+        ):
+            logger.warning(
+                "Skipping memory maintenance for table %s: id column must be string",
+                self._collection_name,
+            )
+            return False
+        seen_ids: set[str] = set()
+        reader = table.search().select(["id"]).limit(None).to_batches(batch_size=512)
+        try:
+            for batch in reader:
+                for note_id in batch.column("id").to_pylist():
+                    if not isinstance(note_id, str) or note_id in seen_ids:
+                        logger.warning(
+                            "Skipping memory maintenance for table %s: "
+                            "ids must be non-null unique strings",
+                            self._collection_name,
+                        )
+                        return False
+                    seen_ids.add(note_id)
+        finally:
+            reader.close()
+        return True
+
     def _ensure_scope_columns(self, conn: Any) -> None:
         """Promote user_id + scope_dims to real columns on an existing table (#822).
 
@@ -428,6 +469,9 @@ class LanceDBMemoryStore(MemoryStore):
         table = conn.open_table(self._collection_name)
         try:
             names = set(table.schema.names)
+            if {USER_ID_COLUMN, SCOPE_DIMS_COLUMN} <= names:
+                return
+
             missing_fields = [
                 field
                 for field in (
@@ -439,36 +483,46 @@ class LanceDBMemoryStore(MemoryStore):
             if missing_fields:
                 table.add_columns(pa.schema(missing_fields))
 
-            rows = (
+            reader = (
                 table.search()
-                .select(["id", "metadata", USER_ID_COLUMN, SCOPE_DIMS_COLUMN])
+                .select(["id", "metadata"])
                 .limit(None)
-                .to_arrow()
+                .to_batches(batch_size=512)
             )
-            for row in rows.to_pylist():
-                user_id, scope_dims = derive_scope_columns(row["metadata"])
-                if (
-                    row[USER_ID_COLUMN] == user_id
-                    and row[SCOPE_DIMS_COLUMN] == scope_dims
-                ):
-                    continue
-                note_id = row["id"]
-                if not isinstance(note_id, str):
-                    raise ValueError("Memory scope maintenance requires string ids")
-                where = f"id = '{escape_lancedb_string(note_id)}'"
-                if scope_dims:
-                    table.update(
-                        where,
-                        {USER_ID_COLUMN: user_id, SCOPE_DIMS_COLUMN: scope_dims},
+            try:
+                for batch in reader:
+                    rows = batch.to_pylist()
+                    projections = [
+                        derive_scope_columns(row["metadata"]) for row in rows
+                    ]
+                    source = pa.table(
+                        {
+                            "id": [row["id"] for row in rows],
+                            "metadata": [row["metadata"] for row in rows],
+                            USER_ID_COLUMN: pa.array(
+                                [projection[0] for projection in projections],
+                                pa.int64(),
+                            ),
+                            SCOPE_DIMS_COLUMN: pa.array(
+                                [projection[1] for projection in projections],
+                                pa.list_(pa.string()),
+                            ),
+                        }
                     )
-                else:
-                    table.update(
-                        where,
-                        values_sql={
-                            USER_ID_COLUMN: "NULL" if user_id is None else str(user_id),
-                            SCOPE_DIMS_COLUMN: "array_slice([''], 1, 0)",
-                        },
+                    merged = (
+                        table.merge_insert("id")
+                        .when_matched_update_all(
+                            where="target.metadata = source.metadata"
+                        )
+                        .execute(source)
                     )
+                    if merged.num_updated_rows != len(rows):
+                        logger.warning(
+                            "Scope maintenance skipped %s concurrently changed rows",
+                            len(rows) - merged.num_updated_rows,
+                        )
+            finally:
+                reader.close()
         finally:
             _safe_close_table(table)
 
@@ -947,6 +1001,32 @@ class LanceDBMemoryStore(MemoryStore):
                 logger.warning(
                     f"Embedding generation failed, using text search: {embedding_error}"
                 )
+
+            if results and k:
+                seen_ids = {note.id for note in results}
+                other_filters = self._flat_other_filters(filters)
+                null_rows = table.search().where("vector IS NULL").to_pandas()
+                for _, row in null_rows.iterrows():
+                    text = row.get("text", "")
+                    if query and query.lower() not in text.lower():
+                        continue
+                    try:
+                        note = self._dict_to_memory_note(row.to_dict())
+                    except Exception as row_error:
+                        logger.warning(
+                            "Skipping malformed NULL-vector row: %s", row_error
+                        )
+                        continue
+                    if note.id in seen_ids or (
+                        filters
+                        and not self._matches_filters(note, filters, other_filters)
+                    ):
+                        continue
+                    if len(results) >= k:
+                        results[-1] = note
+                    else:
+                        results.append(note)
+                    seen_ids.add(note.id)
 
             # Fallback to text search if no vector results or vector search failed
             if not results:

--- a/src/xagent/core/memory/schema_migration.py
+++ b/src/xagent/core/memory/schema_migration.py
@@ -24,10 +24,11 @@ discarding data on failure.
 
 from __future__ import annotations
 
+import json
 import logging
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Mapping, Optional
 
 import pyarrow as pa  # type: ignore
 from lancedb.db import DBConnection
@@ -41,13 +42,31 @@ __all__ = [
     "MEMORY_VECTOR_COLUMN",
     "MemoryMismatchKind",
     "MemorySchemaMismatch",
+    "VectorSpaceCompatibility",
     "classify_memory_schema_mismatch",
+    "inspect_vector_space",
     "migrate_table_swap",
 ]
 
 # The memory schema is fixed: the only variable is the vector column's width.
 MEMORY_NON_VECTOR_COLUMNS = ("id", "text", "metadata")
 MEMORY_VECTOR_COLUMN = "vector"
+VECTOR_SPACE_METADATA_KEY = b"xagent.memory.vector_space"
+LEGACY_DASHSCOPE_IDENTITY = {
+    "provider": "dashscope",
+    "model": "text-embedding-v4",
+    "endpoint": "https://dashscope.aliyuncs.com/api/v1/services/embeddings/"
+    "text-embedding/text-embedding",
+    "instruct": None,
+}
+
+
+class VectorSpaceCompatibility(str, Enum):
+    """Read-only compatibility state for a shared memory table."""
+
+    LEGACY_COMPATIBLE = "legacy_compatible"
+    MATCHING = "matching"
+    MISMATCHING = "mismatching"
 
 
 class MemoryMismatchKind(str, Enum):
@@ -87,6 +106,53 @@ def _vector_width(schema: Any) -> Optional[int]:
         return int(vector_type.list_size)
     # A variable-length list has no fixed width to compare against.
     return None
+
+
+def inspect_vector_space(
+    schema: Any, expected_identity: Mapping[str, Any]
+) -> VectorSpaceCompatibility:
+    """Classify persisted vectors using schema metadata only.
+
+    Scope projection columns are ordinary maintenance, not vector identity.
+    """
+    expected = dict(expected_identity)
+    if set(expected) != {*LEGACY_DASHSCOPE_IDENTITY, "dimension"}:
+        return VectorSpaceCompatibility.MISMATCHING
+    try:
+        dimension = int(expected["dimension"])
+        vector_type = schema.field(MEMORY_VECTOR_COLUMN).type
+        strings_match = all(
+            schema.field(name).type == pa.string() for name in MEMORY_NON_VECTOR_COLUMNS
+        )
+    except (KeyError, TypeError, ValueError):
+        return VectorSpaceCompatibility.MISMATCHING
+    if not (
+        strings_match
+        and pa.types.is_fixed_size_list(vector_type)
+        and vector_type.value_type == pa.float32()
+        and int(vector_type.list_size) == dimension
+    ):
+        return VectorSpaceCompatibility.MISMATCHING
+
+    encoded = (schema.metadata or {}).get(VECTOR_SPACE_METADATA_KEY)
+    if encoded is None:
+        legacy = {key: expected[key] for key in LEGACY_DASHSCOPE_IDENTITY}
+        return (
+            VectorSpaceCompatibility.LEGACY_COMPATIBLE
+            if legacy == LEGACY_DASHSCOPE_IDENTITY
+            else VectorSpaceCompatibility.MISMATCHING
+        )
+    try:
+        stored = json.loads(encoded.decode())
+    except (AttributeError, UnicodeDecodeError, json.JSONDecodeError):
+        return VectorSpaceCompatibility.MISMATCHING
+    if not isinstance(stored, dict):
+        return VectorSpaceCompatibility.MISMATCHING
+    return (
+        VectorSpaceCompatibility.MATCHING
+        if stored == expected
+        else VectorSpaceCompatibility.MISMATCHING
+    )
 
 
 def classify_memory_schema_mismatch(

--- a/src/xagent/core/model/embedding/adapter.py
+++ b/src/xagent/core/model/embedding/adapter.py
@@ -34,6 +34,21 @@ def create_embedding_adapter(model_config: EmbeddingModelConfig) -> BaseEmbeddin
     )
 
 
+def embedding_identity_from_config(model_config: EmbeddingModelConfig) -> dict:
+    """Return the canonical vector-space identity for an embedding config."""
+    embedding = EmbeddingModelAdapter(model_config)._embedding_model
+    provider = model_config.model_provider.lower().strip()
+    if provider in ("openai_embedding", "openai-compatible"):
+        provider = "openai"
+    return {
+        "provider": provider,
+        "model": getattr(embedding, "model", model_config.model_name),
+        "endpoint": getattr(embedding, "base_url", model_config.base_url),
+        "dimension": embedding.get_dimension(),
+        "instruct": getattr(embedding, "instruct", model_config.instruct),
+    }
+
+
 class EmbeddingModelAdapter(BaseEmbedding):
     """Adapter that makes the new embedding interface compatible with existing EmbeddingModel configs."""
 

--- a/src/xagent/core/model/embedding/adapter.py
+++ b/src/xagent/core/model/embedding/adapter.py
@@ -34,14 +34,18 @@ def create_embedding_adapter(model_config: EmbeddingModelConfig) -> BaseEmbeddin
     )
 
 
+def _normalize_embedding_provider(name: str) -> str:
+    provider = name.lower().strip()
+    if provider in ("openai_embedding", "openai-compatible"):
+        return "openai"
+    return provider
+
+
 def embedding_identity_from_config(model_config: EmbeddingModelConfig) -> dict:
     """Return the canonical vector-space identity for an embedding config."""
     embedding = EmbeddingModelAdapter(model_config)._embedding_model
-    provider = model_config.model_provider.lower().strip()
-    if provider in ("openai_embedding", "openai-compatible"):
-        provider = "openai"
     return {
-        "provider": provider,
+        "provider": _normalize_embedding_provider(model_config.model_provider),
         "model": getattr(embedding, "model", model_config.model_name),
         "endpoint": getattr(embedding, "base_url", model_config.base_url),
         "dimension": embedding.get_dimension(),
@@ -60,7 +64,7 @@ class EmbeddingModelAdapter(BaseEmbedding):
         """Create the actual embedding model from configuration."""
         # Normalize provider name: map variants to canonical names
         # Note: 'openai_embedding' is a legacy value that should be treated as 'openai'
-        provider = self.model_config.model_provider.lower().strip()
+        provider = _normalize_embedding_provider(self.model_config.model_provider)
         if provider in ("openai", "openai_embedding", "openai-compatible"):
             return OpenAIEmbedding(
                 model=self.model_config.model_name,

--- a/src/xagent/providers/vector_store/lancedb.py
+++ b/src/xagent/providers/vector_store/lancedb.py
@@ -230,6 +230,7 @@ class LanceDBVectorStore(VectorStore):
         db_dir: str,
         collection_name: str = "vectors",
         connection_manager: Optional[LanceDBConnectionManager] = None,
+        initial_data: Optional[Any] = None,
     ):
         """
         Initialize LanceDB vector store.
@@ -243,9 +244,9 @@ class LanceDBVectorStore(VectorStore):
         self._collection_name = collection_name
         self._conn_manager = connection_manager or LanceDBConnectionManager()
         self._conn = self._conn_manager.get_connection(db_dir)
-        self._ensure_table()
+        self._ensure_table(initial_data)
 
-    def _ensure_table(self) -> None:
+    def _ensure_table(self, initial_data: Optional[Any] = None) -> None:
         """Ensure the vector table exists."""
         table = None
         try:
@@ -266,7 +267,14 @@ class LanceDBVectorStore(VectorStore):
                     "metadata": "{}",
                 }
             ]
-            table = self._conn.create_table(self._collection_name, data=sample_data)
+            if initial_data is not None:
+                sample_data = initial_data
+            try:
+                table = self._conn.create_table(self._collection_name, data=sample_data)
+            except Exception:
+                # A concurrent constructor may have created the shared table.
+                # Open its winner; never overwrite it during acquisition.
+                table = self._conn.open_table(self._collection_name)
             # Remove sample data
             table.delete("id = 'sample'")
         finally:

--- a/src/xagent/providers/vector_store/lancedb.py
+++ b/src/xagent/providers/vector_store/lancedb.py
@@ -231,7 +231,7 @@ class LanceDBVectorStore(VectorStore):
         db_dir: str,
         collection_name: str = "vectors",
         connection_manager: Optional[LanceDBConnectionManager] = None,
-        initial_data: Optional[Any | Callable[[], Any]] = None,
+        initial_data: Optional[Callable[[], Any]] = None,
     ):
         """
         Initialize LanceDB vector store.
@@ -247,9 +247,7 @@ class LanceDBVectorStore(VectorStore):
         self._conn = self._conn_manager.get_connection(db_dir)
         self._ensure_table(initial_data)
 
-    def _ensure_table(
-        self, initial_data: Optional[Any | Callable[[], Any]] = None
-    ) -> None:
+    def _ensure_table(self, initial_data: Optional[Callable[[], Any]] = None) -> None:
         """Ensure the vector table exists."""
         table = None
         try:
@@ -273,7 +271,7 @@ class LanceDBVectorStore(VectorStore):
                 }
             ]
             if initial_data is not None:
-                sample_data = initial_data() if callable(initial_data) else initial_data
+                sample_data = initial_data()
             created = False
             try:
                 table = self._conn.create_table(self._collection_name, data=sample_data)

--- a/src/xagent/providers/vector_store/lancedb.py
+++ b/src/xagent/providers/vector_store/lancedb.py
@@ -14,9 +14,10 @@ import os
 import time
 from pathlib import Path
 from threading import RLock
-from typing import Any, ClassVar, Dict, List, Optional, Tuple
+from typing import Any, Callable, ClassVar, Dict, List, Optional, Tuple
 
 import lancedb
+import pyarrow as pa  # type: ignore
 from lancedb.db import DBConnection
 
 from ...config import get_lancedb_path, get_storage_root
@@ -230,7 +231,7 @@ class LanceDBVectorStore(VectorStore):
         db_dir: str,
         collection_name: str = "vectors",
         connection_manager: Optional[LanceDBConnectionManager] = None,
-        initial_data: Optional[Any] = None,
+        initial_data: Optional[Any | Callable[[], Any]] = None,
     ):
         """
         Initialize LanceDB vector store.
@@ -246,12 +247,16 @@ class LanceDBVectorStore(VectorStore):
         self._conn = self._conn_manager.get_connection(db_dir)
         self._ensure_table(initial_data)
 
-    def _ensure_table(self, initial_data: Optional[Any] = None) -> None:
+    def _ensure_table(
+        self, initial_data: Optional[Any | Callable[[], Any]] = None
+    ) -> None:
         """Ensure the vector table exists."""
         table = None
         try:
             table = self._conn.open_table(self._collection_name)
         except Exception as e:
+            if "was not found" not in str(e):
+                raise
             logger.debug(
                 "Table %s does not exist or open failed (%s), creating new table.",
                 self._collection_name,
@@ -268,15 +273,30 @@ class LanceDBVectorStore(VectorStore):
                 }
             ]
             if initial_data is not None:
-                sample_data = initial_data
+                sample_data = initial_data() if callable(initial_data) else initial_data
+            created = False
             try:
                 table = self._conn.create_table(self._collection_name, data=sample_data)
-            except Exception:
+                created = True
+            except Exception as create_error:
+                if "already exists" not in str(create_error):
+                    raise
                 # A concurrent constructor may have created the shared table.
                 # Open its winner; never overwrite it during acquisition.
                 table = self._conn.open_table(self._collection_name)
-            # Remove sample data
-            table.delete("id = 'sample'")
+                if isinstance(sample_data, pa.Table):
+                    expected = sample_data.schema
+                    if any(
+                        name not in table.schema.names
+                        or table.schema.field(name).type != expected.field(name).type
+                        for name in expected.names
+                    ):
+                        raise ValueError(
+                            f"Concurrent table {self._collection_name!r} has an "
+                            "incompatible schema"
+                        )
+            if created:
+                table.delete("id = 'sample'")
         finally:
             _safe_close_table(table)
 

--- a/src/xagent/web/app.py
+++ b/src/xagent/web/app.py
@@ -1342,6 +1342,8 @@ async def startup_event() -> None:
     from .dynamic_memory_store import get_memory_store_manager
 
     manager = get_memory_store_manager()
+    with _startup_phase("memory schema maintenance"):
+        await asyncio.to_thread(manager.maintain_schema)
     store_info = manager.get_store_info()
 
     if store_info["is_lancedb"]:

--- a/src/xagent/web/dynamic_memory_store.py
+++ b/src/xagent/web/dynamic_memory_store.py
@@ -174,6 +174,9 @@ class DynamicMemoryStoreManager:
                         dimension=int(embedding_model.dimension or 1024),
                     ),
                     similarity_threshold=self._similarity_threshold or 1.5,
+                    # Store acquisition happens on request paths. Schema
+                    # maintenance belongs to an explicit startup/admin phase.
+                    run_schema_maintenance=False,
                 )
                 logger.info("Created LanceDB store with DashScope embedding model")
                 return UserIsolatedMemoryStore(lancedb_store)

--- a/src/xagent/web/dynamic_memory_store.py
+++ b/src/xagent/web/dynamic_memory_store.py
@@ -13,7 +13,7 @@ from .models.database import get_db
 from .models.model import Model as DBModel
 from .models.user import UserDefaultModel
 from .services.db_runtime import is_database_pool_timeout
-from .user_isolated_memory import UserIsolatedMemoryStore, current_user_id
+from .user_isolated_memory import UserIsolatedMemoryStore
 
 logger = logging.getLogger(__name__)
 
@@ -69,17 +69,20 @@ class DynamicMemoryStoreManager:
             logger.info("Initialized with in-memory store")
 
     def _get_embedding_model_from_db(self) -> Optional[DBModel]:
-        """Get the current embedding model from database."""
+        """Get the one global embedding model for the shared memory table."""
         try:
             db = next(get_db())
             try:
-                # Get current user ID from context
-                user_id = current_user_id.get()
+                # A shared table must not switch embedding identity with request
+                # context. Resolve only the shared/admin default.
+                user_id = None
 
-                from .services.model_service import _is_model_visible_to_user
+                from .services.model_service import (
+                    _is_model_visible_to_user,
+                    get_default_embedding_model,
+                )
 
                 if user_id:
-                    # First, try to get user's default embedding model
                     user_default = (
                         db.query(UserDefaultModel)
                         .filter(
@@ -90,7 +93,6 @@ class DynamicMemoryStoreManager:
                     )
 
                     if user_default:
-                        # Get the actual model
                         embedding_model = (
                             db.query(DBModel)
                             .filter(
@@ -107,7 +109,6 @@ class DynamicMemoryStoreManager:
                                 logger.warning(
                                     f"User default embedding model {user_default.model_id} is no longer visible"
                                 )
-                                # fall through to system fallback
                             else:
                                 logger.info(
                                     f"Found user's default embedding model: {embedding_model.model_id}"
@@ -118,10 +119,14 @@ class DynamicMemoryStoreManager:
                                 f"User default embedding model {user_default.model_id} not found or inactive"
                             )
 
-                # Fallback: look for first active embedding model visible to user
+                model_id = get_default_embedding_model(None, db=db)
+                if model_id is None:
+                    logger.info("No global shared embedding model found")
+                    return None
                 all_active_embeddings = (
                     db.query(DBModel)
                     .filter(
+                        DBModel.model_id == model_id,
                         DBModel.category == "embedding",
                         DBModel.is_active,
                     )
@@ -131,11 +136,11 @@ class DynamicMemoryStoreManager:
                 for embedding_model in all_active_embeddings:
                     if _is_model_visible_to_user(db, embedding_model.id, user_id):
                         logger.info(
-                            f"Using visible active embedding model: {embedding_model.model_id}"
+                            f"Using global shared embedding model: {embedding_model.model_id}"
                         )
                         return embedding_model
 
-                logger.info("No visible active embedding model found")
+                logger.info("No global shared embedding model found")
                 return None
             finally:
                 db.close()
@@ -146,7 +151,7 @@ class DynamicMemoryStoreManager:
             return None
 
     def _create_lancedb_store(
-        self, embedding_model: DBModel, *, fallback_on_error: bool = True
+        self, embedding_model: DBModel
     ) -> UserIsolatedMemoryStore:
         """Create LanceDB store with the given embedding model."""
         try:
@@ -191,13 +196,9 @@ class DynamicMemoryStoreManager:
                 )
                 self._initialize_in_memory_store()
                 return self._memory_store  # type: ignore[return-value]
-        except Exception as e:
-            if not fallback_on_error:
-                raise
-            logger.error(f"Error creating LanceDB store: {e}")
-            # Fallback to in-memory store
-            self._initialize_in_memory_store()
-            return self._memory_store  # type: ignore[return-value]
+        except Exception:
+            logger.exception("Error creating LanceDB store")
+            raise
 
     def _check_and_update_store(self, *, fallback_on_error: bool = True) -> None:
         """Check if embedding model configuration has changed and update store accordingly."""
@@ -233,9 +234,13 @@ class DynamicMemoryStoreManager:
 
             if should_update:
                 if embedding_model:
-                    self._memory_store = self._create_lancedb_store(
-                        embedding_model, fallback_on_error=fallback_on_error
-                    )
+                    try:
+                        new_store = self._create_lancedb_store(embedding_model)
+                    except Exception:
+                        if not fallback_on_error:
+                            raise
+                        return
+                    self._memory_store = new_store
                     self._is_lancedb = True
                     self._last_embedding_model_id = current_model_id  # type: ignore[assignment]
                     self._last_embedding_model_fingerprint = current_fingerprint

--- a/src/xagent/web/dynamic_memory_store.py
+++ b/src/xagent/web/dynamic_memory_store.py
@@ -7,7 +7,7 @@ from typing import Optional, Union
 
 from ..core.memory.in_memory import InMemoryMemoryStore
 from ..core.memory.lancedb import LanceDBMemoryStore
-from ..core.model.embedding import DashScopeEmbedding
+from ..core.model import EmbeddingModelConfig
 from ..core.storage.manager import get_storage_root
 from .models.database import get_db
 from .models.model import Model as DBModel
@@ -146,7 +146,7 @@ class DynamicMemoryStoreManager:
             return None
 
     def _create_lancedb_store(
-        self, embedding_model: DBModel
+        self, embedding_model: DBModel, *, fallback_on_error: bool = True
     ) -> UserIsolatedMemoryStore:
         """Create LanceDB store with the given embedding model."""
         try:
@@ -169,8 +169,12 @@ class DynamicMemoryStoreManager:
             if embedding_model.model_provider == "dashscope":
                 lancedb_store = LanceDBMemoryStore(
                     db_dir=db_dir,
-                    embedding_model=DashScopeEmbedding(
+                    embedding_model=EmbeddingModelConfig(
+                        id=str(embedding_model.model_id),
+                        model_provider=str(embedding_model.model_provider),
+                        model_name=str(embedding_model.model_name),
                         api_key=str(embedding_model.api_key),
+                        base_url=embedding_model.base_url,
                         dimension=int(embedding_model.dimension or 1024),
                     ),
                     similarity_threshold=self._similarity_threshold or 1.5,
@@ -188,12 +192,14 @@ class DynamicMemoryStoreManager:
                 self._initialize_in_memory_store()
                 return self._memory_store  # type: ignore[return-value]
         except Exception as e:
+            if not fallback_on_error:
+                raise
             logger.error(f"Error creating LanceDB store: {e}")
             # Fallback to in-memory store
             self._initialize_in_memory_store()
             return self._memory_store  # type: ignore[return-value]
 
-    def _check_and_update_store(self) -> None:
+    def _check_and_update_store(self, *, fallback_on_error: bool = True) -> None:
         """Check if embedding model configuration has changed and update store accordingly."""
         with self._lock:
             embedding_model = self._get_embedding_model_from_db()
@@ -227,7 +233,9 @@ class DynamicMemoryStoreManager:
 
             if should_update:
                 if embedding_model:
-                    self._memory_store = self._create_lancedb_store(embedding_model)
+                    self._memory_store = self._create_lancedb_store(
+                        embedding_model, fallback_on_error=fallback_on_error
+                    )
                     self._is_lancedb = True
                     self._last_embedding_model_id = current_model_id  # type: ignore[assignment]
                     self._last_embedding_model_fingerprint = current_fingerprint
@@ -245,6 +253,19 @@ class DynamicMemoryStoreManager:
         """
         self._check_and_update_store()
         return self._memory_store  # type: ignore[return-value]
+
+    def maintain_schema(self) -> None:
+        """Run persistent-memory maintenance during application startup."""
+        with self._lock:
+            self._check_and_update_store(fallback_on_error=False)
+            store = self._memory_store
+            base_store = (
+                store._base_store
+                if isinstance(store, UserIsolatedMemoryStore)
+                else store
+            )
+            if isinstance(base_store, LanceDBMemoryStore):
+                base_store.maintain_schema()
 
     def force_reinitialize(self) -> None:
         """Force reinitialization of the memory store."""

--- a/src/xagent/web/memory_utils.py
+++ b/src/xagent/web/memory_utils.py
@@ -74,8 +74,6 @@ def create_memory_store(
 
             if embedding_model:
                 # Create LanceDB store with embedding model
-                from xagent.core.model.embedding import create_embedding_adapter
-
                 current_dir = os.path.dirname(
                     os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
                 )
@@ -83,7 +81,7 @@ def create_memory_store(
 
                 lancedb_store = LanceDBMemoryStore(
                     db_dir=db_dir,
-                    embedding_model=create_embedding_adapter(embedding_model),
+                    embedding_model=embedding_model,
                     similarity_threshold=similarity_threshold,
                 )
                 # Wrap with user isolation for web application

--- a/tests/core/memory/test_lancedb_migration.py
+++ b/tests/core/memory/test_lancedb_migration.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import shutil
 import tempfile
+from concurrent.futures import ThreadPoolExecutor
 
 import lancedb  # type: ignore
 import pyarrow as pa  # type: ignore
@@ -11,6 +12,10 @@ import pytest
 
 from xagent.core.memory.core import MemoryNote
 from xagent.core.memory.lancedb import LanceDBMemoryStore
+from xagent.core.memory.schema_migration import (
+    LEGACY_DASHSCOPE_IDENTITY,
+    VectorSpaceCompatibility,
+)
 from xagent.core.model.embedding import BaseEmbedding
 from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
 
@@ -21,8 +26,10 @@ class MockEmbedding(BaseEmbedding):
     def __init__(self, dim: int = 64, value: float = 0.1):
         self._dimension = dim
         self._value = value
+        self.inputs = []
 
     def encode(self, text, dimension=None, instruct=None):
+        self.inputs.append(text)
         if isinstance(text, str):
             return [self._value] * self._dimension
         return [[self._value] * self._dimension for _ in text]
@@ -66,16 +73,64 @@ def temp_db_dir():
     shutil.rmtree(temp_dir, ignore_errors=True)
 
 
-def _store(temp_db_dir, embedding_model, name="mem"):
+def _store(temp_db_dir, embedding_model, name="mem", identity=None, maintain=True):
     return LanceDBMemoryStore(
         db_dir=temp_db_dir,
         collection_name=name,
         embedding_model=embedding_model,
+        vector_space_identity=identity,
+        run_schema_maintenance=maintain,
     )
 
 
-def test_add_preserves_rows_on_dimension_change(temp_db_dir):
-    """Writing at dim A, switching to dim B, then add() keeps A-rows and stores B."""
+def _identity(model="text-embedding-v4", dimension=64):
+    return {**LEGACY_DASHSCOPE_IDENTITY, "model": model, "dimension": dimension}
+
+
+def test_real_legacy_inspection_is_read_only_and_scope_columns_are_optional(
+    temp_db_dir,
+):
+    _seed_table_missing_scope = lancedb.connect(temp_db_dir)
+    table = _seed_table_missing_scope.create_table(
+        "legacy",
+        data=pa.table(
+            {
+                "id": ["old"],
+                "text": ["alpha"],
+                "metadata": ["{}"],
+                "vector": pa.array([[0.1] * 64], pa.list_(pa.float32(), 64)),
+            }
+        ),
+    )
+    _safe_close_table(table)
+    embedding = MockEmbedding(64)
+    store = _store(temp_db_dir, embedding, "legacy", _identity(), False)
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        inspections = pool.submit(
+            lambda: [store.inspect_vector_space() for _ in range(8)]
+        )
+        write = pool.submit(store.add, MemoryNote(id="new", content="beta"))
+        states, added = inspections.result(), write.result()
+
+    assert states == [VectorSpaceCompatibility.LEGACY_COMPATIBLE] * 8
+    assert added.success and embedding.inputs == ["beta"]
+    arrow = _seed_table_missing_scope.open_table("legacy").to_arrow()
+    assert set(arrow.column("id").to_pylist()) == {"old", "new"}
+    assert {"user_id", "scope_dims"}.isdisjoint(arrow.schema.names)
+
+
+def test_real_persisted_identity_match_and_mismatch(temp_db_dir):
+    matching = _store(temp_db_dir, MockEmbedding(64), "identified", _identity(), False)
+    mismatch = _store(
+        temp_db_dir, MockEmbedding(64), "identified", _identity(model="other"), False
+    )
+    assert matching.inspect_vector_space() is VectorSpaceCompatibility.MATCHING
+    assert mismatch.inspect_vector_space() is VectorSpaceCompatibility.MISMATCHING
+
+
+def test_add_dimension_change_falls_back_without_replacing_vectors(temp_db_dir):
+    """A new vector space writes text-only and leaves existing vectors intact."""
     store_a = _store(temp_db_dir, MockEmbedding(64))
     added = store_a.add(MemoryNote(content="alpha"))
     assert added.success
@@ -86,15 +141,15 @@ def test_add_preserves_rows_on_dimension_change(temp_db_dir):
     new = store_b.add(MemoryNote(content="beta"))
     assert new.success
 
-    # The dimension-A row survived the migration...
+    # Both rows survive, while the authoritative vector schema remains at A.
     got_alpha = store_b.get(alpha_id)
     assert got_alpha.success
     assert got_alpha.content.content == "alpha"
-    # ...and the new dimension-B row was stored.
     assert store_b.get(new.memory_id).success
-    # Both are retrievable via search at the new dimension.
-    contents = {n.content for n in store_b.search("beta", k=10)}
-    assert {"alpha", "beta"} <= contents
+    table = store_b._vector_store.get_raw_connection().open_table("mem")
+    arrow = table.to_arrow()
+    assert arrow.schema.field("vector").type.list_size == 64
+    assert arrow.column("vector").to_pylist()[1] is None
 
 
 def test_add_backfills_missing_non_vector_column(temp_db_dir):
@@ -110,7 +165,8 @@ def test_add_backfills_missing_non_vector_column(temp_db_dir):
     finally:
         _safe_close_table(table)
 
-    # add() must backfill metadata in place (no rebuild) and preserve rows.
+    # Maintenance is explicit; request-time add never rewrites the table.
+    store.maintain_schema()
     assert store.add(MemoryNote(id="y", content="new")).success
 
     table = conn.open_table("mem")
@@ -125,8 +181,8 @@ def test_add_backfills_missing_non_vector_column(temp_db_dir):
     assert store.get("y").success
 
 
-def test_add_migration_failure_leaves_table_intact(temp_db_dir):
-    """If re-embedding fails mid-migration, no data is lost and add() fails."""
+def test_dimension_mismatch_never_attempts_batch_reembedding(temp_db_dir):
+    """A mismatching requester cannot re-embed the shared table."""
     store_a = _store(temp_db_dir, MockEmbedding(64))
     added = store_a.add(MemoryNote(content="alpha"))
     assert added.success
@@ -135,14 +191,13 @@ def test_add_migration_failure_leaves_table_intact(temp_db_dir):
     # Switch to a model that fails the batched re-embed at a new dimension.
     store_fail = _store(temp_db_dir, BatchFailEmbedding(128))
     result = store_fail.add(MemoryNote(content="beta"))
-    assert not result.success
+    assert result.success
 
     # The original row is untouched and still retrievable via the dim-64 store.
     got_alpha = store_a.get(alpha_id)
     assert got_alpha.success
     assert got_alpha.content.content == "alpha"
-    # No partial state: only the original row exists.
-    assert len(store_a.list_all()) == 1
+    assert len(store_a.list_all()) == 2
 
 
 def test_build_migrated_table_vectorless_when_no_model(temp_db_dir):
@@ -205,6 +260,7 @@ def test_init_backfills_missing_column_without_wipe(temp_db_dir):
 
     # Constructing the store runs _ensure_table_schema, which must migrate.
     store = _store(temp_db_dir, MockEmbedding(64))
+    store.maintain_schema()
 
     conn = store._vector_store.get_raw_connection()
     table = conn.open_table("mem")
@@ -234,14 +290,12 @@ def test_init_does_not_wipe_on_dimension_change(temp_db_dir):
     assert added.memory_id in ids
 
 
-def test_init_migration_failure_leaves_table_intact(temp_db_dir):
-    """If init migration fails, the original table is left intact (no wipe)."""
+def test_init_maintenance_never_rebuilds_mismatching_vectors(temp_db_dir):
+    """Ordinary maintenance backfills columns without vector migration."""
     _seed_table_missing_metadata(temp_db_dir)
 
-    # Missing metadata + a vector-dimension change whose batched re-embed fails
-    # forces a rebuild that aborts; init must surface the error, not wipe.
-    with pytest.raises(Exception):
-        _store(temp_db_dir, BatchFailEmbedding(128))
+    store = _store(temp_db_dir, BatchFailEmbedding(128))
+    store.maintain_schema()
 
     conn = lancedb.connect(temp_db_dir)
     table = conn.open_table("mem")
@@ -250,9 +304,10 @@ def test_init_migration_failure_leaves_table_intact(temp_db_dir):
     finally:
         _safe_close_table(table)
     assert arrow.column("id").to_pylist() == ["a"]
-    # The vector column was not rebuilt; the table is untouched.
+    # The vector column was not rebuilt; only ordinary columns were maintained.
     assert "vector" in arrow.schema.names
-    assert "metadata" not in arrow.schema.names
+    assert arrow.schema.field("vector").type.list_size == 64
+    assert "metadata" in arrow.schema.names
 
 
 def test_add_record_without_embedding_into_vector_table(temp_db_dir):

--- a/tests/core/memory/test_lancedb_migration.py
+++ b/tests/core/memory/test_lancedb_migration.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import shutil
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
+from threading import Event
+from unittest.mock import patch
 
 import lancedb  # type: ignore
 import pyarrow as pa  # type: ignore
@@ -17,6 +19,7 @@ from xagent.core.memory.schema_migration import (
     VectorSpaceCompatibility,
 )
 from xagent.core.model.embedding import BaseEmbedding
+from xagent.core.model.model import EmbeddingModelConfig
 from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
 
 
@@ -66,6 +69,11 @@ class BatchFailEmbedding(BaseEmbedding):
         return ["embed"]
 
 
+class UnknownDimensionEmbedding(MockEmbedding):
+    def get_dimension(self):
+        return None
+
+
 @pytest.fixture
 def temp_db_dir():
     temp_dir = tempfile.mkdtemp()
@@ -106,16 +114,29 @@ def test_real_legacy_inspection_is_read_only_and_scope_columns_are_optional(
     embedding = MockEmbedding(64)
     store = _store(temp_db_dir, embedding, "legacy", _identity(), False)
 
-    with ThreadPoolExecutor(max_workers=2) as pool:
-        inspections = pool.submit(
-            lambda: [store.inspect_vector_space() for _ in range(8)]
-        )
-        write = pool.submit(store.add, MemoryNote(id="new", content="beta"))
-        states, added = inspections.result(), write.result()
+    inspected = Event()
+    release = Event()
 
-    assert states == [VectorSpaceCompatibility.LEGACY_COMPATIBLE] * 8
+    def inspect_during_write():
+        state = store.inspect_vector_space()
+        inspected.set()
+        assert release.wait(5)
+        return state
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        inspection = pool.submit(inspect_during_write)
+        assert inspected.wait(5)
+        added = pool.submit(store.add, MemoryNote(id="new", content="beta")).result()
+        release.set()
+        states = [inspection.result()]
+
+    assert states == [VectorSpaceCompatibility.LEGACY_COMPATIBLE]
     assert added.success and embedding.inputs == ["beta"]
-    arrow = _seed_table_missing_scope.open_table("legacy").to_arrow()
+    table = _seed_table_missing_scope.open_table("legacy")
+    try:
+        arrow = table.to_arrow()
+    finally:
+        _safe_close_table(table)
     assert set(arrow.column("id").to_pylist()) == {"old", "new"}
     assert {"user_id", "scope_dims"}.isdisjoint(arrow.schema.names)
 
@@ -127,6 +148,53 @@ def test_real_persisted_identity_match_and_mismatch(temp_db_dir):
     )
     assert matching.inspect_vector_space() is VectorSpaceCompatibility.MATCHING
     assert mismatch.inspect_vector_space() is VectorSpaceCompatibility.MISMATCHING
+
+
+def test_config_identity_keeps_model_and_endpoint(temp_db_dir):
+    config = EmbeddingModelConfig(
+        id="configured",
+        model_provider="dashscope",
+        model_name="text-embedding-custom",
+        base_url="https://embedding.example/v1",
+        api_key="unused",
+        dimension=64,
+    )
+    store = _store(temp_db_dir, config, identity=None, maintain=False)
+
+    assert store._vector_space_identity == {
+        "provider": "dashscope",
+        "model": "text-embedding-custom",
+        "endpoint": "https://embedding.example/v1",
+        "dimension": 64,
+        "instruct": None,
+    }
+    assert store.inspect_vector_space() is VectorSpaceCompatibility.MATCHING
+
+
+def test_unknown_dimension_is_probed_only_for_new_table(temp_db_dir):
+    first_embedding = UnknownDimensionEmbedding(64)
+    first = _store(temp_db_dir, first_embedding, maintain=False)
+    table = first._vector_store.get_raw_connection().open_table("mem")
+    try:
+        assert table.schema.field("vector").type.list_size == 64
+    finally:
+        _safe_close_table(table)
+    assert first_embedding.inputs == ["sample"]
+    assert first.add(MemoryNote(id="vectorized", content="alpha")).success
+    assert first_embedding.inputs == ["sample", "alpha"]
+
+    existing_embedding = UnknownDimensionEmbedding(128)
+    _store(temp_db_dir, existing_embedding, maintain=False)
+    assert existing_embedding.inputs == []
+
+
+def test_vector_compatibility_is_cached(temp_db_dir):
+    store = _store(temp_db_dir, MockEmbedding(64), identity=_identity(), maintain=False)
+    conn = store._vector_store.get_raw_connection()
+    with patch.object(conn, "open_table", wraps=conn.open_table) as opened:
+        assert store._vectors_are_compatible()
+        assert store._vectors_are_compatible()
+    assert opened.call_count == 1
 
 
 def test_add_dimension_change_falls_back_without_replacing_vectors(temp_db_dir):
@@ -146,6 +214,7 @@ def test_add_dimension_change_falls_back_without_replacing_vectors(temp_db_dir):
     assert got_alpha.success
     assert got_alpha.content.content == "alpha"
     assert store_b.get(new.memory_id).success
+    assert [note.id for note in store_b.search("beta", k=10)] == [new.memory_id]
     table = store_b._vector_store.get_raw_connection().open_table("mem")
     arrow = table.to_arrow()
     assert arrow.schema.field("vector").type.list_size == 64
@@ -179,6 +248,35 @@ def test_add_backfills_missing_non_vector_column(temp_db_dir):
     assert set(arrow.column("id").to_pylist()) == {"x", "y"}
     # The fully-formed new row round-trips through get().
     assert store.get("y").success
+
+
+def test_default_add_rejects_missing_required_columns(temp_db_dir):
+    conn = lancedb.connect(temp_db_dir)
+    table = conn.create_table(
+        "partial", data=pa.table({"id": ["old"], "text": ["old"]})
+    )
+    _safe_close_table(table)
+    store = _store(temp_db_dir, None, "partial", maintain=False)
+
+    result = store.add(MemoryNote(id="new", content="secret", metadata={"user_id": 7}))
+
+    assert not result.success
+    table = conn.open_table("partial")
+    try:
+        assert table.to_arrow().column("id").to_pylist() == ["old"]
+    finally:
+        _safe_close_table(table)
+
+
+def test_vectorless_record_uses_store_dimension_for_additive_maintenance(temp_db_dir):
+    _seed_table_missing_metadata(temp_db_dir)
+    store = _store(temp_db_dir, MockEmbedding(64), maintain=False)
+    store._run_schema_maintenance = True
+
+    result = store.add(MemoryNote(id="blank", content="   "))
+
+    assert result.success
+    assert store.get("blank").success
 
 
 def test_dimension_mismatch_never_attempts_batch_reembedding(temp_db_dir):

--- a/tests/core/memory/test_lancedb_migration.py
+++ b/tests/core/memory/test_lancedb_migration.py
@@ -169,6 +169,9 @@ def test_config_identity_keeps_model_and_endpoint(temp_db_dir):
         "instruct": None,
     }
     assert store.inspect_vector_space() is VectorSpaceCompatibility.MATCHING
+    config.model_provider = "openai-compatible"
+    alias = _store(temp_db_dir, config, "alias", maintain=False)
+    assert alias._vector_space_identity["provider"] == "openai"
 
 
 def test_unknown_dimension_is_probed_only_for_new_table(temp_db_dir):
@@ -180,11 +183,19 @@ def test_unknown_dimension_is_probed_only_for_new_table(temp_db_dir):
     finally:
         _safe_close_table(table)
     assert first_embedding.inputs == ["sample"]
-    assert first.add(MemoryNote(id="vectorized", content="alpha")).success
+    assert first.add(
+        MemoryNote(id="vectorized", content="alpha", metadata={"user_id": 7})
+    ).success
     assert first_embedding.inputs == ["sample", "alpha"]
 
+    table = first._vector_store.get_raw_connection().open_table("mem")
+    table.drop_columns(["user_id", "scope_dims"])
     existing_embedding = UnknownDimensionEmbedding(128)
-    _store(temp_db_dir, existing_embedding, maintain=False)
+    existing = _store(temp_db_dir, existing_embedding, maintain=False)
+    assert existing_embedding.inputs == []
+    assert [
+        n.id for n in existing.search("alpha", filters={"metadata": {"user_id": 7}})
+    ] == ["vectorized"]
     assert existing_embedding.inputs == []
 
 
@@ -200,21 +211,29 @@ def test_vector_compatibility_is_cached(temp_db_dir):
 def test_add_dimension_change_falls_back_without_replacing_vectors(temp_db_dir):
     """A new vector space writes text-only and leaves existing vectors intact."""
     store_a = _store(temp_db_dir, MockEmbedding(64))
-    added = store_a.add(MemoryNote(content="alpha"))
+    added = store_a.add(MemoryNote(content="alpha", metadata={"user_id": 7}))
     assert added.success
     alpha_id = added.memory_id
 
     # New store over the same table with a different embedding dimension.
     store_b = _store(temp_db_dir, MockEmbedding(128))
-    new = store_b.add(MemoryNote(content="beta"))
+    new = store_b.add(MemoryNote(content="beta", metadata={"user_id": 7}))
     assert new.success
+    secret = store_b.add(
+        MemoryNote(content="secret", metadata={"user_id": 8})
+    ).memory_id
 
-    # Both rows survive, while the authoritative vector schema remains at A.
     got_alpha = store_b.get(alpha_id)
     assert got_alpha.success
     assert got_alpha.content.content == "alpha"
     assert store_b.get(new.memory_id).success
     assert [note.id for note in store_b.search("beta", k=10)] == [new.memory_id]
+    matching_results = store_a.search("beta", k=1, filters={"metadata": {"user_id": 7}})
+    assert [note.id for note in matching_results] == [new.memory_id]
+    assert secret not in {
+        note.id
+        for note in store_a.search("secret", k=2, filters={"metadata": {"user_id": 7}})
+    }
     table = store_b._vector_store.get_raw_connection().open_table("mem")
     arrow = table.to_arrow()
     assert arrow.schema.field("vector").type.list_size == 64
@@ -234,7 +253,6 @@ def test_add_backfills_missing_non_vector_column(temp_db_dir):
     finally:
         _safe_close_table(table)
 
-    # Maintenance is explicit; request-time add never rewrites the table.
     store.maintain_schema()
     assert store.add(MemoryNote(id="y", content="new")).success
 
@@ -402,7 +420,6 @@ def test_init_maintenance_never_rebuilds_mismatching_vectors(temp_db_dir):
     finally:
         _safe_close_table(table)
     assert arrow.column("id").to_pylist() == ["a"]
-    # The vector column was not rebuilt; only ordinary columns were maintained.
     assert "vector" in arrow.schema.names
     assert arrow.schema.field("vector").type.list_size == 64
     assert "metadata" in arrow.schema.names

--- a/tests/core/memory/test_schema_migration.py
+++ b/tests/core/memory/test_schema_migration.py
@@ -10,8 +10,12 @@ import pyarrow as pa  # type: ignore
 import pytest
 
 from xagent.core.memory.schema_migration import (
+    LEGACY_DASHSCOPE_IDENTITY,
     MemoryMismatchKind,
+    VECTOR_SPACE_METADATA_KEY,
+    VectorSpaceCompatibility,
     classify_memory_schema_mismatch,
+    inspect_vector_space,
     migrate_table_swap,
 )
 from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
@@ -47,6 +51,45 @@ def _vector_schema(dim: int) -> pa.Schema:
             pa.field("metadata", pa.string()),
             pa.field("vector", pa.list_(pa.float32(), list_size=dim)),
         ]
+    )
+
+
+def _identity(**overrides):
+    return {
+        **LEGACY_DASHSCOPE_IDENTITY,
+        "dimension": 64,
+        **overrides,
+    }
+
+
+@pytest.mark.parametrize(
+    ("schema", "identity", "expected"),
+    [
+        (_vector_schema(64), _identity(), VectorSpaceCompatibility.LEGACY_COMPATIBLE),
+        (
+            _vector_schema(64),
+            _identity(model="other"),
+            VectorSpaceCompatibility.MISMATCHING,
+        ),
+        (_vector_schema(32), _identity(), VectorSpaceCompatibility.MISMATCHING),
+        (_vector_schema(64), {"dimension": 64}, VectorSpaceCompatibility.MISMATCHING),
+    ],
+)
+def test_vector_space_legacy_contract_requires_more_than_dimension(
+    schema, identity, expected
+):
+    assert inspect_vector_space(schema, identity) is expected
+
+
+def test_vector_space_persisted_identity_matches_exactly():
+    identity = _identity()
+    metadata = {VECTOR_SPACE_METADATA_KEY: __import__("json").dumps(identity).encode()}
+    schema = _vector_schema(64).with_metadata(metadata)
+
+    assert inspect_vector_space(schema, identity) is VectorSpaceCompatibility.MATCHING
+    assert (
+        inspect_vector_space(schema, _identity(endpoint="https://other"))
+        is VectorSpaceCompatibility.MISMATCHING
     )
 
 

--- a/tests/core/memory/test_schema_migration.py
+++ b/tests/core/memory/test_schema_migration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import shutil
 import tempfile
 
@@ -11,8 +12,8 @@ import pytest
 
 from xagent.core.memory.schema_migration import (
     LEGACY_DASHSCOPE_IDENTITY,
-    MemoryMismatchKind,
     VECTOR_SPACE_METADATA_KEY,
+    MemoryMismatchKind,
     VectorSpaceCompatibility,
     classify_memory_schema_mismatch,
     inspect_vector_space,
@@ -83,7 +84,7 @@ def test_vector_space_legacy_contract_requires_more_than_dimension(
 
 def test_vector_space_persisted_identity_matches_exactly():
     identity = _identity()
-    metadata = {VECTOR_SPACE_METADATA_KEY: __import__("json").dumps(identity).encode()}
+    metadata = {VECTOR_SPACE_METADATA_KEY: json.dumps(identity).encode()}
     schema = _vector_schema(64).with_metadata(metadata)
 
     assert inspect_vector_space(schema, identity) is VectorSpaceCompatibility.MATCHING

--- a/tests/core/memory/test_scope_column_promotion.py
+++ b/tests/core/memory/test_scope_column_promotion.py
@@ -38,6 +38,7 @@ def _store(temp_db_dir, name="mem", embedding=None):
         db_dir=temp_db_dir,
         collection_name=name,
         embedding_model=embedding if embedding is not None else ConstantEmbedding(64),
+        run_schema_maintenance=True,
     )
 
 
@@ -117,7 +118,6 @@ def _create_legacy_table(temp_db_dir, name="mem"):
 def test_legacy_table_is_migrated_and_backfilled(temp_db_dir):
     _create_legacy_table(temp_db_dir)
 
-    # Constructing the store triggers _ensure_scope_columns during init.
     store = _store(temp_db_dir)
 
     arrow = _arrow(store)

--- a/tests/core/memory/test_scope_column_promotion.py
+++ b/tests/core/memory/test_scope_column_promotion.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import json
 import shutil
 import tempfile
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event
 
 import lancedb  # type: ignore
 import pytest
@@ -18,7 +20,11 @@ import pytest
 from xagent.core.execution_scope import MEMORY_DIMENSION_METADATA_PREFIX
 from xagent.core.memory.core import MemoryNote
 from xagent.core.memory.lancedb import LanceDBMemoryStore
-from xagent.core.memory.scope_columns import SCOPE_DIMS_COLUMN, USER_ID_COLUMN
+from xagent.core.memory.scope_columns import (
+    SCOPE_DIMS_COLUMN,
+    USER_ID_COLUMN,
+    derive_scope_columns,
+)
 from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import _safe_close_table
 
 from .conftest import ConstantEmbedding
@@ -155,3 +161,48 @@ def test_promotion_is_idempotent(temp_db_dir):
     arrow = _arrow(store)
     assert arrow.num_rows == 2
     assert {USER_ID_COLUMN, SCOPE_DIMS_COLUMN} <= set(arrow.schema.names)
+
+
+def test_promotion_never_overwrites_a_concurrent_append(temp_db_dir, monkeypatch):
+    _create_legacy_table(temp_db_dir)
+    store = LanceDBMemoryStore(
+        db_dir=temp_db_dir,
+        collection_name="mem",
+        embedding_model=ConstantEmbedding(64),
+        run_schema_maintenance=False,
+    )
+    entered = Event()
+    release = Event()
+    original = derive_scope_columns
+
+    def pause_after_snapshot(metadata_json):
+        entered.set()
+        assert release.wait(5)
+        return original(metadata_json)
+
+    monkeypatch.setattr(
+        "xagent.core.memory.lancedb.derive_scope_columns", pause_after_snapshot
+    )
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        maintenance = pool.submit(store.maintain_schema)
+        assert entered.wait(5)
+        table = store._vector_store.get_raw_connection().open_table("mem")
+        try:
+            table.add(
+                [
+                    {
+                        "id": "concurrent",
+                        "text": "new",
+                        "metadata": "{}",
+                        "vector": [0.3] * 64,
+                        USER_ID_COLUMN: None,
+                        SCOPE_DIMS_COLUMN: [],
+                    }
+                ]
+            )
+        finally:
+            _safe_close_table(table)
+        release.set()
+        maintenance.result()
+
+    assert set(_arrow(store).column("id").to_pylist()) == {"1", "2", "concurrent"}

--- a/tests/core/memory/test_scope_column_promotion.py
+++ b/tests/core/memory/test_scope_column_promotion.py
@@ -9,12 +9,14 @@ existing rows and the authoritative metadata JSON byte-for-byte.
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from threading import Event
 
 import lancedb  # type: ignore
+import pyarrow as pa  # type: ignore
 import pytest
 
 from xagent.core.execution_scope import MEMORY_DIMENSION_METADATA_PREFIX
@@ -55,6 +57,21 @@ def _arrow(store, name="mem"):
         return table.to_arrow()
     finally:
         _safe_close_table(table)
+
+
+def _version(store, name="mem"):
+    table = store._vector_store.get_raw_connection().open_table(name)
+    try:
+        return table.version
+    finally:
+        _safe_close_table(table)
+
+
+def _create_raw_table(temp_db_dir, data):
+    table = lancedb.connect(temp_db_dir).create_table("mem", data=pa.table(data))
+    version = table.version
+    _safe_close_table(table)
+    return version
 
 
 def test_fresh_table_has_scope_columns(temp_db_dir):
@@ -155,15 +172,19 @@ def test_legacy_table_is_migrated_and_backfilled(temp_db_dir):
 
 def test_promotion_is_idempotent(temp_db_dir):
     _create_legacy_table(temp_db_dir)
-    _store(temp_db_dir)  # first construction migrates
+    first = _store(temp_db_dir)  # first construction migrates
+    version = _version(first)
     # Second construction must not error, wipe, or duplicate rows.
     store = _store(temp_db_dir)
     arrow = _arrow(store)
+    assert _version(store) == version
     assert arrow.num_rows == 2
     assert {USER_ID_COLUMN, SCOPE_DIMS_COLUMN} <= set(arrow.schema.names)
 
 
-def test_promotion_never_overwrites_a_concurrent_append(temp_db_dir, monkeypatch):
+def test_promotion_never_overwrites_a_concurrent_append(
+    temp_db_dir, monkeypatch, caplog
+):
     _create_legacy_table(temp_db_dir)
     store = LanceDBMemoryStore(
         db_dir=temp_db_dir,
@@ -200,9 +221,60 @@ def test_promotion_never_overwrites_a_concurrent_append(temp_db_dir, monkeypatch
                     }
                 ]
             )
+            table.update(
+                "id = '1'",
+                {
+                    "metadata": json.dumps({"user_id": 99}),
+                    USER_ID_COLUMN: 99,
+                },
+            )
         finally:
             _safe_close_table(table)
         release.set()
         maintenance.result()
 
     assert set(_arrow(store).column("id").to_pylist()) == {"1", "2", "concurrent"}
+    rows = {row["id"]: row for row in _arrow(store).to_pylist()}
+    assert rows["1"][USER_ID_COLUMN] == 99
+    assert "skipped 1 concurrently changed rows" in caplog.text
+
+
+@pytest.mark.parametrize(
+    "ids",
+    [
+        pa.array([None], pa.string()),
+        pa.array([1], pa.int64()),
+        pa.array(["same", "same"], pa.string()),
+    ],
+)
+def test_malformed_legacy_ids_skip_all_maintenance(temp_db_dir, caplog, ids):
+    version = _create_raw_table(
+        temp_db_dir,
+        {"id": ids, "text": ["x"] * len(ids), "metadata": ["{}"] * len(ids)},
+    )
+    store = LanceDBMemoryStore(temp_db_dir, "mem", None)
+
+    with caplog.at_level(logging.WARNING):
+        store.maintain_schema()
+
+    assert _version(store) == version
+    assert {"user_id", "scope_dims"}.isdisjoint(_arrow(store).schema.names)
+    assert "Skipping memory maintenance" in caplog.text
+
+
+def test_scope_promotion_batches_and_handles_backslash_ids(temp_db_dir):
+    count = 513
+    ids = ["path\\note", *[f"n{i}" for i in range(count - 1)]]
+    version = _create_raw_table(
+        temp_db_dir,
+        {
+            "id": ids,
+            "text": ["x"] * count,
+            "metadata": [json.dumps({"user_id": 7})] * count,
+        },
+    )
+    store = LanceDBMemoryStore(temp_db_dir, "mem", None)
+    store.maintain_schema()
+
+    assert _version(store) == version + 3
+    assert _arrow(store).column(USER_ID_COLUMN).to_pylist() == [7] * count

--- a/tests/integration/test_auto_migration_startup.py
+++ b/tests/integration/test_auto_migration_startup.py
@@ -14,11 +14,14 @@ import tempfile
 import threading
 from types import ModuleType
 
+import lancedb
 import pyarrow as pa
 import pytest
 
+from xagent.core.memory.lancedb import LanceDBMemoryStore
 from xagent.core.tools.core.RAG_tools.core.config import MIN_INT64
 from xagent.core.tools.core.RAG_tools.LanceDB.schema_manager import (
+    _safe_close_table,
     check_table_needs_migration,
 )
 from xagent.migrations.lancedb.backfill_user_id import (
@@ -712,8 +715,9 @@ def test_phase2_ensures_tables_exist(temp_lancedb_dir):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("schema_io_failure", [False, True], ids=["malformed", "io"])
 async def test_startup_event_skips_when_auto_migrate_disabled(
-    monkeypatch: pytest.MonkeyPatch, temp_lancedb_dir
+    monkeypatch: pytest.MonkeyPatch, temp_lancedb_dir, schema_io_failure
 ):
     """Startup should not create migration task when auto migration is disabled."""
     import importlib
@@ -733,6 +737,31 @@ async def test_startup_event_skips_when_auto_migrate_disabled(
             return []
 
     class _FakeMemoryStoreManager(_MemoryMaintenanceStub):
+        def maintain_schema(self) -> None:
+            table = lancedb.connect(temp_lancedb_dir).create_table(
+                "startup_memory",
+                pa.table(
+                    {
+                        "id": pa.array([None], pa.string()),
+                        "text": ["x"],
+                        "metadata": ["{}"],
+                    }
+                ),
+            )
+            _safe_close_table(table)
+            store = LanceDBMemoryStore(temp_lancedb_dir, "startup_memory", None)
+            if schema_io_failure:
+                store._vector_store.get_raw_connection = lambda: type(
+                    "BrokenConn",
+                    (),
+                    {
+                        "open_table": lambda *_: (_ for _ in ()).throw(
+                            OSError("schema I/O")
+                        )
+                    },
+                )()
+            store.maintain_schema()
+
         def get_store_info(self) -> dict[str, object]:
             return {
                 "is_lancedb": True,
@@ -833,6 +862,10 @@ async def test_startup_event_skips_when_auto_migrate_disabled(
     monkeypatch.setattr(web_app_module.asyncio, "to_thread", _fake_to_thread)
     monkeypatch.setattr(web_app_module.asyncio, "create_task", _track_create_task)
 
+    if schema_io_failure:
+        with pytest.raises(OSError, match="schema I/O"):
+            await web_app_module.startup_event()
+        return
     await web_app_module.startup_event()
     if created_tasks:
         await asyncio.gather(*created_tasks)

--- a/tests/integration/test_auto_migration_startup.py
+++ b/tests/integration/test_auto_migration_startup.py
@@ -33,6 +33,11 @@ from xagent.providers.vector_store.lancedb import get_connection_from_env
 from xagent.sandbox.base import SandboxRuntimeConflictError
 
 
+class _MemoryMaintenanceStub:
+    def maintain_schema(self) -> None:
+        return None
+
+
 def _patch_channel_modules_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
     """Avoid chat-channel startup work in migration tests.
 
@@ -727,7 +732,7 @@ async def test_startup_event_skips_when_auto_migrate_disabled(
         async def list_templates(self) -> list[str]:
             return []
 
-    class _FakeMemoryStoreManager:
+    class _FakeMemoryStoreManager(_MemoryMaintenanceStub):
         def get_store_info(self) -> dict[str, object]:
             return {
                 "is_lancedb": True,
@@ -859,7 +864,7 @@ async def test_startup_event_triggers_background_auto_migration(
         async def list_templates(self) -> list[str]:
             return []
 
-    class _FakeMemoryStoreManager:
+    class _FakeMemoryStoreManager(_MemoryMaintenanceStub):
         def get_store_info(self) -> dict[str, object]:
             return {
                 "is_lancedb": True,
@@ -993,7 +998,7 @@ async def test_startup_event_no_task_when_no_table_needs_migration(
         async def list_templates(self) -> list[str]:
             return []
 
-    class _FakeMemoryStoreManager:
+    class _FakeMemoryStoreManager(_MemoryMaintenanceStub):
         def get_store_info(self) -> dict[str, object]:
             return {
                 "is_lancedb": True,
@@ -1318,7 +1323,7 @@ async def test_failed_startup_leaves_no_unsignaled_temp_file_cleanup(
         async def list_templates(self) -> list[str]:
             return []
 
-    class _FakeMemoryStoreManager:
+    class _FakeMemoryStoreManager(_MemoryMaintenanceStub):
         def get_store_info(self) -> dict[str, object]:
             return {
                 "is_lancedb": True,
@@ -1504,7 +1509,7 @@ async def test_startup_event_runs_sandbox_readiness_before_cleanup_and_warmup(
         async def list_templates(self) -> list[str]:
             return []
 
-    class _FakeMemoryStoreManager:
+    class _FakeMemoryStoreManager(_MemoryMaintenanceStub):
         def get_store_info(self) -> dict[str, object]:
             return {
                 "is_lancedb": True,
@@ -1600,7 +1605,7 @@ async def test_startup_event_raises_on_readiness_conflict_with_probe_true(
         async def list_templates(self) -> list[str]:
             return []
 
-    class _FakeMemoryStoreManager:
+    class _FakeMemoryStoreManager(_MemoryMaintenanceStub):
         def get_store_info(self) -> dict[str, object]:
             return {
                 "is_lancedb": True,
@@ -1693,7 +1698,7 @@ async def test_startup_event_skips_sandbox_readiness_when_manager_is_none(
         async def list_templates(self) -> list[str]:
             return []
 
-    class _FakeMemoryStoreManager:
+    class _FakeMemoryStoreManager(_MemoryMaintenanceStub):
         def get_store_info(self) -> dict[str, object]:
             return {
                 "is_lancedb": True,

--- a/tests/providers/vector_store/test_lancedb.py
+++ b/tests/providers/vector_store/test_lancedb.py
@@ -10,13 +10,13 @@ from __future__ import annotations
 import os
 import time
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
+import pyarrow as pa  # type: ignore
 import pytest
 
-from xagent.core.tools.core.RAG_tools.utils.lancedb_query_utils import (
-    list_table_names,
-)
+from xagent.core.tools.core.RAG_tools.utils.lancedb_query_utils import list_table_names
 from xagent.providers.vector_store.lancedb import (
     LanceDBConnectionManager,
     LanceDBVectorStore,
@@ -125,6 +125,42 @@ class TestLanceDBVectorStore:
         conn = store.get_raw_connection()
         table = conn.open_table("test_collection")
         assert table is not None
+
+    @pytest.mark.parametrize("failure", [RuntimeError("open I/O"), OSError("disk I/O")])
+    def test_ensure_table_does_not_hide_open_failures(self, failure):
+        store = LanceDBVectorStore.__new__(LanceDBVectorStore)
+        store._collection_name = "memory"
+        store._conn = SimpleNamespace(
+            open_table=lambda _name: (_ for _ in ()).throw(failure)
+        )
+
+        with pytest.raises(type(failure), match="I/O"):
+            store._ensure_table()
+
+    def test_concurrent_create_rejects_an_incompatible_winner(self):
+        class Connection:
+            def __init__(self):
+                self.opens = 0
+
+            def open_table(self, _name):
+                self.opens += 1
+                if self.opens == 1:
+                    raise ValueError("Table 'memory' was not found")
+                return SimpleNamespace(
+                    schema=pa.schema([pa.field("text", pa.string())]),
+                    close=lambda: None,
+                )
+
+            def create_table(self, _name, data):
+                raise ValueError("Table 'memory' already exists")
+
+        store = LanceDBVectorStore.__new__(LanceDBVectorStore)
+        store._collection_name = "memory"
+        store._conn = Connection()
+        seed = pa.table({"id": ["sample"], "text": ["sample"]})
+
+        with pytest.raises(ValueError, match="incompatible schema"):
+            store._ensure_table(seed)
 
     def test_add_vectors_basic(self, vector_store):
         """Test basic vector addition."""

--- a/tests/providers/vector_store/test_lancedb.py
+++ b/tests/providers/vector_store/test_lancedb.py
@@ -160,7 +160,7 @@ class TestLanceDBVectorStore:
         seed = pa.table({"id": ["sample"], "text": ["sample"]})
 
         with pytest.raises(ValueError, match="incompatible schema"):
-            store._ensure_table(seed)
+            store._ensure_table(lambda: seed)
 
     def test_add_vectors_basic(self, vector_store):
         """Test basic vector addition."""

--- a/tests/web/test_dynamic_memory_store.py
+++ b/tests/web/test_dynamic_memory_store.py
@@ -6,8 +6,10 @@ from typing import Any
 import pytest
 
 from xagent.core.model import EmbeddingModelConfig
+from xagent.core.user_context import current_user_id
 from xagent.web import dynamic_memory_store
 from xagent.web.dynamic_memory_store import DynamicMemoryStoreManager
+from xagent.web.user_isolated_memory import UserIsolatedMemoryStore
 
 
 class FakeLanceStore:
@@ -87,25 +89,70 @@ def test_embedding_configuration_read_happens_under_lock(monkeypatch) -> None:
 def test_startup_maintenance_reaches_the_persistent_store(monkeypatch) -> None:
     holder = {"model": _model(2, "2026-07-17 10:00:00", "key")}
     manager = _manager_with_fake_db(monkeypatch, holder)
+    base = FakeLanceStore(holder["model"])
     monkeypatch.setattr(dynamic_memory_store, "LanceDBMemoryStore", FakeLanceStore)
+    monkeypatch.setattr(
+        manager, "_create_lancedb_store", lambda _model: UserIsolatedMemoryStore(base)
+    )
 
     manager.maintain_schema()
 
-    assert manager._memory_store.maintenance_calls == 1
+    assert base.maintenance_calls == 1
 
 
 def test_startup_maintenance_propagates_store_creation_failure(monkeypatch) -> None:
     holder = {"model": _model(2, "2026-07-17 10:00:00", "key")}
     manager = _manager_with_fake_db(monkeypatch, holder)
 
-    def fail(_model, *, fallback_on_error=True):
-        assert not fallback_on_error
+    def fail(_model):
         raise RuntimeError("memory table unavailable")
 
     monkeypatch.setattr(manager, "_create_lancedb_store", fail)
 
     with pytest.raises(RuntimeError, match="memory table unavailable"):
         manager.maintain_schema()
+
+
+def test_request_store_creation_failure_preserves_manager_state(monkeypatch) -> None:
+    holder = {"model": _model(2, "2026-07-17 10:00:00", "key")}
+    manager = _manager_with_fake_db(monkeypatch, holder)
+    original = manager.get_memory_store()
+    fingerprint = manager._last_embedding_model_fingerprint
+    holder["model"] = _model(2, "2026-07-17 11:00:00", "new-key")
+    monkeypatch.setattr(
+        manager,
+        "_create_lancedb_store",
+        lambda _model: (_ for _ in ()).throw(RuntimeError("unavailable")),
+    )
+
+    assert manager.get_memory_store() is original
+    assert manager._is_lancedb
+    assert manager._last_embedding_model_fingerprint == fingerprint
+
+
+def test_shared_embedding_identity_ignores_request_user(monkeypatch) -> None:
+    model = _model(2, "2026-07-17 10:00:00", "key")
+    query = SimpleNamespace(filter=lambda *_args: query, all=lambda: [model])
+    db = SimpleNamespace(query=lambda *_args: query, close=lambda: None)
+    monkeypatch.setattr(dynamic_memory_store, "get_db", lambda: iter([db]))
+    monkeypatch.setattr(
+        "xagent.web.services.model_service.get_default_embedding_model",
+        lambda user_id, *, db: "embedding-2" if user_id is None else None,
+    )
+    manager = DynamicMemoryStoreManager()
+    monkeypatch.setattr(
+        manager, "_create_lancedb_store", lambda _model: FakeLanceStore(model)
+    )
+
+    resolved = []
+    for user_id in (7, 9):
+        token = current_user_id.set(user_id)
+        try:
+            resolved.append(manager.get_memory_store())
+        finally:
+            current_user_id.reset(token)
+    assert isinstance(resolved[0], FakeLanceStore)
+    assert resolved[1] is resolved[0]
 
 
 def test_dynamic_store_preserves_complete_embedding_config(

--- a/tests/web/test_dynamic_memory_store.py
+++ b/tests/web/test_dynamic_memory_store.py
@@ -3,12 +3,20 @@
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
+
+from xagent.core.model import EmbeddingModelConfig
+from xagent.web import dynamic_memory_store
 from xagent.web.dynamic_memory_store import DynamicMemoryStoreManager
 
 
 class FakeLanceStore:
     def __init__(self, model: Any) -> None:
         self.model = model
+        self.maintenance_calls = 0
+
+    def maintain_schema(self) -> None:
+        self.maintenance_calls += 1
 
 
 def _manager_with_fake_db(monkeypatch, model_holder: dict) -> DynamicMemoryStoreManager:
@@ -19,7 +27,7 @@ def _manager_with_fake_db(monkeypatch, model_holder: dict) -> DynamicMemoryStore
     monkeypatch.setattr(
         manager,
         "_create_lancedb_store",
-        lambda model: FakeLanceStore(model),
+        lambda model, **_kwargs: FakeLanceStore(model),
     )
     return manager
 
@@ -29,7 +37,10 @@ def _model(model_id: int, updated_at: str, api_key: str) -> Any:
         id=model_id,
         updated_at=updated_at,
         api_key=api_key,
+        model_id=f"embedding-{model_id}",
         model_provider="dashscope",
+        model_name="text-embedding-v4",
+        base_url="https://embedding.example/v1",
         dimension=1024,
     )
 
@@ -71,3 +82,49 @@ def test_embedding_configuration_read_happens_under_lock(monkeypatch) -> None:
     monkeypatch.setattr(manager, "_get_embedding_model_from_db", get_model_under_lock)
 
     assert isinstance(manager.get_memory_store(), FakeLanceStore)
+
+
+def test_startup_maintenance_reaches_the_persistent_store(monkeypatch) -> None:
+    holder = {"model": _model(2, "2026-07-17 10:00:00", "key")}
+    manager = _manager_with_fake_db(monkeypatch, holder)
+    monkeypatch.setattr(dynamic_memory_store, "LanceDBMemoryStore", FakeLanceStore)
+
+    manager.maintain_schema()
+
+    assert manager._memory_store.maintenance_calls == 1
+
+
+def test_startup_maintenance_propagates_store_creation_failure(monkeypatch) -> None:
+    holder = {"model": _model(2, "2026-07-17 10:00:00", "key")}
+    manager = _manager_with_fake_db(monkeypatch, holder)
+
+    def fail(_model, *, fallback_on_error=True):
+        assert not fallback_on_error
+        raise RuntimeError("memory table unavailable")
+
+    monkeypatch.setattr(manager, "_create_lancedb_store", fail)
+
+    with pytest.raises(RuntimeError, match="memory table unavailable"):
+        manager.maintain_schema()
+
+
+def test_dynamic_store_preserves_complete_embedding_config(
+    monkeypatch, tmp_path
+) -> None:
+    captured = {}
+
+    def build_store(**kwargs):
+        captured.update(kwargs)
+        return FakeLanceStore(kwargs["embedding_model"])
+
+    monkeypatch.setattr(dynamic_memory_store, "get_storage_root", lambda: tmp_path)
+    monkeypatch.setattr(dynamic_memory_store, "LanceDBMemoryStore", build_store)
+    monkeypatch.setattr(dynamic_memory_store.os.path, "exists", lambda _path: False)
+    manager = DynamicMemoryStoreManager()
+
+    manager._create_lancedb_store(_model(7, "2026-07-17 10:00:00", "key"))
+
+    config = captured["embedding_model"]
+    assert isinstance(config, EmbeddingModelConfig)
+    assert config.model_name == "text-embedding-v4"
+    assert config.base_url == "https://embedding.example/v1"

--- a/tests/web/test_model_service.py
+++ b/tests/web/test_model_service.py
@@ -386,6 +386,12 @@ class TestModelService:
                 lambda db, model_id, user_id: model_id != 99,
             )
             monkeypatch.setattr(
+                "xagent.web.services.model_service.get_default_embedding_model",
+                lambda user_id, *, db: (
+                    "system-embedding-model" if user_id is None else None
+                ),
+            )
+            monkeypatch.setattr(
                 "xagent.web.dynamic_memory_store.get_db",
                 mock_get_db,
             )


### PR DESCRIPTION
## Summary

- classify shared memory tables as legacy-compatible, matching, or mismatching using the complete vector-space identity and Arrow schema contract
- keep store acquisition and compatibility inspection read-only while exposing serialized schema maintenance as an explicit lifecycle action
- preserve non-strict legacy behavior through text fallback and schema-aware inserts without request-time re-embedding or table replacement
- persist one authoritative vector-space identity on newly created shared memory tables

## Validation

- 213 focused memory, agent memory-tool, isolation, dynamic-manager, and policy tests
- Ruff format and lint checks on all changed files
- Python bytecode compilation for all changed production modules
- mutation checks for relaxed legacy identity matching, request-time schema mutation, and mismatched-space re-embedding

Closes #2170