### PR TITLE
feat(web): tell the OAuth token resolver hook what auth a connector declares

### DIFF
--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
@@ -619,19 +618,24 @@ def connector_auth_type(server: Any) -> str | None:
     ``"none"`` when the connector declares no authentication (``auth`` absent,
     JSON null, an empty object, ``{"type": null}``, or an explicit
     ``{"type": "none"}``); the declared ``type`` string otherwise; ``None``
-    when the shape is not recognisable (non-mapping ``auth``, or a ``type``
+    when the shape is not recognisable (non-``dict`` ``auth``, or a ``type``
     that is a non-string or the empty string). Callers must treat ``None`` as
     unknown, not as "no credential".
 
+    ``"none"`` means only that the connector declares no ``auth`` JSON; it does
+    not mean the connector carries no credential, because static ``headers``
+    (e.g. ``Authorization``) are sent regardless and are not inspected here.
+
     Reads the raw (encrypted-at-rest) ``auth`` JSON rather than the decrypted
     form used by ``_is_mcp_oauth_http_server`` above: ``type`` is not one of
-    the sensitive fields encryption touches (see ``SENSITIVE_AUTH_FIELDS``),
-    so no decryption is needed to classify it.
+    the sensitive fields encryption touches (see ``SENSITIVE_AUTH_FIELDS`` in
+    ``xagent.core.tools.core.mcp.model``), so no decryption is needed to
+    classify it.
     """
     auth = getattr(server, "auth", None)
     if auth is None:
         return "none"
-    if not isinstance(auth, Mapping):
+    if not isinstance(auth, dict):
         return None
     raw = auth.get("type")
     if raw is None:

--- a/src/xagent/web/services/mcp_runtime.py
+++ b/src/xagent/web/services/mcp_runtime.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
 from contextlib import contextmanager
 from dataclasses import dataclass
 from dataclasses import field as dataclass_field
@@ -600,9 +601,41 @@ def _is_mcp_oauth_http_server(server: Any, auth_config: Any) -> bool:
     # Runtime classification of a *connected* server from its decrypted auth,
     # a different layer than the catalog auth_type (mcp_apps.classify_app_auth):
     # this also covers user-added custom HTTP servers that were never catalog
-    # entries, so it stays independent by design.
+    # entries, so it stays independent by design. Keep in sync with
+    # connector_auth_type() below: that function reports "mcp_oauth" for the
+    # same shape of ``auth`` this function treats as mcp_oauth (transport is
+    # not part of connector_auth_type's own check, since it only classifies
+    # the declared auth, not whether the transport is HTTP).
     return (
         getattr(server, "transport", None) in HTTP_MCP_TRANSPORTS
         and isinstance(auth_config, dict)
         and auth_config.get("type") == "mcp_oauth"
     )
+
+
+def connector_auth_type(server: Any) -> str | None:
+    """Return the connector's declared auth type without decrypting it.
+
+    ``"none"`` when the connector declares no authentication (``auth`` absent,
+    JSON null, an empty object, ``{"type": null}``, or an explicit
+    ``{"type": "none"}``); the declared ``type`` string otherwise; ``None``
+    when the shape is not recognisable (non-mapping ``auth``, or a ``type``
+    that is a non-string or the empty string). Callers must treat ``None`` as
+    unknown, not as "no credential".
+
+    Reads the raw (encrypted-at-rest) ``auth`` JSON rather than the decrypted
+    form used by ``_is_mcp_oauth_http_server`` above: ``type`` is not one of
+    the sensitive fields encryption touches (see ``SENSITIVE_AUTH_FIELDS``),
+    so no decryption is needed to classify it.
+    """
+    auth = getattr(server, "auth", None)
+    if auth is None:
+        return "none"
+    if not isinstance(auth, Mapping):
+        return None
+    raw = auth.get("type")
+    if raw is None:
+        return "none"
+    if not isinstance(raw, str) or not raw:
+        return None
+    return raw

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -134,7 +134,10 @@ class TokenRequest:
     ``"oauth2"``, ``"mcp_oauth"``); it is the literal string ``"builtin_oauth"``
     for catalog apps whose OAuth is implied by ``transport == "oauth"``; and it
     is ``None`` when the type cannot be determined, which a resolver should
-    treat as "unknown", never as "no credential needed".
+    treat as "unknown", never as "no credential needed". ``"none"`` means only
+    that the connector declares no ``auth`` JSON; it does not mean the
+    connector carries no credential, because static ``headers`` (e.g.
+    ``Authorization``) are sent regardless and are not inspected there.
     """
 
     provider: str
@@ -3287,7 +3290,7 @@ class WebToolConfig(BaseToolConfig):
         providers: list[str],
         resource: str | None,
         resolver: TokenResolver | None = None,
-        auth_type: str | None = None,
+        auth_type: str | None,
     ) -> _ResolvedHookToken | None:
         if resolver is None:
             resolver, _ = _get_oauth_token_resolver_hook()

--- a/src/xagent/web/tools/config.py
+++ b/src/xagent/web/tools/config.py
@@ -129,6 +129,12 @@ class TokenRequest:
     without canonicalization. ``scope`` is the current execution scope from
     ``WebToolConfig.get_execution_scope()`` when present; it is typed as
     Optional[Any] to avoid importing the core scope type into this config layer.
+    ``auth_type`` is the connector's declared authentication type as classified
+    by ``connector_auth_type()`` (e.g. ``"none"``, ``"bearer"``, ``"api_key"``,
+    ``"oauth2"``, ``"mcp_oauth"``); it is the literal string ``"builtin_oauth"``
+    for catalog apps whose OAuth is implied by ``transport == "oauth"``; and it
+    is ``None`` when the type cannot be determined, which a resolver should
+    treat as "unknown", never as "no credential needed".
     """
 
     provider: str
@@ -136,6 +142,7 @@ class TokenRequest:
     scope: Optional[Any] = None
     resource: str | None = None
     refresh: OAuthRefreshContext | None = None
+    auth_type: str | None = None
 
 
 @dataclass(frozen=True)
@@ -3280,6 +3287,7 @@ class WebToolConfig(BaseToolConfig):
         providers: list[str],
         resource: str | None,
         resolver: TokenResolver | None = None,
+        auth_type: str | None = None,
     ) -> _ResolvedHookToken | None:
         if resolver is None:
             resolver, _ = _get_oauth_token_resolver_hook()
@@ -3292,6 +3300,7 @@ class WebToolConfig(BaseToolConfig):
                 user_id=int(self._user_id),
                 scope=self.get_execution_scope(),
                 resource=resource,
+                auth_type=auth_type,
             )
             try:
                 resolved = await _maybe_await_oauth_token_resolver_result(
@@ -3332,6 +3341,7 @@ class WebToolConfig(BaseToolConfig):
         resource: str | None,
         failed_generation: str | None,
         non_auth_connection: dict[str, Any],
+        auth_type: str | None,
     ) -> dict[str, Any] | ClassifiedToolFailure | None:
         from ...web.services.mcp_oauth import MCPAuthorizationChallenge
 
@@ -3356,6 +3366,7 @@ class WebToolConfig(BaseToolConfig):
                 challenge_scope=challenge.scope,
                 failed_generation=failed_generation,
             ),
+            auth_type=auth_type,
         )
         try:
             resolved = await _maybe_await_oauth_token_resolver_result(resolver(request))
@@ -3397,6 +3408,7 @@ class WebToolConfig(BaseToolConfig):
             scope=scope,
             resource=resource,
             non_auth_connection=non_auth_connection,
+            auth_type=auth_type,
         )
 
     def _build_resolver_owned_mcp_connection(
@@ -3410,6 +3422,7 @@ class WebToolConfig(BaseToolConfig):
         scope: Any,
         resource: str | None,
         non_auth_connection: dict[str, Any],
+        auth_type: str | None,
     ) -> dict[str, Any]:
         from ...web.services.mcp_runtime import connection_with_bearer_authorization
 
@@ -3427,6 +3440,7 @@ class WebToolConfig(BaseToolConfig):
                 resource=resource,
                 failed_generation=resolved.generation,
                 non_auth_connection=non_auth_connection,
+                auth_type=auth_type,
             )
 
         connection = connection_with_bearer_authorization(
@@ -4087,6 +4101,7 @@ class WebToolConfig(BaseToolConfig):
                     hook_token = await self._resolve_oauth_token_from_hook(
                         providers=providers_to_resolve,
                         resource=configured_resource,
+                        auth_type="builtin_oauth",
                     )
                 except _OAuthTokenResolverFailed as error:
                     return self._resolver_failure_config(
@@ -4218,6 +4233,7 @@ class WebToolConfig(BaseToolConfig):
             from ...web.services.mcp_runtime import (
                 build_mcp_runtime_connection,
                 connection_to_transport_config,
+                connector_auth_type,
                 effective_mcp_oauth_resource,
             )
 
@@ -4293,6 +4309,7 @@ class WebToolConfig(BaseToolConfig):
             remote_providers_to_resolve: list[str] = []
             remote_configured_resource: str | None = None
             remote_hook_token: _ResolvedHookToken | None = None
+            remote_auth_type: str | None = None
             if resolver is not None and not actor_remote_oauth:
                 remote_providers_to_resolve = (
                     _oauth_token_provider_candidates(app_info)
@@ -4303,12 +4320,14 @@ class WebToolConfig(BaseToolConfig):
                     server,
                     mcp_auth_context=auth_context,
                 )
+                remote_auth_type = connector_auth_type(server)
                 if remote_providers_to_resolve:
                     try:
                         remote_hook_token = await self._resolve_oauth_token_from_hook(
                             providers=remote_providers_to_resolve,
                             resource=remote_configured_resource,
                             resolver=resolver,
+                            auth_type=remote_auth_type,
                         )
                     except _OAuthTokenResolverFailed as error:
                         return self._resolver_failure_config(
@@ -4331,6 +4350,7 @@ class WebToolConfig(BaseToolConfig):
                         runtime_values=runtime_values,
                         runtime_bindings=runtime_bindings,
                     ),
+                    auth_type=remote_auth_type,
                 )
                 transport_config.update(
                     connection_to_transport_config(resolver_connection)

--- a/tests/web/services/test_mcp_runtime_auth_type.py
+++ b/tests/web/services/test_mcp_runtime_auth_type.py
@@ -53,7 +53,7 @@ def test_connector_auth_type_classifies_declared_shapes(auth, expected):
 
 
 def test_connector_auth_type_non_mapping_mock_auth_is_unrecognisable():
-    # A Mock is not a Mapping, so this must fall into "unknown", not "none".
+    # A Mock is not a dict, so this must fall into "unknown", not "none".
     server = SimpleNamespace(auth=MagicMock())
     assert connector_auth_type(server) is None
 
@@ -95,6 +95,8 @@ def test_connector_auth_type_agrees_with_http_oauth_classifier(auth):
 
     # Build the second argument the way the production caller does, in
     # build_mcp_runtime_connection: decrypt the raw auth before classifying.
+    # This expression mirrors the call site in mcp_runtime.py's
+    # build_mcp_runtime_connection and must be kept in sync with it.
     auth_config = MCPServer._decrypt_auth_config(getattr(server, "auth", None))
 
     is_mcp_oauth = _is_mcp_oauth_http_server(server, auth_config)

--- a/tests/web/services/test_mcp_runtime_auth_type.py
+++ b/tests/web/services/test_mcp_runtime_auth_type.py
@@ -1,0 +1,101 @@
+"""Tests for connector_auth_type() and its agreement with the HTTP mcp_oauth
+runtime classifier (_is_mcp_oauth_http_server) in mcp_runtime.py.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from xagent.web.models import MCPServer
+from xagent.web.services.mcp_runtime import (
+    _is_mcp_oauth_http_server,
+    connector_auth_type,
+)
+
+
+def test_connector_auth_type_no_auth_attribute_is_none():
+    assert connector_auth_type(SimpleNamespace()) == "none"
+
+
+@pytest.mark.parametrize(
+    ("auth", "expected"),
+    [
+        (None, "none"),
+        ({}, "none"),
+        ({"type": None}, "none"),
+        ({"type": "bearer"}, "bearer"),
+        ({"type": "api_key"}, "api_key"),
+        ({"type": "oauth2"}, "oauth2"),
+        ({"type": "mcp_oauth"}, "mcp_oauth"),
+        ({"type": "none"}, "none"),
+        ({"type": ""}, None),
+        ({"type": 3}, None),
+        ("string", None),
+    ],
+    ids=[
+        "auth-none",
+        "auth-empty-dict",
+        "type-none",
+        "type-bearer",
+        "type-api-key",
+        "type-oauth2",
+        "type-mcp-oauth",
+        "type-literal-none",
+        "type-empty-string",
+        "type-non-string",
+        "auth-non-mapping-string",
+    ],
+)
+def test_connector_auth_type_classifies_declared_shapes(auth, expected):
+    server = SimpleNamespace(auth=auth)
+    assert connector_auth_type(server) == expected
+
+
+def test_connector_auth_type_non_mapping_mock_auth_is_unrecognisable():
+    # A Mock is not a Mapping, so this must fall into "unknown", not "none".
+    server = SimpleNamespace(auth=MagicMock())
+    assert connector_auth_type(server) is None
+
+
+@pytest.mark.parametrize(
+    "auth",
+    [
+        None,
+        {},
+        {"type": None},
+        {"type": ""},
+        {"type": 3},
+        {"type": "bearer"},
+        {"type": "api_key"},
+        {"type": "oauth2"},
+        {"type": "mcp_oauth"},
+        "string",
+    ],
+    ids=[
+        "auth-none",
+        "auth-empty-dict",
+        "type-none",
+        "type-empty-string",
+        "type-non-string",
+        "type-bearer",
+        "type-api-key",
+        "type-oauth2",
+        "type-mcp-oauth",
+        "auth-non-mapping-string",
+    ],
+)
+def test_connector_auth_type_agrees_with_http_oauth_classifier(auth):
+    """connector_auth_type() must say "mcp_oauth" exactly when the runtime's
+    own HTTP mcp_oauth classifier (_is_mcp_oauth_http_server) says so, for an
+    HTTP-transport server. Both must move together or resolvers can be told
+    "mcp_oauth" for a connector the runtime does not actually treat as one
+    (or vice versa)."""
+    server = SimpleNamespace(transport="streamable_http", auth=auth)
+
+    # Build the second argument the way the production caller does, in
+    # build_mcp_runtime_connection: decrypt the raw auth before classifying.
+    auth_config = MCPServer._decrypt_auth_config(getattr(server, "auth", None))
+
+    is_mcp_oauth = _is_mcp_oauth_http_server(server, auth_config)
+    assert is_mcp_oauth == (connector_auth_type(server) == "mcp_oauth")

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -31,10 +31,11 @@ from xagent.web.tools.config import (
 )
 
 
-def test_token_request_refresh_defaults_to_none():
+def test_token_request_refresh_and_auth_type_default_to_none():
     request = TokenRequest(provider="google", user_id=1)
 
     assert request.refresh is None
+    assert request.auth_type is None
 
 
 def test_resolver_contract_repr_hides_token_and_generation():
@@ -1894,6 +1895,7 @@ async def test_hook_preserves_valid_generation_during_normalization(
     resolved = await _tool_config(db, user)._resolve_oauth_token_from_hook(
         providers=["google"],
         resource=None,
+        auth_type=None,
     )
 
     assert resolved is not None
@@ -1969,6 +1971,7 @@ async def test_hook_is_skipped_when_user_id_is_none(db_session):
     resolved = await cfg._resolve_oauth_token_from_hook(
         providers=["google"],
         resource=None,
+        auth_type=None,
     )
 
     assert resolved is None
@@ -2691,12 +2694,23 @@ async def test_remote_hook_failure_code_property_error_is_sanitized(db_session):
     assert "resolver-internal-secret" not in public_output
 
 
+@pytest.mark.parametrize(
+    ("auth", "expected_auth_type"),
+    [
+        (None, "none"),
+        ({"type": "mcp_oauth", "resource": "https://mcp.example/api"}, "mcp_oauth"),
+    ],
+    ids=["auth-none", "auth-mcp-oauth"],
+)
 @pytest.mark.asyncio
-async def test_remote_hook_consecutive_refreshes_advance_failed_generation(db_session):
+async def test_remote_hook_consecutive_refreshes_advance_failed_generation(
+    db_session, auth, expected_auth_type
+):
     db, user = db_session
     server = _add_remote_server(
         db,
         user,
+        auth=auth,
         headers={"X-Static": "static", "Authorization": "Bearer static-token"},
     )
     requests: list[TokenRequest] = []
@@ -2717,7 +2731,7 @@ async def test_remote_hook_consecutive_refreshes_advance_failed_generation(db_se
 
     assert requests[1].provider == requests[0].provider == "records"
     assert requests[1].resource == requests[0].resource == server.url
-    assert requests[1].auth_type == requests[0].auth_type == "none"
+    assert requests[1].auth_type == requests[0].auth_type == expected_auth_type
     assert requests[1].refresh == web_tools_config.OAuthRefreshContext(
         reason="invalid_token",
         resource_metadata_url=(

--- a/tests/web/tools/test_oauth_token_resolver_hook.py
+++ b/tests/web/tools/test_oauth_token_resolver_hook.py
@@ -426,10 +426,12 @@ async def test_hook_request_receives_provider_resource_and_scope_verbatim(db_ses
     scope = object()
     resource = "https://MCP.EXAMPLE.com:443/mcp/%7Euser/?Q=1#Fragment"
     _add_oauth_server(db, user, launch_config=_launch_config(resource=resource))
-    seen: list[tuple[str, str | None, object | None]] = []
+    seen: list[tuple[str, str | None, object | None, str | None]] = []
 
     async def resolver(request: TokenRequest) -> ResolvedToken | None:
-        seen.append((request.provider, request.resource, request.scope))
+        seen.append(
+            (request.provider, request.resource, request.scope, request.auth_type)
+        )
         if request.provider == "resolver-google-drive":
             return ResolvedToken(
                 access_token="hook-token",
@@ -443,9 +445,13 @@ async def test_hook_request_receives_provider_resource_and_scope_verbatim(db_ses
         db, user, execution_scope=scope
     ).get_mcp_server_configs()
 
+    # These catalog OAuth apps have no `auth` object of their own; the
+    # transport ("oauth") itself implies OAuth, so the request always
+    # reports the fixed "builtin_oauth" auth_type rather than something
+    # derived from a per-connector auth config.
     assert seen == [
-        ("google", resource, scope),
-        ("resolver-google-drive", resource, scope),
+        ("google", resource, scope, "builtin_oauth"),
+        ("resolver-google-drive", resource, scope, "builtin_oauth"),
     ]
     assert _access_token_env(configs[0]) == "hook-token"
 
@@ -2339,16 +2345,29 @@ async def test_remote_hook_near_expiry_token_is_used_but_not_cached(db_session):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("auth", "expected_auth_type"),
+    [
+        (
+            {"type": "mcp_oauth", "resource": "https://auth.example/resource"},
+            "mcp_oauth",
+        ),
+        (None, "none"),
+    ],
+    ids=["mcp-oauth", "no-auth-declared"],
+)
 async def test_remote_hook_owns_connection_and_preserves_non_auth_snapshot(
     db_session,
     caplog,
+    auth,
+    expected_auth_type,
 ):
     db, user = db_session
     scope = object()
     server = _add_remote_server(
         db,
         user,
-        auth={"type": "mcp_oauth", "resource": "https://auth.example/resource"},
+        auth=auth,
         headers={"X-Static": "static", "authorization": "Bearer static-token"},
         runtime_bindings=_remote_runtime_bindings(),
         allow_delegated_authorization=True,
@@ -2387,8 +2406,16 @@ async def test_remote_hook_owns_connection_and_preserves_non_auth_snapshot(
         configs = await cfg.get_mcp_server_configs()
 
     assert [
-        (request.provider, request.resource, request.scope) for request in requests
-    ] == [("records", " https://selector.example/resource ", scope)]
+        (request.provider, request.resource, request.scope, request.auth_type)
+        for request in requests
+    ] == [
+        (
+            "records",
+            " https://selector.example/resource ",
+            scope,
+            expected_auth_type,
+        )
+    ]
     assert configs[0]["config"]["headers"] == {
         "X-Static": "static",
         "X-Runtime": "runtime",
@@ -2690,6 +2717,7 @@ async def test_remote_hook_consecutive_refreshes_advance_failed_generation(db_se
 
     assert requests[1].provider == requests[0].provider == "records"
     assert requests[1].resource == requests[0].resource == server.url
+    assert requests[1].auth_type == requests[0].auth_type == "none"
     assert requests[1].refresh == web_tools_config.OAuthRefreshContext(
         reason="invalid_token",
         resource_metadata_url=(


### PR DESCRIPTION
## What

Tell the OAuth token resolver hook what authentication a connector declares, by adding an optional `auth_type` field to `TokenRequest` and filling it at both places the loader calls the hook. No behavior changes: nothing reads the field yet.

## Why

`WebToolConfig` asks the registered resolver hook for a delegated credential before it connects to an MCP server, but the `TokenRequest` it hands over never says what authentication the connector itself declares. A resolver therefore cannot tell a connector that needs a per-user OAuth credential from one whose auth is `none`, and has to answer both the same way. An embedder whose resolver fails closed on a missing credential ends up marking every custom HTTP connector unavailable on that path, including connectors that need no credential at all.

Passing the declared auth type lets the resolver make that distinction. Deciding what to do with it stays the resolver's job and is out of scope here.

## How

- `TokenRequest` gains a trailing field `auth_type: str | None = None`. Every existing construction is keyword-based, so the addition is source-compatible; a resolver that ignores the field behaves exactly as before. The docstring states the contract: the classified type string, the literal `"builtin_oauth"` for catalog apps whose OAuth is implied by `transport == "oauth"`, and `None` for unknown, which a resolver should never treat as "no credential needed".
- `connector_auth_type(server)` in `web/services/mcp_runtime.py` classifies a connector from its raw `auth` JSON without decrypting it (`type` is not a sensitive field). It returns `"none"` when the connector declares no authentication (`auth` absent, JSON null, an empty object, `{"type": null}`, or an explicit `{"type": "none"}`), the declared string otherwise, and `None` when the shape is not recognisable (a non-mapping `auth`, or a `type` that is a non-string or the empty string). It uses `getattr` and a `Mapping` check because the loader is also exercised with plain namespaces and mocks.
- Both call sites of `_resolve_oauth_token_from_hook` fill the field: the `transport == "oauth"` branch passes `"builtin_oauth"` verbatim, since those catalog servers carry no `auth` object; the HTTP remote branch passes `connector_auth_type(server)`.
- The refresh path builds its own `TokenRequest`; the same `auth_type` is threaded through `_build_resolver_owned_mcp_connection` and `_refresh_resolver_owned_mcp_connection` so a refresh carries the value the originating request had. The parameter has no default on those internal helpers, so a future caller that forgets it fails loudly instead of silently sending `None`.

## Tests

- `tests/web/services/test_mcp_runtime_auth_type.py` (new): classification over the recognisable and unrecognisable shapes, and a consistency check that `connector_auth_type` reports `"mcp_oauth"` exactly when the runtime's own `_is_mcp_oauth_http_server` classifier does, built the way the production caller builds its argument.
- `tests/web/tools/test_oauth_token_resolver_hook.py`: the existing request-capturing tests now also assert `auth_type`: `"builtin_oauth"` on the catalog OAuth path, `"mcp_oauth"` and `"none"` on the remote path (parametrized), and that a refresh request carries the same value as the first request.

Full `tests/web/tools` and `tests/web/services` pass.
