### PR TITLE
fix(calendar): attach real Google Meet links and invite attendees

### DIFF
--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -8,7 +8,7 @@ from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build  # type: ignore
 from mcp.server.fastmcp import FastMCP
 
-from .utils import setup_proxy_env
+from .utils import setup_proxy_env, success_with_capped_dict
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("calendar-mcp")
@@ -125,21 +125,21 @@ def _merge_attendees(event: dict[str, Any], attendees: list[str] | None) -> None
 
 
 def _needs_conference_request(event: dict[str, Any]) -> bool:
-    """True if add_google_meet should (re)send a createRequest: the event has
-    no conferenceData yet, or its only conferenceData is a *failed*
-    createRequest (status.statusCode == "failure").
+    """True if add_google_meet should (re)send a createRequest.
 
-    A conference that's still *pending* must not be treated the same as a
-    failed one -- both lack entryPoints/conferenceSolution while Google is
-    still provisioning them, so checking for those fields can't tell "failed,
-    safe to retry" apart from "pending, do not clobber the in-flight
-    request". Read status.statusCode directly instead (the same field
-    _event_response already reads for the opposite purpose). A conference
-    that has already resolved (has entryPoints or a conferenceSolution --
-    Meet or otherwise) also returns False, so it isn't clobbered either. A
-    legacy event carrying `hangoutLink` with no `conferenceData` at all (pre-
-    dates the conferenceData API) is also treated as already resolved, or
-    add_google_meet=True would request a second, duplicate conference for it.
+    The only signal this reads is createRequest.status.statusCode: it
+    returns True when the event has no conferenceData at all, or when the
+    only conferenceData present is a createRequest whose status.statusCode
+    is "failure". Everything else returns False, so it's left untouched:
+    a still-*pending* createRequest (status.statusCode == "pending" --
+    which, like a failed one, has no entryPoints/conferenceSolution yet,
+    so those fields can't be used to tell "safe to retry" apart from "do
+    not clobber the in-flight request"); an already-resolved conference
+    (its createRequest, if it went through one at all, carries
+    status.statusCode == "success", or there's no createRequest key at all
+    for a conference attached some other way -- e.g. a Zoom add-on);
+    a legacy event carrying `hangoutLink` with no `conferenceData` at all
+    (predates the conferenceData API).
     """
     if event.get("hangoutLink"):
         return False
@@ -151,10 +151,19 @@ def _needs_conference_request(event: dict[str, Any]) -> bool:
     return status_code == "failure"
 
 
-def _conference_and_notify_kwargs(
-    event: dict[str, Any], notify_attendees: bool, add_google_meet: bool
-) -> dict[str, Any]:
-    """Apply add_google_meet to event in place, and build the insert()/update() kwargs.
+def _apply_conference_request(event: dict[str, Any], add_google_meet: bool) -> None:
+    """Mutates event in place: attaches a fresh Meet createRequest when
+    add_google_meet=True and _needs_conference_request(event) says one isn't
+    already in flight or resolved. A no-op (no error, no signal in the
+    response) if the event already has a *non*-Meet conference (e.g. Zoom) --
+    see the add_google_meet docstring on the public tools.
+    """
+    if add_google_meet and _needs_conference_request(event):
+        _add_conference_request(event)
+
+
+def _api_call_kwargs(event: dict[str, Any], notify_attendees: bool) -> dict[str, Any]:
+    """Build the conferenceDataVersion/sendUpdates kwargs for insert()/update().
 
     conferenceDataVersion is always sent as 1: it only declares that the caller
     understands conference data, it does not request or remove a conference by
@@ -163,16 +172,33 @@ def _conference_and_notify_kwargs(
     which would silently drop an event's existing Meet link on every update that
     doesn't also pass add_google_meet=True.
     """
-    if add_google_meet and _needs_conference_request(event):
-        _add_conference_request(event)
     return {
         "conferenceDataVersion": 1,
         "sendUpdates": "all" if notify_attendees and event.get("attendees") else "none",
     }
 
 
-def _event_response(event: dict[str, Any]) -> dict[str, Any]:
-    response = {"status": "success", "event": event}
+def _error_message(exc: Exception, add_google_meet: bool) -> str:
+    """Append an actionable hint when a request that asked for a Google Meet
+    conference fails outright (as opposed to the conference itself merely
+    failing to provision -- see _needs_conference_request/conference_status
+    for that path). If the account/domain can't create Meet conferences at
+    all, Google can reject the whole insert()/update() call, taking the
+    entire event create/update down with it; that's indistinguishable here
+    from any other request-level failure, so at least point the caller at
+    the one thing in this request that's most likely to be the cause.
+    """
+    message = str(exc)
+    if add_google_meet:
+        message += (
+            " (this request included a Google Meet conference request; if this"
+            " Google account/domain cannot create Meet conferences, retry with"
+            " add_google_meet=False)"
+        )
+    return message
+
+
+def _event_response(event: dict[str, Any]) -> str:
     conference_data = event.get("conferenceData") or {}
 
     hangout_link = event.get("hangoutLink")
@@ -194,16 +220,28 @@ def _event_response(event: dict[str, Any]) -> dict[str, Any]:
                     hangout_link = entry_point["uri"]
                     break
 
+    extra: dict[str, Any] = {}
     if hangout_link:
-        response["hangout_link"] = hangout_link
+        extra["hangout_link"] = hangout_link
     else:
         create_request = conference_data.get("createRequest") or {}
         status_code = (create_request.get("status") or {}).get("statusCode")
         if status_code:
             # Meet link creation is asynchronous; surface the status instead of
-            # implying failure when hangoutLink isn't populated yet.
-            response["conference_status"] = status_code
-    return response
+            # implying failure when hangoutLink isn't populated yet. A status
+            # other than "pending" (e.g. "failure") won't resolve on its own --
+            # call create/update again with add_google_meet=True to retry,
+            # rather than polling google_calendar_get_event for it to change.
+            extra["conference_status"] = status_code
+
+    # The event itself (description, attendees, recurrence rules, ...) can be
+    # large enough to blow past the platform's output-length budget; cap it
+    # the same way the rest of this package caps large single-record
+    # responses, then splice the convenience fields back in afterwards so
+    # capping never has to reason about them.
+    response = json.loads(success_with_capped_dict("event", event))
+    response.update(extra)
+    return json.dumps(response)
 
 
 @mcp.tool()
@@ -226,7 +264,11 @@ def google_calendar_create_events(
     Set add_google_meet=True to attach a real Google Meet video-conference link to the event. The
     link is returned as hangout_link once Google finishes provisioning it; if it isn't ready yet the
     response includes conference_status instead (e.g. "pending") — call google_calendar_get_event
-    shortly after to fetch the link. A plain "Google Meet" string in location does not create a link.
+    shortly after to fetch the link. A conference_status other than "pending" (e.g. "failure") won't
+    resolve on its own; call this tool again with add_google_meet=True to retry, rather than polling
+    google_calendar_get_event for it to change. A plain "Google Meet" string in location does not
+    create a link, and if the account/domain can't create Meet conferences at all, this whole call
+    can fail outright rather than just skipping the link.
     """
     try:
         service = get_calendar_service()
@@ -246,21 +288,21 @@ def google_calendar_create_events(
         if location:
             event["location"] = location
         _merge_attendees(event, attendees)
+        _apply_conference_request(event, add_google_meet)
 
-        request_kwargs = _conference_and_notify_kwargs(
-            event, notify_attendees, add_google_meet
-        )
         request = service.events().insert(
             calendarId="primary",
             body=event,
-            **request_kwargs,
+            **_api_call_kwargs(event, notify_attendees),
         )
         created_event = request.execute()
-        return json.dumps(_event_response(created_event))
+        return _event_response(created_event)
 
     except Exception as e:
         logger.error(f"Error creating event: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps(
+            {"status": "error", "message": _error_message(e, add_google_meet)}
+        )
 
 
 @mcp.tool()
@@ -274,7 +316,7 @@ def google_calendar_get_event(event_id: str) -> str:
     try:
         service = get_calendar_service()
         event = service.events().get(calendarId="primary", eventId=event_id).execute()
-        return json.dumps(_event_response(event))
+        return _event_response(event)
     except Exception as e:
         logger.error(f"Error getting event: {e}")
         return json.dumps({"status": "error", "message": str(e)})
@@ -296,14 +338,21 @@ def google_calendar_update_events(
     Update an existing event in Google Calendar.
     start_time and end_time must be RFC3339 formatted if provided.
     attendees is a list of email addresses to add to the event; attendees already on the event are
-    kept. Adding attendees does not, by itself, email anyone; set notify_attendees=True to have
-    Google Calendar send a native invite/update immediately to every attendee on the event (existing
-    and newly added). Confirm the recipient list with the user before setting notify_attendees=True.
+    kept, and there is no way to remove an attendee through this parameter. Adding attendees does
+    not, by itself, email anyone; set notify_attendees=True to have Google Calendar send a native
+    invite/update immediately to every attendee on the event (existing and newly added). Confirm the
+    recipient list with the user before setting notify_attendees=True.
     Set add_google_meet=True to attach a real Google Meet video-conference link to the event if it
-    doesn't already have a conference (an existing conference is left untouched). The link is
-    returned as hangout_link once Google finishes provisioning it; if it isn't ready yet the response
-    includes conference_status instead (e.g. "pending") — call google_calendar_get_event shortly
-    after to fetch the link. A plain "Google Meet" string in location does not create a link.
+    doesn't already have a conference (an existing conference is left untouched, whether it's a Meet
+    conference or a non-Google one such as Zoom -- in the latter case this is a silent no-op, with no
+    hangout_link/conference_status in the response, since the event already has a conference). The
+    link is returned as hangout_link once Google finishes provisioning it; if it isn't ready yet the
+    response includes conference_status instead (e.g. "pending") — call google_calendar_get_event
+    shortly after to fetch the link. A conference_status other than "pending" (e.g. "failure") won't
+    resolve on its own; call this tool again with add_google_meet=True to retry, rather than polling
+    google_calendar_get_event for it to change. A plain "Google Meet" string in location does not
+    create a link, and if the account/domain can't create Meet conferences at all, this whole call
+    can fail outright rather than just skipping the link.
     """
     try:
         service = get_calendar_service()
@@ -322,22 +371,22 @@ def google_calendar_update_events(
         if location:
             event["location"] = location
         _merge_attendees(event, attendees)
+        _apply_conference_request(event, add_google_meet)
 
-        request_kwargs = _conference_and_notify_kwargs(
-            event, notify_attendees, add_google_meet
-        )
         request = service.events().update(
             calendarId="primary",
             eventId=event_id,
             body=event,
-            **request_kwargs,
+            **_api_call_kwargs(event, notify_attendees),
         )
         updated_event = request.execute()
-        return json.dumps(_event_response(updated_event))
+        return _event_response(updated_event)
 
     except Exception as e:
         logger.error(f"Error updating event: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps(
+            {"status": "error", "message": _error_message(e, add_google_meet)}
+        )
 
 
 @mcp.tool()

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -105,13 +105,15 @@ def google_calendar_create_events(
     description: str | None = None,
     location: str | None = None,
     attendees: list[str] | None = None,
+    notify_attendees: bool = False,
     add_google_meet: bool = False,
 ) -> str:
     """
     Create a new event in Google Calendar.
     start_time and end_time must be RFC3339 formatted (e.g., '2024-01-01T10:00:00Z' or '2024-01-01T10:00:00-07:00').
-    attendees is a list of email addresses to invite; passing any attendees makes Google Calendar
-    email them a native invite immediately, so confirm the recipient list with the user first.
+    attendees is a list of email addresses to add to the event. Adding attendees does not, by
+    itself, email them; set notify_attendees=True to have Google Calendar send them a native
+    invite immediately. Confirm the recipient list with the user before setting notify_attendees=True.
     Set add_google_meet=True to attach a real Google Meet video-conference link to the event
     (the link is returned as hangout_link); a plain "Google Meet" string in location does not do this.
     """
@@ -141,7 +143,7 @@ def google_calendar_create_events(
             calendarId="primary",
             body=event,
             conferenceDataVersion=1 if add_google_meet else 0,
-            sendUpdates="all" if attendees else "none",
+            sendUpdates="all" if (attendees and notify_attendees) else "none",
         )
         created_event = request.execute()
         return json.dumps(_event_response(created_event))
@@ -174,13 +176,15 @@ def google_calendar_update_events(
     description: str | None = None,
     location: str | None = None,
     attendees: list[str] | None = None,
+    notify_attendees: bool = False,
     add_google_meet: bool = False,
 ) -> str:
     """
     Update an existing event in Google Calendar.
     start_time and end_time must be RFC3339 formatted if provided.
-    attendees is a list of email addresses to invite; passing any attendees makes Google Calendar
-    email them a native invite immediately, so confirm the recipient list with the user first.
+    attendees is a list of email addresses to add to the event. Adding attendees does not, by
+    itself, email them; set notify_attendees=True to have Google Calendar send them a native
+    invite immediately. Confirm the recipient list with the user before setting notify_attendees=True.
     Set add_google_meet=True to attach a real Google Meet video-conference link to the event
     (the link is returned as hangout_link); a plain "Google Meet" string in location does not do this.
     """
@@ -210,7 +214,7 @@ def google_calendar_update_events(
             eventId=event_id,
             body=event,
             conferenceDataVersion=1 if add_google_meet else 0,
-            sendUpdates="all" if attendees else "none",
+            sendUpdates="all" if (attendees and notify_attendees) else "none",
         )
         updated_event = request.execute()
         return json.dumps(_event_response(updated_event))

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -95,9 +95,13 @@ def _merge_attendees(event: dict[str, Any], attendees: list[str] | None) -> None
         return
     existing = event.get("attendees") or []
     existing_emails = {a.get("email") for a in existing if isinstance(a, dict)}
-    event["attendees"] = existing + [
-        {"email": email} for email in attendees if email not in existing_emails
-    ]
+    new_attendees = []
+    seen = set()
+    for email in attendees:
+        if email not in existing_emails and email not in seen:
+            new_attendees.append({"email": email})
+            seen.add(email)
+    event["attendees"] = existing + new_attendees
 
 
 def _conference_and_notify_kwargs(
@@ -128,8 +132,9 @@ def _event_response(event: dict[str, Any]) -> dict[str, Any]:
     if hangout_link:
         response["hangout_link"] = hangout_link
     else:
-        create_request = event.get("conferenceData", {}).get("createRequest", {})
-        status_code = create_request.get("status", {}).get("statusCode")
+        conference_data = event.get("conferenceData") or {}
+        create_request = conference_data.get("createRequest") or {}
+        status_code = (create_request.get("status") or {}).get("statusCode")
         if status_code:
             # Meet link creation is asynchronous; surface the status instead of
             # implying failure when hangoutLink isn't populated yet.

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -173,12 +173,21 @@ def _event_response(event: dict[str, Any]) -> dict[str, Any]:
     hangout_link = event.get("hangoutLink")
     if not hangout_link:
         # hangoutLink is a legacy convenience field that's only reliably
-        # populated for Meet conferences; entryPoints is the canonical,
-        # solution-agnostic source, so fall back to it when present.
-        for entry_point in conference_data.get("entryPoints") or []:
-            if entry_point.get("entryPointType") == "video" and entry_point.get("uri"):
-                hangout_link = entry_point["uri"]
-                break
+        # populated for Meet conferences. Only fall back to entryPoints when
+        # the conference actually IS a Meet conference -- entryPoints with
+        # entryPointType "video" is solution-agnostic, so a Zoom/Teams/other
+        # third-party conference would otherwise get mislabeled as a
+        # "hangout_link" (a name callers reasonably read as "this is Meet").
+        solution_type = (
+            (conference_data.get("conferenceSolution") or {}).get("key", {}).get("type")
+        )
+        if solution_type == "hangoutsMeet":
+            for entry_point in conference_data.get("entryPoints") or []:
+                if entry_point.get("entryPointType") == "video" and entry_point.get(
+                    "uri"
+                ):
+                    hangout_link = entry_point["uri"]
+                    break
 
     if hangout_link:
         response["hangout_link"] = hangout_link
@@ -252,12 +261,15 @@ def google_calendar_create_events(
 @mcp.tool()
 def google_calendar_get_event(event_id: str) -> str:
     """
-    Get a specific event from Google Calendar.
+    Get a specific event from Google Calendar. If the event has a Google Meet
+    link, it's returned as hangout_link (or as conference_status if it's
+    still being provisioned) -- this is the tool to call to pick up a link
+    that wasn't ready yet right after create/update.
     """
     try:
         service = get_calendar_service()
         event = service.events().get(calendarId="primary", eventId=event_id).execute()
-        return json.dumps({"status": "success", "event": event})
+        return json.dumps(_event_response(event))
     except Exception as e:
         logger.error(f"Error getting event: {e}")
         return json.dumps({"status": "error", "message": str(e)})

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import uuid
 from typing import Any
 
 from google.oauth2.credentials import Credentials
@@ -79,6 +80,23 @@ def google_calendar_search_events(
         return json.dumps({"status": "error", "message": str(e)})
 
 
+def _add_conference_request(event: dict[str, Any]) -> None:
+    event["conferenceData"] = {
+        "createRequest": {
+            "requestId": uuid.uuid4().hex,
+            "conferenceSolutionKey": {"type": "hangoutsMeet"},
+        }
+    }
+
+
+def _event_response(event: dict[str, Any]) -> dict[str, Any]:
+    response = {"status": "success", "event": event}
+    hangout_link = event.get("hangoutLink")
+    if hangout_link:
+        response["hangout_link"] = hangout_link
+    return response
+
+
 @mcp.tool()
 def google_calendar_create_events(
     summary: str,
@@ -86,15 +104,21 @@ def google_calendar_create_events(
     end_time: str,
     description: str | None = None,
     location: str | None = None,
+    attendees: list[str] | None = None,
+    add_google_meet: bool = False,
 ) -> str:
     """
     Create a new event in Google Calendar.
     start_time and end_time must be RFC3339 formatted (e.g., '2024-01-01T10:00:00Z' or '2024-01-01T10:00:00-07:00').
+    attendees is a list of email addresses to invite; passing any attendees makes Google Calendar
+    email them a native invite immediately, so confirm the recipient list with the user first.
+    Set add_google_meet=True to attach a real Google Meet video-conference link to the event
+    (the link is returned as hangout_link); a plain "Google Meet" string in location does not do this.
     """
     try:
         service = get_calendar_service()
 
-        event = {
+        event: dict[str, Any] = {
             "summary": summary,
             "start": {
                 "dateTime": start_time,
@@ -108,11 +132,19 @@ def google_calendar_create_events(
             event["description"] = description
         if location:
             event["location"] = location
+        if attendees:
+            event["attendees"] = [{"email": email} for email in attendees]
+        if add_google_meet:
+            _add_conference_request(event)
 
-        created_event = (
-            service.events().insert(calendarId="primary", body=event).execute()
+        request = service.events().insert(
+            calendarId="primary",
+            body=event,
+            conferenceDataVersion=1 if add_google_meet else 0,
+            sendUpdates="all" if attendees else "none",
         )
-        return json.dumps({"status": "success", "event": created_event})
+        created_event = request.execute()
+        return json.dumps(_event_response(created_event))
 
     except Exception as e:
         logger.error(f"Error creating event: {e}")
@@ -141,10 +173,16 @@ def google_calendar_update_events(
     end_time: str | None = None,
     description: str | None = None,
     location: str | None = None,
+    attendees: list[str] | None = None,
+    add_google_meet: bool = False,
 ) -> str:
     """
     Update an existing event in Google Calendar.
     start_time and end_time must be RFC3339 formatted if provided.
+    attendees is a list of email addresses to invite; passing any attendees makes Google Calendar
+    email them a native invite immediately, so confirm the recipient list with the user first.
+    Set add_google_meet=True to attach a real Google Meet video-conference link to the event
+    (the link is returned as hangout_link); a plain "Google Meet" string in location does not do this.
     """
     try:
         service = get_calendar_service()
@@ -162,13 +200,20 @@ def google_calendar_update_events(
             event["description"] = description
         if location:
             event["location"] = location
+        if attendees:
+            event["attendees"] = [{"email": email} for email in attendees]
+        if add_google_meet:
+            _add_conference_request(event)
 
-        updated_event = (
-            service.events()
-            .update(calendarId="primary", eventId=event_id, body=event)
-            .execute()
+        request = service.events().update(
+            calendarId="primary",
+            eventId=event_id,
+            body=event,
+            conferenceDataVersion=1 if add_google_meet else 0,
+            sendUpdates="all" if attendees else "none",
         )
-        return json.dumps({"status": "success", "event": updated_event})
+        updated_event = request.execute()
+        return json.dumps(_event_response(updated_event))
 
     except Exception as e:
         logger.error(f"Error updating event: {e}")

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -95,13 +95,14 @@ def _merge_attendees(event: dict[str, Any], attendees: list[str] | None) -> None
         return
     existing = event.get("attendees") or []
     existing_emails = {a.get("email") for a in existing if isinstance(a, dict)}
-    new_attendees = []
-    seen = set()
-    for email in attendees:
-        if email not in existing_emails and email not in seen:
-            new_attendees.append({"email": email})
-            seen.add(email)
-    event["attendees"] = existing + new_attendees
+
+    # dict.fromkeys dedupes attendees while preserving order (Python 3.7+).
+    unique_new_emails = dict.fromkeys(attendees)
+    new_attendees = [
+        {"email": email} for email in unique_new_emails if email not in existing_emails
+    ]
+    if new_attendees:
+        event["attendees"] = existing + new_attendees
 
 
 def _conference_and_notify_kwargs(
@@ -120,9 +121,7 @@ def _conference_and_notify_kwargs(
         _add_conference_request(event)
     return {
         "conferenceDataVersion": 1,
-        "sendUpdates": "all"
-        if (event.get("attendees") and notify_attendees)
-        else "none",
+        "sendUpdates": "all" if notify_attendees and event.get("attendees") else "none",
     }
 
 

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -151,15 +151,24 @@ def _needs_conference_request(event: dict[str, Any]) -> bool:
     return status_code == "failure"
 
 
-def _apply_conference_request(event: dict[str, Any], add_google_meet: bool) -> None:
+def _apply_conference_request(event: dict[str, Any], add_google_meet: bool) -> bool:
     """Mutates event in place: attaches a fresh Meet createRequest when
     add_google_meet=True and _needs_conference_request(event) says one isn't
     already in flight or resolved. A no-op (no error, no signal in the
     response) if the event already has a *non*-Meet conference (e.g. Zoom) --
     see the add_google_meet docstring on the public tools.
+
+    Returns whether a createRequest was actually added to `event` this call
+    -- the caller's raw add_google_meet argument isn't enough on its own to
+    tell whether this specific request's body ended up carrying one (it may
+    have been a no-op), which matters for _error_message: blaming a Meet
+    conference request for a failure is only accurate when this call's body
+    actually contained one.
     """
     if add_google_meet and _needs_conference_request(event):
         _add_conference_request(event)
+        return True
+    return False
 
 
 def _api_call_kwargs(event: dict[str, Any], notify_attendees: bool) -> dict[str, Any]:
@@ -178,18 +187,28 @@ def _api_call_kwargs(event: dict[str, Any], notify_attendees: bool) -> dict[str,
     }
 
 
-def _error_message(exc: Exception, add_google_meet: bool) -> str:
-    """Append an actionable hint when a request that asked for a Google Meet
-    conference fails outright (as opposed to the conference itself merely
-    failing to provision -- see _needs_conference_request/conference_status
-    for that path). If the account/domain can't create Meet conferences at
-    all, Google can reject the whole insert()/update() call, taking the
-    entire event create/update down with it; that's indistinguishable here
-    from any other request-level failure, so at least point the caller at
-    the one thing in this request that's most likely to be the cause.
+def _error_message(exc: Exception, requested_conference: bool) -> str:
+    """Append an actionable hint when a request whose body actually included
+    a Google Meet createRequest fails outright (as opposed to the conference
+    itself merely failing to provision -- see
+    _needs_conference_request/conference_status for that path). If the
+    account/domain can't create Meet conferences at all, Google can reject
+    the whole insert()/update() call, taking the entire event create/update
+    down with it; that's indistinguishable here from any other request-level
+    failure, so at least point the caller at the one thing in this request
+    that's most likely to be the cause.
+
+    requested_conference must be whether THIS call's body actually carried a
+    createRequest (_apply_conference_request's return value), not the raw
+    add_google_meet argument: add_google_meet=True is a no-op whenever the
+    event already has a conference, and a failure can also happen before
+    _apply_conference_request ever runs (auth setup, or update()'s
+    preliminary event fetch) -- in both cases blaming a Meet conference
+    request that was never actually part of this call would misdirect the
+    caller at an unrelated failure's real cause.
     """
     message = str(exc)
-    if add_google_meet:
+    if requested_conference:
         message += (
             " (this request included a Google Meet conference request; if this"
             " Google account/domain cannot create Meet conferences, retry with"
@@ -270,6 +289,7 @@ def google_calendar_create_events(
     create a link, and if the account/domain can't create Meet conferences at all, this whole call
     can fail outright rather than just skipping the link.
     """
+    requested_conference = False
     try:
         service = get_calendar_service()
 
@@ -288,7 +308,7 @@ def google_calendar_create_events(
         if location:
             event["location"] = location
         _merge_attendees(event, attendees)
-        _apply_conference_request(event, add_google_meet)
+        requested_conference = _apply_conference_request(event, add_google_meet)
 
         request = service.events().insert(
             calendarId="primary",
@@ -301,7 +321,7 @@ def google_calendar_create_events(
     except Exception as e:
         logger.error(f"Error creating event: {e}")
         return json.dumps(
-            {"status": "error", "message": _error_message(e, add_google_meet)}
+            {"status": "error", "message": _error_message(e, requested_conference)}
         )
 
 
@@ -354,6 +374,7 @@ def google_calendar_update_events(
     create a link, and if the account/domain can't create Meet conferences at all, this whole call
     can fail outright rather than just skipping the link.
     """
+    requested_conference = False
     try:
         service = get_calendar_service()
 
@@ -371,7 +392,7 @@ def google_calendar_update_events(
         if location:
             event["location"] = location
         _merge_attendees(event, attendees)
-        _apply_conference_request(event, add_google_meet)
+        requested_conference = _apply_conference_request(event, add_google_meet)
 
         request = service.events().update(
             calendarId="primary",
@@ -385,7 +406,7 @@ def google_calendar_update_events(
     except Exception as e:
         logger.error(f"Error updating event: {e}")
         return json.dumps(
-            {"status": "error", "message": _error_message(e, add_google_meet)}
+            {"status": "error", "message": _error_message(e, requested_conference)}
         )
 
 

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -89,11 +89,51 @@ def _add_conference_request(event: dict[str, Any]) -> None:
     }
 
 
+def _merge_attendees(event: dict[str, Any], attendees: list[str] | None) -> None:
+    """Add attendees to the event without dropping ones already on it."""
+    if not attendees:
+        return
+    existing = event.get("attendees") or []
+    existing_emails = {a.get("email") for a in existing if isinstance(a, dict)}
+    event["attendees"] = existing + [
+        {"email": email} for email in attendees if email not in existing_emails
+    ]
+
+
+def _conference_and_notify_kwargs(
+    event: dict[str, Any], notify_attendees: bool, add_google_meet: bool
+) -> dict[str, Any]:
+    """Apply add_google_meet to event in place, and build the insert()/update() kwargs.
+
+    conferenceDataVersion is always sent as 1: it only declares that the caller
+    understands conference data, it does not request or remove a conference by
+    itself (that's driven by whether `body` carries a createRequest). Omitting it
+    (or sending 0) makes Google ignore any conferenceData already in the body,
+    which would silently drop an event's existing Meet link on every update that
+    doesn't also pass add_google_meet=True.
+    """
+    if add_google_meet and not event.get("conferenceData"):
+        _add_conference_request(event)
+    return {
+        "conferenceDataVersion": 1,
+        "sendUpdates": "all"
+        if (event.get("attendees") and notify_attendees)
+        else "none",
+    }
+
+
 def _event_response(event: dict[str, Any]) -> dict[str, Any]:
     response = {"status": "success", "event": event}
     hangout_link = event.get("hangoutLink")
     if hangout_link:
         response["hangout_link"] = hangout_link
+    else:
+        create_request = event.get("conferenceData", {}).get("createRequest", {})
+        status_code = create_request.get("status", {}).get("statusCode")
+        if status_code:
+            # Meet link creation is asynchronous; surface the status instead of
+            # implying failure when hangoutLink isn't populated yet.
+            response["conference_status"] = status_code
     return response
 
 
@@ -114,8 +154,10 @@ def google_calendar_create_events(
     attendees is a list of email addresses to add to the event. Adding attendees does not, by
     itself, email them; set notify_attendees=True to have Google Calendar send them a native
     invite immediately. Confirm the recipient list with the user before setting notify_attendees=True.
-    Set add_google_meet=True to attach a real Google Meet video-conference link to the event
-    (the link is returned as hangout_link); a plain "Google Meet" string in location does not do this.
+    Set add_google_meet=True to attach a real Google Meet video-conference link to the event. The
+    link is returned as hangout_link once Google finishes provisioning it; if it isn't ready yet the
+    response includes conference_status instead (e.g. "pending") — call google_calendar_get_event
+    shortly after to fetch the link. A plain "Google Meet" string in location does not create a link.
     """
     try:
         service = get_calendar_service()
@@ -134,16 +176,15 @@ def google_calendar_create_events(
             event["description"] = description
         if location:
             event["location"] = location
-        if attendees:
-            event["attendees"] = [{"email": email} for email in attendees]
-        if add_google_meet:
-            _add_conference_request(event)
+        _merge_attendees(event, attendees)
 
+        request_kwargs = _conference_and_notify_kwargs(
+            event, notify_attendees, add_google_meet
+        )
         request = service.events().insert(
             calendarId="primary",
             body=event,
-            conferenceDataVersion=1 if add_google_meet else 0,
-            sendUpdates="all" if (attendees and notify_attendees) else "none",
+            **request_kwargs,
         )
         created_event = request.execute()
         return json.dumps(_event_response(created_event))
@@ -182,11 +223,15 @@ def google_calendar_update_events(
     """
     Update an existing event in Google Calendar.
     start_time and end_time must be RFC3339 formatted if provided.
-    attendees is a list of email addresses to add to the event. Adding attendees does not, by
-    itself, email them; set notify_attendees=True to have Google Calendar send them a native
-    invite immediately. Confirm the recipient list with the user before setting notify_attendees=True.
-    Set add_google_meet=True to attach a real Google Meet video-conference link to the event
-    (the link is returned as hangout_link); a plain "Google Meet" string in location does not do this.
+    attendees is a list of email addresses to add to the event; attendees already on the event are
+    kept. Adding attendees does not, by itself, email anyone; set notify_attendees=True to have
+    Google Calendar send a native invite/update immediately to every attendee on the event (existing
+    and newly added). Confirm the recipient list with the user before setting notify_attendees=True.
+    Set add_google_meet=True to attach a real Google Meet video-conference link to the event if it
+    doesn't already have a conference (an existing conference is left untouched). The link is
+    returned as hangout_link once Google finishes provisioning it; if it isn't ready yet the response
+    includes conference_status instead (e.g. "pending") — call google_calendar_get_event shortly
+    after to fetch the link. A plain "Google Meet" string in location does not create a link.
     """
     try:
         service = get_calendar_service()
@@ -204,17 +249,16 @@ def google_calendar_update_events(
             event["description"] = description
         if location:
             event["location"] = location
-        if attendees:
-            event["attendees"] = [{"email": email} for email in attendees]
-        if add_google_meet:
-            _add_conference_request(event)
+        _merge_attendees(event, attendees)
 
+        request_kwargs = _conference_and_notify_kwargs(
+            event, notify_attendees, add_google_meet
+        )
         request = service.events().update(
             calendarId="primary",
             eventId=event_id,
             body=event,
-            conferenceDataVersion=1 if add_google_meet else 0,
-            sendUpdates="all" if (attendees and notify_attendees) else "none",
+            **request_kwargs,
         )
         updated_event = request.execute()
         return json.dumps(_event_response(updated_event))

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -124,31 +124,46 @@ def _merge_attendees(event: dict[str, Any], attendees: list[str] | None) -> None
         event["attendees"] = existing + new_attendees
 
 
+def _create_request_status_code(conference_data: dict[str, Any]) -> str | None:
+    """Safely read conferenceData.createRequest.status.statusCode, or None
+    if any part of that path is absent or explicitly null.
+
+    Shared by _needs_conference_request (decides whether to retry) and
+    _event_response (decides what to tell the caller): this exact chain has
+    already needed two separate null-safety fixes (a missing conferenceData,
+    then a missing conferenceSolution.key -- an unrelated field, but caught
+    by the same class of review), each landing in only one of the two
+    call sites at a time because the logic lived in two places. Keeping one
+    copy means a future defensive-parsing fix only has to land once.
+    """
+    create_request = conference_data.get("createRequest") or {}
+    return (create_request.get("status") or {}).get("statusCode")
+
+
 def _needs_conference_request(event: dict[str, Any]) -> bool:
     """True if add_google_meet should (re)send a createRequest.
 
-    The only signal this reads is createRequest.status.statusCode: it
-    returns True when the event has no conferenceData at all, or when the
-    only conferenceData present is a createRequest whose status.statusCode
-    is "failure". Everything else returns False, so it's left untouched:
-    a still-*pending* createRequest (status.statusCode == "pending" --
-    which, like a failed one, has no entryPoints/conferenceSolution yet,
-    so those fields can't be used to tell "safe to retry" apart from "do
-    not clobber the in-flight request"); an already-resolved conference
-    (its createRequest, if it went through one at all, carries
-    status.statusCode == "success", or there's no createRequest key at all
-    for a conference attached some other way -- e.g. a Zoom add-on);
-    a legacy event carrying `hangoutLink` with no `conferenceData` at all
-    (predates the conferenceData API).
+    Checks two signals, in order. First, a legacy `hangoutLink` with no
+    `conferenceData` at all (predates the conferenceData API) counts as
+    already resolved -- False, so it isn't clobbered by a duplicate
+    conference. Otherwise: True when the event has no conferenceData at
+    all, or when the only conferenceData present is a createRequest whose
+    status.statusCode is "failure". Everything else returns False, so it's
+    left untouched: a still-*pending* createRequest (status.statusCode ==
+    "pending" -- which, like a failed one, has no entryPoints/
+    conferenceSolution yet, so those fields alone can't be used to tell
+    "safe to retry" apart from "do not clobber the in-flight request"); an
+    already-resolved conference (its createRequest, if it went through one
+    at all, carries status.statusCode == "success", or there's no
+    createRequest key at all for a conference attached some other way --
+    e.g. a Zoom add-on).
     """
     if event.get("hangoutLink"):
         return False
     conference_data = event.get("conferenceData") or {}
     if not conference_data:
         return True
-    create_request = conference_data.get("createRequest") or {}
-    status_code = (create_request.get("status") or {}).get("statusCode")
-    return status_code == "failure"
+    return _create_request_status_code(conference_data) == "failure"
 
 
 def _apply_conference_request(event: dict[str, Any], add_google_meet: bool) -> bool:
@@ -243,8 +258,7 @@ def _event_response(event: dict[str, Any]) -> str:
     if hangout_link:
         extra["hangout_link"] = hangout_link
     else:
-        create_request = conference_data.get("createRequest") or {}
-        status_code = (create_request.get("status") or {}).get("statusCode")
+        status_code = _create_request_status_code(conference_data)
         if status_code:
             # Meet link creation is asynchronous; surface the status instead of
             # implying failure when hangoutLink isn't populated yet. A status

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -136,8 +136,13 @@ def _needs_conference_request(event: dict[str, Any]) -> bool:
     request". Read status.statusCode directly instead (the same field
     _event_response already reads for the opposite purpose). A conference
     that has already resolved (has entryPoints or a conferenceSolution --
-    Meet or otherwise) also returns False, so it isn't clobbered either.
+    Meet or otherwise) also returns False, so it isn't clobbered either. A
+    legacy event carrying `hangoutLink` with no `conferenceData` at all (pre-
+    dates the conferenceData API) is also treated as already resolved, or
+    add_google_meet=True would request a second, duplicate conference for it.
     """
+    if event.get("hangoutLink"):
+        return False
     conference_data = event.get("conferenceData") or {}
     if not conference_data:
         return True
@@ -179,8 +184,8 @@ def _event_response(event: dict[str, Any]) -> dict[str, Any]:
         # third-party conference would otherwise get mislabeled as a
         # "hangout_link" (a name callers reasonably read as "this is Meet").
         solution_type = (
-            (conference_data.get("conferenceSolution") or {}).get("key", {}).get("type")
-        )
+            (conference_data.get("conferenceSolution") or {}).get("key") or {}
+        ).get("type")
         if solution_type == "hangoutsMeet":
             for entry_point in conference_data.get("entryPoints") or []:
                 if entry_point.get("entryPointType") == "video" and entry_point.get(

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -90,19 +90,48 @@ def _add_conference_request(event: dict[str, Any]) -> None:
 
 
 def _merge_attendees(event: dict[str, Any], attendees: list[str] | None) -> None:
-    """Add attendees to the event without dropping ones already on it."""
+    """Add attendees to the event without dropping ones already on it.
+
+    Matching against existing attendees (and within the new list) is
+    case-/whitespace-insensitive, since `Alice@Example.com` and
+    `alice@example.com` are the same mailbox and would otherwise be added
+    as a redundant duplicate.
+    """
     if not attendees:
         return
     existing = event.get("attendees") or []
-    existing_emails = {a.get("email") for a in existing if isinstance(a, dict)}
+    existing_emails = {
+        email.strip().lower()
+        for a in existing
+        if isinstance(a, dict) and (email := a.get("email"))
+    }
 
-    # dict.fromkeys dedupes attendees while preserving order (Python 3.7+).
-    unique_new_emails = dict.fromkeys(attendees)
-    new_attendees = [
-        {"email": email} for email in unique_new_emails if email not in existing_emails
-    ]
+    seen = set()
+    new_attendees = []
+    for email in attendees:
+        if not email:
+            continue
+        normalized = email.strip()
+        key = normalized.lower()
+        if key in existing_emails or key in seen:
+            continue
+        seen.add(key)
+        new_attendees.append({"email": normalized})
+
     if new_attendees:
         event["attendees"] = existing + new_attendees
+
+
+def _has_resolved_conference(event: dict[str, Any]) -> bool:
+    """True if the event has a conference Google actually created (it has
+    entry points or a resolved conference solution) -- as opposed to
+    conferenceData left over from a *failed* createRequest (status.statusCode
+    == "failure"), which has neither and must not block a retry.
+    """
+    conference_data = event.get("conferenceData") or {}
+    return bool(
+        conference_data.get("entryPoints") or conference_data.get("conferenceSolution")
+    )
 
 
 def _conference_and_notify_kwargs(
@@ -117,7 +146,7 @@ def _conference_and_notify_kwargs(
     which would silently drop an event's existing Meet link on every update that
     doesn't also pass add_google_meet=True.
     """
-    if add_google_meet and not event.get("conferenceData"):
+    if add_google_meet and not _has_resolved_conference(event):
         _add_conference_request(event)
     return {
         "conferenceDataVersion": 1,
@@ -127,11 +156,21 @@ def _conference_and_notify_kwargs(
 
 def _event_response(event: dict[str, Any]) -> dict[str, Any]:
     response = {"status": "success", "event": event}
+    conference_data = event.get("conferenceData") or {}
+
     hangout_link = event.get("hangoutLink")
+    if not hangout_link:
+        # hangoutLink is a legacy convenience field that's only reliably
+        # populated for Meet conferences; entryPoints is the canonical,
+        # solution-agnostic source, so fall back to it when present.
+        for entry_point in conference_data.get("entryPoints") or []:
+            if entry_point.get("entryPointType") == "video" and entry_point.get("uri"):
+                hangout_link = entry_point["uri"]
+                break
+
     if hangout_link:
         response["hangout_link"] = hangout_link
     else:
-        conference_data = event.get("conferenceData") or {}
         create_request = conference_data.get("createRequest") or {}
         status_code = (create_request.get("status") or {}).get("statusCode")
         if status_code:

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -112,6 +112,8 @@ def _merge_attendees(event: dict[str, Any], attendees: list[str] | None) -> None
         if not email:
             continue
         normalized = email.strip()
+        if not normalized:
+            continue
         key = normalized.lower()
         if key in existing_emails or key in seen:
             continue
@@ -122,16 +124,26 @@ def _merge_attendees(event: dict[str, Any], attendees: list[str] | None) -> None
         event["attendees"] = existing + new_attendees
 
 
-def _has_resolved_conference(event: dict[str, Any]) -> bool:
-    """True if the event has a conference Google actually created (it has
-    entry points or a resolved conference solution) -- as opposed to
-    conferenceData left over from a *failed* createRequest (status.statusCode
-    == "failure"), which has neither and must not block a retry.
+def _needs_conference_request(event: dict[str, Any]) -> bool:
+    """True if add_google_meet should (re)send a createRequest: the event has
+    no conferenceData yet, or its only conferenceData is a *failed*
+    createRequest (status.statusCode == "failure").
+
+    A conference that's still *pending* must not be treated the same as a
+    failed one -- both lack entryPoints/conferenceSolution while Google is
+    still provisioning them, so checking for those fields can't tell "failed,
+    safe to retry" apart from "pending, do not clobber the in-flight
+    request". Read status.statusCode directly instead (the same field
+    _event_response already reads for the opposite purpose). A conference
+    that has already resolved (has entryPoints or a conferenceSolution --
+    Meet or otherwise) also returns False, so it isn't clobbered either.
     """
     conference_data = event.get("conferenceData") or {}
-    return bool(
-        conference_data.get("entryPoints") or conference_data.get("conferenceSolution")
-    )
+    if not conference_data:
+        return True
+    create_request = conference_data.get("createRequest") or {}
+    status_code = (create_request.get("status") or {}).get("statusCode")
+    return status_code == "failure"
 
 
 def _conference_and_notify_kwargs(
@@ -146,7 +158,7 @@ def _conference_and_notify_kwargs(
     which would silently drop an event's existing Meet link on every update that
     doesn't also pass add_google_meet=True.
     """
-    if add_google_meet and not _has_resolved_conference(event):
+    if add_google_meet and _needs_conference_request(event):
         _add_conference_request(event)
     return {
         "conferenceDataVersion": 1,

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -51,7 +51,7 @@ def test_create_event_without_attendees_or_meet_omits_conference_and_invites(
     assert kwargs["sendUpdates"] == "none"
 
 
-def test_create_event_with_attendees_and_meet_requests_conference_and_invites(
+def test_create_event_with_attendees_but_no_notify_does_not_send_invites(
     monkeypatch,
 ):
     execute_result = {
@@ -81,10 +81,46 @@ def test_create_event_with_attendees_and_meet_requests_conference_and_invites(
         "type": "hangoutsMeet"
     }
     assert kwargs["conferenceDataVersion"] == 1
+    # Attendees are recorded on the event, but nobody is emailed unless
+    # notify_attendees is explicitly set.
+    assert kwargs["sendUpdates"] == "none"
+
+
+def test_create_event_with_attendees_and_notify_sends_invites(monkeypatch):
+    service = _fake_service({"id": "evt1"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_create_events(
+        summary="1:1",
+        start_time="2026-09-07T15:00:00+08:00",
+        end_time="2026-09-07T16:00:00+08:00",
+        attendees=["someone@example.com"],
+        notify_attendees=True,
+    )
+
+    _, kwargs = service.events.return_value.insert.call_args
+    assert kwargs["body"]["attendees"] == [{"email": "someone@example.com"}]
     assert kwargs["sendUpdates"] == "all"
 
 
-def test_update_event_with_attendees_and_meet_requests_conference_and_invites(
+def test_create_event_notify_attendees_without_attendees_does_not_send_invites(
+    monkeypatch,
+):
+    service = _fake_service({"id": "evt1"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_create_events(
+        summary="1:1",
+        start_time="2026-09-07T15:00:00+08:00",
+        end_time="2026-09-07T16:00:00+08:00",
+        notify_attendees=True,
+    )
+
+    _, kwargs = service.events.return_value.insert.call_args
+    assert kwargs["sendUpdates"] == "none"
+
+
+def test_update_event_with_attendees_but_no_notify_does_not_send_invites(
     monkeypatch,
 ):
     execute_result = {
@@ -112,6 +148,21 @@ def test_update_event_with_attendees_and_meet_requests_conference_and_invites(
         "type": "hangoutsMeet"
     }
     assert kwargs["conferenceDataVersion"] == 1
+    assert kwargs["sendUpdates"] == "none"
+
+
+def test_update_event_with_attendees_and_notify_sends_invites(monkeypatch):
+    service = _fake_service({"id": "evt1"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_update_events(
+        event_id="evt1",
+        attendees=["someone@example.com"],
+        notify_attendees=True,
+    )
+
+    _, kwargs = service.events.return_value.update.call_args
+    assert kwargs["body"]["attendees"] == [{"email": "someone@example.com"}]
     assert kwargs["sendUpdates"] == "all"
 
 

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1,0 +1,135 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from xagent.web.tools.mcp import calendar
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("GOOGLE_ACCESS_TOKEN", "access-token")
+
+
+def _fake_service(execute_result: dict):
+    """A stand-in for the googleapiclient Calendar service that records the
+    kwargs passed to events().insert()/update() and returns execute_result."""
+    events = Mock()
+    request = Mock()
+    request.execute.return_value = execute_result
+    events.insert = Mock(return_value=request)
+    events.update = Mock(return_value=request)
+    events.get = Mock(return_value=Mock(execute=Mock(return_value={"id": "evt1"})))
+    service = Mock()
+    service.events.return_value = events
+    return service
+
+
+def test_create_event_without_attendees_or_meet_omits_conference_and_invites(
+    monkeypatch,
+):
+    service = _fake_service({"id": "evt1"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="1:1",
+            start_time="2026-09-07T15:00:00+08:00",
+            end_time="2026-09-07T16:00:00+08:00",
+            location="Google Meet",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert "hangout_link" not in result
+
+    _, kwargs = service.events.return_value.insert.call_args
+    assert "attendees" not in kwargs["body"]
+    assert "conferenceData" not in kwargs["body"]
+    assert kwargs["body"]["location"] == "Google Meet"
+    assert kwargs["conferenceDataVersion"] == 0
+    assert kwargs["sendUpdates"] == "none"
+
+
+def test_create_event_with_attendees_and_meet_requests_conference_and_invites(
+    monkeypatch,
+):
+    execute_result = {
+        "id": "evt1",
+        "hangoutLink": "https://meet.google.com/abc-defg-hij",
+    }
+    service = _fake_service(execute_result)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="1:1",
+            start_time="2026-09-07T15:00:00+08:00",
+            end_time="2026-09-07T16:00:00+08:00",
+            attendees=["someone@example.com"],
+            add_google_meet=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["hangout_link"] == "https://meet.google.com/abc-defg-hij"
+
+    _, kwargs = service.events.return_value.insert.call_args
+    body = kwargs["body"]
+    assert body["attendees"] == [{"email": "someone@example.com"}]
+    assert body["conferenceData"]["createRequest"]["conferenceSolutionKey"] == {
+        "type": "hangoutsMeet"
+    }
+    assert kwargs["conferenceDataVersion"] == 1
+    assert kwargs["sendUpdates"] == "all"
+
+
+def test_update_event_with_attendees_and_meet_requests_conference_and_invites(
+    monkeypatch,
+):
+    execute_result = {
+        "id": "evt1",
+        "hangoutLink": "https://meet.google.com/abc-defg-hij",
+    }
+    service = _fake_service(execute_result)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="evt1",
+            attendees=["someone@example.com"],
+            add_google_meet=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["hangout_link"] == "https://meet.google.com/abc-defg-hij"
+
+    _, kwargs = service.events.return_value.update.call_args
+    body = kwargs["body"]
+    assert body["attendees"] == [{"email": "someone@example.com"}]
+    assert body["conferenceData"]["createRequest"]["conferenceSolutionKey"] == {
+        "type": "hangoutsMeet"
+    }
+    assert kwargs["conferenceDataVersion"] == 1
+    assert kwargs["sendUpdates"] == "all"
+
+
+def test_update_event_without_attendees_or_meet_omits_conference_and_invites(
+    monkeypatch,
+):
+    service = _fake_service({"id": "evt1"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_update_events(event_id="evt1", summary="New title")
+    )
+
+    assert result["status"] == "success"
+    assert "hangout_link" not in result
+
+    _, kwargs = service.events.return_value.update.call_args
+    assert "attendees" not in kwargs["body"]
+    assert "conferenceData" not in kwargs["body"]
+    assert kwargs["conferenceDataVersion"] == 0
+    assert kwargs["sendUpdates"] == "none"

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -233,6 +233,19 @@ def test_update_event_dedupes_repeated_emails_in_the_same_attendees_call(monkeyp
     assert kwargs["body"]["attendees"] == [{"email": "bob@example.com"}]
 
 
+def test_update_event_ignores_a_whitespace_only_attendee_entry(monkeypatch):
+    service = _fake_service({"id": "evt1"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_update_events(
+        event_id="evt1",
+        attendees=["   ", "bob@example.com"],
+    )
+
+    _, kwargs = service.events.return_value.update.call_args
+    assert kwargs["body"]["attendees"] == [{"email": "bob@example.com"}]
+
+
 def test_update_event_attendee_matching_is_case_and_whitespace_insensitive(
     monkeypatch,
 ):
@@ -380,6 +393,33 @@ def test_update_event_add_google_meet_retries_after_a_failed_create_request(
     new_create_request = kwargs["body"]["conferenceData"]["createRequest"]
     assert new_create_request["requestId"] != "abc123"
     assert new_create_request["conferenceSolutionKey"] == {"type": "hangoutsMeet"}
+
+
+def test_update_event_add_google_meet_does_not_clobber_a_pending_create_request(
+    monkeypatch,
+):
+    """Regression test: a *pending* createRequest has no entryPoints/
+    conferenceSolution yet either -- the same shape as a failed one. It must
+    not be treated as retryable, or a second add_google_meet=True call (e.g.
+    while also changing the time) abandons the in-flight request and starts
+    a new, unrelated one."""
+    existing_event = {
+        "id": "evt1",
+        "conferenceData": {
+            "createRequest": {
+                "requestId": "abc123",
+                "status": {"statusCode": "pending"},
+            }
+        },
+    }
+    service = _fake_service({"id": "evt1"}, existing_event=existing_event)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_update_events(event_id="evt1", add_google_meet=True)
+
+    _, kwargs = service.events.return_value.update.call_args
+    assert kwargs["body"]["conferenceData"] == existing_event["conferenceData"]
+    assert kwargs["body"]["conferenceData"]["createRequest"]["requestId"] == "abc123"
 
 
 def test_event_response_falls_back_to_entry_points_when_hangout_link_is_absent(

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -212,6 +212,19 @@ def test_update_event_does_not_duplicate_an_already_invited_attendee(monkeypatch
     ]
 
 
+def test_update_event_dedupes_repeated_emails_in_the_same_attendees_call(monkeypatch):
+    service = _fake_service({"id": "evt1"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_update_events(
+        event_id="evt1",
+        attendees=["bob@example.com", "bob@example.com"],
+    )
+
+    _, kwargs = service.events.return_value.update.call_args
+    assert kwargs["body"]["attendees"] == [{"email": "bob@example.com"}]
+
+
 def test_update_event_with_no_new_attendees_leaves_existing_attendees_untouched(
     monkeypatch,
 ):
@@ -336,3 +349,22 @@ def test_response_surfaces_pending_conference_status_instead_of_hangout_link(
 
     assert "hangout_link" not in result
     assert result["conference_status"] == "pending"
+
+
+def test_response_handles_null_conference_data_without_crashing(monkeypatch):
+    """Guard against event["conferenceData"] (or nested keys) being present but
+    explicitly null in the API response, not just absent."""
+    service = _fake_service({"id": "evt1", "conferenceData": None})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="1:1",
+            start_time="2026-09-07T15:00:00+08:00",
+            end_time="2026-09-07T16:00:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert "hangout_link" not in result
+    assert "conference_status" not in result

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -346,6 +346,27 @@ def test_update_event_add_google_meet_creates_conference_when_none_exists(
     ] == {"type": "hangoutsMeet"}
 
 
+def test_update_event_add_google_meet_does_not_duplicate_a_legacy_hangout_link(
+    monkeypatch,
+):
+    """Regression test: a legacy event can carry hangoutLink with no
+    conferenceData at all (it predates the conferenceData API). Without a
+    hangoutLink check, add_google_meet=True would see "no conferenceData" and
+    request a second, duplicate conference for an event that already has
+    one."""
+    existing_event = {
+        "id": "evt1",
+        "hangoutLink": "https://meet.google.com/abc-defg-hij",
+    }
+    service = _fake_service({"id": "evt1"}, existing_event=existing_event)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_update_events(event_id="evt1", add_google_meet=True)
+
+    _, kwargs = service.events.return_value.update.call_args
+    assert "conferenceData" not in kwargs["body"]
+
+
 def test_update_event_add_google_meet_does_not_replace_existing_conference(
     monkeypatch,
 ):
@@ -533,6 +554,30 @@ def test_response_handles_null_conference_data_without_crashing(monkeypatch):
     assert result["status"] == "success"
     assert "hangout_link" not in result
     assert "conference_status" not in result
+
+
+def test_response_handles_null_conference_solution_key_without_crashing(monkeypatch):
+    """Guard against conferenceData.conferenceSolution.key being present but
+    explicitly null, not just absent -- .get("key", {}) only defaults for a
+    missing key, not a present-but-null one."""
+    service = _fake_service(
+        {
+            "id": "evt1",
+            "conferenceData": {"conferenceSolution": {"key": None}},
+        }
+    )
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="1:1",
+            start_time="2026-09-07T15:00:00+08:00",
+            end_time="2026-09-07T16:00:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert "hangout_link" not in result
 
 
 def test_get_event_surfaces_hangout_link_like_create_and_update_do(monkeypatch):

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -426,17 +426,20 @@ def test_event_response_falls_back_to_entry_points_when_hangout_link_is_absent(
     monkeypatch,
 ):
     """hangoutLink is only reliably populated for Meet conferences; fall back
-    to the canonical conferenceData.entryPoints when it's missing."""
+    to the canonical conferenceData.entryPoints when it's missing, but only
+    for an actual Meet conference (conferenceSolution.key.type ==
+    "hangoutsMeet") -- see the sibling test below for the non-Meet case."""
     execute_result = {
         "id": "evt1",
         "conferenceData": {
+            "conferenceSolution": {"key": {"type": "hangoutsMeet"}},
             "entryPoints": [
                 {"entryPointType": "phone", "uri": "tel:+1-234-567-8900"},
                 {
                     "entryPointType": "video",
                     "uri": "https://meet.google.com/abc-defg-hij",
                 },
-            ]
+            ],
         },
     }
     service = _fake_service(execute_result)
@@ -452,6 +455,35 @@ def test_event_response_falls_back_to_entry_points_when_hangout_link_is_absent(
     )
 
     assert result["hangout_link"] == "https://meet.google.com/abc-defg-hij"
+
+
+def test_event_response_does_not_label_a_non_meet_conference_as_hangout_link(
+    monkeypatch,
+):
+    """Regression test: a third-party conference (e.g. Zoom's Calendar add-on)
+    also registers its join URL under entryPointType "video". Surfacing that
+    as hangout_link would mislead a caller into thinking it's a Meet link."""
+    execute_result = {
+        "id": "evt1",
+        "conferenceData": {
+            "conferenceSolution": {"key": {"type": "addOn"}, "name": "Zoom Meeting"},
+            "entryPoints": [
+                {"entryPointType": "video", "uri": "https://zoom.us/j/123456789"},
+            ],
+        },
+    }
+    service = _fake_service(execute_result)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="1:1",
+            start_time="2026-09-07T15:00:00+08:00",
+            end_time="2026-09-07T16:00:00+08:00",
+        )
+    )
+
+    assert "hangout_link" not in result
 
 
 def test_response_surfaces_pending_conference_status_instead_of_hangout_link(
@@ -501,3 +533,21 @@ def test_response_handles_null_conference_data_without_crashing(monkeypatch):
     assert result["status"] == "success"
     assert "hangout_link" not in result
     assert "conference_status" not in result
+
+
+def test_get_event_surfaces_hangout_link_like_create_and_update_do(monkeypatch):
+    """Regression test: both tool docstrings tell callers to fall back to
+    google_calendar_get_event to pick up a Meet link that wasn't ready yet
+    at create/update time -- it must honor that by using the same
+    hangout_link/conference_status convention, not return the raw event."""
+    fetched_event = {
+        "id": "evt1",
+        "hangoutLink": "https://meet.google.com/abc-defg-hij",
+    }
+    service = _fake_service({"id": "evt1"}, existing_event=fetched_event)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(calendar.google_calendar_get_event(event_id="evt1"))
+
+    assert result["status"] == "success"
+    assert result["hangout_link"] == "https://meet.google.com/abc-defg-hij"

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1,28 +1,36 @@
+import copy
 import json
 from unittest.mock import Mock
 
-import pytest
-
 from xagent.web.tools.mcp import calendar
-
-
-@pytest.fixture(autouse=True)
-def _credentials(monkeypatch):
-    monkeypatch.setenv("GOOGLE_ACCESS_TOKEN", "access-token")
 
 
 def _fake_service(execute_result: dict, existing_event: dict | None = None):
     """A stand-in for the googleapiclient Calendar service that records the
     kwargs passed to events().insert()/update() and returns execute_result.
     existing_event is what events().get() returns, simulating an event that
-    already has state (attendees, conferenceData) before this call."""
+    already has state (attendees, conferenceData) before this call.
+
+    A deep copy is handed to the code under test (rather than the caller's
+    own existing_event object): calendar.py mutates the dict it gets back
+    from events().get().execute() in place before resending it as the update
+    body, so returning the original object would let that mutation leak back
+    into the test's "expected" value and make before/after comparisons a
+    tautology.
+    """
     events = Mock()
     request = Mock()
     request.execute.return_value = execute_result
     events.insert = Mock(return_value=request)
     events.update = Mock(return_value=request)
     events.get = Mock(
-        return_value=Mock(execute=Mock(return_value=existing_event or {"id": "evt1"}))
+        return_value=Mock(
+            execute=Mock(
+                return_value=copy.deepcopy(existing_event)
+                if existing_event
+                else {"id": "evt1"}
+            )
+        )
     )
     service = Mock()
     service.events.return_value = events
@@ -225,6 +233,32 @@ def test_update_event_dedupes_repeated_emails_in_the_same_attendees_call(monkeyp
     assert kwargs["body"]["attendees"] == [{"email": "bob@example.com"}]
 
 
+def test_update_event_attendee_matching_is_case_and_whitespace_insensitive(
+    monkeypatch,
+):
+    """Regression test: `Alice@Example.com` and `alice@example.com ` are the
+    same mailbox and must not produce a duplicate attendee entry."""
+    existing_event = {
+        "id": "evt1",
+        "attendees": [{"email": "alice@example.com", "responseStatus": "accepted"}],
+    }
+    service = _fake_service({"id": "evt1"}, existing_event=existing_event)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_update_events(
+        event_id="evt1",
+        attendees=["Alice@Example.com ", " BOB@example.com", "bob@example.com"],
+    )
+
+    _, kwargs = service.events.return_value.update.call_args
+    # Alice's existing entry is kept as-is (not duplicated under different
+    # casing), and Bob is added once despite two differently-cased spellings.
+    assert kwargs["body"]["attendees"] == [
+        {"email": "alice@example.com", "responseStatus": "accepted"},
+        {"email": "BOB@example.com"},
+    ]
+
+
 def test_update_event_with_no_new_attendees_leaves_existing_attendees_untouched(
     monkeypatch,
 ):
@@ -319,6 +353,65 @@ def test_update_event_add_google_meet_does_not_replace_existing_conference(
     _, kwargs = service.events.return_value.update.call_args
     assert kwargs["body"]["conferenceData"] == existing_event["conferenceData"]
     assert "createRequest" not in kwargs["body"]["conferenceData"]
+
+
+def test_update_event_add_google_meet_retries_after_a_failed_create_request(
+    monkeypatch,
+):
+    """Regression test: a failed createRequest leaves conferenceData set but
+    with no entryPoints/conferenceSolution. add_google_meet=True must treat
+    that as "no conference yet" and retry, not as an existing conference to
+    preserve -- otherwise the event is permanently stuck with no Meet link."""
+    existing_event = {
+        "id": "evt1",
+        "conferenceData": {
+            "createRequest": {
+                "requestId": "abc123",
+                "status": {"statusCode": "failure"},
+            }
+        },
+    }
+    service = _fake_service({"id": "evt1"}, existing_event=existing_event)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_update_events(event_id="evt1", add_google_meet=True)
+
+    _, kwargs = service.events.return_value.update.call_args
+    new_create_request = kwargs["body"]["conferenceData"]["createRequest"]
+    assert new_create_request["requestId"] != "abc123"
+    assert new_create_request["conferenceSolutionKey"] == {"type": "hangoutsMeet"}
+
+
+def test_event_response_falls_back_to_entry_points_when_hangout_link_is_absent(
+    monkeypatch,
+):
+    """hangoutLink is only reliably populated for Meet conferences; fall back
+    to the canonical conferenceData.entryPoints when it's missing."""
+    execute_result = {
+        "id": "evt1",
+        "conferenceData": {
+            "entryPoints": [
+                {"entryPointType": "phone", "uri": "tel:+1-234-567-8900"},
+                {
+                    "entryPointType": "video",
+                    "uri": "https://meet.google.com/abc-defg-hij",
+                },
+            ]
+        },
+    }
+    service = _fake_service(execute_result)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="1:1",
+            start_time="2026-09-07T15:00:00+08:00",
+            end_time="2026-09-07T16:00:00+08:00",
+            add_google_meet=True,
+        )
+    )
+
+    assert result["hangout_link"] == "https://meet.google.com/abc-defg-hij"
 
 
 def test_response_surfaces_pending_conference_status_instead_of_hangout_link(

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1,8 +1,10 @@
 import copy
 import json
+import re
 from unittest.mock import Mock
 
 from xagent.web.tools.mcp import calendar
+from xagent.web.tools.mcp import utils as mcp_utils
 
 
 def _fake_service(execute_result: dict, existing_event: dict | None = None):
@@ -272,6 +274,31 @@ def test_update_event_attendee_matching_is_case_and_whitespace_insensitive(
     ]
 
 
+def test_update_event_tolerates_a_malformed_existing_attendee_list(monkeypatch):
+    """Regression test: an existing attendee entry with no "email" key (e.g.
+    a resource/room attendee), or a non-dict item, must not crash the merge
+    or get treated as a real email to match/duplicate against."""
+    existing_event = {
+        "id": "evt1",
+        "attendees": [
+            {"displayName": "Conference Room A"},
+            "not-a-dict",
+            {"email": "alice@example.com"},
+        ],
+    }
+    service = _fake_service({"id": "evt1"}, existing_event=existing_event)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_update_events(
+        event_id="evt1", attendees=["bob@example.com"]
+    )
+
+    _, kwargs = service.events.return_value.update.call_args
+    assert kwargs["body"]["attendees"] == existing_event["attendees"] + [
+        {"email": "bob@example.com"}
+    ]
+
+
 def test_update_event_with_no_new_attendees_leaves_existing_attendees_untouched(
     monkeypatch,
 ):
@@ -412,6 +439,10 @@ def test_update_event_add_google_meet_retries_after_a_failed_create_request(
 
     _, kwargs = service.events.return_value.update.call_args
     new_create_request = kwargs["body"]["conferenceData"]["createRequest"]
+    # A hardcoded different literal would also satisfy `!= "abc123"`; check
+    # it's actually a fresh uuid4().hex (32 lowercase hex chars), not just
+    # any old different string.
+    assert re.fullmatch(r"[0-9a-f]{32}", new_create_request["requestId"])
     assert new_create_request["requestId"] != "abc123"
     assert new_create_request["conferenceSolutionKey"] == {"type": "hangoutsMeet"}
 
@@ -596,3 +627,106 @@ def test_get_event_surfaces_hangout_link_like_create_and_update_do(monkeypatch):
 
     assert result["status"] == "success"
     assert result["hangout_link"] == "https://meet.google.com/abc-defg-hij"
+
+
+def test_create_event_error_message_hints_at_add_google_meet_on_failure(monkeypatch):
+    """Regression test: if the whole insert() call fails while add_google_meet
+    was requested (e.g. the account/domain can't create Meet conferences at
+    all), the error should point at add_google_meet as the likely cause --
+    it's otherwise indistinguishable from any other request-level failure."""
+    service = _fake_service({"id": "evt1"})
+    service.events.return_value.insert.return_value.execute.side_effect = RuntimeError(
+        "Bad Request"
+    )
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="1:1",
+            start_time="2026-09-07T15:00:00+08:00",
+            end_time="2026-09-07T16:00:00+08:00",
+            add_google_meet=True,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "Bad Request" in result["message"]
+    assert "add_google_meet" in result["message"]
+
+
+def test_update_event_error_message_hints_at_add_google_meet_on_failure(monkeypatch):
+    service = _fake_service({"id": "evt1"})
+    service.events.return_value.update.return_value.execute.side_effect = RuntimeError(
+        "Bad Request"
+    )
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_update_events(event_id="evt1", add_google_meet=True)
+    )
+
+    assert result["status"] == "error"
+    assert "Bad Request" in result["message"]
+    assert "add_google_meet" in result["message"]
+
+
+def test_create_event_error_message_has_no_hint_without_add_google_meet(monkeypatch):
+    service = _fake_service({"id": "evt1"})
+    service.events.return_value.insert.return_value.execute.side_effect = RuntimeError(
+        "Bad Request"
+    )
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="1:1",
+            start_time="2026-09-07T15:00:00+08:00",
+            end_time="2026-09-07T16:00:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert result["message"] == "Bad Request"
+
+
+def test_event_response_caps_a_large_event_like_other_tools_in_this_package(
+    monkeypatch,
+):
+    """Regression test: the raw Google event (description, attendees,
+    recurrence rules, ...) can be large enough to blow past the platform's
+    output-length budget; this package's other tools already guard against
+    that with success_with_capped_dict, and this response builder must too."""
+    monkeypatch.setattr(mcp_utils, "get_tool_max_output_length", lambda: 300)
+    execute_result = {
+        "id": "evt1",
+        "attendees": [{"email": f"person{i}@example.com"} for i in range(200)],
+    }
+    service = _fake_service(execute_result)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    raw = calendar.google_calendar_create_events(
+        summary="1:1",
+        start_time="2026-09-07T15:00:00+08:00",
+        end_time="2026-09-07T16:00:00+08:00",
+    )
+    result = json.loads(raw)
+
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert len(result["event"]["attendees"]) < 200
+
+
+def test_event_response_does_not_truncate_a_small_event(monkeypatch):
+    service = _fake_service({"id": "evt1", "summary": "1:1"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="1:1",
+            start_time="2026-09-07T15:00:00+08:00",
+            end_time="2026-09-07T16:00:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["truncated"] is False

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -11,21 +11,25 @@ def _credentials(monkeypatch):
     monkeypatch.setenv("GOOGLE_ACCESS_TOKEN", "access-token")
 
 
-def _fake_service(execute_result: dict):
+def _fake_service(execute_result: dict, existing_event: dict | None = None):
     """A stand-in for the googleapiclient Calendar service that records the
-    kwargs passed to events().insert()/update() and returns execute_result."""
+    kwargs passed to events().insert()/update() and returns execute_result.
+    existing_event is what events().get() returns, simulating an event that
+    already has state (attendees, conferenceData) before this call."""
     events = Mock()
     request = Mock()
     request.execute.return_value = execute_result
     events.insert = Mock(return_value=request)
     events.update = Mock(return_value=request)
-    events.get = Mock(return_value=Mock(execute=Mock(return_value={"id": "evt1"})))
+    events.get = Mock(
+        return_value=Mock(execute=Mock(return_value=existing_event or {"id": "evt1"}))
+    )
     service = Mock()
     service.events.return_value = events
     return service
 
 
-def test_create_event_without_attendees_or_meet_omits_conference_and_invites(
+def test_create_event_without_attendees_or_meet_sends_conference_version_and_no_invites(
     monkeypatch,
 ):
     service = _fake_service({"id": "evt1"})
@@ -47,13 +51,15 @@ def test_create_event_without_attendees_or_meet_omits_conference_and_invites(
     assert "attendees" not in kwargs["body"]
     assert "conferenceData" not in kwargs["body"]
     assert kwargs["body"]["location"] == "Google Meet"
-    assert kwargs["conferenceDataVersion"] == 0
+    # conferenceDataVersion=1 must always be sent: it only declares capability,
+    # it doesn't create a conference by itself (that needs a createRequest in
+    # the body), but omitting it would make Google ignore any conferenceData
+    # that IS present -- see the update() tests below for why this matters.
+    assert kwargs["conferenceDataVersion"] == 1
     assert kwargs["sendUpdates"] == "none"
 
 
-def test_create_event_with_attendees_but_no_notify_does_not_send_invites(
-    monkeypatch,
-):
+def test_create_event_with_attendees_but_no_notify_does_not_send_invites(monkeypatch):
     execute_result = {
         "id": "evt1",
         "hangoutLink": "https://meet.google.com/abc-defg-hij",
@@ -120,53 +126,7 @@ def test_create_event_notify_attendees_without_attendees_does_not_send_invites(
     assert kwargs["sendUpdates"] == "none"
 
 
-def test_update_event_with_attendees_but_no_notify_does_not_send_invites(
-    monkeypatch,
-):
-    execute_result = {
-        "id": "evt1",
-        "hangoutLink": "https://meet.google.com/abc-defg-hij",
-    }
-    service = _fake_service(execute_result)
-    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
-
-    result = json.loads(
-        calendar.google_calendar_update_events(
-            event_id="evt1",
-            attendees=["someone@example.com"],
-            add_google_meet=True,
-        )
-    )
-
-    assert result["status"] == "success"
-    assert result["hangout_link"] == "https://meet.google.com/abc-defg-hij"
-
-    _, kwargs = service.events.return_value.update.call_args
-    body = kwargs["body"]
-    assert body["attendees"] == [{"email": "someone@example.com"}]
-    assert body["conferenceData"]["createRequest"]["conferenceSolutionKey"] == {
-        "type": "hangoutsMeet"
-    }
-    assert kwargs["conferenceDataVersion"] == 1
-    assert kwargs["sendUpdates"] == "none"
-
-
-def test_update_event_with_attendees_and_notify_sends_invites(monkeypatch):
-    service = _fake_service({"id": "evt1"})
-    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
-
-    calendar.google_calendar_update_events(
-        event_id="evt1",
-        attendees=["someone@example.com"],
-        notify_attendees=True,
-    )
-
-    _, kwargs = service.events.return_value.update.call_args
-    assert kwargs["body"]["attendees"] == [{"email": "someone@example.com"}]
-    assert kwargs["sendUpdates"] == "all"
-
-
-def test_update_event_without_attendees_or_meet_omits_conference_and_invites(
+def test_update_event_without_attendees_or_meet_sends_conference_version_and_no_invites(
     monkeypatch,
 ):
     service = _fake_service({"id": "evt1"})
@@ -182,5 +142,197 @@ def test_update_event_without_attendees_or_meet_omits_conference_and_invites(
     _, kwargs = service.events.return_value.update.call_args
     assert "attendees" not in kwargs["body"]
     assert "conferenceData" not in kwargs["body"]
-    assert kwargs["conferenceDataVersion"] == 0
+    assert kwargs["conferenceDataVersion"] == 1
     assert kwargs["sendUpdates"] == "none"
+
+
+def test_update_event_preserves_existing_meet_link_when_add_google_meet_not_set(
+    monkeypatch,
+):
+    """Regression test: conferenceDataVersion must be 1 even when
+    add_google_meet isn't passed, or Google ignores the conferenceData this
+    call resends from the fetched event and silently drops the Meet link."""
+    existing_event = {
+        "id": "evt1",
+        "conferenceData": {
+            "conferenceId": "abc-defg-hij",
+            "entryPoints": [{"uri": "https://meet.google.com/abc-defg-hij"}],
+        },
+        "hangoutLink": "https://meet.google.com/abc-defg-hij",
+    }
+    service = _fake_service(existing_event, existing_event=existing_event)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_update_events(event_id="evt1", summary="New title")
+
+    _, kwargs = service.events.return_value.update.call_args
+    # The existing conferenceData must still be present in the body...
+    assert kwargs["body"]["conferenceData"] == existing_event["conferenceData"]
+    # ...and conferenceDataVersion must be 1, or Google would ignore it.
+    assert kwargs["conferenceDataVersion"] == 1
+
+
+def test_update_event_merges_new_attendees_with_existing_ones(monkeypatch):
+    existing_event = {
+        "id": "evt1",
+        "attendees": [{"email": "alice@example.com", "responseStatus": "accepted"}],
+    }
+    service = _fake_service({"id": "evt1"}, existing_event=existing_event)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_update_events(
+        event_id="evt1", attendees=["bob@example.com"]
+    )
+
+    _, kwargs = service.events.return_value.update.call_args
+    # Alice is kept (with her existing RSVP metadata intact), Bob is added.
+    assert kwargs["body"]["attendees"] == [
+        {"email": "alice@example.com", "responseStatus": "accepted"},
+        {"email": "bob@example.com"},
+    ]
+
+
+def test_update_event_does_not_duplicate_an_already_invited_attendee(monkeypatch):
+    existing_event = {
+        "id": "evt1",
+        "attendees": [{"email": "alice@example.com", "responseStatus": "accepted"}],
+    }
+    service = _fake_service({"id": "evt1"}, existing_event=existing_event)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_update_events(
+        event_id="evt1", attendees=["alice@example.com"]
+    )
+
+    _, kwargs = service.events.return_value.update.call_args
+    # Alice's existing entry (with her RSVP status) is kept, not replaced with
+    # a bare {"email": ...} dict, and she isn't duplicated.
+    assert kwargs["body"]["attendees"] == [
+        {"email": "alice@example.com", "responseStatus": "accepted"}
+    ]
+
+
+def test_update_event_with_no_new_attendees_leaves_existing_attendees_untouched(
+    monkeypatch,
+):
+    existing_event = {
+        "id": "evt1",
+        "attendees": [{"email": "alice@example.com", "responseStatus": "accepted"}],
+    }
+    service = _fake_service({"id": "evt1"}, existing_event=existing_event)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_update_events(event_id="evt1", summary="New title")
+
+    _, kwargs = service.events.return_value.update.call_args
+    assert kwargs["body"]["attendees"] == existing_event["attendees"]
+
+
+def test_update_event_notify_attendees_notifies_existing_attendees_without_repassing_them(
+    monkeypatch,
+):
+    """Regression test: notify_attendees must look at the event's actual
+    attendees, not just the attendees param on this call, or you can never
+    notify already-invited people of e.g. a reschedule."""
+    existing_event = {
+        "id": "evt1",
+        "attendees": [{"email": "alice@example.com"}],
+    }
+    service = _fake_service({"id": "evt1"}, existing_event=existing_event)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_update_events(
+        event_id="evt1",
+        start_time="2026-09-08T15:00:00+08:00",
+        notify_attendees=True,
+    )
+
+    _, kwargs = service.events.return_value.update.call_args
+    assert kwargs["sendUpdates"] == "all"
+
+
+def test_update_event_notify_attendees_is_noop_when_event_has_no_attendees(
+    monkeypatch,
+):
+    service = _fake_service({"id": "evt1"})
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_update_events(
+        event_id="evt1", summary="New title", notify_attendees=True
+    )
+
+    _, kwargs = service.events.return_value.update.call_args
+    assert kwargs["sendUpdates"] == "none"
+
+
+def test_update_event_add_google_meet_creates_conference_when_none_exists(
+    monkeypatch,
+):
+    execute_result = {
+        "id": "evt1",
+        "hangoutLink": "https://meet.google.com/abc-defg-hij",
+    }
+    service = _fake_service(execute_result)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_update_events(event_id="evt1", add_google_meet=True)
+    )
+
+    assert result["hangout_link"] == "https://meet.google.com/abc-defg-hij"
+    _, kwargs = service.events.return_value.update.call_args
+    assert kwargs["body"]["conferenceData"]["createRequest"][
+        "conferenceSolutionKey"
+    ] == {"type": "hangoutsMeet"}
+
+
+def test_update_event_add_google_meet_does_not_replace_existing_conference(
+    monkeypatch,
+):
+    """Regression test: add_google_meet=True must not orphan a Meet link
+    that's already shared with attendees by generating a brand-new one."""
+    existing_event = {
+        "id": "evt1",
+        "conferenceData": {
+            "conferenceId": "abc-defg-hij",
+            "entryPoints": [{"uri": "https://meet.google.com/abc-defg-hij"}],
+        },
+    }
+    service = _fake_service({"id": "evt1"}, existing_event=existing_event)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    calendar.google_calendar_update_events(event_id="evt1", add_google_meet=True)
+
+    _, kwargs = service.events.return_value.update.call_args
+    assert kwargs["body"]["conferenceData"] == existing_event["conferenceData"]
+    assert "createRequest" not in kwargs["body"]["conferenceData"]
+
+
+def test_response_surfaces_pending_conference_status_instead_of_hangout_link(
+    monkeypatch,
+):
+    """Meet link creation is asynchronous; if hangoutLink isn't populated yet
+    the response should say so instead of silently omitting everything."""
+    execute_result = {
+        "id": "evt1",
+        "conferenceData": {
+            "createRequest": {
+                "requestId": "abc123",
+                "status": {"statusCode": "pending"},
+            }
+        },
+    }
+    service = _fake_service(execute_result)
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="1:1",
+            start_time="2026-09-07T15:00:00+08:00",
+            end_time="2026-09-07T16:00:00+08:00",
+            add_google_meet=True,
+        )
+    )
+
+    assert "hangout_link" not in result
+    assert result["conference_status"] == "pending"

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -670,6 +670,77 @@ def test_update_event_error_message_hints_at_add_google_meet_on_failure(monkeypa
     assert "add_google_meet" in result["message"]
 
 
+def test_update_event_error_message_has_no_hint_when_add_google_meet_was_a_noop(
+    monkeypatch,
+):
+    """Regression test: add_google_meet=True is a no-op when the event
+    already has a resolved conference -- this call's body never actually
+    carried a createRequest, so a failure has nothing to do with Meet and
+    the hint would misdirect the caller."""
+    existing_event = {
+        "id": "evt1",
+        "conferenceData": {
+            "conferenceSolution": {"key": {"type": "hangoutsMeet"}},
+            "entryPoints": [{"entryPointType": "video", "uri": "https://x"}],
+        },
+    }
+    service = _fake_service({"id": "evt1"}, existing_event=existing_event)
+    service.events.return_value.update.return_value.execute.side_effect = RuntimeError(
+        "Bad Request"
+    )
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_update_events(event_id="evt1", add_google_meet=True)
+    )
+
+    assert result["status"] == "error"
+    assert result["message"] == "Bad Request"
+
+
+def test_update_event_error_message_has_no_hint_when_the_preliminary_fetch_fails(
+    monkeypatch,
+):
+    """Regression test: a failure in the preliminary events().get() fetch
+    (e.g. a bad event_id) happens before _apply_conference_request ever
+    runs, so this call's body never carried a createRequest either."""
+    service = _fake_service({"id": "evt1"})
+    service.events.return_value.get.return_value.execute.side_effect = RuntimeError(
+        "Not Found"
+    )
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+
+    result = json.loads(
+        calendar.google_calendar_update_events(event_id="evt1", add_google_meet=True)
+    )
+
+    assert result["status"] == "error"
+    assert result["message"] == "Not Found"
+
+
+def test_create_event_error_message_has_no_hint_when_service_setup_fails(monkeypatch):
+    """Regression test: a failure before any event body is even built (e.g.
+    a missing/invalid credential) happens before _apply_conference_request
+    ever runs, so blaming a Meet conference request would be wrong."""
+
+    def _raise():
+        raise ValueError("GOOGLE_ACCESS_TOKEN environment variable is missing")
+
+    monkeypatch.setattr(calendar, "get_calendar_service", _raise)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="1:1",
+            start_time="2026-09-07T15:00:00+08:00",
+            end_time="2026-09-07T16:00:00+08:00",
+            add_google_meet=True,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "add_google_meet" not in result["message"]
+
+
 def test_create_event_error_message_has_no_hint_without_add_google_meet(monkeypatch):
     service = _fake_service({"id": "evt1"})
     service.events.return_value.insert.return_value.execute.side_effect = RuntimeError(


### PR DESCRIPTION
## Summary
- `google_calendar_create_events`/`google_calendar_update_events` only wrote a plain "Google Meet" string into the event's `location` field and never requested `conferenceData`, so a real Meet link was never generated and Toby had nothing to pass on to invitees.
- There was also no way to invite attendees at all, so Toby had to fall back to manually emailing invite text.

## Changes
- Add an `attendees: list[str] | None` param to both tools. Attendees are *merged* into the event by email (existing attendees, and their RSVP/organizer metadata, are kept) rather than replacing the roster.
- Add a `notify_attendees: bool` param (default `False`). Only when `True` does the API call use `sendUpdates="all"`, gated on the event's actual attendee list (not just the ones passed in this call) — so, e.g., rescheduling an event can notify its existing attendees without re-listing them. This mirrors `gmail_send_messages`'s safe-by-default `action="draft"` behavior instead of emailing external attendees the moment any are listed.
- Add an `add_google_meet: bool` param. When `True` and the event doesn't already have a conference, it requests `conferenceData` (`hangoutsMeet`); an existing conference is left untouched rather than replaced. `conferenceDataVersion=1` is now sent unconditionally on every insert/update call — omitting it (the previous behavior) makes Google ignore any `conferenceData` already present in the body, which was silently stripping an event's existing Meet link on any unrelated update (title/time/location change).
- The resulting `hangout_link` is surfaced in the tool's JSON response once Google finishes provisioning it; since Meet creation is asynchronous, a `conference_status` (e.g. `"pending"`) is returned instead when it isn't ready yet.

## Test plan
- [x] `pytest tests/web/tools/test_google_calendar_mcp.py` — covers attendee merging/dedup, notify_attendees gated on actual attendees (not just the param), add_google_meet skipping an existing conference, the conferenceDataVersion regression (event that already has a Meet link keeps it across an unrelated update), and the pending-conference-status response.
- [x] `pytest tests/web/tools/` (no regressions)
- [x] `ruff format --check`, `ruff check`, `mypy` on the changed file