### PR TITLE
enh(frontend): give ClarificationForm's onSend the internal path's delivery contract

### DIFF
--- a/frontend/src/components/build/agent-builder-chat.test.tsx
+++ b/frontend/src/components/build/agent-builder-chat.test.tsx
@@ -135,8 +135,13 @@ vi.mock("@/components/chat/ChatMessage", () => ({
                 new File(["data"], "data.txt", { type: "text/plain" }),
               ])
               setStatus("resolved")
-            } catch {
-              setStatus("rejected")
+            } catch (error) {
+              // Surface the declared delivery contract (#1485): the form
+              // probes `disposition` off whatever this callback rejects with.
+              const disposition = (error as { disposition?: unknown })?.disposition
+              setStatus(
+                `rejected:${typeof disposition === "string" ? disposition : "untyped"}`,
+              )
             }
           }}
         >
@@ -279,8 +284,39 @@ describe("AgentBuilderChat", () => {
     })
 
     await waitFor(() => {
-      expect(screen.getByText("rejected")).toBeInTheDocument()
+      // The upload failed before anything reached the agent, and the typed
+      // failure must say so - "not_sent" is what lets ClarificationForm tell
+      // the visitor a resubmit is safe.
+      expect(screen.getByText("rejected:not_sent")).toBeInTheDocument()
     })
+    // The resubmit that hint invites must not stack a duplicate answer: both
+    // optimistic bubbles (user + assistant placeholder) are rolled back,
+    // leaving only the initial greeting.
+    expect(screen.getAllByTestId("chat-message")).toHaveLength(1)
+  })
+
+  it("rolls back both optimistic bubbles when the connection setup throws", async () => {
+    apiRequestMock.mockResolvedValueOnce(
+      successfulUploadResponse([{ file_id: "file-1", filename: "data.txt" }])
+    )
+    class ThrowingWebSocket {
+      static OPEN = 1
+      constructor(_url: string) {
+        throw new Error("SecurityError: insecure WebSocket")
+      }
+    }
+    globalThis.WebSocket = ThrowingWebSocket as unknown as typeof WebSocket
+
+    renderBuilderChat()
+    fireEvent.click(await screen.findByText("send-file-interaction"))
+
+    // Nothing reached the wire, so the interaction rejects as not_sent and
+    // the transcript returns to just the greeting - a hinted resubmit must
+    // not find a stranded answer bubble or blank placeholder.
+    await waitFor(() => {
+      expect(screen.getByText("rejected:not_sent")).toBeInTheDocument()
+    })
+    expect(screen.getAllByTestId("chat-message")).toHaveLength(1)
   })
 
   it.each([

--- a/frontend/src/components/build/agent-builder-chat.test.tsx
+++ b/frontend/src/components/build/agent-builder-chat.test.tsx
@@ -128,6 +128,9 @@ vi.mock("@/components/chat/ChatMessage", () => ({
         data-process-status={processStatus || ""}
         data-trace-count={traceEvents?.length ?? 0}
       >
+        {/* Rendered so the rollback tests can tell the surviving row apart
+            from the optimistic bubbles it is supposed to have removed. */}
+        <div>{content}</div>
         <button
           type="button"
           onClick={async () => {
@@ -294,6 +297,9 @@ describe("AgentBuilderChat", () => {
     // optimistic bubbles (user + assistant placeholder) are rolled back,
     // leaving only the initial greeting.
     expect(screen.getAllByTestId("chat-message")).toHaveLength(1)
+    expect(screen.getAllByTestId("chat-message")[0]).toHaveTextContent(
+      "builds.configForm.chat.initialMessage"
+    )
   })
 
   it("rolls back both optimistic bubbles when the connection setup throws", async () => {
@@ -318,6 +324,9 @@ describe("AgentBuilderChat", () => {
       expect(screen.getByText("rejected:not_sent")).toBeInTheDocument()
     })
     expect(screen.getAllByTestId("chat-message")).toHaveLength(1)
+    expect(screen.getAllByTestId("chat-message")[0]).toHaveTextContent(
+      "builds.configForm.chat.initialMessage"
+    )
   })
 
   it.each([

--- a/frontend/src/components/build/agent-builder-chat.test.tsx
+++ b/frontend/src/components/build/agent-builder-chat.test.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import type { ClarificationOnSend } from "@/components/chat/clarification-delivery"
 
 const apiRequestMock = vi.hoisted(() => vi.fn())
 const toastErrorMock = vi.hoisted(() => vi.fn())
@@ -103,7 +104,7 @@ vi.mock("@/components/chat/ChatMessage", () => ({
     traceEvents,
   }: {
     content?: React.ReactNode
-    onSendInteraction?: (text: string, files?: File[]) => Promise<void> | void
+    onSendInteraction?: ClarificationOnSend
     processStatus?: string
     traceEvents?: unknown[]
   }) => {
@@ -133,7 +134,7 @@ vi.mock("@/components/chat/ChatMessage", () => ({
             try {
               await onSendInteraction("upload this", [
                 new File(["data"], "data.txt", { type: "text/plain" }),
-              ])
+              ], {}, { clientMessageId: "test-attempt" })
               setStatus("resolved")
             } catch (error) {
               // Surface the declared delivery contract (#1485): the form

--- a/frontend/src/components/build/agent-builder-chat.test.tsx
+++ b/frontend/src/components/build/agent-builder-chat.test.tsx
@@ -1,5 +1,5 @@
 import React from "react"
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react"
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { ClarificationOnSend } from "@/components/chat/clarification-delivery"
 
@@ -180,6 +180,7 @@ import { AgentBuilderChat, type AgentConfig } from "./agent-builder-chat"
 class MockWebSocket {
   static OPEN = 1
   static CONNECTING = 0
+  static CLOSED = 3
   static instances: MockWebSocket[] = []
 
   readyState = MockWebSocket.CONNECTING
@@ -198,13 +199,21 @@ class MockWebSocket {
   }
 
   close() {
-    this.readyState = 3
+    this.readyState = MockWebSocket.CLOSED
     this.onclose?.()
   }
 
   open() {
     this.readyState = MockWebSocket.OPEN
     this.onopen?.()
+  }
+
+  /** Async connection failure (refused / dropped) - the constructor never
+   * throws for this, so the only signal is onerror followed by onclose. */
+  fail() {
+    this.readyState = MockWebSocket.CLOSED
+    this.onerror?.(new Event("error"))
+    this.onclose?.()
   }
 }
 
@@ -327,6 +336,135 @@ describe("AgentBuilderChat", () => {
     expect(screen.getAllByTestId("chat-message")[0]).toHaveTextContent(
       "builds.configForm.chat.initialMessage"
     )
+    expect(MockWebSocket.instances.flatMap((ws) => ws.sentMessages)).toEqual([])
+  })
+
+  it("reports not_sent when the connection fails before the payload is sent", async () => {
+    // Against a refused/unreachable backend the WebSocket constructor does
+    // NOT throw - the failure only surfaces later via onerror/onclose - so
+    // this exercises the async-failure path the constructor-throw test above
+    // cannot reach.
+    apiRequestMock.mockResolvedValueOnce(
+      successfulUploadResponse([{ file_id: "file-1", filename: "data.txt" }])
+    )
+    renderBuilderChat()
+    fireEvent.click(await screen.findByText("send-file-interaction"))
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1)
+    })
+
+    await act(async () => {
+      MockWebSocket.instances[0].fail()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("rejected:not_sent")).toBeInTheDocument()
+    })
+    // Nothing ever reached the wire, and the resubmit the "not sent" hint
+    // invites must not find a stranded answer bubble or blank placeholder.
+    expect(MockWebSocket.instances.flatMap((ws) => ws.sentMessages)).toEqual([])
+    expect(screen.getAllByTestId("chat-message")).toHaveLength(1)
+    expect(screen.getAllByTestId("chat-message")[0]).toHaveTextContent(
+      "builds.configForm.chat.initialMessage"
+    )
+    // Surfaced exactly once, with connection copy rather than the
+    // setup-throw copy.
+    expect(toastErrorMock).toHaveBeenCalledTimes(1)
+    expect(toastErrorMock.mock.calls[0][0]).toBe(
+      "builds.configForm.chat.errorConnection:Xagent"
+    )
+  })
+
+  it("tells the plain chat input a failed send never went out", async () => {
+    // The chat input has no clarification alert to fall back on, so this
+    // path must never fail silently - it is the one the delivery-failure
+    // toast routing exists for.
+    renderBuilderChat()
+    fireEvent.click(screen.getByText("send-chat-input"))
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1)
+    })
+
+    await act(async () => {
+      MockWebSocket.instances[0].fail()
+    })
+
+    await waitFor(() => {
+      expect(toastErrorMock.mock.calls[0]?.[0]).toBe(
+        "builds.configForm.chat.errorConnection:Xagent"
+      )
+    })
+    expect(MockWebSocket.instances.flatMap((ws) => ws.sentMessages)).toEqual([])
+    expect(screen.getAllByTestId("chat-message")).toHaveLength(1)
+  })
+
+  it("stays quiet when unmounting closes an in-flight connection", async () => {
+    // The unmount cleanup closes the socket, which fails the in-flight send
+    // - but that failure is our own doing and the toast is global, so it
+    // would otherwise surface on whatever page the visitor moved to.
+    const { unmount } = renderBuilderChat()
+    fireEvent.click(screen.getByText("send-chat-input"))
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1)
+    })
+
+    await act(async () => {
+      unmount()
+    })
+
+    expect(toastErrorMock).not.toHaveBeenCalled()
+  })
+
+  it("does not resolve the interaction until the payload is actually sent", async () => {
+    apiRequestMock.mockResolvedValueOnce(
+      successfulUploadResponse([{ file_id: "file-1", filename: "data.txt" }])
+    )
+    renderBuilderChat()
+    fireEvent.click(await screen.findByText("send-file-interaction"))
+
+    await waitFor(() => {
+      expect(MockWebSocket.instances).toHaveLength(1)
+    })
+    // The connection is open-pending: the interaction must stay unresolved
+    // until sendPayload has actually run inside onopen. Every ChatMessage in
+    // this mock renders its own idle/resolved/rejected span regardless of
+    // whether it was the one clicked, so assert none has moved past "idle"
+    // rather than assuming a single match.
+    expect(screen.queryByText("resolved")).not.toBeInTheDocument()
+    expect(screen.queryByText(/^rejected:/)).not.toBeInTheDocument()
+    expect(screen.getAllByText("idle").length).toBeGreaterThan(0)
+
+    await act(async () => {
+      MockWebSocket.instances[0].open()
+    })
+
+    await waitFor(() => {
+      expect(screen.getByText("resolved")).toBeInTheDocument()
+    })
+  })
+
+  it("returns false and sends nothing for a second send while the first is in flight", async () => {
+    render(
+      <AgentBuilderChat
+        agentConfig={agentConfig}
+        onUpdateConfig={vi.fn()}
+      />
+    )
+
+    fireEvent.click(screen.getByText("send-chat-input"))
+    expect(MockWebSocket.instances).toHaveLength(1)
+
+    // isLoading is now true - a second send while the first is still in
+    // flight (the socket hasn't even opened yet) must return false and touch
+    // neither the message list nor the wire.
+    fireEvent.click(screen.getByText("send-chat-input"))
+
+    expect(MockWebSocket.instances).toHaveLength(1)
+    expect(screen.getAllByTestId("chat-message")).toHaveLength(3)
+    expect(MockWebSocket.instances[0].sentMessages).toEqual([])
   })
 
   it.each([

--- a/frontend/src/components/build/agent-builder-chat.tsx
+++ b/frontend/src/components/build/agent-builder-chat.tsx
@@ -15,6 +15,10 @@ import { useI18n } from "@/contexts/i18n-context"
 import { toast } from "@/components/ui/sonner"
 import { getBrandingFromEnv } from "@/lib/branding"
 import { normalizeUploadFileIds } from "@/lib/upload-file-ids"
+import {
+  clarificationSendFailure,
+  type ClarificationSendMetadata,
+} from "@/components/chat/clarification-delivery"
 
 import { Interaction } from "@/contexts/app-context-chat"
 
@@ -142,7 +146,7 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
     }
   }, [messages])
 
-  const handleSendMessage = useCallback(async (text: string, files?: File[], metadata?: any) => {
+  const handleSendMessage = useCallback(async (text: string, files?: File[], metadata?: ClarificationSendMetadata) => {
     if ((!text.trim() && (!files || files.length === 0)) || isLoading) return false
 
     let displayMessage: string | React.ReactNode = text || t("chatPage.clarification.uploadedFiles")
@@ -236,7 +240,10 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
         console.error("Failed to upload files", err);
         toast.error(err instanceof Error ? err.message : "Failed to upload files");
         setIsLoading(false);
-        setMessages(prev => prev.slice(0, -1));
+        // Nothing was sent, so the optimistic user bubble comes back out with
+        // the assistant placeholder - otherwise a resubmit (which the form's
+        // "not sent" hint now invites) shows the same answer twice.
+        setMessages(prev => prev.slice(0, -2));
         return false;
       }
     } else if (metadata?.url) {
@@ -514,6 +521,11 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
       console.error(error)
       toast.error(t("builds.configForm.chat.errorInit") || "Failed to initialize connection.")
       setIsLoading(false)
+      // Same rollback as the upload failure above: the WebSocket constructor
+      // threw before anything was sent, so both optimistic bubbles come back
+      // out - the "not sent" hint invites a resubmit that must not stack a
+      // duplicate answer over a blank placeholder.
+      setMessages(prev => prev.slice(0, -2))
       return false
     }
     return true
@@ -551,9 +563,19 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
               timestamp={msg.timestamp}
               interactions={msg.interactions}
               onSendInteraction={async (text, files, meta) => {
+                // The attempt identity (4th arg) is accepted but unused: the
+                // build websocket has no delivery dedup to hand it to.
                 const didSend = await handleSendMessage(text, files, meta)
                 if (!didSend) {
-                  throw new Error("Failed to send interaction")
+                  // Every false return happens before anything is handed to
+                  // the websocket (empty input, upload failure, connection
+                  // setup throw), so "not_sent" is accurate: the visitor can
+                  // resubmit safely. handleSendMessage already toasted the
+                  // actionable reason, so this stays non-user-facing.
+                  throw clarificationSendFailure(
+                    "Failed to send interaction",
+                    "not_sent",
+                  )
                 }
               }}
             />

--- a/frontend/src/components/build/agent-builder-chat.tsx
+++ b/frontend/src/components/build/agent-builder-chat.tsx
@@ -529,7 +529,7 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
       return false
     }
     return true
-  }, [messages, isLoading, token, agentConfig, onUpdateConfig])
+  }, [messages, isLoading, token, agentConfig, onUpdateConfig, t, toolCategories, branding.appName])
 
   const handleStop = () => {
     if (wsRef.current) {

--- a/frontend/src/components/build/agent-builder-chat.tsx
+++ b/frontend/src/components/build/agent-builder-chat.tsx
@@ -16,13 +16,20 @@ import { toast } from "@/components/ui/sonner"
 import { getBrandingFromEnv } from "@/lib/branding"
 import { normalizeUploadFileIds } from "@/lib/upload-file-ids"
 import {
-  clarificationSendFailure,
+  createClarificationSendFailure,
+  readSendDisposition,
   type ClarificationSendMetadata,
 } from "@/components/chat/clarification-delivery"
 
 import { Interaction } from "@/contexts/app-context-chat"
 
 import { FileAttachment } from "@/components/file/file-attachment"
+
+// A refused/unreachable backend never throws from the WebSocket constructor -
+// it fails async via onerror/onclose, or never opens at all - so cap how long
+// a new connection is given to actually deliver the payload before the send
+// is failed outright.
+const WS_DELIVERY_TIMEOUT_MS = 15_000
 
 interface Message {
   role: "user" | "assistant" | "system"
@@ -123,10 +130,16 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
   const [isLoading, setIsLoading] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
   const wsRef = useRef<WebSocket | null>(null)
+  const mountedRef = useRef(true)
 
   // Clean up WebSocket on unmount
   useEffect(() => {
+    mountedRef.current = true
     return () => {
+      // Closing here fails an in-flight send, which is correct - but it is
+      // our own doing, so the failure must stay silent (see the catch in
+      // handleSendMessage).
+      mountedRef.current = false
       if (wsRef.current) {
         wsRef.current.close()
         wsRef.current = null
@@ -272,17 +285,19 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
 
     try {
       if (wsRef.current && wsRef.current.readyState === WebSocket.OPEN) {
-        // Reuse existing connection
-        sendPayload(wsRef.current)
+        // Reuse existing connection. send() still throws if the socket
+        // started closing since the readyState check; that is a delivery
+        // failure, not a setup failure, so it is typed like one.
+        try {
+          sendPayload(wsRef.current)
+        } catch {
+          throw createClarificationSendFailure("Connection send failed", "not_sent")
+        }
       } else {
         // Create new connection if none exists or it was closed
         const wsUrl = getApiUrl().replace(/^http/, "ws") + `/ws/build/chat?token=${token}`
         const ws = new WebSocket(wsUrl)
         wsRef.current = ws
-
-        ws.onopen = () => {
-          sendPayload(ws)
-        }
 
         ws.onmessage = (event) => {
           try {
@@ -506,25 +521,108 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
           }
         }
 
-        ws.onerror = (error) => {
-          console.error("WebSocket error:", error)
-          setIsLoading(false)
-          toast.error(t("builds.configForm.chat.errorConnection", { appName: branding.appName }))
-        }
+        // Resolve/reject only once actual delivery is decided - not merely
+        // once the constructor has been called - so the caller (and
+        // ClarificationForm, through onSendInteraction) never sees success
+        // before sendPayload has actually run. ws.onerror/ws.onclose below
+        // are ALSO the long-lived handlers for the rest of this connection's
+        // life, so their pre-existing side effects (logging, isLoading,
+        // clearing wsRef) keep firing both before and after delivery; what
+        // the two flags gate is which of them settles this promise, and
+        // which one owns the error toast.
+        await new Promise<void>((resolve, reject) => {
+          // `settled` = this promise already has its outcome. `delivered` =
+          // the payload actually went out. They are NOT the same: a timeout
+          // settles without delivering, and closing a still-CONNECTING
+          // socket fails the connection, so the close below re-enters
+          // onerror with `settled` already true. Deciding the toast on
+          // `settled` would make that path toast here AND in the catch.
+          let settled = false
+          let delivered = false
+          const settle = (outcome: () => void) => {
+            if (settled) return
+            settled = true
+            clearTimeout(deliveryTimeout)
+            outcome()
+          }
 
-        ws.onclose = () => {
-          setIsLoading(false)
-          wsRef.current = null
-        }
+          const deliveryTimeout = setTimeout(() => {
+            settle(() => {
+              // Nothing was sent and the socket never opened or failed.
+              // Close it so a late handshake cannot deliver after the send
+              // has already been failed, and fail the send: holding the
+              // form in "submitting" indefinitely is worse than telling the
+              // visitor it did not go out.
+              ws.close()
+              reject(createClarificationSendFailure("Connection timed out", "not_sent"))
+            })
+          }, WS_DELIVERY_TIMEOUT_MS)
+
+          ws.onopen = () => {
+            try {
+              sendPayload(ws)
+              delivered = true
+              settle(resolve)
+            } catch {
+              // Typed like the other pre-delivery failures so the catch
+              // below picks connection copy, not setup copy.
+              settle(() => reject(
+                createClarificationSendFailure("Connection send failed", "not_sent"),
+              ))
+            }
+          }
+
+          ws.onerror = (error) => {
+            console.error("WebSocket error:", error)
+            setIsLoading(false)
+            settle(() => {
+              reject(createClarificationSendFailure("Connection failed", "not_sent"))
+            })
+            // Before delivery the catch below owns the message, so toasting
+            // here would double up. After delivery this handler is the only
+            // one left that can report the drop, exactly as it did
+            // unconditionally before this change.
+            if (delivered) {
+              toast.error(t("builds.configForm.chat.errorConnection", { appName: branding.appName }))
+            }
+          }
+
+          ws.onclose = () => {
+            setIsLoading(false)
+            // Only disown the socket this handler belongs to: a send that
+            // already failed and was retried has installed a newer socket
+            // in the ref, and this late close must not null that one out.
+            if (wsRef.current === ws) {
+              wsRef.current = null
+            }
+            settle(() => {
+              reject(createClarificationSendFailure("Connection closed before delivery", "not_sent"))
+            })
+          }
+        })
       }
     } catch (error) {
       console.error(error)
-      toast.error(t("builds.configForm.chat.errorInit") || "Failed to initialize connection.")
+      // Unmounting closes the socket ourselves, which lands here as a
+      // delivery failure. There is no visitor left to tell, and the toast
+      // is global - it would surface on whatever page they navigated to.
+      if (!mountedRef.current) {
+        return false
+      }
+      // Every failure that got as far as attempting delivery gets exactly
+      // one toast here, and the copy has to match what actually happened: a
+      // delivery failure (readSendDisposition non-null - see
+      // clarification-delivery.ts) is a connection problem, while anything
+      // else is a genuine setup throw. This path also serves the plain chat
+      // input, which has no clarification alert of its own to fall back on.
+      toast.error(readSendDisposition(error) !== null
+        ? t("builds.configForm.chat.errorConnection", { appName: branding.appName })
+        : t("builds.configForm.chat.errorInit") || "Failed to initialize connection.")
       setIsLoading(false)
-      // Same rollback as the upload failure above: the WebSocket constructor
-      // threw before anything was sent, so both optimistic bubbles come back
-      // out - the "not sent" hint invites a resubmit that must not stack a
-      // duplicate answer over a blank placeholder.
+      // Same rollback as the upload failure above: nothing was sent, so both
+      // optimistic bubbles come back out - the "not sent" hint invites a
+      // resubmit that must not stack a duplicate answer over a blank
+      // placeholder.
       setMessages(prev => prev.slice(0, -2))
       return false
     }
@@ -567,12 +665,16 @@ export function AgentBuilderChat({ agentConfig, onUpdateConfig, availableOptions
                 // build websocket has no delivery dedup to hand it to.
                 const didSend = await handleSendMessage(text, files, meta)
                 if (!didSend) {
-                  // Every false return happens before anything is handed to
-                  // the websocket (empty input, upload failure, connection
-                  // setup throw), so "not_sent" is accurate: the visitor can
-                  // resubmit safely. handleSendMessage already toasted the
-                  // actionable reason, so this stays non-user-facing.
-                  throw clarificationSendFailure(
+                  // Every false return means the payload never went out -
+                  // empty input, a send already in flight, upload failure,
+                  // setup throw, or a new connection that failed, closed,
+                  // or timed out before sendPayload ran - so "not_sent" is
+                  // accurate and the visitor can resubmit safely. Every one
+                  // of those that attempted delivery has already toasted its
+                  // own reason (the in-flight guard stays quiet on purpose:
+                  // the first send is still running), so this carries no
+                  // user-facing text of its own.
+                  throw createClarificationSendFailure(
                     "Failed to send interaction",
                     "not_sent",
                   )

--- a/frontend/src/components/chat/ChatMessage.tsx
+++ b/frontend/src/components/chat/ChatMessage.tsx
@@ -21,6 +21,7 @@ import { Button } from "@/components/ui/button";
 import { normalizeTimestampMs } from "@/lib/time-utils";
 import { FileChip } from "./FileChip";
 import { ClarificationForm } from "./clarification-form";
+import type { ClarificationOnSend } from "./clarification-delivery";
 import { isStoppedTraceProcessStatus, resolveTraceProcessStatus } from "@/lib/trace-process-status";
 import {
   TaskRuntimeMessageMetadataExtension,
@@ -94,7 +95,7 @@ export interface ChatMessageProps {
   showEmptyStatus?: boolean;
   onOpenExecutionPlan?: () => void;
   onAgentExecutionClick?: (execution: AgentExecutionSummary) => void;
-  onSendInteraction?: (message: string, files?: File[], metadata?: any) => Promise<void> | void;
+  onSendInteraction?: ClarificationOnSend;
   contextBadges?: Array<{
     kind: "computer_use";
     label: string;

--- a/frontend/src/components/chat/clarification-delivery.test.ts
+++ b/frontend/src/components/chat/clarification-delivery.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest"
 import { MessageDeliveryError } from "@/hooks/use-websocket"
 import {
-  clarificationSendFailure,
+  createClarificationSendFailure,
   readSendDisposition,
   readSendErrorCode,
   readSendReason,
@@ -25,7 +25,7 @@ describe("clarification-delivery readers", () => {
   })
 
   it("the factory's product satisfies the same readers", () => {
-    const failure = clarificationSendFailure("Failed to send interaction", "not_sent")
+    const failure = createClarificationSendFailure("Failed to send interaction", "not_sent")
 
     expect(readSendDisposition(failure)).toBe("not_sent")
     expect(readSendRetryWithNewId(failure)).toBe(false)

--- a/frontend/src/components/chat/clarification-delivery.test.ts
+++ b/frontend/src/components/chat/clarification-delivery.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest"
+import { MessageDeliveryError } from "@/hooks/use-websocket"
+import {
+  clarificationSendFailure,
+  readSendDisposition,
+  readSendErrorCode,
+  readSendReason,
+  readSendRetryWithNewId,
+} from "./clarification-delivery"
+
+describe("clarification-delivery readers", () => {
+  it("reads every contract field off a real MessageDeliveryError", () => {
+    const error = new MessageDeliveryError(
+      "A previous guidance message is still being applied.",
+      "outcome_unknown",
+      { retryWithNewId: true, userFacing: true, errorCode: "guidance_in_progress" },
+    )
+
+    expect(readSendDisposition(error)).toBe("outcome_unknown")
+    expect(readSendRetryWithNewId(error)).toBe(true)
+    expect(readSendReason(error)).toBe(
+      "A previous guidance message is still being applied.",
+    )
+    expect(readSendErrorCode(error)).toBe("guidance_in_progress")
+  })
+
+  it("the factory's product satisfies the same readers", () => {
+    const failure = clarificationSendFailure("Failed to send interaction", "not_sent")
+
+    expect(readSendDisposition(failure)).toBe("not_sent")
+    expect(readSendRetryWithNewId(failure)).toBe(false)
+    expect(readSendReason(failure)).toBe("")
+    expect(readSendErrorCode(failure)).toBeNull()
+  })
+})

--- a/frontend/src/components/chat/clarification-delivery.ts
+++ b/frontend/src/components/chat/clarification-delivery.ts
@@ -1,0 +1,136 @@
+import type { MessageDeliveryDisposition } from "@/hooks/use-websocket"
+import type { TranslationKey } from "@/i18n/translations"
+import { readClientErrorCode, type ClientErrorCode } from "@/lib/client-errors"
+
+/**
+ * The delivery contract shared by ClarificationForm's two send paths (#1485).
+ *
+ * The internal path (AppContext.sendMessage) and any injected `onSend`
+ * provider are held to the same shape: a send is one delivery attempt with a
+ * stable identity, and a failed send rejects with a discriminated failure the
+ * form can act on. Failures are still probed structurally rather than by
+ * `instanceof`, because a provider's rejection need not be an `Error`
+ * subclass — the contract is the fields, not the class.
+ */
+
+/** Metadata a clarification answer travels with. */
+export interface ClarificationSendMetadata {
+  request_id?: string
+  url?: string
+}
+
+/**
+ * The identity of one delivery attempt. The form keeps the same
+ * `clientMessageId` for an unresolved submission across resubmits (and hands
+ * it to both send paths), so a consumer that dedups on it — the internal
+ * path's server does — can recognize a retry instead of recording the answer
+ * twice. A provider that cannot dedup may ignore it; the form's failure copy
+ * only warns about resubmits, it never promises safety.
+ */
+export interface ClarificationSendAttempt {
+  clientMessageId: string
+}
+
+export type ClarificationOnSend = (
+  message: string,
+  files: File[],
+  metadata: ClarificationSendMetadata,
+  attempt: ClarificationSendAttempt,
+) => Promise<void> | void
+
+/**
+ * The discriminated failure a send path rejects with — the same shape
+ * use-websocket's MessageDeliveryError carries, declared here so an `onSend`
+ * provider can construct it without depending on the websocket hook.
+ */
+export type ClarificationSendFailure = Error & {
+  disposition: MessageDeliveryDisposition
+  userFacing: boolean
+  errorCode: ClientErrorCode | null
+  retryWithNewId: boolean
+}
+
+export interface ClarificationSendFailureOptions {
+  /** Whether `message` is the sender-actionable reason, safe to display. */
+  userFacing?: boolean
+  errorCode?: ClientErrorCode | null
+  /** The attempt's identity is burned; a retry must mint a new one. */
+  retryWithNewId?: boolean
+}
+
+export const clarificationSendFailure = (
+  message: string,
+  disposition: MessageDeliveryDisposition,
+  options: ClarificationSendFailureOptions = {},
+): ClarificationSendFailure => Object.assign(new Error(message), {
+  disposition,
+  userFacing: options.userFacing ?? false,
+  errorCode: options.errorCode ?? null,
+  retryWithNewId: options.retryWithNewId ?? false,
+})
+
+/**
+ * Delivery failures carry whether the turn definitely never reached the agent.
+ * Plain errors (local validation, unexpected throws) carry nothing, and are
+ * left unqualified rather than guessed at: telling a visitor to resubmit a
+ * turn that may have landed is worse than saying nothing.
+ */
+export const readSendDisposition = (error: unknown): MessageDeliveryDisposition | null => {
+  if (typeof error !== "object" || error === null || !("disposition" in error)) {
+    return null
+  }
+  const disposition = (error as { disposition: unknown }).disposition
+  return disposition === "not_sent"
+    || disposition === "rejected"
+    || disposition === "outcome_unknown"
+    ? disposition
+    : null
+}
+
+/**
+ * Whether the failure says this attempt's identity must not be reused. Only
+ * an explicit `true` counts: an untyped rejection keeps the identity, so an
+ * unchanged resubmit stays recognizable as a retry.
+ */
+export const readSendRetryWithNewId = (error: unknown): boolean =>
+  typeof error === "object"
+  && error !== null
+  && (error as { retryWithNewId?: unknown }).retryWithNewId === true
+
+/**
+ * Only the reasons the sender can act on — the backend's rejection text — are
+ * shown as-is. Connection plumbing messages stay behind the localized string:
+ * they are English diagnostics, and a widget visitor is not the audience for
+ * them. Nothing new becomes displayable through an arbitrary provider either
+ * way — `userFacing` still has to be set.
+ */
+export const readSendReason = (error: unknown): string => {
+  if (
+    typeof error !== "object"
+    || error === null
+    || (error as { userFacing?: unknown }).userFacing !== true
+  ) {
+    return ""
+  }
+  const message = (error as { message?: unknown }).message
+  return typeof message === "string" ? message.trim() : ""
+}
+
+export const readSendErrorCode = (error: unknown): ClientErrorCode | null => {
+  if (typeof error !== "object" || error === null) return null
+  return readClientErrorCode((error as { errorCode?: unknown }).errorCode)
+}
+
+/**
+ * The hint that belongs with a disposition, as a key rather than a translated
+ * string: the toast needs it once at failure time, while the persistent alert
+ * has to re-resolve it on every render so a locale switch is not stuck behind
+ * whatever language was active when the send failed.
+ */
+export const sendHintKey = (
+  disposition: MessageDeliveryDisposition | null,
+): TranslationKey | null => disposition === "outcome_unknown"
+  ? "chatPage.clarification.sendOutcomeUnknown"
+  : disposition === "not_sent" || disposition === "rejected"
+    ? "chatPage.clarification.sendNotSent"
+    : null

--- a/frontend/src/components/chat/clarification-delivery.ts
+++ b/frontend/src/components/chat/clarification-delivery.ts
@@ -51,23 +51,21 @@ export type ClarificationSendFailure = Error & Pick<
   "disposition" | "userFacing" | "errorCode" | "retryWithNewId"
 >
 
-export interface ClarificationSendFailureOptions {
-  /** Whether `message` is the sender-actionable reason, safe to display. */
-  userFacing?: boolean
-  errorCode?: ClientErrorCode | null
-  /** The attempt's identity is burned; a retry must mint a new one. */
-  retryWithNewId?: boolean
-}
-
-export const clarificationSendFailure = (
+/**
+ * Every caller so far wants the same defaults: non-user-facing (the message
+ * is a developer diagnostic), no error code, and keep the delivery identity.
+ * Should a provider ever need different values, the type above declares all
+ * four fields, so they can be set on the returned error - or this can grow
+ * an options argument again at that point.
+ */
+export const createClarificationSendFailure = (
   message: string,
   disposition: MessageDeliveryDisposition,
-  options: ClarificationSendFailureOptions = {},
 ): ClarificationSendFailure => Object.assign(new Error(message), {
   disposition,
-  userFacing: options.userFacing ?? false,
-  errorCode: options.errorCode ?? null,
-  retryWithNewId: options.retryWithNewId ?? false,
+  userFacing: false,
+  errorCode: null,
+  retryWithNewId: false,
 })
 
 const asRecord = (error: unknown): Record<string, unknown> | null =>

--- a/frontend/src/components/chat/clarification-delivery.ts
+++ b/frontend/src/components/chat/clarification-delivery.ts
@@ -1,4 +1,4 @@
-import type { MessageDeliveryDisposition } from "@/hooks/use-websocket"
+import type { MessageDeliveryDisposition, MessageDeliveryError } from "@/hooks/use-websocket"
 import type { TranslationKey } from "@/i18n/translations"
 import { readClientErrorCode, type ClientErrorCode } from "@/lib/client-errors"
 
@@ -39,16 +39,17 @@ export type ClarificationOnSend = (
 ) => Promise<void> | void
 
 /**
- * The discriminated failure a send path rejects with — the same shape
- * use-websocket's MessageDeliveryError carries, declared here so an `onSend`
- * provider can construct it without depending on the websocket hook.
+ * The discriminated failure a send path rejects with — its shape is derived
+ * from use-websocket's MessageDeliveryError (a type-only import, so this
+ * still has no runtime dependency on the websocket hook). Deriving via Pick
+ * means renaming or removing one of these four fields on the class fails
+ * type-check here; it does not notice fields *added* to the class, and the
+ * readers below stay deliberately structural (they take `unknown`).
  */
-export type ClarificationSendFailure = Error & {
-  disposition: MessageDeliveryDisposition
-  userFacing: boolean
-  errorCode: ClientErrorCode | null
-  retryWithNewId: boolean
-}
+export type ClarificationSendFailure = Error & Pick<
+  MessageDeliveryError,
+  "disposition" | "userFacing" | "errorCode" | "retryWithNewId"
+>
 
 export interface ClarificationSendFailureOptions {
   /** Whether `message` is the sender-actionable reason, safe to display. */

--- a/frontend/src/components/chat/clarification-delivery.ts
+++ b/frontend/src/components/chat/clarification-delivery.ts
@@ -70,6 +70,9 @@ export const clarificationSendFailure = (
   retryWithNewId: options.retryWithNewId ?? false,
 })
 
+const asRecord = (error: unknown): Record<string, unknown> | null =>
+  typeof error === "object" && error !== null ? error as Record<string, unknown> : null
+
 /**
  * Delivery failures carry whether the turn definitely never reached the agent.
  * Plain errors (local validation, unexpected throws) carry nothing, and are
@@ -77,10 +80,7 @@ export const clarificationSendFailure = (
  * turn that may have landed is worse than saying nothing.
  */
 export const readSendDisposition = (error: unknown): MessageDeliveryDisposition | null => {
-  if (typeof error !== "object" || error === null || !("disposition" in error)) {
-    return null
-  }
-  const disposition = (error as { disposition: unknown }).disposition
+  const disposition = asRecord(error)?.disposition
   return disposition === "not_sent"
     || disposition === "rejected"
     || disposition === "outcome_unknown"
@@ -94,9 +94,7 @@ export const readSendDisposition = (error: unknown): MessageDeliveryDisposition 
  * unchanged resubmit stays recognizable as a retry.
  */
 export const readSendRetryWithNewId = (error: unknown): boolean =>
-  typeof error === "object"
-  && error !== null
-  && (error as { retryWithNewId?: unknown }).retryWithNewId === true
+  asRecord(error)?.retryWithNewId === true
 
 /**
  * Only the reasons the sender can act on — the backend's rejection text — are
@@ -106,21 +104,14 @@ export const readSendRetryWithNewId = (error: unknown): boolean =>
  * way — `userFacing` still has to be set.
  */
 export const readSendReason = (error: unknown): string => {
-  if (
-    typeof error !== "object"
-    || error === null
-    || (error as { userFacing?: unknown }).userFacing !== true
-  ) {
-    return ""
-  }
-  const message = (error as { message?: unknown }).message
+  const record = asRecord(error)
+  if (record?.userFacing !== true) return ""
+  const message = record.message
   return typeof message === "string" ? message.trim() : ""
 }
 
-export const readSendErrorCode = (error: unknown): ClientErrorCode | null => {
-  if (typeof error !== "object" || error === null) return null
-  return readClientErrorCode((error as { errorCode?: unknown }).errorCode)
-}
+export const readSendErrorCode = (error: unknown): ClientErrorCode | null =>
+  readClientErrorCode(asRecord(error)?.errorCode)
 
 /**
  * The hint that belongs with a disposition, as a key rather than a translated

--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -137,6 +137,7 @@ describe("ClarificationForm Session file capability", () => {
         "Note: Continue without a file",
         [],
         {},
+        { clientMessageId: expect.any(String) },
       )
     })
   })
@@ -195,7 +196,12 @@ describe("ClarificationForm Session file capability", () => {
     )
 
     await waitFor(() => {
-      expect(onSend).toHaveBeenCalledWith("Source: Skip upload", [], {})
+      expect(onSend).toHaveBeenCalledWith(
+        "Source: Skip upload",
+        [],
+        {},
+        { clientMessageId: expect.any(String) },
+      )
     })
   })
 
@@ -230,6 +236,7 @@ describe("ClarificationForm Session file capability", () => {
         "chatPage.clarification.uploadedFiles",
         [file],
         {},
+        { clientMessageId: expect.any(String) },
       )
     })
   })
@@ -352,6 +359,7 @@ describe("ClarificationForm connect_apps interaction", () => {
         "chatPage.clarification.connectApps.skip",
         [],
         {},
+        { clientMessageId: expect.any(String) },
       )
     })
   })
@@ -372,6 +380,7 @@ describe("ClarificationForm connect_apps interaction", () => {
         {
           force: true,
           metadata: { request_id: "inputreq_0011223344556677889900aabbccddee" },
+          clientMessageId: expect.any(String),
         },
         [],
       )
@@ -507,8 +516,9 @@ describe("ClarificationForm delivery failures", () => {
   })
 
   it("warns before a resubmit when the delivery outcome is unknown", async () => {
-    // No resubmit guard exists in this component (a retry mints a fresh
-    // client message id today), so the copy must warn - not promise safety.
+    // An unchanged resubmit reuses the delivery identity, but only the
+    // internal path is known to dedup on it - an onSend provider may not -
+    // so the copy must warn, not promise safety.
     const onSend = vi.fn().mockRejectedValue(deliveryError(
       "The task is busy applying an earlier answer.",
       "outcome_unknown",
@@ -745,7 +755,183 @@ describe("ClarificationForm interaction identity", () => {
       "City: Sydney",
       [],
       { request_id: "inputreq_0011223344556677889900aabbccddee" },
+      { clientMessageId: expect.any(String) },
     ))
+  })
+})
+
+describe("ClarificationForm delivery identity", () => {
+  beforeEach(() => {
+    appContextMock.dispatch.mockReset()
+    appContextMock.filesDisabled = false
+    appContextMock.providerAvailable = true
+    appContextMock.sendMessage.mockReset()
+    toastErrorMock.mockReset()
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  // Structural, not a MessageDeliveryError instance: the contract is probed
+  // off whatever a provider throws (see clarification-delivery.ts).
+  const deliveryFailure = (
+    disposition: string,
+    options: Record<string, unknown> = {},
+  ) => Object.assign(new Error("delivery failed"), { disposition, ...options })
+
+  const interactions = [
+    { type: "text_input" as const, field: "city", label: "City" },
+  ]
+
+  const submit = () =>
+    fireEvent.click(
+      screen.getByRole("button", { name: "chatPage.clarification.submit" }),
+    )
+
+  const typeAndSubmit = (value = "Beijing") => {
+    fireEvent.change(screen.getByRole("textbox"), { target: { value } })
+    submit()
+  }
+
+  const sentClientMessageIds = () =>
+    appContextMock.sendMessage.mock.calls.map((call) => call[1]?.clientMessageId)
+
+  it("reuses one clientMessageId when the unchanged draft is resubmitted", async () => {
+    // The duplicate-turn guarantee: a resubmit of the same unresolved answer
+    // must present the same delivery identity, so the internal path's
+    // server-side dedup can recognize it instead of answering twice.
+    appContextMock.sendMessage
+      .mockRejectedValueOnce(deliveryFailure("outcome_unknown"))
+      .mockResolvedValueOnce(undefined)
+    render(<ClarificationForm interactions={interactions} />)
+
+    typeAndSubmit()
+    await screen.findByRole("alert")
+    submit()
+    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(2))
+
+    const [first, second] = sentClientMessageIds()
+    expect(first).toEqual(expect.any(String))
+    expect(first).not.toBe("")
+    expect(second).toBe(first)
+  })
+
+  it("mints a fresh clientMessageId when the failure demands a new id", async () => {
+    // `retryWithNewId` is the server saying the old identity is burned - the
+    // same semantics ChatInput already honours.
+    appContextMock.sendMessage
+      .mockRejectedValueOnce(deliveryFailure("rejected", { retryWithNewId: true }))
+      .mockResolvedValueOnce(undefined)
+    render(<ClarificationForm interactions={interactions} />)
+
+    typeAndSubmit()
+    await screen.findByRole("alert")
+    submit()
+    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(2))
+
+    const [first, second] = sentClientMessageIds()
+    expect(second).toEqual(expect.any(String))
+    expect(second).not.toBe(first)
+  })
+
+  it("mints a fresh clientMessageId when the draft changes between attempts", async () => {
+    // A different answer is a different turn, not a retry of the failed one.
+    appContextMock.sendMessage
+      .mockRejectedValueOnce(deliveryFailure("not_sent"))
+      .mockResolvedValueOnce(undefined)
+    render(<ClarificationForm interactions={interactions} />)
+
+    typeAndSubmit("Beijing")
+    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(1))
+    typeAndSubmit("Shanghai")
+    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(2))
+
+    const [first, second] = sentClientMessageIds()
+    expect(second).not.toBe(first)
+  })
+
+  it("hands onSend a delivery attempt and keeps it across an unchanged resubmit", async () => {
+    // The injected path receives the same identity the internal path sends,
+    // so a provider that can dedup gets the chance to (#1485).
+    const onSend = vi.fn()
+      .mockRejectedValueOnce(deliveryFailure("outcome_unknown"))
+      .mockResolvedValueOnce(undefined)
+    render(<ClarificationForm interactions={interactions} onSend={onSend} />)
+
+    typeAndSubmit()
+    await screen.findByRole("alert")
+    submit()
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(2))
+
+    const attempts = onSend.mock.calls.map((call) => call[3])
+    expect(attempts[0]).toEqual({ clientMessageId: expect.any(String) })
+    expect(attempts[1]).toEqual(attempts[0])
+  })
+
+  it("keeps the submit attempt alive across an interleaved connect-apps skip", async () => {
+    // A mixed interaction list renders the skip button beside Submit, so a
+    // skip can land between two submits of the same unresolved draft. The
+    // skip is its own submission - it must not burn the submit's identity.
+    mcpAppsMock.apps = [
+      {
+        id: "gmail",
+        name: "Gmail",
+        description: "",
+        icon: "",
+        users: "",
+        transport: "builtin",
+        provider: "google",
+        category: "Communication",
+        is_connected: false,
+      },
+    ]
+    mcpAppsMock.refresh.mockReset().mockResolvedValue(undefined)
+    const mixedInteractions = [
+      { type: "connect_apps" as const, field: "apps", label: "Connect", apps: ["Gmail"] },
+      { type: "text_input" as const, field: "city", label: "City" },
+    ]
+    appContextMock.sendMessage
+      .mockRejectedValueOnce(deliveryFailure("outcome_unknown"))
+      .mockResolvedValue(undefined)
+    render(<ClarificationForm interactions={mixedInteractions} />)
+
+    typeAndSubmit()
+    await screen.findByRole("alert")
+    fireEvent.click(screen.getByText("chatPage.clarification.connectApps.skip"))
+    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(2))
+    submit()
+    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(3))
+
+    const submitIds = appContextMock.sendMessage.mock.calls
+      .filter((call) => call[0] === "City: Beijing")
+      .map((call) => call[1]?.clientMessageId)
+    const skipIds = appContextMock.sendMessage.mock.calls
+      .filter((call) => call[0] === "chatPage.clarification.connectApps.skip")
+      .map((call) => call[1]?.clientMessageId)
+    expect(submitIds).toHaveLength(2)
+    expect(skipIds).toHaveLength(1)
+    expect(submitIds[1]).toBe(submitIds[0])
+    expect(skipIds[0]).not.toBe(submitIds[0])
+  })
+
+  it("scopes the delivery attempt to the rendered request", async () => {
+    // A new clarification round is a new question; its answer must never
+    // reuse the identity of the previous round's unresolved attempt.
+    appContextMock.sendMessage.mockRejectedValue(deliveryFailure("outcome_unknown"))
+    const form = (requestId: string) => (
+      <ClarificationForm interactions={interactions} requestId={requestId} />
+    )
+    const { rerender } = render(form("inputreq_r1"))
+
+    typeAndSubmit()
+    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(1))
+    rerender(form("inputreq_r2"))
+    typeAndSubmit()
+    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(2))
+
+    const [first, second] = sentClientMessageIds()
+    expect(second).not.toBe(first)
   })
 })
 

--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -67,7 +67,7 @@ vi.mock("@/contexts/auth-context", () => ({
 }))
 
 import { ClarificationForm } from "./clarification-form"
-import { clarificationSendFailure } from "./clarification-delivery"
+import { createClarificationSendFailure } from "./clarification-delivery"
 
 // Every describe in this file gets the identity translate back, so a locale
 // swapped by one test cannot leak into a suite added below it.
@@ -706,7 +706,7 @@ describe("ClarificationForm delivery failures", () => {
     // unset - exactly what agent-builder-chat throws. The raw string is a
     // developer diagnostic, not visitor copy.
     const onSend = vi.fn().mockRejectedValue(
-      clarificationSendFailure("Failed to send interaction", "not_sent"),
+      createClarificationSendFailure("Failed to send interaction", "not_sent"),
     )
 
     await submitAnswer(onSend)
@@ -796,6 +796,11 @@ describe("ClarificationForm delivery identity", () => {
     appContextMock.providerAvailable = true
     appContextMock.sendMessage.mockReset()
     toastErrorMock.mockReset()
+    // Reset what the "keeps the submit attempt alive across an interleaved
+    // connect-apps skip" test below mutates, so a later test in this
+    // describe never inherits its Gmail app.
+    mcpAppsMock.apps = []
+    mcpAppsMock.refresh.mockReset().mockResolvedValue(undefined)
   })
 
   afterEach(() => {
@@ -896,6 +901,25 @@ describe("ClarificationForm delivery identity", () => {
     const attempts = onSend.mock.calls.map((call) => call[3])
     expect(attempts[0]).toEqual({ clientMessageId: expect.any(String) })
     expect(attempts[1]).toEqual(attempts[0])
+  })
+
+  it("mints a fresh clientMessageId via the injected onSend path when the failure demands a new id", async () => {
+    // Mirrors "mints a fresh clientMessageId when the failure demands a new
+    // id" above, but through the injected onSend provider - retryWithNewId
+    // must reset the identity regardless of which send path rejected.
+    const onSend = vi.fn()
+      .mockRejectedValueOnce(deliveryFailure("rejected", { retryWithNewId: true }))
+      .mockResolvedValueOnce(undefined)
+    render(<ClarificationForm interactions={interactions} onSend={onSend} />)
+
+    typeAndSubmit()
+    await screen.findByRole("alert")
+    submit()
+    await waitFor(() => expect(onSend).toHaveBeenCalledTimes(2))
+
+    const ids = onSend.mock.calls.map((call) => call[3]?.clientMessageId)
+    expect(ids[1]).toEqual(expect.any(String))
+    expect(ids[1]).not.toBe(ids[0])
   })
 
   it("keeps the submit attempt alive across an interleaved connect-apps skip", async () => {

--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -66,6 +66,7 @@ vi.mock("@/contexts/auth-context", () => ({
 }))
 
 import { ClarificationForm } from "./clarification-form"
+import { clarificationSendFailure } from "./clarification-delivery"
 
 // Every describe in this file gets the identity translate back, so a locale
 // swapped by one test cannot leak into a suite added below it.
@@ -695,6 +696,29 @@ describe("ClarificationForm delivery failures", () => {
 
     expect(screen.queryByRole("alert")).toBeNull()
   })
+
+  it("never shows the builder's internal diagnostic to the visitor", async () => {
+    // The builder path rejects with the factory's product and userFacing
+    // unset - exactly what agent-builder-chat throws. The raw string is a
+    // developer diagnostic, not visitor copy.
+    const onSend = vi.fn().mockRejectedValue(
+      clarificationSendFailure("Failed to send interaction", "not_sent"),
+    )
+
+    await submitAnswer(onSend)
+
+    await waitFor(() => {
+      expect(toastErrorMock).toHaveBeenCalledWith(
+        "chatPage.clarification.sendError",
+        { description: "chatPage.clarification.sendNotSent" },
+      )
+    })
+    // Positive anchor first: the alert must carry the localized copy, so the
+    // negative assertion below cannot pass vacuously on an unrelated alert.
+    const alert = await screen.findByRole("alert")
+    expect(alert).toHaveTextContent("chatPage.clarification.sendError")
+    expect(alert).not.toHaveTextContent("Failed to send interaction")
+  })
 })
 
 describe("ClarificationForm interaction identity", () => {
@@ -927,6 +951,31 @@ describe("ClarificationForm delivery identity", () => {
     typeAndSubmit()
     await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(1))
     rerender(form("inputreq_r2"))
+    typeAndSubmit()
+    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(2))
+
+    const [first, second] = sentClientMessageIds()
+    expect(second).not.toBe(first)
+  })
+
+  it("mints a fresh clientMessageId when the form is re-activated for a new round", async () => {
+    // Round 1's answer can land server-side while the client sees
+    // outcome_unknown (ref kept for the retry). The backend never populates
+    // request_id, so when round 2 re-activates this same instance the only
+    // signal is the active flip - without clearing the attempt there, a
+    // same-text round-2 answer would reuse round 1's resolved id, which the
+    // server ACKs without re-enqueueing: the answer is silently swallowed.
+    appContextMock.sendMessage
+      .mockRejectedValueOnce(deliveryFailure("outcome_unknown"))
+      .mockResolvedValueOnce(undefined)
+    const { rerender } = render(<ClarificationForm interactions={interactions} active />)
+
+    typeAndSubmit()
+    await screen.findByRole("alert")
+
+    rerender(<ClarificationForm interactions={interactions} active={false} />)
+    rerender(<ClarificationForm interactions={interactions} active />)
+
     typeAndSubmit()
     await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(2))
 

--- a/frontend/src/components/chat/clarification-form.test.tsx
+++ b/frontend/src/components/chat/clarification-form.test.tsx
@@ -15,6 +15,7 @@ import { resolveTranslation } from "@/i18n/translations"
 const appContextMock = vi.hoisted(() => ({
   dispatch: vi.fn(),
   filesDisabled: false,
+  isConnected: true,
   providerAvailable: true,
   sendMessage: vi.fn(),
 }))
@@ -78,6 +79,7 @@ describe("ClarificationForm Session file capability", () => {
   beforeEach(() => {
     appContextMock.dispatch.mockReset()
     appContextMock.filesDisabled = false
+    appContextMock.isConnected = true
     appContextMock.providerAvailable = true
     appContextMock.sendMessage.mockReset()
     toastErrorMock.mockReset()
@@ -279,6 +281,7 @@ describe("ClarificationForm connect_apps interaction", () => {
   beforeEach(() => {
     appContextMock.dispatch.mockReset()
     appContextMock.filesDisabled = false
+    appContextMock.isConnected = true
     appContextMock.providerAvailable = true
     appContextMock.sendMessage.mockReset()
     toastErrorMock.mockReset()
@@ -443,6 +446,7 @@ describe("ClarificationForm delivery failures", () => {
   beforeEach(() => {
     appContextMock.dispatch.mockReset()
     appContextMock.filesDisabled = false
+    appContextMock.isConnected = true
     appContextMock.providerAvailable = true
     appContextMock.sendMessage.mockReset()
     toastErrorMock.mockReset()
@@ -788,6 +792,7 @@ describe("ClarificationForm delivery identity", () => {
   beforeEach(() => {
     appContextMock.dispatch.mockReset()
     appContextMock.filesDisabled = false
+    appContextMock.isConnected = true
     appContextMock.providerAvailable = true
     appContextMock.sendMessage.mockReset()
     toastErrorMock.mockReset()
@@ -939,9 +944,11 @@ describe("ClarificationForm delivery identity", () => {
     expect(skipIds[0]).not.toBe(submitIds[0])
   })
 
-  it("scopes the delivery attempt to the rendered request", async () => {
-    // A new clarification round is a new question; its answer must never
-    // reuse the identity of the previous round's unresolved attempt.
+  it("scopes the delivery key to the rendered request", async () => {
+    // The delivery key embeds the requestId, so a new clarification round's
+    // resolveDeliveryAttempt lookup already misses the previous round's
+    // unresolved attempt - the layout-effect ref clear above is belt-and-
+    // braces on top of that.
     appContextMock.sendMessage.mockRejectedValue(deliveryFailure("outcome_unknown"))
     const form = (requestId: string) => (
       <ClarificationForm interactions={interactions} requestId={requestId} />
@@ -982,12 +989,73 @@ describe("ClarificationForm delivery identity", () => {
     const [first, second] = sentClientMessageIds()
     expect(second).not.toBe(first)
   })
+
+  it("mints a fresh clientMessageId for a file-bearing answer on every attempt", async () => {
+    // Files are re-uploaded raw (the File[] itself, not a reference) on every
+    // attempt, minting fresh file_ids server-side; a reused clientMessageId
+    // with "new" attachments trips the server's same-id payload match and is
+    // rejected as MESSAGE_ID_CONFLICT (#2175 round 3) - so a file-bearing
+    // answer must never reuse an identity, unlike a text-only resubmit.
+    appContextMock.sendMessage
+      .mockRejectedValueOnce(deliveryFailure("outcome_unknown"))
+      .mockResolvedValueOnce(undefined)
+    const fileInteractions = [
+      { type: "file_upload" as const, field: "evidence", label: "Evidence" },
+    ]
+    const { container } = render(
+      <ClarificationForm interactions={fileInteractions} filesDisabled={false} />,
+    )
+
+    const file = new File(["report"], "report.txt", { type: "text/plain" })
+    fireEvent.change(
+      container.querySelector<HTMLInputElement>('input[type="file"]')!,
+      { target: { files: [file] } },
+    )
+    submit()
+    await screen.findByRole("alert")
+    submit()
+    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(2))
+
+    const [first, second] = sentClientMessageIds()
+    expect(first).toEqual(expect.any(String))
+    expect(second).toEqual(expect.any(String))
+    expect(second).not.toBe(first)
+
+    const filesSent = appContextMock.sendMessage.mock.calls.map((call) => call[2])
+    expect(filesSent[0]).toHaveLength(1)
+    expect(filesSent[1]).toHaveLength(1)
+  })
+
+  it("clears the delivery attempt when the connection returns after a disconnect", async () => {
+    // A reconnect can land waiting_for_user -> waiting_for_user across two
+    // distinct rounds (the backend never mints a per-round request_id - see
+    // #2251 - and a missed broadcast means `active` never flips), so the
+    // active-flip proxy above misses that boundary. The connection edge is
+    // the remaining observable signal for it.
+    appContextMock.sendMessage.mockRejectedValue(deliveryFailure("outcome_unknown"))
+    const { rerender } = render(<ClarificationForm interactions={interactions} />)
+
+    typeAndSubmit()
+    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(1))
+
+    appContextMock.isConnected = false
+    rerender(<ClarificationForm interactions={interactions} />)
+    appContextMock.isConnected = true
+    rerender(<ClarificationForm interactions={interactions} />)
+
+    typeAndSubmit()
+    await waitFor(() => expect(appContextMock.sendMessage).toHaveBeenCalledTimes(2))
+
+    const [first, second] = sentClientMessageIds()
+    expect(second).not.toBe(first)
+  })
 })
 
 describe("ClarificationForm blank option filtering", () => {
   beforeEach(() => {
     appContextMock.dispatch.mockReset()
     appContextMock.filesDisabled = false
+    appContextMock.isConnected = true
     appContextMock.providerAvailable = true
     appContextMock.sendMessage.mockReset()
     toastErrorMock.mockReset()

--- a/frontend/src/components/chat/clarification-form.tsx
+++ b/frontend/src/components/chat/clarification-form.tsx
@@ -14,12 +14,18 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/component
 import { ChevronDown, ChevronRight, MessageSquare, Upload, File as FileIcon, X, Globe } from "lucide-react"
 import { ConnectAppsField } from "./connect-apps-field"
 import type { MessageDeliveryDisposition } from "@/hooks/use-websocket"
-import type { TranslationKey } from "@/i18n/translations"
+import { generateClientMessageId } from "@/lib/utils"
+import { clientErrorTranslationKey, type ClientErrorCode } from "@/lib/client-errors"
 import {
-  clientErrorTranslationKey,
-  readClientErrorCode,
-  type ClientErrorCode,
-} from "@/lib/client-errors"
+  readSendDisposition,
+  readSendErrorCode,
+  readSendReason,
+  readSendRetryWithNewId,
+  sendHintKey,
+  type ClarificationOnSend,
+  type ClarificationSendAttempt,
+  type ClarificationSendMetadata,
+} from "./clarification-delivery"
 
 interface ClarificationFormProps {
   message?: string
@@ -28,7 +34,13 @@ interface ClarificationFormProps {
   requestId?: string
   active?: boolean
   filesDisabled?: boolean
-  onSend?: (message: string, files?: File[], metadata?: any) => Promise<void> | void
+  /**
+   * Injected send path (e.g. the agent builder chat). Held to the delivery
+   * contract in clarification-delivery.ts: it receives the attempt identity
+   * the internal path sends, and rejects with the same discriminated failure
+   * shape (#1485).
+   */
+  onSend?: ClarificationOnSend
 }
 
 const FILE_ACTION_VALUE_RE = /(^|[-_\s])(upload|file)(?=$|[-_\s])/i
@@ -52,67 +64,6 @@ const isFileActionSelection = (
 ): boolean => option
   ? isFileActionOption(option)
   : isFileActionValue(value)
-
-/**
- * Delivery failures carry whether the turn definitely never reached the agent.
- * Plain errors (local validation, unexpected throws) carry nothing, and are
- * left unqualified rather than guessed at: telling a visitor to resubmit a
- * turn that may have landed is worse than saying nothing. Errors are probed
- * structurally rather than by `instanceof`, because the `onSend` branch's
- * failures come from arbitrary builder callbacks (see #1485).
- */
-const readSendDisposition = (error: unknown): MessageDeliveryDisposition | null => {
-  if (typeof error !== "object" || error === null || !("disposition" in error)) {
-    return null
-  }
-  const disposition = (error as { disposition: unknown }).disposition
-  return disposition === "not_sent"
-    || disposition === "rejected"
-    || disposition === "outcome_unknown"
-    ? disposition
-    : null
-}
-
-/**
- * Only the reasons the sender can act on — the backend's rejection text — are
- * shown as-is. Connection plumbing messages stay behind the localized string:
- * they are English diagnostics, and a widget visitor is not the audience for
- * them.
- *
- * The message is probed structurally for the same reason the disposition is:
- * an `onSend` callback's rejection need not be an `Error` instance. Nothing
- * new becomes displayable either way — `userFacing` still has to be set.
- */
-const readSendReason = (error: unknown): string => {
-  if (
-    typeof error !== "object"
-    || error === null
-    || (error as { userFacing?: unknown }).userFacing !== true
-  ) {
-    return ""
-  }
-  const message = (error as { message?: unknown }).message
-  return typeof message === "string" ? message.trim() : ""
-}
-
-const readSendErrorCode = (error: unknown): ClientErrorCode | null => {
-  if (typeof error !== "object" || error === null) return null
-  return readClientErrorCode((error as { errorCode?: unknown }).errorCode)
-}
-
-/**
- * The hint that belongs with a disposition, as a key rather than a translated
- * string: the toast needs it once at failure time, while the persistent alert
- * has to re-resolve it on every render so a locale switch is not stuck behind
- * whatever language was active when the send failed.
- */
-const sendHintKey = (
-  disposition: MessageDeliveryDisposition | null,
-): TranslationKey | null => disposition === "outcome_unknown"
-  ? "chatPage.clarification.sendOutcomeUnknown"
-  : disposition === "not_sent" || disposition === "rejected"
-    ? "chatPage.clarification.sendNotSent"
-    : null
 
 // Interaction types that are "live widgets" reflecting external state (e.g.
 // useMcpApps()'s connection state), not a question with an answer to submit
@@ -172,6 +123,41 @@ export function ClarificationForm({
   const [formState, setFormState] = useState<Record<string, any>>({})
   const previousRequestIdRef = useRef(requestId)
   const latestRequestIdRef = useRef(requestId)
+  // One delivery identity per unresolved submission, handed to both send
+  // paths: an unchanged resubmit presents the same clientMessageId (so a
+  // dedup-capable consumer can recognize the retry), while a changed draft,
+  // a delivered send, or a `retryWithNewId` failure mints a fresh one. Same
+  // semantics as ChatInput's delivery attempt. Submit and the connect-apps
+  // skip are independent submissions a mixed interaction list renders side
+  // by side, so each keeps its own slot - a skip between two submits of the
+  // same draft must not burn the submit's identity.
+  type DeliveryAttempt = { key: string } & ClarificationSendAttempt
+  const submitAttemptRef = useRef<DeliveryAttempt | null>(null)
+  const skipAttemptRef = useRef<DeliveryAttempt | null>(null)
+
+  const resolveDeliveryAttempt = (
+    ref: React.MutableRefObject<DeliveryAttempt | null>,
+    deliveryKey: string,
+  ): string => {
+    const previous = ref.current
+    const clientMessageId = previous?.key === deliveryKey
+      ? previous.clientMessageId
+      : generateClientMessageId()
+    ref.current = { key: deliveryKey, clientMessageId }
+    return clientMessageId
+  }
+
+  // Clears only the attempt this send owns: a concurrent send of the same
+  // kind (e.g. a double-clicked skip) may have replaced the slot with its
+  // own attempt, which must survive this send's resolution.
+  const settleDeliveryAttempt = (
+    ref: React.MutableRefObject<DeliveryAttempt | null>,
+    clientMessageId: string,
+  ) => {
+    if (ref.current?.clientMessageId === clientMessageId) {
+      ref.current = null
+    }
+  }
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [isSubmitted, setIsSubmitted] = useState(!active && !isConnectAppsOnly)
   const [isOpen, setIsOpen] = useState(active || isConnectAppsOnly)
@@ -194,6 +180,10 @@ export function ClarificationForm({
     setIsSubmitted(!active && !isConnectAppsOnly)
     setIsOpen(active || isConnectAppsOnly)
     setSendFailure(null)
+    // A new request is a new question; its answer must never present the
+    // previous round's unresolved delivery identity.
+    submitAttemptRef.current = null
+    skipAttemptRef.current = null
   }, [active, isConnectAppsOnly, requestId])
 
   useEffect(() => {
@@ -291,7 +281,7 @@ export function ClarificationForm({
   const handleSubmit = async () => {
     const submittedRequestId = requestId
     // Construct the message
-    const metadata: any = requestId ? { request_id: requestId } : {}
+    const metadata: ClarificationSendMetadata = requestId ? { request_id: requestId } : {}
     const lines = normalizedInteractions.flatMap(interaction => {
       const value = formState[interaction.field]
 
@@ -377,18 +367,27 @@ export function ClarificationForm({
       }
     })
 
+    // If textMessage is empty but we have files, send a generic message?
+    const outboundFiles = filesDisabled ? [] : files
+    const finalMessage = textMessage || (outboundFiles.length > 0 ? t("chatPage.clarification.uploadedFiles") : t("chatPage.clarification.confirmed"))
+
+    const clientMessageId = resolveDeliveryAttempt(submitAttemptRef, JSON.stringify([
+      submittedRequestId ?? null,
+      finalMessage,
+      outboundFiles.map((file) => [file.name, file.size, file.lastModified]),
+    ]))
+
     try {
       setIsSubmitting(true)
       setSendFailure(null)
-      // If textMessage is empty but we have files, send a generic message?
-      const outboundFiles = filesDisabled ? [] : files
-      const finalMessage = textMessage || (outboundFiles.length > 0 ? t("chatPage.clarification.uploadedFiles") : t("chatPage.clarification.confirmed"))
 
       if (onSend) {
-        await onSend(finalMessage, outboundFiles, metadata);
+        await onSend(finalMessage, outboundFiles, metadata, { clientMessageId })
       } else if (sendMessage) {
-        await sendMessage(finalMessage, { force: true, metadata }, outboundFiles)
+        await sendMessage(finalMessage, { force: true, metadata, clientMessageId }, outboundFiles)
       }
+      // Delivered: the identity is spent whether or not this render is stale.
+      settleDeliveryAttempt(submitAttemptRef, clientMessageId)
 
       if (latestRequestIdRef.current !== submittedRequestId) return
       setIsSubmitted(true)
@@ -397,6 +396,9 @@ export function ClarificationForm({
         dispatch({ type: "UPDATE_TASK_STATUS", payload: { status: "running" } })
       }
     } catch (error) {
+      if (readSendRetryWithNewId(error)) {
+        settleDeliveryAttempt(submitAttemptRef, clientMessageId)
+      }
       if (latestRequestIdRef.current !== submittedRequestId) return
       console.error("Failed to send clarification response", error)
       // The rejection reason ("a previous guidance message is still being
@@ -409,8 +411,9 @@ export function ClarificationForm({
       // The toast is a snapshot - it keeps whatever language was active when
       // it fired. The alert below is not, and re-resolves on every render.
       // The draft is preserved and Submit stays enabled in every case, so the
-      // copy may only warn, never promise: a resubmit after an unknown
-      // outcome mints a fresh delivery and could answer the question twice.
+      // copy may only warn, never promise: an unchanged resubmit re-presents
+      // the same delivery identity, but only the internal path is known to
+      // dedup on it - an onSend provider may still answer the question twice.
       const hintKey = sendHintKey(disposition)
       const hint = hintKey ? t(hintKey) : null
       const errorMessage = errorCode
@@ -433,14 +436,27 @@ export function ClarificationForm({
   // formState machinery handleSubmit above uses (there's nothing to gather).
   const handleSkipConnectApps = async () => {
     const message = t("chatPage.clarification.connectApps.skip")
-    const metadata = requestId ? { request_id: requestId } : {}
+    const metadata: ClarificationSendMetadata = requestId ? { request_id: requestId } : {}
+    // A skip is a delivery attempt like any other. The button unmounts on
+    // its first click, so the reuse only covers a double-click racing ahead
+    // of that re-render - but a skip must never clobber the submit slot's
+    // unresolved identity, which is why it gets its own.
+    const clientMessageId = resolveDeliveryAttempt(skipAttemptRef, JSON.stringify([
+      "connect_apps_skip",
+      requestId ?? null,
+      message,
+    ]))
     try {
       if (onSend) {
-        await onSend(message, [], metadata)
+        await onSend(message, [], metadata, { clientMessageId })
       } else if (sendMessage) {
-        await sendMessage(message, { force: true, metadata }, [])
+        await sendMessage(message, { force: true, metadata, clientMessageId }, [])
       }
+      settleDeliveryAttempt(skipAttemptRef, clientMessageId)
     } catch (error) {
+      if (readSendRetryWithNewId(error)) {
+        settleDeliveryAttempt(skipAttemptRef, clientMessageId)
+      }
       console.error("Failed to send connect-apps skip response", error)
       toast.error(t("chatPage.clarification.sendError"))
     }

--- a/frontend/src/components/chat/clarification-form.tsx
+++ b/frontend/src/components/chat/clarification-form.tsx
@@ -194,6 +194,21 @@ export function ClarificationForm({
       setIsSubmitted(false)
       setIsOpen(true)
       setSendFailure(null)
+      // A re-activation is a new clarification round (the backend never
+      // populates request_id, so the requestId reset above cannot be relied
+      // on, and the live turn path reuses this instance). Round 1's delivery
+      // identity must not leak into round 2: the server ACKs a resolved
+      // client_message_id without re-enqueueing, which would silently
+      // swallow round 2's answer (#2175 review). The trade: a transient
+      // active flap inside one round (an inferred-running dispatch racing a
+      // re-broadcast wait) burns a legitimately kept identity, regressing
+      // that resubmit to the old mint-fresh behavior - bounded server-side
+      // by the guidance_in_progress claim check. The draft is deliberately
+      // kept: wiping formState on such a flap would cost the visitor their
+      // answer, and with the ref cleared even an identical draft mints a
+      // fresh id, so keeping it cannot re-open the swallow.
+      submitAttemptRef.current = null
+      skipAttemptRef.current = null
     }
   }, [active])
 

--- a/frontend/src/components/chat/clarification-form.tsx
+++ b/frontend/src/components/chat/clarification-form.tsx
@@ -83,12 +83,13 @@ export function ClarificationForm({
   onSend,
 }: ClarificationFormProps) {
   // If onSend is provided, use it (e.g., from builder chat), otherwise use useApp
-  let sendMessage: any, dispatch: any, contextFilesDisabled: boolean | undefined;
+  let sendMessage: any, dispatch: any, contextFilesDisabled: boolean | undefined, isConnected: boolean | undefined;
   try {
     const appCtx = useApp();
     sendMessage = appCtx.sendMessage;
     dispatch = appCtx.dispatch;
     contextFilesDisabled = appCtx.filesDisabled;
+    isConnected = appCtx.isConnected;
   } catch {
     // We might not be in the app context (e.g., agent builder chat)
   }
@@ -123,39 +124,36 @@ export function ClarificationForm({
   const [formState, setFormState] = useState<Record<string, any>>({})
   const previousRequestIdRef = useRef(requestId)
   const latestRequestIdRef = useRef(requestId)
-  // One delivery identity per unresolved submission, handed to both send
-  // paths: an unchanged resubmit presents the same clientMessageId (so a
-  // dedup-capable consumer can recognize the retry), while a changed draft,
-  // a delivered send, or a `retryWithNewId` failure mints a fresh one. Same
-  // semantics as ChatInput's delivery attempt. Submit and the connect-apps
-  // skip are independent submissions a mixed interaction list renders side
-  // by side, so each keeps its own slot - a skip between two submits of the
-  // same draft must not burn the submit's identity.
+  // One delivery identity per unresolved TEXT-ONLY submission: an unchanged
+  // resubmit presents the same clientMessageId (so a dedup-capable consumer
+  // can recognize the retry), while a changed draft, a delivered send, a
+  // `retryWithNewId` failure, a new round, or a reconnect mints a fresh one
+  // (ChatInput keeps only the first three of those rules - this form also
+  // has round/connection resets because its rounds share one instance).
+  // File-bearing answers never reuse an identity (see handleSubmit), and the
+  // connect-apps skip deliberately keeps no identity of its own (see
+  // handleSkipConnectApps) - a mixed interaction list renders it beside
+  // Submit, and a skip that shared this slot could burn the submit's
+  // unresolved identity out from under it.
   type DeliveryAttempt = { key: string } & ClarificationSendAttempt
   const submitAttemptRef = useRef<DeliveryAttempt | null>(null)
-  const skipAttemptRef = useRef<DeliveryAttempt | null>(null)
+  const wasDisconnectedRef = useRef(false)
 
-  const resolveDeliveryAttempt = (
-    ref: React.MutableRefObject<DeliveryAttempt | null>,
-    deliveryKey: string,
-  ): string => {
-    const previous = ref.current
+  const resolveDeliveryAttempt = (deliveryKey: string): string => {
+    const previous = submitAttemptRef.current
     const clientMessageId = previous?.key === deliveryKey
       ? previous.clientMessageId
       : generateClientMessageId()
-    ref.current = { key: deliveryKey, clientMessageId }
+    submitAttemptRef.current = { key: deliveryKey, clientMessageId }
     return clientMessageId
   }
 
-  // Clears only the attempt this send owns: a concurrent send of the same
-  // kind (e.g. a double-clicked skip) may have replaced the slot with its
-  // own attempt, which must survive this send's resolution.
-  const settleDeliveryAttempt = (
-    ref: React.MutableRefObject<DeliveryAttempt | null>,
-    clientMessageId: string,
-  ) => {
-    if (ref.current?.clientMessageId === clientMessageId) {
-      ref.current = null
+  // Clears only the attempt this send owns: a concurrent send (e.g. a
+  // double-clicked submit) may have replaced the slot with its own attempt,
+  // which must survive this send's resolution.
+  const settleDeliveryAttempt = (clientMessageId: string) => {
+    if (submitAttemptRef.current?.clientMessageId === clientMessageId) {
+      submitAttemptRef.current = null
     }
   }
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -183,7 +181,6 @@ export function ClarificationForm({
     // A new request is a new question; its answer must never present the
     // previous round's unresolved delivery identity.
     submitAttemptRef.current = null
-    skipAttemptRef.current = null
   }, [active, isConnectAppsOnly, requestId])
 
   useEffect(() => {
@@ -208,9 +205,27 @@ export function ClarificationForm({
       // answer, and with the ref cleared even an identical draft mints a
       // fresh id, so keeping it cannot re-open the swallow.
       submitAttemptRef.current = null
-      skipAttemptRef.current = null
     }
   }, [active])
+
+  // A reconnect can land waiting_for_user -> waiting_for_user across two
+  // DISTINCT rounds (the backend never mints a per-round request_id - see
+  // #2251 - and a missed broadcast means `active` never flips), so the
+  // active-flip proxy above misses that boundary. The connection edge is the
+  // remaining observable signal: any identity kept across a disconnect gap
+  // may belong to a previous round, and dropping it only regresses that one
+  // resubmit to minting a fresh id. Strictly false -> true: the builder path
+  // has no app context (isConnected stays undefined) and must not clear.
+  useEffect(() => {
+    if (isConnected === false) {
+      wasDisconnectedRef.current = true
+      return
+    }
+    if (isConnected === true && wasDisconnectedRef.current) {
+      wasDisconnectedRef.current = false
+      submitAttemptRef.current = null
+    }
+  }, [isConnected])
 
   const normalizedInteractions = useMemo(() => {
     const seenFields = new Set<string>()
@@ -386,11 +401,24 @@ export function ClarificationForm({
     const outboundFiles = filesDisabled ? [] : files
     const finalMessage = textMessage || (outboundFiles.length > 0 ? t("chatPage.clarification.uploadedFiles") : t("chatPage.clarification.confirmed"))
 
-    const clientMessageId = resolveDeliveryAttempt(submitAttemptRef, JSON.stringify([
-      submittedRequestId ?? null,
-      finalMessage,
-      outboundFiles.map((file) => [file.name, file.size, file.lastModified]),
-    ]))
+    let clientMessageId: string
+    if (outboundFiles.length > 0) {
+      // File answers never reuse an identity: this path re-uploads the raw
+      // File[] on every attempt, minting fresh file_ids, and the server's
+      // same-id payload match compares attachments BY file_id - a reused id
+      // with "new" files is rejected as MESSAGE_ID_CONFLICT (#2175 round 3).
+      // Until uploads are tagged back with their file_id (ChatInput-style),
+      // a fresh id per attempt restores the exact pre-#2175 behavior here.
+      submitAttemptRef.current = null
+      clientMessageId = generateClientMessageId()
+    } else {
+      // Text-only by construction (the file branch above never stores an
+      // attempt), so the key needs no file component.
+      clientMessageId = resolveDeliveryAttempt(JSON.stringify([
+        submittedRequestId ?? null,
+        finalMessage,
+      ]))
+    }
 
     try {
       setIsSubmitting(true)
@@ -402,7 +430,7 @@ export function ClarificationForm({
         await sendMessage(finalMessage, { force: true, metadata, clientMessageId }, outboundFiles)
       }
       // Delivered: the identity is spent whether or not this render is stale.
-      settleDeliveryAttempt(submitAttemptRef, clientMessageId)
+      settleDeliveryAttempt(clientMessageId)
 
       if (latestRequestIdRef.current !== submittedRequestId) return
       setIsSubmitted(true)
@@ -412,7 +440,7 @@ export function ClarificationForm({
       }
     } catch (error) {
       if (readSendRetryWithNewId(error)) {
-        settleDeliveryAttempt(submitAttemptRef, clientMessageId)
+        settleDeliveryAttempt(clientMessageId)
       }
       if (latestRequestIdRef.current !== submittedRequestId) return
       console.error("Failed to send clarification response", error)
@@ -426,9 +454,10 @@ export function ClarificationForm({
       // The toast is a snapshot - it keeps whatever language was active when
       // it fired. The alert below is not, and re-resolves on every render.
       // The draft is preserved and Submit stays enabled in every case, so the
-      // copy may only warn, never promise: an unchanged resubmit re-presents
-      // the same delivery identity, but only the internal path is known to
-      // dedup on it - an onSend provider may still answer the question twice.
+      // copy may only warn, never promise: an unchanged text-only resubmit
+      // re-presents the same delivery identity, but a file answer mints a
+      // fresh one each attempt, and only the internal path is known to dedup
+      // - an onSend provider may still answer the question twice.
       const hintKey = sendHintKey(disposition)
       const hint = hintKey ? t(hintKey) : null
       const errorMessage = errorCode
@@ -452,26 +481,18 @@ export function ClarificationForm({
   const handleSkipConnectApps = async () => {
     const message = t("chatPage.clarification.connectApps.skip")
     const metadata: ClarificationSendMetadata = requestId ? { request_id: requestId } : {}
-    // A skip is a delivery attempt like any other. The button unmounts on
-    // its first click, so the reuse only covers a double-click racing ahead
-    // of that re-render - but a skip must never clobber the submit slot's
-    // unresolved identity, which is why it gets its own.
-    const clientMessageId = resolveDeliveryAttempt(skipAttemptRef, JSON.stringify([
-      "connect_apps_skip",
-      requestId ?? null,
-      message,
-    ]))
+    // A skip mints a fresh identity per click: the button unmounts on its
+    // first click (skipped never resets), so identity reuse is unreachable,
+    // and by not touching the submit slot at all a skip can never burn an
+    // unresolved submit attempt (#2175 round 3).
+    const clientMessageId = generateClientMessageId()
     try {
       if (onSend) {
         await onSend(message, [], metadata, { clientMessageId })
       } else if (sendMessage) {
         await sendMessage(message, { force: true, metadata, clientMessageId }, [])
       }
-      settleDeliveryAttempt(skipAttemptRef, clientMessageId)
     } catch (error) {
-      if (readSendRetryWithNewId(error)) {
-        settleDeliveryAttempt(skipAttemptRef, clientMessageId)
-      }
       console.error("Failed to send connect-apps skip response", error)
       toast.error(t("chatPage.clarification.sendError"))
     }


### PR DESCRIPTION
Closes #1485.

## What

`ClarificationForm`'s two send paths now share one declared delivery contract, and the form owns the delivery identity for both.

- **New module `frontend/src/components/chat/clarification-delivery.ts`** — the contract in one place: the typed `onSend` signature (`message, files, metadata, attempt`), a discriminated failure shape (`disposition` / `userFacing` / `errorCode` / `retryWithNewId`, structurally matching `MessageDeliveryError`), a failure factory for providers, and the structural probes the form already used (moved verbatim, plus a new `readSendRetryWithNewId`).
- **`ClarificationForm` owns one delivery identity per unresolved submission**, with `ChatInput`'s semantics: an unchanged resubmit re-presents the same `clientMessageId` (so the internal path's server-side dedup recognizes the retry instead of answering the question twice), while a delivered send, a changed draft, or a `retryWithNewId` failure mints a fresh one. Submit and the connect-apps skip are independent submissions a mixed interaction list renders side by side, so each keeps its own slot. The id travels through `config.clientMessageId` internally (consumed at `app-context-chat.tsx` `sendMessage`) and as the new `attempt` argument to `onSend`.
- **The agent builder chat now rejects with a typed `not_sent` failure** instead of a plain `Error`. Verified against every `false` return of `handleSendMessage`: all happen before anything is handed to the websocket. Because the form's "not sent" hint now invites a resubmit, both failure paths that had pushed optimistic bubbles (upload failure, connection-setup throw) roll them back so a resubmit can't stack a duplicate answer over a blank placeholder.
- `metadata?: any` retired on `ClarificationFormProps.onSend`, `ChatMessage.onSendInteraction`, and the builder's `handleSendMessage`.

## Why

#1485: the injected `onSend` path had no delivery id and no attempt context, its only provider threw a plain `Error`, and the form probed the failure protocol off whatever was thrown. The internal path was no better off *from this form* — every submit minted a fresh `clientMessageId`, so a resubmit after `outcome_unknown` could answer a clarification twice (the old code comment admitted exactly this).

## Out of scope (pre-existing, tracked)

- #2174 — unifying this contract with `use-websocket`'s `MessageDeliveryError` and `ChatInput`'s inline probes/attempt machinery; typing `AppContext.sendMessage`'s `config?: any` and its untyped pre-flight throws (which still surface without a disposition hint); `uploadFiles`' bare-array shape. All hub-file refactors, deliberately split out.
- #2173 — `PROVIDER_DISPLAY_NAMES` missing the `salesforce` builtin provider; `connect-apps-field.test.tsx` fails on a clean `main` (reproduced at c531d417 in a throwaway worktree). Unrelated to this diff; it is the only failure in the full frontend suite on this branch.

## Notes for review (known judgement calls, deliberate)

- `ClarificationSendFailure` re-declares `MessageDeliveryError`'s fields structurally rather than importing the class, so builder components don't take a runtime dependency on the websocket hook; single-home unification is #2174.
- `resolveDeliveryAttempt`/`settleDeliveryAttempt` live in the component (they manage refs); moving to a shared hook with `ChatInput` is #2174.
- The `requestId`-change reset clears both attempt slots even though the delivery keys also embed the request id — belt and braces, both cheap.
- The skip slot's reuse only covers a double-click racing the button's unmount; its real purpose is keeping a skip from clobbering the submit slot's unresolved identity (regression-tested).

## Verification

- `vitest`: targeted suites 44/44; full frontend suite 2924 tests with the single pre-existing #2173 failure.
- `tsc --noEmit` clean; `eslint` adds no new problems on touched files (counts strictly decreased vs `main`).
- New regression tests: identity reuse on unchanged resubmit (both paths), fresh id on `retryWithNewId` / changed draft / new request, skip/submit interleaving keeps the submit identity, builder rejects `not_sent`, and both builder rollback paths restore the transcript.
