### PR TITLE
feat(auth): support transactional first-admin setup hooks (toby)

### DIFF
--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -44,6 +44,7 @@ from ..auth_config import (
     REFRESH_TOKEN_EXPIRE_DAYS,
 )
 from ..auth_dependencies import get_current_user
+from ..first_admin_setup import FirstAdminIdentity, run_first_admin_setup_hook
 from ..models.actor_oauth_flow import ActorOAuthFlowState
 from ..models.database import (
     get_db,
@@ -1276,7 +1277,9 @@ async def setup_status(db: Session = Depends(get_db)) -> SetupStatusResponse:
 
 @auth_router.post("/setup-admin", response_model=RegisterResponse)
 async def setup_admin(
-    request: RegisterRequest, db: Session = Depends(get_db)
+    request: RegisterRequest,
+    http_request: Request,
+    db: Session = Depends(get_db),
 ) -> RegisterResponse:
     if len(request.password) < PASSWORD_MIN_LENGTH:
         return RegisterResponse(
@@ -1322,11 +1325,17 @@ async def setup_admin(
         setup_setting = SystemSetting(key=SETUP_COMPLETED_SETTING_KEY, value="true")
         db.add(setup_setting)
 
+        run_first_admin_setup_hook(
+            http_request.app, db, FirstAdminIdentity(user_id=int(user.id))
+        )
         db.commit()
         db.refresh(user)
     except IntegrityError:
         db.rollback()
         return RegisterResponse(success=False, message="Setup already completed")
+    except Exception:
+        db.rollback()
+        raise
 
     return RegisterResponse(
         success=True,

--- a/src/xagent/web/first_admin_setup.py
+++ b/src/xagent/web/first_admin_setup.py
@@ -1,0 +1,51 @@
+"""Host extension point for transactional first-administrator setup."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+from fastapi import FastAPI
+from sqlalchemy.orm import Session
+
+_HOOK_STATE_KEY = "_first_admin_setup_hook"
+
+
+@dataclass(frozen=True)
+class FirstAdminIdentity:
+    """Stable identity exposed while the administrator row is still staged."""
+
+    user_id: int
+
+
+class FirstAdminSetupHook(Protocol):
+    """Stage host-owned rows without ending the caller's transaction."""
+
+    def __call__(self, db: Session, admin: FirstAdminIdentity) -> None: ...
+
+
+def register_first_admin_setup_hook(app: FastAPI, hook: FirstAdminSetupHook) -> None:
+    """Install this application's hook for first-administrator setup.
+
+    The hook runs after the core user and setup setting are staged and before
+    the route's sole commit. It may add or flush rows on ``db``, but must not
+    commit, roll back, or close the caller-owned session. Raising aborts and
+    rolls back the complete setup transaction.
+    """
+    setattr(app.state, _HOOK_STATE_KEY, hook)
+
+
+def run_first_admin_setup_hook(
+    app: FastAPI, db: Session, admin: FirstAdminIdentity
+) -> None:
+    """Run the hook registered on ``app``, if any."""
+    hook = getattr(app.state, _HOOK_STATE_KEY, None)
+    if hook is not None:
+        hook(db, admin)
+
+
+__all__ = [
+    "FirstAdminIdentity",
+    "FirstAdminSetupHook",
+    "register_first_admin_setup_hook",
+]

--- a/tests/web/test_first_admin_setup_hook.py
+++ b/tests/web/test_first_admin_setup_hook.py
@@ -1,0 +1,155 @@
+from collections.abc import Iterator
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import StaticPool
+
+from xagent.web.api.auth import auth_router
+from xagent.web.first_admin_setup import (
+    FirstAdminIdentity,
+    register_first_admin_setup_hook,
+)
+from xagent.web.models.database import Base, get_db
+from xagent.web.models.system_setting import SystemSetting
+from xagent.web.models.user import User
+
+ADMIN = {
+    "username": "admin",
+    "email": "admin@example.com",
+    "password": "admin123",
+}
+
+
+@pytest.fixture
+def app_factory() -> Iterator:
+    engines = []
+
+    def make_app() -> tuple[FastAPI, sessionmaker[Session]]:
+        engine = create_engine(
+            "sqlite://",
+            connect_args={"check_same_thread": False},
+            poolclass=StaticPool,
+        )
+        engines.append(engine)
+        Base.metadata.create_all(engine)
+        session_local = sessionmaker(bind=engine, autoflush=False, autocommit=False)
+
+        def override_get_db() -> Iterator[Session]:
+            with session_local() as db:
+                yield db
+
+        app = FastAPI()
+        app.include_router(auth_router)
+        app.dependency_overrides[get_db] = override_get_db
+        return app, session_local
+
+    yield make_app
+    for engine in engines:
+        engine.dispose()
+
+
+def _post_setup(app: FastAPI, *, raise_server_exceptions: bool = True):
+    with TestClient(app, raise_server_exceptions=raise_server_exceptions) as client:
+        return client.post("/api/auth/setup-admin", json=ADMIN)
+
+
+def test_hook_stages_with_core_setup_in_one_commit(app_factory):
+    app, session_local = app_factory()
+    commits = 0
+    observed: dict[str, object] = {}
+
+    def hook(db: Session, admin: FirstAdminIdentity) -> None:
+        observed["session"] = db
+        observed["admin"] = admin
+        assert db.get(User, admin.user_id).username == ADMIN["username"]
+        assert any(
+            isinstance(row, SystemSetting)
+            and row.key == "setup_completed"
+            and row.value == "true"
+            for row in db.new
+        )
+        db.add(SystemSetting(key="host_admin_id", value=str(admin.user_id)))
+
+    def count_commit(_session: Session) -> None:
+        nonlocal commits
+        commits += 1
+
+    register_first_admin_setup_hook(app, hook)
+    event.listen(Session, "after_commit", count_commit)
+    try:
+        response = _post_setup(app)
+    finally:
+        event.remove(Session, "after_commit", count_commit)
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    assert commits == 1
+    assert isinstance(observed["admin"], FirstAdminIdentity)
+    with session_local() as db:
+        admin = db.query(User).one()
+        assert (
+            db.query(SystemSetting).filter_by(key="setup_completed").one().value
+            == "true"
+        )
+        assert db.query(SystemSetting).filter_by(
+            key="host_admin_id"
+        ).one().value == str(admin.id)
+
+
+def test_hook_failure_rolls_back_core_and_hook_rows(app_factory):
+    app, session_local = app_factory()
+
+    def failing_hook(db: Session, admin: FirstAdminIdentity) -> None:
+        db.add(SystemSetting(key="host_admin_id", value=str(admin.user_id)))
+        db.flush()
+        raise RuntimeError("host setup failed")
+
+    register_first_admin_setup_hook(app, failing_hook)
+    response = _post_setup(app, raise_server_exceptions=False)
+
+    assert response.status_code == 500
+    with session_local() as db:
+        assert db.query(User).count() == 0
+        assert db.query(SystemSetting).count() == 0
+
+
+def test_hook_registration_is_isolated_by_app(app_factory):
+    hooked_app, hooked_sessions = app_factory()
+    plain_app, plain_sessions = app_factory()
+
+    register_first_admin_setup_hook(
+        hooked_app,
+        lambda db, admin: db.add(
+            SystemSetting(key="host_admin_id", value=str(admin.user_id))
+        ),
+    )
+
+    assert _post_setup(plain_app).json()["success"] is True
+    assert _post_setup(hooked_app).json()["success"] is True
+    with plain_sessions() as db:
+        assert (
+            db.query(SystemSetting).filter_by(key="host_admin_id").one_or_none() is None
+        )
+    with hooked_sessions() as db:
+        assert (
+            db.query(SystemSetting).filter_by(key="host_admin_id").one_or_none()
+            is not None
+        )
+
+
+def test_setup_without_hook_remains_compatible(app_factory):
+    app, session_local = app_factory()
+
+    response = _post_setup(app)
+
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    with session_local() as db:
+        assert db.query(User).filter_by(is_admin=True).count() == 1
+        assert (
+            db.query(SystemSetting).filter_by(key="setup_completed").one().value
+            == "true"
+        )


### PR DESCRIPTION
Closes #2180

## Contract

- Adds an application-scoped registration API for one trusted first-administrator setup hook.
- Invokes the hook with the live caller-owned SQLAlchemy session and an immutable identity containing only user_id.
- Runs after the administrator row is flushed and setup_completed is staged, but before the route commit.
- Commits core and host-owned rows once on success and rolls all staged writes back when the hook raises.
- Preserves the existing no-hook, eligibility, authentication, and authorization behavior.
- Hook implementations may stage or flush writes, but must not commit, roll back, or close the caller-owned session.

## Validation

- 7 focused integration and existing auth tests passed.
- Ruff format and lint checks passed for all changed files.
- py_compile passed for all changed Python files.
- Mutation checks failed as expected when the hook invocation was removed, the commit moved before the hook, and hook exceptions were swallowed.
- Production plus test changes: 217 changed lines.

## Host integration

The SaaS #1055 follow-up should register finalize_platform_models_for_admin on the FastAPI app and adapt it to accept FirstAdminIdentity.user_id. Its setup override must pass the incoming Request through when it directly invokes the core setup_admin endpoint function; the separate post-success finalization call should then be removed.