### PR TITLE
fix: fence task execution writes by lease attempt (Phase A)

### DIFF
--- a/docs/architecture/phase-a-implementation-review.md
+++ b/docs/architecture/phase-a-implementation-review.md
@@ -1,0 +1,40 @@
+# A 阶段：执行租约任期隔离
+
+基线：`origin/main`（`becb865c2`）。
+
+执行资格使用 `(task_id, runner_id, run_id, attempt_id)`，复用已有
+`tasks.lease_attempt_id`，不修改数据库结构。同 runner、同 run 重新获取
+lease 后，旧句柄不能继续续租、结算或写入受保护状态。renew 延长原任期，
+预先获取的 lease 和 heartbeat 交接继续使用原对象。
+
+## 写入边界
+
+- 续租、释放、错误结算、恢复输入、clarification 和 interaction staging
+  校验完整任期；缺少 acquisition token 视为失效。
+- 心跳按完整任期分组，旧批次结果不会影响后继任期；同任期订阅共享心跳。
+- WebSocket 实时输入使用数据库快照查找本事件循环中已注册的 lease，
+  找不到持有者时沿用 defer 路径，不把任务行快照直接作为执行资格。
+- 结果结算先用条件 UPDATE 取得写锁，再读取及提交，兼容 SQLite 和
+  PostgreSQL；标题、Workforce 状态和 token 统计也带原任期。
+- 普通 Trace 和 outbound 写入先取得任期条件锁。checkpoint 沿用条件
+  指针 UPDATE，保留任务已删除时 required / best-effort 的错误分类。
+- TTL 回收快照带 attempt，旧扫描不能清除同 runner、同 run 的新任期。
+
+本实现直接适配 main 的现有持久化路径，不包含尚未合并的执行事件 writer。
+mailbox、命令生命周期接管及获取入口统一属于后续阶段；命令回执继续使用
+现有 `claimed_by + attempt_count` 条件保护，原有 acquisition 行为保留。
+
+## 验证
+
+`tests/web/services/test_task_lease_epoch.py` 在 SQLite 和 PostgreSQL 上
+验证旧／缺失 token、心跳交接和延迟批次、并发重新获取、取消清理、结算锁、
+过期扫描及各结果写入点。相关 API、互动、checkpoint 和统计用例一起回归。
+
+移植后 32 个相关测试文件共 **1323 项通过**，包含 SQLite 和 PostgreSQL
+用例。全部适用 pre-commit 检查及 `git diff --check` 通过。
+
+## 部署边界
+
+上线前排空或停止旧 worker 的执行、心跳和命令处理。旧进程仍能发送不含
+attempt 条件的 SQL，因此不能依赖新代码约束混跑中的旧 worker。
+本阶段保护内部持久状态，不撤回已发出的外部请求。

--- a/src/xagent/web/api/a2a.py
+++ b/src/xagent/web/api/a2a.py
@@ -81,6 +81,7 @@ from ..services.task_lease_service import (
     run_task_lease_heartbeat,
     run_while_task_lease_owned,
     stop_task_lease_heartbeat,
+    task_lease_attempt_predicate,
 )
 from ..services.task_orchestrator import (
     TaskTurnError,
@@ -355,6 +356,7 @@ def _update_a2a_resume_input_sync(
                 Task.id == task_lease.task_id,
                 Task.status == TaskStatus.RUNNING,
                 Task.runner_id == task_lease.runner_id,
+                task_lease_attempt_predicate(task_lease),
                 Task.run_id == task_lease.run_id,
             )
             .update(

--- a/src/xagent/web/api/chat.py
+++ b/src/xagent/web/api/chat.py
@@ -136,6 +136,7 @@ from ..services.task_lease_service import (
     run_task_lease_heartbeat,
     run_while_task_lease_owned,
     stop_task_lease_heartbeat,
+    task_lease_attempt_predicate,
 )
 from ..services.task_runtime import (
     FILE_OPERATION_ACCESS_VERSION_KEY,
@@ -1052,6 +1053,7 @@ def _update_task_title_isolated(
                 .where(
                     Task.id == task_id,
                     Task.runner_id == task_lease.runner_id,
+                    task_lease_attempt_predicate(task_lease),
                     Task.run_id == task_lease.run_id,
                     Task.title != task_name,
                 )
@@ -3651,6 +3653,11 @@ class AgentServiceManager:
                         task_id=int(tracker_task_id),
                         expected_run_id=(
                             tracking_lease.run_id
+                            if tracking_lease is not None
+                            else None
+                        ),
+                        expected_attempt_id=(
+                            tracking_lease.attempt_id
                             if tracking_lease is not None
                             else None
                         ),

--- a/src/xagent/web/api/trace_handlers.py
+++ b/src/xagent/web/api/trace_handlers.py
@@ -46,6 +46,8 @@ from ...web.services.task_interaction_schema import interaction_requests_table_e
 from ...web.services.task_lease_service import (
     TASK_RUN_ID_TRACE_FIELD,
     current_task_lease,
+    lock_task_lease_no_commit,
+    task_lease_attempt_predicate,
 )
 from ...web.services.trace_event_staging import (
     checkpoint_run_partition_filter,
@@ -982,6 +984,29 @@ class DatabaseTraceHandler(BaseTraceHandler):
 
             # Serialize data to ensure JSON compatibility
             data = self._serialize_data_for_json(event.data or {})
+            lease = current_task_lease() if self.build_id is None else None
+            is_legacy_checkpoint = (
+                event_type_str == "system_update_general"
+                and isinstance(data, dict)
+                and data.get("checkpoint_type") == CHECKPOINT_TYPE
+            )
+            # Checkpoints use the conditional pointer UPDATE below: it rolls
+            # back the staged row on a fence miss and retains the established
+            # missing-task classification. Other legacy traces need a lock
+            # before their projection is staged.
+            if not is_legacy_checkpoint and lease is not None:
+                if lease.task_id != self.task_id or not lock_task_lease_no_commit(
+                    db, lease
+                ):
+                    if (
+                        db.query(Task.id).filter(Task.id == self.task_id).first()
+                        is None
+                    ):
+                        db.rollback()
+                        if not event.require_persisted:
+                            return
+                        raise RuntimeError(f"Task {self.task_id} no longer exists")
+                    raise RuntimeError("Trace event producer lost its task lease")
             if event_type_str in {
                 "tool_execution_start",
                 "tool_execution_end",
@@ -1035,6 +1060,7 @@ class DatabaseTraceHandler(BaseTraceHandler):
                         Task.id == self.task_id,
                         Task.status == TaskStatus.RUNNING,
                         Task.runner_id == checkpoint_lease.runner_id,
+                        task_lease_attempt_predicate(checkpoint_lease),
                         Task.run_id == checkpoint_lease.run_id,
                     )
                     .values(

--- a/src/xagent/web/api/v1/task_reply.py
+++ b/src/xagent/web/api/v1/task_reply.py
@@ -77,6 +77,7 @@ from ...services.task_lease_service import (
     run_task_lease_heartbeat,
     run_while_task_lease_owned,
     stop_task_lease_heartbeat,
+    task_lease_attempt_predicate,
 )
 from .deps import ApiKeyPrincipal, record_key_usage
 from .errors import V1ApiError, V1ErrorCode
@@ -334,6 +335,7 @@ def _update_reply_input_sync(
                 Task.id == task_lease.task_id,
                 Task.status == TaskStatus.RUNNING,
                 Task.runner_id == task_lease.runner_id,
+                task_lease_attempt_predicate(task_lease),
                 Task.run_id == task_lease.run_id,
             )
             .update(

--- a/src/xagent/web/api/websocket.py
+++ b/src/xagent/web/api/websocket.py
@@ -211,10 +211,13 @@ from ..services.task_lease_service import (
     acquire_task_lease_cancellation_safe,
     acquire_task_lease_no_commit,
     bind_task_lease_context,
+    lock_task_lease_no_commit,
+    registered_task_lease,
     release_task_lease_no_commit,
     run_task_lease_heartbeat,
     run_while_task_lease_owned,
     stop_task_lease_heartbeat,
+    task_lease_attempt_predicate,
 )
 from ..services.task_runtime import (
     SELECTED_FILE_IDS_AGENT_CONFIG_KEY,
@@ -1080,6 +1083,13 @@ def _persist_agent_outbound_event(task_id: int, event: Dict[str, Any]) -> None:
             parent_event_id=None,
             data=data,
         )
+        from ..services.task_lease_service import current_task_lease
+
+        lease = current_task_lease()
+        if lease is not None and (
+            lease.task_id != task_id or not lock_task_lease_no_commit(db, lease)
+        ):
+            raise TaskLeaseLostError("Outbound event producer lost its task lease")
         db.add(trace_event)
 
         if bool(data.get("expect_response")):
@@ -1104,8 +1114,10 @@ def _persist_agent_outbound_event(task_id: int, event: Dict[str, Any]) -> None:
                 )
 
         db.commit()
-    except Exception:
+    except Exception as exc:
         db.rollback()
+        if isinstance(exc, TaskLeaseLostError):
+            raise
         logger.exception(
             "Failed to persist agent outbound message for task %s", task_id
         )
@@ -2389,7 +2401,7 @@ def _task_run_id(task: Any) -> str | None:
 
 
 def _task_lease_snapshot(task: Any) -> TaskLease | None:
-    """Detach the exact active run identity needed by live-control writes."""
+    """Detach a routing key; resolve its registered holder before live writes."""
 
     task_id = getattr(task, "id", None)
     runner_id = getattr(task, "runner_id", None)
@@ -2397,10 +2409,9 @@ def _task_lease_snapshot(task: Any) -> TaskLease | None:
     if task_id is None or runner_id is None or run_id is None:
         return None
     return TaskLease(
-        # attempt_id is left at its None default on purpose: every field here
-        # comes from the task row, so reading lease_attempt_id from that same
-        # row would make any later attempt check compare a value against
-        # itself. See TaskLease's docstring in task_lease_service.py.
+        # Routing observation only. The async caller resolves this key to
+        # a registered acquisition before binding it to an execution writer.
+        attempt_id=getattr(task, "lease_attempt_id", None),
         task_id=int(task_id),
         runner_id=str(runner_id),
         run_id=str(run_id),
@@ -2482,9 +2493,11 @@ def _finalize_task_execution_result_isolated(
                 task_updated = None
                 late_result = True
             else:
+                lock_task_lease_no_commit(finalize_db, task_lease)
                 task_updated = (
                     task_query.filter(
                         Task.runner_id == task_lease.runner_id,
+                        task_lease_attempt_predicate(task_lease),
                         Task.run_id == task_lease.run_id,
                     )
                     .with_for_update()
@@ -3220,11 +3233,13 @@ def _finalize_resumed_task(
     metadata_committed = False
     cleanup_claims: tuple[SupersededObjectCleanupClaim, ...] = ()
     try:
+        lock_task_lease_no_commit(db, task_lease)
         task = (
             db.query(Task)
             .filter(
                 Task.id == task_id,
                 Task.runner_id == task_lease.runner_id,
+                task_lease_attempt_predicate(task_lease),
                 Task.run_id == task_lease.run_id,
             )
             .with_for_update()
@@ -3729,6 +3744,7 @@ async def execute_resume_background(
                 task_id=int(task_id),
                 expected_run_id=lease.run_id,
                 expected_runner_id=lease.runner_id,
+                expected_attempt_id=lease.attempt_id,
             )
             await resume_tracker.start_tracking()
             agent_service.set_interrupt_checker(
@@ -6615,7 +6631,9 @@ async def _handle_chat_message_unserialized(
             task_status = routing.status
             task_run_id = routing.run_id
             live_task_lease = (
-                routing.task_lease if task_status == TaskStatus.RUNNING else None
+                registered_task_lease(routing.task_lease)
+                if task_status == TaskStatus.RUNNING
+                else None
             )
             agent_service = None
             supports_live_control = False

--- a/src/xagent/web/services/task_clarification_draft.py
+++ b/src/xagent/web/services/task_clarification_draft.py
@@ -474,14 +474,8 @@ def resolve_publishable_clarification(
     3. ``task.runner_id == lease.runner_id and task.run_id == lease.run_id``
        -- the task row must still be owned by the lease that produced the
        result.
-    4. ``lease.attempt_id is None or task.lease_attempt_id == lease.attempt_id``
-       -- ``None`` means the lease cannot prove attempt identity at all and
-       must be treated as "skip this check", never as "matches" (the same
-       reading ``interaction_handoff`` itself uses for the identical
-       sentinel). A concrete mismatch means a later attempt has already
-       claimed the row, and this settlement must be discarded wholesale
-       rather than degrade -- an attempt that is no longer current has no
-       business writing anything at all.
+    4. ``lease.attempt_id is not None and task.lease_attempt_id == lease.attempt_id``
+       -- a missing or superseded acquisition cannot publish a clarification.
 
        Guards 2 through 4 evaluate ``lease_is_fenced``,
        ``task_row_matches_lease_owner`` and ``task_row_matches_lease_attempt``

--- a/src/xagent/web/services/task_interaction_staging.py
+++ b/src/xagent/web/services/task_interaction_staging.py
@@ -1230,8 +1230,8 @@ class InteractionHandoff:
     def _assert_current_attempt(self) -> None:
         """Raise unless the task row's current attempt is this lease's.
 
-        The comparison itself, and why ``lease.attempt_id is None`` skips
-        the check rather than failing it, live with the predicate
+        The comparison, including rejection of a missing attempt, lives with
+        the predicate
         (``task_row_matches_lease_attempt``, ``task_lease_service.py``).
 
         What stays here is what the predicate cannot know: this reads
@@ -1254,13 +1254,9 @@ class InteractionHandoff:
         row lock is ever actually taken there (the same fact
         ``get_next_expired_task_lease_candidate_for_update`` in
         ``task_lease_service.py`` documents for its own row-lock read).
-        What keeps this comparison's window closed on SQLite instead is
-        single-writer semantics: SQLite's database-wide writer lock
-        serializes every write regardless of which row it targets. That
-        makes this a TOCTOU (time-of-check-to-time-of-use) gap that happens
-        to stay closed because nothing else can be writing concurrently,
-        not a genuine row-level lock -- a caller that assumes real row
-        locking here is assuming something SQLite does not provide.
+        The caller must acquire SQLite's writer lock before reading the task,
+        for example through ``lock_task_lease_no_commit``. Single-writer
+        semantics alone do not protect a SELECT performed before that lock.
         """
 
         if not task_row_matches_lease_attempt(self.task, self.lease):
@@ -1531,14 +1527,9 @@ def interaction_handoff(
     on the session's own dialect and skipped entirely on PostgreSQL, which
     was checked directly and does not share this behavior at all.
 
-    In the wiring-window while ``lease.attempt_id is None`` is still
-    possible (see ``_assert_current_attempt``'s docstring), this handoff's
-    identity key is already run-scoped (``uq_task_interaction_request_identity``
-    covers ``task_id, run_id, request_idempotency_key``), which is weaker
-    protection against a stale worker than the task-scoped identity an
-    earlier design considered: both the attempt fence and the stale-worker
-    protection a task-scoped key would have given are absent for the same
-    rolling-restart window at once.
+    Missing acquisition tokens are rejected by the attempt check. Existing
+    workers must be drained before enabling strict-owner execution; a new
+    process must not adopt a predecessor's token from the task row.
     """
 
     # A zero-row, SQLite-only, single-column UPDATE, issued deliberately

--- a/src/xagent/web/services/task_lease_service.py
+++ b/src/xagent/web/services/task_lease_service.py
@@ -14,7 +14,7 @@ from datetime import datetime, timedelta, timezone
 from enum import Enum
 from typing import Any, Callable, Coroutine, Iterator, Sequence, TypeVar, cast
 
-from sqlalchemy import and_, case, func, or_, update
+from sqlalchemy import and_, case, false, func, or_, update
 from sqlalchemy.exc import MultipleResultsFound
 from sqlalchemy.orm import Query, Session
 from sqlalchemy.sql.elements import ColumnElement
@@ -58,31 +58,12 @@ class TaskLease:
     a holder can later prove the row still belongs to *its* attempt rather
     than to a successor that reused the same ``(runner_id, run_id)`` tuple.
 
-    ``attempt_id is None`` is a fail-open sentinel with two distinct sources:
-
-    * a lease acquired by a worker running code from before this column
-      existed -- a rolling-restart window that closes on its own once every
-      worker has restarted; and
-    * ``_task_lease_snapshot`` in ``websocket.py``, which reconstructs an
-      ambient lease from an already-loaded task row. That one carries None
-      permanently and on purpose: every one of its fields is read from the
-      task row, so populating ``attempt_id`` from the same row would make any
-      later ``task.lease_attempt_id != lease.attempt_id`` check compare a
-      value against itself -- an always-passing fence, which is strictly
-      worse than an explicit None that callers can detect and skip. Today
-      that snapshot only feeds checkpoint fencing via
-      ``bind_task_lease_context`` and never reaches a settlement path, so
-      the permanent None also has no behavioural cost.
-
-    Consumers must therefore treat None as "cannot prove attempt identity"
-    and fall back to whatever fence they already had, never as "matches".
-
-    The existing lease writers (refresh, release, fail-and-release) do not
-    fence on this column yet, deliberately: rejecting a stale attempt there
-    turns its refresh into a LOST classification and an active cancellation,
-    which is a behavior change that belongs to the first consumer of this
-    column, with its own tests. Until then the pre-existing
-    ``(runner_id, run_id)`` fences are the only guards on those paths.
+    A missing attempt cannot authorize execution writes or renewal. Acquired
+    leases carry the token through background handoff; live injection must
+    reuse a registered holder rather than adopt a token from a task row.
+    Acquisition still supports the existing same-runner orchestration until
+    the owner mailbox replaces those callers; each acquisition supersedes
+    all previous handles, including handles in the same process.
     """
 
     task_id: int
@@ -137,24 +118,38 @@ def task_row_matches_lease_owner(task: Task, lease: TaskLease) -> bool:
 
 
 def task_row_matches_lease_attempt(task: Task, lease: TaskLease) -> bool:
-    """Whether ``task``'s current attempt is the one ``lease`` names.
+    """Whether the caller proves the exact acquisition still owns the row."""
 
-    ``lease.attempt_id is None`` returns True. That is a fail-open
-    sentinel and it is deliberate: ``None`` means this lease cannot prove
-    attempt identity at all (a pre-attempt-column lease, or the
-    permanently-``None`` ambient snapshot ``_task_lease_snapshot`` builds
-    in ``websocket.py`` -- see ``TaskLease.attempt_id`` for both sources),
-    and the established reading is "skip this check", never "treat it as a
-    mismatch". A caller that needs attempt identity proven rather than
-    merely not-contradicted has to check ``lease.attempt_id is not None``
-    itself; this predicate does not make that distinction for it.
+    return bool(
+        lease.attempt_id is not None and task.lease_attempt_id == lease.attempt_id
+    )
 
-    This is a plain Python object comparison, not a SQL expression: the
-    ``== None`` -> ``IS NULL`` folding that affects a SQLAlchemy column
-    comparison compiled to SQL does not apply here.
+
+def task_lease_attempt_predicate(lease: TaskLease) -> ColumnElement[bool]:
+    """SQL fence for a holder's acquisition; missing tokens never match."""
+    if lease.run_id is None or lease.attempt_id is None:
+        return false()
+    return Task.lease_attempt_id == lease.attempt_id
+
+
+def lock_task_lease_no_commit(db: Session, lease: TaskLease) -> bool:
+    """Fence and lock before an ORM settlement, including on SQLite.
+
+    SQLite ignores SELECT FOR UPDATE. A conditional no-op UPDATE takes its
+    write lock before reading state and holds it through the caller's commit.
     """
-
-    return bool(lease.attempt_id is None or task.lease_attempt_id == lease.attempt_id)
+    result = db.execute(
+        update(Task)
+        .where(
+            Task.id == lease.task_id,
+            Task.runner_id == lease.runner_id,
+            Task.run_id == lease.run_id,
+            task_lease_attempt_predicate(lease),
+        )
+        .values(updated_at=Task.updated_at)
+        .execution_options(synchronize_session=False)
+    )
+    return _rowcount(result) == 1
 
 
 _CURRENT_TASK_LEASE: ContextVar[TaskLease | None] = ContextVar(
@@ -197,6 +192,7 @@ class TaskLeaseRecoveryCandidate:
     state_version: int
     last_checkpoint_event_id: str | None
     last_checkpoint_trace_event_id: int | None
+    attempt_id: str | None = None
 
     @property
     def cursor(self) -> tuple[datetime, int]:
@@ -229,11 +225,11 @@ class TaskLeaseRefreshState(str, Enum):
     LOST = "lost"
 
 
-TaskLeaseKey = tuple[int, str, str | None]
+TaskLeaseKey = tuple[int, str, str | None, str | None]
 
 
 def _task_lease_key(lease: TaskLease) -> TaskLeaseKey:
-    return lease.task_id, lease.runner_id, lease.run_id
+    return lease.task_id, lease.runner_id, lease.run_id, lease.attempt_id
 
 
 async def run_while_task_lease_owned(
@@ -612,6 +608,7 @@ def _expired_task_lease_candidates_query(
             Task.runner_id,
             Task.run_id,
             Task.lease_expires_at,
+            Task.lease_attempt_id,
             Task.state_version,
             Task.last_checkpoint_event_id,
             Task.last_checkpoint_trace_event_id,
@@ -648,6 +645,7 @@ def _task_lease_recovery_candidate_from_row(
         runner_id=str(row.runner_id) if row.runner_id is not None else None,
         run_id=str(row.run_id) if row.run_id is not None else None,
         lease_expires_at=lease_expires_at,
+        attempt_id=row.lease_attempt_id,
         state_version=int(row.state_version or 0),
         last_checkpoint_event_id=(
             str(row.last_checkpoint_event_id)
@@ -753,6 +751,7 @@ def recover_expired_task_lease_no_commit(
             task_status_predicate.eq(TaskStatus.RUNNING),
             _nullable_match(Task.runner_id, candidate.runner_id),
             _nullable_match(Task.run_id, candidate.run_id),
+            _nullable_match(Task.lease_attempt_id, candidate.attempt_id),
             Task.lease_expires_at == candidate.lease_expires_at,
             Task.lease_expires_at < recovered_at,
             Task.state_version == candidate.state_version,
@@ -819,7 +818,12 @@ def acquire_task_lease_no_commit(
     new_run: bool = False,
     claim_predicates: Sequence[ColumnElement[bool]] = (),
 ) -> TaskLease | None:
-    """Stage one atomic lease claim; the caller owns commit/rollback."""
+    """Stage one atomic claim; the caller owns commit/rollback.
+
+    Existing entry-point reservations still govern same-runner reacquisition.
+    Every successful acquisition supersedes previous handles; continuation or
+    handoff of an existing owner must use its lease instead of reacquiring.
+    """
     runner = runner_id or get_runner_id()
     now = utc_now()
     expires_at = task_lease_expires_at(now)
@@ -940,6 +944,7 @@ def _refresh_task_lease_no_commit(
         update(Task)
         .where(Task.id == lease.task_id)
         .where(Task.runner_id == lease.runner_id)
+        .where(task_lease_attempt_predicate(lease))
         .where(task_status_predicate.eq(TaskStatus.RUNNING))
         .values(last_heartbeat_at=now, lease_expires_at=expires_at)
     )
@@ -952,6 +957,7 @@ def _refresh_task_lease_no_commit(
     owned_query = db.query(Task.status).filter(
         Task.id == lease.task_id,
         Task.runner_id == lease.runner_id,
+        task_lease_attempt_predicate(lease),
     )
     if lease.run_id is not None:
         owned_query = owned_query.filter(Task.run_id == lease.run_id)
@@ -1082,6 +1088,7 @@ def release_task_lease_no_commit(
         update(Task)
         .where(Task.id == lease.task_id)
         .where(Task.runner_id == lease.runner_id)
+        .where(task_lease_attempt_predicate(lease))
         .values(**values)
     )
     if lease.run_id is not None:
@@ -1111,6 +1118,7 @@ def fail_and_release_task_lease_no_commit(
         update(Task)
         .where(Task.id == lease.task_id)
         .where(Task.runner_id == lease.runner_id)
+        .where(task_lease_attempt_predicate(lease))
         .where(Task.run_id == lease.run_id)
         .where(task_status_predicate.eq(TaskStatus.RUNNING))
         .values(
@@ -1137,7 +1145,10 @@ def release_current_runner_task_lease(
     runner_id: str | None = None,
     expected_run_id: str | None = None,
 ) -> bool:
-    """Release the current runner's lease for a task."""
+    """Release the context holder; a runner id alone cannot authorize release."""
+    lease = current_task_lease()
+    if lease is None or lease.task_id != task_id:
+        return False
     if status == TaskStatus.RUNNING:
         raise ValueError("Cannot release a task lease with RUNNING status")
     runner = runner_id or get_runner_id()
@@ -1147,6 +1158,8 @@ def release_current_runner_task_lease(
         update(Task)
         .where(Task.id == task_id)
         .where(Task.runner_id == runner)
+        .where(Task.run_id == lease.run_id)
+        .where(task_lease_attempt_predicate(lease))
         .values(
             status=task_status_predicate.value(status),
             runner_id=None,
@@ -1389,6 +1402,23 @@ def _get_task_lease_heartbeat_manager() -> _TaskLeaseHeartbeatManager:
         manager = _TaskLeaseHeartbeatManager(loop)
         _task_lease_heartbeat_manager = manager
     return manager
+
+
+def registered_task_lease(snapshot: TaskLease | None) -> TaskLease | None:
+    """Resolve a routing observation to the actual local heartbeat holder.
+
+    The database observation is only a lookup key, never an ownership grant.
+    SQL writers still validate the returned holder after any intervening takeover.
+    """
+    if snapshot is None or snapshot.attempt_id is None:
+        return None
+    manager = _task_lease_heartbeat_manager
+    if manager is None or manager._loop is not asyncio.get_running_loop():
+        return None
+    entry = manager._entries.get(_task_lease_key(snapshot))
+    if entry is None or entry.terminal_event.is_set():
+        return None
+    return entry.lease
 
 
 async def wait_for_heartbeat_manager_idle() -> None:

--- a/src/xagent/web/services/task_orchestrator.py
+++ b/src/xagent/web/services/task_orchestrator.py
@@ -111,10 +111,12 @@ from .task_lease_service import (
     acquire_task_lease_no_commit,
     fail_and_release_task_lease_no_commit,
     get_runner_id,
+    lock_task_lease_no_commit,
     release_task_lease,
     run_task_lease_heartbeat,
     run_while_task_lease_owned,
     stop_task_lease_heartbeat,
+    task_lease_attempt_predicate,
     validate_preacquired_task_lease_isolated,
 )
 from .task_runtime import mcp_runtime_authorization_policy_required
@@ -1180,6 +1182,7 @@ def _claim_turn_no_commit(
                 Task.id == task_id,
                 Task.status == TaskStatus.RUNNING,
                 Task.runner_id == task_lease.runner_id,
+                task_lease_attempt_predicate(task_lease),
                 Task.run_id == task_lease.run_id,
             )
             .one()
@@ -1291,6 +1294,7 @@ def _reconcile_claimed_turn_after_commit_ack_failure(
                     Task.status == TaskStatus.RUNNING,
                     Task.run_id == claimed.run_id,
                     Task.runner_id == claimed.task_lease.runner_id,
+                    task_lease_attempt_predicate(claimed.task_lease),
                 )
                 .first()
             )
@@ -1561,8 +1565,10 @@ def finish_turn(
                 task_id,
             )
             return False
+        lock_task_lease_no_commit(bg_db, task_lease)
         query = query.filter(
             Task.runner_id == task_lease.runner_id,
+            task_lease_attempt_predicate(task_lease),
             Task.run_id == task_lease.run_id,
         )
         # PostgreSQL locks the exact owned row until release_task_lease commits;

--- a/src/xagent/web/services/workforce_runtime.py
+++ b/src/xagent/web/services/workforce_runtime.py
@@ -13,8 +13,10 @@ from xagent.web.models.task import Task, TaskStatus
 from ..models.workforce import Workforce, WorkforceAgent, WorkforceRun
 from .task_lease_service import (
     TaskLease,
+    lock_task_lease_no_commit,
     release_current_runner_task_lease,
     release_task_lease,
+    task_lease_attempt_predicate,
 )
 from .workforce_snapshot import (
     WORKFORCE_CONFIG_FINGERPRINT_VERSION,
@@ -654,8 +656,10 @@ def _sync_workforce_run_status_for_task_id(
     if task_lease is not None:
         if task_lease.task_id != int(task_id) or task_lease.run_id is None:
             return False
+        lock_task_lease_no_commit(db, task_lease)
         task_query = task_query.filter(
             Task.runner_id == task_lease.runner_id,
+            task_lease_attempt_predicate(task_lease),
             Task.run_id == task_lease.run_id,
         )
     task = task_query.with_for_update().first()

--- a/src/xagent/web/tracking/task_tracker.py
+++ b/src/xagent/web/tracking/task_tracker.py
@@ -72,6 +72,7 @@ def _task_for_run(
     task_id: int,
     expected_run_id: str | None,
     expected_runner_id: str | None = None,
+    expected_attempt_id: str | None = None,
 ) -> Any | None:
     from ..models.task import Task
 
@@ -79,7 +80,14 @@ def _task_for_run(
     if expected_run_id is not None:
         query = query.filter(Task.run_id == expected_run_id)
     if expected_runner_id is not None:
-        query = query.filter(Task.runner_id == expected_runner_id)
+        from sqlalchemy import false
+
+        query = query.filter(
+            Task.runner_id == expected_runner_id,
+            Task.lease_attempt_id == expected_attempt_id
+            if expected_attempt_id is not None
+            else false(),
+        )
     return query.first()
 
 
@@ -88,12 +96,14 @@ def _task_seed_from_session(
     task_id: int,
     expected_run_id: str | None = None,
     expected_runner_id: str | None = None,
+    expected_attempt_id: str | None = None,
 ) -> _TaskTrackingSeed:
     task = _task_for_run(
         db_session,
         task_id,
         expected_run_id,
         expected_runner_id,
+        expected_attempt_id,
     )
     if task is None:
         run_suffix = (
@@ -121,6 +131,7 @@ def _load_task_seed_sync(
     task_id: int,
     expected_run_id: str | None = None,
     expected_runner_id: str | None = None,
+    expected_attempt_id: str | None = None,
 ) -> _TaskTrackingSeed:
     db_session = _new_short_session()
     try:
@@ -129,6 +140,7 @@ def _load_task_seed_sync(
             task_id,
             expected_run_id,
             expected_runner_id,
+            expected_attempt_id,
         )
     finally:
         db_session.close()
@@ -140,6 +152,7 @@ def _commit_task_usage_if_owned(
     usage: TokenUsage,
     expected_run_id: str | None = None,
     expected_runner_id: str | None = None,
+    expected_attempt_id: str | None = None,
 ) -> bool:
     """Persist counters only while the durable run owner still matches.
 
@@ -153,7 +166,14 @@ def _commit_task_usage_if_owned(
     if expected_run_id is not None:
         query = query.filter(Task.run_id == expected_run_id)
     if expected_runner_id is not None:
-        query = query.filter(Task.runner_id == expected_runner_id)
+        from sqlalchemy import false
+
+        query = query.filter(
+            Task.runner_id == expected_runner_id,
+            Task.lease_attempt_id == expected_attempt_id
+            if expected_attempt_id is not None
+            else false(),
+        )
     updated = query.update(
         {
             Task.input_tokens: usage.input_tokens,
@@ -176,6 +196,7 @@ def _write_task_usage_sync(
     usage: TokenUsage,
     expected_run_id: str | None = None,
     expected_runner_id: str | None = None,
+    expected_attempt_id: str | None = None,
 ) -> bool:
     db_session = _new_short_session()
     try:
@@ -185,6 +206,7 @@ def _write_task_usage_sync(
             usage,
             expected_run_id,
             expected_runner_id,
+            expected_attempt_id,
         )
     except Exception:
         try:
@@ -249,6 +271,7 @@ def _complete_task_usage_sync(
     usage: TokenUsage,
     expected_run_id: str | None = None,
     expected_runner_id: str | None = None,
+    expected_attempt_id: str | None = None,
 ) -> bool:
     """Persist one run while its durable ownership fence still wins."""
     from ..services.db_runtime import is_database_pool_timeout
@@ -262,6 +285,7 @@ def _complete_task_usage_sync(
                 usage,
                 expected_run_id,
                 expected_runner_id,
+                expected_attempt_id,
             )
         except Exception as error:  # noqa: BLE001
             logger.warning(
@@ -323,6 +347,7 @@ class TaskTracker:
         update_interval_seconds: int = 15,
         expected_run_id: str | None = None,
         expected_runner_id: str | None = None,
+        expected_attempt_id: str | None = None,
     ) -> None:
         """Initialize the task tracker.
 
@@ -335,12 +360,14 @@ class TaskTracker:
             expected_run_id: Optional durable run fence. When provided, writes
                 are ignored after a replacement run changes the task's run id.
             expected_runner_id: Optional durable runner fence. When provided,
-                seed reads and writes require both the expected run and runner.
+                seed reads and writes require the run, runner, and acquisition.
+            expected_attempt_id: Acquisition that owns the tracked counters.
         """
         self.task_id = task_id
         self.update_interval_seconds = update_interval_seconds
         self.expected_run_id = expected_run_id
         self.expected_runner_id = expected_runner_id
+        self.expected_attempt_id = expected_attempt_id
         self._is_tracking = False
         self._update_task: Optional[asyncio.Task] = None
         self._stop_event = asyncio.Event()
@@ -359,6 +386,7 @@ class TaskTracker:
                 task_id,
                 expected_run_id,
                 expected_runner_id,
+                expected_attempt_id,
             )
             if db_session is not None
             else None
@@ -383,6 +411,7 @@ class TaskTracker:
                     self.task_id,
                     self.expected_run_id,
                     self.expected_runner_id,
+                    self.expected_attempt_id,
                 )
             )
             self._seed = seed
@@ -431,6 +460,7 @@ class TaskTracker:
                     usage,
                     self.expected_run_id,
                     self.expected_runner_id,
+                    self.expected_attempt_id,
                 )
             )
             if not task_exists:
@@ -590,6 +620,7 @@ class TaskTracker:
                     usage,
                     self.expected_run_id,
                     self.expected_runner_id,
+                    self.expected_attempt_id,
                 )
             )
         except Exception as e:  # noqa: BLE001

--- a/tests/web/api/test_a2a_api.py
+++ b/tests/web/api/test_a2a_api.py
@@ -840,6 +840,7 @@ def test_update_a2a_resume_input_rolls_back_the_interaction_close_with_the_fence
             source="a2a",
             is_visible=False,
             interaction_protocol_version=1,
+            lease_attempt_id="test-attempt",
         )
         db.add(task)
         db.commit()
@@ -855,7 +856,10 @@ def test_update_a2a_resume_input_rolls_back_the_interaction_close_with_the_fence
     # clause requires an exact match, so this lease has already lost the
     # race by the time the write is attempted.
     stale_lease = TaskLease(
-        task_id=task_id, runner_id="a-different-runner", run_id="run-atomicity"
+        task_id=task_id,
+        runner_id="a-different-runner",
+        run_id="run-atomicity",
+        attempt_id="test-attempt",
     )
     updated = a2a_api._update_a2a_resume_input_sync(
         stale_lease,
@@ -1404,6 +1408,7 @@ def test_checkpoint_resume_rejects_duplicate_request_while_exact_lease_is_live()
             source="a2a",
             is_visible=False,
             agent_config={"a2a_context_id": "ctx-duplicate"},
+            lease_attempt_id="test-attempt",
         )
         db.add(task)
         db.commit()
@@ -1603,6 +1608,7 @@ def test_prelease_restore_from_a_cancelled_acquisition_leaves_marker_untouched()
             source="a2a",
             is_visible=False,
             interaction_protocol_version=1,
+            lease_attempt_id="test-attempt",
         )
         db.add(task)
         db.commit()
@@ -1621,6 +1627,7 @@ def test_prelease_restore_from_a_cancelled_acquisition_leaves_marker_untouched()
         task_id=task_id,
         runner_id="cancelled-acquire-runner",
         run_id="run-cancelled-acquire",
+        attempt_id="test-attempt",
     )
     restored = a2a_api._restore_a2a_resume_prelease_sync(
         acquired_lease, status=TaskStatus.WAITING_FOR_USER
@@ -2866,6 +2873,7 @@ async def test_cancel_accepts_exact_same_run_local_settlement() -> None:
             source="a2a",
             is_visible=False,
             agent_config={"a2a_context_id": "ctx-local-settlement"},
+            lease_attempt_id="test-attempt",
         )
         db.add(task)
         db.commit()
@@ -2961,6 +2969,7 @@ def test_cancel_rejects_unattributed_or_incomplete_failed_settlement(
             is_visible=False,
             agent_config={"a2a_context_id": "ctx-unattributed-settlement"},
             error_message="task execution failed",
+            lease_attempt_id="test-attempt",
         )
         db.add(task)
         db.commit()

--- a/tests/web/api/test_durable_message_resume_contention.py
+++ b/tests/web/api/test_durable_message_resume_contention.py
@@ -10,6 +10,9 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from tests.web.services.task_lease_shared import (
+    live_task_lease as live_task_lease_fixture,
+)
 from xagent.core.agent.runner import UserMessageInjectionOutcome
 from xagent.web.api import websocket as websocket_api
 from xagent.web.api.websocket import (
@@ -36,6 +39,8 @@ from xagent.web.services.task_command_transport import (
     get_runner_id,
     max_command_defers,
 )
+
+live_task_lease = live_task_lease_fixture
 
 
 @pytest.fixture()
@@ -232,6 +237,7 @@ async def test_recovered_delivery_makes_contention_unsafe_to_resend(
 
 @pytest.mark.asyncio
 async def test_dispatcher_reclaims_and_applies_message_after_contention_clears(
+    live_task_lease,
     db_session,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -241,6 +247,7 @@ async def test_dispatcher_reclaims_and_applies_message_after_contention_clears(
     task.runner_id = get_runner_id()
     task.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=1)
     db_session.commit()
+    live_task_lease(db_session, task)
 
     enqueued = enqueue_task_command(
         db_session,

--- a/tests/web/api/test_execution_scope_turn_wiring.py
+++ b/tests/web/api/test_execution_scope_turn_wiring.py
@@ -887,6 +887,7 @@ async def test_resume_db_lifecycle_runs_in_short_session_workers() -> None:
             assert kwargs == {
                 "expected_run_id": "run-a",
                 "expected_runner_id": "runner-a",
+                "expected_attempt_id": None,
             }
 
         async def start_tracking(self) -> None:
@@ -966,6 +967,7 @@ async def test_resume_final_usage_and_heartbeat_finish_before_lease_release() ->
             assert kwargs == {
                 "expected_run_id": "run-a",
                 "expected_runner_id": "runner-a",
+                "expected_attempt_id": None,
             }
 
         async def start_tracking(self) -> None:
@@ -1057,6 +1059,7 @@ async def test_resume_pool_timeout_does_not_start_secondary_db_cleanup(caplog) -
             assert kwargs == {
                 "expected_run_id": "run-a",
                 "expected_runner_id": "runner-a",
+                "expected_attempt_id": None,
             }
             self.complete_tracking = AsyncMock()
             self.stop_periodic_updates = AsyncMock()
@@ -1649,6 +1652,7 @@ async def test_resume_tracker_pool_timeout_skips_result_and_lease_checkouts() ->
             assert kwargs == {
                 "expected_run_id": "run-a",
                 "expected_runner_id": "runner-a",
+                "expected_attempt_id": None,
             }
 
         async def start_tracking(self) -> None:
@@ -1718,6 +1722,7 @@ async def test_resume_heartbeat_pool_timeout_skips_result_and_lease_checkouts() 
             assert kwargs == {
                 "expected_run_id": "run-a",
                 "expected_runner_id": "runner-a",
+                "expected_attempt_id": None,
             }
 
         async def start_tracking(self) -> None:
@@ -1792,6 +1797,7 @@ async def test_resume_lease_loss_cancels_execution_without_stale_side_effects() 
             assert kwargs == {
                 "expected_run_id": "run-a",
                 "expected_runner_id": "runner-a",
+                "expected_attempt_id": None,
             }
             self.complete_tracking = AsyncMock()
             self.stop_periodic_updates = AsyncMock()
@@ -1884,6 +1890,7 @@ async def test_resume_error_delivery_pool_timeout_skips_lease_checkout() -> None
             assert kwargs == {
                 "expected_run_id": "run-a",
                 "expected_runner_id": "runner-a",
+                "expected_attempt_id": None,
             }
 
         async def start_tracking(self) -> None:
@@ -1966,6 +1973,7 @@ async def test_resume_cancellation_drains_all_final_cleanup() -> None:
             assert kwargs == {
                 "expected_run_id": "run-a",
                 "expected_runner_id": "runner-a",
+                "expected_attempt_id": None,
             }
 
         async def start_tracking(self) -> None:

--- a/tests/web/api/test_legacy_failure_history_replay.py
+++ b/tests/web/api/test_legacy_failure_history_replay.py
@@ -40,6 +40,7 @@ def _running_task(
             title=title,
             description=title,
             status=TaskStatus.RUNNING,
+            lease_attempt_id="test-attempt" if runner_id is not None else None,
             runner_id=runner_id,
             run_id=run_id,
             lease_expires_at=(
@@ -735,6 +736,7 @@ def test_failed_resumed_websocket_result_prefers_diagnostic_error_over_display_t
             "error": raw_error,
         },
         task_lease=TaskLease(
+            attempt_id="test-attempt",
             task_id=task_id,
             runner_id="resume-runner-1730",
             run_id="resume-run-1730",
@@ -769,6 +771,7 @@ def test_lease_failure_writer_persists_safe_provenance(_test_db) -> None:
 
     committed = settle_task_lease_isolated(
         TaskLease(
+            attempt_id="test-attempt",
             task_id=task_id,
             runner_id="runner-1730",
             run_id="run-1730",
@@ -798,6 +801,7 @@ async def test_failed_managed_result_replays_only_safe_history(
         committed = finalize_managed_task_lease_result(
             db,
             TaskLease(
+                attempt_id="test-attempt",
                 task_id=task_id,
                 runner_id="managed-runner-1730",
                 run_id="managed-run-1730",

--- a/tests/web/api/test_task_output_storage_boundary.py
+++ b/tests/web/api/test_task_output_storage_boundary.py
@@ -47,6 +47,7 @@ def _seed_running_task(*, runner_id: str, run_id: str) -> tuple[int, int]:
             user_id=int(user.id),
             title="Durable output",
             status=TaskStatus.RUNNING,
+            lease_attempt_id="test-attempt",
             runner_id=runner_id,
             run_id=run_id,
         )
@@ -289,6 +290,7 @@ async def test_output_staging_holds_no_pool_slot_or_task_lock(
             result={"success": True, "output": "done", "file_outputs": []},
             expected_run_id="run-a",
             task_lease=TaskLease(
+                attempt_id="test-attempt",
                 task_id=task_id,
                 runner_id="runner-a",
                 run_id="run-a",
@@ -378,6 +380,7 @@ async def test_takeover_during_output_upload_cannot_commit_old_run_metadata(
             result={"success": True, "output": "stale", "file_outputs": []},
             expected_run_id="run-old",
             task_lease=TaskLease(
+                attempt_id="test-attempt",
                 task_id=task_id,
                 runner_id="runner-old",
                 run_id="run-old",
@@ -480,6 +483,7 @@ def test_metadata_version_change_rolls_back_entire_task_finalization(
                 },
                 expected_run_id="cas-run",
                 task_lease=TaskLease(
+                    attempt_id="test-attempt",
                     task_id=task_id,
                     runner_id="cas-runner",
                     run_id="cas-run",
@@ -544,6 +548,7 @@ def test_resumed_finalizer_uses_same_prepared_output_transaction(
             task_owner_user_id=user_id,
             result={"success": True, "output": "resume done", "file_outputs": []},
             task_lease=TaskLease(
+                attempt_id="test-attempt",
                 task_id=task_id,
                 runner_id="resume-runner",
                 run_id="resume-run",
@@ -635,6 +640,7 @@ def test_lost_resume_owner_compensates_new_version_without_deleting_committed_ob
             task_owner_user_id=user_id,
             result={"success": True, "output": "stale", "file_outputs": []},
             task_lease=TaskLease(
+                attempt_id="test-attempt",
                 task_id=task_id,
                 runner_id="version-runner-old",
                 run_id="version-run-old",
@@ -748,6 +754,7 @@ def test_superseded_output_is_deleted_only_after_exact_metadata_commit(
             result={"success": True, "output": "done", "file_outputs": []},
             expected_run_id="commit-run",
             task_lease=TaskLease(
+                attempt_id="test-attempt",
                 task_id=task_id,
                 runner_id="commit-runner",
                 run_id="commit-run",
@@ -848,6 +855,7 @@ def _assert_cleanup_failure_does_not_reclassify_committed_finalization(
             fail_cleanup_after_commit,
         )
         lease = TaskLease(
+            attempt_id="test-attempt",
             task_id=task_id,
             runner_id=runner_id,
             run_id=run_id,
@@ -1145,7 +1153,12 @@ async def test_cancelled_output_staging_compensates_late_result_before_return(
 
 @pytest.mark.asyncio
 async def test_resume_output_staging_finishes_while_heartbeat_is_still_active() -> None:
-    lease = TaskLease(task_id=42, runner_id="resume-runner", run_id="resume-run")
+    lease = TaskLease(
+        attempt_id="test-attempt",
+        task_id=42,
+        runner_id="resume-runner",
+        run_id="resume-run",
+    )
     heartbeat_stop = asyncio.Event()
     stage_started = threading.Event()
     allow_stage = threading.Event()

--- a/tests/web/api/test_websocket_client_safe_errors.py
+++ b/tests/web/api/test_websocket_client_safe_errors.py
@@ -21,6 +21,9 @@ from tests.web.api.client_safe_ast_guard import (
     _scan,
 )
 from tests.web.api.client_safe_ast_guard import guard_offenders as _guard_offenders
+from tests.web.services.task_lease_shared import (
+    live_task_lease as live_task_lease_fixture,
+)
 from xagent.web.api import websocket as websocket_api
 from xagent.web.models.task import Task, TaskStatus
 from xagent.web.models.user import User
@@ -31,6 +34,8 @@ from xagent.web.services.mcp_runtime import (
 from xagent.web.services.task_orchestrator import TaskTurnOrchestrator
 
 from .conftest import _direct_db_session
+
+live_task_lease = live_task_lease_fixture
 
 SECRET = "/srv/xagent/secrets/prod.key"
 
@@ -2209,6 +2214,7 @@ async def test_unexpected_intervention_error_keeps_its_traceback(
 
 @pytest.mark.asyncio
 async def test_chat_validation_redacts_both_the_ack_and_the_broadcast(
+    live_task_lease,
     _test_db: None,
 ) -> None:
     """The inner chat validation branch answers on two sinks; assert both.
@@ -2236,6 +2242,7 @@ async def test_chat_validation_redacts_both_the_ack_and_the_broadcast(
         task.runner_id = "rt5-runner"
         task.run_id = "rt5-run"
         db.commit()
+        live_task_lease(db, task)
         task_id, owner_id = int(task.id), int(owner.id)
     finally:
         db.close()
@@ -2329,6 +2336,7 @@ def _chat_runtime_error_harness(secret_error: Exception):
 
 @pytest.mark.asyncio
 async def test_runtime_error_is_redacted_and_coded_for_every_audience(
+    live_task_lease,
     _test_db: None,
 ) -> None:
     """Neither the initiator nor task subscribers may receive exception text."""
@@ -2350,6 +2358,7 @@ async def test_runtime_error_is_redacted_and_coded_for_every_audience(
         task.runner_id = "rt6-runner"
         task.run_id = "rt6-run"
         db.commit()
+        live_task_lease(db, task)
         task_id, owner_id = int(task.id), int(owner.id)
     finally:
         db.close()
@@ -2694,6 +2703,7 @@ async def test_origin_entry_dies_with_its_command_or_socket(
 
 @pytest.mark.asyncio
 async def test_durable_chat_runtime_error_is_safe_for_verified_origin(
+    live_task_lease,
     _test_db: None,
 ) -> None:
     """Durable chat sends one safe, coded bubble to its verified origin."""
@@ -2715,6 +2725,7 @@ async def test_durable_chat_runtime_error_is_safe_for_verified_origin(
         task.runner_id = "rt7-runner"
         task.run_id = "rt7-run"
         db.commit()
+        live_task_lease(db, task)
         task_id, owner_id = int(task.id), int(owner.id)
     finally:
         db.close()
@@ -3041,6 +3052,7 @@ def test_same_command_id_on_two_tasks_is_isolated(_clean_origins: None) -> None:
 
 @pytest.mark.asyncio
 async def test_live_chat_runtime_error_sends_one_safe_rejection(
+    live_task_lease,
     _test_db: None,
 ) -> None:
     """The live path returns one coded rejection and never exposes detail."""
@@ -3062,6 +3074,7 @@ async def test_live_chat_runtime_error_sends_one_safe_rejection(
         task.runner_id = "rt8-runner"
         task.run_id = "rt8-run"
         db.commit()
+        live_task_lease(db, task)
         task_id, owner_id = int(task.id), int(owner.id)
     finally:
         db.close()

--- a/tests/web/api/test_websocket_owner_actor.py
+++ b/tests/web/api/test_websocket_owner_actor.py
@@ -25,6 +25,9 @@ from sqlalchemy.orm import Session, sessionmaker
 from sqlalchemy.pool import QueuePool
 
 from tests.shared.execution_scope import register_scope_resolver
+from tests.web.services.task_lease_shared import (
+    live_task_lease as live_task_lease_fixture,
+)
 from xagent.core.agent.checkpoint import (
     CheckpointAccessRefusedError,
     CheckpointCorruptError,
@@ -76,6 +79,8 @@ from xagent.web.services.task_lease_service import (
     current_task_lease,
     get_runner_id,
 )
+
+live_task_lease = live_task_lease_fixture
 
 
 @pytest.fixture()
@@ -1260,12 +1265,15 @@ async def test_chat_without_client_id_uses_durable_command_id_as_turn_id(
 
 
 @pytest.mark.asyncio
-async def test_running_chat_message_is_persisted_before_resume(db_session) -> None:
+async def test_running_chat_message_is_persisted_before_resume(
+    live_task_lease, db_session
+) -> None:
     owner = _user(db_session, "owner")
     task = _task(db_session, owner.id, status=TaskStatus.RUNNING)
     task.runner_id = "live-runner"
     task.run_id = "live-run"
     db_session.commit()
+    live_lease = live_task_lease(db_session, task)
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
@@ -1320,13 +1328,7 @@ async def test_running_chat_message_is_persisted_before_resume(db_session) -> No
     assert stored.content == "Use the audio tool"
     assert stored.turn_id == "live-turn-1"
     assert agent.post_user_message.await_args.kwargs["turn_id"] == "live-turn-1"
-    assert observed_leases == [
-        TaskLease(
-            task_id=int(task.id),
-            runner_id="live-runner",
-            run_id="live-run",
-        )
-    ]
+    assert observed_leases == [live_lease]
     bg_mgr.register_reserved_resume.assert_called_once()
     accepted = [
         call.args[0]
@@ -1601,6 +1603,7 @@ async def test_deferred_chat_message_is_acked_after_durable_command_commit(
 
 @pytest.mark.asyncio
 async def test_live_lease_injection_degrades_to_deferred_on_checkpoint_unavailable(
+    live_task_lease,
     db_session,
 ) -> None:
     """A checkpoint read failure during live injection must fold into the
@@ -1611,6 +1614,7 @@ async def test_live_lease_injection_degrades_to_deferred_on_checkpoint_unavailab
     task.runner_id = "unavailable-runner"
     task.run_id = "unavailable-run"
     db_session.commit()
+    live_task_lease(db_session, task)
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
@@ -1723,6 +1727,7 @@ async def test_live_lease_injection_degrades_to_deferred_on_checkpoint_unavailab
     ids=["live-ack", "suppressed-ack"],
 )
 async def test_durable_failure_keeps_detail_sender_only(
+    live_task_lease,
     db_session,
     error: Exception,
     sender_error_code: str,
@@ -1735,6 +1740,7 @@ async def test_durable_failure_keeps_detail_sender_only(
     task.runner_id = "rejected-runner"
     task.run_id = "rejected-run"
     db_session.commit()
+    live_task_lease(db_session, task)
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
@@ -1908,6 +1914,7 @@ async def test_attachment_bind_race_keeps_specific_failure_on_origin_lane(
 
 @pytest.mark.asyncio
 async def test_resume_registration_failure_keeps_injected_delivery_pending(
+    live_task_lease,
     db_session,
 ) -> None:
     owner = _user(db_session, "owner")
@@ -1915,6 +1922,7 @@ async def test_resume_registration_failure_keeps_injected_delivery_pending(
     task.runner_id = "registration-runner"
     task.run_id = "registration-run"
     db_session.commit()
+    live_task_lease(db_session, task)
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
@@ -1977,6 +1985,7 @@ async def test_resume_registration_failure_keeps_injected_delivery_pending(
 
 @pytest.mark.asyncio
 async def test_live_marker_failure_after_registered_handoff_is_still_accepted(
+    live_task_lease,
     db_session,
 ) -> None:
     owner = _user(db_session, "marker-failure-owner")
@@ -1984,6 +1993,7 @@ async def test_live_marker_failure_after_registered_handoff_is_still_accepted(
     task.runner_id = "marker-failure-runner"
     task.run_id = "marker-failure-run"
     db_session.commit()
+    live_task_lease(db_session, task)
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
@@ -2033,6 +2043,7 @@ async def test_live_marker_failure_after_registered_handoff_is_still_accepted(
 
 @pytest.mark.asyncio
 async def test_live_resume_reads_the_interaction_row_before_injecting(
+    live_task_lease,
     db_session,
 ) -> None:
     """The close is keyed on the row observed *before* the injection, and
@@ -2046,6 +2057,7 @@ async def test_live_resume_reads_the_interaction_row_before_injecting(
     task.runner_id = "close-order-runner"
     task.run_id = "close-order-run"
     db_session.commit()
+    live_task_lease(db_session, task)
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
@@ -2107,6 +2119,7 @@ async def test_live_resume_reads_the_interaction_row_before_injecting(
 
 @pytest.mark.asyncio
 async def test_live_injection_skips_the_close_on_a_replayed_turn_id(
+    live_task_lease,
     db_session,
 ) -> None:
     """A replayed turn id short-circuits inside AgentRunner.inject_user_message
@@ -2125,6 +2138,7 @@ async def test_live_injection_skips_the_close_on_a_replayed_turn_id(
     task.run_id = "close-replay-run"
     task.interaction_protocol_version = 1
     db_session.commit()
+    live_task_lease(db_session, task)
     task_id = int(task.id)
     _seed_active_interaction_row(
         db_session,
@@ -2176,6 +2190,7 @@ async def test_live_injection_skips_the_close_on_a_replayed_turn_id(
 
 @pytest.mark.asyncio
 async def test_live_close_failure_after_registered_handoff_is_still_accepted(
+    live_task_lease,
     db_session,
 ) -> None:
     """A legacy resume interaction close failure must not turn an already
@@ -2185,6 +2200,7 @@ async def test_live_close_failure_after_registered_handoff_is_still_accepted(
     task.runner_id = "close-failure-runner"
     task.run_id = "close-failure-run"
     db_session.commit()
+    live_task_lease(db_session, task)
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
@@ -2237,6 +2253,7 @@ async def test_live_close_failure_after_registered_handoff_is_still_accepted(
 
 @pytest.mark.asyncio
 async def test_live_close_cancellation_does_not_abort_registered_handoff(
+    live_task_lease,
     db_session,
 ) -> None:
     """Same guarantee as the failure case above, for the CancelledError
@@ -2246,6 +2263,7 @@ async def test_live_close_cancellation_does_not_abort_registered_handoff(
     task.runner_id = "close-cancel-runner"
     task.run_id = "close-cancel-run"
     db_session.commit()
+    live_task_lease(db_session, task)
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
@@ -2334,12 +2352,16 @@ def test_lease_restore_clears_the_marker_once_no_active_row_remains(
     owner = _user(db_session, "restore-clears-marker-owner")
     task = _task(db_session, owner.id, status=TaskStatus.WAITING_FOR_USER)
     task.runner_id = "current-runner"
+    task.lease_attempt_id = "restore-attempt"
     task.run_id = "run-clears-marker"
     task.interaction_protocol_version = 1
     db_session.commit()
 
     lease = TaskLease(
-        task_id=int(task.id), runner_id="current-runner", run_id="run-clears-marker"
+        task_id=int(task.id),
+        runner_id="current-runner",
+        run_id="run-clears-marker",
+        attempt_id="restore-attempt",
     )
     restored = _restore_resumed_task_lease_to_prior_status(
         lease, status=TaskStatus.WAITING_FOR_USER
@@ -2534,6 +2556,7 @@ async def test_message_handoff_registers_the_minted_run_not_the_stale_one(
 
 @pytest.mark.asyncio
 async def test_live_marker_cancellation_does_not_cancel_registered_handoff(
+    live_task_lease,
     db_session,
 ) -> None:
     owner = _user(db_session, "marker-cancellation-owner")
@@ -2541,6 +2564,7 @@ async def test_live_marker_cancellation_does_not_cancel_registered_handoff(
     task.runner_id = "marker-cancellation-runner"
     task.run_id = "marker-cancellation-run"
     db_session.commit()
+    live_task_lease(db_session, task)
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
@@ -2840,6 +2864,7 @@ def test_missing_task_prepare_keeps_an_absent_commit_outcome_unknown(
 
 @pytest.mark.asyncio
 async def test_live_control_delivery_failure_pool_timeout_is_not_retried(
+    live_task_lease,
     db_session,
 ) -> None:
     """One failed DELIVERY_FAILED checkout still produces one rejection ack."""
@@ -2848,6 +2873,7 @@ async def test_live_control_delivery_failure_pool_timeout_is_not_retried(
     task.runner_id = "pool-timeout-runner"
     task.run_id = "pool-timeout-run"
     db_session.commit()
+    live_task_lease(db_session, task)
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None
@@ -2907,6 +2933,7 @@ async def test_live_control_delivery_failure_pool_timeout_is_not_retried(
 
 @pytest.mark.asyncio
 async def test_delivery_failure_persistence_drains_before_cancellation(
+    live_task_lease,
     db_session,
 ) -> None:
     owner = _user(db_session, "delivery-cancellation-owner")
@@ -2914,6 +2941,7 @@ async def test_delivery_failure_persistence_drains_before_cancellation(
     task.runner_id = "delivery-cancellation-runner"
     task.run_id = "delivery-cancellation-run"
     db_session.commit()
+    live_task_lease(db_session, task)
     agent = MagicMock()
     agent.supports_live_control.return_value = True
     agent.get_dag_pattern.return_value = None

--- a/tests/web/services/task_lease_shared.py
+++ b/tests/web/services/task_lease_shared.py
@@ -1,0 +1,30 @@
+"""Real acquisition and heartbeat registration for live-input API tests."""
+
+import pytest
+
+from xagent.web.services import task_lease_service as leases
+
+
+@pytest.fixture
+async def live_task_lease():
+    manager = leases._get_task_lease_heartbeat_manager()
+    registrations = []
+
+    def acquire(db, task):
+        lease = leases.acquire_task_lease(
+            db,
+            int(task.id),
+            runner_id=leases.get_runner_id(),
+            expected_run_id=str(task.run_id),
+        )
+        assert lease is not None
+        registrations.append(manager.register(lease))
+        db.refresh(task)
+        return lease
+
+    try:
+        yield acquire
+    finally:
+        for registration in registrations:
+            await registration.close()
+        await manager.wait_until_idle()

--- a/tests/web/services/test_interaction_handoff_surface.py
+++ b/tests/web/services/test_interaction_handoff_surface.py
@@ -62,6 +62,8 @@ def _seed(session_factory) -> tuple[int, int]:
     db = session_factory()
     user_id = make_user(db)
     task_id = make_task(db, user_id=user_id)
+    db.get(Task, task_id).lease_attempt_id = "test-attempt"
+    db.commit()
     anchor_id = make_trace_event(db, task_id=task_id)
     db.close()
     return task_id, anchor_id
@@ -84,7 +86,7 @@ def _anchor(trace_event_id: int, **overrides: Any) -> InteractionAnchor:
 
 def _lease(task_id: int, *, run_id: str = "run-a") -> TaskLease:
     return TaskLease(
-        task_id=task_id, runner_id="runner-1", run_id=run_id, attempt_id=None
+        task_id=task_id, runner_id="runner-1", run_id=run_id, attempt_id="test-attempt"
     )
 
 

--- a/tests/web/services/test_interaction_staging.py
+++ b/tests/web/services/test_interaction_staging.py
@@ -95,6 +95,10 @@ def _seed(session_factory) -> tuple[int, int]:
     db = session_factory()
     user_id = make_user(db)
     task_id = make_task(db, user_id=user_id)
+    db.execute(
+        sa.update(Task).where(Task.id == task_id).values(lease_attempt_id="attempt-a")
+    )
+    db.commit()
     anchor_id = make_trace_event(db, task_id=task_id)
     db.close()
     return task_id, anchor_id
@@ -1548,7 +1552,7 @@ def test_p_reclaim_survives_a_conflict_on_its_own_calls_insert(
 
 
 def _lease(
-    task_id: int, *, run_id: str = "run-a", attempt_id: str | None = None
+    task_id: int, *, run_id: str = "run-a", attempt_id: str | None = "attempt-a"
 ) -> TaskLease:
     return TaskLease(
         task_id=task_id, runner_id="runner-1", run_id=run_id, attempt_id=attempt_id
@@ -2049,7 +2053,7 @@ def test_cm2d_bare_runtime_error_from_with_body_propagates_and_unwinds(
     db.close()
 
 
-def test_cm3_attempt_assertion_gates_on_not_none(tmp_path: Path) -> None:
+def test_cm3_missing_attempt_cannot_stage(tmp_path: Path) -> None:
     engine = _engine(tmp_path)
     session_factory = _session_factory(engine)
     task_id, anchor_id = _seed(session_factory)
@@ -2057,15 +2061,9 @@ def test_cm3_attempt_assertion_gates_on_not_none(tmp_path: Path) -> None:
     anchor = _anchor(anchor_id)
     task = db.get(Task, task_id)
 
-    # attempt_id is None -> assertion is skipped even though task's own
-    # lease_attempt_id disagrees.
-    db.execute(
-        sa.update(Task).where(Task.id == task_id).values(lease_attempt_id="whatever")
-    )
-    db.commit()
     lease = _lease(task_id, attempt_id=None)
     with interaction_handoff(db, lease, task=task, anchor=anchor, now=_now()) as h:
-        result = h.stage(
+        h.stage(
             kind="clarification",
             protocol_version=1,
             request_payload={"prompt": "p"},
@@ -2073,8 +2071,8 @@ def test_cm3_attempt_assertion_gates_on_not_none(tmp_path: Path) -> None:
             expires_at=_now() + timedelta(minutes=15),
         )
     db.commit()
-    assert result.created is True
-    assert ops_signals.active_degradations() == {}
+    assert db.query(TaskInteractionRequest).count() == 0
+    assert ops_signals.INTERACTION_HANDOFF_DEGRADED in ops_signals.active_degradations()
     db.close()
 
 
@@ -2432,7 +2430,7 @@ def test_cm8d_stage_call_that_raises_before_staging_names_no_row(
     db = session_factory()
     anchor = _anchor(anchor_id)
     lease = TaskLease(
-        task_id=task_id, runner_id="runner-1", run_id=None, attempt_id=None
+        task_id=task_id, runner_id="runner-1", run_id=None, attempt_id="attempt-a"
     )
     task = db.get(Task, task_id)
 
@@ -3020,7 +3018,7 @@ def test_cm12_lease_without_run_id_is_rejected_in_stage(tmp_path: Path) -> None:
     db = session_factory()
     anchor = _anchor(anchor_id)
     lease = TaskLease(
-        task_id=task_id, runner_id="runner-1", run_id=None, attempt_id=None
+        task_id=task_id, runner_id="runner-1", run_id=None, attempt_id="attempt-a"
     )
     task = db.get(Task, task_id)
 

--- a/tests/web/services/test_interaction_staging_postgresql.py
+++ b/tests/web/services/test_interaction_staging_postgresql.py
@@ -110,6 +110,10 @@ def db_session(session_factory):
 def fixtures(db_session):
     user_id = make_user(db_session)
     task_id = make_task(db_session, user_id=user_id)
+    db_session.execute(
+        sa.update(Task).where(Task.id == task_id).values(lease_attempt_id="attempt-a")
+    )
+    db_session.commit()
     anchor_id = make_trace_event(db_session, task_id=task_id)
     return task_id, anchor_id
 
@@ -158,7 +162,7 @@ def _stage_kwargs(anchor: InteractionAnchor, **overrides: Any) -> dict[str, Any]
 
 def _lease(task_id: int) -> TaskLease:
     return TaskLease(
-        task_id=task_id, runner_id="runner-1", run_id="run-a", attempt_id=None
+        task_id=task_id, runner_id="runner-1", run_id="run-a", attempt_id="attempt-a"
     )
 
 
@@ -233,7 +237,10 @@ def test_p_over_length_run_id_rejected_before_sql_via_handoff(
     long_run_id = "x" * 65
     anchor = _anchor(anchor_id)
     lease = TaskLease(
-        task_id=task_id, runner_id="runner-1", run_id=long_run_id, attempt_id=None
+        task_id=task_id,
+        runner_id="runner-1",
+        run_id=long_run_id,
+        attempt_id="attempt-a",
     )
     db = db_session
     task = db.get(Task, task_id)

--- a/tests/web/services/test_task_clarification_draft.py
+++ b/tests/web/services/test_task_clarification_draft.py
@@ -331,10 +331,8 @@ def test_guards_run_most_specific_failure_first() -> None:
     assert resolution.fail_closed_reason == "ownership_changed"
 
 
-def test_none_attempt_id_skips_the_attempt_guard() -> None:
-    """``lease.attempt_id is None`` cannot prove attempt identity at all and
-    must be treated as "skip this check", never as "matches" -- the same
-    reading ``interaction_handoff`` uses for the identical sentinel."""
+def test_none_attempt_id_fails_closed() -> None:
+    """A missing acquisition cannot authorize publishing a question."""
 
     result = {"status": "waiting_for_user", "clarification_draft": _draft()}
     resolution = resolve_publishable_clarification(
@@ -344,7 +342,8 @@ def test_none_attempt_id_skips_the_attempt_guard() -> None:
         anchor=_anchor(),
         now=_now(),
     )
-    assert isinstance(resolution, Publishable)
+    assert isinstance(resolution, FailClosed)
+    assert resolution.fail_closed_reason == "attempt_mismatch"
 
 
 def test_missing_draft_guard_wins_over_unfenced_lease_guard() -> None:
@@ -1334,10 +1333,14 @@ def test_cross_run_anchor_mismatch_degrades_downstream_in_the_staging_primitive(
         task = db.get(Task, task_id)
         task.runner_id = "runner-a"
         task.run_id = "run-a"
+        task.lease_attempt_id = "attempt-a"
         db.flush([task])
 
         lease = TaskLease(
-            task_id=task_id, runner_id="runner-a", run_id="run-a", attempt_id=None
+            task_id=task_id,
+            runner_id="runner-a",
+            run_id="run-a",
+            attempt_id="attempt-a",
         )
         draft = _draft()
         result = {"status": "waiting_for_user", "clarification_draft": draft}

--- a/tests/web/services/test_task_command_transport.py
+++ b/tests/web/services/test_task_command_transport.py
@@ -25,6 +25,9 @@ from tests.web.pool_contention_shared import (
     gated_pool_checkout,
     wait_for_ticks,
 )
+from tests.web.services.task_lease_shared import (
+    live_task_lease as live_task_lease_fixture,
+)
 from xagent.core.agent.runner import UserMessageInjectionOutcome
 from xagent.db.sqlite import apply_sqlite_concurrency_pragmas
 from xagent.web.api import websocket as websocket_api
@@ -80,6 +83,8 @@ from xagent.web.services.task_command_transport import (
     task_has_live_foreign_runner,
     task_has_live_runner,
 )
+
+live_task_lease = live_task_lease_fixture
 
 
 @pytest.fixture()
@@ -1011,6 +1016,7 @@ def test_failed_command_retry_preserves_immutable_target(db_session) -> None:
 
 @pytest.mark.asyncio
 async def test_recovery_dispatches_committed_message_across_run_rotation(
+    live_task_lease,
     db_session,
 ) -> None:
     user, task = _create_running_task(db_session)
@@ -1048,6 +1054,7 @@ async def test_recovery_dispatches_committed_message_across_run_rotation(
     task.run_id = "run-2"
     task.lease_expires_at = datetime.utcnow() - timedelta(seconds=1)
     db_session.commit()
+    live_task_lease(db_session, task)
 
     runtime_agent = MagicMock()
     runtime_agent.supports_live_control.return_value = True

--- a/tests/web/services/test_task_lease_epoch.py
+++ b/tests/web/services/test_task_lease_epoch.py
@@ -1,0 +1,553 @@
+"""Acquisition fencing against real SQLite and PostgreSQL task rows."""
+
+import asyncio
+from datetime import timedelta
+
+import pytest
+from sqlalchemy.orm import sessionmaker
+
+from tests.web.services.test_task_execution_event_store import engine as engine_fixture
+from tests.web.services.test_task_execution_event_store import (
+    task_id as task_id_fixture,
+)
+from xagent.web.api.websocket import _task_lease_snapshot
+from xagent.web.models.task import Task, TaskStatus
+from xagent.web.services import task_lease_service as leases
+
+engine = engine_fixture
+task_id = task_id_fixture
+
+
+@pytest.fixture
+def lease_database(engine, task_id, monkeypatch):
+    factory = sessionmaker(engine)
+    monkeypatch.setattr("xagent.web.models.database.get_session_local", lambda: factory)
+    monkeypatch.setattr(
+        "xagent.web.api.trace_handlers.get_db", lambda: iter([factory()])
+    )
+    return factory, task_id
+
+
+@pytest.mark.parametrize("change", ["none", "state_version", "expired", "waiting"])
+def test_valid_renewal_and_settlement_survive_epoch_check(lease_database, change):
+    factory, tid = lease_database
+    with factory() as db:
+        lease = leases.acquire_task_lease(db, tid, runner_id="worker", new_run=True)
+        row = db.get(Task, tid)
+        if change == "state_version":
+            row.state_version += 1
+            row.control_state = "pause_requested"
+        elif change == "expired":
+            row.lease_expires_at = leases.utc_now() - timedelta(seconds=1)
+        elif change == "waiting":
+            row.status = TaskStatus.WAITING_FOR_USER
+        db.commit()
+        assert leases.refresh_task_lease(db, lease) == (
+            leases.TaskLeaseRefreshState.SETTLEMENT_READY
+            if change == "waiting"
+            else leases.TaskLeaseRefreshState.REFRESHED
+        )
+
+
+def test_old_epoch_lost_but_new_epoch_renews(lease_database):
+    factory, tid = lease_database
+    with factory() as db:
+        first = leases.acquire_task_lease(db, tid, runner_id="worker", new_run=True)
+        second = leases.acquire_task_lease(
+            db, tid, runner_id="worker", expected_run_id=first.run_id
+        )
+        assert leases.refresh_task_lease(db, first) == leases.TaskLeaseRefreshState.LOST
+        assert (
+            leases.refresh_task_lease(db, second)
+            == leases.TaskLeaseRefreshState.REFRESHED
+        )
+        db.get(Task, tid).status = TaskStatus.WAITING_FOR_USER
+        db.commit()
+        assert leases.refresh_task_lease(db, first) == leases.TaskLeaseRefreshState.LOST
+        assert (
+            leases.refresh_task_lease(db, second)
+            == leases.TaskLeaseRefreshState.SETTLEMENT_READY
+        )
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_sharing_requires_epoch_key(lease_database, monkeypatch):
+    factory, tid = lease_database
+    with factory() as db:
+        first = leases.acquire_task_lease(db, tid, runner_id="worker", new_run=True)
+        second = leases.acquire_task_lease(
+            db, tid, runner_id="worker", expected_run_id=first.run_id
+        )
+    monkeypatch.setattr(leases, "get_task_lease_heartbeat_seconds", lambda: 0.005)
+    manager = leases._TaskLeaseHeartbeatManager(asyncio.get_running_loop())
+    old = manager.register(first)
+    new = manager.register(second)
+    try:
+        await asyncio.wait_for(old.terminal_event.wait(), timeout=5)
+        assert old._entry.outcome.lease_lost
+        assert old._entry is not new._entry
+        assert not new.terminal_event.is_set()
+        assert not new._entry.outcome.lease_lost
+    finally:
+        await old.close()
+        await new.close()
+        await manager.wait_until_idle()
+
+
+@pytest.mark.asyncio
+async def test_routing_snapshot_requires_registered_holder(lease_database, monkeypatch):
+    factory, tid = lease_database
+    with factory() as db:
+        lease = leases.acquire_task_lease(db, tid, runner_id="worker", new_run=True)
+        snapshot = _task_lease_snapshot(db.get(Task, tid))
+    manager = leases._TaskLeaseHeartbeatManager(asyncio.get_running_loop())
+    monkeypatch.setattr(leases, "_task_lease_heartbeat_manager", manager)
+    assert leases.registered_task_lease(snapshot) is None
+    registration = manager.register(lease)
+    try:
+        assert leases.registered_task_lease(snapshot) is lease
+    finally:
+        await registration.close()
+        await manager.wait_until_idle()
+    assert leases.registered_task_lease(snapshot) is None
+
+
+@pytest.mark.asyncio
+async def test_same_epoch_handoff_keeps_shared_heartbeat(lease_database, monkeypatch):
+    factory, tid = lease_database
+    with factory() as db:
+        lease = leases.acquire_task_lease(db, tid, runner_id="worker", new_run=True)
+    loop = asyncio.get_running_loop()
+    refreshed = asyncio.Event()
+    refresh_batch = leases.refresh_task_leases_isolated
+
+    def observe_refresh(batch):
+        result = refresh_batch(batch)
+        loop.call_soon_threadsafe(refreshed.set)
+        return result
+
+    monkeypatch.setattr(leases, "refresh_task_leases_isolated", observe_refresh)
+    monkeypatch.setattr(leases, "get_task_lease_heartbeat_seconds", lambda: 0.005)
+    manager = leases._TaskLeaseHeartbeatManager(loop)
+    first = manager.register(lease)
+    successor = manager.register(lease)
+    try:
+        assert first._entry is successor._entry
+        await asyncio.wait_for(refreshed.wait(), timeout=5)
+        assert not (await first.close()).lease_lost
+        refreshed.clear()
+        await asyncio.wait_for(refreshed.wait(), timeout=5)
+        assert not successor.terminal_event.is_set()
+        assert not (await successor.close()).lease_lost
+    finally:
+        await first.close()
+        await successor.close()
+        await manager.wait_until_idle()
+
+
+@pytest.mark.asyncio
+async def test_epoch_key_preserves_soft_pool_timeout_and_recovery(monkeypatch):
+    calls = 0
+
+    def refresh(batch):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise TimeoutError("simulated pool wait")
+        return {
+            leases._task_lease_key(item): leases.TaskLeaseRefreshState.REFRESHED
+            for item in batch
+        }
+
+    monkeypatch.setattr(leases, "refresh_task_leases_isolated", refresh)
+    monkeypatch.setattr(leases, "is_database_pool_timeout", lambda error: True)
+    monkeypatch.setattr(leases, "get_task_lease_heartbeat_seconds", lambda: 0.005)
+    manager = leases._TaskLeaseHeartbeatManager(asyncio.get_running_loop())
+    outcomes = []
+    recovered = asyncio.Event()
+    settle = manager._settle_refresh_waiter
+
+    def observe(entry, waiter, outcome, **kwargs):
+        settle(entry, waiter, outcome, **kwargs)
+        outcomes.append(outcome)
+        if len(outcomes) >= 2:
+            recovered.set()
+
+    monkeypatch.setattr(manager, "_settle_refresh_waiter", observe)
+    registration = manager.register(
+        leases.TaskLease(
+            task_id=1, runner_id="worker", run_id="run", attempt_id="epoch"
+        )
+    )
+    try:
+        await asyncio.wait_for(recovered.wait(), timeout=5)
+        assert outcomes[0].pool_timeout is not None
+        assert not outcomes[0].lease_lost
+        assert outcomes[1].pool_timeout is None
+        assert not outcomes[1].lease_lost
+        assert not registration.terminal_event.is_set()
+    finally:
+        await registration.close()
+        await manager.wait_until_idle()
+
+
+@pytest.mark.parametrize("identity", ["superseded", "missing"])
+@pytest.mark.parametrize(
+    "writer",
+    [
+        "release",
+        "fail",
+        "managed",
+        "finish",
+        "result",
+        "resume",
+        "title",
+        "a2a_input",
+        "reply_input",
+        "checkpoint",
+        "outbound",
+        "usage",
+    ],
+)
+def test_old_acquisition_cannot_commit_any_execution_result(
+    lease_database, monkeypatch, identity, writer
+):
+    from dataclasses import replace
+
+    from xagent.core.agent.checkpoint import CHECKPOINT_EVENT_TYPE, CHECKPOINT_TYPE
+    from xagent.core.agent.runner import UserMessageInjectionOutcome
+    from xagent.core.agent.trace import TraceEvent as CoreTraceEvent
+    from xagent.web.api import a2a, chat, websocket
+    from xagent.web.api.trace_handlers import DatabaseTraceHandler
+    from xagent.web.api.v1 import task_reply
+    from xagent.web.models.chat_message import TaskChatMessage
+    from xagent.web.models.task import TraceEvent
+    from xagent.web.models.task_execution_event import TaskExecutionEvent
+    from xagent.web.services.managed_task_lease import (
+        finalize_managed_task_lease_result,
+    )
+    from xagent.web.services.task_orchestrator import finish_turn
+
+    factory, tid = lease_database
+    monkeypatch.setattr(websocket, "get_db", lambda: iter([factory()]))
+    monkeypatch.setattr(websocket, "get_session_local", lambda: factory)
+    monkeypatch.setattr(a2a, "get_session_local", lambda: factory)
+    monkeypatch.setattr(task_reply, "get_session_local", lambda: factory)
+    with factory() as db:
+        old = leases.acquire_task_lease(db, tid, runner_id="worker", new_run=True)
+        current = leases.acquire_task_lease(
+            db, tid, runner_id="worker", expected_run_id=old.run_id
+        )
+        old = replace(current, attempt_id=None) if identity == "missing" else old
+        task = db.get(Task, tid)
+        user_id = task.user_id
+        before = (task.title, task.input, task.output, task.error_message)
+
+    empty_outputs = websocket._PreparedTaskFileOutputs((), (), ())
+    with leases.bind_task_lease_context(old), factory() as db:
+        if writer == "release":
+            assert not leases.release_task_lease(db, old, status=TaskStatus.COMPLETED)
+        elif writer == "fail":
+            assert not leases.fail_and_release_task_lease_no_commit(
+                db, old, error_message="stale"
+            )
+            db.commit()
+        elif writer == "managed":
+            assert not finalize_managed_task_lease_result(
+                db, old, status=TaskStatus.COMPLETED, assistant_content="stale"
+            )
+        elif writer == "finish":
+            assert not finish_turn(db, tid, task_lease=old)
+        elif writer == "result":
+            result = websocket._finalize_task_execution_result_isolated(
+                task_id=tid,
+                task_user_id=user_id,
+                pre_run_status=TaskStatus.RUNNING,
+                result={"status": "completed", "success": True, "output": "stale"},
+                expected_run_id=old.run_id,
+                task_lease=old,
+                resolved_scope_segments=(),
+                prepared_outputs=empty_outputs,
+            )
+            assert result.late_result
+        elif writer == "resume":
+            result = websocket._finalize_resumed_task(
+                tid,
+                status="completed",
+                success=True,
+                output="stale",
+                task_owner_user_id=user_id,
+                result={"output": "stale"},
+                task_lease=old,
+                prepared_outputs=empty_outputs,
+            )
+            assert result["late_result"]
+        elif writer == "title":
+            assert not chat._update_task_title_isolated(tid, "stale", task_lease=old)
+        elif writer == "a2a_input":
+            assert not a2a._update_a2a_resume_input_sync(
+                old, "stale", None, UserMessageInjectionOutcome.NOT_POSTED
+            )
+        elif writer == "reply_input":
+            assert not task_reply._update_reply_input_sync(old, "stale", None)
+        elif writer == "usage":
+            from xagent.web.tracking.task_tracker import (
+                TokenUsage,
+                _write_task_usage_sync,
+            )
+
+            assert not _write_task_usage_sync(
+                tid,
+                TokenUsage(input_tokens=99),
+                old.run_id,
+                old.runner_id,
+                old.attempt_id,
+            )
+        elif writer == "checkpoint":
+            handler = DatabaseTraceHandler(tid)
+            event = CoreTraceEvent(
+                CHECKPOINT_EVENT_TYPE,
+                task_id=str(tid),
+                data={
+                    "checkpoint_type": CHECKPOINT_TYPE,
+                    "execution_id": str(tid),
+                    "snapshot": {"label": "stale"},
+                },
+            )
+            with pytest.raises(RuntimeError, match="lease"):
+                handler._save_trace_event(db, event)
+        else:
+            with pytest.raises(RuntimeError):
+                websocket._persist_agent_outbound_event(
+                    tid,
+                    {
+                        "type": "agent_message",
+                        "event_id": "stale-message",
+                        "data": {"message": "stale", "expect_response": True},
+                    },
+                )
+
+    with factory() as db:
+        task = db.get(Task, tid)
+        assert task.status == TaskStatus.RUNNING
+        assert task.lease_attempt_id == current.attempt_id
+        assert (task.title, task.input, task.output, task.error_message) == before
+        assert task.last_checkpoint_event_id is None
+        assert task.last_checkpoint_trace_event_id is None
+        assert db.query(TaskChatMessage).count() == 0
+        assert db.query(TaskExecutionEvent).count() == 0
+        assert db.query(TraceEvent).count() == 0
+
+
+def test_expiry_snapshot_cannot_release_a_new_epoch_with_identical_timestamps(
+    lease_database, monkeypatch
+):
+    factory, tid = lease_database
+    now = leases.utc_now()
+    monkeypatch.setattr(leases, "utc_now", lambda: now)
+    with factory() as db:
+        first = leases.acquire_task_lease(db, tid, runner_id="worker", new_run=True)
+        cutoff = now + timedelta(days=1)
+        candidate = leases.get_expired_task_lease_candidates(
+            db, cutoff=cutoff, limit=1
+        )[0]
+        second = leases.acquire_task_lease(
+            db, tid, runner_id="worker", expected_run_id=first.run_id
+        )
+        assert second.attempt_id != candidate.attempt_id
+        assert not leases.recover_expired_task_lease_no_commit(
+            db,
+            candidate,
+            status=TaskStatus.FAILED,
+            recovered_at=cutoff,
+            error_message="expired",
+        )
+        db.commit()
+        assert db.get(Task, tid).lease_attempt_id == second.attempt_id
+        assert db.get(Task, tid).status == TaskStatus.RUNNING
+
+
+def test_acquisition_and_old_renewal_race_preserves_the_winning_epoch(lease_database):
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Barrier
+
+    factory, tid = lease_database
+    with factory() as db:
+        old = leases.acquire_task_lease(db, tid, runner_id="worker", new_run=True)
+    barrier = Barrier(2)
+
+    def acquire():
+        with factory() as db:
+            barrier.wait(timeout=5)
+            return leases.acquire_task_lease(
+                db, tid, runner_id="worker", expected_run_id=old.run_id
+            )
+
+    def renew():
+        with factory() as db:
+            barrier.wait(timeout=5)
+            return leases.refresh_task_lease(db, old)
+
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        acquisition = executor.submit(acquire)
+        renewal = executor.submit(renew)
+        current = acquisition.result(timeout=10)
+        assert renewal.result(timeout=10) in {
+            leases.TaskLeaseRefreshState.REFRESHED,
+            leases.TaskLeaseRefreshState.LOST,
+        }
+    with factory() as db:
+        assert db.get(Task, tid).lease_attempt_id == current.attempt_id
+        assert leases.refresh_task_lease(db, old) == leases.TaskLeaseRefreshState.LOST
+        assert (
+            leases.refresh_task_lease(db, current)
+            == leases.TaskLeaseRefreshState.REFRESHED
+        )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_acquisition_cleanup_cannot_release_its_successor(
+    lease_database,
+):
+    import threading
+
+    factory, tid = lease_database
+    acquired = threading.Event()
+    return_lease = threading.Event()
+    holder = []
+    cleanup_results = []
+
+    def acquire():
+        with factory() as db:
+            lease = leases.acquire_task_lease(db, tid, runner_id="worker", new_run=True)
+        holder.append(lease)
+        acquired.set()
+        assert return_lease.wait(timeout=5)
+        return lease
+
+    def cleanup(lease):
+        with factory() as db:
+            cleanup_results.append(
+                leases.release_task_lease(db, lease, status=TaskStatus.FAILED)
+            )
+
+    operation = asyncio.create_task(
+        leases.acquire_task_lease_cancellation_safe(acquire, cleanup)
+    )
+    try:
+        assert await asyncio.to_thread(acquired.wait, 5)
+        operation.cancel()
+        with factory() as db:
+            current = leases.acquire_task_lease(
+                db, tid, runner_id="worker", expected_run_id=holder[0].run_id
+            )
+        return_lease.set()
+        with pytest.raises(asyncio.CancelledError):
+            await operation
+        assert cleanup_results == [False]
+        with factory() as db:
+            assert db.get(Task, tid).lease_attempt_id == current.attempt_id
+            assert db.get(Task, tid).status == TaskStatus.RUNNING
+    finally:
+        return_lease.set()
+        await asyncio.gather(operation, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_delayed_old_heartbeat_batch_cannot_renew_or_cancel_new_registration(
+    lease_database, monkeypatch
+):
+    import threading
+
+    factory, tid = lease_database
+    with factory() as db:
+        old_lease = leases.acquire_task_lease(db, tid, runner_id="worker", new_run=True)
+    batch_ready = threading.Event()
+    deliver_batch = threading.Event()
+    original_refresh = leases.refresh_task_leases_isolated
+    calls = 0
+
+    def delayed_refresh(batch):
+        nonlocal calls
+        states = original_refresh(batch)
+        calls += 1
+        if calls == 1:
+            batch_ready.set()
+            assert deliver_batch.wait(timeout=5)
+        return states
+
+    monkeypatch.setattr(leases, "refresh_task_leases_isolated", delayed_refresh)
+    monkeypatch.setattr(leases, "get_task_lease_heartbeat_seconds", lambda: 0.005)
+    manager = leases._TaskLeaseHeartbeatManager(asyncio.get_running_loop())
+    old = manager.register(old_lease)
+    new = None
+    try:
+        assert await asyncio.to_thread(batch_ready.wait, 5)
+        with factory() as db:
+            current = leases.acquire_task_lease(
+                db, tid, runner_id="worker", expected_run_id=old_lease.run_id
+            )
+        new = manager.register(current)
+        deliver_batch.set()
+        await asyncio.wait_for(old.terminal_event.wait(), timeout=5)
+        assert not new.terminal_event.is_set()
+        assert not new._entry.outcome.lease_lost
+        with factory() as db:
+            assert db.get(Task, tid).lease_attempt_id == current.attempt_id
+    finally:
+        deliver_batch.set()
+        await old.close()
+        if new is not None:
+            await new.close()
+        await manager.wait_until_idle()
+
+
+@pytest.mark.parametrize("status", [TaskStatus.RUNNING, TaskStatus.WAITING_FOR_USER])
+def test_missing_epoch_cannot_renew_or_claim_settlement_ready(lease_database, status):
+    from dataclasses import replace
+
+    factory, tid = lease_database
+    with factory() as db:
+        lease = leases.acquire_task_lease(db, tid, runner_id="worker", new_run=True)
+        db.get(Task, tid).status = status
+        db.commit()
+        assert (
+            leases.refresh_task_lease(db, replace(lease, attempt_id=None))
+            == leases.TaskLeaseRefreshState.LOST
+        )
+
+
+def test_settlement_lock_serializes_same_process_reacquisition(lease_database):
+    from concurrent.futures import ThreadPoolExecutor
+    from threading import Event
+
+    factory, tid = lease_database
+    with factory() as db:
+        old = leases.acquire_task_lease(db, tid, runner_id="worker", new_run=True)
+    started = Event()
+    acquired = Event()
+
+    def takeover():
+        with factory() as db:
+            started.set()
+            result = leases.acquire_task_lease(
+                db, tid, runner_id="worker", expected_run_id=old.run_id
+            )
+            acquired.set()
+            return result
+
+    with ThreadPoolExecutor(max_workers=1) as executor, factory() as db:
+        assert leases.lock_task_lease_no_commit(db, old)
+        future = executor.submit(takeover)
+        try:
+            assert started.wait(timeout=5)
+            assert not acquired.wait(timeout=0.05)
+            db.get(Task, tid).output = "committed by original owner"
+            db.commit()
+        finally:
+            db.rollback()
+        current = future.result(timeout=5)
+    with factory() as db:
+        assert db.get(Task, tid).output == "committed by original owner"
+        assert db.get(Task, tid).lease_attempt_id == current.attempt_id
+        assert not leases.lock_task_lease_no_commit(db, old)

--- a/tests/web/services/test_task_lease_recovery.py
+++ b/tests/web/services/test_task_lease_recovery.py
@@ -144,6 +144,7 @@ def _candidate_for_task(task: Task) -> TaskLeaseRecoveryCandidate:
         runner_id=task.runner_id,
         run_id=task.run_id,
         lease_expires_at=task.lease_expires_at,
+        attempt_id=task.lease_attempt_id,
         state_version=int(task.state_version or 0),
         last_checkpoint_event_id=task.last_checkpoint_event_id,
         last_checkpoint_trace_event_id=task.last_checkpoint_trace_event_id,

--- a/tests/web/services/test_task_orchestrator.py
+++ b/tests/web/services/test_task_orchestrator.py
@@ -433,6 +433,7 @@ async def test_begin_turn_claim_replaces_stale_lease_and_checkpoint_pointer(
         output="answer",
     )
     task.runner_id = "dead-runner-from-crash"
+    task.lease_attempt_id = "test-attempt"
     task.lease_expires_at = utc_now() + timedelta(hours=1)
     task.last_checkpoint_event_id = "previous-run-checkpoint"
     stale_checkpoint = TraceEvent(
@@ -1036,6 +1037,7 @@ def test_schedule_failure_compensation_does_not_fail_foreign_live_lease(
     task.agent_config = {"workforce_run_id": int(run.id)}
     task.run_id = "claimed-run"
     task.runner_id = "replacement-runner"
+    task.lease_attempt_id = "test-attempt"
     task.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
     task.error_message = "replacement still running"
     db_session.commit()
@@ -1046,6 +1048,7 @@ def test_schedule_failure_compensation_does_not_fail_foreign_live_lease(
                 task_id=int(task.id),
                 runner_id="stale-runner",
                 run_id="claimed-run",
+                attempt_id="test-attempt",
             ),
             error_message="stale schedule failure",
         )
@@ -1073,6 +1076,7 @@ def test_error_settlement_releases_terminal_lease_without_reporting_failure(
     task = _create_task(db_session, user.id, status=TaskStatus.COMPLETED)
     task.run_id = "completed-run"
     task.runner_id = "completed-runner"
+    task.lease_attempt_id = "test-attempt"
     task.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
     db_session.add(
         TaskChatMessage(
@@ -1090,6 +1094,7 @@ def test_error_settlement_releases_terminal_lease_without_reporting_failure(
             task_id=int(task.id),
             runner_id="completed-runner",
             run_id="completed-run",
+            attempt_id="test-attempt",
         ),
         error_message="completion broadcast failed",
     )
@@ -1298,6 +1303,7 @@ async def test_begin_turn_schedules_even_when_caller_cancelled(db_session) -> No
                 task_id=task_id,
                 runner_id=get_runner_id(),
                 run_id="slow-claim-run",
+                attempt_id="test-attempt",
             ),
             status=TaskStatus.RUNNING,
             updated_at=datetime.now(timezone.utc),
@@ -1361,6 +1367,7 @@ async def test_repeated_cancellation_keeps_turn_command_gate_until_claim_settles
                 task_id=task_id,
                 runner_id=get_runner_id(),
                 run_id="blocked-claim-run",
+                attempt_id="test-attempt",
             ),
             status=TaskStatus.RUNNING,
             updated_at=datetime.now(timezone.utc),
@@ -1448,6 +1455,7 @@ async def test_schedule_claimed_create_turn_offloads_cache_invalidation(
             task_id=task_id,
             runner_id=get_runner_id(),
             run_id="committed-run",
+            attempt_id="test-attempt",
         ),
         status=TaskStatus.RUNNING,
         updated_at=None,
@@ -1616,6 +1624,7 @@ def test_finish_turn_running_skips_when_other_worker_holds_live_lease(
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
     # Plant a live lease held by a different runner
     task.runner_id = "other-worker"
+    task.lease_attempt_id = "test-attempt"
     task.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
     task.output = "other worker's in-progress output"
     db_session.commit()
@@ -1655,6 +1664,7 @@ def test_finish_turn_running_flips_failed_when_lease_expired(db_session) -> None
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
     task.runner_id = "other-worker"
+    task.lease_attempt_id = "test-attempt"
     task.lease_expires_at = datetime.now(timezone.utc) - timedelta(minutes=5)
     db_session.commit()
 
@@ -1669,6 +1679,7 @@ def test_finish_turn_running_flips_failed_when_we_own_lease(db_session) -> None:
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
     task.runner_id = get_runner_id()  # our own process
+    task.lease_attempt_id = "test-attempt"
     task.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
     db_session.commit()
 
@@ -1690,6 +1701,7 @@ def test_finish_turn_does_not_touch_a_new_run_owned_by_same_process(
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
     task.runner_id = get_runner_id()
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "new-run"
     task.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
     db_session.commit()
@@ -1698,6 +1710,7 @@ def test_finish_turn_does_not_touch_a_new_run_owned_by_same_process(
         task_id=int(task.id),
         runner_id=get_runner_id(),
         run_id="old-run",
+        attempt_id="test-attempt",
     )
     finish_turn(db_session, int(task.id), task_lease=stale_lease)
 
@@ -1716,6 +1729,7 @@ def test_finish_turn_cache_invalidation_failure_is_non_fatal_after_release(
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.FAILED)
     task.runner_id = "settlement-runner"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "settlement-run"
     task.error_message = "execution failed"
     db_session.commit()
@@ -1723,6 +1737,7 @@ def test_finish_turn_cache_invalidation_failure_is_non_fatal_after_release(
         task_id=int(task.id),
         runner_id="settlement-runner",
         run_id="settlement-run",
+        attempt_id="test-attempt",
     )
 
     with patch(
@@ -1790,9 +1805,10 @@ async def test_schedule_bg_cancels_execution_after_heartbeat_loses_lease(
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
     task.runner_id = "test-runner"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db_session.commit()
-    lease = TaskLease(int(task.id), "test-runner", "run-a")
+    lease = TaskLease(int(task.id), "test-runner", "run-a", attempt_id="test-attempt")
     execution_started = asyncio.Event()
     execution_cancelled = asyncio.Event()
 
@@ -1975,7 +1991,9 @@ async def test_schedule_bg_resolves_scope_off_loop_before_execution(
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
     task_id = int(task.id)
-    fake_lease = TaskLease(task_id=task_id, runner_id="test-runner")
+    fake_lease = TaskLease(
+        task_id=task_id, runner_id="test-runner", attempt_id="test-attempt"
+    )
     # The scope lookup must wait for the slot, never give up on it.
     engine, SessionLocal = queue_pool_runtime_db_factory(
         pool_timeout=CONTENTION_POOL_TIMEOUT
@@ -2082,7 +2100,9 @@ async def test_schedule_bg_persists_setup_failures_off_loop(
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
     task_id = int(task.id)
-    fake_lease = TaskLease(task_id=task_id, runner_id="test-runner")
+    fake_lease = TaskLease(
+        task_id=task_id, runner_id="test-runner", attempt_id="test-attempt"
+    )
     loop_thread = get_ident()
     marker_threads: list[int] = []
     snapshot = None if failure_point == "missing_snapshot" else MagicMock()
@@ -2158,10 +2178,16 @@ async def test_schedule_bg_pool_timeout_defers_settlement_to_lease_recovery(
         user_id = int(user.id)
         task_source = task.source
         task.runner_id = "test-runner"
+        task.lease_attempt_id = "test-attempt"
         task.run_id = "run-a"
         seed_db.commit()
 
-    lease = TaskLease(task_id=task_id, runner_id="test-runner", run_id="run-a")
+    lease = TaskLease(
+        task_id=task_id,
+        runner_id="test-runner",
+        run_id="run-a",
+        attempt_id="test-attempt",
+    )
 
     def load_snapshot_from_contended_pool(*_args, **_kwargs):
         with SessionLocal() as snapshot_db:
@@ -2242,7 +2268,12 @@ async def test_schedule_bg_heartbeat_pool_timeout_skips_settlement(
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
     task_id = int(task.id)
-    lease = TaskLease(task_id=task_id, runner_id="test-runner", run_id="run-a")
+    lease = TaskLease(
+        task_id=task_id,
+        runner_id="test-runner",
+        run_id="run-a",
+        attempt_id="test-attempt",
+    )
     heartbeat_timeout = SQLAlchemyTimeoutError("heartbeat pool timeout")
 
     with (
@@ -2321,6 +2352,7 @@ async def test_schedule_bg_settles_owned_terminal_task_observed_by_heartbeat(
     task_id = int(task.id)
     task.source = "trigger"
     task.runner_id = "terminal-runner"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "terminal-run"
     task.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
     run = TriggerRun(
@@ -2336,6 +2368,7 @@ async def test_schedule_bg_settles_owned_terminal_task_observed_by_heartbeat(
         task_id=task_id,
         runner_id="terminal-runner",
         run_id="terminal-run",
+        attempt_id="test-attempt",
     )
     terminal_committed = asyncio.Event()
     allow_execution_return = asyncio.Event()
@@ -2426,6 +2459,7 @@ async def test_schedule_bg_releases_lease_without_blocking_pool_checkout(
         user_id = int(user.id)
         task_source = task.source
         task.runner_id = runner_id
+        task.lease_attempt_id = "test-attempt"
         task.run_id = "run-a"
         seed_db.commit()
 
@@ -2448,6 +2482,7 @@ async def test_schedule_bg_releases_lease_without_blocking_pool_checkout(
                 task_id=task_id,
                 runner_id=runner_id,
                 run_id="run-a",
+                attempt_id="test-attempt",
             ),
         ),
         patch(
@@ -2516,7 +2551,9 @@ async def test_schedule_bg_releases_lease_on_execute_task_background_exception(
 
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
-    fake_lease = TaskLease(task_id=int(task.id), runner_id="test-runner")
+    fake_lease = TaskLease(
+        task_id=int(task.id), runner_id="test-runner", attempt_id="test-attempt"
+    )
     payload = TaskTurnPayload("x")
     _store_runtime_secret_for_turn(payload.turn_id)
     assert get_ephemeral_runtime_values(payload.turn_id) is not None
@@ -2580,7 +2617,9 @@ async def test_schedule_bg_broadcasts_failure_only_after_exact_settlement(
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
     task_id = int(task.id)
-    lease = TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a")
+    lease = TaskLease(
+        task_id=task_id, runner_id="runner-a", run_id="run-a", attempt_id="test-attempt"
+    )
     events: list[str] = []
 
     def settle(*_args, **_kwargs) -> bool:
@@ -2702,7 +2741,12 @@ async def test_marked_legacy_execution_rejects_before_scheduling(db_session) -> 
 @pytest.mark.asyncio
 async def test_trusted_marked_create_schedule_forwards_actor_policy() -> None:
     policy = MCPBuiltinOAuthActorPolicy(resource_owner_key="actor:alice")
-    lease = TaskLease(task_id=42, runner_id="trusted-direct", run_id="run-42")
+    lease = TaskLease(
+        task_id=42,
+        runner_id="trusted-direct",
+        run_id="run-42",
+        attempt_id="test-attempt",
+    )
     claimed = _ClaimedTurn(
         task_lease=lease,
         status=TaskStatus.RUNNING,
@@ -2760,7 +2804,9 @@ async def test_schedule_bg_forwards_execution_message_to_execute_task_background
 
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
-    fake_lease = TaskLease(task_id=int(task.id), runner_id="test-runner")
+    fake_lease = TaskLease(
+        task_id=int(task.id), runner_id="test-runner", attempt_id="test-attempt"
+    )
     payload = TaskTurnPayload(
         transcript_message="summarize this",
         execution_message="summarize this\n\n[uploaded file: secret.txt]",
@@ -2835,6 +2881,7 @@ async def test_schedule_bg_acquires_expired_lease_on_first_try(db_session) -> No
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
     task.runner_id = "dead-runner"
+    task.lease_attempt_id = "test-attempt"
     task.lease_expires_at = utc_now() - timedelta(seconds=5)
     db_session.commit()
 
@@ -2907,10 +2954,14 @@ async def test_schedule_bg_marks_task_failed_when_snapshot_load_raises(
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
     task.runner_id = "test-runner"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db_session.commit()
     fake_lease = TaskLease(
-        task_id=int(task.id), runner_id="test-runner", run_id="run-a"
+        task_id=int(task.id),
+        runner_id="test-runner",
+        run_id="run-a",
+        attempt_id="test-attempt",
     )
     payload = TaskTurnPayload("x")
     _store_runtime_secret_for_turn(payload.turn_id)
@@ -2985,7 +3036,9 @@ async def test_schedule_bg_cleanup_handles_missing_payload_turn_id(db_session) -
 
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
-    fake_lease = TaskLease(task_id=int(task.id), runner_id="test-runner")
+    fake_lease = TaskLease(
+        task_id=int(task.id), runner_id="test-runner", attempt_id="test-attempt"
+    )
 
     with (
         patch(
@@ -3037,9 +3090,15 @@ async def test_schedule_bg_preserves_public_safe_required_mcp_failure(
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
     task.runner_id = "test-runner"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db_session.commit()
-    lease = TaskLease(task_id=int(task.id), runner_id="test-runner", run_id="run-a")
+    lease = TaskLease(
+        task_id=int(task.id),
+        runner_id="test-runner",
+        run_id="run-a",
+        attempt_id="test-attempt",
+    )
     public_message = "Required MCP servers are unavailable."
 
     with (
@@ -3103,10 +3162,14 @@ async def test_schedule_bg_marks_task_failed_when_execute_raises(
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
     task.runner_id = "test-runner"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db_session.commit()
     fake_lease = TaskLease(
-        task_id=int(task.id), runner_id="test-runner", run_id="run-a"
+        task_id=int(task.id),
+        runner_id="test-runner",
+        run_id="run-a",
+        attempt_id="test-attempt",
     )
 
     # Snapshot loader returns a minimal sentinel snapshot so the test
@@ -3177,10 +3240,14 @@ async def test_schedule_bg_does_not_overwrite_terminal_status_from_execute(
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
     task.runner_id = "test-runner"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db_session.commit()
     fake_lease = TaskLease(
-        task_id=int(task.id), runner_id="test-runner", run_id="run-a"
+        task_id=int(task.id),
+        runner_id="test-runner",
+        run_id="run-a",
+        attempt_id="test-attempt",
     )
     fake_snapshot = MagicMock()
 
@@ -3477,9 +3544,15 @@ def _finalize_turn_fixture(db_session, *, turn_id: str):
         db_session, task_id=int(task.id), user_id=int(user.id), turn_id=turn_id
     )
     task.runner_id = "test-runner"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db_session.commit()
-    lease = TaskLease(task_id=int(task.id), runner_id="test-runner", run_id="run-a")
+    lease = TaskLease(
+        task_id=int(task.id),
+        runner_id="test-runner",
+        run_id="run-a",
+        attempt_id="test-attempt",
+    )
     return user, task, payload, lease
 
 
@@ -3888,7 +3961,9 @@ def _captured_terminal_broadcast(setup_or_run_error: BaseException, db_session):
     user = _create_user(db_session)
     task = _create_task(db_session, user.id, status=TaskStatus.RUNNING)
     task_id = int(task.id)
-    lease = TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a")
+    lease = TaskLease(
+        task_id=task_id, runner_id="runner-a", run_id="run-a", attempt_id="test-attempt"
+    )
     frames: list[dict] = []
     settlements: list[dict] = []
 
@@ -4214,7 +4289,10 @@ async def test_leased_auto_failure_preserves_client_classification(db_session) -
             await _run_failing_turn(task_id, int(task.user_id), task.source)
         execute.assert_awaited_once()
         assert execute.await_args.kwargs["task_lease"] == TaskLease(
-            task_id=task_id, runner_id="runner-a", run_id="run-a"
+            task_id=task_id,
+            runner_id="runner-a",
+            run_id="run-a",
+            attempt_id="test-attempt",
         )
 
     assert len(frames) == 1

--- a/tests/web/services/test_trace_event_staging.py
+++ b/tests/web/services/test_trace_event_staging.py
@@ -514,9 +514,15 @@ def test_shell_passes_the_partition_stamped_data_into_prune(
     task = db.get(Task, task_id)
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a-t6"
     db.commit()
-    lease = TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a-t6")
+    lease = TaskLease(
+        task_id=task_id,
+        runner_id="runner-a",
+        run_id="run-a-t6",
+        attempt_id="test-attempt",
+    )
 
     captured: list[dict[str, Any]] = []
     original_prune = DatabaseTraceHandler._prune_checkpoint_history

--- a/tests/web/test_agent_checkpoint_stream.py
+++ b/tests/web/test_agent_checkpoint_stream.py
@@ -986,7 +986,9 @@ def test_database_trace_handler_build_checkpoint_does_not_update_task_pointer() 
             },
         )
 
-        with bind_task_lease_context(TaskLease(int(task.id), "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(int(task.id), "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             handler._save_trace_event(db, event)
         db.refresh(task)
 
@@ -1002,12 +1004,14 @@ def test_database_trace_handler_tags_and_points_to_current_run_checkpoint() -> N
     _, db, task = _create_trace_handler_test_task("current-run-checkpoint")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     lease = TaskLease(
         task_id=int(task.id),
         runner_id="runner-a",
         run_id="run-a",
+        attempt_id="test-attempt",
     )
     event = TraceEvent(
         CHECKPOINT_EVENT_TYPE,
@@ -1057,12 +1061,14 @@ def test_database_trace_handler_rejects_stale_checkpoint(
     _, db, task = _create_trace_handler_test_task("stale-run-checkpoint")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-b"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-b"
     db.commit()
     stale_lease = TaskLease(
         task_id=int(task.id),
         runner_id="runner-a",
         run_id="run-a",
+        attempt_id="test-attempt",
     )
     event = TraceEvent(
         CHECKPOINT_EVENT_TYPE,
@@ -1112,10 +1118,13 @@ def test_database_trace_handler_pointer_update_skips_silently_when_task_is_gone(
     )
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
-    lease = TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a")
+    lease = TaskLease(
+        task_id=task_id, runner_id="runner-a", run_id="run-a", attempt_id="test-attempt"
+    )
     event = TraceEvent(
         CHECKPOINT_EVENT_TYPE,
         task_id=str(task_id),
@@ -1151,6 +1160,7 @@ def test_cached_database_trace_handler_reads_run_context_per_event() -> None:
     handler = DatabaseTraceHandler(int(task.id))
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     first = TraceEvent(
@@ -1173,14 +1183,19 @@ def test_cached_database_trace_handler_reads_run_context_per_event() -> None:
     )
 
     try:
-        with bind_task_lease_context(TaskLease(int(task.id), "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(int(task.id), "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             handler._save_trace_event(db, first)
 
         task.runner_id = "runner-b"
+        task.lease_attempt_id = "test-attempt"
         task.run_id = "run-b"
         task.last_checkpoint_event_id = None
         db.commit()
-        with bind_task_lease_context(TaskLease(int(task.id), "runner-b", "run-b")):
+        with bind_task_lease_context(
+            TaskLease(int(task.id), "runner-b", "run-b", attempt_id="test-attempt")
+        ):
             handler._save_trace_event(db, second)
 
         rows = (
@@ -1248,7 +1263,9 @@ def test_database_trace_handler_load_latest_checkpoint_is_build_scoped(
             ),
         )
 
-        with bind_task_lease_context(TaskLease(int(task.id), "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(int(task.id), "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             # The root checkpoint was written before the lease bound above,
             # so it carries no run tag. With no tagged checkpoint on record
             # for this task, the root reader's partition widens to the
@@ -1277,6 +1294,7 @@ def test_database_trace_handler_loads_checkpoint_only_from_bound_run(
     SessionLocal, db, task = _create_trace_handler_test_task("run-scoped-load")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-b"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-b"
     db.commit()
     task_id = int(task.id)
@@ -1313,7 +1331,9 @@ def test_database_trace_handler_loads_checkpoint_only_from_bound_run(
     monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-b", "run-b")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-b", "run-b", attempt_id="test-attempt")
+        ):
             assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                 "shared-execution"
             ) == {"label": "run-b"}
@@ -1333,7 +1353,9 @@ async def test_database_trace_handler_load_worker_inherits_run_context(
 
     monkeypatch.setattr(handler, "_sync_load_latest_checkpoint", observe_bound_run)
 
-    with bind_task_lease_context(TaskLease(7, "runner-b", "run-b")):
+    with bind_task_lease_context(
+        TaskLease(7, "runner-b", "run-b", attempt_id="test-attempt")
+    ):
         assert await handler.load_latest_checkpoint("shared-execution") == {
             "run_id": "run-b"
         }
@@ -1353,6 +1375,7 @@ def test_database_trace_handler_bound_run_widens_to_legacy_checkpoint_when_untag
     SessionLocal, db, task = _create_trace_handler_test_task("run-legacy-load")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-b"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-b"
     db.commit()
     task_id = int(task.id)
@@ -1377,7 +1400,9 @@ def test_database_trace_handler_bound_run_widens_to_legacy_checkpoint_when_untag
     monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-b", "run-b")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-b", "run-b", attempt_id="test-attempt")
+        ):
             assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                 "shared-execution"
             ) == {"label": "legacy"}
@@ -1393,6 +1418,7 @@ def test_database_trace_handler_load_without_pk_anchor_uses_legacy_scan(
     SessionLocal, db, task = _create_trace_handler_test_task("no-pk-anchor-load")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -1419,7 +1445,9 @@ def test_database_trace_handler_load_without_pk_anchor_uses_legacy_scan(
     monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                 "shared-execution"
             ) == {"label": "legacy-only"}
@@ -1435,6 +1463,7 @@ def test_database_trace_handler_load_uses_pk_anchor_over_newer_row(
     SessionLocal, db, task = _create_trace_handler_test_task("pk-anchor-load")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -1473,7 +1502,9 @@ def test_database_trace_handler_load_uses_pk_anchor_over_newer_row(
     monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                 "shared-execution"
             ) == {"label": "anchored"}
@@ -1533,6 +1564,7 @@ def test_database_trace_handler_load_pk_anchor_single_fault_raises_corrupt(
     )
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -1601,7 +1633,9 @@ def test_database_trace_handler_load_pk_anchor_single_fault_raises_corrupt(
     monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             with pytest.raises(CheckpointCorruptError):
                 DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                     "shared-execution"
@@ -1646,6 +1680,7 @@ def test_database_trace_handler_load_pk_anchor_absent_run_field_still_raises_cor
     )
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -1693,7 +1728,9 @@ def test_database_trace_handler_load_pk_anchor_absent_run_field_still_raises_cor
     monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             with pytest.raises(CheckpointCorruptError):
                 DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                     "shared-execution"
@@ -1719,6 +1756,7 @@ def test_database_trace_handler_load_pk_anchor_without_execution_identity_loads(
     )
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -1751,7 +1789,9 @@ def test_database_trace_handler_load_pk_anchor_without_execution_identity_loads(
     monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                 "shared-execution"
             ) == {"label": "no-execution-identity"}
@@ -1775,6 +1815,7 @@ def test_database_trace_handler_load_dangling_pk_anchor_falls_back_with_telemetr
     SessionLocal, db, task = _create_trace_handler_test_task("pk-anchor-dangling")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -1802,7 +1843,9 @@ def test_database_trace_handler_load_dangling_pk_anchor_falls_back_with_telemetr
 
     clear_degradation(CHECKPOINT_PK_ANCHOR_DANGLING)
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                 "shared-execution"
             ) == {"label": "legacy-fallback"}
@@ -1901,6 +1944,7 @@ def test_database_trace_handler_unbound_root_load_fails_closed_for_active_run(
     SessionLocal, db, task = _create_trace_handler_test_task("unbound-active-load")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -1957,7 +2001,9 @@ def test_database_trace_handler_load_refuses_lease_bound_to_another_task(
 
     try:
         with (
-            bind_task_lease_context(TaskLease(task_id + 1, "runner-a", "run-a")),
+            bind_task_lease_context(
+                TaskLease(task_id + 1, "runner-a", "run-a", attempt_id="test-attempt")
+            ),
             pytest.raises(CheckpointAccessRefusedError) as excinfo,
         ):
             DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
@@ -2007,7 +2053,9 @@ def test_partition_refusal_is_distinct_from_absence(
         # A reader that IS bound to the tagged run reads its own partition
         # and, for an execution id with no matching row there, gets the
         # authoritative "queried successfully, found nothing" result.
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             assert (
                 DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                     "other-execution"
@@ -2028,6 +2076,7 @@ def test_read_partition_keeps_bound_run_when_a_tagged_checkpoint_exists(
     SessionLocal, db, task = _create_trace_handler_test_task("tagged-keeps-bound")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -2063,7 +2112,9 @@ def test_read_partition_keeps_bound_run_when_a_tagged_checkpoint_exists(
     monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                 "shared-execution"
             ) == {"label": "tagged"}
@@ -2147,6 +2198,7 @@ def test_legacy_checkpoint_is_read_after_a_run_id_is_minted(
     )
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -2175,7 +2227,9 @@ def test_legacy_checkpoint_is_read_after_a_run_id_is_minted(
     monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                 "shared-execution"
             ) == {"label": "legacy"}
@@ -2212,6 +2266,7 @@ def test_widened_partition_is_confirmed_before_rejecting_a_row_failing_any_other
     )
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -2281,7 +2336,9 @@ def test_widened_partition_is_confirmed_before_rejecting_a_row_failing_any_other
     expected_partition = "run-a" if field == "run_partition" else None
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             assert (
                 DatabaseTraceHandler(task_id)._root_checkpoint_read_partition(db).run_id
                 == expected_partition
@@ -2338,6 +2395,7 @@ def test_widened_read_never_returns_without_a_fresh_recheck(
     SessionLocal, db, task = _create_trace_handler_test_task(f"widened-recheck-{shape}")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -2422,7 +2480,9 @@ def test_widened_read_never_returns_without_a_fresh_recheck(
     )
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             with pytest.raises(CheckpointUnavailableError):
                 DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                     "shared-execution"
@@ -2442,6 +2502,7 @@ def test_widened_read_is_not_flagged_stale_when_nothing_concurrent_happens(
     SessionLocal, db, task = _create_trace_handler_test_task("widened-recheck-no-race")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -2456,7 +2517,9 @@ def test_widened_read_is_not_flagged_stale_when_nothing_concurrent_happens(
     monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             assert (
                 DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                     "shared-execution"
@@ -2572,6 +2635,7 @@ def test_recheck_probe_failure_surfaces_as_unavailable_not_a_snapshot(
     SessionLocal, db, task = _create_trace_handler_test_task("recheck-probe-failure")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -2618,7 +2682,9 @@ def test_recheck_probe_failure_surfaces_as_unavailable_not_a_snapshot(
     )
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             with pytest.raises(CheckpointUnavailableError):
                 DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                     "shared-execution"
@@ -2639,6 +2705,7 @@ def test_run_bound_read_issues_no_extra_probe(
     SessionLocal, db, task = _create_trace_handler_test_task("run-bound-no-extra-probe")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -2675,7 +2742,9 @@ def test_run_bound_read_issues_no_extra_probe(
     )
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                 "shared-execution"
             ) == {"label": "tagged"}
@@ -2755,6 +2824,7 @@ def test_probe_failure_registers_signal_from_both_callers(
     if leased:
         task.status = TaskStatus.RUNNING
         task.runner_id = "runner-a"
+        task.lease_attempt_id = "test-attempt"
         task.run_id = "run-a"
         db.commit()
     else:
@@ -2791,7 +2861,9 @@ def test_probe_failure_registers_signal_from_both_callers(
     clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
     try:
         if leased:
-            with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+            with bind_task_lease_context(
+                TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+            ):
                 with pytest.raises(CheckpointUnavailableError):
                     DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                         "shared-execution"
@@ -2818,6 +2890,7 @@ def test_widening_self_extinguishes_after_the_first_tagged_checkpoint(
     SessionLocal, db, task = _create_trace_handler_test_task("self-extinguish")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -2842,7 +2915,9 @@ def test_widening_self_extinguishes_after_the_first_tagged_checkpoint(
     monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             # Before this run has tagged anything, the partition itself is
             # widened -- not merely serving stale content that could
             # coincidentally match a narrower partition.
@@ -2912,6 +2987,7 @@ def test_widening_increments_its_counter_only_when_it_engages(
     SessionLocal, db, task = _create_trace_handler_test_task("widening-counter")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -2936,7 +3012,9 @@ def test_widening_increments_its_counter_only_when_it_engages(
     monkeypatch.setattr("xagent.web.api.trace_handlers.get_db", get_test_db)
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             # 1. No run-tagged checkpoint yet: the lease-bound read widens,
             # and the counter moves by exactly one.
             before = widened_count()
@@ -4459,6 +4537,7 @@ def test_database_trace_handler_load_pk_anchor_undecodable_payload_falls_back_to
     SessionLocal, db, task = _create_trace_handler_test_task("anchor-undecodable-older")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -4496,7 +4575,9 @@ def test_database_trace_handler_load_pk_anchor_undecodable_payload_falls_back_to
     )
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             assert DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                 "shared-execution"
             ) == {"label": "older-readable"}
@@ -4515,6 +4596,7 @@ def test_database_trace_handler_load_pk_anchor_undecodable_payload_without_older
     SessionLocal, db, task = _create_trace_handler_test_task("anchor-undecodable-only")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -4539,7 +4621,9 @@ def test_database_trace_handler_load_pk_anchor_undecodable_payload_without_older
     )
 
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             with pytest.raises(CheckpointCorruptError):
                 DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                     "shared-execution"
@@ -4564,6 +4648,7 @@ def test_database_trace_handler_load_pk_anchor_generic_decode_failure_is_unavail
     SessionLocal, db, task = _create_trace_handler_test_task("anchor-generic-only")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -4588,7 +4673,9 @@ def test_database_trace_handler_load_pk_anchor_generic_decode_failure_is_unavail
     clear_degradation(CHECKPOINT_DECODE_FALLBACK)
     clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             with pytest.raises(CheckpointUnavailableError):
                 DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                     "shared-execution"
@@ -4632,6 +4719,7 @@ def test_database_trace_handler_decode_fallback_clears_after_a_successful_decode
     )
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -4658,7 +4746,9 @@ def test_database_trace_handler_decode_fallback_clears_after_a_successful_decode
         CHECKPOINT_DECODE_FALLBACK, "left over from an earlier fallback"
     )
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             assert (
                 DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                     "shared-execution"
@@ -4694,6 +4784,7 @@ def test_database_trace_handler_load_pk_anchor_database_failure_is_unavailable(
     )
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -4736,7 +4827,9 @@ def test_database_trace_handler_load_pk_anchor_database_failure_is_unavailable(
 
     clear_degradation(CHECKPOINT_LOAD_UNAVAILABLE)
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             with pytest.raises(CheckpointUnavailableError):
                 DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                     "shared-execution"
@@ -4773,6 +4866,7 @@ def test_database_trace_handler_anchored_read_clears_the_dangling_signal(
     )
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
@@ -4800,7 +4894,9 @@ def test_database_trace_handler_anchored_read_clears_the_dangling_signal(
         CHECKPOINT_PK_ANCHOR_DANGLING, "left over from another task's read"
     )
     try:
-        with bind_task_lease_context(TaskLease(task_id, "runner-a", "run-a")):
+        with bind_task_lease_context(
+            TaskLease(task_id, "runner-a", "run-a", attempt_id="test-attempt")
+        ):
             assert (
                 DatabaseTraceHandler(task_id)._sync_load_latest_checkpoint(
                     "shared-execution"
@@ -4914,10 +5010,13 @@ def test_database_trace_handler_flush_without_primary_key_refuses_to_write_the_a
     _, db, task = _create_trace_handler_test_task("flush-without-pk")
     task.status = TaskStatus.RUNNING
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "run-a"
     db.commit()
     task_id = int(task.id)
-    lease = TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a")
+    lease = TaskLease(
+        task_id=task_id, runner_id="runner-a", run_id="run-a", attempt_id="test-attempt"
+    )
     event = TraceEvent(
         CHECKPOINT_EVENT_TYPE,
         task_id=str(task_id),

--- a/tests/web/test_execute_task_manage_task_lease.py
+++ b/tests/web/test_execute_task_manage_task_lease.py
@@ -93,7 +93,9 @@ def _create_single_connection_runtime_db(tmp_path, filename: str):
 @pytest.mark.asyncio
 async def test_execute_task_binds_outer_lease_only_during_agent_execution() -> None:
     manager = AgentServiceManager()
-    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    lease = TaskLease(
+        task_id=42, runner_id="runner-a", run_id="run-a", attempt_id="test-attempt"
+    )
     observed_leases: list[TaskLease | None] = []
 
     class LeaseObservingAgent(_FakeAgentService):
@@ -128,7 +130,9 @@ async def test_execute_task_binds_outer_lease_only_during_agent_execution() -> N
 @pytest.mark.asyncio
 async def test_execute_task_tracks_usage_for_outer_owned_lease() -> None:
     manager = AgentServiceManager()
-    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    lease = TaskLease(
+        task_id=42, runner_id="runner-a", run_id="run-a", attempt_id="test-attempt"
+    )
     tracker = MagicMock(
         start_tracking=AsyncMock(),
         complete_tracking=AsyncMock(),
@@ -174,6 +178,7 @@ async def test_execute_task_tracks_usage_for_outer_owned_lease() -> None:
         task_id=42,
         expected_run_id="run-a",
         expected_runner_id="runner-a",
+        expected_attempt_id="test-attempt",
     )
     tracker.start_tracking.assert_awaited_once()
     tracker.complete_tracking.assert_awaited_once()
@@ -182,7 +187,9 @@ async def test_execute_task_tracks_usage_for_outer_owned_lease() -> None:
 @pytest.mark.asyncio
 async def test_execute_task_external_lease_loss_cancels_agent_execution() -> None:
     manager = AgentServiceManager()
-    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    lease = TaskLease(
+        task_id=42, runner_id="runner-a", run_id="run-a", attempt_id="test-attempt"
+    )
     execution_started = asyncio.Event()
     execution_cancelled = asyncio.Event()
 
@@ -226,7 +233,9 @@ async def test_execute_task_external_lease_loss_cancels_agent_execution() -> Non
 @pytest.mark.asyncio
 async def test_execute_task_managed_lease_loss_skips_usage_and_release() -> None:
     manager = AgentServiceManager()
-    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    lease = TaskLease(
+        task_id=42, runner_id="runner-a", run_id="run-a", attempt_id="test-attempt"
+    )
     execution_started = asyncio.Event()
     execution_cancelled = asyncio.Event()
     tracker = MagicMock(
@@ -303,7 +312,9 @@ async def test_execute_task_lease_loss_during_title_update_cancels_stale_write()
     None
 ):
     manager = AgentServiceManager()
-    lease = TaskLease(task_id=42, runner_id="runner-a", run_id="run-a")
+    lease = TaskLease(
+        task_id=42, runner_id="runner-a", run_id="run-a", attempt_id="test-attempt"
+    )
     title_started = asyncio.Event()
     title_cancelled = asyncio.Event()
 
@@ -403,6 +414,7 @@ async def test_execute_task_workforce_pool_timeout_stops_tracker_checkout(
         task_id=task_id,
         runner_id="test-runner",
         run_id="test-run",
+        attempt_id="test-attempt",
     )
     release_lease = MagicMock(return_value=True)
     stop_heartbeat = AsyncMock()
@@ -474,6 +486,7 @@ async def test_execute_task_pre_run_timeout_waits_for_shared_heartbeat_batch() -
         task_id=task_id,
         runner_id="test-runner",
         run_id="test-run",
+        attempt_id="test-attempt",
     )
     manager = AgentServiceManager()
     workforce_started = threading.Event()
@@ -575,6 +588,7 @@ async def test_execute_task_waits_for_shared_heartbeat_timeout_and_retains_lease
         task_id=task_id,
         runner_id="test-runner",
         run_id="test-run",
+        attempt_id="test-attempt",
     )
     manager = AgentServiceManager()
     usage_started = threading.Event()
@@ -680,6 +694,7 @@ async def test_execute_task_tracker_pool_timeout_stops_execution_and_release() -
         task_id=task_id,
         runner_id="test-runner",
         run_id="test-run",
+        attempt_id="test-attempt",
     )
     manager = AgentServiceManager()
     agent_service = _FakeAgentService()
@@ -988,6 +1003,7 @@ async def test_execute_task_acquires_and_releases_lease_when_manage_true(
         task_id=int(task.id),
         runner_id="test-runner",
         run_id="test-run",
+        attempt_id="test-attempt",
     )
     manager = AgentServiceManager()
 
@@ -1227,6 +1243,7 @@ async def test_execute_task_cancellation_during_workforce_sync_releases_lease() 
         task_id=task_id,
         runner_id="test-runner",
         run_id="test-run",
+        attempt_id="test-attempt",
     )
     manager = AgentServiceManager()
     workforce_sync_started = threading.Event()
@@ -1318,6 +1335,7 @@ async def test_execute_task_cancellation_during_tracker_start_releases_lease() -
         task_id=task_id,
         runner_id="test-runner",
         run_id="test-run",
+        attempt_id="test-attempt",
     )
     manager = AgentServiceManager()
     tracker_start_entered = asyncio.Event()
@@ -1420,6 +1438,7 @@ async def test_execute_task_cleans_up_when_sandbox_acquire_raises(
         task_id=int(task.id),
         runner_id="test-runner",
         run_id="test-run",
+        attempt_id="test-attempt",
     )
     manager = AgentServiceManager()
     tracker = MagicMock()
@@ -1489,6 +1508,7 @@ async def test_execute_task_persists_final_usage_before_releasing_lease() -> Non
         task_id=task_id,
         runner_id="test-runner",
         run_id="test-run",
+        attempt_id="test-attempt",
     )
     manager = AgentServiceManager()
     events: list[str] = []
@@ -1560,6 +1580,7 @@ async def test_execute_task_persists_final_usage_before_releasing_lease() -> Non
         task_id=task_id,
         expected_run_id="test-run",
         expected_runner_id="test-runner",
+        expected_attempt_id="test-attempt",
     )
     assert events == ["usage", "heartbeat", "lease", "sandbox"]
 
@@ -1572,6 +1593,7 @@ async def test_execute_task_releases_sandbox_when_lease_release_raises() -> None
         task_id=task_id,
         runner_id="test-runner",
         run_id="test-run",
+        attempt_id="test-attempt",
     )
     manager = AgentServiceManager()
     tracker = MagicMock()
@@ -1635,6 +1657,7 @@ async def test_execute_task_final_usage_pool_timeout_retains_lease() -> None:
         task_id=task_id,
         runner_id="test-runner",
         run_id="test-run",
+        attempt_id="test-attempt",
     )
     manager = AgentServiceManager()
     tracker = MagicMock()
@@ -1706,6 +1729,7 @@ async def test_execute_task_heartbeat_pool_timeout_retains_lease() -> None:
         task_id=task_id,
         runner_id="test-runner",
         run_id="test-run",
+        attempt_id="test-attempt",
     )
     manager = AgentServiceManager()
     tracker = MagicMock()
@@ -1774,6 +1798,7 @@ async def test_execute_task_heartbeat_loss_after_result_rejects_success() -> Non
         task_id=task_id,
         runner_id="test-runner",
         run_id="test-run",
+        attempt_id="test-attempt",
     )
     manager = AgentServiceManager()
     tracker = MagicMock()
@@ -1840,6 +1865,7 @@ def test_task_title_update_is_fenced_by_exact_lease(db_session) -> None:
         status=TaskStatus.RUNNING,
         runner_id="current-runner",
         run_id="current-run",
+        lease_attempt_id="test-attempt",
     )
     db_session.add(task)
     db_session.commit()
@@ -1848,11 +1874,13 @@ def test_task_title_update_is_fenced_by_exact_lease(db_session) -> None:
         task_id=int(task.id),
         runner_id="stale-runner",
         run_id="stale-run",
+        attempt_id="test-attempt",
     )
     current = TaskLease(
         task_id=int(task.id),
         runner_id="current-runner",
         run_id="current-run",
+        attempt_id="test-attempt",
     )
 
     assert (
@@ -1887,6 +1915,7 @@ async def test_execute_task_cancellation_during_heartbeat_stop_drains_cleanup() 
         task_id=task_id,
         runner_id="test-runner",
         run_id="test-run",
+        attempt_id="test-attempt",
     )
     manager = AgentServiceManager()
     events: list[str] = []
@@ -2081,6 +2110,7 @@ def test_delayed_workforce_running_projection_cannot_resurrect_terminal_run(
         agent_id=manager.id,
         agent_config={},
         execution_mode="auto",
+        lease_attempt_id="test-attempt",
     )
     db_session.add(task)
     db_session.flush()
@@ -2102,6 +2132,7 @@ def test_delayed_workforce_running_projection_cannot_resurrect_terminal_run(
             task_id=int(task.id),
             runner_id="stale-a",
             run_id="same-run",
+            attempt_id="test-attempt",
         )
         if use_stale_lease
         else None

--- a/tests/web/test_task_lease_service.py
+++ b/tests/web/test_task_lease_service.py
@@ -320,6 +320,7 @@ def test_refresh_batch_uses_one_pool_checkout(
                 execution_mode="auto",
                 runner_id="runner-a",
                 run_id=run_id,
+                lease_attempt_id="test-attempt",
             )
             seed_db.add(task)
             seed_db.flush()
@@ -328,6 +329,7 @@ def test_refresh_batch_uses_one_pool_checkout(
                     task_id=int(task.id),
                     runner_id="runner-a",
                     run_id=run_id,
+                    attempt_id="test-attempt",
                 )
             )
         seed_db.commit()
@@ -377,6 +379,7 @@ def test_fail_and_release_task_lease_rejects_superseded_owner(db_session) -> Non
     assert stale_lease is not None
 
     task.runner_id = "new-runner"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "new-run"
     task.error_message = None
     task.output = "new owner output"
@@ -504,6 +507,7 @@ async def test_lease_heartbeat_keeps_loop_responsive_during_pool_checkout(
         task = _create_task(seed_db, status=TaskStatus.RUNNING)
         task_id = int(task.id)
         task.runner_id = "runner-a"
+        task.lease_attempt_id = "test-attempt"
         task.run_id = "run-a"
         seed_db.commit()
 
@@ -541,7 +545,12 @@ async def test_lease_heartbeat_keeps_loop_responsive_during_pool_checkout(
     with gated_pool_checkout(engine) as gate:
         heartbeat_task = asyncio.create_task(
             run_task_lease_heartbeat(
-                TaskLease(task_id=task_id, runner_id="runner-a", run_id="run-a"),
+                TaskLease(
+                    task_id=task_id,
+                    runner_id="runner-a",
+                    run_id="run-a",
+                    attempt_id="test-attempt",
+                ),
                 stop_event,
             )
         )
@@ -577,7 +586,7 @@ async def test_stop_heartbeat_waits_for_shared_batch_result(monkeypatch) -> None
         refresh_started.set()
         assert allow_refresh_to_finish.wait(timeout=2)
         return {
-            (lease.task_id, lease.runner_id, lease.run_id): (
+            (lease.task_id, lease.runner_id, lease.run_id, lease.attempt_id): (
                 TaskLeaseRefreshState.REFRESHED
             )
             for lease in leases
@@ -597,7 +606,12 @@ async def test_stop_heartbeat_waits_for_shared_batch_result(monkeypatch) -> None
     stop_event = asyncio.Event()
     heartbeat_task = asyncio.create_task(
         run_task_lease_heartbeat(
-            TaskLease(task_id=1, runner_id="runner-a", run_id="run-a"),
+            TaskLease(
+                task_id=1,
+                runner_id="runner-a",
+                run_id="run-a",
+                attempt_id="test-attempt",
+            ),
             stop_event,
         )
     )
@@ -629,7 +643,7 @@ async def test_cancelled_heartbeat_manager_settles_active_registration(
         refresh_started.set()
         assert allow_refresh_to_finish.wait(timeout=2)
         return {
-            (lease.task_id, lease.runner_id, lease.run_id): (
+            (lease.task_id, lease.runner_id, lease.run_id, lease.attempt_id): (
                 TaskLeaseRefreshState.REFRESHED
             )
             for lease in leases
@@ -648,7 +662,9 @@ async def test_cancelled_heartbeat_manager_settles_active_registration(
 
     manager = task_lease_service._TaskLeaseHeartbeatManager(asyncio.get_running_loop())
     registration = manager.register(
-        TaskLease(task_id=1, runner_id="runner-a", run_id="run-a")
+        TaskLease(
+            task_id=1, runner_id="runner-a", run_id="run-a", attempt_id="test-attempt"
+        )
     )
     await asyncio.wait_for(asyncio.to_thread(refresh_started.wait, 1), timeout=1)
 
@@ -716,7 +732,7 @@ async def test_repeated_cancellation_drains_heartbeat_close_and_waiters(
         refresh_started.set()
         assert allow_refresh_to_finish.wait(timeout=2)
         return {
-            (lease.task_id, lease.runner_id, lease.run_id): (
+            (lease.task_id, lease.runner_id, lease.run_id, lease.attempt_id): (
                 TaskLeaseRefreshState.REFRESHED
             )
             for lease in leases
@@ -741,7 +757,12 @@ async def test_repeated_cancellation_drains_heartbeat_close_and_waiters(
 
     heartbeat_task = asyncio.get_running_loop().create_task(
         run_task_lease_heartbeat(
-            TaskLease(task_id=1, runner_id="runner-a", run_id="run-a"),
+            TaskLease(
+                task_id=1,
+                runner_id="runner-a",
+                run_id="run-a",
+                attempt_id="test-attempt",
+            ),
             asyncio.Event(),
         )
     )
@@ -777,7 +798,7 @@ async def test_repeated_cancellation_drains_heartbeat_close_and_waiters(
 
 @pytest.mark.asyncio
 async def test_heartbeat_requires_exact_run_id() -> None:
-    lease = TaskLease(task_id=1, runner_id="runner-a")
+    lease = TaskLease(task_id=1, runner_id="runner-a", attempt_id="test-attempt")
 
     with pytest.raises(ValueError, match="exact run_id fence"):
         await run_task_lease_heartbeat(lease, asyncio.Event())
@@ -821,7 +842,7 @@ async def test_heartbeat_batches_registered_leases(
         batches.append(leases)
         refreshed.set()
         return {
-            (lease.task_id, lease.runner_id, lease.run_id): (
+            (lease.task_id, lease.runner_id, lease.run_id, lease.attempt_id): (
                 TaskLeaseRefreshState.REFRESHED
             )
             for lease in leases
@@ -842,13 +863,23 @@ async def test_heartbeat_batches_registered_leases(
     second_stop = asyncio.Event()
     first_task = asyncio.create_task(
         run_task_lease_heartbeat(
-            TaskLease(task_id=1, runner_id="runner-a", run_id="run-a"),
+            TaskLease(
+                task_id=1,
+                runner_id="runner-a",
+                run_id="run-a",
+                attempt_id="test-attempt",
+            ),
             first_stop,
         )
     )
     second_task = asyncio.create_task(
         run_task_lease_heartbeat(
-            TaskLease(task_id=2, runner_id="runner-a", run_id="run-b"),
+            TaskLease(
+                task_id=2,
+                runner_id="runner-a",
+                run_id="run-b",
+                attempt_id="test-attempt",
+            ),
             second_stop,
         )
     )
@@ -880,8 +911,10 @@ async def test_old_batch_result_does_not_contaminate_replacement_registration(
     second_refresh_started = threading.Event()
     allow_second_refresh = threading.Event()
     attempts = 0
-    lease = TaskLease(task_id=1, runner_id="runner-a", run_id="run-a")
-    key = (lease.task_id, lease.runner_id, lease.run_id)
+    lease = TaskLease(
+        task_id=1, runner_id="runner-a", run_id="run-a", attempt_id="test-attempt"
+    )
+    key = (lease.task_id, lease.runner_id, lease.run_id, lease.attempt_id)
 
     def refresh_batch(
         _leases: tuple[TaskLease, ...],
@@ -998,13 +1031,23 @@ async def test_stop_heartbeat_reports_shared_batch_pool_timeout(
         with caplog.at_level(logging.WARNING):
             first_heartbeat_task = asyncio.create_task(
                 run_task_lease_heartbeat(
-                    TaskLease(task_id=1, runner_id="runner-a", run_id="run-a"),
+                    TaskLease(
+                        task_id=1,
+                        runner_id="runner-a",
+                        run_id="run-a",
+                        attempt_id="test-attempt",
+                    ),
                     first_stop_event,
                 )
             )
             second_heartbeat_task = asyncio.create_task(
                 run_task_lease_heartbeat(
-                    TaskLease(task_id=2, runner_id="runner-b", run_id="run-b"),
+                    TaskLease(
+                        task_id=2,
+                        runner_id="runner-b",
+                        run_id="run-b",
+                        attempt_id="test-attempt",
+                    ),
                     second_stop_event,
                 )
             )
@@ -1069,7 +1112,12 @@ async def test_stop_heartbeat_reports_lost_ownership(monkeypatch) -> None:
         leases: tuple[TaskLease, ...],
     ) -> dict[tuple[int, str, str | None], TaskLeaseRefreshState]:
         return {
-            (lease.task_id, lease.runner_id, lease.run_id): TaskLeaseRefreshState.LOST
+            (
+                lease.task_id,
+                lease.runner_id,
+                lease.run_id,
+                lease.attempt_id,
+            ): TaskLeaseRefreshState.LOST
             for lease in leases
         }
 
@@ -1087,7 +1135,12 @@ async def test_stop_heartbeat_reports_lost_ownership(monkeypatch) -> None:
     stop_event = asyncio.Event()
     heartbeat_task = asyncio.create_task(
         run_task_lease_heartbeat(
-            TaskLease(task_id=1, runner_id="runner-a", run_id="run-a"),
+            TaskLease(
+                task_id=1,
+                runner_id="runner-a",
+                run_id="run-a",
+                attempt_id="test-attempt",
+            ),
             stop_event,
         )
     )
@@ -1108,7 +1161,7 @@ async def test_heartbeat_does_not_report_settlement_ready_as_lease_lost(
         leases: tuple[TaskLease, ...],
     ) -> dict[tuple[int, str, str | None], TaskLeaseRefreshState]:
         return {
-            (lease.task_id, lease.runner_id, lease.run_id): (
+            (lease.task_id, lease.runner_id, lease.run_id, lease.attempt_id): (
                 TaskLeaseRefreshState.SETTLEMENT_READY
             )
             for lease in leases
@@ -1135,7 +1188,12 @@ async def test_heartbeat_does_not_report_settlement_ready_as_lease_lost(
 
     outcome = await asyncio.wait_for(
         run_task_lease_heartbeat(
-            TaskLease(task_id=1, runner_id="runner-a", run_id="run-a"),
+            TaskLease(
+                task_id=1,
+                runner_id="runner-a",
+                run_id="run-a",
+                attempt_id="test-attempt",
+            ),
             asyncio.Event(),
         ),
         timeout=5,
@@ -1162,7 +1220,7 @@ async def test_batch_heartbeat_recovers_after_transient_pool_timeout(
             raise SQLAlchemyTimeoutError("transient pool checkout timeout")
         refresh_recovered.set()
         return {
-            (lease.task_id, lease.runner_id, lease.run_id): (
+            (lease.task_id, lease.runner_id, lease.run_id, lease.attempt_id): (
                 TaskLeaseRefreshState.REFRESHED
             )
             for lease in leases
@@ -1182,7 +1240,12 @@ async def test_batch_heartbeat_recovers_after_transient_pool_timeout(
     stop_event = asyncio.Event()
     heartbeat_task = asyncio.create_task(
         run_task_lease_heartbeat(
-            TaskLease(task_id=1, runner_id="runner-a", run_id="run-a"),
+            TaskLease(
+                task_id=1,
+                runner_id="runner-a",
+                run_id="run-a",
+                attempt_id="test-attempt",
+            ),
             stop_event,
         )
     )
@@ -1200,7 +1263,9 @@ async def test_cancellation_safe_acquire_drains_and_cleans_returned_lease() -> N
     allow_acquire_to_finish = threading.Event()
     cleanup_started = threading.Event()
     allow_cleanup_to_finish = threading.Event()
-    expected_lease = TaskLease(task_id=9, runner_id="runner-a", run_id="run-a")
+    expected_lease = TaskLease(
+        task_id=9, runner_id="runner-a", run_id="run-a", attempt_id="test-attempt"
+    )
     cleaned_leases: list[TaskLease] = []
 
     def acquire() -> TaskLease:
@@ -1354,6 +1419,7 @@ def test_running_task_reacquire_retains_checkpoint_pointer_via_case(
     """
     task = _create_task(db_session, status=TaskStatus.RUNNING)
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "existing-run"
     task.last_checkpoint_event_id = "existing-checkpoint"
     checkpoint = TraceEvent(
@@ -1408,6 +1474,7 @@ def test_old_lease_cannot_refresh_or_release_a_new_run(db_session) -> None:
     task.status = TaskStatus.RUNNING
     task.control_state = "running"
     task.runner_id = "runner-a"
+    task.lease_attempt_id = "test-attempt"
     db_session.commit()
 
     assert refresh_task_lease(db_session, old_lease) == TaskLeaseRefreshState.LOST
@@ -1455,6 +1522,7 @@ def test_stale_running_task_with_checkpoint_becomes_paused(db_session) -> None:
 def test_stale_running_task_ignores_child_agent_checkpoint(db_session) -> None:
     task = _create_task(db_session, status=TaskStatus.RUNNING)
     task.runner_id = "dead-runner"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "child-checkpoint-run"
     task.lease_expires_at = utc_now() - timedelta(seconds=1)
     task.last_checkpoint_event_id = "child-checkpoint-1"
@@ -1491,6 +1559,7 @@ def test_stale_running_task_ignores_child_agent_checkpoint(db_session) -> None:
 def test_stale_running_task_with_legacy_checkpoint_becomes_paused(db_session) -> None:
     task = _create_task(db_session, status=TaskStatus.RUNNING)
     task.runner_id = "dead-runner"
+    task.lease_attempt_id = "test-attempt"
     task.run_id = "legacy-checkpoint-run"
     task.lease_expires_at = utc_now() - timedelta(seconds=1)
     task.last_checkpoint_event_id = "legacy-checkpoint-1"
@@ -1660,22 +1729,21 @@ def test_release_current_runner_task_lease_clears_the_attempt_id(db_session) -> 
     db_session.refresh(task)
     assert task.lease_attempt_id is not None
 
-    changed = task_lease_service.release_current_runner_task_lease(
-        db_session,
-        int(task.id),
-        status=TaskStatus.PAUSED,
-        runner_id="runner-a",
-    )
+    with task_lease_service.bind_task_lease_context(lease):
+        changed = task_lease_service.release_current_runner_task_lease(
+            db_session,
+            int(task.id),
+            status=TaskStatus.PAUSED,
+            runner_id="runner-a",
+        )
 
     assert changed is True
     db_session.refresh(task)
     assert task.lease_attempt_id is None
 
 
-def test_task_lease_snapshot_never_carries_an_attempt_id() -> None:
-    """The ambient snapshot rebuilt from a task row must keep attempt_id None
-    even when the row has one, so a later attempt check cannot compare a
-    value against itself and always pass."""
+def test_task_lease_snapshot_carries_the_routing_epoch() -> None:
+    """A routing key includes the epoch; it must resolve to a local holder."""
     from types import SimpleNamespace
 
     from xagent.web.api.websocket import _task_lease_snapshot
@@ -1688,4 +1756,4 @@ def test_task_lease_snapshot_never_carries_an_attempt_id() -> None:
     )
     lease = _task_lease_snapshot(row)
     assert lease is not None
-    assert lease.attempt_id is None
+    assert lease.attempt_id == "attempt-c"

--- a/tests/web/test_websocket_uploaded_files_context.py
+++ b/tests/web/test_websocket_uploaded_files_context.py
@@ -77,6 +77,7 @@ def _create_task(
         title=f"task-{task_id}",
         description="task",
         status=status,
+        lease_attempt_id="test-attempt" if runner_id is not None else None,
         runner_id=runner_id,
         run_id=run_id,
         agent_config=(
@@ -127,6 +128,7 @@ def _task_setup_snapshot(
 
 def _task_lease(task_id: int) -> TaskLease:
     return TaskLease(
+        attempt_id="test-attempt",
         task_id=task_id,
         runner_id="test-runner",
         run_id=f"run-{task_id}",

--- a/tests/web/test_workforce_run_service.py
+++ b/tests/web/test_workforce_run_service.py
@@ -31,7 +31,10 @@ from xagent.web.models.task import TaskStatus
 from xagent.web.models.uploaded_file import UploadedFile
 from xagent.web.services import task_orchestrator as task_orchestrator_module
 from xagent.web.services import workforce_runs as workforce_runs_module
-from xagent.web.services.task_lease_service import acquire_task_lease
+from xagent.web.services.task_lease_service import (
+    acquire_task_lease,
+    bind_task_lease_context,
+)
 from xagent.web.services.workforce_access import WorkforcePolicy, set_workforce_policy
 from xagent.web.services.workforce_runs import (
     create_preview_workforce_run,
@@ -1529,14 +1532,15 @@ def test_release_current_runner_task_lease_with_workforce_sync_pauses_run(
     lease = acquire_task_lease(db_session, int(task.id))
     assert lease is not None
 
-    assert (
-        release_current_runner_task_lease_with_workforce_sync(
-            db_session,
-            int(task.id),
-            status=TaskStatus.WAITING_FOR_USER,
+    with bind_task_lease_context(lease):
+        assert (
+            release_current_runner_task_lease_with_workforce_sync(
+                db_session,
+                int(task.id),
+                status=TaskStatus.WAITING_FOR_USER,
+            )
+            is True
         )
-        is True
-    )
     db_session.refresh(task)
     db_session.refresh(run)
 

--- a/tests/web/tracking/test_task_tracker.py
+++ b/tests/web/tracking/test_task_tracker.py
@@ -566,8 +566,9 @@ class TestTaskTracker:
         engine.dispose()
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("takeover", ["runner", "attempt"])
     async def test_runner_fence_rejects_same_run_takeover_at_every_db_boundary(
-        self, monkeypatch, tmp_path
+        self, monkeypatch, tmp_path, takeover
     ):
         """A stale tracker must not seed or write after runner ownership changes."""
         from xagent.web.models import database
@@ -593,6 +594,7 @@ class TestTaskTracker:
                         status=TaskStatus.RUNNING,
                         run_id="run-a",
                         runner_id="runner-a",
+                        lease_attempt_id="attempt-a",
                         input_tokens=4,
                         output_tokens=2,
                         total_tokens=6,
@@ -613,12 +615,14 @@ class TestTaskTracker:
                 update_interval_seconds=60,
                 expected_run_id="run-a",
                 expected_runner_id="runner-a",
+                expected_attempt_id="attempt-a",
             )
             final_tracker = TaskTracker(
                 task_id=124,
                 update_interval_seconds=60,
                 expected_run_id="run-a",
                 expected_runner_id="runner-a",
+                expected_attempt_id="attempt-a",
             )
             await periodic_tracker.start_tracking()
             await final_tracker.start_tracking()
@@ -627,7 +631,10 @@ class TestTaskTracker:
                 for task_id in (123, 124, 125):
                     replacement = takeover_db.get(Task, task_id)
                     assert replacement is not None
-                    replacement.runner_id = "runner-b"
+                    if takeover == "runner":
+                        replacement.runner_id = "runner-b"
+                    else:
+                        replacement.lease_attempt_id = "attempt-b"
                     replacement.input_tokens = 100
                     replacement.output_tokens = 50
                     replacement.total_tokens = 150
@@ -641,6 +648,7 @@ class TestTaskTracker:
                 task_id=125,
                 expected_run_id="run-a",
                 expected_runner_id="runner-a",
+                expected_attempt_id="attempt-a",
             )
             with pytest.raises(ValueError, match="Task 125.*not found"):
                 await seed_tracker.start_tracking()
@@ -654,7 +662,9 @@ class TestTaskTracker:
                 replacement = verify_db.get(Task, task_id)
                 assert replacement is not None
                 assert replacement.run_id == "run-a"
-                assert replacement.runner_id == "runner-b"
+                assert replacement.runner_id == (
+                    "runner-b" if takeover == "runner" else "runner-a"
+                )
                 assert replacement.input_tokens == 100
                 assert replacement.output_tokens == 50
                 assert replacement.total_tokens == 150
@@ -734,6 +744,7 @@ class TestTaskTracker:
                     status=TaskStatus.RUNNING,
                     run_id="run-a",
                     runner_id="runner-a",
+                    lease_attempt_id="attempt-a",
                     input_tokens=4,
                     output_tokens=2,
                     total_tokens=6,
@@ -761,6 +772,7 @@ class TestTaskTracker:
                 update_interval_seconds=60,
                 expected_run_id="run-a",
                 expected_runner_id="runner-a",
+                expected_attempt_id="attempt-a",
             )
             await tracker.start_tracking()
             add_token_usage(input_tokens=16, output_tokens=8)


### PR DESCRIPTION
## Summary

When the same runner reacquires a task in the same run, an old execution handle can still renew or modify the successor's state. Validate the full `(task_id, runner_id, run_id, attempt_id)` identity across renewal, release, execution settlement, checkpoints and traces, outbound messages, interaction staging, recovery, and token tracking.

Heartbeat subscriptions and batch results are isolated by acquisition attempt while same-attempt handoffs continue sharing a heartbeat. Live WebSocket input resolves an actually registered lease holder. Conditional UPDATE locks protect settlement before reading on both SQLite and PostgreSQL. Existing acquisition behavior and deleted-task checkpoint error classification are preserved.

This change is based directly on current upstream `main` (`ae11c3a96`) and contains only Phase A. It has no dependency on the unmerged execution event writers. There are no schema or core tool-lifecycle changes. Mailbox ownership and command lifecycle changes remain subsequent work; command receipts retain their existing claim-attempt fencing.

## Validation

- CI fixture follow-up: 1,395 tests passed across 38 related files using four workers and the CI fast-test marker filter. Updated six legacy fixture files to provide valid acquisition identities and bind the acquired lease for current-holder release; existing assertions and production fencing are unchanged.

- 1,323 tests passed across 32 related files, including SQLite and isolated PostgreSQL.
- All applicable pre-commit checks passed, including repository-wide mypy, ruff, isort, and codespell.
- `git diff --check` passed.

## Deployment

Drain or stop old workers, including execution, heartbeat, and command processing, before starting the new version. Old workers issue SQL without attempt fencing, so mixed-version execution does not enforce this contract. External tool side effects are outside the internal persistence guarantee.


