### PR TITLE
fix(mcp): Close actor OAuth callback popups

### DIFF
--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -22,7 +22,7 @@ from uuid import UUID
 
 import httpx
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, status
-from fastapi.responses import JSONResponse, RedirectResponse, Response
+from fastapi.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from pydantic import BaseModel, ConfigDict, Field
 from sqlalchemy import text
 from sqlalchemy.exc import IntegrityError
@@ -5327,7 +5327,7 @@ async def get_mcp_server_tools(
 async def mcp_oauth_callback(
     request: Request,
     db: Session = Depends(get_db),
-) -> RedirectResponse:
+) -> Response:
     """Complete MCP OAuth Authorization Code + PKCE and store an encrypted grant."""
     code = request.query_params.get("code")
     state_value = request.query_params.get("state")
@@ -5350,6 +5350,13 @@ async def mcp_oauth_callback(
     callback_redirect_after = (
         str(flow_state.redirect_after) if flow_state.redirect_after else None
     )
+    # Snapshot before claim/commit expires the flow. Actor browsers need not
+    # have an Xagent login, so they cannot reach the authenticated tools page.
+    close_actor_popup = str(
+        flow_state.resource_owner_key
+    ) != _default_resource_owner_key(
+        int(flow_state.user_id)
+    ) and callback_redirect_after in (None, "/tools")
     try:
         _validate_mcp_oauth_state_cookie(request, state_value)
     except HTTPException as exc:
@@ -5513,18 +5520,31 @@ async def mcp_oauth_callback(
             message="MCP OAuth authorization failed",
         )
 
-    # Positive success signal: the connect popup's self-close logic keys on
-    # this param instead of inferring success from "no error params", so a
-    # future error param added to the error redirect can't be mistaken for
-    # success by an out-of-date guard.
-    response = RedirectResponse(
-        _mcp_oauth_redirect_after_url(
-            _redirect_after_with_params(
-                callback_redirect_after,
-                (("mcp_oauth_success", "1"),),
+    response: Response
+    if close_actor_popup:
+        response = HTMLResponse(
+            '<!doctype html><html lang="en"><head><meta charset="utf-8">'
+            "<title>Connected</title></head><body><h1>Connected</h1>"
+            "<p>You can close this window now.</p>"
+            "<script>window.close();</script></body></html>",
+            headers={
+                "Cache-Control": "no-store",
+                "Referrer-Policy": "no-referrer",
+                "Content-Security-Policy": (
+                    "default-src 'none'; script-src 'unsafe-inline'; frame-ancestors 'none'"
+                ),
+            },
+        )
+    else:
+        # Preserve ordinary-user and explicit custom redirects.
+        response = RedirectResponse(
+            _mcp_oauth_redirect_after_url(
+                _redirect_after_with_params(
+                    callback_redirect_after,
+                    (("mcp_oauth_success", "1"),),
+                )
             )
         )
-    )
     _clear_mcp_oauth_state_cookie(response)
     return response
 

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -11,7 +11,7 @@ from uuid import uuid4
 
 import httpx
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, status
 from sqlalchemy import create_engine, event
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker
@@ -3100,6 +3100,86 @@ async def test_delete_mcp_server_revokes_only_the_disconnecting_users_grant(
         .one_or_none()
         is None
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("redirect_after", [None, "/tools"])
+async def test_actor_callback_closes_popup(db_session, monkeypatch, redirect_after):
+    db, user, _ = db_session
+    _, _, flow = _add_callback_client_and_state(
+        db, user, state="actor-popup", redirect_after=redirect_after
+    )
+    owner = "toby:slack:workspace:alice"
+    flow.resource_owner_key = owner
+    db.commit()
+
+    async def exchange(**kwargs):
+        assert kwargs["code_verifier"] == "verifier-123"
+        return {
+            "access_token": "actor-token",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        }
+
+    monkeypatch.setattr(mcp_api, "_exchange_mcp_oauth_code", exchange)
+    # Only OAuth state proof is present: the actor has no Xagent browser login.
+    response = await mcp_oauth_callback(
+        _request("/api/mcp/oauth/callback?code=consent&state=actor-popup"), db
+    )
+
+    assert response.status_code == status.HTTP_200_OK
+    assert "location" not in response.headers
+    assert response.headers["content-type"].startswith("text/html")
+    assert response.headers["cache-control"] == "no-store"
+    assert "window.close()" in response.body.decode()
+    assert "You can close this window" in response.body.decode()
+    assert "actor-token" not in response.body.decode()
+    assert owner not in response.body.decode()
+    assert "Max-Age=0" in response.headers["set-cookie"]
+    grant = db.query(MCPOAuthGrant).one()
+    assert grant.resource_owner_key == owner
+    assert decrypt_value(grant.access_token) == "actor-token"
+    assert db.query(MCPOAuthFlowState).one().consumed_at is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["ordinary", "denied", "commit_failure"])
+async def test_callback_preserves_redirects(db_session, monkeypatch, outcome):
+    db, user, _ = db_session
+    _, _, flow = _add_callback_client_and_state(
+        db, user, state="popup-control", redirect_after="/tools"
+    )
+    if outcome != "ordinary":
+        flow.resource_owner_key = "toby:slack:workspace:alice"
+        db.commit()
+
+    async def exchange(**_kwargs):
+        if outcome == "denied":
+            pytest.fail("Denied consent must not exchange tokens")
+        if outcome == "commit_failure":
+
+            def fail_commit():
+                raise RuntimeError("Commit failed")
+
+            monkeypatch.setattr(db, "commit", fail_commit)
+        return {"access_token": "control-token", "token_type": "Bearer"}
+
+    monkeypatch.setattr(mcp_api, "_exchange_mcp_oauth_code", exchange)
+    query = "error=access_denied" if outcome == "denied" else "code=consent"
+    response = await mcp_oauth_callback(
+        _request(f"/api/mcp/oauth/callback?{query}&state=popup-control"), db
+    )
+
+    assert response.status_code == status.HTTP_307_TEMPORARY_REDIRECT
+    assert "window.close()" not in response.body.decode()
+    if outcome == "ordinary":
+        assert _redirect_query(response)["mcp_oauth_success"] == ["1"]
+        assert (
+            db.query(MCPOAuthGrant).one().resource_owner_key == f"xagent:user:{user.id}"
+        )
+    else:
+        assert "mcp_oauth_error" in _redirect_query(response)
+        assert db.query(MCPOAuthGrant).count() == 0
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Intention and boundary

Fix successful actor MCP OAuth popup completion without requiring a separate Xagent browser login.

Toby users can authorize a connector without an Xagent browser session. The callback currently stores their grant, then redirects to `/tools`. Its login guard prevents the popup-close effect from mounting.

For a successful non-default-owner flow targeting the default `/tools` page, return a small self-closing HTML response after the grant commit. Keep a visible manual-close message and clear the existing OAuth state cookie. The response contains no token or actor identity.

Ordinary-user flows and explicit custom redirect targets retain their existing redirects. This change does not alter discovery, PKCE, state validation, token exchange, grant ownership, or lifecycle locking.

## Rejected behavior

- Do not make `/tools` public or weaken its login guard.
- Do not close a popup as successful when consent, state validation, token exchange, or grant persistence fails.
- Do not override explicit custom redirect targets.
- Do not add a frontend page, schema change, or new dependency.

## Accepted errors and trade-offs

- Browsers can reject `window.close()` for tabs not opened by script. The success page tells the user to close the window manually.
- Existing error redirects are unchanged; unauthenticated actor error-page UX is outside this success-completion fix.
- Default actor flows receive HTTP 200 HTML rather than HTTP 307 to `/tools`. Ordinary-user and explicit custom redirects remain compatible.
- This is separate from xorbitsai/xagent-saas#990. After merge, SaaS needs a submodule repin and an update to its callback-response test expectation. The compatible Toby popup changes remain in xorbitsai/toby#10.
- Origin normalization and the other tracked SaaS follow-ups are not included.

## Verification

- Observed the actor popup regression fail with HTTP 307 before the fix, then pass with the self-closing HTML response.
- 245 OAuth flow, discovery, actor-runtime, and runtime tests passed.
- 10 PostgreSQL lifecycle tests passed against a disposable local cluster.
- Chromium closed a script-opened popup using the real callback response without an Xagent login; the opener remained open. Browser response delivery was mocked, not a live-provider test.
- Applicable pre-commit hooks passed, including Ruff, mypy, isort, and codespell.
- Regression coverage preserves ordinary redirects and prevents success completion for denied consent and failed grant commits. Existing custom actor redirect tests also pass.

No live provider or deployed-environment verification is claimed.
