### PR TITLE
fix(calendar): detect scheduling conflicts before booking or moving events

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.svg,*.png,*.jpg,*.jpeg,*.gif,*.ico,*.webp,pyproject.toml,*node_modules*,uploads/,generated_db_for_test/,memory_store/,data/lancedb/,**/package-lock.json
-ignore-words-list = fo,nd,te,hav,hte,wil,clol,loove,assertIn,ser,mis,pres,wit,asend,createable
+ignore-words-list = fo,nd,te,hav,hte,wil,clol,loove,assertIn,ser,mis,pres,wit,asend,createable,fle

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,11 @@ dependencies = [
   "matplotlib>=3.5.0",
   "google-auth-oauthlib>=1.2.0",
   "google-api-python-client>=2.145.0",
+  # zoneinfo's IANA timezone database - stdlib zoneinfo relies on the OS's
+  # tz data, which minimal container images may not ship; this guarantees
+  # it's present regardless of platform (calendar/outlook conflict-check
+  # timezone math needs real zone offsets, not just zone names).
+  "tzdata>=2024.1",
   "boxlite>=0.6.0; sys_platform == 'linux' and platform_machine == 'x86_64'",
   "boxlite>=0.6.0; sys_platform == 'darwin' and platform_machine == 'arm64'",
   "filelock>=3.0.0",

--- a/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
+++ b/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
@@ -1,0 +1,128 @@
+"""add calendar.freebusy to the Google Calendar connector's OAuth scope
+
+The scheduling-conflict check added to the calendar connector's create/update
+tools calls Google's ``freebusy.query`` endpoint to check attendees'
+availability. That endpoint is not authorized by ``.../auth/calendar.events``
+alone (per Google's own Calendar API scope reference) - it needs one of
+``calendar``, ``calendar.readonly``, ``calendar.freebusy``, or
+``calendar.events.freebusy``. ``calendar.freebusy`` is the minimal addition
+that covers it without also granting broader calendar read access.
+
+For a builtin app, the scope actually requested at authorize time is sourced
+live from ``builtin_mcp_registry.py``, not from this table -- this migration
+only converges the persisted ``public_mcp_apps.oauth_scopes`` row so
+``validate_builtin_public_mcp_apps`` stops reporting drift against that
+registry value on an already-seeded database.
+
+Unlike the earlier narrowing migration (20260817_narrow_google_calendar_scope),
+this one WIDENS the scope: an already-issued ``user_oauth`` grant only has
+the narrower ``calendar.events`` scope and does not automatically pick up
+the new one. Existing users must reconnect the Google Calendar connector
+before attendee free/busy checks stop 403ing for them; this migration does
+not (and cannot) retroactively fix already-issued tokens.
+
+Revision ID: 20260907_add_calendar_freebusy_scope
+Revises: 20260904_add_auto_model_config
+Create Date: 2026-09-07
+
+"""
+
+import json
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260907_add_calendar_freebusy_scope"
+down_revision: Union[str, None] = "20260904_add_auto_model_config"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+)
+
+APP_ID = "google-calendar"
+OLD_SCOPES = ("https://www.googleapis.com/auth/calendar.events",)
+NEW_SCOPES = (
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+)
+
+
+def _columns_present(
+    bind: sa.engine.Connection, table_name: str, required_columns: set[str]
+) -> bool:
+    """Whether ``table_name`` exists and has all of ``required_columns``.
+
+    Used by _set_calendar_scopes(), the online path upgrade() and
+    downgrade() both call: this migration must be a no-op (not an error)
+    against a database mid-way through a schema this old, or an admin's
+    reduced-schema table, rather than assume a table shape that matches
+    only the current model.
+    """
+    inspector = sa.inspect(bind)
+    if table_name not in set(inspector.get_table_names()):
+        return False
+    columns = {column["name"] for column in inspector.get_columns(table_name)}
+    return required_columns.issubset(columns)
+
+
+def _offline_scopes_literal(scopes: Sequence[str], dialect_name: str) -> object:
+    # Match the online sa.JSON binding contract: values are stored as JSON,
+    # not as a bare SQL string literal, on every supported dialect.
+    serialized_literal = op.inline_literal(json.dumps(scopes))
+    if dialect_name == "postgresql":
+        return sa.cast(serialized_literal, sa.JSON())
+    return serialized_literal
+
+
+def _set_calendar_scopes_offline(scopes: Sequence[str]) -> None:
+    dialect_name = op.get_context().dialect.name
+    statement = (
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == op.inline_literal(APP_ID))
+        .values(oauth_scopes=_offline_scopes_literal(scopes, dialect_name))
+    )
+    op.execute(statement)
+
+
+def _set_calendar_scopes(scopes: Sequence[str]) -> None:
+    """Write ``scopes`` to the google-calendar row's oauth_scopes column.
+
+    oauth_scopes is in admin_mcp's _BUILTIN_PROTECTED_FIELDS, so an operator
+    can never have customized it via the admin PATCH endpoint -- safe to
+    overwrite unconditionally, with no prior-value check, in both
+    directions. Online-only: the caller has already handled the offline
+    (``--sql``) path, since there's no live ``bind`` to use here otherwise.
+    """
+    bind = op.get_bind()
+    if not _columns_present(bind, "public_mcp_apps", {"app_id", "oauth_scopes"}):
+        return
+
+    bind.execute(
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+        .values(oauth_scopes=scopes)
+    )
+
+
+def upgrade() -> None:
+    # Offline (--sql) generation has a MockConnection, so reflection is
+    # unavailable -- emit the unconditional UPDATE instead of inspecting.
+    if op.get_context().as_sql:
+        _set_calendar_scopes_offline(NEW_SCOPES)
+        return
+
+    _set_calendar_scopes(NEW_SCOPES)
+
+
+def downgrade() -> None:
+    if op.get_context().as_sql:
+        _set_calendar_scopes_offline(OLD_SCOPES)
+        return
+
+    _set_calendar_scopes(OLD_SCOPES)

--- a/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
+++ b/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
@@ -22,7 +22,7 @@ before attendee free/busy checks stop 403ing for them; this migration does
 not (and cannot) retroactively fix already-issued tokens.
 
 Revision ID: 20260907_add_calendar_freebusy_scope
-Revises: 20260901_seed_zendesk_mcp_app
+Revises: 370740d9125a
 Create Date: 2026-09-07
 
 """
@@ -34,7 +34,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260907_add_calendar_freebusy_scope"
-down_revision: Union[str, None] = "20260901_seed_zendesk_mcp_app"
+down_revision: Union[str, None] = "370740d9125a"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
+++ b/src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py
@@ -22,7 +22,7 @@ before attendee free/busy checks stop 403ing for them; this migration does
 not (and cannot) retroactively fix already-issued tokens.
 
 Revision ID: 20260907_add_calendar_freebusy_scope
-Revises: 20260904_add_auto_model_config
+Revises: 20260901_seed_zendesk_mcp_app
 Create Date: 2026-09-07
 
 """
@@ -34,7 +34,7 @@ import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260907_add_calendar_freebusy_scope"
-down_revision: Union[str, None] = "20260904_add_auto_model_config"
+down_revision: Union[str, None] = "20260901_seed_zendesk_mcp_app"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/src/xagent/migrations/versions/20260909_add_calendar_calendars_readonly_scope.py
+++ b/src/xagent/migrations/versions/20260909_add_calendar_calendars_readonly_scope.py
@@ -1,0 +1,137 @@
+"""add calendar.calendars.readonly to the Google Calendar connector's OAuth scope
+
+The all-day conflict-check path calls Google's ``calendars.get`` endpoint (via
+``_primary_calendar_timezone``) to widen an all-day boundary using the primary
+calendar's own configured timezone. That endpoint is not authorized by
+``.../auth/calendar.events`` or ``.../auth/calendar.freebusy`` (per Google's
+own Calendar API scope reference for ``calendars.get``) -- it needs one of
+``calendar``, ``calendar.readonly``, ``calendar.app.created``,
+``calendar.calendars``, or ``calendar.calendars.readonly``.
+``calendar.calendars.readonly`` is the minimal addition that covers it
+without also granting event read access beyond what ``calendar.events``
+already does.
+
+For a builtin app, the scope actually requested at authorize time is sourced
+live from ``builtin_mcp_registry.py``, not from this table -- this migration
+only converges the persisted ``public_mcp_apps.oauth_scopes`` row so
+``validate_builtin_public_mcp_apps`` stops reporting drift against that
+registry value on an already-seeded database.
+
+Like 20260907_add_calendar_freebusy_scope, this WIDENS the scope: an
+already-issued ``user_oauth`` grant does not automatically pick up the new
+scope. Existing users must reconnect the Google Calendar connector before
+all-day conflict checks stop 403ing for them; this migration does not (and
+cannot) retroactively fix already-issued tokens. Unlike the freebusy gap,
+which degraded to "attendee unchecked but still books", the calendar.py
+caller now rejects the write outright on this missing-scope signal rather
+than silently proceeding (see google_calendar_update_events).
+
+Revision ID: 20260909_add_calendar_calendars_readonly_scope
+Revises: 20260907_add_calendar_freebusy_scope
+Create Date: 2026-09-09
+
+"""
+
+import json
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260909_add_calendar_calendars_readonly_scope"
+down_revision: Union[str, None] = "20260907_add_calendar_freebusy_scope"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("oauth_scopes", sa.JSON),
+)
+
+APP_ID = "google-calendar"
+OLD_SCOPES = (
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+)
+NEW_SCOPES = (
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+    "https://www.googleapis.com/auth/calendar.calendars.readonly",
+)
+
+
+def _columns_present(
+    bind: sa.engine.Connection, table_name: str, required_columns: set[str]
+) -> bool:
+    """Whether ``table_name`` exists and has all of ``required_columns``.
+
+    Used by _set_calendar_scopes(), the online path upgrade() and
+    downgrade() both call: this migration must be a no-op (not an error)
+    against a database mid-way through a schema this old, or an admin's
+    reduced-schema table, rather than assume a table shape that matches
+    only the current model.
+    """
+    inspector = sa.inspect(bind)
+    if table_name not in set(inspector.get_table_names()):
+        return False
+    columns = {column["name"] for column in inspector.get_columns(table_name)}
+    return required_columns.issubset(columns)
+
+
+def _offline_scopes_literal(scopes: Sequence[str], dialect_name: str) -> object:
+    # Match the online sa.JSON binding contract: values are stored as JSON,
+    # not as a bare SQL string literal, on every supported dialect.
+    serialized_literal = op.inline_literal(json.dumps(scopes))
+    if dialect_name == "postgresql":
+        return sa.cast(serialized_literal, sa.JSON())
+    return serialized_literal
+
+
+def _set_calendar_scopes_offline(scopes: Sequence[str]) -> None:
+    dialect_name = op.get_context().dialect.name
+    statement = (
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == op.inline_literal(APP_ID))
+        .values(oauth_scopes=_offline_scopes_literal(scopes, dialect_name))
+    )
+    op.execute(statement)
+
+
+def _set_calendar_scopes(scopes: Sequence[str]) -> None:
+    """Write ``scopes`` to the google-calendar row's oauth_scopes column.
+
+    oauth_scopes is in admin_mcp's _BUILTIN_PROTECTED_FIELDS, so an operator
+    can never have customized it via the admin PATCH endpoint -- safe to
+    overwrite unconditionally, with no prior-value check, in both
+    directions. Online-only: the caller has already handled the offline
+    (``--sql``) path, since there's no live ``bind`` to use here otherwise.
+    """
+    bind = op.get_bind()
+    if not _columns_present(bind, "public_mcp_apps", {"app_id", "oauth_scopes"}):
+        return
+
+    bind.execute(
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID)
+        .values(oauth_scopes=scopes)
+    )
+
+
+def upgrade() -> None:
+    # Offline (--sql) generation has a MockConnection, so reflection is
+    # unavailable -- emit the unconditional UPDATE instead of inspecting.
+    if op.get_context().as_sql:
+        _set_calendar_scopes_offline(NEW_SCOPES)
+        return
+
+    _set_calendar_scopes(NEW_SCOPES)
+
+
+def downgrade() -> None:
+    if op.get_context().as_sql:
+        _set_calendar_scopes_offline(OLD_SCOPES)
+        return
+
+    _set_calendar_scopes(OLD_SCOPES)

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -470,6 +470,7 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "oauth_scopes": [
                 "https://www.googleapis.com/auth/calendar.events",
                 "https://www.googleapis.com/auth/calendar.freebusy",
+                "https://www.googleapis.com/auth/calendar.calendars.readonly",
             ],
             "is_visible_in_connector": True,
             "launch_config": {

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -467,7 +467,10 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "transport": "oauth",
             "provider_name": "google",
             "category": "Scheduling",
-            "oauth_scopes": ["https://www.googleapis.com/auth/calendar.events"],
+            "oauth_scopes": [
+                "https://www.googleapis.com/auth/calendar.events",
+                "https://www.googleapis.com/auth/calendar.freebusy",
+            ],
             "is_visible_in_connector": True,
             "launch_config": {
                 "command": "python",

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import uuid
+from datetime import datetime
 from typing import Any
 
 from google.oauth2.credentials import Credentials
@@ -9,16 +10,16 @@ from googleapiclient.discovery import build  # type: ignore
 from googleapiclient.errors import HttpError  # type: ignore
 from mcp.server.fastmcp import FastMCP
 
-from .utils import attendees_needing_check as _attendees_needing_check
 from .utils import attendees_to_add as _attendees_to_add
 from .utils import calendar_day_bounds as _calendar_day_bounds
 from .utils import conflict_response as _conflict_response
 from .utils import datetime_key_for_comparison as _datetime_key_for_comparison
 from .utils import normalize_addresses as _normalize_addresses
+from .utils import offset_datetime_string as _offset_datetime_string
 from .utils import reject_reversed_window as _reject_reversed_window
 from .utils import setup_proxy_env, success_with_capped_dict
 from .utils import unchecked_extra as _unchecked_extra
-from .utils import windows_overlap as _windows_overlap
+from .utils import window_delta_segments as _window_delta_segments
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("calendar-mcp")
@@ -83,7 +84,7 @@ def _find_conflicts(
     *,
     exclude_event_id: str | None = None,
     check_organizer: bool = True,
-) -> tuple[list[dict[str, Any]], list[str], str | None]:
+) -> tuple[list[dict[str, Any]], list[str]]:
     """Check the organizer's own calendar (when check_organizer) plus each
     attendee's free/busy for anything overlapping [time_min, time_max).
 
@@ -99,16 +100,16 @@ def _find_conflicts(
     (see google_calendar_update_events) rather than relying on this function
     to exclude the event's own footprint on attendee calendars.
 
-    Returns (conflicts, unchecked_attendees, unchecked_reason). The third
-    element is set only when attendees ended up unchecked because of a
-    missing-scope 403 - the one unchecked case an LLM caller can actually
-    act on (ask the user to reconnect the connector) - not for the other,
-    self-explanatory unchecked cases (absent from the response, or a
-    per-attendee error entry).
+    Returns (conflicts, unchecked_attendees). A missing-scope 403 covering
+    the whole call raises ValueError instead of degrading to unchecked -
+    that's OUR OWN credential's problem, not a per-attendee visibility
+    gap, and writing an event whose availability was never actually
+    checked would defeat the point of this feature. Every entry that
+    does end up in `unchecked_attendees` is the self-explanatory kind
+    (absent from the response, or its own per-attendee error).
     """
     conflicts: list[dict[str, Any]] = []
     unchecked_attendees: list[str] = []
-    unchecked_reason: str | None = None
 
     if check_organizer:
         organizer_events = (
@@ -131,19 +132,16 @@ def _find_conflicts(
                 continue
             if exclude_event_id and item.get("id") == exclude_event_id:
                 continue
-            # An event the organizer personally declined still sits on
-            # their calendar (declining doesn't clear transparency), but
-            # it's not something they're actually busy for.
-            self_response = next(
-                (
-                    a.get("responseStatus")
-                    for a in item.get("attendees") or []
-                    if a.get("self")
-                ),
-                None,
-            )
-            if self_response == "declined":
-                continue
+            # NOTE: declining an invite (attendees[].responseStatus ==
+            # "declined" for the organizer's own self entry) is NOT used
+            # as a busy/free signal here - Google's own Events docs treat
+            # responseStatus and transparency as independent fields, with
+            # no documented guarantee that declining clears transparency
+            # to "transparent". An earlier version of this check skipped
+            # declined events outright, which silently treated a
+            # still-opaque declined event as free and permitted a real
+            # double booking. `transparency` above is the one field
+            # Google actually documents as the busy/free predicate.
             start = item.get("start") or {}
             end = item.get("end") or {}
             conflicts.append(
@@ -179,16 +177,21 @@ def _find_conflicts(
                 # This connection's OAuth token predates the
                 # calendar.freebusy scope (see the
                 # 20260907_add_calendar_freebusy_scope migration) and
-                # hasn't been reconnected yet. Don't abort the whole
-                # booking over an availability check the token can't
-                # run - report this batch as unchecked instead.
-                unchecked_attendees.extend(batch)
-                unchecked_reason = (
+                # hasn't been reconnected yet. This is OUR OWN
+                # credential's problem, not a per-attendee visibility gap
+                # (e.g. a specific attendee's calendar being unreadable,
+                # which genuinely can't be fixed and still degrades to
+                # unchecked below) - proceeding to write an event whose
+                # availability was never actually checked would defeat
+                # the entire point of this feature, so reject instead of
+                # silently booking over a possible conflict.
+                raise ValueError(
                     "Missing the calendar.freebusy permission needed to "
                     "check attendee availability - reconnect the Google "
-                    "Calendar connector to grant it."
-                )
-                continue
+                    "Calendar connector to grant it, or pass "
+                    "ignore_conflicts=true if the user has confirmed "
+                    "they want to proceed without this check."
+                ) from exc
             raise
 
         # Google's own calendarList entries are case-normalized; be
@@ -220,26 +223,62 @@ def _find_conflicts(
                     }
                 )
 
-    return conflicts, unchecked_attendees, unchecked_reason
+    return conflicts, unchecked_attendees
 
 
 def _primary_calendar_timezone(service: Any) -> str:
     """The primary calendar's own configured IANA timezone (falls back to
     UTC if somehow absent - Google's Calendar resource always carries a
-    timeZone, so this is a defensive last resort, not the expected path)."""
-    return (
-        service.calendars().get(calendarId="primary").execute().get("timeZone") or "UTC"
-    )
+    timeZone, so this is a defensive last resort, not the expected path).
+
+    Needs the calendar.calendars.readonly scope (see the
+    20260909_add_calendar_calendars_readonly_scope migration) - neither
+    calendar.events nor calendar.freebusy authorizes calendars.get, per
+    Google's own scope reference for that endpoint.
+    """
+    try:
+        calendar = service.calendars().get(calendarId="primary").execute()
+    except HttpError as exc:
+        if exc.resp.status == 403 and _is_insufficient_scope_error(exc):
+            # This connection's OAuth token predates the
+            # calendar.calendars.readonly scope. Without the calendar's
+            # own timezone, an all-day boundary can't be safely widened
+            # for the conflict check that's about to run - reject rather
+            # than silently guessing (e.g. defaulting to UTC), which
+            # could misjudge the query window by the calendar's real
+            # UTC offset.
+            raise ValueError(
+                "Missing the calendar.calendars.readonly permission "
+                "needed to look up the calendar's timezone for this "
+                "all-day event - reconnect the Google Calendar "
+                "connector to grant it, or pass ignore_conflicts=true "
+                "if the user has confirmed they want to proceed without "
+                "this check."
+            ) from exc
+        raise
+    return calendar.get("timeZone") or "UTC"
 
 
 def _event_boundary(field: dict[str, Any] | None, tz_name: str) -> str | None:
     """Return a RFC3339 timestamp usable as a freebusy/events.list time
     bound for one side (start or end) of an event.
 
-    Google represents a timed event's boundary as {"dateTime": ...} (which
-    already carries its own zone offset - used as-is) and an all-day
-    event's as {"date": "YYYY-MM-DD"} - timeMin/timeMax require a full
-    RFC3339 timestamp with a zone offset, so a bare date needs widening.
+    Google represents a timed event's boundary as {"dateTime": ...} and an
+    all-day event's as {"date": "YYYY-MM-DD"} - timeMin/timeMax require a
+    full RFC3339 timestamp with a zone offset, so a bare date needs
+    widening.
+
+    A timed boundary's `dateTime` USUALLY already carries its own zone
+    offset, but Google's own EventDateTime docs are explicit that this
+    isn't guaranteed: "A time zone offset is required unless a time zone
+    is explicitly specified in timeZone" - a client (including one that
+    isn't this tool) can legally write an offsetless `dateTime` paired
+    with a sibling `timeZone` field instead. Comparing that offsetless
+    string as if it were self-describing would compare naive against
+    aware for what could be the same instant, defeating the overlap math
+    this whole module exists to get right - so it must be resolved
+    against its own `timeZone` (falling back to the calendar's default,
+    `tz_name`, only if this specific field is missing one).
 
     An all-day event's date is a day on the *calendar's own* calendar, not
     a UTC day - `tz_name` must be that calendar's configured timezone, not
@@ -251,7 +290,13 @@ def _event_boundary(field: dict[str, Any] | None, tz_name: str) -> str | None:
     field = field or {}
     date_time: str | None = field.get("dateTime")
     if date_time:
-        return date_time
+        try:
+            is_naive = datetime.fromisoformat(date_time).tzinfo is None
+        except ValueError:
+            return date_time  # malformed - pass through unchanged, as before
+        if not is_naive:
+            return date_time
+        return _offset_datetime_string(date_time, field.get("timeZone") or tz_name)
     date_value: str | None = field.get("date")
     if date_value:
         start, _ = _calendar_day_bounds(date_value, tz_name)
@@ -520,9 +565,8 @@ def google_calendar_create_events(
         normalized_attendees = _normalize_addresses(attendees) if attendees else []
 
         unchecked_attendees: list[str] = []
-        unchecked_reason: str | None = None
         if not ignore_conflicts:
-            conflicts, unchecked_attendees, unchecked_reason = _find_conflicts(
+            conflicts, unchecked_attendees = _find_conflicts(
                 service, start_time, end_time, normalized_attendees
             )
             if conflicts:
@@ -531,7 +575,6 @@ def google_calendar_create_events(
                     unchecked_attendees,
                     start_time,
                     end_time,
-                    unchecked_reason=unchecked_reason,
                 )
 
         event: dict[str, Any] = {
@@ -560,9 +603,7 @@ def google_calendar_create_events(
             **_api_call_kwargs(event, notify_attendees),
         )
         created_event = request.execute()
-        return _event_response(
-            created_event, **_unchecked_extra(unchecked_attendees, unchecked_reason)
-        )
+        return _event_response(created_event, **_unchecked_extra(unchecked_attendees))
 
     except Exception as e:
         logger.error(f"Error creating event: {e}")
@@ -652,9 +693,20 @@ def google_calendar_update_events(
         # boundary (see _event_boundary) - fetch it lazily so a plain
         # timed-event update doesn't pay for an extra API call it has no
         # use for.
-        calendar_timezone = (
-            _primary_calendar_timezone(service) if existing_is_all_day else "UTC"
-        )
+        try:
+            calendar_timezone = (
+                _primary_calendar_timezone(service) if existing_is_all_day else "UTC"
+            )
+        except ValueError:
+            if not ignore_conflicts:
+                raise
+            # ignore_conflicts=True means the caller has already decided
+            # the conflict check doesn't need to run - a missing-scope
+            # 403 here would only ever be surfaced by that check (or by
+            # the reversed-window sanity check below, which is fine to
+            # run a little less precisely against UTC than to block a
+            # write the caller explicitly opted out of checking).
+            calendar_timezone = "UTC"
         existing_start = _event_boundary(event.get("start"), calendar_timezone)
         existing_end = _event_boundary(event.get("end"), calendar_timezone)
         effective_start = start_time or existing_start
@@ -680,58 +732,70 @@ def google_calendar_update_events(
         }
         # attendees only ever ADDS: there's no way to remove an existing
         # attendee through this parameter (matching this tool's own
-        # docstring), so the effective set for conflict-checking purposes
-        # is always existing-plus-newly-added, never a caller-supplied
-        # subset that could silently drop someone. `added_attendees` (the
-        # ones actually new) is what the write step appends below.
+        # docstring). `added_attendees` (genuinely new) and
+        # `existing_attendees_raw` (retained) are checked separately
+        # below - a retained attendee only needs checking against the
+        # portion of a moved window that's actually new territory, while
+        # a newly-added one needs the whole effective window checked.
         added_attendees = _attendees_to_add(attendees, existing_attendee_emails)
-        # Preserve the casing already on the event - only the membership
-        # check below needs to be case-insensitive, not what gets
-        # queried/reported back to the caller.
-        normalized_attendees = sorted(existing_attendees_raw + added_attendees)
 
         unchecked_attendees: list[str] = []
-        unchecked_reason: str | None = None
         if not ignore_conflicts and effective_start and effective_end:
-            # A partial nudge that still overlaps the old window is just
-            # as unsafe to free/busy-check existing attendees against as
-            # the unchanged-window case: the overlap still contains this
-            # event's own busy block on their calendars, which isn't a
-            # real conflict. Only a window that's moved to somewhere
-            # completely disjoint from the old one is safe to check every
-            # attendee against. The organizer side has no such problem
-            # (excluded by event id, not by window), so it only needs
-            # `window_changed`, not the stricter disjoint test.
-            overlapping = _windows_overlap(
-                existing_start_key,
-                existing_end_key,
-                effective_start_key,
-                effective_end_key,
-            )
-            attendees_to_check = _attendees_needing_check(
-                normalized_attendees,
-                existing_attendee_emails,
-                moved_to_a_disjoint_window=window_changed and not overlapping,
-            )
             check_organizer = window_changed
+            all_conflicts: list[dict[str, Any]] = []
 
-            if check_organizer or attendees_to_check:
-                conflicts, unchecked_attendees, unchecked_reason = _find_conflicts(
+            # A newly-added attendee has no footprint on this event at
+            # all, so the FULL effective window is safe (and necessary)
+            # to check for them - same call also covers the organizer,
+            # who's excluded by event id rather than by window, so
+            # `window_changed` alone (not a disjoint-move test) decides
+            # whether to re-check them.
+            if check_organizer or added_attendees:
+                conflicts, unchecked = _find_conflicts(
                     service,
                     effective_start,
                     effective_end,
-                    attendees_to_check,
+                    added_attendees,
                     exclude_event_id=event_id,
                     check_organizer=check_organizer,
                 )
-                if conflicts:
-                    return _conflict_response(
-                        conflicts,
-                        unchecked_attendees,
-                        effective_start,
-                        effective_end,
-                        unchecked_reason=unchecked_reason,
+                all_conflicts.extend(conflicts)
+                unchecked_attendees.extend(unchecked)
+
+            # A retained attendee's own busy block for THIS event covers
+            # the entire OLD window - querying that overlap can't tell
+            # "busy because of this event" from a real conflict. Only the
+            # portion of the new window that's genuinely new territory
+            # (window_delta_segments - empty for an unchanged/shrunk
+            # window, up to two segments for a partial nudge that extends
+            # past the old window on one or both sides, or the whole new
+            # window for a fully disjoint move) can hide a real conflict
+            # for them.
+            if existing_attendees_raw:
+                for seg_start, seg_end in _window_delta_segments(
+                    existing_start_key,
+                    existing_end_key,
+                    effective_start_key,
+                    effective_end_key,
+                ):
+                    conflicts, unchecked = _find_conflicts(
+                        service,
+                        seg_start.isoformat(),
+                        seg_end.isoformat(),
+                        existing_attendees_raw,
+                        exclude_event_id=event_id,
+                        check_organizer=False,
                     )
+                    all_conflicts.extend(conflicts)
+                    unchecked_attendees.extend(unchecked)
+
+            if all_conflicts:
+                return _conflict_response(
+                    all_conflicts,
+                    unchecked_attendees,
+                    effective_start,
+                    effective_end,
+                )
 
         if summary:
             event["summary"] = summary
@@ -760,9 +824,7 @@ def google_calendar_update_events(
             **_api_call_kwargs(event, notify_attendees),
         )
         updated_event = request.execute()
-        return _event_response(
-            updated_event, **_unchecked_extra(unchecked_attendees, unchecked_reason)
-        )
+        return _event_response(updated_event, **_unchecked_extra(unchecked_attendees))
 
     except Exception as e:
         logger.error(f"Error updating event: {e}")

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -15,8 +15,7 @@ from .utils import calendar_day_bounds as _calendar_day_bounds
 from .utils import conflict_response as _conflict_response
 from .utils import datetime_key_for_comparison as _datetime_key_for_comparison
 from .utils import normalize_addresses as _normalize_addresses
-from .utils import setup_proxy_env
-from .utils import success_with_capped_dict
+from .utils import setup_proxy_env, success_with_capped_dict
 from .utils import unchecked_extra as _unchecked_extra
 from .utils import windows_overlap as _windows_overlap
 

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -15,6 +15,7 @@ from .utils import attendees_to_add as _attendees_to_add
 from .utils import calendar_day_bounds as _calendar_day_bounds
 from .utils import conflict_response as _conflict_response
 from .utils import datetime_key_for_comparison as _datetime_key_for_comparison
+from .utils import merge_scope_error as _merge_scope_error
 from .utils import normalize_addresses as _normalize_addresses
 from .utils import offset_datetime_string as _offset_datetime_string
 from .utils import reject_reversed_window as _reject_reversed_window
@@ -586,15 +587,7 @@ def google_calendar_create_events(
                     service, start_time, end_time, normalized_attendees
                 )
             except InsufficientScopeError as exc:
-                # A real conflict (e.g. on the organizer's own calendar,
-                # which doesn't need the freebusy scope) can already have
-                # been confirmed before a later attendee batch hit this
-                # scope error - reporting it is always safe regardless of
-                # what else couldn't be checked, so only reject the write
-                # outright when nothing was confirmed yet.
-                if not exc.conflicts:
-                    raise
-                conflicts, unchecked_attendees = exc.conflicts, exc.unchecked_attendees
+                conflicts, unchecked_attendees = _merge_scope_error(exc, [], [])
             if conflicts:
                 return _conflict_response(
                     conflicts,
@@ -746,7 +739,14 @@ def google_calendar_update_events(
         existing_end = _event_boundary(event.get("end"), calendar_timezone)
         effective_start = start_time or existing_start
         effective_end = end_time or existing_end
-        if effective_start and effective_end:
+        if (start_time or end_time) and effective_start and effective_end:
+            # Only worth checking when this call is actually about to
+            # write a (possibly partly-existing) window - an
+            # attendees/summary-only edit that never moves either
+            # boundary would otherwise re-validate the event's
+            # already-stored, unchanged start/end and could reject an
+            # unrelated field edit over pre-existing data this call
+            # never touches.
             _reject_reversed_window(effective_start, effective_end)
         existing_start_key = _datetime_key_for_comparison(existing_start)
         existing_end_key = _datetime_key_for_comparison(existing_end)
@@ -825,17 +825,9 @@ def google_calendar_update_events(
                         all_conflicts.extend(conflicts)
                         unchecked_attendees.extend(unchecked)
             except InsufficientScopeError as exc:
-                # A real conflict can already have been confirmed by an
-                # earlier call above (or earlier in this same call, e.g.
-                # an organizer conflict found before the attendee batch
-                # that hit this scope error) - reporting it is always
-                # safe regardless of what else couldn't be checked, so
-                # only reject the write outright when nothing was
-                # confirmed yet.
-                all_conflicts.extend(exc.conflicts)
-                unchecked_attendees.extend(exc.unchecked_attendees)
-                if not all_conflicts:
-                    raise
+                all_conflicts, unchecked_attendees = _merge_scope_error(
+                    exc, all_conflicts, unchecked_attendees
+                )
 
             if all_conflicts:
                 return _conflict_response(

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -10,6 +10,7 @@ from googleapiclient.discovery import build  # type: ignore
 from googleapiclient.errors import HttpError  # type: ignore
 from mcp.server.fastmcp import FastMCP
 
+from .utils import InsufficientScopeError
 from .utils import attendees_to_add as _attendees_to_add
 from .utils import calendar_day_bounds as _calendar_day_bounds
 from .utils import conflict_response as _conflict_response
@@ -101,12 +102,15 @@ def _find_conflicts(
     to exclude the event's own footprint on attendee calendars.
 
     Returns (conflicts, unchecked_attendees). A missing-scope 403 covering
-    the whole call raises ValueError instead of degrading to unchecked -
+    the whole call raises `InsufficientScopeError` (carrying whatever was
+    already confirmed in `conflicts`/`unchecked_attendees` before the
+    error) instead of degrading to unchecked and returning normally -
     that's OUR OWN credential's problem, not a per-attendee visibility
     gap, and writing an event whose availability was never actually
     checked would defeat the point of this feature. Every entry that
-    does end up in `unchecked_attendees` is the self-explanatory kind
-    (absent from the response, or its own per-attendee error).
+    does end up in `unchecked_attendees` on a normal return is the
+    self-explanatory kind (absent from the response, or its own
+    per-attendee error).
     """
     conflicts: list[dict[str, Any]] = []
     unchecked_attendees: list[str] = []
@@ -184,13 +188,24 @@ def _find_conflicts(
                 # unchecked below) - proceeding to write an event whose
                 # availability was never actually checked would defeat
                 # the entire point of this feature, so reject instead of
-                # silently booking over a possible conflict.
-                raise ValueError(
+                # silently booking over a possible conflict. Carrying
+                # `conflicts` (e.g. an organizer conflict already found
+                # above, before this batch ever ran) lets a caller still
+                # report it rather than silently discarding a known
+                # problem just because this later, unrelated check also
+                # failed.
+                raise InsufficientScopeError(
                     "Missing the calendar.freebusy permission needed to "
                     "check attendee availability - reconnect the Google "
                     "Calendar connector to grant it, or pass "
                     "ignore_conflicts=true if the user has confirmed "
-                    "they want to proceed without this check."
+                    "they want to proceed without this check.",
+                    conflicts,
+                    # Every attendee from this failed batch onward is
+                    # unchecked - every remaining batch would hit this
+                    # same scope error too, so there's nothing left to
+                    # gain by attempting them.
+                    unchecked_attendees + attendees[offset:],
                 ) from exc
             raise
 
@@ -566,9 +581,20 @@ def google_calendar_create_events(
 
         unchecked_attendees: list[str] = []
         if not ignore_conflicts:
-            conflicts, unchecked_attendees = _find_conflicts(
-                service, start_time, end_time, normalized_attendees
-            )
+            try:
+                conflicts, unchecked_attendees = _find_conflicts(
+                    service, start_time, end_time, normalized_attendees
+                )
+            except InsufficientScopeError as exc:
+                # A real conflict (e.g. on the organizer's own calendar,
+                # which doesn't need the freebusy scope) can already have
+                # been confirmed before a later attendee batch hit this
+                # scope error - reporting it is always safe regardless of
+                # what else couldn't be checked, so only reject the write
+                # outright when nothing was confirmed yet.
+                if not exc.conflicts:
+                    raise
+                conflicts, unchecked_attendees = exc.conflicts, exc.unchecked_attendees
             if conflicts:
                 return _conflict_response(
                     conflicts,
@@ -690,12 +716,21 @@ def google_calendar_update_events(
             )
 
         # The calendar's own timezone is only needed to widen an all-day
-        # boundary (see _event_boundary) - fetch it lazily so a plain
-        # timed-event update doesn't pay for an extra API call it has no
-        # use for.
+        # boundary (see _event_boundary) so a moved window or an
+        # added/retained attendee gets checked against the right absolute
+        # instant - fetch it lazily so a plain timed-event update, or a
+        # summary/location/description-only edit of an all-day event that
+        # never touches its window or attendees, doesn't pay for an extra
+        # API call (or a scope-403 that would otherwise block an edit
+        # that never needed timezone precision at all) it has no use for.
+        needs_real_calendar_timezone = existing_is_all_day and (
+            bool(start_time) or bool(end_time) or bool(attendees)
+        )
         try:
             calendar_timezone = (
-                _primary_calendar_timezone(service) if existing_is_all_day else "UTC"
+                _primary_calendar_timezone(service)
+                if needs_real_calendar_timezone
+                else "UTC"
             )
         except ValueError:
             if not ignore_conflicts:
@@ -744,50 +779,63 @@ def google_calendar_update_events(
             check_organizer = window_changed
             all_conflicts: list[dict[str, Any]] = []
 
-            # A newly-added attendee has no footprint on this event at
-            # all, so the FULL effective window is safe (and necessary)
-            # to check for them - same call also covers the organizer,
-            # who's excluded by event id rather than by window, so
-            # `window_changed` alone (not a disjoint-move test) decides
-            # whether to re-check them.
-            if check_organizer or added_attendees:
-                conflicts, unchecked = _find_conflicts(
-                    service,
-                    effective_start,
-                    effective_end,
-                    added_attendees,
-                    exclude_event_id=event_id,
-                    check_organizer=check_organizer,
-                )
-                all_conflicts.extend(conflicts)
-                unchecked_attendees.extend(unchecked)
-
-            # A retained attendee's own busy block for THIS event covers
-            # the entire OLD window - querying that overlap can't tell
-            # "busy because of this event" from a real conflict. Only the
-            # portion of the new window that's genuinely new territory
-            # (window_delta_segments - empty for an unchanged/shrunk
-            # window, up to two segments for a partial nudge that extends
-            # past the old window on one or both sides, or the whole new
-            # window for a fully disjoint move) can hide a real conflict
-            # for them.
-            if existing_attendees_raw:
-                for seg_start, seg_end in _window_delta_segments(
-                    existing_start_key,
-                    existing_end_key,
-                    effective_start_key,
-                    effective_end_key,
-                ):
+            try:
+                # A newly-added attendee has no footprint on this event
+                # at all, so the FULL effective window is safe (and
+                # necessary) to check for them - same call also covers
+                # the organizer, who's excluded by event id rather than
+                # by window, so `window_changed` alone (not a
+                # disjoint-move test) decides whether to re-check them.
+                if check_organizer or added_attendees:
                     conflicts, unchecked = _find_conflicts(
                         service,
-                        seg_start.isoformat(),
-                        seg_end.isoformat(),
-                        existing_attendees_raw,
+                        effective_start,
+                        effective_end,
+                        added_attendees,
                         exclude_event_id=event_id,
-                        check_organizer=False,
+                        check_organizer=check_organizer,
                     )
                     all_conflicts.extend(conflicts)
                     unchecked_attendees.extend(unchecked)
+
+                # A retained attendee's own busy block for THIS event
+                # covers the entire OLD window - querying that overlap
+                # can't tell "busy because of this event" from a real
+                # conflict. Only the portion of the new window that's
+                # genuinely new territory (window_delta_segments - empty
+                # for an unchanged/shrunk window, up to two segments for
+                # a partial nudge that extends past the old window on one
+                # or both sides, or the whole new window for a fully
+                # disjoint move) can hide a real conflict for them.
+                if existing_attendees_raw:
+                    for seg_start, seg_end in _window_delta_segments(
+                        existing_start_key,
+                        existing_end_key,
+                        effective_start_key,
+                        effective_end_key,
+                    ):
+                        conflicts, unchecked = _find_conflicts(
+                            service,
+                            seg_start.isoformat(),
+                            seg_end.isoformat(),
+                            existing_attendees_raw,
+                            exclude_event_id=event_id,
+                            check_organizer=False,
+                        )
+                        all_conflicts.extend(conflicts)
+                        unchecked_attendees.extend(unchecked)
+            except InsufficientScopeError as exc:
+                # A real conflict can already have been confirmed by an
+                # earlier call above (or earlier in this same call, e.g.
+                # an organizer conflict found before the attendee batch
+                # that hit this scope error) - reporting it is always
+                # safe regardless of what else couldn't be checked, so
+                # only reject the write outright when nothing was
+                # confirmed yet.
+                all_conflicts.extend(exc.conflicts)
+                unchecked_attendees.extend(exc.unchecked_attendees)
+                if not all_conflicts:
+                    raise
 
             if all_conflicts:
                 return _conflict_response(

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -10,11 +10,12 @@ from googleapiclient.errors import HttpError  # type: ignore
 from mcp.server.fastmcp import FastMCP
 
 from .utils import attendees_needing_check as _attendees_needing_check
-from .utils import attendees_were_given as _attendees_were_given
+from .utils import attendees_to_add as _attendees_to_add
 from .utils import calendar_day_bounds as _calendar_day_bounds
 from .utils import conflict_response as _conflict_response
 from .utils import datetime_key_for_comparison as _datetime_key_for_comparison
 from .utils import normalize_addresses as _normalize_addresses
+from .utils import reject_reversed_window as _reject_reversed_window
 from .utils import setup_proxy_env, success_with_capped_dict
 from .utils import unchecked_extra as _unchecked_extra
 from .utils import windows_overlap as _windows_overlap
@@ -30,6 +31,43 @@ mcp = FastMCP("calendar-mcp")
 # freebusy.query accepts at most this many calendars per call
 # (Google's calendarExpansionMax).
 _MAX_ATTENDEES_PER_FREEBUSY_QUERY = 50
+
+
+def _is_insufficient_scope_error(exc: Any) -> bool:
+    """Whether `exc` is specifically "the access token doesn't have the
+    scope this call needs", not just any 403.
+
+    Google's error body can carry this reason on either of two fields,
+    and both show up in practice: the legacy `error.errors[].reason ==
+    "insufficientPermissions"`, and a newer `error.details[].reason ==
+    "ACCESS_TOKEN_SCOPE_INSUFFICIENT"` (an ErrorInfo entry) that a real
+    Calendar API 403 for this exact case carries ALONGSIDE the legacy
+    one, not instead of it. `HttpError._get_reason` picks one field per
+    a fixed priority order (`detail` > `details` > `errors` > `message`)
+    to build `exc.error_details`/`str(exc)` - when both are present,
+    `details` wins and the legacy reason string is dropped entirely from
+    the formatted message. So a plain substring check on `str(exc)` can
+    silently stop matching real scope errors the moment Google's backend
+    starts including both. Check the parsed body directly instead of
+    trusting which one HttpError's own formatting happens to surface.
+    """
+    try:
+        data = json.loads(exc.content.decode("utf-8"))
+    except (ValueError, AttributeError):
+        return False
+    error = data.get("error") if isinstance(data, dict) else None
+    if not isinstance(error, dict):
+        return False
+    for entry in error.get("errors") or []:
+        if isinstance(entry, dict) and entry.get("reason") == "insufficientPermissions":
+            return True
+    for entry in error.get("details") or []:
+        if (
+            isinstance(entry, dict)
+            and entry.get("reason") == "ACCESS_TOKEN_SCOPE_INSUFFICIENT"
+        ):
+            return True
+    return False
 
 
 def _find_conflicts(
@@ -132,7 +170,7 @@ def _find_conflicts(
                 .execute()
             )
         except HttpError as exc:
-            if exc.resp.status == 403 and "insufficientPermissions" in str(exc):
+            if exc.resp.status == 403 and _is_insufficient_scope_error(exc):
                 # This connection's OAuth token predates the
                 # calendar.freebusy scope (see the
                 # 20260907_add_calendar_freebusy_scope migration) and
@@ -472,6 +510,7 @@ def google_calendar_create_events(
     """
     requested_conference = False
     try:
+        _reject_reversed_window(start_time, end_time)
         service = get_calendar_service()
         normalized_attendees = _normalize_addresses(attendees) if attendees else []
 
@@ -588,8 +627,6 @@ def google_calendar_update_events(
         # First get the existing event
         event = service.events().get(calendarId="primary", eventId=event_id).execute()
 
-        attendees_given = _attendees_were_given(attendees)
-
         existing_is_all_day = "date" in (event.get("start") or {}) or "date" in (
             event.get("end") or {}
         )
@@ -640,17 +677,7 @@ def google_calendar_update_events(
         # is always existing-plus-newly-added, never a caller-supplied
         # subset that could silently drop someone. `added_attendees` (the
         # ones actually new) is what the write step appends below.
-        if attendees_given:
-            assert (
-                attendees is not None
-            )  # narrows for mypy; attendees_given implies this
-            added_attendees = [
-                address
-                for address in _normalize_addresses(attendees)
-                if address.lower() not in existing_attendee_emails
-            ]
-        else:
-            added_attendees = []
+        added_attendees = _attendees_to_add(attendees, existing_attendee_emails)
         # Preserve the casing already on the event - only the membership
         # check below needs to be case-insensitive, not what gets
         # queried/reported back to the caller.

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -58,15 +58,20 @@ def _is_insufficient_scope_error(exc: Any) -> bool:
     error = data.get("error") if isinstance(data, dict) else None
     if not isinstance(error, dict):
         return False
-    for entry in error.get("errors") or []:
-        if isinstance(entry, dict) and entry.get("reason") == "insufficientPermissions":
-            return True
-    for entry in error.get("details") or []:
-        if (
-            isinstance(entry, dict)
-            and entry.get("reason") == "ACCESS_TOKEN_SCOPE_INSUFFICIENT"
-        ):
-            return True
+    for field, reason in (
+        ("errors", "insufficientPermissions"),
+        ("details", "ACCESS_TOKEN_SCOPE_INSUFFICIENT"),
+    ):
+        entries = error.get(field)
+        if not isinstance(entries, list):
+            # A real Google error body always shapes these as arrays -
+            # this is defensive against a malformed/unexpected body,
+            # which is exactly the "can't tell" case this function
+            # already treats as False elsewhere (e.g. non-JSON content).
+            continue
+        for entry in entries:
+            if isinstance(entry, dict) and entry.get("reason") == reason:
+                return True
     return False
 
 
@@ -654,6 +659,8 @@ def google_calendar_update_events(
         existing_end = _event_boundary(event.get("end"), calendar_timezone)
         effective_start = start_time or existing_start
         effective_end = end_time or existing_end
+        if effective_start and effective_end:
+            _reject_reversed_window(effective_start, effective_end)
         existing_start_key = _datetime_key_for_comparison(existing_start)
         existing_end_key = _datetime_key_for_comparison(existing_end)
         effective_start_key = _datetime_key_for_comparison(effective_start)

--- a/src/xagent/web/tools/mcp/calendar.py
+++ b/src/xagent/web/tools/mcp/calendar.py
@@ -6,9 +6,19 @@ from typing import Any
 
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build  # type: ignore
+from googleapiclient.errors import HttpError  # type: ignore
 from mcp.server.fastmcp import FastMCP
 
-from .utils import setup_proxy_env, success_with_capped_dict
+from .utils import attendees_needing_check as _attendees_needing_check
+from .utils import attendees_were_given as _attendees_were_given
+from .utils import calendar_day_bounds as _calendar_day_bounds
+from .utils import conflict_response as _conflict_response
+from .utils import datetime_key_for_comparison as _datetime_key_for_comparison
+from .utils import normalize_addresses as _normalize_addresses
+from .utils import setup_proxy_env
+from .utils import success_with_capped_dict
+from .utils import unchecked_extra as _unchecked_extra
+from .utils import windows_overlap as _windows_overlap
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("calendar-mcp")
@@ -17,6 +27,194 @@ logger = logging.getLogger("calendar-mcp")
 setup_proxy_env()
 
 mcp = FastMCP("calendar-mcp")
+
+# freebusy.query accepts at most this many calendars per call
+# (Google's calendarExpansionMax).
+_MAX_ATTENDEES_PER_FREEBUSY_QUERY = 50
+
+
+def _find_conflicts(
+    service: Any,
+    time_min: str,
+    time_max: str,
+    attendees: list[str],
+    *,
+    exclude_event_id: str | None = None,
+    check_organizer: bool = True,
+) -> tuple[list[dict[str, Any]], list[str], str | None]:
+    """Check the organizer's own calendar (when check_organizer) plus each
+    attendee's free/busy for anything overlapping [time_min, time_max).
+
+    Delegates the actual interval-overlap comparison to the Google Calendar
+    API's timeMin/timeMax semantics rather than parsing/normalizing the
+    timestamps locally, so this can't reproduce a timezone-comparison bug.
+
+    Free/busy has no concept of "exclude this event": it only returns raw
+    busy time ranges, so a query against a window an attendee is *already*
+    busy for (because that's the very event being updated) can't be told
+    apart from a genuine conflict here. Callers that aren't moving the event
+    to a new window must restrict `attendees` to only the newly-added ones
+    (see google_calendar_update_events) rather than relying on this function
+    to exclude the event's own footprint on attendee calendars.
+
+    Returns (conflicts, unchecked_attendees, unchecked_reason). The third
+    element is set only when attendees ended up unchecked because of a
+    missing-scope 403 - the one unchecked case an LLM caller can actually
+    act on (ask the user to reconnect the connector) - not for the other,
+    self-explanatory unchecked cases (absent from the response, or a
+    per-attendee error entry).
+    """
+    conflicts: list[dict[str, Any]] = []
+    unchecked_attendees: list[str] = []
+    unchecked_reason: str | None = None
+
+    if check_organizer:
+        organizer_events = (
+            service.events()
+            .list(
+                calendarId="primary",
+                timeMin=time_min,
+                timeMax=time_max,
+                singleEvents=True,
+                orderBy="startTime",
+            )
+            .execute()
+            .get("items")
+            or []
+        )
+        for item in organizer_events:
+            if item.get("status") == "cancelled":
+                continue
+            if item.get("transparency") == "transparent":
+                continue
+            if exclude_event_id and item.get("id") == exclude_event_id:
+                continue
+            # An event the organizer personally declined still sits on
+            # their calendar (declining doesn't clear transparency), but
+            # it's not something they're actually busy for.
+            self_response = next(
+                (
+                    a.get("responseStatus")
+                    for a in item.get("attendees") or []
+                    if a.get("self")
+                ),
+                None,
+            )
+            if self_response == "declined":
+                continue
+            start = item.get("start") or {}
+            end = item.get("end") or {}
+            conflicts.append(
+                {
+                    "calendar": "organizer",
+                    "summary": item.get("summary") or "(no title)",
+                    "start": start.get("dateTime") or start.get("date"),
+                    "end": end.get("dateTime") or end.get("date"),
+                }
+            )
+
+    # freebusy.query caps the number of calendars per call
+    # (Google's calendarExpansionMax) - chunk rather than giving up on the
+    # whole batch, so a large invite list still gets everyone it can check
+    # only. `range(0, 0, N)` is empty, so this is also just a no-op loop
+    # when `attendees` is empty.
+    for offset in range(0, len(attendees), _MAX_ATTENDEES_PER_FREEBUSY_QUERY):
+        batch = attendees[offset : offset + _MAX_ATTENDEES_PER_FREEBUSY_QUERY]
+        try:
+            freebusy = (
+                service.freebusy()
+                .query(
+                    body={
+                        "timeMin": time_min,
+                        "timeMax": time_max,
+                        "items": [{"id": email} for email in batch],
+                    }
+                )
+                .execute()
+            )
+        except HttpError as exc:
+            if exc.resp.status == 403 and "insufficientPermissions" in str(exc):
+                # This connection's OAuth token predates the
+                # calendar.freebusy scope (see the
+                # 20260907_add_calendar_freebusy_scope migration) and
+                # hasn't been reconnected yet. Don't abort the whole
+                # booking over an availability check the token can't
+                # run - report this batch as unchecked instead.
+                unchecked_attendees.extend(batch)
+                unchecked_reason = (
+                    "Missing the calendar.freebusy permission needed to "
+                    "check attendee availability - reconnect the Google "
+                    "Calendar connector to grant it."
+                )
+                continue
+            raise
+
+        # Google's own calendarList entries are case-normalized; be
+        # defensive in case freebusy echoes calendar ids back
+        # differently from how the caller supplied them, rather than
+        # silently dropping a real conflict/error for that attendee.
+        calendars = {
+            key.lower(): value
+            for key, value in (freebusy.get("calendars") or {}).items()
+        }
+        for email in batch:
+            if email.lower() not in calendars:
+                # Not even present in the response - can't tell
+                # whether they're free, so don't silently report them
+                # as clear.
+                unchecked_attendees.append(email)
+                continue
+            info = calendars[email.lower()] or {}
+            if info.get("errors"):
+                unchecked_attendees.append(email)
+                continue
+            for busy in info.get("busy") or []:
+                conflicts.append(
+                    {
+                        "calendar": email,
+                        "summary": None,
+                        "start": busy.get("start"),
+                        "end": busy.get("end"),
+                    }
+                )
+
+    return conflicts, unchecked_attendees, unchecked_reason
+
+
+def _primary_calendar_timezone(service: Any) -> str:
+    """The primary calendar's own configured IANA timezone (falls back to
+    UTC if somehow absent - Google's Calendar resource always carries a
+    timeZone, so this is a defensive last resort, not the expected path)."""
+    return (
+        service.calendars().get(calendarId="primary").execute().get("timeZone") or "UTC"
+    )
+
+
+def _event_boundary(field: dict[str, Any] | None, tz_name: str) -> str | None:
+    """Return a RFC3339 timestamp usable as a freebusy/events.list time
+    bound for one side (start or end) of an event.
+
+    Google represents a timed event's boundary as {"dateTime": ...} (which
+    already carries its own zone offset - used as-is) and an all-day
+    event's as {"date": "YYYY-MM-DD"} - timeMin/timeMax require a full
+    RFC3339 timestamp with a zone offset, so a bare date needs widening.
+
+    An all-day event's date is a day on the *calendar's own* calendar, not
+    a UTC day - `tz_name` must be that calendar's configured timezone, not
+    a hardcoded UTC, or the widened boundary is off by the calendar's own
+    UTC offset. All-day events already store both start.date and end.date
+    as the correct (exclusive-end) calendar-day range, so no day-arithmetic
+    is needed here - just giving each date its own midnight in tz_name.
+    """
+    field = field or {}
+    date_time: str | None = field.get("dateTime")
+    if date_time:
+        return date_time
+    date_value: str | None = field.get("date")
+    if date_value:
+        start, _ = _calendar_day_bounds(date_value, tz_name)
+        return start
+    return None
 
 
 def get_calendar_service() -> Any:
@@ -87,41 +285,6 @@ def _add_conference_request(event: dict[str, Any]) -> None:
             "conferenceSolutionKey": {"type": "hangoutsMeet"},
         }
     }
-
-
-def _merge_attendees(event: dict[str, Any], attendees: list[str] | None) -> None:
-    """Add attendees to the event without dropping ones already on it.
-
-    Matching against existing attendees (and within the new list) is
-    case-/whitespace-insensitive, since `Alice@Example.com` and
-    `alice@example.com` are the same mailbox and would otherwise be added
-    as a redundant duplicate.
-    """
-    if not attendees:
-        return
-    existing = event.get("attendees") or []
-    existing_emails = {
-        email.strip().lower()
-        for a in existing
-        if isinstance(a, dict) and (email := a.get("email"))
-    }
-
-    seen = set()
-    new_attendees = []
-    for email in attendees:
-        if not email:
-            continue
-        normalized = email.strip()
-        if not normalized:
-            continue
-        key = normalized.lower()
-        if key in existing_emails or key in seen:
-            continue
-        seen.add(key)
-        new_attendees.append({"email": normalized})
-
-    if new_attendees:
-        event["attendees"] = existing + new_attendees
 
 
 def _create_request_status_code(conference_data: dict[str, Any]) -> str | None:
@@ -232,7 +395,7 @@ def _error_message(exc: Exception, requested_conference: bool) -> str:
     return message
 
 
-def _event_response(event: dict[str, Any]) -> str:
+def _event_response(event: dict[str, Any], **extra_fields: Any) -> str:
     conference_data = event.get("conferenceData") or {}
 
     hangout_link = event.get("hangoutLink")
@@ -274,7 +437,8 @@ def _event_response(event: dict[str, Any]) -> str:
     # capping never has to reason about them.
     response = json.loads(success_with_capped_dict("event", event))
     response.update(extra)
-    return json.dumps(response)
+    response.update(extra_fields)
+    return json.dumps(response, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -284,16 +448,20 @@ def google_calendar_create_events(
     end_time: str,
     description: str | None = None,
     location: str | None = None,
-    attendees: list[str] | None = None,
+    attendees: list[str] | str | None = None,
     notify_attendees: bool = False,
     add_google_meet: bool = False,
+    ignore_conflicts: bool = False,
 ) -> str:
     """
     Create a new event in Google Calendar.
     start_time and end_time must be RFC3339 formatted (e.g., '2024-01-01T10:00:00Z' or '2024-01-01T10:00:00-07:00').
-    attendees is a list of email addresses to add to the event. Adding attendees does not, by
-    itself, email them; set notify_attendees=True to have Google Calendar send them a native
-    invite immediately. Confirm the recipient list with the user before setting notify_attendees=True.
+    attendees, if given, are checked for scheduling conflicts together with the organizer's own
+    calendar; a conflict returns status="conflict" instead of creating the event. Pass
+    ignore_conflicts=True to create it anyway once the user has explicitly confirmed a conflict is
+    fine. Adding attendees does not, by itself, email them; set notify_attendees=True to have Google
+    Calendar send them a native invite immediately. Confirm the recipient list with the user before
+    setting notify_attendees=True.
     Set add_google_meet=True to attach a real Google Meet video-conference link to the event. The
     link is returned as hangout_link once Google finishes provisioning it; if it isn't ready yet the
     response includes conference_status instead (e.g. "pending") — call google_calendar_get_event
@@ -306,6 +474,22 @@ def google_calendar_create_events(
     requested_conference = False
     try:
         service = get_calendar_service()
+        normalized_attendees = _normalize_addresses(attendees) if attendees else []
+
+        unchecked_attendees: list[str] = []
+        unchecked_reason: str | None = None
+        if not ignore_conflicts:
+            conflicts, unchecked_attendees, unchecked_reason = _find_conflicts(
+                service, start_time, end_time, normalized_attendees
+            )
+            if conflicts:
+                return _conflict_response(
+                    conflicts,
+                    unchecked_attendees,
+                    start_time,
+                    end_time,
+                    unchecked_reason=unchecked_reason,
+                )
 
         event: dict[str, Any] = {
             "summary": summary,
@@ -321,7 +505,10 @@ def google_calendar_create_events(
             event["description"] = description
         if location:
             event["location"] = location
-        _merge_attendees(event, attendees)
+        if normalized_attendees:
+            event["attendees"] = [
+                {"email": address} for address in normalized_attendees
+            ]
         requested_conference = _apply_conference_request(event, add_google_meet)
 
         request = service.events().insert(
@@ -330,7 +517,9 @@ def google_calendar_create_events(
             **_api_call_kwargs(event, notify_attendees),
         )
         created_event = request.execute()
-        return _event_response(created_event)
+        return _event_response(
+            created_event, **_unchecked_extra(unchecked_attendees, unchecked_reason)
+        )
 
     except Exception as e:
         logger.error(f"Error creating event: {e}")
@@ -364,13 +553,18 @@ def google_calendar_update_events(
     end_time: str | None = None,
     description: str | None = None,
     location: str | None = None,
-    attendees: list[str] | None = None,
+    attendees: list[str] | str | None = None,
     notify_attendees: bool = False,
     add_google_meet: bool = False,
+    ignore_conflicts: bool = False,
 ) -> str:
     """
     Update an existing event in Google Calendar.
     start_time and end_time must be RFC3339 formatted if provided.
+    If the update moves the event to a new time, or adds attendees, that change is checked for
+    conflicts the same way google_calendar_create_events is; pass ignore_conflicts=True to skip the
+    check once the user has explicitly confirmed a conflict is fine. Editing other fields (summary,
+    description, location) without moving the event is never blocked.
     attendees is a list of email addresses to add to the event; attendees already on the event are
     kept, and there is no way to remove an attendee through this parameter. Adding attendees does
     not, by itself, email anyone; set notify_attendees=True to have Google Calendar send a native
@@ -395,6 +589,117 @@ def google_calendar_update_events(
         # First get the existing event
         event = service.events().get(calendarId="primary", eventId=event_id).execute()
 
+        attendees_given = _attendees_were_given(attendees)
+
+        existing_is_all_day = "date" in (event.get("start") or {}) or "date" in (
+            event.get("end") or {}
+        )
+        if existing_is_all_day and bool(start_time) != bool(end_time):
+            # The existing event's start/end are {"date": ...}; writing
+            # only one of start_time/end_time would overwrite just that
+            # side with {"dateTime": ...} while the other side keeps its
+            # {"date": ...} shape - Google rejects a body mixing the two
+            # formats between an event's start and end.
+            raise ValueError(
+                "Existing event is all-day (uses date-only start/end); "
+                "updating only one of start_time/end_time would mix "
+                "date-only and dateTime formats. Pass both start_time and "
+                "end_time together."
+            )
+
+        # The calendar's own timezone is only needed to widen an all-day
+        # boundary (see _event_boundary) - fetch it lazily so a plain
+        # timed-event update doesn't pay for an extra API call it has no
+        # use for.
+        calendar_timezone = (
+            _primary_calendar_timezone(service) if existing_is_all_day else "UTC"
+        )
+        existing_start = _event_boundary(event.get("start"), calendar_timezone)
+        existing_end = _event_boundary(event.get("end"), calendar_timezone)
+        effective_start = start_time or existing_start
+        effective_end = end_time or existing_end
+        existing_start_key = _datetime_key_for_comparison(existing_start)
+        existing_end_key = _datetime_key_for_comparison(existing_end)
+        effective_start_key = _datetime_key_for_comparison(effective_start)
+        effective_end_key = _datetime_key_for_comparison(effective_end)
+        window_changed = (effective_start_key, effective_end_key) != (
+            existing_start_key,
+            existing_end_key,
+        )
+
+        existing_attendees_raw = [
+            a["email"]
+            for a in (event.get("attendees") or [])
+            if isinstance(a, dict) and a.get("email")
+        ]
+        existing_attendee_emails = {
+            address.lower() for address in existing_attendees_raw
+        }
+        # attendees only ever ADDS: there's no way to remove an existing
+        # attendee through this parameter (matching this tool's own
+        # docstring), so the effective set for conflict-checking purposes
+        # is always existing-plus-newly-added, never a caller-supplied
+        # subset that could silently drop someone. `added_attendees` (the
+        # ones actually new) is what the write step appends below.
+        if attendees_given:
+            assert (
+                attendees is not None
+            )  # narrows for mypy; attendees_given implies this
+            added_attendees = [
+                address
+                for address in _normalize_addresses(attendees)
+                if address.lower() not in existing_attendee_emails
+            ]
+        else:
+            added_attendees = []
+        # Preserve the casing already on the event - only the membership
+        # check below needs to be case-insensitive, not what gets
+        # queried/reported back to the caller.
+        normalized_attendees = sorted(existing_attendees_raw + added_attendees)
+
+        unchecked_attendees: list[str] = []
+        unchecked_reason: str | None = None
+        if not ignore_conflicts and effective_start and effective_end:
+            # A partial nudge that still overlaps the old window is just
+            # as unsafe to free/busy-check existing attendees against as
+            # the unchanged-window case: the overlap still contains this
+            # event's own busy block on their calendars, which isn't a
+            # real conflict. Only a window that's moved to somewhere
+            # completely disjoint from the old one is safe to check every
+            # attendee against. The organizer side has no such problem
+            # (excluded by event id, not by window), so it only needs
+            # `window_changed`, not the stricter disjoint test.
+            overlapping = _windows_overlap(
+                existing_start_key,
+                existing_end_key,
+                effective_start_key,
+                effective_end_key,
+            )
+            attendees_to_check = _attendees_needing_check(
+                normalized_attendees,
+                existing_attendee_emails,
+                moved_to_a_disjoint_window=window_changed and not overlapping,
+            )
+            check_organizer = window_changed
+
+            if check_organizer or attendees_to_check:
+                conflicts, unchecked_attendees, unchecked_reason = _find_conflicts(
+                    service,
+                    effective_start,
+                    effective_end,
+                    attendees_to_check,
+                    exclude_event_id=event_id,
+                    check_organizer=check_organizer,
+                )
+                if conflicts:
+                    return _conflict_response(
+                        conflicts,
+                        unchecked_attendees,
+                        effective_start,
+                        effective_end,
+                        unchecked_reason=unchecked_reason,
+                    )
+
         if summary:
             event["summary"] = summary
         if start_time:
@@ -405,7 +710,14 @@ def google_calendar_update_events(
             event["description"] = description
         if location:
             event["location"] = location
-        _merge_attendees(event, attendees)
+        if added_attendees:
+            # Only append the newly-added attendees - existing entries are
+            # left completely untouched (dict identity and all), so their
+            # RSVP state (responseStatus, optional, comment, ...) is never
+            # at risk of being clobbered by a re-submission.
+            event["attendees"] = (event.get("attendees") or []) + [
+                {"email": address} for address in added_attendees
+            ]
         requested_conference = _apply_conference_request(event, add_google_meet)
 
         request = service.events().update(
@@ -415,7 +727,9 @@ def google_calendar_update_events(
             **_api_call_kwargs(event, notify_attendees),
         )
         updated_event = request.execute()
-        return _event_response(updated_event)
+        return _event_response(
+            updated_event, **_unchecked_extra(unchecked_attendees, unchecked_reason)
+        )
 
     except Exception as e:
         logger.error(f"Error updating event: {e}")

--- a/src/xagent/web/tools/mcp/outlook.py
+++ b/src/xagent/web/tools/mcp/outlook.py
@@ -133,6 +133,39 @@ def _message_body(content: str, content_type: str) -> dict[str, str]:
     return {"contentType": normalized, "content": content}
 
 
+def _utc_field_in_zone(field: dict[str, Any], zone_name: str) -> dict[str, Any]:
+    """Convert a dateTimeTimeZone field from a plain (unprefixed) GET -
+    Microsoft's own docs: "By default, the start/end time is in UTC" -
+    into the equivalent wall-clock value in `zone_name`, computed locally
+    rather than by re-fetching with a Prefer header.
+
+    Needed anywhere `zone_name` comes from `originalStartTimeZone` (the
+    event's real configured zone) rather than from this same field's own
+    "timeZone" (always "UTC" here): pairing that real zone name with the
+    UTC clock value unchanged - e.g. via `_offset_datetime_string` - would
+    silently mislabel a UTC instant as if it were already expressed in
+    the real zone, off by the real zone's UTC offset. This also matters
+    for is_all_day day-bounds widening, which operates on the naive
+    clock value's own date - a UTC-denominated date can name a different
+    calendar day than the instant's real local one, near a day boundary.
+
+    Falls back to `field` unchanged when there's nothing to convert (no
+    dateTime) or `zone_name` doesn't resolve - a wrong zone name here is
+    caught elsewhere (`_resolve_zoneinfo` is also used on the write path),
+    not silently swallowed by this being a no-op.
+    """
+    date_time = field.get("dateTime")
+    if not date_time:
+        return field
+    try:
+        zone = _resolve_zoneinfo(zone_name)
+    except ValueError:
+        return field
+    utc_instant = datetime.fromisoformat(date_time).replace(tzinfo=dt_timezone.utc)
+    local_instant = utc_instant.astimezone(zone).replace(tzinfo=None)
+    return {"dateTime": local_instant.isoformat(), "timeZone": zone_name}
+
+
 def _next_link_path(next_link: str) -> str:
     """Strip GRAPH_BASE_URL from an @odata.nextLink so it can be re-issued
     through `_graph_request` as a plain path+query (the link is always an
@@ -744,6 +777,22 @@ def outlook_update_event(
             existing_timezone = existing.get("originalStartTimeZone")
             if existing_timezone and not existing_timezone.startswith("tzone://"):
                 existing_zone = existing_timezone
+                # existing_start_field/existing_end_field are still the
+                # plain-GET UTC values above - re-express them as the real
+                # zone's own wall-clock reading (computed locally, no
+                # extra round trip) so they're not a UTC clock value
+                # mislabeled with a different zone's name. That mismatch
+                # would misjudge a same-instant resubmission as "moved" in
+                # _key() below, and - separately - would widen an
+                # is_all_day toggle to the wrong calendar day whenever the
+                # real zone's offset pushes the instant across a day
+                # boundary from its UTC date.
+                existing_start_field = _utc_field_in_zone(
+                    existing_start_field, existing_timezone
+                )
+                existing_end_field = _utc_field_in_zone(
+                    existing_end_field, existing_timezone
+                )
             else:
                 existing_zone = existing_start_field.get("timeZone")
 

--- a/src/xagent/web/tools/mcp/outlook.py
+++ b/src/xagent/web/tools/mcp/outlook.py
@@ -7,7 +7,18 @@ from urllib.parse import quote
 import requests
 from mcp.server.fastmcp import FastMCP
 
+from .utils import attendees_needing_check as _attendees_needing_check
+from .utils import attendees_were_given as _attendees_were_given
+from .utils import conflict_response as _conflict_response
+from .utils import datetime_key_for_comparison as _datetime_key_for_comparison
+from .utils import naive_day_bounds as _naive_day_bounds
+from .utils import normalize_addresses as _normalize_addresses
+from .utils import offset_datetime_string as _offset_datetime_string
+from .utils import resolve_zoneinfo as _resolve_zoneinfo
 from .utils import setup_proxy_env
+from .utils import timezones_could_differ as _timezones_could_differ
+from .utils import unchecked_extra as _unchecked_extra
+from .utils import windows_overlap as _windows_overlap
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("outlook-mcp")
@@ -18,6 +29,25 @@ mcp = FastMCP("outlook-mcp")
 
 GRAPH_BASE_URL = "https://graph.microsoft.com/v1.0"
 DEFAULT_TIMEOUT_SECONDS = 30
+
+# getSchedule accepts at most this many schedules (users/resources) per call.
+_MAX_ATTENDEES_PER_SCHEDULE_QUERY = 20
+
+
+class _GraphRequestError(RuntimeError):
+    """Raised by _graph_request on any HTTP error response.
+
+    Carries status_code so a caller that needs to distinguish e.g. a 403
+    (likely a missing-scope/permission issue on a /me/... call) from other
+    failures doesn't have to string-match the rendered message - Graph has
+    no single canonical error code for "missing scope" the way Slack does.
+    Still a RuntimeError, so every existing bare `except Exception` call
+    site keeps working unchanged.
+    """
+
+    def __init__(self, message: str, *, status_code: int) -> None:
+        super().__init__(message)
+        self.status_code = status_code
 
 
 def _success(**payload: Any) -> str:
@@ -69,17 +99,11 @@ def _graph_request(
         message = str(exc)
         if response_text:
             message = f"{message} - {response_text}"
-        raise RuntimeError(message) from exc
+        raise _GraphRequestError(message, status_code=response.status_code) from exc
 
     if response.status_code == 204 or not response.content:
         return {}
     return response.json()
-
-
-def _normalize_addresses(addresses: list[str] | str) -> list[str]:
-    if isinstance(addresses, str):
-        return [address.strip() for address in addresses.split(",") if address.strip()]
-    return [address.strip() for address in addresses if address and address.strip()]
 
 
 def _recipient_list(addresses: list[str] | str) -> list[dict[str, Any]]:
@@ -104,6 +128,201 @@ def _message_body(content: str, content_type: str) -> dict[str, str]:
     if normalized not in {"text", "html"}:
         raise ValueError("content_type must be either 'text' or 'html'")
     return {"contentType": normalized, "content": content}
+
+
+def _next_link_path(next_link: str) -> str:
+    """Strip GRAPH_BASE_URL from an @odata.nextLink so it can be re-issued
+    through `_graph_request` as a plain path+query (the link is always an
+    absolute URL; `_graph_request` builds its own URL as
+    ``f"{GRAPH_BASE_URL}{path}"``, so passing the absolute link verbatim as
+    `path` would double up the host instead of following it)."""
+    if next_link.startswith(GRAPH_BASE_URL):
+        return next_link[len(GRAPH_BASE_URL) :]
+    return next_link
+
+
+# Defensive cap on calendarView pages followed for one organizer-side
+# conflict check - comfortably more than any single-window query should
+# ever need, just bounding the loop against an unexpected/pathological
+# amount of paging rather than looping forever.
+_MAX_CALENDAR_VIEW_PAGES = 20
+
+
+def _find_conflicts(
+    start_datetime: str,
+    end_datetime: str,
+    timezone: str,
+    attendees: list[str],
+    *,
+    exclude_event_id: str | None = None,
+    check_organizer: bool = True,
+) -> tuple[list[dict[str, Any]], list[str], str | None]:
+    """Check the organizer's own calendar (when check_organizer) plus each
+    attendee's schedule for anything overlapping [start_datetime,
+    end_datetime) in the given timezone.
+
+    `start_datetime`/`end_datetime` are naive (no embedded offset) clock
+    values paired with `timezone` - the same shape Outlook's own
+    dateTimeTimeZone resource uses, and getSchedule's structured
+    startTime/endTime fields accept directly. calendarView's
+    startDateTime/endDateTime query parameters are different: Graph's own
+    docs say they're "interpreted using the timezone offset specified in
+    the value" and "aren't impacted by the value of the Prefer ... header"
+    - a naive value there is silently read as UTC. So only the calendarView
+    call needs an explicit offset attached before it's sent.
+
+    getSchedule has no concept of "exclude this event": it only returns raw
+    busy blocks, so a query against a window an attendee is *already* busy
+    for (because that's the very event being updated) can't be told apart
+    from a genuine conflict here. Callers that aren't moving the event to a
+    new window must restrict `attendees` to only the newly-added ones (see
+    outlook_update_event) rather than relying on this function to exclude
+    the event's own footprint on attendee schedules.
+
+    Returns (conflicts, unchecked_attendees, unchecked_reason). The third
+    element is set only when attendees ended up unchecked because of a
+    missing-scope 403 - the one unchecked case an LLM caller can actually
+    act on (ask the user to reconnect the connector) - not for the other,
+    self-explanatory unchecked cases (absent from the response, or a
+    per-attendee error entry).
+    """
+    conflicts: list[dict[str, Any]] = []
+    unchecked_attendees: list[str] = []
+    unchecked_reason: str | None = None
+
+    if check_organizer:
+        offset_start = _offset_datetime_string(start_datetime, timezone)
+        offset_end = _offset_datetime_string(end_datetime, timezone)
+        params: dict[str, Any] | None = {
+            "startDateTime": offset_start,
+            "endDateTime": offset_end,
+            "$top": 250,
+            "$select": "id,subject,start,end,isCancelled,showAs,responseStatus",
+        }
+        next_path: str | None = None
+        for _ in range(_MAX_CALENDAR_VIEW_PAGES):
+            calendar_view = _graph_request(
+                "GET",
+                next_path if next_path is not None else "/me/calendarView",
+                params=params if next_path is None else None,
+                extra_headers={"Prefer": f'outlook.timezone="{timezone}"'},
+            )
+            for item in calendar_view.get("value") or []:
+                if item.get("isCancelled"):
+                    continue
+                # Graph's own showAs enum documents "unknown" as an
+                # unclassified value (e.g. an event synced from a
+                # third-party calendar that never set it), not
+                # specifically a permission gap - it can represent a
+                # genuinely busy block. Missing a real conflict is worse
+                # than occasionally over-flagging one the caller can
+                # dismiss with ignore_conflicts, so only skip the values
+                # that are unambiguously not-busy - matching the policy
+                # used for attendees' schedules below.
+                if item.get("showAs") in ("free", "workingElsewhere"):
+                    continue
+                if exclude_event_id and item.get("id") == exclude_event_id:
+                    continue
+                # `/me/calendarView` reports OUR OWN response to each event
+                # via `responseStatus` (matching google_calendar's check of
+                # the organizer's own attendee entry) - an event the
+                # organizer personally declined still sits on their
+                # calendar (declining doesn't clear showAs), but it's not
+                # something they're actually busy for.
+                if (item.get("responseStatus") or {}).get("response") == "declined":
+                    continue
+                start = item.get("start") or {}
+                end = item.get("end") or {}
+                conflicts.append(
+                    {
+                        "calendar": "organizer",
+                        "summary": item.get("subject") or "(no subject)",
+                        "start": start.get("dateTime"),
+                        "end": end.get("dateTime"),
+                    }
+                )
+            next_link = calendar_view.get("@odata.nextLink")
+            if not next_link:
+                break
+            next_path = _next_link_path(next_link)
+
+    # getSchedule accepts at most _MAX_ATTENDEES_PER_SCHEDULE_QUERY
+    # schedules per call - chunk rather than giving up on the whole batch,
+    # so a large invite list still gets everyone it can check checked.
+    # `range(0, 0, N)` is empty, so this is also just a no-op loop when
+    # `attendees` is empty.
+    for offset in range(0, len(attendees), _MAX_ATTENDEES_PER_SCHEDULE_QUERY):
+        batch = attendees[offset : offset + _MAX_ATTENDEES_PER_SCHEDULE_QUERY]
+        try:
+            schedule = _graph_request(
+                "POST",
+                "/me/calendar/getSchedule",
+                body={
+                    "schedules": batch,
+                    "startTime": {"dateTime": start_datetime, "timeZone": timezone},
+                    "endTime": {"dateTime": end_datetime, "timeZone": timezone},
+                    "availabilityViewInterval": 30,
+                },
+            )
+        except _GraphRequestError as exc:
+            if exc.status_code == 403:
+                # Graph gives no single reliable code for "this is a
+                # missing-scope/permission issue" (unlike Google's
+                # PERMISSION_DENIED/insufficientPermissions pairing) -
+                # but a 403 on this /me/... call for the signed-in
+                # user's own mailbox is not expected to have another
+                # cause here. Don't abort the whole booking over an
+                # availability check that can't run; the caller still
+                # sees this batch as unchecked, not silently clear.
+                unchecked_attendees.extend(batch)
+                unchecked_reason = (
+                    "Missing the calendars.read/schedule permission "
+                    "needed to check attendee availability - reconnect "
+                    "the Outlook connector to grant it."
+                )
+                continue
+            raise
+
+        # Keyed by Graph's own scheduleId casing for lookup, but every
+        # value reported back below (conflicts and unchecked_attendees)
+        # uses the caller's original attendees casing - matching
+        # google_calendar's _find_conflicts, which iterates `attendees`
+        # for the same reason.
+        by_schedule_id = {
+            (entry.get("scheduleId") or "").lower(): entry
+            for entry in (schedule.get("value") or [])
+        }
+        for email in batch:
+            entry = by_schedule_id.get(email.lower())
+            if entry is None:
+                # Not even present in the response - can't tell
+                # whether they're free, so don't silently report them
+                # as clear.
+                unchecked_attendees.append(email)
+                continue
+            if entry.get("error"):
+                unchecked_attendees.append(email)
+                continue
+            for item in entry.get("scheduleItems") or []:
+                # See the matching comment on the organizer-side loop
+                # above: "unknown" is unclassified, not confirmed-free,
+                # so it's treated the same way here for consistency -
+                # missing a real conflict is worse than occasionally
+                # over-flagging one the caller can dismiss with
+                # ignore_conflicts.
+                if item.get("status") in ("busy", "tentative", "oof", "unknown"):
+                    start = item.get("start") or {}
+                    end = item.get("end") or {}
+                    conflicts.append(
+                        {
+                            "calendar": email,
+                            "summary": None,
+                            "start": start.get("dateTime"),
+                            "end": end.get("dateTime"),
+                        }
+                    )
+
+    return conflicts, unchecked_attendees, unchecked_reason
 
 
 @mcp.tool()
@@ -282,9 +501,33 @@ def outlook_create_event(
     location: str | None = None,
     attendees: list[str] | str | None = None,
     is_all_day: bool = False,
+    ignore_conflicts: bool = False,
 ) -> str:
-    """Create an Outlook calendar event."""
+    """Create an Outlook calendar event.
+    attendees, if given, are invited by email (Graph emails them the invite)
+    and are checked for scheduling conflicts together with the organizer's
+    own calendar; a conflict returns status="conflict" instead of creating
+    the event. Pass ignore_conflicts=True to create it anyway once the user
+    has explicitly confirmed a conflict is fine.
+    """
     try:
+        normalized_attendees = _normalize_addresses(attendees) if attendees else []
+
+        unchecked_attendees: list[str] = []
+        unchecked_reason: str | None = None
+        if not ignore_conflicts:
+            conflicts, unchecked_attendees, unchecked_reason = _find_conflicts(
+                start_datetime, end_datetime, timezone, normalized_attendees
+            )
+            if conflicts:
+                return _conflict_response(
+                    conflicts,
+                    unchecked_attendees,
+                    start_datetime,
+                    end_datetime,
+                    unchecked_reason=unchecked_reason,
+                )
+
         payload: dict[str, Any] = {
             "subject": subject,
             "start": {"dateTime": start_datetime, "timeZone": timezone},
@@ -295,11 +538,13 @@ def outlook_create_event(
             payload["body"] = _message_body(body, "text")
         if location:
             payload["location"] = {"displayName": location}
-        if attendees:
-            payload["attendees"] = _attendee_list(attendees)
+        if normalized_attendees:
+            payload["attendees"] = _attendee_list(normalized_attendees)
 
         result = _graph_request("POST", "/me/events", body=payload)
-        return _success(event=result)
+        return _success(
+            event=result, **_unchecked_extra(unchecked_attendees, unchecked_reason)
+        )
     except Exception as e:
         logger.error("Error creating Outlook event: %s", e)
         return _error(str(e))
@@ -311,39 +556,387 @@ def outlook_update_event(
     subject: str | None = None,
     start_datetime: str | None = None,
     end_datetime: str | None = None,
-    timezone: str = "UTC",
+    timezone: str | None = None,
     body: str | None = None,
     location: str | None = None,
     attendees: list[str] | str | None = None,
     is_all_day: bool | None = None,
+    ignore_conflicts: bool = False,
 ) -> str:
-    """Update an existing Outlook calendar event."""
+    """Update an existing Outlook calendar event.
+    If the update moves the event to a new time, or adds attendees, that
+    change is checked for conflicts the same way outlook_create_event is;
+    pass ignore_conflicts=True to skip the check once the user has
+    explicitly confirmed a conflict is fine. Editing other fields (subject,
+    body, location) without moving the event is never blocked.
+    attendees is a list of email addresses to add to the event; attendees
+    already on the event are kept, and there is no way to remove an
+    attendee through this parameter.
+    Passing only one of start_datetime/end_datetime nudges that boundary
+    while keeping the other as-is; leave timezone unset for this case and
+    the event's own existing timezone is reused automatically. Passing
+    both together fully replaces the window, and timezone then describes
+    both new values (defaulting to UTC if also left unset).
+    """
     try:
+        attendees_given = _attendees_were_given(attendees)
+
+        touches_schedule = (
+            start_datetime is not None
+            or end_datetime is not None
+            or attendees_given
+            or is_all_day is not None
+        )
+
+        # A single boundary changing without the other means the untouched
+        # one keeps its existing clock value - but Graph needs ONE timeZone
+        # per boundary object, and writing the new boundary in a different
+        # zone than the one the untouched boundary (and any conflict check)
+        # is actually anchored to would silently shift the event by the
+        # zone offset. So this case always needs the existing event's own
+        # timeZone, for the PATCH body itself, not just for the conflict
+        # check - unlike every other needs_existing reason below, this one
+        # applies even with ignore_conflicts=True.
+        single_boundary_update = (start_datetime is not None) != (
+            end_datetime is not None
+        )
+
+        # Needed for the conflict check below, for resolving the timezone
+        # a single-boundary update must be written in, and (when attendees
+        # is given) to merge into rather than replace the existing attendee
+        # array - fetch it once up front whenever any of those is actually
+        # needed. ignore_conflicts only skips the check itself, not the
+        # timezone-resolution or attendee-merge uses, so those still need
+        # this even then; a plain is_all_day-only edit (or a full
+        # start_datetime+end_datetime replace) with ignore_conflicts=True
+        # needs none of them and stays a single PATCH.
+        existing: dict[str, Any] = {}
+        needs_existing = (
+            attendees_given
+            or single_boundary_update
+            or (not ignore_conflicts and touches_schedule)
+        )
+        if needs_existing:
+            existing = _graph_request(
+                "GET",
+                f"/me/events/{quote(event_id, safe='')}",
+                params={
+                    "$select": "start,end,attendees,isAllDay,originalStartTimeZone"
+                },
+            )
+
+        existing_attendees_raw = [
+            a["emailAddress"]["address"]
+            for a in (existing.get("attendees") or [])
+            if (a.get("emailAddress") or {}).get("address")
+        ]
+        existing_attendee_emails = {
+            address.lower() for address in existing_attendees_raw
+        }
+
+        if single_boundary_update:
+            # A plain GET (no Prefer header, as above) always returns
+            # start/end in UTC regardless of the event's actual configured
+            # zone - Microsoft's own docs for both properties: "By
+            # default, the start/end time is in UTC." So start.timeZone
+            # here is always "UTC", never useful as "the event's real
+            # timezone". originalStartTimeZone is the one field that
+            # reports the zone the event was actually created in,
+            # unaffected by any Prefer header.
+            existing_timezone = existing.get("originalStartTimeZone")
+            if not existing_timezone:
+                raise ValueError(
+                    "Existing event has no originalStartTimeZone; cannot "
+                    "safely update only one of start_datetime/end_datetime "
+                    "without it."
+                )
+            if existing_timezone.startswith("tzone://"):
+                # A legacy custom timezone set in desktop Outlook (Graph's
+                # own docs call this out specifically for this field) -
+                # not a real IANA/Windows zone name, so it can't be used as
+                # a Prefer header value or a dateTimeTimeZone.timeZone on
+                # write. There's no value this code could resolve to here
+                # that Graph would actually accept.
+                raise ValueError(
+                    "Existing event uses a legacy custom timezone "
+                    f"({existing_timezone!r}) that can't be reused for a "
+                    "single-boundary update; pass both start_datetime and "
+                    "end_datetime together with an explicit timezone."
+                )
+            if timezone is not None:
+                try:
+                    _resolve_zoneinfo(timezone)
+                except ValueError as exc:
+                    # `timezones_could_differ` treats "can't resolve" as
+                    # "benefit of the doubt, not confirmed different" -
+                    # right for a name Graph itself reported (it's always
+                    # written verbatim from `existing_timezone`, never from
+                    # this value), but wrong for the caller's OWN value: an
+                    # unresolvable `timezone` here is a bad argument, not an
+                    # ambiguous-but-plausible one, and must not be silently
+                    # discarded in favor of the existing zone.
+                    raise ValueError(f"Unknown timezone {timezone!r}.") from exc
+            if timezone is not None and _timezones_could_differ(
+                timezone, existing_timezone
+            ):
+                # Only one boundary is moving, and the caller explicitly
+                # gave a timezone that positively denotes a different real
+                # zone than the one the untouched boundary is actually
+                # recorded in - there's no single timezone that correctly
+                # describes both endpoints here. (An unset `timezone` is
+                # not treated as a conflicting choice - it just means "use
+                # whatever this event already uses"; nor is a same-zone
+                # value written differently, e.g. a Windows name Graph
+                # reported vs. the IANA name the caller supplied.)
+                raise ValueError(
+                    "Updating only start_datetime or only end_datetime "
+                    f"with a timezone ({timezone!r}) that denotes a "
+                    "different real zone than the existing event's "
+                    f"({existing_timezone!r}) is ambiguous; pass both "
+                    "start_datetime and end_datetime together, or omit "
+                    "timezone to reuse the existing one."
+                )
+            resolved_timezone = existing_timezone
+            # The first GET (no Prefer header) returned start/end in UTC,
+            # not `resolved_timezone` - re-query specifically in that zone
+            # so the untouched boundary's clock value is expressed the
+            # same way the PATCH itself is about to write it, rather than
+            # this code guessing at a UTC<->zone conversion Graph already
+            # knows how to do correctly.
+            existing_zoned = _graph_request(
+                "GET",
+                f"/me/events/{quote(event_id, safe='')}",
+                params={"$select": "start,end"},
+                extra_headers={"Prefer": f'outlook.timezone="{resolved_timezone}"'},
+            )
+            existing_start_field = existing_zoned.get("start") or {}
+            existing_end_field = existing_zoned.get("end") or {}
+            existing_zone = resolved_timezone
+        else:
+            resolved_timezone = timezone or "UTC"
+            existing_start_field = existing.get("start") or {}
+            existing_end_field = existing.get("end") or {}
+            # A plain GET (no Prefer header) reports start/end in UTC by
+            # default, but trust whatever `timeZone` Graph actually put on
+            # the field rather than assuming it - this may be absent
+            # (validated below, only where it's actually needed).
+            existing_zone = existing_start_field.get("timeZone")
+
         payload: dict[str, Any] = {}
         if subject is not None:
             payload["subject"] = subject
         if start_datetime is not None:
-            payload["start"] = {"dateTime": start_datetime, "timeZone": timezone}
+            payload["start"] = {
+                "dateTime": start_datetime,
+                "timeZone": resolved_timezone,
+            }
         if end_datetime is not None:
-            payload["end"] = {"dateTime": end_datetime, "timeZone": timezone}
+            payload["end"] = {"dateTime": end_datetime, "timeZone": resolved_timezone}
         if body is not None:
             payload["body"] = _message_body(body, "text")
         if location is not None:
             payload["location"] = {"displayName": location}
-        if attendees is not None:
-            payload["attendees"] = _attendee_list(attendees)
+        # attendees only ever ADDS: there's no way to remove an existing
+        # attendee through this parameter (matching this tool's own
+        # docstring), so the effective set for conflict-checking purposes
+        # is always existing-plus-newly-added, never a caller-supplied
+        # subset that could silently drop someone.
+        if attendees_given:
+            assert (
+                attendees is not None
+            )  # narrows for mypy; attendees_given implies this
+            added_attendees = [
+                address
+                for address in _normalize_addresses(attendees)
+                if address.lower() not in existing_attendee_emails
+            ]
+        else:
+            added_attendees = []
+        # Preserve the casing already on the event - only the
+        # membership check below needs to be case-insensitive, not
+        # what gets queried/reported back to the caller.
+        normalized_attendees = sorted(existing_attendees_raw + added_attendees)
+        if added_attendees:
+            # Only append the newly-added attendees - existing entries
+            # (their raw dicts, untouched) are carried over as-is, so
+            # their RSVP state (status, type, ...) is never at risk of
+            # being clobbered by a re-submission.
+            payload["attendees"] = list(existing.get("attendees") or []) + [
+                {"emailAddress": {"address": address}, "type": "required"}
+                for address in added_attendees
+            ]
         if is_all_day is not None:
             payload["isAllDay"] = is_all_day
 
-        if not payload:
+        if not payload and not attendees_given:
+            # attendees_given alone can leave `payload` empty (every
+            # address it named was already on the event, so there was
+            # nothing new to append) without this having been a no-arg
+            # call - the caller did provide a real field, it just happens
+            # to be a no-op given the event's current state.
             raise ValueError("at least one field must be provided to update the event")
+
+        unchecked_attendees: list[str] = []
+        unchecked_reason: str | None = None
+        if not ignore_conflicts and touches_schedule:
+            existing_end = existing_end_field.get("dateTime")
+            existing_start = existing_start_field.get("dateTime")
+            effective_start = start_datetime or existing_start
+            effective_end = end_datetime or existing_end
+            # Both boundaries always end up denominated in the same zone
+            # here: when only one of start_datetime/end_datetime is given
+            # (single_boundary_update), `existing_zone` already equals
+            # `resolved_timezone`; when both are given, `resolved_timezone`
+            # is used for the query. Only when NEITHER is given (an
+            # attendees/is_all_day-only edit) does the query need the
+            # existing event's own recorded zone. Whether that zone is
+            # actually known (and, if not, whether that's fatal) is
+            # resolved lazily below, only once it's clear a query will
+            # really run - a same-attendees, same-window resubmission
+            # must stay a no-op PATCH even if the existing event happens
+            # to be missing timezone info that would only matter for a
+            # query nothing here ends up needing.
+            provisional_query_timezone = (
+                resolved_timezone
+                if (start_datetime is not None or end_datetime is not None)
+                else (existing_zone or "UTC")
+            )
+
+            # existing_start/existing_end are naive Graph values - they're
+            # only comparable against effective_start/effective_end (also
+            # naive, but not necessarily in the same zone: existing_zone
+            # can be plain UTC from an un-prefixed GET while
+            # query_timezone is whatever the caller/event actually uses)
+            # once both sides carry a real, matching UTC offset. Comparing
+            # the naive strings directly would read a same-instant
+            # resubmission written in a different zone as "the window
+            # moved" - resurrecting the self-conflict bug this whole
+            # timezone-resolution logic exists to prevent. This comparison
+            # only decides whether to widen the attendee check, never what
+            # gets written or queried, so an unknown zone falls back to
+            # UTC here (the conservative direction: a wrong guess makes
+            # the window look more likely to have "changed", which only
+            # means checking more attendees, never fewer).
+            existing_start_key = _datetime_key_for_comparison(
+                _offset_datetime_string(existing_start, existing_zone or "UTC")
+                if existing_start
+                else None
+            )
+            existing_end_key = _datetime_key_for_comparison(
+                _offset_datetime_string(existing_end, existing_zone or "UTC")
+                if existing_end
+                else None
+            )
+            effective_start_key = _datetime_key_for_comparison(
+                _offset_datetime_string(effective_start, provisional_query_timezone)
+                if effective_start
+                else None
+            )
+            effective_end_key = _datetime_key_for_comparison(
+                _offset_datetime_string(effective_end, provisional_query_timezone)
+                if effective_end
+                else None
+            )
+
+            # is_all_day changes the event's effective span even when the
+            # literal start/end clock values don't move (e.g. turning a
+            # 30-minute meeting into an all-day one) - treat that the same
+            # as a moved window for deciding whether to check the
+            # organizer at all (organizer conflicts are always safe to
+            # re-check: excluded by event id, not by window).
+            literal_window_changed = (effective_start_key, effective_end_key) != (
+                existing_start_key,
+                existing_end_key,
+            )
+            existing_is_all_day = bool(existing.get("isAllDay"))
+            effective_is_all_day = (
+                is_all_day if is_all_day is not None else existing_is_all_day
+            )
+            check_organizer = literal_window_changed or (
+                effective_is_all_day != existing_is_all_day
+            )
+
+            # An all-day event/toggle occupies the *whole* calendar day(s)
+            # it lands on, not just the literal clock-time slot it was
+            # given - widen the actual query window to that before
+            # checking, or a conflict elsewhere that day (or this event's
+            # own now-irrelevant narrow slot) would be missed/misjudged.
+            # Outside that case, query_start/query_end are exactly
+            # effective_start/effective_end, so their keys are exactly
+            # effective_start_key/effective_end_key already computed above
+            # - no need to recompute them from scratch.
+            query_start, query_end = effective_start, effective_end
+            query_start_key, query_end_key = effective_start_key, effective_end_key
+            if effective_is_all_day and effective_start and effective_end:
+                query_start, _ = _naive_day_bounds(effective_start)
+                _, query_end = _naive_day_bounds(effective_end)
+                query_start_key = _datetime_key_for_comparison(
+                    _offset_datetime_string(query_start, provisional_query_timezone)
+                )
+                query_end_key = _datetime_key_for_comparison(
+                    _offset_datetime_string(query_end, provisional_query_timezone)
+                )
+
+            # A window (literally moved, or widened to a full day by an
+            # is_all_day toggle) that still overlaps the event's own
+            # existing window is just as unsafe to free/busy-check
+            # existing attendees against as the unchanged-window case: the
+            # overlap still contains this event's own busy block on their
+            # calendars, which isn't a real conflict. Only a window that's
+            # moved to somewhere completely disjoint from the old one is
+            # safe to check every attendee against. `windows_overlap`
+            # itself already treats a missing/unparsed key as "can't
+            # confirm disjoint" (True), so no extra None-guard is needed
+            # here.
+            overlapping = _windows_overlap(
+                existing_start_key, existing_end_key, query_start_key, query_end_key
+            )
+            attendees_to_check = _attendees_needing_check(
+                normalized_attendees,
+                existing_attendee_emails,
+                moved_to_a_disjoint_window=literal_window_changed and not overlapping,
+            )
+
+            if query_start and query_end and (check_organizer or attendees_to_check):
+                # Only now, with a query actually about to run, does a
+                # missing existing-event timezone (relevant only when
+                # neither start_datetime nor end_datetime was given)
+                # become fatal rather than a moot point.
+                if (
+                    start_datetime is None
+                    and end_datetime is None
+                    and not existing_zone
+                ):
+                    raise ValueError(
+                        "Existing event has no timeZone on its start "
+                        "time; cannot safely check conflicts for this "
+                        "update."
+                    )
+                conflicts, unchecked_attendees, unchecked_reason = _find_conflicts(
+                    query_start,
+                    query_end,
+                    provisional_query_timezone,
+                    attendees_to_check,
+                    exclude_event_id=event_id,
+                    check_organizer=check_organizer,
+                )
+                if conflicts:
+                    return _conflict_response(
+                        conflicts,
+                        unchecked_attendees,
+                        query_start,
+                        query_end,
+                        unchecked_reason=unchecked_reason,
+                    )
 
         result = _graph_request(
             "PATCH",
             f"/me/events/{quote(event_id, safe='')}",
             body=payload,
         )
-        return _success(event=result)
+        return _success(
+            event=result, **_unchecked_extra(unchecked_attendees, unchecked_reason)
+        )
     except Exception as e:
         logger.error("Error updating Outlook event %s: %s", event_id, e)
         return _error(str(e))

--- a/src/xagent/web/tools/mcp/outlook.py
+++ b/src/xagent/web/tools/mcp/outlook.py
@@ -14,6 +14,7 @@ from .utils import attendees_to_add as _attendees_to_add
 from .utils import attendees_were_given as _attendees_were_given
 from .utils import conflict_response as _conflict_response
 from .utils import datetime_key_for_comparison as _datetime_key_for_comparison
+from .utils import merge_scope_error as _merge_scope_error
 from .utils import naive_day_bounds as _naive_day_bounds
 from .utils import normalize_addresses as _normalize_addresses
 from .utils import offset_datetime_string as _offset_datetime_string
@@ -578,26 +579,41 @@ def outlook_create_event(
 
         unchecked_attendees: list[str] = []
         if not ignore_conflicts:
+            # An all-day event occupies the *whole* calendar day(s) it
+            # lands on, not just the literal clock-time slot given -
+            # widen the query window to that before checking, or a
+            # conflict elsewhere that day would be missed. Graph itself
+            # doesn't require start/end to already be day-aligned for
+            # isAllDay=True, so a caller passing e.g. business hours with
+            # is_all_day=True must still get the whole day checked.
+            query_start, query_end = start_datetime, end_datetime
+            if is_all_day:
+                query_start, _ = _naive_day_bounds(start_datetime)
+                end_of_its_day, next_day_start = _naive_day_bounds(end_datetime)
+                # end_datetime may already BE a well-formed exclusive day
+                # boundary (exactly midnight) - naive_day_bounds always
+                # treats its input as a day that needs widening to [that
+                # midnight, next midnight), so applying it unconditionally
+                # would push an already-correct boundary one whole day
+                # too far.
+                query_end = (
+                    end_datetime
+                    if datetime.fromisoformat(end_datetime)
+                    == datetime.fromisoformat(end_of_its_day)
+                    else next_day_start
+                )
             try:
                 conflicts, unchecked_attendees = _find_conflicts(
-                    start_datetime, end_datetime, timezone, normalized_attendees
+                    query_start, query_end, timezone, normalized_attendees
                 )
             except InsufficientScopeError as exc:
-                # A real conflict (e.g. on the organizer's own calendar,
-                # which doesn't need the schedule scope) can already have
-                # been confirmed before a later attendee batch hit this
-                # scope error - reporting it is always safe regardless of
-                # what else couldn't be checked, so only reject the write
-                # outright when nothing was confirmed yet.
-                if not exc.conflicts:
-                    raise
-                conflicts, unchecked_attendees = exc.conflicts, exc.unchecked_attendees
+                conflicts, unchecked_attendees = _merge_scope_error(exc, [], [])
             if conflicts:
                 return _conflict_response(
                     conflicts,
                     unchecked_attendees,
-                    start_datetime,
-                    end_datetime,
+                    query_start,
+                    query_end,
                 )
 
         payload: dict[str, Any] = {
@@ -913,12 +929,17 @@ def outlook_update_event(
         # asked to write), not a conflict-check decision the caller can
         # opt out of. Matches google_calendar_update_events, and this
         # tool's own create path, both of which validate regardless of
-        # ignore_conflicts too.
+        # ignore_conflicts too. Only worth checking when this call is
+        # actually about to write a (possibly partly-existing) window -
+        # an attendees/subject-only edit that never moves either boundary
+        # would otherwise re-validate the event's already-stored,
+        # unchanged start/end and could reject an unrelated field edit
+        # over pre-existing data this call never touches.
         existing_end = existing_end_field.get("dateTime")
         existing_start = existing_start_field.get("dateTime")
         effective_start = start_datetime or existing_start
         effective_end = end_datetime or existing_end
-        if effective_start and effective_end:
+        if (start_datetime or end_datetime) and effective_start and effective_end:
             _reject_reversed_window(effective_start, effective_end)
 
         unchecked_attendees: list[str] = []
@@ -1110,17 +1131,9 @@ def outlook_update_event(
                         all_conflicts.extend(conflicts)
                         unchecked_attendees.extend(unchecked)
             except InsufficientScopeError as exc:
-                # A real conflict can already have been confirmed by an
-                # earlier call above (or earlier in this same call, e.g.
-                # an organizer conflict found before the attendee batch
-                # that hit this scope error) - reporting it is always
-                # safe regardless of what else couldn't be checked, so
-                # only reject the write outright when nothing was
-                # confirmed yet.
-                all_conflicts.extend(exc.conflicts)
-                unchecked_attendees.extend(exc.unchecked_attendees)
-                if not all_conflicts:
-                    raise
+                all_conflicts, unchecked_attendees = _merge_scope_error(
+                    exc, all_conflicts, unchecked_attendees
+                )
 
             if all_conflicts:
                 # narrows for mypy: a conflict can only have been found by

--- a/src/xagent/web/tools/mcp/outlook.py
+++ b/src/xagent/web/tools/mcp/outlook.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+from datetime import datetime
 from typing import Any
 from urllib.parse import quote
 
@@ -278,9 +279,12 @@ def _find_conflicts(
                 # sees this batch as unchecked, not silently clear.
                 unchecked_attendees.extend(batch)
                 unchecked_reason = (
-                    "Missing the calendars.read/schedule permission "
-                    "needed to check attendee availability - reconnect "
-                    "the Outlook connector to grant it."
+                    "Missing the calendars.read/schedule permission needed "
+                    "to check attendee availability - reconnecting the "
+                    "Outlook connector may grant it; if the connector "
+                    "already has calendar access, this is more likely an "
+                    "org-level policy blocking this call, which a "
+                    "reconnect won't fix."
                 )
                 continue
             raise
@@ -772,15 +776,22 @@ def outlook_update_event(
             # to be a no-op given the event's current state.
             raise ValueError("at least one field must be provided to update the event")
 
+        # Checked unconditionally, not gated on ignore_conflicts - this is
+        # basic input sanity (a window a provider API should never be
+        # asked to write), not a conflict-check decision the caller can
+        # opt out of. Matches google_calendar_update_events, and this
+        # tool's own create path, both of which validate regardless of
+        # ignore_conflicts too.
+        existing_end = existing_end_field.get("dateTime")
+        existing_start = existing_start_field.get("dateTime")
+        effective_start = start_datetime or existing_start
+        effective_end = end_datetime or existing_end
+        if effective_start and effective_end:
+            _reject_reversed_window(effective_start, effective_end)
+
         unchecked_attendees: list[str] = []
         unchecked_reason: str | None = None
         if not ignore_conflicts and touches_schedule:
-            existing_end = existing_end_field.get("dateTime")
-            existing_start = existing_start_field.get("dateTime")
-            effective_start = start_datetime or existing_start
-            effective_end = end_datetime or existing_end
-            if effective_start and effective_end:
-                _reject_reversed_window(effective_start, effective_end)
             # Both boundaries always end up denominated in the same zone
             # here: when only one of start_datetime/end_datetime is given
             # (single_boundary_update), `existing_zone` already equals
@@ -815,26 +826,15 @@ def outlook_update_event(
             # UTC here (the conservative direction: a wrong guess makes
             # the window look more likely to have "changed", which only
             # means checking more attendees, never fewer).
-            existing_start_key = _datetime_key_for_comparison(
-                _offset_datetime_string(existing_start, existing_zone or "UTC")
-                if existing_start
-                else None
-            )
-            existing_end_key = _datetime_key_for_comparison(
-                _offset_datetime_string(existing_end, existing_zone or "UTC")
-                if existing_end
-                else None
-            )
-            effective_start_key = _datetime_key_for_comparison(
-                _offset_datetime_string(effective_start, provisional_query_timezone)
-                if effective_start
-                else None
-            )
-            effective_end_key = _datetime_key_for_comparison(
-                _offset_datetime_string(effective_end, provisional_query_timezone)
-                if effective_end
-                else None
-            )
+            def _key(value: str | None, tz_name: str) -> datetime | str | None:
+                return _datetime_key_for_comparison(
+                    _offset_datetime_string(value, tz_name) if value else None
+                )
+
+            existing_start_key = _key(existing_start, existing_zone or "UTC")
+            existing_end_key = _key(existing_end, existing_zone or "UTC")
+            effective_start_key = _key(effective_start, provisional_query_timezone)
+            effective_end_key = _key(effective_end, provisional_query_timezone)
 
             # is_all_day changes the event's effective span even when the
             # literal start/end clock values don't move (e.g. turning a
@@ -868,12 +868,8 @@ def outlook_update_event(
             if effective_is_all_day and effective_start and effective_end:
                 query_start, _ = _naive_day_bounds(effective_start)
                 _, query_end = _naive_day_bounds(effective_end)
-                query_start_key = _datetime_key_for_comparison(
-                    _offset_datetime_string(query_start, provisional_query_timezone)
-                )
-                query_end_key = _datetime_key_for_comparison(
-                    _offset_datetime_string(query_end, provisional_query_timezone)
-                )
+                query_start_key = _key(query_start, provisional_query_timezone)
+                query_end_key = _key(query_end, provisional_query_timezone)
 
             # A window (literally moved, or widened to a full day by an
             # is_all_day toggle) that still overlaps the event's own

--- a/src/xagent/web/tools/mcp/outlook.py
+++ b/src/xagent/web/tools/mcp/outlook.py
@@ -779,6 +779,8 @@ def outlook_update_event(
             existing_start = existing_start_field.get("dateTime")
             effective_start = start_datetime or existing_start
             effective_end = end_datetime or existing_end
+            if effective_start and effective_end:
+                _reject_reversed_window(effective_start, effective_end)
             # Both boundaries always end up denominated in the same zone
             # here: when only one of start_datetime/end_datetime is given
             # (single_boundary_update), `existing_zone` already equals

--- a/src/xagent/web/tools/mcp/outlook.py
+++ b/src/xagent/web/tools/mcp/outlook.py
@@ -2,13 +2,13 @@ import json
 import logging
 import os
 from datetime import datetime
+from datetime import timezone as dt_timezone
 from typing import Any
 from urllib.parse import quote
 
 import requests
 from mcp.server.fastmcp import FastMCP
 
-from .utils import attendees_needing_check as _attendees_needing_check
 from .utils import attendees_to_add as _attendees_to_add
 from .utils import attendees_were_given as _attendees_were_given
 from .utils import conflict_response as _conflict_response
@@ -21,7 +21,7 @@ from .utils import resolve_zoneinfo as _resolve_zoneinfo
 from .utils import setup_proxy_env
 from .utils import timezones_could_differ as _timezones_could_differ
 from .utils import unchecked_extra as _unchecked_extra
-from .utils import windows_overlap as _windows_overlap
+from .utils import window_delta_segments as _window_delta_segments
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("outlook-mcp")
@@ -159,7 +159,7 @@ def _find_conflicts(
     *,
     exclude_event_id: str | None = None,
     check_organizer: bool = True,
-) -> tuple[list[dict[str, Any]], list[str], str | None]:
+) -> tuple[list[dict[str, Any]], list[str]]:
     """Check the organizer's own calendar (when check_organizer) plus each
     attendee's schedule for anything overlapping [start_datetime,
     end_datetime) in the given timezone.
@@ -182,16 +182,16 @@ def _find_conflicts(
     outlook_update_event) rather than relying on this function to exclude
     the event's own footprint on attendee schedules.
 
-    Returns (conflicts, unchecked_attendees, unchecked_reason). The third
-    element is set only when attendees ended up unchecked because of a
-    missing-scope 403 - the one unchecked case an LLM caller can actually
-    act on (ask the user to reconnect the connector) - not for the other,
-    self-explanatory unchecked cases (absent from the response, or a
-    per-attendee error entry).
+    Returns (conflicts, unchecked_attendees). A missing-scope 403 covering
+    the whole call raises ValueError instead of degrading to unchecked -
+    that's OUR OWN credential/policy problem, not a per-attendee
+    visibility gap, and writing an event whose availability was never
+    actually checked would defeat the point of this feature. Every entry
+    that does end up in `unchecked_attendees` is the self-explanatory
+    kind (absent from the response, or its own per-attendee error).
     """
     conflicts: list[dict[str, Any]] = []
     unchecked_attendees: list[str] = []
-    unchecked_reason: str | None = None
 
     if check_organizer:
         offset_start = _offset_datetime_string(start_datetime, timezone)
@@ -226,14 +226,16 @@ def _find_conflicts(
                     continue
                 if exclude_event_id and item.get("id") == exclude_event_id:
                     continue
-                # `/me/calendarView` reports OUR OWN response to each event
-                # via `responseStatus` (matching google_calendar's check of
-                # the organizer's own attendee entry) - an event the
-                # organizer personally declined still sits on their
-                # calendar (declining doesn't clear showAs), but it's not
-                # something they're actually busy for.
-                if (item.get("responseStatus") or {}).get("response") == "declined":
-                    continue
+                # NOTE: declining an invite (responseStatus.response ==
+                # "declined") is NOT used as a busy/free signal here -
+                # Microsoft's event resource documents responseStatus and
+                # showAs as independent fields, with no documented
+                # guarantee that declining clears showAs to "free". An
+                # earlier version of this check skipped declined events
+                # outright, which silently treated a still-busy declined
+                # event as free and permitted a real double booking.
+                # `showAs` above is the one field Graph actually
+                # documents as the busy/free predicate.
                 start = item.get("start") or {}
                 end = item.get("end") or {}
                 conflicts.append(
@@ -274,19 +276,23 @@ def _find_conflicts(
                 # PERMISSION_DENIED/insufficientPermissions pairing) -
                 # but a 403 on this /me/... call for the signed-in
                 # user's own mailbox is not expected to have another
-                # cause here. Don't abort the whole booking over an
-                # availability check that can't run; the caller still
-                # sees this batch as unchecked, not silently clear.
-                unchecked_attendees.extend(batch)
-                unchecked_reason = (
-                    "Missing the calendars.read/schedule permission needed "
-                    "to check attendee availability - reconnecting the "
-                    "Outlook connector may grant it; if the connector "
-                    "already has calendar access, this is more likely an "
-                    "org-level policy blocking this call, which a "
-                    "reconnect won't fix."
-                )
-                continue
+                # cause here. This is OUR OWN credential/policy problem,
+                # not a per-attendee visibility gap (which genuinely
+                # can't be fixed and still degrades to unchecked below) -
+                # proceeding to write an event whose availability was
+                # never actually checked would defeat the entire point
+                # of this feature, so reject instead of silently booking
+                # over a possible conflict.
+                raise ValueError(
+                    "Missing the calendars.read/schedule permission "
+                    "needed to check attendee availability - "
+                    "reconnecting the Outlook connector may grant it; if "
+                    "the connector already has calendar access, this is "
+                    "more likely an org-level policy blocking this call, "
+                    "which a reconnect won't fix. Pass "
+                    "ignore_conflicts=true if the user has confirmed "
+                    "they want to proceed without this check."
+                ) from exc
             raise
 
         # Keyed by Graph's own scheduleId casing for lookup, but every
@@ -328,7 +334,7 @@ def _find_conflicts(
                         }
                     )
 
-    return conflicts, unchecked_attendees, unchecked_reason
+    return conflicts, unchecked_attendees
 
 
 @mcp.tool()
@@ -524,9 +530,8 @@ def outlook_create_event(
         normalized_attendees = _normalize_addresses(attendees) if attendees else []
 
         unchecked_attendees: list[str] = []
-        unchecked_reason: str | None = None
         if not ignore_conflicts:
-            conflicts, unchecked_attendees, unchecked_reason = _find_conflicts(
+            conflicts, unchecked_attendees = _find_conflicts(
                 start_datetime, end_datetime, timezone, normalized_attendees
             )
             if conflicts:
@@ -535,7 +540,6 @@ def outlook_create_event(
                     unchecked_attendees,
                     start_datetime,
                     end_datetime,
-                    unchecked_reason=unchecked_reason,
                 )
 
         payload: dict[str, Any] = {
@@ -552,9 +556,7 @@ def outlook_create_event(
             payload["attendees"] = _attendee_list(normalized_attendees)
 
         result = _graph_request("POST", "/me/events", body=payload)
-        return _success(
-            event=result, **_unchecked_extra(unchecked_attendees, unchecked_reason)
-        )
+        return _success(event=result, **_unchecked_extra(unchecked_attendees))
     except Exception as e:
         logger.error("Error creating Outlook event: %s", e)
         return _error(str(e))
@@ -579,9 +581,10 @@ def outlook_update_event(
     pass ignore_conflicts=True to skip the check once the user has
     explicitly confirmed a conflict is fine. Editing other fields (subject,
     body, location) without moving the event is never blocked.
-    attendees is a list of email addresses to add to the event; attendees
-    already on the event are kept, and there is no way to remove an
-    attendee through this parameter.
+    attendees, if given, fully replaces the event's attendee list: any
+    address already on the event that's left out is removed, and passing
+    an explicit empty list clears every attendee. Leave attendees unset to
+    keep the existing list untouched.
     Passing only one of start_datetime/end_datetime nudges that boundary
     while keeping the other as-is; leave timezone unset for this case and
     the event's own existing timezone is reused automatically. Passing
@@ -727,10 +730,22 @@ def outlook_update_event(
             existing_start_field = existing.get("start") or {}
             existing_end_field = existing.get("end") or {}
             # A plain GET (no Prefer header) reports start/end in UTC by
-            # default, but trust whatever `timeZone` Graph actually put on
-            # the field rather than assuming it - this may be absent
-            # (validated below, only where it's actually needed).
-            existing_zone = existing_start_field.get("timeZone")
+            # default, so its own "timeZone" field is never useful as
+            # "the event's real timezone" - same caveat as the
+            # single-boundary branch above. originalStartTimeZone is the
+            # field that actually reports it (used here, unlike the
+            # single-boundary branch, without erroring on a legacy
+            # `tzone://` custom zone or an absent value - this branch
+            # doesn't always need the real zone at all, e.g. a plain
+            # attendees-only edit on a timed event never widens anything
+            # with it, so fall back to the UTC-normalized field, the
+            # prior behavior, rather than failing a call that may not
+            # need this value to be exact).
+            existing_timezone = existing.get("originalStartTimeZone")
+            if existing_timezone and not existing_timezone.startswith("tzone://"):
+                existing_zone = existing_timezone
+            else:
+                existing_zone = existing_start_field.get("timeZone")
 
         payload: dict[str, Any] = {}
         if subject is not None:
@@ -746,34 +761,62 @@ def outlook_update_event(
             payload["body"] = _message_body(body, "text")
         if location is not None:
             payload["location"] = {"displayName": location}
-        # attendees only ever ADDS: there's no way to remove an existing
-        # attendee through this parameter (matching this tool's own
-        # docstring), so the effective set for conflict-checking purposes
-        # is always existing-plus-newly-added, never a caller-supplied
-        # subset that could silently drop someone.
+        # attendees fully REPLACES the event's attendee list (matching this
+        # connector's pre-existing base behavior before this tool's
+        # conflict-detection support was added): an explicit [] clears
+        # everyone, and any existing address left out of the new list is
+        # removed. `added_attendees` (genuinely new) and
+        # `retained_attendees_raw` (kept from before) are checked
+        # separately below - a retained attendee only needs checking
+        # against the portion of a moved window that's actually new
+        # territory, while a newly-added one needs the whole query window
+        # checked; a removed attendee needs no check at all.
         added_attendees = _attendees_to_add(attendees, existing_attendee_emails)
-        # Preserve the casing already on the event - only the
-        # membership check below needs to be case-insensitive, not
-        # what gets queried/reported back to the caller.
-        normalized_attendees = sorted(existing_attendees_raw + added_attendees)
-        if added_attendees:
-            # Only append the newly-added attendees - existing entries
-            # (their raw dicts, untouched) are carried over as-is, so
-            # their RSVP state (status, type, ...) is never at risk of
-            # being clobbered by a re-submission.
-            payload["attendees"] = list(existing.get("attendees") or []) + [
-                {"emailAddress": {"address": address}, "type": "required"}
-                for address in added_attendees
+        if attendees_given:
+            # Reuse each retained attendee's existing raw dict (not just
+            # its address) so its RSVP state (status, type, ...) is never
+            # clobbered by a re-submission - only a genuinely new address
+            # gets a fresh minimal dict.
+            existing_by_email = {
+                a["emailAddress"]["address"].lower(): a
+                for a in (existing.get("attendees") or [])
+                if (a.get("emailAddress") or {}).get("address")
+            }
+            assert (
+                attendees is not None
+            )  # narrows for mypy; attendees_given implies this
+            desired_addresses = _normalize_addresses(attendees)
+            desired_lower = {address.lower() for address in desired_addresses}
+            if desired_lower != existing_attendee_emails:
+                # A byte-identical resubmission (same members, regardless
+                # of order) is not a real change - leaving the field out of
+                # the PATCH entirely, rather than resending a reconstructed
+                # copy of it, is a stronger guarantee against wiping RSVP
+                # state than relying on every entry happening to compare
+                # equal.
+                payload["attendees"] = [
+                    existing_by_email.get(
+                        address.lower(),
+                        {"emailAddress": {"address": address}, "type": "required"},
+                    )
+                    for address in desired_addresses
+                ]
+            retained_attendees_raw = [
+                address
+                for address in existing_attendees_raw
+                if address.lower() in desired_lower
             ]
+        else:
+            retained_attendees_raw = existing_attendees_raw
         if is_all_day is not None:
             payload["isAllDay"] = is_all_day
 
         if not payload and not attendees_given:
-            # attendees_given alone can leave `payload` empty (every
-            # address it named was already on the event, so there was
-            # nothing new to append) without this having been a no-arg
-            # call - the caller did provide a real field, it just happens
-            # to be a no-op given the event's current state.
+            # attendees_given alone can leave `payload` empty (the
+            # resubmitted set exactly matches what's already on the event)
+            # without this having been a no-arg call - the caller did
+            # provide a real field, it just happens to be a no-op given the
+            # event's current state.
             raise ValueError("at least one field must be provided to update the event")
 
         # Checked unconditionally, not gated on ignore_conflicts - this is
@@ -790,7 +833,6 @@ def outlook_update_event(
             _reject_reversed_window(effective_start, effective_end)
 
         unchecked_attendees: list[str] = []
-        unchecked_reason: str | None = None
         if not ignore_conflicts and touches_schedule:
             # Both boundaries always end up denominated in the same zone
             # here: when only one of start_datetime/end_datetime is given
@@ -867,35 +909,61 @@ def outlook_update_event(
             query_start_key, query_end_key = effective_start_key, effective_end_key
             if effective_is_all_day and effective_start and effective_end:
                 query_start, _ = _naive_day_bounds(effective_start)
-                _, query_end = _naive_day_bounds(effective_end)
+                end_of_its_day, next_day_start = _naive_day_bounds(effective_end)
+                # effective_end may already BE a well-formed exclusive
+                # day boundary (exactly midnight, e.g. an existing
+                # all-day event's own end untouched by this update) -
+                # naive_day_bounds always treats its input as a day that
+                # needs widening to [that midnight, next midnight), so
+                # applying it here unconditionally would push an
+                # already-correct boundary one whole day too far,
+                # falsely conflicting with a following-day event. Only
+                # push to the next midnight when effective_end isn't
+                # already sitting exactly on one.
+                query_end = (
+                    effective_end
+                    if datetime.fromisoformat(effective_end)
+                    == datetime.fromisoformat(end_of_its_day)
+                    else next_day_start
+                )
                 query_start_key = _key(query_start, provisional_query_timezone)
                 query_end_key = _key(query_end, provisional_query_timezone)
 
-            # A window (literally moved, or widened to a full day by an
-            # is_all_day toggle) that still overlaps the event's own
-            # existing window is just as unsafe to free/busy-check
-            # existing attendees against as the unchanged-window case: the
-            # overlap still contains this event's own busy block on their
-            # calendars, which isn't a real conflict. Only a window that's
-            # moved to somewhere completely disjoint from the old one is
-            # safe to check every attendee against. `windows_overlap`
-            # itself already treats a missing/unparsed key as "can't
-            # confirm disjoint" (True), so no extra None-guard is needed
-            # here.
-            overlapping = _windows_overlap(
-                existing_start_key, existing_end_key, query_start_key, query_end_key
-            )
-            attendees_to_check = _attendees_needing_check(
-                normalized_attendees,
-                existing_attendee_emails,
-                moved_to_a_disjoint_window=literal_window_changed and not overlapping,
+            all_conflicts: list[dict[str, Any]] = []
+
+            # window_delta_segments is safe to call even when existing_zone
+            # is unknown: existing_start_key/existing_end_key and
+            # query_start_key/query_end_key all fall back to the same "UTC"
+            # assumption in that case (see the `_key` closure above), and a
+            # uniform (even if wrong) offset applied to both sides of the
+            # comparison can't change which portion is genuinely new
+            # territory - only the *absolute* query values sent to Graph
+            # below would be wrong, which is exactly what the fatal check
+            # right after this guards against, and only when a query is
+            # actually about to use them.
+            retained_segments = (
+                _window_delta_segments(
+                    existing_start_key, existing_end_key, query_start_key, query_end_key
+                )
+                if retained_attendees_raw
+                else []
             )
 
-            if query_start and query_end and (check_organizer or attendees_to_check):
+            any_query_needed = (
+                query_start
+                and query_end
+                and (check_organizer or added_attendees or retained_segments)
+            )
+            if any_query_needed:
                 # Only now, with a query actually about to run, does a
                 # missing existing-event timezone (relevant only when
                 # neither start_datetime nor end_datetime was given)
-                # become fatal rather than a moot point.
+                # become fatal rather than a moot point - a same-attendees,
+                # same-effective-window resubmission (retained_segments
+                # empty, no organizer/added-attendee query needed) must
+                # stay a no-op PATCH even if the existing event happens to
+                # be missing timezone info that would only matter for a
+                # query nothing here ends up needing.
                 if (
                     start_datetime is None
                     and end_datetime is None
@@ -906,31 +974,72 @@ def outlook_update_event(
                         "time; cannot safely check conflicts for this "
                         "update."
                     )
-                conflicts, unchecked_attendees, unchecked_reason = _find_conflicts(
+
+            if query_start and query_end and (check_organizer or added_attendees):
+                # A newly-added attendee has no footprint on this event
+                # at all, so the FULL query window is safe (and
+                # necessary) to check for them - same call also covers
+                # the organizer, who's excluded by event id rather than
+                # by window.
+                conflicts, unchecked = _find_conflicts(
                     query_start,
                     query_end,
                     provisional_query_timezone,
-                    attendees_to_check,
+                    added_attendees,
                     exclude_event_id=event_id,
                     check_organizer=check_organizer,
                 )
-                if conflicts:
-                    return _conflict_response(
-                        conflicts,
-                        unchecked_attendees,
-                        query_start,
-                        query_end,
-                        unchecked_reason=unchecked_reason,
+                all_conflicts.extend(conflicts)
+                unchecked_attendees.extend(unchecked)
+
+            # A retained attendee's own busy block for THIS event covers
+            # the entire OLD (unwidened, literal) window - querying that
+            # overlap can't tell "busy because of this event" from a real
+            # conflict. Only the portion of the query window that's
+            # genuinely new territory (window_delta_segments - empty for
+            # an unchanged/shrunk window, up to two segments for a
+            # partial nudge, or the whole query window for a disjoint
+            # move or an is_all_day widening) can hide a real conflict
+            # for them.
+            if retained_segments:
+                for seg_start, seg_end in retained_segments:
+                    seg_start_naive = seg_start.astimezone(dt_timezone.utc).replace(
+                        tzinfo=None
                     )
+                    seg_end_naive = seg_end.astimezone(dt_timezone.utc).replace(
+                        tzinfo=None
+                    )
+                    conflicts, unchecked = _find_conflicts(
+                        seg_start_naive.isoformat(),
+                        seg_end_naive.isoformat(),
+                        "UTC",
+                        retained_attendees_raw,
+                        exclude_event_id=event_id,
+                        check_organizer=False,
+                    )
+                    all_conflicts.extend(conflicts)
+                    unchecked_attendees.extend(unchecked)
+
+            if all_conflicts:
+                # narrows for mypy: a conflict can only have been found by
+                # a query that ran, and every query above only runs when
+                # query_start/query_end (or the delta segments derived
+                # from them) are real values.
+                assert query_start is not None
+                assert query_end is not None
+                return _conflict_response(
+                    all_conflicts,
+                    unchecked_attendees,
+                    query_start,
+                    query_end,
+                )
 
         result = _graph_request(
             "PATCH",
             f"/me/events/{quote(event_id, safe='')}",
             body=payload,
         )
-        return _success(
-            event=result, **_unchecked_extra(unchecked_attendees, unchecked_reason)
-        )
+        return _success(event=result, **_unchecked_extra(unchecked_attendees))
     except Exception as e:
         logger.error("Error updating Outlook event %s: %s", event_id, e)
         return _error(str(e))

--- a/src/xagent/web/tools/mcp/outlook.py
+++ b/src/xagent/web/tools/mcp/outlook.py
@@ -775,7 +775,22 @@ def outlook_update_event(
             # prior behavior, rather than failing a call that may not
             # need this value to be exact).
             existing_timezone = existing.get("originalStartTimeZone")
+            existing_timezone_resolves = False
             if existing_timezone and not existing_timezone.startswith("tzone://"):
+                try:
+                    _resolve_zoneinfo(existing_timezone)
+                    existing_timezone_resolves = True
+                except ValueError:
+                    # An unmapped/legacy Windows zone id (the same gap
+                    # `_WINDOWS_TO_IANA` can't ever fully close) - using it
+                    # as existing_zone anyway would crash the later _key()
+                    # comparison instead of leaving this branch's original
+                    # "may not need this value to be exact" guarantee
+                    # intact, so fall back to the UTC-normalized field
+                    # exactly as if originalStartTimeZone were absent.
+                    pass
+            if existing_timezone_resolves:
+                assert existing_timezone is not None  # narrows for mypy
                 existing_zone = existing_timezone
                 # existing_start_field/existing_end_field are still the
                 # plain-GET UTC values above - re-express them as the real

--- a/src/xagent/web/tools/mcp/outlook.py
+++ b/src/xagent/web/tools/mcp/outlook.py
@@ -9,6 +9,7 @@ from urllib.parse import quote
 import requests
 from mcp.server.fastmcp import FastMCP
 
+from .utils import InsufficientScopeError
 from .utils import attendees_to_add as _attendees_to_add
 from .utils import attendees_were_given as _attendees_were_given
 from .utils import conflict_response as _conflict_response
@@ -216,12 +217,15 @@ def _find_conflicts(
     the event's own footprint on attendee schedules.
 
     Returns (conflicts, unchecked_attendees). A missing-scope 403 covering
-    the whole call raises ValueError instead of degrading to unchecked -
+    the whole call raises `InsufficientScopeError` (carrying whatever was
+    already confirmed in `conflicts`/`unchecked_attendees` before the
+    error) instead of degrading to unchecked and returning normally -
     that's OUR OWN credential/policy problem, not a per-attendee
     visibility gap, and writing an event whose availability was never
     actually checked would defeat the point of this feature. Every entry
-    that does end up in `unchecked_attendees` is the self-explanatory
-    kind (absent from the response, or its own per-attendee error).
+    that does end up in `unchecked_attendees` on a normal return is the
+    self-explanatory kind (absent from the response, or its own
+    per-attendee error).
     """
     conflicts: list[dict[str, Any]] = []
     unchecked_attendees: list[str] = []
@@ -315,8 +319,12 @@ def _find_conflicts(
                 # proceeding to write an event whose availability was
                 # never actually checked would defeat the entire point
                 # of this feature, so reject instead of silently booking
-                # over a possible conflict.
-                raise ValueError(
+                # over a possible conflict. Carrying `conflicts` (e.g. an
+                # organizer conflict already found above, before this
+                # batch ever ran) lets a caller still report it rather
+                # than silently discarding a known problem just because
+                # this later, unrelated check also failed.
+                raise InsufficientScopeError(
                     "Missing the calendars.read/schedule permission "
                     "needed to check attendee availability - "
                     "reconnecting the Outlook connector may grant it; if "
@@ -324,7 +332,13 @@ def _find_conflicts(
                     "more likely an org-level policy blocking this call, "
                     "which a reconnect won't fix. Pass "
                     "ignore_conflicts=true if the user has confirmed "
-                    "they want to proceed without this check."
+                    "they want to proceed without this check.",
+                    conflicts,
+                    # Every attendee from this failed batch onward is
+                    # unchecked - every remaining batch would hit this
+                    # same scope error too, so there's nothing left to
+                    # gain by attempting them.
+                    unchecked_attendees + attendees[offset:],
                 ) from exc
             raise
 
@@ -564,9 +578,20 @@ def outlook_create_event(
 
         unchecked_attendees: list[str] = []
         if not ignore_conflicts:
-            conflicts, unchecked_attendees = _find_conflicts(
-                start_datetime, end_datetime, timezone, normalized_attendees
-            )
+            try:
+                conflicts, unchecked_attendees = _find_conflicts(
+                    start_datetime, end_datetime, timezone, normalized_attendees
+                )
+            except InsufficientScopeError as exc:
+                # A real conflict (e.g. on the organizer's own calendar,
+                # which doesn't need the schedule scope) can already have
+                # been confirmed before a later attendee batch hit this
+                # scope error - reporting it is always safe regardless of
+                # what else couldn't be checked, so only reject the write
+                # outright when nothing was confirmed yet.
+                if not exc.conflicts:
+                    raise
+                conflicts, unchecked_attendees = exc.conflicts, exc.unchecked_attendees
             if conflicts:
                 return _conflict_response(
                     conflicts,
@@ -1039,50 +1064,63 @@ def outlook_update_event(
                         "update."
                     )
 
-            if query_start and query_end and (check_organizer or added_attendees):
-                # A newly-added attendee has no footprint on this event
-                # at all, so the FULL query window is safe (and
-                # necessary) to check for them - same call also covers
-                # the organizer, who's excluded by event id rather than
-                # by window.
-                conflicts, unchecked = _find_conflicts(
-                    query_start,
-                    query_end,
-                    provisional_query_timezone,
-                    added_attendees,
-                    exclude_event_id=event_id,
-                    check_organizer=check_organizer,
-                )
-                all_conflicts.extend(conflicts)
-                unchecked_attendees.extend(unchecked)
-
-            # A retained attendee's own busy block for THIS event covers
-            # the entire OLD (unwidened, literal) window - querying that
-            # overlap can't tell "busy because of this event" from a real
-            # conflict. Only the portion of the query window that's
-            # genuinely new territory (window_delta_segments - empty for
-            # an unchanged/shrunk window, up to two segments for a
-            # partial nudge, or the whole query window for a disjoint
-            # move or an is_all_day widening) can hide a real conflict
-            # for them.
-            if retained_segments:
-                for seg_start, seg_end in retained_segments:
-                    seg_start_naive = seg_start.astimezone(dt_timezone.utc).replace(
-                        tzinfo=None
-                    )
-                    seg_end_naive = seg_end.astimezone(dt_timezone.utc).replace(
-                        tzinfo=None
-                    )
+            try:
+                if query_start and query_end and (check_organizer or added_attendees):
+                    # A newly-added attendee has no footprint on this
+                    # event at all, so the FULL query window is safe (and
+                    # necessary) to check for them - same call also
+                    # covers the organizer, who's excluded by event id
+                    # rather than by window.
                     conflicts, unchecked = _find_conflicts(
-                        seg_start_naive.isoformat(),
-                        seg_end_naive.isoformat(),
-                        "UTC",
-                        retained_attendees_raw,
+                        query_start,
+                        query_end,
+                        provisional_query_timezone,
+                        added_attendees,
                         exclude_event_id=event_id,
-                        check_organizer=False,
+                        check_organizer=check_organizer,
                     )
                     all_conflicts.extend(conflicts)
                     unchecked_attendees.extend(unchecked)
+
+                # A retained attendee's own busy block for THIS event
+                # covers the entire OLD (unwidened, literal) window -
+                # querying that overlap can't tell "busy because of this
+                # event" from a real conflict. Only the portion of the
+                # query window that's genuinely new territory
+                # (window_delta_segments - empty for an unchanged/shrunk
+                # window, up to two segments for a partial nudge, or the
+                # whole query window for a disjoint move or an is_all_day
+                # widening) can hide a real conflict for them.
+                if retained_segments:
+                    for seg_start, seg_end in retained_segments:
+                        seg_start_naive = seg_start.astimezone(dt_timezone.utc).replace(
+                            tzinfo=None
+                        )
+                        seg_end_naive = seg_end.astimezone(dt_timezone.utc).replace(
+                            tzinfo=None
+                        )
+                        conflicts, unchecked = _find_conflicts(
+                            seg_start_naive.isoformat(),
+                            seg_end_naive.isoformat(),
+                            "UTC",
+                            retained_attendees_raw,
+                            exclude_event_id=event_id,
+                            check_organizer=False,
+                        )
+                        all_conflicts.extend(conflicts)
+                        unchecked_attendees.extend(unchecked)
+            except InsufficientScopeError as exc:
+                # A real conflict can already have been confirmed by an
+                # earlier call above (or earlier in this same call, e.g.
+                # an organizer conflict found before the attendee batch
+                # that hit this scope error) - reporting it is always
+                # safe regardless of what else couldn't be checked, so
+                # only reject the write outright when nothing was
+                # confirmed yet.
+                all_conflicts.extend(exc.conflicts)
+                unchecked_attendees.extend(exc.unchecked_attendees)
+                if not all_conflicts:
+                    raise
 
             if all_conflicts:
                 # narrows for mypy: a conflict can only have been found by

--- a/src/xagent/web/tools/mcp/outlook.py
+++ b/src/xagent/web/tools/mcp/outlook.py
@@ -8,12 +8,14 @@ import requests
 from mcp.server.fastmcp import FastMCP
 
 from .utils import attendees_needing_check as _attendees_needing_check
+from .utils import attendees_to_add as _attendees_to_add
 from .utils import attendees_were_given as _attendees_were_given
 from .utils import conflict_response as _conflict_response
 from .utils import datetime_key_for_comparison as _datetime_key_for_comparison
 from .utils import naive_day_bounds as _naive_day_bounds
 from .utils import normalize_addresses as _normalize_addresses
 from .utils import offset_datetime_string as _offset_datetime_string
+from .utils import reject_reversed_window as _reject_reversed_window
 from .utils import resolve_zoneinfo as _resolve_zoneinfo
 from .utils import setup_proxy_env
 from .utils import timezones_could_differ as _timezones_could_differ
@@ -511,6 +513,10 @@ def outlook_create_event(
     has explicitly confirmed a conflict is fine.
     """
     try:
+        # Both sides share the same `timezone`, so comparing them as naive
+        # values (no offset attached) is already a valid relative
+        # comparison - it doesn't matter which real zone that is.
+        _reject_reversed_window(start_datetime, end_datetime)
         normalized_attendees = _normalize_addresses(attendees) if attendees else []
 
         unchecked_attendees: list[str] = []
@@ -741,17 +747,7 @@ def outlook_update_event(
         # docstring), so the effective set for conflict-checking purposes
         # is always existing-plus-newly-added, never a caller-supplied
         # subset that could silently drop someone.
-        if attendees_given:
-            assert (
-                attendees is not None
-            )  # narrows for mypy; attendees_given implies this
-            added_attendees = [
-                address
-                for address in _normalize_addresses(attendees)
-                if address.lower() not in existing_attendee_emails
-            ]
-        else:
-            added_attendees = []
+        added_attendees = _attendees_to_add(attendees, existing_attendee_emails)
         # Preserve the casing already on the event - only the
         # membership check below needs to be case-insensitive, not
         # what gets queried/reported back to the caller.

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -314,15 +314,23 @@ def reject_reversed_window(start_value: str, end_value: str) -> None:
     Deliberately permissive when either side doesn't parse to a real,
     comparable instant (stays silent rather than rejecting) - matching
     this module's other datetime comparisons, which treat "can't tell"
-    as "don't block", not "assume invalid".
+    as "don't block", not "assume invalid". That includes the case where
+    both sides parse but one is offset-aware and the other naive (e.g. a
+    ``Z``-suffixed value alongside a naive one): Python raises
+    ``TypeError`` comparing those with ``<=`` even though both are real
+    ``datetime`` instances, so the ``isinstance`` check alone isn't
+    enough to guarantee a safe comparison - see ``windows_overlap``,
+    which guards the identical hazard the same way.
     """
     start_key = datetime_key_for_comparison(start_value)
     end_key = datetime_key_for_comparison(end_value)
-    if (
-        isinstance(start_key, datetime)
-        and isinstance(end_key, datetime)
-        and end_key <= start_key
-    ):
+    if not (isinstance(start_key, datetime) and isinstance(end_key, datetime)):
+        return
+    try:
+        reversed_or_empty = end_key <= start_key
+    except TypeError:
+        return
+    if reversed_or_empty:
         raise ValueError(f"end ({end_value!r}) must be after start ({start_value!r}).")
 
 

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -40,6 +40,30 @@ class InsufficientScopeError(ValueError):
         self.unchecked_attendees = unchecked_attendees
 
 
+def merge_scope_error(
+    exc: InsufficientScopeError,
+    conflicts: list[dict[str, Any]],
+    unchecked_attendees: list[str],
+) -> tuple[list[dict[str, Any]], list[str]]:
+    """Fold an `InsufficientScopeError` caught mid-accumulation into the
+    running `conflicts`/`unchecked_attendees` a connector's create/update
+    tool is building up (potentially across more than one `_find_conflicts`
+    call) - merging the error's own already-confirmed findings in first, so
+    a real conflict found before the error is never lost regardless of
+    which of possibly several calls actually raised.
+
+    Re-raises `exc` itself (preserving its original traceback/cause) when
+    the merged `conflicts` is still empty: nothing was confirmed yet, so
+    there is no already-known problem safe to report instead of rejecting
+    the write outright.
+    """
+    conflicts = [*conflicts, *exc.conflicts]
+    unchecked_attendees = [*unchecked_attendees, *exc.unchecked_attendees]
+    if not conflicts:
+        raise exc
+    return conflicts, unchecked_attendees
+
+
 def require_clean_identifier(value: str, field_name: str) -> str:
     """Reject an empty or whitespace-padded id rather than silently fixing it.
 

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -11,6 +11,35 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 from ....config import get_tool_max_output_length
 
 
+class InsufficientScopeError(ValueError):
+    """Raised by a connector's ``_find_conflicts`` on a whole-batch
+    missing-scope error (see that function's own docstring for why this
+    is raised at all rather than degrading to unchecked).
+
+    Carries whatever ``conflicts``/``unchecked_attendees`` had already
+    been confirmed before the error - a caller accumulating results
+    across multiple ``_find_conflicts`` calls for one create/update (e.g.
+    one call for newly-added attendees, another per delta segment for
+    retained attendees) needs this to still report an already-confirmed
+    real conflict (found before the error, in this call or an earlier
+    one) instead of silently discarding it just because a *later*,
+    unrelated check also hit the same scope problem. Reporting a known
+    conflict is always safe regardless of what else couldn't be checked;
+    only the "nothing confirmed yet, can't tell if this is safe" case
+    should still reject the write outright.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        conflicts: list[dict[str, Any]],
+        unchecked_attendees: list[str],
+    ) -> None:
+        super().__init__(message)
+        self.conflicts = conflicts
+        self.unchecked_attendees = unchecked_attendees
+
+
 def require_clean_identifier(value: str, field_name: str) -> str:
     """Reject an empty or whitespace-padded id rather than silently fixing it.
 
@@ -153,12 +182,17 @@ def conflict_response(
     returns instead of creating/updating an event, so the calling agent
     reports the conflict to the user rather than silently double-booking.
 
-    `unchecked_attendees` here is always the self-explanatory kind (an
+    `unchecked_attendees` is usually the self-explanatory kind (an
     attendee absent from the provider's response, or its own per-attendee
     error) - a missing-OAuth-scope 403 covering the whole call is instead
-    raised as a ValueError before this response is ever built, since
+    raised as `InsufficientScopeError` before ever reaching here, since
     writing an event whose availability could never actually be checked
-    would defeat the point of this feature.
+    would defeat the point of this feature. The one exception: a caller
+    that catches `InsufficientScopeError` because `conflicts` was already
+    non-empty (a real conflict was confirmed before the scope error hit)
+    may pass that error's own `unchecked_attendees` through here too - at
+    that point the write is already correctly blocked by the known
+    conflict, so being honest about who else couldn't be checked is safe.
     """
     payload = {
         "status": "conflict",

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -306,10 +306,11 @@ def datetime_key_for_comparison(value: str | None) -> datetime | str | None:
 
 
 def reject_reversed_window(start_value: str, end_value: str) -> None:
-    """Raise ValueError when `end_value` is not after `start_value`, for a
-    brand-new event window a caller is about to create - catching an
-    obviously backwards request locally rather than forwarding it to the
-    provider API as-is.
+    """Raise ValueError when `end_value` is not after `start_value` - an
+    event window's basic ordering sanity, checked before forwarding it to
+    the provider API as-is (both on create, and on update's effective
+    window regardless of ignore_conflicts - this isn't a conflict-check
+    decision a caller can opt out of).
 
     Deliberately permissive when either side doesn't parse to a real,
     comparable instant (stays silent rather than rejecting) - matching
@@ -327,11 +328,12 @@ def reject_reversed_window(start_value: str, end_value: str) -> None:
     if not (isinstance(start_key, datetime) and isinstance(end_key, datetime)):
         return
     try:
-        reversed_or_empty = end_key <= start_key
+        if end_key <= start_key:
+            raise ValueError(
+                f"end ({end_value!r}) must be after start ({start_value!r})."
+            )
     except TypeError:
         return
-    if reversed_or_empty:
-        raise ValueError(f"end ({end_value!r}) must be after start ({start_value!r}).")
 
 
 # Microsoft Graph timeZone values come in two shapes depending on how/where

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -2,8 +2,11 @@ import json
 import os
 import re
 import urllib.request
+from datetime import date, datetime, time, timedelta
+from datetime import timezone as dt_timezone
 from typing import Any
 from urllib.parse import quote
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from ....config import get_tool_max_output_length
 
@@ -116,6 +119,424 @@ def success_with_capped_dict(field_name: str, data: Any) -> str:
         truncated = True
         response = _build(working, truncated)
     return response
+
+
+def normalize_addresses(addresses: list[str] | str) -> list[str]:
+    """Split/strip a comma-separated string or list of email addresses into a
+    clean list, dropping anything blank and case-insensitive duplicates
+    (keeping the first casing seen - email addresses are case-insensitive,
+    so a caller passing the same person twice with different casing, e.g.
+    from a human-written invite list, must not become two separate
+    attendee entries downstream)."""
+    if isinstance(addresses, str):
+        raw = [address.strip() for address in addresses.split(",") if address.strip()]
+    else:
+        raw = [address.strip() for address in addresses if address and address.strip()]
+    seen: set[str] = set()
+    deduped = []
+    for address in raw:
+        key = address.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(address)
+    return deduped
+
+
+def conflict_response(
+    conflicts: list[dict[str, Any]],
+    unchecked_attendees: list[str],
+    start: str,
+    end: str,
+    *,
+    unchecked_reason: str | None = None,
+) -> str:
+    """Build the status="conflict" envelope a calendar-writing MCP tool
+    returns instead of creating/updating an event, so the calling agent
+    reports the conflict to the user rather than silently double-booking.
+
+    `unchecked_reason`, when given, is a short human-readable explanation
+    of why `unchecked_attendees` couldn't be checked (e.g. a missing OAuth
+    scope) - included only when there's an actionable cause to relay,
+    since most unchecked cases (an attendee absent from the provider's
+    response, or its own per-attendee error) are already self-explanatory.
+    """
+    payload = {
+        "status": "conflict",
+        "message": f"{len(conflicts)} existing event(s) overlap {start} - {end}",
+        "conflicts": conflicts,
+        "unchecked_attendees": unchecked_attendees,
+        "hint": (
+            "Do not retry with the same time slot. Report these conflicts to "
+            "the user and ask them to pick a different time or confirm they "
+            "want to proceed anyway. Only call this tool again with "
+            "ignore_conflicts=true after the user has explicitly confirmed "
+            "they still want this slot."
+        ),
+    }
+    if unchecked_reason:
+        payload["unchecked_reason"] = unchecked_reason
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def unchecked_extra(
+    unchecked_attendees: list[str], unchecked_reason: str | None
+) -> dict[str, Any]:
+    """Extra fields for a status="success" envelope when some attendees
+    ended up unchecked - empty (nothing to add) when there's nothing to
+    report, matching `conflict_response`'s own "only when actionable"
+    policy for `unchecked_reason`."""
+    if not unchecked_attendees:
+        return {}
+    extra: dict[str, Any] = {"unchecked_attendees": unchecked_attendees}
+    if unchecked_reason:
+        extra["unchecked_reason"] = unchecked_reason
+    return extra
+
+
+def attendees_were_given(attendees: list[str] | str | None) -> bool:
+    """Whether `attendees` was actually provided by the caller for an
+    update, treating an empty string the same as not-provided at all -
+    matching every other optional field's truthy convention here (and the
+    create path's own check) - rather than as "clear every attendee".
+    That's still expressible, just via an explicit empty list: `[]` is a
+    deliberate, differently-typed value that must keep working."""
+    return attendees is not None and attendees != ""
+
+
+def attendees_needing_check(
+    normalized_attendees: list[str],
+    existing_attendee_emails: set[str],
+    *,
+    moved_to_a_disjoint_window: bool,
+) -> list[str]:
+    """Which attendees actually need a fresh free/busy check on an update.
+
+    An existing attendee's schedule will always show this event's own
+    busy block for the window it currently occupies - querying that
+    window for them can't distinguish "busy because of this very event"
+    from a real conflict. Only once the window has moved somewhere that
+    no longer overlaps the old one is it safe to re-check everyone;
+    otherwise only the newly-added attendees (who have no such footprint
+    yet) are worth checking.
+    """
+    if moved_to_a_disjoint_window:
+        return normalized_attendees
+    return [
+        address
+        for address in normalized_attendees
+        if address.lower() not in existing_attendee_emails
+    ]
+
+
+_OVERLONG_FRACTIONAL_SECONDS = re.compile(r"(\.\d{6})\d+")
+
+
+def datetime_key_for_comparison(value: str | None) -> datetime | str | None:
+    """Return a value suitable for equality-comparing two datetime strings
+    that may be written in different but equivalent formats.
+
+    A caller re-submitting the same instant it just read back from an API
+    (or a value it typed by hand) can differ in formatting alone - "Z" vs
+    "+00:00", a different (but equal-instant) zone offset, missing vs
+    present fractional seconds - while meaning the same moment. Comparing
+    such strings directly treats a same-instant resubmission as a real
+    change, which for a scheduling-conflict check means re-querying (and,
+    worse, misjudging self-conflicts against) a window that never actually
+    moved.
+
+    Parses to a `datetime` and returns it: two aware datetimes compare
+    equal when they denote the same instant regardless of differing zone
+    offsets, which a string/isoformat() comparison would not catch. Two
+    naive datetimes (Outlook's dateTime values, which carry no offset of
+    their own) compare directly, which is correct since both sides here
+    always come from the same source. An aware value never equals a naive
+    one, which is fine - these are simply never the same source's values
+    (never worse than the plain-string comparison this replaces).
+
+    Returns the original value unchanged if it doesn't parse (None stays
+    None, and a genuinely malformed value still compares by raw string,
+    same as before this normalization existed - never worse, never a
+    crash).
+
+    Outlook commonly reports 7-digit (100-nanosecond) fractional seconds
+    (e.g. ".0000000"), one more digit than a `datetime` microsecond can
+    hold. `fromisoformat`'s tolerance for that is a CPython-version detail
+    the caller shouldn't need to know about, so any fractional-seconds run
+    longer than 6 digits is truncated to 6 before parsing, rather than
+    relying on the current interpreter to accept (and correctly truncate)
+    the extra digits itself.
+    """
+    if value is None:
+        return None
+    normalized = value
+    if normalized[-1:] in ("Z", "z"):
+        # Only the trailing UTC marker, not a blanket .replace("Z", ...) -
+        # a naive str.replace would also touch a "Z"/"z" anywhere else in
+        # the string, which happens to never occur in a valid ISO
+        # datetime today but is needless coupling to that happening to
+        # stay true.
+        normalized = normalized[:-1] + "+00:00"
+    normalized = _OVERLONG_FRACTIONAL_SECONDS.sub(r"\1", normalized)
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return value
+
+
+# Microsoft Graph timeZone values come in two shapes depending on how/where
+# an event was created: IANA names (e.g. "Asia/Singapore", which Graph also
+# accepts on write) and legacy Windows names (e.g. "Pacific Standard Time",
+# from desktop Outlook or an Exchange org defaulting to them). zoneinfo only
+# understands the former. This is the standard (CLDR) Windows-to-IANA
+# mapping, restricted to the zone list Graph's own dateTimeTimeZone docs
+# enumerate as supported - not exhaustive of every Windows zone that has
+# ever existed, but covers every zone Graph itself claims to support.
+_WINDOWS_TO_IANA: dict[str, str] = {
+    "UTC": "UTC",
+    "GMT Standard Time": "Europe/London",
+    "Greenwich Standard Time": "Atlantic/Reykjavik",
+    "W. Europe Standard Time": "Europe/Berlin",
+    "Central Europe Standard Time": "Europe/Budapest",
+    "Central European Standard Time": "Europe/Warsaw",
+    "Romance Standard Time": "Europe/Paris",
+    "E. Europe Standard Time": "Europe/Bucharest",
+    "FLE Standard Time": "Europe/Kyiv",
+    "Turkey Standard Time": "Europe/Istanbul",
+    "Russian Standard Time": "Europe/Moscow",
+    "Arabic Standard Time": "Asia/Baghdad",
+    "Arab Standard Time": "Asia/Riyadh",
+    "Israel Standard Time": "Asia/Jerusalem",
+    "Jordan Standard Time": "Asia/Amman",
+    "Middle East Standard Time": "Asia/Beirut",
+    "Egypt Standard Time": "Africa/Cairo",
+    "South Africa Standard Time": "Africa/Johannesburg",
+    "Iran Standard Time": "Asia/Tehran",
+    "Arabian Standard Time": "Asia/Dubai",
+    "Azerbaijan Standard Time": "Asia/Baku",
+    "Georgian Standard Time": "Asia/Tbilisi",
+    "Caucasus Standard Time": "Asia/Yerevan",
+    "Afghanistan Standard Time": "Asia/Kabul",
+    "Pakistan Standard Time": "Asia/Karachi",
+    "West Asia Standard Time": "Asia/Tashkent",
+    "India Standard Time": "Asia/Kolkata",
+    "Sri Lanka Standard Time": "Asia/Colombo",
+    "Nepal Standard Time": "Asia/Kathmandu",
+    "Central Asia Standard Time": "Asia/Almaty",
+    "Bangladesh Standard Time": "Asia/Dhaka",
+    "Myanmar Standard Time": "Asia/Yangon",
+    "SE Asia Standard Time": "Asia/Bangkok",
+    "China Standard Time": "Asia/Shanghai",
+    "Singapore Standard Time": "Asia/Singapore",
+    "Taipei Standard Time": "Asia/Taipei",
+    "W. Australia Standard Time": "Australia/Perth",
+    "Tokyo Standard Time": "Asia/Tokyo",
+    "Korea Standard Time": "Asia/Seoul",
+    "Cen. Australia Standard Time": "Australia/Adelaide",
+    "AUS Central Standard Time": "Australia/Darwin",
+    "E. Australia Standard Time": "Australia/Brisbane",
+    "AUS Eastern Standard Time": "Australia/Sydney",
+    "West Pacific Standard Time": "Pacific/Port_Moresby",
+    "Tasmania Standard Time": "Australia/Hobart",
+    "Central Pacific Standard Time": "Pacific/Guadalcanal",
+    "New Zealand Standard Time": "Pacific/Auckland",
+    "Fiji Standard Time": "Pacific/Fiji",
+    "Tonga Standard Time": "Pacific/Tongatapu",
+    "Samoa Standard Time": "Pacific/Apia",
+    "Line Islands Standard Time": "Pacific/Kiritimati",
+    "Dateline Standard Time": "Etc/GMT+12",
+    "Hawaiian Standard Time": "Pacific/Honolulu",
+    "Alaskan Standard Time": "America/Anchorage",
+    "Pacific Standard Time (Mexico)": "America/Santa_Isabel",
+    "Pacific Standard Time": "America/Los_Angeles",
+    "US Mountain Standard Time": "America/Phoenix",
+    "Mountain Standard Time (Mexico)": "America/Chihuahua",
+    "Mountain Standard Time": "America/Denver",
+    "Central America Standard Time": "America/Guatemala",
+    "Central Standard Time": "America/Chicago",
+    "Central Standard Time (Mexico)": "America/Mexico_City",
+    "Canada Central Standard Time": "America/Regina",
+    "SA Pacific Standard Time": "America/Bogota",
+    "Eastern Standard Time": "America/New_York",
+    "US Eastern Standard Time": "America/Indiana/Indianapolis",
+    "Venezuela Standard Time": "America/Caracas",
+    "Paraguay Standard Time": "America/Asuncion",
+    "Atlantic Standard Time": "America/Halifax",
+    "Central Brazilian Standard Time": "America/Cuiaba",
+    "SA Western Standard Time": "America/La_Paz",
+    "Pacific SA Standard Time": "America/Santiago",
+    "Newfoundland Standard Time": "America/St_Johns",
+    "E. South America Standard Time": "America/Sao_Paulo",
+    "Argentina Standard Time": "America/Argentina/Buenos_Aires",
+    "SA Eastern Standard Time": "America/Cayenne",
+    "Greenland Standard Time": "America/Godthab",
+    "Montevideo Standard Time": "America/Montevideo",
+    "Bahia Standard Time": "America/Bahia",
+    "Azores Standard Time": "Atlantic/Azores",
+    "Cape Verde Standard Time": "Atlantic/Cape_Verde",
+    "Morocco Standard Time": "Africa/Casablanca",
+    "Namibia Standard Time": "Africa/Windhoek",
+    "W. Central Africa Standard Time": "Africa/Lagos",
+}
+
+
+def resolve_zone_name(name: str) -> str:
+    """Map a Graph timeZone value to a name zoneinfo can load.
+
+    Returns the input unchanged when it isn't a recognized legacy Windows
+    zone name - it's then assumed to already be IANA-shaped, which
+    zoneinfo can load directly.
+    """
+    return _WINDOWS_TO_IANA.get(name, name)
+
+
+def resolve_zoneinfo(name: str) -> ZoneInfo:
+    """Resolve a Graph timeZone value (Windows or IANA) to a real
+    ``ZoneInfo``, for use anywhere a working zone is required (not just a
+    best-effort comparison) - e.g. attaching a real UTC offset to a naive
+    datetime string.
+
+    Raises ``ValueError`` rather than silently defaulting to UTC when the
+    name can't be resolved: a wrong silent guess here is exactly the class
+    of bug (a query or write running in the wrong real-world window) this
+    helper exists to prevent.
+    """
+    try:
+        return ZoneInfo(resolve_zone_name(name))
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        raise ValueError(
+            f"Timezone {name!r} isn't a recognized IANA or Windows zone name."
+        ) from exc
+
+
+def timezones_could_differ(a: str, b: str) -> bool:
+    """True only when two Graph timeZone values can be POSITIVELY
+    confirmed to denote different zones (compared by current UTC offset,
+    not just the zone key, so e.g. a Windows name and the IANA name Graph
+    also accepts for the same real zone compare equal).
+
+    False whenever that can't be confirmed - including when either name
+    fails to resolve (an unmappable legacy Windows zone) - because "can't
+    tell" must never read as "these are different": the only use of this
+    function is deciding whether to reject a caller-supplied timezone as
+    ambiguous, and the actual write always uses Graph's own already-valid
+    timeZone string regardless of this check's answer. Wrongly rejecting
+    a same-zone resubmission (written in a different but equally valid
+    form) is the real failure mode to avoid; wrongly allowing a genuinely
+    different but unresolvable zone through is never worse than what
+    happens when the caller omits the argument entirely.
+    """
+    if a == b:
+        return False
+    try:
+        zone_a = resolve_zoneinfo(a)
+        zone_b = resolve_zoneinfo(b)
+    except ValueError:
+        return False
+    now = datetime.now(dt_timezone.utc)
+    return now.astimezone(zone_a).utcoffset() != now.astimezone(zone_b).utcoffset()
+
+
+def offset_datetime_string(value: str, tz_name: str) -> str:
+    """Combine a naive datetime string (no embedded UTC offset - Outlook's
+    dateTimeTimeZone.dateTime is always this shape, paired with a separate
+    timeZone field) with its zone name into an offset-bearing ISO 8601
+    string.
+
+    Needed anywhere a naive value has to be sent to an API that (unlike
+    Outlook's own structured ``{"dateTime", "timeZone"}`` request bodies)
+    takes a single datetime string and infers UTC when it carries no
+    offset of its own. Graph's own docs for List calendarView's
+    startDateTime/endDateTime query parameters say exactly this: they're
+    "interpreted using the timezone offset specified in the value" and
+    "aren't impacted by the value of the Prefer ... header" - a naive
+    value there is silently read as UTC regardless of what timezone the
+    caller actually meant.
+
+    Raises ``ValueError`` (via ``resolve_zoneinfo``) rather than falling
+    back to UTC when ``tz_name`` can't be resolved.
+    """
+    naive = datetime.fromisoformat(value)
+    return naive.replace(tzinfo=resolve_zoneinfo(tz_name)).isoformat()
+
+
+def naive_day_bounds(date_value: str, *, days: int = 1) -> tuple[str, str]:
+    """Return (start, end) NAIVE ISO datetime strings spanning ``days``
+    full calendar day(s) starting at ``date_value``'s date - the
+    zone-agnostic counterpart to ``calendar_day_bounds``, for an API like
+    Outlook's dateTimeTimeZone that wants a naive clock value paired with
+    a separate timeZone field rather than an embedded offset (attaching a
+    zone here and stripping it back off would just be lossy round-tripping
+    for no benefit, since no zone conversion is actually needed - "midnight
+    of this date" is the same clock reading regardless of which zone it's
+    later paired with).
+
+    ``date_value`` may be a bare "YYYY-MM-DD" or a full datetime string
+    (only its date component is used).
+    """
+    day: date = datetime.fromisoformat(date_value).date()
+    start = datetime.combine(day, time.min)
+    end = start + timedelta(days=days)
+    return start.isoformat(), end.isoformat()
+
+
+def calendar_day_bounds(
+    date_value: str, tz_name: str, *, days: int = 1
+) -> tuple[str, str]:
+    """Return (start, end) offset-bearing ISO instants spanning ``days``
+    full calendar day(s) starting at ``date_value``'s date, in ``tz_name``.
+
+    ``date_value`` may be a bare "YYYY-MM-DD" or a full datetime string
+    (only its date component is used). Used to widen an all-day event's
+    (or an all-day toggle's) boundary into a real queryable window: an
+    all-day event occupies the *calendar's own* day, not a UTC day, so a
+    hardcoded "T00:00:00Z" is only correct for a UTC calendar.
+    """
+    zone = resolve_zoneinfo(tz_name)
+    day: date = datetime.fromisoformat(date_value).date()
+    start = datetime.combine(day, time.min, tzinfo=zone)
+    end = start + timedelta(days=days)
+    return start.isoformat(), end.isoformat()
+
+
+def windows_overlap(
+    existing_start: datetime | str | None,
+    existing_end: datetime | str | None,
+    new_start: datetime | str | None,
+    new_end: datetime | str | None,
+) -> bool:
+    """Whether two half-open [start, end) intervals share any instant.
+
+    Takes comparison keys already produced by ``datetime_key_for_comparison``
+    (so an equal-instant value compares equal regardless of formatting/zone
+    differences), not raw strings.
+
+    A calendar-conflict check must tell "moved to a genuinely disjoint
+    window" (safe to re-check every existing attendee - this event's own
+    footprint can't appear in a window it doesn't occupy) apart from "same
+    or overlapping window" (an existing attendee's free/busy would still
+    show this very event's own busy block inside the overlap, which isn't
+    a real conflict). This is that test.
+
+    If any key isn't a real parsed ``datetime`` - still a raw string
+    because it failed to parse, or (rarer) one side aware and the other
+    naive - "can't confirm disjoint" applies, so this returns ``True``
+    (overlapping) rather than assuming a safety it can't verify. A raw
+    string still compares (and orders) against another string with `<`
+    without raising, so this can't rely on catching ``TypeError`` alone -
+    it must check that every key actually is a comparable `datetime`.
+    """
+    if not (
+        isinstance(existing_start, datetime)
+        and isinstance(existing_end, datetime)
+        and isinstance(new_start, datetime)
+        and isinstance(new_end, datetime)
+    ):
+        return True
+    try:
+        return existing_start < new_end and new_start < existing_end
+    except TypeError:
+        return True
 
 
 def clamp_limit(limit: int, *, max_limit: int) -> int:

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -204,6 +204,27 @@ def attendees_were_given(attendees: list[str] | str | None) -> bool:
     return attendees is not None and attendees != ""
 
 
+def attendees_to_add(
+    attendees: list[str] | str | None, existing_attendee_emails: set[str]
+) -> list[str]:
+    """The newly-added addresses from an update's `attendees` argument,
+    normalized and deduped, that aren't already in
+    `existing_attendee_emails` - what actually needs writing when
+    `attendees` only ever adds attendees and never removes any. Returns
+    [] for anything `attendees_were_given` treats as not-provided (None,
+    ""), matching its own convention, as well as for a caller-supplied
+    list/string that turns out to name only people already on the event.
+    """
+    if not attendees_were_given(attendees):
+        return []
+    assert attendees is not None  # narrows for mypy; attendees_were_given implies this
+    return [
+        address
+        for address in normalize_addresses(attendees)
+        if address.lower() not in existing_attendee_emails
+    ]
+
+
 def attendees_needing_check(
     normalized_attendees: list[str],
     existing_attendee_emails: set[str],
@@ -284,6 +305,27 @@ def datetime_key_for_comparison(value: str | None) -> datetime | str | None:
         return value
 
 
+def reject_reversed_window(start_value: str, end_value: str) -> None:
+    """Raise ValueError when `end_value` is not after `start_value`, for a
+    brand-new event window a caller is about to create - catching an
+    obviously backwards request locally rather than forwarding it to the
+    provider API as-is.
+
+    Deliberately permissive when either side doesn't parse to a real,
+    comparable instant (stays silent rather than rejecting) - matching
+    this module's other datetime comparisons, which treat "can't tell"
+    as "don't block", not "assume invalid".
+    """
+    start_key = datetime_key_for_comparison(start_value)
+    end_key = datetime_key_for_comparison(end_value)
+    if (
+        isinstance(start_key, datetime)
+        and isinstance(end_key, datetime)
+        and end_key <= start_key
+    ):
+        raise ValueError(f"end ({end_value!r}) must be after start ({start_value!r}).")
+
+
 # Microsoft Graph timeZone values come in two shapes depending on how/where
 # an event was created: IANA names (e.g. "Asia/Singapore", which Graph also
 # accepts on write) and legacy Windows names (e.g. "Pacific Standard Time",
@@ -304,13 +346,17 @@ _WINDOWS_TO_IANA: dict[str, str] = {
     "FLE Standard Time": "Europe/Kyiv",
     "Turkey Standard Time": "Europe/Istanbul",
     "Russian Standard Time": "Europe/Moscow",
+    "Kaliningrad Standard Time": "Europe/Kaliningrad",
     "Arabic Standard Time": "Asia/Baghdad",
+    "Syria Standard Time": "Asia/Damascus",
     "Arab Standard Time": "Asia/Riyadh",
     "Israel Standard Time": "Asia/Jerusalem",
     "Jordan Standard Time": "Asia/Amman",
     "Middle East Standard Time": "Asia/Beirut",
     "Egypt Standard Time": "Africa/Cairo",
     "South Africa Standard Time": "Africa/Johannesburg",
+    "E. Africa Standard Time": "Africa/Nairobi",
+    "Mauritius Standard Time": "Indian/Mauritius",
     "Iran Standard Time": "Asia/Tehran",
     "Arabian Standard Time": "Asia/Dubai",
     "Azerbaijan Standard Time": "Asia/Baku",
@@ -324,11 +370,16 @@ _WINDOWS_TO_IANA: dict[str, str] = {
     "Nepal Standard Time": "Asia/Kathmandu",
     "Central Asia Standard Time": "Asia/Almaty",
     "Bangladesh Standard Time": "Asia/Dhaka",
+    "Ekaterinburg Standard Time": "Asia/Yekaterinburg",
     "Myanmar Standard Time": "Asia/Yangon",
     "SE Asia Standard Time": "Asia/Bangkok",
+    "Novosibirsk Standard Time": "Asia/Novosibirsk",
     "China Standard Time": "Asia/Shanghai",
+    "North Asia Standard Time": "Asia/Krasnoyarsk",
     "Singapore Standard Time": "Asia/Singapore",
     "Taipei Standard Time": "Asia/Taipei",
+    "Ulaanbaatar Standard Time": "Asia/Ulaanbaatar",
+    "North Asia East Standard Time": "Asia/Irkutsk",
     "W. Australia Standard Time": "Australia/Perth",
     "Tokyo Standard Time": "Asia/Tokyo",
     "Korea Standard Time": "Asia/Seoul",
@@ -338,9 +389,12 @@ _WINDOWS_TO_IANA: dict[str, str] = {
     "AUS Eastern Standard Time": "Australia/Sydney",
     "West Pacific Standard Time": "Pacific/Port_Moresby",
     "Tasmania Standard Time": "Australia/Hobart",
+    "Yakutsk Standard Time": "Asia/Yakutsk",
     "Central Pacific Standard Time": "Pacific/Guadalcanal",
+    "Vladivostok Standard Time": "Asia/Vladivostok",
     "New Zealand Standard Time": "Pacific/Auckland",
     "Fiji Standard Time": "Pacific/Fiji",
+    "Magadan Standard Time": "Asia/Magadan",
     "Tonga Standard Time": "Pacific/Tongatapu",
     "Samoa Standard Time": "Pacific/Apia",
     "Line Islands Standard Time": "Pacific/Kiritimati",
@@ -454,10 +508,25 @@ def offset_datetime_string(value: str, tz_name: str) -> str:
     caller actually meant.
 
     Raises ``ValueError`` (via ``resolve_zoneinfo``) rather than falling
-    back to UTC when ``tz_name`` can't be resolved.
+    back to UTC when ``tz_name`` can't be resolved - and also raises if
+    ``value`` turns out to already carry its own offset/``Z``, rather
+    than silently relabeling those same clock digits with `tz_name`'s
+    offset instead of converting them (``.replace(tzinfo=...)`` changes
+    what zone a datetime is interpreted in without changing the instant
+    it names, e.g. turning "10:00 UTC" into "10:00 <tz_name>" - a real
+    shift, not a no-op, whenever the two offsets differ). No public tool
+    parameter is documented as requiring a naive value, so a caller
+    passing one with an offset already attached is a real, reachable
+    input here, not just a theoretical one.
     """
-    naive = datetime.fromisoformat(value)
-    return naive.replace(tzinfo=resolve_zoneinfo(tz_name)).isoformat()
+    parsed = datetime.fromisoformat(value)
+    if parsed.tzinfo is not None:
+        raise ValueError(
+            f"{value!r} already carries a UTC offset; pass a naive "
+            "datetime string (no trailing 'Z' or +HH:MM) together with "
+            "its timezone name instead of embedding an offset in both."
+        )
+    return parsed.replace(tzinfo=resolve_zoneinfo(tz_name)).isoformat()
 
 
 def naive_day_bounds(date_value: str, *, days: int = 1) -> tuple[str, str]:

--- a/src/xagent/web/tools/mcp/utils.py
+++ b/src/xagent/web/tools/mcp/utils.py
@@ -148,18 +148,17 @@ def conflict_response(
     unchecked_attendees: list[str],
     start: str,
     end: str,
-    *,
-    unchecked_reason: str | None = None,
 ) -> str:
     """Build the status="conflict" envelope a calendar-writing MCP tool
     returns instead of creating/updating an event, so the calling agent
     reports the conflict to the user rather than silently double-booking.
 
-    `unchecked_reason`, when given, is a short human-readable explanation
-    of why `unchecked_attendees` couldn't be checked (e.g. a missing OAuth
-    scope) - included only when there's an actionable cause to relay,
-    since most unchecked cases (an attendee absent from the provider's
-    response, or its own per-attendee error) are already self-explanatory.
+    `unchecked_attendees` here is always the self-explanatory kind (an
+    attendee absent from the provider's response, or its own per-attendee
+    error) - a missing-OAuth-scope 403 covering the whole call is instead
+    raised as a ValueError before this response is ever built, since
+    writing an event whose availability could never actually be checked
+    would defeat the point of this feature.
     """
     payload = {
         "status": "conflict",
@@ -174,24 +173,16 @@ def conflict_response(
             "they still want this slot."
         ),
     }
-    if unchecked_reason:
-        payload["unchecked_reason"] = unchecked_reason
     return json.dumps(payload, ensure_ascii=False)
 
 
-def unchecked_extra(
-    unchecked_attendees: list[str], unchecked_reason: str | None
-) -> dict[str, Any]:
+def unchecked_extra(unchecked_attendees: list[str]) -> dict[str, Any]:
     """Extra fields for a status="success" envelope when some attendees
     ended up unchecked - empty (nothing to add) when there's nothing to
-    report, matching `conflict_response`'s own "only when actionable"
-    policy for `unchecked_reason`."""
+    report."""
     if not unchecked_attendees:
         return {}
-    extra: dict[str, Any] = {"unchecked_attendees": unchecked_attendees}
-    if unchecked_reason:
-        extra["unchecked_reason"] = unchecked_reason
-    return extra
+    return {"unchecked_attendees": unchecked_attendees}
 
 
 def attendees_were_given(attendees: list[str] | str | None) -> bool:
@@ -221,31 +212,6 @@ def attendees_to_add(
     return [
         address
         for address in normalize_addresses(attendees)
-        if address.lower() not in existing_attendee_emails
-    ]
-
-
-def attendees_needing_check(
-    normalized_attendees: list[str],
-    existing_attendee_emails: set[str],
-    *,
-    moved_to_a_disjoint_window: bool,
-) -> list[str]:
-    """Which attendees actually need a fresh free/busy check on an update.
-
-    An existing attendee's schedule will always show this event's own
-    busy block for the window it currently occupies - querying that
-    window for them can't distinguish "busy because of this very event"
-    from a real conflict. Only once the window has moved somewhere that
-    no longer overlaps the old one is it safe to re-check everyone;
-    otherwise only the newly-added attendees (who have no such footprint
-    yet) are worth checking.
-    """
-    if moved_to_a_disjoint_window:
-        return normalized_attendees
-    return [
-        address
-        for address in normalized_attendees
         if address.lower() not in existing_attendee_emails
     ]
 
@@ -320,7 +286,7 @@ def reject_reversed_window(start_value: str, end_value: str) -> None:
     ``Z``-suffixed value alongside a naive one): Python raises
     ``TypeError`` comparing those with ``<=`` even though both are real
     ``datetime`` instances, so the ``isinstance`` check alone isn't
-    enough to guarantee a safe comparison - see ``windows_overlap``,
+    enough to guarantee a safe comparison - see ``window_delta_segments``,
     which guards the identical hazard the same way.
     """
     start_key = datetime_key_for_comparison(start_value)
@@ -353,6 +319,7 @@ _WINDOWS_TO_IANA: dict[str, str] = {
     "Central European Standard Time": "Europe/Warsaw",
     "Romance Standard Time": "Europe/Paris",
     "E. Europe Standard Time": "Europe/Bucharest",
+    "GTB Standard Time": "Europe/Bucharest",
     "FLE Standard Time": "Europe/Kyiv",
     "Turkey Standard Time": "Europe/Istanbul",
     "Russian Standard Time": "Europe/Moscow",
@@ -578,44 +545,70 @@ def calendar_day_bounds(
     return start.isoformat(), end.isoformat()
 
 
-def windows_overlap(
+def window_delta_segments(
     existing_start: datetime | str | None,
     existing_end: datetime | str | None,
     new_start: datetime | str | None,
     new_end: datetime | str | None,
-) -> bool:
-    """Whether two half-open [start, end) intervals share any instant.
+) -> list[tuple[datetime, datetime]]:
+    """The portion(s) of the half-open [new_start, new_end) window that
+    fall OUTSIDE [existing_start, existing_end) - the only territory an
+    attendee already on the event needs a fresh free/busy check against.
 
-    Takes comparison keys already produced by ``datetime_key_for_comparison``
-    (so an equal-instant value compares equal regardless of formatting/zone
-    differences), not raw strings.
+    An attendee already on the event will always show this very event's
+    own busy block for any instant inside the OLD window - querying that
+    overlap can't distinguish "busy because of this event" from a real
+    conflict, the exact self-conflict bug this function exists to avoid.
+    But a window can move in a way that's neither identical/subset (no
+    new territory at all) nor fully disjoint (the whole new window is new
+    territory) - a partial nudge like 10:00-10:30 -> 10:15-10:45 makes
+    10:30-10:45 new territory while 10:15-10:30 is still old ground, and
+    checking the retained attendee only over the confirmed-safe old
+    portion (or not at all) would silently miss a genuine conflict
+    sitting in that new segment. This computes exactly that new territory
+    so the caller can check retained attendees against precisely it,
+    while newly-added attendees (who have no footprint on this event at
+    all) still get the FULL new window checked regardless of any of this
+    - they need every instant in it verified, delta or not.
 
-    A calendar-conflict check must tell "moved to a genuinely disjoint
-    window" (safe to re-check every existing attendee - this event's own
-    footprint can't appear in a window it doesn't occupy) apart from "same
-    or overlapping window" (an existing attendee's free/busy would still
-    show this very event's own busy block inside the overlap, which isn't
-    a real conflict). This is that test.
-
-    If any key isn't a real parsed ``datetime`` - still a raw string
-    because it failed to parse, or (rarer) one side aware and the other
-    naive - "can't confirm disjoint" applies, so this returns ``True``
-    (overlapping) rather than assuming a safety it can't verify. A raw
-    string still compares (and orders) against another string with `<`
-    without raising, so this can't rely on catching ``TypeError`` alone -
-    it must check that every key actually is a comparable `datetime`.
+    Returns:
+    - ``[]`` when the new window is confirmed to add no territory beyond
+      the old one (identical or a subset) - nothing new for a retained
+      attendee to be checked against.
+    - Up to two disjoint segments when the new window extends past the
+      old one's start, end, or both (e.g. extending a meeting on both
+      sides in one call).
+    - The whole ``[new_start, new_end)`` as a single segment when the two
+      windows are confirmed to not overlap at all (matching "moved
+      somewhere completely disjoint -> check the whole thing"), OR when
+      any value isn't a real, mutually-comparable ``datetime`` (parsing
+      failure, or one side aware and the other naive) - "can't confirm
+      the delta is smaller than the whole window" must never silently
+      shrink what gets checked, so treat it as needing the full window.
+    - ``[]`` in the same can't-tell scenario if there's no valid new
+      window at all to fall back to (``new_start``/``new_end`` themselves
+      aren't real instants) - there is nothing meaningful to check.
     """
+    if not (isinstance(new_start, datetime) and isinstance(new_end, datetime)):
+        return []
     if not (
-        isinstance(existing_start, datetime)
-        and isinstance(existing_end, datetime)
-        and isinstance(new_start, datetime)
-        and isinstance(new_end, datetime)
+        isinstance(existing_start, datetime) and isinstance(existing_end, datetime)
     ):
-        return True
+        return [(new_start, new_end)]
     try:
-        return existing_start < new_end and new_start < existing_end
+        fully_disjoint = new_end <= existing_start or new_start >= existing_end
+        if fully_disjoint:
+            return [(new_start, new_end)]
+        segments = []
+        if new_start < existing_start:
+            segments.append((new_start, existing_start))
+        if new_end > existing_end:
+            segments.append((existing_end, new_end))
+        return segments
     except TypeError:
-        return True
+        # Real datetimes that still can't be compared (aware vs. naive) -
+        # same "can't confirm smaller than the whole window" fallback.
+        return [(new_start, new_end)]
 
 
 def clamp_limit(limit: int, *, max_limit: int) -> int:

--- a/tests/alembic/test_20260907_add_calendar_freebusy_scope.py
+++ b/tests/alembic/test_20260907_add_calendar_freebusy_scope.py
@@ -379,4 +379,4 @@ def test_revision_metadata() -> None:
     migration = _load_migration_module()
 
     assert migration.revision == "20260907_add_calendar_freebusy_scope"
-    assert migration.down_revision == "20260904_add_auto_model_config"
+    assert migration.down_revision == "20260901_seed_zendesk_mcp_app"

--- a/tests/alembic/test_20260907_add_calendar_freebusy_scope.py
+++ b/tests/alembic/test_20260907_add_calendar_freebusy_scope.py
@@ -374,4 +374,4 @@ def test_revision_metadata() -> None:
     migration = _load_migration_module()
 
     assert migration.revision == "20260907_add_calendar_freebusy_scope"
-    assert migration.down_revision == "20260901_seed_zendesk_mcp_app"
+    assert migration.down_revision == "370740d9125a"

--- a/tests/alembic/test_20260907_add_calendar_freebusy_scope.py
+++ b/tests/alembic/test_20260907_add_calendar_freebusy_scope.py
@@ -1,4 +1,4 @@
-"""Tests for narrowing the Google Calendar connector's OAuth scope."""
+"""Tests for adding calendar.freebusy to the Google Calendar connector's scope."""
 
 import importlib.util
 import json
@@ -13,16 +13,19 @@ from alembic.operations import Operations
 
 MIGRATION_PATH = (
     Path(__file__).parent.parent.parent
-    / "src/xagent/migrations/versions/20260817_narrow_google_calendar_scope.py"
+    / "src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py"
 )
 
-OLD_SCOPES = ["https://www.googleapis.com/auth/calendar"]
-NEW_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+OLD_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+NEW_SCOPES = [
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+]
 
 
 def _load_migration_module():
     spec = importlib.util.spec_from_file_location(
-        "narrow_google_calendar_scope_migration", MIGRATION_PATH
+        "add_calendar_freebusy_scope_migration", MIGRATION_PATH
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
@@ -49,9 +52,7 @@ def _scopes_by_app_id(connection, table: sa.Table) -> dict[str, object]:
     return {row.app_id: row.oauth_scopes for row in rows}
 
 
-def test_upgrade_narrows_google_calendar_scope_without_touching_other_apps(
-    tmp_path,
-) -> None:
+def test_upgrade_adds_freebusy_scope_without_touching_other_apps(tmp_path) -> None:
     migration = _load_migration_module()
     engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     metadata = sa.MetaData()
@@ -149,7 +150,7 @@ def test_upgrade_skips_when_oauth_scopes_column_is_absent() -> None:
     assert stored["app_id"] == "google-calendar"
 
 
-def test_downgrade_restores_the_full_calendar_scope(tmp_path) -> None:
+def test_downgrade_restores_the_events_only_scope(tmp_path) -> None:
     migration = _load_migration_module()
     engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     metadata = sa.MetaData()
@@ -171,7 +172,7 @@ def test_downgrade_restores_the_full_calendar_scope(tmp_path) -> None:
     assert scopes["google-calendar"] == OLD_SCOPES
 
 
-def test_downgrade_restores_the_full_calendar_scope_without_touching_other_apps(
+def test_downgrade_restores_the_events_only_scope_without_touching_other_apps(
     tmp_path,
 ) -> None:
     migration = _load_migration_module()
@@ -198,6 +199,56 @@ def test_downgrade_restores_the_full_calendar_scope_without_touching_other_apps(
     assert scopes["gmail"] == ["gmail-scope"]
 
 
+def test_upgrade_downgrade_upgrade_converges_on_the_new_scope(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            {"app_id": "google-calendar", "oauth_scopes": OLD_SCOPES},
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+            migration.upgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes["google-calendar"] == NEW_SCOPES
+
+
+def test_upgrade_after_downgrade_does_not_touch_other_apps(tmp_path) -> None:
+    migration = _load_migration_module()
+    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    metadata = sa.MetaData()
+    table = _public_mcp_apps(metadata)
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            sa.insert(table),
+            [
+                {"app_id": "google-calendar", "oauth_scopes": OLD_SCOPES},
+                {"app_id": "gmail", "oauth_scopes": ["gmail-scope"]},
+            ],
+        )
+
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+            migration.upgrade()
+
+        scopes = _scopes_by_app_id(connection, table)
+
+    assert scopes["google-calendar"] == NEW_SCOPES
+    assert scopes["gmail"] == ["gmail-scope"]
+
+
 def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     migration = _load_migration_module()
     output = StringIO()
@@ -213,7 +264,7 @@ def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     assert sql.count("UPDATE public_mcp_apps SET") == 1
     assert "oauth_scopes=" in sql
     assert "public_mcp_apps.app_id = 'google-calendar'" in sql
-    assert "calendar.events" in sql
+    assert "calendar.freebusy" in sql
     assert "INSERT INTO public_mcp_apps" not in sql
     assert "DELETE FROM public_mcp_apps" not in sql
     assert "%(" not in sql
@@ -264,13 +315,11 @@ def test_offline_postgresql_downgrade_emits_literal_update_only_sql() -> None:
     assert sql.count("UPDATE public_mcp_apps SET") == 1
     assert "oauth_scopes=" in sql
     assert "public_mcp_apps.app_id = 'google-calendar'" in sql
-    # "auth/calendar" alone is a substring of both OLD_SCOPES and NEW_SCOPES
-    # ("auth/calendar.events"), so it can't distinguish which one was
-    # emitted; assert the narrower scope is absent to catch a swapped
-    # OLD_SCOPES/NEW_SCOPES argument in downgrade()'s
-    # _set_calendar_scopes_offline() call.
-    assert "auth/calendar" in sql
-    assert "calendar.events" not in sql
+    # Assert the freebusy scope is absent, not just present-or-absent by
+    # accident, to catch a swapped OLD_SCOPES/NEW_SCOPES argument in
+    # downgrade()'s _set_calendar_scopes_offline() call.
+    assert "calendar.events" in sql
+    assert "calendar.freebusy" not in sql
     assert "INSERT INTO public_mcp_apps" not in sql
     assert "DELETE FROM public_mcp_apps" not in sql
     assert "%(" not in sql
@@ -306,20 +355,22 @@ def test_offline_sqlite_downgrade_round_trips_json_scope_value() -> None:
     assert json.loads(stored[0]) == OLD_SCOPES
 
 
-def test_migration_fields_match_this_files_expectations() -> None:
-    # This migration has since been superseded by
-    # 20260907_add_calendar_freebusy_scope, which adds calendar.freebusy on
-    # top of what this one set - so migration.NEW_SCOPES is no longer
-    # expected to equal the live registry value; that comparison now lives
-    # in the newer migration's own test instead.
-    #
-    # This file's own OLD_SCOPES/NEW_SCOPES (used throughout the tests
-    # above) are a separate copy of the migration's constants, not a
-    # reference to them -- if the migration's values ever changed without
-    # this file's copy following, every test above would keep passing
-    # against a stale expectation instead of failing loudly.
-    migration = _load_migration_module()
+def test_migration_fields_match_registry() -> None:
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
 
+    migration = _load_migration_module()
+    registry_row = next(
+        row
+        for row in get_builtin_public_mcp_app_rows()
+        if row["app_id"] == "google-calendar"
+    )
+
+    assert list(migration.NEW_SCOPES) == registry_row["oauth_scopes"]
+    # This file's own OLD_SCOPES/NEW_SCOPES (used throughout the tests above)
+    # are a separate copy of the migration's constants, not a reference to
+    # them -- if the migration's values ever changed without this file's
+    # copy following, every test above would keep passing against a stale
+    # expectation instead of failing loudly.
     assert list(migration.OLD_SCOPES) == OLD_SCOPES
     assert list(migration.NEW_SCOPES) == NEW_SCOPES
 
@@ -327,5 +378,5 @@ def test_migration_fields_match_this_files_expectations() -> None:
 def test_revision_metadata() -> None:
     migration = _load_migration_module()
 
-    assert migration.revision == "20260817_narrow_google_calendar_scope"
-    assert migration.down_revision == "20260825_add_slack_channels_join_scope"
+    assert migration.revision == "20260907_add_calendar_freebusy_scope"
+    assert migration.down_revision == "20260904_add_auto_model_config"

--- a/tests/alembic/test_20260909_add_calendar_calendars_readonly_scope.py
+++ b/tests/alembic/test_20260909_add_calendar_calendars_readonly_scope.py
@@ -1,4 +1,5 @@
-"""Tests for adding calendar.freebusy to the Google Calendar connector's scope."""
+"""Tests for adding calendar.calendars.readonly to the Google Calendar
+connector's scope."""
 
 import importlib.util
 import json
@@ -13,19 +14,23 @@ from alembic.operations import Operations
 
 MIGRATION_PATH = (
     Path(__file__).parent.parent.parent
-    / "src/xagent/migrations/versions/20260907_add_calendar_freebusy_scope.py"
+    / "src/xagent/migrations/versions/20260909_add_calendar_calendars_readonly_scope.py"
 )
 
-OLD_SCOPES = ["https://www.googleapis.com/auth/calendar.events"]
+OLD_SCOPES = [
+    "https://www.googleapis.com/auth/calendar.events",
+    "https://www.googleapis.com/auth/calendar.freebusy",
+]
 NEW_SCOPES = [
     "https://www.googleapis.com/auth/calendar.events",
     "https://www.googleapis.com/auth/calendar.freebusy",
+    "https://www.googleapis.com/auth/calendar.calendars.readonly",
 ]
 
 
 def _load_migration_module():
     spec = importlib.util.spec_from_file_location(
-        "add_calendar_freebusy_scope_migration", MIGRATION_PATH
+        "add_calendar_calendars_readonly_scope_migration", MIGRATION_PATH
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
@@ -52,7 +57,9 @@ def _scopes_by_app_id(connection, table: sa.Table) -> dict[str, object]:
     return {row.app_id: row.oauth_scopes for row in rows}
 
 
-def test_upgrade_adds_freebusy_scope_without_touching_other_apps(tmp_path) -> None:
+def test_upgrade_adds_calendars_readonly_scope_without_touching_other_apps(
+    tmp_path,
+) -> None:
     migration = _load_migration_module()
     engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     metadata = sa.MetaData()
@@ -150,7 +157,7 @@ def test_upgrade_skips_when_oauth_scopes_column_is_absent() -> None:
     assert stored["app_id"] == "google-calendar"
 
 
-def test_downgrade_restores_the_events_only_scope(tmp_path) -> None:
+def test_downgrade_restores_the_freebusy_only_scope(tmp_path) -> None:
     migration = _load_migration_module()
     engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     metadata = sa.MetaData()
@@ -172,7 +179,7 @@ def test_downgrade_restores_the_events_only_scope(tmp_path) -> None:
     assert scopes["google-calendar"] == OLD_SCOPES
 
 
-def test_downgrade_restores_the_events_only_scope_without_touching_other_apps(
+def test_downgrade_restores_the_freebusy_only_scope_without_touching_other_apps(
     tmp_path,
 ) -> None:
     migration = _load_migration_module()
@@ -222,33 +229,6 @@ def test_upgrade_downgrade_upgrade_converges_on_the_new_scope(tmp_path) -> None:
     assert scopes["google-calendar"] == NEW_SCOPES
 
 
-def test_upgrade_after_downgrade_does_not_touch_other_apps(tmp_path) -> None:
-    migration = _load_migration_module()
-    engine = sa.create_engine(f"sqlite:///{tmp_path / 'test.db'}")
-    metadata = sa.MetaData()
-    table = _public_mcp_apps(metadata)
-    metadata.create_all(engine)
-
-    with engine.begin() as connection:
-        connection.execute(
-            sa.insert(table),
-            [
-                {"app_id": "google-calendar", "oauth_scopes": OLD_SCOPES},
-                {"app_id": "gmail", "oauth_scopes": ["gmail-scope"]},
-            ],
-        )
-
-        with patch.object(migration, "op", _operations(connection)):
-            migration.upgrade()
-            migration.downgrade()
-            migration.upgrade()
-
-        scopes = _scopes_by_app_id(connection, table)
-
-    assert scopes["google-calendar"] == NEW_SCOPES
-    assert scopes["gmail"] == ["gmail-scope"]
-
-
 def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     migration = _load_migration_module()
     output = StringIO()
@@ -264,7 +244,7 @@ def test_offline_postgresql_upgrade_emits_literal_update_only_sql() -> None:
     assert sql.count("UPDATE public_mcp_apps SET") == 1
     assert "oauth_scopes=" in sql
     assert "public_mcp_apps.app_id = 'google-calendar'" in sql
-    assert "calendar.freebusy" in sql
+    assert "calendar.calendars.readonly" in sql
     assert "INSERT INTO public_mcp_apps" not in sql
     assert "DELETE FROM public_mcp_apps" not in sql
     assert "%(" not in sql
@@ -315,11 +295,11 @@ def test_offline_postgresql_downgrade_emits_literal_update_only_sql() -> None:
     assert sql.count("UPDATE public_mcp_apps SET") == 1
     assert "oauth_scopes=" in sql
     assert "public_mcp_apps.app_id = 'google-calendar'" in sql
-    # Assert the freebusy scope is absent, not just present-or-absent by
-    # accident, to catch a swapped OLD_SCOPES/NEW_SCOPES argument in
-    # downgrade()'s _set_calendar_scopes_offline() call.
-    assert "calendar.events" in sql
-    assert "calendar.freebusy" not in sql
+    # Assert the calendars.readonly scope is absent, not just present-or-
+    # absent by accident, to catch a swapped OLD_SCOPES/NEW_SCOPES argument
+    # in downgrade()'s _set_calendar_scopes_offline() call.
+    assert "calendar.freebusy" in sql
+    assert "calendar.calendars.readonly" not in sql
     assert "INSERT INTO public_mcp_apps" not in sql
     assert "DELETE FROM public_mcp_apps" not in sql
     assert "%(" not in sql
@@ -355,17 +335,22 @@ def test_offline_sqlite_downgrade_round_trips_json_scope_value() -> None:
     assert json.loads(stored[0]) == OLD_SCOPES
 
 
-def test_migration_fields_match_this_files_constants() -> None:
-    """This migration is no longer the last word on the google-calendar
-    scope (20260909_add_calendar_calendars_readonly_scope widens it
-    further) - checking against the *live* registry belongs on the most
-    recent scope-widening migration's own test, not here. This just
-    guards against this file's own OLD_SCOPES/NEW_SCOPES (used throughout
-    the tests above) silently drifting from the migration's real
-    constants, which are a separate copy, not a reference.
-    """
-    migration = _load_migration_module()
+def test_migration_fields_match_registry() -> None:
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
 
+    migration = _load_migration_module()
+    registry_row = next(
+        row
+        for row in get_builtin_public_mcp_app_rows()
+        if row["app_id"] == "google-calendar"
+    )
+
+    assert list(migration.NEW_SCOPES) == registry_row["oauth_scopes"]
+    # This file's own OLD_SCOPES/NEW_SCOPES (used throughout the tests above)
+    # are a separate copy of the migration's constants, not a reference to
+    # them -- if the migration's values ever changed without this file's
+    # copy following, every test above would keep passing against a stale
+    # expectation instead of failing loudly.
     assert list(migration.OLD_SCOPES) == OLD_SCOPES
     assert list(migration.NEW_SCOPES) == NEW_SCOPES
 
@@ -373,5 +358,5 @@ def test_migration_fields_match_this_files_constants() -> None:
 def test_revision_metadata() -> None:
     migration = _load_migration_module()
 
-    assert migration.revision == "20260907_add_calendar_freebusy_scope"
-    assert migration.down_revision == "20260901_seed_zendesk_mcp_app"
+    assert migration.revision == "20260909_add_calendar_calendars_readonly_scope"
+    assert migration.down_revision == "20260907_add_calendar_freebusy_scope"

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -863,6 +863,33 @@ class _FakeHttpResp:
 
 
 def _insufficient_scope_error() -> HttpError:
+    """A real Google API 403 for this case carries the reason on BOTH the
+    legacy `errors[].reason` field and a newer `details[].reason`
+    ErrorInfo entry at once - not one or the other. `HttpError`'s own
+    `_get_reason()` picks `details` over `errors` whenever both are
+    present, dropping the legacy reason from `str(exc)` entirely, which
+    is exactly what makes a naive `"insufficientPermissions" in str(exc)`
+    substring check unreliable (see `_is_insufficient_scope_error`)."""
+    return HttpError(
+        _FakeHttpResp(403),
+        (
+            b'{"error": {"code": 403, '
+            b'"message": "Request had insufficient authentication scopes.", '
+            b'"errors": [{"message": "Insufficient Permission", '
+            b'"domain": "global", "reason": "insufficientPermissions"}], '
+            b'"status": "PERMISSION_DENIED", '
+            b'"details": [{"@type": "type.googleapis.com/google.rpc.ErrorInfo", '
+            b'"reason": "ACCESS_TOKEN_SCOPE_INSUFFICIENT", '
+            b'"domain": "googleapis.com", '
+            b'"metadata": {"service": "calendar-json.googleapis.com", '
+            b'"method": "calendar.v3.Freebusy.Query"}}]}}'
+        ),
+    )
+
+
+def _legacy_only_insufficient_scope_error() -> HttpError:
+    """Older/less-instrumented responses may still carry only the legacy
+    field - must keep matching this shape too, not just the dual one."""
     return HttpError(
         _FakeHttpResp(403),
         (
@@ -1073,6 +1100,21 @@ def test_create_events_ignore_conflicts_skips_the_check_entirely(fake_service):
     assert result["status"] == "success"
     assert fake_service._events.list_calls == []
     assert len(fake_service._events.insert_calls) == 1
+
+
+def test_create_events_rejects_a_reversed_window(fake_service):
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:30:00+08:00",
+            end_time="2026-08-27T10:00:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "must be after" in result["message"]
+    assert fake_service._events.list_calls == []
+    assert fake_service._events.insert_calls == []
 
 
 def test_update_events_excludes_the_event_being_moved_from_its_own_conflicts(
@@ -1476,6 +1518,53 @@ def test_freebusy_missing_scope_degrades_to_unchecked_instead_of_erroring(
     assert result["unchecked_attendees"] == ["chelsea@example.com"]
     assert "reconnect" in result["unchecked_reason"].lower()
     assert len(fake_service._events.insert_calls) == 1
+
+
+def test_freebusy_missing_scope_legacy_only_body_still_degrades(fake_service):
+    """The dual-format body is what a real Calendar API 403 actually
+    carries, but a response with only the legacy `errors[]` field must
+    still be recognized - not just the newer `details[]` shape."""
+    fake_service._freebusy = FakeFreebusy(
+        raise_error=_legacy_only_insufficient_scope_error()
+    )
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["unchecked_attendees"] == ["chelsea@example.com"]
+
+
+def test_is_insufficient_scope_error_matches_details_only_body():
+    """Regression test for the actual bug: HttpError._get_reason() prefers
+    `details` over `errors` whenever a response carries both, dropping
+    "insufficientPermissions" from str(exc) entirely - a plain substring
+    check on str(exc) would miss this. Must check the parsed body's
+    fields directly instead."""
+    details_only = HttpError(
+        _FakeHttpResp(403),
+        (b'{"error": {"details": [{"reason": "ACCESS_TOKEN_SCOPE_INSUFFICIENT"}]}}'),
+    )
+    assert calendar._is_insufficient_scope_error(details_only) is True
+
+
+def test_is_insufficient_scope_error_rejects_unrelated_403():
+    other = HttpError(
+        _FakeHttpResp(403),
+        b'{"error": {"errors": [{"reason": "forbiddenForNonOrganizer"}]}}',
+    )
+    assert calendar._is_insufficient_scope_error(other) is False
+
+
+def test_is_insufficient_scope_error_tolerates_malformed_body():
+    malformed = HttpError(_FakeHttpResp(403), b"not json")
+    assert calendar._is_insufficient_scope_error(malformed) is False
 
 
 def test_freebusy_other_http_errors_still_propagate(fake_service):

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1,7 +1,11 @@
 import copy
 import json
 import re
+from typing import Any
 from unittest.mock import Mock
+
+import pytest
+from googleapiclient.errors import HttpError
 
 from xagent.web.tools.mcp import calendar
 from xagent.web.tools.mcp import utils as mcp_utils
@@ -34,8 +38,16 @@ def _fake_service(execute_result: dict, existing_event: dict | None = None):
             )
         )
     )
+    # These Meet-focused tests don't exercise the scheduling-conflict
+    # check (that's the other half of this file's test suite) - stub the
+    # organizer/attendee queries it always runs (unless ignore_conflicts)
+    # to report "no conflicts" so it doesn't block on an un-mocked Mock.
+    events.list = Mock(return_value=Mock(execute=Mock(return_value={"items": []})))
     service = Mock()
     service.events.return_value = events
+    service.freebusy.return_value = Mock(
+        query=Mock(return_value=Mock(execute=Mock(return_value={"calendars": {}})))
+    )
     return service
 
 
@@ -801,3 +813,1049 @@ def test_event_response_does_not_truncate_a_small_event(monkeypatch):
 
     assert result["status"] == "success"
     assert result["truncated"] is False
+
+
+class _Exec:
+    def __init__(self, result: dict[str, Any]):
+        self._result = result
+
+    def execute(self) -> dict[str, Any]:
+        return self._result
+
+
+class FakeEvents:
+    def __init__(
+        self,
+        *,
+        list_result: dict[str, Any] | None = None,
+        get_result: dict[str, Any] | None = None,
+        insert_result: dict[str, Any] | None = None,
+        update_result: dict[str, Any] | None = None,
+    ):
+        self._list_result = list_result if list_result is not None else {"items": []}
+        self._get_result = get_result or {}
+        self._insert_result = insert_result or {"id": "created"}
+        self._update_result = update_result or {"id": "updated"}
+        self.list_calls: list[dict[str, Any]] = []
+        self.insert_calls: list[dict[str, Any]] = []
+        self.update_calls: list[dict[str, Any]] = []
+
+    def list(self, **kwargs: Any) -> _Exec:
+        self.list_calls.append(kwargs)
+        return _Exec(self._list_result)
+
+    def get(self, **kwargs: Any) -> _Exec:
+        return _Exec(self._get_result)
+
+    def insert(self, **kwargs: Any) -> _Exec:
+        self.insert_calls.append(kwargs)
+        return _Exec(self._insert_result)
+
+    def update(self, **kwargs: Any) -> _Exec:
+        self.update_calls.append(kwargs)
+        return _Exec(self._update_result)
+
+
+class _FakeHttpResp:
+    def __init__(self, status: int):
+        self.status = status
+        self.reason = "error"
+
+
+def _insufficient_scope_error() -> HttpError:
+    return HttpError(
+        _FakeHttpResp(403),
+        (
+            b'{"error": {"errors": [{"reason": "insufficientPermissions"}], '
+            b'"message": "Request had insufficient authentication scopes."}}'
+        ),
+    )
+
+
+class FakeFreebusy:
+    def __init__(
+        self,
+        result: dict[str, Any] | None = None,
+        *,
+        raise_error: Exception | None = None,
+    ):
+        self._result = result or {"calendars": {}}
+        self._raise_error = raise_error
+        self.query_calls: list[dict[str, Any]] = []
+
+    def query(self, **kwargs: Any) -> _Exec:
+        self.query_calls.append(kwargs)
+        if self._raise_error is not None:
+            raise self._raise_error
+        return _Exec(self._result)
+
+
+class FakeCalendars:
+    def __init__(self, timezone: str = "UTC"):
+        self._timezone = timezone
+        self.get_calls: list[dict[str, Any]] = []
+
+    def get(self, **kwargs: Any) -> _Exec:
+        self.get_calls.append(kwargs)
+        return _Exec({"timeZone": self._timezone})
+
+
+class FakeService:
+    def __init__(
+        self,
+        events: FakeEvents | None = None,
+        freebusy: FakeFreebusy | None = None,
+        calendars: FakeCalendars | None = None,
+    ):
+        self._events = events or FakeEvents()
+        self._freebusy = freebusy or FakeFreebusy()
+        self._calendars = calendars or FakeCalendars()
+
+    def events(self) -> FakeEvents:
+        return self._events
+
+    def freebusy(self) -> FakeFreebusy:
+        return self._freebusy
+
+    def calendars(self) -> FakeCalendars:
+        return self._calendars
+
+
+@pytest.fixture
+def fake_service(monkeypatch):
+    service = FakeService()
+    monkeypatch.setattr(calendar, "get_calendar_service", lambda: service)
+    return service
+
+
+def _confirmed_event(
+    event_id="existing-1",
+    summary="1:1 with Hazel",
+    transparency=None,
+    status="confirmed",
+):
+    event: dict[str, Any] = {
+        "id": event_id,
+        "summary": summary,
+        "status": status,
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+    }
+    if transparency:
+        event["transparency"] = transparency
+    return event
+
+
+def test_create_events_detects_organizer_conflict_same_timezone(fake_service):
+    """Reproduces the reported bug: booking a slot that overlaps an existing
+    event, both in the same timezone, must be caught rather than silently
+    created."""
+    fake_service._events._list_result = {"items": [_confirmed_event()]}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert len(result["conflicts"]) == 1
+    assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
+    assert fake_service._events.insert_calls == []
+
+
+def test_create_events_ignores_transparent_organizer_event(fake_service):
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(transparency="transparent")]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.insert_calls) == 1
+
+
+def test_create_events_ignores_cancelled_organizer_event(fake_service):
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(status="cancelled")]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_create_events_detects_attendee_freebusy_conflict(fake_service):
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "chelsea@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "chelsea@example.com"
+    assert fake_service._events.insert_calls == []
+
+
+def test_create_events_unchecked_attendee_does_not_block_creation(fake_service):
+    """An attendee whose calendar can't be queried (external/unshared) must
+    not block booking — only be surfaced so Toby can say so."""
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "outsider@gmail.com": {"errors": [{"reason": "notFound"}]},
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["outsider@gmail.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["unchecked_attendees"] == ["outsider@gmail.com"]
+    insert_call = fake_service._events.insert_calls[0]
+    assert insert_call["body"]["attendees"] == [{"email": "outsider@gmail.com"}]
+    # notify_attendees defaults to False - adding an attendee never emails
+    # them without the caller explicitly opting in.
+    assert insert_call["sendUpdates"] == "none"
+
+
+def test_create_events_ignore_conflicts_skips_the_check_entirely(fake_service):
+    fake_service._events._list_result = {"items": [_confirmed_event()]}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._events.list_calls == []
+    assert len(fake_service._events.insert_calls) == 1
+
+
+def test_update_events_excludes_the_event_being_moved_from_its_own_conflicts(
+    fake_service,
+):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+    }
+    fake_service._events._list_result = {
+        "items": [
+            {
+                "id": "self-1",
+                "summary": "old slot",
+                "status": "confirmed",
+                "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+                "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+            },
+            _confirmed_event(event_id="other-1", summary="Board sync"),
+        ]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert [c["summary"] for c in result["conflicts"]] == ["Board sync"]
+
+
+def test_update_events_metadata_only_edit_never_checks_conflicts(fake_service):
+    """A pure metadata edit (no time/attendee change) must never run the
+    conflict check at all - not just tolerate it, since even running the
+    check would spuriously self-conflict against the event's own attendees
+    (see the two tests below)."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "chelsea@example.com"}],
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            summary="New Title",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._events.list_calls == []
+    assert fake_service._freebusy.query_calls == []
+    assert fake_service._events.update_calls[0]["sendUpdates"] == "none"
+
+
+def test_update_events_same_window_only_checks_newly_added_attendee(fake_service):
+    """Adding an attendee without moving the event must only check the new
+    attendee's free/busy - checking an existing attendee against the
+    unchanged window would always find the event's own busy block on their
+    calendar and falsely report a conflict."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "old@example.com"}],
+    }
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "old@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                },
+                "new@example.com": {"busy": []},
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["old@example.com", "new@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._events.list_calls == []
+    queried_emails = {
+        item["id"]
+        for call in fake_service._freebusy.query_calls
+        for item in call["body"]["items"]
+    }
+    assert queried_emails == {"new@example.com"}
+
+
+def test_update_events_treats_existing_attendee_case_insensitively(fake_service):
+    """Regression test for a review finding: an existing attendee re-passed
+    with different casing must still be recognized as "already there" -
+    otherwise it's treated as newly-added, gets checked against the
+    unchanged window, and always self-conflicts on its own busy block for
+    this very event."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "old@example.com"}],
+    }
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                # This event's own busy block on the existing attendee's
+                # calendar - present so the test would fail with a false
+                # "conflict" if the case-insensitive exclusion regressed.
+                "old@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                },
+                "new@example.com": {"busy": []},
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["Old@Example.com", "new@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    queried_emails = {
+        item["id"]
+        for call in fake_service._freebusy.query_calls
+        for item in call["body"]["items"]
+    }
+    assert queried_emails == {"new@example.com"}
+
+
+def test_update_events_reports_original_casing_in_conflicts(fake_service):
+    """Regression test: falling back to the event's existing attendees (no
+    attendees param passed) while moving the time must report a conflict
+    using the originally-stored casing, not the lowercased form used
+    internally for the case-insensitive membership check."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "John.Smith@Example.com"}],
+    }
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "john.smith@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "John.Smith@Example.com"
+
+
+def test_update_events_moving_time_checks_organizer_and_all_attendees(fake_service):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert len(fake_service._events.list_calls) == 1
+    queried_emails = {
+        item["id"]
+        for call in fake_service._freebusy.query_calls
+        for item in call["body"]["items"]
+    }
+    assert queried_emails == {"existing@example.com"}
+
+
+def test_freebusy_lookup_is_case_insensitive(fake_service):
+    """Not confirmed against real Google API behavior, but the lookup should
+    be defensive either way: a case-mismatched key must not silently
+    swallow a real conflict."""
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "Chelsea@Example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                }
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+
+
+def test_organizer_events_list_tolerates_null_items(fake_service):
+    """Regression test for a review finding: the API can return an explicit
+    "items": null instead of omitting the key, which must not crash the
+    tool with a TypeError."""
+    fake_service._events._list_result = {"items": None}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_freebusy_tolerates_null_calendars(fake_service):
+    """Regression test for a review finding: freebusy.query can return an
+    explicit "calendars": null, which must not crash the tool with an
+    AttributeError."""
+    fake_service._freebusy = FakeFreebusy({"calendars": None})
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_update_events_ignore_conflicts_skips_the_check(fake_service):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+    }
+    fake_service._events._list_result = {"items": [_confirmed_event()]}
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
+def test_organizer_declined_event_is_not_a_conflict(fake_service):
+    """The organizer personally declining an invite doesn't clear its
+    transparency, but it's not something they're actually busy for."""
+    event = _confirmed_event()
+    event["attendees"] = [
+        {"email": "me@example.com", "self": True, "responseStatus": "declined"}
+    ]
+    fake_service._events._list_result = {"items": [event]}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_organizer_accepted_event_is_still_a_conflict(fake_service):
+    event = _confirmed_event()
+    event["attendees"] = [
+        {"email": "me@example.com", "self": True, "responseStatus": "accepted"}
+    ]
+    fake_service._events._list_result = {"items": [event]}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+
+
+def test_freebusy_batch_over_limit_is_chunked_into_multiple_calls(fake_service):
+    """Regression test: an over-limit attendee list must be split into
+    multiple <=50-sized freebusy.query calls and the results merged,
+    rather than giving up on checking anyone at all."""
+    attendees = [f"person{i}@example.com" for i in range(51)]
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "person0@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                },
+                "person50@example.com": {"busy": []},
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="All hands",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=attendees,
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "person0@example.com"
+    batch_sizes = sorted(
+        len(call["body"]["items"]) for call in fake_service._freebusy.query_calls
+    )
+    assert batch_sizes == [1, 50]
+
+
+def test_freebusy_missing_scope_degrades_to_unchecked_instead_of_erroring(
+    fake_service,
+):
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["unchecked_attendees"] == ["chelsea@example.com"]
+    assert "reconnect" in result["unchecked_reason"].lower()
+    assert len(fake_service._events.insert_calls) == 1
+
+
+def test_freebusy_other_http_errors_still_propagate(fake_service):
+    other_error = HttpError(_FakeHttpResp(500), b'{"error": {"message": "boom"}}')
+    fake_service._freebusy = FakeFreebusy(raise_error=other_error)
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+
+
+def test_freebusy_attendee_absent_from_response_is_marked_unchecked(fake_service):
+    """An attendee simply missing from calendars (no entry at all, not even
+    an "errors" key) must not be silently reported as free."""
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["ghost@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["unchecked_attendees"] == ["ghost@example.com"]
+
+
+def test_update_events_checks_conflicts_for_an_all_day_event(fake_service):
+    """Regression test: an all-day event stores its bounds under "date", not
+    "dateTime" - previously existing_start/existing_end came back None for
+    it, so the whole conflict check (and thus adding attendees) silently
+    skipped, even though sendUpdates="all" would still fire real invites.
+
+    Adding an attendee without moving the (all-day) window only checks the
+    newly-added attendee, same as the timed-event case - so this asserts
+    the freebusy query actually ran, with the date widened into a valid
+    RFC3339 bound, rather than an organizer-side conflict.
+    """
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "new@example.com": {
+                    "busy": [
+                        {"start": "2026-08-27T09:00:00Z", "end": "2026-08-27T10:00:00Z"}
+                    ]
+                }
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["new@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    query_call = fake_service._freebusy.query_calls[0]
+    assert query_call["body"]["timeMin"] == "2026-08-27T00:00:00+00:00"
+    assert query_call["body"]["timeMax"] == "2026-08-28T00:00:00+00:00"
+
+
+def test_update_events_rejects_single_boundary_change_on_an_all_day_event(
+    fake_service,
+):
+    """Regression test: an all-day event's start/end are {"date": ...} -
+    writing only one of start_time/end_time would overwrite just that side
+    with {"dateTime": ...} while the other side keeps its {"date": ...}
+    shape, which Google rejects as a malformed mixed body. Must fail
+    loudly with an actionable message instead of sending that request."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "all-day" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_allows_replacing_both_boundaries_on_an_all_day_event(
+    fake_service,
+):
+    """Both start_time and end_time together are a full, unambiguous
+    replacement of an all-day event's bounds, so this must succeed."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._events._list_result = {"items": []}
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_update_events_widens_all_day_boundary_in_the_calendars_own_timezone(
+    fake_service,
+):
+    """Regression test: an all-day event's date is a day on the
+    *calendar's own* calendar, not a UTC day - hardcoding "T00:00:00Z"
+    shifts the queried window by the calendar's own UTC offset instead of
+    asking what timezone the calendar is actually configured in."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._calendars = FakeCalendars(timezone="Asia/Singapore")
+    fake_service._freebusy = FakeFreebusy(
+        {"calendars": {"new@example.com": {"busy": []}}}
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["new@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    query_call = fake_service._freebusy.query_calls[0]
+    assert query_call["body"]["timeMin"] == "2026-08-27T00:00:00+08:00"
+    assert query_call["body"]["timeMax"] == "2026-08-28T00:00:00+08:00"
+    assert fake_service._calendars.get_calls  # actually looked it up
+
+
+def test_update_events_timed_event_never_looks_up_calendar_timezone(fake_service):
+    """The calendar-timezone lookup is only needed to widen an all-day
+    boundary - a plain timed-event update must not pay for it."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(event_id="self-1", summary="Renamed")
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._calendars.get_calls == []
+
+
+def test_update_events_partial_overlap_nudge_does_not_self_conflict(fake_service):
+    """Regression test: nudging a meeting to a window that still overlaps
+    its old one (e.g. 10:00-10:30 -> 10:15-10:45) must not check existing
+    attendees against the new window - the overlap still contains this
+    event's own busy block on their calendars, which isn't a real
+    conflict. Only a genuinely disjoint move is safe to check everyone
+    against."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                # This event's own footprint on the existing attendee's
+                # calendar for the overlapping sliver (10:15-10:30) -
+                # would wrongly read as a conflict if existing attendees
+                # were checked against the new, overlapping window.
+                "existing@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T10:00:00+08:00",
+                            "end": "2026-08-27T10:30:00+08:00",
+                        }
+                    ]
+                },
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:15:00+08:00",
+            end_time="2026-08-27T10:45:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._freebusy.query_calls == []
+
+
+def test_update_events_disjoint_move_checks_existing_attendees(fake_service):
+    """The counterpart to the partial-overlap test: moving to a window
+    that's completely disjoint from the old one IS safe to check every
+    existing attendee against, since this event's own busy block can't
+    show up in a window it doesn't occupy."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy(
+        {
+            "calendars": {
+                "existing@example.com": {
+                    "busy": [
+                        {
+                            "start": "2026-08-27T14:00:00+08:00",
+                            "end": "2026-08-27T14:30:00+08:00",
+                        }
+                    ]
+                },
+            }
+        }
+    )
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T14:00:00+08:00",
+            end_time="2026-08-27T14:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "existing@example.com"
+
+
+def test_update_events_empty_string_attendees_is_treated_as_not_provided(
+    fake_service,
+):
+    """Regression test: an accidental empty string (a stray default from a
+    template, or an LLM passing "" instead of omitting the argument) must
+    not be treated as a genuine attendees argument - attendees only ever
+    adds people, so there'd be nothing to add either way, but this
+    confirms the event's existing attendee data is left alone rather than
+    triggering any attendee-processing path at all."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com", "responseStatus": "accepted"}],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(event_id="self-1", attendees="")
+    )
+
+    assert result["status"] == "success"
+    update_call = fake_service._events.update_calls[0]
+    assert update_call["body"]["attendees"] == [
+        {"email": "existing@example.com", "responseStatus": "accepted"}
+    ]
+    assert update_call["sendUpdates"] == "none"
+
+
+def test_update_events_preserves_attendee_rsvp_state_on_resubmission(fake_service):
+    """Re-passing the same attendee list must not wipe responseStatus etc.
+    by replacing the whole array with bare {"email": ...} objects."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [
+            {
+                "email": "existing@example.com",
+                "responseStatus": "accepted",
+                "comment": "looking forward to it",
+            }
+        ],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["existing@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    update_call = fake_service._events.update_calls[0]
+    assert update_call["body"]["attendees"] == [
+        {
+            "email": "existing@example.com",
+            "responseStatus": "accepted",
+            "comment": "looking forward to it",
+        }
+    ]
+    # Byte-identical resubmission is not a real change - no notification.
+    assert update_call["sendUpdates"] == "none"
+
+
+def test_update_events_treats_equivalent_timestamp_formats_as_unchanged(
+    fake_service,
+):
+    """A same-instant resubmission written in a different (but equivalent)
+    format must not be treated as a real time change - that would run the
+    organizer check on the same window and self-conflict."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T02:00:00+00:00"},
+        "end": {"dateTime": "2026-08-27T02:30:00+00:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",  # same instant, "Z"-free offset form
+            end_time="2026-08-27T10:30:00+08:00",
+            location="Room 4",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._events.list_calls == []
+    assert fake_service._freebusy.query_calls == []
+    assert fake_service._events.update_calls[0]["sendUpdates"] == "none"
+
+
+def test_update_events_unchecked_reason_appears_alongside_a_conflict(fake_service):
+    """unchecked_attendees/unchecked_reason must still surface even when the
+    response status is "conflict" (from the organizer or another attendee),
+    not just on a clean "success" - a caller acting on the conflict still
+    needs to know some attendees were never actually checked."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["outsider@gmail.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["unchecked_attendees"] == ["outsider@gmail.com"]
+    assert "reconnect" in result["unchecked_reason"].lower()

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -918,12 +918,15 @@ class FakeFreebusy:
 
 
 class FakeCalendars:
-    def __init__(self, timezone: str = "UTC"):
+    def __init__(self, timezone: str = "UTC", *, raise_error: Exception | None = None):
         self._timezone = timezone
+        self._raise_error = raise_error
         self.get_calls: list[dict[str, Any]] = []
 
     def get(self, **kwargs: Any) -> _Exec:
         self.get_calls.append(kwargs)
+        if self._raise_error is not None:
+            raise self._raise_error
         return _Exec({"timeZone": self._timezone})
 
 
@@ -1446,10 +1449,30 @@ def test_update_events_ignore_conflicts_skips_the_check(fake_service):
     assert len(fake_service._events.update_calls) == 1
 
 
-def test_organizer_declined_event_is_not_a_conflict(fake_service):
-    """The organizer personally declining an invite doesn't clear its
-    transparency, but it's not something they're actually busy for."""
+def test_organizer_declined_but_opaque_event_is_still_a_conflict(fake_service):
+    """Google documents `responseStatus` and `transparency` as independent
+    fields with no guaranteed link - declining an invite doesn't reliably
+    clear its transparency, so a still-opaque declined event must still be
+    treated as busy rather than assumed free."""
     event = _confirmed_event()
+    event["attendees"] = [
+        {"email": "me@example.com", "self": True, "responseStatus": "declined"}
+    ]
+    fake_service._events._list_result = {"items": [event]}
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+
+
+def test_organizer_declined_and_transparent_event_is_not_a_conflict(fake_service):
+    event = _confirmed_event(transparency="transparent")
     event["attendees"] = [
         {"email": "me@example.com", "self": True, "responseStatus": "declined"}
     ]
@@ -1522,9 +1545,11 @@ def test_freebusy_batch_over_limit_is_chunked_into_multiple_calls(fake_service):
     assert batch_sizes == [1, 50]
 
 
-def test_freebusy_missing_scope_degrades_to_unchecked_instead_of_erroring(
-    fake_service,
-):
+def test_freebusy_missing_scope_rejects_the_write(fake_service):
+    """A whole-batch 403 means our own credential/scope is insufficient,
+    not that a particular attendee's calendar is merely invisible - proceed
+    would silently skip the entire conflict check, defeating the feature.
+    The write must be rejected rather than degraded to unchecked."""
     fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
 
     result = json.loads(
@@ -1536,13 +1561,50 @@ def test_freebusy_missing_scope_degrades_to_unchecked_instead_of_erroring(
         )
     )
 
+    assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
+    assert fake_service._events.insert_calls == []
+
+
+def test_freebusy_missing_scope_rejects_the_write_even_with_ignore_conflicts_false(
+    fake_service,
+):
+    """`ignore_conflicts` is the caller's explicit escape hatch - without it,
+    a scope-insufficient 403 must reject rather than silently proceed."""
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+            ignore_conflicts=False,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert fake_service._events.insert_calls == []
+
+
+def test_freebusy_missing_scope_can_be_bypassed_with_ignore_conflicts(fake_service):
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+            ignore_conflicts=True,
+        )
+    )
+
     assert result["status"] == "success"
-    assert result["unchecked_attendees"] == ["chelsea@example.com"]
-    assert "reconnect" in result["unchecked_reason"].lower()
     assert len(fake_service._events.insert_calls) == 1
 
 
-def test_freebusy_missing_scope_legacy_only_body_still_degrades(fake_service):
+def test_freebusy_missing_scope_legacy_only_body_still_rejects(fake_service):
     """The dual-format body is what a real Calendar API 403 actually
     carries, but a response with only the legacy `errors[]` field must
     still be recognized - not just the newer `details[]` shape."""
@@ -1559,8 +1621,8 @@ def test_freebusy_missing_scope_legacy_only_body_still_degrades(fake_service):
         )
     )
 
-    assert result["status"] == "success"
-    assert result["unchecked_attendees"] == ["chelsea@example.com"]
+    assert result["status"] == "error"
+    assert fake_service._events.insert_calls == []
 
 
 def test_is_insufficient_scope_error_matches_details_only_body():
@@ -1760,6 +1822,60 @@ def test_update_events_widens_all_day_boundary_in_the_calendars_own_timezone(
     assert fake_service._calendars.get_calls  # actually looked it up
 
 
+def test_update_events_calendar_timezone_lookup_missing_scope_rejects_the_write(
+    fake_service,
+):
+    """The calendars.get call needed to widen an all-day boundary needs its
+    own calendar.calendars.readonly scope - a token that predates that
+    migration must reject the write outright, same as a missing
+    freebusy scope, rather than silently guessing at UTC."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._calendars = FakeCalendars(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            attendees=["new@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_calendar_timezone_lookup_missing_scope_falls_back_with_ignore_conflicts(
+    fake_service,
+):
+    """ignore_conflicts is the caller's explicit escape hatch - it must not
+    be defeated by an unrelated all-day-timezone-lookup failure; the
+    write still proceeds, just without a real calendar timezone."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._calendars = FakeCalendars(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1
+
+
 def test_update_events_timed_event_never_looks_up_calendar_timezone(fake_service):
     """The calendar-timezone lookup is only needed to widen an all-day
     boundary - a plain timed-event update must not pay for it."""
@@ -1778,13 +1894,52 @@ def test_update_events_timed_event_never_looks_up_calendar_timezone(fake_service
     assert fake_service._calendars.get_calls == []
 
 
-def test_update_events_partial_overlap_nudge_does_not_self_conflict(fake_service):
+def test_update_events_partial_overlap_nudge_only_checks_the_new_delta_segment(
+    fake_service,
+):
     """Regression test: nudging a meeting to a window that still overlaps
-    its old one (e.g. 10:00-10:30 -> 10:15-10:45) must not check existing
-    attendees against the new window - the overlap still contains this
-    event's own busy block on their calendars, which isn't a real
-    conflict. Only a genuinely disjoint move is safe to check everyone
-    against."""
+    its old one (e.g. 10:00-10:30 -> 10:15-10:45) must only check existing
+    attendees against the genuinely new sliver (10:30-10:45) - the
+    retained 10:15-10:30 overlap still contains this event's own busy
+    block on their calendars, which isn't a real conflict. Checking the
+    delta segment (rather than skipping the check outright) still catches
+    a real conflict that happens to land in the newly-added time."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00+08:00"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+    fake_service._events._list_result = {"items": []}
+    # The fake, unlike the real freebusy.query endpoint, doesn't filter its
+    # configured busy blocks down to the requested [timeMin, timeMax) - so
+    # this leaves it empty and instead asserts directly on the query's
+    # timeMin/timeMax below. That's the actual behavior under our control;
+    # Google's own server is responsible for only returning busy blocks
+    # that overlap whatever window we send it.
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:15:00+08:00",
+            end_time="2026-08-27T10:45:00+08:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._freebusy.query_calls) == 1
+    query_call = fake_service._freebusy.query_calls[0]
+    assert query_call["body"]["timeMin"] == "2026-08-27T10:30:00+08:00"
+    assert query_call["body"]["timeMax"] == "2026-08-27T10:45:00+08:00"
+
+
+def test_update_events_partial_overlap_nudge_still_catches_a_real_conflict(
+    fake_service,
+):
+    """The delta segment isn't just a smaller no-op window - a genuine
+    conflict that only exists in the newly-added time must still be
+    caught."""
     fake_service._events._get_result = {
         "id": "self-1",
         "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
@@ -1795,15 +1950,11 @@ def test_update_events_partial_overlap_nudge_does_not_self_conflict(fake_service
     fake_service._freebusy = FakeFreebusy(
         {
             "calendars": {
-                # This event's own footprint on the existing attendee's
-                # calendar for the overlapping sliver (10:15-10:30) -
-                # would wrongly read as a conflict if existing attendees
-                # were checked against the new, overlapping window.
                 "existing@example.com": {
                     "busy": [
                         {
-                            "start": "2026-08-27T10:00:00+08:00",
-                            "end": "2026-08-27T10:30:00+08:00",
+                            "start": "2026-08-27T10:35:00+08:00",
+                            "end": "2026-08-27T10:40:00+08:00",
                         }
                     ]
                 },
@@ -1819,8 +1970,8 @@ def test_update_events_partial_overlap_nudge_does_not_self_conflict(fake_service
         )
     )
 
-    assert result["status"] == "success"
-    assert fake_service._freebusy.query_calls == []
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "existing@example.com"
 
 
 def test_update_events_disjoint_move_checks_existing_attendees(fake_service):
@@ -1954,11 +2105,42 @@ def test_update_events_treats_equivalent_timestamp_formats_as_unchanged(
     assert fake_service._events.update_calls[0]["sendUpdates"] == "none"
 
 
-def test_update_events_unchecked_reason_appears_alongside_a_conflict(fake_service):
-    """unchecked_attendees/unchecked_reason must still surface even when the
-    response status is "conflict" (from the organizer or another attendee),
-    not just on a clean "success" - a caller acting on the conflict still
-    needs to know some attendees were never actually checked."""
+def test_update_events_respects_sibling_timezone_on_an_offsetless_datetime(
+    fake_service,
+):
+    """Regression test: Google's own docs say dateTime "may" omit its
+    offset when a sibling timeZone field is present instead - treating
+    that offsetless value as if it belonged to some other zone (e.g. the
+    calendar's, or UTC) would misjudge a same-instant resubmission as a
+    real time change and run the organizer check against the event's own
+    now-"moved" window."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T02:00:00", "timeZone": "UTC"},
+        "end": {"dateTime": "2026-08-27T02:30:00", "timeZone": "UTC"},
+        "attendees": [{"email": "existing@example.com"}],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",  # same instant, different offset
+            end_time="2026-08-27T10:30:00+08:00",
+            location="Room 4",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._events.list_calls == []
+    assert fake_service._freebusy.query_calls == []
+    assert fake_service._events.update_calls[0]["sendUpdates"] == "none"
+
+
+def test_update_events_missing_scope_rejects_the_write(fake_service):
+    """A whole-batch 403 while checking the newly-added attendee is our own
+    credential's problem, not a per-attendee visibility gap - the write
+    must be rejected outright, even though the organizer's own calendar
+    already turned up a real conflict."""
     fake_service._events._get_result = {
         "id": "self-1",
         "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
@@ -1979,6 +2161,32 @@ def test_update_events_unchecked_reason_appears_alongside_a_conflict(fake_servic
         )
     )
 
-    assert result["status"] == "conflict"
-    assert result["unchecked_attendees"] == ["outsider@gmail.com"]
-    assert "reconnect" in result["unchecked_reason"].lower()
+    assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_missing_scope_can_be_bypassed_with_ignore_conflicts(
+    fake_service,
+):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["outsider@gmail.com"],
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert len(fake_service._events.update_calls) == 1

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1337,6 +1337,28 @@ def test_update_events_moving_time_checks_organizer_and_all_attendees(fake_servi
     assert queried_emails == {"existing@example.com"}
 
 
+def test_update_events_rejects_a_reversed_window(fake_service):
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:30:00+08:00",
+            end_time="2026-08-27T10:00:00+08:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "must be after" in result["message"]
+    assert fake_service._events.list_calls == []
+    assert fake_service._events.update_calls == []
+
+
 def test_freebusy_lookup_is_case_insensitive(fake_service):
     """Not confirmed against real Google API behavior, but the lookup should
     be defensive either way: a case-mismatched key must not silently
@@ -1565,6 +1587,18 @@ def test_is_insufficient_scope_error_rejects_unrelated_403():
 def test_is_insufficient_scope_error_tolerates_malformed_body():
     malformed = HttpError(_FakeHttpResp(403), b"not json")
     assert calendar._is_insufficient_scope_error(malformed) is False
+
+
+def test_is_insufficient_scope_error_tolerates_non_list_error_fields():
+    """Regression test: valid JSON whose "errors"/"details" field is
+    present but isn't an array (e.g. a boolean/object, from a malformed
+    or unexpected error body) must not crash - `x or []` treats a truthy
+    non-list value as itself, and iterating a non-iterable raises
+    TypeError; must fall through to "can't tell, so False" instead."""
+    non_list_fields = HttpError(
+        _FakeHttpResp(403), b'{"error": {"errors": true, "details": 42}}'
+    )
+    assert calendar._is_insufficient_scope_error(non_list_fields) is False
 
 
 def test_freebusy_other_http_errors_still_propagate(fake_service):

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -2190,3 +2190,36 @@ def test_update_events_missing_scope_can_be_bypassed_with_ignore_conflicts(
 
     assert result["status"] == "success"
     assert len(fake_service._events.update_calls) == 1
+
+
+def test_update_events_conflict_response_still_reports_unchecked_attendees(
+    fake_service,
+):
+    """A conflict found via one source (the organizer's own calendar) must
+    not suppress unchecked_attendees info for a different attendee whose
+    calendar couldn't be read (absent from the freebusy response, a
+    per-attendee gap rather than a whole-batch 403) - a caller acting on
+    the conflict still needs to know that attendee was never actually
+    checked."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+    }
+    fake_service._events._list_result = {
+        "items": [_confirmed_event(event_id="other-1")]
+    }
+    fake_service._freebusy = FakeFreebusy({"calendars": {}})
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["ghost@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["unchecked_attendees"] == ["ghost@example.com"]

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -2163,6 +2163,32 @@ def test_update_events_treats_equivalent_timestamp_formats_as_unchanged(
     assert fake_service._events.update_calls[0]["sendUpdates"] == "none"
 
 
+def test_update_events_summary_only_edit_never_revalidates_the_existing_window(
+    fake_service,
+):
+    """Regression test: an update that never touches start_time/end_time
+    isn't about to write any window at all, so it must not re-validate
+    the event's already-stored start/end - a zero-duration or malformed
+    pre-existing window (e.g. from another client/tool) would otherwise
+    reject an unrelated summary edit that never asked to change the
+    time."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T10:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T10:00:00+08:00"},  # zero-duration
+        "attendees": [],
+    }
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            summary="Renamed",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
 def test_update_events_respects_sibling_timezone_on_an_offsetless_datetime(
     fake_service,
 ):

--- a/tests/web/tools/test_google_calendar_mcp.py
+++ b/tests/web/tools/test_google_calendar_mcp.py
@@ -1604,6 +1604,35 @@ def test_freebusy_missing_scope_can_be_bypassed_with_ignore_conflicts(fake_servi
     assert len(fake_service._events.insert_calls) == 1
 
 
+def test_freebusy_missing_scope_still_reports_an_already_confirmed_conflict(
+    fake_service,
+):
+    """Regression test: a real conflict already confirmed before the scope
+    error hit (here, the organizer's own calendar, which doesn't need the
+    freebusy scope at all) must not be silently discarded just because a
+    later, unrelated attendee check then hit the same missing-scope 403 -
+    reporting a known conflict is always safe, and blindly rejecting
+    instead would tell the caller to retry with ignore_conflicts=true,
+    which would then book straight over the real conflict nobody ever
+    mentioned."""
+    fake_service._events._list_result = {"items": [_confirmed_event()]}
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_create_events(
+            summary="Kickoff",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
+    assert result["unchecked_attendees"] == ["chelsea@example.com"]
+    assert fake_service._events.insert_calls == []
+
+
 def test_freebusy_missing_scope_legacy_only_body_still_rejects(fake_service):
     """The dual-format body is what a real Calendar API 403 actually
     carries, but a response with only the legacy `errors[]` field must
@@ -1847,6 +1876,35 @@ def test_update_events_calendar_timezone_lookup_missing_scope_rejects_the_write(
     assert result["status"] == "error"
     assert "reconnect" in result["message"].lower()
     assert fake_service._events.update_calls == []
+
+
+def test_update_events_summary_only_edit_of_all_day_event_never_looks_up_calendar_timezone(
+    fake_service,
+):
+    """Regression test: a summary/location/description-only edit of an
+    all-day event never moves its window or touches attendees, so it has
+    no use for the calendar's real timezone - looking it up anyway would
+    needlessly block this benign edit behind a calendar.calendars.readonly
+    scope-403 for every pre-migration token, a far bigger blast radius
+    than the migration's stated purpose (all-day conflict checks)."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"date": "2026-08-27"},
+        "end": {"date": "2026-08-28"},
+        "attendees": [],
+    }
+    fake_service._calendars = FakeCalendars(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            summary="Renamed",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert fake_service._calendars.get_calls == []
+    assert len(fake_service._events.update_calls) == 1
 
 
 def test_update_events_calendar_timezone_lookup_missing_scope_falls_back_with_ignore_conflicts(
@@ -2138,9 +2196,42 @@ def test_update_events_respects_sibling_timezone_on_an_offsetless_datetime(
 
 def test_update_events_missing_scope_rejects_the_write(fake_service):
     """A whole-batch 403 while checking the newly-added attendee is our own
-    credential's problem, not a per-attendee visibility gap - the write
-    must be rejected outright, even though the organizer's own calendar
-    already turned up a real conflict."""
+    credential's problem, not a per-attendee visibility gap - with nothing
+    else already confirmed, the write must be rejected outright."""
+    fake_service._events._get_result = {
+        "id": "self-1",
+        "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
+        "end": {"dateTime": "2026-08-27T09:30:00+08:00"},
+        "attendees": [],
+    }
+    fake_service._events._list_result = {"items": []}
+    fake_service._freebusy = FakeFreebusy(raise_error=_insufficient_scope_error())
+
+    result = json.loads(
+        calendar.google_calendar_update_events(
+            event_id="self-1",
+            start_time="2026-08-27T10:00:00+08:00",
+            end_time="2026-08-27T10:30:00+08:00",
+            attendees=["outsider@gmail.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
+    assert fake_service._events.update_calls == []
+
+
+def test_update_events_missing_scope_still_reports_an_already_confirmed_conflict(
+    fake_service,
+):
+    """Regression test: a real conflict already confirmed before the scope
+    error hit (here, the organizer's own calendar, which doesn't need the
+    freebusy scope at all) must not be silently discarded just because a
+    later, unrelated attendee check then hit the same missing-scope 403 -
+    reporting a known conflict is always safe, and blindly rejecting
+    instead would tell the caller to retry with ignore_conflicts=true,
+    which would then book straight over the real conflict nobody ever
+    mentioned."""
     fake_service._events._get_result = {
         "id": "self-1",
         "start": {"dateTime": "2026-08-27T09:00:00+08:00"},
@@ -2161,9 +2252,9 @@ def test_update_events_missing_scope_rejects_the_write(fake_service):
         )
     )
 
-    assert result["status"] == "error"
-    assert "reconnect" in result["message"].lower()
-    assert fake_service._events.update_calls == []
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
+    assert result["unchecked_attendees"] == ["outsider@gmail.com"]
 
 
 def test_update_events_missing_scope_can_be_bypassed_with_ignore_conflicts(

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -115,3 +115,88 @@ def test_url_path_id_output_survives_requests_url_normalization():
 
     with pytest.raises(ValueError):
         utils.url_path_id("..", "record_id")
+
+
+def test_datetime_key_for_comparison_truncates_seven_digit_fractional_seconds():
+    """Outlook commonly reports 100-nanosecond (7-digit) fractional
+    seconds, one more digit than a microsecond can hold - this must not
+    depend on whichever CPython version happens to run it."""
+    key = utils.datetime_key_for_comparison("2026-08-27T10:00:00.0000000")
+    assert key == utils.datetime_key_for_comparison("2026-08-27T10:00:00")
+
+
+def test_datetime_key_for_comparison_treats_equal_instants_as_equal_across_offsets():
+    z_form = utils.datetime_key_for_comparison("2026-08-27T02:00:00Z")
+    offset_form = utils.datetime_key_for_comparison("2026-08-27T10:00:00+08:00")
+    assert z_form == offset_form
+
+
+def test_datetime_key_for_comparison_falls_back_to_raw_string_on_malformed_input():
+    assert utils.datetime_key_for_comparison("not-a-date") == "not-a-date"
+
+
+def test_datetime_key_for_comparison_passes_none_through():
+    assert utils.datetime_key_for_comparison(None) is None
+
+
+def test_normalize_addresses_drops_case_insensitive_duplicates():
+    """Regression test: email addresses are case-insensitive, so the same
+    person listed twice with different casing must not become two separate
+    attendee entries downstream - keeps the first casing seen."""
+    assert utils.normalize_addresses(
+        ["Chelsea@Example.com", "chelsea@example.com", "new@example.com"]
+    ) == ["Chelsea@Example.com", "new@example.com"]
+
+
+def test_normalize_addresses_dedup_works_for_comma_separated_string_input():
+    assert utils.normalize_addresses("a@x.com, A@X.com, b@x.com") == [
+        "a@x.com",
+        "b@x.com",
+    ]
+
+
+def test_attendees_were_given_treats_empty_string_as_not_provided():
+    assert utils.attendees_were_given(None) is False
+    assert utils.attendees_were_given("") is False
+
+
+def test_attendees_were_given_treats_empty_list_as_provided():
+    """An explicit [] is a deliberate "clear everyone" - distinct from
+    not-provided, unlike an empty string."""
+    assert utils.attendees_were_given([]) is True
+    assert utils.attendees_were_given(["a@x.com"]) is True
+    assert utils.attendees_were_given("a@x.com") is True
+
+
+def test_unchecked_extra_empty_when_nothing_unchecked():
+    assert utils.unchecked_extra([], None) == {}
+    assert utils.unchecked_extra([], "some reason") == {}
+
+
+def test_unchecked_extra_includes_reason_only_when_given():
+    assert utils.unchecked_extra(["a@x.com"], None) == {
+        "unchecked_attendees": ["a@x.com"]
+    }
+    assert utils.unchecked_extra(["a@x.com"], "reconnect the connector") == {
+        "unchecked_attendees": ["a@x.com"],
+        "unchecked_reason": "reconnect the connector",
+    }
+
+
+def test_attendees_needing_check_disjoint_window_checks_everyone():
+    assert utils.attendees_needing_check(
+        ["old@x.com", "new@x.com"],
+        {"old@x.com"},
+        moved_to_a_disjoint_window=True,
+    ) == ["old@x.com", "new@x.com"]
+
+
+def test_attendees_needing_check_same_or_overlapping_window_checks_only_new():
+    """An existing attendee's schedule always shows this event's own busy
+    block for a window it still occupies - only newly-added attendees are
+    safe to check there."""
+    assert utils.attendees_needing_check(
+        ["old@x.com", "new@x.com"],
+        {"old@x.com"},
+        moved_to_a_disjoint_window=False,
+    ) == ["new@x.com"]

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -181,68 +181,121 @@ def test_attendees_to_add_returns_empty_for_not_provided_or_empty():
 
 
 def test_unchecked_extra_empty_when_nothing_unchecked():
-    assert utils.unchecked_extra([], None) == {}
-    assert utils.unchecked_extra([], "some reason") == {}
+    assert utils.unchecked_extra([]) == {}
 
 
-def test_unchecked_extra_includes_reason_only_when_given():
-    assert utils.unchecked_extra(["a@x.com"], None) == {
-        "unchecked_attendees": ["a@x.com"]
-    }
-    assert utils.unchecked_extra(["a@x.com"], "reconnect the connector") == {
-        "unchecked_attendees": ["a@x.com"],
-        "unchecked_reason": "reconnect the connector",
-    }
+def test_unchecked_extra_includes_attendees_when_given():
+    assert utils.unchecked_extra(["a@x.com"]) == {"unchecked_attendees": ["a@x.com"]}
 
 
-def test_attendees_needing_check_disjoint_window_checks_everyone():
-    assert utils.attendees_needing_check(
-        ["old@x.com", "new@x.com"],
-        {"old@x.com"},
-        moved_to_a_disjoint_window=True,
-    ) == ["old@x.com", "new@x.com"]
+def _key(value: str):
+    return utils.datetime_key_for_comparison(value)
 
 
-def test_attendees_needing_check_same_or_overlapping_window_checks_only_new():
-    """An existing attendee's schedule always shows this event's own busy
-    block for a window it still occupies - only newly-added attendees are
-    safe to check there."""
-    assert utils.attendees_needing_check(
-        ["old@x.com", "new@x.com"],
-        {"old@x.com"},
-        moved_to_a_disjoint_window=False,
-    ) == ["new@x.com"]
-
-
-def test_windows_overlap_detects_overlapping_and_disjoint_windows():
-    overlapping_a = utils.datetime_key_for_comparison("2026-08-27T10:00:00+00:00")
-    overlapping_b = utils.datetime_key_for_comparison("2026-08-27T10:30:00+00:00")
-    disjoint_a = utils.datetime_key_for_comparison("2026-08-27T14:00:00+00:00")
-    disjoint_b = utils.datetime_key_for_comparison("2026-08-27T14:30:00+00:00")
-
-    assert (
-        utils.windows_overlap(
-            overlapping_a, overlapping_b, overlapping_a, overlapping_b
-        )
-        is True
+def test_window_delta_segments_empty_for_unchanged_or_shrunk_window():
+    """A retained attendee's own busy block already covers everything
+    inside the old window - a new window that's identical, or a strict
+    subset of it, adds no territory worth checking them against."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
     )
+    assert utils.window_delta_segments(old_start, old_end, old_start, old_end) == []
+
+    shrunk_start = _key("2026-08-27T10:05:00+00:00")
+    shrunk_end = _key("2026-08-27T10:25:00+00:00")
     assert (
-        utils.windows_overlap(overlapping_a, overlapping_b, disjoint_a, disjoint_b)
-        is False
+        utils.window_delta_segments(old_start, old_end, shrunk_start, shrunk_end) == []
     )
 
 
-def test_windows_overlap_is_conservative_on_unparseable_or_mismatched_keys():
-    """Regression test: "can't confirm disjoint" must read as overlapping
-    (True), never as disjoint (False) - both for a key that never parsed
-    to a real datetime, and for two real datetimes that can't be compared
-    against each other (aware vs. naive raises TypeError on `<`)."""
-    real_key = utils.datetime_key_for_comparison("2026-08-27T10:00:00+00:00")
-    assert utils.windows_overlap("not-a-date", "also-not", real_key, real_key) is True
+def test_window_delta_segments_returns_the_new_only_portion_of_a_partial_nudge():
+    """10:00-10:30 nudged to 10:15-10:45 - only 10:30-10:45 is new
+    territory a retained attendee could have a genuine conflict in;
+    10:15-10:30 is still covered by their busy block for this event."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    new_start, new_end = (
+        _key("2026-08-27T10:15:00+00:00"),
+        _key("2026-08-27T10:45:00+00:00"),
+    )
 
-    aware_key = utils.datetime_key_for_comparison("2026-08-27T10:00:00+00:00")
-    naive_key = utils.datetime_key_for_comparison("2026-08-27T10:00:00")
-    assert utils.windows_overlap(aware_key, aware_key, naive_key, naive_key) is True
+    segments = utils.window_delta_segments(old_start, old_end, new_start, new_end)
+
+    assert segments == [(old_end, new_end)]
+
+
+def test_window_delta_segments_returns_two_segments_when_widened_on_both_sides():
+    """Extending a meeting earlier AND later in the same call creates new
+    territory on both sides of the old window."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    new_start, new_end = (
+        _key("2026-08-27T09:45:00+00:00"),
+        _key("2026-08-27T10:45:00+00:00"),
+    )
+
+    segments = utils.window_delta_segments(old_start, old_end, new_start, new_end)
+
+    assert len(segments) == 2
+    assert segments[0] == (new_start, old_start)
+    assert segments[1] == (old_end, new_end)
+
+
+def test_window_delta_segments_returns_the_whole_window_for_a_disjoint_move():
+    """A move to somewhere with zero overlap with the old window means the
+    entire new window is new territory - this test also confirms the
+    move-by-15-minutes example from the actual reported bug is caught:
+    the delta segment here is the same shape as the disjoint case."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    new_start, new_end = (
+        _key("2026-08-27T14:00:00+00:00"),
+        _key("2026-08-27T14:30:00+00:00"),
+    )
+
+    assert utils.window_delta_segments(old_start, old_end, new_start, new_end) == [
+        (new_start, new_end)
+    ]
+
+
+def test_window_delta_segments_is_conservative_on_unparseable_or_mismatched_keys():
+    """ "Can't confirm the delta is smaller than the whole window" must
+    never silently shrink what gets checked - falls back to the whole new
+    window, both for a key that never parsed to a real datetime, and for
+    two real datetimes that can't be compared (aware vs. naive raises
+    TypeError on `<`)."""
+    new_start, new_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    assert utils.window_delta_segments(
+        "not-a-date", "also-not", new_start, new_end
+    ) == [(new_start, new_end)]
+
+    naive_start = _key("2026-08-27T09:00:00")
+    naive_end = _key("2026-08-27T11:00:00")
+    assert utils.window_delta_segments(naive_start, naive_end, new_start, new_end) == [
+        (new_start, new_end)
+    ]
+
+
+def test_window_delta_segments_empty_when_new_window_itself_is_unparseable():
+    """No valid new window at all means nothing meaningful to check,
+    regardless of the old window."""
+    old_start, old_end = (
+        _key("2026-08-27T10:00:00+00:00"),
+        _key("2026-08-27T10:30:00+00:00"),
+    )
+    assert (
+        utils.window_delta_segments(old_start, old_end, "not-a-date", "also-not") == []
+    )
 
 
 def test_reject_reversed_window_raises_when_end_is_not_after_start():
@@ -274,8 +327,8 @@ def test_reject_reversed_window_is_permissive_when_aware_and_naive_are_mixed():
     `TypeError` in Python - the `isinstance` check alone doesn't guard
     against this, only checking that both are `datetime` instances of the
     SAME awareness does. Must stay permissive here, not crash with a raw
-    TypeError, matching `windows_overlap`'s handling of the identical
-    hazard."""
+    TypeError, matching `window_delta_segments`'s handling of the
+    identical hazard."""
     utils.reject_reversed_window("2026-08-27T10:30:00", "2026-08-27T10:30:00Z")
     utils.reject_reversed_window("2026-08-27T10:30:00Z", "2026-08-27T10:00:00")
 

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -237,6 +237,18 @@ def test_reject_reversed_window_is_permissive_on_unparseable_input():
     utils.reject_reversed_window("not-a-date", "also-not-a-date")
 
 
+def test_reject_reversed_window_is_permissive_when_aware_and_naive_are_mixed():
+    """Regression test: both sides parse to real `datetime` instances, but
+    comparing an offset-aware one against a naive one with `<=` raises
+    `TypeError` in Python - the `isinstance` check alone doesn't guard
+    against this, only checking that both are `datetime` instances of the
+    SAME awareness does. Must stay permissive here, not crash with a raw
+    TypeError, matching `windows_overlap`'s handling of the identical
+    hazard."""
+    utils.reject_reversed_window("2026-08-27T10:30:00", "2026-08-27T10:30:00Z")
+    utils.reject_reversed_window("2026-08-27T10:30:00Z", "2026-08-27T10:00:00")
+
+
 def test_resolve_zone_name_covers_graphs_additional_time_zones():
     """Regression test: `_WINDOWS_TO_IANA` was missing several of the
     Windows names for zones Microsoft's own dateTimeTimeZone docs list

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -214,6 +214,37 @@ def test_attendees_needing_check_same_or_overlapping_window_checks_only_new():
     ) == ["new@x.com"]
 
 
+def test_windows_overlap_detects_overlapping_and_disjoint_windows():
+    overlapping_a = utils.datetime_key_for_comparison("2026-08-27T10:00:00+00:00")
+    overlapping_b = utils.datetime_key_for_comparison("2026-08-27T10:30:00+00:00")
+    disjoint_a = utils.datetime_key_for_comparison("2026-08-27T14:00:00+00:00")
+    disjoint_b = utils.datetime_key_for_comparison("2026-08-27T14:30:00+00:00")
+
+    assert (
+        utils.windows_overlap(
+            overlapping_a, overlapping_b, overlapping_a, overlapping_b
+        )
+        is True
+    )
+    assert (
+        utils.windows_overlap(overlapping_a, overlapping_b, disjoint_a, disjoint_b)
+        is False
+    )
+
+
+def test_windows_overlap_is_conservative_on_unparseable_or_mismatched_keys():
+    """Regression test: "can't confirm disjoint" must read as overlapping
+    (True), never as disjoint (False) - both for a key that never parsed
+    to a real datetime, and for two real datetimes that can't be compared
+    against each other (aware vs. naive raises TypeError on `<`)."""
+    real_key = utils.datetime_key_for_comparison("2026-08-27T10:00:00+00:00")
+    assert utils.windows_overlap("not-a-date", "also-not", real_key, real_key) is True
+
+    aware_key = utils.datetime_key_for_comparison("2026-08-27T10:00:00+00:00")
+    naive_key = utils.datetime_key_for_comparison("2026-08-27T10:00:00")
+    assert utils.windows_overlap(aware_key, aware_key, naive_key, naive_key) is True
+
+
 def test_reject_reversed_window_raises_when_end_is_not_after_start():
     with pytest.raises(ValueError, match="must be after"):
         utils.reject_reversed_window(

--- a/tests/web/tools/test_mcp_utils.py
+++ b/tests/web/tools/test_mcp_utils.py
@@ -168,6 +168,18 @@ def test_attendees_were_given_treats_empty_list_as_provided():
     assert utils.attendees_were_given("a@x.com") is True
 
 
+def test_attendees_to_add_filters_out_existing_and_normalizes():
+    assert utils.attendees_to_add(
+        ["Old@Example.com", "new@example.com"], {"old@example.com"}
+    ) == ["new@example.com"]
+
+
+def test_attendees_to_add_returns_empty_for_not_provided_or_empty():
+    assert utils.attendees_to_add(None, {"old@example.com"}) == []
+    assert utils.attendees_to_add("", {"old@example.com"}) == []
+    assert utils.attendees_to_add([], {"old@example.com"}) == []
+
+
 def test_unchecked_extra_empty_when_nothing_unchecked():
     assert utils.unchecked_extra([], None) == {}
     assert utils.unchecked_extra([], "some reason") == {}
@@ -200,3 +212,60 @@ def test_attendees_needing_check_same_or_overlapping_window_checks_only_new():
         {"old@x.com"},
         moved_to_a_disjoint_window=False,
     ) == ["new@x.com"]
+
+
+def test_reject_reversed_window_raises_when_end_is_not_after_start():
+    with pytest.raises(ValueError, match="must be after"):
+        utils.reject_reversed_window(
+            "2026-08-27T10:30:00+00:00", "2026-08-27T10:00:00+00:00"
+        )
+    with pytest.raises(ValueError, match="must be after"):
+        utils.reject_reversed_window(
+            "2026-08-27T10:00:00+00:00", "2026-08-27T10:00:00+00:00"
+        )
+
+
+def test_reject_reversed_window_allows_a_forward_window():
+    utils.reject_reversed_window(
+        "2026-08-27T10:00:00+00:00", "2026-08-27T10:30:00+00:00"
+    )
+
+
+def test_reject_reversed_window_is_permissive_on_unparseable_input():
+    """Can't-tell must never read as "reject" - only a confirmed reversal
+    should raise."""
+    utils.reject_reversed_window("not-a-date", "also-not-a-date")
+
+
+def test_resolve_zone_name_covers_graphs_additional_time_zones():
+    """Regression test: `_WINDOWS_TO_IANA` was missing several of the
+    Windows names for zones Microsoft's own dateTimeTimeZone docs list
+    under "Additional time zones" (e.g. Kaliningrad, Ekaterinburg) - an
+    event whose originalStartTimeZone happened to be one of these
+    previously hard-failed every single-boundary update and conflict
+    check outright."""
+    assert utils.resolve_zone_name("Kaliningrad Standard Time") == "Europe/Kaliningrad"
+    assert utils.resolve_zone_name("Ekaterinburg Standard Time") == "Asia/Yekaterinburg"
+    assert utils.resolve_zone_name("Vladivostok Standard Time") == "Asia/Vladivostok"
+
+
+def test_offset_datetime_string_attaches_the_zone_offset_to_a_naive_value():
+    assert (
+        utils.offset_datetime_string("2026-08-27T10:00:00", "Asia/Singapore")
+        == "2026-08-27T10:00:00+08:00"
+    )
+
+
+def test_offset_datetime_string_rejects_input_that_already_carries_an_offset():
+    """Regression test: no public tool parameter is documented as requiring
+    a naive value, so a caller passing one with a trailing 'Z' or an
+    explicit offset is a real, reachable mistake - not a theoretical one.
+    `.replace(tzinfo=...)` doesn't convert an aware datetime, it just
+    relabels the same clock digits under a different zone, silently
+    shifting the real instant by however much the two offsets differ
+    (e.g. "10:00:00Z" relabeled as Asia/Shanghai reads as 10:00 Shanghai
+    time - actually 8 hours earlier). Must fail loudly instead."""
+    with pytest.raises(ValueError, match="already carries a UTC offset"):
+        utils.offset_datetime_string("2026-08-27T10:00:00Z", "Asia/Shanghai")
+    with pytest.raises(ValueError, match="already carries a UTC offset"):
+        utils.offset_datetime_string("2026-08-27T10:00:00+00:00", "Asia/Shanghai")

--- a/tests/web/tools/test_outlook_mcp.py
+++ b/tests/web/tools/test_outlook_mcp.py
@@ -235,6 +235,23 @@ def test_create_event_ignore_conflicts_skips_the_check_entirely(monkeypatch):
     assert graph_request.call_args.args[:2] == ("POST", "/me/events")
 
 
+def test_create_event_rejects_a_reversed_window(monkeypatch):
+    graph_request = Mock()
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:30:00",
+            end_datetime="2026-08-27T10:00:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "must be after" in result["message"]
+    graph_request.assert_not_called()
+
+
 def test_update_event_excludes_the_event_being_moved_from_its_own_conflicts(
     monkeypatch,
 ):

--- a/tests/web/tools/test_outlook_mcp.py
+++ b/tests/web/tools/test_outlook_mcp.py
@@ -81,15 +81,34 @@ def test_create_event_ignores_free_and_cancelled_events(monkeypatch):
     assert graph_request.call_args.args[:2] == ("POST", "/me/events")
 
 
-def test_create_event_ignores_organizers_own_declined_event(monkeypatch):
-    """Regression test matching google_calendar's equivalent check: an
-    event the organizer personally declined still sits on their calendar
-    (declining doesn't clear showAs), but it's not something they're
-    actually busy for. `/me/calendarView` reports the signed-in user's own
-    response via `responseStatus`."""
+def test_create_event_declined_but_busy_event_is_still_a_conflict(monkeypatch):
+    """Regression test matching google_calendar's equivalent check:
+    Microsoft documents `responseStatus` and `showAs` as independent
+    fields with no guaranteed link - declining an invite doesn't reliably
+    clear its `showAs`, so a still-busy declined event must still be
+    treated as a conflict rather than assumed free."""
     graph_request = Mock(
         side_effect=[
             {"value": [_busy_event(response="declined")]},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+
+
+def test_create_event_ignores_organizers_own_declined_and_free_event(monkeypatch):
+    graph_request = Mock(
+        side_effect=[
+            {"value": [_busy_event(response="declined", show_as="free")]},
             {"id": "created"},
         ]
     )
@@ -838,15 +857,16 @@ def test_update_event_toggling_all_day_alone_still_triggers_a_real_check(monkeyp
     assert result["status"] == "conflict"
 
 
-def test_update_event_toggling_all_day_alone_does_not_self_conflict_on_attendees(
+def test_update_event_toggling_all_day_alone_still_checks_the_widened_delta_for_attendees(
     monkeypatch,
 ):
     """Regression test: toggling is_all_day alone doesn't move the literal
-    start/end clock values, so querying an EXISTING attendee's schedule for
-    that same unmoved window would always find this very event's own busy
-    block there. The organizer check may legitimately run (see the test
-    above), but existing attendees must not be re-checked against an
-    unmoved window just because is_all_day flipped."""
+    start/end clock values, but it does widen the event's EFFECTIVE span to
+    the whole day - an existing attendee could have a real conflict
+    somewhere in that day outside the original 10:00-10:30 slot, so the
+    widened territory (excluding the original slot, which only ever shows
+    this event's own busy block) must still be checked for them, same as a
+    genuine time-window nudge."""
     graph_request = Mock(
         side_effect=[
             {
@@ -856,6 +876,8 @@ def test_update_event_toggling_all_day_alone_does_not_self_conflict_on_attendees
                 "isAllDay": False,
             },
             {"value": []},
+            {"value": [{"scheduleId": "existing@example.com", "scheduleItems": []}]},
+            {"value": [{"scheduleId": "existing@example.com", "scheduleItems": []}]},
             {"id": "updated"},
         ]
     )
@@ -869,11 +891,59 @@ def test_update_event_toggling_all_day_alone_does_not_self_conflict_on_attendees
     )
 
     assert result["status"] == "success"
-    # Only the organizer's calendarView should have been queried (2nd
-    # call) - no getSchedule call for the existing attendee.
-    assert graph_request.call_count == 3
+    assert graph_request.call_count == 5
     assert graph_request.call_args_list[0].args[:2] == ("GET", "/me/events/self-1")
     assert graph_request.call_args_list[1].args[:2] == ("GET", "/me/calendarView")
+    assert graph_request.call_args_list[2].args[:2] == (
+        "POST",
+        "/me/calendar/getSchedule",
+    )
+    assert graph_request.call_args_list[3].args[:2] == (
+        "POST",
+        "/me/calendar/getSchedule",
+    )
+
+
+def test_update_event_toggling_all_day_alone_catches_a_conflict_in_the_widened_territory(
+    monkeypatch,
+):
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [{"emailAddress": {"address": "existing@example.com"}}],
+                "isAllDay": False,
+            },
+            {"value": []},
+            {
+                "value": [
+                    {
+                        "scheduleId": "existing@example.com",
+                        "scheduleItems": [
+                            {
+                                "status": "busy",
+                                "start": {"dateTime": "2026-08-27T14:00:00"},
+                                "end": {"dateTime": "2026-08-27T14:30:00"},
+                            }
+                        ],
+                    }
+                ]
+            },
+            {"value": [{"scheduleId": "existing@example.com", "scheduleItems": []}]},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            is_all_day=True,
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "existing@example.com"
 
 
 def test_update_event_moving_time_checks_organizer_and_all_attendees(monkeypatch):
@@ -1041,12 +1111,16 @@ def test_create_event_batch_over_limit_is_chunked_into_multiple_calls(
     assert sorted(len(batch) for batch in calls) == [1, 20]
 
 
-def test_create_event_missing_schedule_scope_degrades_to_unchecked(monkeypatch):
+def test_create_event_missing_schedule_scope_rejects_the_write(monkeypatch):
+    """A whole-batch 403 means our own credential/policy is insufficient,
+    not that a particular attendee's schedule is merely invisible -
+    proceeding would silently skip the entire conflict check, defeating
+    the feature. The write must be rejected rather than degraded to
+    unchecked."""
     graph_request = Mock(
         side_effect=[
             {"value": []},  # organizer calendarView
             outlook._GraphRequestError("403 Forbidden", status_code=403),
-            {"id": "created"},
         ]
     )
     monkeypatch.setattr(outlook, "_graph_request", graph_request)
@@ -1060,11 +1134,30 @@ def test_create_event_missing_schedule_scope_degrades_to_unchecked(monkeypatch):
         )
     )
 
+    assert result["status"] == "error"
+    # The message must give an LLM caller something actionable -
+    # reconnecting the connector - rather than a bare error string.
+    assert "reconnect" in result["message"].lower()
+
+
+def test_create_event_missing_schedule_scope_can_be_bypassed_with_ignore_conflicts(
+    monkeypatch,
+):
+    graph_request = Mock(return_value={"id": "created"})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["chelsea@example.com"],
+            ignore_conflicts=True,
+        )
+    )
+
     assert result["status"] == "success"
-    assert result["unchecked_attendees"] == ["chelsea@example.com"]
-    # The reason must give an LLM caller something actionable - reconnecting
-    # the connector - rather than a bare error string.
-    assert "reconnect" in result["unchecked_reason"].lower()
+    assert graph_request.call_count == 1
 
 
 def test_create_event_other_graph_errors_still_propagate(monkeypatch):
@@ -1197,6 +1290,133 @@ def test_update_event_resubmitting_only_existing_attendees_does_not_touch_them(
     assert result["status"] == "success"
     patch_call = graph_request.call_args_list[1]
     assert "attendees" not in patch_call.kwargs["body"]
+
+
+def test_update_event_attendees_replace_drops_addresses_left_out_of_the_new_list(
+    monkeypatch,
+):
+    """attendees fully replaces the event's attendee list (this connector's
+    pre-existing base behavior) - an existing address left out of the new
+    list must actually be removed, not silently kept the way an
+    append-only design would."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [
+                    {
+                        "emailAddress": {"address": "keep@example.com"},
+                        "type": "required",
+                    },
+                    {
+                        "emailAddress": {"address": "drop@example.com"},
+                        "type": "required",
+                    },
+                ],
+                "isAllDay": False,
+            },
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            attendees=["keep@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    patch_call = graph_request.call_args_list[1]
+    assert {
+        a["emailAddress"]["address"] for a in patch_call.kwargs["body"]["attendees"]
+    } == {"keep@example.com"}
+
+
+def test_update_event_attendees_empty_list_clears_every_attendee(monkeypatch):
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [
+                    {
+                        "emailAddress": {"address": "existing@example.com"},
+                        "type": "required",
+                    },
+                ],
+                "isAllDay": False,
+            },
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            attendees=[],
+        )
+    )
+
+    assert result["status"] == "success"
+    patch_call = graph_request.call_args_list[1]
+    assert patch_call.kwargs["body"]["attendees"] == []
+
+
+def test_update_event_attendees_replace_preserves_rsvp_state_for_retained_entries(
+    monkeypatch,
+):
+    """A replace that both keeps an existing attendee and adds a new one
+    must reuse the retained entry's own raw dict (preserving its RSVP
+    state) while giving the genuinely new address a fresh minimal one."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [
+                    {
+                        "emailAddress": {"address": "existing@example.com"},
+                        "type": "required",
+                        "status": {
+                            "response": "accepted",
+                            "time": "2026-08-20T00:00:00Z",
+                        },
+                    }
+                ],
+                "isAllDay": False,
+            },
+            # No window/is_all_day change, so check_organizer is False here
+            # - only the newly-added attendee's schedule is queried.
+            {"value": [{"scheduleId": "new@example.com", "scheduleItems": []}]},
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            attendees=["existing@example.com", "new@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    patch_call = graph_request.call_args_list[-1]
+    by_address = {
+        a["emailAddress"]["address"]: a for a in patch_call.kwargs["body"]["attendees"]
+    }
+    assert by_address["existing@example.com"]["status"] == {
+        "response": "accepted",
+        "time": "2026-08-20T00:00:00Z",
+    }
+    assert by_address["new@example.com"] == {
+        "emailAddress": {"address": "new@example.com"},
+        "type": "required",
+    }
 
 
 def test_update_event_treats_equivalent_timestamp_formats_as_unchanged(monkeypatch):
@@ -1336,12 +1556,14 @@ def test_update_event_windows_and_iana_names_for_the_same_zone_are_not_ambiguous
     assert result["status"] == "success"
 
 
-def test_update_event_partial_overlap_nudge_does_not_self_conflict(monkeypatch):
+def test_update_event_partial_overlap_nudge_only_checks_the_new_delta_segment(
+    monkeypatch,
+):
     """Regression test: nudging a boundary to a window that still overlaps
-    the event's OLD window is just as unsafe to check existing attendees
-    against as an unchanged window - the overlap still contains this
-    event's own busy block on their calendar. Only a genuinely disjoint
-    move is safe to re-check everyone."""
+    the event's OLD window (10:00-10:30 -> 10:15-10:45) must only check
+    existing attendees against the genuinely new sliver (10:30-10:45) -
+    the retained 10:15-10:30 overlap still contains this event's own busy
+    block on their calendar, which isn't a real conflict."""
     graph_request = Mock(
         side_effect=[
             {
@@ -1351,6 +1573,7 @@ def test_update_event_partial_overlap_nudge_does_not_self_conflict(monkeypatch):
                 "isAllDay": False,
             },
             {"value": []},  # organizer calendarView
+            {"value": [{"scheduleId": "existing@example.com", "scheduleItems": []}]},
             {"id": "updated"},
         ]
     )
@@ -1365,10 +1588,58 @@ def test_update_event_partial_overlap_nudge_does_not_self_conflict(monkeypatch):
     )
 
     assert result["status"] == "success"
-    # Existing-event GET + organizer calendarView + PATCH - no getSchedule
-    # call for the existing attendee.
-    assert graph_request.call_count == 3
-    assert graph_request.call_args_list[-1].args[:2] == ("PATCH", "/me/events/self-1")
+    assert graph_request.call_count == 4
+    schedule_call = graph_request.call_args_list[2]
+    assert schedule_call.args[:2] == ("POST", "/me/calendar/getSchedule")
+    assert (
+        schedule_call.kwargs["body"]["startTime"]["dateTime"] == "2026-08-27T10:30:00"
+    )
+    assert schedule_call.kwargs["body"]["endTime"]["dateTime"] == "2026-08-27T10:45:00"
+
+
+def test_update_event_partial_overlap_nudge_still_catches_a_real_conflict(
+    monkeypatch,
+):
+    """The delta segment isn't just a smaller no-op window - a genuine
+    conflict that only exists in the newly-added time must still be
+    caught."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [{"emailAddress": {"address": "existing@example.com"}}],
+                "isAllDay": False,
+            },
+            {"value": []},  # organizer calendarView
+            {
+                "value": [
+                    {
+                        "scheduleId": "existing@example.com",
+                        "scheduleItems": [
+                            {
+                                "status": "busy",
+                                "start": {"dateTime": "2026-08-27T10:35:00"},
+                                "end": {"dateTime": "2026-08-27T10:40:00"},
+                            }
+                        ],
+                    }
+                ]
+            },
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            start_datetime="2026-08-27T10:15:00",
+            end_datetime="2026-08-27T10:45:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "existing@example.com"
 
 
 def test_update_event_disjoint_move_checks_existing_attendees(monkeypatch):
@@ -1454,6 +1725,93 @@ def test_update_event_moving_to_all_day_widens_query_to_the_full_day(monkeypatch
     )
 
 
+def test_update_event_moving_to_all_day_does_not_double_widen_a_boundary_already_at_midnight(
+    monkeypatch,
+):
+    """Regression test: effective_end may already BE a well-formed
+    exclusive day boundary (exactly midnight) - naive_day_bounds always
+    treats its input as needing widening to [that midnight, next
+    midnight), so applying it unconditionally here would push an
+    already-correct boundary one whole day too far, falsely conflicting
+    with a following-day event."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [],
+                "isAllDay": False,
+            },
+            {"value": []},
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            start_datetime="2026-08-27T00:00:00",
+            end_datetime="2026-08-28T00:00:00",
+            is_all_day=True,
+            timezone="UTC",
+        )
+    )
+
+    assert result["status"] == "success"
+    calendar_view_call = graph_request.call_args_list[1]
+    assert calendar_view_call.kwargs["params"]["startDateTime"] == (
+        "2026-08-27T00:00:00+00:00"
+    )
+    # Must stay at the 28th, not get pushed to the 29th.
+    assert calendar_view_call.kwargs["params"]["endDateTime"] == (
+        "2026-08-28T00:00:00+00:00"
+    )
+
+
+def test_update_event_flag_only_all_day_toggle_widens_in_the_events_real_timezone(
+    monkeypatch,
+):
+    """Regression test: a plain GET (no Prefer header) always reports
+    start/end in UTC regardless of the event's actual configured zone -
+    using that UTC-normalized field as "the event's real timezone" for a
+    flag-only is_all_day toggle silently widens the query window in the
+    wrong zone. originalStartTimeZone is the field that reports the real
+    one."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T02:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T02:30:00", "timeZone": "UTC"},
+                "attendees": [],
+                "isAllDay": False,
+                "originalStartTimeZone": "Asia/Singapore",
+            },
+            {"value": []},
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            is_all_day=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    calendar_view_call = graph_request.call_args_list[1]
+    # 02:00-02:30 UTC is 10:00-10:30 in Asia/Singapore (+08:00) - the day
+    # bounds must widen around THAT day, not the UTC one.
+    assert calendar_view_call.kwargs["params"]["startDateTime"] == (
+        "2026-08-27T00:00:00+08:00"
+    )
+    assert calendar_view_call.kwargs["params"]["endDateTime"] == (
+        "2026-08-28T00:00:00+08:00"
+    )
+
+
 def test_update_event_empty_string_attendees_is_treated_as_not_provided(monkeypatch):
     """An empty string for attendees (e.g. an accidental default) must be
     treated the same as not passing attendees at all - not as "clear
@@ -1507,12 +1865,11 @@ def test_send_message_normalizes_and_dedupes_recipients(monkeypatch):
     ]
 
 
-def test_update_event_unchecked_reason_appears_alongside_a_conflict(monkeypatch):
-    """unchecked_attendees/unchecked_reason must still surface even when
-    the response status is "conflict" (from the organizer or another
-    attendee), not just on a clean "success" - a caller acting on the
-    conflict still needs to know some attendees were never actually
-    checked."""
+def test_update_event_missing_schedule_scope_rejects_the_write(monkeypatch):
+    """A whole-batch 403 while checking the newly-added attendee is our own
+    credential's problem, not a per-attendee visibility gap - the write
+    must be rejected outright, even though the organizer's own calendar
+    already turned up a real conflict."""
     graph_request = Mock(
         side_effect=[
             {
@@ -1536,6 +1893,36 @@ def test_update_event_unchecked_reason_appears_alongside_a_conflict(monkeypatch)
         )
     )
 
-    assert result["status"] == "conflict"
-    assert result["unchecked_attendees"] == ["outsider@gmail.com"]
-    assert "reconnect" in result["unchecked_reason"].lower()
+    assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
+
+
+def test_update_event_missing_schedule_scope_can_be_bypassed_with_ignore_conflicts(
+    monkeypatch,
+):
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [],
+                "isAllDay": False,
+            },
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            start_datetime="2026-08-27T14:00:00",
+            end_datetime="2026-08-27T14:30:00",
+            attendees=["outsider@gmail.com"],
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert graph_request.call_count == 2
+    assert graph_request.call_args_list[-1].args[:2] == ("PATCH", "/me/events/self-1")

--- a/tests/web/tools/test_outlook_mcp.py
+++ b/tests/web/tools/test_outlook_mcp.py
@@ -866,6 +866,31 @@ def test_update_event_moving_time_checks_organizer_and_all_attendees(monkeypatch
     assert graph_request.call_count == 3
 
 
+def test_update_event_rejects_a_reversed_window(monkeypatch):
+    graph_request = Mock(
+        return_value={
+            "start": {"dateTime": "2026-08-27T09:00:00", "timeZone": "UTC"},
+            "end": {"dateTime": "2026-08-27T09:30:00", "timeZone": "UTC"},
+            "attendees": [],
+            "isAllDay": False,
+        }
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            start_datetime="2026-08-27T10:30:00",
+            end_datetime="2026-08-27T10:00:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "must be after" in result["message"]
+    # Only the existing-event GET - no calendarView/getSchedule/PATCH.
+    assert graph_request.call_count == 1
+
+
 def test_all_day_events_are_no_longer_exempt_from_conflict_checks(monkeypatch):
     """Regression check: the create path used to skip the conflict check
     whenever is_all_day was True, with no equivalent skip on the Google

--- a/tests/web/tools/test_outlook_mcp.py
+++ b/tests/web/tools/test_outlook_mcp.py
@@ -1774,15 +1774,18 @@ def test_update_event_flag_only_all_day_toggle_widens_in_the_events_real_timezon
 ):
     """Regression test: a plain GET (no Prefer header) always reports
     start/end in UTC regardless of the event's actual configured zone -
-    using that UTC-normalized field as "the event's real timezone" for a
-    flag-only is_all_day toggle silently widens the query window in the
-    wrong zone. originalStartTimeZone is the field that reports the real
-    one."""
+    using that UTC clock value's own date as "the event's real calendar
+    day" for a flag-only is_all_day toggle silently widens the query to
+    the wrong day whenever the real zone's offset pushes the instant
+    across a day boundary from its UTC date. originalStartTimeZone
+    reports the real zone; 20:00 UTC is 04:00 the *next* day in
+    Asia/Singapore (+08:00), so the correct widened day is the 28th, not
+    the UTC date's 27th."""
     graph_request = Mock(
         side_effect=[
             {
-                "start": {"dateTime": "2026-08-27T02:00:00", "timeZone": "UTC"},
-                "end": {"dateTime": "2026-08-27T02:30:00", "timeZone": "UTC"},
+                "start": {"dateTime": "2026-08-27T20:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T20:30:00", "timeZone": "UTC"},
                 "attendees": [],
                 "isAllDay": False,
                 "originalStartTimeZone": "Asia/Singapore",
@@ -1802,14 +1805,60 @@ def test_update_event_flag_only_all_day_toggle_widens_in_the_events_real_timezon
 
     assert result["status"] == "success"
     calendar_view_call = graph_request.call_args_list[1]
-    # 02:00-02:30 UTC is 10:00-10:30 in Asia/Singapore (+08:00) - the day
-    # bounds must widen around THAT day, not the UTC one.
     assert calendar_view_call.kwargs["params"]["startDateTime"] == (
-        "2026-08-27T00:00:00+08:00"
-    )
-    assert calendar_view_call.kwargs["params"]["endDateTime"] == (
         "2026-08-28T00:00:00+08:00"
     )
+    assert calendar_view_call.kwargs["params"]["endDateTime"] == (
+        "2026-08-29T00:00:00+08:00"
+    )
+
+
+def test_update_event_adding_attendee_queries_the_correct_absolute_window_in_the_events_real_timezone(
+    monkeypatch,
+):
+    """Regression test: even without any is_all_day widening, a plain
+    attendees-only edit's conflict check for the newly-added attendee
+    still needs the existing window's boundaries paired with the event's
+    REAL zone (from originalStartTimeZone), not the UTC clock value a
+    plain GET reports left mislabeled with that real zone's name - that
+    mismatch sends Graph an absolute window off by the real zone's UTC
+    offset."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T02:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T02:30:00", "timeZone": "UTC"},
+                "attendees": [],
+                "isAllDay": False,
+                "originalStartTimeZone": "Asia/Singapore",
+            },
+            {"value": [{"scheduleId": "new@example.com", "scheduleItems": []}]},
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            attendees=["new@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    schedule_call = graph_request.call_args_list[1]
+    assert schedule_call.args[:2] == ("POST", "/me/calendar/getSchedule")
+    # 02:00 UTC is 10:00 in Asia/Singapore (+08:00) - the query sent to
+    # Graph must carry that real wall-clock reading paired with the real
+    # zone name, not the raw UTC clock value mislabeled with it.
+    assert schedule_call.kwargs["body"]["startTime"] == {
+        "dateTime": "2026-08-27T10:00:00",
+        "timeZone": "Asia/Singapore",
+    }
+    assert schedule_call.kwargs["body"]["endTime"] == {
+        "dateTime": "2026-08-27T10:30:00",
+        "timeZone": "Asia/Singapore",
+    }
 
 
 def test_update_event_empty_string_attendees_is_treated_as_not_provided(monkeypatch):

--- a/tests/web/tools/test_outlook_mcp.py
+++ b/tests/web/tools/test_outlook_mcp.py
@@ -1,0 +1,1437 @@
+import json
+from typing import Any
+from unittest.mock import Mock
+
+import pytest
+
+from xagent.web.tools.mcp import outlook
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("AUTH_TOKEN", "token")
+
+
+def _busy_event(
+    event_id="existing-1",
+    subject="1:1 with Hazel",
+    show_as="busy",
+    is_cancelled=False,
+    response=None,
+):
+    event = {
+        "id": event_id,
+        "subject": subject,
+        "isCancelled": is_cancelled,
+        "showAs": show_as,
+        "start": {"dateTime": "2026-08-27T10:00:00"},
+        "end": {"dateTime": "2026-08-27T10:30:00"},
+    }
+    if response is not None:
+        event["responseStatus"] = {"response": response}
+    return event
+
+
+def test_create_event_detects_organizer_conflict_same_timezone(monkeypatch):
+    """Reproduces the reported bug: booking a slot that overlaps an existing
+    event, both in the same timezone, must be caught rather than silently
+    created and emailed to attendees."""
+    graph_request = Mock(return_value={"value": [_busy_event()]})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            timezone="Asia/Singapore",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "1:1 with Hazel"
+    graph_request.assert_called_once()
+    assert graph_request.call_args.args[:2] == ("GET", "/me/calendarView")
+
+
+def test_create_event_ignores_free_and_cancelled_events(monkeypatch):
+    graph_request = Mock(
+        side_effect=[
+            {
+                "value": [
+                    _busy_event(event_id="e1", show_as="free"),
+                    _busy_event(event_id="e2", is_cancelled=True),
+                ]
+            },
+            {"id": "created"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert graph_request.call_count == 2
+    assert graph_request.call_args.args[:2] == ("POST", "/me/events")
+
+
+def test_create_event_ignores_organizers_own_declined_event(monkeypatch):
+    """Regression test matching google_calendar's equivalent check: an
+    event the organizer personally declined still sits on their calendar
+    (declining doesn't clear showAs), but it's not something they're
+    actually busy for. `/me/calendarView` reports the signed-in user's own
+    response via `responseStatus`."""
+    graph_request = Mock(
+        side_effect=[
+            {"value": [_busy_event(response="declined")]},
+            {"id": "created"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert graph_request.call_count == 2
+
+
+def test_create_event_detects_attendee_schedule_conflict(monkeypatch):
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},
+            {
+                "value": [
+                    {
+                        "scheduleId": "chelsea@example.com",
+                        "scheduleItems": [
+                            {
+                                "status": "busy",
+                                "start": {"dateTime": "2026-08-27T10:00:00"},
+                                "end": {"dateTime": "2026-08-27T10:30:00"},
+                            }
+                        ],
+                    }
+                ]
+            },
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "chelsea@example.com"
+    assert graph_request.call_count == 2
+
+
+def test_create_event_conflict_reports_caller_casing_not_graphs(monkeypatch):
+    """Regression test: the conflict's "calendar" field must echo back the
+    casing the caller supplied (matching google_calendar's equivalent
+    fix), not whatever casing Graph's own scheduleId happens to use in its
+    response."""
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},
+            {
+                "value": [
+                    {
+                        "scheduleId": "chelsea@example.com",
+                        "scheduleItems": [
+                            {
+                                "status": "busy",
+                                "start": {"dateTime": "2026-08-27T10:00:00"},
+                                "end": {"dateTime": "2026-08-27T10:30:00"},
+                            }
+                        ],
+                    }
+                ]
+            },
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["Chelsea@Example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "Chelsea@Example.com"
+
+
+def test_create_event_unchecked_attendee_does_not_block_creation(monkeypatch):
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},
+            {
+                "value": [
+                    {
+                        "scheduleId": "outsider@gmail.com",
+                        "error": {"message": "no access"},
+                    }
+                ]
+            },
+            {"id": "created"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["outsider@gmail.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["unchecked_attendees"] == ["outsider@gmail.com"]
+    create_call = graph_request.call_args_list[-1]
+    assert create_call.args[:2] == ("POST", "/me/events")
+    assert create_call.kwargs["body"]["attendees"] == [
+        {"emailAddress": {"address": "outsider@gmail.com"}, "type": "required"}
+    ]
+
+
+def test_create_event_ignore_conflicts_skips_the_check_entirely(monkeypatch):
+    graph_request = Mock(return_value={"id": "created"})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    graph_request.assert_called_once()
+    assert graph_request.call_args.args[:2] == ("POST", "/me/events")
+
+
+def test_update_event_excludes_the_event_being_moved_from_its_own_conflicts(
+    monkeypatch,
+):
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T09:00:00"},
+                "end": {"dateTime": "2026-08-27T09:30:00"},
+                "attendees": [],
+                "isAllDay": False,
+            },
+            {
+                "value": [
+                    _busy_event(event_id="self-1", subject="old slot"),
+                    _busy_event(event_id="other-1", subject="Board sync"),
+                ]
+            },
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert [c["summary"] for c in result["conflicts"]] == ["Board sync"]
+
+
+def test_update_event_metadata_only_edit_never_checks_conflicts(monkeypatch):
+    """A pure metadata edit (no time/attendee change) must never fetch the
+    existing event or run the conflict check at all - not just tolerate it,
+    since even running the check would spuriously self-conflict against the
+    event's own attendees (see the test below)."""
+    graph_request = Mock(return_value={"id": "updated"})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            subject="New Subject",
+        )
+    )
+
+    assert result["status"] == "success"
+    graph_request.assert_called_once()
+    assert graph_request.call_args.args[:2] == ("PATCH", "/me/events/self-1")
+
+
+def test_update_event_same_window_only_checks_newly_added_attendee(monkeypatch):
+    """Adding an attendee without moving the event must only check the new
+    attendee's schedule - checking an existing attendee against the
+    unchanged window would always find the event's own busy block on their
+    schedule and falsely report a conflict."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [
+                    {"emailAddress": {"address": "old@example.com"}},
+                ],
+            },
+            {"value": [{"scheduleId": "new@example.com", "scheduleItems": []}]},
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            attendees=["old@example.com", "new@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    schedule_call = graph_request.call_args_list[1]
+    assert schedule_call.args[:2] == ("POST", "/me/calendar/getSchedule")
+    assert schedule_call.kwargs["body"]["schedules"] == ["new@example.com"]
+    assert graph_request.call_count == 3
+
+
+def test_update_event_treats_existing_attendee_case_insensitively(monkeypatch):
+    """Regression test for a review finding: an existing attendee re-passed
+    with different casing must still be recognized as "already there" -
+    otherwise it's treated as newly-added, gets checked against the
+    unchanged window, and always self-conflicts on its own busy block for
+    this very event."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [
+                    {"emailAddress": {"address": "old@example.com"}},
+                ],
+            },
+            {"value": [{"scheduleId": "new@example.com", "scheduleItems": []}]},
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            attendees=["Old@Example.com", "new@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    schedule_call = graph_request.call_args_list[1]
+    assert schedule_call.kwargs["body"]["schedules"] == ["new@example.com"]
+
+
+def test_update_event_reuses_existing_timezone_when_time_is_unchanged(monkeypatch):
+    """Regression test for a review finding: when only attendees change
+    (start_datetime not passed), the conflict check must use the existing
+    event's own timeZone, not whatever `timezone` the caller happened to
+    pass. `timezone` only describes a start_datetime/end_datetime the
+    caller is ALSO providing; existing_start/end came back from Graph
+    as-is (no Prefer header sent), so they're only meaningful paired with
+    the timeZone Graph actually reported for them."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {
+                    "dateTime": "2026-08-27T10:00:00",
+                    "timeZone": "Asia/Singapore",
+                },
+                "end": {
+                    "dateTime": "2026-08-27T10:30:00",
+                    "timeZone": "Asia/Singapore",
+                },
+                "attendees": [],
+            },
+            {"value": [{"scheduleId": "new@example.com", "scheduleItems": []}]},
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            attendees=["new@example.com"],
+            timezone="UTC",
+        )
+    )
+
+    assert result["status"] == "success"
+    schedule_call = graph_request.call_args_list[1]
+    assert schedule_call.kwargs["body"]["startTime"]["timeZone"] == "Asia/Singapore"
+    assert schedule_call.kwargs["body"]["endTime"]["timeZone"] == "Asia/Singapore"
+
+
+def test_update_event_fails_loudly_when_existing_event_has_no_timezone(monkeypatch):
+    graph_request = Mock(
+        return_value={
+            "start": {"dateTime": "2026-08-27T10:00:00"},
+            "end": {"dateTime": "2026-08-27T10:30:00"},
+            "attendees": [],
+        }
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            attendees=["new@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "timeZone" in result["message"]
+
+
+def test_update_event_skips_timezone_resolution_when_nothing_new_to_check(monkeypatch):
+    """Regression test: re-passing only the attendees the event already has
+    (no genuinely new ones, no time/is_all_day change) must not need to
+    resolve a timezone at all - even if the existing event happens to be
+    missing a timeZone on its start time - since no conflict check ends up
+    running. Failing loudly here would block a call that was always a
+    no-op for scheduling purposes."""
+    graph_request = Mock(
+        return_value={
+            "start": {"dateTime": "2026-08-27T10:00:00"},
+            "end": {"dateTime": "2026-08-27T10:30:00"},
+            "attendees": [{"emailAddress": {"address": "old@example.com"}}],
+            "isAllDay": False,
+        }
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            attendees=["old@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert graph_request.call_count == 2
+
+
+def test_update_event_rejects_ambiguous_single_boundary_timezone_change(monkeypatch):
+    """Regression test: moving only end_datetime while leaving start
+    untouched, with a timezone different from the existing event's, is
+    ambiguous - there's no single timezone that correctly describes both
+    the unmoved start and the newly given end. Must fail loudly rather
+    than silently mis-check conflicts in the wrong timezone."""
+    graph_request = Mock(
+        return_value={
+            "start": {"dateTime": "2026-08-27T02:00:00", "timeZone": "UTC"},
+            "end": {"dateTime": "2026-08-27T02:30:00", "timeZone": "UTC"},
+            "attendees": [],
+            "isAllDay": False,
+            "originalStartTimeZone": "Asia/Singapore",
+        }
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            end_datetime="2026-08-27T11:00:00",
+            timezone="UTC",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "ambiguous" in result["message"].lower()
+
+
+def test_update_event_single_boundary_rejects_unresolvable_caller_timezone(
+    monkeypatch,
+):
+    """Regression test: `timezones_could_differ` treats "can't resolve" as
+    "benefit of the doubt, not confirmed different" - correct for a zone
+    name Graph itself reported (never written verbatim; the PATCH always
+    uses `existing_timezone`), but wrong for the CALLER's own `timezone`
+    argument. A typo'd/unknown zone string must be rejected outright, not
+    silently discarded in favor of the existing zone with no signal to
+    the caller that their argument had no effect."""
+    graph_request = Mock(
+        return_value={
+            "start": {"dateTime": "2026-08-27T02:00:00", "timeZone": "UTC"},
+            "end": {"dateTime": "2026-08-27T02:30:00", "timeZone": "UTC"},
+            "attendees": [],
+            "isAllDay": False,
+            "originalStartTimeZone": "Pacific Standard Time",
+        }
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            end_datetime="2026-08-27T11:00:00",
+            timezone="This/IsNotAZone",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "This/IsNotAZone" in result["message"]
+    graph_request.assert_called_once()
+
+
+def test_update_event_single_boundary_change_with_matching_timezone_succeeds(
+    monkeypatch,
+):
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T02:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T02:30:00", "timeZone": "UTC"},
+                "attendees": [],
+                "isAllDay": False,
+                "originalStartTimeZone": "Asia/Singapore",
+            },
+            {
+                "start": {
+                    "dateTime": "2026-08-27T10:00:00",
+                    "timeZone": "Asia/Singapore",
+                },
+                "end": {
+                    "dateTime": "2026-08-27T10:30:00",
+                    "timeZone": "Asia/Singapore",
+                },
+            },
+            {"value": []},
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            end_datetime="2026-08-27T11:00:00",
+            timezone="Asia/Singapore",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_update_event_single_boundary_change_with_unset_timezone_reuses_existing(
+    monkeypatch,
+):
+    """Regression test: timezone's default must not look like an explicit
+    "UTC" request - omitting it entirely (the common case: the caller just
+    wants to nudge one boundary) must reuse the existing event's timezone
+    rather than being treated as a UTC/existing-timezone mismatch.
+
+    A plain GET (no Prefer header) always returns start/end in UTC
+    regardless of the event's actual zone (Microsoft's documented default),
+    so the real timezone comes from originalStartTimeZone instead - and the
+    untouched boundary's clock value must be re-fetched WITH a matching
+    Prefer header rather than trusting the dateTime the first (UTC) GET
+    returned.
+    """
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T02:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T02:30:00", "timeZone": "UTC"},
+                "attendees": [],
+                "isAllDay": False,
+                "originalStartTimeZone": "Asia/Singapore",
+            },
+            {
+                "start": {
+                    "dateTime": "2026-08-27T10:00:00",
+                    "timeZone": "Asia/Singapore",
+                },
+                "end": {
+                    "dateTime": "2026-08-27T10:30:00",
+                    "timeZone": "Asia/Singapore",
+                },
+            },
+            {"value": []},
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            end_datetime="2026-08-27T11:00:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    zoned_refetch_call = graph_request.call_args_list[1]
+    assert zoned_refetch_call.kwargs["extra_headers"] == {
+        "Prefer": 'outlook.timezone="Asia/Singapore"'
+    }
+    calendar_view_call = graph_request.call_args_list[2]
+    assert calendar_view_call.kwargs["extra_headers"] == {
+        "Prefer": 'outlook.timezone="Asia/Singapore"'
+    }
+    # Regression test: the conflict check running in the existing event's
+    # timezone is only meaningful if the actual PATCH is written in that
+    # same timezone - writing it as "UTC" instead would silently move the
+    # event by the zone offset despite the check having just verified a
+    # different, correct instant.
+    patch_call = graph_request.call_args_list[3]
+    assert patch_call.kwargs["body"]["end"] == {
+        "dateTime": "2026-08-27T11:00:00",
+        "timeZone": "Asia/Singapore",
+    }
+
+
+def test_update_event_single_boundary_writes_the_checked_timezone_even_with_ignore_conflicts(
+    monkeypatch,
+):
+    """The same timezone-resolution bug is reachable with ignore_conflicts=
+    True too, since the PATCH write itself (not just the skipped check)
+    needs the existing event's timezone for a single-boundary change."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T02:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T02:30:00", "timeZone": "UTC"},
+                "attendees": [],
+                "isAllDay": False,
+                "originalStartTimeZone": "Asia/Singapore",
+            },
+            {
+                "start": {
+                    "dateTime": "2026-08-27T10:00:00",
+                    "timeZone": "Asia/Singapore",
+                },
+                "end": {
+                    "dateTime": "2026-08-27T10:30:00",
+                    "timeZone": "Asia/Singapore",
+                },
+            },
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            end_datetime="2026-08-27T11:00:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    assert graph_request.call_count == 3
+    patch_call = graph_request.call_args_list[2]
+    assert patch_call.kwargs["body"]["end"] == {
+        "dateTime": "2026-08-27T11:00:00",
+        "timeZone": "Asia/Singapore",
+    }
+
+
+def test_update_event_single_boundary_fails_loudly_without_original_timezone(
+    monkeypatch,
+):
+    """Regression test: a plain GET always reports start.timeZone as "UTC"
+    (Microsoft's documented default) - that must never be mistaken for the
+    event's real zone. Only originalStartTimeZone can answer that, so its
+    absence must fail loudly rather than silently resolve to "UTC"."""
+    graph_request = Mock(
+        return_value={
+            "start": {"dateTime": "2026-08-27T02:00:00", "timeZone": "UTC"},
+            "end": {"dateTime": "2026-08-27T02:30:00", "timeZone": "UTC"},
+            "attendees": [],
+            "isAllDay": False,
+        }
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            end_datetime="2026-08-27T11:00:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "originalStartTimeZone" in result["message"]
+
+
+def test_update_event_single_boundary_rejects_legacy_custom_timezone(monkeypatch):
+    """Regression test: a `tzone://Microsoft/Custom` originalStartTimeZone
+    (Microsoft's own docs: set for events created in a legacy custom
+    Outlook-desktop timezone) is not a real IANA/Windows zone name Graph
+    would accept as a Prefer header or a written timeZone - must fail
+    loudly rather than pass it straight through to another API call."""
+    graph_request = Mock(
+        return_value={
+            "start": {"dateTime": "2026-08-27T02:00:00", "timeZone": "UTC"},
+            "end": {"dateTime": "2026-08-27T02:30:00", "timeZone": "UTC"},
+            "attendees": [],
+            "isAllDay": False,
+            "originalStartTimeZone": "tzone://Microsoft/Custom",
+        }
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            end_datetime="2026-08-27T11:00:00",
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "custom timezone" in result["message"].lower()
+    assert graph_request.call_count == 1
+
+
+def test_update_event_both_boundaries_changed_ignores_missing_existing_timezone(
+    monkeypatch,
+):
+    """When both start_datetime and end_datetime are supplied together,
+    the existing event's own timeZone is irrelevant to the query - it
+    must not be required, even if missing."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00"},
+                "end": {"dateTime": "2026-08-27T10:30:00"},
+                "attendees": [],
+                "isAllDay": False,
+            },
+            {"value": []},
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            start_datetime="2026-08-27T14:00:00",
+            end_datetime="2026-08-27T14:30:00",
+            timezone="UTC",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_update_event_toggling_all_day_alone_still_triggers_a_real_check(monkeypatch):
+    """Regression test: is_all_day changes the event's effective span even
+    when the literal start/end clock values don't move (a 30-minute meeting
+    becoming an all-day event now overlaps the organizer's whole day). An
+    earlier version of this fix only added is_all_day to the "should we
+    even look" gate without teaching window_changed about it, so the
+    literal-string comparison stayed unchanged and the check was silently
+    skipped anyway - this must now actually run the organizer check."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [],
+                "isAllDay": False,
+            },
+            {"value": [_busy_event(event_id="other-1", subject="Board sync")]},
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            is_all_day=True,
+        )
+    )
+
+    assert result["status"] == "conflict"
+
+
+def test_update_event_toggling_all_day_alone_does_not_self_conflict_on_attendees(
+    monkeypatch,
+):
+    """Regression test: toggling is_all_day alone doesn't move the literal
+    start/end clock values, so querying an EXISTING attendee's schedule for
+    that same unmoved window would always find this very event's own busy
+    block there. The organizer check may legitimately run (see the test
+    above), but existing attendees must not be re-checked against an
+    unmoved window just because is_all_day flipped."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [{"emailAddress": {"address": "existing@example.com"}}],
+                "isAllDay": False,
+            },
+            {"value": []},
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            is_all_day=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    # Only the organizer's calendarView should have been queried (2nd
+    # call) - no getSchedule call for the existing attendee.
+    assert graph_request.call_count == 3
+    assert graph_request.call_args_list[0].args[:2] == ("GET", "/me/events/self-1")
+    assert graph_request.call_args_list[1].args[:2] == ("GET", "/me/calendarView")
+
+
+def test_update_event_moving_time_checks_organizer_and_all_attendees(monkeypatch):
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T09:00:00"},
+                "end": {"dateTime": "2026-08-27T09:30:00"},
+                "attendees": [
+                    {"emailAddress": {"address": "existing@example.com"}},
+                ],
+            },
+            {"value": [_busy_event(event_id="other-1", subject="Board sync")]},
+            {"value": [{"scheduleId": "existing@example.com", "scheduleItems": []}]},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert graph_request.call_count == 3
+
+
+def test_all_day_events_are_no_longer_exempt_from_conflict_checks(monkeypatch):
+    """Regression check: the create path used to skip the conflict check
+    whenever is_all_day was True, with no equivalent skip on the Google
+    side - a genuinely overlapping all-day event must now be caught too."""
+    graph_request = Mock(return_value={"value": [_busy_event()]})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Offsite",
+            start_datetime="2026-08-27T00:00:00",
+            end_datetime="2026-08-28T00:00:00",
+            is_all_day=True,
+        )
+    )
+
+    assert result["status"] == "conflict"
+
+
+def test_update_event_ignore_conflicts_skips_the_check(monkeypatch):
+    graph_request = Mock(return_value={"id": "updated"})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    graph_request.assert_called_once()
+    assert graph_request.call_args.args[:2] == ("PATCH", "/me/events/self-1")
+
+
+def test_create_event_batch_over_limit_is_chunked_into_multiple_calls(
+    monkeypatch,
+):
+    """Regression test: an over-limit attendee list must be split into
+    multiple <=20-sized getSchedule calls and the results merged, rather
+    than giving up on checking anyone at all."""
+    attendees = [f"person{i}@example.com" for i in range(21)]
+
+    def fake_get_schedule(batch: list[str]) -> dict[str, Any]:
+        return {
+            "value": [
+                {
+                    "scheduleId": email,
+                    "scheduleItems": (
+                        [{"status": "busy", "start": {}, "end": {}}]
+                        if email == "person0@example.com"
+                        else []
+                    ),
+                }
+                for email in batch
+            ]
+        }
+
+    calls: list[list[str]] = []
+
+    def graph_request(method, path, **kwargs):
+        if path == "/me/calendarView":
+            return {"value": []}
+        if path == "/me/calendar/getSchedule":
+            batch = kwargs["body"]["schedules"]
+            calls.append(batch)
+            return fake_get_schedule(batch)
+        assert (method, path) == ("POST", "/me/events")
+        return {"id": "created"}
+
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="All hands",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=attendees,
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "person0@example.com"
+    assert sorted(len(batch) for batch in calls) == [1, 20]
+
+
+def test_create_event_missing_schedule_scope_degrades_to_unchecked(monkeypatch):
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},  # organizer calendarView
+            outlook._GraphRequestError("403 Forbidden", status_code=403),
+            {"id": "created"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["unchecked_attendees"] == ["chelsea@example.com"]
+    # The reason must give an LLM caller something actionable - reconnecting
+    # the connector - rather than a bare error string.
+    assert "reconnect" in result["unchecked_reason"].lower()
+
+
+def test_create_event_other_graph_errors_still_propagate(monkeypatch):
+    """Only a 403 is treated as a missing-scope signal; any other error must
+    still surface as a real failure. Asserting the actual message (not just
+    status="error") matters here - an exhausted mock raises its own
+    StopIteration on an unexpected extra call, which this same try/except
+    would also report as status="error", so a bare status check alone
+    could pass for the wrong reason if a future change altered the call
+    count instead of genuinely propagating this error."""
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},  # organizer calendarView
+            outlook._GraphRequestError("500 boom", status_code=500),
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "500 boom" in result["message"]
+
+
+def test_create_event_attendee_absent_from_schedule_response_is_unchecked(
+    monkeypatch,
+):
+    """An attendee simply missing from getSchedule's response (no entry at
+    all, not even an error) must not be silently reported as free."""
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},  # organizer calendarView
+            {"value": []},  # getSchedule - no entry at all for the attendee
+            {"id": "created"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["ghost@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["unchecked_attendees"] == ["ghost@example.com"]
+
+
+def test_create_event_treats_unknown_showas_as_a_conflict(monkeypatch):
+    """Graph's showAs enum documents "unknown" as simply unclassified (e.g.
+    an event synced from a third-party calendar that never set it) - it can
+    represent a genuinely busy block, so it must not be silently treated as
+    free. Missing a real conflict is worse than an occasional over-flag the
+    caller can dismiss with ignore_conflicts."""
+    graph_request = Mock(
+        return_value={
+            "value": [
+                {
+                    "id": "other-1",
+                    "subject": "Mystery event",
+                    "isCancelled": False,
+                    "showAs": "unknown",
+                    "start": {"dateTime": "2026-08-27T10:00:00"},
+                    "end": {"dateTime": "2026-08-27T10:30:00"},
+                }
+            ]
+        }
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "Mystery event"
+
+
+def test_update_event_resubmitting_only_existing_attendees_does_not_touch_them(
+    monkeypatch,
+):
+    """Re-passing only addresses already on the event adds nothing new, so
+    the PATCH body must not carry an "attendees" key at all - Graph's PATCH
+    is a true partial update, and simply not touching the field is a
+    stronger guarantee against wiping RSVP state (status/type etc.) than
+    resending a reconstructed copy of it would be."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [
+                    {
+                        "emailAddress": {"address": "existing@example.com"},
+                        "type": "required",
+                        "status": {
+                            "response": "accepted",
+                            "time": "2026-08-20T00:00:00Z",
+                        },
+                    }
+                ],
+                "isAllDay": False,
+            },
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            attendees=["existing@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    patch_call = graph_request.call_args_list[1]
+    assert "attendees" not in patch_call.kwargs["body"]
+
+
+def test_update_event_treats_equivalent_timestamp_formats_as_unchanged(monkeypatch):
+    """A same-instant resubmission written with different fractional-second
+    precision must not be treated as a real time change."""
+    graph_request = Mock(
+        return_value={
+            "start": {"dateTime": "2026-08-27T10:00:00.0000000", "timeZone": "UTC"},
+            "end": {"dateTime": "2026-08-27T10:30:00.0000000", "timeZone": "UTC"},
+            "attendees": [],
+            "isAllDay": False,
+        }
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            location="Room 4",
+        )
+    )
+
+    assert result["status"] == "success"
+    # Only the existing-event GET and the PATCH - no calendarView/getSchedule.
+    assert graph_request.call_count == 2
+
+
+def test_create_event_calendarview_query_carries_an_explicit_offset(monkeypatch):
+    """Regression test for the critical review finding: calendarView's
+    startDateTime/endDateTime query parameters are, per Graph's own docs,
+    "interpreted using the timezone offset specified in the value" and
+    read as UTC if none is present - unlike the request body, they are
+    NOT affected by the Prefer header. A naive value there would silently
+    be checked against the wrong instant whenever the caller isn't in
+    UTC."""
+    graph_request = Mock(return_value={"value": []})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            timezone="Asia/Singapore",
+        )
+    )
+
+    assert result["status"] == "success"
+    calendar_view_call = graph_request.call_args_list[0]
+    assert calendar_view_call.kwargs["params"]["startDateTime"] == (
+        "2026-08-27T10:00:00+08:00"
+    )
+    assert calendar_view_call.kwargs["params"]["endDateTime"] == (
+        "2026-08-27T10:30:00+08:00"
+    )
+
+
+def test_create_event_calendarview_follows_pagination(monkeypatch):
+    """A tenant with more events than fit on one page must have every page
+    checked, not just the first - Graph signals more pages via
+    @odata.nextLink rather than ever returning everything at once."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "value": [],
+                "@odata.nextLink": (
+                    f"{outlook.GRAPH_BASE_URL}/me/calendarView?%24skip=250"
+                ),
+            },
+            {"value": [_busy_event(event_id="other-1", subject="Board sync")]},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "Board sync"
+    assert graph_request.call_count == 2
+    second_call = graph_request.call_args_list[1]
+    assert second_call.args[:2] == ("GET", "/me/calendarView?%24skip=250")
+    # The nextLink is a complete, already-parameterized URL - no separate
+    # params dict should be re-sent alongside it.
+    assert second_call.kwargs.get("params") is None
+
+
+def test_update_event_windows_and_iana_names_for_the_same_zone_are_not_ambiguous(
+    monkeypatch,
+):
+    """Regression test: a single-boundary update whose timezone denotes the
+    SAME real zone as the existing event's originalStartTimeZone - just
+    spelled differently (a Windows name vs. the equivalent IANA name) -
+    must not be rejected as ambiguous. A raw string comparison would
+    reject this even though there is no real conflict in what zone either
+    boundary is in."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T02:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T02:30:00", "timeZone": "UTC"},
+                "attendees": [],
+                "isAllDay": False,
+                "originalStartTimeZone": "Pacific Standard Time",
+            },
+            {
+                "start": {
+                    "dateTime": "2026-08-27T10:00:00",
+                    "timeZone": "Pacific Standard Time",
+                },
+                "end": {
+                    "dateTime": "2026-08-27T10:30:00",
+                    "timeZone": "Pacific Standard Time",
+                },
+            },
+            {"value": []},
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            end_datetime="2026-08-27T11:00:00",
+            timezone="America/Los_Angeles",
+        )
+    )
+
+    assert result["status"] == "success"
+
+
+def test_update_event_partial_overlap_nudge_does_not_self_conflict(monkeypatch):
+    """Regression test: nudging a boundary to a window that still overlaps
+    the event's OLD window is just as unsafe to check existing attendees
+    against as an unchanged window - the overlap still contains this
+    event's own busy block on their calendar. Only a genuinely disjoint
+    move is safe to re-check everyone."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [{"emailAddress": {"address": "existing@example.com"}}],
+                "isAllDay": False,
+            },
+            {"value": []},  # organizer calendarView
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            start_datetime="2026-08-27T10:15:00",
+            end_datetime="2026-08-27T10:45:00",
+        )
+    )
+
+    assert result["status"] == "success"
+    # Existing-event GET + organizer calendarView + PATCH - no getSchedule
+    # call for the existing attendee.
+    assert graph_request.call_count == 3
+    assert graph_request.call_args_list[-1].args[:2] == ("PATCH", "/me/events/self-1")
+
+
+def test_update_event_disjoint_move_checks_existing_attendees(monkeypatch):
+    """A move to a window that is completely disjoint from the event's old
+    one is the one case an existing attendee's schedule is safe (and
+    necessary) to re-check - the old window's busy block on their
+    calendar is no longer where the query is looking."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [{"emailAddress": {"address": "existing@example.com"}}],
+                "isAllDay": False,
+            },
+            {"value": []},  # organizer calendarView
+            {
+                "value": [
+                    {
+                        "scheduleId": "existing@example.com",
+                        "scheduleItems": [
+                            {
+                                "status": "busy",
+                                "start": {"dateTime": "2026-08-27T14:00:00"},
+                                "end": {"dateTime": "2026-08-27T14:30:00"},
+                            }
+                        ],
+                    }
+                ]
+            },
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            start_datetime="2026-08-27T14:00:00",
+            end_datetime="2026-08-27T14:30:00",
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["calendar"] == "existing@example.com"
+
+
+def test_update_event_moving_to_all_day_widens_query_to_the_full_day(monkeypatch):
+    """Regression test: converting to an all-day event occupies the whole
+    calendar day(s), not just the literal clock-time slot given - the
+    conflict check must be widened to that full-day window, or a
+    conflict elsewhere that day would be missed."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [],
+                "isAllDay": False,
+            },
+            {"value": []},
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            is_all_day=True,
+            timezone="UTC",
+        )
+    )
+
+    assert result["status"] == "success"
+    calendar_view_call = graph_request.call_args_list[1]
+    assert calendar_view_call.kwargs["params"]["startDateTime"] == (
+        "2026-08-27T00:00:00+00:00"
+    )
+    assert calendar_view_call.kwargs["params"]["endDateTime"] == (
+        "2026-08-28T00:00:00+00:00"
+    )
+
+
+def test_update_event_empty_string_attendees_is_treated_as_not_provided(monkeypatch):
+    """An empty string for attendees (e.g. an accidental default) must be
+    treated the same as not passing attendees at all - not as "clear
+    every attendee" - matching every other optional field's truthy
+    convention here and outlook_create_event's own check."""
+    graph_request = Mock(return_value={"id": "updated"})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            subject="New Subject",
+            attendees="",
+        )
+    )
+
+    assert result["status"] == "success"
+    # A subject-only edit (attendees="" not counting as given) never needs
+    # the existing event - just the one PATCH.
+    graph_request.assert_called_once()
+    patch_call = graph_request.call_args
+    assert patch_call.args[:2] == ("PATCH", "/me/events/self-1")
+    assert "attendees" not in patch_call.kwargs["body"]
+
+
+def test_send_message_normalizes_and_dedupes_recipients(monkeypatch):
+    """Regression test: outlook_send_message's to/cc/bcc go through the same
+    normalize_addresses dedup as the calendar tools - a case-variant
+    duplicate must collapse to one recipient (keeping the first casing
+    seen), not be sent twice."""
+    graph_request = Mock(return_value={})
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_send_message(
+            to=["Alice@Example.com", "alice@example.com", "bob@example.com"],
+            subject="Hi",
+            body="Hello",
+            cc=["Carol@Example.com", "carol@example.com"],
+        )
+    )
+
+    assert result["status"] == "success"
+    message = graph_request.call_args.kwargs["body"]["message"]
+    assert message["toRecipients"] == [
+        {"emailAddress": {"address": "Alice@Example.com"}},
+        {"emailAddress": {"address": "bob@example.com"}},
+    ]
+    assert message["ccRecipients"] == [
+        {"emailAddress": {"address": "Carol@Example.com"}},
+    ]
+
+
+def test_update_event_unchecked_reason_appears_alongside_a_conflict(monkeypatch):
+    """unchecked_attendees/unchecked_reason must still surface even when
+    the response status is "conflict" (from the organizer or another
+    attendee), not just on a clean "success" - a caller acting on the
+    conflict still needs to know some attendees were never actually
+    checked."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [],
+                "isAllDay": False,
+            },
+            {"value": [_busy_event(event_id="other-1", subject="Board sync")]},
+            outlook._GraphRequestError("403 Forbidden", status_code=403),
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            start_datetime="2026-08-27T14:00:00",
+            end_datetime="2026-08-27T14:30:00",
+            attendees=["outsider@gmail.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["unchecked_attendees"] == ["outsider@gmail.com"]
+    assert "reconnect" in result["unchecked_reason"].lower()

--- a/tests/web/tools/test_outlook_mcp.py
+++ b/tests/web/tools/test_outlook_mcp.py
@@ -1140,6 +1140,39 @@ def test_create_event_missing_schedule_scope_rejects_the_write(monkeypatch):
     assert "reconnect" in result["message"].lower()
 
 
+def test_create_event_missing_schedule_scope_still_reports_an_already_confirmed_conflict(
+    monkeypatch,
+):
+    """Regression test: a real conflict already confirmed before the scope
+    error hit (here, the organizer's own calendar, which doesn't need the
+    schedule scope at all) must not be silently discarded just because a
+    later, unrelated attendee check then hit the same missing-scope 403 -
+    reporting a known conflict is always safe, and blindly rejecting
+    instead would tell the caller to retry with ignore_conflicts=true,
+    which would then book straight over the real conflict nobody ever
+    mentioned."""
+    graph_request = Mock(
+        side_effect=[
+            {"value": [_busy_event(event_id="other-1", subject="Board sync")]},
+            outlook._GraphRequestError("403 Forbidden", status_code=403),
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees=["chelsea@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "Board sync"
+    assert result["unchecked_attendees"] == ["chelsea@example.com"]
+
+
 def test_create_event_missing_schedule_scope_can_be_bypassed_with_ignore_conflicts(
     monkeypatch,
 ):
@@ -1959,9 +1992,46 @@ def test_send_message_normalizes_and_dedupes_recipients(monkeypatch):
 
 def test_update_event_missing_schedule_scope_rejects_the_write(monkeypatch):
     """A whole-batch 403 while checking the newly-added attendee is our own
-    credential's problem, not a per-attendee visibility gap - the write
-    must be rejected outright, even though the organizer's own calendar
-    already turned up a real conflict."""
+    credential's problem, not a per-attendee visibility gap - with nothing
+    else already confirmed, the write must be rejected outright."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [],
+                "isAllDay": False,
+            },
+            {"value": []},
+            outlook._GraphRequestError("403 Forbidden", status_code=403),
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            start_datetime="2026-08-27T14:00:00",
+            end_datetime="2026-08-27T14:30:00",
+            attendees=["outsider@gmail.com"],
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "reconnect" in result["message"].lower()
+
+
+def test_update_event_missing_schedule_scope_still_reports_an_already_confirmed_conflict(
+    monkeypatch,
+):
+    """Regression test: a real conflict already confirmed before the scope
+    error hit (here, the organizer's own calendar, which doesn't need the
+    schedule scope at all) must not be silently discarded just because a
+    later, unrelated attendee check then hit the same missing-scope 403 -
+    reporting a known conflict is always safe, and blindly rejecting
+    instead would tell the caller to retry with ignore_conflicts=true,
+    which would then book straight over the real conflict nobody ever
+    mentioned."""
     graph_request = Mock(
         side_effect=[
             {
@@ -1985,8 +2055,9 @@ def test_update_event_missing_schedule_scope_rejects_the_write(monkeypatch):
         )
     )
 
-    assert result["status"] == "error"
-    assert "reconnect" in result["message"].lower()
+    assert result["status"] == "conflict"
+    assert result["conflicts"][0]["summary"] == "Board sync"
+    assert result["unchecked_attendees"] == ["outsider@gmail.com"]
 
 
 def test_update_event_missing_schedule_scope_can_be_bypassed_with_ignore_conflicts(

--- a/tests/web/tools/test_outlook_mcp.py
+++ b/tests/web/tools/test_outlook_mcp.py
@@ -309,6 +309,49 @@ def test_create_event_rejects_a_reversed_window(monkeypatch):
     graph_request.assert_not_called()
 
 
+def test_create_event_widens_all_day_conflict_check_to_the_full_day(monkeypatch):
+    """Regression test: Graph doesn't require start/end to already be
+    day-aligned for isAllDay=True, so a caller passing a literal
+    business-hours slot with is_all_day=True must still get the WHOLE
+    day checked for conflicts - a conflict earlier or later that same
+    day would otherwise be silently missed."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "value": [
+                    {
+                        "id": "other-1",
+                        "subject": "Early standup",
+                        "isCancelled": False,
+                        "showAs": "busy",
+                        "start": {"dateTime": "2026-08-27T08:00:00"},
+                        "end": {"dateTime": "2026-08-27T08:30:00"},
+                    }
+                ]
+            },
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Company holiday",
+            start_datetime="2026-08-27T09:00:00",
+            end_datetime="2026-08-27T17:00:00",
+            is_all_day=True,
+        )
+    )
+
+    assert result["status"] == "conflict"
+    calendar_view_call = graph_request.call_args_list[0]
+    assert calendar_view_call.kwargs["params"]["startDateTime"] == (
+        "2026-08-27T00:00:00+00:00"
+    )
+    assert calendar_view_call.kwargs["params"]["endDateTime"] == (
+        "2026-08-28T00:00:00+00:00"
+    )
+
+
 def test_update_event_excludes_the_event_being_moved_from_its_own_conflicts(
     monkeypatch,
 ):
@@ -1477,6 +1520,34 @@ def test_update_event_treats_equivalent_timestamp_formats_as_unchanged(monkeypat
     assert result["status"] == "success"
     # Only the existing-event GET and the PATCH - no calendarView/getSchedule.
     assert graph_request.call_count == 2
+
+
+def test_update_event_subject_only_edit_never_revalidates_the_existing_window(
+    monkeypatch,
+):
+    """Regression test: an update that never touches start_datetime/
+    end_datetime isn't about to write any window at all, so it must not
+    re-validate the event's already-stored start/end - a zero-duration
+    or malformed pre-existing window would otherwise reject an unrelated
+    subject edit that never asked to change the time."""
+    graph_request = Mock(
+        return_value={
+            "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+            "end": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+            "attendees": [],
+            "isAllDay": False,
+        }
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            subject="Renamed",
+        )
+    )
+
+    assert result["status"] == "success"
 
 
 def test_create_event_calendarview_query_carries_an_explicit_offset(monkeypatch):

--- a/tests/web/tools/test_outlook_mcp.py
+++ b/tests/web/tools/test_outlook_mcp.py
@@ -1813,6 +1813,49 @@ def test_update_event_flag_only_all_day_toggle_widens_in_the_events_real_timezon
     )
 
 
+def test_update_event_unresolvable_original_timezone_falls_back_to_utc_instead_of_erroring(
+    monkeypatch,
+):
+    """Regression test: originalStartTimeZone can be a legacy/exotic
+    Windows zone id that isn't in the (necessarily incomplete)
+    Windows-to-IANA map - using it as existing_zone anyway without
+    checking it actually resolves would crash the later timezone-key
+    comparison with a raw ValueError, even for a plain flag-only edit
+    that never needed the real zone to be exact in the first place. Must
+    gracefully fall back to the UTC-normalized field instead, exactly as
+    if originalStartTimeZone were absent."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T10:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T10:30:00", "timeZone": "UTC"},
+                "attendees": [],
+                "isAllDay": False,
+                "originalStartTimeZone": "Some Exotic Legacy Standard Time",
+            },
+            {"value": []},
+            {"id": "updated"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            is_all_day=True,
+        )
+    )
+
+    assert result["status"] == "success"
+    calendar_view_call = graph_request.call_args_list[1]
+    assert calendar_view_call.kwargs["params"]["startDateTime"] == (
+        "2026-08-27T00:00:00+00:00"
+    )
+    assert calendar_view_call.kwargs["params"]["endDateTime"] == (
+        "2026-08-28T00:00:00+00:00"
+    )
+
+
 def test_update_event_adding_attendee_queries_the_correct_absolute_window_in_the_events_real_timezone(
     monkeypatch,
 ):
@@ -1975,3 +2018,39 @@ def test_update_event_missing_schedule_scope_can_be_bypassed_with_ignore_conflic
     assert result["status"] == "success"
     assert graph_request.call_count == 2
     assert graph_request.call_args_list[-1].args[:2] == ("PATCH", "/me/events/self-1")
+
+
+def test_update_event_conflict_response_still_reports_unchecked_attendees(
+    monkeypatch,
+):
+    """A conflict found via one source (the organizer's own calendar) must
+    not suppress unchecked_attendees info for a different attendee whose
+    schedule couldn't be read (absent from the getSchedule response, a
+    per-attendee gap rather than a whole-batch 403) - a caller acting on
+    the conflict still needs to know that attendee was never actually
+    checked."""
+    graph_request = Mock(
+        side_effect=[
+            {
+                "start": {"dateTime": "2026-08-27T09:00:00", "timeZone": "UTC"},
+                "end": {"dateTime": "2026-08-27T09:30:00", "timeZone": "UTC"},
+                "attendees": [],
+                "isAllDay": False,
+            },
+            {"value": [_busy_event(event_id="other-1", subject="Board sync")]},
+            {"value": []},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            start_datetime="2026-08-27T14:00:00",
+            end_datetime="2026-08-27T14:30:00",
+            attendees=["ghost@example.com"],
+        )
+    )
+
+    assert result["status"] == "conflict"
+    assert result["unchecked_attendees"] == ["ghost@example.com"]

--- a/tests/web/tools/test_outlook_mcp.py
+++ b/tests/web/tools/test_outlook_mcp.py
@@ -143,6 +143,44 @@ def test_create_event_detects_attendee_schedule_conflict(monkeypatch):
     assert graph_request.call_count == 2
 
 
+def test_create_event_accepts_attendees_as_a_comma_separated_string(monkeypatch):
+    """attendees is documented as list[str] | str - a comma-separated
+    string (as opposed to a list) must be end-to-end equivalent, not just
+    accepted by normalize_addresses in isolation."""
+    graph_request = Mock(
+        side_effect=[
+            {"value": []},
+            {
+                "value": [
+                    {"scheduleId": "chelsea@example.com", "scheduleItems": []},
+                    {"scheduleId": "dana@example.com", "scheduleItems": []},
+                ]
+            },
+            {"id": "created"},
+        ]
+    )
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_create_event(
+            subject="Kickoff",
+            start_datetime="2026-08-27T10:00:00",
+            end_datetime="2026-08-27T10:30:00",
+            attendees="chelsea@example.com, dana@example.com",
+        )
+    )
+
+    assert result["status"] == "success"
+    assert "unchecked_attendees" not in result
+    create_call = graph_request.call_args_list[-1]
+    assert {
+        a["emailAddress"]["address"] for a in create_call.kwargs["body"]["attendees"]
+    } == {
+        "chelsea@example.com",
+        "dana@example.com",
+    }
+
+
 def test_create_event_conflict_reports_caller_casing_not_graphs(monkeypatch):
     """Regression test: the conflict's "calendar" field must echo back the
     casing the caller supplied (matching google_calendar's equivalent
@@ -926,6 +964,30 @@ def test_update_event_ignore_conflicts_skips_the_check(monkeypatch):
     assert result["status"] == "success"
     graph_request.assert_called_once()
     assert graph_request.call_args.args[:2] == ("PATCH", "/me/events/self-1")
+
+
+def test_update_event_rejects_a_reversed_window_even_with_ignore_conflicts(
+    monkeypatch,
+):
+    """Regression test: the reversed-window guard is basic input sanity,
+    not a conflict-check decision - it must still run when
+    ignore_conflicts=True skips the actual conflict check, matching
+    google_calendar_update_events and this tool's own create path."""
+    graph_request = Mock()
+    monkeypatch.setattr(outlook, "_graph_request", graph_request)
+
+    result = json.loads(
+        outlook.outlook_update_event(
+            event_id="self-1",
+            start_datetime="2026-08-27T10:30:00",
+            end_datetime="2026-08-27T10:00:00",
+            ignore_conflicts=True,
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "must be after" in result["message"]
+    graph_request.assert_not_called()
 
 
 def test_create_event_batch_over_limit_is_chunked_into_multiple_calls(

--- a/uv.lock
+++ b/uv.lock
@@ -4064,9 +4064,9 @@ name = "ocrmac"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "click" },
-    { name = "pillow" },
-    { name = "pyobjc-framework-vision" },
+    { name = "click", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-vision", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/5e/07/3e15ab404f75875c5e48c47163300eb90b7409044d8711fc3aaf52503f2e/ocrmac-1.0.1.tar.gz", hash = "sha256:507fe5e4cbd67b2d03f6729a52bbc11f9d0b58241134eb958a5daafd4b9d93d9", size = 1454317, upload-time = "2026-01-08T16:44:26.412Z" }
 wheels = [
@@ -5404,7 +5404,7 @@ name = "pyobjc-framework-cocoa"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/02/a3/16ca9a15e77c061a9250afbae2eae26f2e1579eb8ca9462ae2d2c71e1169/pyobjc_framework_cocoa-12.1.tar.gz", hash = "sha256:5556c87db95711b985d5efdaaf01c917ddd41d148b1e52a0c66b1a2e2c5c1640", size = 2772191, upload-time = "2025-11-14T10:13:02.069Z" }
 wheels = [
@@ -5421,8 +5421,8 @@ name = "pyobjc-framework-coreml"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/30/2d/baa9ea02cbb1c200683cb7273b69b4bee5070e86f2060b77e6a27c2a9d7e/pyobjc_framework_coreml-12.1.tar.gz", hash = "sha256:0d1a4216891a18775c9e0170d908714c18e4f53f9dc79fb0f5263b2aa81609ba", size = 40465, upload-time = "2025-11-14T10:14:02.265Z" }
 wheels = [
@@ -5439,8 +5439,8 @@ name = "pyobjc-framework-quartz"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/94/18/cc59f3d4355c9456fc945eae7fe8797003c4da99212dd531ad1b0de8a0c6/pyobjc_framework_quartz-12.1.tar.gz", hash = "sha256:27f782f3513ac88ec9b6c82d9767eef95a5cf4175ce88a1e5a65875fee799608", size = 3159099, upload-time = "2025-11-14T10:21:24.31Z" }
 wheels = [
@@ -5457,10 +5457,10 @@ name = "pyobjc-framework-vision"
 version = "12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "pyobjc-core" },
-    { name = "pyobjc-framework-cocoa" },
-    { name = "pyobjc-framework-coreml" },
-    { name = "pyobjc-framework-quartz" },
+    { name = "pyobjc-core", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-cocoa", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-coreml", marker = "sys_platform == 'darwin'" },
+    { name = "pyobjc-framework-quartz", marker = "sys_platform == 'darwin'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/c2/5a/08bb3e278f870443d226c141af14205ff41c0274da1e053b72b11dfc9fb2/pyobjc_framework_vision-12.1.tar.gz", hash = "sha256:a30959100e85dcede3a786c544e621ad6eb65ff6abf85721f805822b8c5fe9b0", size = 59538, upload-time = "2025-11-14T10:23:21.979Z" }
 wheels = [
@@ -6897,13 +6897,13 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform == 'darwin'" },
+    { name = "fsspec", marker = "sys_platform == 'darwin'" },
+    { name = "jinja2", marker = "sys_platform == 'darwin'" },
+    { name = "networkx", marker = "sys_platform == 'darwin'" },
+    { name = "setuptools", marker = "sys_platform == 'darwin'" },
+    { name = "sympy", marker = "sys_platform == 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:10802fd383bbfed646212e765a72c37d2185205d4f26eb197a254e8ac7ddcb25", upload-time = "2026-05-12T16:20:07Z" },
@@ -6931,13 +6931,13 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "filelock" },
-    { name = "fsspec" },
-    { name = "jinja2" },
-    { name = "networkx" },
-    { name = "setuptools" },
-    { name = "sympy" },
-    { name = "typing-extensions" },
+    { name = "filelock", marker = "sys_platform != 'darwin'" },
+    { name = "fsspec", marker = "sys_platform != 'darwin'" },
+    { name = "jinja2", marker = "sys_platform != 'darwin'" },
+    { name = "networkx", marker = "sys_platform != 'darwin'" },
+    { name = "setuptools", marker = "sys_platform != 'darwin'" },
+    { name = "sympy", marker = "sys_platform != 'darwin'" },
+    { name = "typing-extensions", marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torch-2.12.0%2Bcpu-cp311-cp311-linux_s390x.whl", hash = "sha256:aaa9c1f5e8c518d7be1e3c3e1b090ca7d63b6e353a1abd6cfdaf902405093467", upload-time = "2026-05-12T23:16:01Z" },
@@ -6981,9 +6981,9 @@ resolution-markers = [
     "python_full_version < '3.12' and sys_platform == 'darwin'",
 ]
 dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" } },
+    { name = "numpy", marker = "sys_platform == 'darwin'" },
+    { name = "pillow", marker = "sys_platform == 'darwin'" },
+    { name = "torch", version = "2.12.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform == 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0-cp311-cp311-macosx_14_0_arm64.whl", hash = "sha256:df0c166b6bdf7c47f88e81e8b43bc085451d5c50d0c5d1691bc474c1227d6fed", upload-time = "2026-05-12T16:20:37Z" },
@@ -7011,9 +7011,9 @@ resolution-markers = [
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
 ]
 dependencies = [
-    { name = "numpy" },
-    { name = "pillow" },
-    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" } },
+    { name = "numpy", marker = "sys_platform != 'darwin'" },
+    { name = "pillow", marker = "sys_platform != 'darwin'" },
+    { name = "torch", version = "2.12.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "sys_platform != 'darwin'" },
 ]
 wheels = [
     { url = "https://download-r2.pytorch.org/whl/cpu/torchvision-0.27.0%2Bcpu-cp311-cp311-manylinux_2_28_aarch64.whl", hash = "sha256:99d05d071ff34305334ee1854f5edf7c2767b96ba59fe92e76d84a1fa72c8e06", upload-time = "2026-05-12T16:20:36Z" },
@@ -7825,6 +7825,7 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "tiktoken" },
     { name = "tqdm" },
+    { name = "tzdata" },
     { name = "uvicorn" },
     { name = "volcengine-python-sdk", extra = ["ark"] },
     { name = "websockets" },
@@ -8088,6 +8089,7 @@ requires-dist = [
     { name = "transformers", marker = "extra == 'router'", specifier = ">=4.51" },
     { name = "typer", marker = "extra == 'all'", specifier = ">=0.9.0" },
     { name = "typer", marker = "extra == 'document-processing'", specifier = ">=0.9.0" },
+    { name = "tzdata", specifier = ">=2024.1" },
     { name = "unstructured", marker = "extra == 'all'", specifier = ">=0.15.0" },
     { name = "unstructured", marker = "extra == 'document-processing'", specifier = ">=0.15.0" },
     { name = "uvicorn", specifier = ">=0.35.0" },


### PR DESCRIPTION
## Summary
- `google_calendar_create_events`/`update_events` and `outlook_create_event`/`update_event` had no conflict/overlap detection at all — an agent could book or move a meeting straight over an existing one (same timezone included) with zero warning, and for Outlook it would still email the invite to attendees.
- Both connectors now check the organizer's calendar and, when attendees are given, each attendee's free/busy before writing the event. A conflict returns `status="conflict"` (with the overlapping events and any attendee whose calendar couldn't be checked) instead of silently booking over it. `ignore_conflicts=true` lets the caller proceed once the user has explicitly confirmed.
- Update calls only check what's actually changing (a moved time, newly-added attendees, or an `is_all_day` flip) — checking an unmoved event's existing attendees against their own calendar would always flag the event's own busy block as a conflict with itself. Same-instant timestamps written in different formats (`Z` vs `+00:00`, differing fractional-second precision) are compared correctly instead of as raw strings, so a same-time resubmission isn't misread as a real move.
- `sendUpdates`/notification behavior on update only fires when the schedule (time or attendees) actually changes, not on unrelated edits — including notifying attendees who are removed down to an empty list.
- Updating an event's attendees now merges into the existing attendee array (keeping each kept attendee's RSVP/status) instead of replacing it wholesale, so a no-op resubmission no longer wipes everyone's response status.
- Outlook's all-day events are no longer exempted from the conflict check; a pre-existing **Google** all-day event (created outside this tool, stored under `start.date` rather than `start.dateTime`) is also correctly checked now instead of silently skipped.
- An organizer's own declined event, and Outlook's `showAs="unknown"`, are treated as non-conflicts rather than false positives; an attendee entirely missing from the provider's free/busy response is reported as unchecked rather than silently assumed free.
- A missing-scope 403 (see below) or an over-limit attendee batch (Google: 50, Outlook: 20 — Microsoft's documented `getSchedule` cap) degrades to "these attendees are unchecked" instead of hard-failing the whole booking.
- `normalize_addresses`/`conflict_response`/a shared datetime-comparison helper moved into `utils.py`, shared by both connectors instead of duplicated.

## Schema note
`outlook_update_event`'s `timezone` parameter default changed from `"UTC"` to `None` — passing nothing now means "reuse whatever timezone the existing event already has" instead of silently assuming UTC, which was the source of a real conflict-check bug on partial updates.

## ⚠️ OAuth scope change — requires reconnecting Google Calendar
The attendee free/busy check calls Google's `freebusy.query`, which per Google's own scope reference is **not** authorized by `calendar.events` alone (the connector's current scope, narrowed in `20260817_narrow_google_calendar_scope`). This PR adds `calendar.freebusy` to the `google-calendar` connector's scope (`builtin_mcp_registry.py` + migration `20260907_add_calendar_freebusy_scope`).

This is a **widening** migration, not a narrowing one: an already-issued OAuth token only carries the old `calendar.events` scope and will not pick up the new permission automatically. Users who connected Google Calendar before this ships will hit the batch/scope degradation path above (attendees reported unchecked) rather than a hard error, until they reconnect the connector. New connections after this ships get the correct scope immediately.

## Known follow-up (not in this PR)
- No optimistic-concurrency guard (etag/If-Match) on the read-check-then-write flow this PR introduces — two near-simultaneous updates could both pass the conflict check and both write. No existing connector in this repo has a precedent for that pattern; flagging as a real but separate gap rather than adding untested concurrency-control code here.

## Test plan
- [x] `pytest tests/web/tools/test_google_calendar_mcp.py tests/web/tools/test_outlook_mcp.py` — 56 tests covering: same-timezone overlap detection (the reported bug), transparent/cancelled/free/declined/unknown-status events ignored, attendee free/busy conflicts (including batch-limit and missing-scope degradation, and attendees absent from the response), unchecked-attendee handling, `ignore_conflicts` bypass, metadata-only updates never triggering a check, adding an attendee only checking the new one (case-insensitively, including on resubmission), moving time checking everyone, notification gating (including on full attendee removal), attendee RSVP preservation on update, all-day events (Google and Outlook) no longer being exempt or silently skipped, equivalent-timestamp-format handling, timezone resolution on partial updates, and null-safety against API responses.
- [x] `pytest tests/alembic/test_20260817_narrow_google_calendar_scope.py tests/alembic/test_20260907_add_calendar_freebusy_scope.py` — scope migration upgrade/downgrade, idempotency, upgrade→downgrade→upgrade convergence, offline SQL generation, registry drift
- [x] `pytest tests/web/tools/ tests/web/api/test_public_mcp_connector_visibility.py tests/web/test_builtin_oauth_catalog.py tests/web/test_meta_oauth.py tests/migrations/test_check_alembic_heads.py` — no regressions
- [x] `alembic heads` — single head confirmed
- [x] `ruff format` / `ruff check` / `mypy` clean on all changed files
- [x] pre-commit hooks pass
