### PR TITLE
fix(oauth): Fence actor callback persistence

### DIFF
--- a/src/xagent/web/api/auth.py
+++ b/src/xagent/web/api/auth.py
@@ -63,6 +63,7 @@ from ..oauth_provider_quirks import (
 from ..services import gmail_provisioning
 from ..services.auth_email import send_password_reset_email
 from ..services.db_runtime import await_task_settlement, propagate_deferred_cancellation
+from ..services.oauth_persistence import require_oauth_owner_active
 from ..services.user_oauth import (
     delete_scoped_user_oauth_accounts,
     normalize_user_oauth_resource_owner_key,
@@ -3553,6 +3554,8 @@ def generic_oauth_callback(
                     provider=provider,
                     app_id=app_id,
                 )
+                assert resource_owner_key is not None
+                require_oauth_owner_active(db, user_id, resource_owner_key)
             except ValueError:
                 db.rollback()
                 return HTMLResponse(

--- a/src/xagent/web/api/mcp.py
+++ b/src/xagent/web/api/mcp.py
@@ -76,6 +76,7 @@ from ..services.mcp_oauth import (
     validate_mcp_oauth_persisted_value,
 )
 from ..services.mcp_runtime import HTTP_MCP_TRANSPORTS
+from ..services.oauth_persistence import require_oauth_owner_active
 from ..services.user_oauth import (
     delete_scoped_user_oauth_accounts,
     list_scoped_user_oauth_accounts,
@@ -898,6 +899,7 @@ def _lock_active_mcp_oauth_lifecycle(
     *,
     association_identity: _MCPOAuthAssociationIdentity,
     flow_identity: _MCPOAuthFlowIdentity | None = None,
+    resource_owner_key: str | None = None,
     association_must_be_active: bool = True,
 ) -> tuple[MCPServer, UserMCPServer, MCPOAuthFlowState | None] | None:
     """Lock server, exact association generation, then exact flow if supplied."""
@@ -933,6 +935,15 @@ def _lock_active_mcp_oauth_lifecycle(
             != association_identity.lifecycle_generation
         ):
             return None
+        # Match connect's association-before-host-lock order, but acquire the
+        # host lock before the flow/grant locks used by suspension cleanup.
+        if resource_owner_key is not None:
+            try:
+                require_oauth_owner_active(
+                    db, association_identity.user_id, resource_owner_key
+                )
+            except ValueError:
+                return None
         flow_state = (
             db.query(MCPOAuthFlowState)
             .filter(
@@ -5350,6 +5361,8 @@ async def mcp_oauth_callback(
     callback_redirect_after = (
         str(flow_state.redirect_after) if flow_state.redirect_after else None
     )
+    callback_user_id = int(flow_state.user_id)
+    callback_owner_key = str(flow_state.resource_owner_key)
     try:
         _validate_mcp_oauth_state_cookie(request, state_value)
     except HTTPException as exc:
@@ -5465,6 +5478,11 @@ async def mcp_oauth_callback(
             db,
             association_identity=association_identity,
             flow_identity=flow_identity,
+            resource_owner_key=(
+                callback_owner_key
+                if callback_owner_key != _default_resource_owner_key(callback_user_id)
+                else None
+            ),
         )
         if lifecycle is None:
             await _rollback_and_revoke_mcp_oauth_issued_token(db, issued_token)

--- a/src/xagent/web/services/oauth_persistence.py
+++ b/src/xagent/web/services/oauth_persistence.py
@@ -1,0 +1,25 @@
+"""Optional host-policy fence for actor OAuth callback persistence."""
+
+from collections.abc import Callable
+
+from sqlalchemy.orm import Session
+
+OAuthPersistenceGuard = Callable[[Session, int, str], None]
+_guard: OAuthPersistenceGuard | None = None
+
+
+def set_oauth_persistence_guard(guard: OAuthPersistenceGuard | None) -> None:
+    """Install the host guard at startup; None preserves standalone behavior."""
+    global _guard
+    _guard = guard
+
+
+def require_oauth_owner_active(db: Session, user_id: int, owner_key: str) -> None:
+    """Fence actor persistence after association locks, before flow/grant locks.
+
+    The guard must raise ValueError to deny persistence. It may acquire locks,
+    but must not commit, roll back, or perform network I/O. The caller retains
+    those locks through credential commit and rolls back on failure.
+    """
+    if _guard is not None:
+        _guard(db, user_id, owner_key)

--- a/tests/web/api/test_mcp_oauth_flow.py
+++ b/tests/web/api/test_mcp_oauth_flow.py
@@ -5272,3 +5272,47 @@ def test_app_teardown_serializes_later_sqlite_replacement(
     assert not teardown_thread.is_alive() and not mutation_thread.is_alive()
     expected_index = 0 if replaced == "catalog" else 1
     assert replacement_generation[0] != generations[expected_index]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("owner", ["ordinary", "actor"])
+async def test_callback_owner_guard(db_session, monkeypatch, owner):
+    from xagent.web.services import oauth_persistence
+
+    db, user, _ = db_session
+    _, _, flow = _add_callback_client_and_state(db, user, state="owner-guard")
+    if owner == "actor":
+        flow.resource_owner_key = "tenant:actor:alice"
+        db.commit()
+    calls = []
+    revoked = []
+
+    def guard(session, user_id, owner_key):
+        assert session is db
+        calls.append((user_id, owner_key))
+        raise ValueError("Owner stopped")
+
+    async def exchange(**kwargs):
+        return {"access_token": "fresh-token", "token_type": "Bearer"}
+
+    async def revoke(snapshot):
+        assert not db.in_transaction()
+        revoked.append(snapshot)
+
+    monkeypatch.setattr(oauth_persistence, "_guard", None)
+    oauth_persistence.set_oauth_persistence_guard(guard)
+    monkeypatch.setattr(mcp_api, "_exchange_mcp_oauth_code", exchange)
+    monkeypatch.setattr(mcp_api, "_revoke_mcp_oauth_issued_token_externally", revoke)
+    response = await mcp_oauth_callback(
+        _request("/api/mcp/oauth/callback?code=consent&state=owner-guard"), db
+    )
+    if owner == "ordinary":
+        assert calls == []
+        assert revoked == []
+        assert "mcp_oauth_success=1" in response.headers["location"]
+        assert db.query(MCPOAuthGrant).count() == 1
+    else:
+        assert calls == [(user.id, "tenant:actor:alice")]
+        assert len(revoked) == 1
+        assert "mcp_oauth_error=invalid_state" in response.headers["location"]
+        assert db.query(MCPOAuthGrant).count() == 0

--- a/tests/web/test_trusted_actor_oauth.py
+++ b/tests/web/test_trusted_actor_oauth.py
@@ -710,3 +710,33 @@ def test_ordinary_oauth_flow_keeps_cookie_free_state_and_provisioning(
     assert response.status_code == 200
     assert db.query(UserOAuth).one().resource_owner_key is None
     side_effects.assert_called_once_with(db, user_id=user.id, connector_key="calendar")
+
+
+def test_callback_owner_guard(oauth_db, monkeypatch):
+    from xagent.web.services import oauth_persistence
+
+    db, user = oauth_db
+    _catalog_link(db, user)
+    response = _start(db, user)
+    cookie_name, cookie_value, _ = _flow_cookie(response)
+    post = _mock_exchange(monkeypatch)
+    calls = []
+
+    def guard(session, user_id, owner_key):
+        assert session is db
+        calls.append((user_id, owner_key))
+        raise ValueError("Owner stopped")
+
+    monkeypatch.setattr(oauth_persistence, "_guard", None)
+    oauth_persistence.set_oauth_persistence_guard(guard)
+    result = auth_api.generic_oauth_callback(
+        "custom",
+        _request(_state(response), cookie=(cookie_name, cookie_value)),
+        db,
+        _provider(),
+    )
+    assert result.status_code == 400
+    assert calls == [(user.id, ACTOR_ALICE)]
+    assert post.call_count == 1
+    assert db.query(UserOAuth).count() == 0
+    oauth_persistence.set_oauth_persistence_guard(None)


### PR DESCRIPTION
## Intention and boundary

Provide a host-policy guard before actor OAuth callbacks persist credentials. This supports the workspace-suspension fix in xorbitsai/xagent-saas#990, for both builtin and native MCP OAuth.

Native flow deletion already rejects callbacks when suspension cleanup succeeds. If cleanup fails, the flow survives and the callback can still store a grant. Builtin callbacks also lack a workspace-state fence. The host application owns workspace state; Xagent must not import SaaS models.

The optional guard receives the callback transaction, user ID, and trusted owner key. It runs after association locking and before flow/credential locking. The host can lock and verify its workspace, retaining that lock through credential commit. A rejected native callback uses the existing rollback and best-effort issued-token revocation path.

Ordinary builtin and default-owner MCP callbacks bypass this guard. Standalone Xagent behavior is unchanged when no guard is installed. No schema, frontend, dependency, or CI changes.

## Rejected behavior

- Do not allow callback persistence when the installed host guard denies the actor.
- Do not check workspace state only at OAuth startup or release its lock before credential commit.
- Do not acquire the host lock before association locks: that deadlocks with concurrent trusted connect.
- Do not commit, roll back, or perform network I/O inside the host guard.
- Do not include the separate popup-completion work from #2189.

## Accepted errors and trade-offs

- Denied builtin callbacks retain the existing invalid-flow HTTP 400 response; native callbacks return the existing invalid-state redirect.
- Provider-side revocation remains best effort for native MCP. This does not add builtin provider revocation or guarantee provider-wide token invalidation.
- Failed suspension cleanup can still leave credentials committed before suspension; this change prevents later callback persistence rather than replacing reconciliation.
- Enforcement requires the SaaS guard registration. The host callback and suspension paths must retain compatible lock ordering.

## Verification

- Observed PostgreSQL failures before the fix: builtin callbacks persisted credentials after both successful and failed cleanup; native callbacks persisted after failed cleanup.
- Observed and fixed a callback/connect deadlock introduced by acquiring the workspace lock too early.
- 216 Xagent OAuth/runtime tests and 19 PostgreSQL OAuth lifecycle tests passed.
- 408 SaaS integration tests and 11 PostgreSQL lifecycle tests passed with the host guard wired in.
- PostgreSQL coverage includes cleanup success/failure, callback-first suspension, and concurrent connect/callback locking.
- Applicable pre-commit hooks, including Ruff and mypy, passed in both repositories.

Addresses the callback-persistence portion of xorbitsai/xagent-saas#1102; does not close that grouped issue. No live provider or deployed-environment verification is claimed.
