### PR TITLE
feat(mcp): add Google Drive sharing and permission tools

### DIFF
--- a/src/xagent/migrations/versions/20260908_update_google_drive_description.py
+++ b/src/xagent/migrations/versions/20260908_update_google_drive_description.py
@@ -31,7 +31,9 @@ PREVIOUS_DESCRIPTION = (
 )
 CURRENT_DESCRIPTION = (
     "Access Google Drive to search for files, read documents, manage your "
-    "cloud storage, and share files or folders with others."
+    "cloud storage, and manage sharing on files or folders -- including "
+    "granting access to someone new and revoking an existing "
+    "collaborator's access."
 )
 
 

--- a/src/xagent/migrations/versions/20260908_update_google_drive_description.py
+++ b/src/xagent/migrations/versions/20260908_update_google_drive_description.py
@@ -1,6 +1,6 @@
 """update Google Drive description for the sharing tools
 
-Revision ID: 20260908_update_google_drive_description_category
+Revision ID: 20260908_update_google_drive_description
 Revises: 20260904_add_auto_model_config
 Create Date: 2026-09-08
 
@@ -11,7 +11,7 @@ from typing import Sequence, Union
 import sqlalchemy as sa
 from alembic import op
 
-revision: str = "20260908_update_google_drive_description_category"
+revision: str = "20260908_update_google_drive_description"
 down_revision: Union[str, None] = "20260904_add_auto_model_config"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/src/xagent/migrations/versions/20260908_update_google_drive_description_category.py
+++ b/src/xagent/migrations/versions/20260908_update_google_drive_description_category.py
@@ -1,0 +1,105 @@
+"""update Google Drive description and category for the sharing tools
+
+Revision ID: 20260908_update_google_drive_description_category
+Revises: 20260904_add_auto_model_config
+Create Date: 2026-09-08
+
+"""
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260908_update_google_drive_description_category"
+down_revision: Union[str, None] = "20260904_add_auto_model_config"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+PUBLIC_MCP_APPS_TABLE = sa.table(
+    "public_mcp_apps",
+    sa.column("app_id", sa.String),
+    sa.column("description", sa.Text),
+    sa.column("category", sa.String),
+)
+
+APP_ID = "google-drive"
+
+PREVIOUS_DESCRIPTION = (
+    "Access Google Drive to search for files, read documents, and manage "
+    "your cloud storage."
+)
+CURRENT_DESCRIPTION = (
+    "Access Google Drive to search for files, read documents, manage your "
+    "cloud storage, and share files or folders with others."
+)
+
+PREVIOUS_CATEGORY = "Support"
+CURRENT_CATEGORY = "Storage"
+
+
+def _columns_present(
+    bind: sa.engine.Connection, table_name: str, required_columns: set[str]
+) -> bool:
+    """Whether ``table_name`` exists and has all of ``required_columns``.
+
+    This migration must be a no-op (not an error) against a database
+    mid-way through a schema this old, or an admin's reduced-schema table,
+    rather than assume a table shape that matches only the current model.
+    """
+    inspector = sa.inspect(bind)
+    if table_name not in set(inspector.get_table_names()):
+        return False
+    columns = {c["name"] for c in inspector.get_columns(table_name)}
+    return required_columns.issubset(columns)
+
+
+def _set_field_if_unchanged(
+    bind: sa.engine.Connection, column: str, expected_current: str, new_value: str
+) -> None:
+    """Refresh a stale registry field on an already-seeded row, without
+    clobbering a customization.
+
+    Neither ``description`` nor ``category`` is in admin_mcp's
+    _BUILTIN_PROTECTED_FIELDS, so an operator can legitimately have edited
+    either via the admin PATCH endpoint. Only overwrite when the persisted
+    value still equals the last-known canonical value (i.e. it was never
+    customized); an edited value matches neither the previous nor the
+    current canonical value and is left alone in either direction.
+
+    Both fields are also excluded from builtin_mcp_registry.py's own
+    _BUILTIN_EXECUTION_FIELD_NAMES drift sync (unlike oauth_scopes/
+    launch_config/etc., which self-heal on every read), and the seed
+    migration only ever inserts a row once -- so without this migration, an
+    already-provisioned install's google-drive row would keep showing
+    "Support"/the pre-sharing description forever, even after upgrading to
+    a build whose source registry has moved on.
+    """
+    if not _columns_present(bind, "public_mcp_apps", {"app_id", column}):
+        return
+
+    bind.execute(
+        sa.update(PUBLIC_MCP_APPS_TABLE)
+        .where(
+            PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID,
+            getattr(PUBLIC_MCP_APPS_TABLE.c, column) == expected_current,
+        )
+        .values(**{column: new_value})
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    _set_field_if_unchanged(
+        bind, "description", PREVIOUS_DESCRIPTION, CURRENT_DESCRIPTION
+    )
+    _set_field_if_unchanged(bind, "category", PREVIOUS_CATEGORY, CURRENT_CATEGORY)
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    _set_field_if_unchanged(
+        bind, "description", CURRENT_DESCRIPTION, PREVIOUS_DESCRIPTION
+    )
+    _set_field_if_unchanged(bind, "category", CURRENT_CATEGORY, PREVIOUS_CATEGORY)

--- a/src/xagent/migrations/versions/20260908_update_google_drive_description_category.py
+++ b/src/xagent/migrations/versions/20260908_update_google_drive_description_category.py
@@ -1,4 +1,4 @@
-"""update Google Drive description and category for the sharing tools
+"""update Google Drive description for the sharing tools
 
 Revision ID: 20260908_update_google_drive_description_category
 Revises: 20260904_add_auto_model_config
@@ -21,7 +21,6 @@ PUBLIC_MCP_APPS_TABLE = sa.table(
     "public_mcp_apps",
     sa.column("app_id", sa.String),
     sa.column("description", sa.Text),
-    sa.column("category", sa.String),
 )
 
 APP_ID = "google-drive"
@@ -34,9 +33,6 @@ CURRENT_DESCRIPTION = (
     "Access Google Drive to search for files, read documents, manage your "
     "cloud storage, and share files or folders with others."
 )
-
-PREVIOUS_CATEGORY = "Support"
-CURRENT_CATEGORY = "Storage"
 
 
 def _columns_present(
@@ -55,51 +51,55 @@ def _columns_present(
     return required_columns.issubset(columns)
 
 
-def _set_field_if_unchanged(
-    bind: sa.engine.Connection, column: str, expected_current: str, new_value: str
+def _set_description_if_unchanged(
+    bind: sa.engine.Connection, expected_current: str, new_value: str
 ) -> None:
-    """Refresh a stale registry field on an already-seeded row, without
-    clobbering a customization.
+    """Refresh the stale registry description on an already-seeded row,
+    without clobbering a customization.
 
-    Neither ``description`` nor ``category`` is in admin_mcp's
-    _BUILTIN_PROTECTED_FIELDS, so an operator can legitimately have edited
-    either via the admin PATCH endpoint. Only overwrite when the persisted
-    value still equals the last-known canonical value (i.e. it was never
-    customized); an edited value matches neither the previous nor the
-    current canonical value and is left alone in either direction.
+    ``description`` is not in admin_mcp's _BUILTIN_PROTECTED_FIELDS, so an
+    operator can legitimately have edited it via the admin PATCH endpoint.
+    Only overwrite when the persisted value still equals the last-known
+    canonical value (i.e. it was never customized); an edited value matches
+    neither the previous nor the current canonical value and is left alone
+    in either direction.
 
-    Both fields are also excluded from builtin_mcp_registry.py's own
+    ``description`` is also excluded from builtin_mcp_registry.py's own
     _BUILTIN_EXECUTION_FIELD_NAMES drift sync (unlike oauth_scopes/
     launch_config/etc., which self-heal on every read), and the seed
     migration only ever inserts a row once -- so without this migration, an
-    already-provisioned install's google-drive row would keep showing
-    "Support"/the pre-sharing description forever, even after upgrading to
-    a build whose source registry has moved on.
+    already-provisioned install's google-drive row would keep showing the
+    pre-sharing description forever, even after upgrading to a build whose
+    source registry has moved on.
+
+    (This migration originally also updated ``category`` from "Support" to
+    "Storage", matching OneDrive's category -- but neither "Storage" nor
+    "Productivity" (used by several other Google connectors) is an actual
+    filter button in frontend/src/components/mcp/connect-mcp-dialog.tsx,
+    whose sidebar only has All/CRM/Communication/Support/Marketing/
+    Scheduling/Payments/Analytics/Operations. "Support" is the one that's
+    genuinely clickable, so the category change was reverted rather than
+    shipped as a change that made Google Drive harder to find in the
+    connect-apps dialog.)
     """
-    if not _columns_present(bind, "public_mcp_apps", {"app_id", column}):
+    if not _columns_present(bind, "public_mcp_apps", {"app_id", "description"}):
         return
 
     bind.execute(
         sa.update(PUBLIC_MCP_APPS_TABLE)
         .where(
             PUBLIC_MCP_APPS_TABLE.c.app_id == APP_ID,
-            getattr(PUBLIC_MCP_APPS_TABLE.c, column) == expected_current,
+            PUBLIC_MCP_APPS_TABLE.c.description == expected_current,
         )
-        .values(**{column: new_value})
+        .values(description=new_value)
     )
 
 
 def upgrade() -> None:
     bind = op.get_bind()
-    _set_field_if_unchanged(
-        bind, "description", PREVIOUS_DESCRIPTION, CURRENT_DESCRIPTION
-    )
-    _set_field_if_unchanged(bind, "category", PREVIOUS_CATEGORY, CURRENT_CATEGORY)
+    _set_description_if_unchanged(bind, PREVIOUS_DESCRIPTION, CURRENT_DESCRIPTION)
 
 
 def downgrade() -> None:
     bind = op.get_bind()
-    _set_field_if_unchanged(
-        bind, "description", CURRENT_DESCRIPTION, PREVIOUS_DESCRIPTION
-    )
-    _set_field_if_unchanged(bind, "category", CURRENT_CATEGORY, PREVIOUS_CATEGORY)
+    _set_description_if_unchanged(bind, CURRENT_DESCRIPTION, PREVIOUS_DESCRIPTION)

--- a/src/xagent/migrations/versions/370740d9125a_merge_heads.py
+++ b/src/xagent/migrations/versions/370740d9125a_merge_heads.py
@@ -1,0 +1,26 @@
+"""merge heads
+
+Revision ID: 370740d9125a
+Revises: 20260909_actor_mcp_connections, a138278b9d0b
+Create Date: 2026-09-09 19:14:27.764331
+
+"""
+
+from typing import Sequence, Union
+
+# revision identifiers, used by Alembic.
+revision: str = "370740d9125a"
+down_revision: Union[str, Sequence[str], None] = (
+    "20260909_actor_mcp_connections",
+    "a138278b9d0b",
+)
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    pass
+
+
+def downgrade() -> None:
+    pass

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -450,7 +450,7 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "icon": "https://www.google.com/s2/favicons?domain=drive.google.com&sz=128",
             "transport": "oauth",
             "provider_name": "google",
-            "category": "Storage",
+            "category": "Support",
             "oauth_scopes": ["https://www.googleapis.com/auth/drive"],
             "is_visible_in_connector": True,
             "launch_config": {

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -446,7 +446,7 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
         {
             "app_id": "google-drive",
             "name": "Google Drive",
-            "description": "Access Google Drive to search for files, read documents, manage your cloud storage, and share files or folders with others.",
+            "description": "Access Google Drive to search for files, read documents, manage your cloud storage, and manage sharing on files or folders -- including granting access to someone new and revoking an existing collaborator's access.",
             "icon": "https://www.google.com/s2/favicons?domain=drive.google.com&sz=128",
             "transport": "oauth",
             "provider_name": "google",

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -450,7 +450,7 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
             "icon": "https://www.google.com/s2/favicons?domain=drive.google.com&sz=128",
             "transport": "oauth",
             "provider_name": "google",
-            "category": "Support",
+            "category": "Storage",
             "oauth_scopes": ["https://www.googleapis.com/auth/drive"],
             "is_visible_in_connector": True,
             "launch_config": {

--- a/src/xagent/web/builtin_mcp_registry.py
+++ b/src/xagent/web/builtin_mcp_registry.py
@@ -446,7 +446,7 @@ def get_builtin_public_mcp_app_rows() -> list[dict[str, Any]]:
         {
             "app_id": "google-drive",
             "name": "Google Drive",
-            "description": "Access Google Drive to search for files, read documents, and manage your cloud storage.",
+            "description": "Access Google Drive to search for files, read documents, manage your cloud storage, and share files or folders with others.",
             "icon": "https://www.google.com/s2/favicons?domain=drive.google.com&sz=128",
             "transport": "oauth",
             "provider_name": "google",

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -32,6 +32,13 @@ mcp = FastMCP("google-drive-mcp")
 # A Drive/Docs/Sheets/Slides/Forms/Drawings id is always [a-zA-Z0-9_-]+.
 _DRIVE_ID_CHARS = re.compile(r"[a-zA-Z0-9_-]+")
 
+# A real Drive id never contains "/" or "?" -- used by both
+# _parse_trusted_drive_url and _resolve_file_id to decide "is this even
+# URL-shaped" before doing any URL parsing. Precompiled to match every
+# other regex in this module rather than left as a literal pattern string
+# re-evaluated at each of its two call sites.
+_DRIVE_URL_SHAPE_HINT = re.compile(r"[/?]")
+
 # The share-link path prefixes _resolve_file_id recognizes, as one source
 # of truth for both patterns below -- so adding a new Drive-family surface
 # (this PR already added forms/drawings once) means editing this tuple
@@ -206,7 +213,7 @@ def _parse_trusted_drive_url(value: str) -> ParseResult | None:
     if not isinstance(value, str):
         return None
     stripped = value.strip()
-    if not re.search(r"[/?]", stripped):
+    if not _DRIVE_URL_SHAPE_HINT.search(stripped):
         return None
     try:
         parsed = urlparse(stripped)
@@ -298,7 +305,7 @@ def _resolve_file_id(file_id: str, field_name: str = "file_id") -> str:
     stripped = file_id.strip()
     if not stripped:
         raise ValueError(f"{field_name} must be a non-empty id")
-    if not re.search(r"[/?]", stripped):
+    if not _DRIVE_URL_SHAPE_HINT.search(stripped):
         # Shares _require_drive_id's character-class check rather than
         # repeating it inline, so file_id's bare-id validation and
         # permission_id's validation can't silently drift apart the way
@@ -385,19 +392,40 @@ def _attach_resource_key(request: Any, file_id: str, resource_key: str | None) -
     _extract_resource_key only ever returns a truthy ``resource_key`` when
     _resolve_id_from_parsed made the identical decision on the same input
     and _resolve_file_id would therefore have taken the same validated-id
-    branch (see _extract_resource_key's docstring). The CR/LF check here is
-    belt-and-suspenders defense against a future call site breaking that
-    invariant -- raising rather than silently skipping the header, since a
-    silent skip would be a *worse* failure mode than surfacing the
-    violation: a pre-2021 link-shared item that genuinely needs this header
-    would otherwise get a confusing 404 from Drive with no indication a
-    resourcekey was computed but silently dropped, instead of a clear,
-    immediate, actionable local error pointing at the actual bug.
+    branch (see _extract_resource_key's docstring). Note this is narrower
+    than "file_id is always safe everywhere": an untrusted/unresolved
+    file_id can still reach the Drive API as the request's own ``fileId=``
+    path parameter with no header involved at all -- that path is
+    protected separately, by googleapiclient's own URI-template expansion
+    percent-encoding reserved characters (including a literal CR/LF)
+    before it ever reaches the wire, not by anything in this function.
+
+    The CR/LF check below only guards the one thing THIS function builds:
+    the resourcekey header value. It's belt-and-suspenders defense against
+    a future call site breaking the invariant above -- raising, rather
+    than silently skipping the header, since a silent skip would be a
+    *worse* failure mode than surfacing the violation: a pre-2021 link-
+    shared item that genuinely needs this header would otherwise get a
+    confusing 404 from Drive with no indication a resourcekey was computed
+    but silently dropped. Raising here signals a bug in this file's own
+    invariant, not a user-input problem -- logged before raising so it's
+    distinguishable in logs from an ordinary validation error, even though
+    the outer per-tool try/except still turns it into the same JSON error
+    envelope as any other exception.
     """
     if not resource_key:
         return request
     if "\r" in file_id or "\n" in file_id:
-        raise ValueError(f"file_id must not contain CR/LF, got {file_id!r}")
+        logger.error(
+            "_attach_resource_key: file_id contains CR/LF, violating the "
+            "caller invariant this function relies on -- this indicates a "
+            "bug in google_drive.py, not bad user input: %r",
+            file_id,
+        )
+        raise ValueError(
+            "internal error (bug in google_drive.py): file_id must not "
+            f"contain CR/LF, got {file_id!r}"
+        )
     request.headers["X-Goog-Drive-Resource-Keys"] = f"{file_id}/{resource_key}"
     return request
 
@@ -502,7 +530,9 @@ def _capped_list_response(
 
 
 def _capped_permissions_response(
-    pages: list[tuple[str | None, list[Any]]], next_page_token: str | None
+    pages: list[tuple[str | None, list[Any]]],
+    next_page_token: str | None,
+    max_output_length: int | None = None,
 ) -> str:
     """Build google_drive_list_permissions' response, shrinking (if
     needed to fit the output cap) by dropping whole pages from the tail
@@ -536,9 +566,12 @@ def _capped_permissions_response(
     ``pages`` is the ordered list of ``(start_token, items)`` fetched
     this call; ``next_page_token`` is the token for whatever page comes
     after the LAST page in ``pages`` (``None`` if that was Drive's last
-    page).
+    page). ``max_output_length`` lets a caller that already read it (e.g.
+    to drive its own fetch-loop early-exit) pass the same value through
+    instead of this function reading it again independently.
     """
-    max_output_length = get_tool_max_output_length()
+    if max_output_length is None:
+        max_output_length = get_tool_max_output_length()
 
     def _token_after(kept: int) -> str | None:
         return next_page_token if kept == len(pages) else pages[kept][0]
@@ -1208,10 +1241,14 @@ def google_drive_list_permissions(file_id: str, page_token: str | None = None) -
     returned permission ids with google_drive_update_permission or
     google_drive_remove_permission.
     For an item in a Shared Drive with more collaborators than fit in one
-    response, "truncated" is true and the result includes a
+    response, "truncated" is true and the result usually includes a
     "next_page_token" -- pass it back as this call's page_token to
     continue listing from where it left off instead of silently missing
-    the rest.
+    the rest. In the rare case where even the earliest unreturned page
+    alone is too large to fit, "truncated" is true but "next_page_token"
+    is absent -- there's no safe way to resume from partway through a
+    single page, so the remaining collaborators on it can't be listed
+    through this tool.
     A permission whose "permissionDetails" marks it "inherited": true comes
     from a parent folder, not this item directly -- it can't be changed or
     removed here; do that on the folder it's inherited from instead.
@@ -1291,7 +1328,9 @@ def google_drive_list_permissions(file_id: str, page_token: str | None = None) -
         # signals "more data exists beyond what was fetched" without
         # needing a separate branch for the loop-safety-bound case.
 
-        return _capped_permissions_response(pages, current_page_token)
+        return _capped_permissions_response(
+            pages, current_page_token, max_output_length
+        )
     except Exception as e:
         logger.error(f"Error listing permissions: {e}")
         return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -241,13 +241,14 @@ def _execute_ignoring_204_ssl_eof(
         )
         try:
             verify_done()
-            raise Exception(
-                f"Operation did not complete, SSL error occurred: {e}"
-            ) from e
         except Exception as verify_err:
             if "404" in str(verify_err) or "not found" in str(verify_err).lower():
                 return  # Successfully completed
             raise e from verify_err
+
+        # verify_done() didn't raise, so the object is still there -- the
+        # delete/permission removal genuinely did not happen.
+        raise Exception(f"Operation did not complete, SSL error occurred: {e}") from e
 
 
 @mcp.tool()

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -5,7 +5,7 @@ import os
 import re
 from collections.abc import Callable
 from typing import Any
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build  # type: ignore[import-not-found]
@@ -16,12 +16,7 @@ from googleapiclient.http import (  # type: ignore[import-not-found]
 from mcp.server.fastmcp import FastMCP
 
 from ....config import get_tool_max_output_length
-from .utils import (
-    clamp_limit,
-    require_clean_identifier,
-    resolve_id_from_url,
-    setup_proxy_env,
-)
+from .utils import clamp_limit, require_clean_identifier, setup_proxy_env
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("google-drive-mcp")
@@ -37,32 +32,26 @@ mcp = FastMCP("google-drive-mcp")
 # than the bare id. The optional "u/<n>/" branch tolerates the account-index
 # segment Google inserts (e.g. ".../file/u/1/d/<id>/view") whenever more than
 # one Google account is signed into the browser -- see google_sheets.py's
-# identical (?:u/\d+/)? tolerance for the spreadsheets URL shape. The
-# "[?&]id=" branch matches the older `drive.google.com/open?id=<id>` /
-# `docs.google.com/open?id=<id>` share-link format, still emitted by
-# DriveApp.getUrl() in Apps Script and some third-party integrations, which
-# has no "/d/<id>" path segment for the first branch to match at all --
-# _resolve_file_id below is what keeps that branch from being host-agnostic.
-# "(?!e/)" after each "d/" excludes the "published to web" link shape
+# identical (?:u/\d+/)? tolerance for the spreadsheets URL shape. "(?!e/)"
+# after each "d/" excludes the "published to web" link shape
 # (".../d/e/<publish-id>/pubhtml"): that "e" is a literal path segment, not
 # part of the id, and the real Drive file id isn't present in that URL at
 # all -- the published-to-web token isn't a valid fileId, so this must not
-# match rather than confidently return the wrong string ("e").
-_DRIVE_URL_ID_PATTERN = re.compile(
-    r"(?:/(?:file/(?:u/\d+/)?d|folders|document/(?:u/\d+/)?d"
-    r"|spreadsheets/(?:u/\d+/)?d|presentation/(?:u/\d+/)?d)/(?!e/)|[?&]id=)"
+# match rather than confidently return the wrong string ("e"). Applied only
+# to a URL's parsed .path (see _resolve_file_id) rather than searched over
+# the whole raw string, so a match can't come from an unrelated substring
+# elsewhere in the URL (e.g. a query value).
+_DRIVE_PATH_ID_PATTERN = re.compile(
+    r"/(?:file/(?:u/\d+/)?d|folders|document/(?:u/\d+/)?d"
+    r"|spreadsheets/(?:u/\d+/)?d|presentation/(?:u/\d+/)?d)/(?!e/)"
     r"([a-zA-Z0-9_-]+)"
 )
 
 # Hosts _resolve_file_id treats as an authoritative Drive/Docs/Sheets/Slides
-# share link. Both the path patterns above and the query-string "id="
-# fallback are otherwise host-agnostic regex/substring matches -- without
-# this check, an untrusted URL (e.g. quoted inside a document an agent
-# reads) that merely happens to contain a matching shape, most easily
-# "?id=<attacker-chosen-id>" since "id" is an extremely common, generic
-# query-param name across the web, would get its id extracted and passed
-# to a share/delete/permission call as if it were this connector's own
-# link.
+# share link. Without this check, an untrusted URL (e.g. quoted inside a
+# document an agent reads) that merely happens to parse with a matching
+# path/query shape would have its id extracted and passed to a share/
+# delete/permission call as if it were this connector's own link.
 _DRIVE_URL_HOSTS = frozenset({"drive.google.com", "docs.google.com"})
 
 # "owner" is deliberately excluded: ownership transfer needs
@@ -88,32 +77,60 @@ _SHARE_ROLES = ("reader", "commenter", "writer")
 # email addresses; the previous "@" not in email check accepted all three.
 _EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
+# Loop-safety bound for google_drive_list_permissions' pagination, not a
+# real expected page count (that's governed by output-size capping instead)
+# -- just enough to guarantee termination if a misbehaving API response
+# kept returning a nextPageToken forever.
+_MAX_PERMISSION_LIST_PAGES = 1000
+
 
 def _resolve_file_id(file_id: str) -> str:
-    if isinstance(file_id, str):
-        stripped = file_id.strip()
-        # A real Drive id is always [a-zA-Z0-9_-]+ and never contains "/"
-        # or "?", so only a value containing one of those characters can be
-        # a URL shape in the first place -- only those go through the host
-        # check. This matters because urlparse only populates
-        # .scheme/.hostname for a string with an explicit "scheme://" (or a
-        # leading "//") prefix: a scheme-less "evil.com/file/d/<id>/view"
-        # (at least as natural a shape for an attacker to plant in text an
-        # agent reads as a full https:// URL) would otherwise report an
-        # empty scheme/hostname and slip straight past a bare
-        # urlparse(stripped) check into the host-agnostic pattern match
-        # below -- exactly the bypass the host allowlist exists to close.
-        # Prepending "//" when there's no "//" already present makes
-        # urlparse treat a bare "host/path" or "host?query" the same way
-        # it treats an explicit "//host/path" protocol-relative URL.
-        if re.search(r"[/?]", stripped):
-            try:
-                parsed = urlparse(stripped if "//" in stripped else f"//{stripped}")
-            except ValueError:
-                return stripped
-            if parsed.hostname not in _DRIVE_URL_HOSTS:
-                return stripped
-    return resolve_id_from_url(file_id, _DRIVE_URL_ID_PATTERN, "file_id")
+    """Return the id captured out of a Drive/Docs/Sheets/Slides share link,
+    or ``file_id`` itself (stripped) when it's already a bare id -- or, for
+    anything URL-shaped that isn't a trusted link, unresolved verbatim so an
+    obviously-invalid fileId reaches the API instead of a silently wrong one.
+
+    A real Drive id is always ``[a-zA-Z0-9_-]+`` and never contains "/" or
+    "?", so only a value containing one of those characters is even
+    considered URL-shaped; a bare id short-circuits immediately.
+
+    urlparse only populates ``.scheme``/``.netloc`` for a string with an
+    explicit "scheme://" prefix (or at least a leading "//"): a scheme-less
+    "evil.com/file/d/<id>/view" (at least as natural a shape for an
+    attacker to plant in text an agent reads as a full https:// URL) would
+    otherwise parse with no netloc and slip past a naive urlparse(value)
+    check. Retrying with a "//" prefix only when the *first* parse found no
+    netloc (rather than keying off whether "//" occurs anywhere in the
+    string) correctly handles a scheme-less link that itself contains a
+    nested "https://" further in, e.g. in a "continue=" query value.
+
+    Once the host is confirmed trusted, the id is extracted from the
+    parsed URL's own ``.path``/``.query`` -- not searched over the whole
+    raw string -- so a URL whose overall host is allowed but whose query
+    *value* merely contains a matching shape (".../search?q=/file/d/<id>")
+    can't have that unrelated substring extracted as if it were the URL's
+    own resource id.
+    """
+    if not isinstance(file_id, str):
+        raise ValueError("file_id must be a string")
+    stripped = file_id.strip()
+    if not re.search(r"[/?]", stripped):
+        return stripped
+    try:
+        parsed = urlparse(stripped)
+        if not parsed.netloc:
+            parsed = urlparse(f"//{stripped}")
+    except ValueError:
+        return stripped
+    if parsed.hostname not in _DRIVE_URL_HOSTS:
+        return stripped
+    match = _DRIVE_PATH_ID_PATTERN.search(parsed.path)
+    if match:
+        return match.group(1)
+    query_id = parse_qs(parsed.query).get("id")
+    if query_id:
+        return query_id[0]
+    return stripped
 
 
 def _require_share_role(role: str) -> str:
@@ -285,11 +302,11 @@ def google_drive_create_file(
     and pass plain text or HTML in the content. For normal text files, use "text/plain".
     """
     try:
-        service = get_drive_service()
         file_metadata: dict[str, Any] = {"name": name, "mimeType": mime_type}
         if parent_id:
             file_metadata["parents"] = [_resolve_file_id(parent_id)]
 
+        service = get_drive_service()
         fh = io.BytesIO(content.encode("utf-8"))
 
         # When creating a Google Doc, the upload mime type needs to be the original content's mime type (like text/plain)
@@ -319,7 +336,6 @@ def google_drive_create_folder(name: str, parent_id: str | None = None) -> str:
     Create a new folder in Google Drive.
     """
     try:
-        service = get_drive_service()
         file_metadata: dict[str, Any] = {
             "name": name,
             "mimeType": "application/vnd.google-apps.folder",
@@ -327,6 +343,7 @@ def google_drive_create_folder(name: str, parent_id: str | None = None) -> str:
         if parent_id:
             file_metadata["parents"] = [_resolve_file_id(parent_id)]
 
+        service = get_drive_service()
         folder = (
             service.files()
             .create(
@@ -474,6 +491,7 @@ def google_drive_list_permissions(file_id: str) -> str:
         service = get_drive_service()
         max_output_length = get_tool_max_output_length()
         permissions: list[Any] = []
+        approx_length = 0
         page_token: str | None = None
         # For an item in a Shared Drive, Drive returns at most 100
         # permissions per page when pageSize isn't set (a non-Shared-Drive
@@ -481,7 +499,7 @@ def google_drive_list_permissions(file_id: str) -> str:
         # nextPageToken so a heavily-shared Shared Drive folder isn't
         # silently under-reported. Bounded so a misbehaving API response
         # can't turn this into an infinite loop.
-        for _ in range(1000):
+        for _ in range(_MAX_PERMISSION_LIST_PAGES):
             results = (
                 service.permissions()
                 .list(
@@ -495,16 +513,33 @@ def google_drive_list_permissions(file_id: str) -> str:
                 )
                 .execute()
             )
-            permissions.extend(results.get("permissions", []))
-            page_token = results.get("nextPageToken")
-            if not page_token:
-                break
+            new_permissions = results.get("permissions", [])
+            permissions.extend(new_permissions)
             # _capped_list_response below will halve this back down to fit
             # the output limit regardless, so once there's already enough
             # data to exceed it, fetching further pages is pure waste: more
             # blocking network round-trips for permissions that get thrown
-            # away immediately after.
-            if len(json.dumps(permissions)) > max_output_length:
+            # away immediately after. Tracked incrementally (each new page's
+            # items serialized once, not the whole accumulated list every
+            # iteration) to stay O(n) rather than O(n^2) for a long
+            # permission list; ensure_ascii=False so this length estimate
+            # isn't inflated relative to what _capped_list_response will
+            # actually measure -- with the default ensure_ascii=True, a
+            # non-ASCII displayName/emailAddress (CJK, accented, emoji names
+            # are common on a Shared Drive) would each be escaped to a
+            # 6+-byte \uXXXX sequence here even though the real response
+            # keeps them as 1-2 bytes, overestimating this list as needing
+            # to stop paginating even though the true payload would still
+            # fit -- and _capped_list_response would then measure the true,
+            # smaller size and leave truncated=False, silently under-
+            # reporting collaborators while claiming a complete result.
+            approx_length += sum(
+                len(json.dumps(p, ensure_ascii=False)) for p in new_permissions
+            )
+            page_token = results.get("nextPageToken")
+            if not page_token:
+                break
+            if approx_length > max_output_length:
                 break
 
         return _capped_list_response("permissions", permissions)

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -15,7 +15,12 @@ from googleapiclient.http import (  # type: ignore[import-not-found]
 from mcp.server.fastmcp import FastMCP
 
 from ....config import get_tool_max_output_length
-from .utils import require_clean_identifier, resolve_id_from_url, setup_proxy_env
+from .utils import (
+    clamp_limit,
+    require_clean_identifier,
+    resolve_id_from_url,
+    setup_proxy_env,
+)
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("google-drive-mcp")
@@ -59,23 +64,26 @@ def _require_share_role(role: str) -> str:
     return role
 
 
-def _capped_permissions_response(permissions: list[Any]) -> str:
-    """Build the success payload, halving ``permissions`` until it fits the
+def _capped_list_response(field_name: str, items: list[Any]) -> str:
+    """Build the success payload, halving ``items`` until it fits the
     platform's output limit -- mirrors deputy.py's/salesforce.py's
     _success_with_capped_list. There is no cursor to resume from here, so
     entries dropped this way are gone for this call, not just this page.
     """
     max_output_length = get_tool_max_output_length()
-    truncated = False
-    response = json.dumps(
-        {"status": "success", "permissions": permissions, "truncated": truncated}
-    )
-    while len(response) > max_output_length and permissions:
-        permissions = permissions[: len(permissions) // 2]
-        truncated = True
-        response = json.dumps(
-            {"status": "success", "permissions": permissions, "truncated": truncated}
+
+    def _build(items: list[Any], truncated: bool) -> str:
+        return json.dumps(
+            {"status": "success", field_name: items, "truncated": truncated},
+            ensure_ascii=False,
         )
+
+    truncated = False
+    response = _build(items, truncated)
+    while len(response) > max_output_length and items:
+        items = items[: len(items) // 2]
+        truncated = True
+        response = _build(items, truncated)
     return response
 
 
@@ -115,17 +123,19 @@ def google_drive_search(query: str = "", max_results: int = 10) -> str:
             service.files()
             .list(
                 q=query if query else None,
-                pageSize=max_results,
+                pageSize=clamp_limit(max_results, max_limit=1000),
+                supportsAllDrives=True,
+                includeItemsFromAllDrives=True,
                 fields="nextPageToken, files(id, name, mimeType, modifiedTime)",
             )
             .execute()
         )
         items = results.get("files", [])
 
-        return json.dumps({"status": "success", "files": items})
+        return _capped_list_response("files", items)
     except Exception as e:
         logger.error(f"Error searching drive: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -139,7 +149,11 @@ def google_drive_get_file_content(file_id: str, mime_type: str = "text/plain") -
         service = get_drive_service()
         file_metadata = (
             service.files()
-            .get(fileId=resolved_file_id, fields="id, name, mimeType")
+            .get(
+                fileId=resolved_file_id,
+                supportsAllDrives=True,
+                fields="id, name, mimeType",
+            )
             .execute()
         )
         file_mime_type = file_metadata.get("mimeType", "")
@@ -151,24 +165,27 @@ def google_drive_get_file_content(file_id: str, mime_type: str = "text/plain") -
             )
         else:
             # Download regular file
-            request = service.files().get_media(fileId=resolved_file_id)
+            request = service.files().get_media(
+                fileId=resolved_file_id, supportsAllDrives=True
+            )
 
         fh = io.BytesIO()
         downloader = MediaIoBaseDownload(fh, request)
         done = False
         while done is False:
-            status, done = downloader.next_chunk()
+            _, done = downloader.next_chunk()
 
         return json.dumps(
             {
                 "status": "success",
                 "file": file_metadata,
                 "content": fh.getvalue().decode("utf-8", errors="replace"),
-            }
+            },
+            ensure_ascii=False,
         )
     except Exception as e:
         logger.error(f"Error getting file content: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -184,7 +201,7 @@ def google_drive_create_file(
         service = get_drive_service()
         file_metadata: dict[str, Any] = {"name": name, "mimeType": mime_type}
         if parent_id:
-            file_metadata["parents"] = [parent_id]
+            file_metadata["parents"] = [_resolve_file_id(parent_id)]
 
         fh = io.BytesIO(content.encode("utf-8"))
 
@@ -197,15 +214,16 @@ def google_drive_create_file(
             .create(
                 body=file_metadata,
                 media_body=media,
+                supportsAllDrives=True,
                 fields="id, name, webViewLink, mimeType",
             )
             .execute()
         )
 
-        return json.dumps({"status": "success", "file": file})
+        return json.dumps({"status": "success", "file": file}, ensure_ascii=False)
     except Exception as e:
         logger.error(f"Error creating file: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -220,18 +238,22 @@ def google_drive_create_folder(name: str, parent_id: str | None = None) -> str:
             "mimeType": "application/vnd.google-apps.folder",
         }
         if parent_id:
-            file_metadata["parents"] = [parent_id]
+            file_metadata["parents"] = [_resolve_file_id(parent_id)]
 
         folder = (
             service.files()
-            .create(body=file_metadata, fields="id, name, webViewLink")
+            .create(
+                body=file_metadata,
+                supportsAllDrives=True,
+                fields="id, name, webViewLink",
+            )
             .execute()
         )
 
-        return json.dumps({"status": "success", "folder": folder})
+        return json.dumps({"status": "success", "folder": folder}, ensure_ascii=False)
     except Exception as e:
         logger.error(f"Error creating folder: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -249,15 +271,18 @@ def google_drive_rename_file(file_id: str, new_name: str) -> str:
             .update(
                 fileId=resolved_file_id,
                 body=file_metadata,
+                supportsAllDrives=True,
                 fields="id, name, webViewLink, mimeType",
             )
             .execute()
         )
 
-        return json.dumps({"status": "success", "file": updated_file})
+        return json.dumps(
+            {"status": "success", "file": updated_file}, ensure_ascii=False
+        )
     except Exception as e:
         logger.error(f"Error renaming file: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 def _execute_ignoring_204_ssl_eof(
@@ -320,11 +345,12 @@ def google_drive_delete_file(file_id: str) -> str:
             {
                 "status": "success",
                 "message": f"File/Folder {resolved_file_id} successfully deleted.",
-            }
+            },
+            ensure_ascii=False,
         )
     except Exception as e:
         logger.error(f"Error deleting file: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -336,21 +362,39 @@ def google_drive_list_permissions(file_id: str) -> str:
     google_drive_remove_permission.
     """
     try:
+        resolved_file_id = _resolve_file_id(file_id)
         service = get_drive_service()
-        results = (
-            service.permissions()
-            .list(
-                fileId=_resolve_file_id(file_id),
-                supportsAllDrives=True,
-                fields="permissions(id, type, role, emailAddress, displayName)",
+        permissions: list[Any] = []
+        page_token: str | None = None
+        # For an item in a Shared Drive, Drive returns at most 100
+        # permissions per page when pageSize isn't set (a non-Shared-Drive
+        # item always returns everything in one page); follow
+        # nextPageToken so a heavily-shared Shared Drive folder isn't
+        # silently under-reported. Bounded so a misbehaving API response
+        # can't turn this into an infinite loop.
+        for _ in range(1000):
+            results = (
+                service.permissions()
+                .list(
+                    fileId=resolved_file_id,
+                    supportsAllDrives=True,
+                    pageToken=page_token,
+                    fields=(
+                        "nextPageToken, "
+                        "permissions(id, type, role, emailAddress, displayName)"
+                    ),
+                )
+                .execute()
             )
-            .execute()
-        )
+            permissions.extend(results.get("permissions", []))
+            page_token = results.get("nextPageToken")
+            if not page_token:
+                break
 
-        return _capped_permissions_response(results.get("permissions", []))
+        return _capped_list_response("permissions", permissions)
     except Exception as e:
         logger.error(f"Error listing permissions: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -393,10 +437,12 @@ def google_drive_share_file(
 
         permission = service.permissions().create(**create_kwargs).execute()
 
-        return json.dumps({"status": "success", "permission": permission})
+        return json.dumps(
+            {"status": "success", "permission": permission}, ensure_ascii=False
+        )
     except Exception as e:
         logger.error(f"Error sharing file: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -428,10 +474,12 @@ def google_drive_update_permission(file_id: str, permission_id: str, role: str) 
             .execute()
         )
 
-        return json.dumps({"status": "success", "permission": permission})
+        return json.dumps(
+            {"status": "success", "permission": permission}, ensure_ascii=False
+        )
     except Exception as e:
         logger.error(f"Error updating permission: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 @mcp.tool()
@@ -472,11 +520,12 @@ def google_drive_remove_permission(file_id: str, permission_id: str) -> str:
             {
                 "status": "success",
                 "message": f"Permission {resolved_permission_id} successfully removed.",
-            }
+            },
+            ensure_ascii=False,
         )
     except Exception as e:
         logger.error(f"Error removing permission: {e}")
-        return json.dumps({"status": "error", "message": str(e)})
+        return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
 if __name__ == "__main__":

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -29,14 +29,29 @@ mcp = FastMCP("google-drive-mcp")
 # A Drive/Docs/Sheets/Slides/Forms/Drawings id is always [a-zA-Z0-9_-]+.
 _DRIVE_ID_CHARS = re.compile(r"[a-zA-Z0-9_-]+")
 
-# Matches the id segment out of any of the common share-link shapes, since a
-# user (and therefore a model relaying the user's words) is far more likely
-# to hand over the URL they see in the browser than the bare id. The
-# optional "u/<n>/" branch tolerates the account-index segment Google
+# The share-link path prefixes _resolve_file_id recognizes, as one source
+# of truth for both patterns below -- so adding a new Drive-family surface
+# (this PR already added forms/drawings once) means editing this tuple
+# once, not two hand-copied regex literals that could silently drift apart.
+# The optional "u/<n>/" branch tolerates the account-index segment Google
 # inserts (e.g. ".../file/u/1/d/<id>/view") whenever more than one Google
 # account is signed into the browser -- see google_sheets.py's identical
-# (?:u/\d+/)? tolerance for the spreadsheets URL shape. "(?!e/)" after each
-# "d/" excludes the "published to web" link shape
+# (?:u/\d+/)? tolerance for the spreadsheets URL shape.
+_DRIVE_PATH_PREFIXES = (
+    r"file/(?:u/\d+/)?d",
+    r"folders",
+    r"document/(?:u/\d+/)?d",
+    r"spreadsheets/(?:u/\d+/)?d",
+    r"presentation/(?:u/\d+/)?d",
+    r"forms/(?:u/\d+/)?d",
+    r"drawings/(?:u/\d+/)?d",
+)
+_DRIVE_PATH_ALTERNATION = "|".join(_DRIVE_PATH_PREFIXES)
+
+# Matches the id segment out of any of the common share-link shapes, since a
+# user (and therefore a model relaying the user's words) is far more likely
+# to hand over the URL they see in the browser than the bare id. "(?!e/)"
+# after each "d/" excludes the "published to web" link shape
 # (".../d/e/<publish-id>/pubhtml"): that "e" is a literal path segment, not
 # part of the id, and the real Drive file id isn't present in that URL at
 # all -- the published-to-web token isn't a valid fileId, so this must not
@@ -45,25 +60,20 @@ _DRIVE_ID_CHARS = re.compile(r"[a-zA-Z0-9_-]+")
 # the whole raw string, so a match can't come from an unrelated substring
 # elsewhere in the URL (e.g. a query value).
 _DRIVE_PATH_ID_PATTERN = re.compile(
-    r"/(?:file/(?:u/\d+/)?d|folders|document/(?:u/\d+/)?d"
-    r"|spreadsheets/(?:u/\d+/)?d|presentation/(?:u/\d+/)?d"
-    r"|forms/(?:u/\d+/)?d|drawings/(?:u/\d+/)?d)/(?!e/)"
-    rf"({_DRIVE_ID_CHARS.pattern})"
+    rf"/(?:{_DRIVE_PATH_ALTERNATION})/(?!e/)({_DRIVE_ID_CHARS.pattern})"
 )
 
-# Same alternation as _DRIVE_PATH_ID_PATTERN but without the id-capturing
-# group or the "(?!e/)" exclusion -- used only to recognize that a path *is*
-# one of these share-link shapes at all, including the shapes deliberately
-# excluded above (e.g. the published-to-web "/d/e/" form). See
-# _resolve_file_id: a path matching this but not _DRIVE_PATH_ID_PATTERN was
-# recognized-and-rejected, not merely unrecognized, and must not fall
-# through to the "?id=" query fallback below -- otherwise the fallback would
-# re-derive an id from the very link shape the exclusion above refused.
-_DRIVE_PATH_SHAPE_PATTERN = re.compile(
-    r"/(?:file/(?:u/\d+/)?d|folders|document/(?:u/\d+/)?d"
-    r"|spreadsheets/(?:u/\d+/)?d|presentation/(?:u/\d+/)?d"
-    r"|forms/(?:u/\d+/)?d|drawings/(?:u/\d+/)?d)/"
-)
+# Same alternation as _DRIVE_PATH_ID_PATTERN, built from the same
+# _DRIVE_PATH_ALTERNATION so the two can't drift apart, but without the
+# id-capturing group or the "(?!e/)" exclusion -- used only to recognize
+# that a path *is* one of these share-link shapes at all, including the
+# shapes deliberately excluded above (e.g. the published-to-web "/d/e/"
+# form). See _resolve_file_id: a path matching this but not
+# _DRIVE_PATH_ID_PATTERN was recognized-and-rejected, not merely
+# unrecognized, and must not fall through to the "?id=" query fallback
+# below -- otherwise the fallback would re-derive an id from the very link
+# shape the exclusion above refused.
+_DRIVE_PATH_SHAPE_PATTERN = re.compile(rf"/(?:{_DRIVE_PATH_ALTERNATION})/")
 
 # Hosts _resolve_file_id treats as an authoritative Drive/Docs/Sheets/Slides
 # share link. Without this check, an untrusted URL (e.g. quoted inside a
@@ -114,8 +124,15 @@ def _resolve_file_id(file_id: str, field_name: str = "file_id") -> str:
 
     A real Drive id is always ``[a-zA-Z0-9_-]+`` (``_DRIVE_ID_CHARS``) and
     never contains "/" or "?", so only a value containing one of those
-    characters is even considered URL-shaped; a bare id short-circuits
-    immediately. Empty/whitespace-only input is rejected outright (matching
+    characters is even considered URL-shaped; anything else is the bare-id
+    case and is validated against that same character class before being
+    accepted (not returned unvalidated) -- otherwise a literal ``".."``
+    (no "/" or "?", so it never reaches the URL-handling code below at all)
+    would reach the Drive API as a request whose fileId is a dot-segment,
+    which normalization can collapse into an unrelated endpoint; this is
+    the same risk the "?id=" query fallback further down is validated
+    against, just reachable directly instead of via a URL. Empty/
+    whitespace-only input is rejected outright (matching
     ``require_clean_identifier``'s treatment of ``email``/``permission_id``
     elsewhere in this file) rather than silently resolving to ``""``, which
     would otherwise reach the Drive API as a request against the bare
@@ -154,6 +171,8 @@ def _resolve_file_id(file_id: str, field_name: str = "file_id") -> str:
     if not stripped:
         raise ValueError(f"{field_name} must be a non-empty id")
     if not re.search(r"[/?]", stripped):
+        if not _DRIVE_ID_CHARS.fullmatch(stripped):
+            raise ValueError(f"{field_name} must look like a Drive id")
         return stripped
     try:
         parsed = urlparse(stripped)

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -159,9 +159,18 @@ def google_drive_get_file_content(file_id: str, mime_type: str = "text/plain") -
         file_mime_type = file_metadata.get("mimeType", "")
 
         if "application/vnd.google-apps" in file_mime_type:
-            # Export Google Workspace document
+            # Export Google Workspace document. Sheets has no text/plain
+            # export format (only Docs/Slides do) and 400s on it, so the
+            # "text/plain" default -- reasonable for the far more common
+            # Docs/Slides case -- needs a per-type fallback for Sheets.
+            export_mime_type = mime_type
+            if (
+                file_mime_type == "application/vnd.google-apps.spreadsheet"
+                and mime_type == "text/plain"
+            ):
+                export_mime_type = "text/csv"
             request = service.files().export_media(
-                fileId=resolved_file_id, mimeType=mime_type
+                fileId=resolved_file_id, mimeType=export_mime_type
             )
         else:
             # Download regular file

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -214,6 +214,18 @@ def _resolve_file_id(file_id: str, field_name: str = "file_id") -> str:
             parsed = urlparse(f"//{stripped}")
     except ValueError:
         return stripped
+    if parsed.username is not None:
+        # A userinfo-bearing authority ("evil.com@drive.google.com", or the
+        # same thing with a literal backslash before the "@") is inherently
+        # ambiguous: Python's parser (correctly, per RFC 3986) treats
+        # everything before the last "@" as userinfo and resolves
+        # .hostname to the part after it, so this would pass the trusted-
+        # host check below -- but a WHATWG-based parser (e.g. a browser
+        # rendering this same string to a human, or a different URL
+        # consumer downstream) can disagree about which side is the real
+        # destination. Reject outright rather than trust a parse that
+        # other consumers of the same string might not agree with.
+        return stripped
     if parsed.hostname not in _DRIVE_URL_HOSTS:
         return stripped
     match = _DRIVE_PATH_ID_PATTERN.search(parsed.path)
@@ -225,6 +237,80 @@ def _resolve_file_id(file_id: str, field_name: str = "file_id") -> str:
     if query_id and _DRIVE_ID_CHARS.fullmatch(query_id[0]):
         return query_id[0]
     return stripped
+
+
+def _extract_resource_key(file_id: str) -> str | None:
+    """Return the ``resourcekey`` query parameter from a Drive share link,
+    or ``None`` if ``file_id`` isn't URL-shaped, isn't a trusted Drive host,
+    or carries no resourcekey.
+
+    Google added resourcekeys in 2021 for items shared via link before that
+    date: such an item's plain fileId alone now 404s on files.get/
+    permissions.list/files.export/etc. unless the request also carries an
+    "X-Goog-Drive-Resource-Keys: <fileId>/<resourceKey>" header (see
+    google_drive_download.py/kb.py for the same header elsewhere in this
+    codebase) -- there is no separate lookup API for a resourcekey; the only
+    place it's ever exposed is the "?resourcekey=" query parameter Drive
+    puts on the share link itself.
+
+    Deliberately a standalone function that re-derives the trusted-host/
+    userinfo checks rather than folding this into _resolve_file_id and
+    returning a tuple: _resolve_file_id's plain-string return is relied on
+    by every call site and by the full existing test suite, and widening
+    its contract for a value that's usually None (only pre-2021 link-shared
+    items carry a resourcekey at all) isn't worth that blast radius.
+    """
+    if not isinstance(file_id, str):
+        return None
+    stripped = file_id.strip()
+    if not re.search(r"[/?]", stripped):
+        return None
+    try:
+        parsed = urlparse(stripped)
+        if not parsed.netloc:
+            parsed = urlparse(f"//{stripped}")
+    except ValueError:
+        return None
+    if parsed.username is not None:
+        return None
+    if parsed.hostname not in _DRIVE_URL_HOSTS:
+        return None
+    resource_key = parse_qs(parsed.query).get("resourcekey")
+    if not resource_key or not _DRIVE_ID_CHARS.fullmatch(resource_key[0]):
+        return None
+    return resource_key[0]
+
+
+def _attach_resource_key(request: Any, file_id: str, resource_key: str | None) -> Any:
+    """Attach the X-Goog-Drive-Resource-Keys header to an unexecuted
+    googleapiclient request when ``resource_key`` is present, mirroring
+    google_drive_download.py's ``request.headers.update(...)`` pattern.
+    Returns ``request`` so the call site can build/attach/execute in one
+    expression.
+    """
+    if resource_key:
+        request.headers["X-Goog-Drive-Resource-Keys"] = f"{file_id}/{resource_key}"
+    return request
+
+
+def _require_drive_id(value: str, field_name: str) -> str:
+    """Validate a raw (non-URL) Drive id such as a permission_id: non-empty,
+    no surrounding whitespace (require_clean_identifier), and restricted to
+    the same character class real Drive ids use (_DRIVE_ID_CHARS).
+
+    Closes the same dot-segment risk _resolve_file_id's bare-id path
+    guards against, for an id that (unlike file_id) never goes through URL
+    resolution at all: require_clean_identifier alone accepts ".."
+    (non-empty, no surrounding whitespace), and googleapiclient does not
+    percent-encode "." before interpolating an id into a URL path segment
+    -- an unvalidated permission_id="..\" reaches the API as a literal
+    dot-segment, which normalization can collapse a permission-removal
+    request into the file's own delete/get endpoint instead.
+    """
+    require_clean_identifier(value, field_name)
+    if not _DRIVE_ID_CHARS.fullmatch(value):
+        raise ValueError(f"{field_name} must look like a Drive id")
+    return value
 
 
 def _require_share_role(role: str) -> str:
@@ -275,13 +361,26 @@ def _capped_response(
 
 
 def _capped_list_response(
-    field_name: str, items: list[Any], *, truncated: bool = False
+    field_name: str,
+    items: list[Any],
+    *,
+    truncated: bool = False,
+    next_page_token: str | None = None,
 ) -> str:
     def _build(items: list[Any], truncated: bool) -> str:
-        return json.dumps(
-            {"status": "success", field_name: items, "truncated": truncated},
-            ensure_ascii=False,
-        )
+        response: dict[str, Any] = {
+            "status": "success",
+            field_name: items,
+            "truncated": truncated,
+        }
+        if next_page_token:
+            # Independent of the halving loop's own `truncated`/`items`
+            # cutting -- a caller-resumable page cursor from the upstream
+            # API, not something local truncation ever produces or
+            # invalidates, so it's attached once here rather than threaded
+            # through render/halve.
+            response["next_page_token"] = next_page_token
+        return json.dumps(response, ensure_ascii=False)
 
     return _capped_response(_build, items, truncated)
 
@@ -378,16 +477,15 @@ def google_drive_get_file_content(file_id: str, mime_type: str = "text/plain") -
     """
     try:
         resolved_file_id = _resolve_file_id(file_id)
+        resource_key = _extract_resource_key(file_id)
         service = get_drive_service()
-        file_metadata = (
-            service.files()
-            .get(
-                fileId=resolved_file_id,
-                supportsAllDrives=True,
-                fields="id, name, mimeType",
-            )
-            .execute()
+        get_request = service.files().get(
+            fileId=resolved_file_id,
+            supportsAllDrives=True,
+            fields="id, name, mimeType",
         )
+        _attach_resource_key(get_request, resolved_file_id, resource_key)
+        file_metadata = get_request.execute()
         file_mime_type = file_metadata.get("mimeType", "")
 
         if file_mime_type in _GOOGLE_APPS_TYPES_WITH_NO_EXPORT:
@@ -431,6 +529,7 @@ def google_drive_get_file_content(file_id: str, mime_type: str = "text/plain") -
             request = service.files().get_media(
                 fileId=resolved_file_id, supportsAllDrives=True
             )
+        _attach_resource_key(request, resolved_file_id, resource_key)
 
         fh = io.BytesIO()
         downloader = MediaIoBaseDownload(fh, request)
@@ -537,19 +636,18 @@ def google_drive_rename_file(file_id: str, new_name: str) -> str:
     """
     try:
         resolved_file_id = _resolve_file_id(file_id)
+        resource_key = _extract_resource_key(file_id)
         service = get_drive_service()
         file_metadata = {"name": new_name}
 
-        updated_file = (
-            service.files()
-            .update(
-                fileId=resolved_file_id,
-                body=file_metadata,
-                supportsAllDrives=True,
-                fields="id, name, webViewLink, mimeType",
-            )
-            .execute()
+        update_request = service.files().update(
+            fileId=resolved_file_id,
+            body=file_metadata,
+            supportsAllDrives=True,
+            fields="id, name, webViewLink, mimeType",
         )
+        _attach_resource_key(update_request, resolved_file_id, resource_key)
+        updated_file = update_request.execute()
 
         return json.dumps(
             {"status": "success", "file": updated_file}, ensure_ascii=False
@@ -633,19 +731,26 @@ def google_drive_delete_file(file_id: str) -> str:
     """
     try:
         resolved_file_id = _resolve_file_id(file_id)
+        resource_key = _extract_resource_key(file_id)
         service = get_drive_service()
-        _execute_ignoring_204_ssl_eof(
-            lambda: (
-                service.files()
-                .delete(fileId=resolved_file_id, supportsAllDrives=True)
-                .execute()
-            ),
-            lambda: (
-                service.files()
-                .get(fileId=resolved_file_id, supportsAllDrives=True)
-                .execute()
-            ),
-        )
+
+        def _delete() -> Any:
+            request = service.files().delete(
+                fileId=resolved_file_id, supportsAllDrives=True
+            )
+            return _attach_resource_key(
+                request, resolved_file_id, resource_key
+            ).execute()
+
+        def _verify_deleted() -> Any:
+            request = service.files().get(
+                fileId=resolved_file_id, supportsAllDrives=True
+            )
+            return _attach_resource_key(
+                request, resolved_file_id, resource_key
+            ).execute()
+
+        _execute_ignoring_204_ssl_eof(_delete, _verify_deleted)
 
         return json.dumps(
             {
@@ -660,20 +765,27 @@ def google_drive_delete_file(file_id: str) -> str:
 
 
 @mcp.tool()
-def google_drive_list_permissions(file_id: str) -> str:
+def google_drive_list_permissions(file_id: str, page_token: str | None = None) -> str:
     """
     List who currently has access to a Drive file or folder (owner,
     editors, commenters, viewers) and their permission ids. Use the
     returned permission ids with google_drive_update_permission or
     google_drive_remove_permission.
+    For an item in a Shared Drive with more collaborators than fit in one
+    response, the result includes a "next_page_token" -- pass it back as
+    this call's page_token to continue listing from where it left off
+    instead of silently missing the rest.
+    A permission whose "permissionDetails" marks it "inherited": true comes
+    from a parent folder, not this item directly -- it can't be changed or
+    removed here; do that on the folder it's inherited from instead.
     """
     try:
         resolved_file_id = _resolve_file_id(file_id)
+        resource_key = _extract_resource_key(file_id)
         service = get_drive_service()
         max_output_length = get_tool_max_output_length()
         permissions: list[Any] = []
         approx_length = 0
-        page_token: str | None = None
         # For an item in a Shared Drive, Drive returns at most 100
         # permissions per page when pageSize isn't set (a non-Shared-Drive
         # item always returns everything in one page); follow
@@ -681,19 +793,19 @@ def google_drive_list_permissions(file_id: str) -> str:
         # silently under-reported. Bounded so a misbehaving API response
         # can't turn this into an infinite loop.
         for _ in range(_MAX_PERMISSION_LIST_PAGES):
-            results = (
-                service.permissions()
-                .list(
-                    fileId=resolved_file_id,
-                    supportsAllDrives=True,
-                    pageToken=page_token,
-                    fields=(
-                        "nextPageToken, "
-                        "permissions(id, type, role, emailAddress, displayName)"
-                    ),
-                )
-                .execute()
+            list_request = service.permissions().list(
+                fileId=resolved_file_id,
+                supportsAllDrives=True,
+                pageToken=page_token,
+                fields=(
+                    "nextPageToken, "
+                    "permissions(id, type, role, emailAddress, displayName, "
+                    "permissionDetails(permissionType, role, inherited, "
+                    "inheritedFrom))"
+                ),
             )
+            _attach_resource_key(list_request, resolved_file_id, resource_key)
+            results = list_request.execute()
             new_permissions = results.get("permissions", [])
             permissions.extend(new_permissions)
             # _capped_list_response below will halve this back down to fit
@@ -728,9 +840,21 @@ def google_drive_list_permissions(file_id: str) -> str:
             # may still exist that was never followed, so this can't
             # honestly report a complete list even if the permissions
             # collected so far happen to still fit under the output cap.
-            return _capped_list_response("permissions", permissions, truncated=True)
+            return _capped_list_response(
+                "permissions",
+                permissions,
+                truncated=True,
+                next_page_token=page_token,
+            )
 
-        return _capped_list_response("permissions", permissions)
+        # page_token here is whatever the last page's nextPageToken was
+        # (None if that page was the last one) -- surfacing it lets a
+        # caller resume an early stop (the size-cap break above) from
+        # exactly where this call left off, rather than losing the rest of
+        # the collaborator list the way a silent truncation would.
+        return _capped_list_response(
+            "permissions", permissions, next_page_token=page_token
+        )
     except Exception as e:
         logger.error(f"Error listing permissions: {e}")
         return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
@@ -767,6 +891,7 @@ def google_drive_share_file(
         if not _EMAIL_PATTERN.match(email):
             raise ValueError("email must be a valid email address")
         resolved_file_id = _resolve_file_id(file_id)
+        resource_key = _extract_resource_key(file_id)
 
         service = get_drive_service()
         # The API rejects emailMessage outright when sendNotificationEmail is
@@ -781,7 +906,9 @@ def google_drive_share_file(
         if send_notification and message is not None:
             create_kwargs["emailMessage"] = message
 
-        permission = service.permissions().create(**create_kwargs).execute()
+        create_request = service.permissions().create(**create_kwargs)
+        _attach_resource_key(create_request, resolved_file_id, resource_key)
+        permission = create_request.execute()
 
         return json.dumps(
             {"status": "success", "permission": permission}, ensure_ascii=False
@@ -803,22 +930,19 @@ def google_drive_update_permission(file_id: str, permission_id: str, role: str) 
     try:
         _require_share_role(role)
         resolved_file_id = _resolve_file_id(file_id)
-        resolved_permission_id = require_clean_identifier(
-            permission_id, "permission_id"
-        )
+        resource_key = _extract_resource_key(file_id)
+        resolved_permission_id = _require_drive_id(permission_id, "permission_id")
 
         service = get_drive_service()
-        permission = (
-            service.permissions()
-            .update(
-                fileId=resolved_file_id,
-                permissionId=resolved_permission_id,
-                body={"role": role},
-                supportsAllDrives=True,
-                fields="id, type, role, emailAddress, displayName",
-            )
-            .execute()
+        update_request = service.permissions().update(
+            fileId=resolved_file_id,
+            permissionId=resolved_permission_id,
+            body={"role": role},
+            supportsAllDrives=True,
+            fields="id, type, role, emailAddress, displayName",
         )
+        _attach_resource_key(update_request, resolved_file_id, resource_key)
+        permission = update_request.execute()
 
         return json.dumps(
             {"status": "success", "permission": permission}, ensure_ascii=False
@@ -837,30 +961,31 @@ def google_drive_remove_permission(file_id: str, permission_id: str) -> str:
     """
     try:
         resolved_file_id = _resolve_file_id(file_id)
-        resolved_permission_id = require_clean_identifier(
-            permission_id, "permission_id"
-        )
+        resource_key = _extract_resource_key(file_id)
+        resolved_permission_id = _require_drive_id(permission_id, "permission_id")
         service = get_drive_service()
-        _execute_ignoring_204_ssl_eof(
-            lambda: (
-                service.permissions()
-                .delete(
-                    fileId=resolved_file_id,
-                    permissionId=resolved_permission_id,
-                    supportsAllDrives=True,
-                )
-                .execute()
-            ),
-            lambda: (
-                service.permissions()
-                .get(
-                    fileId=resolved_file_id,
-                    permissionId=resolved_permission_id,
-                    supportsAllDrives=True,
-                )
-                .execute()
-            ),
-        )
+
+        def _delete() -> Any:
+            request = service.permissions().delete(
+                fileId=resolved_file_id,
+                permissionId=resolved_permission_id,
+                supportsAllDrives=True,
+            )
+            return _attach_resource_key(
+                request, resolved_file_id, resource_key
+            ).execute()
+
+        def _verify_deleted() -> Any:
+            request = service.permissions().get(
+                fileId=resolved_file_id,
+                permissionId=resolved_permission_id,
+                supportsAllDrives=True,
+            )
+            return _attach_resource_key(
+                request, resolved_file_id, resource_key
+            ).execute()
+
+        _execute_ignoring_204_ssl_eof(_delete, _verify_deleted)
 
         return json.dumps(
             {

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -91,9 +91,28 @@ _EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
 def _resolve_file_id(file_id: str) -> str:
     if isinstance(file_id, str):
-        parsed = urlparse(file_id.strip())
-        if parsed.scheme and parsed.hostname not in _DRIVE_URL_HOSTS:
-            return file_id.strip()
+        stripped = file_id.strip()
+        # A real Drive id is always [a-zA-Z0-9_-]+ and never contains "/"
+        # or "?", so only a value containing one of those characters can be
+        # a URL shape in the first place -- only those go through the host
+        # check. This matters because urlparse only populates
+        # .scheme/.hostname for a string with an explicit "scheme://" (or a
+        # leading "//") prefix: a scheme-less "evil.com/file/d/<id>/view"
+        # (at least as natural a shape for an attacker to plant in text an
+        # agent reads as a full https:// URL) would otherwise report an
+        # empty scheme/hostname and slip straight past a bare
+        # urlparse(stripped) check into the host-agnostic pattern match
+        # below -- exactly the bypass the host allowlist exists to close.
+        # Prepending "//" when there's no "//" already present makes
+        # urlparse treat a bare "host/path" or "host?query" the same way
+        # it treats an explicit "//host/path" protocol-relative URL.
+        if re.search(r"[/?]", stripped):
+            try:
+                parsed = urlparse(stripped if "//" in stripped else f"//{stripped}")
+            except ValueError:
+                return stripped
+            if parsed.hostname not in _DRIVE_URL_HOSTS:
+                return stripped
     return resolve_id_from_url(file_id, _DRIVE_URL_ID_PATTERN, "file_id")
 
 
@@ -103,36 +122,39 @@ def _require_share_role(role: str) -> str:
     return role
 
 
-def _capped_list_response(field_name: str, items: list[Any]) -> str:
-    """Build the success payload, halving ``items`` until it fits the
-    platform's output limit -- mirrors deputy.py's/salesforce.py's
+def _capped_response(build: Callable[[Any, bool], str], value: Any) -> str:
+    """Halve ``value`` (a list or a string) until ``build(value, truncated)``
+    fits the platform's output limit -- mirrors deputy.py's/salesforce.py's
     _success_with_capped_list. There is no cursor to resume from here, so
-    entries dropped this way are gone for this call, not just this page.
+    entries/content dropped this way are gone for this call, not just this
+    page. Shared by _capped_list_response and _capped_content_response so a
+    future change to the halving strategy only has one loop to update.
     """
     max_output_length = get_tool_max_output_length()
+    truncated = False
+    response = build(value, truncated)
+    while len(response) > max_output_length and value:
+        value = value[: len(value) // 2]
+        truncated = True
+        response = build(value, truncated)
+    return response
 
+
+def _capped_list_response(field_name: str, items: list[Any]) -> str:
     def _build(items: list[Any], truncated: bool) -> str:
         return json.dumps(
             {"status": "success", field_name: items, "truncated": truncated},
             ensure_ascii=False,
         )
 
-    truncated = False
-    response = _build(items, truncated)
-    while len(response) > max_output_length and items:
-        items = items[: len(items) // 2]
-        truncated = True
-        response = _build(items, truncated)
-    return response
+    return _capped_response(_build, items)
 
 
 def _capped_content_response(file_metadata: dict[str, Any], content: str) -> str:
-    """Build the success payload, halving ``content`` until it fits the
-    platform's output limit -- same halving idea as _capped_list_response,
-    applied to a single string instead of a list since downloaded/exported
-    file content has no natural list of records to shrink.
+    """Same halving idea as _capped_list_response, applied to a single
+    string instead of a list since downloaded/exported file content has no
+    natural list of records to shrink.
     """
-    max_output_length = get_tool_max_output_length()
 
     def _build(content: str, truncated: bool) -> str:
         return json.dumps(
@@ -145,13 +167,7 @@ def _capped_content_response(file_metadata: dict[str, Any], content: str) -> str
             ensure_ascii=False,
         )
 
-    truncated = False
-    response = _build(content, truncated)
-    while len(response) > max_output_length and content:
-        content = content[: len(content) // 2]
-        truncated = True
-        response = _build(content, truncated)
-    return response
+    return _capped_response(_build, content)
 
 
 def get_drive_service() -> Any:
@@ -456,6 +472,7 @@ def google_drive_list_permissions(file_id: str) -> str:
     try:
         resolved_file_id = _resolve_file_id(file_id)
         service = get_drive_service()
+        max_output_length = get_tool_max_output_length()
         permissions: list[Any] = []
         page_token: str | None = None
         # For an item in a Shared Drive, Drive returns at most 100
@@ -481,6 +498,13 @@ def google_drive_list_permissions(file_id: str) -> str:
             permissions.extend(results.get("permissions", []))
             page_token = results.get("nextPageToken")
             if not page_token:
+                break
+            # _capped_list_response below will halve this back down to fit
+            # the output limit regardless, so once there's already enough
+            # data to exceed it, fetching further pages is pure waste: more
+            # blocking network round-trips for permissions that get thrown
+            # away immediately after.
+            if len(json.dumps(permissions)) > max_output_length:
                 break
 
         return _capped_list_response("permissions", permissions)

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -6,7 +6,7 @@ import os
 import re
 from collections.abc import Callable
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import ParseResult, parse_qs, urlparse
 
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build  # type: ignore[import-not-found]
@@ -150,6 +150,62 @@ _TEXT_PLAIN_EXPORT_FALLBACK = {
 }
 
 
+def _parse_trusted_drive_url(value: str) -> ParseResult | None:
+    """Return the parsed URL if ``value`` is URL-shaped, parses cleanly,
+    carries no userinfo ambiguity, and its host is in _DRIVE_URL_HOSTS --
+    otherwise ``None``.
+
+    This is the one place that decides "is this a URL this connector
+    trusts as its own Drive share link", shared by _resolve_file_id and
+    _extract_resource_key so that decision can't drift between them.
+    Before this was factored out, the two functions each carried their
+    own copy of this logic, and they *did* silently disagree: a
+    published-to-web "/d/e/" link that _resolve_file_id correctly refuses
+    to resolve an id for was nonetheless treated as trusted enough by
+    _extract_resource_key to pull a resourcekey out of -- the id-shape
+    exclusion lived only in _resolve_file_id's copy. Sharing this parse
+    step means a future fix to the trust decision (a new excluded shape,
+    another parser-differential case, etc.) applies to both call sites at
+    once instead of needing to be found and re-applied twice.
+
+    urlparse only populates ``.scheme``/``.netloc`` for a string with an
+    explicit "scheme://" prefix (or at least a leading "//"): a scheme-less
+    "evil.com/file/d/<id>/view" (at least as natural a shape for an
+    attacker to plant in text an agent reads as a full https:// URL) would
+    otherwise parse with no netloc and slip past a naive urlparse(value)
+    check. Retrying with a "//" prefix only when the *first* parse found no
+    netloc (rather than keying off whether "//" occurs anywhere in the
+    string) correctly handles a scheme-less link that itself contains a
+    nested "https://" further in, e.g. in a "continue=" query value.
+
+    A userinfo-bearing authority ("evil.com@drive.google.com", or the same
+    thing with a literal backslash before the "@") is inherently
+    ambiguous: Python's parser (correctly, per RFC 3986) treats everything
+    before the last "@" as userinfo and resolves .hostname to the part
+    after it, so this would pass the trusted-host check below -- but a
+    WHATWG-based parser (e.g. a browser rendering this same string to a
+    human, or a different URL consumer downstream) can disagree about
+    which side is the real destination. Reject outright rather than trust
+    a parse that other consumers of the same string might not agree with.
+    """
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    if not re.search(r"[/?]", stripped):
+        return None
+    try:
+        parsed = urlparse(stripped)
+        if not parsed.netloc:
+            parsed = urlparse(f"//{stripped}")
+    except ValueError:
+        return None
+    if parsed.username is not None:
+        return None
+    if parsed.hostname not in _DRIVE_URL_HOSTS:
+        return None
+    return parsed
+
+
 def _resolve_file_id(file_id: str, field_name: str = "file_id") -> str:
     """Return the id captured out of a Drive/Docs/Sheets/Slides share link,
     or ``file_id`` itself (stripped) when it's already a bare id -- or, for
@@ -172,32 +228,22 @@ def _resolve_file_id(file_id: str, field_name: str = "file_id") -> str:
     would otherwise reach the Drive API as a request against the bare
     ``.../files/`` collection endpoint instead of a specific file.
 
-    urlparse only populates ``.scheme``/``.netloc`` for a string with an
-    explicit "scheme://" prefix (or at least a leading "//"): a scheme-less
-    "evil.com/file/d/<id>/view" (at least as natural a shape for an
-    attacker to plant in text an agent reads as a full https:// URL) would
-    otherwise parse with no netloc and slip past a naive urlparse(value)
-    check. Retrying with a "//" prefix only when the *first* parse found no
-    netloc (rather than keying off whether "//" occurs anywhere in the
-    string) correctly handles a scheme-less link that itself contains a
-    nested "https://" further in, e.g. in a "continue=" query value.
-
-    Once the host is confirmed trusted, the id is extracted from the
-    parsed URL's own ``.path``/``.query`` -- not searched over the whole
-    raw string -- so a URL whose overall host is allowed but whose query
-    *value* merely contains a matching shape (".../search?q=/file/d/<id>")
-    can't have that unrelated substring extracted as if it were the URL's
-    own resource id. A path recognized as a share-link shape that
-    _DRIVE_PATH_ID_PATTERN deliberately excludes (the published-to-web
-    "/d/e/" form) is rejected outright rather than falling through to the
-    "?id=" query check -- otherwise appending "?id=<anything>" to an
-    excluded link would trivially re-derive an id the path exclusion just
-    refused to give up. A query "id=" value is validated against the same
-    id character class as the path form: unlike a path segment, Drive's own
-    client library does not percent-encode "." before sending it, so an
-    unvalidated "id=.." would reach the API as a literal ".." path segment,
-    which dot-segment normalization can collapse into an unrelated
-    endpoint.
+    Once the host is confirmed trusted (see _parse_trusted_drive_url), the
+    id is extracted from the parsed URL's own ``.path``/``.query`` -- not
+    searched over the whole raw string -- so a URL whose overall host is
+    allowed but whose query *value* merely contains a matching shape
+    (".../search?q=/file/d/<id>") can't have that unrelated substring
+    extracted as if it were the URL's own resource id. A path recognized
+    as a share-link shape that _DRIVE_PATH_ID_PATTERN deliberately
+    excludes (the published-to-web "/d/e/" form) is rejected outright
+    rather than falling through to the "?id=" query check -- otherwise
+    appending "?id=<anything>" to an excluded link would trivially
+    re-derive an id the path exclusion just refused to give up. A query
+    "id=" value is validated against the same id character class as the
+    path form: unlike a path segment, Drive's own client library does not
+    percent-encode "." before sending it, so an unvalidated "id=.." would
+    reach the API as a literal ".." path segment, which dot-segment
+    normalization can collapse into an unrelated endpoint.
     """
     if not isinstance(file_id, str):
         raise ValueError(f"{field_name} must be a string")
@@ -205,28 +251,17 @@ def _resolve_file_id(file_id: str, field_name: str = "file_id") -> str:
     if not stripped:
         raise ValueError(f"{field_name} must be a non-empty id")
     if not re.search(r"[/?]", stripped):
-        if not _DRIVE_ID_CHARS.fullmatch(stripped):
-            raise ValueError(f"{field_name} must look like a Drive id")
-        return stripped
-    try:
-        parsed = urlparse(stripped)
-        if not parsed.netloc:
-            parsed = urlparse(f"//{stripped}")
-    except ValueError:
-        return stripped
-    if parsed.username is not None:
-        # A userinfo-bearing authority ("evil.com@drive.google.com", or the
-        # same thing with a literal backslash before the "@") is inherently
-        # ambiguous: Python's parser (correctly, per RFC 3986) treats
-        # everything before the last "@" as userinfo and resolves
-        # .hostname to the part after it, so this would pass the trusted-
-        # host check below -- but a WHATWG-based parser (e.g. a browser
-        # rendering this same string to a human, or a different URL
-        # consumer downstream) can disagree about which side is the real
-        # destination. Reject outright rather than trust a parse that
-        # other consumers of the same string might not agree with.
-        return stripped
-    if parsed.hostname not in _DRIVE_URL_HOSTS:
+        # Shares _require_drive_id's character-class check rather than
+        # repeating it inline, so file_id's bare-id validation and
+        # permission_id's validation can't silently drift apart the way
+        # _resolve_file_id/_extract_resource_key's trust logic once did
+        # (see _parse_trusted_drive_url). require_clean_identifier's own
+        # empty/whitespace check is a no-op here -- stripped is already
+        # non-empty and already stripped -- so the only error this can
+        # raise is the character-class one.
+        return _require_drive_id(stripped, field_name)
+    parsed = _parse_trusted_drive_url(stripped)
+    if parsed is None:
         return stripped
     match = _DRIVE_PATH_ID_PATTERN.search(parsed.path)
     if match:
@@ -253,32 +288,45 @@ def _extract_resource_key(file_id: str) -> str | None:
     place it's ever exposed is the "?resourcekey=" query parameter Drive
     puts on the share link itself.
 
-    Deliberately a standalone function that re-derives the trusted-host/
-    userinfo checks rather than folding this into _resolve_file_id and
-    returning a tuple: _resolve_file_id's plain-string return is relied on
-    by every call site and by the full existing test suite, and widening
-    its contract for a value that's usually None (only pre-2021 link-shared
+    Shares _parse_trusted_drive_url with _resolve_file_id rather than
+    keeping its own copy of the host/userinfo trust logic, and applies the
+    same "/d/e/" published-to-web path-shape exclusion _resolve_file_id
+    enforces (a share-link shape with no real Drive fileId in it at all --
+    _resolve_file_id refuses to resolve an id for it, so a resourcekey
+    extracted here would only ever be attached to a request whose fileId
+    is that same untrusted, unresolved raw string) -- so the two
+    functions' trust decisions for identical input can't silently diverge
+    the way they did before this was factored out. Kept as its own
+    function rather than folding into _resolve_file_id and returning a
+    tuple: _resolve_file_id's plain-string return is relied on by every
+    call site and by the full existing test suite, and widening its
+    contract for a value that's usually None (only pre-2021 link-shared
     items carry a resourcekey at all) isn't worth that blast radius.
     """
-    if not isinstance(file_id, str):
+    parsed = _parse_trusted_drive_url(file_id)
+    if parsed is None:
         return None
-    stripped = file_id.strip()
-    if not re.search(r"[/?]", stripped):
-        return None
-    try:
-        parsed = urlparse(stripped)
-        if not parsed.netloc:
-            parsed = urlparse(f"//{stripped}")
-    except ValueError:
-        return None
-    if parsed.username is not None:
-        return None
-    if parsed.hostname not in _DRIVE_URL_HOSTS:
+    if _DRIVE_PATH_SHAPE_PATTERN.search(
+        parsed.path
+    ) and not _DRIVE_PATH_ID_PATTERN.search(parsed.path):
         return None
     resource_key = parse_qs(parsed.query).get("resourcekey")
-    if not resource_key or not _DRIVE_ID_CHARS.fullmatch(resource_key[0]):
+    if not resource_key:
         return None
-    return resource_key[0]
+    candidate = resource_key[0]
+    # A real resourcekey isn't restricted to _DRIVE_ID_CHARS's fileId
+    # charset -- kb.py's own CloudFile.resourceKey field (api/kb.py:3319)
+    # deliberately validates only `^[^\r\n]*$`, rejecting nothing but
+    # CR/LF (header-injection safety) rather than inventing a narrower
+    # grammar; tests/web/api/test_kb_dir.py's
+    # test_kb_ingest_cloud_accepts_punctuation_in_drive_identifiers asserts
+    # exactly this for a resourceKey containing a colon. Matching that
+    # precedent here avoids silently discarding a legitimate resourcekey
+    # (and getting a confusing 404) just because it contains a character
+    # this connector didn't anticipate.
+    if not candidate or "\r" in candidate or "\n" in candidate:
+        return None
+    return candidate
 
 
 def _attach_resource_key(request: Any, file_id: str, resource_key: str | None) -> Any:
@@ -383,6 +431,79 @@ def _capped_list_response(
         return json.dumps(response, ensure_ascii=False)
 
     return _capped_response(_build, items, truncated)
+
+
+def _capped_permissions_response(
+    pages: list[tuple[str | None, list[Any]]], next_page_token: str | None
+) -> str:
+    """Build google_drive_list_permissions' response, shrinking (if
+    needed to fit the output cap) by dropping whole pages from the tail
+    before ever cutting an individual page's items.
+
+    A flat item-level cut (_capped_list_response's default halving)
+    can't be paired safely with a resumable page token: Drive's
+    ``pageToken`` only resumes at a page boundary, so if size-capping
+    dropped items from *inside* an already-fetched page, a
+    next_page_token that only ever points past whole pages would skip
+    those dropped items forever, even though they were already fetched
+    from the API this call. Dropping only whole pages avoids that: the
+    first dropped page's own start token is always available as the
+    resume point, so a caller who follows next_page_token is guaranteed
+    to see every permission again (at worst once more, never zero
+    times).
+
+    If even the single earliest remaining page doesn't fit under the cap
+    on its own, this falls back to _capped_list_response's plain
+    item-level cut of just that page's contents -- and deliberately never
+    passes a next_page_token through to it in that case. This isn't an
+    oversight: at that point every candidate token is unsafe to offer --
+    ``pages[1][0]`` (the next already-fetched page's start) would skip
+    whatever this fallback had to cut from the *current* page, and this
+    page's own start token would just refetch the same too-big page
+    again. A cut inside one page has no page-granular resume point that
+    doesn't silently skip something, so omitting the token entirely is
+    the honest answer, not a simplification worth "fixing" by wiring one
+    of those back in.
+
+    ``pages`` is the ordered list of ``(start_token, items)`` fetched
+    this call; ``next_page_token`` is the token for whatever page comes
+    after the LAST page in ``pages`` (``None`` if that was Drive's last
+    page).
+    """
+    max_output_length = get_tool_max_output_length()
+
+    def _token_after(kept: int) -> str | None:
+        return next_page_token if kept == len(pages) else pages[kept][0]
+
+    def _render(items: list[Any], truncated: bool, token: str | None) -> str:
+        response: dict[str, Any] = {
+            "status": "success",
+            "permissions": items,
+            "truncated": truncated,
+        }
+        if token:
+            response["next_page_token"] = token
+        return json.dumps(response, ensure_ascii=False)
+
+    truncated = next_page_token is not None
+    kept = len(pages)
+    permissions = [item for _, items in pages for item in items]
+    response = _render(permissions, truncated, _token_after(kept))
+
+    while len(response) > max_output_length and kept > 1:
+        kept -= 1
+        truncated = True
+        permissions = [item for _, items in pages[:kept] for item in items]
+        response = _render(permissions, truncated, _token_after(kept))
+
+    if len(response) > max_output_length:
+        # Only the earliest remaining page is left and it alone doesn't
+        # fit -- fall through to the same plain item-level halving every
+        # other capped list response uses (no page-granular token to
+        # offer here regardless, see the docstring above).
+        response = _capped_list_response("permissions", permissions, truncated=True)
+
+    return response
 
 
 def _halve_base64(value: str) -> str:
@@ -572,8 +693,12 @@ def google_drive_create_file(
     """
     try:
         file_metadata: dict[str, Any] = {"name": name, "mimeType": mime_type}
+        resolved_parent_id = None
+        parent_resource_key = None
         if parent_id:
-            file_metadata["parents"] = [_resolve_file_id(parent_id, "parent_id")]
+            resolved_parent_id = _resolve_file_id(parent_id, "parent_id")
+            parent_resource_key = _extract_resource_key(parent_id)
+            file_metadata["parents"] = [resolved_parent_id]
 
         service = get_drive_service()
         fh = io.BytesIO(content.encode("utf-8"))
@@ -582,16 +707,17 @@ def google_drive_create_file(
         upload_mime_type = "text/plain" if "google-apps" in mime_type else mime_type
         media = MediaIoBaseUpload(fh, mimetype=upload_mime_type, resumable=True)
 
-        file = (
-            service.files()
-            .create(
-                body=file_metadata,
-                media_body=media,
-                supportsAllDrives=True,
-                fields="id, name, webViewLink, mimeType",
-            )
-            .execute()
+        create_request = service.files().create(
+            body=file_metadata,
+            media_body=media,
+            supportsAllDrives=True,
+            fields="id, name, webViewLink, mimeType",
         )
+        if resolved_parent_id is not None:
+            _attach_resource_key(
+                create_request, resolved_parent_id, parent_resource_key
+            )
+        file = create_request.execute()
 
         return json.dumps({"status": "success", "file": file}, ensure_ascii=False)
     except Exception as e:
@@ -609,19 +735,24 @@ def google_drive_create_folder(name: str, parent_id: str | None = None) -> str:
             "name": name,
             "mimeType": "application/vnd.google-apps.folder",
         }
+        resolved_parent_id = None
+        parent_resource_key = None
         if parent_id:
-            file_metadata["parents"] = [_resolve_file_id(parent_id, "parent_id")]
+            resolved_parent_id = _resolve_file_id(parent_id, "parent_id")
+            parent_resource_key = _extract_resource_key(parent_id)
+            file_metadata["parents"] = [resolved_parent_id]
 
         service = get_drive_service()
-        folder = (
-            service.files()
-            .create(
-                body=file_metadata,
-                supportsAllDrives=True,
-                fields="id, name, webViewLink, mimeType",
-            )
-            .execute()
+        create_request = service.files().create(
+            body=file_metadata,
+            supportsAllDrives=True,
+            fields="id, name, webViewLink, mimeType",
         )
+        if resolved_parent_id is not None:
+            _attach_resource_key(
+                create_request, resolved_parent_id, parent_resource_key
+            )
+        folder = create_request.execute()
 
         return json.dumps({"status": "success", "folder": folder}, ensure_ascii=False)
     except Exception as e:
@@ -723,11 +854,11 @@ def _execute_ignoring_204_ssl_eof(
 @mcp.tool()
 def google_drive_delete_file(file_id: str) -> str:
     """
-    Delete a file or folder in Google Drive.
+    Delete a file or folder in Google Drive. This is an external action --
+    confirm with the user before calling it.
     Note: this skips the trash and permanently deletes the file -- there is
-    no separate "move to trash" tool on this connector, so confirm with the
-    user that permanent deletion (not just removing it from view) is what
-    they want before calling this.
+    no separate "move to trash" tool on this connector, so make sure
+    permanent deletion (not just removing it from view) is what they want.
     """
     try:
         resolved_file_id = _resolve_file_id(file_id)
@@ -784,8 +915,17 @@ def google_drive_list_permissions(file_id: str, page_token: str | None = None) -
         resource_key = _extract_resource_key(file_id)
         service = get_drive_service()
         max_output_length = get_tool_max_output_length()
-        permissions: list[Any] = []
+        # Each fetched page is kept alongside the token that fetched it
+        # (see _capped_permissions_response): if the response must shrink
+        # to fit the output cap, only whole pages are dropped from the
+        # tail, so the surfaced next_page_token always resumes at a page
+        # boundary Drive will refetch from scratch -- never at a point
+        # *inside* a page whose later items a flat item-level cut
+        # (_capped_list_response's default halving) would have silently
+        # discarded after page_token had already advanced past them.
+        pages: list[tuple[str | None, list[Any]]] = []
         approx_length = 0
+        current_page_token = page_token
         # For an item in a Shared Drive, Drive returns at most 100
         # permissions per page when pageSize isn't set (a non-Shared-Drive
         # item always returns everything in one page); follow
@@ -796,7 +936,7 @@ def google_drive_list_permissions(file_id: str, page_token: str | None = None) -
             list_request = service.permissions().list(
                 fileId=resolved_file_id,
                 supportsAllDrives=True,
-                pageToken=page_token,
+                pageToken=current_page_token,
                 fields=(
                     "nextPageToken, "
                     "permissions(id, type, role, emailAddress, displayName, "
@@ -807,54 +947,45 @@ def google_drive_list_permissions(file_id: str, page_token: str | None = None) -
             _attach_resource_key(list_request, resolved_file_id, resource_key)
             results = list_request.execute()
             new_permissions = results.get("permissions", [])
-            permissions.extend(new_permissions)
-            # _capped_list_response below will halve this back down to fit
-            # the output limit regardless, so once there's already enough
-            # data to exceed it, fetching further pages is pure waste: more
-            # blocking network round-trips for permissions that get thrown
-            # away immediately after. Tracked incrementally (each new page's
-            # items serialized once, not the whole accumulated list every
-            # iteration) to stay O(n) rather than O(n^2) for a long
-            # permission list; ensure_ascii=False so this length estimate
-            # isn't inflated relative to what _capped_list_response will
-            # actually measure -- with the default ensure_ascii=True, a
-            # non-ASCII displayName/emailAddress (CJK, accented, emoji names
-            # are common on a Shared Drive) would each be escaped to a
+            pages.append((current_page_token, new_permissions))
+            # _capped_permissions_response below will drop whole pages
+            # back off to fit the output limit regardless, so once
+            # there's already enough data to exceed it, fetching further
+            # pages is pure waste: more blocking network round-trips for
+            # permissions that get thrown away immediately after. Tracked
+            # incrementally (each new page's items serialized once, not
+            # the whole accumulated list every iteration) to stay O(n)
+            # rather than O(n^2) for a long permission list;
+            # ensure_ascii=False so this length estimate isn't inflated
+            # relative to what _capped_permissions_response will actually
+            # measure -- with the default ensure_ascii=True, a non-ASCII
+            # displayName/emailAddress (CJK, accented, emoji names are
+            # common on a Shared Drive) would each be escaped to a
             # 6+-byte \uXXXX sequence here even though the real response
             # keeps them as 1-2 bytes, overestimating this list as needing
             # to stop paginating even though the true payload would still
-            # fit -- and _capped_list_response would then measure the true,
-            # smaller size and leave truncated=False, silently under-
-            # reporting collaborators while claiming a complete result.
+            # fit -- and _capped_permissions_response would then measure
+            # the true, smaller size and leave truncated=False, silently
+            # under-reporting collaborators while claiming a complete
+            # result.
             approx_length += sum(
                 len(json.dumps(p, ensure_ascii=False)) for p in new_permissions
             )
-            page_token = results.get("nextPageToken")
-            if not page_token:
+            next_token = results.get("nextPageToken")
+            current_page_token = next_token
+            if not next_token:
                 break
             if approx_length > max_output_length:
                 break
-        else:
-            # The loop ran out of iterations without either a natural
-            # "no more pages" or "already too big" stop -- a nextPageToken
-            # may still exist that was never followed, so this can't
-            # honestly report a complete list even if the permissions
-            # collected so far happen to still fit under the output cap.
-            return _capped_list_response(
-                "permissions",
-                permissions,
-                truncated=True,
-                next_page_token=page_token,
-            )
+        # current_page_token is None only when the loop broke because
+        # Drive reported no further pages. If the loop instead exhausted
+        # _MAX_PERMISSION_LIST_PAGES without ever seeing a falsy
+        # nextPageToken, current_page_token still holds that last (truthy)
+        # token -- so, same as the early size-cap break, it correctly
+        # signals "more data exists beyond what was fetched" without
+        # needing a separate branch for the loop-safety-bound case.
 
-        # page_token here is whatever the last page's nextPageToken was
-        # (None if that page was the last one) -- surfacing it lets a
-        # caller resume an early stop (the size-cap break above) from
-        # exactly where this call left off, rather than losing the rest of
-        # the collaborator list the way a silent truncation would.
-        return _capped_list_response(
-            "permissions", permissions, next_page_token=page_token
-        )
+        return _capped_permissions_response(pages, current_page_token)
     except Exception as e:
         logger.error(f"Error listing permissions: {e}")
         return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -1,3 +1,4 @@
+import base64
 import io
 import json
 import logging
@@ -115,6 +116,39 @@ _EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 # kept returning a nextPageToken forever.
 _MAX_PERMISSION_LIST_PAGES = 1000
 
+# Google Workspace types with no files.export support at all, for any
+# mimeType (confirmed against Google's own export-formats reference) --
+# google_drive_get_file_content rejects these outright with an actionable
+# message instead of letting them fall into the generic export branch and
+# 400 opaquely. Folder/shortcut aren't documents at all, but are included
+# here since they share the same "no content to export" outcome and the
+# same "application/vnd.google-apps" prefix that would otherwise route
+# them into that branch too.
+_GOOGLE_APPS_TYPES_WITH_NO_EXPORT = frozenset(
+    {
+        "application/vnd.google-apps.folder",
+        "application/vnd.google-apps.shortcut",
+        "application/vnd.google-apps.form",
+        "application/vnd.google-apps.site",
+    }
+)
+
+# Maps a Google Workspace mimeType to what google_drive_get_file_content
+# should export it as when the caller left mime_type at its "text/plain"
+# default -- either because text/plain isn't a supported export format for
+# that type at all (Sheets, Drawings, Apps Script all 400 on it), or
+# because a different format is what a caller who didn't specify one
+# almost certainly wants. Each value here is genuine text (CSV/SVG-as-XML/
+# JSON), so it decodes sensibly through this function's existing
+# decode("utf-8", errors="replace") path, unlike Drawings' other export
+# options (pdf/png/jpeg), which would come out as garbled replacement
+# characters.
+_TEXT_PLAIN_EXPORT_FALLBACK = {
+    "application/vnd.google-apps.spreadsheet": "text/csv",
+    "application/vnd.google-apps.drawing": "image/svg+xml",
+    "application/vnd.google-apps.script": "application/vnd.google-apps.script+json",
+}
+
 
 def _resolve_file_id(file_id: str, field_name: str = "file_id") -> str:
     """Return the id captured out of a Drive/Docs/Sheets/Slides share link,
@@ -200,8 +234,15 @@ def _require_share_role(role: str) -> str:
     return role
 
 
+def _default_halve(value: Any) -> Any:
+    return value[: len(value) // 2]
+
+
 def _capped_response(
-    render: Callable[[Any, bool], str], value: Any, truncated: bool = False
+    render: Callable[[Any, bool], str],
+    value: Any,
+    truncated: bool = False,
+    halve: Callable[[Any], Any] = _default_halve,
 ) -> str:
     """Halve ``value`` (a list or a string) until ``render(value, truncated)``
     fits the platform's output limit -- mirrors deputy.py's/salesforce.py's
@@ -216,13 +257,18 @@ def _capped_response(
     up before exhausting every page) can report that honestly even if the
     partial ``value`` it did collect happens to still fit under the limit.
 
+    ``halve`` defaults to a plain half-length slice, but a caller whose
+    ``value`` has structure a byte-offset cut could break (e.g. base64,
+    where an arbitrary cut produces a string that isn't just incomplete
+    but genuinely invalid) can supply an alignment-preserving version.
+
     Named ``render``, not ``build``, to avoid shadowing the module-level
     ``build`` imported from googleapiclient.discovery.
     """
     max_output_length = get_tool_max_output_length()
     response = render(value, truncated)
     while len(response) > max_output_length and value:
-        value = value[: len(value) // 2]
+        value = halve(value)
         truncated = True
         response = render(value, truncated)
     return response
@@ -240,10 +286,20 @@ def _capped_list_response(
     return _capped_response(_build, items, truncated)
 
 
-def _capped_content_response(file_metadata: dict[str, Any], content: str) -> str:
+def _halve_base64(value: str) -> str:
+    return value[: (len(value) // 2) // 4 * 4]
+
+
+def _capped_content_response(
+    file_metadata: dict[str, Any], content: str, encoding: str = "utf-8"
+) -> str:
     """Same halving idea as _capped_list_response, applied to a single
     string instead of a list since downloaded/exported file content has no
     natural list of records to shrink.
+
+    ``encoding`` tells the caller how ``content`` is represented (see
+    google_drive_get_file_content, which falls back to base64 for content
+    that isn't valid UTF-8) and picks the matching halving strategy.
     """
 
     def _build(content: str, truncated: bool) -> str:
@@ -252,12 +308,14 @@ def _capped_content_response(file_metadata: dict[str, Any], content: str) -> str
                 "status": "success",
                 "file": file_metadata,
                 "content": content,
+                "encoding": encoding,
                 "truncated": truncated,
             },
             ensure_ascii=False,
         )
 
-    return _capped_response(_build, content)
+    halve = _halve_base64 if encoding == "base64" else _default_halve
+    return _capped_response(_build, content, halve=halve)
 
 
 def get_drive_service() -> Any:
@@ -291,12 +349,13 @@ def google_drive_search(query: str = "", max_results: int = 10) -> str:
     Use query parameter for Google Drive search syntax (e.g. "name contains 'meeting'").
     """
     try:
+        page_size = clamp_limit(max_results, max_limit=1000)
         service = get_drive_service()
         results = (
             service.files()
             .list(
                 q=query if query else None,
-                pageSize=clamp_limit(max_results, max_limit=1000),
+                pageSize=page_size,
                 supportsAllDrives=True,
                 includeItemsFromAllDrives=True,
                 fields="nextPageToken, files(id, name, mimeType, modifiedTime)",
@@ -331,42 +390,39 @@ def google_drive_get_file_content(file_id: str, mime_type: str = "text/plain") -
         )
         file_mime_type = file_metadata.get("mimeType", "")
 
-        if file_mime_type in (
-            "application/vnd.google-apps.folder",
-            "application/vnd.google-apps.shortcut",
-            "application/vnd.google-apps.form",
-        ):
-            # These three all start with "application/vnd.google-apps" and
-            # would otherwise fall into the export_media branch below,
-            # which makes no sense for any of them (a folder has no content
-            # to export; a shortcut is a pointer, not a document; Forms has
-            # no files.export support at all, for any mimeType) and would
-            # fail with an opaque API error instead of an actionable one.
-            # Now that folder/form share links resolve via _resolve_file_id
-            # (forms/d/ was added alongside folders/documents/etc.), this
-            # is a directly reachable input, not a hypothetical.
+        if file_mime_type in _GOOGLE_APPS_TYPES_WITH_NO_EXPORT:
+            # These all start with "application/vnd.google-apps" and would
+            # otherwise fall into the export_media branch below, which
+            # makes no sense for any of them (a folder/shortcut has no
+            # document content; Forms and Sites have no files.export
+            # support at all, for any mimeType) and would fail with an
+            # opaque API error instead of an actionable one. Folder/form
+            # share links are directly reachable via _resolve_file_id
+            # (forms/d/ was added alongside folders/documents/etc.), not a
+            # hypothetical.
             raise ValueError(
                 f"file_id resolves to a {file_mime_type.rsplit('.', 1)[-1]}, "
                 "which has no content to read."
             )
 
         if "application/vnd.google-apps" in file_mime_type:
-            # Export Google Workspace document. Sheets has no text/plain
-            # export format (only Docs/Slides do) and 400s on it, so the
-            # "text/plain" default -- reasonable for the far more common
-            # Docs/Slides case -- needs a per-type fallback for Sheets.
-            # Drawings has no text/plain export either, and unlike Sheets
-            # there's no text-shaped alternative to fall back to -- only
-            # pdf/png/jpeg/svg -- so it defaults to svg specifically
-            # because it's the one of those that's actual text (XML) and
-            # will decode sensibly below, rather than raw image/PDF bytes
-            # coming out as garbled replacement characters.
+            # Export Google Workspace document. The tool's "text/plain"
+            # default is reasonable for the common Docs/Slides case, but
+            # several other Workspace types either have no text/plain
+            # export at all (400s outright) or export something other
+            # than what a caller who left mime_type untouched would want.
+            # _TEXT_PLAIN_EXPORT_FALLBACK maps each such type to the
+            # format that (a) Drive actually supports exporting it as and
+            # (b) is genuinely text (CSV/SVG-XML/JSON), so it decodes
+            # sensibly below instead of raw binary bytes coming out as
+            # garbled replacement characters. Only consulted when the
+            # caller left mime_type at its default -- an explicit
+            # mime_type is always honored as-is.
             export_mime_type = mime_type
             if mime_type == "text/plain":
-                if file_mime_type == "application/vnd.google-apps.spreadsheet":
-                    export_mime_type = "text/csv"
-                elif file_mime_type == "application/vnd.google-apps.drawing":
-                    export_mime_type = "image/svg+xml"
+                export_mime_type = _TEXT_PLAIN_EXPORT_FALLBACK.get(
+                    file_mime_type, mime_type
+                )
             request = service.files().export_media(
                 fileId=resolved_file_id, mimeType=export_mime_type
             )
@@ -382,9 +438,25 @@ def google_drive_get_file_content(file_id: str, mime_type: str = "text/plain") -
         while done is False:
             _, done = downloader.next_chunk()
 
-        return _capped_content_response(
-            file_metadata, fh.getvalue().decode("utf-8", errors="replace")
-        )
+        raw_bytes = fh.getvalue()
+        try:
+            # A strict decode, not errors="replace": the export branch
+            # above only ever requests genuinely text formats (plain
+            # text/CSV/SVG-as-XML/JSON), so a UTF-8 failure there would be
+            # a real bug worth surfacing, not something to paper over. The
+            # get_media (regular download) branch can return any binary
+            # file -- a PDF, image, zip, or non-UTF-8-encoded text file --
+            # which replace-decoding would silently corrupt into
+            # replacement characters with no signal anything was lost;
+            # base64 preserves it exactly, same pattern as onedrive.py's
+            # onedrive_get_file_content/_decode_bytes.
+            content = raw_bytes.decode("utf-8")
+            encoding = "utf-8"
+        except UnicodeDecodeError:
+            content = base64.b64encode(raw_bytes).decode("ascii")
+            encoding = "base64"
+
+        return _capped_content_response(file_metadata, content, encoding)
     except Exception as e:
         logger.error(f"Error getting file content: {e}")
         return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
@@ -447,7 +519,7 @@ def google_drive_create_folder(name: str, parent_id: str | None = None) -> str:
             .create(
                 body=file_metadata,
                 supportsAllDrives=True,
-                fields="id, name, webViewLink",
+                fields="id, name, webViewLink, mimeType",
             )
             .execute()
         )
@@ -554,8 +626,10 @@ def _execute_ignoring_204_ssl_eof(
 def google_drive_delete_file(file_id: str) -> str:
     """
     Delete a file or folder in Google Drive.
-    Note: This skips the trash and permanently deletes the file if the user has permission.
-    Otherwise, you may want to use google_drive_trash_file if needed, but this permanently deletes.
+    Note: this skips the trash and permanently deletes the file -- there is
+    no separate "move to trash" tool on this connector, so confirm with the
+    user that permanent deletion (not just removing it from view) is what
+    they want before calling this.
     """
     try:
         resolved_file_id = _resolve_file_id(file_id)

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -61,9 +61,14 @@ _DRIVE_PATH_ALTERNATION = "|".join(_DRIVE_PATH_PREFIXES)
 # match rather than confidently return the wrong string ("e"). Applied only
 # to a URL's parsed .path (see _resolve_file_id) rather than searched over
 # the whole raw string, so a match can't come from an unrelated substring
-# elsewhere in the URL (e.g. a query value).
+# elsewhere in the URL (e.g. a query value). The trailing "(?=/|$)" requires
+# the captured id to run all the way to the next path separator (or the end
+# of the path) -- without it, a malformed segment like ".../file/d/ABC.DEF/
+# view" would silently capture just "ABC" (the id charset stops at the
+# "."), acting on a truncated, wrong id instead of falling through to the
+# "not a recognized shape" branch and returning the whole URL unresolved.
 _DRIVE_PATH_ID_PATTERN = re.compile(
-    rf"/(?:{_DRIVE_PATH_ALTERNATION})/(?!e/)({_DRIVE_ID_CHARS.pattern})"
+    rf"/(?:{_DRIVE_PATH_ALTERNATION})/(?!e/)({_DRIVE_ID_CHARS.pattern})(?=/|$)"
 )
 
 # Same alternation as _DRIVE_PATH_ID_PATTERN, built from the same
@@ -291,27 +296,38 @@ def _extract_resource_key(file_id: str) -> str | None:
     puts on the share link itself.
 
     Shares _parse_trusted_drive_url with _resolve_file_id rather than
-    keeping its own copy of the host/userinfo trust logic, and applies the
-    same "/d/e/" published-to-web path-shape exclusion _resolve_file_id
-    enforces (a share-link shape with no real Drive fileId in it at all --
-    _resolve_file_id refuses to resolve an id for it, so a resourcekey
-    extracted here would only ever be attached to a request whose fileId
-    is that same untrusted, unresolved raw string) -- so the two
-    functions' trust decisions for identical input can't silently diverge
-    the way they did before this was factored out. Kept as its own
-    function rather than folding into _resolve_file_id and returning a
-    tuple: _resolve_file_id's plain-string return is relied on by every
-    call site and by the full existing test suite, and widening its
-    contract for a value that's usually None (only pre-2021 link-shared
-    items carry a resourcekey at all) isn't worth that blast radius.
+    keeping its own copy of the host/userinfo trust logic, and mirrors
+    _resolve_file_id's exact three-branch decision (path-id match, then
+    shape-exclusion, then the legacy "?id=" query fallback) rather than a
+    looser approximation of it -- covering not just the published-to-web
+    "/d/e/" exclusion but any other trusted-host URL whose path isn't a
+    recognized share-link shape at all. This guarantees that whenever this
+    function returns a resourcekey, _resolve_file_id on the same input
+    took the identical branch and returned a real, _DRIVE_ID_CHARS-
+    validated fileId -- never the raw unresolved URL string -- which is
+    also what keeps _attach_resource_key's header value free of characters
+    (including a literal CR/LF) the fileId half was never validated
+    against. Kept as its own function rather than folding into
+    _resolve_file_id and returning a tuple: _resolve_file_id's plain-string
+    return is relied on by every call site and by the full existing test
+    suite, and widening its contract for a value that's usually None (only
+    pre-2021 link-shared items carry a resourcekey at all) isn't worth that
+    blast radius.
     """
     parsed = _parse_trusted_drive_url(file_id)
     if parsed is None:
         return None
-    if _DRIVE_PATH_SHAPE_PATTERN.search(
-        parsed.path
-    ) and not _DRIVE_PATH_ID_PATTERN.search(parsed.path):
-        return None
+    if not _DRIVE_PATH_ID_PATTERN.search(parsed.path):
+        if _DRIVE_PATH_SHAPE_PATTERN.search(parsed.path):
+            # Recognized-but-excluded shape (e.g. published-to-web "/d/e/")
+            # -- _resolve_file_id refuses to resolve an id for this shape
+            # at all, never falling through to the "?id=" query check
+            # either (see its own comment on that exact point), so neither
+            # should this.
+            return None
+        query_id = parse_qs(parsed.query).get("id")
+        if not (query_id and _DRIVE_ID_CHARS.fullmatch(query_id[0])):
+            return None
     resource_key = parse_qs(parsed.query).get("resourcekey")
     if not resource_key:
         return None
@@ -337,8 +353,21 @@ def _attach_resource_key(request: Any, file_id: str, resource_key: str | None) -
     google_drive_download.py's ``request.headers.update(...)`` pattern.
     Returns ``request`` so the call site can build/attach/execute in one
     expression.
+
+    ``file_id`` is expected to already be _DRIVE_ID_CHARS-clean by this
+    point -- every call site passes the result of _resolve_file_id, and
+    _extract_resource_key only ever returns a truthy ``resource_key`` when
+    _resolve_file_id would have taken the same validated-id branch on the
+    same input (see _extract_resource_key's docstring). The CR/LF check
+    here is belt-and-suspenders defense against a future call site breaking
+    that invariant, not the primary guard against it: this function has no
+    way to signal "skip the header" other than silently doing so, so a
+    literal CR/LF in ``file_id`` still reaching here would otherwise build
+    a header value most HTTP clients reject outright (http.client raises
+    ValueError on a raw CR/LF in a header value) rather than the clean,
+    actionable error this connector's own validation would give.
     """
-    if resource_key:
+    if resource_key and "\r" not in file_id and "\n" not in file_id:
         request.headers["X-Goog-Drive-Resource-Keys"] = f"{file_id}/{resource_key}"
     return request
 
@@ -673,6 +702,9 @@ def google_drive_search(query: str = "", max_results: int = 10) -> str:
     """
     Search for files in Google Drive.
     Use query parameter for Google Drive search syntax (e.g. "name contains 'meeting'").
+    The result's "truncated" field is true if the output was too large and
+    some matching files were cut to fit -- treat the "files" list as
+    possibly incomplete in that case rather than the full result set.
     """
     try:
         page_size = clamp_limit(max_results, max_limit=1000)
@@ -709,6 +741,13 @@ def google_drive_get_file_content(file_id: str, mime_type: str = "text/plain") -
     PDF, an Office format, an image, or any other binary content, use
     google_drive_download_file instead, which writes the real bytes to a
     file instead of decoding them as text.
+    The result's "encoding" field is "utf-8" for ordinary text, or "base64"
+    for the rare case where content typed as text still wasn't valid UTF-8
+    (e.g. a legacy-encoded file) -- check this before treating "content" as
+    literal text, since a base64 string decoded and displayed as-is is
+    unreadable. "truncated" is true if the output was too large and
+    "content" was cut to fit -- treat it as possibly incomplete in that
+    case rather than the full file.
     """
     try:
         if not _is_text_mime_type(mime_type):
@@ -1132,9 +1171,10 @@ def google_drive_list_permissions(file_id: str, page_token: str | None = None) -
     returned permission ids with google_drive_update_permission or
     google_drive_remove_permission.
     For an item in a Shared Drive with more collaborators than fit in one
-    response, the result includes a "next_page_token" -- pass it back as
-    this call's page_token to continue listing from where it left off
-    instead of silently missing the rest.
+    response, "truncated" is true and the result includes a
+    "next_page_token" -- pass it back as this call's page_token to
+    continue listing from where it left off instead of silently missing
+    the rest.
     A permission whose "permissionDetails" marks it "inherited": true comes
     from a parent folder, not this item directly -- it can't be changed or
     removed here; do that on the folder it's inherited from instead.
@@ -1227,26 +1267,34 @@ def google_drive_share_file(
     role: str = "reader",
     send_notification: bool = True,
     message: str | None = None,
+    entity_type: str = "user",
 ) -> str:
     """
-    Grant a user (by email) access to a Drive file or folder, making it
-    visible to someone outside this conversation. This is an external
-    action -- confirm the target file, the email, and the role with the
-    user before calling it.
+    Grant a user or Google Group (by email) access to a Drive file or
+    folder, making it visible to someone outside this conversation. This
+    is an external action -- confirm the target file, the email, the
+    role, and whether it's a user or group with the user before calling
+    it.
     role: "reader" (can view), "commenter" (can view and comment), or
     "writer" (can edit). Sharing a folder gives that access to everything
-    inside it. When send_notification is True, Google emails the person
-    being added; message is included in that email if given. If
+    inside it. entity_type: "user" (default) for an individual's email
+    address, or "group" for a Google Group's email address -- a group's
+    role semantics are otherwise identical to a user's. When
+    send_notification is True, Google emails the person or group being
+    added; message is included in that email if given. If
     send_notification is False, message is silently discarded (Google's
     API rejects a notification message when no notification is sent) --
     the response won't flag this, so don't rely on the message being
     delivered without also checking send_notification.
-    This grants access to a specific email only; it can't create "anyone
-    with the link" link-sharing. google_drive_remove_permission can still
-    revoke an existing link-shared permission if one is already present.
+    This grants access to a specific user or group only; it can't create
+    "anyone with the link" link-sharing or share with an entire domain.
+    google_drive_remove_permission can still revoke an existing
+    link-shared permission if one is already present.
     """
     try:
         _require_share_role(role)
+        if entity_type not in ("user", "group"):
+            raise ValueError('entity_type must be "user" or "group"')
         require_clean_identifier(email, "email")
         if not _EMAIL_PATTERN.match(email):
             raise ValueError("email must be a valid email address")
@@ -1258,7 +1306,7 @@ def google_drive_share_file(
         # false, so it's only included when a notification is actually going out.
         create_kwargs: dict[str, Any] = {
             "fileId": resolved_file_id,
-            "body": {"type": "user", "role": role, "emailAddress": email},
+            "body": {"type": entity_type, "role": role, "emailAddress": email},
             "sendNotificationEmail": send_notification,
             "supportsAllDrives": True,
             "fields": "id, type, role, emailAddress, displayName",

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -2,6 +2,8 @@ import io
 import json
 import logging
 import os
+import re
+from collections.abc import Callable
 from typing import Any
 
 from google.oauth2.credentials import Credentials
@@ -12,7 +14,7 @@ from googleapiclient.http import (  # type: ignore[import-not-found]
 )
 from mcp.server.fastmcp import FastMCP
 
-from .utils import setup_proxy_env
+from .utils import require_clean_identifier, resolve_id_from_url, setup_proxy_env
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger("google-drive-mcp")
@@ -21,6 +23,24 @@ logger = logging.getLogger("google-drive-mcp")
 setup_proxy_env()
 
 mcp = FastMCP("google-drive-mcp")
+
+# Matches the id segment out of any of the common Drive/Docs/Sheets/Slides
+# share-link shapes, since a user (and therefore a model relaying the user's
+# words) is far more likely to hand over the URL they see in the browser
+# than the bare id.
+_DRIVE_URL_ID_PATTERN = re.compile(
+    r"/(?:file/d|folders|document/d|spreadsheets/d|presentation/d)/([a-zA-Z0-9_-]+)"
+)
+
+# "owner" is deliberately excluded: ownership transfer needs
+# transferOwnership=True, is not reversible the way a role change is, and is
+# a distinct product decision from "share this with someone" -- one this
+# connector doesn't make on the model's behalf.
+_SHARE_ROLES = ("reader", "commenter", "writer")
+
+
+def _resolve_file_id(file_id: str) -> str:
+    return resolve_id_from_url(file_id, _DRIVE_URL_ID_PATTERN, "file_id")
 
 
 def get_drive_service() -> Any:
@@ -198,6 +218,38 @@ def google_drive_rename_file(file_id: str, new_name: str) -> str:
         return json.dumps({"status": "error", "message": str(e)})
 
 
+def _execute_ignoring_204_ssl_eof(
+    execute: Callable[[], Any], verify_done: Callable[[], None]
+) -> None:
+    """Run a Drive delete-style call that returns 204 No Content, tolerating
+    the SSL EOF error a proxy can raise on that empty response.
+
+    httplib2 (via a proxy) can turn a 204 response into
+    ``UNEXPECTED_EOF_WHILE_READING`` even though the delete already
+    succeeded server-side. When that happens, confirm the object is
+    actually gone (``verify_done`` should raise a 404-shaped error once it
+    is) before treating the call as successful; any other error propagates
+    unchanged.
+    """
+    try:
+        execute()
+    except Exception as e:
+        if "UNEXPECTED_EOF_WHILE_READING" not in str(e):
+            raise
+        logger.warning(
+            f"Ignored SSL EOF error (often caused by proxy on 204 response): {e}"
+        )
+        try:
+            verify_done()
+            raise Exception(
+                f"Operation did not complete, SSL error occurred: {e}"
+            ) from e
+        except Exception as verify_err:
+            if "404" in str(verify_err) or "not found" in str(verify_err).lower():
+                return  # Successfully completed
+            raise e from verify_err
+
+
 @mcp.tool()
 def google_drive_delete_file(file_id: str) -> str:
     """
@@ -206,35 +258,167 @@ def google_drive_delete_file(file_id: str) -> str:
     Otherwise, you may want to use google_drive_trash_file if needed, but this permanently deletes.
     """
     try:
+        resolved_file_id = _resolve_file_id(file_id)
         service = get_drive_service()
-        try:
-            service.files().delete(fileId=file_id).execute()
-        except Exception as e:
-            # Handle httplib2 proxy issue with 204 No Content responses causing SSL EOF
-            if "UNEXPECTED_EOF_WHILE_READING" in str(e):
-                logger.warning(
-                    f"Ignored SSL EOF error during delete (often caused by proxy on 204 response): {e}"
-                )
-                # Verify if it was actually deleted
-                try:
-                    service.files().get(fileId=file_id).execute()
-                    raise Exception(f"File was not deleted, SSL error occurred: {e}")
-                except Exception as get_err:
-                    if "404" in str(get_err) or "not found" in str(get_err).lower():
-                        pass  # Successfully deleted
-                    else:
-                        raise e
-            else:
-                raise e
+        _execute_ignoring_204_ssl_eof(
+            lambda: service.files().delete(fileId=resolved_file_id).execute(),
+            lambda: service.files().get(fileId=resolved_file_id).execute(),
+        )
 
         return json.dumps(
             {
                 "status": "success",
-                "message": f"File/Folder {file_id} successfully deleted.",
+                "message": f"File/Folder {resolved_file_id} successfully deleted.",
             }
         )
     except Exception as e:
         logger.error(f"Error deleting file: {e}")
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+@mcp.tool()
+def google_drive_list_permissions(file_id: str) -> str:
+    """
+    List who currently has access to a Drive file or folder (owner,
+    editors, commenters, viewers) and their permission ids. Use the
+    returned permission ids with google_drive_update_permission or
+    google_drive_remove_permission.
+    """
+    try:
+        service = get_drive_service()
+        results = (
+            service.permissions()
+            .list(
+                fileId=_resolve_file_id(file_id),
+                supportsAllDrives=True,
+                fields="permissions(id, type, role, emailAddress, displayName)",
+            )
+            .execute()
+        )
+
+        return json.dumps(
+            {"status": "success", "permissions": results.get("permissions", [])}
+        )
+    except Exception as e:
+        logger.error(f"Error listing permissions: {e}")
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+@mcp.tool()
+def google_drive_share_file(
+    file_id: str,
+    email: str,
+    role: str = "reader",
+    send_notification: bool = True,
+    message: str | None = None,
+) -> str:
+    """
+    Grant a user (by email) access to a Drive file or folder, making it
+    visible to someone outside this conversation. This is an external
+    action -- confirm the target file, the email, and the role with the
+    user before calling it.
+    role: "reader" (can view), "commenter" (can view and comment), or
+    "writer" (can edit). Sharing a folder gives that access to everything
+    inside it. When send_notification is True, Google emails the person
+    being added; message is included in that email if given.
+    """
+    try:
+        if role not in _SHARE_ROLES:
+            raise ValueError(f"role must be one of {_SHARE_ROLES}")
+        require_clean_identifier(email, "email")
+        if "@" not in email:
+            raise ValueError("email must be a valid email address")
+
+        service = get_drive_service()
+        permission = (
+            service.permissions()
+            .create(
+                fileId=_resolve_file_id(file_id),
+                body={"type": "user", "role": role, "emailAddress": email},
+                sendNotificationEmail=send_notification,
+                emailMessage=message,
+                supportsAllDrives=True,
+                fields="id, type, role, emailAddress, displayName",
+            )
+            .execute()
+        )
+
+        return json.dumps({"status": "success", "permission": permission})
+    except Exception as e:
+        logger.error(f"Error sharing file: {e}")
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+@mcp.tool()
+def google_drive_update_permission(file_id: str, permission_id: str, role: str) -> str:
+    """
+    Change an existing collaborator's role on a Drive file or folder (e.g.
+    upgrade a viewer to an editor). Get permission_id from
+    google_drive_list_permissions. This is an external action -- confirm
+    the change with the user before calling it.
+    role: "reader", "commenter", or "writer".
+    """
+    try:
+        if role not in _SHARE_ROLES:
+            raise ValueError(f"role must be one of {_SHARE_ROLES}")
+
+        service = get_drive_service()
+        permission = (
+            service.permissions()
+            .update(
+                fileId=_resolve_file_id(file_id),
+                permissionId=require_clean_identifier(permission_id, "permission_id"),
+                body={"role": role},
+                supportsAllDrives=True,
+                fields="id, type, role, emailAddress, displayName",
+            )
+            .execute()
+        )
+
+        return json.dumps({"status": "success", "permission": permission})
+    except Exception as e:
+        logger.error(f"Error updating permission: {e}")
+        return json.dumps({"status": "error", "message": str(e)})
+
+
+@mcp.tool()
+def google_drive_remove_permission(file_id: str, permission_id: str) -> str:
+    """
+    Revoke a collaborator's access to a Drive file or folder. Get
+    permission_id from google_drive_list_permissions. This is an external
+    action -- confirm who is losing access with the user before calling it.
+    """
+    try:
+        resolved_file_id = _resolve_file_id(file_id)
+        resolved_permission_id = require_clean_identifier(
+            permission_id, "permission_id"
+        )
+        service = get_drive_service()
+        _execute_ignoring_204_ssl_eof(
+            lambda: (
+                service.permissions()
+                .delete(
+                    fileId=resolved_file_id,
+                    permissionId=resolved_permission_id,
+                    supportsAllDrives=True,
+                )
+                .execute()
+            ),
+            lambda: (
+                service.permissions()
+                .get(fileId=resolved_file_id, permissionId=resolved_permission_id)
+                .execute()
+            ),
+        )
+
+        return json.dumps(
+            {
+                "status": "success",
+                "message": f"Permission {resolved_permission_id} successfully removed.",
+            }
+        )
+    except Exception as e:
+        logger.error(f"Error removing permission: {e}")
         return json.dumps({"status": "error", "message": str(e)})
 
 

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -106,6 +106,14 @@ _DRIVE_URL_HOSTS = frozenset(
 # this connector chooses to expose.
 _SHARE_ROLES = ("reader", "commenter", "writer")
 
+# "domain" and "anyone" are deliberately excluded, matching
+# google_drive_share_file's own docstring ("can't share with an entire
+# domain" / no "anyone with the link" support): both grant access to a much
+# broader audience than "one specific user or group", which is a distinct
+# product decision this connector doesn't make on the model's behalf, the
+# same reasoning _SHARE_ROLES above already applies to "owner"/"organizer".
+_SHARE_ENTITY_TYPES = ("user", "group")
+
 # Same shape as api/auth.py's EMAIL_PATTERN, kept as its own local copy
 # rather than imported: this module runs as its own subprocess per MCP tool
 # call (see get_drive_service's callers), and auth.py is a ~3800-line
@@ -213,6 +221,39 @@ def _parse_trusted_drive_url(value: str) -> ParseResult | None:
     return parsed
 
 
+def _resolve_id_from_parsed(
+    parsed: ParseResult, query_params: dict[str, list[str]] | None = None
+) -> str | None:
+    """Given an already-trusted, parsed Drive URL (see
+    _parse_trusted_drive_url), return the real fileId it resolves to, or
+    ``None`` if it doesn't resolve to one at all -- a recognized-but-
+    excluded path shape (e.g. the published-to-web "/d/e/" form), or a
+    path/query that doesn't match any known share-link shape.
+
+    The single source of truth for "does this URL resolve to a real
+    fileId", shared by _resolve_file_id and _extract_resource_key so their
+    answers to that question can't independently drift -- they did,
+    twice: once for the "/d/e/" exclusion specifically (fixed by factoring
+    out _parse_trusted_drive_url for the host/userinfo trust decision),
+    and once for any other unrecognized path shape (fixed by factoring out
+    this function for the id-resolution decision itself). A caller that
+    already has ``parsed.query`` parsed for its own purposes (e.g.
+    _extract_resource_key, which needs it again for "resourcekey") can
+    pass ``query_params`` to avoid parsing it a second time here.
+    """
+    match = _DRIVE_PATH_ID_PATTERN.search(parsed.path)
+    if match:
+        return match.group(1)
+    if _DRIVE_PATH_SHAPE_PATTERN.search(parsed.path):
+        return None
+    if query_params is None:
+        query_params = parse_qs(parsed.query)
+    query_id = query_params.get("id")
+    if query_id and _DRIVE_ID_CHARS.fullmatch(query_id[0]):
+        return query_id[0]
+    return None
+
+
 def _resolve_file_id(file_id: str, field_name: str = "file_id") -> str:
     """Return the id captured out of a Drive/Docs/Sheets/Slides share link,
     or ``file_id`` itself (stripped) when it's already a bare id -- or, for
@@ -236,9 +277,9 @@ def _resolve_file_id(file_id: str, field_name: str = "file_id") -> str:
     ``.../files/`` collection endpoint instead of a specific file.
 
     Once the host is confirmed trusted (see _parse_trusted_drive_url), the
-    id is extracted from the parsed URL's own ``.path``/``.query`` -- not
-    searched over the whole raw string -- so a URL whose overall host is
-    allowed but whose query *value* merely contains a matching shape
+    id is extracted via _resolve_id_from_parsed -- not searched over the
+    whole raw string -- so a URL whose overall host is allowed but whose
+    query *value* merely contains a matching shape
     (".../search?q=/file/d/<id>") can't have that unrelated substring
     extracted as if it were the URL's own resource id. A path recognized
     as a share-link shape that _DRIVE_PATH_ID_PATTERN deliberately
@@ -270,15 +311,8 @@ def _resolve_file_id(file_id: str, field_name: str = "file_id") -> str:
     parsed = _parse_trusted_drive_url(stripped)
     if parsed is None:
         return stripped
-    match = _DRIVE_PATH_ID_PATTERN.search(parsed.path)
-    if match:
-        return match.group(1)
-    if _DRIVE_PATH_SHAPE_PATTERN.search(parsed.path):
-        return stripped
-    query_id = parse_qs(parsed.query).get("id")
-    if query_id and _DRIVE_ID_CHARS.fullmatch(query_id[0]):
-        return query_id[0]
-    return stripped
+    resolved = _resolve_id_from_parsed(parsed)
+    return resolved if resolved is not None else stripped
 
 
 def _extract_resource_key(file_id: str) -> str | None:
@@ -295,15 +329,15 @@ def _extract_resource_key(file_id: str) -> str | None:
     place it's ever exposed is the "?resourcekey=" query parameter Drive
     puts on the share link itself.
 
-    Shares _parse_trusted_drive_url with _resolve_file_id rather than
-    keeping its own copy of the host/userinfo trust logic, and mirrors
-    _resolve_file_id's exact three-branch decision (path-id match, then
-    shape-exclusion, then the legacy "?id=" query fallback) rather than a
-    looser approximation of it -- covering not just the published-to-web
-    "/d/e/" exclusion but any other trusted-host URL whose path isn't a
-    recognized share-link shape at all. This guarantees that whenever this
+    Shares _parse_trusted_drive_url and _resolve_id_from_parsed with
+    _resolve_file_id rather than keeping its own copy of either the host/
+    userinfo trust logic or the id-resolution decision -- covering not
+    just the published-to-web "/d/e/" exclusion but any other trusted-host
+    URL whose path isn't a recognized share-link shape at all. Sharing
+    _resolve_id_from_parsed (rather than each function keeping its own
+    copy of that three-branch decision) guarantees that whenever this
     function returns a resourcekey, _resolve_file_id on the same input
-    took the identical branch and returned a real, _DRIVE_ID_CHARS-
+    made the identical decision and returned a real, _DRIVE_ID_CHARS-
     validated fileId -- never the raw unresolved URL string -- which is
     also what keeps _attach_resource_key's header value free of characters
     (including a literal CR/LF) the fileId half was never validated
@@ -317,18 +351,10 @@ def _extract_resource_key(file_id: str) -> str | None:
     parsed = _parse_trusted_drive_url(file_id)
     if parsed is None:
         return None
-    if not _DRIVE_PATH_ID_PATTERN.search(parsed.path):
-        if _DRIVE_PATH_SHAPE_PATTERN.search(parsed.path):
-            # Recognized-but-excluded shape (e.g. published-to-web "/d/e/")
-            # -- _resolve_file_id refuses to resolve an id for this shape
-            # at all, never falling through to the "?id=" query check
-            # either (see its own comment on that exact point), so neither
-            # should this.
-            return None
-        query_id = parse_qs(parsed.query).get("id")
-        if not (query_id and _DRIVE_ID_CHARS.fullmatch(query_id[0])):
-            return None
-    resource_key = parse_qs(parsed.query).get("resourcekey")
+    query_params = parse_qs(parsed.query)
+    if _resolve_id_from_parsed(parsed, query_params) is None:
+        return None
+    resource_key = query_params.get("resourcekey")
     if not resource_key:
         return None
     candidate = resource_key[0]
@@ -357,18 +383,22 @@ def _attach_resource_key(request: Any, file_id: str, resource_key: str | None) -
     ``file_id`` is expected to already be _DRIVE_ID_CHARS-clean by this
     point -- every call site passes the result of _resolve_file_id, and
     _extract_resource_key only ever returns a truthy ``resource_key`` when
-    _resolve_file_id would have taken the same validated-id branch on the
-    same input (see _extract_resource_key's docstring). The CR/LF check
-    here is belt-and-suspenders defense against a future call site breaking
-    that invariant, not the primary guard against it: this function has no
-    way to signal "skip the header" other than silently doing so, so a
-    literal CR/LF in ``file_id`` still reaching here would otherwise build
-    a header value most HTTP clients reject outright (http.client raises
-    ValueError on a raw CR/LF in a header value) rather than the clean,
-    actionable error this connector's own validation would give.
+    _resolve_id_from_parsed made the identical decision on the same input
+    and _resolve_file_id would therefore have taken the same validated-id
+    branch (see _extract_resource_key's docstring). The CR/LF check here is
+    belt-and-suspenders defense against a future call site breaking that
+    invariant -- raising rather than silently skipping the header, since a
+    silent skip would be a *worse* failure mode than surfacing the
+    violation: a pre-2021 link-shared item that genuinely needs this header
+    would otherwise get a confusing 404 from Drive with no indication a
+    resourcekey was computed but silently dropped, instead of a clear,
+    immediate, actionable local error pointing at the actual bug.
     """
-    if resource_key and "\r" not in file_id and "\n" not in file_id:
-        request.headers["X-Goog-Drive-Resource-Keys"] = f"{file_id}/{resource_key}"
+    if not resource_key:
+        return request
+    if "\r" in file_id or "\n" in file_id:
+        raise ValueError(f"file_id must not contain CR/LF, got {file_id!r}")
+    request.headers["X-Goog-Drive-Resource-Keys"] = f"{file_id}/{resource_key}"
     return request
 
 
@@ -397,6 +427,13 @@ def _require_share_role(role: str) -> str:
         allowed = ", ".join(_SHARE_ROLES)
         raise ValueError(f"role must be one of {allowed}")
     return role
+
+
+def _require_entity_type(entity_type: str) -> str:
+    if entity_type not in _SHARE_ENTITY_TYPES:
+        allowed = ", ".join(_SHARE_ENTITY_TYPES)
+        raise ValueError(f"entity_type must be one of {allowed}")
+    return entity_type
 
 
 def _default_halve(value: Any) -> Any:
@@ -1293,8 +1330,7 @@ def google_drive_share_file(
     """
     try:
         _require_share_role(role)
-        if entity_type not in ("user", "group"):
-            raise ValueError('entity_type must be "user" or "group"')
+        _require_entity_type(entity_type)
         require_clean_identifier(email, "email")
         if not _EMAIL_PATTERN.match(email):
             raise ValueError("email must be a valid email address")

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -14,6 +14,7 @@ from googleapiclient.http import (  # type: ignore[import-not-found]
 )
 from mcp.server.fastmcp import FastMCP
 
+from ....config import get_tool_max_output_length
 from .utils import require_clean_identifier, resolve_id_from_url, setup_proxy_env
 
 logging.basicConfig(level=logging.INFO)
@@ -27,9 +28,18 @@ mcp = FastMCP("google-drive-mcp")
 # Matches the id segment out of any of the common Drive/Docs/Sheets/Slides
 # share-link shapes, since a user (and therefore a model relaying the user's
 # words) is far more likely to hand over the URL they see in the browser
-# than the bare id.
+# than the bare id. The optional "u/<n>/" branch tolerates the account-index
+# segment Google inserts (e.g. ".../file/u/1/d/<id>/view") whenever more than
+# one Google account is signed into the browser -- see google_sheets.py's
+# identical (?:u/\d+/)? tolerance for the spreadsheets URL shape. The
+# "[?&]id=" branch matches the older `drive.google.com/open?id=<id>` /
+# `docs.google.com/open?id=<id>` share-link format, still emitted by
+# DriveApp.getUrl() in Apps Script and some third-party integrations, which
+# has no "/d/<id>" path segment for the first branch to match at all.
 _DRIVE_URL_ID_PATTERN = re.compile(
-    r"/(?:file/d|folders|document/d|spreadsheets/d|presentation/d)/([a-zA-Z0-9_-]+)"
+    r"(?:/(?:file/(?:u/\d+/)?d|folders|document/(?:u/\d+/)?d"
+    r"|spreadsheets/(?:u/\d+/)?d|presentation/(?:u/\d+/)?d)/|[?&]id=)"
+    r"([a-zA-Z0-9_-]+)"
 )
 
 # "owner" is deliberately excluded: ownership transfer needs
@@ -41,6 +51,32 @@ _SHARE_ROLES = ("reader", "commenter", "writer")
 
 def _resolve_file_id(file_id: str) -> str:
     return resolve_id_from_url(file_id, _DRIVE_URL_ID_PATTERN, "file_id")
+
+
+def _require_share_role(role: str) -> str:
+    if role not in _SHARE_ROLES:
+        raise ValueError(f"role must be one of {_SHARE_ROLES}")
+    return role
+
+
+def _capped_permissions_response(permissions: list[Any]) -> str:
+    """Build the success payload, halving ``permissions`` until it fits the
+    platform's output limit -- mirrors deputy.py's/salesforce.py's
+    _success_with_capped_list. There is no cursor to resume from here, so
+    entries dropped this way are gone for this call, not just this page.
+    """
+    max_output_length = get_tool_max_output_length()
+    truncated = False
+    response = json.dumps(
+        {"status": "success", "permissions": permissions, "truncated": truncated}
+    )
+    while len(response) > max_output_length and permissions:
+        permissions = permissions[: len(permissions) // 2]
+        truncated = True
+        response = json.dumps(
+            {"status": "success", "permissions": permissions, "truncated": truncated}
+        )
+    return response
 
 
 def get_drive_service() -> Any:
@@ -99,18 +135,23 @@ def google_drive_get_file_content(file_id: str, mime_type: str = "text/plain") -
     If it's a Google Workspace document (Docs, Sheets), it will be exported to the requested mime_type.
     """
     try:
+        resolved_file_id = _resolve_file_id(file_id)
         service = get_drive_service()
         file_metadata = (
-            service.files().get(fileId=file_id, fields="id, name, mimeType").execute()
+            service.files()
+            .get(fileId=resolved_file_id, fields="id, name, mimeType")
+            .execute()
         )
         file_mime_type = file_metadata.get("mimeType", "")
 
         if "application/vnd.google-apps" in file_mime_type:
             # Export Google Workspace document
-            request = service.files().export_media(fileId=file_id, mimeType=mime_type)
+            request = service.files().export_media(
+                fileId=resolved_file_id, mimeType=mime_type
+            )
         else:
             # Download regular file
-            request = service.files().get_media(fileId=file_id)
+            request = service.files().get_media(fileId=resolved_file_id)
 
         fh = io.BytesIO()
         downloader = MediaIoBaseDownload(fh, request)
@@ -199,13 +240,14 @@ def google_drive_rename_file(file_id: str, new_name: str) -> str:
     Rename an existing file or folder in Google Drive.
     """
     try:
+        resolved_file_id = _resolve_file_id(file_id)
         service = get_drive_service()
         file_metadata = {"name": new_name}
 
         updated_file = (
             service.files()
             .update(
-                fileId=file_id,
+                fileId=resolved_file_id,
                 body=file_metadata,
                 fields="id, name, webViewLink, mimeType",
             )
@@ -305,9 +347,7 @@ def google_drive_list_permissions(file_id: str) -> str:
             .execute()
         )
 
-        return json.dumps(
-            {"status": "success", "permissions": results.get("permissions", [])}
-        )
+        return _capped_permissions_response(results.get("permissions", []))
     except Exception as e:
         logger.error(f"Error listing permissions: {e}")
         return json.dumps({"status": "error", "message": str(e)})
@@ -332,17 +372,17 @@ def google_drive_share_file(
     being added; message is included in that email if given.
     """
     try:
-        if role not in _SHARE_ROLES:
-            raise ValueError(f"role must be one of {_SHARE_ROLES}")
+        _require_share_role(role)
         require_clean_identifier(email, "email")
         if "@" not in email:
             raise ValueError("email must be a valid email address")
+        resolved_file_id = _resolve_file_id(file_id)
 
         service = get_drive_service()
         # The API rejects emailMessage outright when sendNotificationEmail is
         # false, so it's only included when a notification is actually going out.
         create_kwargs: dict[str, Any] = {
-            "fileId": _resolve_file_id(file_id),
+            "fileId": resolved_file_id,
             "body": {"type": "user", "role": role, "emailAddress": email},
             "sendNotificationEmail": send_notification,
             "supportsAllDrives": True,
@@ -369,15 +409,18 @@ def google_drive_update_permission(file_id: str, permission_id: str, role: str) 
     role: "reader", "commenter", or "writer".
     """
     try:
-        if role not in _SHARE_ROLES:
-            raise ValueError(f"role must be one of {_SHARE_ROLES}")
+        _require_share_role(role)
+        resolved_file_id = _resolve_file_id(file_id)
+        resolved_permission_id = require_clean_identifier(
+            permission_id, "permission_id"
+        )
 
         service = get_drive_service()
         permission = (
             service.permissions()
             .update(
-                fileId=_resolve_file_id(file_id),
-                permissionId=require_clean_identifier(permission_id, "permission_id"),
+                fileId=resolved_file_id,
+                permissionId=resolved_permission_id,
                 body={"role": role},
                 supportsAllDrives=True,
                 fields="id, type, role, emailAddress, displayName",

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -334,14 +334,17 @@ def google_drive_get_file_content(file_id: str, mime_type: str = "text/plain") -
         if file_mime_type in (
             "application/vnd.google-apps.folder",
             "application/vnd.google-apps.shortcut",
+            "application/vnd.google-apps.form",
         ):
-            # Both mimeTypes start with "application/vnd.google-apps" and
+            # These three all start with "application/vnd.google-apps" and
             # would otherwise fall into the export_media branch below,
-            # which makes no sense for either (a folder has no content to
-            # export; a shortcut is a pointer, not a document) and would
+            # which makes no sense for any of them (a folder has no content
+            # to export; a shortcut is a pointer, not a document; Forms has
+            # no files.export support at all, for any mimeType) and would
             # fail with an opaque API error instead of an actionable one.
-            # Now that folder share links resolve via _resolve_file_id,
-            # this is a directly reachable input, not a hypothetical.
+            # Now that folder/form share links resolve via _resolve_file_id
+            # (forms/d/ was added alongside folders/documents/etc.), this
+            # is a directly reachable input, not a hypothetical.
             raise ValueError(
                 f"file_id resolves to a {file_mime_type.rsplit('.', 1)[-1]}, "
                 "which has no content to read."
@@ -352,12 +355,18 @@ def google_drive_get_file_content(file_id: str, mime_type: str = "text/plain") -
             # export format (only Docs/Slides do) and 400s on it, so the
             # "text/plain" default -- reasonable for the far more common
             # Docs/Slides case -- needs a per-type fallback for Sheets.
+            # Drawings has no text/plain export either, and unlike Sheets
+            # there's no text-shaped alternative to fall back to -- only
+            # pdf/png/jpeg/svg -- so it defaults to svg specifically
+            # because it's the one of those that's actual text (XML) and
+            # will decode sensibly below, rather than raw image/PDF bytes
+            # coming out as garbled replacement characters.
             export_mime_type = mime_type
-            if (
-                file_mime_type == "application/vnd.google-apps.spreadsheet"
-                and mime_type == "text/plain"
-            ):
-                export_mime_type = "text/csv"
+            if mime_type == "text/plain":
+                if file_mime_type == "application/vnd.google-apps.spreadsheet":
+                    export_mime_type = "text/csv"
+                elif file_mime_type == "application/vnd.google-apps.drawing":
+                    export_mime_type = "image/svg+xml"
             request = service.files().export_media(
                 fileId=resolved_file_id, mimeType=export_mime_type
             )
@@ -495,7 +504,16 @@ def _is_confirmed_gone(verify_err: Exception) -> bool:
     """
     status = getattr(getattr(verify_err, "resp", None), "status", None)
     if status is not None:
-        return bool(status == 404)
+        # httplib2.Response coerces .status to int, so this is always an
+        # int in practice via the real client -- try/except rather than an
+        # isinstance/str check so a status representation this doesn't
+        # anticipate (a different transport, a mock, a future library
+        # version) still compares correctly instead of silently skipping
+        # the real-status check it exists to provide.
+        try:
+            return int(status) == 404
+        except (TypeError, ValueError):
+            pass
     return "404" in str(verify_err) or "not found" in str(verify_err).lower()
 
 

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -261,8 +261,16 @@ def google_drive_delete_file(file_id: str) -> str:
         resolved_file_id = _resolve_file_id(file_id)
         service = get_drive_service()
         _execute_ignoring_204_ssl_eof(
-            lambda: service.files().delete(fileId=resolved_file_id).execute(),
-            lambda: service.files().get(fileId=resolved_file_id).execute(),
+            lambda: (
+                service.files()
+                .delete(fileId=resolved_file_id, supportsAllDrives=True)
+                .execute()
+            ),
+            lambda: (
+                service.files()
+                .get(fileId=resolved_file_id, supportsAllDrives=True)
+                .execute()
+            ),
         )
 
         return json.dumps(
@@ -330,18 +338,19 @@ def google_drive_share_file(
             raise ValueError("email must be a valid email address")
 
         service = get_drive_service()
-        permission = (
-            service.permissions()
-            .create(
-                fileId=_resolve_file_id(file_id),
-                body={"type": "user", "role": role, "emailAddress": email},
-                sendNotificationEmail=send_notification,
-                emailMessage=message,
-                supportsAllDrives=True,
-                fields="id, type, role, emailAddress, displayName",
-            )
-            .execute()
-        )
+        # The API rejects emailMessage outright when sendNotificationEmail is
+        # false, so it's only included when a notification is actually going out.
+        create_kwargs: dict[str, Any] = {
+            "fileId": _resolve_file_id(file_id),
+            "body": {"type": "user", "role": role, "emailAddress": email},
+            "sendNotificationEmail": send_notification,
+            "supportsAllDrives": True,
+            "fields": "id, type, role, emailAddress, displayName",
+        }
+        if send_notification and message is not None:
+            create_kwargs["emailMessage"] = message
+
+        permission = service.permissions().create(**create_kwargs).execute()
 
         return json.dumps({"status": "success", "permission": permission})
     except Exception as e:
@@ -406,7 +415,11 @@ def google_drive_remove_permission(file_id: str, permission_id: str) -> str:
             ),
             lambda: (
                 service.permissions()
-                .get(fileId=resolved_file_id, permissionId=resolved_permission_id)
+                .get(
+                    fileId=resolved_file_id,
+                    permissionId=resolved_permission_id,
+                    supportsAllDrives=True,
+                )
                 .execute()
             ),
         )

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -5,6 +5,7 @@ import os
 import re
 from collections.abc import Callable
 from typing import Any
+from urllib.parse import urlparse
 
 from google.oauth2.credentials import Credentials
 from googleapiclient.discovery import build  # type: ignore[import-not-found]
@@ -40,21 +41,59 @@ mcp = FastMCP("google-drive-mcp")
 # "[?&]id=" branch matches the older `drive.google.com/open?id=<id>` /
 # `docs.google.com/open?id=<id>` share-link format, still emitted by
 # DriveApp.getUrl() in Apps Script and some third-party integrations, which
-# has no "/d/<id>" path segment for the first branch to match at all.
+# has no "/d/<id>" path segment for the first branch to match at all --
+# _resolve_file_id below is what keeps that branch from being host-agnostic.
+# "(?!e/)" after each "d/" excludes the "published to web" link shape
+# (".../d/e/<publish-id>/pubhtml"): that "e" is a literal path segment, not
+# part of the id, and the real Drive file id isn't present in that URL at
+# all -- the published-to-web token isn't a valid fileId, so this must not
+# match rather than confidently return the wrong string ("e").
 _DRIVE_URL_ID_PATTERN = re.compile(
     r"(?:/(?:file/(?:u/\d+/)?d|folders|document/(?:u/\d+/)?d"
-    r"|spreadsheets/(?:u/\d+/)?d|presentation/(?:u/\d+/)?d)/|[?&]id=)"
+    r"|spreadsheets/(?:u/\d+/)?d|presentation/(?:u/\d+/)?d)/(?!e/)|[?&]id=)"
     r"([a-zA-Z0-9_-]+)"
 )
+
+# Hosts _resolve_file_id treats as an authoritative Drive/Docs/Sheets/Slides
+# share link. Both the path patterns above and the query-string "id="
+# fallback are otherwise host-agnostic regex/substring matches -- without
+# this check, an untrusted URL (e.g. quoted inside a document an agent
+# reads) that merely happens to contain a matching shape, most easily
+# "?id=<attacker-chosen-id>" since "id" is an extremely common, generic
+# query-param name across the web, would get its id extracted and passed
+# to a share/delete/permission call as if it were this connector's own
+# link.
+_DRIVE_URL_HOSTS = frozenset({"drive.google.com", "docs.google.com"})
 
 # "owner" is deliberately excluded: ownership transfer needs
 # transferOwnership=True, is not reversible the way a role change is, and is
 # a distinct product decision from "share this with someone" -- one this
-# connector doesn't make on the model's behalf.
+# connector doesn't make on the model's behalf. The Shared-Drive-only
+# "organizer"/"fileOrganizer" roles are excluded for the same reason: they
+# grant administrative control over the drive/folder (managing membership,
+# restructuring), which is a materially different, more privileged action
+# than the plain collaboration roles below -- not an oversight of
+# supportsAllDrives support, which applies independently of which roles
+# this connector chooses to expose.
 _SHARE_ROLES = ("reader", "commenter", "writer")
+
+# Same shape as api/auth.py's EMAIL_PATTERN, kept as its own local copy
+# rather than imported: this module runs as its own subprocess per MCP tool
+# call (see get_drive_service's callers), and auth.py is a ~3800-line
+# FastAPI router with heavy top-level imports (fastapi, jose, and an
+# import-time os.environ mutation) -- pulling that whole module in for one
+# regex would add real per-call import cost and an unwarranted dependency
+# from a connector tool onto the web API layer. "a@b" (no dot in the
+# domain) and "a@"/"@b" (an empty local or domain part) are not valid
+# email addresses; the previous "@" not in email check accepted all three.
+_EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
 
 def _resolve_file_id(file_id: str) -> str:
+    if isinstance(file_id, str):
+        parsed = urlparse(file_id.strip())
+        if parsed.scheme and parsed.hostname not in _DRIVE_URL_HOSTS:
+            return file_id.strip()
     return resolve_id_from_url(file_id, _DRIVE_URL_ID_PATTERN, "file_id")
 
 
@@ -84,6 +123,34 @@ def _capped_list_response(field_name: str, items: list[Any]) -> str:
         items = items[: len(items) // 2]
         truncated = True
         response = _build(items, truncated)
+    return response
+
+
+def _capped_content_response(file_metadata: dict[str, Any], content: str) -> str:
+    """Build the success payload, halving ``content`` until it fits the
+    platform's output limit -- same halving idea as _capped_list_response,
+    applied to a single string instead of a list since downloaded/exported
+    file content has no natural list of records to shrink.
+    """
+    max_output_length = get_tool_max_output_length()
+
+    def _build(content: str, truncated: bool) -> str:
+        return json.dumps(
+            {
+                "status": "success",
+                "file": file_metadata,
+                "content": content,
+                "truncated": truncated,
+            },
+            ensure_ascii=False,
+        )
+
+    truncated = False
+    response = _build(content, truncated)
+    while len(response) > max_output_length and content:
+        content = content[: len(content) // 2]
+        truncated = True
+        response = _build(content, truncated)
     return response
 
 
@@ -184,13 +251,8 @@ def google_drive_get_file_content(file_id: str, mime_type: str = "text/plain") -
         while done is False:
             _, done = downloader.next_chunk()
 
-        return json.dumps(
-            {
-                "status": "success",
-                "file": file_metadata,
-                "content": fh.getvalue().decode("utf-8", errors="replace"),
-            },
-            ensure_ascii=False,
+        return _capped_content_response(
+            file_metadata, fh.getvalue().decode("utf-8", errors="replace")
         )
     except Exception as e:
         logger.error(f"Error getting file content: {e}")
@@ -294,6 +356,27 @@ def google_drive_rename_file(file_id: str, new_name: str) -> str:
         return json.dumps({"status": "error", "message": str(e)}, ensure_ascii=False)
 
 
+def _is_confirmed_gone(verify_err: Exception) -> bool:
+    """Whether ``verify_err`` (raised by re-fetching the object) means it is
+    actually gone, i.e. a 404.
+
+    An ``HttpError``'s own ``resp.status`` is the real, unambiguous HTTP
+    status code and is checked first when available. Falling back to
+    substring-matching "404"/"not found" in ``str(verify_err)`` is fragile
+    on its own: ``HttpError.__str__`` embeds the request URI, which
+    contains the resolved file/permission id, so a real 403 (object still
+    exists; access was merely denied) on an id that happens to contain the
+    digits "404" would otherwise be misread as "confirmed gone" --
+    reporting a delete/permission-removal that never happened as a success.
+    The string fallback stays for non-HttpError exceptions (e.g. a plain
+    error from a different failure path, or in tests).
+    """
+    status = getattr(getattr(verify_err, "resp", None), "status", None)
+    if status is not None:
+        return bool(status == 404)
+    return "404" in str(verify_err) or "not found" in str(verify_err).lower()
+
+
 def _execute_ignoring_204_ssl_eof(
     execute: Callable[[], Any], verify_done: Callable[[], None]
 ) -> None:
@@ -318,7 +401,7 @@ def _execute_ignoring_204_ssl_eof(
         try:
             verify_done()
         except Exception as verify_err:
-            if "404" in str(verify_err) or "not found" in str(verify_err).lower():
+            if _is_confirmed_gone(verify_err):
                 return  # Successfully completed
             raise e from verify_err
 
@@ -427,7 +510,7 @@ def google_drive_share_file(
     try:
         _require_share_role(role)
         require_clean_identifier(email, "email")
-        if "@" not in email:
+        if not _EMAIL_PATTERN.match(email):
             raise ValueError("email must be a valid email address")
         resolved_file_id = _resolve_file_id(file_id)
 

--- a/src/xagent/web/tools/mcp/google_drive.py
+++ b/src/xagent/web/tools/mcp/google_drive.py
@@ -26,14 +26,17 @@ setup_proxy_env()
 
 mcp = FastMCP("google-drive-mcp")
 
-# Matches the id segment out of any of the common Drive/Docs/Sheets/Slides
-# share-link shapes, since a user (and therefore a model relaying the user's
-# words) is far more likely to hand over the URL they see in the browser
-# than the bare id. The optional "u/<n>/" branch tolerates the account-index
-# segment Google inserts (e.g. ".../file/u/1/d/<id>/view") whenever more than
-# one Google account is signed into the browser -- see google_sheets.py's
-# identical (?:u/\d+/)? tolerance for the spreadsheets URL shape. "(?!e/)"
-# after each "d/" excludes the "published to web" link shape
+# A Drive/Docs/Sheets/Slides/Forms/Drawings id is always [a-zA-Z0-9_-]+.
+_DRIVE_ID_CHARS = re.compile(r"[a-zA-Z0-9_-]+")
+
+# Matches the id segment out of any of the common share-link shapes, since a
+# user (and therefore a model relaying the user's words) is far more likely
+# to hand over the URL they see in the browser than the bare id. The
+# optional "u/<n>/" branch tolerates the account-index segment Google
+# inserts (e.g. ".../file/u/1/d/<id>/view") whenever more than one Google
+# account is signed into the browser -- see google_sheets.py's identical
+# (?:u/\d+/)? tolerance for the spreadsheets URL shape. "(?!e/)" after each
+# "d/" excludes the "published to web" link shape
 # (".../d/e/<publish-id>/pubhtml"): that "e" is a literal path segment, not
 # part of the id, and the real Drive file id isn't present in that URL at
 # all -- the published-to-web token isn't a valid fileId, so this must not
@@ -43,8 +46,23 @@ mcp = FastMCP("google-drive-mcp")
 # elsewhere in the URL (e.g. a query value).
 _DRIVE_PATH_ID_PATTERN = re.compile(
     r"/(?:file/(?:u/\d+/)?d|folders|document/(?:u/\d+/)?d"
-    r"|spreadsheets/(?:u/\d+/)?d|presentation/(?:u/\d+/)?d)/(?!e/)"
-    r"([a-zA-Z0-9_-]+)"
+    r"|spreadsheets/(?:u/\d+/)?d|presentation/(?:u/\d+/)?d"
+    r"|forms/(?:u/\d+/)?d|drawings/(?:u/\d+/)?d)/(?!e/)"
+    rf"({_DRIVE_ID_CHARS.pattern})"
+)
+
+# Same alternation as _DRIVE_PATH_ID_PATTERN but without the id-capturing
+# group or the "(?!e/)" exclusion -- used only to recognize that a path *is*
+# one of these share-link shapes at all, including the shapes deliberately
+# excluded above (e.g. the published-to-web "/d/e/" form). See
+# _resolve_file_id: a path matching this but not _DRIVE_PATH_ID_PATTERN was
+# recognized-and-rejected, not merely unrecognized, and must not fall
+# through to the "?id=" query fallback below -- otherwise the fallback would
+# re-derive an id from the very link shape the exclusion above refused.
+_DRIVE_PATH_SHAPE_PATTERN = re.compile(
+    r"/(?:file/(?:u/\d+/)?d|folders|document/(?:u/\d+/)?d"
+    r"|spreadsheets/(?:u/\d+/)?d|presentation/(?:u/\d+/)?d"
+    r"|forms/(?:u/\d+/)?d|drawings/(?:u/\d+/)?d)/"
 )
 
 # Hosts _resolve_file_id treats as an authoritative Drive/Docs/Sheets/Slides
@@ -52,7 +70,11 @@ _DRIVE_PATH_ID_PATTERN = re.compile(
 # document an agent reads) that merely happens to parse with a matching
 # path/query shape would have its id extracted and passed to a share/
 # delete/permission call as if it were this connector's own link.
-_DRIVE_URL_HOSTS = frozenset({"drive.google.com", "docs.google.com"})
+# drive.usercontent.google.com is Google's own host for direct-download
+# links (e.g. from a "confirm download" interstitial for large files).
+_DRIVE_URL_HOSTS = frozenset(
+    {"drive.google.com", "docs.google.com", "drive.usercontent.google.com"}
+)
 
 # "owner" is deliberately excluded: ownership transfer needs
 # transferOwnership=True, is not reversible the way a role change is, and is
@@ -84,15 +106,20 @@ _EMAIL_PATTERN = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 _MAX_PERMISSION_LIST_PAGES = 1000
 
 
-def _resolve_file_id(file_id: str) -> str:
+def _resolve_file_id(file_id: str, field_name: str = "file_id") -> str:
     """Return the id captured out of a Drive/Docs/Sheets/Slides share link,
     or ``file_id`` itself (stripped) when it's already a bare id -- or, for
     anything URL-shaped that isn't a trusted link, unresolved verbatim so an
     obviously-invalid fileId reaches the API instead of a silently wrong one.
 
-    A real Drive id is always ``[a-zA-Z0-9_-]+`` and never contains "/" or
-    "?", so only a value containing one of those characters is even
-    considered URL-shaped; a bare id short-circuits immediately.
+    A real Drive id is always ``[a-zA-Z0-9_-]+`` (``_DRIVE_ID_CHARS``) and
+    never contains "/" or "?", so only a value containing one of those
+    characters is even considered URL-shaped; a bare id short-circuits
+    immediately. Empty/whitespace-only input is rejected outright (matching
+    ``require_clean_identifier``'s treatment of ``email``/``permission_id``
+    elsewhere in this file) rather than silently resolving to ``""``, which
+    would otherwise reach the Drive API as a request against the bare
+    ``.../files/`` collection endpoint instead of a specific file.
 
     urlparse only populates ``.scheme``/``.netloc`` for a string with an
     explicit "scheme://" prefix (or at least a leading "//"): a scheme-less
@@ -109,11 +136,23 @@ def _resolve_file_id(file_id: str) -> str:
     raw string -- so a URL whose overall host is allowed but whose query
     *value* merely contains a matching shape (".../search?q=/file/d/<id>")
     can't have that unrelated substring extracted as if it were the URL's
-    own resource id.
+    own resource id. A path recognized as a share-link shape that
+    _DRIVE_PATH_ID_PATTERN deliberately excludes (the published-to-web
+    "/d/e/" form) is rejected outright rather than falling through to the
+    "?id=" query check -- otherwise appending "?id=<anything>" to an
+    excluded link would trivially re-derive an id the path exclusion just
+    refused to give up. A query "id=" value is validated against the same
+    id character class as the path form: unlike a path segment, Drive's own
+    client library does not percent-encode "." before sending it, so an
+    unvalidated "id=.." would reach the API as a literal ".." path segment,
+    which dot-segment normalization can collapse into an unrelated
+    endpoint.
     """
     if not isinstance(file_id, str):
-        raise ValueError("file_id must be a string")
+        raise ValueError(f"{field_name} must be a string")
     stripped = file_id.strip()
+    if not stripped:
+        raise ValueError(f"{field_name} must be a non-empty id")
     if not re.search(r"[/?]", stripped):
         return stripped
     try:
@@ -127,44 +166,59 @@ def _resolve_file_id(file_id: str) -> str:
     match = _DRIVE_PATH_ID_PATTERN.search(parsed.path)
     if match:
         return match.group(1)
+    if _DRIVE_PATH_SHAPE_PATTERN.search(parsed.path):
+        return stripped
     query_id = parse_qs(parsed.query).get("id")
-    if query_id:
+    if query_id and _DRIVE_ID_CHARS.fullmatch(query_id[0]):
         return query_id[0]
     return stripped
 
 
 def _require_share_role(role: str) -> str:
     if role not in _SHARE_ROLES:
-        raise ValueError(f"role must be one of {_SHARE_ROLES}")
+        allowed = ", ".join(_SHARE_ROLES)
+        raise ValueError(f"role must be one of {allowed}")
     return role
 
 
-def _capped_response(build: Callable[[Any, bool], str], value: Any) -> str:
-    """Halve ``value`` (a list or a string) until ``build(value, truncated)``
+def _capped_response(
+    render: Callable[[Any, bool], str], value: Any, truncated: bool = False
+) -> str:
+    """Halve ``value`` (a list or a string) until ``render(value, truncated)``
     fits the platform's output limit -- mirrors deputy.py's/salesforce.py's
     _success_with_capped_list. There is no cursor to resume from here, so
     entries/content dropped this way are gone for this call, not just this
     page. Shared by _capped_list_response and _capped_content_response so a
     future change to the halving strategy only has one loop to update.
+
+    ``truncated`` seeds the initial state rather than always starting
+    False, so a caller that already knows the value is incomplete for a
+    reason this function can't see itself (e.g. a paginated fetch that gave
+    up before exhausting every page) can report that honestly even if the
+    partial ``value`` it did collect happens to still fit under the limit.
+
+    Named ``render``, not ``build``, to avoid shadowing the module-level
+    ``build`` imported from googleapiclient.discovery.
     """
     max_output_length = get_tool_max_output_length()
-    truncated = False
-    response = build(value, truncated)
+    response = render(value, truncated)
     while len(response) > max_output_length and value:
         value = value[: len(value) // 2]
         truncated = True
-        response = build(value, truncated)
+        response = render(value, truncated)
     return response
 
 
-def _capped_list_response(field_name: str, items: list[Any]) -> str:
+def _capped_list_response(
+    field_name: str, items: list[Any], *, truncated: bool = False
+) -> str:
     def _build(items: list[Any], truncated: bool) -> str:
         return json.dumps(
             {"status": "success", field_name: items, "truncated": truncated},
             ensure_ascii=False,
         )
 
-    return _capped_response(_build, items)
+    return _capped_response(_build, items, truncated)
 
 
 def _capped_content_response(file_metadata: dict[str, Any], content: str) -> str:
@@ -258,6 +312,22 @@ def google_drive_get_file_content(file_id: str, mime_type: str = "text/plain") -
         )
         file_mime_type = file_metadata.get("mimeType", "")
 
+        if file_mime_type in (
+            "application/vnd.google-apps.folder",
+            "application/vnd.google-apps.shortcut",
+        ):
+            # Both mimeTypes start with "application/vnd.google-apps" and
+            # would otherwise fall into the export_media branch below,
+            # which makes no sense for either (a folder has no content to
+            # export; a shortcut is a pointer, not a document) and would
+            # fail with an opaque API error instead of an actionable one.
+            # Now that folder share links resolve via _resolve_file_id,
+            # this is a directly reachable input, not a hypothetical.
+            raise ValueError(
+                f"file_id resolves to a {file_mime_type.rsplit('.', 1)[-1]}, "
+                "which has no content to read."
+            )
+
         if "application/vnd.google-apps" in file_mime_type:
             # Export Google Workspace document. Sheets has no text/plain
             # export format (only Docs/Slides do) and 400s on it, so the
@@ -304,7 +374,7 @@ def google_drive_create_file(
     try:
         file_metadata: dict[str, Any] = {"name": name, "mimeType": mime_type}
         if parent_id:
-            file_metadata["parents"] = [_resolve_file_id(parent_id)]
+            file_metadata["parents"] = [_resolve_file_id(parent_id, "parent_id")]
 
         service = get_drive_service()
         fh = io.BytesIO(content.encode("utf-8"))
@@ -341,7 +411,7 @@ def google_drive_create_folder(name: str, parent_id: str | None = None) -> str:
             "mimeType": "application/vnd.google-apps.folder",
         }
         if parent_id:
-            file_metadata["parents"] = [_resolve_file_id(parent_id)]
+            file_metadata["parents"] = [_resolve_file_id(parent_id, "parent_id")]
 
         service = get_drive_service()
         folder = (
@@ -541,6 +611,13 @@ def google_drive_list_permissions(file_id: str) -> str:
                 break
             if approx_length > max_output_length:
                 break
+        else:
+            # The loop ran out of iterations without either a natural
+            # "no more pages" or "already too big" stop -- a nextPageToken
+            # may still exist that was never followed, so this can't
+            # honestly report a complete list even if the permissions
+            # collected so far happen to still fit under the output cap.
+            return _capped_list_response("permissions", permissions, truncated=True)
 
         return _capped_list_response("permissions", permissions)
     except Exception as e:
@@ -564,7 +641,14 @@ def google_drive_share_file(
     role: "reader" (can view), "commenter" (can view and comment), or
     "writer" (can edit). Sharing a folder gives that access to everything
     inside it. When send_notification is True, Google emails the person
-    being added; message is included in that email if given.
+    being added; message is included in that email if given. If
+    send_notification is False, message is silently discarded (Google's
+    API rejects a notification message when no notification is sent) --
+    the response won't flag this, so don't rely on the message being
+    delivered without also checking send_notification.
+    This grants access to a specific email only; it can't create "anyone
+    with the link" link-sharing. google_drive_remove_permission can still
+    revoke an existing link-shared permission if one is already present.
     """
     try:
         _require_share_role(role)

--- a/tests/alembic/test_20260908_update_google_drive_description.py
+++ b/tests/alembic/test_20260908_update_google_drive_description.py
@@ -4,6 +4,7 @@ import importlib.util
 from pathlib import Path
 from unittest.mock import patch
 
+import sqlalchemy as sa
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 from sqlalchemy import create_engine, text
@@ -12,10 +13,10 @@ from sqlalchemy import create_engine, text
 def _load_migration_module():
     migration_file = (
         Path(__file__).parent.parent.parent
-        / "src/xagent/migrations/versions/20260908_update_google_drive_description_category.py"
+        / "src/xagent/migrations/versions/20260908_update_google_drive_description.py"
     )
     spec = importlib.util.spec_from_file_location(
-        "update_google_drive_description_category_migration", migration_file
+        "update_google_drive_description_migration", migration_file
     )
     module = importlib.util.module_from_spec(spec)
     assert spec.loader is not None
@@ -145,6 +146,40 @@ def test_upgrade_without_description_column_is_a_noop(tmp_path):
         )
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()  # must not raise when description is missing
+        # The column genuinely doesn't exist -- confirms the no-op above
+        # actually exercised the missing-column guard, not a coincidence.
+        columns = {
+            c["name"] for c in sa.inspect(connection).get_columns("public_mcp_apps")
+        }
+        assert "description" not in columns
+
+
+def test_upgrade_without_app_id_column_is_a_noop(tmp_path):
+    """_columns_present requires BOTH app_id and description; only the
+    description-missing half was covered above."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE public_mcp_apps (
+                    id INTEGER PRIMARY KEY,
+                    description TEXT
+                )
+                """
+            )
+        )
+        connection.execute(
+            text("INSERT INTO public_mcp_apps (description) VALUES (:d)"),
+            {"d": migration.PREVIOUS_DESCRIPTION},
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()  # must not raise when app_id is missing
+        description = connection.execute(
+            text("SELECT description FROM public_mcp_apps")
+        ).scalar()
+        assert description == migration.PREVIOUS_DESCRIPTION
 
 
 def test_upgrade_without_table_is_a_noop(tmp_path):
@@ -153,6 +188,8 @@ def test_upgrade_without_table_is_a_noop(tmp_path):
     with engine.begin() as connection:
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()  # must not raise when the table doesn't exist
+        tables = set(sa.inspect(connection).get_table_names())
+        assert "public_mcp_apps" not in tables
 
 
 def test_upgrade_without_matching_row_is_a_noop(tmp_path):

--- a/tests/alembic/test_20260908_update_google_drive_description_category.py
+++ b/tests/alembic/test_20260908_update_google_drive_description_category.py
@@ -1,4 +1,4 @@
-"""Tests for updating the Google Drive connector's description and category."""
+"""Tests for updating the Google Drive connector's description."""
 
 import importlib.util
 from pathlib import Path
@@ -27,15 +27,8 @@ def _operations(connection):
     return Operations(MigrationContext.configure(connection))
 
 
-def _create_table(
-    connection,
-    description: str,
-    category: str,
-    with_description_column: bool = True,
-    with_category_column: bool = True,
-):
+def _create_table(connection, description: str, with_description_column: bool = True):
     description_column = "description TEXT," if with_description_column else ""
-    category_column = "category VARCHAR(100)," if with_category_column else ""
     connection.execute(
         text(
             f"""
@@ -43,108 +36,70 @@ def _create_table(
                 id INTEGER PRIMARY KEY,
                 app_id VARCHAR(100) NOT NULL UNIQUE,
                 {description_column}
-                {category_column}
                 oauth_scopes JSON
             )
             """
         )
     )
-    columns = ["app_id"]
-    values = {"app_id": "google-drive"}
-    params = [":app_id"]
-    if with_description_column:
-        columns.append("description")
-        params.append(":description")
-        values["description"] = description
-    if with_category_column:
-        columns.append("category")
-        params.append(":category")
-        values["category"] = category
+    description_col = ", description" if with_description_column else ""
+    description_val = ", :description" if with_description_column else ""
     connection.execute(
         text(
-            f"INSERT INTO public_mcp_apps ({', '.join(columns)}) "
-            f"VALUES ({', '.join(params)})"
+            f"INSERT INTO public_mcp_apps (app_id{description_col}) "
+            f"VALUES ('google-drive'{description_val})"
         ),
-        values,
+        {"description": description},
     )
 
 
-def _row(connection):
-    row = connection.execute(
-        text(
-            "SELECT description, category FROM public_mcp_apps "
-            "WHERE app_id='google-drive'"
-        )
-    ).first()
-    return row[0], row[1]
+def _description(connection):
+    return connection.execute(
+        text("SELECT description FROM public_mcp_apps WHERE app_id='google-drive'")
+    ).scalar()
 
 
-def test_upgrade_updates_description_and_category(tmp_path):
+def test_upgrade_updates_description(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()
     with engine.begin() as connection:
-        _create_table(
-            connection,
-            description=migration.PREVIOUS_DESCRIPTION,
-            category=migration.PREVIOUS_CATEGORY,
-        )
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
-        description, category = _row(connection)
-        assert description == migration.CURRENT_DESCRIPTION
-        assert category == migration.CURRENT_CATEGORY
+        assert _description(connection) == migration.CURRENT_DESCRIPTION
 
 
 def test_upgrade_is_idempotent(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()
     with engine.begin() as connection:
-        _create_table(
-            connection,
-            description=migration.PREVIOUS_DESCRIPTION,
-            category=migration.PREVIOUS_CATEGORY,
-        )
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
             migration.upgrade()
-        description, category = _row(connection)
-        assert description == migration.CURRENT_DESCRIPTION
-        assert category == migration.CURRENT_CATEGORY
+        assert _description(connection) == migration.CURRENT_DESCRIPTION
 
 
-def test_downgrade_restores_previous_description_and_category(tmp_path):
+def test_downgrade_restores_previous_description(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()
     with engine.begin() as connection:
-        _create_table(
-            connection,
-            description=migration.PREVIOUS_DESCRIPTION,
-            category=migration.PREVIOUS_CATEGORY,
-        )
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
             migration.downgrade()
-        description, category = _row(connection)
-        assert description == migration.PREVIOUS_DESCRIPTION
-        assert category == migration.PREVIOUS_CATEGORY
+        assert _description(connection) == migration.PREVIOUS_DESCRIPTION
 
 
 def test_upgrade_downgrade_upgrade_round_trip(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()
     with engine.begin() as connection:
-        _create_table(
-            connection,
-            description=migration.PREVIOUS_DESCRIPTION,
-            category=migration.PREVIOUS_CATEGORY,
-        )
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
             migration.downgrade()
             migration.upgrade()
-        description, category = _row(connection)
-        assert description == migration.CURRENT_DESCRIPTION
-        assert category == migration.CURRENT_CATEGORY
+        assert _description(connection) == migration.CURRENT_DESCRIPTION
 
 
 def test_upgrade_preserves_admin_customized_description(tmp_path):
@@ -155,43 +110,17 @@ def test_upgrade_preserves_admin_customized_description(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()
     with engine.begin() as connection:
-        _create_table(
-            connection,
-            description="Our internal Drive connector",
-            category=migration.PREVIOUS_CATEGORY,
-        )
+        _create_table(connection, description="Our internal Drive connector")
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
-        description, category = _row(connection)
-        assert description == "Our internal Drive connector"
-        assert category == migration.CURRENT_CATEGORY
-
-
-def test_upgrade_preserves_admin_customized_category(tmp_path):
-    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
-    migration = _load_migration_module()
-    with engine.begin() as connection:
-        _create_table(
-            connection,
-            description=migration.PREVIOUS_DESCRIPTION,
-            category="Productivity",
-        )
-        with patch.object(migration, "op", _operations(connection)):
-            migration.upgrade()
-        description, category = _row(connection)
-        assert description == migration.CURRENT_DESCRIPTION
-        assert category == "Productivity"
+        assert _description(connection) == "Our internal Drive connector"
 
 
 def test_downgrade_preserves_admin_customized_description(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()
     with engine.begin() as connection:
-        _create_table(
-            connection,
-            description=migration.PREVIOUS_DESCRIPTION,
-            category=migration.PREVIOUS_CATEGORY,
-        )
+        _create_table(connection, description=migration.PREVIOUS_DESCRIPTION)
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
             connection.execute(
@@ -202,69 +131,20 @@ def test_downgrade_preserves_admin_customized_description(tmp_path):
                 {"d": "Our internal Drive connector"},
             )
             migration.downgrade()
-        description, category = _row(connection)
-        assert description == "Our internal Drive connector"
-        assert category == migration.PREVIOUS_CATEGORY
+        assert _description(connection) == "Our internal Drive connector"
 
 
-def test_downgrade_preserves_admin_customized_category(tmp_path):
+def test_upgrade_without_description_column_is_a_noop(tmp_path):
     engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
     migration = _load_migration_module()
     with engine.begin() as connection:
         _create_table(
             connection,
             description=migration.PREVIOUS_DESCRIPTION,
-            category=migration.PREVIOUS_CATEGORY,
-        )
-        with patch.object(migration, "op", _operations(connection)):
-            migration.upgrade()
-            connection.execute(
-                text(
-                    "UPDATE public_mcp_apps SET category = :c "
-                    "WHERE app_id = 'google-drive'"
-                ),
-                {"c": "Productivity"},
-            )
-            migration.downgrade()
-        description, category = _row(connection)
-        assert description == migration.PREVIOUS_DESCRIPTION
-        assert category == "Productivity"
-
-
-def test_upgrade_without_description_column_still_updates_category(tmp_path):
-    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
-    migration = _load_migration_module()
-    with engine.begin() as connection:
-        _create_table(
-            connection,
-            description=migration.PREVIOUS_DESCRIPTION,
-            category=migration.PREVIOUS_CATEGORY,
             with_description_column=False,
         )
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()  # must not raise when description is missing
-        category = connection.execute(
-            text("SELECT category FROM public_mcp_apps WHERE app_id='google-drive'")
-        ).scalar()
-        assert category == migration.CURRENT_CATEGORY
-
-
-def test_upgrade_without_category_column_still_updates_description(tmp_path):
-    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
-    migration = _load_migration_module()
-    with engine.begin() as connection:
-        _create_table(
-            connection,
-            description=migration.PREVIOUS_DESCRIPTION,
-            category=migration.PREVIOUS_CATEGORY,
-            with_category_column=False,
-        )
-        with patch.object(migration, "op", _operations(connection)):
-            migration.upgrade()  # must not raise when category is missing
-        description = connection.execute(
-            text("SELECT description FROM public_mcp_apps WHERE app_id='google-drive'")
-        ).scalar()
-        assert description == migration.CURRENT_DESCRIPTION
 
 
 def test_upgrade_without_table_is_a_noop(tmp_path):
@@ -288,7 +168,6 @@ def test_upgrade_without_matching_row_is_a_noop(tmp_path):
                     id INTEGER PRIMARY KEY,
                     app_id VARCHAR(100) NOT NULL UNIQUE,
                     description TEXT,
-                    category VARCHAR(100),
                     oauth_scopes JSON
                 )
                 """
@@ -296,20 +175,16 @@ def test_upgrade_without_matching_row_is_a_noop(tmp_path):
         )
         connection.execute(
             text(
-                "INSERT INTO public_mcp_apps (app_id, description, category) "
-                "VALUES ('onedrive', 'unrelated', 'Storage')"
+                "INSERT INTO public_mcp_apps (app_id, description) "
+                "VALUES ('onedrive', 'unrelated')"
             )
         )
         with patch.object(migration, "op", _operations(connection)):
             migration.upgrade()
-        row = connection.execute(
-            text(
-                "SELECT description, category FROM public_mcp_apps "
-                "WHERE app_id='onedrive'"
-            )
-        ).first()
-        assert row[0] == "unrelated"
-        assert row[1] == "Storage"
+        description = connection.execute(
+            text("SELECT description FROM public_mcp_apps WHERE app_id='onedrive'")
+        ).scalar()
+        assert description == "unrelated"
 
 
 def test_migration_fields_match_registry():
@@ -320,4 +195,4 @@ def test_migration_fields_match_registry():
         r for r in get_builtin_public_mcp_app_rows() if r["app_id"] == "google-drive"
     )
     assert registry_row["description"] == migration.CURRENT_DESCRIPTION
-    assert registry_row["category"] == migration.CURRENT_CATEGORY
+    assert registry_row["category"] == "Support"

--- a/tests/alembic/test_20260908_update_google_drive_description_category.py
+++ b/tests/alembic/test_20260908_update_google_drive_description_category.py
@@ -1,0 +1,323 @@
+"""Tests for updating the Google Drive connector's description and category."""
+
+import importlib.util
+from pathlib import Path
+from unittest.mock import patch
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine, text
+
+
+def _load_migration_module():
+    migration_file = (
+        Path(__file__).parent.parent.parent
+        / "src/xagent/migrations/versions/20260908_update_google_drive_description_category.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "update_google_drive_description_category_migration", migration_file
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def _operations(connection):
+    return Operations(MigrationContext.configure(connection))
+
+
+def _create_table(
+    connection,
+    description: str,
+    category: str,
+    with_description_column: bool = True,
+    with_category_column: bool = True,
+):
+    description_column = "description TEXT," if with_description_column else ""
+    category_column = "category VARCHAR(100)," if with_category_column else ""
+    connection.execute(
+        text(
+            f"""
+            CREATE TABLE public_mcp_apps (
+                id INTEGER PRIMARY KEY,
+                app_id VARCHAR(100) NOT NULL UNIQUE,
+                {description_column}
+                {category_column}
+                oauth_scopes JSON
+            )
+            """
+        )
+    )
+    columns = ["app_id"]
+    values = {"app_id": "google-drive"}
+    params = [":app_id"]
+    if with_description_column:
+        columns.append("description")
+        params.append(":description")
+        values["description"] = description
+    if with_category_column:
+        columns.append("category")
+        params.append(":category")
+        values["category"] = category
+    connection.execute(
+        text(
+            f"INSERT INTO public_mcp_apps ({', '.join(columns)}) "
+            f"VALUES ({', '.join(params)})"
+        ),
+        values,
+    )
+
+
+def _row(connection):
+    row = connection.execute(
+        text(
+            "SELECT description, category FROM public_mcp_apps "
+            "WHERE app_id='google-drive'"
+        )
+    ).first()
+    return row[0], row[1]
+
+
+def test_upgrade_updates_description_and_category(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(
+            connection,
+            description=migration.PREVIOUS_DESCRIPTION,
+            category=migration.PREVIOUS_CATEGORY,
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        description, category = _row(connection)
+        assert description == migration.CURRENT_DESCRIPTION
+        assert category == migration.CURRENT_CATEGORY
+
+
+def test_upgrade_is_idempotent(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(
+            connection,
+            description=migration.PREVIOUS_DESCRIPTION,
+            category=migration.PREVIOUS_CATEGORY,
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.upgrade()
+        description, category = _row(connection)
+        assert description == migration.CURRENT_DESCRIPTION
+        assert category == migration.CURRENT_CATEGORY
+
+
+def test_downgrade_restores_previous_description_and_category(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(
+            connection,
+            description=migration.PREVIOUS_DESCRIPTION,
+            category=migration.PREVIOUS_CATEGORY,
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+        description, category = _row(connection)
+        assert description == migration.PREVIOUS_DESCRIPTION
+        assert category == migration.PREVIOUS_CATEGORY
+
+
+def test_upgrade_downgrade_upgrade_round_trip(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(
+            connection,
+            description=migration.PREVIOUS_DESCRIPTION,
+            category=migration.PREVIOUS_CATEGORY,
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            migration.downgrade()
+            migration.upgrade()
+        description, category = _row(connection)
+        assert description == migration.CURRENT_DESCRIPTION
+        assert category == migration.CURRENT_CATEGORY
+
+
+def test_upgrade_preserves_admin_customized_description(tmp_path):
+    """description is not in _BUILTIN_PROTECTED_FIELDS (admin_mcp.py), so an
+    operator can have edited it via the admin PATCH endpoint. The migration
+    must not clobber a value that no longer matches the last-known default.
+    """
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(
+            connection,
+            description="Our internal Drive connector",
+            category=migration.PREVIOUS_CATEGORY,
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        description, category = _row(connection)
+        assert description == "Our internal Drive connector"
+        assert category == migration.CURRENT_CATEGORY
+
+
+def test_upgrade_preserves_admin_customized_category(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(
+            connection,
+            description=migration.PREVIOUS_DESCRIPTION,
+            category="Productivity",
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        description, category = _row(connection)
+        assert description == migration.CURRENT_DESCRIPTION
+        assert category == "Productivity"
+
+
+def test_downgrade_preserves_admin_customized_description(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(
+            connection,
+            description=migration.PREVIOUS_DESCRIPTION,
+            category=migration.PREVIOUS_CATEGORY,
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            connection.execute(
+                text(
+                    "UPDATE public_mcp_apps SET description = :d "
+                    "WHERE app_id = 'google-drive'"
+                ),
+                {"d": "Our internal Drive connector"},
+            )
+            migration.downgrade()
+        description, category = _row(connection)
+        assert description == "Our internal Drive connector"
+        assert category == migration.PREVIOUS_CATEGORY
+
+
+def test_downgrade_preserves_admin_customized_category(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(
+            connection,
+            description=migration.PREVIOUS_DESCRIPTION,
+            category=migration.PREVIOUS_CATEGORY,
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+            connection.execute(
+                text(
+                    "UPDATE public_mcp_apps SET category = :c "
+                    "WHERE app_id = 'google-drive'"
+                ),
+                {"c": "Productivity"},
+            )
+            migration.downgrade()
+        description, category = _row(connection)
+        assert description == migration.PREVIOUS_DESCRIPTION
+        assert category == "Productivity"
+
+
+def test_upgrade_without_description_column_still_updates_category(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(
+            connection,
+            description=migration.PREVIOUS_DESCRIPTION,
+            category=migration.PREVIOUS_CATEGORY,
+            with_description_column=False,
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()  # must not raise when description is missing
+        category = connection.execute(
+            text("SELECT category FROM public_mcp_apps WHERE app_id='google-drive'")
+        ).scalar()
+        assert category == migration.CURRENT_CATEGORY
+
+
+def test_upgrade_without_category_column_still_updates_description(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        _create_table(
+            connection,
+            description=migration.PREVIOUS_DESCRIPTION,
+            category=migration.PREVIOUS_CATEGORY,
+            with_category_column=False,
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()  # must not raise when category is missing
+        description = connection.execute(
+            text("SELECT description FROM public_mcp_apps WHERE app_id='google-drive'")
+        ).scalar()
+        assert description == migration.CURRENT_DESCRIPTION
+
+
+def test_upgrade_without_table_is_a_noop(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()  # must not raise when the table doesn't exist
+
+
+def test_upgrade_without_matching_row_is_a_noop(tmp_path):
+    """A different app_id in the table must be untouched, and no matching
+    row is not a customization to protect -- it's simply nothing to do."""
+    engine = create_engine(f"sqlite:///{tmp_path / 'test.db'}")
+    migration = _load_migration_module()
+    with engine.begin() as connection:
+        connection.execute(
+            text(
+                """
+                CREATE TABLE public_mcp_apps (
+                    id INTEGER PRIMARY KEY,
+                    app_id VARCHAR(100) NOT NULL UNIQUE,
+                    description TEXT,
+                    category VARCHAR(100),
+                    oauth_scopes JSON
+                )
+                """
+            )
+        )
+        connection.execute(
+            text(
+                "INSERT INTO public_mcp_apps (app_id, description, category) "
+                "VALUES ('onedrive', 'unrelated', 'Storage')"
+            )
+        )
+        with patch.object(migration, "op", _operations(connection)):
+            migration.upgrade()
+        row = connection.execute(
+            text(
+                "SELECT description, category FROM public_mcp_apps "
+                "WHERE app_id='onedrive'"
+            )
+        ).first()
+        assert row[0] == "unrelated"
+        assert row[1] == "Storage"
+
+
+def test_migration_fields_match_registry():
+    from xagent.web.builtin_mcp_registry import get_builtin_public_mcp_app_rows
+
+    migration = _load_migration_module()
+    registry_row = next(
+        r for r in get_builtin_public_mcp_app_rows() if r["app_id"] == "google-drive"
+    )
+    assert registry_row["description"] == migration.CURRENT_DESCRIPTION
+    assert registry_row["category"] == migration.CURRENT_CATEGORY

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -170,10 +170,80 @@ def test_resolve_file_id_rejects_non_string_input():
         google_drive._resolve_file_id(12345)
 
 
+@pytest.mark.parametrize("value", ["", "   ", "\t\n"])
+def test_resolve_file_id_rejects_empty_or_whitespace_input(value):
+    """An unrejected empty file_id would reach the Drive API as a request
+    against the bare .../files/ collection endpoint instead of a specific
+    file -- reject it the same way email/permission_id already are via
+    require_clean_identifier."""
+    with pytest.raises(ValueError, match="file_id must be a non-empty id"):
+        google_drive._resolve_file_id(value)
+
+
+def test_resolve_file_id_uses_the_given_field_name_in_errors():
+    with pytest.raises(ValueError, match="parent_id must be a non-empty id"):
+        google_drive._resolve_file_id("", "parent_id")
+    with pytest.raises(ValueError, match="parent_id must be a string"):
+        google_drive._resolve_file_id(123, "parent_id")
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # googleapiclient does not percent-encode "." before sending it, so
+        # an unvalidated id reaches the API as a literal path segment;
+        # dot-segment normalization could then collapse "files/.." into an
+        # unrelated endpoint. Character-class-validating the query "id="
+        # value (matching what the path branch already implicitly requires)
+        # closes this off.
+        "https://drive.google.com/x?id=..",
+        "https://drive.google.com/x?id=.",
+        "https://drive.google.com/x?id=../../etc",
+    ],
+)
+def test_resolve_file_id_rejects_dot_segments_from_query_fallback(url):
+    assert google_drive._resolve_file_id(url) == url
+
+
+def test_resolve_file_id_query_fallback_respects_published_link_exclusion():
+    """The path pattern's "(?!e/)" exclusion for published-to-web links
+    must not be bypassable by simply appending "?id=<anything>": the query
+    fallback used to run unconditionally whenever the path match failed,
+    without knowing *why* it failed."""
+    url = "https://docs.google.com/document/d/e/2PACX-1abcXYZ/pub?id=SNEAKY"
+    assert google_drive._resolve_file_id(url) == url
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://drive.google.com/forms/d/abc123/edit", "abc123"),
+        ("https://drive.google.com/forms/u/1/d/abc123/edit", "abc123"),
+        ("https://drive.google.com/drawings/d/abc123/edit", "abc123"),
+        ("https://drive.google.com/drawings/u/2/d/abc123/edit", "abc123"),
+    ],
+)
+def test_resolve_file_id_supports_forms_and_drawings(url, expected):
+    assert google_drive._resolve_file_id(url) == expected
+
+
+def test_resolve_file_id_supports_usercontent_host():
+    url = "https://drive.usercontent.google.com/download?id=abc123&export=download"
+    assert google_drive._resolve_file_id(url) == "abc123"
+
+
 @pytest.mark.parametrize("bad_role", ["owner", "organizer", ""])
 def test_require_share_role_rejects_roles_outside_the_allowed_set(bad_role):
     with pytest.raises(ValueError, match="role"):
         google_drive._require_share_role(bad_role)
+
+
+def test_require_share_role_error_message_is_not_a_tuple_repr():
+    with pytest.raises(ValueError) as exc_info:
+        google_drive._require_share_role("owner")
+    message = str(exc_info.value)
+    assert "(" not in message and "'" not in message
+    assert "reader, commenter, writer" in message
 
 
 @pytest.mark.parametrize("good_role", ["reader", "commenter", "writer"])
@@ -271,6 +341,10 @@ def test_search_passes_shared_drive_support_and_clamps_max_results(monkeypatch):
 
 
 def test_search_caps_oversized_output(monkeypatch):
+    # Pinned rather than relying on the ~50KB default: XAGENT_TOOL_MAX_OUTPUT_LENGTH
+    # is honored and tests/conftest.py force-loads .env, so an environment
+    # override could otherwise make this flaky in either direction.
+    monkeypatch.setattr(google_drive, "get_tool_max_output_length", lambda: 3000)
     service = _mock_drive_service(monkeypatch)
     huge_files = [
         {"id": f"f{i}", "name": "x" * 200, "mimeType": "text/plain"}
@@ -346,7 +420,7 @@ def test_create_file_validates_parent_id_before_building_service(monkeypatch):
     )
 
     assert result["status"] == "error"
-    assert "file_id must be a string" in result["message"]
+    assert "parent_id must be a string" in result["message"]
     get_service.assert_not_called()
 
 
@@ -359,7 +433,7 @@ def test_create_folder_validates_parent_id_before_building_service(monkeypatch):
     )
 
     assert result["status"] == "error"
-    assert "file_id must be a string" in result["message"]
+    assert "parent_id must be a string" in result["message"]
     get_service.assert_not_called()
 
 
@@ -482,7 +556,39 @@ def test_get_file_content_keeps_text_plain_default_for_docs(monkeypatch):
     )
 
 
+@pytest.mark.parametrize(
+    "folder_mime_type",
+    [
+        "application/vnd.google-apps.folder",
+        "application/vnd.google-apps.shortcut",
+    ],
+)
+def test_get_file_content_rejects_folder_and_shortcut_with_a_clear_message(
+    monkeypatch, folder_mime_type
+):
+    """Both mimeTypes start with "application/vnd.google-apps" and would
+    otherwise fall into the export_media branch, which makes no sense for
+    either -- and folder share links are now resolvable via
+    _resolve_file_id, so this is directly reachable, not hypothetical."""
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.get.return_value.execute.return_value = {
+        "id": "abc123",
+        "name": "Team Folder",
+        "mimeType": folder_mime_type,
+    }
+
+    result = json.loads(google_drive.google_drive_get_file_content("abc123"))
+
+    assert result["status"] == "error"
+    assert "no content to read" in result["message"]
+    service.files.return_value.export_media.assert_not_called()
+    service.files.return_value.get_media.assert_not_called()
+
+
 def test_get_file_content_caps_oversized_output(monkeypatch):
+    # Pinned rather than relying on the ~50KB default -- see
+    # test_search_caps_oversized_output's comment for why.
+    monkeypatch.setattr(google_drive, "get_tool_max_output_length", lambda: 3000)
     service = _mock_drive_service(monkeypatch)
     service.files.return_value.get.return_value.execute.return_value = {
         "id": "abc123",
@@ -545,6 +651,9 @@ def test_list_permissions_returns_permissions(monkeypatch):
 
 
 def test_list_permissions_caps_oversized_output(monkeypatch):
+    # Pinned rather than relying on the ~50KB default -- see
+    # test_search_caps_oversized_output's comment for why.
+    monkeypatch.setattr(google_drive, "get_tool_max_output_length", lambda: 3000)
     service = _mock_drive_service(monkeypatch)
     huge_permissions = [
         {
@@ -589,6 +698,28 @@ def test_list_permissions_follows_next_page_token(monkeypatch):
     calls = service.permissions.return_value.list.call_args_list
     assert calls[0].kwargs["pageToken"] is None
     assert calls[1].kwargs["pageToken"] == "page2"
+
+
+def test_list_permissions_reports_truncated_when_page_bound_is_exhausted(
+    monkeypatch,
+):
+    """If the loop-safety bound is hit while a nextPageToken still exists
+    and the accumulated size never crossed the output cap, the result must
+    still say truncated=True -- more permissions may exist on pages that
+    were never fetched, so reporting a complete list would be dishonest
+    even though what little was collected happens to fit comfortably."""
+    monkeypatch.setattr(google_drive, "_MAX_PERMISSION_LIST_PAGES", 3)
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.list.return_value.execute.return_value = {
+        "permissions": [{"id": "perm"}],
+        "nextPageToken": "more",  # always another page available
+    }
+
+    result = json.loads(google_drive.google_drive_list_permissions("fid"))
+
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert service.permissions.return_value.list.call_count == 3
 
 
 def test_list_permissions_stops_paginating_once_over_the_output_limit(monkeypatch):
@@ -715,8 +846,9 @@ def test_share_file_defaults_to_reader_with_notification(monkeypatch):
     service = _mock_drive_service(monkeypatch)
     service.permissions.return_value.create.return_value.execute.return_value = {}
 
-    json.loads(google_drive.google_drive_share_file("fid", "a@x.com"))
+    result = json.loads(google_drive.google_drive_share_file("fid", "a@x.com"))
 
+    assert result["status"] == "success"
     kwargs = service.permissions.return_value.create.call_args.kwargs
     assert kwargs["body"]["role"] == "reader"
     assert kwargs["sendNotificationEmail"] is True
@@ -730,12 +862,13 @@ def test_share_file_omits_email_message_when_notification_disabled(monkeypatch):
     service = _mock_drive_service(monkeypatch)
     service.permissions.return_value.create.return_value.execute.return_value = {}
 
-    json.loads(
+    result = json.loads(
         google_drive.google_drive_share_file(
             "fid", "a@x.com", send_notification=False, message="hi"
         )
     )
 
+    assert result["status"] == "success"
     kwargs = service.permissions.return_value.create.call_args.kwargs
     assert kwargs["sendNotificationEmail"] is False
     assert "emailMessage" not in kwargs

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -93,6 +93,26 @@ def test_resolve_file_id_does_not_extract_id_from_untrusted_hosts(url):
 @pytest.mark.parametrize(
     "url",
     [
+        # A userinfo-bearing authority is inherently ambiguous across URL
+        # parsers: Python's urlparse (RFC 3986) resolves .hostname to
+        # whatever follows the *last* "@", so each of these has .hostname
+        # == "drive.google.com" and would pass a naive host check -- but a
+        # WHATWG-based parser (a browser rendering the same string to a
+        # human, or a different URL consumer downstream) can disagree about
+        # which side is the real destination. The literal backslash variant
+        # is the same ambiguity with an extra separator character thrown
+        # in; both must be rejected identically, not just the plain form.
+        r"https://evil.com@drive.google.com/x?id=ATTACKER_ID",
+        r"https://evil.com\@drive.google.com/x?id=ATTACKER_ID",
+    ],
+)
+def test_resolve_file_id_rejects_userinfo_bearing_authority(url):
+    assert google_drive._resolve_file_id(url) == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
         "drive.google.com/file/d/abc123/view",
         "drive.google.com/drive/folders/abc123",
         "docs.google.com/open?id=abc123",
@@ -246,6 +266,37 @@ def test_resolve_file_id_supports_forms_and_drawings(url, expected):
 def test_resolve_file_id_supports_usercontent_host():
     url = "https://drive.usercontent.google.com/download?id=abc123&export=download"
     assert google_drive._resolve_file_id(url) == "abc123"
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("abc123", None),  # bare id: never URL-shaped, nothing to extract
+        ("https://drive.google.com/file/d/abc123/view", None),  # no resourcekey
+        (
+            "https://drive.google.com/file/d/abc123/view?resourcekey=0-Rkey123",
+            "0-Rkey123",
+        ),
+        (
+            "https://docs.google.com/document/d/abc123/edit?resourcekey=0-Rkey123",
+            "0-Rkey123",
+        ),
+        # Untrusted host: must not leak a resourcekey-shaped query value
+        # from a URL this connector doesn't otherwise trust at all.
+        ("https://evil.com/x?id=abc123&resourcekey=0-Rkey123", None),
+        # Userinfo-bearing authority: same rejection as _resolve_file_id.
+        (
+            "https://evil.com@drive.google.com/file/d/abc123/view?resourcekey=0-Rkey123",
+            None,
+        ),
+        # A resourcekey value containing characters outside the id
+        # charset is rejected rather than passed through unvalidated into
+        # a header value.
+        ("https://drive.google.com/file/d/abc123/view?resourcekey=bad key", None),
+    ],
+)
+def test_extract_resource_key(value, expected):
+    assert google_drive._extract_resource_key(value) == expected
 
 
 @pytest.mark.parametrize("bad_role", ["owner", "organizer", ""])
@@ -500,6 +551,75 @@ def test_get_file_content_resolves_full_drive_url(monkeypatch):
     assert media_kwargs["supportsAllDrives"] is True
     assert result["content"] == "hello"
     assert result["encoding"] == "utf-8"
+
+
+def test_get_file_content_attaches_resource_key_header_from_share_link(monkeypatch):
+    """A pre-2021 link-shared item's plain fileId 404s on files.get/
+    files.get_media/files.export_media without the resourcekey from its
+    share link attached as an X-Goog-Drive-Resource-Keys header (see
+    google_drive_download.py for the same header used elsewhere in this
+    codebase). The header must be attached to both the metadata fetch and
+    the content download/export request."""
+    service = _mock_drive_service(monkeypatch)
+    get_request = service.files.return_value.get.return_value
+    get_request.headers = {}
+    get_request.execute.return_value = {
+        "id": "abc123",
+        "name": "notes.txt",
+        "mimeType": "text/plain",
+    }
+    media_request = service.files.return_value.get_media.return_value
+    media_request.headers = {}
+
+    class _FakeDownloader:
+        def __init__(self, fh, _request):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(b"hello")
+            return None, True
+
+    monkeypatch.setattr(google_drive, "MediaIoBaseDownload", _FakeDownloader)
+
+    url = "https://drive.google.com/file/d/abc123/view?resourcekey=0-Rkey123"
+    result = json.loads(google_drive.google_drive_get_file_content(url))
+
+    assert result["status"] == "success"
+    expected_header = {"X-Goog-Drive-Resource-Keys": "abc123/0-Rkey123"}
+    assert get_request.headers == expected_header
+    assert media_request.headers == expected_header
+
+
+def test_get_file_content_omits_resource_key_header_for_bare_id(monkeypatch):
+    """A bare id (or a share link with no resourcekey) never carries a
+    resourcekey -- the header must not be attached (or attached as
+    "id/None") in that ordinary case."""
+    service = _mock_drive_service(monkeypatch)
+    get_request = service.files.return_value.get.return_value
+    get_request.headers = {}
+    get_request.execute.return_value = {
+        "id": "abc123",
+        "name": "notes.txt",
+        "mimeType": "text/plain",
+    }
+    media_request = service.files.return_value.get_media.return_value
+    media_request.headers = {}
+
+    class _FakeDownloader:
+        def __init__(self, fh, _request):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(b"hello")
+            return None, True
+
+    monkeypatch.setattr(google_drive, "MediaIoBaseDownload", _FakeDownloader)
+
+    result = json.loads(google_drive.google_drive_get_file_content("abc123"))
+
+    assert result["status"] == "success"
+    assert get_request.headers == {}
+    assert media_request.headers == {}
 
 
 def test_get_file_content_falls_back_to_base64_for_binary_content(monkeypatch):
@@ -833,6 +953,18 @@ def test_rename_file_resolves_full_drive_url(monkeypatch):
     assert kwargs["supportsAllDrives"] is True
 
 
+def test_rename_file_attaches_resource_key_header(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    update_request = service.files.return_value.update.return_value
+    update_request.headers = {}
+    update_request.execute.return_value = {"id": "abc123", "name": "renamed"}
+
+    url = "https://drive.google.com/file/d/abc123/view?resourcekey=0-Rkey123"
+    google_drive.google_drive_rename_file(url, "renamed")
+
+    assert update_request.headers == {"X-Goog-Drive-Resource-Keys": "abc123/0-Rkey123"}
+
+
 def test_list_permissions_returns_permissions(monkeypatch):
     service = _mock_drive_service(monkeypatch)
     service.permissions.return_value.list.return_value.execute.return_value = {
@@ -850,6 +982,91 @@ def test_list_permissions_returns_permissions(monkeypatch):
         service.permissions.return_value.list.call_args.kwargs["supportsAllDrives"]
         is True
     )
+
+
+def test_list_permissions_requests_permission_details_field(monkeypatch):
+    """Without permissionDetails, a caller can't tell an inherited
+    permission (comes from a parent folder, can't be changed/removed on
+    this item directly) from a direct one -- only observable for a Shared
+    Drive item, but the field must always be requested to expose it when
+    it's there."""
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.list.return_value.execute.return_value = {
+        "permissions": []
+    }
+
+    google_drive.google_drive_list_permissions("fid")
+
+    fields = service.permissions.return_value.list.call_args.kwargs["fields"]
+    assert "permissionDetails" in fields
+    assert "inherited" in fields
+
+
+def test_list_permissions_accepts_a_caller_supplied_page_token(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.list.return_value.execute.return_value = {
+        "permissions": [{"id": "perm1"}]
+    }
+
+    google_drive.google_drive_list_permissions("fid", page_token="resume-here")
+
+    assert (
+        service.permissions.return_value.list.call_args.kwargs["pageToken"]
+        == "resume-here"
+    )
+
+
+def test_list_permissions_returns_next_page_token_when_stopped_early(monkeypatch):
+    """When pagination stops early (either because accumulated size
+    already exceeds the output cap, or the loop-safety bound was hit) a
+    nextPageToken may still exist -- it must be surfaced so a caller can
+    resume the listing instead of the rest of the collaborators being
+    silently lost."""
+    monkeypatch.setattr(google_drive, "get_tool_max_output_length", lambda: 3000)
+    service = _mock_drive_service(monkeypatch)
+    huge_page = [
+        {
+            "id": f"perm{i}",
+            "type": "user",
+            "role": "reader",
+            "emailAddress": f"user{i}@example.com",
+            "displayName": "x" * 200,
+        }
+        for i in range(2000)
+    ]
+    service.permissions.return_value.list.return_value.execute.return_value = {
+        "permissions": huge_page,
+        "nextPageToken": "page2",
+    }
+
+    result = json.loads(google_drive.google_drive_list_permissions("fid"))
+
+    assert result["truncated"] is True
+    assert result["next_page_token"] == "page2"
+
+
+def test_list_permissions_omits_next_page_token_when_list_is_complete(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.list.return_value.execute.return_value = {
+        "permissions": [{"id": "perm1"}]
+    }
+
+    result = json.loads(google_drive.google_drive_list_permissions("fid"))
+
+    assert result["truncated"] is False
+    assert "next_page_token" not in result
+
+
+def test_list_permissions_attaches_resource_key_header(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    list_request = service.permissions.return_value.list.return_value
+    list_request.headers = {}
+    list_request.execute.return_value = {"permissions": []}
+
+    url = "https://drive.google.com/file/d/abc123/view?resourcekey=0-Rkey123"
+    google_drive.google_drive_list_permissions(url)
+
+    assert list_request.headers == {"X-Goog-Drive-Resource-Keys": "abc123/0-Rkey123"}
 
 
 def test_list_permissions_caps_oversized_output(monkeypatch):
@@ -911,6 +1128,7 @@ def test_list_permissions_reports_truncated_when_page_bound_is_exhausted(
     were never fetched, so reporting a complete list would be dishonest
     even though what little was collected happens to fit comfortably."""
     monkeypatch.setattr(google_drive, "_MAX_PERMISSION_LIST_PAGES", 3)
+    monkeypatch.setattr(google_drive, "get_tool_max_output_length", lambda: 3000)
     service = _mock_drive_service(monkeypatch)
     service.permissions.return_value.list.return_value.execute.return_value = {
         "permissions": [{"id": "perm"}],
@@ -930,6 +1148,7 @@ def test_list_permissions_stops_paginating_once_over_the_output_limit(monkeypatc
     limit, fetching further pages is pure waste -- more blocking API calls
     for data that gets thrown away immediately after."""
     service = _mock_drive_service(monkeypatch)
+    monkeypatch.setattr(google_drive, "get_tool_max_output_length", lambda: 3000)
     huge_page = [
         {
             "id": f"perm{i}",
@@ -1044,6 +1263,23 @@ def test_share_file_grants_role_to_email(monkeypatch):
     assert kwargs["supportsAllDrives"] is True
 
 
+def test_share_file_attaches_resource_key_header(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    create_request = service.permissions.return_value.create.return_value
+    create_request.headers = {}
+    create_request.execute.return_value = {
+        "id": "perm1",
+        "type": "user",
+        "role": "reader",
+        "emailAddress": "a@x.com",
+    }
+
+    url = "https://drive.google.com/file/d/abc123/view?resourcekey=0-Rkey123"
+    google_drive.google_drive_share_file(url, "a@x.com")
+
+    assert create_request.headers == {"X-Goog-Drive-Resource-Keys": "abc123/0-Rkey123"}
+
+
 def test_share_file_defaults_to_reader_with_notification(monkeypatch):
     service = _mock_drive_service(monkeypatch)
     service.permissions.return_value.create.return_value.execute.return_value = {}
@@ -1138,6 +1374,54 @@ def test_update_permission_changes_role(monkeypatch):
     assert kwargs["fields"] == "id, type, role, emailAddress, displayName"
 
 
+def test_update_permission_attaches_resource_key_header(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    update_request = service.permissions.return_value.update.return_value
+    update_request.headers = {}
+    update_request.execute.return_value = {"id": "perm1", "role": "writer"}
+
+    url = "https://drive.google.com/file/d/abc123/view?resourcekey=0-Rkey123"
+    google_drive.google_drive_update_permission(url, "perm1", "writer")
+
+    assert update_request.headers == {"X-Goog-Drive-Resource-Keys": "abc123/0-Rkey123"}
+
+
+@pytest.mark.parametrize("bad_permission_id", ["..", "../other", "perm/../file"])
+def test_update_permission_rejects_dot_segment_permission_id(
+    monkeypatch, bad_permission_id
+):
+    """permission_id never goes through URL resolution, but googleapiclient
+    does not percent-encode "." before interpolating it into the request
+    path -- an unvalidated dot-segment id can be collapsed by normalization
+    into an unrelated endpoint. require_clean_identifier alone accepts
+    ".." (non-empty, no surrounding whitespace); _require_drive_id must
+    additionally reject it via the same character class real ids use."""
+    service = _mock_drive_service(monkeypatch)
+
+    result = json.loads(
+        google_drive.google_drive_update_permission("fid", bad_permission_id, "reader")
+    )
+
+    assert result["status"] == "error"
+    assert "permission_id" in result["message"]
+    service.permissions.return_value.update.assert_not_called()
+
+
+@pytest.mark.parametrize("bad_permission_id", ["..", "../other", "perm/../file"])
+def test_remove_permission_rejects_dot_segment_permission_id(
+    monkeypatch, bad_permission_id
+):
+    service = _mock_drive_service(monkeypatch)
+
+    result = json.loads(
+        google_drive.google_drive_remove_permission("fid", bad_permission_id)
+    )
+
+    assert result["status"] == "error"
+    assert "permission_id" in result["message"]
+    service.permissions.return_value.delete.assert_not_called()
+
+
 @pytest.mark.parametrize("bad_role", ["owner", "organizer", ""])
 def test_update_permission_rejects_role_outside_the_share_roles(monkeypatch, bad_role):
     service = _mock_drive_service(monkeypatch)
@@ -1174,6 +1458,18 @@ def test_remove_permission_success(monkeypatch):
     assert result["status"] == "success"
     assert "perm1" in result["message"]
     service.permissions.return_value.get.assert_not_called()
+
+
+def test_remove_permission_attaches_resource_key_header(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    delete_request = service.permissions.return_value.delete.return_value
+    delete_request.headers = {}
+    delete_request.execute.return_value = {}
+
+    url = "https://drive.google.com/file/d/abc123/view?resourcekey=0-Rkey123"
+    google_drive.google_drive_remove_permission(url, "perm1")
+
+    assert delete_request.headers == {"X-Goog-Drive-Resource-Keys": "abc123/0-Rkey123"}
 
 
 def test_remove_permission_returns_error_payload_on_failure(monkeypatch):
@@ -1318,6 +1614,18 @@ def test_delete_file_rejects_dot_segment_file_id_before_calling_the_api(monkeypa
     assert result["status"] == "error"
     assert "file_id must look like a Drive id" in result["message"]
     get_service.assert_not_called()
+
+
+def test_delete_file_attaches_resource_key_header(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    delete_request = service.files.return_value.delete.return_value
+    delete_request.headers = {}
+    delete_request.execute.return_value = {}
+
+    url = "https://drive.google.com/file/d/abc123/view?resourcekey=0-Rkey123"
+    google_drive.google_drive_delete_file(url)
+
+    assert delete_request.headers == {"X-Goog-Drive-Resource-Keys": "abc123/0-Rkey123"}
 
 
 def test_remove_permission_tolerates_ssl_eof_on_204_response(monkeypatch):

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -205,6 +205,21 @@ def test_resolve_file_id_rejects_dot_segments_from_query_fallback(url):
     assert google_drive._resolve_file_id(url) == url
 
 
+@pytest.mark.parametrize("value", ["..", ".", "...", "~", "%2e%2e"])
+def test_resolve_file_id_rejects_dot_segments_from_bare_input(value):
+    """The bare-id fast path (no "/" or "?" at all, so it never reaches the
+    URL-handling code, or the query-fallback validation above) is the most
+    common call shape -- every caller normally passes a plain id, not a
+    URL -- and was left completely unvalidated. A literal file_id=".."
+    reaches google_drive_delete_file (which "skips the trash and
+    permanently deletes") as fileId=".." verbatim, which dot-segment
+    normalization can collapse into an unrelated endpoint -- the exact risk
+    the query-fallback case above is already guarded against, just
+    reachable more directly here."""
+    with pytest.raises(ValueError, match="file_id must look like a Drive id"):
+        google_drive._resolve_file_id(value)
+
+
 def test_resolve_file_id_query_fallback_respects_published_link_exclusion():
     """The path pattern's "(?!e/)" exclusion for published-to-web links
     must not be bypassable by simply appending "?id=<anything>": the query
@@ -1093,6 +1108,20 @@ def test_delete_file_tolerates_ssl_eof_on_204_response(monkeypatch):
     result = json.loads(google_drive.google_drive_delete_file("fid"))
 
     assert result["status"] == "success"
+
+
+def test_delete_file_rejects_dot_segment_file_id_before_calling_the_api(monkeypatch):
+    """google_drive_delete_file "skips the trash and permanently deletes" --
+    a literal file_id=".." reaching the API as a dot-segment fileId is the
+    highest-stakes reachable case of the bare-input validation gap."""
+    get_service = Mock()
+    monkeypatch.setattr(google_drive, "get_drive_service", get_service)
+
+    result = json.loads(google_drive.google_drive_delete_file(".."))
+
+    assert result["status"] == "error"
+    assert "file_id must look like a Drive id" in result["message"]
+    get_service.assert_not_called()
 
 
 def test_remove_permission_tolerates_ssl_eof_on_204_response(monkeypatch):

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -113,6 +113,29 @@ def test_resolve_file_id_rejects_userinfo_bearing_authority(url):
 @pytest.mark.parametrize(
     "url",
     [
+        # Untrusted/ambiguous URLs _resolve_file_id refuses to resolve an
+        # id for. _resolve_file_id and _extract_resource_key share
+        # _parse_trusted_drive_url specifically so their trust decisions
+        # for the same input can't drift apart the way they once did (see
+        # _parse_trusted_drive_url's docstring) -- this asserts that
+        # agreement directly, from one shared list, rather than only
+        # exercising each function's own hand-picked cases.
+        "https://evil.com/x?id=ATTACKER_CHOSEN_ID",
+        "https://evil.com@drive.google.com/x?id=ATTACKER_ID",
+        r"https://evil.com\@drive.google.com/x?id=ATTACKER_ID",
+        "https://docs.google.com/spreadsheets/d/e/2PACX-1vTabc123xyz/pubhtml",
+    ],
+)
+def test_resolve_file_id_and_extract_resource_key_agree_on_untrusted_input(url):
+    separator = "&" if "?" in url else "?"
+    resource_key_url = f"{url}{separator}resourcekey=0-Rkey123"
+    assert google_drive._resolve_file_id(resource_key_url) == resource_key_url
+    assert google_drive._extract_resource_key(resource_key_url) is None
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
         "drive.google.com/file/d/abc123/view",
         "drive.google.com/drive/folders/abc123",
         "docs.google.com/open?id=abc123",
@@ -289,10 +312,25 @@ def test_resolve_file_id_supports_usercontent_host():
             "https://evil.com@drive.google.com/file/d/abc123/view?resourcekey=0-Rkey123",
             None,
         ),
-        # A resourcekey value containing characters outside the id
-        # charset is rejected rather than passed through unvalidated into
-        # a header value.
-        ("https://drive.google.com/file/d/abc123/view?resourcekey=bad key", None),
+        # A resourcekey isn't restricted to the fileId character class --
+        # kb.py's own CloudFile.resourceKey field validates only
+        # "^[^\r\n]*$" (see test_kb_ingest_cloud_accepts_punctuation_in_
+        # drive_identifiers in test_kb_dir.py), so punctuation like a
+        # colon must be preserved rather than silently discarded.
+        (
+            "https://drive.google.com/file/d/abc123/view?resourcekey=resource:key_1-2",
+            "resource:key_1-2",
+        ),
+        # Published-to-web links ("/d/e/") have no real Drive fileId in
+        # them at all -- _resolve_file_id refuses to resolve an id for
+        # this exact shape, so a resourcekey must not be extracted for it
+        # either; doing so would attach a resourcekey header to a request
+        # whose fileId is the unresolved raw URL.
+        (
+            "https://docs.google.com/spreadsheets/d/e/2PACX-1vTabc123xyz/pubhtml"
+            "?resourcekey=0-Rkey123",
+            None,
+        ),
     ],
 )
 def test_extract_resource_key(value, expected):
@@ -494,6 +532,47 @@ def test_create_folder_resolves_parent_id_url_and_supports_shared_drives(monkeyp
     assert kwargs["body"]["parents"] == ["abc123"]
     assert kwargs["supportsAllDrives"] is True
     assert kwargs["fields"] == "id, name, webViewLink, mimeType"
+
+
+def test_create_file_attaches_resource_key_header_for_parent(monkeypatch):
+    """A pre-2021 link-shared parent folder needs its own resourcekey
+    attached the same way every other file_id-taking tool does, or
+    files.create 404s resolving a parent that genuinely exists."""
+    service = _mock_drive_service(monkeypatch)
+    create_request = service.files.return_value.create.return_value
+    create_request.headers = {}
+    create_request.execute.return_value = {"id": "new1", "name": "notes.txt"}
+
+    url = "https://drive.google.com/drive/folders/abc123?resourcekey=0-Rkey123"
+    google_drive.google_drive_create_file("notes.txt", "hello", parent_id=url)
+
+    assert create_request.headers == {"X-Goog-Drive-Resource-Keys": "abc123/0-Rkey123"}
+
+
+def test_create_folder_attaches_resource_key_header_for_parent(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    create_request = service.files.return_value.create.return_value
+    create_request.headers = {}
+    create_request.execute.return_value = {"id": "new1", "name": "Subfolder"}
+
+    url = "https://drive.google.com/drive/folders/abc123?resourcekey=0-Rkey123"
+    google_drive.google_drive_create_folder("Subfolder", parent_id=url)
+
+    assert create_request.headers == {"X-Goog-Drive-Resource-Keys": "abc123/0-Rkey123"}
+
+
+def test_create_file_omits_resource_key_header_without_parent_id(monkeypatch):
+    """No parent_id at all must not call _attach_resource_key with a None
+    resolved_parent_id (which would otherwise build a nonsensical
+    "None/None" header value)."""
+    service = _mock_drive_service(monkeypatch)
+    create_request = service.files.return_value.create.return_value
+    create_request.headers = {}
+    create_request.execute.return_value = {"id": "new1", "name": "notes.txt"}
+
+    google_drive.google_drive_create_file("notes.txt", "hello")
+
+    assert create_request.headers == {}
 
 
 def test_create_file_validates_parent_id_before_building_service(monkeypatch):
@@ -1017,11 +1096,55 @@ def test_list_permissions_accepts_a_caller_supplied_page_token(monkeypatch):
 
 
 def test_list_permissions_returns_next_page_token_when_stopped_early(monkeypatch):
-    """When pagination stops early (either because accumulated size
-    already exceeds the output cap, or the loop-safety bound was hit) a
-    nextPageToken may still exist -- it must be surfaced so a caller can
-    resume the listing instead of the rest of the collaborators being
-    silently lost."""
+    """When pagination stops early because accumulated size already
+    exceeds the output cap, a nextPageToken may still exist -- it must be
+    surfaced so a caller can resume the listing instead of the rest of
+    the collaborators being silently lost.
+
+    Uses two pages (a small one that fits, then a huge one that doesn't)
+    rather than one huge page: the response must resume from the *first
+    dropped whole page*'s own start token, not from whatever nextPageToken
+    the last-fetched page happened to report -- otherwise a caller who
+    followed that resumed token would skip the second page's contents
+    entirely, since size-capping already dropped every one of its items
+    from this response.
+    """
+    monkeypatch.setattr(google_drive, "get_tool_max_output_length", lambda: 3000)
+    service = _mock_drive_service(monkeypatch)
+    small_page = [{"id": "perm0", "type": "user", "role": "reader"}]
+    huge_page = [
+        {
+            "id": f"perm{i}",
+            "type": "user",
+            "role": "reader",
+            "emailAddress": f"user{i}@example.com",
+            "displayName": "x" * 200,
+        }
+        for i in range(2000)
+    ]
+    service.permissions.return_value.list.return_value.execute.side_effect = [
+        {"permissions": small_page, "nextPageToken": "page2"},
+        {"permissions": huge_page, "nextPageToken": "page3"},
+    ]
+
+    result = json.loads(google_drive.google_drive_list_permissions("fid"))
+
+    assert result["truncated"] is True
+    # Resumes from page2 (the huge page's own start token) -- not page3
+    # (which would skip everything on page2, since none of it survived
+    # size-capping in this response).
+    assert result["next_page_token"] == "page2"
+    assert [p["id"] for p in result["permissions"]] == ["perm0"]
+
+
+def test_list_permissions_omits_resume_token_when_a_single_page_overflows_alone(
+    monkeypatch,
+):
+    """If even the single earliest page doesn't fit under the cap on its
+    own, there is no page-granular resume point to offer honestly (Drive's
+    pageToken can't resume from the middle of a page) -- next_page_token
+    must be omitted rather than pointing at the next page and silently
+    skipping whatever this response had to cut from the current one."""
     monkeypatch.setattr(google_drive, "get_tool_max_output_length", lambda: 3000)
     service = _mock_drive_service(monkeypatch)
     huge_page = [
@@ -1042,7 +1165,8 @@ def test_list_permissions_returns_next_page_token_when_stopped_early(monkeypatch
     result = json.loads(google_drive.google_drive_list_permissions("fid"))
 
     assert result["truncated"] is True
-    assert result["next_page_token"] == "page2"
+    assert "next_page_token" not in result
+    assert 0 < len(result["permissions"]) < len(huge_page)
 
 
 def test_list_permissions_omits_next_page_token_when_list_is_complete(monkeypatch):

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -39,10 +39,32 @@ def test_get_drive_service_requires_access_token(monkeypatch):
         ("https://docs.google.com/document/d/abc123/edit", "abc123"),
         ("https://docs.google.com/spreadsheets/d/abc123/edit#gid=0", "abc123"),
         ("https://docs.google.com/presentation/d/abc123/edit", "abc123"),
+        # Google inserts this account-index segment into a copied share link
+        # whenever more than one Google account is signed into the browser.
+        ("https://drive.google.com/file/u/1/d/abc123/view", "abc123"),
+        ("https://drive.google.com/drive/u/1/folders/abc123", "abc123"),
+        ("https://docs.google.com/document/u/2/d/abc123/edit", "abc123"),
+        ("https://docs.google.com/spreadsheets/u/0/d/abc123/edit#gid=0", "abc123"),
+        ("https://docs.google.com/presentation/u/1/d/abc123/edit", "abc123"),
+        # Legacy share-link format with no "/d/<id>" path segment at all,
+        # still emitted by DriveApp.getUrl() in Apps Script.
+        ("https://drive.google.com/open?id=abc123", "abc123"),
+        ("https://docs.google.com/open?id=abc123&authuser=0", "abc123"),
     ],
 )
 def test_resolve_file_id_accepts_bare_id_and_url_forms(value, expected):
     assert google_drive._resolve_file_id(value) == expected
+
+
+@pytest.mark.parametrize("bad_role", ["owner", "organizer", ""])
+def test_require_share_role_rejects_roles_outside_the_allowed_set(bad_role):
+    with pytest.raises(ValueError, match="role"):
+        google_drive._require_share_role(bad_role)
+
+
+@pytest.mark.parametrize("good_role", ["reader", "commenter", "writer"])
+def test_require_share_role_accepts_allowed_roles(good_role):
+    assert google_drive._require_share_role(good_role) == good_role
 
 
 _FOLDER_URL_WITH_ID = "https://drive.google.com/drive/folders/abc123"
@@ -115,6 +137,46 @@ def test_id_taking_tools_resolve_full_drive_urls(monkeypatch, mock_target, invok
     assert mock_target(service).call_args.kwargs["fileId"] == "abc123"
 
 
+def test_get_file_content_resolves_full_drive_url(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.get.return_value.execute.return_value = {
+        "id": "abc123",
+        "name": "notes.txt",
+        "mimeType": "text/plain",
+    }
+
+    class _FakeDownloader:
+        def __init__(self, fh, _request):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(b"hello")
+            return None, True
+
+    monkeypatch.setattr(google_drive, "MediaIoBaseDownload", _FakeDownloader)
+
+    result = json.loads(google_drive.google_drive_get_file_content(_FOLDER_URL_WITH_ID))
+
+    assert result["status"] == "success"
+    assert service.files.return_value.get.call_args.kwargs["fileId"] == "abc123"
+    assert service.files.return_value.get_media.call_args.kwargs["fileId"] == "abc123"
+
+
+def test_rename_file_resolves_full_drive_url(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.update.return_value.execute.return_value = {
+        "id": "abc123",
+        "name": "renamed",
+    }
+
+    result = json.loads(
+        google_drive.google_drive_rename_file(_FOLDER_URL_WITH_ID, "renamed")
+    )
+
+    assert result["status"] == "success"
+    assert service.files.return_value.update.call_args.kwargs["fileId"] == "abc123"
+
+
 def test_list_permissions_returns_permissions(monkeypatch):
     service = _mock_drive_service(monkeypatch)
     service.permissions.return_value.list.return_value.execute.return_value = {
@@ -127,10 +189,34 @@ def test_list_permissions_returns_permissions(monkeypatch):
 
     assert result["status"] == "success"
     assert result["permissions"][0]["id"] == "perm1"
+    assert result["truncated"] is False
     assert (
         service.permissions.return_value.list.call_args.kwargs["supportsAllDrives"]
         is True
     )
+
+
+def test_list_permissions_caps_oversized_output(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    huge_permissions = [
+        {
+            "id": f"perm{i}",
+            "type": "user",
+            "role": "reader",
+            "emailAddress": f"user{i}@example.com",
+            "displayName": "x" * 200,
+        }
+        for i in range(2000)
+    ]
+    service.permissions.return_value.list.return_value.execute.return_value = {
+        "permissions": huge_permissions
+    }
+
+    result = json.loads(google_drive.google_drive_list_permissions("fid"))
+
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert 0 < len(result["permissions"]) < len(huge_permissions)
 
 
 def test_list_permissions_defaults_missing_key(monkeypatch):
@@ -268,14 +354,16 @@ def test_update_permission_changes_role(monkeypatch):
     assert kwargs["body"] == {"role": "writer"}
 
 
-def test_update_permission_rejects_invalid_role(monkeypatch):
+@pytest.mark.parametrize("bad_role", ["owner", "organizer", ""])
+def test_update_permission_rejects_role_outside_the_share_roles(monkeypatch, bad_role):
     service = _mock_drive_service(monkeypatch)
 
     result = json.loads(
-        google_drive.google_drive_update_permission("fid", "perm1", "owner")
+        google_drive.google_drive_update_permission("fid", "perm1", bad_role)
     )
 
     assert result["status"] == "error"
+    assert "role" in result["message"]
     service.permissions.return_value.update.assert_not_called()
 
 

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -162,6 +162,13 @@ def test_resolve_file_id_rejects_userinfo_bearing_authority(url):
         "https://evil.com@drive.google.com/x?id=ATTACKER_ID",
         r"https://evil.com\@drive.google.com/x?id=ATTACKER_ID",
         "https://docs.google.com/spreadsheets/d/e/2PACX-1vTabc123xyz/pubhtml",
+        # A trusted-host URL whose path isn't a recognized share-link
+        # shape at all (not even an excluded one) -- both functions must
+        # agree this doesn't resolve to a real id.
+        "https://drive.google.com/drive/my-drive",
+        # A malformed path segment the end-anchor now rejects instead of
+        # truncating -- both functions must agree on that too.
+        "https://drive.google.com/file/d/ABC.DEF/view",
     ],
 )
 def test_resolve_file_id_and_extract_resource_key_agree_on_untrusted_input(url):
@@ -418,17 +425,18 @@ def test_extract_resource_key(value, expected):
 def test_attach_resource_key_refuses_a_file_id_containing_crlf(malicious_file_id):
     """Belt-and-suspenders defense: _extract_resource_key's guard should
     make this unreachable in practice (a resourcekey is only ever
-    extracted alongside a _DRIVE_ID_CHARS-validated file_id), but this
-    function has no other way to signal "don't attach" than silently
-    skipping -- confirms it does, rather than building a header value most
-    HTTP clients (http.client raises ValueError on a raw CR/LF in a header
-    value) would reject anyway."""
+    extracted alongside a _DRIVE_ID_CHARS-validated file_id), but if a
+    future call site ever breaks that invariant, this must raise rather
+    than silently skip the header -- a silent skip would send a request
+    that legitimately needed the header without it, surfacing later as a
+    confusing 404 instead of an immediate, actionable local error."""
     request = Mock()
     request.headers = {}
 
-    result = google_drive._attach_resource_key(request, malicious_file_id, "0-Rkey123")
+    with pytest.raises(ValueError, match="CR/LF"):
+        google_drive._attach_resource_key(request, malicious_file_id, "0-Rkey123")
 
-    assert result.headers == {}
+    assert request.headers == {}
 
 
 def test_attach_resource_key_attaches_normally_for_a_clean_file_id():
@@ -457,6 +465,17 @@ def test_require_share_role_error_message_is_not_a_tuple_repr():
 @pytest.mark.parametrize("good_role", ["reader", "commenter", "writer"])
 def test_require_share_role_accepts_allowed_roles(good_role):
     assert google_drive._require_share_role(good_role) == good_role
+
+
+@pytest.mark.parametrize("bad_entity_type", ["domain", "anyone", ""])
+def test_require_entity_type_rejects_types_outside_the_allowed_set(bad_entity_type):
+    with pytest.raises(ValueError, match="entity_type"):
+        google_drive._require_entity_type(bad_entity_type)
+
+
+@pytest.mark.parametrize("good_entity_type", ["user", "group"])
+def test_require_entity_type_accepts_allowed_types(good_entity_type):
+    assert google_drive._require_entity_type(good_entity_type) == good_entity_type
 
 
 _FOLDER_URL_WITH_ID = "https://drive.google.com/drive/folders/abc123"

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -69,6 +69,15 @@ def test_resolve_file_id_accepts_bare_id_and_url_forms(value, expected):
         # non-Google URL can be made to match the same path shape.
         "https://evil.com/file/d/ATTACKER_ID/view",
         "https://evil.com/drive/folders/ATTACKER_ID",
+        # Scheme-less and protocol-relative variants of the same attack --
+        # urlparse only populates .scheme/.hostname for an explicit
+        # "scheme://" or leading "//" prefix, so these are at least as
+        # natural a shape for an attacker to plant in text an agent reads
+        # as the full https:// form, and must be rejected identically.
+        "evil.com/file/d/ATTACKER_ID/view",
+        "//evil.com/file/d/ATTACKER_ID/view",
+        "evil.com/x?id=ATTACKER_CHOSEN_ID",
+        "evil.com/drive/folders/ATTACKER_ID",
     ],
 )
 def test_resolve_file_id_does_not_extract_id_from_untrusted_hosts(url):
@@ -78,6 +87,21 @@ def test_resolve_file_id_does_not_extract_id_from_untrusted_hosts(url):
     URL happens to name -- it should fail as an obviously-invalid fileId
     instead, by returning the URL unresolved."""
     assert google_drive._resolve_file_id(url) == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "drive.google.com/file/d/abc123/view",
+        "drive.google.com/drive/folders/abc123",
+        "docs.google.com/open?id=abc123",
+    ],
+)
+def test_resolve_file_id_resolves_scheme_less_trusted_host_urls(url):
+    """The scheme-less-URL check above must reject untrusted hosts without
+    also rejecting a legitimate Drive/Docs URL a user pasted without its
+    "https://" prefix."""
+    assert google_drive._resolve_file_id(url) == "abc123"
 
 
 @pytest.mark.parametrize(
@@ -497,6 +521,36 @@ def test_list_permissions_follows_next_page_token(monkeypatch):
     calls = service.permissions.return_value.list.call_args_list
     assert calls[0].kwargs["pageToken"] is None
     assert calls[1].kwargs["pageToken"] == "page2"
+
+
+def test_list_permissions_stops_paginating_once_over_the_output_limit(monkeypatch):
+    """_capped_list_response will halve an oversized permissions list back
+    down anyway, so once accumulated permissions already exceed the output
+    limit, fetching further pages is pure waste -- more blocking API calls
+    for data that gets thrown away immediately after."""
+    service = _mock_drive_service(monkeypatch)
+    huge_page = [
+        {
+            "id": f"perm{i}",
+            "type": "user",
+            "role": "reader",
+            "emailAddress": f"user{i}@example.com",
+            "displayName": "x" * 200,
+        }
+        for i in range(2000)
+    ]
+    service.permissions.return_value.list.return_value.execute.return_value = {
+        "permissions": huge_page,
+        "nextPageToken": "page2",  # would keep going forever if not stopped
+    }
+
+    result = json.loads(google_drive.google_drive_list_permissions("fid"))
+
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    # Stopped after the first oversized page rather than following
+    # nextPageToken indefinitely.
+    assert service.permissions.return_value.list.call_count == 1
 
 
 def test_list_permissions_defaults_missing_key(monkeypatch):

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -355,6 +355,23 @@ class TestExecuteIgnoring204SslEof:
         with pytest.raises(Exception, match="UNEXPECTED_EOF_WHILE_READING"):
             google_drive._execute_ignoring_204_ssl_eof(execute, verify_done)
 
+    def test_raises_even_when_original_error_text_contains_not_found(self):
+        """The "not complete" exception raised when verify_done() shows the
+        object is still there must never be caught by the except clause that
+        is meant to interpret *verify_done's own* exception -- if it were,
+        an original SSL error whose text happens to mention "not found" or
+        "404" (plausible in a proxy's wrapped error message) would make a
+        genuine failure-to-delete look like a success."""
+        execute = Mock(
+            side_effect=Exception(
+                "UNEXPECTED_EOF_WHILE_READING: upstream returned 404 not found"
+            )
+        )
+        verify_done = Mock(return_value=None)  # object is still there
+
+        with pytest.raises(Exception, match="did not complete"):
+            google_drive._execute_ignoring_204_ssl_eof(execute, verify_done)
+
 
 def test_delete_file_tolerates_ssl_eof_on_204_response(monkeypatch):
     """End-to-end regression for the pre-existing SSL EOF tolerance that

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -1,0 +1,368 @@
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from xagent.web.tools.mcp import google_drive
+
+
+@pytest.fixture(autouse=True)
+def _credentials(monkeypatch):
+    monkeypatch.setenv("GOOGLE_ACCESS_TOKEN", "access-token")
+    # tests/conftest.py force-loads the project .env into the test process, so
+    # any refresh credentials configured there would leak into the "absent"
+    # assertions below.
+    monkeypatch.delenv("GOOGLE_REFRESH_TOKEN", raising=False)
+    monkeypatch.delenv("GOOGLE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("GOOGLE_CLIENT_SECRET", raising=False)
+
+
+def _mock_drive_service(monkeypatch):
+    service = Mock()
+    monkeypatch.setattr(google_drive, "get_drive_service", lambda: service)
+    return service
+
+
+def test_get_drive_service_requires_access_token(monkeypatch):
+    monkeypatch.delenv("GOOGLE_ACCESS_TOKEN")
+
+    with pytest.raises(ValueError, match="GOOGLE_ACCESS_TOKEN"):
+        google_drive.get_drive_service()
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("abc123", "abc123"),
+        ("https://drive.google.com/file/d/abc123/view?usp=sharing", "abc123"),
+        ("https://drive.google.com/drive/folders/abc123", "abc123"),
+        ("https://docs.google.com/document/d/abc123/edit", "abc123"),
+        ("https://docs.google.com/spreadsheets/d/abc123/edit#gid=0", "abc123"),
+        ("https://docs.google.com/presentation/d/abc123/edit", "abc123"),
+    ],
+)
+def test_resolve_file_id_accepts_bare_id_and_url_forms(value, expected):
+    assert google_drive._resolve_file_id(value) == expected
+
+
+_FOLDER_URL_WITH_ID = "https://drive.google.com/drive/folders/abc123"
+
+
+def _stub_happy_path(service):
+    """Wire every mocked call this module can make to a benign response, so
+    a test driving one specific tool doesn't also need to know how the
+    others behave."""
+    service.files.return_value.delete.return_value.execute.return_value = {}
+    service.files.return_value.get.return_value.execute.return_value = {}
+    service.permissions.return_value.list.return_value.execute.return_value = {
+        "permissions": []
+    }
+    service.permissions.return_value.create.return_value.execute.return_value = {
+        "id": "perm1"
+    }
+    service.permissions.return_value.update.return_value.execute.return_value = {
+        "id": "perm1"
+    }
+    service.permissions.return_value.delete.return_value.execute.return_value = {}
+    service.permissions.return_value.get.return_value.execute.return_value = {}
+
+
+@pytest.mark.parametrize(
+    ("mock_target", "invoke"),
+    [
+        (
+            lambda s: s.files.return_value.delete,
+            lambda fid: google_drive.google_drive_delete_file(fid),
+        ),
+        (
+            lambda s: s.permissions.return_value.list,
+            lambda fid: google_drive.google_drive_list_permissions(fid),
+        ),
+        (
+            lambda s: s.permissions.return_value.create,
+            lambda fid: google_drive.google_drive_share_file(fid, "a@example.com"),
+        ),
+        (
+            lambda s: s.permissions.return_value.update,
+            lambda fid: google_drive.google_drive_update_permission(
+                fid, "perm1", "reader"
+            ),
+        ),
+        (
+            lambda s: s.permissions.return_value.delete,
+            lambda fid: google_drive.google_drive_remove_permission(fid, "perm1"),
+        ),
+    ],
+    ids=[
+        "delete_file",
+        "list_permissions",
+        "share_file",
+        "update_permission",
+        "remove_permission",
+    ],
+)
+def test_id_taking_tools_resolve_full_drive_urls(monkeypatch, mock_target, invoke):
+    """Every id-taking tool touched by this change calls _resolve_file_id
+    before hitting the API, but a test that only ever passes an already-bare
+    id would not notice if that call were missing from a given tool. Drive
+    this through the real call sites with a full folder URL and assert the
+    *resolved* id is what reached the mocked API call."""
+    service = _mock_drive_service(monkeypatch)
+    _stub_happy_path(service)
+
+    invoke(_FOLDER_URL_WITH_ID)
+
+    assert mock_target(service).call_args.kwargs["fileId"] == "abc123"
+
+
+def test_list_permissions_returns_permissions(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.list.return_value.execute.return_value = {
+        "permissions": [
+            {"id": "perm1", "type": "user", "role": "reader", "emailAddress": "a@x.com"}
+        ]
+    }
+
+    result = json.loads(google_drive.google_drive_list_permissions("fid"))
+
+    assert result["status"] == "success"
+    assert result["permissions"][0]["id"] == "perm1"
+    assert (
+        service.permissions.return_value.list.call_args.kwargs["supportsAllDrives"]
+        is True
+    )
+
+
+def test_list_permissions_defaults_missing_key(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.list.return_value.execute.return_value = {}
+
+    result = json.loads(google_drive.google_drive_list_permissions("fid"))
+
+    assert result["status"] == "success"
+    assert result["permissions"] == []
+
+
+def test_list_permissions_returns_error_payload_on_failure(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.list.return_value.execute.side_effect = (
+        RuntimeError("not found")
+    )
+
+    result = json.loads(google_drive.google_drive_list_permissions("fid"))
+
+    assert result["status"] == "error"
+    assert "not found" in result["message"]
+
+
+def test_share_file_grants_role_to_email(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.create.return_value.execute.return_value = {
+        "id": "perm1",
+        "type": "user",
+        "role": "writer",
+        "emailAddress": "a@x.com",
+    }
+
+    result = json.loads(
+        google_drive.google_drive_share_file(
+            "fid", "a@x.com", role="writer", send_notification=False, message="hi"
+        )
+    )
+
+    assert result["status"] == "success"
+    assert result["permission"]["id"] == "perm1"
+    kwargs = service.permissions.return_value.create.call_args.kwargs
+    assert kwargs["body"] == {
+        "type": "user",
+        "role": "writer",
+        "emailAddress": "a@x.com",
+    }
+    assert kwargs["sendNotificationEmail"] is False
+    assert kwargs["emailMessage"] == "hi"
+    assert kwargs["supportsAllDrives"] is True
+
+
+def test_share_file_defaults_to_reader_with_notification(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.create.return_value.execute.return_value = {}
+
+    json.loads(google_drive.google_drive_share_file("fid", "a@x.com"))
+
+    kwargs = service.permissions.return_value.create.call_args.kwargs
+    assert kwargs["body"]["role"] == "reader"
+    assert kwargs["sendNotificationEmail"] is True
+
+
+@pytest.mark.parametrize("bad_role", ["owner", "organizer", ""])
+def test_share_file_rejects_role_outside_the_share_roles(monkeypatch, bad_role):
+    """ "owner" is deliberately not accepted: ownership transfer is a
+    distinct, irreversible action this connector does not perform on the
+    model's behalf."""
+    service = _mock_drive_service(monkeypatch)
+
+    result = json.loads(
+        google_drive.google_drive_share_file("fid", "a@x.com", role=bad_role)
+    )
+
+    assert result["status"] == "error"
+    assert "role" in result["message"]
+    service.permissions.return_value.create.assert_not_called()
+
+
+@pytest.mark.parametrize("bad_email", ["", "not-an-email", " a@x.com"])
+def test_share_file_rejects_invalid_email(monkeypatch, bad_email):
+    service = _mock_drive_service(monkeypatch)
+
+    result = json.loads(google_drive.google_drive_share_file("fid", bad_email))
+
+    assert result["status"] == "error"
+    service.permissions.return_value.create.assert_not_called()
+
+
+def test_share_file_returns_error_payload_on_failure(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.create.return_value.execute.side_effect = (
+        RuntimeError("insufficientFilePermissions")
+    )
+
+    result = json.loads(google_drive.google_drive_share_file("fid", "a@x.com"))
+
+    assert result["status"] == "error"
+    assert "insufficientFilePermissions" in result["message"]
+
+
+def test_update_permission_changes_role(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.update.return_value.execute.return_value = {
+        "id": "perm1",
+        "role": "writer",
+    }
+
+    result = json.loads(
+        google_drive.google_drive_update_permission("fid", "perm1", "writer")
+    )
+
+    assert result["status"] == "success"
+    kwargs = service.permissions.return_value.update.call_args.kwargs
+    assert kwargs["permissionId"] == "perm1"
+    assert kwargs["body"] == {"role": "writer"}
+
+
+def test_update_permission_rejects_invalid_role(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+
+    result = json.loads(
+        google_drive.google_drive_update_permission("fid", "perm1", "owner")
+    )
+
+    assert result["status"] == "error"
+    service.permissions.return_value.update.assert_not_called()
+
+
+def test_update_permission_returns_error_payload_on_failure(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.update.return_value.execute.side_effect = (
+        RuntimeError("permission not found")
+    )
+
+    result = json.loads(
+        google_drive.google_drive_update_permission("fid", "perm1", "reader")
+    )
+
+    assert result["status"] == "error"
+    assert "permission not found" in result["message"]
+
+
+def test_remove_permission_success(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.delete.return_value.execute.return_value = {}
+
+    result = json.loads(google_drive.google_drive_remove_permission("fid", "perm1"))
+
+    assert result["status"] == "success"
+    assert "perm1" in result["message"]
+    service.permissions.return_value.get.assert_not_called()
+
+
+def test_remove_permission_returns_error_payload_on_failure(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.delete.return_value.execute.side_effect = (
+        RuntimeError("permission not found")
+    )
+
+    result = json.loads(google_drive.google_drive_remove_permission("fid", "perm1"))
+
+    assert result["status"] == "error"
+    assert "permission not found" in result["message"]
+
+
+class TestExecuteIgnoring204SslEof:
+    """Unit coverage for the helper shared by google_drive_delete_file and
+    google_drive_remove_permission, which both call Drive endpoints that
+    return 204 No Content -- a response shape a proxy can turn into an SSL
+    EOF error even though the operation already succeeded server-side."""
+
+    def test_returns_normally_when_execute_succeeds(self):
+        execute = Mock()
+        verify_done = Mock()
+
+        google_drive._execute_ignoring_204_ssl_eof(execute, verify_done)
+
+        execute.assert_called_once()
+        verify_done.assert_not_called()
+
+    def test_propagates_unrelated_errors_without_verifying(self):
+        execute = Mock(side_effect=RuntimeError("quota exceeded"))
+        verify_done = Mock()
+
+        with pytest.raises(RuntimeError, match="quota exceeded"):
+            google_drive._execute_ignoring_204_ssl_eof(execute, verify_done)
+
+        verify_done.assert_not_called()
+
+    def test_swallows_ssl_eof_when_verify_confirms_it_completed(self):
+        execute = Mock(side_effect=Exception("UNEXPECTED_EOF_WHILE_READING"))
+        verify_done = Mock(side_effect=Exception("404 not found"))
+
+        google_drive._execute_ignoring_204_ssl_eof(execute, verify_done)
+
+        verify_done.assert_called_once()
+
+    def test_raises_ssl_eof_when_verify_shows_it_did_not_complete(self):
+        execute = Mock(side_effect=Exception("UNEXPECTED_EOF_WHILE_READING"))
+        verify_done = Mock(return_value=None)  # object is still there
+
+        with pytest.raises(Exception, match="UNEXPECTED_EOF_WHILE_READING"):
+            google_drive._execute_ignoring_204_ssl_eof(execute, verify_done)
+
+
+def test_delete_file_tolerates_ssl_eof_on_204_response(monkeypatch):
+    """End-to-end regression for the pre-existing SSL EOF tolerance that
+    used to live inline in google_drive_delete_file, now routed through the
+    shared helper."""
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.delete.return_value.execute.side_effect = Exception(
+        "UNEXPECTED_EOF_WHILE_READING"
+    )
+    service.files.return_value.get.return_value.execute.side_effect = Exception(
+        "404: not found"
+    )
+
+    result = json.loads(google_drive.google_drive_delete_file("fid"))
+
+    assert result["status"] == "success"
+
+
+def test_remove_permission_tolerates_ssl_eof_on_204_response(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.delete.return_value.execute.side_effect = (
+        Exception("UNEXPECTED_EOF_WHILE_READING")
+    )
+    service.permissions.return_value.get.return_value.execute.side_effect = Exception(
+        "404: not found"
+    )
+
+    result = json.loads(google_drive.google_drive_remove_permission("fid", "perm1"))
+
+    assert result["status"] == "success"

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -137,6 +137,90 @@ def test_id_taking_tools_resolve_full_drive_urls(monkeypatch, mock_target, invok
     assert mock_target(service).call_args.kwargs["fileId"] == "abc123"
 
 
+def test_search_passes_shared_drive_support_and_clamps_max_results(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.list.return_value.execute.return_value = {
+        "files": [{"id": "f1", "name": "notes.txt"}]
+    }
+
+    result = json.loads(google_drive.google_drive_search("notes", max_results=999999))
+
+    assert result["status"] == "success"
+    assert result["files"][0]["id"] == "f1"
+    assert result["truncated"] is False
+    kwargs = service.files.return_value.list.call_args.kwargs
+    assert kwargs["supportsAllDrives"] is True
+    assert kwargs["includeItemsFromAllDrives"] is True
+    assert kwargs["pageSize"] == 1000  # clamped, not the raw 999999
+
+
+def test_search_caps_oversized_output(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    huge_files = [
+        {"id": f"f{i}", "name": "x" * 200, "mimeType": "text/plain"}
+        for i in range(2000)
+    ]
+    service.files.return_value.list.return_value.execute.return_value = {
+        "files": huge_files
+    }
+
+    result = json.loads(google_drive.google_drive_search("x"))
+
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert 0 < len(result["files"]) < len(huge_files)
+
+
+def test_search_returns_error_payload_on_failure(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.list.return_value.execute.side_effect = RuntimeError(
+        "quota exceeded"
+    )
+
+    result = json.loads(google_drive.google_drive_search("x"))
+
+    assert result["status"] == "error"
+    assert "quota exceeded" in result["message"]
+
+
+def test_create_file_resolves_parent_id_url_and_supports_shared_drives(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.create.return_value.execute.return_value = {
+        "id": "new1",
+        "name": "notes.txt",
+    }
+
+    result = json.loads(
+        google_drive.google_drive_create_file(
+            "notes.txt", "hello", parent_id=_FOLDER_URL_WITH_ID
+        )
+    )
+
+    assert result["status"] == "success"
+    kwargs = service.files.return_value.create.call_args.kwargs
+    assert kwargs["body"]["parents"] == ["abc123"]
+    assert kwargs["supportsAllDrives"] is True
+
+
+def test_create_folder_resolves_parent_id_url_and_supports_shared_drives(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.create.return_value.execute.return_value = {
+        "id": "new1",
+        "name": "Subfolder",
+    }
+
+    result = json.loads(
+        google_drive.google_drive_create_folder(
+            "Subfolder", parent_id=_FOLDER_URL_WITH_ID
+        )
+    )
+
+    assert result["status"] == "success"
+    kwargs = service.files.return_value.create.call_args.kwargs
+    assert kwargs["body"]["parents"] == ["abc123"]
+    assert kwargs["supportsAllDrives"] is True
+
+
 def test_get_file_content_resolves_full_drive_url(monkeypatch):
     service = _mock_drive_service(monkeypatch)
     service.files.return_value.get.return_value.execute.return_value = {
@@ -217,6 +301,30 @@ def test_list_permissions_caps_oversized_output(monkeypatch):
     assert result["status"] == "success"
     assert result["truncated"] is True
     assert 0 < len(result["permissions"]) < len(huge_permissions)
+
+
+def test_list_permissions_follows_next_page_token(monkeypatch):
+    """A Shared Drive item returns at most 100 permissions per page when
+    pageSize isn't set; without following nextPageToken, a heavily-shared
+    Shared Drive folder would silently under-report collaborators."""
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.list.return_value.execute.side_effect = [
+        {
+            "permissions": [{"id": "perm1"}],
+            "nextPageToken": "page2",
+        },
+        {
+            "permissions": [{"id": "perm2"}],
+        },
+    ]
+
+    result = json.loads(google_drive.google_drive_list_permissions("fid"))
+
+    assert result["status"] == "success"
+    assert [p["id"] for p in result["permissions"]] == ["perm1", "perm2"]
+    calls = service.permissions.return_value.list.call_args_list
+    assert calls[0].kwargs["pageToken"] is None
+    assert calls[1].kwargs["pageToken"] == "page2"
 
 
 def test_list_permissions_defaults_missing_key(monkeypatch):

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -166,7 +166,7 @@ def test_share_file_grants_role_to_email(monkeypatch):
 
     result = json.loads(
         google_drive.google_drive_share_file(
-            "fid", "a@x.com", role="writer", send_notification=False, message="hi"
+            "fid", "a@x.com", role="writer", send_notification=True, message="hi"
         )
     )
 
@@ -178,7 +178,7 @@ def test_share_file_grants_role_to_email(monkeypatch):
         "role": "writer",
         "emailAddress": "a@x.com",
     }
-    assert kwargs["sendNotificationEmail"] is False
+    assert kwargs["sendNotificationEmail"] is True
     assert kwargs["emailMessage"] == "hi"
     assert kwargs["supportsAllDrives"] is True
 
@@ -192,6 +192,25 @@ def test_share_file_defaults_to_reader_with_notification(monkeypatch):
     kwargs = service.permissions.return_value.create.call_args.kwargs
     assert kwargs["body"]["role"] == "reader"
     assert kwargs["sendNotificationEmail"] is True
+
+
+def test_share_file_omits_email_message_when_notification_disabled(monkeypatch):
+    """The Drive API rejects emailMessage outright when sendNotificationEmail
+    is false, so a message passed alongside send_notification=False must not
+    reach the request -- regardless of whether the caller also wanted a
+    message, suppressing the notification wins."""
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.create.return_value.execute.return_value = {}
+
+    json.loads(
+        google_drive.google_drive_share_file(
+            "fid", "a@x.com", send_notification=False, message="hi"
+        )
+    )
+
+    kwargs = service.permissions.return_value.create.call_args.kwargs
+    assert kwargs["sendNotificationEmail"] is False
+    assert "emailMessage" not in kwargs
 
 
 @pytest.mark.parametrize("bad_role", ["owner", "organizer", ""])

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -1,3 +1,4 @@
+import base64
 import json
 from unittest.mock import Mock
 
@@ -388,6 +389,23 @@ def test_search_returns_error_payload_on_failure(monkeypatch):
     assert "quota exceeded" in result["message"]
 
 
+def test_search_validates_max_results_before_building_service(monkeypatch):
+    """Every other tool in this file validates/resolves its input before
+    calling get_drive_service() (Credentials construction + a discovery-
+    doc build); google_drive_search was the one outlier that built the
+    service first and only clamped max_results afterward, paying that
+    cost on every malformed call before ever rejecting it."""
+    get_service = Mock()
+    monkeypatch.setattr(google_drive, "get_drive_service", get_service)
+
+    result = json.loads(
+        google_drive.google_drive_search("x", max_results="not-a-number")
+    )
+
+    assert result["status"] == "error"
+    get_service.assert_not_called()
+
+
 def test_create_file_resolves_parent_id_url_and_supports_shared_drives(monkeypatch):
     service = _mock_drive_service(monkeypatch)
     service.files.return_value.create.return_value.execute.return_value = {
@@ -424,6 +442,7 @@ def test_create_folder_resolves_parent_id_url_and_supports_shared_drives(monkeyp
     kwargs = service.files.return_value.create.call_args.kwargs
     assert kwargs["body"]["parents"] == ["abc123"]
     assert kwargs["supportsAllDrives"] is True
+    assert kwargs["fields"] == "id, name, webViewLink, mimeType"
 
 
 def test_create_file_validates_parent_id_before_building_service(monkeypatch):
@@ -479,6 +498,40 @@ def test_get_file_content_resolves_full_drive_url(monkeypatch):
     media_kwargs = service.files.return_value.get_media.call_args.kwargs
     assert media_kwargs["fileId"] == "abc123"
     assert media_kwargs["supportsAllDrives"] is True
+    assert result["content"] == "hello"
+    assert result["encoding"] == "utf-8"
+
+
+def test_get_file_content_falls_back_to_base64_for_binary_content(monkeypatch):
+    """A regular (non-Workspace) file downloaded via get_media can be
+    anything -- a PDF, image, zip, or non-UTF-8-encoded text file. Forcing
+    a UTF-8 decode with errors="replace" would silently corrupt it into
+    replacement characters with status: success and no signal anything
+    was lost; base64 preserves it exactly, matching onedrive.py's
+    onedrive_get_file_content/_decode_bytes pattern for the same problem."""
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.get.return_value.execute.return_value = {
+        "id": "img1",
+        "name": "photo.png",
+        "mimeType": "image/png",
+    }
+    binary_content = b"\x89PNG\r\n\x1a\n\x00\x01\xff\xfe"
+
+    class _FakeDownloader:
+        def __init__(self, fh, _request):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(binary_content)
+            return None, True
+
+    monkeypatch.setattr(google_drive, "MediaIoBaseDownload", _FakeDownloader)
+
+    result = json.loads(google_drive.google_drive_get_file_content("img1"))
+
+    assert result["status"] == "success"
+    assert result["encoding"] == "base64"
+    assert base64.b64decode(result["content"]) == binary_content
 
 
 def test_get_file_content_defaults_spreadsheet_export_to_csv(monkeypatch):
@@ -603,6 +656,38 @@ def test_get_file_content_respects_explicit_mime_type_for_drawing(monkeypatch):
     )
 
 
+def test_get_file_content_defaults_apps_script_export_to_json(monkeypatch):
+    """Apps Script projects have exactly one supported export format
+    (application/vnd.google-apps.script+json) -- text/plain 400s on it the
+    same way it does for Sheets/Drawings, but unlike those two there's no
+    other plausible default a caller might have meant, so this is the only
+    fallback that makes sense."""
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.get.return_value.execute.return_value = {
+        "id": "script1",
+        "name": "My Script",
+        "mimeType": "application/vnd.google-apps.script",
+    }
+
+    class _FakeDownloader:
+        def __init__(self, fh, _request):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(b'{"files": []}')
+            return None, True
+
+    monkeypatch.setattr(google_drive, "MediaIoBaseDownload", _FakeDownloader)
+
+    result = json.loads(google_drive.google_drive_get_file_content("script1"))
+
+    assert result["status"] == "success"
+    assert (
+        service.files.return_value.export_media.call_args.kwargs["mimeType"]
+        == "application/vnd.google-apps.script+json"
+    )
+
+
 def test_get_file_content_keeps_text_plain_default_for_docs(monkeypatch):
     """The text/csv fallback is specific to spreadsheets -- Docs supports
     text/plain export natively and must not be redirected to csv too."""
@@ -638,17 +723,18 @@ def test_get_file_content_keeps_text_plain_default_for_docs(monkeypatch):
         "application/vnd.google-apps.folder",
         "application/vnd.google-apps.shortcut",
         "application/vnd.google-apps.form",
+        "application/vnd.google-apps.site",
     ],
 )
 def test_get_file_content_rejects_folder_and_shortcut_with_a_clear_message(
     monkeypatch, folder_mime_type
 ):
-    """All three mimeTypes start with "application/vnd.google-apps" and
+    """All of these mimeTypes start with "application/vnd.google-apps" and
     would otherwise fall into the export_media branch, which makes no
     sense for any of them (a folder has no content; a shortcut is a
-    pointer; Forms has no files.export support at all) -- and folder/form
-    share links are now resolvable via _resolve_file_id, so this is
-    directly reachable, not hypothetical."""
+    pointer; Forms and Sites have no files.export support at all) -- and
+    folder/form share links are now resolvable via _resolve_file_id, so
+    this is directly reachable, not hypothetical."""
     service = _mock_drive_service(monkeypatch)
     service.files.return_value.get.return_value.execute.return_value = {
         "id": "abc123",
@@ -691,6 +777,43 @@ def test_get_file_content_caps_oversized_output(monkeypatch):
     assert result["status"] == "success"
     assert result["truncated"] is True
     assert 0 < len(result["content"]) < len(huge_content)
+
+
+def test_get_file_content_caps_oversized_binary_content_as_valid_base64(monkeypatch):
+    """Halving a base64 string at an arbitrary character offset (as the
+    plain-text halving does) can produce a result that isn't just
+    incomplete but genuinely invalid base64 -- unlike truncated text,
+    which merely cuts off mid-character/word. The halving used for
+    encoding="base64" must stay 4-character aligned so the truncated
+    result still decodes."""
+    monkeypatch.setattr(google_drive, "get_tool_max_output_length", lambda: 3000)
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.get.return_value.execute.return_value = {
+        "id": "img1",
+        "name": "big.png",
+        "mimeType": "image/png",
+    }
+    huge_binary = bytes(range(256)) * 100  # not valid UTF-8
+
+    class _FakeDownloader:
+        def __init__(self, fh, _request):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(huge_binary)
+            return None, True
+
+    monkeypatch.setattr(google_drive, "MediaIoBaseDownload", _FakeDownloader)
+
+    result = json.loads(google_drive.google_drive_get_file_content("img1"))
+
+    assert result["status"] == "success"
+    assert result["encoding"] == "base64"
+    assert result["truncated"] is True
+    # Must not raise -- confirms the truncated string is still valid,
+    # correctly-padded base64, not an arbitrary character-offset cut.
+    decoded = base64.b64decode(result["content"], validate=True)
+    assert 0 < len(decoded) < len(huge_binary)
 
 
 def test_rename_file_resolves_full_drive_url(monkeypatch):

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -128,6 +128,48 @@ def test_resolve_file_id_still_matches_a_real_id_starting_with_e():
     )
 
 
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        # A scheme-less trusted-host link whose query value itself embeds
+        # a full URL. An earlier "does '//' occur anywhere in the string"
+        # heuristic failed to prepend "//" here (since "//" already
+        # appears, just not at the front), so urlparse saw no netloc and
+        # the whole string was rejected as untrusted -- even though this
+        # is a perfectly legitimate Drive link.
+        (
+            "docs.google.com/document/d/ABCID123/edit"
+            "?usp=sharing&continue=https://other.com/x",
+            "ABCID123",
+        ),
+        # A harmless double-slash typo in the path must not defeat
+        # resolution either, for the same reason.
+        ("drive.google.com/file/d/ABCID123//view", "ABCID123"),
+    ],
+)
+def test_resolve_file_id_handles_scheme_less_urls_containing_another_scheme(
+    url, expected
+):
+    assert google_drive._resolve_file_id(url) == expected
+
+
+def test_resolve_file_id_does_not_extract_id_from_unrelated_query_value():
+    """The host check validates the URL's overall authority, but the id
+    must come from the URL's own path/query structure -- not a free-text
+    search of the whole string. Otherwise a URL whose host is a real,
+    trusted drive.google.com but whose query VALUE merely contains a
+    matching shape (here, a hypothetical search results page) would have
+    that unrelated substring extracted as if it were the URL's own
+    resource id."""
+    url = "https://drive.google.com/search?q=/file/d/OTHERID/view"
+    assert google_drive._resolve_file_id(url) == url
+
+
+def test_resolve_file_id_rejects_non_string_input():
+    with pytest.raises(ValueError, match="file_id must be a string"):
+        google_drive._resolve_file_id(12345)
+
+
 @pytest.mark.parametrize("bad_role", ["owner", "organizer", ""])
 def test_require_share_role_rejects_roles_outside_the_allowed_set(bad_role):
     with pytest.raises(ValueError, match="role"):
@@ -293,6 +335,32 @@ def test_create_folder_resolves_parent_id_url_and_supports_shared_drives(monkeyp
     kwargs = service.files.return_value.create.call_args.kwargs
     assert kwargs["body"]["parents"] == ["abc123"]
     assert kwargs["supportsAllDrives"] is True
+
+
+def test_create_file_validates_parent_id_before_building_service(monkeypatch):
+    get_service = Mock()
+    monkeypatch.setattr(google_drive, "get_drive_service", get_service)
+
+    result = json.loads(
+        google_drive.google_drive_create_file("notes.txt", "hello", parent_id=123)
+    )
+
+    assert result["status"] == "error"
+    assert "file_id must be a string" in result["message"]
+    get_service.assert_not_called()
+
+
+def test_create_folder_validates_parent_id_before_building_service(monkeypatch):
+    get_service = Mock()
+    monkeypatch.setattr(google_drive, "get_drive_service", get_service)
+
+    result = json.loads(
+        google_drive.google_drive_create_folder("Subfolder", parent_id=123)
+    )
+
+    assert result["status"] == "error"
+    assert "file_id must be a string" in result["message"]
+    get_service.assert_not_called()
 
 
 def test_get_file_content_resolves_full_drive_url(monkeypatch):
@@ -551,6 +619,46 @@ def test_list_permissions_stops_paginating_once_over_the_output_limit(monkeypatc
     # Stopped after the first oversized page rather than following
     # nextPageToken indefinitely.
     assert service.permissions.return_value.list.call_count == 1
+
+
+def test_list_permissions_pagination_check_matches_the_real_encoding(monkeypatch):
+    """The early-stop length check must use ensure_ascii=False, matching
+    _capped_list_response's actual encoding -- otherwise a page of
+    non-ASCII displayName/emailAddress values (CJK/accented/emoji names are
+    common on a Shared Drive) inflates the check's estimate (each such
+    character escapes to a 6+-char \\uXXXX sequence under the ensure_ascii
+    default) well past what the real, smaller ensure_ascii=False payload
+    needs, causing pagination to stop before a real nextPageToken is
+    exhausted -- while the final response, measuring the true smaller size,
+    reports truncated=False and silently omits the remaining page(s)."""
+    service = _mock_drive_service(monkeypatch)
+    monkeypatch.setattr(google_drive, "get_tool_max_output_length", lambda: 3000)
+
+    page1 = [
+        {
+            "id": f"perm{i}",
+            "type": "user",
+            "role": "reader",
+            "emailAddress": f"user{i}@example.com",
+            "displayName": "中文姓名" * 5,
+        }
+        for i in range(15)
+    ]
+    page2 = [
+        {"id": "perm15", "type": "user", "role": "reader", "emailAddress": "a@x.com"},
+        {"id": "perm16", "type": "user", "role": "reader", "emailAddress": "b@x.com"},
+    ]
+    service.permissions.return_value.list.return_value.execute.side_effect = [
+        {"permissions": page1, "nextPageToken": "page2"},
+        {"permissions": page2},
+    ]
+
+    result = json.loads(google_drive.google_drive_list_permissions("fid"))
+
+    assert service.permissions.return_value.list.call_count == 2
+    assert result["status"] == "success"
+    assert result["truncated"] is False
+    assert {p["id"] for p in result["permissions"]} == {f"perm{i}" for i in range(17)}
 
 
 def test_list_permissions_defaults_missing_key(monkeypatch):

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -211,6 +211,22 @@ def test_resolve_file_id_still_matches_a_real_id_starting_with_e():
 
 
 @pytest.mark.parametrize(
+    "url",
+    [
+        # A malformed path segment must be rejected outright, not silently
+        # truncated to the leading run of valid characters -- without an
+        # end-anchor, ".../file/d/ABC.DEF/view" would capture just "ABC"
+        # (the id charset stops at the "."), acting on a wrong, truncated
+        # id instead of returning the whole URL unresolved.
+        "https://drive.google.com/file/d/ABC.DEF/view",
+        "https://drive.google.com/drive/folders/ABC.DEF",
+    ],
+)
+def test_resolve_file_id_rejects_malformed_path_segment_instead_of_truncating(url):
+    assert google_drive._resolve_file_id(url) == url
+
+
+@pytest.mark.parametrize(
     ("url", "expected"),
     [
         # A scheme-less trusted-host link whose query value itself embeds
@@ -369,10 +385,59 @@ def test_resolve_file_id_supports_usercontent_host():
             "?resourcekey=0-Rkey123",
             None,
         ),
+        # A trusted-host URL whose path isn't a recognized share-link
+        # shape at all (not even the excluded "/d/e/" one) must not have a
+        # resourcekey extracted either -- _resolve_file_id can't derive a
+        # real fileId from it, so a resourcekey extracted here would only
+        # ever be attached to a request whose fileId is the unresolved raw
+        # URL. Broader than the "/d/e/" case above: this is any
+        # unrecognized path, not just a deliberately-excluded known one.
+        ("https://drive.google.com/drive/my-drive?resourcekey=0-Rkey123", None),
+        # The legacy "?id=" query-fallback share-link shape must still
+        # extract a resourcekey normally -- the widened exclusion guard
+        # must not accidentally reject this legitimate, already-supported
+        # shape along with the unrecognized-path case above.
+        (
+            "https://drive.google.com/open?id=abc123&resourcekey=0-Rkey123",
+            "0-Rkey123",
+        ),
     ],
 )
 def test_extract_resource_key(value, expected):
     assert google_drive._extract_resource_key(value) == expected
+
+
+@pytest.mark.parametrize(
+    "malicious_file_id",
+    [
+        "evil\r\nX-Injected-Header: 1",
+        "evil\rX-Injected-Header: 1",
+        "evil\nX-Injected-Header: 1",
+    ],
+)
+def test_attach_resource_key_refuses_a_file_id_containing_crlf(malicious_file_id):
+    """Belt-and-suspenders defense: _extract_resource_key's guard should
+    make this unreachable in practice (a resourcekey is only ever
+    extracted alongside a _DRIVE_ID_CHARS-validated file_id), but this
+    function has no other way to signal "don't attach" than silently
+    skipping -- confirms it does, rather than building a header value most
+    HTTP clients (http.client raises ValueError on a raw CR/LF in a header
+    value) would reject anyway."""
+    request = Mock()
+    request.headers = {}
+
+    result = google_drive._attach_resource_key(request, malicious_file_id, "0-Rkey123")
+
+    assert result.headers == {}
+
+
+def test_attach_resource_key_attaches_normally_for_a_clean_file_id():
+    request = Mock()
+    request.headers = {}
+
+    result = google_drive._attach_resource_key(request, "abc123", "0-Rkey123")
+
+    assert result.headers == {"X-Goog-Drive-Resource-Keys": "abc123/0-Rkey123"}
 
 
 @pytest.mark.parametrize("bad_role", ["owner", "organizer", ""])
@@ -1460,6 +1525,47 @@ def test_share_file_grants_role_to_email(monkeypatch):
     assert kwargs["sendNotificationEmail"] is True
     assert kwargs["emailMessage"] == "hi"
     assert kwargs["supportsAllDrives"] is True
+
+
+def test_share_file_grants_role_to_group(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.permissions.return_value.create.return_value.execute.return_value = {
+        "id": "perm1",
+        "type": "group",
+        "role": "reader",
+        "emailAddress": "team@x.com",
+    }
+
+    result = json.loads(
+        google_drive.google_drive_share_file(
+            "fid", "team@x.com", role="reader", entity_type="group"
+        )
+    )
+
+    assert result["status"] == "success"
+    kwargs = service.permissions.return_value.create.call_args.kwargs
+    assert kwargs["body"] == {
+        "type": "group",
+        "role": "reader",
+        "emailAddress": "team@x.com",
+    }
+
+
+@pytest.mark.parametrize("bad_entity_type", ["domain", "anyone", ""])
+def test_share_file_rejects_entity_type_outside_user_or_group(
+    monkeypatch, bad_entity_type
+):
+    service = _mock_drive_service(monkeypatch)
+
+    result = json.loads(
+        google_drive.google_drive_share_file(
+            "fid", "a@x.com", entity_type=bad_entity_type
+        )
+    )
+
+    assert result["status"] == "error"
+    assert "entity_type" in result["message"]
+    service.permissions.return_value.create.assert_not_called()
 
 
 def test_share_file_attaches_resource_key_header(monkeypatch):

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -542,6 +542,67 @@ def test_get_file_content_respects_explicit_mime_type_for_spreadsheet(monkeypatc
     )
 
 
+def test_get_file_content_defaults_drawing_export_to_svg(monkeypatch):
+    """Drawings has no text/plain export format either (only
+    pdf/png/jpeg/svg), and unlike Sheets there's no other text-shaped
+    format to fall back to -- svg is the one of those that's actually text
+    (XML) and will decode sensibly, rather than raw image/PDF bytes coming
+    out as garbled replacement characters."""
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.get.return_value.execute.return_value = {
+        "id": "drawing1",
+        "name": "Diagram",
+        "mimeType": "application/vnd.google-apps.drawing",
+    }
+
+    class _FakeDownloader:
+        def __init__(self, fh, _request):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(b"<svg></svg>")
+            return None, True
+
+    monkeypatch.setattr(google_drive, "MediaIoBaseDownload", _FakeDownloader)
+
+    result = json.loads(google_drive.google_drive_get_file_content("drawing1"))
+
+    assert result["status"] == "success"
+    assert (
+        service.files.return_value.export_media.call_args.kwargs["mimeType"]
+        == "image/svg+xml"
+    )
+
+
+def test_get_file_content_respects_explicit_mime_type_for_drawing(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.get.return_value.execute.return_value = {
+        "id": "drawing1",
+        "name": "Diagram",
+        "mimeType": "application/vnd.google-apps.drawing",
+    }
+
+    class _FakeDownloader:
+        def __init__(self, fh, _request):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(b"fake-png-bytes")
+            return None, True
+
+    monkeypatch.setattr(google_drive, "MediaIoBaseDownload", _FakeDownloader)
+
+    result = json.loads(
+        google_drive.google_drive_get_file_content("drawing1", mime_type="image/png")
+    )
+
+    assert result["status"] == "success"
+    assert (
+        service.files.return_value.export_media.call_args.kwargs["mimeType"]
+        == "image/png"
+    )
+
+
 def test_get_file_content_keeps_text_plain_default_for_docs(monkeypatch):
     """The text/csv fallback is specific to spreadsheets -- Docs supports
     text/plain export natively and must not be redirected to csv too."""
@@ -576,15 +637,18 @@ def test_get_file_content_keeps_text_plain_default_for_docs(monkeypatch):
     [
         "application/vnd.google-apps.folder",
         "application/vnd.google-apps.shortcut",
+        "application/vnd.google-apps.form",
     ],
 )
 def test_get_file_content_rejects_folder_and_shortcut_with_a_clear_message(
     monkeypatch, folder_mime_type
 ):
-    """Both mimeTypes start with "application/vnd.google-apps" and would
-    otherwise fall into the export_media branch, which makes no sense for
-    either -- and folder share links are now resolvable via
-    _resolve_file_id, so this is directly reachable, not hypothetical."""
+    """All three mimeTypes start with "application/vnd.google-apps" and
+    would otherwise fall into the export_media branch, which makes no
+    sense for any of them (a folder has no content; a shortcut is a
+    pointer; Forms has no files.export support at all) -- and folder/form
+    share links are now resolvable via _resolve_file_id, so this is
+    directly reachable, not hypothetical."""
     service = _mock_drive_service(monkeypatch)
     service.files.return_value.get.return_value.execute.return_value = {
         "id": "abc123",
@@ -1074,6 +1138,15 @@ class TestExecuteIgnoring204SslEof:
         verify_done = Mock(side_effect=not_found)
 
         google_drive._execute_ignoring_204_ssl_eof(execute, verify_done)  # no raise
+
+    def test_is_confirmed_gone_handles_a_stringified_status(self):
+        """httplib2.Response always coerces .status to int in practice, but
+        the check shouldn't silently stop working (skip straight to
+        returning False, never reaching the string fallback) if some other
+        transport, mock, or future library version ever represents it as
+        e.g. "404" instead of 404."""
+        err = type("Err", (), {"resp": type("Resp", (), {"status": "404"})()})()
+        assert google_drive._is_confirmed_gone(err) is True
 
     def test_raises_even_when_original_error_text_contains_not_found(self):
         """The "not complete" exception raised when verify_done() shows the

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -246,6 +246,96 @@ def test_get_file_content_resolves_full_drive_url(monkeypatch):
     assert service.files.return_value.get_media.call_args.kwargs["fileId"] == "abc123"
 
 
+def test_get_file_content_defaults_spreadsheet_export_to_csv(monkeypatch):
+    """Google Sheets has no text/plain export format and 400s on it, so the
+    tool's own "text/plain" default -- fine for the far more common Docs
+    case -- must not be sent as-is when the target turns out to be a Sheet."""
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.get.return_value.execute.return_value = {
+        "id": "sheet1",
+        "name": "Budget",
+        "mimeType": "application/vnd.google-apps.spreadsheet",
+    }
+
+    class _FakeDownloader:
+        def __init__(self, fh, _request):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(b"a,b\n1,2")
+            return None, True
+
+    monkeypatch.setattr(google_drive, "MediaIoBaseDownload", _FakeDownloader)
+
+    result = json.loads(google_drive.google_drive_get_file_content("sheet1"))
+
+    assert result["status"] == "success"
+    assert (
+        service.files.return_value.export_media.call_args.kwargs["mimeType"]
+        == "text/csv"
+    )
+
+
+def test_get_file_content_respects_explicit_mime_type_for_spreadsheet(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.get.return_value.execute.return_value = {
+        "id": "sheet1",
+        "name": "Budget",
+        "mimeType": "application/vnd.google-apps.spreadsheet",
+    }
+
+    class _FakeDownloader:
+        def __init__(self, fh, _request):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(b"<html></html>")
+            return None, True
+
+    monkeypatch.setattr(google_drive, "MediaIoBaseDownload", _FakeDownloader)
+
+    result = json.loads(
+        google_drive.google_drive_get_file_content(
+            "sheet1", mime_type="application/pdf"
+        )
+    )
+
+    assert result["status"] == "success"
+    assert (
+        service.files.return_value.export_media.call_args.kwargs["mimeType"]
+        == "application/pdf"
+    )
+
+
+def test_get_file_content_keeps_text_plain_default_for_docs(monkeypatch):
+    """The text/csv fallback is specific to spreadsheets -- Docs supports
+    text/plain export natively and must not be redirected to csv too."""
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.get.return_value.execute.return_value = {
+        "id": "doc1",
+        "name": "Notes",
+        "mimeType": "application/vnd.google-apps.document",
+    }
+
+    class _FakeDownloader:
+        def __init__(self, fh, _request):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(b"hello")
+            return None, True
+
+    monkeypatch.setattr(google_drive, "MediaIoBaseDownload", _FakeDownloader)
+
+    result = json.loads(google_drive.google_drive_get_file_content("doc1"))
+
+    assert result["status"] == "success"
+    assert (
+        service.files.return_value.export_media.call_args.kwargs["mimeType"]
+        == "text/plain"
+    )
+
+
 def test_rename_file_resolves_full_drive_url(monkeypatch):
     service = _mock_drive_service(monkeypatch)
     service.files.return_value.update.return_value.execute.return_value = {

--- a/tests/web/tools/test_google_drive_mcp.py
+++ b/tests/web/tools/test_google_drive_mcp.py
@@ -56,6 +56,54 @@ def test_resolve_file_id_accepts_bare_id_and_url_forms(value, expected):
     assert google_drive._resolve_file_id(value) == expected
 
 
+@pytest.mark.parametrize(
+    "url",
+    [
+        # "id" is an extremely common, generic query-param name -- without
+        # host-gating, any unrelated site's link would get its id extracted
+        # and passed to a share/delete/permission call as if it were this
+        # connector's own share link.
+        "https://example.com/article?id=12345",
+        "https://evil.com/x?id=ATTACKER_CHOSEN_ID",
+        # Same risk for the path-shaped patterns: a deliberately-crafted,
+        # non-Google URL can be made to match the same path shape.
+        "https://evil.com/file/d/ATTACKER_ID/view",
+        "https://evil.com/drive/folders/ATTACKER_ID",
+    ],
+)
+def test_resolve_file_id_does_not_extract_id_from_untrusted_hosts(url):
+    """A prompt-injected agent could be fed a URL like these (e.g. quoted
+    inside a document's content) as `file_id`; the resolver must not
+    silently redirect a share/delete/permission call onto whatever id that
+    URL happens to name -- it should fail as an obviously-invalid fileId
+    instead, by returning the URL unresolved."""
+    assert google_drive._resolve_file_id(url) == url
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        # "Publish to web" links have no real Drive file id in them at all
+        # -- "e" is a literal path segment, not part of an id, and the
+        # actual publish token isn't usable as a fileId.
+        "https://docs.google.com/spreadsheets/d/e/2PACX-1vTabc123xyz/pubhtml",
+        "https://docs.google.com/document/d/e/2PACX-1vTabc123xyz/pub",
+        "https://docs.google.com/presentation/d/e/2PACX-1vTabc123xyz/pub",
+    ],
+)
+def test_resolve_file_id_does_not_mistake_published_link_e_segment_for_id(url):
+    assert google_drive._resolve_file_id(url) == url
+
+
+def test_resolve_file_id_still_matches_a_real_id_starting_with_e():
+    """The "/d/e/" exclusion for published links must be specific to that
+    literal segment, not reject any id that happens to start with "e"."""
+    assert (
+        google_drive._resolve_file_id("https://drive.google.com/file/d/e5f6g7/view")
+        == "e5f6g7"
+    )
+
+
 @pytest.mark.parametrize("bad_role", ["owner", "organizer", ""])
 def test_require_share_role_rejects_roles_outside_the_allowed_set(bad_role):
     with pytest.raises(ValueError, match="role"):
@@ -134,7 +182,9 @@ def test_id_taking_tools_resolve_full_drive_urls(monkeypatch, mock_target, invok
 
     invoke(_FOLDER_URL_WITH_ID)
 
-    assert mock_target(service).call_args.kwargs["fileId"] == "abc123"
+    kwargs = mock_target(service).call_args.kwargs
+    assert kwargs["fileId"] == "abc123"
+    assert kwargs["supportsAllDrives"] is True
 
 
 def test_search_passes_shared_drive_support_and_clamps_max_results(monkeypatch):
@@ -242,8 +292,12 @@ def test_get_file_content_resolves_full_drive_url(monkeypatch):
     result = json.loads(google_drive.google_drive_get_file_content(_FOLDER_URL_WITH_ID))
 
     assert result["status"] == "success"
-    assert service.files.return_value.get.call_args.kwargs["fileId"] == "abc123"
-    assert service.files.return_value.get_media.call_args.kwargs["fileId"] == "abc123"
+    get_kwargs = service.files.return_value.get.call_args.kwargs
+    assert get_kwargs["fileId"] == "abc123"
+    assert get_kwargs["supportsAllDrives"] is True
+    media_kwargs = service.files.return_value.get_media.call_args.kwargs
+    assert media_kwargs["fileId"] == "abc123"
+    assert media_kwargs["supportsAllDrives"] is True
 
 
 def test_get_file_content_defaults_spreadsheet_export_to_csv(monkeypatch):
@@ -336,6 +390,32 @@ def test_get_file_content_keeps_text_plain_default_for_docs(monkeypatch):
     )
 
 
+def test_get_file_content_caps_oversized_output(monkeypatch):
+    service = _mock_drive_service(monkeypatch)
+    service.files.return_value.get.return_value.execute.return_value = {
+        "id": "abc123",
+        "name": "big.txt",
+        "mimeType": "text/plain",
+    }
+    huge_content = ("x" * 200_000).encode("utf-8")
+
+    class _FakeDownloader:
+        def __init__(self, fh, _request):
+            self._fh = fh
+
+        def next_chunk(self):
+            self._fh.write(huge_content)
+            return None, True
+
+    monkeypatch.setattr(google_drive, "MediaIoBaseDownload", _FakeDownloader)
+
+    result = json.loads(google_drive.google_drive_get_file_content("abc123"))
+
+    assert result["status"] == "success"
+    assert result["truncated"] is True
+    assert 0 < len(result["content"]) < len(huge_content)
+
+
 def test_rename_file_resolves_full_drive_url(monkeypatch):
     service = _mock_drive_service(monkeypatch)
     service.files.return_value.update.return_value.execute.return_value = {
@@ -348,7 +428,9 @@ def test_rename_file_resolves_full_drive_url(monkeypatch):
     )
 
     assert result["status"] == "success"
-    assert service.files.return_value.update.call_args.kwargs["fileId"] == "abc123"
+    kwargs = service.files.return_value.update.call_args.kwargs
+    assert kwargs["fileId"] == "abc123"
+    assert kwargs["supportsAllDrives"] is True
 
 
 def test_list_permissions_returns_permissions(monkeypatch):
@@ -513,13 +595,19 @@ def test_share_file_rejects_role_outside_the_share_roles(monkeypatch, bad_role):
     service.permissions.return_value.create.assert_not_called()
 
 
-@pytest.mark.parametrize("bad_email", ["", "not-an-email", " a@x.com"])
+@pytest.mark.parametrize(
+    "bad_email",
+    ["", "not-an-email", " a@x.com", "a@", "@b", "a@b"],
+)
 def test_share_file_rejects_invalid_email(monkeypatch, bad_email):
+    """ "a@", "@b", and "a@b" (no dot in the domain) look email-shaped enough
+    to pass a bare "@" in email check, but are not valid addresses."""
     service = _mock_drive_service(monkeypatch)
 
     result = json.loads(google_drive.google_drive_share_file("fid", bad_email))
 
     assert result["status"] == "error"
+    assert "email" in result["message"]
     service.permissions.return_value.create.assert_not_called()
 
 
@@ -550,6 +638,7 @@ def test_update_permission_changes_role(monkeypatch):
     kwargs = service.permissions.return_value.update.call_args.kwargs
     assert kwargs["permissionId"] == "perm1"
     assert kwargs["body"] == {"role": "writer"}
+    assert kwargs["fields"] == "id, type, role, emailAddress, displayName"
 
 
 @pytest.mark.parametrize("bad_role", ["owner", "organizer", ""])
@@ -640,6 +729,41 @@ class TestExecuteIgnoring204SslEof:
 
         with pytest.raises(Exception, match="UNEXPECTED_EOF_WHILE_READING"):
             google_drive._execute_ignoring_204_ssl_eof(execute, verify_done)
+
+    def test_trusts_http_status_over_uri_text_on_a_real_http_error(self):
+        """A real HttpError's __str__ embeds the request URI (which
+        contains the resolved file/permission id) alongside the actual
+        status code. If an id happens to contain the digits "404", a naive
+        substring match on str(verify_err) would misread a genuine 403
+        (object still exists; access merely denied) as "confirmed gone".
+        Checking verify_err.resp.status first must not fall for that."""
+        from googleapiclient.errors import HttpError
+
+        resp = type("Resp", (), {"status": 403, "reason": "Forbidden"})()
+        forbidden = HttpError(
+            resp,
+            b'{"error": {"message": "Permission denied"}}',
+            uri="https://www.googleapis.com/drive/v3/files/1AbC404xyz?fields=id",
+        )
+        assert "404" in str(forbidden)  # confirms the trap is real
+
+        execute = Mock(side_effect=Exception("UNEXPECTED_EOF_WHILE_READING"))
+        verify_done = Mock(side_effect=forbidden)
+
+        with pytest.raises(Exception, match="UNEXPECTED_EOF_WHILE_READING"):
+            google_drive._execute_ignoring_204_ssl_eof(execute, verify_done)
+
+    def test_treats_a_real_http_404_as_confirmed_gone(self):
+        from googleapiclient.errors import HttpError
+
+        resp = type("Resp", (), {"status": 404, "reason": "Not Found"})()
+        not_found = HttpError(
+            resp, b'{"error": {"message": "File not found"}}', uri="https://x/1abc"
+        )
+        execute = Mock(side_effect=Exception("UNEXPECTED_EOF_WHILE_READING"))
+        verify_done = Mock(side_effect=not_found)
+
+        google_drive._execute_ignoring_204_ssl_eof(execute, verify_done)  # no raise
 
     def test_raises_even_when_original_error_text_contains_not_found(self):
         """The "not complete" exception raised when verify_done() shows the


### PR DESCRIPTION
## Summary
- The Google Drive MCP connector could search, read, create, rename, and delete files, but had no way to grant or manage access to a file/folder -- there was no tool backed by the Drive `permissions` resource.
- Add `google_drive_share_file`, `google_drive_list_permissions`, `google_drive_update_permission`, and `google_drive_remove_permission`. `owner` is deliberately not an accepted role: ownership transfer is a distinct, irreversible action. Shared-Drive-only `organizer`/`fileOrganizer` are excluded for the same reason (administrative control, not a plain collaboration role).
- `file_id`/`parent_id` on every tool that takes one now also accept a Drive/Docs/Sheets/Slides/Forms/Drawings share-link URL, not just a bare id -- resolved via a local `_resolve_file_id`, anchored to `drive.google.com`/`docs.google.com`/`drive.usercontent.google.com` and parsed against the URL's own path/query (not a free-text search of the raw string), specifically to avoid an untrusted URL (e.g. quoted in content an agent reads) redirecting a share/delete/permission call onto an attacker-chosen id.
- Extracted the existing "tolerate a proxy's SSL EOF on a 204 No Content response" retry (previously inline only in `google_drive_delete_file`) into a shared `_execute_ignoring_204_ssl_eof` helper, reused by the new `google_drive_remove_permission`. Its post-EOF verification now trusts a real `HttpError.resp.status` over string-matching the exception text where available.
- `google_drive_search`/`google_drive_list_permissions`/`google_drive_get_file_content` all cap their output to the platform's output-length limit; `list_permissions` paginates through `nextPageToken` (bounded) since a Shared Drive item returns at most 100 permissions per page.
- **Behavior change beyond the stated scope**: `google_drive_search` now passes `supportsAllDrives=True`/`includeItemsFromAllDrives=True`, so Shared Drive items now appear in search results where they previously didn't (existing callers may see more results than before).
- Updated the connector's registry description to mention sharing; added a data migration (`20260908_update_google_drive_description`) so an already-provisioned install's row picks up the new description too, since that field isn't in the registry's own drift-sync list.
- The connector already requests the `https://www.googleapis.com/auth/drive` OAuth scope, so existing connections do not need to be reauthorized.

## Test plan
- [x] `pytest tests/web/tools/test_google_drive_mcp.py tests/alembic/test_20260908_update_google_drive_description.py` -- covers URL/id resolution (including several adversarial-input cases: scheme-less/protocol-relative hosts, dot-segment injection via the query fallback, published-to-web link exclusion bypass attempts), each tool's success/error paths, role/email validation, output capping/pagination, the 204/SSL-EOF tolerance, and the migration's upgrade/downgrade/no-clobber/no-op behavior
- [x] `ruff check` / `ruff format --check`
- [x] `mypy` -- no new errors (the 4 pre-existing `import-untyped` errors on the googleapiclient imports predate this change)
- [x] `scripts/check_alembic_heads.sh` -- single head confirmed
- [ ] Manual: connect Google Drive in a workspace, ask the agent to share a file/folder with another email, confirm it appears in Drive's sharing UI